### PR TITLE
Add users to groups

### DIFF
--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -4,8 +4,10 @@
 
 from lms.views.decorators.h_api import create_h_user
 from lms.views.decorators.h_api import create_course_group
+from lms.views.decorators.h_api import add_user_to_group
 
 __all__ = (
     "create_h_user",
     "create_course_group",
+    "add_user_to_group",
 )

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -174,6 +174,11 @@ def add_user_to_group(wrapped):
 
         group = models.CourseGroup.get(request.db, tool_consumer_instance_guid, context_id)
 
+        assert group is not None, ("create_course_group() should always have "
+                                   "been run successfully before this "
+                                   "function gets called, so group should "
+                                   "never be None.")
+
         # Deliberately assume that generate_username() will succeed and not
         # raise an error.  create_h_user() should always have been run
         # successfully before this function gets called, so if

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -17,6 +17,7 @@ from lms.models.tokens import find_token_by_user_id
 from lms.models.application_instance import find_by_oauth_consumer_key
 from lms.views.decorators import create_h_user
 from lms.views.decorators import create_course_group
+from lms.views.decorators import add_user_to_group
 
 
 def can_configure_module_item(roles):
@@ -181,6 +182,7 @@ def should_launch(request):
 @lti_launch
 @create_h_user
 @create_course_group
+@add_user_to_group
 @associate_user
 @authorize_lms(
     authorization_base_endpoint='login/oauth2/auth',

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -271,7 +271,7 @@ class TestAddUserToGroup:
     def test_it_raises_if_the_group_doesnt_exist(self, add_user_to_group, pyramid_request, models):
         models.CourseGroup.get.return_value = None
 
-        with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'pubid'"):
+        with pytest.raises(AssertionError, match="group should never be None"):
             add_user_to_group(pyramid_request, mock.sentinel.jwt)
 
     def test_it_gets_the_group_from_the_db(self, add_user_to_group, models, pyramid_request):


### PR DESCRIPTION
~Depends on https://github.com/hypothesis/lms/pull/235 and https://github.com/hypothesis/lms/pull/236.~

When a Canvas user launches an assignment call the h API to add their corresponding h user to the assignment's course group.

Manual testing checklist:

- [x] It should not do anything (not add anyone to any group) for an application instance for which the `AUTO_PROVISIONING` feature isn't enabled

When `AUTO_PROVISIONING` _is_ enabled for the application instance:

- [x] "Instructor must launch assignment first" error page if student launches assignment when a course group hasn't been created yet.
- [x] The teacher who the course group was created on behalf of will already be a member of the group. Things should work fine when this teacher views the assignment - it will try to add the teacher to the group again, which will be a no-op.
- [x] A second teacher on the same course should be added to the group on viewing an assignment. Viewing the same or another assignment again should do nothing
- [x] A student should be added to the group on viewing an assignment. Viewing the same or another assignment again should do nothing
