### PR TITLE
Change label on `developer_key` form field

### DIFF
--- a/lms/templates/application_instances/new_application_instance.html.jinja2
+++ b/lms/templates/application_instances/new_application_instance.html.jinja2
@@ -67,7 +67,7 @@
     <h2>Canvas File Picker Integration</h2>
     <p class="modal-text">The following fields are only needed if you are using the Canvas LMS and would like to enable the file picker.</p>
     <div class="input">
-      <label for="developer-key">Canvas Developer Key (optional)</label>
+      <label for="developer-key">Canvas Developer ID (optional)</label>
       <input id="developer-key" type="text" name="developer_key"/>
       <span class="error"></span>
     </div>


### PR DESCRIPTION
Users are confused when using the “welcome” (create credentials) form
because to set up Google Picker integration they were asked to
provide a “Developer Key”, which in Canvas-world has no meaning.

Unfortunately, the imprecise naming of `developer_key` goes all the way
down (to DB column names) so excising it entirely is beyond the scope
of a quick-fix PR.

Fixes https://github.com/hypothesis/lms/issues/184