### PR TITLE
Fix exception handling using pyramid_exclogger

### DIFF
--- a/.prospector.base.yaml
+++ b/.prospector.base.yaml
@@ -16,6 +16,7 @@ pep257:
     - D102  # Missing docstring in public method
     - D103  # Missing docstring in public function
     - D104  # Missing docstring in public package
+    - D107  # Missing docstring in __init__
     - D203  # "1 blank line required before class docstring" conflicts with
             #  another pep257 rule D211 "No blank lines allowed before class
             # docstring".

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -10,6 +10,8 @@ pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_debugtoolbar
 
+exclog.extra_info = true
+
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
@@ -29,13 +31,13 @@ timeout: 0
 ###
 
 [loggers]
-keys = root, lms
+keys = root, lms, exc_logger
 
 [handlers]
-keys = console
+keys = console, exc_handler
 
 [formatters]
-keys = generic
+keys = generic, exc_formatter
 
 [logger_root]
 level = INFO
@@ -46,11 +48,26 @@ level = DEBUG
 handlers =
 qualname = lms
 
+[logger_exc_logger]
+level = ERROR
+handlers = exc_handler
+qualname = exc_logger
+propagate = 0
+
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
 formatter = generic
 
+[handler_exc_handler]
+class = StreamHandler
+args = (sys.stderr,)
+level = ERROR
+formatter = exc_formatter
+
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
+
+[formatter_exc_formatter]
+format = %(asctime)s %(message)s

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -24,13 +24,13 @@ use: egg:raven#raven
 ###
 
 [loggers]
-keys = root, lms, alembic, sentry
+keys = root, lms, alembic, sentry, exc_logger
 
 [handlers]
-keys = console, sentry
+keys = console, sentry, exc_handler
 
 [formatters]
-keys = generic
+keys = generic, exc_formatter
 
 [logger_root]
 level = INFO
@@ -40,6 +40,12 @@ handlers = console, sentry
 level = DEBUG
 handlers =
 qualname = lms
+
+[logger_exc_logger]
+level = ERROR
+handlers = exc_handler
+qualname = exc_logger
+propagate = 0
 
 [logger_alembic]
 level = INFO
@@ -58,6 +64,12 @@ args = (sys.stderr,)
 level = NOTSET
 formatter = generic
 
+[handler_exc_handler]
+class = StreamHandler
+args = (sys.stderr,)
+level = ERROR
+formatter = exc_formatter
+
 [handler_sentry]
 level = WARNING
 class = raven.handlers.logging.SentryHandler
@@ -66,3 +78,6 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
+
+[formatter_exc_formatter]
+format = %(asctime)s %(message)s

--- a/lms/app.py
+++ b/lms/app.py
@@ -15,6 +15,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
 
     config.include('pyramid_jinja2')
     config.include('pyramid_tm')
+    config.include('pyramid_exclog')
 
     config.include('lms.sentry')
     config.include('lms.models')

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 alembic
 newrelic
 pyramid
+pyramid_exclog
 pyramid_tm
 pyramid_jinja2
 pyramid_services

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ psycopg2==2.7.5
 pycrypto==2.6.1
 pyjwt==1.6.4
 pylti==0.7.0
+pyramid-exclog==1.0
 pyramid-jinja2==2.7
 pyramid-services==2.1
 pyramid-tm==2.2

--- a/tests/lms/views/error_test.py
+++ b/tests/lms/views/error_test.py
@@ -64,15 +64,6 @@ class TestErrorViews:
 
         assert pyramid_request.raven.captureException.call_count == 1
 
-    def test_it_re_raises_exception_in_debug_mode(self, pyramid_request):
-        exc = Exception('test exception msg')
-        pyramid_request.registry.settings = {'debug': True}
-
-        error_views = error.ErrorViews(exc, pyramid_request)
-
-        with pytest.raises(Exception, match="test exception msg"):
-            error_views.error()
-
     def test_it_sets_correct_message_for_missing_lti_param_error_for_missing_lti_launch_params(self, pyramid_request):
         exc = MissingLTILaunchParamError('test')
 


### PR DESCRIPTION
Fix the in-browser exception views (error page) and printing of exceptions to the console in dev.

This was all just completely broken. Fix it by using `pyramid_exclog` to log exceptions to the console, and also fix up the exception views / error page to not crash, and tidy up the code and docstrings.

See:

* <https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html#logging-exceptions>
* <https://docs.pylonsproject.org/projects/pyramid_exclog/en/latest/>