### PR TITLE
Use the groupid field when creating new groups in h

### DIFF
--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -174,7 +174,9 @@ def _maybe_create_group(context, request):
 
     # Create the group in h.
     response = request.find_service(name="hapi").post(
-        "groups", {"name": context.h_group_name}, context.h_userid
+        "groups",
+        {"groupid": context.h_groupid, "name": context.h_group_name},
+        context.h_userid,
     )
 
     # Save a record of the group's pubid in the DB so that we can find it

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -136,6 +136,32 @@ class TestLTILaunch:
             resources.LTILaunch(pyramid_request).h_display_name == expected_display_name
         )
 
+    def test_h_groupid_raises_if_theres_no_tool_consumer_instance_guid(
+        self, lti_params_for, pyramid_request
+    ):
+        lti_params_for.return_value = {}
+        with pytest.raises(
+            HTTPBadRequest,
+            match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
+        ):
+            resources.LTILaunch(pyramid_request).h_groupid
+
+    def test_h_groupid_raises_if_theres_no_context_id(
+        self, lti_params_for, pyramid_request
+    ):
+        lti_params_for.return_value = {"tool_consumer_instance_guid": "test_guid"}
+        with pytest.raises(
+            HTTPBadRequest,
+            match='Required parameter "context_id" missing from LTI params',
+        ):
+            resources.LTILaunch(pyramid_request).h_groupid
+
+    def test_h_groupid(self, lti_launch):
+        assert (
+            lti_launch.h_groupid
+            == "group:d55a3c86dd79d390ec8dc6a8096d0943044ea268@TEST_AUTHORITY"
+        )
+
     def test_h_group_name_raises_if_theres_no_context_title(self, lti_launch):
         with pytest.raises(HTTPBadRequest):
             lti_launch.h_group_name

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -182,7 +182,9 @@ class TestCreateCourseGroup:
         create_course_group(pyramid_request, mock.sentinel.jwt, context)
 
         hapi_svc.post.assert_called_once_with(
-            "groups", {"name": "test_group_name"}, "acct:test_username@TEST_AUTHORITY"
+            "groups",
+            {"groupid": "test_groupid", "name": "test_group_name"},
+            "acct:test_username@TEST_AUTHORITY",
         )
 
     def test_it_raises_if_post_raises(
@@ -343,6 +345,7 @@ def context():
         spec_set=True,
         instance=True,
         h_display_name="test_display_name",
+        h_groupid="test_groupid",
         h_group_name="test_group_name",
         h_username="test_username",
         h_userid="acct:test_username@TEST_AUTHORITY",


### PR DESCRIPTION
Generate a groupid from LMS params, and send it to the h API when creating the group.

There's also a code duplication commit in here.