### PR TITLE
Deduplicate application instance getter code with new ApplicationInstanceGetter service

### DIFF
--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -7,7 +7,6 @@ from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.security import Allow
 
 from lms.util import lti_params_for
-from lms.services import ConsumerKeyError
 
 
 class Root:
@@ -221,10 +220,7 @@ class LTILaunch:
         :raise HTTPBadRequest: if there's no oauth_consumer_key in the request
           params
         """
-        try:
-            return self._ai_getter.provisioning(self._get_param("oauth_consumer_key"))
-        except ConsumerKeyError:
-            return False
+        return self._ai_getter.provisioning(self._get_param("oauth_consumer_key"))
 
     def _get_param(self, param_name):
         """Return the named param from the request or raise a 400."""

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -7,7 +7,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.security import Allow
 
 from lms.util import lti_params_for
-from lms.models.application_instance import find_by_oauth_consumer_key
+from lms.services import ConsumerKeyError
 
 
 class Root:
@@ -36,6 +36,7 @@ class LTILaunch:
         """Return the context resource for an LTI launch request."""
         self._request = request
         self._authority = self._request.registry.settings["h_authority"]
+        self._ai_getter = self._request.find_service(name="ai_getter")
 
         # This will raise HTTPBadRequest if the request looks like an OAuth
         # redirect request but no DB-stashed LTI params can be found for the
@@ -220,12 +221,10 @@ class LTILaunch:
         :raise HTTPBadRequest: if there's no oauth_consumer_key in the request
           params
         """
-        application_instance = find_by_oauth_consumer_key(
-            self._request.db, self._get_param("oauth_consumer_key")
-        )
-        if application_instance is None:
+        try:
+            return self._ai_getter.provisioning(self._get_param("oauth_consumer_key"))
+        except ConsumerKeyError:
             return False
-        return application_instance.provisioning
 
     def _get_param(self, param_name):
         """Return the named param from the request or raise a 400."""

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -220,7 +220,9 @@ class LTILaunch:
         :raise HTTPBadRequest: if there's no oauth_consumer_key in the request
           params
         """
-        return self._ai_getter.provisioning_enabled(self._get_param("oauth_consumer_key"))
+        return self._ai_getter.provisioning_enabled(
+            self._get_param("oauth_consumer_key")
+        )
 
     def _get_param(self, param_name):
         """Return the named param from the request or raise a 400."""

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -220,7 +220,7 @@ class LTILaunch:
         :raise HTTPBadRequest: if there's no oauth_consumer_key in the request
           params
         """
-        return self._ai_getter.provisioning(self._get_param("oauth_consumer_key"))
+        return self._ai_getter.provisioning_enabled(self._get_param("oauth_consumer_key"))
 
     def _get_param(self, param_name):
         """Return the named param from the request or raise a 400."""

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -21,12 +21,6 @@ def encrypt_oauth_secret(oauth_secret, key, init_v):
     return cipher.encrypt(oauth_secret)
 
 
-def decrypt_oauth_secret(encrypted_secret, key, init_v):
-    """Decrypt AES encrypted secret."""
-    cipher = AES.new(key, AES.MODE_CFB, init_v)
-    return cipher.decrypt(encrypted_secret)
-
-
 class ApplicationInstance(BASE):
     """Class to represent a single lms install."""
 
@@ -47,10 +41,6 @@ class ApplicationInstance(BASE):
         server_default=sa.sql.expression.true(),
         nullable=False,
     )
-
-    def decrypted_developer_secret(self, key):
-        encrypted_secret = self.developer_secret
-        return decrypt_oauth_secret(encrypted_secret, key, self.aes_cipher_iv)
 
 
 def find_by_oauth_consumer_key(session, key):

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -43,14 +43,6 @@ class ApplicationInstance(BASE):
     )
 
 
