### PR TITLE
Re-enable minification of frontend code in the Docker build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var through = require('through2');
 var createBundle = require('./scripts/gulp/create-bundle');
 var manifest = require('./scripts/gulp/manifest');
 
-var IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production' && false;
+var IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production';
 var SCRIPT_DIR = 'build/scripts';
 
 function parseCommandLine() {


### PR DESCRIPTION
This was disabled without explanation when the gulpfile was first added
to the repository. As a result the JS bundle for the file picker is much
larger than it needs to be.