### PR TITLE
Pin Tox to 3.7.0 to fix our Tox envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 addons:
     postgresql: "9.4"
 before_script: createdb lms_test; npm install;
-install: pip install tox tox-pip-extensions
+install: pip install tox===3.7.0 tox-pip-extensions
 jobs:
   include:
     - env: ACTION=test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
         try {
             testApp(image: img, runArgs: "-u root -e TEST_DATABASE_URL=${databaseUrl}") {
                 sh 'apk-install build-base postgresql-dev python3-dev'
-                sh 'pip3 install -q tox tox-pip-extensions'
+                sh 'pip3 install -q tox===3.7.0 tox-pip-extensions'
                 sh 'cd /var/lib/lms && tox -e py36-tests'
             }
         } finally {


### PR DESCRIPTION
Tox 3.8.0 has both broken tox-pip-extensions and changed Tox's command line option parsing in a way that breaks our Makefile. For now workaround the issues by pinning Tox to the previous version.