### PR TITLE
Add generate_display_name() and generate_username() functions

### DIFF
--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -3,7 +3,7 @@ from lms.util.associate_user import associate_user
 from lms.util.authenticate import authenticate
 from lms.util.authorize_lms import authorize_lms, save_token
 from lms.util.canvas_api import canvas_api, GET, POST
-from lms.util.h import generate_username
+from lms.util.h import generate_display_name, generate_username
 from lms.util.jwt import jwt
 from lms.util.lti_launch import lti_launch
 from lms.util.view_renderer import view_renderer
@@ -13,6 +13,7 @@ __all__ = (
     'authenticate',
     'authorize_lms',
     'canvas_api',
+    'generate_display_name',
     'generate_username',
     'jwt',
     'lti_launch',

--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -3,6 +3,7 @@ from lms.util.associate_user import associate_user
 from lms.util.authenticate import authenticate
 from lms.util.authorize_lms import authorize_lms, save_token
 from lms.util.canvas_api import canvas_api, GET, POST
+from lms.util.h import generate_username
 from lms.util.jwt import jwt
 from lms.util.lti_launch import lti_launch
 from lms.util.view_renderer import view_renderer
@@ -12,6 +13,7 @@ __all__ = (
     'authenticate',
     'authorize_lms',
     'canvas_api',
+    'generate_username',
     'jwt',
     'lti_launch',
     'save_token',

--- a/lms/util/h.py
+++ b/lms/util/h.py
@@ -12,8 +12,32 @@ USERNAME_ALLOWED_CHARS = string.ascii_letters + string.digits + "._"
 """The characters that are allowed in h usernames."""
 
 
+DISPLAY_NAME_MAX_LENGTH = 30
+"""The maximum length of an h display name."""
+
+
 USERNAME_MAX_LENGTH = 30
 """The maximum length of an h username."""
+
+
+def generate_display_name(request_params):
+    full_name = (request_params.get("lis_person_name_full") or "").strip()
+    given_name = (request_params.get("lis_person_name_given") or "").strip()
+    family_name = (request_params.get("lis_person_name_family") or "").strip()
+
+    if full_name:
+        display_name = full_name
+    else:
+        display_name = " ".join((given_name, family_name))
+
+    display_name = display_name.strip()
+
+    display_name = display_name or "Anonymous"
+
+    if len(display_name) > DISPLAY_NAME_MAX_LENGTH:
+        display_name = display_name[:DISPLAY_NAME_MAX_LENGTH - 1].rstrip() + "…"
+
+    return display_name
 
 
 def generate_username(request_params):

--- a/lms/util/h.py
+++ b/lms/util/h.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+"""Utility functions for working with the h API."""
+
+from __future__ import unicode_literals
+
+import random
+import string
+
+
+USERNAME_ALLOWED_CHARS = string.ascii_letters + string.digits + "._"
+"""The characters that are allowed in h usernames."""
+
+
+USERNAME_MAX_LENGTH = 30
+"""The maximum length of an h username."""
+
+
+def generate_username(request_params):
+    """Return an h username generated from the given LTI launch request params."""
+    full_name = request_params.get("lis_person_name_full") or ""
+    user_id = request_params.get("user_id") or ""
+
+    def n_valid_chars_from(s, n):  # pylint: disable=invalid-name
+        """Return a string of up to ``n`` valid chars from the start of ``s``."""
+        valid_chars = []
+        for char in s:
+            if char in USERNAME_ALLOWED_CHARS:
+                valid_chars.append(char)
+            if len(valid_chars) >= n:
+                break
+        return "".join(valid_chars)
+
+    def pad(s, n):  # pylint: disable=invalid-name
+        """Pad ``s`` so that it's ``n`` chars long."""
+        while len(s) < n:
+            s = s + random.choice(USERNAME_ALLOWED_CHARS)
+        return s
+
+    # The number of chars from user_id that we'll use in the returned username.
+    max_chars_from_user_id = 8
+
+    # The number of chars from full_name that we'll use in the returned username.
+    max_chars_from_full_name = USERNAME_MAX_LENGTH - max_chars_from_user_id
+
+    full_name = n_valid_chars_from(full_name, n=max_chars_from_full_name)
+    full_name = full_name or "Anonymous"
+
+    user_id = n_valid_chars_from(user_id, n=max_chars_from_user_id)
+    user_id = pad(user_id, max_chars_from_user_id)
+
+    return full_name + user_id

--- a/tests/lms/util/test_h.py
+++ b/tests/lms/util/test_h.py
@@ -5,7 +5,170 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
+from lms.util import generate_display_name
 from lms.util import generate_username
+
+
+class TestGenerateDisplayName:
+    @pytest.mark.parametrize("request_params,expected_display_name", [
+        # It returns the full name if there is one.
+        (
+            {
+                "lis_person_name_full": "Test Full",
+                # Add given and family names too. These should be ignored.
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Full",
+        ),
+
+        # It strips leading and trailing whitespace from the full name.
+        (
+            {
+                "lis_person_name_full": " Test Full  ",
+            },
+            "Test Full",
+        ),
+
+        # If theres no full name it concatenates given and family names.
+        (
+            {
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Given Test Family",
+        ),
+
+        # If full name is empty it concatenates given and family names.
+        (
+            {
+                "lis_person_name_full": "",
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Given Test Family",
+        ),
+        (
+            {
+                "lis_person_name_full": "   ",
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Given Test Family",
+        ),
+
+        # It strips leading and trailing whitespace from the concatenated
+        # given name and family name.
+        (
+            {
+                "lis_person_name_given": "  Test Given  ",
+                "lis_person_name_family": "  Test Family  ",
+            },
+            "Test Given Test Family",
+        ),
+
+        # If theres no full name or given name it uses just the family name.
+        (
+            {
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Family",
+        ),
+        (
+            {
+                "lis_person_name_full": "   ",
+                "lis_person_name_given": "",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Family",
+        ),
+
+        # It strips leading and trailing whitespace from just the family name.
+        (
+            {
+                "lis_person_name_family": "  Test Family ",
+            },
+            "Test Family",
+        ),
+
+        # If theres no full name or family name it uses just the given name.
+        (
+            {
+                "lis_person_name_given": "Test Given",
+            },
+            "Test Given",
+        ),
+        (
+            {
+                "lis_person_name_full": "   ",
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "",
+            },
+            "Test Given",
+        ),
+
+        # It strips leading and trailing whitespace from just the given name.
+        (
+            {
+                "lis_person_name_given": "  Test Given ",
+            },
+            "Test Given",
+        ),
+
+        # If there's nothing else it just returns "Anonymous".
+        (
+            {},
+            "Anonymous",
+        ),
+        (
+            {
+                "lis_person_name_full": "   ",
+                "lis_person_name_given": " ",
+                "lis_person_name_family": "",
+            },
+            "Anonymous",
+        ),
+
+        # If the full name is more than 30 characters long it truncates it.
+        (
+            {
+                "lis_person_name_full": "Test Very Very Looong Full Name",
+            },
+            "Test Very Very Looong Full Na…",
+        ),
+
+        # If the given name is more than 30 characters long it truncates it.
+        (
+            {
+                "lis_person_name_given": "Test Very Very Looong Given Name",
+            },
+            "Test Very Very Looong Given N…",
+        ),
+
+        # If the family name is more than 30 characters long it truncates it.
+        (
+            {
+                "lis_person_name_family": "Test Very Very Looong Family Name",
+            },
+            "Test Very Very Looong Family…",
+        ),
+
+        # If the concatenated given name + family name is more than 30
+        # characters long it truncates it.
+        (
+            {
+                "lis_person_name_given": "Test Very Very",
+                "lis_person_name_family": "Looong Concatenated Name",
+            },
+            "Test Very Very Looong Concate…",
+        ),
+    ])
+    def test_it_returns_display_names_generated_from_lti_request_params(
+        self, request_params, expected_display_name
+    ):
+        display_name   = generate_display_name(request_params)
+
+        assert display_name == expected_display_name
 
 
 @pytest.mark.usefixtures("random")

--- a/tests/lms/util/test_h.py
+++ b/tests/lms/util/test_h.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from lms.util import generate_username
+
+
+@pytest.mark.usefixtures("random")
+class TestGenerateUsername(object):
+    @pytest.mark.parametrize(
+        "full_name,user_id,expected_username",
+        [
+            # It uses the full name plus the first 8 chars of the user_id as the h username.
+            (
+                "janeqpublic",
+                "0ae836b9-7fc9-4060-006f-27b2066ac545",
+                "janeqpublic0ae836b9",
+            ),
+            # It truncates the full name if it's longer than 22 chars.
+            (
+                "janeqpublicthethirdmarquessofbute",
+                "0ae836b9-7fc9-4060-006f-27b2066ac545",
+                "janeqpublicthethirdmar0ae836b9",
+            ),
+            # Capital letters, dots and underscores in the full name are preserved.
+            (
+                "Jane_Q._Public",
+                "0ae836b9-7fc9-4060-006f-27b2066ac545",
+                "Jane_Q._Public0ae836b9",
+            ),
+            # Capital letters, dots and underscores in the user_id are preserved too.
+            (
+                "janeqpublic",
+                "0.A_e836b9-7fc9-4060-006f-27b2066ac545",
+                "janeqpublic0.A_e836",
+            ),
+            # Spaces are removed from the full name.
+            (
+                "jane q public",
+                "0ae836b9-7fc9-4060-006f-27b2066ac545",
+                "janeqpublic0ae836b9",
+            ),
+            # Multiple spaces in a row get removed too.
+            (
+                "jane  q   public",
+                "0ae836b9-7fc9-4060-006f-27b2066ac545",
+                "janeqpublic0ae836b9",
+            ),
+            # Leading and trailing spaces get removed too.
+            (
+                " janeqpublic  ",
+                "0ae836b9-7fc9-4060-006f-27b2066ac545",
+                "janeqpublic0ae836b9",
+            ),
+            # Other special characters are also removed from the full name.
+            (
+                "jane-@-public!",
+                "0ae836b9-7fc9-4060-006f-27b2066ac545",
+                "janepublic0ae836b9",
+            ),
+            # Special chars are removed from the userid too.
+            (
+                "janeqpublic",
+                " 0a-@b! 0ae836b9-7fc9-4060-006f-27b2066ac545",
+                "janeqpublic0ab0ae83",
+            ),
+        ],
+    )
+    def test_it_returns_usernames_generated_from_lti_request_params(
+        self, full_name, user_id, expected_username
+    ):
+        request_params = {"lis_person_name_full": full_name, "user_id": user_id}
+
+        username = generate_username(request_params)
+
+        assert username == expected_username
+
+    def test_it_uses_anonymous_if_the_full_name_is_missing(self):
+        request_params = {"user_id": "0ae836b9-7fc9-4060-006f-27b2066ac545"}
+
+        username = generate_username(request_params)
+
+        assert username == "Anonymous0ae836b9"
+
+    @pytest.mark.parametrize(
+        "full_name", [None, "", "   ", "!$@-"]  # All disallowed characters.
+    )
+    def test_it_uses_anonymous_if_the_full_name_is_empty(self, full_name):
+        request_params = {
+            "lis_person_name_full": full_name,
+            "user_id": "0ae836b9-7fc9-4060-006f-27b2066ac545",
+        }
+
+        username = generate_username(request_params)
+
+        assert username == "Anonymous0ae836b9"
+
+    def test_it_uses_random_characters_if_the_userid_is_missing(self):
+        request_params = {"lis_person_name_full": "janeqpublic"}
+
+        username = generate_username(request_params)
+
+        assert username == "janeqpublicrandom_c"
+
+    def test_it_uses_only_valid_random_characters(self, random):
+        # Passing no ``user_id`` in ``request_params`` here, to force
+        # ``generate_username()`` to replace ``user_id`` with random chars.
+        request_params = {"lis_person_name_full": "janeqpublic"}
+
+        generate_username(request_params)
+
+        # The characters that are valid in h usernames.
+        valid_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._"
+        for call in random.choice.mock_calls:
+            assert call == mock.call(valid_chars)
+
+    @pytest.mark.parametrize(
+        "user_id", [None, "", "   ", "!$@-"]  # All disallowed characters.
+    )
+    def test_it_uses_random_characters_if_the_userid_is_empty(self, user_id):
+        request_params = {"lis_person_name_full": "janeqpublic", "user_id": user_id}
+
+        username = generate_username(request_params)
+
+        assert username == "janeqpublicrandom_c"
+
+    def test_it_pads_with_random_characters_if_the_userid_is_too_short(self):
+        request_params = {"lis_person_name_full": "janeqpublic", "user_id": "0ae8"}
+
+        username = generate_username(request_params)
+
+        assert username == "janeqpublic0ae8rand"
+
+    def test_it_generates_a_username_if_both_full_name_and_user_id_are_missing(
+        self
+    ):
+        request_params = {}
+
+        username = generate_username(request_params)
+
+        assert username == "Anonymousrandom_c"
+
+    @pytest.fixture
+    def random(self, patch):
+        random = patch("lms.util.h.random")
+        random.choice.side_effect = "random_characters"
+        return random


### PR DESCRIPTION
This pr contains the `generate_username()` function from <https://github.com/hypothesis/lms/pull/125> (unmodified) plus a new `generate_display_name()` function.