### PR TITLE
LTI bearer tokens 3/n: Move authentication policy into lms.authentication

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -14,6 +14,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("pyramid_services")
     config.include("pyramid_tm")
 
+    config.include("lms.authentication")
     config.include("lms.extensions.feature_flags")
     config.add_feature_flag_providers(
         "lms.extensions.feature_flags.config_file_provider",

--- a/lms/authentication/__init__.py
+++ b/lms/authentication/__init__.py
@@ -1,0 +1,16 @@
+from pyramid.authentication import AuthTktAuthenticationPolicy
+
+from lms.security import groupfinder
+
+
+__all__ = ()
+
+
+def includeme(config):
+    config.set_authentication_policy(
+        AuthTktAuthenticationPolicy(
+            config.registry.settings["lms_secret"],
+            callback=groupfinder,
+            hashalg="sha512",
+        )
+    )

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -2,12 +2,9 @@
 
 """Configuration for the Pyramid application."""
 
-from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
 from pyramid.config import aslist
-
-from lms.security import groupfinder
 
 from lms.config.settings import SettingError, env_setting
 
@@ -64,11 +61,7 @@ def configure(settings):
     config = Configurator(settings=settings, root_factory=".resources.Root")
 
     # Security policies
-    authn_policy = AuthTktAuthenticationPolicy(
-        settings["lms_secret"], callback=groupfinder, hashalg="sha512"
-    )
     authz_policy = ACLAuthorizationPolicy()
-    config.set_authentication_policy(authn_policy)
     config.set_authorization_policy(authz_policy)
 
     return config

--- a/tests/lms/authentication/__init___test.py
+++ b/tests/lms/authentication/__init___test.py
@@ -1,0 +1,34 @@
+import pytest
+from pyramid.authorization import ACLAuthorizationPolicy
+from pyramid import testing
+from pyramid.interfaces import IAuthenticationPolicy
+
+from lms.authentication import includeme
+
+
+class TestIncludeMe:
+    def test_it_sets_the_authentication_policy(
+        self, groupfinder, pyramid_config, AuthTktAuthenticationPolicy
+    ):
+        # We need to set an authorization policy first otherwise setting an
+        # authentication policy will fail (you can't have an authentication
+        # policy without an authorization policy).
+        pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
+
+        includeme(pyramid_config)
+
+        AuthTktAuthenticationPolicy.assert_called_once_with(
+            "TEST_LMS_SECRET", callback=groupfinder, hashalg="sha512"
+        )
+        assert (
+            pyramid_config.registry.queryUtility(IAuthenticationPolicy)
+            == AuthTktAuthenticationPolicy.return_value
+        )
+
+    @pytest.fixture(autouse=True)
+    def AuthTktAuthenticationPolicy(self, patch):
+        return patch("lms.authentication.AuthTktAuthenticationPolicy")
+
+    @pytest.fixture(autouse=True)
+    def groupfinder(self, patch):
+        return patch("lms.authentication.groupfinder")

--- a/tests/lms/config/__init___test.py
+++ b/tests/lms/config/__init___test.py
@@ -10,12 +10,7 @@ from lms.config import configure
 from lms.config import SettingError
 
 
-@pytest.mark.usefixtures(
-    "env_setting",
-    "groupfinder",
-    "ACLAuthorizationPolicy",
-    "AuthTktAuthenticationPolicy",
-)
+@pytest.mark.usefixtures("env_setting", "ACLAuthorizationPolicy")
 class TestConfigure:
     def test_it_returns_a_Configurator_with_the_deployment_settings_set(
         self, env_setting
@@ -222,27 +217,6 @@ class TestConfigure:
 
         assert configurator.registry.settings["foo"] == "bar"
 
-    def test_it_sets_the_pyramid_authentication_policy(
-        self, AuthTktAuthenticationPolicy, config, env_setting, groupfinder
-    ):
-        def side_effect(
-            envvar_name, *args, **kwargs
-        ):  # pylint: disable=unused-argument
-            if envvar_name == "LMS_SECRET":
-                return "test_lms_secret"
-            return mock.DEFAULT
-
-        env_setting.side_effect = side_effect
-
-        configure({})
-
-        AuthTktAuthenticationPolicy.assert_called_once_with(
-            "test_lms_secret", callback=groupfinder, hashalg="sha512"
-        )
-        config.set_authentication_policy.assert_called_once_with(
-            AuthTktAuthenticationPolicy.return_value
-        )
-
     def test_it_sets_the_pyramid_authorization_policy(
         self, ACLAuthorizationPolicy, config
     ):
@@ -258,10 +232,6 @@ class TestConfigure:
         return patch("lms.config.ACLAuthorizationPolicy")
 
     @pytest.fixture
-    def AuthTktAuthenticationPolicy(self, patch):
-        return patch("lms.config.AuthTktAuthenticationPolicy")
-
-    @pytest.fixture
     def config(self, patch):
         configurator_class = patch("lms.config.Configurator")
         return configurator_class.return_value
@@ -269,7 +239,3 @@ class TestConfigure:
     @pytest.fixture
     def env_setting(self, patch):
         return patch("lms.config.env_setting")
-
-    @pytest.fixture
-    def groupfinder(self, patch):
-        return patch("lms.config.groupfinder")

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -154,7 +154,7 @@ def pyramid_config(pyramid_request):
         "google_client_id": "fake_client_id",
         "google_developer_key": "fake_developer_key",
         "google_app_id": "fake_app_id",
-        "lms_secret": "J4hd4epmhDGUibjsiUtKaLbyDEtUis8qGMFnQUJlDtYrQB1m2SM0j2oRpCXhSp7K",
+        "lms_secret": "TEST_LMS_SECRET",
         "hashed_pw": "e46df2a5b4d50e259b5154b190529483a5f8b7aaaa22a50447e377d33792577a",
         "salt": "fbe82ee0da72b77b",
         "username": "report_viewer",


### PR DESCRIPTION
I'm going to be adding more authentication stuff and I need this to be here, not in config which is totally the wrong place for it.

Note that the authorization policy is still being set in lms.config. That should move too, to lms.authorization, but I don't need to do that right now.