### PR TITLE
Shorten length of generated consumer secrets to 64 hex digits

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -56,8 +56,8 @@ def find_by_oauth_consumer_key(session, key):
 
 
 def build_shared_secret():
-    """Generate a shared secrect."""
-    return secrets.token_hex(64)
+    """Generate a shared secret."""
+    return secrets.token_hex(32)
 
 
 def build_unique_key():


### PR DESCRIPTION
The Brightspace settings page for configuring LTI tools sets a limit of 100
chars on the field for the shared secret for signing LTI launch requests using
OAuth 1.0. With the previous secret size of 64 bytes / 128 hex digits, the value
would be silently truncated upon entering the secret into the form.

Solve the problem by halving the length to 32 bytes / 64 hex digits which is the
same size as a SHA-256 hash, and perfectly adequate from a security point of
view.

This change will not affect existing app installations. We will need to modify
our existing Brightspace installs to make those work.

Fixes #258