### PR TITLE
Don't log HTTP errors

### DIFF
--- a/conf/production.ini
+++ b/conf/production.ini
@@ -6,9 +6,6 @@ pipeline:
 [app:lms]
 use = call:lms.app:create_app
 pyramid.includes = pyramid_exclog
-# Do log HTTPErrors. pyramid_exclog ignores WSGIHTTPException and subclasses by
-# default.
-exclog.ignore =
 exclog.extra_info = true
 
 [server:main]


### PR DESCRIPTION
These may just be noise in the logs. Also, sentry_sdk's logger integration is picking these up and sending them to Sentry, where we don't want them.