### PR TITLE
Remove Python 2 stuff

### DIFF
--- a/lms/assets.py
+++ b/lms/assets.py
@@ -6,7 +6,7 @@ from pyramid.settings import aslist
 from pyramid.static import static_view
 
 
-class _CachedFile(object):
+class _CachedFile:
     """
     Parses content from a file and caches the result.
 
@@ -48,7 +48,7 @@ class _CachedFile(object):
         return self._cached
 
 
-class Environment(object):
+class Environment:
     """
     Environment for generating URLs for Hypothesis' static assets.
 

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -2,8 +2,6 @@
 
 """Configuration for the Pyramid application."""
 
-from __future__ import unicode_literals
-
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -1,7 +1,7 @@
 from pyramid.security import Allow
 
 
-class Root(object):
+class Root:
     """Create list of users and what they are allowed to access."""
 
     __acl__ = [(Allow, 'report_viewers', 'view')]

--- a/lms/config/settings.py
+++ b/lms/config/settings.py
@@ -2,8 +2,6 @@
 
 """Functions for reading config settings."""
 
-from __future__ import unicode_literals
-
 import os
 
 

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker

--- a/lms/exceptions.py
+++ b/lms/exceptions.py
@@ -2,8 +2,6 @@
 
 """Exceptions raised by LTI launch code."""
 
-from __future__ import unicode_literals
-
 from pyramid.httpexceptions import HTTPBadRequest
 
 

--- a/lms/migrations/env.py
+++ b/lms/migrations/env.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import os
 from logging.config import fileConfig
 

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from lms.models.application_instance import ApplicationInstance, build_from_lms_url
 from lms.models.lti_launches import LtiLaunches
 from lms.models.module_item_configuration import ModuleItemConfiguration

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 
 def includeme(config):
     config.add_route('index', '/')

--- a/lms/util/exceptions.py
+++ b/lms/util/exceptions.py
@@ -2,8 +2,6 @@
 
 """Exceptions raised by lms.util code."""
 
-from __future__ import unicode_literals
-
 
 class UtilError(Exception):
     pass

--- a/lms/util/h_api.py
+++ b/lms/util/h_api.py
@@ -2,8 +2,6 @@
 
 """Utility functions for working with the h API."""
 
-from __future__ import unicode_literals
-
 import hashlib
 
 from lms.util.exceptions import MissingToolConsumerIntanceGUIDError

--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -2,8 +2,6 @@
 
 """Python decorators meant to be used for decorating Pyramid view functions."""
 
-from __future__ import unicode_literals
-
 from lms.views.decorators.h_api import create_h_user
 from lms.views.decorators.h_api import create_course_group
 

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -2,8 +2,6 @@
 
 """View decorators for working with the h API."""
 
-from __future__ import unicode_literals
-
 import functools
 import json
 import requests

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid import httpexceptions
 from pyramid import i18n
 from pyramid.view import view_config

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -11,7 +11,7 @@ _ = i18n.TranslationStringFactory(__package__)
 
 
 @view_defaults(renderer='lms:templates/error.html.jinja2')
-class ErrorViews(object):
+class ErrorViews:
     """Show user an error page and an appropriate message."""
 
     def __init__(self, exc, request):

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 from datetime import datetime
 

--- a/tests/lms/config/__init___test.py
+++ b/tests/lms/config/__init___test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import mock
 import pytest
 import pyramid.config

--- a/tests/lms/config/settings_test.py
+++ b/tests/lms/config/settings_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from lms.config import settings

--- a/tests/lms/config/settings_test.py
+++ b/tests/lms/config/settings_test.py
@@ -6,7 +6,7 @@ from lms.config import settings
 
 
 @pytest.mark.usefixtures('os_fixture')
-class TestEnvSetting(object):
+class TestEnvSetting:
 
     def test_it_returns_the_value_from_the_environment_variable(self, os_fixture):
         os_fixture.environ = {'FOOBAR': 'the_value'}

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import os
 import functools
 import json

--- a/tests/lms/factories.py
+++ b/tests/lms/factories.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import factory
 import faker
 

