### PR TITLE
Improve error logging again

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -7,9 +7,7 @@ pyramid.debug_authorization = false
 pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
-pyramid.includes = pyramid_exclog
-
-exclog.extra_info = true
+pyramid.includes = pyramid_debugtoolbar
 
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -29,13 +29,13 @@ timeout: 0
 ###
 
 [loggers]
-keys = root, lms, exc_logger
+keys = root, lms
 
 [handlers]
-keys = console, exc_handler
+keys = console
 
 [formatters]
-keys = generic, exc_formatter
+keys = generic
 
 [logger_root]
 level = INFO
@@ -46,26 +46,11 @@ level = DEBUG
 handlers =
 qualname = lms
 
-[logger_exc_logger]
-level = ERROR
-handlers = exc_handler
-qualname = exc_logger
-propagate = 0
-
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
 formatter = generic
 
-[handler_exc_handler]
-class = StreamHandler
-args = (sys.stderr,)
-level = ERROR
-formatter = exc_formatter
-
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
-
-[formatter_exc_formatter]
-format = %(asctime)s %(message)s

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -7,6 +7,7 @@ pyramid.debug_authorization = false
 pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
+pyramid.includes = pyramid_exclog
 
 exclog.extra_info = true
 

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -5,6 +5,7 @@ pipeline:
 
 [app:lms]
 use = call:lms.app:create_app
+pyramid.includes = pyramid_exclog
 
 [server:main]
 use: egg:gunicorn

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -6,7 +6,7 @@ pipeline:
 [app:lms]
 use = call:lms.app:create_app
 pyramid.includes = pyramid_exclog
-# Do log HTTPErrors. pyramid_exclog ignores WSGIHTTPException and subclasses dy
+# Do log HTTPErrors. pyramid_exclog ignores WSGIHTTPException and subclasses by
 # default.
 exclog.ignore =
 

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -20,13 +20,13 @@ use: egg:PasteDeploy#prefix
 ###
 
 [loggers]
-keys = root, lms, alembic, exc_logger
+keys = root, lms, alembic
 
 [handlers]
-keys = console, exc_handler
+keys = console
 
 [formatters]
-keys = generic, exc_formatter
+keys = generic
 
 [logger_root]
 level = INFO
@@ -36,12 +36,6 @@ handlers = console
 level = DEBUG
 handlers =
 qualname = lms
-
-[logger_exc_logger]
-level = ERROR
-handlers = exc_handler
-qualname = exc_logger
-propagate = 0
 
 [logger_alembic]
 level = INFO
@@ -54,14 +48,5 @@ args = (sys.stderr,)
 level = NOTSET
 formatter = generic
 
-[handler_exc_handler]
-class = StreamHandler
-args = (sys.stderr,)
-level = ERROR
-formatter = exc_formatter
-
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
-
-[formatter_exc_formatter]
-format = %(asctime)s %(message)s

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -6,6 +6,9 @@ pipeline:
 [app:lms]
 use = call:lms.app:create_app
 pyramid.includes = pyramid_exclog
+# Do log HTTPErrors. pyramid_exclog ignores WSGIHTTPException and subclasses dy
+# default.
+exclog.ignore =
 
 [server:main]
 use: egg:gunicorn

--- a/lms/app.py
+++ b/lms/app.py
@@ -21,6 +21,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include('lms.db')
     config.include('lms.routes')
     config.include('lms.assets')
+    config.include('lms.views.error')
     config.add_static_view(name='export', path='lms:static/export')
     config.add_static_view(name='static', path='lms:static')
 

--- a/lms/app.py
+++ b/lms/app.py
@@ -15,7 +15,6 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
 
     config.include('pyramid_jinja2')
     config.include('pyramid_tm')
-    config.include('pyramid_exclog')
 
     config.include('lms.sentry')
     config.include('lms.models')

--- a/tests/lms/views/error_test.py
+++ b/tests/lms/views/error_test.py
@@ -3,63 +3,59 @@
 from pyramid.httpexceptions import HTTPNotImplemented
 import pytest
 
-from lms.views.error import ErrorViews
+from lms.views import error
 from lms.exceptions import LTILaunchError
 
 
-class TestErrorViews:
-    def test_http_error_reports_exception_to_sentry(self, pyramid_request, sentry_sdk):
+class TestHTTPError:
+    def test_it_reports_exception_to_sentry(self, pyramid_request, sentry_sdk):
         exc = HTTPNotImplemented()
 
-        ErrorViews(exc, pyramid_request).http_error()
+        error.http_error(exc, pyramid_request)
 
         sentry_sdk.capture_exception.assert_called_once_with(exc)
 
-    def test_http_error_sets_response_status(self, pyramid_request):
+    def test_it_sets_response_status(self, pyramid_request):
         exc = HTTPNotImplemented()
 
-        ErrorViews(exc, pyramid_request).http_error()
+        error.http_error(exc, pyramid_request)
 
         assert pyramid_request.response.status_int == 501
 
-    def test_http_error_shows_the_exception_message_to_the_user(self, pyramid_request):
+    def test_it_shows_the_exception_message_to_the_user(self, pyramid_request):
         exc = HTTPNotImplemented("This is the error message")
 
-        result = ErrorViews(exc, pyramid_request).http_error()
+        result = error.http_error(exc, pyramid_request)
 
         assert result["message"] == "This is the error message"
 
-    def test_lti_launch_error_reports_exception_to_sentry(
-        self, pyramid_request, sentry_sdk
-    ):
+
+class TestLTILaunchError:
+    def test_it_reports_exception_to_sentry(self, pyramid_request, sentry_sdk):
         exc = LTILaunchError("the_message")
 
