### PR TITLE
Login integration 1/n: New config settings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,30 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
       need the generated <samp>Client ID</samp> and <samp>Client secret</samp>
       for setting your environment variables later.
 
+1. Also create a jwt_bearer auth client in h.
+
+   The LMS app also requires the `client_id` and `client_secret` from a
+   `jwt_bearer`-type auth client in h in order to generate authorization grant
+   tokens for logging in to h user accounts.
+
+   Go to <http://localhost:5000/admin/oauthclients/new> and create an auth
+   client with these settings:
+
+      <dl>
+        <dt>Name</dt>
+        <dd>LMS JWT</dd>
+        <dt>Authority</dt>
+        <dd>lms.hypothes.is</dd>
+        <dt>Grant type</dt>
+        <dd>jwt_bearer</dd>
+        <dt>Redirect URL</dt>
+        <dd>(Leave empty)</dd>
+      </dl>
+
+      Click <samp>Register client</samp> and keep the tab open because you'll
+      need the generated <samp>Client ID</samp> and <samp>Client secret</samp>
+      for setting your environment variables later.
+
 1. **Configure environment variables**
 
     Setting up [Google API integration](#google-apis) and [application instance reports](#instance-reports) access is optional at this point; you can leave the default values for related environment variables for now, if you like.
@@ -112,6 +136,12 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
     export H_CLIENT_SECRET="eVJ4***rXkk"
     export H_AUTHORITY="lms.hypothes.is"
     export H_API_URL="http://localhost:5000/api"
+
+    # For logging in to the Hypothesis client.
+    # The values for H_JWT_CLIENT_ID and H_JWT_CLIENT_SECRET should come from
+    # the jwt_bearer auth client that you created in h earlier.
+    export H_JWT_CLIENT_ID="3ac7***71e4"
+    export H_JWT_CLIENT_SECRET="OJGx***c8x4"
 
     # An optional space-separated list of the consumer keys of the application
     # instances for which the "auto provisioning" features should be enabled.

--- a/README.markdown
+++ b/README.markdown
@@ -143,6 +143,11 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
     export H_JWT_CLIENT_ID="3ac7***71e4"
     export H_JWT_CLIENT_SECRET="OJGx***c8x4"
 
+    # A space-separated list of window origins from which JSON-RPC requests
+    # will be accepted over postMessage. In a development environment the
+    # Hypothesis client would normally be served from localhost:5000.
+    export RPC_ALLOWED_ORIGINS="http://localhost:5000"
+
     # An optional space-separated list of the consumer keys of the application
     # instances for which the "auto provisioning" features should be enabled.
     # Defaults to an empty list ([]) if none provided (i.e. the features will

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -39,6 +39,10 @@ def configure(settings):
         'h_client_id': env_setting('H_CLIENT_ID', required=True),
         'h_client_secret': env_setting('H_CLIENT_SECRET', required=True),
 
+        # The OAuth 2.0 client_id and client_secret for logging users in to h.
+        'h_jwt_client_id': env_setting('H_JWT_CLIENT_ID', required=True),
+        'h_jwt_client_secret': env_setting('H_JWT_CLIENT_SECRET', required=True),
+
         # The authority that we'll create h users and groups in (e.g. "lms.hypothes.is").
         'h_authority': env_setting('H_AUTHORITY', required=True),
 

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -52,6 +52,9 @@ def configure(settings):
         # The list of `oauth_consumer_key`s of the application instances for
         # which the automatic user and group provisioning features are enabled.
         'auto_provisioning': env_setting('AUTO_PROVISIONING', default=''),
+
+        # The postMessage origins from which to accept RPC requests.
+        'rpc_allowed_origins': env_setting('RPC_ALLOWED_ORIGINS', required=True),
     }
 
     database_url = env_setting('DATABASE_URL')
@@ -67,6 +70,7 @@ def configure(settings):
         raise SettingError("LMS_SECRET must contain only ASCII characters")
 
     env_settings['auto_provisioning'] = aslist(env_settings['auto_provisioning'])
