### PR TITLE
Add validation layer and validate /canvas_oauth_callback

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -24,6 +24,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.assets")
     config.include("lms.views.error")
     config.include("lms.services")
+    config.include("lms.validation")
     config.add_static_view(name="export", path="lms:static/export")
     config.add_static_view(name="static", path="lms:static")
 

--- a/lms/templates/validation_error.html.jinja2
+++ b/lms/templates/validation_error.html.jinja2
@@ -1,0 +1,20 @@
+{% extends 'templates/base.html.jinja2' %}
+
+{% set title = error.message %}
+
+{% block content %}
+  <img src="{{ 'lms:static/images/sad-annotation.svg'|static_path }}">
+  <p>{% trans %}Hypothesis received an invalid request.
+  There were problems with these request parameters:{% endtrans %}</p>
+  <ul>
+  {% for field in error.messages %}
+    <li>
+      {{ field }}:
+      <ul>
+        {% for message in error.messages[field] %}
+          <li>{{ message }}</li>
+        {% endfor %}
+      </ul>
+    </li>
+  {% endfor %}
+{% endblock %}

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -1,3 +1,29 @@
+"""
+Schemas for parsing and validating requests.
+
+This package contains schemas that views can use to validate and parse
+requests. The idea is that the request is validated before the view is called.
+If validation fails an error response is sent back and the view is never
+called. If validation succeeds the parsed and validated parameters are made
+available to the view as ``request.parsed_params``. The view's own code can
+assume that all the parsed params are valid and that all required params are
+present.
+
+Usage::
+
+    from lms.validation import FOO_SCHEMA
+
+    @view_config(..., schema=FOO_SCHEMA)
+    def foo_view(request):
+        validated_arg_1 = request.parsed_params["validated_arg_1"]
+        validated_arg_2 = request.parsed_params["validated_arg_2"]
+        ...
+
+Note that we're using our own view deriver (the ``schema`` argument to
+``view_config``) to integrate our schemas and views, rather than using webargs's
+``@use_args()`` / ``@use_kwargs()`` decorators. For the reasons for this see
+commit message f61a5ff3cae6b983e24db809d8e4b4933aca1e92.
+"""
 from webargs import pyramidparser
 
 from lms.validation._exceptions import ValidationError

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -1,0 +1,15 @@
+from webargs import pyramidparser
+
+from lms.validation._exceptions import ValidationError
+from lms.validation._oauth import CANVAS_OAUTH_CALLBACK_ARGS
+
+
+__all__ = ("parser", "CANVAS_OAUTH_CALLBACK_ARGS", "ValidationError")
+
+
+parser = pyramidparser.PyramidParser()
+
+
+@parser.error_handler
+def _handle_error(error, _req, _schema, _status_code, _headers):
+    raise ValidationError(messages=error.messages) from error

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -13,3 +13,42 @@ parser = pyramidparser.PyramidParser()
 @parser.error_handler
 def _handle_error(error, _req, _schema, _status_code, _headers):
     raise ValidationError(messages=error.messages) from error
+
+
+def _validated_view(view, info):
+    """
+    Validate the request and then call the view.
+
+    Validate the request params using the view's configured
+    schema and, if validation succeeds, go on to call the view normally.
+
+    Make the validated and parsed params available to the view as
+    ``request.parsed_params``.
+
+    If validation fails don't call the view.
+
+    This is a Pyramid "view deriver" that Pyramid calls if the view has a
+    ``schema=some_schema`` argument in its view config. For example
+    ``@view_config(..., schema=lms.validation.foo_schema)``. See:
+
+    https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#custom-view-derivers
+    """
+    if "schema" in info.options:
+
+        def wrapper_view(context, request):
+            # Use the view's configured schema to validate the request,
+            # and make the validated and parsed request params available as
+            # request.parsed_params.
+            # If validation fails this will raise ValidationError and the view won't be called.
+            request.parsed_params = parser.parse(info.options["schema"], request)
+
+            # Call the view normally.
+            return view(context, request)
+
+        return wrapper_view
+    return view
+
+
+def includeme(config):
+    _validated_view.options = ["schema"]
+    config.add_view_deriver(_validated_view)

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -1,10 +1,10 @@
 from webargs import pyramidparser
 
 from lms.validation._exceptions import ValidationError
