### PR TITLE
fix migration chain

### DIFF
--- a/lms/migrations/versions/64d9eacab937_add_oauth_support.py
+++ b/lms/migrations/versions/64d9eacab937_add_oauth_support.py
@@ -2,7 +2,7 @@
 Add oauth support.
 
 Revision ID: 64d9eacab937
-Revises: 58f2693de313
+Revises: 51889ae54178
 Create Date: 2017-11-28 13:56:48.270643
 
 """
@@ -13,7 +13,7 @@ from datetime import datetime
 
 # revision identifiers, used by Alembic.
 revision = '64d9eacab937'
-down_revision = 'a6a78f338d4a'
+down_revision = '51889ae54178'
 
 
 def upgrade():


### PR DESCRIPTION
Some where down the road we ended up with migrations that branched off of the main chain. This sets them into one chain so that when we deploy we shouldn't have to run upgrade heads.