### PR TITLE
Enable provisioning by default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -140,15 +140,15 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
     export RPC_ALLOWED_ORIGINS="http://localhost:5000"
 
     # An optional space-separated list of the consumer keys of the application
-    # instances for which the "auto provisioning" features should be enabled.
+    # instances for which the "auto provisioning" features should be disabled.
     # Defaults to an empty list ([]) if none provided (i.e. the features will
-    # be disabled for all application instances).
+    # be enabled for all application instances).
     #
     # The consumer key strings here should match the values in the
     # lms.models.ApplicationInstances.consumer_key column in the database,
     # which are also the same as the LTI "oauth_consumer_key" parameter values
     # that LMS's send to us in LTI launch requests.
-    export AUTO_PROVISIONING="Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20"
+    export NO_AUTO_PROVISIONING="Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20"
     ```
 
 1. **Try out the postgres docker container**

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -42,8 +42,8 @@ def configure(settings):
         # The base URL of the h API (e.g. "https://hypothes.is/api).
         "h_api_url": env_setting("H_API_URL", required=True),
         # The list of `oauth_consumer_key`s of the application instances for
-        # which the automatic user and group provisioning features are enabled.
-        "auto_provisioning": env_setting("AUTO_PROVISIONING", default=""),
+        # which the automatic user and group provisioning features are disabled.
+        "no_auto_provisioning": env_setting("NO_AUTO_PROVISIONING", default=""),
         # The postMessage origins from which to accept RPC requests.
         "rpc_allowed_origins": env_setting("RPC_ALLOWED_ORIGINS", required=True),
     }
@@ -60,7 +60,7 @@ def configure(settings):
     except UnicodeEncodeError:
         raise SettingError("LMS_SECRET must contain only ASCII characters")
 
-    env_settings["auto_provisioning"] = aslist(env_settings["auto_provisioning"])
+    env_settings["no_auto_provisioning"] = aslist(env_settings["no_auto_provisioning"])
     env_settings["rpc_allowed_origins"] = aslist(env_settings["rpc_allowed_origins"])
 
     settings.update(env_settings)

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -210,8 +210,8 @@ class LTILaunch:
 
     @property
     def _auto_provisioning_feature_enabled(self):
-        enabled_consumer_keys = self._request.registry.settings["auto_provisioning"]
-        return self._get_param("oauth_consumer_key") in enabled_consumer_keys
+        disabled_consumer_keys = self._request.registry.settings["no_auto_provisioning"]
+        return self._get_param("oauth_consumer_key") not in disabled_consumer_keys
 
     def _get_param(self, param_name):
         """Return the named param from the request or raise a 400."""

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -179,5 +179,5 @@ def _auto_provisioning_feature_enabled(request):
     oauth_consumer_key = _get_param(  # pylint: disable=too-many-function-args
         request, "oauth_consumer_key"
     )
-    enabled_consumer_keys = request.registry.settings["auto_provisioning"]
-    return oauth_consumer_key in enabled_consumer_keys
+    disabled_consumer_keys = request.registry.settings["no_auto_provisioning"]
+    return oauth_consumer_key not in disabled_consumer_keys

--- a/tests/lms/config/__init___test.py
+++ b/tests/lms/config/__init___test.py
@@ -189,13 +189,13 @@ class TestConfigure:
             ("  ", []),
         ],
     )
-    def test_auto_provisioning_setting(
+    def test_no_auto_provisioning_setting(
         self, env_setting, envvar_value, expected_setting
     ):
         def side_effect(
             envvar_name, *args, **kwargs
         ):  # pylint: disable=unused-argument
-            if envvar_name == "AUTO_PROVISIONING":
+            if envvar_name == "NO_AUTO_PROVISIONING":
                 return envvar_value
             return mock.DEFAULT
 
@@ -203,7 +203,9 @@ class TestConfigure:
 
         configurator = configure({})
 
-        assert configurator.registry.settings["auto_provisioning"] == expected_setting
+        assert (
+            configurator.registry.settings["no_auto_provisioning"] == expected_setting
+        )
 
     @pytest.mark.parametrize(
         "envvar_value,expected_setting",

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -370,7 +370,9 @@ class TestLTILaunch:
     def test_hypothesis_config_is_empty_if_provisioning_feature_is_disabled(
         self, pyramid_request, lti_launch, lti_params_for
     ):
-        lti_params_for.return_value.update({"oauth_consumer_key": "some_other_key"})
+        lti_params_for.return_value.update(
+            {"oauth_consumer_key": "no_provisioning_key"}
+        )
         assert lti_launch.hypothesis_config == {}
 
     def test_rpc_server_config(self, lti_launch):

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -167,7 +167,7 @@ def pyramid_config(pyramid_request):
         "h_jwt_client_secret": "TEST_JWT_CLIENT_SECRET",
         "h_authority": "TEST_AUTHORITY",
         "h_api_url": "https://example.com/api/",
-        "auto_provisioning": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20",
+        "no_auto_provisioning": "no_provisioning_key",
         "rpc_allowed_origins": ["http://localhost:5000"],
     }
 

--- a/tests/lms/views/decorators/test_h_api.py
+++ b/tests/lms/views/decorators/test_h_api.py
@@ -32,7 +32,7 @@ class TestCreateHUser:
     def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
         self, create_h_user, context, pyramid_request, wrapped
     ):
-        pyramid_request.params["oauth_consumer_key"] = "foo"
+        pyramid_request.params["oauth_consumer_key"] = "no_provisioning_key"
 
         returned = create_h_user(pyramid_request, mock.sentinel.jwt, context)
 
@@ -42,7 +42,7 @@ class TestCreateHUser:
     def test_it_doesnt_use_the_h_api_if_feature_not_enabled(
         self, create_h_user, context, hapi_svc, pyramid_request
     ):
-        pyramid_request.params["oauth_consumer_key"] = "foo"
+        pyramid_request.params["oauth_consumer_key"] = "no_provisioning_key"
 
         create_h_user(pyramid_request, mock.sentinel.jwt, context)
 
@@ -117,7 +117,7 @@ class TestCreateCourseGroup:
         # If the auto provisioning feature isn't enabled for this application
         # instance then create_course_group() doesn't do anything - just calls the
         # wrapped view.
-        pyramid_request.params["oauth_consumer_key"] = "foo"
+        pyramid_request.params["oauth_consumer_key"] = "no_provisioning_key"
 
         returned = create_course_group(pyramid_request, mock.sentinel.jwt, context)
 
@@ -198,7 +198,7 @@ class TestAddUserToGroup:
     def test_it_doesnt_post_to_the_api_if_feature_not_enabled(
         self, add_user_to_group, context, pyramid_request, hapi_svc
     ):
-        pyramid_request.params["oauth_consumer_key"] = "foo"
+        pyramid_request.params["oauth_consumer_key"] = "no_provisioning_key"
 
         add_user_to_group(pyramid_request, mock.sentinel.jwt, context)
 
@@ -207,7 +207,7 @@ class TestAddUserToGroup:
     def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
         self, add_user_to_group, context, pyramid_request, wrapped
     ):
-        pyramid_request.params["oauth_consumer_key"] = "foo"
+        pyramid_request.params["oauth_consumer_key"] = "no_provisioning_key"
 
         returned = add_user_to_group(pyramid_request, mock.sentinel.jwt, context)
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ skip_install = true
 passenv =
     tests: TEST_DATABASE_URL
     tests: PYTEST_ADDOPTS
-    dev: AUTO_PROVISIONING
     dev: DATABASE_URL
     dev: DEBUG
     dev: GOOGLE_APP_ID
@@ -24,6 +23,7 @@ passenv =
     dev: HASHED_PW
     dev: JWT_SECRET
     dev: LMS_SECRET
+    dev: NO_AUTO_PROVISIONING
     dev: RPC_ALLOWED_ORIGINS
     dev: SALT
     dev: SENTRY_DSN


### PR DESCRIPTION
Convert user and group provisioning from a whitelist of consumer keys managed by the `AUTO_PROVISIONING` env var to a blacklist managed by the `NO_AUTO_PROVISIONING` PR.

This **depends on https://github.com/hypothesis/lms/pull/373** because otherwise tests fail due to provisioning-related code being activated in decorators in tests that are not concerned with testing the decorators.

Before we can merge this, we need to add the `NO_AUTO_PROVISIONING` blacklist to the env configuration for the lms-qa and lms-prod app. The existing `AUTO_PROVISIONING` env var can remain until after this change is deployed out to prod.

Fixes https://github.com/hypothesis/lms/issues/288