### PR TITLE
Only test view function, not decorated function in lti_launches, content_item_selection view tests

### DIFF
--- a/lms/util/associate_user.py
+++ b/lms/util/associate_user.py
@@ -1,4 +1,6 @@
 """Decorator to find a user from the lms user_id guid."""
+import functools
+
 from lms.models.users import find_by_lms_guid, build_from_lti_params
 
 
@@ -10,6 +12,7 @@ def associate_user(view_function):
     associated with the user_id then a new user will be created.
     """
 
+    @functools.wraps(view_function)
     def wrapper(request, *args, **kwargs):
         """Look for a user with a matching lms_guid."""
         lms_guid = request.params["user_id"]

--- a/lms/util/authenticate.py
+++ b/lms/util/authenticate.py
@@ -1,4 +1,6 @@
 """Decorate routes with the ability to authenticate requests."""
+import functools
+
 import jwt
 from pyramid.response import Response
 from lms.models.users import find_by_lms_guid
@@ -7,6 +9,7 @@ from lms.models.users import find_by_lms_guid
 def authenticate(view_function):
     """Wrap a view function with with JWT authentication."""
 
+    @functools.wraps(view_function)
     def wrapper(request, *args, **kwargs):
         """Validate the JWT signature."""
         try:

--- a/lms/util/authorize_lms.py
+++ b/lms/util/authorize_lms.py
@@ -1,4 +1,6 @@
+import functools
 import urllib
+
 import requests_oauthlib
 import pyramid.httpexceptions as exc
 from lms.models import find_or_create_from_user, find_user_from_state
@@ -59,6 +61,7 @@ def authorize_lms(
     def decorator(view_function):
         """Decorate view function."""
 
+        @functools.wraps(view_function)
         def wrapper(request, *args, user=None, **kwargs):
             """Redirect user."""
             if oauth_condition(request) is False:
@@ -101,6 +104,7 @@ def authorize_lms(
 def save_token(view_function):
     """Decorate an oauth callback route to save access token."""
     # pylint: disable=too-many-locals
+    @functools.wraps(view_function)
     def wrapper(request, *args, **kwargs):
         """Route to handle content item selection oauth response."""
         if "state" not in request.params or "code" not in request.params:

--- a/lms/util/canvas_api.py
+++ b/lms/util/canvas_api.py
@@ -1,3 +1,5 @@
+import functools
+
 import requests
 import pyramid.httpexceptions as exc
 from lms.models.application_instance import find_by_oauth_consumer_key
@@ -70,6 +72,7 @@ def canvas_api(view_function):
     }
     """
 
+    @functools.wraps(view_function)
     def wrapper(request, decoded_jwt, user):
         """Wrap view function."""
         if user is None:

--- a/lms/util/lti_launch.py
+++ b/lms/util/lti_launch.py
@@ -1,4 +1,6 @@
 """Decorator that add lti validation capabilities to a pyramid view."""
+from functools import wraps
+
 import pylti.common
 
 from lms.models import application_instance as ai
