### PR TITLE
Respond to the client's postMessage requests for grant tokens

### DIFF
--- a/lms/templates/lti_launches/new_lti_launch.html.jinja2
+++ b/lms/templates/lti_launches/new_lti_launch.html.jinja2
@@ -1,1 +1,17 @@
+<script>
+  function receiveMessage(event) {
+    if (event.origin !== "http://localhost:5000") {
+      return;
+    }
+
+    if (event.data !== "gimme_grant_token") {
+      return;
+    }
+
+    // Send back grant token in response.
+    var grantToken = '{{ grant_token }}';
+    event.source.postMessage(grantToken, event.origin)
+  }
+  window.addEventListener("message", receiveMessage, false);
+</script>
 <iframe width="100%" height="100%" src="{{hypothesis_url}}" />

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -202,10 +202,29 @@ def lti_launches(request, jwt, user=None):
 
 @view_renderer(renderer='lms:templates/lti_launches/new_lti_launch.html.jinja2')
 def _view_document(request, document_url, jwt):
+
+    def grant_token():
+        import datetime
+        import jwt
+        from lms import util
+
+        now = datetime.datetime.utcnow()
+        username = util.generate_username(request.params)
+
+        claims = {
+            'aud': "localhost",
+            'iss': "a76b2074-af6e-11e8-8d65-0b3c44e2567a",
+            'sub': "acct:{}@{}".format(username, "lms.hypothes.is"),
+            'nbf': now,
+            'exp': now + datetime.timedelta(minutes=5),
+        }
+        return jwt.encode(claims, "uHzsLp8-W4-A2r0Zys9k4svegKTmNtbbVym_8C4lMV8", algorithm="HS256")
+
+    grant_token_ = grant_token()
     return {
-        'hypothesis_url':
-        f"{request.registry.settings['via_url']}/{document_url}",
-        'jwt': jwt
+        "hypothesis_url": f"{request.registry.settings['via_url']}/{document_url}",
+        "jwt": jwt,
+        "grant_token": grant_token_.decode("utf-8"),
     }
 
 


### PR DESCRIPTION
Receive [`postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) requests from the client asking for grant tokens by generating a grant token for the Hypothesis user corresponding to the logged-in LMS user and sending it back to the client over `postMessage()`.

The grant tokens used here are exactly the same as [the ones used by eLife](https://h.readthedocs.io/projects/client/en/latest/publishers/config/#cmdoption-arg-granttoken). The grant token-generating code is the same as [that used by the publisher account test site](https://github.com/hypothesis/publisher-account-test-site/blob/8e929d2669cc95c0a04d8d34c6e4390588bf1e58/hypothesis.py#L59-L75). The only difference is that we're sending the grant token over `postMessage()` rather than rendering it into the page.

Security concerns abound here. Is there a way for an attacker to steal grant tokens for accounts that don't belong to them? Does some additional source of trust between the LMS app and (what claims to be) the client need to be established and verified? Or is what we're doing here enough?