### PR TITLE
Enable JS linting on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ addons:
 before_script: createdb lms_test; npm install;
 jobs:
   include:
-    - script: make test
-    - script: make lint
+    - env: ACTION=test
+      script: make test
+    - env: ACTION=lint
+      script: make lint
 after_success:
   - make coverage codecov
 cache:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ codecov: .coverage
 lint:
 	@pip install -q tox
 	tox -e lint
+	$(GULP) lint
 
 .PHONY: docker
 docker:

--- a/lms/static/scripts/.eslintrc
+++ b/lms/static/scripts/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  }
+}

--- a/lms/static/scripts/file_picker/_file_picker.js
+++ b/lms/static/scripts/file_picker/_file_picker.js
@@ -14,6 +14,6 @@ new FilePicker(
   {
     mountId: '#file-picker',
     courseId: window.DEFAULT_SETTINGS.courseId,
-    pickerCallback
+    pickerCallback,
   }
 ).render();

--- a/lms/static/scripts/file_picker/canvas_api.js
+++ b/lms/static/scripts/file_picker/canvas_api.js
@@ -5,8 +5,8 @@ export const Constants = {
   POST: 'post',
   DEL: 'del',
   PUT: 'put',
-  GET_ALL: 'get_all'
-}
+  GET_ALL: 'get_all',
+};
 
 // Handle the requests to the canvas proxy on the server.
 export default class CanvasApi {

--- a/lms/static/scripts/file_picker/components/component-test.js
+++ b/lms/static/scripts/file_picker/components/component-test.js
@@ -2,34 +2,34 @@ import Component from './component';
 import Store from '../store';
 
 class TestComponent1 extends Component {
-  render(){ return 'Test1'}
+  render() { return 'Test1';}
 }
 
 class TestComponent2 extends Component {
-  render() { return 'Test2'}
+  render() { return 'Test2';}
 }
 
 describe('component', () => {
   beforeEach(() => {
-    window.DEFAULT_SETTINGS = {}
+    window.DEFAULT_SETTINGS = {};
   });
 
   it('#r should render single sub components', () => {
-    const store = new Store()
+    const store = new Store();
     const component = new Component(store);
     const output = component.r`${new TestComponent1(store)}${new TestComponent2()}`;
     assert.equal(output, 'Test1Test2');
   });
 
   it('#r should render lists of sub components', () => {
-    const store = new Store()
+    const store = new Store();
     const component = new Component(store);
     const output = component.r`${[new TestComponent1(store), new TestComponent2(store)]}`;
     assert.equal(output, 'Test1Test2');
   });
 
   it('#r should render primative values', () => {
-    const store = new Store()
+    const store = new Store();
     const component = new Component(store);
     const output = component.r`${'hello world'}`;
     assert.equal(output, 'hello world');

--- a/lms/static/scripts/file_picker/components/component.js
+++ b/lms/static/scripts/file_picker/components/component.js
@@ -15,7 +15,7 @@ export default class Component {
 
   // Return an html string from this method. Can be called explicitly or will be
   // called by the `r` method below.
-  render() {};
+  render() {}
 
   // A template literal tag that takes a template literal interploted with
   // instances of the Component class.
@@ -26,10 +26,10 @@ export default class Component {
       .map((part, index) => {
         const comp = components[index];
         // handle rendering of strings and other primitive values
-        if(comp && typeof comp !== 'object') {
+        if (comp && typeof comp !== 'object') {
           return `${part}${comp}`;
         }
-        let output = _.chain([comp])
+        const output = _.chain([comp])
           .flatten()
           .compact()
           .map(value => value.render())

--- a/lms/static/scripts/file_picker/components/file_picker-test.js
+++ b/lms/static/scripts/file_picker/components/file_picker-test.js
@@ -27,15 +27,15 @@ describe('file picker', () => {
     const filePicker = new FilePicker(store, {});
     store.unsubscribe(filePicker); // hack to avoid api calls
     const output = filePicker.render();
-    assert.include(output, 'picker-button')
+    assert.include(output, 'picker-button');
     store.setState(
       {
         ...store.getState(),
-        pickerOpen: true
+        pickerOpen: true,
       },
       store.eventTypes.PICKER_OPENED
     );
     const secondOutput = filePicker.render();
-    assert.include(secondOutput, '<main')
+    assert.include(secondOutput, '<main');
   });
 });

--- a/lms/static/scripts/file_picker/components/file_picker.js
+++ b/lms/static/scripts/file_picker/components/file_picker.js
@@ -6,7 +6,7 @@ import PickerTableRow from './picker_table_row';
 import PickerFooter from './picker_footer';
 import { Constants } from '../canvas_api';
 
-export default class FilePicker extends Component{
+export default class FilePicker extends Component {
   initializeComponent() {
     this.store.subscribe(this);
   }
@@ -44,13 +44,13 @@ export default class FilePicker extends Component{
         Constants.GET_ALL,
         { content_types: ['application/pdf'] }
       ).then((res) => {
-        const currentState = this.store.getState()
+        const currentState = this.store.getState();
         this.store.setState({
-            ...currentState,
-            files: JSON.parse(res.text),
-          },
+          ...currentState,
+          files: JSON.parse(res.text),
+        },
           this.store.eventTypes.FILES_LOADED
-        )
+        );
       });
     }
   }
@@ -59,7 +59,7 @@ export default class FilePicker extends Component{
     const state = this.store.getState();
     let output;
     // Only render the picker if the picker is open
-    if(state.pickerOpen) {
+    if (state.pickerOpen) {
       // This can be a little scary if you are not familiar with tagged template
       // literals. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals
       // Using this is not necessary just more declarative. r simply calls the render
@@ -71,7 +71,7 @@ export default class FilePicker extends Component{
               <table class="list-view" role="listbox">
                 ${new PickerTableHeader(this.store)}
                 <tbody>
-                  ${_.map(state.files, (file) => new PickerTableRow(this.store, { file }))}
+                  ${_.map(state.files, file => new PickerTableRow(this.store, { file }))}
                 </tbody>
               </table>
             </div>
@@ -95,9 +95,9 @@ export default class FilePicker extends Component{
     }
 
     // Find the element on the page and set the inner html to output html
-    $(this.props.mountId).html(output)
+    $(this.props.mountId).html(output);
     // Tell the app we are done rendering so that even listeners can be added.
-    this.store.triggerUpdate(this.store.eventTypes.DOCUMENT_RENDERED)
+    this.store.triggerUpdate(this.store.eventTypes.DOCUMENT_RENDERED);
     return output;
   }
 }

--- a/lms/static/scripts/file_picker/components/picker_footer.js
+++ b/lms/static/scripts/file_picker/components/picker_footer.js
@@ -4,7 +4,7 @@ import Component from './component';
 export default class PickerHeaderTable extends Component {
 
   initializeComponent() {
-    this.store.subscribe(this)
+    this.store.subscribe(this);
   }
 
   handleUpdate() {
@@ -17,7 +17,7 @@ export default class PickerHeaderTable extends Component {
           pickerOpen: false,
         },
         this.store.eventTypes.PICKER_CLOSED
-      )
+      );
     });
     $('#picker-submit').off('click');
     $('#picker-submit').on('click', () => {

--- a/lms/static/scripts/file_picker/components/picker_table_row-test.js
+++ b/lms/static/scripts/file_picker/components/picker_table_row-test.js
@@ -10,7 +10,7 @@ describe('picker table row', () => {
     };
     const pickerTableRow = new PickerTableRow(store, { file });
     const output = pickerTableRow.render();
-    assert.include(output, 'Test'),
+    assert.include(output, 'Test');
     assert.include(output, '11/11/11');
   });
 });

--- a/lms/static/scripts/file_picker/components/picker_table_row-test.js
+++ b/lms/static/scripts/file_picker/components/picker_table_row-test.js
@@ -6,11 +6,11 @@ describe('picker table row', () => {
     const file = {
       filename: 'Test',
       updated_at: '11/11/11',
-      id: '1'
-    }
+      id: '1',
+    };
     const pickerTableRow = new PickerTableRow(store, { file });
     const output = pickerTableRow.render();
     assert.include(output, 'Test'),
-    assert.include(output, '11/11/11')
+    assert.include(output, '11/11/11');
   });
 });

--- a/lms/static/scripts/file_picker/components/picker_table_row.js
+++ b/lms/static/scripts/file_picker/components/picker_table_row.js
@@ -8,23 +8,23 @@ export default class PickerFooter extends Component {
   }
 
   handleUpdate(state, eventType) {
-    if(eventType === this.store.eventTypes.DOCUMENT_RENDERED) {
+    if (eventType === this.store.eventTypes.DOCUMENT_RENDERED) {
       // handle file selection
       $(`#file-${this.props.file.id}`).off('click');
       $(`#file-${this.props.file.id}`).on('click', () => {
         this.store.setState(
           {
             ...this.store.getState(),
-            selectedFileId: this.props.file.id
+            selectedFileId: this.props.file.id,
           },
           this.store.eventTypes.FILE_SELECTED
-        )
+        );
       });
     }
   }
 
   render() {
-    const state = this.store.getState()
+    const state = this.store.getState();
     let className = '';
 
     // highlight the selected file.

--- a/lms/static/scripts/file_picker/store-test.js
+++ b/lms/static/scripts/file_picker/store-test.js
@@ -1,4 +1,4 @@
-import Store from './store'
+import Store from './store';
 
 class Subscriber {
   handleUpdate() {}
@@ -7,35 +7,35 @@ class Subscriber {
 describe('store', () => {
 
   beforeEach(() => {
-    window.DEFAULT_SETTINGS = {}
+    window.DEFAULT_SETTINGS = {};
   });
 
   it('#subscribe should correctly subscribe observers',  () => {
     const store = new Store();
-    const sub = new Subscriber()
+    const sub = new Subscriber();
     store.subscribe(sub);
-    assert.equal(store.subscribers.length, 1)
+    assert.equal(store.subscribers.length, 1);
   });
 
   it('#triggerUpdate should call the subscribers handleUpdateMethod', () => {
     const store = new Store();
-    const sub = new Subscriber()
-    sub.handleUpdate = sinon.stub()
-    const newState = {}
+    const sub = new Subscriber();
+    sub.handleUpdate = sinon.stub();
+    const newState = {};
     store.subscribe(sub);
-    store.triggerUpdate('TEST_UPDATE')
-    assert.calledWith(sub.handleUpdate, store.getState(), 'TEST_UPDATE')
+    store.triggerUpdate('TEST_UPDATE');
+    assert.calledWith(sub.handleUpdate, store.getState(), 'TEST_UPDATE');
   });
 
   it('#setState should change the state value and call trigger update', () => {
     const store = new Store();
-    const sub = new Subscriber()
-    store.triggerUpdate = sinon.stub()
-    const newState = {}
+    const sub = new Subscriber();
+    store.triggerUpdate = sinon.stub();
+    const newState = {};
     store.subscribe(sub);
     store.setState(newState, 'TEST_UPDATE');
     assert.equal(store.getState(), newState);
-    assert.calledWith(store.triggerUpdate, 'TEST_UPDATE')
+    assert.calledWith(store.triggerUpdate, 'TEST_UPDATE');
   });
 
   it('#unsubscribe should unsubscribe', () => {

--- a/lms/static/scripts/file_picker/store-test.js
+++ b/lms/static/scripts/file_picker/store-test.js
@@ -21,7 +21,6 @@ describe('store', () => {
     const store = new Store();
     const sub = new Subscriber();
     sub.handleUpdate = sinon.stub();
-    const newState = {};
     store.subscribe(sub);
     store.triggerUpdate('TEST_UPDATE');
     assert.calledWith(sub.handleUpdate, store.getState(), 'TEST_UPDATE');

--- a/lms/static/scripts/file_picker/store.js
+++ b/lms/static/scripts/file_picker/store.js
@@ -5,7 +5,7 @@ const defaultState = {
   pickerOpen: false,
   selectedFileId: null,
   files: [],
-}
+};
 
 const eventTypes = {
   DOCUMENT_RENDERED: 'DOCUMENT_RENDERED',
@@ -14,7 +14,7 @@ const eventTypes = {
   PICKER_CLOSED: 'PICKER_CLOSED',
   FILE_SELECTED: 'FILE_SELECTED',
   FILE_SUBMITED: 'FILE_SUBMITTED',
-}
+};
 
 // Store handles the application state and implements a basic observer pattern.
 // Subscribers are notified any time an update is triggered via the triggerUpdate function, the

--- a/lms/static/scripts/karma.config.js
+++ b/lms/static/scripts/karma.config.js
@@ -1,4 +1,4 @@
-var babelify = require('babelify');
+const babelify = require('babelify');
 
 module.exports = function(config) {
   config.set({

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "gulp lint",
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR enables running of JS linting in Travis CI builds.

- The first commit enables parsing of ES6 modules by ESLint for files in lms/static
- The second commit uses ESLint's `--fix` mode to autofix most outstanding issues
- The third commit fixes a couple of minor issues that ESLint could not auto-fix
- The last commit enables running of linting on each CI build. I also followed the convention of h of adding an "ACTION=<task>" env var so that the role of each Travis job can easily be distinguished when looking at Travis build output.