### PR TITLE
LTI bearer tokens 7/n: Add the `request.lti_user` property

### DIFF
--- a/lms/authentication/_helpers.py
+++ b/lms/authentication/_helpers.py
@@ -1,0 +1,28 @@
+from lms.validation import LaunchParamsSchema, BearerTokenSchema, ValidationError
+
+
+def get_lti_user(request):
+    """
+    Return an :class:`~lms.values.LTIUser` for the authenticated LTI user.
+
+    Get the authenticated user from the validated LTI launch params or, failing
+    that, from one of our LTI bearer tokens (also validated).
+
+    If the request doesn't contain either valid LTI launch params or a valid
+    bearer token then return ``None``.
+
+    :rtype: lms.values.LTIUser
+    """
+    try:
+        return LaunchParamsSchema(request).lti_user()
+    except ValidationError:
+        pass
+
+    try:
+        return BearerTokenSchema(request).lti_user()
+    except ValidationError:
+        return None
+
+
+def includeme(config):
+    config.add_request_method(get_lti_user, name="lti_user", property=True, reify=True)

--- a/tests/lms/authentication/_helpers_test.py
+++ b/tests/lms/authentication/_helpers_test.py
@@ -1,0 +1,79 @@
+import pytest
+
+from lms.authentication._helpers import get_lti_user
+from lms.validation import ValidationError
+
+
+class TestGetLTIUser:
+    def test_it_returns_the_LTIUser_from_LaunchParamsSchema(
+        self,
+        bearer_token_schema,
+        LaunchParamsSchema,
+        launch_params_schema,
+        pyramid_request,
+    ):
+        bearer_token_schema.lti_user.side_effect = ValidationError(
+            ["TEST_ERROR_MESSAGE"]
+        )
+
+        lti_user = get_lti_user(pyramid_request)
+
+        LaunchParamsSchema.assert_called_once_with(pyramid_request)
+        launch_params_schema.lti_user.assert_called_once_with()
+        assert lti_user == launch_params_schema.lti_user.return_value
+
+    def test_if_LaunchParamsSchema_fails_it_falls_back_on_BearerTokenSchema(
+        self,
+        launch_params_schema,
+        BearerTokenSchema,
+        bearer_token_schema,
+        pyramid_request,
+    ):
+        launch_params_schema.lti_user.side_effect = ValidationError(
+            ["TEST_ERROR_MESSAGE"]
+        )
+
+        lti_user = get_lti_user(pyramid_request)
+
+        BearerTokenSchema.assert_called_once_with(pyramid_request)
+        bearer_token_schema.lti_user.assert_called_once_with()
+        assert lti_user == bearer_token_schema.lti_user.return_value
+
+    def test_it_returns_None_if_both_schemas_fail(
+        self, launch_params_schema, bearer_token_schema, pyramid_request
+    ):
+        launch_params_schema.lti_user.side_effect = ValidationError(
+            ["TEST_ERROR_MESSAGE"]
+        )
+        bearer_token_schema.lti_user.side_effect = ValidationError(
+            ["TEST_ERROR_MESSAGE"]
+        )
+
+        assert get_lti_user(pyramid_request) is None
+
+    def test_LaunchParamsSchema_overrides_BearerTokenSchema(
+        self, launch_params_schema, pyramid_request
+    ):
+        assert (
+            get_lti_user(pyramid_request) == launch_params_schema.lti_user.return_value
+        )
+
+
+@pytest.fixture(autouse=True)
+def BearerTokenSchema(patch):
+    return patch("lms.authentication._helpers.BearerTokenSchema")
+
+
+@pytest.fixture
+def bearer_token_schema(BearerTokenSchema):
+    return BearerTokenSchema.return_value
+
+
+@pytest.fixture(autouse=True)
+def LaunchParamsSchema(patch):
+    return patch("lms.authentication._helpers.LaunchParamsSchema")
+
+
+@pytest.fixture
+def launch_params_schema(LaunchParamsSchema):
+    return LaunchParamsSchema.return_value

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -22,6 +22,7 @@ from lms.models import build_from_lms_url
 from lms.util import GET
 from lms.services.application_instance_getter import ApplicationInstanceGetter
 from lms.services.launch_verifier import LaunchVerifier
+from lms.values import LTIUser
 
 TEST_DATABASE_URL = os.environ.get(
     "TEST_DATABASE_URL", "postgresql://postgres@localhost:5433/lms_test"
@@ -126,6 +127,10 @@ def pyramid_request(db_session):
             "lti_version": "TEST",
         }
     )
+    pyramid_request.feature = mock.create_autospec(
+        lambda feature: False, return_value=False
+    )
+    pyramid_request.lti_user = LTIUser("TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY")
 
     return pyramid_request
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/530

Add a new request property, `request.lti_user`, that contains a [`LTIUser`](https://github.com/hypothesis/lms/pull/530) object for the current LTI user whenever an LTI user has been authenticated either via launch params or a bearer token.

Uses [`LaunchParamsSchema`](https://github.com/hypothesis/lms/pull/531) to validate the launch params and create the `LTIUser` or, if that fails, tries [`BearerTokenSchema`](https://github.com/hypothesis/lms/pull/532) instead. If both fail then `request.lti_user` is `None`.