### PR TITLE
LTI bearer tokens 9/n: Add an authentication policy for LTI users

### DIFF
--- a/lms/authentication/__init__.py
+++ b/lms/authentication/__init__.py
@@ -7,6 +7,7 @@ __all__ = ()
 
 
 def includeme(config):
+    config.include("lms.authentication._helpers")
     config.set_authentication_policy(
         AuthTktAuthenticationPolicy(
             config.registry.settings["lms_secret"],

--- a/lms/authentication/__init__.py
+++ b/lms/authentication/__init__.py
@@ -1,6 +1,4 @@
-from pyramid.authentication import AuthTktAuthenticationPolicy
-
-from lms.security import groupfinder
+from lms.authentication._policy import AuthenticationPolicy
 
 
 __all__ = ()
@@ -9,9 +7,5 @@ __all__ = ()
 def includeme(config):
     config.include("lms.authentication._helpers")
     config.set_authentication_policy(
-        AuthTktAuthenticationPolicy(
-            config.registry.settings["lms_secret"],
-            callback=groupfinder,
-            hashalg="sha512",
-        )
+        AuthenticationPolicy(config.registry.settings["lms_secret"])
     )

--- a/lms/authentication/_lti_policy.py
+++ b/lms/authentication/_lti_policy.py
@@ -1,0 +1,29 @@
+from pyramid import security
+
+from lms.authentication import _helpers
+
+
+class LTIAuthenticationPolicy:
+    def authenticated_userid(self, request):
+        return self.unauthenticated_userid(request)
+
+    def unauthenticated_userid(self, request):  # pylint:disable=no-self-use
+        if request.lti_user is None:
+            return None
+
+        return _helpers.authenticated_userid(request.lti_user)
+
+    def effective_principals(self, request):
+        userid = self.authenticated_userid(request)
+        principals = [security.Everyone]
+
+        if userid:
+            principals.extend([security.Authenticated, userid])
+
+        return principals
+
+    def remember(self, request, userid, **kw):
+        pass
+
+    def forget(self, request):
+        pass

--- a/lms/authentication/_policy.py
+++ b/lms/authentication/_policy.py
@@ -1,0 +1,41 @@
+import functools
+
+from pyramid.authentication import AuthTktAuthenticationPolicy
+
+from lms.authentication._lti_policy import LTIAuthenticationPolicy
+from lms.security import groupfinder
+
+
+__all__ = ("AuthenticationPolicy",)
+
+
+class AuthenticationPolicy:
+    """Top-level authentication policy that delegates to sub-policies."""
+
+    def __init__(self, lms_secret):
+        self._lti_authentication_policy = LTIAuthenticationPolicy()
+        self._auth_tkt_authentication_policy = AuthTktAuthenticationPolicy(
+            lms_secret, callback=groupfinder, hashalg="sha512"
+        )
+
+    def authenticated_userid(self, request):
+        return self._policy(request).authenticated_userid(request)
+
+    def unauthenticated_userid(self, request):
+        return self._policy(request).unauthenticated_userid(request)
+
+    def effective_principals(self, request):
+        return self._policy(request).effective_principals(request)
+
+    def remember(self, request, userid, **kw):
+        return self._policy(request).remember(request, userid, **kw)
+
+    def forget(self, request):
+        return self._policy(request).forget(request)
+
+    @functools.lru_cache(maxsize=1)
+    def _policy(self, request):
+        if self._lti_authentication_policy.authenticated_userid(request):
+            return self._lti_authentication_policy
+
+        return self._auth_tkt_authentication_policy

--- a/tests/lms/authentication/__init___test.py
+++ b/tests/lms/authentication/__init___test.py
@@ -8,7 +8,7 @@ from lms.authentication import includeme
 
 class TestIncludeMe:
     def test_it_sets_the_authentication_policy(
-        self, groupfinder, pyramid_config, AuthTktAuthenticationPolicy
+        self, pyramid_config, AuthenticationPolicy
     ):
         # We need to set an authorization policy first otherwise setting an
         # authentication policy will fail (you can't have an authentication
@@ -17,18 +17,12 @@ class TestIncludeMe:
 
         includeme(pyramid_config)
 
-        AuthTktAuthenticationPolicy.assert_called_once_with(
-            "TEST_LMS_SECRET", callback=groupfinder, hashalg="sha512"
-        )
+        AuthenticationPolicy.assert_called_once_with("TEST_LMS_SECRET")
         assert (
             pyramid_config.registry.queryUtility(IAuthenticationPolicy)
-            == AuthTktAuthenticationPolicy.return_value
+            == AuthenticationPolicy.return_value
         )
 
     @pytest.fixture(autouse=True)
-    def AuthTktAuthenticationPolicy(self, patch):
-        return patch("lms.authentication.AuthTktAuthenticationPolicy")
-
-    @pytest.fixture(autouse=True)
-    def groupfinder(self, patch):
-        return patch("lms.authentication.groupfinder")
+    def AuthenticationPolicy(self, patch):
+        return patch("lms.authentication.AuthenticationPolicy")

--- a/tests/lms/authentication/_lti_policy_test.py
+++ b/tests/lms/authentication/_lti_policy_test.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest import mock
+
+from pyramid import security
+
+from lms.authentication._lti_policy import LTIAuthenticationPolicy
+
+
+class TestLTIAuthenticationPolicy:
+    @pytest.mark.parametrize(
+        "method_name", ["authenticated_userid", "unauthenticated_userid"]
+    )
+    def test_it_returns_the_lti_userid(self, method_name, pyramid_request, _helpers):
+        policy = LTIAuthenticationPolicy()
+        method = getattr(policy, method_name)
+
+        userid = policy.authenticated_userid(pyramid_request)
+
+        _helpers.authenticated_userid.assert_called_once_with(pyramid_request.lti_user)
+        assert userid == _helpers.authenticated_userid.return_value
+
+    @pytest.mark.parametrize(
+        "method_name", ["authenticated_userid", "unauthenticated_userid"]
+    )
+    def test_it_returns_None_if_theres_no_lti_user(self, method_name, pyramid_request):
+        pyramid_request.lti_user = None
+        policy = LTIAuthenticationPolicy()
+        method = getattr(policy, method_name)
+
+        assert policy.authenticated_userid(pyramid_request) is None
+
+    def test_effective_principals_when_theres_an_lti_user(
+        self, pyramid_request, _helpers
+    ):
+        policy = LTIAuthenticationPolicy()
+
+        principals = policy.effective_principals(pyramid_request)
+
+        _helpers.authenticated_userid.assert_called_once_with(pyramid_request.lti_user)
+        assert principals == [
+            security.Everyone,
+            security.Authenticated,
+            _helpers.authenticated_userid.return_value,
+        ]
+
+    def test_effective_principals_when_theres_no_lti_user(
+        self, pyramid_request, _helpers
+    ):
+        pyramid_request.lti_user = None
+        policy = LTIAuthenticationPolicy()
+
+        principals = policy.effective_principals(pyramid_request)
+
+        _helpers.authenticated_userid.assert_not_called()
+        assert principals == [security.Everyone]
+
+    def test_remember(self, pyramid_request):
+        LTIAuthenticationPolicy().remember(
+            pyramid_request, "TEST_USERID", kwarg=mock.sentinel.kwarg
+        )
+
+    def test_forget(self, pyramid_request):
+        LTIAuthenticationPolicy().forget(pyramid_request)
+
+
+@pytest.fixture(autouse=True)
+def _helpers(patch):
+    return patch("lms.authentication._lti_policy._helpers")

--- a/tests/lms/authentication/_policy_test.py
+++ b/tests/lms/authentication/_policy_test.py
@@ -1,0 +1,147 @@
+import base64
+from unittest import mock
+
+import pytest
+
+from lms.authentication._policy import AuthenticationPolicy
+from lms.values import LTIUser
+
+
+class TestAuthenticationPolicy:
+    @pytest.mark.parametrize(
+        "method_name",
+        ("authenticated_userid", "unauthenticated_userid", "effective_principals"),
+    )
+    def test_it_returns_the_userid_from_LTIAuthenticationPolicy(
+        self, method_name, policy, LTIAuthenticationPolicy, lti_authentication_policy
+    ):
+        method = getattr(policy, method_name)
+
+        user_id = method(mock.sentinel.request)
+
+        LTIAuthenticationPolicy.assert_called_once_with()
+        lti_authentication_policy_method = getattr(
+            lti_authentication_policy, method_name
+        )
+        lti_authentication_policy_method.assert_called_with(mock.sentinel.request)
+        assert user_id == lti_authentication_policy_method.return_value
+
+    @pytest.mark.parametrize(
+        "method_name",
+        ("authenticated_userid", "unauthenticated_userid", "effective_principals"),
+    )
+    def test_it_falls_back_on_AuthTktAuthenticationPolicy_if_theres_no_LTI_user(
+        self,
+        AuthTktAuthenticationPolicy,
+        auth_tkt_authentication_policy,
+        groupfinder,
+        lti_authentication_policy,
+        method_name,
+        policy,
+    ):
+        lti_authentication_policy.authenticated_userid.return_value = None
+        method = getattr(policy, method_name)
+
+        user_id = method(mock.sentinel.request)
+
+        AuthTktAuthenticationPolicy.assert_called_once_with(
+            "TEST_SECRET", groupfinder, hashalg="sha512"
+        )
+        auth_tkt_authentication_policy_method = getattr(
+            auth_tkt_authentication_policy, method_name
+        )
+        auth_tkt_authentication_policy_method.assert_called_once_with(
+            mock.sentinel.request
+        )
+        assert user_id == auth_tkt_authentication_policy_method.return_value
+
+    def test_remember_delegates_to_LTIAuthenticationPolicy(
+        self,
+        policy,
+        LTIAuthenticationPolicy,
+        lti_authentication_policy,
+        auth_tkt_authentication_policy,
+    ):
+        policy.remember(
+            mock.sentinel.request, mock.sentinel.userid, kwarg=mock.sentinel.kwarg
+        )
+
+        LTIAuthenticationPolicy.assert_called_once_with()
+        lti_authentication_policy.remember.assert_called_once_with(
+            mock.sentinel.request, mock.sentinel.userid, kwarg=mock.sentinel.kwarg
+        )
+        auth_tkt_authentication_policy.remember.assert_not_called()
+
+    def test_remember_falls_back_on_AuthTktAuthenticationPolicy(
+        self,
+        policy,
+        lti_authentication_policy,
+        AuthTktAuthenticationPolicy,
+        auth_tkt_authentication_policy,
+    ):
+        lti_authentication_policy.authenticated_userid.return_value = None
+
+        policy.remember(
+            mock.sentinel.request, mock.sentinel.userid, kwarg=mock.sentinel.kwarg
+        )
+        auth_tkt_authentication_policy.remember.assert_called_once_with(
+            mock.sentinel.request, mock.sentinel.userid, kwarg=mock.sentinel.kwarg
+        )
+        lti_authentication_policy.remember.assert_not_called()
+
+    def test_forget_delegates_to_LTIAuthenticationPolicy(
+        self,
+        policy,
+        LTIAuthenticationPolicy,
+        lti_authentication_policy,
+        auth_tkt_authentication_policy,
+    ):
+        policy.forget(mock.sentinel.request)
+
+        LTIAuthenticationPolicy.assert_called_once_with()
+        lti_authentication_policy.forget.assert_called_once_with(mock.sentinel.request)
+        auth_tkt_authentication_policy.forget.assert_not_called()
+
+    def test_forget_falls_back_on_AuthTktAuthenticationPolicy(
+        self,
+        policy,
+        lti_authentication_policy,
+        AuthTktAuthenticationPolicy,
+        auth_tkt_authentication_policy,
+    ):
+        lti_authentication_policy.authenticated_userid.return_value = None
+
+        policy.forget(mock.sentinel.request)
+        auth_tkt_authentication_policy.forget.assert_called_once_with(
+            mock.sentinel.request
+        )
+        lti_authentication_policy.forget.assert_not_called()
+
+    @pytest.fixture
+    def policy(self):
+        return AuthenticationPolicy("TEST_SECRET")
+
+
+@pytest.fixture(autouse=True)
+def AuthTktAuthenticationPolicy(patch):
+    return patch("lms.authentication._policy.AuthTktAuthenticationPolicy")
+
+
+@pytest.fixture
+def auth_tkt_authentication_policy(AuthTktAuthenticationPolicy):
+    return AuthTktAuthenticationPolicy.return_value
+
+
+@pytest.fixture(autouse=True)
+def LTIAuthenticationPolicy(patch):
+    return patch("lms.authentication._policy.LTIAuthenticationPolicy")
+
+
+@pytest.fixture
+def lti_authentication_policy(LTIAuthenticationPolicy):
+    return LTIAuthenticationPolicy.return_value
+
+
+@pytest.fixture(autouse=True)
+def groupfinder(patch):
+    return patch("lms.authentication._policy.groupfinder")


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/533 and https://github.com/hypothesis/lms/pull/534.

Add a Pyramid  [authentication policy](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html#creating-your-own-authentication-policy) that sets `request.authenticated_userid` to a userid string based on the LTI user whenever an LTI user is authenticated either via launch params or a bearer token.

This is in addition to the existing cookie-based `AuthTktAuthenticationPolicy` that's used for the `/reports` page. If no launch params or bearer token are found in the request then the new authentication policy delegates to the old `AuthTktAuthenticationPolicy`.