### PR TITLE
Fix blank page after creating assignment

### DIFF
--- a/lms/views/module_item_configurations.py
+++ b/lms/views/module_item_configurations.py
@@ -18,6 +18,6 @@ def create_module_item_configuration(request, _jwt, **_):
 
     request.db.add(instance)
     return {
-        "hypothesis_url": f"{request.registry.settings['via_url']}/{instance.document_url}",
+        "via_url": f"{request.registry.settings['via_url']}/{instance.document_url}",
         "jwt_token": request.params["jwt_token"],
     }


### PR DESCRIPTION
Fix a blank page after creating an assignment in Blackboard or Moodle.

The hypothesis_url template variable was renamed to via_url in baf66092872b3a1a701bbab834eb8acf6544f8bc

Fixes https://github.com/hypothesis/lms/issues/310