### PR TITLE
Feature flags cookie 6/n: Read feature flags from cookies

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -19,6 +19,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.add_feature_flag_providers(
         "lms.extensions.feature_flags.config_file_provider",
         "lms.extensions.feature_flags.envvar_provider",
+        "lms.extensions.feature_flags.cookie_provider",
         "lms.extensions.feature_flags.query_string_provider",
     )
 

--- a/lms/extensions/feature_flags/__init__.py
+++ b/lms/extensions/feature_flags/__init__.py
@@ -6,9 +6,10 @@ multiple sources including:
 
 - The config file
 - Environment variables
+- A feature flags cookie
 - URL query string parameters
 - Custom providers (you could add providers for reading feature flags from a
-  cookie, the database, a feature flags microservice queried over HTTPS, ...)
+  database, a feature flags microservice queried over HTTPS, ...)
 
 Usage
 =====
@@ -83,6 +84,34 @@ environment variables, one envvar per feature flag. For example::
     export FEATURE_FLAG_FOO=true
     export FEATURE_FLAG_BAR=false
 
+``cookie_provider``
+-------------------
+
+Enable or disable feature flags using a browser cookie.
+
+Usage::
+
+    config.add_feature_flag_provider("lms.extensions.feature_flags.cookie_provider")
+
+This will add a ``/flags`` page to your app that you can visit to enable or disable
+feature flags in your browser's feature flags cookie.
+
+To use this provider you need to add two deployment settings to your ``.ini`` file:
+
+``feature_flags_cookie_secret`` is a secret string that'll be used to sign the
+feature flags cookie::
+
+  feature_flags_cookie_secret = "notasecret"
+
+You can generate a suitable ``feature_flags_cookie_secret`` string like this::
+
+  python3 -c 'import secrets; print(secrets.token_hex())'
+
+``feature_flags_allowed_in_cookie`` is a list of the feature flags that can be
+toggled on or off in the cookie and that will appear on the ``/flags`` page::
+
+  feature_flags_allowed_in_cookie = my_feature my_other_feature
+
 ``query_string_provider``
 -------------------------
 
@@ -118,6 +147,7 @@ from ._exceptions import SettingError
 from ._feature_flags import FeatureFlags
 from ._providers import config_file_provider  # noqa
 from ._providers import envvar_provider  # noqa
+from ._providers import cookie_provider  # noqa
 from ._providers import query_string_provider  # noqa
 
 

--- a/lms/extensions/feature_flags/_providers.py
+++ b/lms/extensions/feature_flags/_providers.py
@@ -8,7 +8,15 @@ import os
 
 from pyramid.settings import asbool
 
-__all__ = ["config_file_provider", "envvar_provider", "query_string_provider"]
+from ._helpers import FeatureFlagsCookieHelper
+
+
+__all__ = [
+    "config_file_provider",
+    "envvar_provider",
+    "cookie_provider",
+    "query_string_provider",
+]
 
 
 def config_file_provider(request, feature_flag_name):
@@ -33,6 +41,10 @@ def envvar_provider(_request, feature_flag_name):
     """
     key = "FEATURE_FLAG_{name}".format(name=feature_flag_name.upper())
     return _bool_or_none_from_dict(os.environ, key)
+
+
+def cookie_provider(request, feature_flag_name):
+    return FeatureFlagsCookieHelper(request).get(feature_flag_name)
 
 
 def query_string_provider(request, feature_flag_name):


### PR DESCRIPTION
CI will be failing until earlier PRs in this series are merged.

This adds the support for actually reading a feature flag's state from the toggles set in the cookie via the `/flags` page.

## Testing

`/flags/test` is a [test page that prints the values of the foo, bar and gar feature flags](https://github.com/hypothesis/lms/blob/master/lms/views/feature_flags_test.py). If you `export FEATURE_FLAGS_ALLOWED_IN_COOKIE="foo bar gar"` and then visit [the `/flags` page](https://github.com/hypothesis/lms/pull/561) you can toggle these on and off in your cookie and then visit `/flags/test` to test that they are in fact toggled on and off.