### PR TITLE
Separate public and private h API URLs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -126,7 +126,8 @@ The Hypothesis LMS app is written for python 3 and uses Node.js and `yarn` for m
     export H_CLIENT_ID="232c***5121"
     export H_CLIENT_SECRET="eVJ4***rXkk"
     export H_AUTHORITY="lms.hypothes.is"
-    export H_API_URL="http://localhost:5000/api/"
+    export H_API_URL_PUBLIC="http://localhost:5000/api/"
+    export H_API_URL_PRIVATE="http://localhost:5000/api/"
 
     # For logging in to the Hypothesis client.
     # The values for H_JWT_CLIENT_ID and H_JWT_CLIENT_SECRET should come from

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -36,8 +36,12 @@ def configure(settings):
         "h_jwt_client_secret": env_setting("H_JWT_CLIENT_SECRET", required=True),
         # The authority that we'll create h users and groups in (e.g. "lms.hypothes.is").
         "h_authority": env_setting("H_AUTHORITY", required=True),
-        # The base URL of the h API (e.g. "https://hypothes.is/api).
-        "h_api_url": env_setting("H_API_URL", required=True),
+        # The public base URL of the h API (e.g. "https://hypothes.is/api).
+        "h_api_url_public": env_setting("H_API_URL_PUBLIC", required=True),
+        # A private (within-VPC) URL for the same h API. Faster and more secure
+        # than the public one. This is used for internal server-to-server
+        # comms.
+        "h_api_url_private": env_setting("H_API_URL_PRIVATE", required=True),
         # The postMessage origins from which to accept RPC requests.
         "rpc_allowed_origins": env_setting("RPC_ALLOWED_ORIGINS", required=True),
     }
@@ -47,7 +51,12 @@ def configure(settings):
         env_settings["sqlalchemy.url"] = database_url
 
     env_settings["via_url"] = _append_trailing_slash(env_settings["via_url"])
-    env_settings["h_api_url"] = _append_trailing_slash(env_settings["h_api_url"])
+    env_settings["h_api_url_public"] = _append_trailing_slash(
+        env_settings["h_api_url_public"]
+    )
+    env_settings["h_api_url_private"] = _append_trailing_slash(
+        env_settings["h_api_url_private"]
+    )
 
     try:
         env_settings["aes_secret"] = env_settings["aes_secret"].encode("ascii")[0:16]

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -177,7 +177,7 @@ class LTILaunch:
 
         client_id = self._request.registry.settings["h_jwt_client_id"]
         client_secret = self._request.registry.settings["h_jwt_client_secret"]
-        api_url = self._request.registry.settings["h_api_url"]
+        api_url = self._request.registry.settings["h_api_url_public"]
         audience = urllib.parse.urlparse(api_url).hostname
 
         def grant_token():

--- a/lms/services/hapi.py
+++ b/lms/services/hapi.py
@@ -32,7 +32,7 @@ class HypothesisAPIService:
         self._client_id = settings["h_client_id"]
         self._client_secret = settings["h_client_secret"]
         self._authority = settings["h_authority"]
