### PR TITLE
Don't use pubids from the database. And also update group names

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,6 +1,7 @@
 from lms.services.exceptions import HAPIError
+from lms.services.exceptions import HAPINotFoundError
 
-__all__ = ("HAPIError",)
+__all__ = ("HAPIError", "HAPINotFoundError")
 
 
 def includeme(config):

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -37,3 +37,7 @@ class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
             self.response.text,
         ]
         return " ".join([part for part in parts if part])
+
+
+class HAPINotFoundError(HAPIError):  # pylint: disable=too-many-ancestors
+    """A 404 error from an API request."""

--- a/lms/services/hapi.py
+++ b/lms/services/hapi.py
@@ -5,6 +5,7 @@ import requests
 from requests import RequestException
 
 from lms.services import HAPIError
+from lms.services import HAPINotFoundError
 
 
 class HypothesisAPIService:
@@ -133,8 +134,12 @@ class HypothesisAPIService:
         except RequestException as err:
             response = getattr(err, "response", None)
             status_code = getattr(response, "status_code", None)
+            if status_code == 404:
+                exception_class = HAPINotFoundError
+            else:
+                exception_class = HAPIError
             if status_code is None or status_code not in statuses:
-                raise HAPIError(
+                raise exception_class(
                     explanation="Connecting to Hypothesis failed", response=response
                 )
 

--- a/lms/services/hapi.py
+++ b/lms/services/hapi.py
@@ -92,7 +92,7 @@ class HypothesisAPIService:
         :type method: str
         :arg path: the h API path to post to, relative to
           ``settings["h_api_url"]``, for example: ``"users"`` or
-          ``"groups/<PUBID>/members/<USERID>"``
+          ``"groups/<GROUPID>/members/<USERID>"``
         :type path: str
         :arg data: the data to post as JSON in the request body
         :type data: dict

--- a/lms/util/lti.py
+++ b/lms/util/lti.py
@@ -24,6 +24,7 @@ def lti_params_for(request):
         lti_params = models.find_lti_params(request.db, request.params["state"])
         if lti_params is None:
             raise HTTPBadRequest("OAuth state was not found")
+
         return lti_params
 
     # This is an LTI launch request.

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -224,7 +224,11 @@ def lti_launch_request(monkeypatch, pyramid_request):
         "pylti.common.verify_request_common", lambda a, b, c, d, e: True
     )
 
-    pyramid_request.context = {"rpc_server_config": {}, "hypothesis_config": {}}
+    pyramid_request.context = mock.MagicMock(
+        spec_set=["rpc_server_config", "hypothesis_config"],
+        rpc_server_config={},
+        hypothesis_config={},
+    )
 
     yield pyramid_request
 

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -15,6 +15,7 @@ from pyramid import testing
 from pyramid.request import apply_request_extensions
 
 from lms import db
+from lms.config.resources import LTILaunch
 from lms.models import User
 from lms.models import Token
 from lms.models import OauthState
@@ -224,8 +225,10 @@ def lti_launch_request(monkeypatch, pyramid_request):
         "pylti.common.verify_request_common", lambda a, b, c, d, e: True
     )
 
-    pyramid_request.context = mock.MagicMock(
-        spec_set=["rpc_server_config", "hypothesis_config"],
+    pyramid_request.context = mock.create_autospec(
+        LTILaunch,
+        spec_set=True,
+        instance=True,
         rpc_server_config={},
         hypothesis_config={},
     )


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/client/pull/824>

This PR does a couple of things:

1. The LMS app's `pubids` that it stores in its database are no longer being used. They're neither written to or read from the DB anymore. Creating, updating and adding members to groups is done using the new `groupid` field instead. The app still needs to pass the `pubid` to the client in order to tell it what group to show (which is annoying -- it would be much easier if `groupid` could be used here), but it gets the `pubid` anew from the h groups API response on each launch, does not store it. Fixes <https://github.com/hypothesis/lms/issues/287>. Follow-up PRs neeed:
 
   1. Remove the `CourseGroups` model code.
   2. DB migration to delete the table.

2. If a course's name changes in the LMS the app now updates the corresponding h group's name the next time anyone launches any Hypothesis assignment in that course. Fixes <https://github.com/hypothesis/lms/issues/253>.

The algorithm that the app uses when talking to the h API to create the group is this:

```
try:
  pubid = PATCH(groupid) (no X-Forwarded-User)
except NotFound:
  # Group does not exist yet.
  if teacher:
    try:
      pubid = PUT(groupid) (with teacher's userid in X-Forwarded-User)
    except:
      Show "Connecting to Hypothesis failed" and exit
  else:
    # The group has not been created yet and the assignment is being launched by a student.
    # This can totally happen in some LMS's e.g. Blackboard, and as well as not creating
    # the group the the teacher will not have selected the assignment's document either.
    Show "Teacher must launch assignment first" and exit
except:
  # The original PATCH failed for some reason other than 404.
  Show "Connecting to Hypothesis failed" and exit

# If we get to here without exiting then we have the pubid, either
# from a successful PATCH or a successful PUT, and we can continue with
# the launch, passing the pubid to the client.

POST to add member to group (using groupid)

Launch assignment, passing pubid to client.
```

The `PATCH` (group update) request is needed for two reasons:

1. The LMS app can make a group update request in response to an LTI launch from a students, not just in response to launches from teachers. This is because the h `userid` of a teacher is needed to _create_ a group, but isn't needed to update a group that already exists. So if the course's name changes in the LMS, the very next time an assignment is launched by anyone (student or teacher) the h group's name will be updated. Rather than having to wait for a teacher to launch the assignment again for the name t o update.

2. Every launch request, student or teacher, needs the group's `pubid`, because the `pubid` has to be passed to the client to tell it which group to show. The app can't remember `pubid`s in its own DB (see <https://github.com/hypothesis/lms/issues/287>), and there's no `GET` API for groups. The only way to get the `pubid` is from a successful response to a group `POST`, `PUT` or `PATCH` request. `POST` and `PUT` require the teacher's h `userid` for the `X-Forwarded-User` header (because h will use this `userid` for the group's `creator` if it needs to create the group). `PATCH` does not need a `userid` so doing a `PATCH` request (even if it may be a no-op request if the course name hasn't changed) is the only universal way to get the `pubid` from h.

   (In case you're wondering no the app can't remember the teacher's `userid` in its DB, this would have the same sync issues as remembering `pubid`s does.)

If the `PATCH` gets a `404` response then we know that the group has not been created yet. In that case if the current LMS user is a teacher we create the group and set them as the creator. If the user is a student we can't create the group (we need a teacher's `userid` to make them the creator and moderator of the group, and we don't have one) so we have no choice but to show an error page (which is already what happens on master too).