### PR TITLE
Blacklist in DB 0/n: Fix DB migration logging

### DIFF
--- a/conf/alembic.ini
+++ b/conf/alembic.ini
@@ -12,7 +12,7 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
+level = INFO
 handlers = console
 qualname =
 


### PR DESCRIPTION
DB migration scripts normally log using `log.info()`. Fix the root logging level so that info messages actually get printed.