### PR TITLE
Update Reports Page

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 from lms.models.application_instance import ApplicationInstance, build_from_lms_url
+from lms.models.lti_launches import LtiLaunches
 from lms.models.module_item_configuration import ModuleItemConfiguration
 from lms.models.oauth_state import OauthState, find_by_state, find_or_create_from_user
 from lms.models.tokens import Token, update_user_token
@@ -10,6 +11,7 @@ from lms.models.users import User, build_from_lti_params
 
 __all__ = (
     'ApplicationInstance',
+    'LtiLaunches',
     'build_from_lms_url',
     'build_from_lti_params',
     'find_by_state',

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -79,4 +79,5 @@ def build_from_lms_url(lms_url, email, developer_key,
         developer_key=developer_key,
         developer_secret=encrypted_secret,
         aes_cipher_iv=aes_iv,
+        created=datetime.utcnow(),
     )

--- a/lms/templates/reports/application_report.html.jinja2
+++ b/lms/templates/reports/application_report.html.jinja2
@@ -11,7 +11,7 @@
             <tr>
                 <th>Created</th>
                 <th>LMS URL</th>
-                <th>Requesters Email</th>
+                <th>Signup Email</th>
                 <th>Consumer Key</th>
             </tr>
         {% for row in apps %}
@@ -29,15 +29,17 @@
         <p>There have been {{ launches|length }} lti launches:</p>
         <table border="1">
             <tr>
-                <th>Created</th>
                 <th>Context ID</th>
-                <th>LTI Key</th>
+                <th>Number of Launches</th>
+                <th>LMS Url</th>
+                <th>Signup Email</th>
+                <th>Consumer Key</th>
             </tr>
         {% for row in launches %}
             <tr>
-                <td>{{  row['created']  }}</td>
-                <td>{{  row['context_id']  }}</td>
-                <td>{{  row['lti_key']  }}</td>
+              {% for element in row %} 
+                <td>{{  element  }}</td>
+              {% endfor %}
             </tr>
         {% endfor %}
         </table>

--- a/lms/templates/reports/application_report.html.jinja2
+++ b/lms/templates/reports/application_report.html.jinja2
@@ -13,6 +13,7 @@
                 <th>Lms Url</th>
                 <th>Signup Email</th>
                 <th>Consumer Key</th>
+                <th>Shared Secret</th>
             </tr>
         {% for row in apps %}
             <tr>
@@ -20,6 +21,7 @@
                 <td>{{  row['lms_url']  }}</td>
                 <td>{{  row['requesters_email']  }}</td>
                 <td>{{  row['consumer_key']  }}</td>
+                <td>{{  row['shared_secret']  }}</td>
             </tr>
         {% endfor %}
         </table>

--- a/lms/templates/reports/application_report.html.jinja2
+++ b/lms/templates/reports/application_report.html.jinja2
@@ -9,8 +9,8 @@
         <p>There are {{ apps|length }} application instances:</p>
         <table border="1">
             <tr>
-                <th>Created</th>
-                <th>LMS URL</th>
+                <th>Created At</th>
+                <th>Lms Url</th>
                 <th>Signup Email</th>
                 <th>Consumer Key</th>
             </tr>
@@ -26,12 +26,12 @@
 
         <br/>
 
-        <p>There have been {{ launches|length }} lti launches:</p>
+        <p>There have been {{ num_launches }} lti launches:</p>
         <table border="1">
             <tr>
                 <th>Context ID</th>
                 <th>Number of Launches</th>
-                <th>LMS Url</th>
+                <th>Lms Url</th>
                 <th>Signup Email</th>
                 <th>Consumer Key</th>
             </tr>

--- a/lms/templates/reports/application_report.html.jinja2
+++ b/lms/templates/reports/application_report.html.jinja2
@@ -12,12 +12,14 @@
                 <th>Created</th>
                 <th>LMS URL</th>
                 <th>Requesters Email</th>
+                <th>Consumer Key</th>
             </tr>
         {% for row in apps %}
             <tr>
                 <td>{{  row['created']  }}</td>
                 <td>{{  row['lms_url']  }}</td>
                 <td>{{  row['requesters_email']  }}</td>
+                <td>{{  row['consumer_key']  }}</td>
             </tr>
         {% endfor %}
         </table>

--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -5,6 +5,7 @@ from lms.views.content_item_selection import content_item_selection
 from lms.views.lti_launches import lti_launches
 from lms.views.module_item_configurations import create_module_item_configuration
 from lms.views.canvas_proxy import canvas_proxy
+from lms.views.reports import list_application_instances
 
 __all__ = (
     'create_application_instance',
@@ -13,6 +14,7 @@ __all__ = (
     'lti_launches',
     'create_module_item_configuration',
     'canvas_proxy',
+    'list_application_instances'
 )
 
 

--- a/lms/views/reports.py
+++ b/lms/views/reports.py
@@ -1,7 +1,7 @@
 from pyramid.view import view_config
 
-from lms.models.application_instance import ApplicationInstance
-from lms.models.lti_launches import LtiLaunches
+from lms.models import ApplicationInstance
+from lms.models import LtiLaunches
 
 
 @view_config(route_name='reports',

--- a/lms/views/reports.py
+++ b/lms/views/reports.py
@@ -16,5 +16,6 @@ def list_application_instances(request):
     return {
         'apps': request.db.query(ApplicationInstance).all(),
         'launches': launches,
+        'num_launches': request.db.query(LtiLaunches).count(),
         'logout_url': request.route_url('logout')
     }

--- a/lms/views/reports.py
+++ b/lms/views/reports.py
@@ -8,8 +8,13 @@ from lms.models.lti_launches import LtiLaunches
              renderer="lms:templates/reports/application_report.html.jinja2",
              permission='view')
 def list_application_instances(request):
+    launches = request.db.execute("SELECT context_id, count(context_id), \
+      lms_url, requesters_email, consumer_key FROM lti_launches LEFT JOIN \
+      application_instances on \
+      lti_launches.lti_key=application_instances.consumer_key GROUP BY \
+      context_id, consumer_key, requesters_email, lms_url;").fetchall()
     return {
         'apps': request.db.query(ApplicationInstance).all(),
-        'launches': request.db.query(LtiLaunches).all(),
+        'launches': launches,
         'logout_url': request.route_url('logout')
     }

--- a/lms/views/reports.py
+++ b/lms/views/reports.py
@@ -12,7 +12,8 @@ def list_application_instances(request):
       lms_url, requesters_email, consumer_key FROM lti_launches LEFT JOIN \
       application_instances on \
       lti_launches.lti_key=application_instances.consumer_key GROUP BY \
-      context_id, consumer_key, requesters_email, lms_url;").fetchall()
+      context_id, consumer_key, requesters_email, lms_url ORDER BY \
+      count(CONTEXT_ID) DESC;").fetchall()
     return {
         'apps': request.db.query(ApplicationInstance).all(),
         'launches': launches,

--- a/tests/lms/views/test_reports.py
+++ b/tests/lms/views/test_reports.py
@@ -1,0 +1,39 @@
+from lms.views.reports import list_application_instances
+from lms.models.application_instance import build_from_lms_url
+from lms.models.lti_launches import LtiLaunches
+
+class TestReports(object):
+    def test_build_launches_rows(self, pyramid_request):
+        test_urls = ['https://example.com', 'https://sub.example.com',
+                     'https://another.example.com']
+        test_emails = ['a@example.com', 'b@sub.example.com',
+                       'c@another.example.com']
+        def build_ai_from_pair(pair):
+          return build_from_lms_url(pair[0], pair[1], None, None, None)
+
+        app_instances = list(
+                         map(build_ai_from_pair, zip(test_urls, test_emails)))
+        for app in app_instances:
+            pyramid_request.db.add(app)
+
+        launch1 = LtiLaunches(context_id="asdf", lti_key=app_instances[0].consumer_key)
+        launch2 = LtiLaunches(context_id="asdf", lti_key=app_instances[0].consumer_key)
+        launch3 = LtiLaunches(context_id="asdf", lti_key=app_instances[0].consumer_key)
+        launch4 = LtiLaunches(context_id="fdsa", lti_key=app_instances[1].consumer_key)
+        launch5 = LtiLaunches(context_id="another", lti_key=app_instances[2].consumer_key)
+        launch6 = LtiLaunches(context_id="another", lti_key=app_instances[2].consumer_key)
+
+
+        for launch in [launch1, launch2, launch3, launch4, launch5, launch6]:
+            pyramid_request.db.add(launch)
+        pyramid_request.db.flush()
+
+        result = list_application_instances(pyramid_request)
+        assert result['num_launches'] == 6
+        assert result['launches'] == [
+            ('asdf', 3, 'https://example.com', 'a@example.com', app_instances[0].consumer_key),
+            ('another', 2, 'https://another.example.com',
+             'c@another.example.com', app_instances[2].consumer_key),
+            ('fdsa', 1, 'https://sub.example.com',
+             'b@sub.example.com', app_instances[1].consumer_key)]
+


### PR DESCRIPTION
This PR fixes a bug where multiple installs were reported to have the same creation time, even though we knew that they were created at different times. 

It also adds the consumer key and shared secret to the installs table. 

For the launches graph, it now only lists each specific context the app has been launched in a single time, but adds a column to list how many times it has been launched. As well as adding the lms url, requesters email, and consumer key that correspond to the application instance that was launched.