### PR TITLE
Fix handling of h API error responses

### DIFF
--- a/.prospector.base.yaml
+++ b/.prospector.base.yaml
@@ -16,6 +16,7 @@ pep257:
     - D102  # Missing docstring in public method
     - D103  # Missing docstring in public function
     - D104  # Missing docstring in public package
+    - D105  # Missing docstring in magic method
     - D107  # Missing docstring in __init__
     - D202  # "No blank lines allowed after function docstring" conflicts with
             # the Black code formatter, which insists on inserting blank lines

--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from lms.views.exceptions import HAPIError
+
+__all__ = ("HAPIError",)
 
 
 def includeme(config):

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -110,7 +110,9 @@ def create_h_user(wrapped):  # noqa: MC0001
         else:
             # Something unexpected went wrong when trying to create the user
             # account in h. Abort and show the user an error page.
-            raise HAPIError(explanation="Connecting to Hypothesis failed")
+            raise HAPIError(
+                explanation="Connecting to Hypothesis faled", response=response
+            )
 
         return wrapped(request, jwt)
 

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -187,7 +187,7 @@ def post(settings, path, data=None, username=None, statuses=None):
     :arg path: the h API path to post to, relative to
       ``settings["h_api_url"]``, for example: ``"/users"`` or
       ``"/groups/<PUBID>/members/<USERID>"``
-    :type url: str
+    :type path: str
     :arg data: the data to post as JSON in the request body
     :type data: dict
     :arg username: the username of the user to post as (using an

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -215,7 +215,7 @@ def post(settings, path, data=None, username=None, statuses=None):
     # The full h API URL to post to.
     url = settings["h_api_url"] + path
 
-    post_args = dict(url=url, auth=(client_id, client_secret), timeout=1)
+    post_args = dict(url=url, auth=(client_id, client_secret), timeout=10)
 
     if data is not None:
         post_args["data"] = json.dumps(data)

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -8,12 +8,11 @@ import requests
 from requests import RequestException
 from requests import ReadTimeout
 
-from pyramid.httpexceptions import HTTPBadGateway
 from pyramid.httpexceptions import HTTPBadRequest
-from pyramid.httpexceptions import HTTPGatewayTimeout
 
 from lms import models
 from lms import util
+from lms.views import HAPIError
 from lms.util import MissingToolConsumerIntanceGUIDError
 from lms.util import MissingUserIDError
 from lms.util import MissingContextTitleError
@@ -100,7 +99,7 @@ def create_h_user(wrapped):  # noqa: MC0001
                 timeout=1,
             )
         except ReadTimeout:
-            raise HTTPGatewayTimeout(explanation="Connecting to Hypothesis failed")
+            raise HAPIError(explanation="Connecting to Hypothesis failed")
 
         if response.status_code == 200:
             # User was created successfully.
@@ -111,7 +110,7 @@ def create_h_user(wrapped):  # noqa: MC0001
         else:
             # Something unexpected went wrong when trying to create the user
             # account in h. Abort and show the user an error page.
-            raise HTTPBadGateway(explanation="Connecting to Hypothesis failed")
+            raise HAPIError(explanation="Connecting to Hypothesis failed")
 
         return wrapped(request, jwt)
 
@@ -205,7 +204,7 @@ def add_user_to_group(wrapped):
             )
             response.raise_for_status()
         except RequestException:
-            raise HTTPGatewayTimeout(explanation="Connecting to Hypothesis failed")
+            raise HAPIError(explanation="Connecting to Hypothesis failed")
 
         return wrapped(request, jwt)
 
@@ -273,7 +272,7 @@ def _maybe_create_group(request):
         )
         response.raise_for_status()
     except RequestException:
-        raise HTTPGatewayTimeout(explanation="Connecting to Hypothesis failed")
+        raise HAPIError(explanation="Connecting to Hypothesis failed")
 
     # Save a record of the group's pubid in the DB so that we can find it
     # again later.

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -12,4 +12,28 @@ class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
     subclass) rather than, say, a 502 Bad Gateway because Cloudflare intercepts
     gateway error responses and replaces our error page with its own error
     page, and we don't want that.
