### PR TITLE
Session 1/n: Make new_lti_launch.html.jinja2 inherit from base

### DIFF
--- a/lms/templates/lti_launches/new_lti_launch.html.jinja2
+++ b/lms/templates/lti_launches/new_lti_launch.html.jinja2
@@ -1,8 +1,14 @@
-<script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson}}</script>
-<script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson}}</script>
+{% extends "lms:templates/base.html.jinja2" %}
 
-{% for url in asset_urls("postmessage_json_rpc_server_js") %}
-  <script src="{{ url }}"></script>
-{% endfor %}
+{% block content %}
+  <iframe width="100%" height="100%" src="{{ via_url }}"></iframe>
+{% endblock %}
 
-<iframe width="100%" height="100%" src="{{ via_url }}" />
+{% block scripts %}
+  <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson }}</script>
+  <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson }}</script>
+
+  {% for url in asset_urls("postmessage_json_rpc_server_js") %}
+    <script src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
Make `new_lti_launch.html.jinja2` inherit from the base template. This means that the contents of our iframe is now a complete HTML document, rather than some HTML with no `<html>`, `<head>` or `<body>` as before.

It also means that stuff added to the base template in the future, such as JSON config objects, will now be present in the `new_lti_launch.html.jinja2` page as well.