### PR TITLE
Require authentication for Canvas API popup window

### DIFF
--- a/lms/authentication/_lti_policy.py
+++ b/lms/authentication/_lti_policy.py
@@ -18,7 +18,7 @@ class LTIAuthenticationPolicy:
         principals = [security.Everyone]
 
         if userid:
-            principals.extend([security.Authenticated, userid])
+            principals.extend([security.Authenticated, userid, "lti_user"])
 
         return principals
 

--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -12,7 +12,7 @@ from lms.util import lti_params_for
 class Root:
     """The default root factory for the application."""
 
-    __acl__ = [(Allow, "report_viewers", "view")]
+    __acl__ = [(Allow, "report_viewers", "view"), (Allow, "lti_user", "canvas_api")]
 
     def __init__(self, request):
         """Return the default root resource object."""

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -7,7 +7,9 @@ from pyramid.view import view_config
 from lms.validation import CanvasOAuthCallbackSchema
 
 
-@view_config(route_name="canvas_api_authorize", request_method="GET")
+@view_config(
+    route_name="canvas_api_authorize", request_method="GET", permission="canvas_api"
+)
 def authorize(request):
     ai_getter = request.find_service(name="ai_getter")
     consumer_key = request.lti_user.oauth_consumer_key

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -3,7 +3,7 @@ import os
 from pyramid import httpexceptions
 from pyramid import i18n
 from pyramid.settings import asbool
-from pyramid.view import notfound_view_config
+from pyramid.view import forbidden_view_config, notfound_view_config
 import sentry_sdk
 
 from lms.validation import ValidationError
@@ -15,6 +15,12 @@ _ = i18n.TranslationStringFactory(__package__)
 def notfound(request):
     request.response.status_int = 404
     return {"message": _("Page not found")}
+
+
+@forbidden_view_config(renderer="lms:templates/error.html.jinja2")
+def forbidden(request):
+    request.response.status_int = 403
+    return {"message": _("You're not authorized to view this page")}
 
 
 def _http_error(exc, request):

--- a/tests/lms/authentication/_lti_policy_test.py
+++ b/tests/lms/authentication/_lti_policy_test.py
@@ -41,6 +41,7 @@ class TestLTIAuthenticationPolicy:
             security.Everyone,
             security.Authenticated,
             _helpers.authenticated_userid.return_value,
+            "lti_user",
         ]
 
     def test_effective_principals_when_theres_no_lti_user(

--- a/tests/lms/views/error_test.py
+++ b/tests/lms/views/error_test.py
@@ -25,6 +25,23 @@ class TestNotFound:
         assert result["message"] == "Page not found"
 
 
+class TestForbidden:
+    def test_it_does_not_report_exception_to_sentry(self, pyramid_request, sentry_sdk):
+        error.forbidden(pyramid_request)
+
+        sentry_sdk.capture_exception.assert_not_called()
+
+    def test_it_sets_response_status(self, pyramid_request):
+        error.forbidden(pyramid_request)
+
+        assert pyramid_request.response.status_int == 403
+
+    def test_it_shows_a_generic_error_message_to_the_user(self, pyramid_request):
+        result = error.forbidden(pyramid_request)
+
+        assert result["message"] == "You're not authorized to view this page"
+
+
 class TestHTTPClientError:
     def test_it_does_not_report_exception_to_sentry(self, pyramid_request, sentry_sdk):
         exc = httpexceptions.HTTPBadRequest()


### PR DESCRIPTION
`/api/canvas/authorize` is the popup window that frontend code opens when it wants to start an OAuth 2 authorization flow with the Canvas API. Require the `"canvas_api"` permission for this view so that, if the URL is requested without LTI authentication, the view won't be called and an authorization error (403) will be sent back.
    
When launching the app within Canvas frontend code will use one of our LTI JWTs in a query param when opening `/api/canvas/authorize` so the permission check will succeed.
    
But if you try to visit `/api/canvas/authorize` in a tab directly you'll get an authorization error page.

Someone who left the page open for a long time, until their JWT expired, and then tried to open the popup window, would also see this authorization error.

The way this works is that:

1. The `"lti_user"` principal is added to `effective_principals` when the user is LTI authenticated (either by launch params or JWT)
2. The default traversal root object adds the `"canvas_api"` permission to the request if it has the `"lti_user"` principal
3. The `@view_config()` for the `authorize()` view requires the `"canvas_api"` permission

If the request lacks the permission Pyramid will call our forbidden view instead of calling the `authorize()` view.

## Testing

- [ ] Creating an assignment in Canvas with the `"new_oauth"` feature flag on should work correctly - popup window opens and works
- [ ] Visiting http://localhost:8001/api/canvas/authorize directly in a tab should give an authorization error. (Set the envvar `DEBUG` to `false` to see the production error page.)