### PR TITLE
Remove dependency on pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,6 @@ deps =
     {tests,lint,docstrings,checkdocstrings}: pytest
     {tests,lint,docstrings,checkdocstrings}: factory-boy
     codecov: codecov
-    lint: pylint
     lint: prospector
     {format,checkformatting}: black
     {docstrings,checkdocstrings}: sphinx


### PR DESCRIPTION
The current version of Prospector (1.1.6.2) is not compatible with the current version of pylint (2.2.0) or pylint's dependency astroid. Removing the pylint dependency lets pip install the version that prospector requires / is compatible with.