+
+    Any arguments or keyword arguments other than ``response`` are passed
+    through to HTTPInternalServerError.
+
+    :param response: The response from the HTTP request to the h API
+    :type response: requests.Response
     """
+
+    def __init__(self, *args, response=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.response = response
+
+    def __str__(self):
+        if self.response is None:
+            return super().__str__()
+
+        # Log the details of the h API response. This goes to both Sentry and
+        # the application's logs. It's helpful for debugging to know how h
+        # responded.
+        parts = [
+            str(self.response.status_code or ""),
+            self.response.reason,
+            self.response.text,
+        ]
+        return " ".join([part for part in parts if part])

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -1,0 +1,15 @@
+from pyramid.httpexceptions import HTTPInternalServerError
+
+
+class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
+    """
+    A problem with an h API request.
+
+    This exception class is raised whenever an h API request times out or when
+    an unsuccessful, invalid or unexpected response is received from the h API.
+
+    An HAPIError is a 500 Internal Server Error response (HTTPInternalServerError
+    subclass) rather than, say, a 502 Bad Gateway because Cloudflare intercepts
+    gateway error responses and replaces our error page with its own error
+    page, and we don't want that.
+    """

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -4,15 +4,15 @@ import json
 from unittest import mock
 import pytest
 
-from pyramid.httpexceptions import HTTPBadGateway
 from pyramid.httpexceptions import HTTPBadRequest
-from pyramid.httpexceptions import HTTPGatewayTimeout
+
 from requests import ConnectionError
 from requests import HTTPError
 from requests import ReadTimeout
 from requests import Response
 from requests import TooManyRedirects
 
+from lms.views import HAPIError
 from lms.views.decorators.h_api import create_h_user
 from lms.views.decorators.h_api import create_course_group
 from lms.views.decorators.h_api import add_user_to_group
@@ -108,7 +108,7 @@ class TestCreateHUser:
     ):
         requests.post.side_effect = ReadTimeout()
 
-        with pytest.raises(HTTPGatewayTimeout):
+        with pytest.raises(HAPIError):
             create_h_user(pyramid_request, mock.sentinel.jwt)
 
     def test_it_continues_to_the_wrapped_function_if_h_200s(
@@ -142,7 +142,7 @@ class TestCreateHUser:
         requests.post.return_value.raise_for_status.side_effect = HTTPError()
         requests.post.return_value.status_code = status
 
-        with pytest.raises(HTTPBadGateway, match="Connecting to Hypothesis failed"):
+        with pytest.raises(HAPIError, match="Connecting to Hypothesis failed"):
             create_h_user(pyramid_request, mock.sentinel.jwt)
 
     @pytest.fixture
@@ -239,7 +239,7 @@ class TestCreateCourseGroup:
     ):
         requests.post.side_effect = request_exception
 
-        with pytest.raises(HTTPGatewayTimeout):
+        with pytest.raises(HAPIError):
             create_course_group(pyramid_request, mock.sentinel.jwt)
 
     def test_it_504s_if_the_h_response_is_unsuccessful(
@@ -247,7 +247,7 @@ class TestCreateCourseGroup:
     ):
         requests.post.return_value.raise_for_status.side_effect = HTTPError()
 
-        with pytest.raises(HTTPGatewayTimeout):
+        with pytest.raises(HAPIError):
             create_course_group(pyramid_request, mock.sentinel.jwt)
 
     def test_it_saves_the_group_to_the_db(
@@ -365,7 +365,7 @@ class TestAddUserToGroup:
     ):
         requests.post.side_effect = request_exception
 
-        with pytest.raises(HTTPGatewayTimeout):
+        with pytest.raises(HAPIError):
             add_user_to_group(pyramid_request, mock.sentinel.jwt)
 
     def test_it_504s_if_the_h_response_is_unsuccessful(
@@ -373,7 +373,7 @@ class TestAddUserToGroup:
     ):
         requests.post.return_value.raise_for_status.side_effect = HTTPError()
 
-        with pytest.raises(HTTPGatewayTimeout):
+        with pytest.raises(HAPIError):
             add_user_to_group(pyramid_request, mock.sentinel.jwt)
 
     def test_it_continues_to_the_wrapped_func(

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -142,7 +142,7 @@ class TestCreateHUser:
         requests.post.return_value.raise_for_status.side_effect = HTTPError()
         requests.post.return_value.status_code = status
 
-        with pytest.raises(HAPIError, match="Connecting to Hypothesis failed"):
+        with pytest.raises(HAPIError):
             create_h_user(pyramid_request, mock.sentinel.jwt)
 
     @pytest.fixture

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -357,7 +357,7 @@ class TestPost:
         requests.post.assert_called_once_with(
             url="https://example.com/api/path",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
-            timeout=1,
+            timeout=10,
         )
 
     def test_it_posts_data_as_json(self, pyramid_request, requests):

--- a/tests/lms/views/exceptions_test.py
+++ b/tests/lms/views/exceptions_test.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+import pytest
+from requests import Response
+
+from lms.views import HAPIError
+
+
+class TestHAPIError:
+    # If no ``response`` kwarg is given to HAPIError() then __str__() falls
+    # back on the HTTPInternalServerError base class's __str__() which is to
+    # use the given detail message string as the string representation of
+    # the exception.
+    def test_when_theres_no_response_uses_detail_message_as_str(self):
+        err = HAPIError("Connecting to Hypothesis failed")
+
+        assert str(err) == "Connecting to Hypothesis failed"
+
+    # If a ``response`` arg is given to HAPIError() then it uses the
+    # Response object's attributes to format a more informative string
+    # representation of the exception. Not all Response objects necessarily
+    # have values for every attribute - certain attributes can be ``None``
+    # or the empty string, so ``__str__()`` needs to handle those.
+    @pytest.mark.parametrize(
+        "status_code,reason,text,expected",
+        [
+            (400, "Bad Request", "Name too long", "400 Bad Request Name too long"),
+            (None, "Bad Request", "Name too long", "Bad Request Name too long"),
+            (400, None, "Name too long", "400 Name too long"),
+            (400, "Bad Request", "", "400 Bad Request"),
+        ],
+    )
+    def test_when_theres_a_response_it_uses_it_in_str(
+        self, status_code, reason, text, expected
+    ):
+        response = mock.create_autospec(
+            Response, instance=True, status_code=status_code, reason=reason, text=text
+        )
+        err = HAPIError("Connecting to Hypothesis failed", response=response)
+
+        assert str(err) == expected


### PR DESCRIPTION
This PR fixes two problems with the handling of h API error responses:

1. The LMS app's HTTP status code when an h API request fails or returns an error response (4xx or 5xx) has been a 502 Bad Gateway or 504 Gateway Timeout. This is no good -- Cloudflare intercepts gateway errors from our app and replaces our error page with its own gateway error page. Fix this by returning 500 Internal Server Error responses instead.

2. The LMS app was swallowing the error response from h API, neither logging it nor sending it to Sentry. In three separate places in the code the app was doing something like this:

   https://github.com/hypothesis/lms/blob/59d00cce854c4eb27f660d80819d42a67f8c537b/lms/views/decorators/h_api.py#L199-L208

   The local variable `response`, which contains the error message from the h API (e.g. "Group name too long" or "User does not exist" etc) is being discarded. For example it's not passed to the exception that's raised.

   The raised exception is both logged and reported to Sentry, but the exception doesn't contain the response from the h API.

   h itself doesn't log this response anywhere either (it logs the response status code but not the response body that contains the actual error message).

   Fix this by introducing a new `HAPIError` class, a subclass of Pyramid's `HTTPInternalServerError`, that takes a `response` argument. The string representation of an `HAPIError` includes the error message from the response body, which means that message gets logged and sent to Sentry.

There's also some refactoring done in this PR. Since the code for calling the h API using `requests.post()` and properly handling all the different exceptions and error responses is getting pretty non-trivial, I've added a `post()` function to wrap it and changed the three places that were using `requests.post()` to now use `post()`, much code duplication removed.

`views/decorators/h_api.py` is absolutely **not** the right place for this `requests.post` wrapper to live, it should live in an `HAPIService`, but the LMS app doesn't have services, so it's just a function in `h_api.py`  for now. (No, I don't want to move it into a util module!)