### PR TITLE
Auth popup 0/n: Add feature_flag="..." view predicate

### DIFF
--- a/lms/extensions/feature_flags/__init__.py
+++ b/lms/extensions/feature_flags/__init__.py
@@ -119,6 +119,7 @@ from ._feature_flags import FeatureFlags
 from ._providers import config_file_provider  # noqa
 from ._providers import envvar_provider  # noqa
 from ._providers import query_string_provider  # noqa
+from .views._predicates import FeatureFlagViewPredicate
 
 
 __all__ = ["SettingError"]
@@ -169,3 +170,5 @@ def includeme(config):
     config.add_directive(
         "add_feature_flag_providers", add_feature_flag_providers, action_wrap=False
     )
+
+    config.add_view_predicate("feature_flag", FeatureFlagViewPredicate)

--- a/lms/extensions/feature_flags/_routes.py
+++ b/lms/extensions/feature_flags/_routes.py
@@ -1,2 +1,3 @@
 def includeme(config):
     config.add_route("feature_flags_cookie_form", "/flags")
+    config.add_route("feature_flags_view_predicate_test", "/flags/test/view-predicate")

--- a/lms/extensions/feature_flags/views/_predicates.py
+++ b/lms/extensions/feature_flags/views/_predicates.py
@@ -1,0 +1,50 @@
+"""
+Custom view predicates.
+
+See:
+
+https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#registering-thirdparty-predicates
+"""
+
+
+__all__ = ["FeatureFlagViewPredicate"]
+
+
+class FeatureFlagViewPredicate:
+    """The ``"feature_flag"`` view predicate."""
+
+    def __init__(self, feature_flag, _config):
+        """
+        Initialize a view predicate that requires ``feature_flag``.
+
+        :arg feature_flag: the feature flag that this predicate requires,
+            for example ``"my_feature"``
+        :type feature_flag: str
+        :arg config: the Pyramid config object
+        :type config: pyramid.config.Configurator
+        """
+        self._feature_flag = feature_flag
+
+    def text(self):
+        """
+        Return a string desribing the behavior of this predicate.
+
+        Used by Pyramid in error messages.
+        """
+        return f"feature_flag = {self._feature_flag}"
+
+    def phash(self):
+        """
+        Return a string uniquely identifying this predicate's name and value.
+
+        Used by Pyramid for view configuration constraints handling.
+        """
+        return self.text()
+
+    def __call__(self, context, request):
+        """
+        Return ``True`` if ``request`` matches this view predicate.
+
+        Return ``False`` otherwise. Used by Pyramid during view lookup.
+        """
+        return request.feature(self._feature_flag)

--- a/lms/extensions/feature_flags/views/_predicates.py
+++ b/lms/extensions/feature_flags/views/_predicates.py
@@ -27,7 +27,7 @@ class FeatureFlagViewPredicate:
 
     def text(self):
         """
-        Return a string desribing the behavior of this predicate.
+        Return a string describing the behavior of this predicate.
 
         Used by Pyramid in error messages.
         """

--- a/lms/extensions/feature_flags/views/cookie_form.py
+++ b/lms/extensions/feature_flags/views/cookie_form.py
@@ -1,14 +1,14 @@
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config, view_defaults
 
-from ._helpers import FeatureFlagsCookieHelper
+from lms.extensions.feature_flags._helpers import FeatureFlagsCookieHelper
 
 
 @view_defaults(
     route_name="feature_flags_cookie_form",
-    renderer="_templates/cookie_form.html.jinja2",
+    renderer="../_templates/cookie_form.html.jinja2",
 )
-class _FeatureFlagsCookieFormViews:
+class CookieFormViews:
     """A form for toggling feature flags in a cookie."""
 
     def __init__(self, request):

--- a/lms/extensions/feature_flags/views/test.py
+++ b/lms/extensions/feature_flags/views/test.py
@@ -1,0 +1,19 @@
+from pyramid.view import view_config, view_defaults
+
+
+@view_defaults(
+    route_name="feature_flags_view_predicate_test",
+    renderer="string",
+    request_method="GET",
+)
+class ViewPredicateTestViews:
+    def __init__(self, request):
+        self._request = request
+
+    @view_config(feature_flag="foo")
+    def view_that_requires_feature_flag(self):
+        return "Feature flag 'foo' is on"
+
+    @view_config()
+    def view_that_doesnt_require_feature_flag(self):
+        return "Feature flag 'foo' is off"

