### PR TITLE
Fix linting change that broke index view

### DIFF
--- a/lms/views/index.py
+++ b/lms/views/index.py
@@ -3,6 +3,6 @@ from pyramid.view import view_config
 
 @view_config(route_name='index',
              renderer="lms:templates/base.html.jinja2")
-def index():
+def index(request):  # pylint: disable=unused-argument
     """Render an empty page that contains a needed Google verification meta tag."""
     return {}


### PR DESCRIPTION
Linter complained about an unused arg (`request`), so I removed it from the index view handler, but that broke the everything.