### PR TITLE
[Create groups 5/n]: Create groups on LTI launches

### DIFF
--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -11,6 +11,7 @@ from lms.util.view_renderer import view_renderer
 from lms.util.associate_user import associate_user
 from lms.util.authorize_lms import authorize_lms
 from lms.views.decorators import create_h_user
+from lms.views.decorators import create_course_group
 
 
 def _check_params(lti_params):
@@ -45,6 +46,7 @@ def should_canvas_oauth(request):
 @view_config(route_name='content_item_selection', request_method='POST')
 @lti_launch
 @create_h_user
+@create_course_group
 @associate_user
 @authorize_lms(
     authorization_base_endpoint='login/oauth2/auth',

--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -5,7 +5,9 @@
 from __future__ import unicode_literals
 
 from lms.views.decorators.h_api import create_h_user
+from lms.views.decorators.h_api import create_course_group
 
 __all__ = (
     "create_h_user",
+    "create_course_group",
 )

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import functools
 import json
 import requests
 
@@ -11,9 +12,11 @@ from pyramid.httpexceptions import HTTPBadGateway
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.httpexceptions import HTTPGatewayTimeout
 
+from lms import models
 from lms import util
 from lms.util import MissingToolConsumerIntanceGUIDError
 from lms.util import MissingUserIDError
+from lms.util import MissingContextTitleError
 
 
 def create_h_user(wrapped):  # noqa: MC0001
@@ -52,15 +55,7 @@ def create_h_user(wrapped):  # noqa: MC0001
     def wrapper(request, jwt):  # pylint: disable=too-many-branches
         params = request.params
 
-        try:
-            oauth_consumer_key = params["oauth_consumer_key"]
-        except KeyError:
-            raise HTTPBadRequest('Required parameter "oauth_consumer_key" missing from LTI params')
-
-        # Only create users for application instances that we've enabled the
-        # auto provisioning features for.
-        enabled_consumer_keys = request.registry.settings["auto_provisioning"]
-        if oauth_consumer_key not in enabled_consumer_keys:
+        if not _auto_provisioning_feature_enabled(request):
             return wrapped(request, jwt)
 
         # Our OAuth 2.0 client_id and client_secret for authenticating to the h API.
@@ -122,3 +117,122 @@ def create_h_user(wrapped):  # noqa: MC0001
         return wrapped(request, jwt)
 
     return wrapper
+
+
+def create_course_group(wrapped):
+    """
+    Create a Hypothesis group for the LTI course, if one doesn't exist already.
+
+    Call the h API to create a group for the LTI course, if one doesn't exist
+    already.
+
+    Groups can only be created if the LTI user is allowed to create Hypothesis
+    groups (for example instructors are allowed to create groups). If the group
+    for the course hasn't been created yet, and if the user isn't allowed to
+    create groups (e.g. if they're just a student) then show an error page
+    instead of continuing with the LTI launch.
+
+    Use this function as a view decorator rather than calling it directly.
+    The decorated view must take ``request`` and ``jwt`` arguments::
+
+      @view_config(...)
+      @create_course_group
+      def my_view(request, jwt):
+          ...
+
+    """
+    # FIXME: This function doesn't do anything with the ``jwt`` argument,
+    # other than pass it through to the wrapped view (or to the next decorator
+    # on the wrapped view). The ``jwt`` argument has to be here because:
+    #
+    # - This decorator is called by the ``@lti_launch`` decorator (because
+    #   ``@lti_launch`` is always placed above this decorator on decorated views)
+    #   and ``@lti_launch`` passes a ``jwt_token`` argument when it calls this
+    #   decorator.
+    #
+    # - The views that this decorator decorates expect a ``jwt`` argument so this
+    #   decorator has to pass it to them (or rather it has to pass it down to the
+    #   next decorator down in the stack, and it eventually gets passed to the
+    #   view).
+    #
+    # This should all be refactored so that views and view decorators aren't
+    # tightly coupled and arguments don't need to be passed through multiple
+    # decorators to the view.
+    def wrapper(request, jwt):
+        _maybe_create_group(request)
+        return wrapped(request, jwt)
+    return wrapper
+
+
+def _maybe_create_group(request):
+    """Create a Hypothesis group for the LTI course, if one doesn't exist."""
+    # Only create groups for application instances that we've enabled the
+    # auto provisioning features for.
+    if not _auto_provisioning_feature_enabled(request):
+        return
+
+    get_param = functools.partial(_get_param, request)
+
+    tool_consumer_instance_guid = get_param("tool_consumer_instance_guid")
+    context_id = get_param("context_id")
+
+    group = models.CourseGroup.get(request.db, tool_consumer_instance_guid, context_id)
+
+    if group:
+        # The group has already been created in h, nothing more to do here.
+        return
+
+    # Show the user an error page if the group hasn't been created yet and
+    # the user isn't allowed to create groups.
+    if not any(role in get_param("roles").lower() for role in ("administrator", "instructor", "teachingassisstant")):
+        raise HTTPBadRequest("Instructor must launch assignment first.")
+
+    create_group_api_url = request.registry.settings["h_api_url"] + "/groups"
+    client_id = request.registry.settings["h_client_id"]
+    client_secret = request.registry.settings["h_client_secret"]
+
+    # Generate the name for the new group.
+    try:
+        name = util.generate_group_name(request.params)
+    except MissingContextTitleError:
+        raise HTTPBadRequest('Required parameter "context_title" missing from LTI params')
+
+    authority = request.registry.settings["h_authority"]
+    username = util.generate_username(request.params)
+
+    # Create the group in h.
+    try:
+        response = requests.post(
+            create_group_api_url,
+            auth=(client_id, client_secret),
+            data=json.dumps({"name": name}),
+            headers={
+                "X-Forwarded-User": "acct:{username}@{authority}".format(username=username, authority=authority),
+            },
+            timeout=1,
+        )
+        response.raise_for_status()
+    except requests.RequestException:
+        raise HTTPGatewayTimeout(explanation="Connecting to Hypothesis failed")
+
+    # Save a record of the group's pubid in the DB so that we can find it
+    # again later.
+    request.db.add(models.CourseGroup(
+        tool_consumer_instance_guid=tool_consumer_instance_guid,
+        context_id=context_id,
+        pubid=response.json()["id"],
+    ))
+
+
+def _get_param(request, param_name):
+    """Return the named param from the request or cause a 400."""
+    try:
+        return request.params[param_name]
+    except KeyError:
+        raise HTTPBadRequest(f'Required parameter "{param_name}" missing from LTI params')
+
+
+def _auto_provisioning_feature_enabled(request):
+    oauth_consumer_key = _get_param(request, "oauth_consumer_key")
+    enabled_consumer_keys = request.registry.settings["auto_provisioning"]
+    return oauth_consumer_key in enabled_consumer_keys

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -19,6 +19,7 @@ from lms.util.authorize_lms import authorize_lms, save_token
 from lms.models.tokens import find_token_by_user_id
 from lms.models.application_instance import find_by_oauth_consumer_key
 from lms.views.decorators import create_h_user
+from lms.views.decorators import create_course_group
 
 
 def can_configure_module_item(roles):
@@ -183,6 +184,7 @@ def should_launch(request):
 @view_config(route_name='lti_launches', request_method='POST')
 @lti_launch
 @create_h_user
+@create_course_group
 @associate_user
 @authorize_lms(
     authorization_base_endpoint='login/oauth2/auth',

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -12,8 +12,10 @@ from pyramid.httpexceptions import HTTPGatewayTimeout
 import requests.exceptions
 
 from lms.views.decorators.h_api import create_h_user
+from lms.views.decorators.h_api import create_course_group
 from lms.util import MissingToolConsumerIntanceGUIDError
 from lms.util import MissingUserIDError
+from lms.models import CourseGroup
 
 
 @pytest.mark.usefixtures("post", "util")
@@ -145,3 +147,175 @@ class TestCreateHUser:
     def wrapped(self):
         """Return the wrapped view function."""
         return mock.MagicMock()
+
+
+@pytest.mark.usefixtures("models", "util", "post")
+class TestCreateCourseGroup:
+    @pytest.mark.parametrize("required_param_name", (
+        "oauth_consumer_key",
+        "tool_consumer_instance_guid",
+        "context_id",
+        "roles",
+    ))
+    def test_it_400s_if_theres_a_required_param_missing(self, create_course_group, pyramid_request, required_param_name):
+        del pyramid_request.params[required_param_name]
+
+        with pytest.raises(HTTPBadRequest, match=required_param_name):
+            create_course_group(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_400s_if_the_user_isnt_allowed_to_create_groups(self, create_course_group, pyramid_request):
+        pyramid_request.params["roles"] = "Learner"
+
+        with pytest.raises(HTTPBadRequest, match="Instructor must launch assignment first"):
+            create_course_group(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_does_nothing_if_the_user_isnt_allowed_to_create_groups_but_the_group_already_exists(
+        self, create_course_group, pyramid_request, models, post, wrapped
+    ):
+        models.CourseGroup.get.return_value = mock.create_autospec(CourseGroup, instance=True)
+        pyramid_request.params["roles"] = "Learner"
+
+        returned = create_course_group(pyramid_request, mock.sentinel.jwt)
+
+        assert not post.called
+        assert not pyramid_request.db.add.called
+        wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
+        assert returned == wrapped.return_value
+
+    def test_it_does_nothing_if_the_feature_isnt_enabled(self, create_course_group, pyramid_request, wrapped, post):
+        # If the auto provisioning feature isn't enabled for this application
+        # instance then create_course_group() doesn't do anything - just calls the
+        # wrapped view.
+        pyramid_request.params = {"oauth_consumer_key": "foo"}
+
+        returned = create_course_group(pyramid_request, mock.sentinel.jwt)
+
+        assert not post.called
+        assert not pyramid_request.db.add.called
+        wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
+        assert returned == wrapped.return_value
+
+    def test_it_does_nothing_if_the_course_group_already_exists(self, create_course_group, models, pyramid_request, wrapped, post):
+        models.CourseGroup.get.return_value = mock.create_autospec(CourseGroup, instance=True)
+
+        returned = create_course_group(pyramid_request, mock.sentinel.jwt)
+
+        assert not post.called
+        assert not pyramid_request.db.add.called
+        wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
+        assert returned == wrapped.return_value
+
+    def test_it_posts_to_the_group_create_api(self, create_course_group, pyramid_request, post):
+        create_course_group(pyramid_request, mock.sentinel.jwt)
+
+        post.assert_called_once_with(
+            "https://example.com/api/groups",
+            auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
+            data='{"name": "TEST_GROUP"}',
+            headers={
+                "X-Forwarded-User": "acct:TEST_USERNAME@TEST_AUTHORITY",
+            },
+            timeout=1,
+        )
+
+    @pytest.mark.parametrize("request_exception", (
+        requests.ConnectionError(),
+        requests.TooManyRedirects(),
+        requests.ReadTimeout(),
+    ))
+    def test_it_504s_if_the_h_request_errors(self, create_course_group, post, pyramid_request, request_exception):
+        post.side_effect = request_exception
+
+        with pytest.raises(HTTPGatewayTimeout):
+            create_course_group(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_504s_if_the_h_response_is_unsuccessful(self, create_course_group, post, pyramid_request):
+        post.return_value.raise_for_status.side_effect = requests.HTTPError()
+
+        with pytest.raises(HTTPGatewayTimeout):
+            create_course_group(pyramid_request, mock.sentinel.jwt)
+
+    def test_it_saves_the_group_to_the_db(self, create_course_group, pyramid_request, models):
+        # It saves a record of the created group to the DB so that next time
+        # this course is used it'll retrieve it from the DB and know not to
+        # create another group for the same course.
+        create_course_group(pyramid_request, mock.sentinel.jwt)
+
+        class CourseGroupMatcher:
+            """An object equal to any other object with matching CourseGroup properties."""
+            def __init__(self, pubid, tool_consumer_instance_guid, context_id):
+                self.pubid = pubid
+                self.tool_consumer_instance_guid = tool_consumer_instance_guid
+                self.context_id = context_id
+
+            def __eq__(self, other):
+                return all((
+                    other.pubid == self.pubid,
+                    other.tool_consumer_instance_guid == self.tool_consumer_instance_guid,
+                    other.context_id == self.context_id,
+                ))
+
+        pyramid_request.db.add.assert_called_once_with(CourseGroupMatcher(
+            pubid="TEST_PUBID",
+            tool_consumer_instance_guid="TEST_GUID",
+            context_id="TEST_CONTEXT",
+        ))
+
+    def test_it_calls_and_returns_the_wrapped_view(self, create_course_group, pyramid_request, wrapped):
+        returned = create_course_group(pyramid_request, mock.sentinel.jwt)
+
+        wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
+        assert returned == wrapped.return_value
+
+    @pytest.fixture
+    def create_course_group(self, wrapped):
+        # Return the actual wrapper function so that tests can call it directly.
+        return create_course_group(wrapped)
+
+    @pytest.fixture
+    def wrapped(self):
+        """Return the wrapped view function."""
+        return mock.MagicMock()
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params = {
+            # A valid oauth_consumer_key (matches one for which the
+            # provisioning features are enabled).
+            "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
+            "tool_consumer_instance_guid": "TEST_GUID",
+            "context_id": "TEST_CONTEXT",
+            "roles": "Instructor,urn:lti:instrole:ims/lis/Administrator",
+        }
+        pyramid_request.db = mock.MagicMock()
+        return pyramid_request
+
+    @pytest.fixture
+    def models(self, patch):
+        models = patch("lms.views.decorators.h_api.models")
+
+        def side_effect(**kwargs):
+            return mock.create_autospec(CourseGroup, instance=True, **kwargs)
+        models.CourseGroup.side_effect = side_effect
+
+        models.CourseGroup.get.return_value = None
+
+        return models
+
+    @pytest.fixture
+    def util(self, patch):
+        util = patch("lms.views.decorators.h_api.util")
+        util.generate_group_name.return_value = "TEST_GROUP"
+        util.generate_username.return_value = "TEST_USERNAME"
+        return util
+
+    @pytest.fixture
+    def post(self, patch):
+        post = patch("lms.views.decorators.h_api.requests.post")
+        post.return_value = mock.create_autospec(
+            requests.models.Response,
+            instance=True,
+            status_code=200,
+        )
+        post.return_value.json.return_value = {"id": "TEST_PUBID"}
+        return post


### PR DESCRIPTION
On LTI launch (either assignment launch or content item selection launch), if the LTI user is allowed to create groups (e.g. if they're a teacher), then create a group for the LTI course in h if one doesn't exist already.

## Depends on

- [x] https://github.com/hypothesis/lms/pull/191
- [x] https://github.com/hypothesis/lms/pull/192

## Todo (before merging this PR)

- [x] Create group on content item selection, not just one assignment launch
- [x] Review and tidy up
- [x] Test manually

## Known limitations (not intending to address in this PR)

- Doesn't update group names if the course name is changed (h has no API for doing this yet)
- Crashes or behaves incorrectly if the groups table in the LMS app's DB gets out of sync with the one in h's DB:

  - If a group is deleted from h's DB but still exists in the LMS app's DB, then the LMS app will try to use the group (thinking it exists in h) and crash.
  - If a group is deleted from the LMS app's DB but still exists in the h's DB then the LMS app will think that no group for the course exists in h yet and will create a second group in h for the same course.

  One or the other of the DBs would require manual fixing up to correct such a situation if it ever happened. (Fortunately LMS users don't have access to h's group pages so they _can't_ delete groups from h's DB, and groups are never deleted from the LMS app's DB either.)