+    env_settings['rpc_allowed_origins'] = aslist(env_settings['rpc_allowed_origins'])
 
     settings.update(env_settings)
 

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -17,6 +17,14 @@ class Root:
     def __init__(self, request):
         """Return the default root resource object."""
         self.request = request
+
+
+class LTILaunch:
+    """Context resource for LTI launch requests."""
+
+    def __init__(self, request):
+        """Return the context resource for an LTI launch request."""
+        self.request = request
         # This will raise HTTPBadRequest if the request looks like an OAuth
         # redirect request but no DB-stashed LTI params can be found for the
         # request.

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -57,3 +57,9 @@ class Root:
                 }
             ]
         }
+
+    @property
+    def rpc_server_config(self):
+        """Return the config object for the JSON-RPC server."""
+        allowed_origins = self.request.registry.settings["rpc_allowed_origins"]
+        return {"allowedOrigins": allowed_origins}

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -1,4 +1,10 @@
+import datetime
+import urllib
+
+import jwt
 from pyramid.security import Allow
+
+from lms import util
 
 
 class Root:
@@ -9,3 +15,45 @@ class Root:
     def __init__(self, request):
         """Return the default root resource object."""
         self.request = request
+
+    @property
+    def hypothesis_config(self):
+        """
+        Return the Hypothesis client config object for the current request.
+
+        Return a dict suitable for dumping to JSON and using as a Hypothesis
+        client config object. Includes settings specific to the current LTI
+        request, such as an authorization grant token for the client to use to
+        log in to the Hypothesis account corresponding to the LTI user that the
+        request comes from.
+
+        See: https://h.readthedocs.io/projects/client/en/latest/publishers/config/#configuring-the-client-using-json
+
+        """
+        client_id = self.request.registry.settings["h_jwt_client_id"]
+        client_secret = self.request.registry.settings["h_jwt_client_secret"]
+        api_url = self.request.registry.settings["h_api_url"]
+        authority = self.request.registry.settings["h_authority"]
+        audience = urllib.parse.urlparse(api_url).hostname
+
+        def grant_token():
+            now = datetime.datetime.utcnow()
+            username = util.generate_username(self.request.params)
+            claims = {
+                "aud": audience,
+                "iss": client_id,
+                "sub": "acct:{}@{}".format(username, authority),
+                "nbf": now,
+                "exp": now + datetime.timedelta(minutes=5),
+            }
+            return jwt.encode(claims, client_secret, algorithm="HS256")
+
+        return {
+            "services": [
+                {
+                    "apiUrl": api_url,
+                    "authority": authority,
+                    "grantToken": grant_token().decode("utf-8"),
+                }
+            ]
+        }

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -40,6 +40,12 @@ class Root:
         authority = self.request.registry.settings["h_authority"]
         audience = urllib.parse.urlparse(api_url).hostname
 
+        # Make sure that the API URL ends with a /.
+        # The client handles it incorrectly otherwise.
+        # See https://github.com/hypothesis/client/issues/783
+        if not api_url.endswith("/"):
+            api_url = api_url + "/"
+
         def grant_token():
             now = datetime.datetime.utcnow()
             username = util.generate_username(self.request.params)

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from lms.config.resources import LTILaunch
 
 
 def includeme(config):
@@ -8,16 +9,20 @@ def includeme(config):
     config.add_route('logout', '/logout')
     config.add_route('reports', '/reports')
     config.add_route('config_xml', '/config_xml')
-    config.add_route('module_item_configurations', '/module_item_configurations')
+    config.add_route(
+        'module_item_configurations', '/module_item_configurations', factory=LTILaunch)
     config.add_route('canvas_proxy', '/canvas_proxy')
 
     # lms routes
-    config.add_route('lti_launches', '/lti_launches')
+    config.add_route('lti_launches', '/lti_launches', factory=LTILaunch)
     config.add_route('content_item_selection', '/content_item_selection')
 
     # Oauth
     config.add_route('canvas_oauth_callback', '/canvas_oauth_callback')
-    config.add_route('module_item_launch_oauth_callback', '/module_item_launch_oauth_callback')
+    config.add_route(
+        'module_item_launch_oauth_callback',
+        '/module_item_launch_oauth_callback',
+        factory=LTILaunch)
 
     # Assets
     config.add_route('assets', '/assets/*subpath')

