### PR TITLE
Fix the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN mkdir /etc/collectd/collectd.conf.d \
 # writeable.
 RUN touch /var/log/collectd.log && chown lms:lms /var/log/collectd.log
 
-RUN apk-install collectd-disk
-
 COPY . .
 
 EXPOSE 8001

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN addgroup -S lms \
   && adduser -S -G lms -h /var/lib/lms lms
 WORKDIR /var/lib/lms
 
-# Copy packaging
-COPY README.markdown requirements.txt ./
+# Copy minimal data to allow installation of dependencies.
+COPY requirements.txt ./
 
 # Install build deps, build, and then clean up.
 RUN apk-install --virtual build-deps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gliderlabs/alpine:3.6
 MAINTAINER Hypothes.is Project and contributors
 
 # Install system build and runtime dependencies.
-RUN apk-install ca-certificates python py-pip libpq \
+RUN apk-install ca-certificates python3 libpq \
   collectd collectd-disk supervisor
 
 # Create the lms user, group, home directory and package directory.
@@ -17,9 +17,9 @@ COPY README.markdown requirements.txt ./
 RUN apk-install --virtual build-deps \
     build-base \
     postgresql-dev \
-    python-dev \
-  && pip install --no-cache-dir -U pip supervisor \
-  && pip install --no-cache-dir -r requirements.txt \
+    python3-dev \
+  && pip3 install --no-cache-dir -U pip \
+  && pip3 install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 
 # Copy collectd config

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM gliderlabs/alpine:3.6
 MAINTAINER Hypothes.is Project and contributors
 
 # Install system build and runtime dependencies.
-RUN apk-install ca-certificates python3 libpq \
-  collectd collectd-disk supervisor
+RUN apk-install ca-certificates python3 libpq collectd collectd-disk supervisor
 
 # Create the lms user, group, home directory and package directory.
 RUN addgroup -S lms \


### PR DESCRIPTION
Fix the `Dockerfile` to make it work with the app again, now that the app uses Python 3. Also some minor tidying up of the `Dockerfile`.

I was able to build the docker image with:

```
docker build -t hypothesis/lms:dev .
```

And then run it with:

```
docker run \
  -p 8001:8001 \
  -e VIA_URL="http://localhost:9080" \
  -e JWT_SECRET="dev_secret" \
  --link lti-postgres:postgres \
  -e DATABASE_URL="postgresql://postgres@postgres/postgres" \
  -e GOOGLE_CLIENT_ID="<YOUR_GOOGLE_OAUTH_CLIENT_ID>" \
  -e GOOGLE_DEVELOPER_KEY="<YOUR_GOOGLE_API_KEY>" \
  -e GOOGLE_APP_ID="<YOUR_GOOGLE_APP_ID>" \
  hypothesis/lms:dev
```

The `--link` requires you to have a postgres docker container named `lti-postgres` running, which you can get by doing:

```
docker run --name lti-postgres postgres
```

With the docker container running you should be able to visit http://localhost:8001/welcome and submit domains and emails to receive consumer keys and shared secrets, and also visit http://localhost:8001/config_xml to see some XML.

If you have Canvas running locally you should be able to add the app to Canvas and create assignments.

Since the docker version of the app doesn't do ssl, I don't think you'll be able to use it with https://hypothesis.instructure.com/