### PR TITLE
Create h users

### DIFF
--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -5,6 +5,7 @@ from lms.util.lti_launch import lti_launch
 from lms.util.view_renderer import view_renderer
 from lms.util.associate_user import associate_user
 from lms.util.authorize_lms import authorize_lms
+from lms.views.decorators import create_h_user
 
 
 def should_show_file_picker(lti_params, request):
@@ -26,6 +27,7 @@ def should_canvas_oauth(request):
 
 @view_config(route_name='content_item_selection', request_method='POST')
 @lti_launch()
+@create_h_user
 @associate_user
 @authorize_lms(
     authorization_base_endpoint='login/oauth2/auth',

--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+"""Python decorators meant to be used for decorating Pyramid view functions."""
+
+from __future__ import unicode_literals
+
+from lms.views.decorators.h_api import create_h_user
+
+__all__ = (
+    "create_h_user",
+)

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -32,6 +32,23 @@ def create_h_user(wrapped):  # noqa: MC0001
           ...
 
     """
+    # FIXME: This function doesn't do anything with the ``jwt`` argument,
+    # other than pass it through to the wrapped view (or to the next decorator
+    # on the wrapped view). The ``jwt`` argument has to be here because:
+    #
+    # - This decorator is called by the ``@lti_launch`` decorator (because
+    #   ``@lti_launch`` is always placed above this decorator on decorated views)
+    #   and ``@lti_launch`` passes a ``jwt_token`` argument when it calls this
+    #   decorator.
+    #
+    # - The views that this decorator decorates expect a ``jwt`` argument so this
+    #   decorator has to pass it to them (or rather it has to pass it down to the
+    #   next decorator down in the stack, and it eventually gets passed to the
+    #   view).
+    #
+    # This should all be refactored so that views and view decorators aren't
+    # tightly coupled and arguments don't need to be passed through multiple
+    # decorators to the view.
     def wrapper(request, jwt):  # pylint: disable=too-many-branches
         params = request.params
 

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -22,6 +22,15 @@ def create_h_user(wrapped):  # noqa: MC0001
 
     Call the h API to create a user for the authorized LTI user, if one doesn't
     exist already.
+
+    Use this function as a decorator rather than calling it directly.
+    The wrapped view must take ``request`` and ``jwt`` arguments::
+
+      @view_config(...)
+      @create_h_user
+      def my_view(request, jwt):
+          ...
+
     """
     def wrapper(request, jwt):  # pylint: disable=too-many-branches
         params = request.params

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -55,7 +55,7 @@ def create_h_user(wrapped):  # noqa: MC0001
         try:
             oauth_consumer_key = params["oauth_consumer_key"]
         except KeyError:
-            raise HTTPBadRequest('Required paramer "oauth_consumer_key" missing from LTI params')
+            raise HTTPBadRequest('Required parameter "oauth_consumer_key" missing from LTI params')
 
         # Only create users for application instances that we've enabled the
         # auto provisioning features for.

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -82,10 +82,12 @@ def create_h_user(wrapped):  # noqa: MC0001
         except MissingUserIDError:
             raise HTTPBadRequest('Required parameter "user_id" missing from LTI params')
 
+        display_name = util.generate_display_name(params)
+
         # The user data that we will post to h.
         user_data = {
             "username": username,
-            "display_name": util.generate_display_name(params),
+            "display_name": display_name,
             "authority": authority,
             "identities": [
                 {

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+"""View decorators for working with the h API."""
+
+from __future__ import unicode_literals
+
+import json
+import requests
+
+from pyramid.httpexceptions import HTTPBadGateway
+from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.httpexceptions import HTTPGatewayTimeout
+
+from lms import util
+from lms.util import MissingToolConsumerIntanceGUIDError
+from lms.util import MissingUserIDError
+
+
+def create_h_user(wrapped):  # noqa: MC0001
+    """
+    Create a user in h if one doesn't exist already.
+
+    Call the h API to create a user for the authorized LTI user, if one doesn't
+    exist already.
+    """
+    def wrapper(request, jwt):  # pylint: disable=too-many-branches
+        params = request.params
+
+        try:
+            oauth_consumer_key = params["oauth_consumer_key"]
+        except KeyError:
+            raise HTTPBadRequest('Required paramer "oauth_consumer_key" missing from LTI params')
+
+        # Only create users for application instances that we've enabled the
+        # auto provisioning features for.
+        enabled_consumer_keys = request.registry.settings["auto_provisioning"]
+        if oauth_consumer_key not in enabled_consumer_keys:
+            return wrapped(request, jwt)
+
+        # Our OAuth 2.0 client_id and client_secret for authenticating to the h API.
+        client_id = request.registry.settings["h_client_id"]
+        client_secret = request.registry.settings["h_client_secret"]
+
+        # The authority that we'll create h users and groups in.
+        authority = request.registry.settings["h_authority"]
+
+        # The URL of h's create user API endpoint.
+        create_user_api_url = request.registry.settings["h_api_url"] + "/users"
+
+        try:
+            username = util.generate_username(params)
+            provider = util.generate_provider(params)
+            provider_unique_id = util.generate_provider_unique_id(params)
+        except MissingToolConsumerIntanceGUIDError:
+            raise HTTPBadRequest('Required parameter "tool_consumer_instance_guid" missing from LTI params')
+        except MissingUserIDError:
+            raise HTTPBadRequest('Required parameter "user_id" missing from LTI params')
+
+        # The user data that we will post to h.
+        user_data = {
+            "username": username,
+            "display_name": util.generate_display_name(params),
+            "authority": authority,
+            "identities": [
+                {
+                    "provider": provider,
+                    "provider_unique_id": provider_unique_id,
+                }
+            ],
+        }
+
+        # Call the h API to create the user in h if it doesn't exist already.
+        try:
+            response = requests.post(
+                create_user_api_url,
+                auth=(client_id, client_secret),
+                data=json.dumps(user_data),
+                timeout=1,
+            )
+        except requests.exceptions.ReadTimeout:
+            raise HTTPGatewayTimeout(explanation="Connecting to Hypothesis failed")
+
+        if response.status_code == 200:
+            # User was created successfully.
+            pass
+        elif response.status_code == 409:
+            # The user already exists in h, so we don't need to do anything.
+            pass
+        else:
+            # Something unexpected went wrong when trying to create the user
+            # account in h. Abort and show the user an error page.
+            raise HTTPBadGateway(explanation="Connecting to Hypothesis failed")
+
+        return wrapped(request, jwt)
+
+    return wrapper

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -14,6 +14,7 @@ from lms.util.canvas_api import CanvasApi, GET
 from lms.util.authorize_lms import authorize_lms, save_token
 from lms.models.tokens import find_token_by_user_id
 from lms.models.application_instance import find_by_oauth_consumer_key
+from lms.views.decorators import create_h_user
 
 
 def can_configure_module_item(roles):
@@ -153,6 +154,7 @@ def should_launch(request):
 
 @view_config(route_name='lti_launches', request_method='POST')
 @lti_launch()
+@create_h_user
 @associate_user
 @authorize_lms(
     authorization_base_endpoint='login/oauth2/auth',

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import json
+import mock
+import pytest
+
+from pyramid.httpexceptions import HTTPBadGateway
+from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.httpexceptions import HTTPGatewayTimeout
+import requests.exceptions
+
+from lms.views.decorators.h_api import create_h_user
+from lms.util import MissingToolConsumerIntanceGUIDError
+from lms.util import MissingUserIDError
+
+
+@pytest.mark.usefixtures("post", "util")
+class TestCreateHUser:
+    def test_it_400s_if_no_oauth_consumer_key_param(self, create_h_user, pyramid_request):
+        del pyramid_request.params["oauth_consumer_key"]
+
+        with pytest.raises(HTTPBadRequest, match="oauth_consumer_key"):
+            create_h_user(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(self, create_h_user, pyramid_request, wrapped):
+        pyramid_request.params = {"oauth_consumer_key": "foo"}
+
+        returned = create_h_user(pyramid_request, mock.sentinel.jwt)
+
+        wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
+        assert returned == wrapped.return_value
+
+    def test_it_doesnt_use_the_h_api_if_feature_not_enabled(self, create_h_user, post, pyramid_request):
+        pyramid_request.params = {"oauth_consumer_key": "foo"}
+
+        create_h_user(pyramid_request, mock.sentinel.jwt)
+
+        assert not post.called
+
+    def test_it_400s_if_generate_username_raises_MissingToolConsumerInstanceGUIDError(self, create_h_user, pyramid_request, util):
+        util.generate_username.side_effect = MissingToolConsumerIntanceGUIDError()
+
+        with pytest.raises(HTTPBadRequest, match="tool_consumer_instance_guid"):
+            create_h_user(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_400s_if_generate_username_raises_MissingUserIDError(self, create_h_user, pyramid_request, util):
+        util.generate_username.side_effect = MissingUserIDError()
+
+        with pytest.raises(HTTPBadRequest, match="user_id"):
+            create_h_user(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_400s_if_generate_provider_raises_MissingToolConsumerInstanceGUIDError(self, create_h_user, pyramid_request, util):
+        util.generate_provider.side_effect = MissingToolConsumerIntanceGUIDError()
+
+        with pytest.raises(HTTPBadRequest, match="tool_consumer_instance_guid"):
+            create_h_user(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_400s_if_generate_provider_unique_id_raises_MissingUserIDError(self, create_h_user, pyramid_request, util):
+        util.generate_provider_unique_id.side_effect = MissingUserIDError()
+
+        with pytest.raises(HTTPBadRequest, match="user_id"):
+            create_h_user(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_creates_the_user_in_h(self, create_h_user, post, pyramid_request):
+        create_h_user(pyramid_request, mock.sentinel.jwt)
+
+        post.assert_called_once_with(
+            "https://example.com/api/users",
+            auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
+            data=json.dumps({
+                "username": "test_username",
+                "display_name": "test_display_name",
+                "authority": "TEST_AUTHORITY",
+                "identities": [{
+                    "provider": "test_provider",
+                    "provider_unique_id": "test_provider_unique_id",
+                }],
+            }),
+            timeout=1,
+        )
+
+    def test_it_504s_if_the_h_request_times_out(self, create_h_user, patch, post, pyramid_request):
+        post.side_effect = requests.exceptions.ReadTimeout()
+
+        with pytest.raises(HTTPGatewayTimeout):
+            create_h_user(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_continues_to_the_wrapped_function_if_h_200s(self, create_h_user, pyramid_request, wrapped):
+        returned = create_h_user(pyramid_request, mock.sentinel.jwt)
+
+        wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
+        assert returned == wrapped.return_value
+
+    def test_it_continues_to_the_wrapped_function_if_h_409s(self, create_h_user, post, pyramid_request, wrapped):
+        post.return_value.status_code = 409
+
+        returned = create_h_user(pyramid_request, mock.sentinel.jwt)
+
+        wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
+        assert returned == wrapped.return_value
+
+    @pytest.mark.parametrize("status", (500, 501, 502, 503, 504, 400, 401, 403, 404, 408))
+    def test_it_502s_for_unexpected_errors_from_h(self, create_h_user, post, pyramid_request, status):
+        post.return_value.status_code = status
+
+        with pytest.raises(HTTPBadGateway, match="Connecting to Hypothesis failed"):
+            create_h_user(pyramid_request, mock.sentinel.jwt)
+
+    @pytest.fixture
+    def create_h_user(self, wrapped):
+        # Return the actual wrapper function so that tests can call it directly.
+        return create_h_user(wrapped)
+
+    @pytest.fixture
+    def post(self, patch):
+        post = patch("lms.views.decorators.h_api.requests.post")
+        post.return_value = mock.create_autospec(
+            requests.models.Response,
+            instance=True,
+            status_code=200,
+        )
+        return post
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params = {
+            # A valid oauth_consumer_key (matches one for which the
+            # provisioning features are enabled).
+            "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
+        }
+        return pyramid_request
+
+    @pytest.fixture
+    def util(self, patch):
+        util = patch("lms.views.decorators.h_api.util")
+        util.generate_username.return_value = "test_username"
+        util.generate_display_name.return_value = "test_display_name"
+        util.generate_provider.return_value = "test_provider"
+        util.generate_provider_unique_id.return_value = "test_provider_unique_id"
+        return util
+
+    @pytest.fixture
+    def wrapped(self):
+        """Return the wrapped view function."""
+        return mock.MagicMock()


### PR DESCRIPTION
For any successful LTI launch (e.g. request had a valid OAuth 1 signature), whether a student or teacher launching an assignment or a teacher creating a new assignment, call the h API to create a new user in h corresponding to the LTI user.

If the h user already exists pass silently.

If anything goes wrong - something missing from the LTI params, or a timeout or unexpected response from h - then abort the entire LTI launch (assignment will not be shown) and show an error to the user.

Fixes https://github.com/hypothesis/product-backlog/issues/712  
Fixes https://github.com/hypothesis/product-backlog/issues/735

Things to test:

- [ ] When creating an assignment, a user account gets created in h
- [ ] When launching an assignment, a user account gets created in h
- [ ] If the account already exists in h "nothing happens" (it will still send the API request to try to create the account, but will pass silently when it receives a conflict response from h)
- [ ] If the LTI launch request is invalid, e.g. the OAuth signature is wrong, then you will see an ugly crash page (not this PR's fault) and no user will be created in h, either when creating or launching an assignment