### PR TITLE
LTI bearer tokens 4/n: Add lms.values.LTIUser value type

### DIFF
--- a/lms/values.py
+++ b/lms/values.py
@@ -1,0 +1,15 @@
+"""Immutable value objects for use throughout the app."""
+from typing import NamedTuple
+
+
+__all__ = ("LTIUser",)
+
+
+class LTIUser(NamedTuple):
+    """An LTI user."""
+
+    user_id: str
+    """The user_id LTI launch parameter."""
+
+    oauth_consumer_key: str
+    """The oauth_consumer_key LTI launch parameter."""


### PR DESCRIPTION
Add a "value object" type for an LTI user -- an immutable object with no methods that just exposes a set of user-related fields. In the future an instance of this class will be exposed as `request.user` whenever an LTI user is authenticated, to contain more info about the user than just the `request.authenticated_userid` string can.

The `LTIUser` for the current launch params or bearer token-authenticated request will always be able to be reconstructed from the verified parameters in the request itself, hence it's not necessary to save this object in the DB.

More fields can be added in the future but currently `LTIUser` contains the two fields from the LTI launch parameters that we're going to need in the future to generate a unique `request.authenticated_userid` string for an LTI user -- `user_id`, `oauth_consumer_key`.