--- a/lms/templates/lti_launches/new_lti_launch.html.jinja2
+++ b/lms/templates/lti_launches/new_lti_launch.html.jinja2
@@ -1,1 +1,2 @@
+<script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson}}</script>
 <iframe width="100%" height="100%" src="{{hypothesis_url}}" />

--- a/lms/templates/lti_launches/new_lti_launch.html.jinja2
+++ b/lms/templates/lti_launches/new_lti_launch.html.jinja2
@@ -1,2 +1,3 @@
+<script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson}}</script>
 <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson}}</script>
 <iframe width="100%" height="100%" src="{{hypothesis_url}}" />

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -1,0 +1,38 @@
+import datetime
+import jwt
+
+import pytest
+
+from lms.config import resources
+
+
+class TestRoot:
+    def test_hypothesis_config_contains_one_service_config(self, root):
+        assert len(root.hypothesis_config["services"]) == 1
+
+    def test_hypothesis_config_includes_the_api_url(self, root):
+        root.hypothesis_config["services"][0]["apiUrl"] == "https://example.com/api"
+
+    def test_hypothesis_config_includes_the_authority(self, root):
+        assert root.hypothesis_config["services"][0]["authority"] == "TEST_AUTHORITY"
+
+    def test_hypothesis_config_includes_grant_token(self, root):
+        before = int(datetime.datetime.now().timestamp())
+
+        grant_token = root.hypothesis_config["services"][0]["grantToken"]
+
+        claims = jwt.decode(
+            grant_token,
+            algorithms=["HS256"],
+            key="TEST_JWT_CLIENT_SECRET",
+            audience="example.com",
+        )
+        after = int(datetime.datetime.now().timestamp())
+        assert claims["iss"] == "TEST_JWT_CLIENT_ID"
+        assert claims["sub"] == "acct:75a0b8df844a493bc789385bbbd885@TEST_AUTHORITY"
+        assert before <= claims["nbf"] <= after
+        assert claims["exp"] > before
+
+    @pytest.fixture
+    def root(self, pyramid_request):
+        return resources.Root(pyramid_request)

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -18,7 +18,7 @@ class TestLTILaunch:
         assert len(lti_launch.hypothesis_config["services"]) == 1
 
     def test_hypothesis_config_includes_the_api_url(self, lti_launch):
-        lti_launch.hypothesis_config["services"][0]["apiUrl"] == "https://example.com/api"
+        assert lti_launch.hypothesis_config["services"][0]["apiUrl"] == "https://example.com/api/"
 
     def test_hypothesis_config_includes_the_authority(self, lti_launch):
         assert lti_launch.hypothesis_config["services"][0]["authority"] == "TEST_AUTHORITY"

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -33,8 +33,25 @@ class TestRoot:
         assert before <= claims["nbf"] <= after
         assert claims["exp"] > before
 
+    def test_hypothesis_config_is_empty_if_provisioning_feature_is_disabled(
+        self, pyramid_request, root
+    ):
+        pyramid_request.params.update({"oauth_consumer_key": "some_other_key"})
+        assert root.hypothesis_config == {}
+
     def test_rpc_server_config(self, root):
         assert root.rpc_server_config == {"allowedOrigins": ["http://localhost:5000"]}
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params.update(
+            {
+                # A valid oauth_consumer_key (matches one for which the
+                # provisioning features are enabled).
+                "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
+            }
+        )
+        return pyramid_request
 
     @pytest.fixture
     def root(self, pyramid_request):

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -7,26 +7,26 @@ from pyramid.httpexceptions import HTTPBadRequest
 from lms.config import resources
 
 
-class TestRoot:
+class TestLTILaunch:
     def test_it_raises_if_no_lti_params_for_request(self, pyramid_request, lti_params_for):
         lti_params_for.side_effect = HTTPBadRequest()
 
         with pytest.raises(HTTPBadRequest):
-            resources.Root(pyramid_request)
+            resources.LTILaunch(pyramid_request)
 
