### PR TITLE
[Create groups 1/n]: Fix Alembic's target_metadata

### DIFF
--- a/lms/migrations/env.py
+++ b/lms/migrations/env.py
@@ -1,8 +1,12 @@
 from __future__ import with_statement
+
 import os
+from logging.config import fileConfig
+
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig
+
+from lms import db
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -16,7 +20,7 @@ fileConfig(config.config_file_name)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = None
+target_metadata = db.BASE.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:


### PR DESCRIPTION
Alembic's `target_metadata` setting is incorrectly set to `None` in `migrations/env.py`, meaning that Alembic migrations scripts generate incorrect names for indexes and unique, check, foreign key and primary key constraints: the names generated by running an Alembic migration differ from the ones that're generated by SQLAlchemy when it creates the database schema anew from the model classes.

Our app's database code sets SQLAlchemy's metadata object to one containing a custom naming convention for indexes and constraints:

https://github.com/hypothesis/lms/blob/947a51874f21ba43d65899d1cd652e8bc4e90371/lms/db/__init__.py#L24-L30

But instead of using the same custom naming convention, our Alembic envirenvironment sets the metadata object to `None`:

https://github.com/hypothesis/lms/blob/947a51874f21ba43d65899d1cd652e8bc4e90371/lms/migrations/env.py#L19

This means that Alembic uses a different naming convention for indexes and constraints than what SQLAlchemy uses. For example, given a new model class like this:

```python
    class Group(BASE):
        __tablename__ = "groups"
        __table_args__ = (
            sa.Index(
                "ix__groups_tool_consumer_instance_guid_context_id",
                "tool_consumer_instance_guid",
                "context_id",
                unique=True,
            ),
        )
        id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
        tool_consumer_instance_guid = sa.Column(sa.UnicodeText, nullable=False)
        context_id = sa.Column(sa.UnicodeText, nullable=False)
        pubid = sa.Column(sa.Text, nullable=False, unique=True)
```

If creating the database schema anew SQLAlchemy would produce this table in Postgres:

                                        Table "public.groups"
            Column            |  Type   | Collation | Nullable |              Default
    -----------------------------+---------+-----------+----------+------------------------------------
    id                          | integer |           | not null | nextval('groups_id_seq'::regclass)
    tool_consumer_instance_guid | text    |           | not null |
    context_id                  | text    |           | not null |
    pubid                       | text    |           | not null |
    Indexes:
        "pk__groups" PRIMARY KEY, btree (id)
        "ix__groups_tool_consumer_instance_guid_context_id" UNIQUE, btree (tool_consumer_instance_guid, context_id)
        "uq__groups__pubid" UNIQUE CONSTRAINT, btree (pubid)

But a correct Alembic migration script to add the table and indexes using Alembic's `op.create_table()` and `op.create_index()` would produce this in Postgres:

                                        Table "public.groups"
            Column            |  Type   | Collation | Nullable |              Default
    -----------------------------+---------+-----------+----------+------------------------------------
    id                          | integer |           | not null | nextval('groups_id_seq'::regclass)
    tool_consumer_instance_guid | text    |           | not null |
    context_id                  | text    |           | not null |
    pubid                       | text    |           | not null |
    Indexes:
        "groups_pkey" PRIMARY KEY, btree (id)
        "groups_pubid_key" UNIQUE CONSTRAINT, btree (pubid)
        "ix__groups_tool_consumer_instance_guid_context_id" UNIQUE, btree (tool_consumer_instance_guid, context_id)

All of the index and constraint names are different.

Fix this by pointing Alembic's metadata in `migrations/env.py` to the same metadata object used by SQLAlchemy in `db/__init__.py`.

See:

* http://alembic.zzzcomputing.com/en/latest/api/runtime.html?highlight=target_metadata#alembic.runtime.environment.EnvironmentContext.configure.params.target_metadata
* http://alembic.zzzcomputing.com/en/latest/naming.html?highlight=target_metadata