### PR TITLE
state param auth 3/n: Fix how CanvasOAuthCallbackSchema is initialized

### DIFF
--- a/lms/validation/_helpers/_schema.py
+++ b/lms/validation/_helpers/_schema.py
@@ -22,7 +22,6 @@ def instantiate_schema(schema, request):
     parse a request.
     """
     if inspect.isclass(schema):
-        schema = schema()
-        schema.context["request"] = request
+        schema = schema(request)
 
     return schema

--- a/lms/validation/_oauth.py
+++ b/lms/validation/_oauth.py
@@ -16,6 +16,13 @@ class CanvasOAuthCallbackSchema(marshmallow.Schema):
         # TODO: Remove this once we've upgraded to marshmallow 3.
         strict = True
 
+    def __init__(self, request):
+        super().__init__()
+        self.context = {
+            "request": request,
+            "secret": request.registry.settings["oauth2_state_secret"],
+        }
+
     @marshmallow.validates("state")
     def validate_state(self, state):
         request = self.context["request"]

--- a/tests/lms/validation/_helpers/_schema_test.py
+++ b/tests/lms/validation/_helpers/_schema_test.py
@@ -29,3 +29,6 @@ class MySchema(marshmallow.Schema):
 
     class Meta:
         strict = True
+
+    def __init__(self, request):
+        self.context = {"request": request}


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/601.

The standard way to initialize a marshmallow schema is:

```python
schema = MySchema()
schema.context["request"] = request
```

But our existing schemas are initialized like this instead:

```python
schema = MySchema(request)
```

Fix `CanvasOAuthCallbackSchema` to be initialized in the same way as our other schema, instead of the way it's done in the webargs docs. Fix the `initialize_schema()` helper to do it this way as well.