### PR TITLE
Add Application Instance Specific Oauth Credentials

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -16,10 +16,6 @@ pyramid.includes =
 
 sqlalchemy.url = postgresql://postgres@localhost:5433/postgres
 
-## Oauth
-oauth.client_id = 43460000000000123
-oauth.client_secret = TSeQ7E3dzbHgu5ydX2xCrKJiXTmfJbOeLogm3sj0ESxCxlsxTSaDAObOK46XEZ84
-
 [server:main]
 use: egg:gunicorn
 host: 0.0.0.0

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -35,6 +35,7 @@ def configure(settings=None):
         'hashed_pw': env_setting('HASHED_PW'),
         'salt': env_setting('SALT'),
         'username': env_setting('USERNAME'),
+        'aes_secret': env_setting('LMS_SECRET').encode('ascii')[0:32]
     }
 
     database_url = env_setting('DATABASE_URL')

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -35,7 +35,9 @@ def configure(settings=None):
         'hashed_pw': env_setting('HASHED_PW'),
         'salt': env_setting('SALT'),
         'username': env_setting('USERNAME'),
-        'aes_secret': env_setting('LMS_SECRET').encode('ascii')[0:32]
+        # We need to use a randomly generated 16 byte array to encrypt secrets.
+        # For now we will use the first 16 bytes of the lms_secret
+        'aes_secret': env_setting('LMS_SECRET').encode('ascii')[0:16]
     }
 
     database_url = env_setting('DATABASE_URL')

--- a/lms/migrations/versions/51889ae54178_add_oauth_credentials_to_.py
+++ b/lms/migrations/versions/51889ae54178_add_oauth_credentials_to_.py
@@ -1,5 +1,5 @@
 """
-Add oauth credentials to ApplicationInstance
+Add oauth credentials to ApplicationInstance.
 
 Revision ID: 51889ae54178
 Revises: 3802f4d2ec5c

--- a/lms/migrations/versions/51889ae54178_add_oauth_credentials_to_.py
+++ b/lms/migrations/versions/51889ae54178_add_oauth_credentials_to_.py
@@ -1,0 +1,34 @@
+"""
+Add oauth credentials to ApplicationInstance
+
+Revision ID: 51889ae54178
+Revises: 3802f4d2ec5c
+Create Date: 2017-12-20 09:41:51.402587
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '51889ae54178'
+down_revision = '3802f4d2ec5c'
+
+
+def upgrade():
+    op.add_column(
+        'application_instances',
+        sa.Column('developer_key', sa.String)
+    )
+
+    op.add_column(
+        'application_instances',
+        sa.Column('developer_secret', sa.String)
+    )
+
+
+
+
+def downgrade():
+    op.drop_column('application_instances', 'developer_key')
+    op.drop_column('application_instances', 'developer_secret')

--- a/lms/migrations/versions/51889ae54178_add_oauth_credentials_to_.py
+++ b/lms/migrations/versions/51889ae54178_add_oauth_credentials_to_.py
@@ -23,12 +23,12 @@ def upgrade():
 
     op.add_column(
         'application_instances',
-        sa.Column('developer_secret', sa.LargeBinary)
+        sa.Column('developer_secret', sa.LargeBinary, default=None)
     )
 
     op.add_column(
         'application_instances',
-        sa.Column('aes_cipher_iv', sa.LargeBinary)
+        sa.Column('aes_cipher_iv', sa.LargeBinary, default=None)
     )
 
 

--- a/lms/migrations/versions/51889ae54178_add_oauth_credentials_to_.py
+++ b/lms/migrations/versions/51889ae54178_add_oauth_credentials_to_.py
@@ -23,12 +23,16 @@ def upgrade():
 
     op.add_column(
         'application_instances',
-        sa.Column('developer_secret', sa.String)
+        sa.Column('developer_secret', sa.LargeBinary)
     )
 
-
+    op.add_column(
+        'application_instances',
+        sa.Column('aes_cipher_iv', sa.LargeBinary)
+    )
 
 
 def downgrade():
     op.drop_column('application_instances', 'developer_key')
     op.drop_column('application_instances', 'developer_secret')
+    op.drop_column('application_instances', 'aes_cipher_iv')

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -34,8 +34,8 @@ class ApplicationInstance(BASE):
     requesters_email = sa.Column(sa.String(2048))
     created = sa.Column(sa.TIMESTAMP, default=datetime.utcnow())
     developer_key = sa.Column(sa.String)
