### PR TITLE
Validate OAuth 2 state param 3/n: Add OAuth 2 "state" params to session cookie

### DIFF
--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -12,6 +12,8 @@ def authorize(request):
     ai_getter = request.find_service(name="ai_getter")
     consumer_key = request.lti_user.oauth_consumer_key
 
+    state = request.session["canvas_api_authorize_state"] = secrets.token_hex()
+
     authorize_url = urlunparse(
         (
             "https",
@@ -23,7 +25,7 @@ def authorize(request):
                     "client_id": ai_getter.developer_key(consumer_key),
                     "response_type": "code",
                     "redirect_uri": request.route_url("canvas_oauth_callback"),
-                    "state": secrets.token_hex(),
+                    "state": state,
                 }
             ),
             "",

--- a/tests/lms/views/api/canvas/authorize_test.py
+++ b/tests/lms/views/api/canvas/authorize_test.py
@@ -47,6 +47,15 @@ class TestAuthorize:
             "http://example.com/canvas_oauth_callback"
         ]
 
+    def test_it_saves_the_state_param_in_the_session(self, pyramid_request, secrets):
+        response = authorize(pyramid_request)
+
+        secrets.token_hex.assert_called_once_with()
+        assert (
+            pyramid_request.session["canvas_api_authorize_state"]
+            == secrets.token_hex.return_value
+        )
+
     def test_it_includes_the_state_param_in_a_query_param(
         self, pyramid_request, secrets
     ):


### PR DESCRIPTION
When the Canvas authorize popup window is opened generate secret string to pass to Canvas as the OAuth 2 `state` param and also save this string in the session cookie for later comparison to the `state` param that Canvas passes back to us.

We were already generating the `state` param and passing it to Canvas, this PR adds the saving it in the session cookie.

The session cookie itself was already added in a [previous PR](https://github.com/hypothesis/lms/pull/557). It's a signed, **not** encrypted, HTTP-only, secure cookie that expires after 20 mins of inactivity. This PR just relies on the session cookie for signing and expiry, doesn't do any of its own.
