### PR TITLE
Update new_application_instance.html.jinja2

### DIFF
--- a/lms/templates/application_instances/new_application_instance.html.jinja2
+++ b/lms/templates/application_instances/new_application_instance.html.jinja2
@@ -30,13 +30,13 @@
     <h2>Canvas File Picker Integration</h2>
     <p class="modal-text">The following fields are only needed if you are using the Canvas LMS and would like to enable the file picker.</p>
     <div class="input">
-      <label for="developer-key">Canvas Developer ID (optional)</label>
-      <input id="developer-key" type="text" name="developer_key"/>
+      <label for="developer-id">Canvas Developer ID (optional)</label>
+      <input id="developer-id" type="text" name="developer_key"/>
       <span class="error"></span>
     </div>
     <div class="input">
-      <label for="developer-secret">Canvas Developer Secret (optional)</label>
-      <input id="developer-secret" type="text" name="developer_secret"/>
+      <label for="developer-key">Canvas Developer Key (optional)</label>
+      <input id="developer-key" type="text" name="developer_secret"/>
       <span class="error"></span>
     </div>
     <div class="form-controls">


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/412.

Canvas Picker setup fields now ask for a Canvas Developer ID and Canvas Developer Key, matching Canvas' naming convention for these credentials.