### PR TITLE
Use a separate Docker build stage to build the frontend assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "make checkdocstrings   Crash if building the docstrings fails"
 	@echo "make pip-compile       Compile requirements.in to requirements.txt"
 	@echo "make docker            Make the app's Docker image"
+	@echo "make run-docker        Run the app's Docker image locally"
 	@echo "make clean             Delete development artefacts (cached files, "
 	@echo "                       dependencies, etc)"
 
@@ -71,6 +72,30 @@ pip-compile:
 .PHONY: docker
 docker:
 	git archive --format=tar.gz HEAD | docker build -t hypothesis/lms:$(DOCKER_TAG) -
+
+.PHONY: run-docker
+run-docker:
+	# To run the Docker container locally, first build the Docker image using
+	# `make docker` and then set the environment variables below to appropriate
+	# values (see conf/development.ini for non-production quality examples).
+	docker run \
+		--net lms_default \
+		-e DATABASE_URL=postgresql://postgres@postgres/postgres \
+		-e FEATURE_FLAGS_COOKIE_SECRET \
+		-e H_API_URL_PRIVATE \
+		-e H_API_URL_PUBLIC \
+		-e H_AUTHORITY \
+		-e H_CLIENT_ID \
+		-e H_CLIENT_SECRET  \
+		-e H_JWT_CLIENT_ID \
+		-e H_JWT_CLIENT_SECRET \
+		-e JWT_SECRET \
+		-e LMS_SECRET \
+		-e RPC_ALLOWED_ORIGINS \
+		-e VIA_URL \
+		-e SESSION_COOKIE_SECRET \
+		-p 8001:8001 \
+		hypothesis/lms:$(DOCKER_TAG)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ GULP := node_modules/.bin/gulp
 build/manifest.json: node_modules/.uptodate
 	$(GULP) build
 
-node_modules/.uptodate: package.json
+node_modules/.uptodate: package.json yarn.lock
 	@echo installing javascript dependencies
-	@node_modules/.bin/check-dependencies 2>/dev/null || yarn --ignore-engines install
+	yarn install
 	@touch $@

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "scripts": {
+    "build": "gulp build",
     "lint": "gulp lint",
     "test": "gulp test"
   },


### PR DESCRIPTION
This PR restructures the Docker build to use a separate stage for building the frontend assets, following the example in the h repo:

- It makes the Docker image smaller, as it won't have Node + Node's build dependencies in it
- It decouples the Node version used to build the frontend assets from the image used to run the Python app.
- I changed the install process to use `yarn install` rather than `npm install`. Since the repo has a yarn lockfile, we need to use yarn rather than npm in order to ensure the lockfile is respected. We could potentially remove yarn and try to use just npm instead, but that was outside the scope of what I wanted to do here

I also added a `run-docker` Makefile target to facilitate testing of the Docker image locally. I'd be happy for someone to submit a better alternative to running the Docker image locally, but for now I've just copied the approach used in the h repo.