-    def test_hypothesis_config_contains_one_service_config(self, root):
-        assert len(root.hypothesis_config["services"]) == 1
+    def test_hypothesis_config_contains_one_service_config(self, lti_launch):
+        assert len(lti_launch.hypothesis_config["services"]) == 1
 
-    def test_hypothesis_config_includes_the_api_url(self, root):
-        root.hypothesis_config["services"][0]["apiUrl"] == "https://example.com/api"
+    def test_hypothesis_config_includes_the_api_url(self, lti_launch):
+        lti_launch.hypothesis_config["services"][0]["apiUrl"] == "https://example.com/api"
 
-    def test_hypothesis_config_includes_the_authority(self, root):
-        assert root.hypothesis_config["services"][0]["authority"] == "TEST_AUTHORITY"
+    def test_hypothesis_config_includes_the_authority(self, lti_launch):
+        assert lti_launch.hypothesis_config["services"][0]["authority"] == "TEST_AUTHORITY"
 
-    def test_hypothesis_config_includes_grant_token(self, root):
+    def test_hypothesis_config_includes_grant_token(self, lti_launch):
         before = int(datetime.datetime.now().timestamp())
 
-        grant_token = root.hypothesis_config["services"][0]["grantToken"]
+        grant_token = lti_launch.hypothesis_config["services"][0]["grantToken"]
 
         claims = jwt.decode(
             grant_token,
@@ -41,17 +41,17 @@ class TestRoot:
         assert claims["exp"] > before
 
     def test_hypothesis_config_is_empty_if_provisioning_feature_is_disabled(
-        self, pyramid_request, root, lti_params_for
+        self, pyramid_request, lti_launch, lti_params_for
     ):
         lti_params_for.return_value.update({"oauth_consumer_key": "some_other_key"})
-        assert root.hypothesis_config == {}
+        assert lti_launch.hypothesis_config == {}
 
-    def test_rpc_server_config(self, root):
-        assert root.rpc_server_config == {"allowedOrigins": ["http://localhost:5000"]}
+    def test_rpc_server_config(self, lti_launch):
+        assert lti_launch.rpc_server_config == {"allowedOrigins": ["http://localhost:5000"]}
 
     @pytest.fixture
-    def root(self, pyramid_request):
-        return resources.Root(pyramid_request)
+    def lti_launch(self, pyramid_request):
+        return resources.LTILaunch(pyramid_request)
 
     @pytest.fixture(autouse=True)
     def lti_params_for(self, patch):

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -2,11 +2,18 @@ import datetime
 import jwt
 
 import pytest
+from pyramid.httpexceptions import HTTPBadRequest
 
 from lms.config import resources
 
 
 class TestRoot:
+    def test_it_raises_if_no_lti_params_for_request(self, pyramid_request, lti_params_for):
+        lti_params_for.side_effect = HTTPBadRequest()
+
+        with pytest.raises(HTTPBadRequest):
+            resources.Root(pyramid_request)
+
     def test_hypothesis_config_contains_one_service_config(self, root):
         assert len(root.hypothesis_config["services"]) == 1
 
@@ -34,25 +41,30 @@ class TestRoot:
         assert claims["exp"] > before
 
     def test_hypothesis_config_is_empty_if_provisioning_feature_is_disabled(
-        self, pyramid_request, root
+        self, pyramid_request, root, lti_params_for
     ):
-        pyramid_request.params.update({"oauth_consumer_key": "some_other_key"})
+        lti_params_for.return_value.update({"oauth_consumer_key": "some_other_key"})
         assert root.hypothesis_config == {}
 
     def test_rpc_server_config(self, root):
         assert root.rpc_server_config == {"allowedOrigins": ["http://localhost:5000"]}
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.params.update(
-            {
-                # A valid oauth_consumer_key (matches one for which the
-                # provisioning features are enabled).
-                "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
-            }
-        )
-        return pyramid_request
-
-    @pytest.fixture
     def root(self, pyramid_request):
         return resources.Root(pyramid_request)
+
+    @pytest.fixture(autouse=True)
+    def lti_params_for(self, patch):
+        lti_params_for = patch("lms.config.resources.lti_params_for")
+        lti_params_for.return_value = {
+            # A valid oauth_consumer_key (matches one for which the
+            # provisioning features are enabled).
+            "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
+        }
+        return lti_params_for
+
+    @pytest.fixture(autouse=True)
+    def util(self, patch):
+        util = patch("lms.config.resources.util")
+        util.generate_username.return_value = "75a0b8df844a493bc789385bbbd885"
+        return util

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -33,6 +33,9 @@ class TestRoot:
         assert before <= claims["nbf"] <= after
         assert claims["exp"] > before
 
+    def test_rpc_server_config(self, root):
+        assert root.rpc_server_config == {"allowedOrigins": ["http://localhost:5000"]}
+
     @pytest.fixture
     def root(self, pyramid_request):
         return resources.Root(pyramid_request)

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -146,6 +146,8 @@ def pyramid_config(pyramid_request):
         },
         'h_client_id': 'TEST_CLIENT_ID',
         'h_client_secret': 'TEST_CLIENT_SECRET',
