### PR TITLE
Fix Sentry error reporting

### DIFF
--- a/conf/production.ini
+++ b/conf/production.ini
@@ -1,7 +1,6 @@
 [pipeline:main]
 pipeline:
   proxy-prefix
-  raven
   lms
 
 [app:lms]
@@ -15,26 +14,23 @@ port: 8001
 [filter:proxy-prefix]
 use: egg:PasteDeploy#prefix
 
-[filter:raven]
-use: egg:raven#raven
-
 ###
 # logging configuration
 # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
 ###
 
 [loggers]
-keys = root, lms, alembic, sentry, exc_logger
+keys = root, lms, alembic, exc_logger
 
 [handlers]
-keys = console, sentry, exc_handler
+keys = console, exc_handler
 
 [formatters]
 keys = generic, exc_formatter
 
 [logger_root]
 level = INFO
-handlers = console, sentry
+handlers = console
 
 [logger_lms]
 level = DEBUG
@@ -52,12 +48,6 @@ level = INFO
 handlers =
 qualname = alembic
 
-[logger_sentry]
-level = WARNING
-handlers = console
-qualname = sentry.errors
-propagate = 0
-
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
@@ -69,12 +59,6 @@ class = StreamHandler
 args = (sys.stderr,)
 level = ERROR
 formatter = exc_formatter
-
-[handler_sentry]
-level = WARNING
-class = raven.handlers.logging.SentryHandler
-args = ()
-formatter = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s

--- a/lms/sentry.py
+++ b/lms/sentry.py
@@ -1,37 +1,8 @@
-"""Report exceptions to Sentry."""
+"""Set up reporting of exceptions to Sentry."""
 
-import os
-
-import raven
-from raven.utils.wsgi import get_environ
+import sentry_sdk
+from sentry_sdk.integrations.pyramid import PyramidIntegration
 
 
-def get_raven_client(request):
-    """Return the Raven client for reporting crashes to Sentry."""
-    client = request.registry["raven.client"]
-    client.http_context({
-        'url': request.url,
-        'method': request.method,
-        'data': request.body,
-        'query_string': request.query_string,
-        'cookies': dict(request.cookies),
-        'headers': dict(request.headers),
-        'env': dict(get_environ(request.environ)),
-    })
-    client.user_context({
-        'ip_address': request.client_addr,
-    })
-    request.add_finished_callback(lambda request: client.context.clear())
-    return client
-
-
-def includeme(config):
-    environment = os.environ.get('ENV', 'dev')
-    config.registry["raven.client"] = raven.Client(
-        environment=environment,
-        processors=[
-            'raven.processors.SanitizePasswordsProcessor',
-            'raven.processors.RemovePostDataProcessor',
-        ],
-    )
-    config.add_request_method(get_raven_client, name="raven", reify=True)
+def includeme(_config):
+    sentry_sdk.init(integrations=[PyramidIntegration()])

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -39,6 +39,7 @@ class ErrorViews:
         response, show the user an error page with the specific error message,
         and report the issue to Sentry.
         """
+        sentry_sdk.capture_exception(self.exc)
         self.request.response.status_int = 400
         return {"message": str(self.exc)}
 

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -16,7 +16,6 @@ class ErrorViews:
         self.request = request
 
     @exception_view_config(httpexceptions.HTTPError)
-    @exception_view_config(httpexceptions.HTTPServerError)
     def httperror(self):
         """
         Handle an HTTP 4xx or 5xx exception.

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -39,7 +39,6 @@ class ErrorViews:
         and report the issue to Sentry.
         """
         self.request.response.status_int = 400
-        self.request.raven.captureException()
         return {"message": str(self.exc)}
 
     @exception_view_config(Exception)
@@ -53,7 +52,6 @@ class ErrorViews:
         Sentry.
         """
         self.request.response.status_int = 500
