### PR TITLE
Add a stubbed version of the upcoming Canvas files API proxy

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -40,4 +40,7 @@ def includeme(config):
     # though we dont link to it.
     config.add_route("favicon", "/favicon.ico")
 
-    config.add_route("canvas_api_authorize", "/api/canvas/authorize")
+    config.add_route("canvas_api.authorize", "/api/canvas/authorize")
+    config.add_route(
+        "canvas_api.courses.files.list", "/api/canvas/courses/{course_id}/files"
+    )

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -8,7 +8,7 @@ from lms.validation import CanvasOAuthCallbackSchema
 
 
 @view_config(
-    route_name="canvas_api_authorize", request_method="GET", permission="canvas_api"
+    route_name="canvas_api.authorize", request_method="GET", permission="canvas_api"
 )
 def authorize(request):
     ai_getter = request.find_service(name="ai_getter")

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -1,0 +1,64 @@
+"""
+Proxy API for Canvas's Files API.
+
+Gives our frontend code access to Canvas's Files API:
+https://canvas.instructure.com/doc/api/files.html
+
+Requests to this proxy API are authenticated using this app's authentication
+policies (for example: a JWT in an ``Authorization`` header) and this API
+therefore knows what LTI user is making the request. This API then makes
+server-to-server requests, authenticated using OAuth 2 access tokens, to the
+appropriate Canvas instance's files API and returns the results to the original
+proxy API caller::
+
+                         +---------+
+                         | Browser |
+                         +---------+
+                         |         ↑
+    1. List files request|         |
+       (JWT auth)        |         |4. Proxied list files response
+                         ↓         |
+                        +-----------+
+                        | Proxy API |
+                        +-----------+
+                         |         ↑
+    2. Proxied list files|         |
+       request (OAuth 2) |         |3. List files response
+                         ↓         |
+                      +---------------+
+                      |Real Canvas API|
+                      +---------------+
+"""
+from pyramid.view import view_config
+
+
+@view_config(
+    permission="canvas_api",
+    renderer="json",
+    request_method="GET",
+    route_name="canvas_api.courses.files.list",
+)
+def list_files(_request):
+    """Return the list of files in the given course."""
+    # TODO: Replace this stub response with a real response based on a response
+    # obtained from the Canvas API.
+    return [
+        {
+            "id": 56,
+            "display_name": "Biography.pdf",
+            "updated_at": "2017-03-06T12:58:27Z",
+        },
+        {"id": 1, "display_name": "Comedies.pdf", "updated_at": "2012-05-01T20:36:32Z"},
+        {
+            "id": 23,
+            "display_name": "Histories.pdf",
+            "updated_at": "2011-011-20T07:23:20Z",
+        },
+        {"id": 460, "display_name": "Poems.pdf", "updated_at": "2018-08-17T11:45:50Z"},
+        {"id": 7, "display_name": "Sonnets.pdf", "updated_at": "2016-06-06T17:58:01"},
+        {
+            "id": 112,
+            "display_name": "Tragedies.pdf",
+            "updated_at": "2010-07-23T14:01:50Z",
+        },
+    ]

--- a/lms/views/api/error.py
+++ b/lms/views/api/error.py
@@ -1,0 +1,18 @@
+"""Error views for the API."""
+from pyramid import i18n
+from pyramid.view import forbidden_view_config, notfound_view_config
+
+
+_ = i18n.TranslationStringFactory(__package__)
+
+
+@forbidden_view_config(path_info="/api/*", renderer="json")
+def forbidden(request):
+    request.response.status_int = 403
+    return {"message": _("You're not authorized to view this page")}
+
+
+@notfound_view_config(path_info="/api/*", renderer="json")
+def notfound(request):
+    request.response.status_int = 404
+    return {"message": _("Endpoint not found")}

--- a/tests/lms/views/api/error_test.py
+++ b/tests/lms/views/api/error_test.py
@@ -1,0 +1,25 @@
+from lms.views.api import error
+
+
+class TestNotFound:
+    def test_it_sets_response_status(self, pyramid_request):
+        error.notfound(pyramid_request)
+
+        assert pyramid_request.response.status_int == 404
+
+    def test_it_shows_a_generic_error_message_to_the_user(self, pyramid_request):
+        result = error.notfound(pyramid_request)
+
+        assert result["message"] == "Endpoint not found"
+
+
+class TestForbidden:
+    def test_it_sets_response_status(self, pyramid_request):
+        error.forbidden(pyramid_request)
+
+        assert pyramid_request.response.status_int == 403
+
+    def test_it_shows_a_generic_error_message_to_the_user(self, pyramid_request):
+        result = error.forbidden(pyramid_request)
+
+        assert result["message"] == "You're not authorized to view this page"


### PR DESCRIPTION
Authentication works correctly (a missing or incorrect `Authorization` header will result in a 403 JSON response).

But when authenticated the actual API response is faked.

To test:

1. Turn on the new_oauth feature flag.

1. Get a JWT. The easiest way to do this is to launch the app in Canvas then inspect the iframe and copy the JWT from the `<script type="application/json" class="js-config">` near the top of the iframe.

2. Send a request: `http GET "http://localhost:8001/api/canvas/courses/4/files" Authorization:"Bearer ***"`

   The course ID (`4` above) doesn't do anything yet but in the real version this'll have to be the actual Canvas course ID.

3. Send a request with a missing or invalid JWT and get a 403: `http GET "http://localhost:8001/api/canvas/courses/4/files" Authorization:"Bearer INVALID"`

4. Request an API endpoint that doesn't exist and get a 404: `http GET "http://localhost:8001/api/canvas/courses/4/doesnt-exist" Authorization:"Bearer ***"`