### PR TITLE
Fix crash when course name too long

### DIFF
--- a/lms/util/h_api.py
+++ b/lms/util/h_api.py
@@ -17,7 +17,7 @@ USERNAME_MAX_LENGTH = 30
 """The maximum length of an h username."""
 
 
-GROUP_NAME_MAX_LENGTH = 30
+GROUP_NAME_MAX_LENGTH = 25
 """The maximum length of an h group name."""
 
 

--- a/tests/lms/util/test_h_api.py
+++ b/tests/lms/util/test_h_api.py
@@ -201,10 +201,9 @@ class TestGenerateGroupName:
             ("Test Course ", "Test Course"),
             (" Test Course ", "Test Course"),
             ("Test   Course", "Test   Course"),
-            ("Object Oriented Programming 101", "Object Oriented Programming 1…"),
-            ("Object Oriented Programming 101", "Object Oriented Programming 1…"),
-            ("Object Oriented Polymorphism 101", "Object Oriented Polymorphism…"),
-            ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorphism…"),
+            ("Object Oriented Programming 101", "Object Oriented Programm…"),
+            ("Object Oriented Polymorphism 101", "Object Oriented Polymorp…"),
+            ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
         ),
     )
     def test_it_returns_group_names_based_on_context_titles(


### PR DESCRIPTION
The max group name length in h is 25, not 30. Fixes https://github.com/hypothesis/lms/issues/330