### PR TITLE
Add tests for config/__init__.py

### DIFF
--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -16,11 +16,8 @@ from lms.config.settings import (
 )
 
 
-def configure(settings=None):
+def configure(settings):
     """Return a Configurator for the Pyramid application."""
-    if settings is None:
-        settings = {}
-
     # Settings from the config file are extended / overwritten by settings from
     # the environment.
     env_settings = {

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -34,7 +34,7 @@ def configure(settings):
         'username': env_setting('USERNAME'),
         # We need to use a randomly generated 16 byte array to encrypt secrets.
         # For now we will use the first 16 bytes of the lms_secret
-        'aes_secret': env_setting('LMS_SECRET').encode('ascii')[0:16]
+        'aes_secret': env_setting('LMS_SECRET', required=True),
     }
 
     database_url = env_setting('DATABASE_URL')
@@ -44,6 +44,11 @@ def configure(settings):
     # Make sure that via_url doesn't end with a /.
     if env_settings['via_url'].endswith('/'):
         env_settings['via_url'] = env_settings['via_url'][:-1]
+
+    try:
+        env_settings["aes_secret"] = env_settings["aes_secret"].encode("ascii")[0:16]
+    except UnicodeEncodeError:
+        raise SettingError("LMS_SECRET must contain only ASCII characters")
 
     settings.update(env_settings)
 

--- a/tests/lms/config/__init___test.py
+++ b/tests/lms/config/__init___test.py
@@ -62,8 +62,7 @@ class TestConfigure:
 
         assert configurator.registry.settings["aes_secret"] == b"test_lms_secret_"
 
-    @pytest.mark.xfail
-    def test_LMS_SECRET_cant_contain_non_ascii_chars(self, env_setting, SettingError):
+    def test_LMS_SECRET_cant_contain_non_ascii_chars(self, env_setting):
         def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
             if envvar_name == "LMS_SECRET":
                 return "test_lms_secret_\u2119"
@@ -71,7 +70,7 @@ class TestConfigure:
 
         env_setting.side_effect = side_effect
 
-        with pytest.raises(SettingError):
+        with pytest.raises(SettingError, match="LMS_SECRET must contain only ASCII characters"):
             configure({})
 
     def test_the_DATABASE_URL_envvar_becomes_the_sqlalchemy_url_setting(self, env_setting):

