### PR TITLE
Move JavaScript for new_application_instance form out of template

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,6 +70,9 @@ var bundles = [{
 },{
   name: 'content_item_selection',
   entry: './lms/static/scripts/content-item-selection.js',
+},{
+  name: 'new_application_instance',
+  entry: './lms/static/scripts/new-application-instance.js',
 }];
 
 var bundleConfigs = bundles.map(function (config) {

--- a/lms/assets.ini
+++ b/lms/assets.ini
@@ -5,3 +5,6 @@ file_picker_js =
 
 content_item_selection_js =
   scripts/content_item_selection.bundle.js
+
+new_application_instance_js =
+  scripts/new_application_instance.bundle.js

--- a/lms/static/scripts/new-application-instance.js
+++ b/lms/static/scripts/new-application-instance.js
@@ -1,0 +1,43 @@
+function addHttp(url) {
+  if (url !== '' && !/^(f|ht)tps?:\/\//i.test(url)) {
+    url = 'https://' + url;
+  }
+  return url;
+}
+
+function handleSubmit(event, form) {
+  if (!validateDomain(form.elements.lms_url) || !validateEmail(form.elements.email)) {
+    event.preventDefault();
+  }
+  form.elements.lms_url.value = addHttp(form.elements.lms_url.value);
+}
+
+function validateEmail(input) {
+  const parent = input.parentElement;
+  if (input.value.indexOf('@') === -1) {
+    parent.classList.add('has-error');
+    parent.getElementsByClassName('error')[0].innerHTML = 'Please enter a valid email address';
+    return false;
+  }
+  parent.classList.remove('has-error');
+  parent.getElementsByClassName('error')[0].innerHTML = '';
+  return true;
+}
+
+function validateDomain(input) {
+  const parent = input.parentElement;
+  if (input.value.length === 0) {
+    parent.classList.add('has-error');
+    parent.getElementsByClassName('error')[0].innerHTML = 'Please enter a valid domain';
+    return false;
+  }
+  parent.classList.remove('has-error');
+  parent.getElementsByClassName('error')[0].innerHTML = '';
+  return true;
+}
+
+window.newApplicationInstanceForm = {
+  handleSubmit,
+  validateDomain,
+  validateEmail,
+};

--- a/lms/templates/application_instances/new_application_instance.html.jinja2
+++ b/lms/templates/application_instances/new_application_instance.html.jinja2
@@ -1,53 +1,16 @@
 <!--suppress CheckValidXmlInScriptTagBody -->
 {% extends "templates/base.html.jinja2" %}
 {% block scripts %}
-<script type="text/javascript">
-  function addHttp(url) {
-    if (url != "" && !/^(f|ht)tps?:\/\//i.test(url)) {
-        url = "https://" + url;
-     }
-     return url;
-  }
-
-  function handleSubmit(event, form) {
-    if(!validateDomain(form.elements['lms_url']) || !validateEmail(form.elements['email'])) {
-      event.preventDefault();
-      return false;
-    }
-    form.elements['lms_url'].value = addHttp(form.elements['lms_url'].value);
-  }
-
-  function validateEmail(input) {
-    var parent = input.parentElement;
-    if (input.value.indexOf('@') === -1) {
-      parent.classList.add('has-error');
-      parent.getElementsByClassName('error')[0].innerHTML = 'Please enter a valid email address';
-      return false;
-    }
-    parent.classList.remove('has-error');
-    parent.getElementsByClassName('error')[0].innerHTML = '';
-    return true;
-  }
-
-  function validateDomain(input) {
-    var parent = input.parentElement;
-    if (input.value.length === 0) {
-      parent.classList.add('has-error');
-      parent.getElementsByClassName('error')[0].innerHTML = 'Please enter a valid domain';
-      return false;
-    }
-    parent.classList.remove('has-error');
-    parent.getElementsByClassName('error')[0].innerHTML = '';
-    return true;
-  }
-</script>
+{% for url in asset_urls("new_application_instance_js") %}
+<script src="{{ url }}"></script>
+{% endfor %}
 {% endblock %}
 
 {% block content %}
 <main class="modal-content">
   <h1>Hypothesis Installation</h1>
   <p class="modal-text">This tool allows you to generate the info you'll need to install Hypothesis in your LMS.</p>
-  <form action="/welcome" method="post" onsubmit="handleSubmit(event, this)">
+  <form action="/welcome" method="post" onsubmit="newApplicationInstanceForm.handleSubmit(event, this)">
     <div class="input">
       <label for="domain">LMS Domain</label>
       <input
@@ -55,13 +18,13 @@
         type="text"
         name="lms_url"
         placeholder="ex. yourschool.instructure.com"
-        onblur="validateDomain(this)"
+        onblur="newApplicationInstanceForm.validateDomain(this)"
       />
       <span class="error"></span>
     </div>
     <div class="input">
       <label for="email">Email</label>
-      <input id="email" type="email" name="email" onblur="validateEmail(this)"/>
+      <input id="email" type="email" name="email" onblur="newApplicationInstanceForm.validateEmail(this)"/>
       <span class="error"></span>
     </div>
     <h2>Canvas File Picker Integration</h2>


### PR DESCRIPTION
Move the inline JavaScript for the new_application_instance form to a JS
bundle to make it easier to refactor in future.

We could potentially replace the client-side validation here with HTML 5 form validation and not have any script at all. For the moment I've just moved the existing code so the user-facing behaviour should be unchanged.

Part of #251 

----

**Testing**

Visit the `/welcome` page and test that email and domain validation is applied when the email/domain fields are blurred and on form submission.