### PR TITLE
Show lines missing coverage, in coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
     format: black lms tests
     checkformatting: black --check lms tests
     coverage: -coverage combine
-    coverage: coverage report
+    coverage: coverage report --show-missing
     codecov: codecov -t {env:CODECOV_TOKEN}
     {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envdir}/rst .
     docstrings: sphinx-autobuild -BqT -z lms -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml


### PR DESCRIPTION
When a file doesn't have 100% test coverage show the line numbers that aren't covered in the coverage report that `make coverage` prints out.