### PR TITLE
Move no-longer-needed MultipleResultsFound handling

### DIFF
--- a/lms/util/_lti_launch.py
+++ b/lms/util/_lti_launch.py
@@ -18,8 +18,6 @@ def get_application_instance(db, consumer_key):
 
     :raise sqlalchemy.orm.exc.NoResultFound: if there's no application instance
       in the DB with the given ``consumer_key``
-    :raise sqlalchemy.orm.exc.MultipleResultsFound: if there's more than one
-      application instance in the DB with the given ``consumer_key``
 
     :return: the matching application instance
     :rtype: lms.models.ApplicationInstance

--- a/tests/lms/util/_lti_launch_test.py
+++ b/tests/lms/util/_lti_launch_test.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.orm.exc import MultipleResultsFound
 from pylti.common import LTIException
 
 from lms.util import get_application_instance
@@ -56,14 +55,6 @@ class TestLTILaunch:
         get_application_instance.side_effect = NoResultFound()
 
         with pytest.raises(NoResultFound):
-            wrapper(pyramid_request)
-
-    def test_it_crashes_if_theres_more_than_one_application_instance_in_the_db(
-        self, pyramid_request, wrapper, get_application_instance
-    ):
-        get_application_instance.side_effect = MultipleResultsFound()
-
-        with pytest.raises(MultipleResultsFound):
             wrapper(pyramid_request)
 
     def test_it_verifies_the_request(self, pyramid_request, pylti, wrapper):


### PR DESCRIPTION
A unique constraint ensures that there can't be multiple ApplicationInstances in the DB with the same consumer_key.