### PR TITLE
Session 2/n: Add JavaScript config object to pages

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -28,6 +28,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.assets")
     config.include("lms.views.error")
     config.include("lms.services")
+    config.include("lms.subscribers")
     config.include("lms.validation")
     config.add_static_view(name="export", path="lms:static/export")
     config.add_static_view(name="static", path="lms:static")

--- a/lms/subscribers/__init__.py
+++ b/lms/subscribers/__init__.py
@@ -1,0 +1,12 @@
+"""
+Pyramid event subscribers.
+
+See https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/events.html
+"""
+
+
+__all__ = []
+
+
+def includeme(config):
+    config.scan(__name__)

--- a/lms/subscribers/_template_environment.py
+++ b/lms/subscribers/_template_environment.py
@@ -1,0 +1,17 @@
+"""Subscribers for setting up the template environment."""
+from pyramid.events import subscriber
+from pyramid.events import BeforeRender
+
+
+__all__ = []
+
+
+@subscriber(BeforeRender)
+def _add_js_config(event):
+    """
+    Add the JavaScript config object to the template environment.
+
+    A template renders this into the HTML page as a JSON object. The object
+    contains general config settings used by the app's JavaScript code.
+    """
+    event["js_config"] = {"urls": {}}

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -27,6 +27,8 @@
     <div class="content">
       {% block content %}{% endblock %}
     </div>
+
+    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
+    {% block scripts %}{% endblock %}
   </body>
-  {% block scripts %}{% endblock %}
 </html>

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -134,6 +134,7 @@ def configure_jinja2_assets(config):
     jinja2_env = config.get_jinja2_environment()
     jinja2_env.globals["asset_url"] = "http://example.com"
     jinja2_env.globals["asset_urls"] = lambda bundle: "http://example.com"
+    jinja2_env.globals["js_config"] = {}
 
 
 @pytest.yield_fixture

--- a/tests/lms/subscribers/test___init__.py
+++ b/tests/lms/subscribers/test___init__.py
@@ -1,0 +1,9 @@
+from pyramid.testing import testConfig
+
+from lms.subscribers import includeme
+
+
+class TestIncludeMe:
+    def test_it_doesnt_crash(self):
+        with testConfig() as config:
+            includeme(config)

--- a/tests/lms/subscribers/test__template_environment.py
+++ b/tests/lms/subscribers/test__template_environment.py
@@ -1,0 +1,11 @@
+from lms.subscribers._template_environment import _add_js_config
+
+
+class TestJSConfig:
+    def test_it_adds_the_urls_to_the_template_environment(self, pyramid_request):
+        event = {"request": pyramid_request}
+
+        _add_js_config(event)
+
+        # urls is an empty dict for now!
+        assert event["js_config"]["urls"] == {}


### PR DESCRIPTION
This adds a `<script type="application/json" class="js-config">.../script>` tag to all our HTML pages (via the base template). The tag contains a JSON config object that'll contain config settings for our JavaScript code. The config object is currently empty.  JavaScript can retrieve the config object with code like:

    config = document.querySelector('.js-config')