-from lms.validation._oauth import CANVAS_OAUTH_CALLBACK_ARGS
+from lms.validation._oauth import CANVAS_OAUTH_CALLBACK_SCHEMA
 
 
-__all__ = ("parser", "CANVAS_OAUTH_CALLBACK_ARGS", "ValidationError")
+__all__ = ("parser", "CANVAS_OAUTH_CALLBACK_SCHEMA", "ValidationError")
 
 
 parser = pyramidparser.PyramidParser()

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -53,7 +53,7 @@ def _validated_view(view, info):
 
     If validation fails don't call the view.
 
-    This is a Pyramid "view deriver" that Pyramid calls if the view has a
+    This is a Pyramid "view deriver" that a view can activate by having a
     ``schema=some_schema`` argument in its view config. For example
     ``@view_config(..., schema=lms.validation.foo_schema)``. See:
 

--- a/lms/validation/_exceptions.py
+++ b/lms/validation/_exceptions.py
@@ -1,0 +1,9 @@
+from pyramid import httpexceptions
+
+
+class ValidationError(
+    httpexceptions.HTTPUnprocessableEntity
+):  # pylint: disable=too-many-ancestors
+    def __init__(self, messages):
+        super().__init__()
+        self.messages = messages

--- a/lms/validation/_oauth.py
+++ b/lms/validation/_oauth.py
@@ -3,7 +3,7 @@ from webargs import fields
 
 
 #: Arguments for the canvas_oauth_callback() view.
