### PR TITLE
Show user the error page when oauth consumer key param is missing and lti launch fails.

### DIFF
--- a/lms/util/jwt.py
+++ b/lms/util/jwt.py
@@ -9,7 +9,7 @@ def build_jwt_from_lti_launch(lti_params, jwt_secret):
     try:
         roles = lti_params['roles']
     except KeyError:
-        raise MissingLTILaunchParamError(_('LTI data parameter roles is required for launch.'))
+        raise MissingLTILaunchParamError(_('Required data param for LTI launch missing: roles'))
 
     data = {
         'user_id': lti_params['user_id'],

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -38,21 +38,27 @@ class TestLtiLaunches(object):
         assert 'This page has not yet been configured' in value.body.decode()
 
     def test_raises_for_missing_context_id_param(self, lti_launch_request):
-        del lti_launch_request.params["context_id"]
+        del lti_launch_request.params['context_id']
 
-        with pytest.raises(MissingLTILaunchParamError, match="LTI data parameter context_id is required for launch."):
+        with pytest.raises(MissingLTILaunchParamError, match='Required data param for LTI launch missing: context_id'):
             lti_launches(lti_launch_request)
 
     def test_raises_for_missing_resource_link_id_param(self, lti_launch_request):
-        with pytest.raises(MissingLTILaunchParamError, match="LTI data parameter resource_link_id is required for launch."):
+        with pytest.raises(MissingLTILaunchParamError, match='Required data param for LTI launch missing: resource_link_id'):
             lti_launches(lti_launch_request)
 
     def test_raises_for_missing_roles_param(self, lti_launch_request, module_item_configuration):
         del lti_launch_request.params['roles']
-        with pytest.raises(MissingLTILaunchParamError, match='LTI data parameter roles is required for launch.'):
+        with pytest.raises(MissingLTILaunchParamError, match='Required data param for LTI launch missing: roles'):
             lti_launches(lti_launch_request)
 
     def test_raises_for_tool_consumer_instance_guid_param(self, lti_launch_request):
         del lti_launch_request.params['tool_consumer_instance_guid']
-        with pytest.raises(MissingLTILaunchParamError, match="LTI data parameter tool_consumer_instance_guid is required for launch."):
+        with pytest.raises(MissingLTILaunchParamError, match='Required data param for LTI launch missing: tool_consumer_instance_guid'):
+            lti_launches(lti_launch_request)
+
+    def test_raises_for_missing_oauth_consumer_key_param(self, lti_launch_request):
+        del lti_launch_request.params['oauth_consumer_key']
+
+        with pytest.raises(MissingLTILaunchParamError, match='Required data param for LTI launch missing: oauth_consumer_key'):
             lti_launches(lti_launch_request)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/132

To test:

In `lms/views/lti_launches.py def lti_launches`:
1. Remove the `@lti_launch()` decorator
2. Set the jwt param to default to None. `def lti_launches(request, jwt=None, user=None):`
3. `brew install httpie`
4. `http --form POST 'http://0.0.0.0:8001/lti_launches' user_id="someone" context_id="x" --verify no`

Result:
![image](https://user-images.githubusercontent.com/502186/43496460-7646b42c-950b-11e8-9af7-d80bdc76c18b.png)

