### PR TITLE
Fix `JWT_SECRET` fails in `make test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 env:
   global:
     - TEST_DATABASE_URL=postgresql://postgres@localhost/lms_test
-    - JWT_SECRET="test_secret"
 language:
   - python
 python:

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -123,7 +123,6 @@ def pyramid_config(pyramid_request):
         'sqlalchemy.url': TEST_DATABASE_URL,
         'client_origin': 'http://TEST_H_SERVER.is',
         'via_url': 'http://TEST_VIA_SERVER.is',
-        'jwt_secret': 'test_secret',
         'username': 'report_viewers',
         'hashed_pw': 'e46df2a5b4d50e259b5154b190529483a5f8b7aaaa22a50447e377d33792577a',
         'salt': 'fbe82ee0da72b77b',

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ deps =
     -rrequirements.txt
 passenv =
     TEST_DATABASE_URL
-    JWT_SECRET
     PYTEST_ADDOPTS
+setenv = JWT_SECRET = test_secret
 commands =
     coverage run --source lms,tests/lms -m pytest {posargs:tests/lms/}
 


### PR DESCRIPTION
- Set the value of the `JWT_SECRET` environment variable in `tox.ini`.
  This gets `make test` working locally, without having to manually set
  `JWT_SECRET` to a test value before running it.

- Remove `JWT_SECRET` from `passenv` in `tox.ini`. Now that we're
  _setting_ `JWT_SECRET` in `tox.ini` we don't need to pass it.

- Remove `JWT_SECRET` from `.travis.yml`. Now that its been added to
  `tox.ini` it shouldn't be needed here anymore. Having it in `tox.ini`
  should get `make test` working both locally and on Travis instead of
  just on Travis.

- Remove the `jwt_secret` from `conftest.py`. I don't think this was
  being used at all - the code reads `JWT_SECRET` from the environment,
  it doesn't read `jwt_secret` from the Pyramid settings.