-def find_by_oauth_consumer_key(session, key):
-    return (
-        session.query(ApplicationInstance)
-        .filter(ApplicationInstance.consumer_key == key)
-        .one_or_none()
-    )
-
-
 def build_shared_secret():
     """Generate a shared secret."""
     return secrets.token_hex(32)

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,10 +1,16 @@
+from lms.services.exceptions import ServiceError
+from lms.services.exceptions import ConsumerKeyError
 from lms.services.exceptions import HAPIError
 from lms.services.exceptions import HAPINotFoundError
 
-__all__ = ("HAPIError", "HAPINotFoundError")
+__all__ = ("ServiceError", "ConsumerKeyError", "HAPIError", "HAPINotFoundError")
 
 
 def includeme(config):
     config.register_service_factory(
         "lms.services.hapi.HypothesisAPIService", name="hapi"
+    )
+    config.register_service_factory(
+        "lms.services.application_instance_getter.ApplicationInstanceGetter",
+        name="ai_getter",
     )

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -63,7 +63,7 @@ class ApplicationInstanceGetter:
         """
         return self._get(consumer_key).lms_url
 
-    def provisioning(self, consumer_key):
+    def provisioning_enabled(self, consumer_key):
         """
         Return ``True`` if provisioning is enabled for the given consumer key.
 

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -1,0 +1,117 @@
+from Crypto.Cipher import AES
+from sqlalchemy.orm.exc import NoResultFound
+
+from lms.services import ConsumerKeyError
+from lms.models import ApplicationInstance
+
+
+class ApplicationInstanceGetter:
+    """Methods for getting properties from application instances."""
+
+    def __init__(self, _context, request):
+        self._db = request.db
+        self._aes_secret = request.registry.settings["aes_secret"]
+
+    def developer_key(self, consumer_key):
+        """
+        Return the Canvas developer key for the given consumer_key, or None.
+
+        :arg consumer_key: the consumer key to search for
+        :type consumer_key: str
+
+        :raise ConsumerKeyError: if the consumer key isn't in the database
+
+        :return: the matching Canvas API developer key or ``None``
+        :rtype: str or ``None``
+        """
+        return self._get(consumer_key).developer_key
+
+    def developer_secret(self, consumer_key):
+        """
+        Return the Canvas developer secret for the given consumer_key, or None.
+
+        :arg consumer_key: the consumer key to search for
+        :type consumer_key: str
+
+        :raise ConsumerKeyError: if the consumer key isn't in the database
+
+        :return: the matching Canvas API developer secret or ``None``
+        :rtype: str or ``None``
+        """
+        application_instance = self._get(consumer_key)
+
+        developer_secret = application_instance.developer_secret
+        if developer_secret is None:
+            return None
+
+        cipher = AES.new(
+            self._aes_secret, AES.MODE_CFB, application_instance.aes_cipher_iv
+        )
+        return cipher.decrypt(developer_secret)
+
+    def lms_url(self, consumer_key):
+        """
+        Return the LMS URL for the given LTI consumer_key.
+
+        :arg consumer_key: the consumer key to search for
+        :type consumer_key: str
+
+        :raise ConsumerKeyError: if the consumer key isn't in the database
+
+        :return: the matching LMS URL
+        :rtype: str
+        """
+        return self._get(consumer_key).lms_url
+
+    def provisioning(self, consumer_key):
+        """
+        Return ``True`` if provisioning is enabled for the given consumer key.
+
+        Return ``True`` if the provisioning feature is enabled for the given
+        consumer key, ``False`` otherwise.
+
+        :arg consumer_key: the consumer key to search for
+        :type consumer_key: str
+        """
+        try:
+            provisioning = self._get(consumer_key).provisioning
+        except ConsumerKeyError:
+            provisioning = False
+        return provisioning
+
+    def shared_secret(self, consumer_key):
+        """
+        Return the LTI/OAuth 1 shared secret for the given LTI consumer_key.
+
+        This is called the ``oauth_consumer_secret`` in the OAuth 1.0 spec.
+
+        :arg consumer_key: the consumer key to search for
+        :type consumer_key: str
+
+        :raise ConsumerKeyError: if the consumer key isn't in the database
+
+        :return: the matching shared secret
+        :rtype: str
+        """
+        return self._get(consumer_key).shared_secret
+
+    def _get(self, consumer_key):
+        """
+        Return the ApplicationInstance with the given consumer_key or ``None``.
+
+        :arg consumer_key: the consumer key to search for
+        :type consumer_key: str
+
+        :raise ConsumerKeyError: if the consumer key isn't in the database
+
+        :return: the matching ApplicationInstance or ``None``
+        :rtype: :cls:`lms.models.ApplicationInstance` or ``None``
+        """
+        try:
+            return (
+                self._db.query(ApplicationInstance)
+                .filter(ApplicationInstance.consumer_key == consumer_key)
+                .one()
+            )
+        except NoResultFound as err:
+            raise ConsumerKeyError() from err

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,6 +1,14 @@
 from pyramid.httpexceptions import HTTPInternalServerError
 
 
