### PR TITLE
Auth popup 2/n: Read auth params from query strings

### DIFF
--- a/lms/validation/_bearer_token.py
+++ b/lms/validation/_bearer_token.py
@@ -118,7 +118,9 @@ class BearerTokenSchema(marshmallow.Schema):
         :rtype: LTIUser
         """
         try:
-            return parser.parse(self, self._request, locations=["headers"])
+            return parser.parse(
+                self, self._request, locations=["headers", "querystring"]
+            )
         except HTTPUnprocessableEntity as error:
             try:
                 authorization_error_message = error.json["authorization"][0]

--- a/tests/lms/validation/_bearer_token_test.py
+++ b/tests/lms/validation/_bearer_token_test.py
@@ -26,9 +26,14 @@ class TestBearerTokenSchema:
     ):
         pyramid_request.headers["authorization"] = authorization_param
 
-        deserialized_lti_user = schema.lti_user()
+        assert schema.lti_user() == lti_user
 
-        assert deserialized_lti_user == lti_user
+    def test_it_deserializes_lti_users_from_authorization_query_params(
+        self, authorization_param, lti_user, pyramid_request, schema
+    ):
+        pyramid_request.params["authorization"] = authorization_param
+
+        assert schema.lti_user() == lti_user
 
     def test_it_raises_if_theres_no_authorization_param(self, schema):
         with pytest.raises(MissingSessionTokenError) as exc_info:


### PR DESCRIPTION
When it opens the upcoming Canvas API authorization endpoint in a popup window JavaScript code is going to have to authenticate a `GET` request using one of our JWT bearer tokens, not just use them to authenticate XHR API requests as envisioned.

Currently these authorization params can only be put in `Authorization` headers in requests, but that doesn't work for the simple `GET` request that happens when JavaScript gets the browser to open a URL in a popup window.

Add support for reading authorization params from query params so that the popup window request can be authenticated.