### PR TITLE
Revert "Remove QA and prod deploys from Jenkinsfile"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,20 @@ node {
     }
 }
 
+onlyOnMaster {
+    milestone()
+    stage('qa deploy') {
+        deployApp(image: img, app: 'lms', env: 'qa')
+    }
+
+    milestone()
+    stage('prod deploy') {
+        input(message: "Deploy to prod?")
+        milestone()
+        deployApp(image: img, app: 'lms', env: 'prod')
+    }
+}
+
 def containerPort(container, port) {
     return sh(
         script: "docker port ${container.id} ${port} | cut -d: -f2",


### PR DESCRIPTION
This reverts commit d01843851b7abc6ce8065b7ffbf2d4aa12de2e98.

I think we've made the necessary changes in the playbook repo, the
deployment repo, and Jenkins now. I'm not sure if these qa and prod
deploys will run successfully in Jenkins yet, I think we may need to
manually create lms-qa and lms-prod environments in Elastic Beanstalk
first, but lets give this a try and find out.