+class ServiceError(Exception):
+    """Base class for all :mod:`lms.services` exceptions."""
+
+
+class ConsumerKeyError(ServiceError):
+    """Raised when a given ``consumer_key`` doesn't exist in the DB."""
+
+
 class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
     """
     A problem with an h API request.

--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -4,7 +4,6 @@ from lms.util.authenticate import authenticate
 from lms.util.authorize_lms import authorize_lms, save_token
 from lms.util.canvas_api import canvas_api, GET, POST
 from lms.util.jwt import jwt
-from lms.util._lti_launch import get_application_instance
 from lms.util._lti_launch import lti_launch
 from lms.util.lti import lti_params_for
 from lms.util.via import via_url
@@ -17,7 +16,6 @@ __all__ = (
     "canvas_api",
     "jwt",
     "lti_launch",
-    "get_application_instance",
     "lti_params_for",
     "save_token",
     "via_url",

--- a/lms/util/_lti_launch.py
+++ b/lms/util/_lti_launch.py
@@ -3,30 +3,8 @@ from functools import wraps
 
 import pylti.common
 
-from lms.models import application_instance as ai
 from lms.util.jwt import build_jwt_from_lti_launch
 from lms.exceptions import MissingLTILaunchParamError
-
-
-def get_application_instance(db, consumer_key):
-    """
-    Return the application instance with the given ``consumer_key``.
-
-    :arg db: the sqlalchemy session
-    :arg consumer_key: the consumer key to search for
-    :type consumer_key: str
-
-    :raise sqlalchemy.orm.exc.NoResultFound: if there's no application instance
-      in the DB with the given ``consumer_key``
-
-    :return: the matching application instance
-    :rtype: lms.models.ApplicationInstance
-    """
-    return (
-        db.query(ai.ApplicationInstance)
-        .filter(ai.ApplicationInstance.consumer_key == consumer_key)
-        .one()
-    )
 
 
 def get_lti_launch_params(request):

--- a/lms/util/_lti_launch.py
+++ b/lms/util/_lti_launch.py
@@ -56,7 +56,9 @@ def lti_launch(view_function):
         except KeyError:
             raise MissingLTILaunchParamError("oauth_consumer_key")
 
-        shared_secret = get_application_instance(request.db, consumer_key).shared_secret
+        shared_secret = request.find_service(name="ai_getter").shared_secret(
+            consumer_key
+        )
 
         consumers = {}
 

--- a/lms/views/oauth.py
+++ b/lms/views/oauth.py
@@ -31,7 +31,7 @@ def canvas_oauth_callback(request):
 
     ai_getter = request.find_service(name="ai_getter")
     client_id = ai_getter.developer_key(consumer_key)
-    client_secret = ai_getter.decrypted_developer_secret(consumer_key)
+    client_secret = ai_getter.developer_secret(consumer_key)
     lms_url = ai_getter.lms_url(consumer_key)
     token_url = build_canvas_token_url(lms_url)
 

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -402,13 +402,6 @@ class TestLTILaunch:
 
         assert lti_launch.provisioning_enabled is False
 
-    def test_provisioning_enabled_returns_False_if_application_instance_not_found(
-        self, ai_getter, lti_launch
-    ):
-        ai_getter.provisioning.side_effect = ConsumerKeyError()
-
-        assert lti_launch.provisioning_enabled is False
-
     def test_provisioning_enabled_raises_if_no_oauth_consumer_key_in_params(
         self, lti_params_for, pyramid_request
     ):

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -372,7 +372,7 @@ class TestLTILaunch:
     def test_hypothesis_config_is_empty_if_provisioning_feature_is_disabled(
         self, lti_launch, ai_getter
     ):
-        ai_getter.provisioning.return_value = False
+        ai_getter.provisioning_enabled.return_value = False
 
         assert lti_launch.hypothesis_config == {}
 
@@ -386,7 +386,7 @@ class TestLTILaunch:
     ):
         lti_launch.provisioning_enabled
 
-        ai_getter.provisioning.assert_called_once_with(
+        ai_getter.provisioning_enabled.assert_called_once_with(
             "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
         )
 
@@ -398,7 +398,7 @@ class TestLTILaunch:
     def test_provisioning_enabled_returns_False_if_provisioning_disabled_for_application_instance(
         self, ai_getter, lti_launch
     ):
-        ai_getter.provisioning.return_value = False
+        ai_getter.provisioning_enabled.return_value = False
 
         assert lti_launch.provisioning_enabled is False
 

--- a/tests/lms/config/resources_test.py
+++ b/tests/lms/config/resources_test.py
@@ -6,7 +6,8 @@ import pytest
 from pyramid.httpexceptions import HTTPBadRequest
 
 from lms.config import resources
-from lms.models import ApplicationInstance
+from lms import models
+from lms.services import ConsumerKeyError
 
 
 class TestLTILaunch:
@@ -369,9 +370,9 @@ class TestLTILaunch:
         ]
 
     def test_hypothesis_config_is_empty_if_provisioning_feature_is_disabled(
-        self, lti_launch, find_by_oauth_consumer_key
+        self, lti_launch, ai_getter
     ):
-        find_by_oauth_consumer_key.return_value.provisioning = False
+        ai_getter.provisioning.return_value = False
 
         assert lti_launch.hypothesis_config == {}
 
@@ -380,33 +381,31 @@ class TestLTILaunch:
             "allowedOrigins": ["http://localhost:5000"]
         }
 
-    def test_provisioning_enabled_gets_application_instance_from_db(
-        self, find_by_oauth_consumer_key, lti_launch, pyramid_request
+    def test_provisioning_enabled_checks_whether_provisioning_is_enabled_for_the_request(
+        self, ai_getter, lti_launch, pyramid_request
     ):
         lti_launch.provisioning_enabled
 
-        find_by_oauth_consumer_key.assert_called_once_with(
-            pyramid_request.db, "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
+        ai_getter.provisioning.assert_called_once_with(
+            "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
         )
 
     def test_provisioning_enabled_returns_True_if_provisioning_enabled_for_application_instance(
-        self, find_by_oauth_consumer_key, lti_launch
+        self, lti_launch
     ):
-        find_by_oauth_consumer_key.return_value.provisioning = True
-
         assert lti_launch.provisioning_enabled is True
 
     def test_provisioning_enabled_returns_False_if_provisioning_disabled_for_application_instance(
-        self, find_by_oauth_consumer_key, lti_launch
+        self, ai_getter, lti_launch
     ):
-        find_by_oauth_consumer_key.return_value.provisioning = False
+        ai_getter.provisioning.return_value = False
 
         assert lti_launch.provisioning_enabled is False
 
     def test_provisioning_enabled_returns_False_if_application_instance_not_found(
-        self, find_by_oauth_consumer_key, lti_launch
+        self, ai_getter, lti_launch
     ):
-        find_by_oauth_consumer_key.return_value = None
+        ai_getter.provisioning.side_effect = ConsumerKeyError()
 
         assert lti_launch.provisioning_enabled is False
 
@@ -433,13 +432,3 @@ class TestLTILaunch:
             "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
         }
         return lti_params_for
-
-    @pytest.fixture(autouse=True)
-    def find_by_oauth_consumer_key(self, patch):
-        find_by_oauth_consumer_key = patch(
-            "lms.config.resources.find_by_oauth_consumer_key"
-        )
-        find_by_oauth_consumer_key.return_value = mock.create_autospec(
-            ApplicationInstance, spec_set=True, instance=True
-        )
-        return find_by_oauth_consumer_key

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -20,6 +20,7 @@ from lms.models import Token
 from lms.models import OauthState
 from lms.models import build_from_lms_url
 from lms.util import GET
+from lms.services.application_instance_getter import ApplicationInstanceGetter
 
 TEST_DATABASE_URL = os.environ.get(
     "TEST_DATABASE_URL", "postgresql://postgres@localhost:5433/lms_test"
@@ -187,6 +188,18 @@ def pyramid_config(pyramid_request):
         apply_request_extensions(pyramid_request)
 
         yield config
+
+
+@pytest.fixture(autouse=True)
+def ai_getter(pyramid_config):
+    ai_getter = mock.create_autospec(
+        ApplicationInstanceGetter, spec_set=True, instance=True
+    )
+    ai_getter.provisioning.return_value = True
+    ai_getter.lms_url.return_value = "https://example.com"
+    ai_getter.shared_secret.return_value = "TEST_SECRET"
+    pyramid_config.register_service(ai_getter, name="ai_getter")
+    return ai_getter
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -195,7 +195,7 @@ def ai_getter(pyramid_config):
     ai_getter = mock.create_autospec(
         ApplicationInstanceGetter, spec_set=True, instance=True
     )
-    ai_getter.provisioning.return_value = True
+    ai_getter.provisioning_enabled.return_value = True
     ai_getter.lms_url.return_value = "https://example.com"
     ai_getter.shared_secret.return_value = "TEST_SECRET"
     pyramid_config.register_service(ai_getter, name="ai_getter")

--- a/tests/lms/models/test_application_instance.py
+++ b/tests/lms/models/test_application_instance.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lms.models import ApplicationInstance
 
 

--- a/tests/lms/services/application_instance_getter_test.py
+++ b/tests/lms/services/application_instance_getter_test.py
@@ -86,12 +86,12 @@ class TestApplicationInstanceGetter:
             ApplicationInstance(consumer_key="TEST_CONSUMER_KEY", provisioning=flag)
         )
 
-        assert ai_getter.provisioning("TEST_CONSUMER_KEY") == flag
+        assert ai_getter.provisioning_enabled("TEST_CONSUMER_KEY") == flag
 
     def test_provisioning_returns_False_if_consumer_key_unknown(
         self, ai_getter, pyramid_request
     ):
-        assert ai_getter.provisioning("UNKNOWN_CONSUMER_KEY") is False
+        assert ai_getter.provisioning_enabled("UNKNOWN_CONSUMER_KEY") is False
 
     def test_shared_secret_returns_the_shared_secret(self, ai_getter, pyramid_request):
         pyramid_request.db.add(

--- a/tests/lms/services/application_instance_getter_test.py
+++ b/tests/lms/services/application_instance_getter_test.py
@@ -1,0 +1,144 @@
+from unittest import mock
+
+import pytest
+
+from lms.services.application_instance_getter import ApplicationInstanceGetter
+from lms.services import ConsumerKeyError
+from lms.models import ApplicationInstance
+from lms.models.application_instance import build_aes_iv
+from lms.models.application_instance import encrypt_oauth_secret
+
+
+class TestApplicationInstanceGetter:
+    def test_developer_key_returns_the_developer_key(self, ai_getter, pyramid_request):
+        pyramid_request.db.add(
+            ApplicationInstance(
+                consumer_key="TEST_CONSUMER_KEY", developer_key="TEST_DEVELOPER_KEY"
+            )
+        )
+
+        assert ai_getter.developer_key("TEST_CONSUMER_KEY") == "TEST_DEVELOPER_KEY"
+
+    def test_developer_key_returns_None_if_ApplicationInstance_has_no_developer_key(
+        self, ai_getter, pyramid_request
+    ):
+        pyramid_request.db.add(ApplicationInstance(consumer_key="TEST_CONSUMER_KEY"))
+
+        assert ai_getter.developer_key("TEST_CONSUMER_KEY") is None
+
+    def test_developer_key_raises_if_consumer_key_unknown(
+        self, ai_getter, pyramid_request
+    ):
+        with pytest.raises(ConsumerKeyError):
+            ai_getter.developer_key("UNKNOWN_CONSUMER_KEY")
+
+    def test_developer_secret_returns_the_decrypted_developer_secret(
+        self, ai_getter, pyramid_request
+    ):
+        aes_iv = build_aes_iv()
+        pyramid_request.db.add(
+            ApplicationInstance(
+                consumer_key="TEST_CONSUMER_KEY",
+                developer_secret=encrypt_oauth_secret(
+                    b"TEST_DEVELOPER_SECRET",
+                    pyramid_request.registry.settings["aes_secret"],
+                    aes_iv,
+                ),
+                aes_cipher_iv=aes_iv,
+            )
+        )
+
+        assert (
+            ai_getter.developer_secret("TEST_CONSUMER_KEY") == b"TEST_DEVELOPER_SECRET"
+        )
+
+    def test_developer_secret_returns_None_if_ApplicationInstance_has_no_developer_secret(
+        self, ai_getter, pyramid_request
+    ):
+        pyramid_request.db.add(ApplicationInstance(consumer_key="TEST_CONSUMER_KEY"))
+
+        assert ai_getter.developer_secret("TEST_CONSUMER_KEY") is None
+
+    def test_developer_secret_raises_if_consumer_key_unknown(
+        self, ai_getter, pyramid_request
+    ):
+        with pytest.raises(ConsumerKeyError):
+            ai_getter.developer_secret("UNKNOWN_CONSUMER_KEY")
+
+    def test_lms_url_returns_the_lms_url(self, ai_getter, pyramid_request):
+        pyramid_request.db.add(
+            ApplicationInstance(
+                consumer_key="TEST_CONSUMER_KEY", lms_url="TEST_LMS_URL"
+            )
+        )
+
+        assert ai_getter.lms_url("TEST_CONSUMER_KEY") == "TEST_LMS_URL"
+
+    def test_lms_url_raises_if_consumer_key_unknown(self, ai_getter, pyramid_request):
+        with pytest.raises(ConsumerKeyError):
+            ai_getter.lms_url("UNKNOWN_CONSUMER_KEY")
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_provisioning_returns_the_provisioning_flag(
+        self, ai_getter, pyramid_request, flag
+    ):
+        pyramid_request.db.add(
+            ApplicationInstance(consumer_key="TEST_CONSUMER_KEY", provisioning=flag)
+        )
+
+        assert ai_getter.provisioning("TEST_CONSUMER_KEY") == flag
+
+    def test_provisioning_returns_False_if_consumer_key_unknown(
+        self, ai_getter, pyramid_request
+    ):
+        assert ai_getter.provisioning("UNKNOWN_CONSUMER_KEY") is False
+
+    def test_shared_secret_returns_the_shared_secret(self, ai_getter, pyramid_request):
+        pyramid_request.db.add(
+            ApplicationInstance(
+                consumer_key="TEST_CONSUMER_KEY", shared_secret="TEST_SHARED_SECRET"
+            )
+        )
+
+        assert ai_getter.shared_secret("TEST_CONSUMER_KEY") == "TEST_SHARED_SECRET"
+
+    def test_shared_secret_raises_if_consumer_key_unknown(
+        self, ai_getter, pyramid_request
+    ):
+        with pytest.raises(ConsumerKeyError):
+            ai_getter.shared_secret("UNKNOWN_CONSUMER_KEY")
+
+    @pytest.fixture
+    def ai_getter(self, pyramid_config, pyramid_request):
+        return ApplicationInstanceGetter(mock.sentinel.context, pyramid_request)
+
+    @pytest.fixture(autouse=True)
+    def application_instances(self, pyramid_request):
+        """Add some "noise" application instances."""
+        # Add some "noise" application instances to the DB for every test, to
+        # make the tests more realistic.
+        application_instances = [
+            ApplicationInstance(
+                consumer_key="NOISE_CONSUMER_KEY_1",
+                developer_key="NOISE_DEVELOPER_KEY_1",
+                lms_url="NOISE_LMS_URL_1",
+                provisioning=True,
+                shared_secret="NOISE_SHARED_SECRET_1",
+            ),
+            ApplicationInstance(
+                consumer_key="NOISE_CONSUMER_KEY_2",
+                developer_key="NOISE_DEVELOPER_KEY_2",
+                lms_url="NOISE_LMS_URL_2",
+                provisioning=True,
+                shared_secret="NOISE_SHARED_SECRET_2",
+            ),
+            ApplicationInstance(
+                consumer_key="NOISE_CONSUMER_KEY_3",
+                developer_key="NOISE_DEVELOPER_KEY_3",
+                lms_url="NOISE_LMS_URL_3",
+                provisioning=True,
+                shared_secret="NOISE_SHARED_SECRET_3",
+            ),
+        ]
+        pyramid_request.db.add_all(application_instances)
+        return application_instances

--- a/tests/lms/util/_lti_launch_test.py
+++ b/tests/lms/util/_lti_launch_test.py
@@ -1,45 +1,12 @@
 from unittest import mock
 
 import pytest
-from sqlalchemy.orm.exc import NoResultFound
 from pylti.common import LTIException
 
-from lms.util import get_application_instance
 from lms.util import lti_launch
 from lms.exceptions import MissingLTILaunchParamError
 from lms.models import ApplicationInstance
-
-
-class TestGetApplicationInstance:
-    def test_it_returns_the_matching_application_instance(self, pyramid_request):
-        application_instance = ApplicationInstance(
-            consumer_key="TEST_OAUTH_CONSUMER_KEY"
-        )
-        pyramid_request.db.add(application_instance)
-
-        assert (
-            get_application_instance(pyramid_request.db, "TEST_OAUTH_CONSUMER_KEY")
-            == application_instance
-        )
-
-    def test_it_crashes_if_theres_no_matching_application_instance(
-        self, pyramid_request
-    ):
-        with pytest.raises(NoResultFound):
-            get_application_instance(pyramid_request.db, "TEST_OAUTH_CONSUMER_KEY")
-
-    @pytest.fixture(autouse=True)
-    def application_instances(self, pyramid_request):
-        """Some "noise" application instances."""
-        # Add some "noise" application instances to the DB for every test, to
-        # make the tests more realistic.
-        application_instances = [
-            ApplicationInstance(consumer_key="NOISE_1"),
-            ApplicationInstance(consumer_key="NOISE_2"),
-            ApplicationInstance(consumer_key="NOISE_3"),
-        ]
-        pyramid_request.db.add_all(application_instances)
-        return application_instances
+from lms.services import ConsumerKeyError
 
 
 class TestLTILaunch:

--- a/tests/lms/util/_lti_launch_test.py
+++ b/tests/lms/util/_lti_launch_test.py
@@ -50,11 +50,11 @@ class TestLTILaunch:
             wrapper(pyramid_request)
 
     def test_it_crashes_if_theres_no_application_instance_in_the_db(
-        self, pyramid_request, wrapper, get_application_instance
+        self, pyramid_request, wrapper, ai_getter
     ):
-        get_application_instance.side_effect = NoResultFound()
+        ai_getter.shared_secret.side_effect = ConsumerKeyError()
 
-        with pytest.raises(NoResultFound):
+        with pytest.raises(ConsumerKeyError):
             wrapper(pyramid_request)
 
     def test_it_verifies_the_request(self, pyramid_request, pylti, wrapper):
@@ -112,14 +112,6 @@ class TestLTILaunch:
     def wrapper(self, view):
         """The wrapped view."""
         return lti_launch(view)
-
-    @pytest.fixture(autouse=True)
-    def get_application_instance(self, patch, application_instance):
-        get_application_instance = patch(
-            "lms.util._lti_launch.get_application_instance"
-        )
-        get_application_instance.return_value = application_instance
-        return get_application_instance
 
     @pytest.fixture(autouse=True)
     def build_jwt_from_lti_launch(self, patch):

--- a/tests/lms/util/test_canvas_api.py
+++ b/tests/lms/util/test_canvas_api.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-value-for-parameter
 from pyramid.response import Response
 from lms.util import canvas_api
+from lms.services import ConsumerKeyError
 
 
 def build_mock_view(assertions):
@@ -50,16 +51,17 @@ class TestCanvasApi:
         )
         assert response.status_code == 404
 
-    def test_it_handles_no_application_instance(self, canvas_api_proxy):
+    def test_it_handles_no_lms_url(self, canvas_api_proxy, ai_getter):
         def assertions(_request, _decoded_jwt, _user, _canvas_api):
             pass
 
+        ai_getter.lms_url.side_effect = ConsumerKeyError()
         request = canvas_api_proxy["request"]
-        application_instance = canvas_api_proxy["application_instance"]
-        request.db.delete(application_instance)
+
         response = build_mock_view(assertions)(
             canvas_api_proxy["request"],
             canvas_api_proxy["decoded_jwt"],
             canvas_api_proxy["user"],
         )
+
         assert response.status_code == 404


### PR DESCRIPTION
Add a new `ApplicationInstanceGetter` (`"ai_getter"`) service that replaces three different functions that were spread throughout for getting `ApplicationInstance`'s from the DB, and fixes some bugs.

Implementing this as a service works out nicer than as `util` functions or as `ApplicationInstance` model methods because Pyramid makes the `request` object, including `request.db`, available to services so code doesn't need to pass in `request.db` every time it calls a service method. (Although you do need to use `request.find_service()` to get the service.)

It turns out that none of the code that was retrieving `ApplicationInstance`'s from the DB actually needed `ApplicationInstance` model objects. Only specific properties like `developer_key`, `lms_url`, etc are needed. So rather than having a public method for retrieving `ApplicationInstance` objects
`ApplicationInstanceGetter` encapsulates `ApplicationInstance` and has methods for retrieving these individual values directly. This means code is dealing only with simple strings and booleans not ORM objects.

In the case of `developer_secret()` it means that `ApplicationInstanceGetter` can do some processing on the value from the DB (decrypting it) before returning it. Code doesn't need to pas pass in `request.registry.settings["aes_secret"]` either, since `ApplicationInstanceGetter` already has it from the `request` from Pyramid.

Similarly `ApplicationInstanceGetter` can just return `False` for the provisioning feature flag if the given `consumer_key` isn't in the DB.
