### PR TITLE
Feature flags cookie 5/n: Add /flags page for toggling flags in cookie

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -18,6 +18,9 @@ sqlalchemy.url = postgresql://postgres@localhost:5433/postgres
 # The secret string that's used to sign the session cookie.
 session_cookie_secret = "notasecret"
 
+# The secret string that's used to sign the feature flags cookie.
+feature_flags_cookie_secret = "notasecret"
+
 [server:main]
 use: egg:gunicorn
 host: 0.0.0.0

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -50,6 +50,15 @@ def configure(settings):
         "h_api_url_private": sg.get("H_API_URL_PRIVATE", required=True),
         # The postMessage origins from which to accept RPC requests.
         "rpc_allowed_origins": sg.get("RPC_ALLOWED_ORIGINS", required=True),
+        # The secret string that's used to sign the feature flags cookie.
+        # For example you can generate one using Python 3 on the command line
+        # like this:
+        #     python3 -c 'import secrets; print(secrets.token_hex())'
+        "feature_flags_cookie_secret": sg.get(
+            "FEATURE_FLAGS_COOKIE_SECRET", required=True
+        ),
+        # The list of feature flags that are allowed to be set in the feature flags cookie.
+        "feature_flags_allowed_in_cookie": sg.get("FEATURE_FLAGS_ALLOWED_IN_COOKIE"),
     }
 
     database_url = sg.get("DATABASE_URL")

