### PR TITLE
Fix Sentry environment support

### DIFF
--- a/lms/sentry.py
+++ b/lms/sentry.py
@@ -1,8 +1,13 @@
 """Set up reporting of exceptions to Sentry."""
 
+import os
+
 import sentry_sdk
 from sentry_sdk.integrations.pyramid import PyramidIntegration
 
 
 def includeme(_config):
-    sentry_sdk.init(integrations=[PyramidIntegration()])
+    sentry_sdk.init(
+        integrations=[PyramidIntegration()],
+        environment=os.environ.get("SENTRY_ENVIRONMENT"),
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ passenv =
     dev: RPC_ALLOWED_ORIGINS
     dev: SALT
     dev: SENTRY_DSN
+    dev: SENTRY_ENVIRONMENT
     dev: USERNAME
     dev: VIA_URL
     codecov: CI TRAVIS*


### PR DESCRIPTION
Our Sentry setup for the LMS app has a single lms-backend project
containing two environments prod and qa, but the app wasn't sending the
environment string with the crash reports so all issues were just going
into the "all environments" screen. Fix it to use the SENTRY_ENVIRONMENT
envvar to set the environment string.

Some of the other Sentry SDK's (e.g. the Node one) have builtin support
for an envvar named SENTRY_ENVIRONMENT but their Python SDK doesn't, we
have to read it ourselves.