### PR TITLE
Require Tox 3.8 or newer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 addons:
     postgresql: "9.4"
 before_script: createdb lms_test; npm install;
-install: pip install tox===3.7.0 tox-pip-extensions
+install: pip install tox>=3.8.0
 jobs:
   include:
     - env: ACTION=test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
         try {
             testApp(image: img, runArgs: "-u root -e TEST_DATABASE_URL=${databaseUrl}") {
                 sh 'apk-install build-base postgresql-dev python3-dev'
-                sh 'pip3 install -q tox===3.7.0 tox-pip-extensions'
+                sh 'pip3 install -q tox>=3.8.0'
                 sh 'cd /var/lib/lms && tox -e py36-tests'
             }
         } finally {

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ help:
 
 .PHONY: dev
 dev: build/manifest.json
-	tox -qe py36-dev
+	tox -q -e py36-dev
 
 .PHONY: shell
 shell:
-	tox -qe py36-dev -- pshell conf/development.ini
+	tox -q -e py36-dev -- pshell conf/development.ini
 
 # FIXME: This requires psql to be installed locally.
 # It should use psql from docker / docker-compose.
@@ -36,41 +36,41 @@ sql:
 
 .PHONY: lint
 lint:
-	tox -qe py36-lint
+	tox -q -e py36-lint
 	$(GULP) lint
 
 .PHONY: format
 format:
-	tox -qe py36-format
+	tox -q -e py36-format
 
 .PHONY: checkformatting
 checkformatting:
-	tox -qe py36-checkformatting
+	tox -q -e py36-checkformatting
 
 .PHONY: test
 test: node_modules/.uptodate
-	tox -qe py36-tests
+	tox -q -e py36-tests
 	$(GULP) test
 
 .PHONY: coverage
 coverage:
-	tox -qe py36-coverage
+	tox -q -e py36-coverage
 
 .PHONY: codecov
 codecov:
-	tox -qe py36-codecov
+	tox -q -e py36-codecov
 
 .PHONY: docstrings
 docstrings:
-	tox -qe py36-docstrings
+	tox -q -e py36-docstrings
 
 .PHONY: checkdocstrings
 checkdocstrings:
-	tox -qe py36-checkdocstrings
+	tox -q -e py36-checkdocstrings
 
 .PHONY: pip-compile
 pip-compile:
-	tox -qe py36-dev -- pip-compile --output-file requirements.txt requirements.in
+	tox -q -e py36-dev -- pip-compile --output-file requirements.txt requirements.in
 
 .PHONY: docker
 docker:

--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
 
 * git
 * python 3
-* [tox](https://tox.readthedocs.io/en/latest/) and [tox-pip-extensions](https://github.com/tox-dev/tox-pip-extensions)
+* [tox](https://tox.readthedocs.io/en/latest/) 3.8 or newer
 * [GNU Make](https://www.gnu.org/software/make/)
 * Docker
 * openssl

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py36-tests
 skipsdist = true
+minversion = 3.8.0
 requires = tox-pip-extensions
 tox_pip_extensions_ext_venv_update = true
 


### PR DESCRIPTION
A new version of `tox-pip-extensions` that works with Tox 3.8 is now out, so we can now upgrade to Tox 3.8, and I want the new auto-provisioning feature.