### PR TITLE
Add optional AUTO_PROVISIONING env var

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -112,6 +112,17 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
     export H_CLIENT_SECRET="eVJ4***rXkk"
     export H_AUTHORITY="lms.hypothes.is"
     export H_API_URL="http://localhost:5000/api"
+
+    # An optional space-separated list of the consumer keys of the application
+    # instances for which the "auto provisioning" features should be enabled.
+    # Defaults to an empty list ([]) if none provided (i.e. the features will
+    # be disabled for all application instances).
+    #
+    # The consumer key strings here should match the values in the
+    # lms.models.ApplicationInstances.consumer_key column in the database,
+    # which are also the same as the LTI "oauth_consumer_key" parameter values
+    # that LMS's send to us in LTI launch requests.
+    export AUTO_PROVISIONING="Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20"
     ```
 
 1. **Configure SSL**

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
+from pyramid.config import aslist
 
 from lms.security import groupfinder
 
@@ -45,6 +46,10 @@ def configure(settings):
 
         # The base URL of the h API (e.g. "https://hypothes.is/api).
         'h_api_url': env_setting('H_API_URL', required=True),
+
+        # The list of `oauth_consumer_key`s of the application instances for
+        # which the automatic user and group provisioning features are enabled.
+        'auto_provisioning': env_setting('AUTO_PROVISIONING', default=''),
     }
 
     database_url = env_setting('DATABASE_URL')
@@ -58,6 +63,8 @@ def configure(settings):
         env_settings["aes_secret"] = env_settings["aes_secret"].encode("ascii")[0:16]
     except UnicodeEncodeError:
         raise SettingError("LMS_SECRET must contain only ASCII characters")
+
+    env_settings['auto_provisioning'] = aslist(env_settings['auto_provisioning'])
 
     settings.update(env_settings)
 

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -150,6 +150,7 @@ def pyramid_config(pyramid_request):
         'h_client_secret': 'TEST_CLIENT_SECRET',
         'h_authority': 'TEST_AUTHORITY',
         'h_api_url': 'https://example.com/api',
+        'auto_provisioning': 'Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20',
     }
 
     with testing.testConfig(request=pyramid_request, settings=settings) as config:


### PR DESCRIPTION
Not used by anything yet. Example usage would be:

```python
if oauth_consumer_key in request.registry.settings["auto_provisioning"]:
    ...
```