### PR TITLE
Fix 404 views

### DIFF
--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -3,11 +3,18 @@ import os
 from pyramid import httpexceptions
 from pyramid import i18n
 from pyramid.settings import asbool
+from pyramid.view import notfound_view_config
 import sentry_sdk
 
 from lms.exceptions import LTILaunchError
 
 _ = i18n.TranslationStringFactory(__package__)
+
+
+@notfound_view_config(renderer="lms:templates/error.html.jinja2")
+def notfound(request):
+    request.response.status_int = 404
+    return {"message": _("Page not found")}
 
 
 def http_error(exc, request):


### PR DESCRIPTION
Add a Pyramid Not Found view, see:

https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#changing-the-not-found-view

This overrides the other error views when the problem is a 404 not found. This fixes two issues:

1. The new notfound view doesn't report 404s to Sentry. Fixes https://github.com/hypothesis/lms/issues/438

2. Internal Pyramid errors are no longer shown to the user on 404 pages. Fixes https://github.com/hypothesis/lms/issues/437