### PR TITLE
Login integration 0/n: Deduplicate LTI param retrieval

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -3,7 +3,7 @@
 from lms.models.application_instance import ApplicationInstance, build_from_lms_url
 from lms.models.lti_launches import LtiLaunches
 from lms.models.module_item_configuration import ModuleItemConfiguration
-from lms.models.oauth_state import OauthState, find_by_state, find_or_create_from_user
+from lms.models.oauth_state import OauthState, find_lti_params, find_or_create_from_user, find_user_from_state
 from lms.models.tokens import Token, update_user_token
 from lms.models.users import User, build_from_lti_params
 from lms.models.course_groups import CourseGroup
@@ -14,8 +14,9 @@ __all__ = (
     'LtiLaunches',
     'build_from_lms_url',
     'build_from_lti_params',
-    'find_by_state',
+    'find_lti_params',
     'find_or_create_from_user',
+    'find_user_from_state',
     'ModuleItemConfiguration',
     'OauthState',
     'Token',

--- a/lms/models/oauth_state.py
+++ b/lms/models/oauth_state.py
@@ -1,4 +1,7 @@
+import json
+
 import sqlalchemy as sa
+
 from lms.db import BASE
 from lms.models.users import User
 
@@ -13,13 +16,10 @@ class OauthState(BASE):
     lti_params = sa.Column(sa.String)
 
 
-def find_by_state(session, state):
-    return session.query(OauthState).filter(
-        OauthState.guid == state).one_or_none()
 
 
 def find_or_create_from_user(session, state, user, lti_params):
-    existing_state = find_by_state(session, state)
+    existing_state = _find_by_state(session, state)
     if existing_state is None:
         oauth_state = OauthState(user_id=user.id, guid=state, lti_params=lti_params)
         session.add(oauth_state)
@@ -28,7 +28,19 @@ def find_or_create_from_user(session, state, user, lti_params):
 
 
 def find_user_from_state(session, state):
-    state = find_by_state(session, state)
+    state = _find_by_state(session, state)
     if state is None:
         return None
     return session.query(User).filter(User.id == state.user_id).one_or_none()
+
+
+def find_lti_params(session, state):
+    oauth_state = _find_by_state(session, state)
+    if oauth_state is None:
+        return None
+    return json.loads(oauth_state.lti_params)
+
+
+def _find_by_state(session, state):
+    return session.query(OauthState).filter(
+        OauthState.guid == state).one_or_none()

--- a/lms/models/oauth_state.py
+++ b/lms/models/oauth_state.py
@@ -21,6 +21,7 @@ class OauthState(BASE):
 def find_or_create_from_user(session, state, user, lti_params):
     existing_state = _find_by_state(session, state)
     if existing_state is None:
+        lti_params = json.dumps(dict(lti_params))
         oauth_state = OauthState(user_id=user.id, guid=state, lti_params=lti_params)
         session.add(oauth_state)
         return oauth_state

--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -14,6 +14,7 @@ from lms.util.h_api import generate_username
 from lms.util.h_api import generate_group_name
 from lms.util.jwt import jwt
 from lms.util.lti_launch import lti_launch
+from lms.util.lti import lti_params_for
 from lms.util.view_renderer import view_renderer
 
 __all__ = (
@@ -28,6 +29,7 @@ __all__ = (
     'generate_group_name',
     'jwt',
     'lti_launch',
+    'lti_params_for',
     'save_token',
     'view_renderer',
     'GET',

--- a/lms/util/authorize_lms.py
+++ b/lms/util/authorize_lms.py
@@ -1,5 +1,4 @@
 import urllib
-import json
 import requests_oauthlib
 import pyramid.httpexceptions as exc
 from lms.models import find_or_create_from_user, find_user_from_state
@@ -76,8 +75,7 @@ def authorize_lms(*, authorization_base_endpoint, redirect_endpoint,
             oauth_session = requests_oauthlib.OAuth2Session(client_id, redirect_uri=redirect_uri)
             authorization_url, state_guid = oauth_session.authorization_url(authorization_base_url)
 
-            lti_params = json.dumps(dict(request.params))
-            oauth_state = find_or_create_from_user(request.db, state_guid, user, lti_params)
+            oauth_state = find_or_create_from_user(request.db, state_guid, user, request.params)
             if oauth_state is None:
                 raise exc.HTTPInternalServerError()
             return exc.HTTPFound(location=authorization_url)

--- a/lms/util/authorize_lms.py
+++ b/lms/util/authorize_lms.py
@@ -2,10 +2,11 @@ import urllib
 import json
 import requests_oauthlib
 import pyramid.httpexceptions as exc
-from lms.models.oauth_state import find_or_create_from_user, find_by_state, find_user_from_state
+from lms.models import find_or_create_from_user, find_user_from_state
 from lms.models.application_instance import find_by_oauth_consumer_key
 from lms.models.tokens import build_token_from_oauth_response, update_user_token
 from lms.util.jwt import build_jwt_from_lti_launch
+from lms.util.lti import lti_params_for
 
 
 def build_canvas_token_url(lms_url):
@@ -92,13 +93,7 @@ def save_token(view_function):
         if 'state' not in request.params or 'code' not in request.params:
             raise exc.HTTPInternalServerError('Invalid Oauth Response')
 
-        state = request.params['state']
-        oauth_state = find_by_state(request.db, state)
-
-        if oauth_state is None:
-            raise exc.HTTPInternalServerError('Oauth state was not found')
-
-        lti_params = json.loads(oauth_state.lti_params)
+        lti_params = lti_params_for(request)
 
         application_instance = find_by_oauth_consumer_key(
             request.db,
@@ -114,6 +109,7 @@ def save_token(view_function):
 
         token_url = build_canvas_token_url(application_instance.lms_url)
 
+        state = request.params["state"]
         session = requests_oauthlib.OAuth2Session(client_id, state=state)
         oauth_resp = session.fetch_token(token_url, client_secret=client_secret,
                                          authorization_response=request.url,

--- a/lms/util/lti.py
+++ b/lms/util/lti.py
@@ -1,0 +1,30 @@
+from pyramid.httpexceptions import HTTPBadRequest
+
+from lms import models
+
+
+def lti_params_for(request):
+    """
+    Return the LTI params for the given request.
+
+    If the request is an LTI launch request then just return request.params.
+
+    If the request is an OAuth 2.0 redirect request then use the request's
+    `state` param to retrieve the launch params that were previously stashed in
+    the DB and return them.
+
+    :raise HTTPBadRequest: if the request is an OAuth redirect but no
+      associated launch params can be found in the DB
+
+    """
+    if "state" in request.params:
+        # This is an OAuth redirect request, not an LTI launch request.
+        # Retrieve the LTI launch params from the database instead of using
+        # request.params directly.
+        lti_params = models.find_lti_params(request.db, request.params["state"])
+        if lti_params is None:
+            raise HTTPBadRequest("OAuth state was not found")
+        return lti_params
+    else:
+        # This is an LTI launch request.
+        return request.params

--- a/lms/views/oauth.py
+++ b/lms/views/oauth.py
@@ -1,10 +1,10 @@
 """Oauth endpoint views."""
-import json
 import jwt
 from pyramid.view import view_config
 from requests_oauthlib import OAuth2Session
 from lms.models.tokens import update_user_token, build_token_from_oauth_response
-from lms.models.oauth_state import find_user_from_state, find_by_state
+from lms.models import find_user_from_state
+from lms.util import lti_params_for
 from lms.util.lti_launch import get_application_instance
 from lms.views.content_item_selection import content_item_form
 
@@ -19,8 +19,8 @@ def build_canvas_token_url(lms_url):
 def canvas_oauth_callback(request):
     """Route to handle content item selection oauth response."""
     state = request.params['state']
-    oauth_state = find_by_state(request.db, state)
-    lti_params = json.loads(oauth_state.lti_params)
+
+    lti_params = lti_params_for(request)
     consumer_key = lti_params['oauth_consumer_key']
     application_instance = get_application_instance(request.db, consumer_key)
     client_id = application_instance.developer_key

--- a/tests/lms/models/test_oauth_state.py
+++ b/tests/lms/models/test_oauth_state.py
@@ -1,6 +1,7 @@
 import json
+
 from lms.models import build_from_lti_params
-from lms.models import OauthState, find_or_create_from_user
+from lms.models import OauthState, find_or_create_from_user, find_lti_params
 
 
 class TestOAuthState:
@@ -33,3 +34,14 @@ class TestOAuthState:
         result = find_or_create_from_user(db_session, state_guid, user, lti_params)
 
         assert result.id == existing_state.id
+
+
+class TestFindLTIParams:
+    def test_if_theres_no_record_in_the_db_it_returns_None(self, db_session):
+        assert find_lti_params(db_session, "foo") is None
+
+    def test_if_theres_a_record_in_the_db_it_returns_the_lti_params(self, db_session):
+        lti_params = {"foo": "bar"}
+        db_session.add(OauthState(user_id=1, guid="test_guid", lti_params=json.dumps(lti_params)))
+
+        assert find_lti_params(db_session, "test_guid") == lti_params

--- a/tests/lms/models/test_oauth_state.py
+++ b/tests/lms/models/test_oauth_state.py
@@ -11,7 +11,7 @@ class TestOAuthState:
         user = build_from_lti_params(lti_launch_request.params)
         session.add(user)
         session.flush()
-        lti_params = json.dumps(dict(lti_launch_request.params))
+        lti_params = lti_launch_request.params
 
         result = find_or_create_from_user(db_session, state_guid, user, lti_params)
 

--- a/tests/lms/util/lti_test.py
+++ b/tests/lms/util/lti_test.py
@@ -1,0 +1,33 @@
+import pytest
+from pyramid.httpexceptions import HTTPBadRequest
+
+from lms.util import lti_params_for
+
+
+class TestLTIParamsFor:
+    def test_with_lti_launch_request(self, pyramid_request):
+        # If the request is an LTI launch request then it just returns
+        # request.params.
+        assert lti_params_for(pyramid_request) == pyramid_request.params
+
+    def test_with_oauth_redirect_request(self, models, pyramid_request):
+        # If the request is an OAuth 2.0 redirect URL request then it retrieves
+        # the LTI launch params that were previously stashed in the database
+        # and returns those instead of request.params.
+        pyramid_request.params = {"state": "foo"}
+
+        assert lti_params_for(pyramid_request) == models.find_lti_params.return_value
+        models.find_lti_params.assert_called_once_with(pyramid_request.db, "foo")
+
+    def test_with_invalid_oauth_redirect_request(self, models, pyramid_request):
+        # If the request is an OAuth 2.0 redirect URL request but somehow we
+        # haven't stashed any LTI params in the DB that match this request's
+        pyramid_request.params = {"state": "foo"}
+        models.find_lti_params.return_value = None
+
+        with pytest.raises(HTTPBadRequest):
+            lti_params_for(pyramid_request)
+
+    @pytest.fixture(autouse=True)
+    def models(self, patch):
+        return patch("lms.util.lti.models")


### PR DESCRIPTION
Deduplicate some code for retrieving stashed LTI launch parameters from the database that was duplicated in a couple of places.

This code is going to be needed in a third place too, in an upcoming commit.

The `find_by_state()` function is no longer used outside of the oauth_state.py file itself, so make it a private function.