### PR TITLE
Add utility functions for h user data from LTI data

### DIFF
--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -3,6 +3,7 @@ from lms.util.associate_user import associate_user
 from lms.util.authenticate import authenticate
 from lms.util.authorize_lms import authorize_lms, save_token
 from lms.util.canvas_api import canvas_api, GET, POST
+from lms.util.h_api import generate_display_name
 from lms.util.jwt import jwt
 from lms.util.lti_launch import lti_launch
 from lms.util.view_renderer import view_renderer
@@ -12,6 +13,7 @@ __all__ = (
     'authenticate',
     'authorize_lms',
     'canvas_api',
+    'generate_display_name',
     'jwt',
     'lti_launch',
     'save_token',

--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -3,7 +3,12 @@ from lms.util.associate_user import associate_user
 from lms.util.authenticate import authenticate
 from lms.util.authorize_lms import authorize_lms, save_token
 from lms.util.canvas_api import canvas_api, GET, POST
+from lms.util.exceptions import UtilError
+from lms.util.exceptions import MissingToolConsumerIntanceGUIDError
+from lms.util.exceptions import MissingUserIDError
 from lms.util.h_api import generate_display_name
+from lms.util.h_api import generate_provider
+from lms.util.h_api import generate_provider_unique_id
 from lms.util.jwt import jwt
 from lms.util.lti_launch import lti_launch
 from lms.util.view_renderer import view_renderer
@@ -14,10 +19,15 @@ __all__ = (
     'authorize_lms',
     'canvas_api',
     'generate_display_name',
+    'generate_provider',
+    'generate_provider_unique_id',
     'jwt',
     'lti_launch',
     'save_token',
     'view_renderer',
     'GET',
-    'POST'
+    'POST',
+    'UtilError',
+    'MissingToolConsumerIntanceGUIDError',
+    'MissingUserIDError',
 )

--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -9,6 +9,7 @@ from lms.util.exceptions import MissingUserIDError
 from lms.util.h_api import generate_display_name
 from lms.util.h_api import generate_provider
 from lms.util.h_api import generate_provider_unique_id
+from lms.util.h_api import generate_username
 from lms.util.jwt import jwt
 from lms.util.lti_launch import lti_launch
 from lms.util.view_renderer import view_renderer
@@ -21,6 +22,7 @@ __all__ = (
     'generate_display_name',
     'generate_provider',
     'generate_provider_unique_id',
+    'generate_username',
     'jwt',
     'lti_launch',
     'save_token',

--- a/lms/util/exceptions.py
+++ b/lms/util/exceptions.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+"""Exceptions raised by lms.util code."""
+
+from __future__ import unicode_literals
+
+
+class UtilError(Exception):
+    pass
+
+
+class MissingToolConsumerIntanceGUIDError(UtilError):
+    pass
+
+
+class MissingUserIDError(UtilError):
+    pass

--- a/lms/util/h_api.py
+++ b/lms/util/h_api.py
@@ -49,10 +49,10 @@ def generate_username(request_params):
     :raises :py:exception:`lms.util.MissingUserIDError`:
       if ``"user_id"`` is missing from ``request_params``
     """
-    h = hashlib.sha1()  # pylint: disable=invalid-name
-    h.update(generate_provider(request_params).encode())
-    h.update(generate_provider_unique_id(request_params).encode())
-    return h.hexdigest()[:USERNAME_MAX_LENGTH]
+    hash_object = hashlib.sha1()
+    hash_object.update(generate_provider(request_params).encode())
+    hash_object.update(generate_provider_unique_id(request_params).encode())
+    return hash_object.hexdigest()[:USERNAME_MAX_LENGTH]
 
 
 def generate_provider(request_params):

--- a/lms/util/h_api.py
+++ b/lms/util/h_api.py
@@ -5,6 +5,10 @@
 from __future__ import unicode_literals
 
 
+from lms.util.exceptions import MissingToolConsumerIntanceGUIDError
+from lms.util.exceptions import MissingUserIDError
+
+
 DISPLAY_NAME_MAX_LENGTH = 30
 """The maximum length of an h display name."""
 
@@ -28,3 +32,35 @@ def generate_display_name(request_params):
         display_name = display_name[:DISPLAY_NAME_MAX_LENGTH - 1].rstrip() + "…"
 
     return display_name
+
+
+def generate_provider(request_params):
+    """
+    Return an h "provider" string from the given LTI launch request params.
+
+    :raises :py:exception:`lms.util.MissingToolConsumerIntanceGUIDError`:
+      if ``"tool_consumer_instance_guid"`` is missing from ``request_params``
+
+    """
+    tool_consumer_instance_guid = request_params.get("tool_consumer_instance_guid")
+
+    if not tool_consumer_instance_guid:
+        raise MissingToolConsumerIntanceGUIDError()
+
+    return tool_consumer_instance_guid
+
+
+def generate_provider_unique_id(request_params):
+    """
+    Return an h provider_unique_id from the given LTI launch request params.
+
+    :raises :py:exception:`lms.util.MissingUserIDError`:
+      if ``"user_id"`` is missing from ``request_params``
+
+    """
+    user_id = request_params.get("user_id")
+
+    if not user_id:
+        raise MissingUserIDError()
+
+    return user_id

--- a/lms/util/h_api.py
+++ b/lms/util/h_api.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""Utility functions for working with the h API."""
+
+from __future__ import unicode_literals
+
+
+DISPLAY_NAME_MAX_LENGTH = 30
+"""The maximum length of an h display name."""
+
+
+def generate_display_name(request_params):
+    """Return an h display_name from the given LTI launch request params."""
+    full_name = (request_params.get("lis_person_name_full") or "").strip()
+    given_name = (request_params.get("lis_person_name_given") or "").strip()
+    family_name = (request_params.get("lis_person_name_family") or "").strip()
+
+    if full_name:
+        display_name = full_name
+    else:
+        display_name = " ".join((given_name, family_name))
+
+    display_name = display_name.strip()
+
+    display_name = display_name or "Anonymous"
+
+    if len(display_name) > DISPLAY_NAME_MAX_LENGTH:
+        display_name = display_name[:DISPLAY_NAME_MAX_LENGTH - 1].rstrip() + "…"
+
+    return display_name

--- a/lms/util/h_api.py
+++ b/lms/util/h_api.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import hashlib
 
 from lms.util.exceptions import MissingToolConsumerIntanceGUIDError
 from lms.util.exceptions import MissingUserIDError
@@ -11,6 +12,10 @@ from lms.util.exceptions import MissingUserIDError
 
 DISPLAY_NAME_MAX_LENGTH = 30
 """The maximum length of an h display name."""
+
+
+USERNAME_MAX_LENGTH = 30
+"""The maximum length of an h username."""
 
 
 def generate_display_name(request_params):
@@ -32,6 +37,22 @@ def generate_display_name(request_params):
         display_name = display_name[:DISPLAY_NAME_MAX_LENGTH - 1].rstrip() + "…"
 
     return display_name
+
+
+def generate_username(request_params):
+    """
+    Return an h username generated from the given LTI launch request params.
+
+    :raises :py:exception:`lms.util.MissingToolConsumerIntanceGUIDError`:
+      if ``"tool_consumer_instance_guid"`` is missing from ``request_params``
+
+    :raises :py:exception:`lms.util.MissingUserIDError`:
+      if ``"user_id"`` is missing from ``request_params``
+    """
+    h = hashlib.sha1()  # pylint: disable=invalid-name
+    h.update(generate_provider(request_params).encode())
+    h.update(generate_provider_unique_id(request_params).encode())
+    return h.hexdigest()[:USERNAME_MAX_LENGTH]
 
 
 def generate_provider(request_params):

--- a/tests/lms/util/test_h_api.py
+++ b/tests/lms/util/test_h_api.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import pytest
 
 from lms.util import generate_display_name
+from lms.util import generate_username
 from lms.util import generate_provider
 from lms.util import generate_provider_unique_id
 from lms.util import MissingToolConsumerIntanceGUIDError
@@ -169,6 +170,35 @@ class TestGenerateDisplayName:
         self, request_params, expected_display_name
     ):
         assert generate_display_name(request_params) == expected_display_name
+
+
+class TestGenerateUsername:
+    def test_it_returns_a_30_char_string(self):
+        request_params = {
+            "tool_consumer_instance_guid": "VCSy*G1u3:canvas-lms",
+            "user_id": "4533***70d9",
+        }
+
+        username = generate_username(request_params)
+
+        assert isinstance(username, str)
+        assert len(username) == 30
+
+    def test_it_raises_if_tool_consumer_instance_guid_is_missing(self):
+        request_params = {
+            "user_id": "4533***70d9",
+        }
+
+        with pytest.raises(MissingToolConsumerIntanceGUIDError):
+            generate_username(request_params)
+
+    def test_it_raises_if_user_id_is_missing(self):
+        request_params = {
+            "tool_consumer_instance_guid": "VCSy*G1u3:canvas-lms",
+        }
+
+        with pytest.raises(MissingUserIDError):
+            generate_username(request_params)
 
 
 class TestGenerateProvider:

--- a/tests/lms/util/test_h_api.py
+++ b/tests/lms/util/test_h_api.py
@@ -5,6 +5,10 @@ from __future__ import unicode_literals
 import pytest
 
 from lms.util import generate_display_name
+from lms.util import generate_provider
+from lms.util import generate_provider_unique_id
+from lms.util import MissingToolConsumerIntanceGUIDError
+from lms.util import MissingUserIDError
 
 
 class TestGenerateDisplayName:
@@ -165,3 +169,39 @@ class TestGenerateDisplayName:
         self, request_params, expected_display_name
     ):
         assert generate_display_name(request_params) == expected_display_name
