### PR TITLE
Refactor Jenkinsfile to use Jenkins's parallel stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,47 +1,93 @@
-#!groovy
+/**
+ * This app's Jenkins Pipeline.
+ *
+ * This is written in Jenkins Scripted Pipeline language.
+ * For docs see:
+ * https://jenkins.io/doc/book/pipeline/syntax/#scripted-pipeline
+*/
 
-@Library('pipeline-library') _
+// Import the Hypothesis shared pipeline library, which is defined in this
+// repo: https://github.com/hypothesis/pipeline-library
+@Library("pipeline-library") _
 
+// The the built hypothesis/lms Docker image.
 def img
 
 node {
-    stage('build') {
-        checkout(scm)
-        img = buildApp(name: 'hypothesis/lms')
+    // The args that we'll pass to Docker run each time we run the Docker
+    // image.
+    runArgs = "-u root -e SITE_PACKAGES=true"
+
+    stage("Build") {
+        // Checkout the commit that triggered this pipeline run.
+        checkout scm
+        // Build the Docker image.
+        img = buildApp(name: "hypothesis/lms")
     }
 
-    stage('test') {
-        hostIp = sh(script: 'facter ipaddress_eth0', returnStdout: true).trim()
-
-        postgres = docker.image('postgres:9.4').run('-P -e POSTGRES_DB=lmstest')
-        databaseUrl = "postgresql://postgres@${hostIp}:${containerPort(postgres, 5432)}/lmstest"
-
-        try {
-            testApp(image: img, runArgs: "-u root -e TEST_DATABASE_URL=${databaseUrl} -e CODECOV_TOKEN=${credentials('LMS_CODECOV_TOKEN')}") {
-                sh 'apk add build-base postgresql-dev python3-dev yarn'
-                sh 'pip3 install -q tox>=3.8.0'
-
-                // Hack to work around a race condition and make sure that
-                // .tox/.tox/bin/tox gets created before any of the parallelised
-                // `make` commands below try to access it.
-                sh 'cd /var/lib/lms && tox -e py36 --notest'
-
-                sh 'cd /var/lib/lms && make -j `nproc` checkformatting lint backend-tests'
-                sh 'cd /var/lib/lms && make coverage codecov'
+    // Run each of the stages in parallel.
+    parallel failFast: true,
+    "Formatting": {
+        stage("Formatting") {
+            testApp(image: img, runArgs: runArgs) {
+                installDeps()
+                run("make checkformatting")
             }
-        } finally {
-            postgres.stop()
         }
+    },
+    "Docstrings": {
+        stage("Docstrings") {
+            testApp(image: img, runArgs: runArgs) {
+                installDeps()
+                run("make checkdocstrings")
+            }
+        }
+    },
+    "Backend lint": {
+        stage("Backend lint") {
+            testApp(image: img, runArgs: runArgs) {
+                installDeps()
+                run("make backend-lint")
+            }
+        }
+    },
+    "Backend tests": {
+        stage("Backend tests") {
+            // Run the Postgres test DB in a Docker container.
+            postgresContainer = docker.image("postgres:9.4").run("-P -e POSTGRES_DB=lmstest")
 
-        nodeEnv = docker.image("node:10-stretch")
-        workspace = pwd()
-        nodeEnv.inside("-u root -e HOME=${workspace}") {
-            sh 'make frontend-tests'
+            try {
+                testApp(image: img, runArgs: "${runArgs} -e TEST_DATABASE_URL=${databaseUrl(postgresContainer)} -e CODECOV_TOKEN=${credentials('LMS_CODECOV_TOKEN')}") {
+                    installDeps()
+                    run("make backend-tests coverage codecov")
+                }
+            } finally {
+                postgresContainer.stop()
+            }
+        }
+    },
+    "Frontend lint": {
+        stage("Frontend lint") {
+            testApp(image: img, runArgs: runArgs) {
+                installDeps()
+                sh "apk add yarn"
+                run("make frontend-lint")
+            }
+        }
+    },
+    "Frontend tests": {
+        stage("Frontend tests") {
+            workspace = pwd()
+            // The frontend tests use a node Docker image because they're
+            // incompatible with the hypothesis/lms image.
+            docker.image("node:10-stretch").inside("${runArgs} -e HOME=${workspace}") {
+                sh "make frontend-tests"
+            }
         }
     }
 
     onlyOnMaster {
-        stage('release') {
+        stage("release") {
             releaseApp(image: img)
         }
     }
@@ -49,21 +95,37 @@ node {
 
 onlyOnMaster {
     milestone()
-    stage('qa deploy') {
-        deployApp(image: img, app: 'lms', env: 'qa')
+    stage("qa deploy") {
+        deployApp(image: img, app: "lms", env: "qa")
     }
 
     milestone()
-    stage('prod deploy') {
+    stage("prod deploy") {
         input(message: "Deploy to prod?")
         milestone()
-        deployApp(image: img, app: 'lms', env: 'prod')
+        deployApp(image: img, app: "lms", env: "prod")
     }
 }
 
-def containerPort(container, port) {
-    return sh(
-        script: "docker port ${container.id} ${port} | cut -d: -f2",
-        returnStdout: true
-    ).trim()
+/** Return the URL of the test database in the Postgres container. */
+def databaseUrl(postgresContainer) {
+    hostIp = sh(script: "facter ipaddress_eth0", returnStdout: true).trim()
+    containerPort = sh(script: "docker port ${postgresContainer.id} 5432 | cut -d: -f2", returnStdout: true).trim()
+    return "postgresql://postgres@${hostIp}:${containerPort}/lmstest"
+}
+
+/**
+ * Install some common system dependencies.
+ *
+ * These are test dependencies that're need to run most of the stages above
+ * (tests, lint, ...) but that aren't installed in the production Docker image.
+ */
+def installDeps() {
+    sh "apk add build-base postgresql-dev python3-dev"
+    sh "pip3 install -q tox>=3.8.0"
+}
+
+/** Run the given command. */
+def run(command) {
+    sh "cd /var/lib/lms && ${command}"
 }

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,7 @@ sql:
 	psql --pset expanded=auto postgresql://postgres@localhost:5433/postgres
 
 .PHONY: lint
-lint: node_modules/.uptodate
-	tox -q -e py36-lint
-	$(GULP) lint
+lint: backend-lint frontend-lint
 
 .PHONY: format
 format:
@@ -80,6 +78,14 @@ clean:
 	find . -type d -name "__pycache__" -delete
 	rm -f node_modules/.uptodate
 	rm -rf build
+
+.PHONY: backend-lint
+backend-lint:
+	tox -q -e py36-lint
+
+.PHONY: frontend-lint
+frontend-lint: node_modules/.uptodate
+	$(GULP) lint
 
 # Backend and frontend tests are split into separate targets because on Jenkins
 # we need to run them with different Docker images, but `make test` runs both.

--- a/tox.ini
+++ b/tox.ini
@@ -65,3 +65,4 @@ commands =
     docstrings: sphinx-autobuild -BqT -z lms -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envdir}/rst {envdir}/dirhtml
     clean: coverage erase
+sitepackages = {env:SITE_PACKAGES:false}


### PR DESCRIPTION
Use Jenkins Pipeline's `parallel` to run everything in separate parallel stages, rather than using `make -j` to do the same.

Also enable tox/virtualenv's `sitepackages` on Jenkins which speeds builds up by 20-30secs or more. Builds are less then 2.5 mins now.

![Screenshot from 2019-05-03 20-29-54](https://user-images.githubusercontent.com/22498/57161008-5f467400-6de2-11e9-8db8-783eb099c443.png)

There were intermittent build failures with `make -j` due to a (probably
fixable) race condition with tox. `make -j` also didn't enable the
frontend tests to be run in parallel with everything else because the
frontend tests need to be run from a different Docker image (and
therefore a different instance of `make`). Finally, with `make -j`
Jenkins is unaware of the concurrency whereas with Jenkins Pipeline
parallel stages Jenkins can show the different stages running
concurrently in its UI and can label the stdout and stderr with which
concurrent stage it comes from.

The new `Jenkinsfile` first runs a `"Build"` stage and then runs
`"Formatting"`, `"Docstrings"`, `"Backend lint"`, `"Backend tests"`,
`"Frontend lint"` and `"Frontend tests"` stages in parallel.

As before, all the stages are run in a Docker container based off the
production Docker image but with additional test dependencies installed.

Also as before the frontend tests use a separate Node Docker image due
to compatibility problems between the frontend tests and the production
Docker image.

The Postgres "sidecar" container is run only for the `"Backend tests"`
stage.

Some tidying up and deduplicating of the `Jenkinsfile` has been done.

`make checkdocstrings` has been added - this wasn't being run on CI
before.

Limitations
-----------

The main limitation of all this is that test dependencies --
dependencies that are not part of the production Docker image but that
need to be installed in the Docker containers to run the various test,
lint, formatting and docstring commands on Jenkins -- are being
installed multiple times over, once for each stage `"Formatting"`,
`"Docstrings"`, `"Backend lint"`, `"Backend tests"`, `"Frontend lint"`
and `"Frontend tests"`. Each stage's dependencies are not exactly the
same, but there's a lot of overlap. A way to avoid doing the same work
multiple times would be good.

I'm not sure that this is a huge limitation though -- I'm not sure that
there's much build time to be shaved off by avoiding duplicate
dependency installs. It may not be worth the complexity it would
introduce. And build times are already pretty good (2-3mins) anyway.

Site Packages
------------------

A second commit turns on tox/virtualenv's `sitepackages` setting when tox is being run on Jenkins. This causes tox to reuse the app's Python dependencies that're already installed in the production Docker image that tox is running in a container from. Previously tox would reinstall all these dependencies in its own virtualenv within the container (and this reinstalling would happen for each Jenkins stage). This seems to reduce Jenkins build time by 20-30 secs.