### PR TITLE
Fix creating assignments in Canvas

### DIFF
--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -71,8 +71,24 @@ def content_item_form(request, lti_params, lms_url, content_item_return_url, jwt
         if param not in lti_params:
             raise MissingLTIContentItemParamError(param)
 
-    form_fields = {"lti_message_type": "ContentItemSelection", "jwt_token": jwt}
-    form_fields.update(lti_params)
+    form_fields = {
+        "lti_message_type": "ContentItemSelection",
+        "lti_version": lti_params["lti_version"],
+        "oauth_version": lti_params["oauth_version"],
+        "oauth_nonce": lti_params["oauth_nonce"],
+        "oauth_consumer_key": lti_params["oauth_consumer_key"],
+        "oauth_signature_method": lti_params["oauth_signature_method"],
+        "oauth_signature": lti_params["oauth_signature"],
+        "jwt_token": jwt,
+    }
+    # These fields appear in blackboard launches, but not in canvas
+    # launches
+    if "resource_link_id" in lti_params:
+        form_fields["resource_link_id"] = lti_params["resource_link_id"]
+    if "tool_consumer_instance_guid" in lti_params:
+        form_fields["tool_consumer_instance_guid"] = lti_params[
+            "tool_consumer_instance_guid"
+        ]
 
     custom_lms_url = None
     if "custom_canvas_api_domain" in lti_params:

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -72,6 +72,8 @@ def content_item_form(request, lti_params, lms_url, content_item_return_url, jwt
             raise MissingLTIContentItemParamError(param)
 
     form_fields = {
+        "context_id": lti_params["context_id"],
+        "user_id": lti_params["user_id"],
         "lti_message_type": "ContentItemSelection",
         "lti_version": lti_params["lti_version"],
         "oauth_version": lti_params["oauth_version"],


### PR DESCRIPTION
This hopefully fixes creating assignments in Canvas without breaking them in Blackboard. There's no way to write unit tests for this function, and we have no way to test the app in Blackboard locally, has to be deployed to QA to test.