### PR TITLE
Add lms header to identify lms api requests to H

### DIFF
--- a/lms/services/hapi.py
+++ b/lms/services/hapi.py
@@ -111,7 +111,7 @@ class HypothesisAPIService:
         """
         statuses = statuses or []
 
-        request_args = {}
+        request_args = {"headers": {"Hypothesis-Application": "lms"}}
 
         if path.startswith("/"):
             path = path[1:]
@@ -120,7 +120,7 @@ class HypothesisAPIService:
             request_args["data"] = json.dumps(data)
 
         if userid is not None:
-            request_args["headers"] = {"X-Forwarded-User": userid}
+            request_args["headers"]["X-Forwarded-User"] = userid
 
         try:
             response = requests.request(

--- a/tests/lms/services/hapi_test.py
+++ b/tests/lms/services/hapi_test.py
@@ -38,6 +38,7 @@ class TestAPIRequest:
             url="https://example.com/api/path",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
             timeout=10,
+            headers={"Hypothesis-Application": "lms"},
         )
 
     def test_it_strips_leading_slashes_from_the_path(
@@ -57,6 +58,7 @@ class TestAPIRequest:
             url="https://example.com/api/path",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
             timeout=10,
+            headers={"Hypothesis-Application": "lms"},
         )
 
     def test_it_sends_data_as_json(self, pyramid_request, requests, svc):
@@ -69,6 +71,13 @@ class TestAPIRequest:
 
         assert requests.request.call_args[1]["headers"]["X-Forwarded-User"] == (
             "acct:seanh@TEST_AUTHORITY"
+        )
+
+    def test_it_sends_hypothesis_lms_header(self, pyramid_request, requests, svc):
+        svc.post("path", data={"foo": "bar"})
+
+        assert requests.request.call_args[1]["headers"]["Hypothesis-Application"] == (
+            "lms"
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Add a header to H api requests that will help distinguish LMS requests from requests made by other services. Rather than making the header specific to lms, make it generic such that it can be used by other Hypothesis services to distinguish their requests as well.