### PR TITLE
Upgrade to Alpine 3.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM gliderlabs/alpine:3.6
+FROM alpine:3.9.2
 MAINTAINER Hypothes.is Project and contributors
 
 # Install system build and runtime dependencies.
-RUN apk-install ca-certificates python3 libpq collectd collectd-disk supervisor nodejs nodejs-npm
+RUN apk add ca-certificates python3 libpq collectd collectd-disk supervisor nodejs nodejs-npm
 
 # Create the lms user, group, home directory and package directory.
 RUN addgroup -S lms \
@@ -13,7 +13,7 @@ WORKDIR /var/lib/lms
 COPY requirements.txt ./
 
 # Install build deps, build, and then clean up.
-RUN apk-install --virtual build-deps \
+RUN apk add --virtual build-deps \
     build-base \
     postgresql-dev \
     python3-dev \
@@ -36,7 +36,7 @@ COPY . .
 # Build frontend assets
 RUN npm install --production
 RUN NODE_ENV=production node_modules/.bin/gulp build
-RUN npm cache clean
+RUN npm cache clean --force
 
 EXPOSE 8001
 USER lms

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node {
 
         try {
             testApp(image: img, runArgs: "-u root -e TEST_DATABASE_URL=${databaseUrl} -e CODECOV_TOKEN=${credentials('LMS_CODECOV_TOKEN')}") {
-                sh 'apk-install build-base postgresql-dev python3-dev'
+                sh 'apk add build-base postgresql-dev python3-dev'
                 sh 'pip3 install -q tox>=3.8.0'
                 sh 'cd /var/lib/lms && tox -e py36-checkformatting -e py36-lint -e py36-tests -e py36-coverage -e py36-codecov'
             }


### PR DESCRIPTION
And move from Glider Labs to the official Alpine Linux images. Once this is merged we should be able to enable Dependabot's docker support to keep it up to date.