### PR TITLE
Fix a docstring

### DIFF
--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -7,5 +7,5 @@ class Root:
     __acl__ = [(Allow, 'report_viewers', 'view')]
 
     def __init__(self, request):
-        """Pass."""
-        pass
+        """Return the default root resource object."""
+        self.request = request


### PR DESCRIPTION
Also make the pointless `__init__()` method (just `pass`) actually do
something by saving the `request` as `self.request`. This will be made
use of in future commits.