+
+
+class TestGenerateProvider:
+    def test_it_just_returns_the_tool_consumer_instance_guid(self):
+        request_params = {"tool_consumer_instance_guid": "VCSy*G1u3:canvas-lms"}
+
+        provider_unique_id = generate_provider(request_params)
+
+        assert provider_unique_id == "VCSy*G1u3:canvas-lms"
+
+    @pytest.mark.parametrize("request_params", [
+        {},
+        {"tool_consumer_instance_guid": ""},
+        {"tool_consumer_instance_guid": None},
+    ])
+    def test_it_raises_if_tool_consumer_instance_guid_is_missing(self, request_params):
+        with pytest.raises(MissingToolConsumerIntanceGUIDError):
+            generate_provider(request_params)
+
+
+class TestGenerateProviderUniqueID:
+    def test_it_just_returns_the_user_id(self):
+        request_params = {"user_id": "4533***70d9"}
+
+        provider_unique_id = generate_provider_unique_id(request_params)
+
+        assert provider_unique_id == "4533***70d9"
+
+    @pytest.mark.parametrize("request_params", [
+        {},
+        {"user_id": ""},
+        {"user_id": None},
+    ])
+    def test_it_raises_if_user_id_is_missing(self, request_params):
+        with pytest.raises(MissingUserIDError):
+            generate_provider_unique_id(request_params)

