### PR TITLE
Fix low-hanging CSS rules, layouts

### DIFF
--- a/lms/static/styles/lms.css
+++ b/lms/static/styles/lms.css
@@ -14,8 +14,11 @@ html{
   font-family: 'Roboto', sans-serif;
   font-size: 14px;
 }
+.data {
+  font-family: 'Inconsolata', 'Hack', 'Courier New', 'Courier', monospace;
+}
 .modal-content{
-  padding: 30px;
+  padding: 10px 30px;
 }
 .modal-text{
   margin: 0 0 20px;
@@ -550,4 +553,30 @@ html{
 
 .selected-file {
   background: #f5f5f5;
+}
+
+/* A few table styles */
+
+table {
+  border-spacing: 0.5rem;
+  border-collapse: collapse;
+  max-width: 100%;
+}
+
+th {
+  border-bottom: 2px solid #dddddd;
+}
+
+th, td {
+  padding: 0.25em;
+  border: 1px solid #ddd;
+}
+
+table tr:nth-child(odd) { /* Zebra-stripe the rows */
+  background: #eee;
+}
+
+td.wrap { /* wrap veryyyyyyyy long data */
+  white-space: normal;
+  word-break: break-all;
 }

--- a/lms/templates/application_instances/new_application_instance.html.jinja2
+++ b/lms/templates/application_instances/new_application_instance.html.jinja2
@@ -45,7 +45,8 @@
 
 {% block content %}
 <main class="modal-content">
-  <p class="modal-text">Please submit the following information to continue.</p>
+  <h1>Hypothesis Installation</h1>
+  <p class="modal-text">This tool allows you to generate the info you'll need to install Hypothesis in your LMS.</p>
   <form action="/welcome" method="post" onsubmit="handleSubmit(event, this)">
     <div class="input">
       <label for="domain">LMS Domain</label>
@@ -63,18 +64,20 @@
       <input id="email" type="email" name="email" onblur="validateEmail(this)"/>
       <span class="error"></span>
     </div>
+    <h2>Canvas File Picker Integration</h2>
+    <p class="modal-text">The following fields are only needed if you are using the Canvas LMS and would like to enable the file picker.</p>
     <div class="input">
-      <label for="developer-key">Developer Key (optional)</label>
+      <label for="developer-key">Canvas Developer Key (optional)</label>
       <input id="developer-key" type="text" name="developer_key"/>
       <span class="error"></span>
     </div>
     <div class="input">
-      <label for="developer-secret">Developer Secret (optional)</label>
+      <label for="developer-secret">Canvas Developer Secret (optional)</label>
       <input id="developer-secret" type="text" name="developer_secret"/>
       <span class="error"></span>
     </div>
     <div class="form-controls">
-      <button type="submit" class="btn">Submit</button>
+      <button type="submit" class="btn">Generate Credentials</button>
     </div>
   </form>
 </main>

--- a/lms/templates/login.html.jinja2
+++ b/lms/templates/login.html.jinja2
@@ -3,22 +3,25 @@
 {% block title %}Please log in{% endblock %}
 
 {% block content %}
-    <div id="content">
-        <h1>Login</h1>
+    <main class="modal-content">
+        <h1>Log in</h1>
         <h3>{{ message }}</h3>
-        <br/>
         <form action="{{ url }}" method="post">
             <input type="hidden" name="came_from"
                    value="{{ came_from }}"/>
-            <label for="username">Username</label>
-            <input type="text" id="username"
+            <div class="input">
+              <label for="username">Username</label>
+              <input type="text" id="username"
                    name="username"
-                   value="{{ username }}"/><br/>
-            <label for="password">Password</label>
-            <input type="password" id="password"
-                   name="password"/><br/>
+                   value="{{ username }}"/>
+            </div>
+            <div class="input">
+              <label for="password">Password</label>
+              <input type="password" id="password"
+                     name="password"/><br/>
+            </div>
             <input type="submit" name="form.submitted"
                    value="Log In"/>
         </form>
-    </div>
+    </main>
 {% endblock %}

--- a/lms/templates/reports/application_report.html.jinja2
+++ b/lms/templates/reports/application_report.html.jinja2
@@ -4,10 +4,11 @@
 
 {% block content %}
     <div id="content">
-        <a href="{{ logout_url }}">Logout</a>
-        <br/>
-        <p>There are {{ apps|length }} application instances:</p>
-        <table border="1">
+        <h1>Application Reports</h1>
+
+        <h2>Generated Application Instances</h2>
+        <p>{{ apps|length }} application instance credentials have been generated:</p>
+        <table>
             <tr>
                 <th>Created At</th>
                 <th>Lms Url</th>
@@ -16,20 +17,19 @@
                 <th>Shared Secret</th>
             </tr>
         {% for row in apps %}
-            <tr>
+            <tr class="data">
                 <td>{{  row['created']  }}</td>
                 <td>{{  row['lms_url']  }}</td>
                 <td>{{  row['requesters_email']  }}</td>
                 <td>{{  row['consumer_key']  }}</td>
-                <td>{{  row['shared_secret']  }}</td>
+                <td class="wrap">{{  row['shared_secret']  }}</td>
             </tr>
         {% endfor %}
         </table>
 
-        <br/>
-
+        <h2>LTI App Launches</h2>
         <p>There have been {{ num_launches }} lti launches:</p>
-        <table border="1">
+        <table>
             <tr>
                 <th>Context ID</th>
                 <th>Number of Launches</th>
@@ -38,12 +38,14 @@
                 <th>Consumer Key</th>
             </tr>
         {% for row in launches %}
-            <tr>
-              {% for element in row %} 
+            <tr class="data">
+              {% for element in row %}
                 <td>{{  element  }}</td>
               {% endfor %}
             </tr>
         {% endfor %}
         </table>
+
+        <div><p><a class="btn btn--gray" href="{{ logout_url }}">Log out</a></p></div>
     </div>
 {% endblock %}


### PR DESCRIPTION
This PR integrates some pre-work that @sheetaluk has done to improve CSS a little and makes some of the app's interfaces a tad more usable.

Welcome form before:

![screen shot 2018-07-27 at 3 18 54 pm](https://user-images.githubusercontent.com/439947/43342391-8bed10f4-91b0-11e8-9ca9-d9d13dcc405f.png)

Welcome form after:

![screen shot 2018-07-27 at 3 17 38 pm](https://user-images.githubusercontent.com/439947/43342396-8fff82f8-91b0-11e8-9df0-198767f20bf7.png)

Reports login page before:

![screen shot 2018-07-27 at 3 18 31 pm](https://user-images.githubusercontent.com/439947/43342405-9c164c3e-91b0-11e8-9946-2022516e6635.png)

Reports login page after:

![screen shot 2018-07-27 at 3 18 11 pm](https://user-images.githubusercontent.com/439947/43342412-a268a5b4-91b0-11e8-96f6-490ab3fa72bc.png)

Reports page before (note: My instance doesn't have any launch data, so those fields are empty):

![screen shot 2018-07-27 at 3 18 44 pm](https://user-images.githubusercontent.com/439947/43342434-acc66352-91b0-11e8-921d-96f0bfd0b9ed.png)

Reports page after:

![screen shot 2018-07-27 at 3 18 03 pm](https://user-images.githubusercontent.com/439947/43342447-b2e4d0b6-91b0-11e8-9af8-c9af4d6b9ebe.png)

Fixes https://github.com/hypothesis/product-backlog/issues/714