### PR TITLE
Validate OAuth 2 state param 4/n: Validate state param on oauth2 redirect

### DIFF
--- a/lms/validation/_oauth.py
+++ b/lms/validation/_oauth.py
@@ -15,3 +15,10 @@ class CanvasOAuthCallbackSchema(marshmallow.Schema):
         # Silence a strict=False deprecation warning from marshmallow.
         # TODO: Remove this once we've upgraded to marshmallow 3.
         strict = True
+
+    @marshmallow.validates("state")
+    def validate_state(self, state):
+        request = self.context["request"]
+
+        if state != request.session.pop("canvas_api_authorize_state", None):
+            raise marshmallow.ValidationError("Invalid or missing state parameter.")


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/586, https://github.com/hypothesis/lms/pull/587 and https://github.com/hypothesis/lms/pull/588/.

When the user clicks <kbd>Authorize</kbd> and Canvas redirects the popup window back to our OAuth 2 redirect_uri (`/canvas_oauth_callback`) check that the `state` param in the request's query params matches the one that we previously generated and saved in the session cookie. If the param doesn't match then don't call the view, and send back a validation error response instead.

## Testing

- [ ] With the `new_oauth` feature flag on create a new assignment in Canvas. Click the <kbd>Select PDF from Canvas</kbd> button and the popup window appears. Click <kbd>Authorize</kbd> and Canvas redirects the popup window back to our redirect_uri. Validation should pass, and you should see a 200 OK response that just shows the received access_code and state,

- [ ] With the `new_oauth` feature flag on generate a state param in the session cookie by creating a new assignment in Canvas and clicking the <kbd>Select PDF from Canvas</kbd> button to open the popup window. **Don't click <kbd>Authorize</kbd>.** Instead open `/canvas_oauth_callback` directly in a new tab, with an invalid `state` param. For example: http://localhost:8001/canvas_oauth_callback?code=foo&state=bar. You should see a validation error. 