### PR TITLE
Validate OAuth 2 state param 2/n: Turn CANVAS_OAUTH_CALLBACK_SCHEMA into a class

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -32,7 +32,7 @@ from lms.validation._exceptions import (
     MissingSessionTokenError,
     InvalidSessionTokenError,
 )
-from lms.validation._oauth import CANVAS_OAUTH_CALLBACK_SCHEMA
+from lms.validation._oauth import CanvasOAuthCallbackSchema
 from lms.validation._launch_params import LaunchParamsSchema
 from lms.validation._bearer_token import BearerTokenSchema
 from lms.validation._helpers import instantiate_schema
@@ -40,7 +40,7 @@ from lms.validation._helpers import instantiate_schema
 
 __all__ = (
     "parser",
-    "CANVAS_OAUTH_CALLBACK_SCHEMA",
+    "CanvasOAuthCallbackSchema",
     "BearerTokenSchema",
     "LaunchParamsSchema",
     "ValidationError",

--- a/lms/validation/_oauth.py
+++ b/lms/validation/_oauth.py
@@ -1,9 +1,17 @@
 """Validation for OAuth views."""
+import marshmallow
 from webargs import fields
 
 
-#: Arguments for the canvas_oauth_callback() view.
-CANVAS_OAUTH_CALLBACK_SCHEMA = {
-    "code": fields.Str(required=True),
-    "state": fields.Str(required=True),
-}
+class CanvasOAuthCallbackSchema(marshmallow.Schema):
+    """Schema for validating OAuth 2 redirect_uri requests from Canvas."""
+
+    code = fields.Str(required=True)
+    state = fields.Str(required=True)
+
+    class Meta:
+        """Marshmallow options for this schema."""
+
+        # Silence a strict=False deprecation warning from marshmallow.
+        # TODO: Remove this once we've upgraded to marshmallow 3.
+        strict = True

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode, urlparse, urlunparse
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
-from lms.validation import CANVAS_OAUTH_CALLBACK_SCHEMA
+from lms.validation import CanvasOAuthCallbackSchema
 
 
 @view_config(route_name="canvas_api_authorize", request_method="GET")
@@ -38,7 +38,7 @@ def authorize(request):
     request_method="GET",
     route_name="canvas_oauth_callback",
     renderer="string",
-    schema=CANVAS_OAUTH_CALLBACK_SCHEMA,
+    schema=CanvasOAuthCallbackSchema,
 )
 def oauth2_redirect(request):
     access_code = request.parsed_params["code"]

--- a/lms/views/oauth.py
+++ b/lms/views/oauth.py
@@ -7,7 +7,7 @@ from lms.models.tokens import update_user_token, build_token_from_oauth_response
 from lms.models import find_user_from_state
 from lms.util import lti_params_for
 from lms.views.content_item_selection import content_item_form
-from lms.validation import CANVAS_OAUTH_CALLBACK_SCHEMA
+from lms.validation import CanvasOAuthCallbackSchema
 
 
 def build_canvas_token_url(lms_url):
@@ -18,7 +18,7 @@ def build_canvas_token_url(lms_url):
 @view_config(
     route_name="canvas_oauth_callback",
     request_method="GET",
-    schema=CANVAS_OAUTH_CALLBACK_SCHEMA,
+    schema=CanvasOAuthCallbackSchema,
 )
 # pylint: disable=too-many-locals
 def canvas_oauth_callback(request):

--- a/tests/lms/validation/_oauth_test.py
+++ b/tests/lms/validation/_oauth_test.py
@@ -1,66 +1,73 @@
 import pytest
 from pyramid import testing
 
-from lms.validation import CANVAS_OAUTH_CALLBACK_SCHEMA
+from lms.validation import CanvasOAuthCallbackSchema
 from lms.validation import parser
 from lms.validation import ValidationError
+from lms.validation._helpers import instantiate_schema
 
 
-class TestCanvasOauthCallbackArgs:
-    def test_it_returns_the_parsed_args_for_a_valid_request(self, valid_request):
-        parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
+class TestCanvasOauthCallbackSchema:
+    def test_it_returns_the_parsed_args_for_a_valid_request(
+        self, schema, valid_request
+    ):
+        parsed_args = parser.parse(schema, valid_request)
 
         assert parsed_args == {"code": "test_code", "state": "test_state"}
 
-    def test_its_invalid_if_state_is_missing(self, valid_request):
+    def test_its_invalid_if_state_is_missing(self, schema, valid_request):
         del valid_request.params["state"]
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
+            parsed_args = parser.parse(schema, valid_request)
 
         assert exc_info.value.messages == {
             "state": ["Missing data for required field."]
         }
 
-    def test_its_invalid_if_state_isnt_a_string(self, valid_request):
+    def test_its_invalid_if_state_isnt_a_string(self, schema, valid_request):
         valid_request.params["state"] = 23
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
+            parsed_args = parser.parse(schema, valid_request)
 
         assert exc_info.value.messages == {"state": ["Not a valid string."]}
 
-    def test_its_invalid_if_state_is_null(self, valid_request):
+    def test_its_invalid_if_state_is_null(self, schema, valid_request):
         valid_request.params["state"] = None
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
+            parsed_args = parser.parse(schema, valid_request)
 
         assert exc_info.value.messages == {"state": ["Field may not be null."]}
 
-    def test_its_invalid_if_code_is_missing(self, valid_request):
+    def test_its_invalid_if_code_is_missing(self, schema, valid_request):
         del valid_request.params["code"]
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
+            parsed_args = parser.parse(schema, valid_request)
 
         assert exc_info.value.messages == {"code": ["Missing data for required field."]}
 
-    def test_its_invalid_if_code_isnt_a_string(self, valid_request):
+    def test_its_invalid_if_code_isnt_a_string(self, schema, valid_request):
         valid_request.params["code"] = 23
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
+            parsed_args = parser.parse(schema, valid_request)
 
         assert exc_info.value.messages == {"code": ["Not a valid string."]}
 
-    def test_its_invalid_if_code_is_null(self, valid_request):
+    def test_its_invalid_if_code_is_null(self, schema, valid_request):
         valid_request.params["code"] = None
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(CANVAS_OAUTH_CALLBACK_SCHEMA, valid_request)
+            parsed_args = parser.parse(schema, valid_request)
 
         assert exc_info.value.messages == {"code": ["Field may not be null."]}
+
+    @pytest.fixture
+    def schema(self, pyramid_request):
+        return instantiate_schema(CanvasOAuthCallbackSchema, pyramid_request)
 
     @pytest.fixture
     def valid_request(self):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/586/

This shouldn't make any functional difference, but means that the schema can access more Marshmallow functionality in future.