### PR TITLE
Fix Reporting Issue

### DIFF
--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from pyramid.view import view_config
 
@@ -67,7 +68,8 @@ def launch_lti(request, lti_key=None, context_id=None, document_url=None,
     try:
         lti_launch_instance = LtiLaunches(
             context_id=context_id,
-            lti_key=lti_key
+            lti_key=lti_key,
+            created=datetime.utcnow()
         )
         request.db.add(lti_launch_instance)
 


### PR DESCRIPTION
Previously we left the created field on the `LtiLaunch` model to be set by the default. I think this was only happening when the database was flushed, and therefore the times showed up in batches according to when they were committed to the database. We now explicitly set to `created` time to reflect the UTC time that the LTI launch actually occurred. 

Below is an example of the reports both before and after the change. Notice all but the last two records have non-unique times. The last two launches occurred after the fix, and have a time that reflects the actual LTI launch time. 

<img width="678" alt="screen shot 2018-01-11 at 3 46 32 pm" src="https://user-images.githubusercontent.com/9383215/34851301-a3a2e670-f6e6-11e7-9d30-5caebf1ffce2.png">
