### PR TITLE
Don't pointlessly export views as public API

### DIFF
--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -1,23 +1,5 @@
 # -*- coding: utf-8 -*-
-from lms.views.application_instances import create_application_instance
-from lms.views.config import config_xml
-from lms.views.content_item_selection import content_item_selection
-from lms.views.index import index
-from lms.views.lti_launches import lti_launches
-from lms.views.module_item_configurations import create_module_item_configuration
-from lms.views.canvas_proxy import canvas_proxy
-from lms.views.reports import list_application_instances
-
-__all__ = (
-    'create_application_instance',
-    'config_xml',
-    'content_item_selection',
-    'index',
-    'lti_launches',
-    'create_module_item_configuration',
-    'canvas_proxy',
-    'list_application_instances'
-)
+from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/tests/lms/views/test_application_instance.py
+++ b/tests/lms/views/test_application_instance.py
@@ -1,4 +1,4 @@
-from lms.views import create_application_instance
+from lms.views.application_instances import create_application_instance
 from lms.models import ApplicationInstance
 
 

--- a/tests/lms/views/test_config.py
+++ b/tests/lms/views/test_config.py
@@ -1,4 +1,4 @@
-from lms.views import config_xml
+from lms.views.config import config_xml
 
 
 class TestConfigXml(object):

--- a/tests/lms/views/test_content_item_selection.py
+++ b/tests/lms/views/test_content_item_selection.py
@@ -1,5 +1,5 @@
 from urllib.parse import urlparse
-from lms.views import content_item_selection
+from lms.views.content_item_selection import content_item_selection
 
 
 class TestContentItemSelection(object):

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -1,4 +1,4 @@
-from lms.views import lti_launches
+from lms.views.lti_launches import lti_launches
 
 
 # TODO write tests for student case

--- a/tests/lms/views/test_module_item_configuration.py
+++ b/tests/lms/views/test_module_item_configuration.py
@@ -1,4 +1,4 @@
-from lms.views import create_module_item_configuration
+from lms.views.module_item_configurations import create_module_item_configuration
 from lms.models import ModuleItemConfiguration
 
 

--- a/tests/lms/views/test_reports.py
+++ b/tests/lms/views/test_reports.py
@@ -1,4 +1,4 @@
-from lms.views import list_application_instances
+from lms.views.reports import list_application_instances
 from lms.models import build_from_lms_url
 from lms.models import LtiLaunches
 


### PR DESCRIPTION
The view callables aren't part of the public API of the `lms.views` package. No code would import `lms.views` and then call `lms.views.*`. Views isn't that kind of package. Instead, the `config.scan()` in
`lms/views/__init__.py` causes Pyramid to scan all of the `lms/views/*.py` modules for `@view_config`s and register all of the views.