### PR TITLE
Revert "Work around a prospector crash with `make lint`"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,6 @@ commands = codecov
 
 [testenv:lint]
 deps =
-    astroid==1.6.5
     pylint==1.9.2
     prospector
     mock


### PR DESCRIPTION
This reverts commit eae31f501c94cd608318224f7410b539fee3d678. The bug was fixed in requirements-detector 0.6, so the workaround is no longer needed:

https://github.com/landscapeio/requirements-detector/issues/20#issuecomment-406849759