### PR TITLE
Work around a prospector crash with `make lint`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ commands = codecov
 
 [testenv:lint]
 deps =
+    astroid==1.6.5
     prospector
     mock
     pytest


### PR DESCRIPTION
`make lint` calls `prospector` which uses a library called
requirements-detector which depends on a lib called astroid. Astroid 2.0
was released a few days ago and breaks requirements-detector which
causes `make lint` to crash:

https://github.com/landscapeio/requirements-detector/issues/20

For now pin us to astroid==1.6.5 to avoid this crash. We should be able
to revert this commit once the above github issue is fixed.