### PR TITLE
Refactor tox.ini and Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 addons:
     postgresql: "9.4"
 before_script: createdb lms_test; npm install;
+install: pip install tox tox-pip-extensions
 jobs:
   include:
     - env: ACTION=test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,8 @@ node {
         try {
             testApp(image: img, runArgs: "-u root -e TEST_DATABASE_URL=${databaseUrl}") {
                 sh 'apk-install build-base postgresql-dev python3-dev'
-                sh 'pip3 install -q tox'
-                sh 'cd /var/lib/lms && tox'
+                sh 'pip3 install -q tox tox-pip-extensions'
+                sh 'cd /var/lib/lms && tox -e py36-tests'
             }
         } finally {
             postgres.stop()

--- a/Makefile
+++ b/Makefile
@@ -1,60 +1,81 @@
-DOCKER_TAG = dev
+.PHONY: default
+default: help
 
-.PHONY: clean
-clean:
-	find . -type f -name "*.py[co]" -delete
-	find . -type d -name "__pycache__" -delete
-	rm -f .pydeps
+.PHONY: help
+help:
+	@echo "make help              Show this help message"
+	@echo "make dev               Run the app in the development server"
+	@echo "make shell             Launch a Python shell in the dev environment"
+	@echo "make sql               Connect to the dev database with a psql shell"
+	@echo "make lint              Run the code linter(s) and print any warnings"
+	@echo "make test              Run the unit tests"
+	@echo "make coverage          Print the unit test coverage report"
+	@echo "make codecov           Upload the coverage report to codecov.io"
+	@echo "make docstrings        View all the docstrings locally as HTML"
+	@echo "make checkdocstrings   Crash if building the docstrings fails"
+	@echo "make docker            Make the app's Docker image"
+	@echo "make clean             Delete development artefacts (cached files, "
+	@echo "                       dependencies, etc)"
 
 .PHONY: dev
-dev: .pydeps
-	gunicorn --paste conf/development.ini
+dev: build/manifest.json
+	tox -e py36-dev
 
 .PHONY: shell
-shell: .pydeps
-	pshell conf/development.ini
+shell:
+	tox -e py36-dev -- pshell conf/development.ini
 
-.PHONY: test
-test:
-	$(GULP) test
-	@pip install -q tox
-	tox
-
-.PHONY: coverage
-coverage: .coverage
-	@pip install -q tox
-	tox -e coverage
-
-.PHONY: codecov
-codecov: .coverage
-	@pip install -q tox
-	tox -e codecov
+# FIXME: This requires psql to be installed locally.
+# It should use psql from docker / docker-compose.
+.PHONY: sql
+sql:
+	psql postgresql://postgres@localhost:5433/postgres
 
 .PHONY: lint
 lint:
-	@pip install -q tox
-	tox -e lint
+	tox -e py36-lint
 	$(GULP) lint
+
+.PHONY: test
+test: node_modules/.uptodate
+	tox -e py36-tests
+	$(GULP) test
+
+.PHONY: coverage
+coverage:
+	tox -e py36-coverage
+
+.PHONY: codecov
+codecov:
+	tox -e py36-codecov
+
+.PHONY: docstrings
+docstrings:
+	tox -e py36-docstrings
+
+.PHONY: checkdocstrings
+checkdocstrings:
+	tox -e py36-checkdocstrings
 
 .PHONY: docker
 docker:
 	git archive --format=tar.gz HEAD | docker build -t hypothesis/lms:$(DOCKER_TAG) -
 
-.pydeps: requirements.txt requirements-dev.in
-	@echo installing python dependencies
-	@pip install -r requirements-dev.in
-	@touch $@
+.PHONY: clean
+clean:
+	find . -type f -name "*.py[co]" -delete
+	find . -type d -name "__pycache__" -delete
+	rm -f node_modules/.uptodate
+	rm -rf build
 
+DOCKER_TAG = dev
 
 GULP := node_modules/.bin/gulp
 
-
-.PHONY: build
-build:
+build/manifest.json: node_modules/.uptodate
 	$(GULP) build
 
-watch:
-	$(GULP) watch
-
-client_test:
-	$(GULP) test
+node_modules/.uptodate: package.json
+	@echo installing javascript dependencies
+	@node_modules/.bin/check-dependencies 2>/dev/null || yarn install
+	@touch $@

--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,5 @@ build/manifest.json: node_modules/.uptodate
 
 node_modules/.uptodate: package.json
 	@echo installing javascript dependencies
-	@node_modules/.bin/check-dependencies 2>/dev/null || yarn install
+	@node_modules/.bin/check-dependencies 2>/dev/null || yarn --ignore-engines install
 	@touch $@

--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,8 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
 
 * git
 * python 3
-* virtualenv
+* [tox](https://tox.readthedocs.io/en/latest/) and [tox-pip-extensions](https://github.com/tox-dev/tox-pip-extensions)
+* [GNU Make](https://www.gnu.org/software/make/)
 * Docker
 * openssl
 * Node.js
@@ -37,15 +38,6 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
 1. **Clone this repository**
 
     The following steps assume that you are working within the `lms` project directory.
-
-1. **Create a Python virtual environment**
-
-    Using `virtualenv` or your preferred virtualenv-management utility, set up virtualenv. Note that this project requires Python 3. The following commands work on a Mac with `virtualenv` installed as of mid 2018:
-
-    ```bash
-    $ virtualenv -p python3 .
-    $ source bin/activate
-    ```
 
 1. Create a client_credentials auth client in h.
 
@@ -158,15 +150,6 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
     export AUTO_PROVISIONING="Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20"
     ```
 
-1. **Build the app's front-end asets**
-
-    Make sure you're in the `lms` project directory. Install Node.js dependencies and build the app's front-end assets:
-
-    ```bash
-    $ yarn install
-    $ make build
-    ```
-
 1. **Try out the postgres docker container**
 
     The app's postgres database runs within a docker container. To start the container:
@@ -184,25 +167,19 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
 <a id="run-webserver"></a>
 ### Running the app locally
 
-1. Make sure your `virtualenv` is activated. Use your preferred virtualenv management utility or:
-
-   ```bash
-   $ source bin/activate
-   ```
-
-2. Start the psql (database) container if it's not already running:
+1. Start the psql (database) container if it's not already running:
 
     ```bash
     $ docker run --rm -d -p 5433:5432 --name lms-postgres postgres
     ```
 
-3. Start the development web server and app:
+1. Start the development web server and app:
 
     ```bash
     $ make dev
     ```
 
-4. Visit [http://localhost:8001/welcome](http://localhost:8001/welcome) in a browser
+1. Visit [http://localhost:8001/welcome](http://localhost:8001/welcome) in a browser
 
 
 <a id="google-apis"></a>
@@ -361,15 +338,6 @@ Useful for debugging or trying things out in development:
 $ make shell
 ```
 
-**Tip**: If you install `pyramid_ipython` then `make shell` will give you an
-IPython shell instead of a plain Python one:
-
-```
-$ pip install pyramid_ipython
-```
-
-There are also `pyramid_` packages for `bpython`, `ptpython`, etc.
-
 #### Database
 
 **Tip**: You can connect to the app's database to inspect its contents by
@@ -377,7 +345,7 @@ installing [psql](https://www.postgresql.org/docs/current/static/app-psql.html)
 and then running:
 
 ```bash
-$ psql postgresql://postgres@localhost:5433/postgres
+$ make psql
 ```
 
 **Tip**: If you want to delete all your data and reset your dev database,

--- a/lms/util/lti.py
+++ b/lms/util/lti.py
@@ -25,6 +25,6 @@ def lti_params_for(request):
         if lti_params is None:
             raise HTTPBadRequest("OAuth state was not found")
         return lti_params
-    else:
-        # This is an LTI launch request.
-        return request.params
+
+    # This is an LTI launch request.
+    return request.params

--- a/lms/views/authentication.py
+++ b/lms/views/authentication.py
@@ -21,7 +21,7 @@ class AuthenticationViews:
         request = self.request
         login_url = request.route_url('login')
         referrer = request.url
-        if referrer == login_url or referrer == '/':
+        if referrer in (login_url, "/"):
             referrer = '/reports'  # never use login form itself as came_from
         came_from = request.params.get('came_from', referrer)
         message = ''

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -278,6 +278,6 @@ def _get_param(request, param_name):
 
 
 def _auto_provisioning_feature_enabled(request):
-    oauth_consumer_key = _get_param(request, "oauth_consumer_key")
+    oauth_consumer_key = _get_param(request, "oauth_consumer_key")  # pylint: disable=too-many-function-args
     enabled_consumer_keys = request.registry.settings["auto_provisioning"]
     return oauth_consumer_key in enabled_consumer_keys

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     {tests,lint,docstrings,checkdocstrings}: pytest
     {tests,lint,docstrings,checkdocstrings}: factory-boy
     codecov: codecov
-    lint: pylint==1.9.2
+    lint: pylint
     lint: prospector
     {docstrings,checkdocstrings}: sphinx
     docstrings: sphinx-autobuild

--- a/tox.ini
+++ b/tox.ini
@@ -1,52 +1,58 @@
 [tox]
-envlist = py36
+envlist = py36-tests
 skipsdist = true
-
-[pytest]
-testpaths = tests
+requires = tox-pip-extensions
+tox_pip_extensions_ext_venv_update = true
 
 [testenv]
-deps =
-    coverage
-    httpretty
-    pytest
-    factory-boy
-    -rrequirements.txt
+skip_install = true
 passenv =
-    TEST_DATABASE_URL
-    PYTEST_ADDOPTS
-setenv =
-  JWT_SECRET = test_secret
-  VIA_URL = https://example.com
-commands =
-    coverage run --source lms,tests/lms -m pytest -Werror {posargs:tests/lms/}
-
-[testenv:clean]
-deps = coverage
-commands = coverage erase
-
-# `tox -e coverage` prints out the coverage report to the terminal.
-# You have to run `tox` on its own (the default testenv above) to generate the
-# .coverage file first.
-[testenv:coverage]
-deps = coverage
-commands =
-    coverage report
-
-# `tox -e codecov` uploads the coverage report to Codecov.
-[testenv:codecov]
-deps = codecov
-passenv = CI TRAVIS*
-commands = codecov
-
-[testenv:lint]
+    tests: TEST_DATABASE_URL
+    tests: PYTEST_ADDOPTS
+    dev: AUTO_PROVISIONING
+    dev: DATABASE_URL
+    dev: GOOGLE_APP_ID
+    dev: GOOGLE_CLIENT_ID
+    dev: GOOGLE_DEVELOPER_KEY
+    dev: H_AUTHORITY
+    dev: H_API_URL
+    dev: H_CLIENT_ID
+    dev: H_CLIENT_SECRET
+    dev: H_JWT_CLIENT_ID
+    dev: H_JWT_CLIENT_SECRET
+    dev: HASHED_PW
+    dev: JWT_SECRET
+    dev: LMS_SECRET
+    dev: RPC_ALLOWED_ORIGINS
+    dev: SALT
+    dev: SENTRY_DSN
+    dev: USERNAME
+    dev: VIA_URL
+    codecov: CI TRAVIS*
 deps =
-    pylint==1.9.2
-    prospector
-    pytest
-    factory-boy
-    httpretty
-    -rrequirements.txt
+    {tests,clean,coverage}: coverage
+    {tests,lint}: httpretty
+    {tests,lint,docstrings,checkdocstrings}: pytest
+    {tests,lint,docstrings,checkdocstrings}: factory-boy
+    codecov: codecov
+    lint: pylint==1.9.2
+    lint: prospector
+    {docstrings,checkdocstrings}: sphinx
+    docstrings: sphinx-autobuild
+    {tests,lint,docstrings,checkdocstrings}: -r requirements.txt
+    dev: -r requirements-dev.in
+setenv =
+    tests: JWT_SECRET = test_secret
+    tests: VIA_URL = https://example.com
 commands =
-    prospector
-    prospector tests
+    tests: coverage run --source lms,tests/lms -m pytest -Werror {posargs:tests/lms/}
+    dev: {posargs:gunicorn --paste conf/development.ini}
+    lint: prospector
+    lint: prospector tests
+    coverage: -coverage combine
+    coverage: coverage report
+    codecov: codecov
+    {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envdir}/rst .
+    docstrings: sphinx-autobuild -BqT -z lms -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml
+    checkdocstrings: sphinx-build -qTn -b dirhtml {envdir}/rst {envdir}/dirhtml
+    clean: coverage erase


### PR DESCRIPTION
Re-do these to work the same as the h and bouncer ones do: run everything in tox-managed venvs, no need to create your own venvs.

This necessitated doing a pylint upgrade which triggered some new lint warnings that I fixed.