### PR TITLE
Use LTILaunch context fixture only where needed

### DIFF
--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -15,7 +15,6 @@ from pyramid import testing
 from pyramid.request import apply_request_extensions
 
 from lms import db
-from lms.config.resources import LTILaunch
 from lms.models import User
 from lms.models import Token
 from lms.models import OauthState
@@ -235,15 +234,6 @@ def lti_launch_request(monkeypatch, pyramid_request):
     pyramid_request.params["context_id"] = "fake_context_id"
     monkeypatch.setattr(
         "pylti.common.verify_request_common", lambda a, b, c, d, e: True
-    )
-
-    pyramid_request.context = mock.create_autospec(
-        LTILaunch,
-        spec_set=True,
-        instance=True,
-        rpc_server_config={},
-        hypothesis_config={},
-        provisioning_enabled=True,
     )
 
     yield pyramid_request

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -4,6 +4,7 @@ import pytest
 
 from lms.views.lti_launches import lti_launches
 from lms.exceptions import MissingLTILaunchParamError
+from lms.config.resources import LTILaunch
 from tests.lms.conftest import unwrap
 
 
@@ -115,6 +116,16 @@ class TestLtiLaunches:
 @pytest.fixture
 def lti_launch_request(lti_launch_request):
     lti_launch_request.params["resource_link_id"] = "test_link_id"
+
+    lti_launch_request.context = mock.create_autospec(
+        LTILaunch,
+        spec_set=True,
+        instance=True,
+        rpc_server_config={},
+        hypothesis_config={},
+        provisioning_enabled=True,
+    )
+
     return lti_launch_request
 
 


### PR DESCRIPTION
Don't set `lti_launch_request.context` to a mock `LTILaunch` object globally for all tests, as this is causing some mysterious test failures on another branch (and I don't understand why). Instead, apply the
`LTILaunch` mock only to the one test module that needs it (and crashes without it).