### PR TITLE
Fix `make frontend-lint` not failing if formatting was incorrect (!)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ backend-lint:
 
 .PHONY: frontend-lint
 frontend-lint: node_modules/.uptodate
-	yarn format
+	yarn checkformatting
 	yarn lint
 
 # Backend and frontend tests are split into separate targets because on Jenkins

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "gulp build",
+    "checkformatting": "prettier --check lms/**/*.js scripts/**/*.js",
     "format": "prettier --list-different --write lms/**/*.js scripts/**/*.js",
     "lint": "gulp lint",
     "test": "gulp test"


### PR DESCRIPTION
Check the formatting of the code instead of reformatting it.