### PR TITLE
Only use pdf's with google picker

### DIFF
--- a/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
@@ -192,7 +192,6 @@
 
   var GOOGLE_MIME_TYPES = {
     'application/vnd.google-apps.document': 'googleDocs',
-    'application/vnd.google-apps.spreadsheet': 'googleSheets',
     'application/pdf': 'googleDriveFile',
   };
 
@@ -223,8 +222,6 @@
      switch(urlBuilder) {
        case 'googleDocs':
          return googleDocUrl(doc);
-       case 'googleSheets':
-         return googleSheetUrl(doc);
        case 'googleDriveFile':
          return googleDriveFileUrl(doc);
        default:
@@ -242,12 +239,6 @@
      return 'https://docs.google.com/document/d/'
        + doc.id
        + '/export?format=pdf';
-   }
-
-   function googleSheetUrl(doc) {
-     return 'https://docs.google.com/spreadsheets/d/'
-       + doc.id
-       + '/export?format=csv';
    }
 
     function pickerCallback(data) {

--- a/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
@@ -191,7 +191,9 @@
     }
 
   var GOOGLE_MIME_TYPES = {
-    'application/vnd.google-apps.document': 'googleDocs',
+    // 'application/vnd.google-apps.document': 'googleDocs', // Note: we can
+    // reenable google documents when we figure out how to make hypothesis
+    // support pdf exports
     'application/pdf': 'googleDriveFile',
   };
 


### PR DESCRIPTION
Update Google Picker to only allow pdf's from drive. We will disallow google drive documents until we figure out how to support google drive exported pdfs in the h client. 