-        self._base_url = settings["h_api_url"]
+        self._base_url = settings["h_api_url_private"]
 
     def delete(self, *args, **kwargs):
         """
@@ -91,7 +91,7 @@ class HypothesisAPIService:
           "PUT", "PATCH" or "DELETE"
         :type method: str
         :arg path: the h API path to post to, relative to
-          ``settings["h_api_url"]``, for example: ``"users"`` or
+          ``settings["h_api_url_private"]``, for example: ``"users"`` or
           ``"groups/<GROUPID>/members/<USERID>"``
         :type path: str
         :arg data: the data to post as JSON in the request body

--- a/tests/lms/config/__init___test.py
+++ b/tests/lms/config/__init___test.py
@@ -128,11 +128,11 @@ class TestConfigure:
 
         assert configurator.registry.settings["via_url"] == "https://via.hypothes.is/"
 
-    def test_trailing_slashes_are_appended_to_h_api_url(self, env_setting):
+    def test_trailing_slashes_are_appended_to_h_api_url_public(self, env_setting):
         def side_effect(
             envvar_name, *args, **kwargs
         ):  # pylint: disable=unused-argument
-            if envvar_name == "H_API_URL":
+            if envvar_name == "H_API_URL_PUBLIC":
                 return "https://hypothes.is/api"
             return mock.DEFAULT
 
@@ -140,7 +140,27 @@ class TestConfigure:
 
         configurator = configure({})
 
-        assert configurator.registry.settings["h_api_url"] == "https://hypothes.is/api/"
+        assert (
+            configurator.registry.settings["h_api_url_public"]
+            == "https://hypothes.is/api/"
+        )
+
+    def test_trailing_slashes_are_appended_to_h_api_url_private(self, env_setting):
+        def side_effect(
+            envvar_name, *args, **kwargs
+        ):  # pylint: disable=unused-argument
+            if envvar_name == "H_API_URL_PRIVATE":
+                return "https://hypothes.is/api"
+            return mock.DEFAULT
+
+        env_setting.side_effect = side_effect
+
+        configurator = configure({})
+
+        assert (
+            configurator.registry.settings["h_api_url_private"]
+            == "https://hypothes.is/api/"
+        )
 
     @pytest.mark.parametrize(
         "envvar_value,expected_setting",

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -173,7 +173,8 @@ def pyramid_config(pyramid_request):
         "h_jwt_client_id": "TEST_JWT_CLIENT_ID",
         "h_jwt_client_secret": "TEST_JWT_CLIENT_SECRET",
         "h_authority": "TEST_AUTHORITY",
-        "h_api_url": "https://example.com/api/",
+        "h_api_url_public": "https://example.com/api/",
+        "h_api_url_private": "https://private.com/api/",
         "rpc_allowed_origins": ["http://localhost:5000"],
     }
 

--- a/tests/lms/services/hapi_test.py
+++ b/tests/lms/services/hapi_test.py
@@ -16,7 +16,8 @@ from lms.services import HAPINotFoundError
 
 class TestAPIRequest:
     @pytest.mark.parametrize(
-        "setting", ["h_client_id", "h_client_secret", "h_authority", "h_api_url"]
+        "setting",
+        ["h_client_id", "h_client_secret", "h_authority", "h_api_url_private"],
     )
     def test_it_crashes_if_a_required_setting_is_missing(
         self, pyramid_request, setting
@@ -35,7 +36,7 @@ class TestAPIRequest:
 
         requests.request.assert_called_once_with(
             method=verb,
-            url="https://example.com/api/path",
+            url="https://private.com/api/path",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
             timeout=10,
             headers={"Hypothesis-Application": "lms"},
@@ -46,7 +47,7 @@ class TestAPIRequest:
     ):
         svc.request("POST", "/path")
 
-        assert requests.request.call_args[1]["url"] == "https://example.com/api/path"
+        assert requests.request.call_args[1]["url"] == "https://private.com/api/path"
 
     # Instead of calling get() or post() etc you can also call request()
     # directly and pass in the HTTP verb as a string.
@@ -55,7 +56,7 @@ class TestAPIRequest:
 
         requests.request.assert_called_once_with(
             method="PUT",
-            url="https://example.com/api/path",
+            url="https://private.com/api/path",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
             timeout=10,
             headers={"Hypothesis-Application": "lms"},

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,8 @@ passenv =
     dev: GOOGLE_CLIENT_ID
     dev: GOOGLE_DEVELOPER_KEY
     dev: H_AUTHORITY
-    dev: H_API_URL
+    dev: H_API_URL_PRIVATE
+    dev: H_API_URL_PUBLIC
     dev: H_CLIENT_ID
     dev: H_CLIENT_SECRET
     dev: H_JWT_CLIENT_ID


### PR DESCRIPTION
Use H_API_URL_PUBLIC as the h API base URL to configure the client with, and H_API_URL_PRIVATE for server-to-server API requests. Remove the old H_API_URL setting.