--- a/tests/lms/factories.py
+++ b/tests/lms/factories.py
@@ -17,7 +17,7 @@ def set_session(value):
 class ModelFactory(factory.alchemy.SQLAlchemyModelFactory):
     """Base class for all factory classes for model classes."""
 
-    class Meta(object):
+    class Meta:
         """Meta class."""
 
         abstract = True

--- a/tests/lms/models/test_application_instance.py
+++ b/tests/lms/models/test_application_instance.py
@@ -1,7 +1,7 @@
 from lms.models import ApplicationInstance
 
 
-class TestApplicationInstance(object):
+class TestApplicationInstance:
     def test_it_persists_application_instance(self, db_session):
         initial_count = db_session.query(ApplicationInstance).count()
         instance = ApplicationInstance(

--- a/tests/lms/models/test_oauth_state.py
+++ b/tests/lms/models/test_oauth_state.py
@@ -3,7 +3,7 @@ from lms.models import build_from_lti_params
 from lms.models import OauthState, find_or_create_from_user
 
 
-class TestOauthState(object):
+class TestOAuthState:
     def test_find_or_create_from_user_creates_user(self, lti_launch_request, db_session):
         session = db_session
         state_guid = "asdf"

--- a/tests/lms/models/test_tokens.py
+++ b/tests/lms/models/test_tokens.py
@@ -4,7 +4,7 @@ from lms.models import User
 FAKE_ACCESS_TOKEN = "FAKE_TOKEN"
 
 
-class TestTokens(object):
+class TestTokens:
     def test_it_updates_none_token(self, db_session):
         user = User()
         db_session.add(user)

--- a/tests/lms/test_routes.py
+++ b/tests/lms/test_routes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import mock
 from lms import routes
 

--- a/tests/lms/test_routes.py
+++ b/tests/lms/test_routes.py
@@ -4,7 +4,7 @@ import mock
 from lms import routes
 
 
-class TestIncludeMe(object):
+class TestIncludeMe:
 
     def test_it_adds_some_routes(self):
         config = mock.MagicMock()

--- a/tests/lms/test_security.py
+++ b/tests/lms/test_security.py
@@ -1,7 +1,7 @@
 from lms import security
 
 
-class TestSecurityPassword(object):
+class TestSecurityPassword:
     def test_correct_password(self):
         salt = 'fbe82ee0da72b77b'
         password = 'asdf'

--- a/tests/lms/util/test_associate_user.py
+++ b/tests/lms/util/test_associate_user.py
@@ -14,7 +14,7 @@ def build_mock_view(assertions):
     return test_view_function
 
 
-class TestAssociateUser(object):
+class TestAssociateUser:
     """Test the associate user decorator."""
 
     def test_it_finds_an_existing_user(self, lti_launch_request, **_):

--- a/tests/lms/util/test_authorize_lms.py
+++ b/tests/lms/util/test_authorize_lms.py
@@ -54,7 +54,7 @@ def create_user(lti_launch_request):
     return existing_user
 
 
-class TestAuthorizeLms(object):
+class TestAuthorizeLms:
     """Test the associate user decorator."""
 
     def test_it_redirects_for_oauth(self, lti_launch_request):

--- a/tests/lms/util/test_canvas_api.py
+++ b/tests/lms/util/test_canvas_api.py
@@ -11,7 +11,7 @@ def build_mock_view(assertions):
     return view_function
 
 
-class TestCanvasApi(object):
+class TestCanvasApi:
     def test_it_creates_canvas_api(self, canvas_api_proxy):
         def assertions(_request, _decoded_jwt, _user, canvas_api):
             assert canvas_api.canvas_token == canvas_api_proxy['token'].access_token

--- a/tests/lms/util/test_get_password_hash.py
+++ b/tests/lms/util/test_get_password_hash.py
@@ -1,7 +1,7 @@
 from lms.util import get_password_hash
 
 
-class TestPasswordHash(object):
+class TestPasswordHash:
     def test_recreate_hash(self):
         password = 'asdf'
         expected_hashed = \

--- a/tests/lms/util/test_h_api.py
+++ b/tests/lms/util/test_h_api.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import pytest
 
 from lms.util import generate_display_name

--- a/tests/lms/views/__init__.py
+++ b/tests/lms/views/__init__.py
@@ -1,3 +1,1 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import json
 import mock
 import pytest

--- a/tests/lms/views/error_test.py
+++ b/tests/lms/views/error_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from pyramid import httpexceptions
 import pytest
 

--- a/tests/lms/views/status_test.py
+++ b/tests/lms/views/status_test.py
@@ -8,7 +8,7 @@ from lms.views import status
 
 
 @pytest.mark.usefixtures('db')
-class TestStatus(object):
+class TestStatus:
     def test_it_returns_okay_on_success(self, pyramid_request):
         result = status.status(pyramid_request)
         assert result == {'status': 'okay'}

--- a/tests/lms/views/test_application_instance.py
+++ b/tests/lms/views/test_application_instance.py
@@ -2,7 +2,7 @@ from lms.views.application_instances import create_application_instance
 from lms.models import ApplicationInstance
 
 
-class TestApplicationInstance(object):
+class TestApplicationInstance:
     def test_it_creates_an_application_instance(self, pyramid_request):
         pyramid_request.method = 'POST'
         pyramid_request.params = {

--- a/tests/lms/views/test_authentication.py
+++ b/tests/lms/views/test_authentication.py
@@ -1,7 +1,7 @@
 from lms.views import authentication
 
 
-class TestAuthentication(object):
+class TestAuthentication:
     def test_login(self, pyramid_request):
         pyramid_request.params = {
             'username': 'report_viewer',

--- a/tests/lms/views/test_config.py
+++ b/tests/lms/views/test_config.py
@@ -1,7 +1,7 @@
 from lms.views.config import config_xml
 
 
-class TestConfigXml(object):
+class TestConfigXml:
     def test_it_renders_the_config_xml(self, pyramid_request):
         response = config_xml(pyramid_request)
         assert response is not None

--- a/tests/lms/views/test_content_item_selection.py
+++ b/tests/lms/views/test_content_item_selection.py
@@ -5,7 +5,7 @@ from lms.exceptions import MissingLTILaunchParamError, MissingLTIContentItemPara
 from lms.views.content_item_selection import content_item_selection, content_item_form
 
 
-class TestContentItemSelection(object):
+class TestContentItemSelection:
 
     def test_it_redirects_to_oauth_provider(self, lti_launch_request):
         response = content_item_selection(lti_launch_request)

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -5,7 +5,7 @@ import pytest
 from lms.exceptions import MissingLTILaunchParamError
 
 # TODO write tests for student case
-class TestLtiLaunches(object):
+class TestLtiLaunches:
     def test_it_renders_the_iframe_when_the_url_is_present_in_the_params(self, lti_launch_request):
         lti_launch_request.params['url'] = 'https://example.com'
         value = lti_launches(lti_launch_request)

--- a/tests/lms/views/test_module_item_configuration.py
+++ b/tests/lms/views/test_module_item_configuration.py
@@ -2,7 +2,7 @@ from lms.views.module_item_configurations import create_module_item_configuratio
 from lms.models import ModuleItemConfiguration
 
 
-class TestModuleItemConfiguration(object):
+class TestModuleItemConfiguration:
     def test_it_creates_a_module_item_configuration(self,
                                                     authenticated_request):
         initial_count = authenticated_request.db.query(

--- a/tests/lms/views/test_reports.py
+++ b/tests/lms/views/test_reports.py
@@ -16,7 +16,7 @@ def setup_launches(pyramid_request, app_instances):
     pyramid_request.db.flush()
 
 
-class TestReports(object):
+class TestReports:
     def test_build_launches_rows(self, pyramid_request):
         test_urls = ['https://example.com', 'https://sub.example.com',
                      'https://another.example.com']


### PR DESCRIPTION
Some low-hanging-fruit refactoring: Remove a bunch of Python 2 stuff that never made sense in this app which has always been a Python 3 app.