### PR TITLE
Fix the styling of the reports page

### DIFF
--- a/lms/static/styles/reports.css
+++ b/lms/static/styles/reports.css
@@ -1,0 +1,31 @@
+html{
+  font-family: 'Roboto', sans-serif;
+}
+
+.data {
+  font-family: 'Inconsolata', 'Hack', 'Courier New', 'Courier', monospace;
+}
+
+table {
+  border-spacing: 0.5rem;
+  border-collapse: collapse;
+  max-width: 100%;
+}
+
+th {
+  border-bottom: 2px solid #dddddd;
+}
+
+th, td {
+  padding: 0.25em;
+  border: 1px solid #ddd;
+}
+
+table tr:nth-child(odd) { /* Zebra-stripe the rows */
+  background: #eee;
+}
+
+td.wrap { /* wrap veryyyyyyyy long data */
+  white-space: normal;
+  word-break: break-all;
+}

--- a/lms/templates/reports/application_report.html.jinja2
+++ b/lms/templates/reports/application_report.html.jinja2
@@ -1,51 +1,53 @@
-{% extends "templates/base.html.jinja2" %}
+<!doctype html>
+<html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <title>Application Instances</title>
+    <link rel="stylesheet" type="text/css" href="{{'lms:static/styles/reports.css'|static_path}}">
+  </head>
+  <body>
+    <h1>Application Reports</h1>
 
-{% block title %}Application Instances{% endblock %}
+    <h2>Generated Application Instances</h2>
+    <p>{{ apps|length }} application instance credentials have been generated:</p>
+    <table>
+      <tr>
+          <th>Created At</th>
+          <th>Lms Url</th>
+          <th>Signup Email</th>
+          <th>Consumer Key</th>
+          <th>Shared Secret</th>
+      </tr>
+      {% for row in apps %}
+        <tr class="data">
+          <td>{{  row['created']  }}</td>
+          <td>{{  row['lms_url']  }}</td>
+          <td>{{  row['requesters_email']  }}</td>
+          <td>{{  row['consumer_key']  }}</td>
+          <td>{{  row['shared_secret']  }}</td>
+        </tr>
+      {% endfor %}
+    </table>
 
-{% block content %}
-    <div id="content">
-        <h1>Application Reports</h1>
+    <h2>LTI App Launches</h2>
+    <p>There have been {{ num_launches }} lti launches:</p>
+    <table>
+      <tr>
+        <th>Context ID</th>
+        <th>Number of Launches</th>
+        <th>Lms Url</th>
+        <th>Signup Email</th>
+        <th>Consumer Key</th>
+      </tr>
+      {% for row in launches %}
+        <tr class="data">
+          {% for element in row %}
+            <td>{{  element  }}</td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </table>
 
-        <h2>Generated Application Instances</h2>
-        <p>{{ apps|length }} application instance credentials have been generated:</p>
-        <table>
-            <tr>
-                <th>Created At</th>
-                <th>Lms Url</th>
-                <th>Signup Email</th>
-                <th>Consumer Key</th>
-                <th>Shared Secret</th>
-            </tr>
-        {% for row in apps %}
-            <tr class="data">
-                <td>{{  row['created']  }}</td>
-                <td>{{  row['lms_url']  }}</td>
-                <td>{{  row['requesters_email']  }}</td>
-                <td>{{  row['consumer_key']  }}</td>
-                <td class="wrap">{{  row['shared_secret']  }}</td>
-            </tr>
-        {% endfor %}
-        </table>
-
-        <h2>LTI App Launches</h2>
-        <p>There have been {{ num_launches }} lti launches:</p>
-        <table>
-            <tr>
-                <th>Context ID</th>
-                <th>Number of Launches</th>
-                <th>Lms Url</th>
-                <th>Signup Email</th>
-                <th>Consumer Key</th>
-            </tr>
-        {% for row in launches %}
-            <tr class="data">
-              {% for element in row %}
-                <td>{{  element  }}</td>
-              {% endfor %}
-            </tr>
-        {% endfor %}
-        </table>
-
-        <div><p><a class="btn btn--gray" href="{{ logout_url }}">Log out</a></p></div>
-    </div>
-{% endblock %}
+    <div><p><a class="btn btn--gray" href="{{ logout_url }}">Log out</a></p></div>
+  </body>
+</html>


### PR DESCRIPTION
The styling of the reports page was such that, once there's enough data, the newest table rows are in a fixed and out-of-view position and can't be seen.

Change application_report.html.jinja2 to be a standalone template and no longer extend base.html.jinja2. This means that the global lms.css file no longer applies to this page. Add a reports.css file for the page instead containing some minimal CSS to make the tables look slightly nicer.