### PR TITLE
Allow longer function and method names in tests

### DIFF
--- a/tests/.prospector.yaml
+++ b/tests/.prospector.yaml
@@ -10,8 +10,8 @@ pylint:
   options:
     # Allow names in tests to be longer and to contain capital letters.
     argument-rgx: "[a-zA-Z_][a-zA-Z0-9_]{2,30}$"
-    function-rgx: "[a-zA-Z_][a-zA-Z0-9_]{2,70}$"
-    method-rgx: "[a-zA-Z_][a-zA-Z0-9_]{2,70}$"
+    function-rgx: "[a-zA-Z_][a-zA-Z0-9_]{2,84}$"
+    method-rgx: "[a-zA-Z_][a-zA-Z0-9_]{2,80}$"
   disable:
     - no-self-use  # There are often reasons to group test methods into classes
                    # even if they don't use self.


### PR DESCRIPTION
Since we never write code that calls our test methods, there's no reason to keep the names short. Allow test functions to be 84 chars long and test names to be 88 chars long - as long as they can be, while keeping within [Black's default line length of 88](https://github.com/ambv/black#line-length).