### PR TITLE
Login integration 2/n: Add JSON-RPC server

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,16 +64,24 @@ var bundleBaseConfig = {
   noParse: vendorNoParseModules,
 };
 
-var bundles = [{
-  name: 'file_picker',
-  entry: './lms/static/scripts/file_picker/_file_picker',
-},{
-  name: 'content_item_selection',
-  entry: './lms/static/scripts/content-item-selection.js',
-},{
-  name: 'new_application_instance',
-  entry: './lms/static/scripts/new-application-instance.js',
-}];
+var bundles = [
+  {
+    name: 'file_picker',
+    entry: './lms/static/scripts/file_picker/_file_picker',
+  },
+  {
+    name: 'content_item_selection',
+    entry: './lms/static/scripts/content-item-selection.js',
+  },
+  {
+    name: 'new_application_instance',
+    entry: './lms/static/scripts/new-application-instance.js',
+  },
+  {
+    name: 'postmessage_json_rpc_server',
+    entry: './lms/static/scripts/postmessage_json_rpc/server/index',
+  },
+];
 
 var bundleConfigs = bundles.map(function (config) {
   return Object.assign({}, bundleBaseConfig, config);

--- a/lms/assets.ini
+++ b/lms/assets.ini
@@ -8,3 +8,6 @@ content_item_selection_js =
 
 new_application_instance_js =
   scripts/new_application_instance.bundle.js
+
+postmessage_json_rpc_server_js =
+  scripts/postmessage_json_rpc_server.bundle.js

--- a/lms/static/scripts/polyfills.js
+++ b/lms/static/scripts/polyfills.js
@@ -1,0 +1,2 @@
+require('core-js/es6/promise');
+require('core-js/fn/array/includes');

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,0 +1,6 @@
+/** The entry point for the postmessage_json_rpc_server bundle. */
+import Server from './server';
+import { requestConfig } from './methods';
+
+const server = new Server();
+server.register('requestConfig', requestConfig);

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -1,0 +1,21 @@
+import { requestConfig } from './methods';
+
+describe('postmessage_json_rpc/methods#requestConfig', () => {
+  let configEl;
+
+  beforeEach('inject the client config into the document', () => {
+    configEl = document.createElement('script');
+    configEl.setAttribute('type', 'application/json');
+    configEl.classList.add('js-hypothesis-config');
+    configEl.textContent = JSON.stringify({foo: 'bar'});
+    document.body.appendChild(configEl);
+  });
+
+  afterEach('remove the client config from the document', () => {
+    configEl.parentNode.removeChild(configEl);
+  });
+
+  it('returns the config object', () => {
+    assert.deepEqual(requestConfig(), {foo: 'bar'});
+  });
+});

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -10,6 +10,6 @@
  * Return a Hypothesis client config object for the current LTI request.
  */
 export function requestConfig() {
-  const configEl = document.getElementsByClassName('js-hypothesis-config')[0];
+  const configEl = document.querySelector('.js-hypothesis-config');
   return JSON.parse(configEl.textContent);
 }

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -1,0 +1,15 @@
+/**
+ * Methods that're remotely callable by JSON-RPC over postMessage.
+ *
+ * Methods that can be remotely called by clients using our
+ * JSON-RPC-over-postMessage server (postmessage_json_rpc/server/server.js) are
+ * defined in one place in this module.
+  */
+
+/**
+ * Return a Hypothesis client config object for the current LTI request.
+ */
+export function requestConfig() {
+  const configEl = document.getElementsByClassName('js-hypothesis-config')[0];
+  return JSON.parse(configEl.textContent);
+}

--- a/lms/static/scripts/postmessage_json_rpc/server/server-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server-test.js
@@ -1,0 +1,243 @@
+import Server from './server';
+
+describe('postmessage_json_rpc/server#Server', () => {
+  // The window origin of the server.
+  // postMessage messages must be sent to this origin in order for the server
+  // to receive them.
+  const serversOrigin = 'http://localhost:9876';
+
+  let configEl;
+  let server;
+  let registeredMethod;
+  let listener;
+  let receiveMessage;
+
+  beforeEach('inject the server config into the document', () => {
+    configEl = document.createElement('script');
+    configEl.setAttribute('type', 'application/json');
+    configEl.classList.add('js-rpc-server-config');
+    configEl.textContent = JSON.stringify({
+      allowedOrigins: ['http://localhost:9876'],
+    });
+    document.body.appendChild(configEl);
+  });
+
+  afterEach('remove the server config from the document', () => {
+    configEl.parentNode.removeChild(configEl);
+  });
+
+  beforeEach('set up the test server', () => {
+    server = new Server();
+    registeredMethod = sinon.stub().returns('test_result');
+    server.register('registeredMethodName', registeredMethod);
+  });
+
+  afterEach('tear down the test server', () => {
+    server.off();
+  });
+
+  beforeEach('listen for JSON-RPC responses', () => {
+    receiveMessage = sinon.stub();
+
+    listener = (event) => {
+      // Only call `receiveMessage` if the event is a JSON-RPC response.
+      // This is to avoid calling receiveMessage with postMessage requests sent
+      // by the tests (intended for the server).
+      if (event.data.jsonrpc === '2.0' && (event.data.result || event.data.error)) {
+        receiveMessage(event);
+      }
+    };
+
+    window.addEventListener('message', listener);
+  });
+
+  afterEach('tear down the JSON-RPC response listener', () => {
+    window.removeEventListener('message', listener);
+  });
+
+  describe('when a valid request is sent', () => {
+    it('calls the registered method', () => {
+      window.postMessage(validRequest(), serversOrigin);
+
+      return Promise.race([
+        new Promise((resolve) => {
+          receiveMessage.callsFake(() => {
+            assert.isTrue(registeredMethod.calledOnce);
+            assert.isTrue(registeredMethod.calledWithExactly());
+            resolve();
+          });
+        }),
+        rejectAfterDelay("Server's response wasn't received"),
+      ]);
+    });
+
+    [null, 'test_id'].forEach((id) => {
+      it('sends a response message', () => {
+        const request = validRequest();
+        request.id = id;
+
+        window.postMessage(request, serversOrigin);
+
+        return Promise.race([
+          new Promise((resolve) => {
+            receiveMessage.callsFake((event) => {
+              assert.equal(event.data.jsonrpc, '2.0');
+              assert.equal(event.data.result, 'test_result');
+              assert.equal(event.data.id, id);
+              resolve();
+            });
+          }),
+          rejectAfterDelay("Server's response wasn't received"),
+        ]);
+      });
+    });
+  });
+
+  describe('when an invalid request is sent', () => {
+    it("doesn't respond to requests from origins that aren't allowed", () => {
+      server._allowedOrigins = ['https://example.com'];
+      window.postMessage(validRequest(), serversOrigin);
+
+      return assertThatTheServerDidntRespond();
+    });
+
+    it("doesn't respond if request data isn't an object", () => {
+      window.postMessage('not_an_object', serversOrigin);
+
+      return assertThatTheServerDidntRespond();
+    });
+
+    it("doesn't respond if the protocol spec is missing", () => {
+      const request = validRequest();
+      delete request.jsonrpc;
+
+      window.postMessage(request, serversOrigin);
+
+      return assertThatTheServerDidntRespond();
+    });
+
+    it("doesn't respond if the protocol spec is wrong", () => {
+      const request = validRequest();
+      request.jsonrpc = '1.0';
+
+      window.postMessage(request, serversOrigin);
+
+      return assertThatTheServerDidntRespond();
+    });
+
+    it("responds with an error if there's no request identifier", () => {
+      const request = validRequest();
+      delete request.id;
+
+      window.postMessage(request, serversOrigin);
+
+      return assertThatServerRespondedWithError('request id invalid', null);
+    });
+
+    // The JSON-RPC spec says that `id` must be a number, string, or null.
+    // If some other type of value is used the server should ignore the request.
+    [{}, true, undefined].forEach((value) => {
+      it('responds with an error if the request identifier is invalid', () => {
+        const request = validRequest();
+        request.id = value;
+
+        window.postMessage(request, serversOrigin);
+
+        return assertThatServerRespondedWithError('request id invalid', null);
+      });
+    });
+
+    it('responds with an error if the method name is missing', () => {
+      const request = validRequest();
+      delete request.method;
+
+      window.postMessage(request, serversOrigin);
+
+      return assertThatServerRespondedWithError('method name not recognized');
+    });
+
+    [{}, true, 2.0, null].forEach((method_name) => {
+      it("responds with an error if the method name isn't a string", () => {
+        const request = validRequest();
+        request.method = method_name;
+
+        window.postMessage(request, serversOrigin);
+
+        return assertThatServerRespondedWithError('method name not recognized');
+      });
+    });
+  });
+
+  /**
+   * Return a Promise that rejects if a response from the server is received.
+   * Resolves otherwise.
+   */
+  function assertThatTheServerDidntRespond() {
+    return Promise.race([
+      new Promise((resolve, reject) => {
+        receiveMessage.callsFake(() => {
+          reject(new Error('No response message should be sent'));
+        });
+      }),
+      resolveAfterDelay(),
+    ]);
+  }
+
+  /**
+   * Return a Promise that resolves if the server responds with a given error.
+   * Rejects otherwise.
+   */
+  function assertThatServerRespondedWithError(message, id='test_id') {
+    return Promise.race([
+      new Promise((resolve) => {
+        receiveMessage.callsFake((event) => {
+          assert.equal(event.data.jsonrpc, '2.0');
+          assert.equal(event.data.id, id);
+          assert.equal(event.data.result, undefined);
+          assert.deepEqual(
+            event.data.error,
+            {
+              code: -32600,
+              message: message,
+            },
+          );
+          resolve();
+        });
+      }),
+      rejectAfterDelay("Server's response wasn't received"),
+    ]);
+  }
+
+  /**
+  * Return a Promise that simply resolves itself after a given delay.
+  */
+  function resolveAfterDelay() {
+    return new Promise((resolve) => {
+      window.setTimeout(resolve, 1);
+    });
+  }
+
+  /**
+  * Return a Promise that simply rejects after a given delay.
+  */
+  function rejectAfterDelay(message) {
+    return new Promise((resolve, reject) => {
+      window.setTimeout(reject, 1500, new Error(message));
+    });
+  }
+
+  /**
+   * Return a valid JSON-RPC-over-postMessage request.
+   *
+   * Suitable for passing as the `message` argument to
+   * window.postMessage(message, serversOrigin) in order to make an RPC request
+   * to the server.
+   */
+  function validRequest() {
+    return {
+      jsonrpc: '2.0',
+      id: 'test_id',
+      method: 'registeredMethodName',
+    };
+  }
+});

--- a/lms/static/scripts/postmessage_json_rpc/server/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server.js
@@ -1,0 +1,117 @@
+/**
+ * A JSON-RPC-over-postMessage server.
+ *
+ * On creation the server automatically finds and reads its config settings
+ * from a JSON config object in the document. For example:
+ *
+ *     <script type="application/json" class="js-rpc-server-config">
+ *       { allowedOrigins: ["https://hypothes.is"] }
+ *     </script>
+ *
+ * After constructing a server you have to call its register() method to
+ * register remotely callable methods. After a method has been registered the
+ * server will respond to remote requests for that method by caling the method
+ * and sending the method's return value, serialized to a JSON string, back to
+ * the caller over postMessage. For example:
+ *
+ *     const server = new Server();
+ *     server.register('requestConfig', requestConfig);
+ *
+ */
+export default class Server {
+
+  constructor() {
+    const configEl = document.getElementsByClassName('js-rpc-server-config')[0];
+    const configObj = JSON.parse(configEl.textContent);
+
+    // JSON-RPC messages that don't come from one of these allowed window
+    // origins will be ignored.
+    this._allowedOrigins = configObj.allowedOrigins;
+
+    // Add a postMessage event listener so we can recieve JSON-RPC requests.
+    this._boundReceiveMessage = this._receiveMessage.bind(this);
+    window.addEventListener('message', this._boundReceiveMessage);
+
+    // The methods that can be called remotely via this server.
+    this._registeredMethods = {};
+  }
+
+  /**
+   * Register a remotely callable method with this server.
+   */
+  register(name, method) {
+    this._registeredMethods[name] = method;
+  }
+
+  /**
+   * Turn off this Server instance, it will no longer respond to messages.
+   */
+  off() {
+    window.removeEventListener('message', this._boundReceiveMessage);
+  }
+
+  /**
+   * Receive a JSON-RPC-postMessage request and respond to it.
+   *
+   * Receive a postMessage event and, if it's a JSON-RPC request from an
+   * allowed origin, post back either a result or an error response.
+   */
+  _receiveMessage(event) {
+    if (!this._allowedOrigins.includes(event.origin)) {
+      return;
+    }
+
+    if (!this._isJSONRPCRequest(event)) {
+      return;
+    }
+
+    event.source.postMessage(this._jsonRPCResponse(event.data), event.origin);
+  }
+
+  /**
+   * Return true if the given postMessage event is a JSON-RPC request.
+   */
+  _isJSONRPCRequest(event) {
+    if (!(event.data instanceof Object) || event.data.jsonrpc !== '2.0') {
+      // Event is neither a JSON-RPC request or response.
+      return false;
+    }
+
+    if (event.data.result || event.data.error) {
+      // Event is a JSON-RPC _response_, rather than a request.
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Return a JSON-RPC response object for the given JSON-RPC request object.
+   */
+  _jsonRPCResponse(request) {
+    // Return an error response if the request id is invalid.
+    // id must be a string, number or null.
+    const id = event.data.id;
+    if (!(['string', 'number'].includes(typeof id) || id === null)) {
+      return {
+        jsonrpc: '2.0',
+        id: null,
+        error: {code: -32600, message: 'request id invalid'},
+      };
+    }
+
+    const method = this._registeredMethods[request.method];
+
+    // Return an error response if the method name is invalid.
+    if (method === undefined) {
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        error: {code: -32600, message: 'method name not recognized'},
+      };
+    }
+
+    // Call the method and return the result response.
+    return {jsonrpc: '2.0', result: method(), id: request.id};
+  }
+}

--- a/lms/templates/lti_launches/new_lti_launch.html.jinja2
+++ b/lms/templates/lti_launches/new_lti_launch.html.jinja2
@@ -1,3 +1,8 @@
 <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson}}</script>
 <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson}}</script>
+
+{% for url in asset_urls("postmessage_json_rpc_server_js") %}
+  <script src="{{ url }}"></script>
+{% endfor %}
+
 <iframe width="100%" height="100%" src="{{hypothesis_url}}" />


### PR DESCRIPTION
Add a JSON-RPC server that responds to JSON messages sent over postMessage.

Currently the only request that is supported is "requestConfig" which returns a client config object for the current LTI launch request. This client config object was already rendered into the HTML document by a previous commit, and the JSON-RPC server reads it from there.

The JSON-RPC server's own config object, including the list of postMessage origins from which RPC requests will be accepted, was also rendered into the document by a previous commit and is now read by the JSON-RPC server.

This depends on <https://github.com/hypothesis/lms/pull/275/>, which adds the client and server config objects into the page. The server will crash without them.

It should be safe to merge this once <https://github.com/hypothesis/lms/pull/275/> is merged. The server will then be running and waiting for requests, but the client will not actually send any requests to the server yet, until <https://github.com/hypothesis/lms/pull/276> is merged.