--- a/tests/lms/config/__init___test.py
+++ b/tests/lms/config/__init___test.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+import pyramid.config
+
+from lms.config import configure
+from lms.config import SettingError
+
+
+@pytest.mark.usefixtures(
+    "env_setting",
+    "groupfinder",
+    "ACLAuthorizationPolicy",
+    "AuthTktAuthenticationPolicy",
+)
+class TestConfigure:
+    def test_it_returns_a_Configurator_with_the_deployment_settings_set(self, env_setting):
+        configurator = configure({})
+
+        assert isinstance(configurator, pyramid.config.Configurator)
+        # Just pick some settings at random to test.
+        for setting in ("jwt_secret", "google_client_id", "lms_secret"):
+            assert configurator.registry.settings[setting] == env_setting.return_value
+
+    def test_when_an_ENV_VAR_isnt_set_it_puts_None_into_the_settings(self, env_setting):
+        def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
+            if envvar_name == "USERNAME":
+                return None
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        configurator = configure({})
+
+        assert configurator.registry.settings["username"] is None
+
+    def test_it_raises_if_a_required_environment_variable_is_missing(self, env_setting):
+        env_setting.side_effect = SettingError("error message")
+
+        with pytest.raises(SettingError, match="error message"):
+            configure({})
+
+    def test_the_aes_secret_setting_is_the_LMS_SECRET_env_var_as_a_byte_string(self, env_setting):
+        def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
+            if envvar_name == "LMS_SECRET":
+                return "test_lms_secret"
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        configurator = configure({})
+
+        assert configurator.registry.settings["aes_secret"] == b"test_lms_secret"
+
+    def test_the_aes_secret_setting_is_truncated_to_16_chars(self, env_setting):
+        env_setting.return_value = "test_lms_secret_with_more_than_16_chars"
+
+        configurator = configure({})
+
+        assert configurator.registry.settings["aes_secret"] == b"test_lms_secret_"
+
+    @pytest.mark.xfail
+    def test_LMS_SECRET_cant_contain_non_ascii_chars(self, env_setting, SettingError):
+        def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
+            if envvar_name == "LMS_SECRET":
+                return "test_lms_secret_\u2119"
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        with pytest.raises(SettingError):
+            configure({})
+
+    def test_the_DATABASE_URL_envvar_becomes_the_sqlalchemy_url_setting(self, env_setting):
+        def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
+            if envvar_name == "DATABASE_URL":
+                return "test_database_url"
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        configurator = configure({})
+
+        assert configurator.registry.settings["sqlalchemy.url"] == "test_database_url"
+
+    def test_the_sqlalchemy_url_setting_is_omitted_if_theres_no_DATABASE_URL(self, env_setting):
+        def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
+            if envvar_name == "DATABASE_URL":
+                return None
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        configurator = configure({})
+
+        # Rather than setting "sqlalchemy.url" to None as is done for any other
+        # ENV_VAR, it omits it entirely.
+        assert "sqlalchemy.url" not in configurator.registry.settings
+
+    def test_trailing_slashes_are_removed_from_via_url(self, env_setting):
+        def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
+            if envvar_name == "VIA_URL":
+                return "https://via.hypothes.is/"
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        configurator = configure({})
+
+        assert configurator.registry.settings["via_url"] == "https://via.hypothes.is"
+
+    # Pre-existing settings in the `settings` dict (which come from the *.ini
+    # file) get overwritten if there's an environment variable with the same
+    # setting name.
+    def test_config_file_settings_are_overwritten(self, env_setting):
+        configurator = configure({"jwt_secret": "original_jwt_secret"})
+
+        assert configurator.registry.settings["jwt_secret"] != "original_jwt_secret"
+        assert configurator.registry.settings["jwt_secret"] == env_setting.return_value
+
+    # If there's an env_setting for a given setting name then, even if the
+    # ENV_VAR isn't set, an ini file setting with the same name will be
+    # overwritten with None.
+    def test_config_file_settings_are_overwritten_with_None(self, env_setting):
+        def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
+            if envvar_name == "JWT_SECRET":
+                return None
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        configurator = configure({"jwt_secret": "original_jwt_secret"})
+
+        assert configurator.registry.settings["jwt_secret"] != "original_jwt_secret"
+        assert configurator.registry.settings["jwt_secret"] is None
+
+    # If there's a config file setting in the ``settings`` dict with a setting
+    # name that _doesn't_ match any of the setting names used in
+    # ``configure()``, then that pre-existing setting is left untouched.
+    def test_config_file_settings_with_different_names_arent_removed(self):
+        configurator = configure({"foo": "bar"})
+
+        assert configurator.registry.settings["foo"] == "bar"
+
+    def test_it_sets_the_pyramid_authentication_policy(
+        self, AuthTktAuthenticationPolicy, config, env_setting, groupfinder
+    ):
+        def side_effect(envvar_name, *args, **kwargs):  # pylint: disable=unused-argument
+            if envvar_name == "LMS_SECRET":
+                return "test_lms_secret"
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        configure({})
+
+        AuthTktAuthenticationPolicy.assert_called_once_with(
+            "test_lms_secret", callback=groupfinder, hashalg="sha512"
+        )
+        config.set_authentication_policy.assert_called_once_with(
+            AuthTktAuthenticationPolicy.return_value
+        )
+
+    def test_it_sets_the_pyramid_authorization_policy(self, ACLAuthorizationPolicy, config):
+        configure({})
+
+        ACLAuthorizationPolicy.assert_called_once_with()
+        config.set_authorization_policy.assert_called_once_with(
+            ACLAuthorizationPolicy.return_value
+        )
+
+    @pytest.fixture
+    def ACLAuthorizationPolicy(self, patch):
+        return patch("lms.config.ACLAuthorizationPolicy")
+
+    @pytest.fixture
+    def AuthTktAuthenticationPolicy(self, patch):
+        return patch("lms.config.AuthTktAuthenticationPolicy")
+
+    @pytest.fixture
+    def config(self, patch):
+        configurator_class = patch("lms.config.Configurator")
+        return configurator_class.return_value
+
+    @pytest.fixture
+    def env_setting(self, patch):
+        return patch("lms.config.env_setting")
+
+    @pytest.fixture
+    def groupfinder(self, patch):
+        return patch("lms.config.groupfinder")


### PR DESCRIPTION
Also removed an unused default value for the `settings` argument to `configure()` and fixed a couple of crashes with the `LMS_SECRET` envvar.