### PR TITLE
Delete the env.sh file

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,2 +1,0 @@
-export VIA_URL="https://via.hypothes.is/"
-


### PR DESCRIPTION
This file now contains only a single environment variable (VIA_URL), and
actually doesn't contain other environment variables that are necessary
to run the app. The README instructions already say to set all the
environment variables (including VIA_URL) manually.

If looking for a way to keep track of and easily apply and unapply env
vars, check out direnv:

https://direnv.net/

And add .envrc to ~/.config/git/gitignore_global, see:

https://help.github.com/articles/ignoring-files/#create-a-global-gitignore