### PR TITLE
Add PATCH request to keep user data in sync

### DIFF
--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -9,7 +9,7 @@ from lms.util.lti_launch import lti_launch
 from lms.util.view_renderer import view_renderer
 from lms.util.associate_user import associate_user
 from lms.util.authorize_lms import authorize_lms
-from lms.views.decorators import create_h_user
+from lms.views.decorators import upsert_h_user
 from lms.views.decorators import create_course_group
 
 
@@ -38,7 +38,7 @@ def should_canvas_oauth(request):
 
 @view_config(route_name="content_item_selection", request_method="POST")
 @lti_launch
-@create_h_user
+@upsert_h_user
 @create_course_group
 @associate_user
 @authorize_lms(

--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -2,8 +2,8 @@
 
 """Python decorators meant to be used for decorating Pyramid view functions."""
 
-from lms.views.decorators.h_api import create_h_user
+from lms.views.decorators.h_api import upsert_h_user
 from lms.views.decorators.h_api import create_course_group
 from lms.views.decorators.h_api import add_user_to_group
 
-__all__ = ("create_h_user", "create_course_group", "add_user_to_group")
+__all__ = ("upsert_h_user", "create_course_group", "add_user_to_group")

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -9,7 +9,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 from lms.services import HAPINotFoundError
 
 
-def create_h_user(wrapped):  # noqa: MC0001
+def upsert_h_user(wrapped):  # noqa: MC0001
     """
     Update or create a Hypothesis LTI user.
 
@@ -20,7 +20,7 @@ def create_h_user(wrapped):  # noqa: MC0001
     The wrapped view must take ``request`` and ``jwt`` arguments::
 
       @view_config(...)
-      @create_h_user
+      @upsert_h_user
       def my_view(request, jwt):
           ...
 

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -16,7 +16,7 @@ from lms.util.authorize_lms import authorize_lms, save_token
 from lms.util import via_url
 from lms.models.tokens import find_token_by_user_id
 from lms.models.application_instance import find_by_oauth_consumer_key
-from lms.views.decorators import create_h_user
+from lms.views.decorators import upsert_h_user
 from lms.views.decorators import create_course_group
 from lms.views.decorators import add_user_to_group
 
@@ -206,7 +206,7 @@ def should_launch(request):
 
 @view_config(route_name="lti_launches", request_method="POST")
 @lti_launch
-@create_h_user
+@upsert_h_user
 @create_course_group
 @add_user_to_group
 @associate_user


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/252

This PR adjusts the way that user API requests are handled in LTI launches. It will now attempt to update an existing user via PATCH—this will have the effect of keeping a LMS user's display name in sync, and potentially other data in the future. If the user doesn't exist yet—if the PATCH request results in a 404—then it will continue on and try to create the new user.

I marked this WIP because of a question I have about 409/Conflict errors.

I have tested this locally by changing my Canvas user's display name and making sure it updates, as well as deleting that user in the `h` database and and launching the assignment again, etc., but it could use some additional scrutiny to be sure.