### PR TITLE
Auth popup 1/n: Don't show login form other than for /reports

### DIFF
--- a/lms/views/authentication.py
+++ b/lms/views/authentication.py
@@ -14,7 +14,7 @@ class AuthenticationViews:
         self.logged_in = request.authenticated_userid
 
     @view_config(route_name="login", renderer="templates/login.html.jinja2")
-    @forbidden_view_config(renderer="templates/login.html.jinja2")
+    @forbidden_view_config(renderer="templates/login.html.jinja2", route_name="reports")
     def login(self):
         request = self.request
         login_url = request.route_url("login")


### PR DESCRIPTION
Don't show the login form (https://lms.hypothes.is/login) except when the user is trying to visit the reports page (https://lms.hypothes.is/reports) and is not logged in.

The type of login provided by the `/login` form is only used by the `/reports` page. If an unauthenticated user tries to visit some other view that requires authentication (for example a view that requires
authentication by LTI launch params, or by a bearer token, maybe an API view) it makes no sense to respond with the login form.

Unauthenticated requests to these other authentication-requiring views will now use Pyramid's default forbidden view (a 403 Forbidden response whose body is a plain HTML error page) instead.