### PR TITLE
Remove deprecated/removed pip `—use-wheel` from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ docker:
 
 .pydeps: requirements.txt requirements-dev.in
 	@echo installing python dependencies
-	@pip install --use-wheel -r requirements-dev.in
+	@pip install -r requirements-dev.in
 	@touch $@
 
 


### PR DESCRIPTION
`make dev` was failing on dependency install because `pip` since version 9 ish no longer has the `--use-wheel` option.