--- a/tests/lms/extensions/feature_flags/views/_predicates_test.py
+++ b/tests/lms/extensions/feature_flags/views/_predicates_test.py
@@ -1,0 +1,25 @@
+from unittest import mock
+
+from lms.extensions.feature_flags.views._predicates import FeatureFlagViewPredicate
+
+
+class TestFeatureFlagsViewPredicate:
+    def test_text(self):
+        assert (
+            FeatureFlagViewPredicate("test_feature", mock.sentinel.config).text()
+            == "feature_flag = test_feature"
+        )
+
+    def test_phash(self):
+        assert (
+            FeatureFlagViewPredicate("test_feature", mock.sentinel.config).phash()
+            == "feature_flag = test_feature"
+        )
+
+    def test_it_delegates_to_request_dot_feature(self, pyramid_request):
+        view_predicate = FeatureFlagViewPredicate("test_feature", mock.sentinel.config)
+
+        matches = view_predicate(mock.sentinel.context, pyramid_request)
+
+        pyramid_request.feature.assert_called_once_with("test_feature")
+        assert matches == pyramid_request.feature.return_value

--- a/tests/lms/extensions/feature_flags/views/cookie_form_test.py
+++ b/tests/lms/extensions/feature_flags/views/cookie_form_test.py
@@ -1,14 +1,14 @@
 import pytest
 from pyramid import httpexceptions
 
-from lms.extensions.feature_flags._views import _FeatureFlagsCookieFormViews
+from lms.extensions.feature_flags.views.cookie_form import CookieFormViews
 
 
 class TestFeatureFlagsCookieFormViews:
     def test_get_passes_the_feature_flags_to_the_template(
         self, pyramid_request, FeatureFlagsCookieHelper, cookie_helper
     ):
-        views = _FeatureFlagsCookieFormViews(pyramid_request)
+        views = CookieFormViews(pyramid_request)
 
         template_data = views.get()
 
@@ -19,14 +19,14 @@ class TestFeatureFlagsCookieFormViews:
     def test_post_sets_cookie_and_redirects_browser(
         self, pyramid_request, FeatureFlagsCookieHelper, cookie_helper
     ):
-        returned = _FeatureFlagsCookieFormViews(pyramid_request).post()
+        returned = CookieFormViews(pyramid_request).post()
 
         assert returned == Redirect302To("http://example.com/flags")
         FeatureFlagsCookieHelper.assert_called_once_with(pyramid_request)
         cookie_helper.set_cookie.assert_called_once_with(returned)
 
     def test_post_flashes_success_message(self, pyramid_request):
-        _FeatureFlagsCookieFormViews(pyramid_request).post()
+        CookieFormViews(pyramid_request).post()
 
         assert pyramid_request.session.peek_flash("feature_flags") == [
             "Feature flags saved in cookie ✔"
@@ -52,7 +52,9 @@ class Redirect302To:
 
 @pytest.fixture(autouse=True)
 def FeatureFlagsCookieHelper(patch):
-    return patch("lms.extensions.feature_flags._views.FeatureFlagsCookieHelper")
+    return patch(
+        "lms.extensions.feature_flags.views.cookie_form.FeatureFlagsCookieHelper"
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
Add a `feature_flag="my_feature"` view predicate (for use in Pyramid `@view_config(...)`'s) that can be used to toggle a view on or off depending on a feature flag, or to direct requests to one view or another depending on a feature flag.

Usage:

        @view_config(route_name="foo", feature_flag="foo")
        def view_that_will_be_called_when_feature_flag_is_on(request):
            ...
    
        @view_config(route_name="foo")
        def view_that_will_be_called_when_feature_flag_is_off(self):
            ...
    
Also add a test page at `/flags/test/view-predicate`.

To test it you can visit http://localhost:8001/flags/test/view-predicate and you should see that `view_that_doesnt_require_feature_flag()` was called. Then turn on the `"foo"` feature flag and visit t http://localhost:8001/flags/test/view-predicate again and you should see that `view_that_requires_feature_flag()` got called. There are a number of ways to turn on the `"foo"` feature flag, for example using a query param: http://localhost:8001/flags/test/view-predicate?feature_flags.foo=true.