### PR TITLE
LTI bearer tokens 6/n: Add a schema for bearer tokens

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -26,16 +26,26 @@ commit message f61a5ff3cae6b983e24db809d8e4b4933aca1e92.
 """
 from webargs import pyramidparser
 
-from lms.validation._exceptions import ValidationError
+from lms.validation._exceptions import (
+    ValidationError,
+    ExpiredSessionTokenError,
+    MissingSessionTokenError,
+    InvalidSessionTokenError,
+)
 from lms.validation._oauth import CANVAS_OAUTH_CALLBACK_SCHEMA
 from lms.validation._launch_params import LaunchParamsSchema
+from lms.validation._bearer_token import BearerTokenSchema
 
 
 __all__ = (
     "parser",
     "CANVAS_OAUTH_CALLBACK_SCHEMA",
+    "BearerTokenSchema",
     "LaunchParamsSchema",
     "ValidationError",
+    "ExpiredSessionTokenError",
+    "MissingSessionTokenError",
+    "InvalidSessionTokenError",
 )
 
 

--- a/lms/validation/_bearer_token.py
+++ b/lms/validation/_bearer_token.py
@@ -1,0 +1,219 @@
+"""Schema for our bearer token-based LTI authentication."""
+import datetime
+
+import jwt
+from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
+from webargs.pyramidparser import parser
+import marshmallow
+from pyramid.httpexceptions import HTTPUnprocessableEntity
+
+from lms.validation._exceptions import (
+    ValidationError,
+    ExpiredSessionTokenError,
+    MissingSessionTokenError,
+    InvalidSessionTokenError,
+)
+from lms.values import LTIUser
+
+
+__all__ = ("BearerTokenSchema",)
+
+
+class BearerTokenSchema(marshmallow.Schema):
+    """
+    Schema for our bearer token-based LTI authentication.
+
+    Serializes :class:`~lms.values.LTIUser` objects into signed and
+    timestamped ``"Bearer <ENCODED_JWT>"`` strings, and deserializes these
+    bearer strings back into :class:`~lms.values.LTIUser` objects. The
+    JWT signature and timestamp are verified during deserialization.
+
+    Usage:
+
+        >>> schema = BearerTokenSchema(request)
+
+        >>> # Serialize an LTIUser (``request.lti_user`` in this example)
+        >>> # into an authorization param value:
+        >>> schema.authorization_param(request.lti_user)
+        'Bearer eyJ...YoM'
+
+        >>> # Deserialize the request's authorization param into an LTI user.
+        >>> schema.lti_user()
+        LTIUser(user_id='...', oauth_consumer_key='...', ...)
+
+    The above are convenience methods that wrap webargs and marshmallow. But
+    this class is also a marshmallow schema and can be used via the usual
+    webargs or marshmallow APIs. For example to serialize a dict and then
+    deserialize the same dict back from its serialized form using marshmallow::
+
+        >>> schema.dump(request.lti_user).data
+        {'authorization': 'Bearer eyJ...YoM'}
+
+        >>> schema.load({'authorization': 'Bearer eyJ...YoM'}).data
+        LTIUser(user_id='...', oauth_consumer_key='...', ...)
+
+    Or to parse an :class:`~lms.values.LTIUser` out of a Pyramid
+    request's authorization param using webargs::
+
+        >>> from webargs.pyramidparser import parser
+        >>> parser.parse(s, request)
+        LTIUser(user_id='...', oauth_consumer_key='...', ...)
+    """
+
+    user_id = marshmallow.fields.Str(required=True)
+    oauth_consumer_key = marshmallow.fields.Str(required=True)
+
+    class Meta:
+        """Marshmallow options for this schema."""
+
+        # Silence a strict=False deprecation warning from marshmallow.
+        # TODO: Remove this once we've upgraded to marshmallow 3.
+        strict = True
+
+    def __init__(self, request):
+        super().__init__()
+        self._request = request
+        # Storing context needed for serialization or deserialization in
+        # self.context is a marshmallow convention.
+        self.context = {"secret": request.registry.settings["jwt_secret"]}
+
+    def authorization_param(self, lti_user):
+        """
+        Return ``lti_user`` serialized into an authorization param.
+
+        Returns a ``"Bearer: <ENCODED_JWT>"`` string suitable for use as the
+        value of an authorization param.
+
+        :arg lti_user: the LTI user to return an auth param for
+        :type lti_user: LTIUser
+
+        :rtype: str
+        """
+        return self.dump(lti_user).data["authorization"]
+
+    def lti_user(self):
+        """
+        Return an :class:`~lms.values.LTIUser` from the request's authorization param.
+
+        Verifies the signature and timestamp of the JWT in the request's
+        authorization param, decodes the JWT, validates the JWT's payload, and
+        returns an :class:`~lms.values.LTIUser` from the payload.
+
+        The authorization param must be in an HTTP header
+        ``Authorization: Bearer <ENCODED_JWT>`` in the request. In the future
+        we may add support for reading the authorization param from other parts
+        of the request, such as from form fields or JSON parameters.
+
+        :raise ExpiredSessionTokenError: if the request's Authorization header
+          contains an expired JWT
+        :raise MissingSessionTokenError: if the request does not contain an
+          Authorization header
+        :raise InvalidSessionTokenError: if the request contains an invalid
+          Authorization header. For example if the Authorization header
+          contains an invalid JWT, or if it doesn't have the required
+          ``"Bearer <ENCODED_JWT>"`` format.
+        :raise ValidationError: if the JWT's payload is invalid, for example if
+          it's missing a required parameter
+
+        :rtype: LTIUser
+        """
+        try:
+            return parser.parse(self, self._request, locations=["headers"])
+        except HTTPUnprocessableEntity as error:
+            try:
+                authorization_error_message = error.json["authorization"][0]
+            except KeyError:
+                exc_class = ValidationError
+            else:
+                if authorization_error_message == "Expired session token":
+                    exc_class = ExpiredSessionTokenError
+                elif authorization_error_message == "Missing data for required field.":
+                    exc_class = MissingSessionTokenError
+                else:
+                    exc_class = InvalidSessionTokenError
+            raise exc_class(messages=error.json) from error
+
+    @marshmallow.post_dump
+    def _encode_jwt(self, data):
+        """
+        Return ``data`` encoded as a JWT enveloped in an authorization param.
+
+        This uses a Marshmallow technique called "enveloping", see:
+
+        https://marshmallow.readthedocs.io/en/2.x-line/extending.html#example-enveloping
+        """
+        one_hour_from_now = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        data["exp"] = one_hour_from_now
+
+        jwt_bytes = jwt.encode(data, self.context["secret"], algorithm="HS256")
+
+        # PyJWT returns JWT's as UTF8-encoded byte strings (this isn't
+        # documented, but see
+        # https://github.com/jpadilla/pyjwt/blob/ed28e495f937f50165a252fd5696a82942cd83a7/jwt/api_jwt.py#L62).
+        # We need a unicode string, so decode it.
+        jwt_str = jwt_bytes.decode("utf-8")
+
+        return {"authorization": "Bearer " + jwt_str}
+
+    @marshmallow.pre_load
+    def _decode_jwt(self, data):
+        """
+        Return the payload from the JWT in the authorization param in ``data``.
+
+        This uses a Marshmallow technique called "enveloping", see:
+
+        https://marshmallow.readthedocs.io/en/2.x-line/extending.html#example-enveloping
+        """
+        try:
+            authorization_param = data["authorization"]
+        except KeyError:
+            raise marshmallow.ValidationError(
+                "Missing data for required field.", "authorization"
+            )
+
+        encoded_jwt = authorization_param[len("Bearer ") :]
+
+        try:
+            payload = jwt.decode(
+                encoded_jwt,
+                self.context["secret"],
+                algorithms=["HS256"],
+                options={"require_exp": True},
+            )
+        except ExpiredSignatureError:
+            raise marshmallow.ValidationError("Expired session token", "authorization")
+        except InvalidTokenError:
+            raise marshmallow.ValidationError("Invalid session token", "authorization")
+
+        del payload["exp"]
+        return payload
+
+    @marshmallow.post_load
+    def _make_user(self, kwargs):  # pylint:disable=no-self-use
+        # See https://marshmallow.readthedocs.io/en/2.x-line/quickstart.html#deserializing-to-objects
+        return LTIUser(**kwargs)
+
+    # This is a hack to make Marshmallow enveloping work even when this schema
+    # is used via webargs.
+    #
+    # A limitation of webargs makes it incompatible with marshmallow schemas
+    # that use enveloping, such as this one. See:
+    #
+    # https://github.com/marshmallow-code/webargs/issues/267
+    # https://github.com/marshmallow-code/webargs/issues/173
+    #
+    # To work around the limitation we have to add an ``authorization`` field
+    # to the schema class and then, since we don't want any ``authorization``
+    # params to show up in deserialized session dicts from the schema, we add a
+    # post_load method to delete them.
+    #
+    # TODO: Remove this hack once https://github.com/marshmallow-code/webargs/issues/267
+    # is fixed.
+    authorization = marshmallow.fields.Str()
+
+    @marshmallow.post_load
+    def _delete_authorization_field(self, data):  # pylint:disable=no-self-use
+        try:
+            del data["authorization"]
+        except KeyError:
+            pass

--- a/lms/validation/_exceptions.py
+++ b/lms/validation/_exceptions.py
@@ -1,5 +1,7 @@
 from pyramid import httpexceptions
 
+# pylint: disable=too-many-ancestors
+
 
 class ValidationError(
     httpexceptions.HTTPUnprocessableEntity
@@ -35,3 +37,15 @@ class ValidationError(
         """
         super().__init__()
         self.messages = messages