--- a/lms/extensions/feature_flags/__init__.py
+++ b/lms/extensions/feature_flags/__init__.py
@@ -114,16 +114,22 @@ set by that source. For example::
         elif feature_flag_name == "disabled_feature_flag":
             return False
 """
+from ._exceptions import SettingError
 from ._feature_flags import FeatureFlags
 from ._providers import config_file_provider  # noqa
 from ._providers import envvar_provider  # noqa
 from ._providers import query_string_provider  # noqa
 
 
-__all__ = []
+__all__ = ["SettingError"]
 
 
 def includeme(config):
+    config.include("lms.extensions.feature_flags._routes")
+    config.add_static_view(
+        name="feature-flags-static", path="lms.extensions.feature_flags:_static"
+    )
+
     # The singleton FeatureFlags instance for the entire app.
     feature_flags = FeatureFlags()
 

--- a/lms/extensions/feature_flags/_exceptions.py
+++ b/lms/extensions/feature_flags/_exceptions.py
@@ -1,0 +1,5 @@
+__all__ = ["SettingError"]
+
+
+class SettingError(Exception):
+    """An invalid setting or a missing required setting."""

--- a/lms/extensions/feature_flags/_helpers.py
+++ b/lms/extensions/feature_flags/_helpers.py
@@ -1,0 +1,67 @@
+import jwt
+from jwt.exceptions import InvalidTokenError
+from pyramid.settings import asbool, aslist
+
+from ._exceptions import SettingError
+
+
+__all__ = ["FeatureFlagsCookieHelper", "JWTCookieHelper"]
+
+
+class FeatureFlagsCookieHelper:
+    """Helper for getting and setting feature flags cookies."""
+
+    def __init__(self, request):
+        # The set of feature flags that are allowed to be toggled on or off by the
+        # feature flags cookie.
+        self._allowed_flags = aslist(
+            request.registry.settings.get("feature_flags_allowed_in_cookie", "") or ""
+        )
+        self._jwt_cookie_helper = JWTCookieHelper("feature_flags", request)
+        self._request = request
+
+    def set_cookie(self, response):
+        flags = self._parse_flags(self._request.params)
+        self._jwt_cookie_helper.set(response, flags)
+
+    def get(self, flag):
+        return self.get_all().get(flag, False)
+
+    def get_all(self):
+        return self._parse_flags(self._jwt_cookie_helper.get())
+
+    def _parse_flags(self, flags):
+        return {flag: asbool(flags.get(flag, False)) for flag in self._allowed_flags}
+
+
+class JWTCookieHelper:
+    """Helper for getting and setting a JWT-encoded cookie."""
+
+    def __init__(self, name, request):
+        # The secret used to sign the cookie.
+        try:
+            self._secret = request.registry.settings["feature_flags_cookie_secret"]
+        except KeyError:
+            raise SettingError(
+                "The feature_flags_cookie_secret deployment setting is required"
+            )
+
+        self._name = name
+        self._request = request
+
+    def set(self, response, payload):
+        jwt_bytes = jwt.encode(payload, self._secret, algorithm="HS256")
+        response.set_cookie(
+            self._name,
+            jwt_bytes,
+            max_age=31536000,  # One year in seconds.
+            overwrite=True,
+            secure=not self._request.registry.settings.get("debug", False),
+        )
+
+    def get(self):
+        jwt_bytes = self._request.cookies.get(self._name, "")
+        try:
+            return jwt.decode(jwt_bytes, self._secret, algorithms=["HS256"])
+        except InvalidTokenError:
+            return {}

--- a/lms/extensions/feature_flags/_routes.py
+++ b/lms/extensions/feature_flags/_routes.py
@@ -1,0 +1,2 @@
+def includeme(config):
+    config.add_route("feature_flags_cookie_form", "/flags")

--- a/lms/extensions/feature_flags/_static/feature-flags.css
+++ b/lms/extensions/feature_flags/_static/feature-flags.css
@@ -1,0 +1,33 @@
+ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+li {
+  margin-bottom: 20px;
+}
+
+input[type=checkbox] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    width: 30px;
+    height: 30px;
+    border: 2px solid black;
+    margin-right: 1em;
+}
+
+input[type=checkbox] , label {
+    vertical-align: middle;
+}
+
+input[type=checkbox]:checked:after {
+    margin-left: 7px;
+    margin-top: -1px;
+    width: 8px;
+    height: 18px;
+    border: solid black;
+    border-width: 0 4px 4px 0;
+    transform: rotate(45deg);
+    content: "";
+    display: inline-block;
+}

--- a/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
+++ b/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
@@ -1,0 +1,76 @@
+{% extends "lms:templates/base.html.jinja2" %}
+
+{% block styles %}
+  <link rel="stylesheet" type="text/css" href="{{ request.static_url('lms.extensions.feature_flags:_static/feature-flags.css') }}">
+{% endblock %}
+
+{% block content %}
+  <main class="modal-content">
+    <h1>Feature Flags Cookie</h1>
+
+    <p class="modal-text">Toggle feature flags on or off with a cookie.</p>
+
+    {% if flags %}
+      <p class="modal-subtext">
+        These feature flag toggles are saved in a browser cookie so they'll apply
+        <strong>whenever you're using this browser</strong>, regardless of which user account
+        you're logged in to.
+
+      <p class="modal-subtext">
+        To toggle feature flags in another browser visit this page with that
+        browser.
+      </p>
+
+      <form class="feature_flags_form" action="{{ request.route_url('feature_flags_cookie_form') }}" method="post">
+
+        <ul>
+        {% for flag in flags %}
+          <li>
+            <input type="checkbox"{% if flags[flag] %} checked{% endif %} id="{{ flag }}" name="{{ flag }}">
+            <label for="{{ flag }}">{{ flag }}</label>
+          </li>
+        {% endfor %}
+        </ul>
+
+        <div class="form-controls">
+          <div style="display:flex; flex-direction:column; align-items:flex-end;">
+            <button class="btn" type="submit">Save</button>
+            {% for message in request.session.pop_flash('feature_flags') %}
+              <p class="js-flash">{{ message }}</p>
+            {% endfor %}
+          </div>
+        </div>
+      </form>
+    {% else %}
+      <p class="modal-subtext">
+        There are currently no feature flags available for toggling in browser cookies.
+      </p>
+      <p class="modal-subtext">
+        To make them appear on this page add your feature flags to the
+        <code>feature_flags_allowed_in_cookie</code> deployment setting in the
+        <code>.ini</code> configuration file. For example:
+      </p>
+
+      <pre><code>[app:main]
+# .. other settings
+feature_flags_allowed_in_cookie =
+  foo
+  bar
+  gar</code></pre>
+    {% endif %}
+  </main>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    window.setTimeout(
+      () => {
+        document.querySelectorAll('.js-flash').forEach((flashMessage) => {
+          flashMessage.style.transition = 'opacity .2s linear 3s';
+          flashMessage.style.opacity = 0;
+        });
+      },
+      0,
+    )
+  </script>
+{% endblock %}

--- a/lms/extensions/feature_flags/_views.py
+++ b/lms/extensions/feature_flags/_views.py
@@ -1,0 +1,33 @@
+from pyramid.httpexceptions import HTTPFound
+from pyramid.view import view_config, view_defaults
+
+from ._helpers import FeatureFlagsCookieHelper
+
+
+@view_defaults(
+    route_name="feature_flags_cookie_form",
+    renderer="_templates/cookie_form.html.jinja2",
+)
+class _FeatureFlagsCookieFormViews:
+    """A form for toggling feature flags in a cookie."""
+
+    def __init__(self, request):
+        self._cookie_helper = FeatureFlagsCookieHelper(request)
+        self._request = request
+
+    @view_config(request_method="GET")
+    def get(self):
+        """Render the feature flags cookie form page."""
+        return {"flags": self._cookie_helper.get_all()}
+
+    @view_config(request_method="POST")
+    def post(self):
+        """Handle a feature flags cookie form submission."""
+        response = HTTPFound(
+            location=self._request.route_url("feature_flags_cookie_form")
+        )
+        self._cookie_helper.set_cookie(response)
+        self._request.session.flash(
+            "Feature flags saved in cookie ✔", "feature_flags", allow_duplicate=False
+        )
+        return response

--- a/tests/lms/extensions/feature_flags/_helpers_test.py
+++ b/tests/lms/extensions/feature_flags/_helpers_test.py
@@ -1,0 +1,200 @@
+import jwt
+import pytest
+from pyramid.httpexceptions import HTTPFound
+
+from lms.extensions.feature_flags._exceptions import SettingError
+from lms.extensions.feature_flags._helpers import (
+    FeatureFlagsCookieHelper,
+    JWTCookieHelper,
+)
+
+
+class TestFeatureFlagsCookieHelper:
+    def test_set_cookie_sets_the_cookie_from_the_request_params(
+        self, pyramid_request, JWTCookieHelper, jwt_cookie_helper
+    ):
+        pyramid_request.params = {"test_flag_one": "on"}
+        response = HTTPFound()
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        helper.set_cookie(response)
+
+        JWTCookieHelper.assert_called_once_with("feature_flags", pyramid_request)
+        jwt_cookie_helper.set.assert_called_once_with(
+            response, {"test_flag_one": True, "test_flag_two": False}
+        )
+
+    def test_set_cookie_omits_disallowed_feature_flags(
+        self, pyramid_request, jwt_cookie_helper
+    ):
+        flags = pyramid_request.params = {
+            "test_flag_one": "on",
+            "disallowed_flag": "on",
+        }
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        helper.set_cookie(HTTPFound())
+
+        assert jwt_cookie_helper.set.call_args[0][1] == {
+            "test_flag_one": True,
+            "test_flag_two": False,
+        }
+
+    def test_get_gets_the_flag_from_the_cookie(
+        self, pyramid_request, JWTCookieHelper, jwt_cookie_helper
+    ):
+        jwt_cookie_helper.get.return_value = {"test_flag_one": True}
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        flag = helper.get("test_flag_one")
+
+        JWTCookieHelper.assert_called_once_with("feature_flags", pyramid_request)
+        jwt_cookie_helper.get.assert_called_once_with()
+        assert flag is True
+
+    def test_get_returns_False_if_flag_is_toggled_off_in_cookie(
+        self, pyramid_request, JWTCookieHelper, jwt_cookie_helper
+    ):
+        jwt_cookie_helper.get.return_value = {"test_flag_one": False}
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        assert helper.get("test_flag_one") is False
+
+    def test_get_omits_disallowed_flags(self, jwt_cookie_helper, pyramid_request):
+        jwt_cookie_helper.get.return_value = {"disallowed_flag": True}
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        assert helper.get("disallowed_flag") is False
+
+    def test_get_all_gets_all_the_flags_from_the_cookie(
+        self, pyramid_request, JWTCookieHelper, jwt_cookie_helper
+    ):
+        jwt_cookie_helper.get.return_value = {
+            "test_flag_one": True,
+            "test_flag_two": False,
+        }
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        returned_flags = helper.get_all()
+
+        JWTCookieHelper.assert_called_once_with("feature_flags", pyramid_request)
+        jwt_cookie_helper.get.assert_called_once_with()
+        assert returned_flags == {"test_flag_one": True, "test_flag_two": False}
+
+    def test_get_all_omits_disallowed_flags(self, pyramid_request, jwt_cookie_helper):
+        jwt_cookie_helper.get.return_value = {
+            "test_flag_one": True,
+            "test_flag_two": False,
+            "disallowed_flag": True,
+        }
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        assert helper.get_all() == {"test_flag_one": True, "test_flag_two": False}
+
+    @pytest.mark.parametrize("flags_setting", ["", None])
+    def test_when_theres_no_flags_allowed_set_turns_off_all_flags(
+        self, pyramid_request, jwt_cookie_helper, flags_setting
+    ):
+        pyramid_request.registry.settings[
+            "feature_flags_allowed_in_cookie"
+        ] = flags_setting
+        pyramid_request.params = {"test_flag_one": "on"}
+        response = HTTPFound()
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        helper.set_cookie(response)
+
+        jwt_cookie_helper.set.assert_called_once_with(response, {})
+
+    def test_when_theres_no_flags_allowed_get_always_returns_False(
+        self, pyramid_request, jwt_cookie_helper
+    ):
+        pyramid_request.registry.settings["feature_flags_allowed_in_cookie"] = ""
+        jwt_cookie_helper.get.return_value = {"test_flag_one": True}
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        assert helper.get("test_flag_one") is False
+
+    def test_when_theres_no_flags_allowed_get_all_returns_an_empty_dict(
+        self, pyramid_request, jwt_cookie_helper
+    ):
+        pyramid_request.registry.settings["feature_flags_allowed_in_cookie"] = ""
+        pyramid_request.params = jwt_cookie_helper.get.return_value = {
+            "test_flag_one": "on"
+        }
+        helper = FeatureFlagsCookieHelper(pyramid_request)
+
+        assert helper.get_all() == {}
+
+    @pytest.fixture
+    def pyramid_config(self, pyramid_config):
+        pyramid_config.registry.settings[
+            "feature_flags_allowed_in_cookie"
+        ] = "test_flag_one test_flag_two"
+        return pyramid_config
+
+    @pytest.fixture(autouse=True)
+    def JWTCookieHelper(self, patch):
+        return patch("lms.extensions.feature_flags._helpers.JWTCookieHelper")
+
+    @pytest.fixture
+    def jwt_cookie_helper(self, JWTCookieHelper):
+        return JWTCookieHelper.return_value
+
+
+class TestJWTCookieHelper:
+    def test_it_crashes_if_no_feature_flags_cookie_secret(self, pyramid_request):
+        del pyramid_request.registry.settings["feature_flags_cookie_secret"]
+
+        with pytest.raises(
+            SettingError,
+            match="The feature_flags_cookie_secret deployment setting is required",
+        ):
+            JWTCookieHelper("test_cookie_name", pyramid_request)
+
+    def test_set_encodes_the_payload_in_the_cookie(self, pyramid_request):
+        original_payload = {"test_key": "test_value"}
+        helper = JWTCookieHelper("test_cookie_name", pyramid_request)
+        response = HTTPFound()
+
+        helper.set(response, original_payload)
+
+        cookie = response.headers["Set-Cookie"].split(";")[0].split("=")[1]
+        decoded_payload = jwt.decode(cookie, "test_secret", algorithms=["HS256"])
+        assert decoded_payload == original_payload
+
+    def test_get_returns_the_decoded_payload(self, pyramid_request):
+        original_payload = {"test_key": "test_value"}
+        encoded_payload = jwt.encode(original_payload, "test_secret", algorithm="HS256")
+        pyramid_request.cookies["test_cookie_name"] = encoded_payload
+        helper = JWTCookieHelper("test_cookie_name", pyramid_request)
+
+        assert helper.get() == original_payload
+
+    def test_get_returns_an_empty_dict_if_the_cookie_is_invalid(self, pyramid_request):
+        pyramid_request.cookies["test_cookie_name"] = "invalid"
+        helper = JWTCookieHelper("test_cookie_name", pyramid_request)
+
+        assert helper.get() == {}
+
+    def test_get_returns_an_empty_dict_if_theres_no_cookie(self, pyramid_request):
+        helper = JWTCookieHelper("test_cookie_name", pyramid_request)
+
+        assert helper.get() == {}
+
+    def test_that_set_and_get_work_together(self, pyramid_request):
+        original_payload = {"test_key": "test_value"}
+        helper = JWTCookieHelper("test_cookie_name", pyramid_request)
+        response = HTTPFound()
+
+        helper.set(response, original_payload)
+
+        cookie = response.headers["Set-Cookie"].split(";")[0].split("=")[1]
+        pyramid_request.cookies["test_cookie_name"] = cookie
+
+        assert helper.get() == original_payload
+
+    @pytest.fixture(autouse=True)
+    def pyramid_config(self, pyramid_config):
+        pyramid_config.registry.settings["feature_flags_cookie_secret"] = "test_secret"
+        return pyramid_config

--- a/tests/lms/extensions/feature_flags/_views_test.py
+++ b/tests/lms/extensions/feature_flags/_views_test.py
@@ -1,0 +1,60 @@
+import pytest
+from pyramid import httpexceptions
+
+from lms.extensions.feature_flags._views import _FeatureFlagsCookieFormViews
+
+
+class TestFeatureFlagsCookieFormViews:
+    def test_get_passes_the_feature_flags_to_the_template(
+        self, pyramid_request, FeatureFlagsCookieHelper, cookie_helper
+    ):
+        views = _FeatureFlagsCookieFormViews(pyramid_request)
+
+        template_data = views.get()
+
+        FeatureFlagsCookieHelper.assert_called_once_with(pyramid_request)
+        cookie_helper.get_all.assert_called_once_with()
+        assert template_data["flags"] == cookie_helper.get_all.return_value
+
+    def test_post_sets_cookie_and_redirects_browser(
+        self, pyramid_request, FeatureFlagsCookieHelper, cookie_helper
+    ):
+        returned = _FeatureFlagsCookieFormViews(pyramid_request).post()
+
+        assert returned == Redirect302To("http://example.com/flags")
+        FeatureFlagsCookieHelper.assert_called_once_with(pyramid_request)
+        cookie_helper.set_cookie.assert_called_once_with(returned)
+
+    def test_post_flashes_success_message(self, pyramid_request):
+        _FeatureFlagsCookieFormViews(pyramid_request).post()
+
+        assert pyramid_request.session.peek_flash("feature_flags") == [
+            "Feature flags saved in cookie ✔"
+        ]
+
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route("feature_flags_cookie_form", "/flags")
+
+
+class Redirect302To:
+    """Matches any HTTPFound redirect to the given location."""
+
+    def __init__(self, location):
+        self.location = location
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, httpexceptions.HTTPFound)
+            and other.location == self.location
+        )
+
+
+@pytest.fixture(autouse=True)
+def FeatureFlagsCookieHelper(patch):
+    return patch("lms.extensions.feature_flags._views.FeatureFlagsCookieHelper")
+
+
+@pytest.fixture
+def cookie_helper(FeatureFlagsCookieHelper):
+    return FeatureFlagsCookieHelper.return_value

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ passenv =
     dev: DATABASE_URL
     dev: DEBUG
     dev: FEATURE_FLAG_*
+    dev: FEATURE_FLAGS_ALLOWED_IN_COOKIE
+    dev: FEATURE_FLAGS_COOKIE_SECRET
     dev: GOOGLE_APP_ID
     dev: GOOGLE_CLIENT_ID
     dev: GOOGLE_DEVELOPER_KEY


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/556>. The diff will be clearer once https://github.com/hypothesis/lms/pull/556 has been merged and this has been rebased.

Add a new required setting `FEATURE_FLAGS_COOKIE_SECRET` / `feature_flags_cookie_secret`, which is a secret used to sign a JWT that is the value of the feature flags cookie.
    
Also add an optional `FEATURE_FLAGS_ALLOWED_IN_COOKIE` / `feature_flags_allowed_in_cookie` setting that is the list of feature flag names that're allowed to toggled on or off in the cookie and that will be shown on the `/flags` page.
    
Then add the `/flags` page itself, that lets you read and write the feature flag toggles in your cookie. This is just the page for reading and writing the cookie, but the cookie isn't actually used to determine feature flag state yet.
    
The `/flags` page has its own Jinja2 template and some CSS of its own in `feature-flags.css` but mostly it inherits the base template and CSS from `base.html.jinja2`. This couples the feature flags extension, which is meant to be a separable extension, to the app's base template and CSS. When the feature flags extension is extracted into its own repo this base template and CSS will have to be extracted (and duplicated) with it.

## Testing

If `feature_flags_cookie_secret` isn't set the app will crash at startup. A default value is set in `development.ini` so developers shouldn't run into this:

```
lms.config.settings.SettingError: Required setting FEATURE_FLAGS_COOKIE_SECRET / feature_flags_cookie_secret isn't set
```

If no feature flag are allowed in the cookie (for example `FEATURE_FLAGS_ALLOWED_IN_COOKIE`  isn't set) the `/flags` page shows an explanation. This is more intended for admins than general users, which I think is fine/appropriate for this page:

![Screenshot from 2019-04-24 11-22-15](https://user-images.githubusercontent.com/22498/56652493-67d0d900-6683-11e9-9364-5cceb26cad7c.png)

Once you do set `FEATURE_FLAGS_ALLOWED_IN_COOKIE` (for example: `export FEATURE_FLAGS_ALLOWED_IN_COOKIE="foo bar gar"`) then you'll see those flags on the `/flags` page:

![Screenshot from 2019-04-24 11-27-02](https://user-images.githubusercontent.com/22498/56652701-e6c61180-6683-11e9-8ab0-9dd26ae098d4.png)

Clicking `Save` writes the flags to your cookie and reloads the form page again via a post-redirect-get. There's also a success flash message that fades out (mouse pointer is invisible in gif, sorry):

![Peek 2019-04-24 11-37](https://user-images.githubusercontent.com/22498/56653375-76b88b00-6685-11e9-9e7c-a0795f9901d2.gif)

`FEATURE_FLAGS_ALLOWED_IN_COOKIE` not only controls which flags show on `/flags` but which flags area allowed to be set by the cookie at all:

1. A form submission post to `/flags` that contains flags not present in `FEATURE_FLAGS_ALLOWED_IN_COOKIE` will not set those flags in the cookie.

2. A validly signed cookie that tries to toggle on a flag not present in `FEATURE_FLAGS_ALLOWED_IN_COOKIE` will not toggle on that flag. (This is actually implemented in the next PR, not this one.)