### PR TITLE
Add verification meta tag to base template and `index` view

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 
 def includeme(config):
+    config.add_route('index', '/')
     config.add_route('welcome', '/welcome')
     config.add_route('login', '/login')
     config.add_route('logout', '/logout')

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -2,6 +2,7 @@
 <html lang=en>
   <head>
     <meta charset=utf-8>
+    <meta name="google-site-verification" content="gaQfw17MvkfgMs1jAeZAEv0kuJTMS28lvH21_rQKBPY" />
     <title>{% block title %}Hypothesis{% endblock %}</title>
     <link rel="stylesheet"
           type="text/css"

--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -2,6 +2,7 @@
 from lms.views.application_instances import create_application_instance
 from lms.views.config import config_xml
 from lms.views.content_item_selection import content_item_selection
+from lms.views.index import index
 from lms.views.lti_launches import lti_launches
 from lms.views.module_item_configurations import create_module_item_configuration
 from lms.views.canvas_proxy import canvas_proxy
@@ -11,6 +12,7 @@ __all__ = (
     'create_application_instance',
     'config_xml',
     'content_item_selection',
+    'index',
     'lti_launches',
     'create_module_item_configuration',
     'canvas_proxy',

--- a/lms/views/index.py
+++ b/lms/views/index.py
@@ -3,6 +3,6 @@ from pyramid.view import view_config
 
 @view_config(route_name='index',
              renderer="lms:templates/base.html.jinja2")
-def index(request):
-    '''Render an empty page that contains a needed Google verification meta tag'''
+def index():
+    """Render an empty page that contains a needed Google verification meta tag."""
     return {}

--- a/lms/views/index.py
+++ b/lms/views/index.py
@@ -1,0 +1,8 @@
+from pyramid.view import view_config
+
+
+@view_config(route_name='index',
+             renderer="lms:templates/base.html.jinja2")
+def index(request):
+    '''Render an empty page that contains a needed Google verification meta tag'''
+    return {}


### PR DESCRIPTION
This PR introduces a view handler and route for the `/` route and updates the base template to include a site verification meta tag. The landing page no longer returns a 404, but the rendered HTML page is currently blank. We could put stuff there if we cared to.

There are no tests for this, though I'm not convinced they'd be warranted beyond testing the route and I don't want to take the time right at this moment to refactor the route tests.

Might fix https://github.com/hypothesis/product-backlog/issues/692