### PR TITLE
Use IPython in `make shell`

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,3 +3,4 @@
 
 pip-tools
 pyramid_debugtoolbar
+pyramid_ipython


### PR DESCRIPTION
Use IPython, a more powerful interactive Python shell, instead of the standard Python shell in `make shell`.