### PR TITLE
Blacklist in DB 5/n: Enable provisioning based on DB

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -138,17 +138,6 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
     # will be accepted over postMessage. In a development environment the
     # Hypothesis client would normally be served from localhost:5000.
     export RPC_ALLOWED_ORIGINS="http://localhost:5000"
-
-    # An optional space-separated list of the consumer keys of the application
-    # instances for which the "auto provisioning" features should be enabled.
-    # Defaults to an empty list ([]) if none provided (i.e. the features will
-    # be disabled for all application instances).
-    #
-    # The consumer key strings here should match the values in the
-    # lms.models.ApplicationInstances.consumer_key column in the database,
-    # which are also the same as the LTI "oauth_consumer_key" parameter values
-    # that LMS's send to us in LTI launch requests.
-    export AUTO_PROVISIONING="Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20"
     ```
 
 1. **Try out the postgres docker container**

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -41,9 +41,6 @@ def configure(settings):
         "h_authority": env_setting("H_AUTHORITY", required=True),
         # The base URL of the h API (e.g. "https://hypothes.is/api).
         "h_api_url": env_setting("H_API_URL", required=True),
-        # The list of `oauth_consumer_key`s of the application instances for
-        # which the automatic user and group provisioning features are enabled.
-        "auto_provisioning": env_setting("AUTO_PROVISIONING", default=""),
         # The postMessage origins from which to accept RPC requests.
         "rpc_allowed_origins": env_setting("RPC_ALLOWED_ORIGINS", required=True),
     }
@@ -60,7 +57,6 @@ def configure(settings):
     except UnicodeEncodeError:
         raise SettingError("LMS_SECRET must contain only ASCII characters")
 
-    env_settings["auto_provisioning"] = aslist(env_settings["auto_provisioning"])
     env_settings["rpc_allowed_origins"] = aslist(env_settings["rpc_allowed_origins"])
 
     settings.update(env_settings)

--- a/tests/lms/config/__init___test.py
+++ b/tests/lms/config/__init___test.py
@@ -152,64 +152,6 @@ class TestConfigure:
         [
             # Strings with spaces in them get turned into lists.
             (
-                "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20",
-                [
-                    "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
-                    "Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20",
-                ],
-            ),
-            # A string with no spaces in it becomes a list of one.
-            (
-                "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
-                ["Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"],
-            ),
-            # Leading and trailing whitespace is ignored.
-            (
-                "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef  ",
-                ["Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"],
-            ),
-            (
-                "  Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
-                ["Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"],
-            ),
-            (
-                "  Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef  ",
-                ["Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"],
-            ),
-            (
-                " Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef   Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20 ",
-                [
-                    "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
-                    "Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20",
-                ],
-            ),
-            # An empty string produces an empty list.
-            ("", []),
-            # A whitespace-only string produces an empty list.
-            ("  ", []),
-        ],
-    )
-    def test_auto_provisioning_setting(
-        self, env_setting, envvar_value, expected_setting
-    ):
-        def side_effect(
-            envvar_name, *args, **kwargs
-        ):  # pylint: disable=unused-argument
-            if envvar_name == "AUTO_PROVISIONING":
-                return envvar_value
-            return mock.DEFAULT
-
-        env_setting.side_effect = side_effect
-
-        configurator = configure({})
-
-        assert configurator.registry.settings["auto_provisioning"] == expected_setting
-
-    @pytest.mark.parametrize(
-        "envvar_value,expected_setting",
-        [
-            # Strings with spaces in them get turned into lists.
-            (
                 "https://example.com https://hypothes.is",
                 ["https://example.com", "https://hypothes.is"],
             ),

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -167,7 +167,6 @@ def pyramid_config(pyramid_request):
         "h_jwt_client_secret": "TEST_JWT_CLIENT_SECRET",
         "h_authority": "TEST_AUTHORITY",
         "h_api_url": "https://example.com/api/",
-        "auto_provisioning": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef Hypothesisf6f3a575c0c73e20ab41aa6be09b9c20",
         "rpc_allowed_origins": ["http://localhost:5000"],
     }
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ skip_install = true
 passenv =
     tests: TEST_DATABASE_URL
     tests: PYTEST_ADDOPTS
-    dev: AUTO_PROVISIONING
     dev: DATABASE_URL
     dev: DEBUG
     dev: GOOGLE_APP_ID


### PR DESCRIPTION
Enable or disable the provisioning feature based on the new `provisioning` column in the DB, instead of on the `AUTO_PROVISIONING` envvar.

This is the PR that actually enables the new DB-based feature flag, and that makes it so that all new instances will now have provisioning enabled by default.