### PR TITLE
Patch requests not request.post

### DIFF
--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -5,6 +5,8 @@
 import functools
 import json
 import requests
+from requests import RequestException
+from requests import ReadTimeout
 
 from pyramid.httpexceptions import HTTPBadGateway
 from pyramid.httpexceptions import HTTPBadRequest
@@ -97,7 +99,7 @@ def create_h_user(wrapped):  # noqa: MC0001
                 data=json.dumps(user_data),
                 timeout=1,
             )
-        except requests.exceptions.ReadTimeout:
+        except ReadTimeout:
             raise HTTPGatewayTimeout(explanation="Connecting to Hypothesis failed")
 
         if response.status_code == 200:
@@ -202,7 +204,7 @@ def add_user_to_group(wrapped):
                 timeout=1,
             )
             response.raise_for_status()
-        except requests.RequestException:
+        except RequestException:
             raise HTTPGatewayTimeout(explanation="Connecting to Hypothesis failed")
 
         return wrapped(request, jwt)
@@ -270,7 +272,7 @@ def _maybe_create_group(request):
             timeout=1,
         )
         response.raise_for_status()
-    except requests.RequestException:
+    except RequestException:
         raise HTTPGatewayTimeout(explanation="Connecting to Hypothesis failed")
 
     # Save a record of the group's pubid in the DB so that we can find it

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -7,7 +7,11 @@ import pytest
 from pyramid.httpexceptions import HTTPBadGateway
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.httpexceptions import HTTPGatewayTimeout
-import requests.exceptions
+from requests import ConnectionError
+from requests import HTTPError
+from requests import ReadTimeout
+from requests import Response
+from requests import TooManyRedirects
 
 from lms.views.decorators.h_api import create_h_user
 from lms.views.decorators.h_api import create_course_group
@@ -37,13 +41,13 @@ class TestCreateHUser:
         assert returned == wrapped.return_value
 
     def test_it_doesnt_use_the_h_api_if_feature_not_enabled(
-        self, create_h_user, post, pyramid_request
+        self, create_h_user, requests, pyramid_request
     ):
         pyramid_request.params["oauth_consumer_key"] = "foo"
 
         create_h_user(pyramid_request, mock.sentinel.jwt)
 
