### PR TITLE
Add a unique constraint to ApplicationInstance.consumer_key

### DIFF
--- a/lms/migrations/versions/cfd94b1300ce_add_applicationinstance_consumer_key_.py
+++ b/lms/migrations/versions/cfd94b1300ce_add_applicationinstance_consumer_key_.py
@@ -1,0 +1,27 @@
+"""
+Add ApplicationInstance.consumer_key unique constraint.
+
+Revision ID: cfd94b1300ce
+Revises: 83f18f61c76a
+Create Date: 2019-03-07 15:43:56.641856
+
+"""
+from alembic import op
+
+
+revision = "cfd94b1300ce"
+down_revision = "83f18f61c76a"
+
+
+def upgrade():
+    op.create_unique_constraint(
+        "uq__application_instances__consumer_key",
+        "application_instances",
+        ["consumer_key"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "uq__application_instances__consumer_key", "application_instances"
+    )

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -33,7 +33,7 @@ class ApplicationInstance(BASE):
     __tablename__ = "application_instances"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
-    consumer_key = sa.Column(sa.String)
+    consumer_key = sa.Column(sa.String, unique=True)
     shared_secret = sa.Column(sa.String)
     lms_url = sa.Column(sa.String(2048))
     requesters_email = sa.Column(sa.String(2048))

--- a/tests/lms/util/_lti_launch_test.py
+++ b/tests/lms/util/_lti_launch_test.py
@@ -23,19 +23,6 @@ class TestGetApplicationInstance:
             == application_instance
         )
 
-    def test_it_crashes_if_theres_more_than_one_matching_application_instance(
-        self, pyramid_request
-    ):
-        pyramid_request.db.add_all(
-            [
-                ApplicationInstance(consumer_key="TEST_OAUTH_CONSUMER_KEY"),
-                ApplicationInstance(consumer_key="TEST_OAUTH_CONSUMER_KEY"),
-            ]
-        )
-
-        with pytest.raises(MultipleResultsFound):
-            get_application_instance(pyramid_request.db, "TEST_OAUTH_CONSUMER_KEY")
-
     def test_it_crashes_if_theres_no_matching_application_instance(
         self, pyramid_request
     ):


### PR DESCRIPTION
In practice ApplicationInstance.consumer_key is always unique. Lets
enforce that in the database schema so that code can stop having to
handle the possibility of duplicate consumer keys.

The only place where we create new ApplicationInstance's is on the
https://hypothes.is/welcome page and that page generates a new unique
consumer key every time.

In the code, the only place where new ApplicationInstance objects are
created is in `build_from_lms_url()` and that uses the `secrets` library
(stdlib) to generate a new random consumer key every time:

https://github.com/hypothesis/lms/blob/5605422139e011dc93267d27510baffe3d32e4e8/lms/models/application_instance.py#L69-L95

Also see the docs for `secrets.token_hex()` here: https://docs.python.org/3/library/secrets.html#secrets.token_hex