### PR TITLE
Remove unneeded lti_launch_error() view

### DIFF
--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -6,7 +6,6 @@ from pyramid.settings import asbool
 from pyramid.view import notfound_view_config
 import sentry_sdk
 
-from lms.exceptions import LTILaunchError
 
 _ = i18n.TranslationStringFactory(__package__)
 
@@ -33,23 +32,6 @@ def http_error(exc, request):
     """
     sentry_sdk.capture_exception(exc)
     request.response.status_int = exc.status_int
-    return {"message": str(exc)}
-
-
-def lti_launch_error(exc, request):
-    """
-    Handle an invalid LTI launch request.
-
-    Code raises :exc:`lms.exceptions.LTILaunchError` if there's a problem
-    with an LTI launch request, such as a required LTI launch parameter
-    missing. When this happens we:
-
-    1. Report the error to Sentry.
-    2. Set the HTTP response status code to 400 Bad Request.
-    3. Show the user an error page containing the specific error message
-    """
-    sentry_sdk.capture_exception(exc)
-    request.response.status_int = 400
     return {"message": str(exc)}
 
 
@@ -95,5 +77,4 @@ def includeme(config):
     config.add_exception_view(
         http_error, context=httpexceptions.HTTPError, **view_defaults
     )
-    config.add_exception_view(lti_launch_error, context=LTILaunchError, **view_defaults)
     config.add_exception_view(error, context=Exception, **view_defaults)

--- a/tests/lms/views/error_test.py
+++ b/tests/lms/views/error_test.py
@@ -4,7 +4,6 @@ from pyramid.httpexceptions import HTTPNotImplemented
 import pytest
 
 from lms.views import error
-from lms.exceptions import LTILaunchError
 
 
 class TestHTTPError:
@@ -28,29 +27,6 @@ class TestHTTPError:
         result = error.http_error(exc, pyramid_request)
 
         assert result["message"] == "This is the error message"
-
-
-class TestLTILaunchError:
-    def test_it_reports_exception_to_sentry(self, pyramid_request, sentry_sdk):
-        exc = LTILaunchError("the_message")
-
-        error.lti_launch_error(exc, pyramid_request)
-
-        sentry_sdk.capture_exception.assert_called_once_with(exc)
-
-    def test_it_sets_response_status(self, pyramid_request):
-        exc = LTILaunchError("the_message")
-
-        error.lti_launch_error(exc, pyramid_request)
-
-        assert pyramid_request.response.status_int == 400
-
-    def test_it_shows_the_exception_message_to_the_user(self, pyramid_request):
-        exc = LTILaunchError("the_message")
-
-        result = error.lti_launch_error(exc, pyramid_request)
-
-        assert result["message"] == "the_message"
 
 
 class TestError:


### PR DESCRIPTION
Without this view LTILaunchErrors will be caught by the http_error() view above which does exactly the same thing.