-    developer_secret = sa.Column(sa.LargeBinary)
-    aes_cipher_iv = sa.Column(sa.LargeBinary)
+    developer_secret = sa.Column(sa.LargeBinary, default=None)
+    aes_cipher_iv = sa.Column(sa.LargeBinary, default=None)
 
     def decrypted_developer_secret(self, key):
         encrypted_secret = self.developer_secret
@@ -62,7 +62,7 @@ def build_from_lms_url(lms_url, email, developer_key,
     """Intantiate ApplicationIntance with lms_url."""
     encrypted_secret = developer_secret
     aes_iv = None
-    if encryption_key is not None:
+    if encryption_key is not None and developer_secret and developer_key:
         aes_iv = build_aes_iv()
         encrypted_secret = encrypt_oauth_secret(developer_secret, encryption_key, aes_iv)
 

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,7 +1,7 @@
 import secrets
+from datetime import datetime
 from Crypto.Cipher import AES
 from Crypto import Random
-from datetime import datetime
 
 import sqlalchemy as sa
 from lms.db import BASE
@@ -14,17 +14,19 @@ def build_aes_iv():
     return Random.new().read(AES.block_size)
 
 
-def encrypt_oauth_secret(oauth_secret, key, iv):
-    cipher = AES.new(key, AES.MODE_CFB, iv)
+def encrypt_oauth_secret(oauth_secret, key, init_v):
+    cipher = AES.new(key, AES.MODE_CFB, init_v)
     return cipher.encrypt(oauth_secret)
 
-def decrypt_oauth_secret(encrypted_secret, key, iv):
-    cipher = AES.new(key, AES.MODE_CFB, iv)
+
+def decrypt_oauth_secret(encrypted_secret, key, init_v):
+    cipher = AES.new(key, AES.MODE_CFB, init_v)
     return cipher.decrypt(encrypted_secret)
 
 
 class ApplicationInstance(BASE):
     """Class to represent a single lms install."""
+
     __tablename__ = 'application_instances'
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
@@ -75,4 +77,3 @@ def build_from_lms_url(lms_url, email, developer_key,
         developer_secret=encrypted_secret,
         aes_cipher_iv=aes_iv,
     )
-

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -11,18 +11,18 @@ LTI_KEY_BASE = "Hypothesis"
 
 
 def build_aes_iv():
-    """Build a 16 byte initialization vector"""
+    """Build a 16 byte initialization vector."""
     return Random.new().read(AES.block_size)
 
 
 def encrypt_oauth_secret(oauth_secret, key, init_v):
-    """Encrypt an oauth secrety via AES encryption"""
+    """Encrypt an oauth secrety via AES encryption."""
     cipher = AES.new(key, AES.MODE_CFB, init_v)
     return cipher.encrypt(oauth_secret)
 
 
 def decrypt_oauth_secret(encrypted_secret, key, init_v):
-    """Decrypt AES encrypted secret"""
+    """Decrypt AES encrypted secret."""
     cipher = AES.new(key, AES.MODE_CFB, init_v)
     return cipher.decrypt(encrypted_secret)
 

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -11,15 +11,18 @@ LTI_KEY_BASE = "Hypothesis"
 
 
 def build_aes_iv():
+    """Build a 16 byte initialization vector"""
     return Random.new().read(AES.block_size)
 
 
 def encrypt_oauth_secret(oauth_secret, key, init_v):
+    """Encrypt an oauth secrety via AES encryption"""
     cipher = AES.new(key, AES.MODE_CFB, init_v)
     return cipher.encrypt(oauth_secret)
 
 
 def decrypt_oauth_secret(encrypted_secret, key, init_v):
+    """Decrypt AES encrypted secret"""
     cipher = AES.new(key, AES.MODE_CFB, init_v)
     return cipher.decrypt(encrypted_secret)
 

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -19,6 +19,8 @@ class ApplicationInstance(BASE):
     lms_url = sa.Column(sa.String(2048))
     requesters_email = sa.Column(sa.String(2048))
     created = sa.Column(sa.TIMESTAMP, default=datetime.utcnow())
+    developer_key = sa.Column('developer_key', sa.String)
+    developer_secret = sa.Column('developer_secret', sa.String)
 
 
 def find_by_oauth_consumer_key(session, key):
@@ -36,11 +38,13 @@ def build_unique_key():
     return LTI_KEY_BASE + secrets.token_hex(16)
 
 
-def build_from_lms_url(lms_url, email):
+def build_from_lms_url(lms_url, email, developer_key, developer_secret):
     """Intantiate ApplicationIntance with lms_url."""
     return ApplicationInstance(
         consumer_key=build_unique_key(),
         shared_secret=build_shared_secret(),
         lms_url=lms_url,
-        requesters_email=email
+        requesters_email=email,
+        developer_key=developer_key,
+        developer_secret=developer_secret
     )

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,4 +1,6 @@
 import secrets
+from Crypto.Cipher import AES
+from Crypto import Random
 from datetime import datetime
 
 import sqlalchemy as sa
@@ -8,9 +10,21 @@ from lms.db import BASE
 LTI_KEY_BASE = "Hypothesis"
 
 
+def build_aes_iv():
+    return Random.new().read(AES.block_size)
+
+
+def encrypt_oauth_secret(oauth_secret, key, iv):
+    cipher = AES.new(key, AES.MODE_CFB, iv)
+    return cipher.encrypt(oauth_secret)
+
+def decrypt_oauth_secret(encrypted_secret, key, iv):
+    cipher = AES.new(key, AES.MODE_CFB, iv)
+    return cipher.decrypt(encrypted_secret)
+
+
 class ApplicationInstance(BASE):
     """Class to represent a single lms install."""
-
     __tablename__ = 'application_instances'
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
@@ -19,8 +33,13 @@ class ApplicationInstance(BASE):
     lms_url = sa.Column(sa.String(2048))
     requesters_email = sa.Column(sa.String(2048))
     created = sa.Column(sa.TIMESTAMP, default=datetime.utcnow())
-    developer_key = sa.Column('developer_key', sa.String)
-    developer_secret = sa.Column('developer_secret', sa.String)
+    developer_key = sa.Column(sa.String)
+    developer_secret = sa.Column(sa.LargeBinary)
+    aes_cipher_iv = sa.Column(sa.LargeBinary)
+
+    def decrypted_developer_secret(self, key):
+        encrypted_secret = self.developer_secret
+        return decrypt_oauth_secret(encrypted_secret, key, self.aes_cipher_iv)
 
 
 def find_by_oauth_consumer_key(session, key):
@@ -38,13 +57,22 @@ def build_unique_key():
     return LTI_KEY_BASE + secrets.token_hex(16)
 
 
-def build_from_lms_url(lms_url, email, developer_key, developer_secret):
+def build_from_lms_url(lms_url, email, developer_key,
+                       developer_secret, encryption_key=None):
     """Intantiate ApplicationIntance with lms_url."""
+    encrypted_secret = developer_secret
+    aes_iv = None
+    if encryption_key is not None:
+        aes_iv = build_aes_iv()
+        encrypted_secret = encrypt_oauth_secret(developer_secret, encryption_key, aes_iv)
+
     return ApplicationInstance(
         consumer_key=build_unique_key(),
         shared_secret=build_shared_secret(),
         lms_url=lms_url,
         requesters_email=email,
         developer_key=developer_key,
-        developer_secret=developer_secret
+        developer_secret=encrypted_secret,
+        aes_cipher_iv=aes_iv,
     )
+

--- a/lms/templates/application_instances/new_application_instance.html.jinja2
+++ b/lms/templates/application_instances/new_application_instance.html.jinja2
@@ -66,6 +66,16 @@
       <input id="email" type="email" name="email" onblur="validateEmail(this)"/>
       <span class="error"></span>
     </div>
+    <div class="input">
+      <label for="developer-key">Developer Key (optional)</label>
+      <input id="developer-key" type="text" name="developer_key"/>
+      <span class="error"></span>
+    </div>
+    <div class="input">
+      <label for="developer-secret">Developer Secret (optional)</label>
+      <input id="developer-secret" type="text" name="developer_secret"/>
+      <span class="error"></span>
+    </div>
     <div class="form-controls">
       <button type="submit" class="btn">Submit</button>
     </div>

--- a/lms/util/authorize_lms.py
+++ b/lms/util/authorize_lms.py
@@ -83,8 +83,10 @@ def authorize_lms(*, authorization_base_endpoint, redirect_endpoint,
         return wrapper
     return decorator
 
+
 def save_token(view_function):
     """Decorate an oauth callback route to save access token."""
+    # pylint: disable=too-many-locals
     def wrapper(request, *args, **kwargs):
         """Route to handle content item selection oauth response."""
         if 'state' not in request.params or 'code' not in request.params:

--- a/lms/util/authorize_lms.py
+++ b/lms/util/authorize_lms.py
@@ -83,7 +83,6 @@ def authorize_lms(*, authorization_base_endpoint, redirect_endpoint,
         return wrapper
     return decorator
 
-
 def save_token(view_function):
     """Decorate an oauth callback route to save access token."""
     def wrapper(request, *args, **kwargs):
@@ -107,8 +106,10 @@ def save_token(view_function):
         if application_instance is None:
             raise exc.HTTPInternalServerError()
 
+        aes_secret = request.registry.settings['aes_secret']
         client_id = application_instance.developer_key
-        client_secret = application_instance.developer_secret
+        client_secret = application_instance.decrypted_developer_secret(aes_secret)
+
         token_url = build_canvas_token_url(application_instance.lms_url)
 
         session = requests_oauthlib.OAuth2Session(client_id, state=state)

--- a/lms/util/authorize_lms.py
+++ b/lms/util/authorize_lms.py
@@ -58,10 +58,11 @@ def authorize_lms(*, authorization_base_endpoint, redirect_endpoint,
             if oauth_condition(request) is False:
                 return view_function(request, *args, user=user, **kwargs)
 
-            client_id = request.registry.settings['oauth.client_id']
             consumer_key = request.params['oauth_consumer_key']
 
             application_instance = find_by_oauth_consumer_key(request.db, consumer_key)
+
+            client_id = application_instance.developer_key
 
             if application_instance is None:
                 raise exc.HTTPInternalServerError()
@@ -90,8 +91,6 @@ def save_token(view_function):
         if 'state' not in request.params or 'code' not in request.params:
             raise exc.HTTPInternalServerError('Invalid Oauth Response')
 
-        client_id = request.registry.settings['oauth.client_id']
-        client_secret = request.registry.settings['oauth.client_secret']
         state = request.params['state']
         oauth_state = find_by_state(request.db, state)
 
@@ -99,12 +98,17 @@ def save_token(view_function):
             raise exc.HTTPInternalServerError('Oauth state was not found')
 
         lti_params = json.loads(oauth_state.lti_params)
-        application_instance = find_by_oauth_consumer_key(request.db,
-                                                          lti_params['oauth_consumer_key'])
+
+        application_instance = find_by_oauth_consumer_key(
+            request.db,
+            lti_params['oauth_consumer_key']
+        )
 
         if application_instance is None:
             raise exc.HTTPInternalServerError()
 
+        client_id = application_instance.developer_key
+        client_secret = application_instance.developer_secret
         token_url = build_canvas_token_url(application_instance.lms_url)
 
         session = requests_oauthlib.OAuth2Session(client_id, state=state)

--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -6,7 +6,6 @@ from lms.models import application_instance as ai
 def create_application_instance(request):
     """Create application instance in the databse and respond with key and secret."""
     # TODO handle missing scheme in lms_url.
-
     instance = ai.build_from_lms_url(request.params['lms_url'],
                                      request.params['email'])
     request.db.add(instance)

--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -5,9 +5,23 @@ from lms.models import application_instance as ai
 @view_config(route_name='welcome', request_method='POST', renderer='lms:templates/application_instances/create_application_instance.html.jinja2')
 def create_application_instance(request):
     """Create application instance in the databse and respond with key and secret."""
-    # TODO handle missing scheme in lms_url.
+    # Check to make sure that both developer key and secret are present. If not set to None.
+    developer_key = request.params['developer_key'].strip()
+    developer_secret = request.params['developer_secret'].strip()
+    if developer_key == '':
+        developer_key = None
+
+    if developer_secret == '':
+        developer_secret = None
+
+    if not developer_key or not developer_secret:
+        developer_key = None
+        developer_secret = None
+
     instance = ai.build_from_lms_url(request.params['lms_url'],
-                                     request.params['email'])
+                                     request.params['email'],
+                                     developer_key,
+                                     developer_secret)
     request.db.add(instance)
 
     return {

--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -21,7 +21,8 @@ def create_application_instance(request):
     instance = ai.build_from_lms_url(request.params['lms_url'],
                                      request.params['email'],
                                      developer_key,
-                                     developer_secret)
+                                     developer_secret,
+                                     request.registry.settings['aes_secret'])
     request.db.add(instance)
 
     return {

--- a/lms/views/oauth.py
+++ b/lms/views/oauth.py
@@ -15,6 +15,7 @@ def build_canvas_token_url(lms_url):
 
 
 @view_config(route_name='canvas_oauth_callback', request_method='GET')
+# pylint: disable=too-many-locals
 def canvas_oauth_callback(request):
     """Route to handle content item selection oauth response."""
     state = request.params['state']

--- a/lms/views/oauth.py
+++ b/lms/views/oauth.py
@@ -23,7 +23,9 @@ def canvas_oauth_callback(request):
     consumer_key = lti_params['oauth_consumer_key']
     application_instance = get_application_instance(request.db, consumer_key)
     client_id = application_instance.developer_key
-    client_secret = application_instance.developer_secret
+
+    aes_secret = request.registry.settings['aes_secret']
+    client_secret = application_instance.decrypted_developer_secret(aes_secret)
     token_url = build_canvas_token_url(application_instance.lms_url)
 
     session = OAuth2Session(client_id, state=state)

--- a/lms/views/oauth.py
+++ b/lms/views/oauth.py
@@ -17,14 +17,13 @@ def build_canvas_token_url(lms_url):
 @view_config(route_name='canvas_oauth_callback', request_method='GET')
 def canvas_oauth_callback(request):
     """Route to handle content item selection oauth response."""
-    client_id = request.registry.settings['oauth.client_id']
-    client_secret = request.registry.settings['oauth.client_secret']
-
     state = request.params['state']
     oauth_state = find_by_state(request.db, state)
     lti_params = json.loads(oauth_state.lti_params)
     consumer_key = lti_params['oauth_consumer_key']
     application_instance = get_application_instance(request.db, consumer_key)
+    client_id = application_instance.developer_key
+    client_secret = application_instance.developer_secret
     token_url = build_canvas_token_url(application_instance.lms_url)
 
     session = OAuth2Session(client_id, state=state)

--- a/requirements.in
+++ b/requirements.in
@@ -13,3 +13,4 @@ PyLTI
 PyJWT
 requests_oauthlib
 requests
+pycrypto==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pastedeploy==1.5.2        # via plaster-pastedeploy, pyramid
 plaster-pastedeploy==0.4.2  # via pyramid
 plaster==1.0              # via plaster-pastedeploy, pyramid
 psycopg2==2.7.3.2
+pycrypto==2.4.0
 pyjwt==1.5.3
 pylti==0.5.1
 pyramid-jinja2==2.7

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -138,6 +138,7 @@ def pyramid_config(pyramid_request):
         'hashed_pw': 'e46df2a5b4d50e259b5154b190529483a5f8b7aaaa22a50447e377d33792577a',
         'salt': 'fbe82ee0da72b77b',
         'username': 'report_viewer',
+        'aes_secret': b'TSeQ7E3dzbHgu5ydX2xCrKJiXTmfJbOe',
         'jinja2.filters': {
             'static_path': 'pyramid_jinja2.filters:static_path_filter',
             'static_url': 'pyramid_jinja2.filters:static_url_filter',
@@ -195,7 +196,8 @@ def lti_launch_request(monkeypatch, pyramid_request):
         'https://hypothesis.instructure.com',
         'address@)hypothes.is',
         'test',
-        'test'
+        b'test',
+        encryption_key=pyramid_request.registry.settings['aes_secret']
     )
     pyramid_request.db.add(instance)
     pyramid_request.params['oauth_consumer_key'] = instance.consumer_key
@@ -213,7 +215,7 @@ def canvas_api_proxy(pyramid_request):
         'https://example.com',
         'test@example.com',
         'test',
-        'test'
+        b'test'
     )
     data = {
         'user_id': user_id,
@@ -299,7 +301,8 @@ def oauth_response(monkeypatch, pyramid_request):
         'https://example.com',
         'test@example.com',
         'test',
-        'test'
+        b'test',
+        pyramid_request.registry.settings['aes_secret']
     )
     state_guid = 'test_oauth_state'
     user = User(lms_guid=user_id)

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -138,8 +138,6 @@ def pyramid_config(pyramid_request):
         'hashed_pw': 'e46df2a5b4d50e259b5154b190529483a5f8b7aaaa22a50447e377d33792577a',
         'salt': 'fbe82ee0da72b77b',
         'username': 'report_viewer',
-        'oauth.client_id': 'fake_oauth_client_id',
-        'oauth.client_secret': 'fake_oauth_client_secret',
         'jinja2.filters': {
             'static_path': 'pyramid_jinja2.filters:static_path_filter',
             'static_url': 'pyramid_jinja2.filters:static_url_filter',
@@ -195,14 +193,15 @@ def lti_launch_request(monkeypatch, pyramid_request):
     from lms.models import application_instance as ai  # pylint:disable=relative-import
     instance = ai.build_from_lms_url(
         'https://hypothesis.instructure.com',
-        'address@)hypothes.is')
+        'address@)hypothes.is',
+        'test',
+        'test'
+    )
     pyramid_request.db.add(instance)
     pyramid_request.params['oauth_consumer_key'] = instance.consumer_key
     pyramid_request.params['custom_canvas_course_id'] = '1'
     pyramid_request.params['context_id'] = 'fake_context_id'
     monkeypatch.setattr('pylti.common.verify_request_common', lambda a, b, c, d, e: True)
-    pyramid_request.registry.settings['oauth.client_id'] = 'fake'
-    pyramid_request.registry.settings['oauth.client_secret'] = 'fake'
     yield pyramid_request
 
 
@@ -210,7 +209,12 @@ def lti_launch_request(monkeypatch, pyramid_request):
 def canvas_api_proxy(pyramid_request):
 
     user_id = 'asdf'
-    application_instance = build_from_lms_url('https://example.com', 'test@example.com')
+    application_instance = build_from_lms_url(
+        'https://example.com',
+        'test@example.com',
+        'test',
+        'test'
+    )
     data = {
         'user_id': user_id,
         'roles': '',
@@ -291,7 +295,12 @@ class MockOauth2Session:
 def oauth_response(monkeypatch, pyramid_request):
     user_id = 'test_user_123'
     roles = 'fake_lti_roles'
-    app_instance = build_from_lms_url('https://example.com', 'test@example.com')
+    app_instance = build_from_lms_url(
+        'https://example.com',
+        'test@example.com',
+        'test',
+        'test'
+    )
     state_guid = 'test_oauth_state'
     user = User(lms_guid=user_id)
     pyramid_request.db.add(user)

--- a/tests/lms/util/test_authorize_lms.py
+++ b/tests/lms/util/test_authorize_lms.py
@@ -36,7 +36,9 @@ def create_application_instance(lti_launch_request):
     lms_url = "https://example.com"
     email = "example@example.com"
     session = lti_launch_request.db
-    application_instance = build_from_lms_url(lms_url, email, 'test', 'test')
+    application_instance = build_from_lms_url(lms_url, email, 'test', b'test',
+                                              encryption_key=lti_launch_request.
+                                              registry.settings['aes_secret'])
     session.add(application_instance)
     session.flush()
     return application_instance

--- a/tests/lms/util/test_authorize_lms.py
+++ b/tests/lms/util/test_authorize_lms.py
@@ -36,7 +36,7 @@ def create_application_instance(lti_launch_request):
     lms_url = "https://example.com"
     email = "example@example.com"
     session = lti_launch_request.db
-    application_instance = build_from_lms_url(lms_url, email)
+    application_instance = build_from_lms_url(lms_url, email, 'test', 'test')
     session.add(application_instance)
     session.flush()
     return application_instance

--- a/tests/lms/views/test_application_instance.py
+++ b/tests/lms/views/test_application_instance.py
@@ -8,6 +8,8 @@ class TestApplicationInstance(object):
         pyramid_request.params = {
             'lms_url': 'canvas.example.com',
             'email': 'email@example.com',
+            'developer_key': '',
+            'developer_secret': ''
         }
         initial_count = pyramid_request.db.query(ApplicationInstance).filter(
             ApplicationInstance.lms_url == pyramid_request.params['lms_url']).count()


### PR DESCRIPTION
Add `ApplicationInstance` specific developer key and secrets. This allows Oauth without the a global instructure developer key and secret. Keys and secrets are both stored in the application_instances table. Developer keys can be accessed via `application_instance.developer_key`. The developer secret is encrypted via AES encryption while at rest. The encrypted secret is can be accessed from an `application_instance` model via `application_instance.developer_secret`. The decrypted secret can be obtained by `application_instance.decrypted_developer_secret(aes_secret)` where the `aes_secret` is a randomly generated byte array of length 16.