### PR TITLE
Include lms.views

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -26,6 +26,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.db")
     config.include("lms.routes")
     config.include("lms.assets")
+    config.include("lms.views")
     config.include("lms.views.error")
     config.include("lms.services")
     config.include("lms.subscribers")


### PR DESCRIPTION
This wasn't being `config.include()`'d, `lms/views/__init__.py::includeme()` was not being called. I'm not sure how Pyramid was nonetheless picking up the view configurations.