### PR TITLE
Login integration 3/n: Add via.* params to Via URL

### DIFF
--- a/lms/templates/lti_launches/new_lti_launch.html.jinja2
+++ b/lms/templates/lti_launches/new_lti_launch.html.jinja2
@@ -5,4 +5,4 @@
   <script src="{{ url }}"></script>
 {% endfor %}
 
-<iframe width="100%" height="100%" src="{{hypothesis_url}}" />
+<iframe width="100%" height="100%" src="{{ via_url }}" />

--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -15,6 +15,7 @@ from lms.util.h_api import generate_group_name
 from lms.util.jwt import jwt
 from lms.util.lti_launch import lti_launch
 from lms.util.lti import lti_params_for
+from lms.util.via import via_url
 from lms.util.view_renderer import view_renderer
 
 __all__ = (
@@ -31,6 +32,7 @@ __all__ = (
     'lti_launch',
     'lti_params_for',
     'save_token',
+    'via_url',
     'view_renderer',
     'GET',
     'POST',

--- a/lms/util/via.py
+++ b/lms/util/via.py
@@ -1,0 +1,52 @@
+from urllib import parse
+
+
+def via_url(request, document_url):
+    """
+    Return the Via URL for annotating the given ``document_url``.
+
+    Return the URL to be used as the ``src`` attribute of the Via iframe in
+    order to annotate the given ``document_url``. For example::
+
+      https://via.hypothes.is/https://example.com/document?via.open_sidebar=1&via...
+
+    The ``https://via.hypothes.is`` part depends on the value of the VIA_URL
+    environment variable.
+
+    The ``https://example.com/document`` part is the ``document_url`` argument
+    passed to this function.
+
+    The ``?via.*=foo&via.*=bar`` query parameters enable non-default Via and
+    client features that're required. Any existing non-Via query parameters on
+    the document URL are preserved in their original order.
+
+    :arg pyramid.request.Request request: the Pyramid request
+    :arg str document_url: the URL of the document to be annotated
+    :return: the Via URL for this assignment
+    :rtype: str
+
+    """
+    parts = parse.urlparse(document_url)
+
+    query_string_as_list = parse.parse_qsl(parts.query)
+    query_string_as_list = [
+        t for t in query_string_as_list if not t[0].startswith("via.")
+    ]
+    query_string_as_list.append(("via.open_sidebar", "1"))
+    query_string_as_list.append(("via.request_config_from_frame", request.host_url))
+    query_string = parse.urlencode(query_string_as_list)
+
+    return (
+        request.registry.settings["via_url"]
+        + "/"
+        + parse.urlunparse(
+            (
+                parts.scheme,
+                parts.netloc,
+                parts.path,
+                parts.params,
+                query_string,
+                parts.fragment,
+            )
+        )
+    )

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -13,6 +13,7 @@ from lms.views.content_item_selection import content_item_form
 from lms.util.associate_user import associate_user
 from lms.util.canvas_api import CanvasApi, GET
 from lms.util.authorize_lms import authorize_lms, save_token
+from lms.util import via_url
 from lms.models.tokens import find_token_by_user_id
 from lms.models.application_instance import find_by_oauth_consumer_key
 from lms.views.decorators import create_h_user
@@ -201,8 +202,7 @@ def lti_launches(request, jwt, user=None):
 @view_renderer(renderer='lms:templates/lti_launches/new_lti_launch.html.jinja2')
 def _view_document(request, document_url, jwt):
     return {
-        'hypothesis_url':
-        f"{request.registry.settings['via_url']}/{document_url}",
+        'via_url': via_url(request, document_url),
         'jwt': jwt
     }
 

--- a/tests/lms/util/via_test.py
+++ b/tests/lms/util/via_test.py
@@ -1,0 +1,51 @@
+import pytest
+
+from lms.util import via_url
+
+
+class TestViaURL:
+    @pytest.mark.parametrize(
+        "document_url,expected_via_url",
+        [
+            # If the document URL has no query params it adds the Via query
+            # params.
+            (
+                "https://example.com",
+                "http://TEST_VIA_SERVER.is/https://example.com"
+                "?via.open_sidebar=1"
+                "&via.request_config_from_frame=http%3A%2F%2Fexample.com",
+            ),
+            (
+                "http://example.com",
+                "http://TEST_VIA_SERVER.is/http://example.com"
+                "?via.open_sidebar=1"
+                "&via.request_config_from_frame=http%3A%2F%2Fexample.com",
+            ),
+            # If the document URL already has query params it appends the Via
+            # params and preserves the existing ones.
+            (
+                "http://example.com?foo=FOO&bar=BAR",
+                "http://TEST_VIA_SERVER.is/http://example.com"
+                "?foo=FOO&bar=BAR&via.open_sidebar=1"
+                "&via.request_config_from_frame=http%3A%2F%2Fexample.com",
+            ),
+            # If the document URL already has via.open_sidebar or
+            # via.request_config_from_frame query params it replaces them with
+            # its own values.
+            (
+                "http://example.com?thing=blah&via.open_sidebar=FOO&via.request_config_from_frame=BAR",
+                "http://TEST_VIA_SERVER.is/http://example.com"
+                "?thing=blah&via.open_sidebar=1"
+                "&via.request_config_from_frame=http%3A%2F%2Fexample.com",
+            ),
+        ],
+    )
+    def test_it_returns_the_url_with_query_params(
+        self, pyramid_request, document_url, expected_via_url
+    ):
+        # A valid oauth_consumer_key (matches one for which the provisioning
+        # features are enabled).
+        # fmt: off
+        pyramid_request.params["oauth_consumer_key"] = "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
+        # fmt: on
+        assert via_url(pyramid_request, document_url) == expected_via_url


### PR DESCRIPTION
Add two query params to the end of the Via URL used as the src of the Via iframe:

1. `via.open_sidebar=1`, tells Via to configure the client to automatically open its sidebar on launch.
2. `via.request_config_from_frame=<LMS_APP'S_ORIGIN>`, tells Via to configure the client to request a config object from the LMS app's origin over postMessage on launch.

These two query params are appended to the Via URL while maintaining any existing query params in the URL-of-the-document-to-be-annotated part of the Via URL, and their order.

This depends on <https://github.com/hypothesis/lms/pull/275/> and <https://github.com/hypothesis/lms/pull/278>. Without those the client will crash because it'll send a JSON-RPC request and get no response.