### PR TITLE
Disable share links on annotation cards

### DIFF
--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -84,6 +84,7 @@ class LTILaunch:
                 {
                     "apiUrl": api_url,
                     "authority": authority,
+                    "enableShareLinks": False,
                     "grantToken": grant_token().decode("utf-8"),
                     "groups": [group.pubid],
                 }

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -32,6 +32,9 @@ class TestLTILaunch:
             lti_launch.hypothesis_config["services"][0]["authority"] == "TEST_AUTHORITY"
         )
 
+    def test_hypothesis_config_disables_share_links(self, lti_launch):
+        assert lti_launch.hypothesis_config["services"][0]["enableShareLinks"] is False
+
     def test_hypothesis_config_includes_grant_token(self, lti_launch):
         before = int(datetime.datetime.now().timestamp())
 


### PR DESCRIPTION
These links do not currently work in the LMS context. Use the config
option added to the client in https://github.com/hypothesis/client/pull/820 to disable them.

Part of https://github.com/hypothesis/product-backlog/issues/843