--- a/tests/lms/util/test_h_api.py
+++ b/tests/lms/util/test_h_api.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from lms.util import generate_display_name
+
+
+class TestGenerateDisplayName:
+    @pytest.mark.parametrize("request_params,expected_display_name", [
+        # It returns the full name if there is one.
+        (
+            {
+                "lis_person_name_full": "Test Full",
+                # Add given and family names too. These should be ignored.
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Full",
+        ),
+
+        # It strips leading and trailing whitespace from the full name.
+        (
+            {
+                "lis_person_name_full": " Test Full  ",
+            },
+            "Test Full",
+        ),
+
+        # If theres no full name it concatenates given and family names.
+        (
+            {
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Given Test Family",
+        ),
+
+        # If full name is empty it concatenates given and family names.
+        (
+            {
+                "lis_person_name_full": "",
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Given Test Family",
+        ),
+        (
+            {
+                "lis_person_name_full": "   ",
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Given Test Family",
+        ),
+
+        # It strips leading and trailing whitespace from the concatenated
+        # given name and family name.
+        (
+            {
+                "lis_person_name_given": "  Test Given  ",
+                "lis_person_name_family": "  Test Family  ",
+            },
+            "Test Given Test Family",
+        ),
+
+        # If theres no full name or given name it uses just the family name.
+        (
+            {
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Family",
+        ),
+        (
+            {
+                "lis_person_name_full": "   ",
+                "lis_person_name_given": "",
+                "lis_person_name_family": "Test Family",
+            },
+            "Test Family",
+        ),
+
+        # It strips leading and trailing whitespace from just the family name.
+        (
+            {
+                "lis_person_name_family": "  Test Family ",
+            },
+            "Test Family",
+        ),
+
+        # If theres no full name or family name it uses just the given name.
+        (
+            {
+                "lis_person_name_given": "Test Given",
+            },
+            "Test Given",
+        ),
+        (
+            {
+                "lis_person_name_full": "   ",
+                "lis_person_name_given": "Test Given",
+                "lis_person_name_family": "",
+            },
+            "Test Given",
+        ),
+
+        # It strips leading and trailing whitespace from just the given name.
+        (
+            {
+                "lis_person_name_given": "  Test Given ",
+            },
+            "Test Given",
+        ),
+
+        # If there's nothing else it just returns "Anonymous".
+        (
+            {},
+            "Anonymous",
+        ),
+        (
+            {
+                "lis_person_name_full": "   ",
+                "lis_person_name_given": " ",
+                "lis_person_name_family": "",
+            },
+            "Anonymous",
+        ),
+
+        # If the full name is more than 30 characters long it truncates it.
+        (
+            {
+                "lis_person_name_full": "Test Very Very Looong Full Name",
+            },
+            "Test Very Very Looong Full Na…",
+        ),
+
+        # If the given name is more than 30 characters long it truncates it.
+        (
+            {
+                "lis_person_name_given": "Test Very Very Looong Given Name",
+            },
+            "Test Very Very Looong Given N…",
+        ),
+
+        # If the family name is more than 30 characters long it truncates it.
+        (
+            {
+                "lis_person_name_family": "Test Very Very Looong Family Name",
+            },
+            "Test Very Very Looong Family…",
+        ),
+
+        # If the concatenated given name + family name is more than 30
+        # characters long it truncates it.
+        (
+            {
+                "lis_person_name_given": "Test Very Very",
+                "lis_person_name_family": "Looong Concatenated Name",
+            },
+            "Test Very Very Looong Concate…",
+        ),
+    ])
+    def test_it_returns_display_names_generated_from_lti_request_params(
+        self, request_params, expected_display_name
+    ):
+        assert generate_display_name(request_params) == expected_display_name


### PR DESCRIPTION
Add functions for generating h display names, usernames and identities from LTI launch params. Nothing calls these functions yet.