### PR TITLE
Speed up Jenkins by running things concurrently

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,8 @@ node {
             testApp(image: img, runArgs: "-u root -e TEST_DATABASE_URL=${databaseUrl} -e CODECOV_TOKEN=${credentials('LMS_CODECOV_TOKEN')}") {
                 sh 'apk add build-base postgresql-dev python3-dev yarn'
                 sh 'pip3 install -q tox>=3.8.0'
-                sh 'cd /var/lib/lms && make checkformatting lint backend-tests coverage codecov'
+                sh 'cd /var/lib/lms && make -j `nproc` checkformatting lint backend-tests'
+                sh 'cd /var/lib/lms && make coverage codecov'
             }
         } finally {
             postgres.stop()


### PR DESCRIPTION
Because we're running frontend tests in a separate Docker container there's a limit to the make-based concurrency we can take advantage of here.

Also the server has only 2 CPUs, and is usually running more than one build at once (even a single PR kicks off two Jenkins builds).

So I don't think this makes much difference.

Things we could do to improve this:

* Have Jenkins run only one build per PR/commit not two
* If we boost the server to one with at least four cores then `-j nproc` should be able to make more of a difference. (Eight cores would be better: I think some of our other projects, like h, have more than four separate make targets that could run concurrently.)
* Be able to run frontend tests in the same Alpine Docker container as the rest. This'd mean they could go in the same `make -j nproc` command so could run concurrently with Python tests. Also I think we're installing all the frontend deps twice per build currently (once in each Docker container)