-CANVAS_OAUTH_CALLBACK_ARGS = {
+CANVAS_OAUTH_CALLBACK_SCHEMA = {
     "code": fields.Str(required=True),
     "state": fields.Str(required=True),
 }

--- a/lms/validation/_oauth.py
+++ b/lms/validation/_oauth.py
@@ -1,0 +1,9 @@
+"""Validation for OAuth views."""
+from webargs import fields
+
+
+#: Arguments for the canvas_oauth_callback() view.
+CANVAS_OAUTH_CALLBACK_ARGS = {
+    "code": fields.Str(required=True),
+    "state": fields.Str(required=True),
+}

--- a/lms/views/oauth.py
+++ b/lms/views/oauth.py
@@ -8,7 +8,6 @@ from lms.models import find_user_from_state
 from lms.util import lti_params_for
 from lms.util.lti_launch import get_application_instance
 from lms.views.content_item_selection import content_item_form
-from lms.validation import parser
 from lms.validation import CANVAS_OAUTH_CALLBACK_ARGS
 
 
@@ -17,11 +16,17 @@ def build_canvas_token_url(lms_url):
     return lms_url + "/login/oauth2/token"
 
 
-@view_config(route_name="canvas_oauth_callback", request_method="GET")
-@parser.use_kwargs(CANVAS_OAUTH_CALLBACK_ARGS)
+@view_config(
+    route_name="canvas_oauth_callback",
+    request_method="GET",
+    schema=CANVAS_OAUTH_CALLBACK_ARGS,
+)
 # pylint: disable=too-many-locals
-def canvas_oauth_callback(request, code, state):
+def canvas_oauth_callback(request):
     """Route to handle content item selection oauth response."""
+    code = request.parsed_params["code"]
+    state = request.parsed_params["state"]
+
     lti_params = lti_params_for(request)
     consumer_key = lti_params["oauth_consumer_key"]
     application_instance = get_application_instance(request.db, consumer_key)

--- a/lms/views/oauth.py
+++ b/lms/views/oauth.py
@@ -8,7 +8,7 @@ from lms.models import find_user_from_state
 from lms.util import lti_params_for
 from lms.util.lti_launch import get_application_instance
 from lms.views.content_item_selection import content_item_form
-from lms.validation import CANVAS_OAUTH_CALLBACK_ARGS
+from lms.validation import CANVAS_OAUTH_CALLBACK_SCHEMA
 
 
 def build_canvas_token_url(lms_url):
@@ -19,7 +19,7 @@ def build_canvas_token_url(lms_url):
 @view_config(
     route_name="canvas_oauth_callback",
     request_method="GET",
-    schema=CANVAS_OAUTH_CALLBACK_ARGS,
+    schema=CANVAS_OAUTH_CALLBACK_SCHEMA,
 )
 # pylint: disable=too-many-locals
 def canvas_oauth_callback(request):

--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ PyJWT
 requests_oauthlib
 requests
 pycrypto==2.6.1
+webargs

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ idna==2.6                 # via requests
 jinja2==2.10              # via pyramid-jinja2
 mako==1.0.7               # via alembic
 markupsafe==1.0           # via jinja2, mako, pyramid-jinja2
+marshmallow==2.18.0       # via webargs
 newrelic==4.12.0.113
 oauth2==1.9.0.post1       # via pylti
 oauthlib==3.0.1           # via requests-oauthlib
@@ -40,6 +41,7 @@ transaction==2.1.2        # via pyramid-tm, zope.sqlalchemy
 translationstring==1.3    # via pyramid
 urllib3==1.24.1           # via requests, sentry-sdk
 venusian==1.1.0           # via pyramid
+webargs==5.1.2
 webob==1.8.3              # via pyramid
 wired==0.1.1              # via pyramid-services
 zope.deprecation==4.3.0   # via pyramid, pyramid-jinja2

--- a/tests/lms/validation/__init___test.py
+++ b/tests/lms/validation/__init___test.py
@@ -2,8 +2,11 @@ from unittest import mock
 
 import pytest
 import webargs
+from pyramid.interfaces import IViewDerivers
 
 from lms.validation import _handle_error
+from lms.validation import _validated_view
+from lms.validation import includeme
 from lms.validation import ValidationError
 
 
@@ -32,3 +35,95 @@ class TestHandleError:
         # It raises the new exception from the original exception, so that the
         # original exception isn't lost.
         assert exc_info.value.__cause__ == webargs_exception
+
+
+class TestValidatedView:
+    def test_it_doesnt_wrap_views_that_dont_have_a_schema(self, info, view):
+        # Pyramid calls every view deriver regardless of which view is being
+        # derived.  It's up to the view deriver itself to not wrap views that
+        # it isn't interested in. _validated_view() is only interested in views
+        # that have a `schema=` argument in their view config.
+        del info.options["schema"]
+
+        assert _validated_view(view, info) == view
+
+    def test_it_validates_the_request_with_the_views_schema(
+        self, context, info, parser, pyramid_request, schema, view
+    ):
+        # Derive and call the wrapper view.
+        _validated_view(view, info)(context, pyramid_request)
+
+        parser.parse.assert_called_once_with(schema, pyramid_request)
+
+    def test_it_adds_the_parsed_params_to_the_request(
+        self, context, info, pyramid_request, view, parsed_params
+    ):
+        # Derive and call the wrapper view.
+        _validated_view(view, info)(context, pyramid_request)
+
+        assert pyramid_request.parsed_params == parsed_params
+
+    def test_it_proxies_to_the_wrapped_view(self, context, info, pyramid_request, view):
+        returned = _validated_view(view, info)(context, pyramid_request)
+
+        view.assert_called_once_with(context, pyramid_request)
+        assert returned == view.return_value
+
+    def test_it_errors_if_validation_fails(
+        self, context, info, parser, pyramid_request, schema, view
+    ):
+        parser.parse.side_effect = ValidationError("error_messages")
+        wrapper_view = _validated_view(view, info)
+
+        with pytest.raises(ValidationError):
+            wrapper_view(context, pyramid_request)
+
+        view.assert_not_called()
+
+    @pytest.fixture
+    def context(self):
+        """Return the Pyramid context object."""
+        return mock.sentinel.context
+
+    @pytest.fixture
+    def info(self):
+        """Return the Pyramid view deriver info object.
+
+        Pyramid passes one of these as an argument to every view deriver.
+        """
+        return mock.MagicMock(options={"schema": mock.sentinel.schema})
+
+    @pytest.fixture()
+    def parsed_params(self, parser):
+        """Return the parsed params as returned by the webargs parser."""
+        return parser.parse.return_value
+
+    @pytest.fixture(autouse=True)
+    def parser(self, patch):
+        """Return the webargs parser object."""
+        return patch("lms.validation.parser")
+
+    @pytest.fixture
+    def schema(self):
+        """Return the view's configured schema object."""
+        return mock.sentinel.schema
+
+    @pytest.fixture
+    def view(self):
+        """Return the view that is being derived."""
+        return mock.MagicMock()
+
+
+class TestIncludeMe:
+    def test_it_registers_the_view_deriver(self, pyramid_config, _validated_view):
+        includeme(pyramid_config)
+
+        assert _validated_view.options == ["schema"]
+        assert (
+            _validated_view
+            in pyramid_config.registry.queryUtility(IViewDerivers).values()
+        )
+
+    @pytest.fixture(autouse=True)
+    def _validated_view(self, patch):
+        return patch("lms.validation._validated_view")

--- a/tests/lms/validation/__init___test.py
+++ b/tests/lms/validation/__init___test.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+import pytest
+import webargs
+
+from lms.validation import _handle_error
+from lms.validation import ValidationError
+
+
+class TestHandleError:
+    def test(self):
+        webargs_exception = webargs.ValidationError(
+            message={
+                "field_name_1": ["Error message 1", "Error message 2"],
+                "field_name_2": ["Error message 3"],
+            }
+        )
+
+        # It wraps the webargs ValidationError in a custom ValidationError.
+        with pytest.raises(ValidationError) as exc_info:
+            _handle_error(
+                webargs_exception,
+                mock.sentinel.req,
+                mock.sentinel.schema,
+                mock.sentinel.status_code,
+                mock.sentinel.headers,
+            )
+
+        # It exposes the webargs exception's messages as .messages.
+        assert exc_info.value.messages == webargs_exception.messages
+
+        # It raises the new exception from the original exception, so that the
+        # original exception isn't lost.
+        assert exc_info.value.__cause__ == webargs_exception

--- a/tests/lms/validation/_exceptions_test.py
+++ b/tests/lms/validation/_exceptions_test.py
@@ -1,0 +1,11 @@
+from unittest import mock
+
+from lms.validation import ValidationError
+
+
+class TestValidationError:
+    def test(self):
+        validation_error = ValidationError(mock.sentinel.messages)
+
+        assert validation_error.messages == mock.sentinel.messages
+        assert validation_error.status_code == 422

--- a/tests/lms/validation/_oauth_test.py
+++ b/tests/lms/validation/_oauth_test.py
@@ -1,0 +1,74 @@
+import pytest
+from pyramid import testing
+
+from lms.validation import CANVAS_OAUTH_CALLBACK_ARGS
+from lms.validation import parser
+from lms.validation import ValidationError
+
+
+class TestCanvasOauthCallbackArgs:
+    def test_it_returns_the_parsed_args_for_a_valid_request(self, valid_request):
+        parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+
+        assert parsed_args == {"code": "test_code", "state": "test_state"}
+
+    def test_its_invalid_if_state_is_missing(self, valid_request):
+        del valid_request.params["state"]
+
+        with pytest.raises(ValidationError) as exc_info:
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+
+        assert exc_info.value.messages == {
+            "state": ["Missing data for required field."]
+        }
+
+    def test_its_invalid_if_state_isnt_a_string(self, valid_request):
+        valid_request.params["state"] = 23
+
+        with pytest.raises(ValidationError) as exc_info:
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+
+        assert exc_info.value.messages == {"state": ["Not a valid string."]}
+
+    def test_its_invalid_if_state_is_null(self, valid_request):
+        valid_request.params["state"] = None
+
+        with pytest.raises(ValidationError) as exc_info:
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+
+        assert exc_info.value.messages == {"state": ["Field may not be null."]}
+
+    def test_its_invalid_if_code_is_missing(self, valid_request):
+        del valid_request.params["code"]
+
+        with pytest.raises(ValidationError) as exc_info:
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+
+        assert exc_info.value.messages == {"code": ["Missing data for required field."]}
+
+    def test_its_invalid_if_code_isnt_a_string(self, valid_request):
+        valid_request.params["code"] = 23
+
+        with pytest.raises(ValidationError) as exc_info:
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+
+        assert exc_info.value.messages == {"code": ["Not a valid string."]}
+
+    def test_its_invalid_if_code_is_null(self, valid_request):
+        valid_request.params["code"] = None
+
+        with pytest.raises(ValidationError) as exc_info:
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+
+        assert exc_info.value.messages == {"code": ["Field may not be null."]}
+
+    @pytest.fixture
+    def valid_request(self):
+        """Return a minimal valid request.
+
+        All required fields are present and valid.
+        """
+        valid_request = testing.DummyRequest()
+        valid_request.params["code"] = "test_code"
+        valid_request.params["state"] = "test_state"
+        return valid_request

--- a/tests/lms/validation/_oauth_test.py
+++ b/tests/lms/validation/_oauth_test.py
@@ -1,14 +1,14 @@
 import pytest
 from pyramid import testing
 
-from lms.validation import CANVAS_OAUTH_CALLBACK_ARGS
+from lms.validation import CANVAS_OAUTH_CALLBACK_SCHEMA
 from lms.validation import parser
 from lms.validation import ValidationError
 
 
 class TestCanvasOauthCallbackArgs:
     def test_it_returns_the_parsed_args_for_a_valid_request(self, valid_request):
-        parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+        parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
 
         assert parsed_args == {"code": "test_code", "state": "test_state"}
 
@@ -16,7 +16,7 @@ class TestCanvasOauthCallbackArgs:
         del valid_request.params["state"]
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
 
         assert exc_info.value.messages == {
             "state": ["Missing data for required field."]
@@ -26,7 +26,7 @@ class TestCanvasOauthCallbackArgs:
         valid_request.params["state"] = 23
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
 
         assert exc_info.value.messages == {"state": ["Not a valid string."]}
 
@@ -34,7 +34,7 @@ class TestCanvasOauthCallbackArgs:
         valid_request.params["state"] = None
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
 
         assert exc_info.value.messages == {"state": ["Field may not be null."]}
 
@@ -42,7 +42,7 @@ class TestCanvasOauthCallbackArgs:
         del valid_request.params["code"]
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
 
         assert exc_info.value.messages == {"code": ["Missing data for required field."]}
 
@@ -50,7 +50,7 @@ class TestCanvasOauthCallbackArgs:
         valid_request.params["code"] = 23
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
 
         assert exc_info.value.messages == {"code": ["Not a valid string."]}
 
@@ -58,7 +58,7 @@ class TestCanvasOauthCallbackArgs:
         valid_request.params["code"] = None
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_ARGS, valid_request)
+            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
 
         assert exc_info.value.messages == {"code": ["Field may not be null."]}
 


### PR DESCRIPTION
Add validation to the `canvas_oauth_callback()` view.

Fixes https://github.com/hypothesis/lms/issues/449

Also fixes an undocumented issue that, given a valid `state` parameter, `canvas_oauth_callback()` would then crash if the `code` parameter was missing.

* Add <https://webargs.readthedocs.io/> as a new dependency, for validating requests

* Add `lms.validation`, a new top-level package intended to hold all validation code

  The way this works is that validation schemas, which are just called "args" in webargs, are defined and unit-tested in `lms.validation` and then imported into views modules and used as decorators on the views. The decorator passes the validated arguments into the view function as arguments or, if validation fails, the view function is never called.
  
  So far we have only one validation schema, very specific to one particular view: `CANVAS_OAUTH_CALLBACK_ARGS`. As it grows `lms.validation` should start to contain less view-specific schemas, having schemas that're reused by multiple views and schemas that reuse each other.

* The `CANVAS_OAUTH_CALLBACK_ARGS` schema is added to the `canvas_oauth_callback()` view. Nothing in the view itself needs to change except that it now receives `code` and `state` as arguments and no longer needs to extract them from `request.params` itself. The view can now safely assume that `code` and `state` are present and valid, which it was already unsafely assuming anyway. The view's tests would need to be updated to pass `code` and `state` as arguments not request parameters, but it doesn't have any tests. I don't want to spend time writing tests for it now either as the entire OAuth code needs overhauled anyway.

* A new `validation_error.html.jinja2` template is added because validation errors need to be rendered differently than other errors. It's the same as the existing `error.html.jinja2` but with support for iterating through the list of error message strings in a `ValidationError`.

  A new `validation_error()` error view is also added to support the new template.

Here's what the error page looks like with two fields having problems:

![screenshot from 2019-02-07 15-47-39](https://user-images.githubusercontent.com/22498/52423822-c6f56780-2af0-11e9-92f3-a4b916b549e4.png)

A single field can have more than one error, I'm sure you can imagine how that would look.

Here's how it looks with just one field with one error:

![screenshot from 2019-02-07 15-47-19](https://user-images.githubusercontent.com/22498/52423919-e7bdbd00-2af0-11e9-8b21-4d637149bbdb.png)

This is certainly not the best looking error page but the LMS app's error page is ugly as it is and I don't want to address that in this PR. This is the most straightforward way to get an error page showing all the (possibly multiple) errors, based on the existing error page design.

The error messages by the way are webargs's default ones, which I think is fine for now, but they are customizable.