### PR TITLE
fixes the google picker origin

### DIFF
--- a/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
@@ -60,6 +60,13 @@
      return url;
   }
 
+  function addHttps(url) {
+    if (url != "" && !/^(f|ht)tps?:\/\//i.test(url)) {
+        url = "https://" + url;
+     }
+     return url;
+  }
+
   function resetError(input) {
     input.parentElement.classList.remove('has-error');
     input.parentElement.getElementsByClassName('error')[0].innerHTML = '';
@@ -228,9 +235,8 @@
         var mimeTypes = Object.keys(GOOGLE_MIME_TYPES).join(',');
         var view = new google.picker.View(google.picker.ViewId.DOCS);
         view.setMimeTypes(mimeTypes);
-
         var picker = new google.picker.PickerBuilder()
-            .setOrigin('{{lms_url}}')
+            .setOrigin(addHttps('{{lms_url}}'))
             .setOAuthToken(state.oauthToken)
             .addView(view)
             .addView(new google.picker.DocsUploadView())


### PR DESCRIPTION
 I mistakenly assumed that canvas sends the lms_url with the protocol during the lti launch but it doesn't. Because of this we were sending an incorrect url to the google picker to use as its origin, thus causing xframe error we have been seeing with the google picker. 
See https://github.com/hypothesis/product-backlog/issues/692#issuecomment-414373324 for more info regarding the issue.