+
+
+class ExpiredSessionTokenError(ValidationError):
+    """Raised when the request has an expired session token."""
+
+
+class MissingSessionTokenError(ValidationError):
+    """Raised when the request has no session token."""
+
+
+class InvalidSessionTokenError(ValidationError):
+    """Raised when the request has an invalid session token."""

--- a/tests/lms/validation/_bearer_token_test.py
+++ b/tests/lms/validation/_bearer_token_test.py
@@ -1,0 +1,179 @@
+import datetime
+import json
+import jwt
+
+import pytest
+from webargs.pyramidparser import parser
+
+from lms.validation import (
+    BearerTokenSchema,
+    ValidationError,
+    ExpiredSessionTokenError,
+    MissingSessionTokenError,
+    InvalidSessionTokenError,
+)
+from lms.values import LTIUser
+
+
+class TestBearerTokenSchema:
+    def test_it_serializes_lti_users_to_bearer_tokens(self, lti_user, schema):
+        authorization_param_value = schema.authorization_param(lti_user)
+
+        assert authorization_param_value.startswith("Bearer ")
+
+    def test_it_deserializes_lti_users_from_authorization_headers(
+        self, authorization_param, lti_user, pyramid_request, schema
+    ):
+        pyramid_request.headers["authorization"] = authorization_param
+
+        deserialized_lti_user = schema.lti_user()
+
+        assert deserialized_lti_user == lti_user
+
+    def test_it_raises_if_theres_no_authorization_param(self, schema):
+        with pytest.raises(MissingSessionTokenError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {
+            "authorization": ["Missing data for required field."]
+        }
+
+    def test_it_raises_if_the_authorization_param_has_the_wrong_format(
+        self, authorization_param, pyramid_request, schema
+    ):
+        # Does not being with "Bearer ":
+        pyramid_request.headers["authorization"] = authorization_param[len("Bearer ") :]
+
+        with pytest.raises(InvalidSessionTokenError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {"authorization": ["Invalid session token"]}
+
+    def test_it_raises_if_the_jwt_is_encoded_with_the_wrong_secret(
+        self, pyramid_request, lti_user, schema
+    ):
+        wrongly_encoded_jwt = self.encode_jwt(lti_user._asdict(), secret="WRONG_SECRET")
+        pyramid_request.headers["authorization"] = "Bearer " + wrongly_encoded_jwt
+
+        with pytest.raises(InvalidSessionTokenError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {"authorization": ["Invalid session token"]}
+
+    def test_it_raises_if_the_jwt_is_encoded_with_the_wrong_algorithm(
+        self, pyramid_request, lti_user, schema
+    ):
+        wrongly_encoded_jwt = self.encode_jwt(lti_user._asdict(), algorithm="HS384")
+        pyramid_request.headers["authorization"] = "Bearer " + wrongly_encoded_jwt
+
+        with pytest.raises(InvalidSessionTokenError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {"authorization": ["Invalid session token"]}
+
+    def test_it_raises_if_the_jwt_has_expired(self, lti_user, pyramid_request, schema):
+        five_minutes_ago = datetime.datetime.utcnow() - datetime.timedelta(minutes=5)
+        payload = lti_user._asdict()
+        payload["exp"] = five_minutes_ago
+        expired_jwt = self.encode_jwt(payload)
+        pyramid_request.headers["authorization"] = "Bearer " + expired_jwt
+
+        with pytest.raises(ExpiredSessionTokenError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {"authorization": ["Expired session token"]}
+
+    def test_it_raises_if_the_jwt_has_no_expiry_time(
+        self, lti_user, pyramid_request, schema
+    ):
+        jwt_with_no_expiry_time = self.encode_jwt(lti_user._asdict(), omit_exp=True)
+        pyramid_request.headers["authorization"] = "Bearer " + jwt_with_no_expiry_time
+
+        with pytest.raises(InvalidSessionTokenError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {"authorization": ["Invalid session token"]}
+
+    def test_it_raises_if_the_user_id_param_is_missing(
+        self, lti_user, pyramid_request, schema
+    ):
+        payload = lti_user._asdict()
+        del payload["user_id"]
+        jwt_with_no_user_id = self.encode_jwt(payload)
+        pyramid_request.headers["authorization"] = "Bearer " + jwt_with_no_user_id
+
+        with pytest.raises(ValidationError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {
+            "user_id": ["Missing data for required field."]
+        }
+
+    def test_it_raises_if_the_oauth_consumer_key_param_is_missing(
+        self, lti_user, pyramid_request, schema
+    ):
+        payload = lti_user._asdict()
+        del payload["oauth_consumer_key"]
+        jwt_with_no_user_id = self.encode_jwt(payload)
+        pyramid_request.headers["authorization"] = "Bearer " + jwt_with_no_user_id
+
+        with pytest.raises(ValidationError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {
+            "oauth_consumer_key": ["Missing data for required field."]
+        }
+
+    def test_serialize_and_deserialize_via_marshmallow_api(self, lti_user, schema):
+        serialized = schema.dump(lti_user)
+        deserialized = schema.load(serialized.data)
+
+        assert deserialized.data == lti_user
+
+    def test_parse_via_webargs_api(
+        self, lti_user, schema, pyramid_request, authorization_param
+    ):
+        pyramid_request.headers["authorization"] = authorization_param
+
+        deserialized = parser.parse(schema, pyramid_request, locations=["headers"])
+
+        assert deserialized == lti_user
+
+    def encode_jwt(self, payload, omit_exp=False, secret=None, algorithm=None):
+        if not omit_exp:
+            # Insert an unexpired expiry time into the given payload dict, if
+            # it doesn't already contain an expiry time.
+            payload.setdefault(
+                "exp", datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+            )
+
+        jwt_bytes = jwt.encode(
+            payload, secret or "test_secret", algorithm=algorithm or "HS256"
+        )
+        # PyJWT returns JWT's as UTF8-encoded byte strings (this isn't
+        # documented, but see
+        # https://github.com/jpadilla/pyjwt/blob/ed28e495f937f50165a252fd5696a82942cd83a7/jwt/api_jwt.py#L62).
+        # We need a unicode string, so decode it.
+        jwt_str = jwt_bytes.decode("utf-8")
+        return jwt_str
+
+    @pytest.fixture
+    def lti_user(self):
+        """The original LTIUser that was encoded as a JWT in the request."""
+        return LTIUser(
+            user_id="TEST_USER_ID", oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY"
+        )
+
+    @pytest.fixture
+    def authorization_param(self, lti_user, pyramid_request):
+        """An authorization param correctly encoded with the right secret."""
+        # We use BearerTokenSchema's own ``authorization_param()`` here so
+        # that the tests are also testing that a BearerTokenSchema can
+        # decode the values that were encoded by another BearerTokenSchema
+        # and return the original value.
+        return BearerTokenSchema(pyramid_request).authorization_param(lti_user)
+
+    @pytest.fixture
+    def schema(self, pyramid_request):
+        """A BearerTokenSchema configured with the right secret."""
+        return BearerTokenSchema(pyramid_request)


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/530.

Add a schema for serializing, deserializing and validating `Bearer <ENCODED_JWT>` tokens in `Authorization` headers. The JWT encodes some of the user-related launch params from an LTI launch.

The way this is going to be used is:

1. When the user launches our app in their LMS, [`LaunchParamsSchema`](https://github.com/hypothesis/lms/pull/531) will be used to validate the launch params and set `request.user` to an [`LTIUser`](https://github.com/hypothesis/lms/pull/530) object.

2. The `BearerTokenSchema` in this PR will be used to **serialize** `request.user` into a signed and timestamped `"Bearer <ENCODED_JWT>"` string rendered into the page HTML.

3. JavaScript on the page will read this `"Bearer <ENCODED_JWT>"` string from the HTML and include it in the `Authorization` header in any API requests made.

4. When an API request with an `Authorization: Bearer <ENCODED_JWT>` request is received the `BearerTokenSchema` in this PR will be used to **deserialize** the encoded JWT and set `request.user` to an `LTIUser` object.

The end result is that whenever processing a request that is authenticated as an LTI user either via launch params or a bearer token, `request.user` is always an `LTIUser` for the authenticated user. So we know which user is acting and can, for example, look up their saved Canvas API access token in the DB.