### PR TITLE
Feature flags cookie 2/n: Add a Pyramid session cookie

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -15,6 +15,9 @@ pyramid.includes = pyramid_debugtoolbar
 
 sqlalchemy.url = postgresql://postgres@localhost:5433/postgres
 
+# The secret string that's used to sign the session cookie.
+session_cookie_secret = "notasecret"
+
 [server:main]
 use: egg:gunicorn
 host: 0.0.0.0

--- a/lms/app.py
+++ b/lms/app.py
@@ -23,6 +23,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     )
 
     config.include("lms.sentry")
+    config.include("lms.session")
     config.include("lms.models")
     config.include("lms.db")
     config.include("lms.routes")

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -25,6 +25,12 @@ def configure(settings):
         "hashed_pw": sg.get("HASHED_PW"),
         "salt": sg.get("SALT"),
         "username": sg.get("USERNAME"),
+        # The secret string that's used to sign the session cookie.
+        # This needs to be a 64-byte, securely generated random string.
+        # For example you can generate one using Python 3 on the command line
+        # like this:
+        #     python3 -c 'import secrets; print(secrets.token_hex(nbytes=64))'
+        "session_cookie_secret": sg.get("SESSION_COOKIE_SECRET", required=True),
         # We need to use a randomly generated 16 byte array to encrypt secrets.
         # For now we will use the first 16 bytes of the lms_secret
         "aes_secret": sg.get("LMS_SECRET", required=True),

--- a/lms/session.py
+++ b/lms/session.py
@@ -1,0 +1,34 @@
+"""The app's Pyramid session."""
+from pyramid.session import JSONSerializer, SignedCookieSessionFactory
+
+
+__all__ = []
+
+
+def includeme(config):
+    """Set up the app's Pyramid session."""
+    # ``secure=True`` is recommended by the Pyramid docs (see
+    # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/sessions.html)
+    # but is inconvenient in development environments, so use insecure cookies
+    # in dev for convenience but use secure (HTTPS-only) cookies otherwise.
+    secure = not config.registry.settings.get("debug", False)
+
+    config.set_session_factory(
+        SignedCookieSessionFactory(
+            secret=config.registry.settings["session_cookie_secret"],
+            secure=secure,
+            # ``httponly=True`` is recommended by the Pyramid docs to protect
+            # the cookie from cross-site scripting vulnerabilities, see:
+            # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/sessions.html
+            httponly=True,
+            # This is the timeout and reissue time recommended in the Pyramid
+            # docs for auto-expiring cookies. See:
+            # https://docs.pylonsproject.org/projects/pyramid/en/latest/api/session.html
+            timeout=1200,
+            reissue_time=120,
+            # The Pyramid docs recommend JSONSerializer instead of the default
+            # serializer for security reasons. See:
+            # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/sessions.html
+            serializer=JSONSerializer(),
+        )
+    )

--- a/tests/lms/session_test.py
+++ b/tests/lms/session_test.py
@@ -1,0 +1,13 @@
+from pyramid.interfaces import ISessionFactory
+
+from lms.session import includeme
+
+
+def test_includeme(pyramid_config):
+    pyramid_config.registry.settings["session_cookie_secret"] = "test_secret"
+
+    includeme(pyramid_config)
+
+    session_factory = pyramid_config.registry.queryUtility(ISessionFactory)
+    assert session_factory is not None
+    assert session_factory._cookie_secure is True

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ skip_install = true
 passenv =
     tests: TEST_DATABASE_URL
     tests: PYTEST_ADDOPTS
+    dev: SESSION_COOKIE_SECRET
     dev: DATABASE_URL
     dev: DEBUG
     dev: FEATURE_FLAG_*


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/556/>.

Add a standard Pyramid session cookie to the app.
    
This is needed right now in order to be able to use flash messages but the session might end up getting used for other things in the future (a Pyramid app can only have one session) so I've paid basic attention to security.
    
Add a new required envvar: `COOKIE_SIGNING_SECRET`.
    
Add new `session.py` module that sets up a standard Pyramid signed (not encrypted) cookie session using the new secret.
