### PR TITLE
Workaround a pylint crash

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ commands = codecov
 [testenv:lint]
 deps =
     astroid==1.6.5
+    pylint==1.9.2
     prospector
     mock
     pytest


### PR DESCRIPTION
Pin pylint to version 1.9.2 to work around a crash we're seeing with 2.0.1 (released 2 days ago) and 2.0 (released 10 days ago). Don't want to deal with getting to the bottom of the linter crash right now so just
pin it for the time being, we'll try upgrading it again later and see whether the problem has been fixed.