### PR TITLE
LTI bearer tokens 10/n: Add `authorization_param` to `js_config`

### DIFF
--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -4,7 +4,7 @@ import urllib
 
 import jwt
 from pyramid.httpexceptions import HTTPBadRequest
-from pyramid.security import Allow
+from pyramid.security import Allow, Authenticated
 
 from lms.util import lti_params_for
 
@@ -12,7 +12,10 @@ from lms.util import lti_params_for
 class Root:
     """The default root factory for the application."""
 
-    __acl__ = [(Allow, "report_viewers", "view")]
+    __acl__ = [
+        (Allow, "report_viewers", "view"),
+        (Allow, Authenticated, "test_permission"),
+    ]
 
     def __init__(self, request):
         """Return the default root resource object."""

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -39,3 +39,6 @@ def includeme(config):
     # Browsers seem to send requests to this URL on their own accord, even
     # though we dont link to it.
     config.add_route("favicon", "/favicon.ico")
+
+    config.add_route("test", "/test")
+    config.add_route("test_xhr", "/api/test")

--- a/lms/subscribers/_template_environment.py
+++ b/lms/subscribers/_template_environment.py
@@ -2,6 +2,8 @@
 from pyramid.events import subscriber
 from pyramid.events import BeforeRender
 
+from lms.validation import BearerTokenSchema
+
 
 __all__ = []
 
@@ -14,4 +16,11 @@ def _add_js_config(event):
     A template renders this into the HTML page as a JSON object. The object
     contains general config settings used by the app's JavaScript code.
     """
+    request = event["request"]
+
     event["js_config"] = {"urls": {}}
+
+    if request.lti_user:
+        event["js_config"]["authorization_param"] = BearerTokenSchema(
+            request
+        ).authorization_param(request.lti_user)

--- a/lms/subscribers/_template_environment.py
+++ b/lms/subscribers/_template_environment.py
@@ -18,7 +18,7 @@ def _add_js_config(event):
     """
     request = event["request"]
 
-    event["js_config"] = {"urls": {}}
+    event["js_config"] = {"urls": {"test_xhr": request.route_url("test_xhr")}}
 
     if request.lti_user:
         event["js_config"]["authorization_param"] = BearerTokenSchema(

--- a/lms/templates/test.html.jinja2
+++ b/lms/templates/test.html.jinja2
@@ -1,0 +1,50 @@
+{% extends "templates/base.html.jinja2" %}
+
+{% block content %}
+  <div style="max-width:50em;">
+    <h1>Test Page</h2>
+    <p>This is a test page. The request (server-side during request processing) was:</p>
+
+    <ul>
+      <li><code>authenticated_userid</code>: {{ request.authenticated_userid }}</li>
+      <li><code>unauthenticated_userid</code>: {{ request.unauthenticated_userid }}</li>
+      <li><code>effective_principals</code>: {{ request.effective_principals }}</li>
+    </ul>
+
+    <button id="button">Send JWT-authenticated XHR request</button>
+
+    <ul id="appendHere">
+    </ul>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    let config = JSON.parse(document.querySelector('.js-config').textContent);
+    let url = config.urls.test_xhr;
+    let authorization_param = config.authorization_param;
+
+    document.querySelector("#button").onclick = function() {
+      fetch(url, {headers: {Authorization: authorization_param}})
+        .then(function(response) {
+          response.json().then(function(data) {
+            let li = document.createElement('li');
+
+            let p = document.createElement('p')
+            p.appendChild(document.createTextNode('authenticated_userid: ' + data.authenticated_userid));
+            li.appendChild(p)
+
+            p = document.createElement('p')
+            p.appendChild(document.createTextNode('unauthenticated_userid: ' + data.unauthenticated_userid));
+            li.appendChild(p)
+
+            p = document.createElement('p')
+            p.appendChild(document.createTextNode('effective_principals: ' + data.effective_principals));
+            li.appendChild(p)
+
+            document.querySelector('#appendHere').appendChild(li);
+          });
+        });
+    }
+  </script>
+{% endblock %}

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -3,7 +3,7 @@ import os
 from pyramid import httpexceptions
 from pyramid import i18n
 from pyramid.settings import asbool
-from pyramid.view import notfound_view_config
+from pyramid.view import notfound_view_config, forbidden_view_config
 import sentry_sdk
 
 from lms.validation import ValidationError
@@ -15,6 +15,12 @@ _ = i18n.TranslationStringFactory(__package__)
 def notfound(request):
     request.response.status_int = 404
     return {"message": _("Page not found")}
+
+
+@forbidden_view_config(renderer="json", path_info="/api/")
+def forbidden_api(request):
+    request.response.status_code = 401
+    return {"message": _("Bad credentials")}
 
 
 def _http_error(exc, request):

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -215,6 +215,10 @@ def should_launch(request):
 )
 def lti_launches(request, jwt, user=None):
     """Route to handle an lti launch to view a module item."""