+        'h_jwt_client_id': 'TEST_JWT_CLIENT_ID',
+        'h_jwt_client_secret': 'TEST_JWT_CLIENT_SECRET',
         'h_authority': 'TEST_AUTHORITY',
         'h_api_url': 'https://example.com/api',
         'auto_provisioning': 'Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20',
@@ -210,6 +212,9 @@ def lti_launch_request(monkeypatch, pyramid_request):
     pyramid_request.params['custom_canvas_course_id'] = '1'
     pyramid_request.params['context_id'] = 'fake_context_id'
     monkeypatch.setattr('pylti.common.verify_request_common', lambda a, b, c, d, e: True)
+
+    pyramid_request.context = {"hypothesis_config": {}}
+
     yield pyramid_request
 
 

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -151,6 +151,7 @@ def pyramid_config(pyramid_request):
         'h_authority': 'TEST_AUTHORITY',
         'h_api_url': 'https://example.com/api',
         'auto_provisioning': 'Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20',
+        'rpc_allowed_origins': ['http://localhost:5000'],
     }
 
     with testing.testConfig(request=pyramid_request, settings=settings) as config:
@@ -213,7 +214,10 @@ def lti_launch_request(monkeypatch, pyramid_request):
     pyramid_request.params['context_id'] = 'fake_context_id'
     monkeypatch.setattr('pylti.common.verify_request_common', lambda a, b, c, d, e: True)
 
-    pyramid_request.context = {"hypothesis_config": {}}
+    pyramid_request.context = {
+        "rpc_server_config": {},
+        "hypothesis_config": {},
+    }
 
     yield pyramid_request
 


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/284>.

This adds three new required config settings:

1. H_JWT_CLIENT_ID
2. H_JWT_CLIENT_SECRET
3. RPC_ALLOWED_ORIGINS

All three will need to be set on QA and production before merging this, otherwise the app will fail to start up.

This PR also makes a `{{ context.hypothesis_config }}` variable available to all templates. It's a JSON-serializable client config object suitable for use in a js-hypothesis-config JSON script. It includes a grant token for the client to use to log the LTI user in to h, generated using the `H_JWT_CLIENT_ID` and `H_JWT_CLIENT_SECRET` (and the user info from LTI).

If the auto provisioning feature is disabled for the current application instance then `{{ context.hypothesis_config }}` will _not_ contain a `services` object or grant token, the client will not attempt automatic login and will use normal first-party accounts instead.

Similarly a `{{ context.rpc_server_config }}` is made available to templates containing config for the forthcoming JavaScript JSON-RPC sever. This config includes the list of postMessage origins that're going to be allowed to make JSON-RPC calls, from the `RPC_ALLOWED_ORIGINS` setting.

Both `{{ context.hypothesis_config }}` and `{{ context.rpc_server_config }}` are rendered into the `new_lti_launch.html.jinja2` template, which is the template for the assignment view. Nothing reads either of these JSON config objects yet though -- both will be read by the forthcoming JSON-RPC server.

It should be safe to merge and deploy this without the JSON-RPC server: all it does is put the JSON objects that the server needs into the page, where no server picks them up yet.