### PR TITLE
Add a /_status endpoint for load balancers

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -14,3 +14,6 @@ def includeme(config):
     # lms routes
     config.add_route('lti_launches', '/lti_launches')
     config.add_route('content_item_selection', '/content_item_selection')
+
+    # Health check endpoint for load balancers to request.
+    config.add_route('status', '/_status')

--- a/lms/views/status.py
+++ b/lms/views/status.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from pyramid.httpexceptions import HTTPInternalServerError
+from pyramid.view import view_config
+
+
+log = logging.getLogger(__name__)
+
+
+@view_config(route_name='status', renderer='json')
+def status(request):
+    try:
+        request.db.execute('SELECT 1')
+        return {'status': 'okay'}
+    except Exception:  # pylint:disable=broad-except
+        log.exception("Executing a simple database query failed:")
+        raise HTTPInternalServerError('Database connection failed')

--- a/tests/lms/views/status_test.py
+++ b/tests/lms/views/status_test.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import mock
+import pytest
+from pyramid.httpexceptions import HTTPInternalServerError
+
+from lms.views import status
+
+
+@pytest.mark.usefixtures('db')
+class TestStatus(object):
+    def test_it_returns_okay_on_success(self, pyramid_request):
+        result = status.status(pyramid_request)
+        assert result == {'status': 'okay'}
+
+    def test_it_fails_when_database_unreachable(self, pyramid_request, db):
+        db.execute.side_effect = Exception('explode!')
+
+        with pytest.raises(HTTPInternalServerError):
+            status.status(pyramid_request)
+
+    @pytest.fixture
+    def db(self, pyramid_request):
+        db = mock.Mock()
+        pyramid_request.db = db
+        return db


### PR DESCRIPTION
The AWS load balancer will be configured to request this endpoint to
test whether an application instance is healthy and can be added in to
or needs to be removed from the load balancer. The endpoint 500s if the
application server isn't healthy, 200s if it is.