### PR TITLE
Feature flags cookie 3/n: Pin modal dialogs to the top of the page

### DIFF
--- a/lms/static/styles/lms.css
+++ b/lms/static/styles/lms.css
@@ -25,11 +25,11 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   height: 100%;
 }
 .modal-content{
-  padding: 10px 30px;
+  padding: 80px 30px;
 }
 .modal-text{
   margin: 0 0 20px;
@@ -590,4 +590,11 @@ table tr:nth-child(odd) { /* Zebra-stripe the rows */
 td.wrap { /* wrap veryyyyyyyy long data */
   white-space: normal;
   word-break: break-all;
+}
+
+/* Horizontally center an element's direct children. */
+.u-horizontally-center-children {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/lms/templates/error.html.jinja2
+++ b/lms/templates/error.html.jinja2
@@ -3,8 +3,10 @@
 {% set title = message %}
 
 {% block content %}
-  <img src="{{ 'lms:static/images/sad-annotation.svg'|static_path }}">
-  <p>
-    {{ message|safe }}
-  </p>
+  <main class="modal-content u-horizontally-center-children">
+    <img src="{{ 'lms:static/images/sad-annotation.svg'|static_path }}">
+    <p>
+      {{ message|safe }}
+    </p>
+  </main>
 {% endblock %}

--- a/lms/templates/lti_launches/unauthorized.html.jinja2
+++ b/lms/templates/lti_launches/unauthorized.html.jinja2
@@ -1,7 +1,9 @@
 {% extends "lms:templates/base.html.jinja2" %}
 {% block content %}
-<div class="warning-icon">
-  <i class="material-icons md-36 red">report_problem</i>
-</div>
-<h2 class="warning-text">This page has not yet been configured</h2>
+<main class="modal-content u-horizontally-center-children">
+  <div class="warning-icon">
+    <i class="material-icons md-36 red">report_problem</i>
+  </div>
+  <h2 class="warning-text">This page has not yet been configured</h2>
+</main>
 {% endblock %}

--- a/lms/templates/validation_error.html.jinja2
+++ b/lms/templates/validation_error.html.jinja2
@@ -3,18 +3,20 @@
 {% set title = error.message %}
 
 {% block content %}
-  <img src="{{ 'lms:static/images/sad-annotation.svg'|static_path }}">
-  <p>{% trans %}Hypothesis received an invalid request.
-  There were problems with these request parameters:{% endtrans %}</p>
-  <ul>
-  {% for field in error.messages %}
-    <li>
-      {{ field }}:
-      <ul>
-        {% for message in error.messages[field] %}
-          <li>{{ message }}</li>
-        {% endfor %}
-      </ul>
-    </li>
-  {% endfor %}
+  <main class="modal-content u-horizontally-center-children">
+    <img src="{{ 'lms:static/images/sad-annotation.svg'|static_path }}">
+    <p>{% trans %}Hypothesis received an invalid request.
+    There were problems with these request parameters:{% endtrans %}</p>
+    <ul>
+    {% for field in error.messages %}
+      <li>
+        {{ field }}:
+        <ul>
+          {% for message in error.messages[field] %}
+            <li>{{ message }}</li>
+          {% endfor %}
+        </ul>
+      </li>
+    {% endfor %}
+  </main>
 {% endblock %}


### PR DESCRIPTION
Pin modal dialogs to the top of the page (with a margin of 80px from the top of the page) instead of vertically centering them.

This prevents dialogs from jumping around when the height of a dialog's contents changes (e.g. a new element gets added to the bottom of the dialog) and the browser vertically re-centers the dialog using its new height.