### PR TITLE
Add assignment selection to xml config

### DIFF
--- a/lms/config.xml.jinja2
+++ b/lms/config.xml.jinja2
@@ -26,6 +26,13 @@ name="message_type">ContentItemSelectionRequest</lticm:property>
       <lticm:property
 name="url">{{ content_item_url }}</lticm:property>
     </lticm:options>
+    <lticm:options name="assignment_selection">
+      <lticm:property
+name="message_type">ContentItemSelectionRequest</lticm:property>
+      <lticm:property name="text">Hypothesis</lticm:property>
+      <lticm:property
+name="url">{{ content_item_url }}</lticm:property>
+    </lticm:options>
     <lticm:property name="privacy_level">public</lticm:property>
   </blti:extensions>
 </cartridge_basiclti_link>


### PR DESCRIPTION
Adds support for `assignment_selection` content item selection. LTI tools are configured with with an xml document that is given to canvas upon installing the application. Adding this section enables content item selection (File chooser app) for selecting an assignment with the hypothesis tool. Unfortunately, because this is a configuration that is set at install time, users must reinstall the app in their canvas instance in order for the update to occur. More information can be found [here](https://canvas.instructure.com/doc/api/file.content_item.html)