### PR TITLE
Validate OAuth 2 state param 1/n: Add support for schema classes

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -35,6 +35,7 @@ from lms.validation._exceptions import (
 from lms.validation._oauth import CANVAS_OAUTH_CALLBACK_SCHEMA
 from lms.validation._launch_params import LaunchParamsSchema
 from lms.validation._bearer_token import BearerTokenSchema
+from lms.validation._helpers import instantiate_schema
 
 
 __all__ = (
@@ -81,8 +82,9 @@ def _validated_view(view, info):
             # Use the view's configured schema to validate the request,
             # and make the validated and parsed request params available as
             # request.parsed_params.
-            # If validation fails this will raise ValidationError and the view won't be called.
-            request.parsed_params = parser.parse(info.options["schema"], request)
+            request.parsed_params = parser.parse(
+                instantiate_schema(info.options["schema"], request), request
+            )
 
             # Call the view normally.
             return view(context, request)

--- a/lms/validation/_helpers.py
+++ b/lms/validation/_helpers.py
@@ -1,0 +1,14 @@
+import inspect
+
+__all__ = ["instantiate_schema"]
+
+
+def instantiate_schema(schema, request):
+    # Schemas can just be dicts or they can be actual
+    # marshmallow.Schema subclasses, in which case we need to
+    # instantiate the class.
+    if inspect.isclass(schema):
+        schema = schema()
+        schema.context["request"] = request
+
+    return schema

--- a/tests/lms/validation/_helpers_test.py
+++ b/tests/lms/validation/_helpers_test.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+import marshmallow
+import pytest
+
+from lms.validation._helpers import instantiate_schema
+
+
+class TestInstantiateSchema:
+    def test_it_returns_dict_schemas_unmodified(self, pyramid_request):
+        schema = {
+            "field1": marshmallow.fields.Str(),
+            "field2": marshmallow.fields.Str(required=True),
+        }
+
+        assert instantiate_schema(schema, pyramid_request) == schema
+
+    def test_it_returns_class_schemas_instantiated(self, pyramid_request):
+        instantiated_schema = instantiate_schema(MySchema, pyramid_request)
+
+        assert isinstance(instantiated_schema, MySchema)
+
+    def test_it_adds_the_request_to_a_schema_objects_context(self, pyramid_request):
+        instantiated_schema = instantiate_schema(MySchema, pyramid_request)
+
+        assert instantiated_schema.context["request"] == pyramid_request
+
+
+class MySchema(marshmallow.Schema):
+    field1 = marshmallow.fields.Str()
+    field2 = marshmallow.fields.Str(required=True)
+
+    class Meta:
+        strict = True


### PR DESCRIPTION
Our Webargs/Marshmallow <> Pyramid integration includes our own Pyramid view deriver that lets you use a schema to guard a view:

```python
@view_config(..., schema=CANVAS_OAUTH_CALLBACK_SCHEMA)
def oauth2_redirect(request):
    # The validated and parsed params are accessible as request.parsed_params.
    ...
```

This is used by [`oauth2_redirect`](https://github.com/hypothesis/lms/blob/cc24cdeafa591307912963ca098c3addb1d6ca42/lms/views/api/canvas/authorize.py#L41) and [`canvas_oauth_callback`](https://github.com/hypothesis/lms/blob/cc24cdeafa591307912963ca098c3addb1d6ca42/lms/views/oauth.py#L21).

It currently supports webargs dict-based schemas like [`CANVAS_OAUTH_CALLBACK_SCHEMA`](https://github.com/hypothesis/lms/blob/cc24cdeafa591307912963ca098c3addb1d6ca42/lms/validation/_oauth.py#L6-L9) as the argument to `schema=`.

Webargs also allows schemas to be `marshmallow.Schema` subclasses, which gives them access to more of marshmallow's features. In this case we need to instantiate the schema class before using it to parse a request.

This PR adds support for detecting and instantiating class-based schemas to our `schema=` view deriver, so that you can do `@view_config(..., schema=MySchemaClass)` and the class will be instantiated and used to parse the request.