@@ -39,6 +41,7 @@ def lti_launch(view_function):
     ...
     """
 
+    @wraps(view_function)
     def wrapper(request):
         """Handle the lms validation."""
         lti_params = get_lti_launch_params(request)

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -42,6 +42,7 @@ def create_h_user(wrapped):  # noqa: MC0001
     # This should all be refactored so that views and view decorators aren't
     # tightly coupled and arguments don't need to be passed through multiple
     # decorators to the view.
+    @functools.wraps(wrapped)
     def wrapper(request, jwt, context=None):
         context = context or request.context
 
@@ -108,6 +109,7 @@ def create_course_group(wrapped):
     # This should all be refactored so that views and view decorators aren't
     # tightly coupled and arguments don't need to be passed through multiple
     # decorators to the view.
+    @functools.wraps(wrapped)
     def wrapper(request, jwt, context=None):
         _maybe_create_group(context or request.context, request)
         return wrapped(request, jwt)
@@ -116,6 +118,7 @@ def create_course_group(wrapped):
 
 
 def add_user_to_group(wrapped):
+    @functools.wraps(wrapped)
     def wrapper(request, jwt, context=None):
         if not _auto_provisioning_feature_enabled(request):
             return wrapped(request, jwt)

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -81,6 +81,19 @@ def autopatcher(request, target, **kwargs):
     return obj
 
 
+def unwrap(decorated_function):
+    """
+    Return the function wrapped by a decorated function.
+
+    Given a function which has been decorated by one or more `functools.wraps`
+    decorators, return the wrapped function.
+    """
+    unwrapped = decorated_function
+    while hasattr(unwrapped, "__wrapped__"):
+        unwrapped = unwrapped.__wrapped__
+    return unwrapped
+
+
 @pytest.fixture
 def patch(request):
     return functools.partial(autopatcher, request)

--- a/tests/lms/views/test_content_item_selection.py
+++ b/tests/lms/views/test_content_item_selection.py
@@ -13,9 +13,6 @@ from tests.lms.conftest import unwrap
 #
 # In these tests we only want to test the view function itself, so extract that
 # from the decorated function.
-#
-# nb. This stack of decorators makes it hard to test. It would be much better to
-# use service method calls to handle the work done by decorators.
 content_item_selection = unwrap(content_item_selection)
 
 

--- a/tests/lms/views/test_content_item_selection.py
+++ b/tests/lms/views/test_content_item_selection.py
@@ -1,18 +1,27 @@
+from unittest.mock import Mock
+
 import pytest
 
 from urllib.parse import urlparse
 from lms.exceptions import MissingLTILaunchParamError, MissingLTIContentItemParamError
 from lms.views.content_item_selection import content_item_selection, content_item_form
+from tests.lms.conftest import unwrap
+
+# The `content_item_selection` view function is wrapped in a series of
+# decorators which handle authorization and creating the user/group for the
+# current course.
+#
+# In these tests we only want to test the view function itself, so extract that
+# from the decorated function.
+#
+# nb. This stack of decorators makes it hard to test. It would be much better to
+# use service method calls to handle the work done by decorators.
+content_item_selection = unwrap(content_item_selection)
 
 
 class TestContentItemSelection:
-    def test_it_redirects_to_oauth_provider(self, lti_launch_request):
-        response = content_item_selection(lti_launch_request)
-
-        location = urlparse(response.location)
-
-        assert response.code == 302
-        assert location.netloc == "hypothesis.instructure.com"
+    # TODO - Tests for `content_item_selection` view
+    pass
 
 
 class TestContentItemForm:

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -1,28 +1,43 @@
-from lms.views.lti_launches import lti_launches
+import unittest.mock as mock
 
 import pytest
 
+from lms.views.lti_launches import lti_launches
 from lms.exceptions import MissingLTILaunchParamError
+from tests.lms.conftest import unwrap
+
+
+# The `lti_launches` view function is wrapped in a series of decorators which
+# handle authorization and creating the user/group for the current course.
+#
+# In these tests we only want to test the view function itself, so extract that
+# from the decorated function.
+#
+# nb. This stack of decorators makes it hard to test. It would be much better to
+# use service method calls to handle the work done by decorators.
+lti_launches = unwrap(lti_launches)
+
 
 # TODO write tests for student case
+@pytest.mark.usefixtures("find_token_by_user_id")
 class TestLtiLaunches:
     def test_it_renders_the_iframe_when_the_url_is_present_in_the_params(
-        self, lti_launch_request
+        self, lti_launch_request, jwt, user
     ):
         lti_launch_request.params["url"] = "https://example.com"
-        value = lti_launches(lti_launch_request)
+        value = lti_launches(lti_launch_request, jwt, user)
         assert "iframe" in value.body.decode()
         assert "example.com" in value.body.decode()
 
     def test_render_the_form_when_the_url_is_not_present_in_the_params(
-        self, lti_launch_request
+        self, lti_launch_request, jwt, user
     ):
         lti_launch_request.params["resource_link_id"] = "test_link_id"
-        value = lti_launches(lti_launch_request)
+        value = lti_launches(lti_launch_request, jwt, user)
         assert "<form" in value.body.decode()
 
     def test_render_the_document_if_configured(
-        self, lti_launch_request, module_item_configuration
+        self, lti_launch_request, module_item_configuration, jwt, user
     ):
         lti_launch_request.db.add(module_item_configuration)
         lti_launch_request.db.flush()
@@ -32,12 +47,12 @@ class TestLtiLaunches:
         lti_launch_request.params[
             "tool_consumer_instance_guid"
         ] = module_item_configuration.tool_consumer_instance_guid
-        value = lti_launches(lti_launch_request)
+        value = lti_launches(lti_launch_request, jwt, user)
         assert "iframe" in value.body.decode()
         assert "example.com" in value.body.decode()
 
     def test_render_unauthorized_for_students(
-        self, lti_launch_request, module_item_configuration
+        self, lti_launch_request, module_item_configuration, jwt, user
     ):
         lti_launch_request.params[
             "resource_link_id"
@@ -46,48 +61,76 @@ class TestLtiLaunches:
             "tool_consumer_instance_guid"
         ] = module_item_configuration.tool_consumer_instance_guid
         lti_launch_request.params["roles"] = "urn:lti:role:ims/lis/Learner"
-        value = lti_launches(lti_launch_request)
+        value = lti_launches(lti_launch_request, jwt, user)
         assert "This page has not yet been configured" in value.body.decode()
 
-    def test_raises_for_missing_context_id_param(self, lti_launch_request):
+    def test_raises_for_missing_context_id_param(self, lti_launch_request, jwt, user):
         del lti_launch_request.params["context_id"]
 
         with pytest.raises(
             MissingLTILaunchParamError,
             match="Required data param for LTI launch missing: context_id",
         ):
-            lti_launches(lti_launch_request)
+            lti_launches(lti_launch_request, jwt, user)
 
-    def test_raises_for_missing_resource_link_id_param(self, lti_launch_request):
+    def test_raises_for_missing_resource_link_id_param(
+        self, lti_launch_request, jwt, user
+    ):
+        del lti_launch_request.params["resource_link_id"]
         with pytest.raises(
             MissingLTILaunchParamError,
             match="Required data param for LTI launch missing: resource_link_id",
         ):
-            lti_launches(lti_launch_request)
+            lti_launches(lti_launch_request, jwt, user)
 
     def test_raises_for_missing_roles_param(
-        self, lti_launch_request, module_item_configuration
+        self, lti_launch_request, module_item_configuration, jwt, user
     ):
         del lti_launch_request.params["roles"]
         with pytest.raises(
             MissingLTILaunchParamError,
             match="Required data param for LTI launch missing: roles",
         ):
-            lti_launches(lti_launch_request)
+            lti_launches(lti_launch_request, jwt, user)
 
-    def test_raises_for_tool_consumer_instance_guid_param(self, lti_launch_request):
+    def test_raises_for_tool_consumer_instance_guid_param(
+        self, lti_launch_request, jwt, user
+    ):
         del lti_launch_request.params["tool_consumer_instance_guid"]
         with pytest.raises(
             MissingLTILaunchParamError,
             match="Required data param for LTI launch missing: tool_consumer_instance_guid",
         ):
-            lti_launches(lti_launch_request)
+            lti_launches(lti_launch_request, jwt, user)
 
-    def test_raises_for_missing_oauth_consumer_key_param(self, lti_launch_request):
+    def test_raises_for_missing_oauth_consumer_key_param(
+        self, lti_launch_request, jwt, user
+    ):
         del lti_launch_request.params["oauth_consumer_key"]
 
         with pytest.raises(
             MissingLTILaunchParamError,
             match="Required data param for LTI launch missing: oauth_consumer_key",
         ):
-            lti_launches(lti_launch_request)
+            lti_launches(lti_launch_request, jwt, user)
+
+
+@pytest.fixture
+def lti_launch_request(lti_launch_request):
+    lti_launch_request.params["resource_link_id"] = "test_link_id"
+    return lti_launch_request
+
+
+@pytest.fixture
+def jwt():
+    return "test_jwt"
+
+
+@pytest.fixture
+def user():
+    return mock.Mock(spec_set=["id", "lms_guid"], id=42)
+
+
+@pytest.fixture
+def find_token_by_user_id(patch):
+    return patch("lms.views.lti_launches.find_token_by_user_id")

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -12,9 +12,6 @@ from tests.lms.conftest import unwrap
 #
 # In these tests we only want to test the view function itself, so extract that
 # from the decorated function.
-#
-# nb. This stack of decorators makes it hard to test. It would be much better to
-# use service method calls to handle the work done by decorators.
 lti_launches = unwrap(lti_launches)
 
 


### PR DESCRIPTION
The `lti_launches` and `content_item_selection` view functions are
wrapped by a nested series of decorators which handle authorization and,
when provisioning is enabled, creation of users and groups in h that
correspond to the lms course.

These decorators are hard to mock/stub in unit tests which are only
concerned with the functionality of the view callable itself. This
problem is about to be exacerbated as provisioning becomes the default
experience and all the provisioning-related decorators therefore get
activated instead of skipping their logic.

The preferred way to resolve this problem would be to refactor the view
callable to perform provisioning setup and authorization in a way that
is more easily mocked, eg. using calls to services.

As an intermediate step, this PR refactors the tests for several view
functions to unwrap the decorated function and just test the view callables.
This involves:

 - Modifying the existing decorators to use `functools.wraps`, which
   adds a `__wrapped__` attr to the decorated function which is a
   reference to the original function.

 - Unwrapping the decorated function in the tests using a helper
   `unwrap` function.

 - Modifying the tests to pass any additional arguments which the
   wrapped function requires.

In the case of the existing `content_item_selection` tests, this
revealed that the existing test had nothing to do with the view function
itself but was in fact a test for logic in `lms.util.authorize_lms`.