-        self.request.raven.captureException()
         return {
             "message": _(
                 "Sorry, but something went wrong. "

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -2,6 +2,7 @@ from pyramid import httpexceptions
 from pyramid import i18n
 from pyramid.view import exception_view_config
 from pyramid.view import view_defaults
+import sentry_sdk
 
 from lms.exceptions import LTILaunchError
 
@@ -24,6 +25,7 @@ class ErrorViews:
         deliberately raised We show the user an error page including specific
         error message but _do not_ report the error to Sentry
         """
+        sentry_sdk.capture_exception(self.exc)
         self.request.response.status_int = self.exc.status_int
         return {"message": str(self.exc)}
 

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -16,7 +16,7 @@ class ErrorViews:
         self.request = request
 
     @exception_view_config(httpexceptions.HTTPError)
-    def httperror(self):
+    def http_error(self):
         """
         Handle an HTTP 4xx or 5xx exception.
 
@@ -25,21 +25,17 @@ class ErrorViews:
         of either, then we:
 
         1. Report the error to Sentry.
-           This has to be done manually, only 500s are reported to Sentry
-           automatically.
         2. Set the HTTP response status to the 4xx or 5xx status from the
            exception.
         3. Show the user an error page containing the specific error message
            from the exception.
-
-        (HTTPError is the base class for HTTPClientError and HTTPServerError).
         """
         sentry_sdk.capture_exception(self.exc)
         self.request.response.status_int = self.exc.status_int
         return {"message": str(self.exc)}
 
     @exception_view_config(LTILaunchError)
-    def missing_lti_param_error(self):
+    def lti_launch_error(self):
         """
         Handle an invalid LTI launch request.
 

--- a/requirements.in
+++ b/requirements.in
@@ -6,10 +6,10 @@ pyramid_tm
 pyramid_jinja2
 pyramid_services
 gunicorn
+sentry-sdk
 sqlalchemy
 psycopg2
 zope.sqlalchemy
-raven
 PyLTI
 PyJWT
 requests_oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 alembic==1.0.2
-certifi==2017.11.5        # via requests
+certifi==2017.11.5        # via requests, sentry-sdk
 chardet==3.0.4            # via requests
 gunicorn==19.9.0
 httplib2==0.10.3          # via oauth2, pylti
@@ -31,14 +31,14 @@ pyramid-tm==2.2.1
 pyramid==1.10.1
 python-dateutil==2.6.1    # via alembic
 python-editor==1.0.3      # via alembic
-raven==6.9.0
 requests-oauthlib==1.0.0
 requests==2.20.1
+sentry-sdk==0.5.4
 six==1.11.0               # via pylti, python-dateutil
 sqlalchemy==1.2.14
 transaction==2.1.2        # via pyramid-tm, zope.sqlalchemy
 translationstring==1.3    # via pyramid
-urllib3==1.22             # via requests
+urllib3==1.22             # via requests, sentry-sdk
 venusian==1.1.0           # via pyramid
 webob==1.8.3              # via pyramid
 wired==0.1.1              # via pyramid-services

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -107,8 +107,6 @@ def pyramid_request():
         'lti_version': 'TEST',
     })
 
-    pyramid_request.raven = mock.MagicMock(spec_set=['captureException'])
-
     return pyramid_request
 
 

--- a/tests/lms/views/error_test.py
+++ b/tests/lms/views/error_test.py
@@ -56,14 +56,6 @@ class TestErrorViews:
 
         assert pyramid_request.response.status_int == 500
 
-    def test_it_logs_non_http_error_in_sentry(self, pyramid_request):
-        exc = Exception()
-
-        error_views = error.ErrorViews(exc, pyramid_request)
-        error_views.error()
-
-        assert pyramid_request.raven.captureException.call_count == 1
-
     def test_it_sets_correct_message_for_missing_lti_param_error_for_missing_lti_launch_params(self, pyramid_request):
         exc = MissingLTILaunchParamError('test')
 
@@ -95,12 +87,3 @@ class TestErrorViews:
         resp = error_views.missing_lti_param_error()
 
         assert pyramid_request.response.status_int == 400
-
-    def test_it_logs_missing_lti_launch_param_error_in_sentry(self, pyramid_request):
-        exc = MissingLTILaunchParamError('test lti launch param error msg')
-
-        error_views = error.ErrorViews(exc, pyramid_request)
-        error_views.missing_lti_param_error()
-
-        assert pyramid_request.raven.captureException.call_count == 1
-        pyramid_request.raven.captureException.assert_called_once_with()


### PR DESCRIPTION
This gets the error reporting to Sentry basically working (but not using any advanced Sentry features yet):

1. The legacy Sentry client (`raven`) is replaced with `sentry-sdk`
2. We use `sentry-sdk`'s builtin Pyramid support, instead of a lot of custom code. This alone means that any 500 responses from our app are reported to Sentry correctly (e.g. with correct tracebacks and request details), without any support from our code. (Other 5xx and 4xx responses aren't reported automatically though.)
3. In `views/error.py` call `sentry_sdk.capture_exception()` to report non-500 5xx and 4xx responses from our app to Sentry.

   This means that when talking to the h API fails and our lms app raises something like `HTTPGatewayTimeout` in response, this will be reported to Sentry.

   This also means that when a bad LTI launch request (e.g. required parameter missing) is received and our app returns a 400 Bad Request, this will be reported to Sentry. Sentry may not be the ideal place for this sort of thing but I'd like to report these to Sentry for now so we at least have visibility, until we come up with a better place for these.

Three different types of errors are handled differently (see `views/error.py`):

1. When our app deliberately raises `HTTPError` (which is Pyramid's base class for 4xx and 5xx errors) we show the user the specific exception message, return the correct 4xx or 5xx status, and report it to Sentry.
2. When our app deliberately raises `LTILaunchError` we show the user the specific exception message, return 400 Bad Request, and report it to Sentry.
3. For any other kind of exception that is raised we show only a generic error message, return a 500, and report it to Sentry.