### PR TITLE
Log more info when an exception happens in prod

### DIFF
--- a/conf/production.ini
+++ b/conf/production.ini
@@ -9,6 +9,7 @@ pyramid.includes = pyramid_exclog
 # Do log HTTPErrors. pyramid_exclog ignores WSGIHTTPException and subclasses by
 # default.
 exclog.ignore =
+exclog.extra_info = true
 
 [server:main]
 use: egg:gunicorn


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/327> and <https://github.com/hypothesis/lms/pull/328>.

Send a lot more information when an exception happens in production by enabling pyramid_exclog's `exclog.extra_info = true` setting. This adds:

* All envvars from the environment
* All params attributes of pyramid.request.Request
* The output from pyramid.security.unauthenticated_id()

See:

https://docs.pylonsproject.org/projects/pyramid_exclog/en/latest/#settings