### PR TITLE
LTI bearer tokens 5/n: Add a schema for validating LTI launch params

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -28,9 +28,15 @@ from webargs import pyramidparser
 
 from lms.validation._exceptions import ValidationError
 from lms.validation._oauth import CANVAS_OAUTH_CALLBACK_SCHEMA
+from lms.validation._launch_params import LaunchParamsSchema
 
 
-__all__ = ("parser", "CANVAS_OAUTH_CALLBACK_SCHEMA", "ValidationError")
+__all__ = (
+    "parser",
+    "CANVAS_OAUTH_CALLBACK_SCHEMA",
+    "LaunchParamsSchema",
+    "ValidationError",
+)
 
 
 parser = pyramidparser.PyramidParser()

--- a/lms/validation/_launch_params.py
+++ b/lms/validation/_launch_params.py
@@ -1,0 +1,80 @@
+"""Schema for validating LTI launch params."""
+import marshmallow
+from webargs.pyramidparser import parser
+from pyramid.httpexceptions import HTTPUnprocessableEntity
+
+from lms.services import LTILaunchVerificationError
+from lms.validation._exceptions import ValidationError
+from lms.values import LTIUser
+
+
+__all__ = ("LaunchParamsSchema",)
+
+
+class LaunchParamsSchema(marshmallow.Schema):
+    """
+    Schema for LTI launch params.
+
+    Validates and verifies LTI launch params. Usage via webargs::
+
+        >>> from webargs.pyramidparser import parser
+        >>>
+        >>> schema = LaunchParamsSchema(request)
+        >>> parsed_params = parser.parse(schema, request, locations=["form"])
+
+    Or to verify the request and get an :class:`~lms.values.LTIUser`
+    from the request's params::
+
+        >>> schema = LaunchParamsSchema(request)
+        >>> schema.lti_user()
+        LTIUser(user_id='...', ...)
+    """
+
+    user_id = marshmallow.fields.Str(required=True)
+
+    oauth_consumer_key = marshmallow.fields.Str(required=True)
+    oauth_nonce = marshmallow.fields.Str(required=True)
+    oauth_signature = marshmallow.fields.Str(required=True)
+    oauth_signature_method = marshmallow.fields.Str(required=True)
+    oauth_timestamp = marshmallow.fields.Str(required=True)
+    oauth_version = marshmallow.fields.Str(required=True)
+
+    class Meta:
+        """Marshmallow options for this schema."""
+
+        # Silence a strict=False deprecation warning from marshmallow.
+        # TODO: Remove this once we've upgraded to marshmallow 3.
+        strict = True
+
+    def __init__(self, request):
+        super().__init__()
+        self._request = request
+        self._launch_verifier = request.find_service(name="launch_verifier")
+
+    def lti_user(self):
+        """
+        Return an :class:`~lms.values.LTIUser` from the request's launch params.
+
+        :raise ValidationError: if the request isn't a valid LTI launch request
+
+        :rtype: LTIUser
+        """
+        try:
+            kwargs = parser.parse(self, self._request, locations=["form"])
+        except HTTPUnprocessableEntity as err:
+            raise ValidationError(err.json) from err
+
+        return LTIUser(kwargs["user_id"], kwargs["oauth_consumer_key"])
+
+    @marshmallow.validates_schema
+    def _verify_oauth_1(self, _data):
+        """
+        Verify the request's OAuth 1 signature, timestamp, etc.
+
+        :raise marshmallow.ValidationError: if the request doesn't have a valid
+            OAuth 1 signature
+        """
+        try:
+            self._launch_verifier.verify()
+        except LTILaunchVerificationError as err:
+            raise marshmallow.ValidationError("Invalid OAuth 1 signature.") from err

--- a/tests/lms/validation/_launch_params_test.py
+++ b/tests/lms/validation/_launch_params_test.py
@@ -1,0 +1,68 @@
+import pytest
+from pyramid.httpexceptions import HTTPUnprocessableEntity
+
+from lms.services import LTILaunchVerificationError
+from lms.validation import LaunchParamsSchema, ValidationError
+from lms.values import LTIUser
+
+
+class TestLaunchParamsSchema:
+    def test_it_returns_the_lti_user_info(self, schema):
+        lti_user = schema.lti_user()
+
+        assert lti_user == LTIUser("TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY")
+
+    def test_it_does_oauth_1_verification(self, launch_verifier, schema):
+        schema.lti_user()
+
+        launch_verifier.verify.assert_called_once_with()
+
+    def test_it_raises_if_oauth_1_verification_fails(self, launch_verifier, schema):
+        launch_verifier.verify.side_effect = LTILaunchVerificationError("Failed")
+
+        with pytest.raises(ValidationError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {"_schema": ["Invalid OAuth 1 signature."]}
+
+    @pytest.mark.parametrize(
+        "missing_param",
+        [
+            "user_id",
+            "oauth_consumer_key",
+            "oauth_nonce",
+            "oauth_signature",
+            "oauth_signature_method",
+            "oauth_timestamp",
+            "oauth_version",
+        ],
+    )
+    def test_it_raises_if_a_required_param_is_missing(
+        self, missing_param, pyramid_request, schema
+    ):
+        del pyramid_request.POST[missing_param]
+
+        with pytest.raises(HTTPUnprocessableEntity) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == dict(
+            [(missing_param, ["Missing data for required field."])]
+        )
+
+    @pytest.fixture
+    def schema(self, pyramid_request):
+        return LaunchParamsSchema(pyramid_request)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.content_type = "application/x-www-form-urlencoded"
+        pyramid_request.POST = {
+            "user_id": "TEST_USER_ID",
+            "oauth_consumer_key": "TEST_OAUTH_CONSUMER_KEY",
+            "oauth_nonce": "TEST_OAUTH_NONCE",
+            "oauth_signature": "TEST_OAUTH_SIGNATURE",
+            "oauth_signature_method": "TEST_OAUTH_SIGNATURE_METHOD",
+            "oauth_timestamp": "TEST_OAUTH_TIMESTAMP",
+            "oauth_version": "TEST_OAUTH_VERSION",
+        }
+        return pyramid_request


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/530>.

Add `lms.validation.LaunchParamsSchema` -- a [marshmallow](https://marshmallow.readthedocs.io/en/2.x-line/) schema for validating LTI launch params. It includes a `LaunchParamsSchema(request).lti_user()` convenience method that returns the [`LTIUser` object](https://github.com/hypothesis/lms/pull/530) for the request if it's a valid LTI launch request.

Not all LTI launch params are validated yet -- only the ones that we need right now. For now this schema is only going to be used (by a future pull request) for the purpose of validating the LTI launch params in order to set `request.authenticated_userid` and `request.user` (an `LTIUser` object), hence it only validates the params needed to do that. In the more distant future I imagine this schema being used to protect LTI assignment and content item views, and growing to contain more LTI launch params