### PR TITLE
Mock all HTTP requests in tests

### DIFF
--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -5,6 +5,9 @@ from __future__ import unicode_literals
 import os
 import functools
 import json
+import re
+
+import httpretty
 import mock
 import pytest
 import jwt
@@ -12,6 +15,7 @@ import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 from pyramid import testing
 from pyramid.request import apply_request_extensions
+
 from lms import db
 from lms.models import User
 from lms.models import Token
@@ -321,3 +325,28 @@ def oauth_response(monkeypatch, pyramid_request):
     pyramid_request.params['state'] = state_guid
     pyramid_request.params['code'] = 'test_code'
     yield pyramid_request
+
+
+@pytest.fixture(autouse=True)
+def httpretty_():
+    """
+    Monkey-patch Python's socket core module to mock all HTTP responses.
+
+    We never want real HTTP requests to be sent by the tests so replace them
+    all with mock responses. This handles requests sent using the standard
+    urllib2 library and the third-party httplib2 and requests libraries.
+    """
+    httpretty.enable()
+
+    # Tell httpretty which HTTP requests we want it to mock (all of them).
+    for method in (httpretty.GET, httpretty.PUT, httpretty.POST, httpretty.DELETE, httpretty.HEAD, httpretty.PATCH, httpretty.OPTIONS, httpretty.CONNECT):
+        httpretty.register_uri(
+            method=method,
+            uri=re.compile(r'http(s?)://.*'),  # Matches all http:// and https:// URLs.
+            body='',
+        )
+
+    yield
+
+    httpretty.disable()
+    httpretty.reset()

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ testpaths = tests
 [testenv]
 deps =
     coverage
+    httpretty
     mock
     pytest
     factory-boy
@@ -47,6 +48,7 @@ deps =
     mock
     pytest
     factory-boy
+    httpretty
     -rrequirements.txt
 commands =
     prospector


### PR DESCRIPTION
We never want our tests to be sending real HTTP requests because:

1. It's slow
2. The tests will fail if you have no Internet connection
3. The tests will fail depending on the response of the Internet URL they're sending HTTP requests to
4. It doesn't allow tests to make HTTP responses in order to test how our code responds to different kinds of responses