### PR TITLE
state param auth 2/n: Add new oauth2_state_secret deployment setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ run-docker:
 		-e RPC_ALLOWED_ORIGINS \
 		-e VIA_URL \
 		-e SESSION_COOKIE_SECRET \
+		-e OAUTH2_STATE_SECRET \
 		-p 8001:8001 \
 		hypothesis/lms:$(DOCKER_TAG)
 

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -21,6 +21,9 @@ session_cookie_secret = "notasecret"
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
 
+# The secret string that's used to sign the OAuth2 state param.
+oauth2_state_secret = "notasecret"
+
 [server:main]
 use: egg:gunicorn
 host: 0.0.0.0

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -59,6 +59,11 @@ def configure(settings):
         ),
         # The list of feature flags that are allowed to be set in the feature flags cookie.
         "feature_flags_allowed_in_cookie": sg.get("FEATURE_FLAGS_ALLOWED_IN_COOKIE"),
+        # The secret string that's used to sign the OAuth 2 state param.
+        # For example you can generate one using Python 3 on the command line
+        # like this:
+        #     python3 -c 'import secrets; print(secrets.token_hex())'
+        "oauth2_state_secret": sg.get("OAUTH2_STATE_SECRET", required=True),
     }
 
     database_url = sg.get("DATABASE_URL")

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -176,6 +176,7 @@ def pyramid_config(pyramid_request):
         "h_api_url_public": "https://example.com/api/",
         "h_api_url_private": "https://private.com/api/",
         "rpc_allowed_origins": ["http://localhost:5000"],
+        "oauth2_state_secret": "test_oauth2_state_secret",
     }
 
     with testing.testConfig(request=pyramid_request, settings=settings) as config:

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ passenv =
     dev: HASHED_PW
     dev: JWT_SECRET
     dev: LMS_SECRET
+    dev: OAUTH2_STATE_SECRET
     dev: RPC_ALLOWED_ORIGINS
     dev: SALT
     dev: SENTRY_DSN


### PR DESCRIPTION
Add a new, required deployment setting `oauth2_state_secret`. This will be used for signing JWT's that're used as OAuth 2 `state` params.