### PR TITLE
Show user the error page when context_id and resource_link_id params are missing and lti launch fails.

### DIFF
--- a/lms/exceptions.py
+++ b/lms/exceptions.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+"""Exceptions raised by lti launch code."""
+
+from __future__ import unicode_literals
+
+from pyramid.httpexceptions import HTTPBadRequest
+
+
+class LTILaunchError(HTTPBadRequest):  # pylint: disable=too-many-ancestors
+    """Base exception for problems handling LTI launches."""
+
+    pass
+
+
+class MissingLTILaunchParamError(LTILaunchError):  # pylint: disable=too-many-ancestors
+    """Exception raised if params required for lti launch are missing."""
+
+    pass

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -8,6 +8,7 @@ from pyramid.view import view_config
 from pyramid.view import view_defaults
 from pyramid.settings import asbool
 
+from lms.exceptions import MissingLTILaunchParamError
 
 _ = i18n.TranslationStringFactory(__package__)
 
@@ -48,3 +49,18 @@ class ErrorViews(object):
         return {'message': _("Sorry, but something went wrong. "
                              "The issue has been reported and we'll try to "
                              "fix it.")}
+
+
+    @view_config(context=MissingLTILaunchParamError)
+    def missing_lti_launch_param_error(self):
+        """
+        Catch MissingLTILaunchParamError, render a 400 page and report the exception to Sentry.
+
+        If code raises a MissingLTILaunchParamError it means that a required parameter was
+        missing from an LTI launch request that we received:
+        1. Show the user an error page including specific error message
+        2. Report the error to Sentry
+        """
+        self.request.response.status_int = 400
+        self.request.raven.captureException()
+        return {'message': str(self.exc)}

--- a/tests/lms/views/error_test.py
+++ b/tests/lms/views/error_test.py
@@ -6,6 +6,7 @@ from pyramid import httpexceptions
 import pytest
 
 from lms.views import error
+from lms.exceptions import MissingLTILaunchParamError
 
 
 class TestErrorViews:
@@ -49,6 +50,14 @@ class TestErrorViews:
 
         assert resp['message'] == 'Sorry, but something went wrong. The issue has been reported and we\'ll try to fix it.'
 
+    def test_it_sets_correct_status_int_for_non_http_error(self, pyramid_request):
+        exc = Exception()
+
+        error_views = error.ErrorViews(exc, pyramid_request)
+        resp = error_views.error()
+
+        assert pyramid_request.response.status_int == 500
+
     def test_it_logs_non_http_error_in_sentry(self, pyramid_request):
         exc = Exception()
 
@@ -65,3 +74,19 @@ class TestErrorViews:
 
         with pytest.raises(Exception, match="test exception msg"):
             error_views.error()
+
+    def test_it_sets_correct_message_for_missing_lti_param_error(self, pyramid_request):
+        exc = MissingLTILaunchParamError('test lti launch param error msg')
+
+        error_views = error.ErrorViews(exc, pyramid_request)
+        resp = error_views.missing_lti_launch_param_error()
+
+        assert resp['message'] == 'test lti launch param error msg'
+
+    def test_it_sets_correct_status_int_for_missing_lti_param_error(self, pyramid_request):
+        exc = MissingLTILaunchParamError('test lti launch param error msg')
+
+        error_views = error.ErrorViews(exc, pyramid_request)
+        resp = error_views.missing_lti_launch_param_error()
+
+        assert pyramid_request.response.status_int == 400

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -1,5 +1,8 @@
 from lms.views.lti_launches import lti_launches
 
+import pytest
+
+from lms.exceptions import MissingLTILaunchParamError
 
 # TODO write tests for student case
 class TestLtiLaunches(object):
@@ -33,3 +36,13 @@ class TestLtiLaunches(object):
         lti_launch_request.params['roles'] = 'urn:lti:role:ims/lis/Learner'
         value = lti_launches(lti_launch_request)
         assert 'This page has not yet been configured' in value.body.decode()
+
+    def test_raises_for_missing_context_id_param(self, lti_launch_request):
+        del lti_launch_request.params["context_id"]
+
+        with pytest.raises(MissingLTILaunchParamError, match="LTI data parameter context_id is required for launch."):
+            lti_launches(lti_launch_request)
+
+    def test_raises_for_missing_resource_link_id_param(self, lti_launch_request):
+        with pytest.raises(MissingLTILaunchParamError, match="LTI data parameter resource_link_id is required for launch."):
+            lti_launches(lti_launch_request)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/138

Test setup:

In `lms/views/decorators/h_api.py def wrapper`:
1. Set the jwt param to default to None. `def wrapper(request, jwt=None):`
In `lms/views/lti_launches.py def lti_launches`:
1. Remove the `@lti_launch()` decorator
2. Set the jwt param to default to None. `def lti_launches(request, jwt=None, user=None):`

To test context_id param missing error page:
1. `brew install httpie`
2. `http --form POST 'http://0.0.0.0:8001/lti_launches' user_id="someone" oauth_consumer_key="foo" --verify no`

Result:
<img width="1280" alt="screen shot 2018-07-31 at 3 08 53 pm" src="https://user-images.githubusercontent.com/502186/43481398-d964c90a-94d3-11e8-8b47-c79a43bf19c1.png">

To test resource_link_id param missing error page:
1. `brew install httpie`
2. `http --form POST 'http://0.0.0.0:8001/lti_launches' user_id="someone" oauth_consumer_key="foo" context_id="bar" --verify no`

Result:
![image](https://user-images.githubusercontent.com/502186/43719070-9f648426-995a-11e8-8573-cf70a7a6ab53.png)

