### PR TITLE
LTI bearer tokens 8/n: Function for generating userids from LTI params

### DIFF
--- a/lms/authentication/_helpers.py
+++ b/lms/authentication/_helpers.py
@@ -1,4 +1,20 @@
+import base64
+
 from lms.validation import LaunchParamsSchema, BearerTokenSchema, ValidationError
+
+
+def authenticated_userid(lti_user):
+    """Return a ``request.authenticated_userid`` string for ``lti_user``."""
+    # urlsafe_b64encode() requires bytes, so encode the userid to bytes.
+    user_id_bytes = lti_user.user_id.encode()
+
+    safe_user_id_bytes = base64.urlsafe_b64encode(user_id_bytes)
+
+    # urlsafe_b64encode() returns ASCII bytes but we need unicode, so
+    # decode it.
+    safe_user_id = safe_user_id_bytes.decode("ascii")
+
+    return ":".join([safe_user_id, lti_user.oauth_consumer_key])
 
 
 def get_lti_user(request):

--- a/tests/lms/authentication/_helpers_test.py
+++ b/tests/lms/authentication/_helpers_test.py
@@ -1,7 +1,26 @@
 import pytest
 
-from lms.authentication._helpers import get_lti_user
+from lms.authentication._helpers import authenticated_userid, get_lti_user
 from lms.validation import ValidationError
+from lms.values import LTIUser
+
+
+class TestAuthenticatedUserID:
+    @pytest.mark.parametrize(
+        "lti_user,expected_userid",
+        [
+            (
+                LTIUser("sam", "Hypothesisf301584250a2dece14f021ab8424018a"),
+                "c2Ft:Hypothesisf301584250a2dece14f021ab8424018a",
+            ),
+            (
+                LTIUser("Sam:Smith", "Hypothesisf301584250a2dece14f021ab8424018a"),
+                "U2FtOlNtaXRo:Hypothesisf301584250a2dece14f021ab8424018a",
+            ),
+        ],
+    )
+    def test_it(self, lti_user, expected_userid):
+        assert authenticated_userid(lti_user) == expected_userid
 
 
 class TestGetLTIUser:


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/530.

Add a helper function for generating a Pyramid `request.authenticated_userid` string from an LTIUser value.

This requires us to decide what a `request.authenticated_userid` string should look like for an LTI user. I've gone with:

    <USER_ID>:<OAUTH_CONSUMER_KEY>

where `<USER_ID>` is the value of the LTI launch param `user_id` (i.e. the user ID from the LMS) base 64 encoded so that we know it doesn't contain `":"`. And `<OAUTH_CONSUMER_KEY>` is the value of the `oauth_consumer_key` launch param which we know doesn't contain `":"` because it was originally generated by us (and the given oauth_consumer_key has been verified to match one in our DB before setting `request.authenticated_userid`).

A `request.authenticated_userid` string is needed if we want to have a Pyramid [authentication policy](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html#creating-your-own-authentication-policy) for launch params and bearer token-authenticated requests.

We could key saved Canvas access tokens in the DB using this `request.authenticated_userid` string, or the DB could just have separate `user_id` and `oauth_consumer_key` columns and use a compound unique constraint on those two columns.

So setting `request.authenticated_userid` probably isn't strictly necessary. It does however enable us to do normal Pyramid things like protecting a view with `permission=pyramid.security.Authenticated`
and we can probably build more principals and permissions-based view gating on top of it in the future.