-        assert not post.called
+        assert not requests.post.called
 
     def test_it_400s_if_generate_username_raises_MissingToolConsumerInstanceGUIDError(
         self, create_h_user, pyramid_request, util
@@ -77,10 +81,10 @@ class TestCreateHUser:
         with pytest.raises(HTTPBadRequest, match="user_id"):
             create_h_user(pyramid_request, mock.sentinel.jwt)
 
-    def test_it_creates_the_user_in_h(self, create_h_user, post, pyramid_request):
+    def test_it_creates_the_user_in_h(self, create_h_user, requests, pyramid_request):
         create_h_user(pyramid_request, mock.sentinel.jwt)
 
-        post.assert_called_once_with(
+        requests.post.assert_called_once_with(
             "https://example.com/api/users",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
             data=json.dumps(
@@ -100,9 +104,9 @@ class TestCreateHUser:
         )
 
     def test_it_504s_if_the_h_request_times_out(
-        self, create_h_user, patch, post, pyramid_request
+        self, create_h_user, patch, requests, pyramid_request
     ):
-        post.side_effect = requests.exceptions.ReadTimeout()
+        requests.post.side_effect = ReadTimeout()
 
         with pytest.raises(HTTPGatewayTimeout):
             create_h_user(pyramid_request, mock.sentinel.jwt)
@@ -116,11 +120,11 @@ class TestCreateHUser:
         assert returned == wrapped.return_value
 
     def test_it_continues_to_the_wrapped_function_if_h_409s(
-        self, create_h_user, post, pyramid_request, wrapped
+        self, create_h_user, requests, pyramid_request, wrapped
     ):
-        response = requests.Response()
-        response.status_code = post.return_value.status_code = 409
-        post.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        response = Response()
+        response.status_code = requests.post.return_value.status_code = 409
+        requests.post.return_value.raise_for_status.side_effect = HTTPError(
             response=response
         )
 
@@ -133,10 +137,10 @@ class TestCreateHUser:
         "status", (500, 501, 502, 503, 504, 400, 401, 403, 404, 408)
     )
     def test_it_502s_for_unexpected_errors_from_h(
-        self, create_h_user, post, pyramid_request, status
+        self, create_h_user, requests, pyramid_request, status
     ):
-        post.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError()
-        post.return_value.status_code = status
+        requests.post.return_value.raise_for_status.side_effect = HTTPError()
+        requests.post.return_value.status_code = status
 
         with pytest.raises(HTTPBadGateway, match="Connecting to Hypothesis failed"):
             create_h_user(pyramid_request, mock.sentinel.jwt)
@@ -171,7 +175,7 @@ class TestCreateCourseGroup:
             create_course_group(pyramid_request, mock.sentinel.jwt)
 
     def test_it_does_nothing_if_the_user_isnt_allowed_to_create_groups_but_the_group_already_exists(
-        self, create_course_group, pyramid_request, models, post, wrapped
+        self, create_course_group, pyramid_request, models, requests, wrapped
     ):
         models.CourseGroup.get.return_value = mock.create_autospec(
             CourseGroup, instance=True
@@ -180,13 +184,13 @@ class TestCreateCourseGroup:
 
         returned = create_course_group(pyramid_request, mock.sentinel.jwt)
 
-        assert not post.called
+        assert not requests.post.called
         assert not pyramid_request.db.add.called
         wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
         assert returned == wrapped.return_value
 
     def test_it_does_nothing_if_the_feature_isnt_enabled(
-        self, create_course_group, pyramid_request, wrapped, post
+        self, create_course_group, pyramid_request, wrapped, requests
     ):
         # If the auto provisioning feature isn't enabled for this application
         # instance then create_course_group() doesn't do anything - just calls the
@@ -195,13 +199,13 @@ class TestCreateCourseGroup:
 
         returned = create_course_group(pyramid_request, mock.sentinel.jwt)
 
-        assert not post.called
+        assert not requests.post.called
         assert not pyramid_request.db.add.called
         wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
         assert returned == wrapped.return_value
 
     def test_it_does_nothing_if_the_course_group_already_exists(
-        self, create_course_group, models, pyramid_request, wrapped, post
+        self, create_course_group, models, pyramid_request, wrapped, requests
     ):
         models.CourseGroup.get.return_value = mock.create_autospec(
             CourseGroup, instance=True
@@ -209,17 +213,17 @@ class TestCreateCourseGroup:
 
         returned = create_course_group(pyramid_request, mock.sentinel.jwt)
 
-        assert not post.called
+        assert not requests.post.called
         assert not pyramid_request.db.add.called
         wrapped.assert_called_once_with(pyramid_request, mock.sentinel.jwt)
         assert returned == wrapped.return_value
 
     def test_it_posts_to_the_group_create_api(
-        self, create_course_group, pyramid_request, post
+        self, create_course_group, pyramid_request, requests
     ):
         create_course_group(pyramid_request, mock.sentinel.jwt)
 
-        post.assert_called_once_with(
+        requests.post.assert_called_once_with(
             "https://example.com/api/groups",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
             data='{"name": "test_group_name"}',
@@ -228,25 +232,20 @@ class TestCreateCourseGroup:
         )
 
     @pytest.mark.parametrize(
-        "request_exception",
-        (
-            requests.ConnectionError(),
-            requests.TooManyRedirects(),
-            requests.ReadTimeout(),
-        ),
+        "request_exception", (ConnectionError(), TooManyRedirects(), ReadTimeout())
     )
     def test_it_504s_if_the_h_request_errors(
-        self, create_course_group, post, pyramid_request, request_exception
+        self, create_course_group, requests, pyramid_request, request_exception
     ):
-        post.side_effect = request_exception
+        requests.post.side_effect = request_exception
 
         with pytest.raises(HTTPGatewayTimeout):
             create_course_group(pyramid_request, mock.sentinel.jwt)
 
     def test_it_504s_if_the_h_response_is_unsuccessful(
-        self, create_course_group, post, pyramid_request
+        self, create_course_group, requests, pyramid_request
     ):
-        post.return_value.raise_for_status.side_effect = requests.HTTPError()
+        requests.post.return_value.raise_for_status.side_effect = HTTPError()
 
         with pytest.raises(HTTPGatewayTimeout):
             create_course_group(pyramid_request, mock.sentinel.jwt)
@@ -298,21 +297,16 @@ class TestCreateCourseGroup:
         # Return the actual wrapper function so that tests can call it directly.
         return create_course_group(wrapped)
 
-    @pytest.fixture
-    def post(self, post):
-        post.return_value.json.return_value = {"id": "TEST_PUBID"}
-        return post
-
 
 class TestAddUserToGroup:
     def test_it_doesnt_post_to_the_api_if_feature_not_enabled(
-        self, add_user_to_group, pyramid_request, post
+        self, add_user_to_group, pyramid_request, requests
     ):
         pyramid_request.params["oauth_consumer_key"] = "foo"
 
         add_user_to_group(pyramid_request, mock.sentinel.jwt)
 
-        post.assert_not_called()
+        requests.post.assert_not_called()
 
     def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
         self, add_user_to_group, pyramid_request, wrapped
@@ -353,36 +347,31 @@ class TestAddUserToGroup:
         )
 
     def test_it_adds_the_user_to_the_group(
-        self, add_user_to_group, pyramid_request, post
+        self, add_user_to_group, pyramid_request, requests
     ):
         add_user_to_group(pyramid_request, mock.sentinel.jwt)
 
-        post.assert_called_once_with(
+        requests.post.assert_called_once_with(
             "https://example.com/api/groups/test_pubid/members/acct:test_username@TEST_AUTHORITY",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
             timeout=1,
         )
 
     @pytest.mark.parametrize(
-        "request_exception",
-        (
-            requests.ConnectionError(),
-            requests.TooManyRedirects(),
-            requests.ReadTimeout(),
-        ),
+        "request_exception", (ConnectionError(), TooManyRedirects(), ReadTimeout())
     )
     def test_it_504s_if_the_h_request_errors(
-        self, add_user_to_group, post, pyramid_request, request_exception
+        self, add_user_to_group, requests, pyramid_request, request_exception
     ):
-        post.side_effect = request_exception
+        requests.post.side_effect = request_exception
 
         with pytest.raises(HTTPGatewayTimeout):
             add_user_to_group(pyramid_request, mock.sentinel.jwt)
 
     def test_it_504s_if_the_h_response_is_unsuccessful(
-        self, add_user_to_group, post, pyramid_request
+        self, add_user_to_group, requests, pyramid_request
     ):
-        post.return_value.raise_for_status.side_effect = requests.HTTPError()
+        requests.post.return_value.raise_for_status.side_effect = HTTPError()
 
         with pytest.raises(HTTPGatewayTimeout):
             add_user_to_group(pyramid_request, mock.sentinel.jwt)
@@ -431,12 +420,13 @@ def models(patch):
 
 
 @pytest.fixture(autouse=True)
-def post(patch):
-    post = patch("lms.views.decorators.h_api.requests.post")
-    post.return_value = mock.create_autospec(
-        requests.models.Response, instance=True, status_code=200
+def requests(patch):
+    requests = patch("lms.views.decorators.h_api.requests")
+    requests.post.return_value = mock.create_autospec(
+        Response, instance=True, status_code=200, reason="OK", text=""
     )
-    return post
+    requests.post.return_value.json.return_value = {"id": "TEST_PUBID"}
+    return requests
 
 
 @pytest.fixture


### PR DESCRIPTION
This is to make way for adding a function named `post` in the future, can't have a test fixture named `post` anymore.