+    if request.feature("new_oauth"):
+        from pyramid.renderers import render_to_response
+
+        return render_to_response("lms:templates/test.html.jinja2", {}, request)
     if user is not None:
         token = find_token_by_user_id(request.db, user.id)
         return handle_lti_launch(

--- a/lms/views/test.py
+++ b/lms/views/test.py
@@ -1,0 +1,18 @@
+from pyramid.view import view_config
+from pyramid import security
+
+
+@view_config(route_name="test", renderer="lms:templates/test.html.jinja2")
+def test_view(request):
+    """Temporary test view."""
+    return {}
+
+
+@view_config(route_name="test_xhr", renderer="json", permission="test_permission")
+def test_xhr_view(request):
+    """Temporary test view."""
+    return {
+        "authenticated_userid": request.authenticated_userid,
+        "unauthenticated_userid": request.unauthenticated_userid,
+        "effective_principals": request.effective_principals,
+    }

--- a/tests/lms/subscribers/test__template_environment.py
+++ b/tests/lms/subscribers/test__template_environment.py
@@ -10,7 +10,7 @@ class TestJSConfig:
         _add_js_config(event)
 
         # urls is an empty dict for now!
-        assert event["js_config"]["urls"] == {}
+        assert event["js_config"]["urls"] == {"test_xhr": "http://example.com/api/test"}
 
     def test_if_theres_an_lti_user_it_adds_the_authorization_param_to_the_template_environment(
         self, bearer_token_schema, BearerTokenSchema, pyramid_request

--- a/tests/lms/subscribers/test__template_environment.py
+++ b/tests/lms/subscribers/test__template_environment.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lms.subscribers._template_environment import _add_js_config
 
 
@@ -9,3 +11,35 @@ class TestJSConfig:
 
         # urls is an empty dict for now!
         assert event["js_config"]["urls"] == {}
+
+    def test_if_theres_an_lti_user_it_adds_the_authorization_param_to_the_template_environment(
+        self, bearer_token_schema, BearerTokenSchema, pyramid_request
+    ):
+        event = {"request": pyramid_request}
+
+        _add_js_config(event)
+
+        BearerTokenSchema.assert_called_once_with(pyramid_request)
+        assert (
+            event["js_config"]["authorization_param"]
+            == bearer_token_schema.authorization_param.return_value
+        )
+
+    def test_if_theres_no_lti_user_it_doesnt_add_the_authorization_param_to_the_template_environment(
+        self, BearerTokenSchema, pyramid_request
+    ):
+        pyramid_request.lti_user = None
+        event = {"request": pyramid_request}
+
+        _add_js_config(event)
+
+        BearerTokenSchema.assert_not_called()
+        assert "authorization_param" not in event["js_config"]
+
+    @pytest.fixture(autouse=True)
+    def BearerTokenSchema(self, patch):
+        return patch("lms.subscribers._template_environment.BearerTokenSchema")
+
+    @pytest.fixture
+    def bearer_token_schema(self, BearerTokenSchema):
+        return BearerTokenSchema.return_value


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/532

Add a `"Bearer <ENCODED_JWT>"` string encoding an [`LTIUser`](https://github.com/hypothesis/lms/pull/530) object for the current LTI user to the JavaScript config object in the page.

Also add some test pages for testing the use of this param from JavaScript.