### PR TITLE
Feature flags cookie 4/n: Add styles block to base Jinja2 template

### DIFF
--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -7,6 +7,7 @@
     <link rel="stylesheet"
           type="text/css"
           href="{{'lms:static/styles/lms.css'|static_path}}">
+    {% block styles %}{% endblock %}
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
           rel="stylesheet">
 


### PR DESCRIPTION
Allows child templates to insert their own `<script>` tags in the right location in the page by overriding the scripts block. This enables a page to have its own CSS file that's only for that page.