-        ErrorViews(exc, pyramid_request).lti_launch_error()
+        error.lti_launch_error(exc, pyramid_request)
 
         sentry_sdk.capture_exception.assert_called_once_with(exc)
 
-    def test_lti_launch_error_sets_response_status(self, pyramid_request):
+    def test_it_sets_response_status(self, pyramid_request):
         exc = LTILaunchError("the_message")
 
-        ErrorViews(exc, pyramid_request).lti_launch_error()
+        error.lti_launch_error(exc, pyramid_request)
 
         assert pyramid_request.response.status_int == 400
 
-    def test_lti_launch_error_shows_the_exception_message_to_the_user(
-        self, pyramid_request
-    ):
+    def test_it_shows_the_exception_message_to_the_user(self, pyramid_request):
         exc = LTILaunchError("the_message")
 
-        result = ErrorViews(exc, pyramid_request).http_error()
+        result = error.lti_launch_error(exc, pyramid_request)
 
         assert result["message"] == "the_message"
 
-    def test_error_does_not_report_exception_to_sentry(
-        self, pyramid_request, sentry_sdk
-    ):
-        exc = RuntimeError()
 
-        ErrorViews(exc, pyramid_request).error()
+class TestError:
+    def test_it_does_not_report_exception_to_sentry(self, pyramid_request, sentry_sdk):
+        error.error(pyramid_request)
 
         # Although I don't think it would do any harm (sentry_sdk seems smart
         # enough to not double report the exception to Sentry) we don't need to
@@ -67,23 +63,20 @@ class TestErrorViews:
         # because Sentry's Pyramid integration does it for us automatically.
         sentry_sdk.capture_exception.assert_not_called()
 
-    def test_error_sets_response_status(self, pyramid_request):
-        exc = RuntimeError()
-
-        ErrorViews(exc, pyramid_request).error()
+    def test_it_sets_response_status(self, pyramid_request):
+        error.error(pyramid_request)
 
         assert pyramid_request.response.status_int == 500
 
-    def test_error_shows_a_generic_error_message_to_the_user(self, pyramid_request):
-        exc = RuntimeError("the_specific_error_message")
-
-        result = ErrorViews(exc, pyramid_request).error()
+    def test_it_shows_a_generic_error_message_to_the_user(self, pyramid_request):
+        result = error.error(pyramid_request)
 
         assert (
             result["message"]
             == "Sorry, but something went wrong. The issue has been reported and we'll try to fix it."
         )
 
-    @pytest.fixture(autouse=True)
-    def sentry_sdk(self, patch):
-        return patch("lms.views.error.sentry_sdk")
+
+@pytest.fixture(autouse=True)
+def sentry_sdk(patch):
+    return patch("lms.views.error.sentry_sdk")

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ passenv =
     tests: PYTEST_ADDOPTS
     dev: AUTO_PROVISIONING
     dev: DATABASE_URL
+    dev: DEBUG
     dev: GOOGLE_APP_ID
     dev: GOOGLE_CLIENT_ID
     dev: GOOGLE_DEVELOPER_KEY


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/327>.

This improves our logging of exceptions in both development and production. By logging I mean to CloudWatch Logs in production, and to the terminal and pyramid_debugtoolbar in dev. This PR does not affect crash reporting to Sentry.

What this PR does:

* Simplifies our ini files by removing a bunch of `exc_logger` stuff that we don't need in them

* Changes us to using `pyramid_debugtoolbar` only in dev and `pyramid_exclog` only in production

  Recently, `pyramid_exclog` was added to both dev and production and `pyramid_debugtoolbar` was removed from dev. This PR gets us to the point of using each extension for what it's meant for: `pyramid_debugtoolbar` for dev and `pyramid_exclog` for production.

* Disables our error views in dev so that `pyramid_debugtoolbar` will print exception tracebacks to the terminal and show them in the browser in dev.

  This was the problem that previously motivated adding `pyramid_exclog` and removing `pyramid_debugtoolbar` in dev. `pyramid_debugtoolbar` was not printing exceptions to the terminal in dev (it was still providing access to them via the `/_debug_toolbar` page in the browser, for people who prefer reading them that way. but was _not_ rendering the exceptions inline in the page that crashed in the browser). It was replaced with `pyramid_exclog` which _does_ print them to the terminal.

  It turns out the reason that `pyramid_debugtoolbar` wasn't printing exceptions was that it doesn't print "squashed" exceptions, which are exceptions that're caught by an exception view, and our app catches _all_ exceptions with an exception view.

  So disable the exception views in dev. When an exception happens in dev you now get the exception rendered inline in the browser, you get the `/_debug_toolbar/` page, and you get the exception printed to the terminal, all just the default behaviour of `pyramid_debugtoolbar` when exception views don't interfere with it.

* Adds a `DEBUG=false` envvar that you can set in dev if you want to enable the exception views to test them in dev.

* Finally, configures `pyramid_exclog` to log `HTTPError`s in production. By default it does not log these.

In the past we had tried to have clever exception views that would re-raise exceptions only in dev so that they would still be printed to the terminal, but this wasn't working (in some cases exceptions were not being printed, in other cases they were being printed multiple times over). The approach of simply not registering the exception views at all in dev is much nicer -- it keeps faulty attempts at "if in dev then re-raise" logic out of our exception views code, and it enables debugtoolbar to render the exception inline in the browser immediately, as well as printing it to the terminal.