### PR TITLE
state param auth 4/n: Support reading LTI user from OAuth2 state param

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -31,6 +31,9 @@ from lms.validation._exceptions import (
     ExpiredSessionTokenError,
     MissingSessionTokenError,
     InvalidSessionTokenError,
+    MissingStateParamError,
+    ExpiredStateParamError,
+    InvalidStateParamError,
 )
 from lms.validation._oauth import CanvasOAuthCallbackSchema
 from lms.validation._launch_params import LaunchParamsSchema
@@ -47,6 +50,9 @@ __all__ = (
     "ExpiredSessionTokenError",
     "MissingSessionTokenError",
     "InvalidSessionTokenError",
+    "MissingStateParamError",
+    "InvalidStateParamError",
+    "ExpiredStateParamError",
 )
 
 

--- a/lms/validation/_exceptions.py
+++ b/lms/validation/_exceptions.py
@@ -49,3 +49,24 @@ class MissingSessionTokenError(ValidationError):
 
 class InvalidSessionTokenError(ValidationError):
     """Raised when the request has an invalid session token."""
+
+
+class MissingStateParamError(ValidationError):
+    """An OAuth 2 redirect request was missing the ``state`` param."""
+
+    def __init__(self):
+        super().__init__({"state": ["Missing `state` parameter"]})
+
+
+class ExpiredStateParamError(ValidationError):
+    """An OAuth 2 redirect request had an expired ``state`` param."""
+
+    def __init__(self):
+        super().__init__({"state": ["Expired `state` parameter"]})
+
+
+class InvalidStateParamError(ValidationError):
+    """An OAuth 2 redirect request had an invalid ``state`` param."""
+
+    def __init__(self):
+        super().__init__({"state": ["Invalid `state` parameter"]})

--- a/lms/validation/_oauth.py
+++ b/lms/validation/_oauth.py
@@ -1,10 +1,59 @@
 """Validation for OAuth views."""
+import secrets
+
 import marshmallow
 from webargs import fields
 
+from lms.validation import _helpers
+from lms.validation._helpers import ExpiredJWTError, InvalidJWTError
+from lms.validation import _exceptions
+from lms.values import LTIUser
+
 
 class CanvasOAuthCallbackSchema(marshmallow.Schema):
-    """Schema for validating OAuth 2 redirect_uri requests from Canvas."""
+    """
+    Schema for validating OAuth 2 redirect_uri requests from Canvas.
+
+    This schema provides two convenience methods:
+
+    First, :meth:`CanvasOAuthCallbackSchema.state_param` returns a string
+    suitable for passing to an authorization server's authorization endpoint as
+    the ``state`` query parameter::
+
+       >>> schema = CanvasOAuthCallbackSchema()
+       >>> schema.context['request'] = request
+       >>> schema.state_param(request.lti_user)
+       'xyz...123'
+
+    Calling :meth:`CanvasOAuthCallbackSchema.state_param` also has the side
+    effect of inserting a CSRF token into the session that will be checked
+    against the ``state`` parameter when the authorization server returns the
+    ``state`` parameter to us in a later ``redirect_uri`` request.
+
+    Second, :meth:`CanvasOAuthCallbackSchema.lti_user` returns the
+    :class:`lms.values.LTIUser` authenticated by the ``state`` param in the
+    current request. This will raise if the request doesn't contain a ``state``
+    query parameter or if the ``state`` is expired or invalid::
+
+       >>> schema.lti_user()
+       LTIUser(user_id='...', oauth_consumer_key='...')
+
+    Finally, :class:`CanvasOAuthCallbackSchema` can also be used as a schema to
+    guard a ``redirect_uri`` view, for example::
+
+        @view_config(..., schema=CanvasOAuthCallbackSchema)
+        def redirect_uri_view(request):
+            # The authorization code and state sent by the authorization server
+            # are available in request.parsed_params.
+            authorization_code = request.parsed_params["code"]
+            state = request.parsed_params["state"]
+            ...
+
+    This will prevent the view from being called if the code or state is
+    missing, if the state is invalid or expired, or if there isn't a matching
+    CSRF token in the session, and it will remove the CSRF token from the
+    session so that it can't be reused.
+    """
 
     code = fields.Str(required=True)
     state = fields.Str(required=True)
@@ -23,9 +72,66 @@ class CanvasOAuthCallbackSchema(marshmallow.Schema):
             "secret": request.registry.settings["oauth2_state_secret"],
         }
 
-    @marshmallow.validates("state")
-    def validate_state(self, state):
+    def state_param(self):
+        """
+        Generate and return the value for an OAuth 2 state param.
+
+        :rtype: str
+        """
+        request = self.context["request"]
+        secret = request.registry.settings["oauth2_state_secret"]
+
+        csrf = secrets.token_hex()
+
+        data = {"user": request.lti_user._asdict(), "csrf": csrf}
+
+        jwt_str = _helpers.encode_jwt(data, secret)
+
+        request.session["oauth2_csrf"] = csrf
+
+        return jwt_str
+
+    def lti_user(self):
+        """
+        Return the LTIUser authenticated by the request's state param.
+
+        Return the :class:`lms.values.LTIUser` authenticated by the current
+        request's ``state`` query parameter.
+
+        :raise lms.validation.MissingStateParamError: if the request has no
+            ``state`` query parameter
+        :raise lms.validation.ExpiredStateParamError: if the request's
+            ``state`` param has expired
+        :raise lms.validation.InvalidStateParamError: if the request's
+            ``state`` param is invalid
+        :rtype: str
+        """
         request = self.context["request"]
 
-        if state != request.session.pop("canvas_api_authorize_state", None):
-            raise marshmallow.ValidationError("Invalid or missing state parameter.")
+        try:
+            state = request.params["state"]
+        except KeyError as err:
+            raise _exceptions.MissingStateParamError() from err
+
+        return LTIUser(**self._decode_state(state)["user"])
+
+    @marshmallow.validates("state")
+    def validate_state(self, state):
+        """Validate the current request's ``state`` param."""
+        request = self.context["request"]
+
+        payload = self._decode_state(state)
+
+        if payload["csrf"] != request.session.pop("oauth2_csrf", None):
+            raise marshmallow.ValidationError("Invalid CSRF token")
+
+    def _decode_state(self, state):
+        """Decode the given state JWT and return its payload or raise."""
+        secret = self.context["request"].registry.settings["oauth2_state_secret"]
+
+        try:
+            return _helpers.decode_jwt(state, secret)
+        except ExpiredJWTError as err:
+            raise _exceptions.ExpiredStateParamError() from err
+        except InvalidJWTError as err:
+            raise _exceptions.InvalidStateParamError() from err

--- a/tests/lms/validation/_oauth_test.py
+++ b/tests/lms/validation/_oauth_test.py
@@ -1,111 +1,190 @@
+import jwt
 import pytest
 from pyramid import testing
 
 from lms.validation import CanvasOAuthCallbackSchema
 from lms.validation import parser
-from lms.validation import ValidationError
-from lms.validation._helpers import instantiate_schema
+from lms.validation import (
+    ValidationError,
+    MissingStateParamError,
+    ExpiredStateParamError,
+    InvalidStateParamError,
+)
+from lms.validation._helpers import ExpiredJWTError, InvalidJWTError, instantiate_schema
+from lms.values import LTIUser
 
 
 class TestCanvasOauthCallbackSchema:
-    def test_it_returns_the_parsed_args_for_a_valid_request(
-        self, schema, valid_request
+    def test_state_param_encodes_lti_user_and_csrf_token_into_state_jwt(
+        self, schema, secrets, _helpers, lti_user
     ):
-        parsed_args = parser.parse(schema, valid_request)
+        state = schema.state_param()
 
-        assert parsed_args == {"code": "test_code", "state": "test_state"}
+        secrets.token_hex.assert_called_once_with()
+        _helpers.encode_jwt.assert_called_once_with(
+            {"user": lti_user._asdict(), "csrf": secrets.token_hex.return_value},
+            "test_oauth2_state_secret",
+        )
+        assert state == _helpers.encode_jwt.return_value
 
-    def test_its_invalid_if_state_is_missing(self, schema, valid_request):
-        del valid_request.params["state"]
+    def test_state_param_also_stashes_csrf_token_in_session(
+        self, schema, secrets, pyramid_request
+    ):
+        del pyramid_request.session["oauth2_csrf"]
+
+        schema.state_param()
+
+        assert pyramid_request.session["oauth2_csrf"] == secrets.token_hex.return_value
+
+    def test_lti_user_returns_the_lti_user_value(self, schema, _helpers, lti_user):
+        returned = schema.lti_user()
+
+        _helpers.decode_jwt.assert_called_once_with(
+            "test_state", "test_oauth2_state_secret"
+        )
+        assert returned == lti_user
+
+    def test_lti_user_raises_if_theres_no_state_param(self, schema, pyramid_request):
+        del pyramid_request.params["state"]
+
+        with pytest.raises(MissingStateParamError):
+            schema.lti_user()
+
+    def test_lti_user_raises_if_the_state_param_is_expired(self, schema, _helpers):
+        _helpers.decode_jwt.side_effect = ExpiredJWTError()
+
+        with pytest.raises(ExpiredStateParamError):
+            schema.lti_user()
+
+    def test_lti_user_raises_if_the_state_param_is_invalid(self, schema, _helpers):
+        _helpers.decode_jwt.side_effect = InvalidJWTError()
+
+        with pytest.raises(InvalidStateParamError):
+            schema.lti_user()
+
+    def test_lti_doesnt_remove_the_csrf_token_from_the_session(
+        self, schema, pyramid_request, secrets
+    ):
+        schema.lti_user()
+
+        assert pyramid_request.session["oauth2_csrf"] == secrets.token_hex.return_value
+
+    def test_it_raises_if_the_authorization_code_is_missing(
+        self, schema, pyramid_request
+    ):
+        del pyramid_request.params["code"]
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(schema, valid_request)
+            self.parse(schema, pyramid_request)
+
+        assert exc_info.value.messages == {"code": ["Missing data for required field."]}
+
+    def test_it_raises_if_the_state_is_missing(self, schema, pyramid_request):
+        del pyramid_request.params["state"]
+
+        with pytest.raises(ValidationError) as exc_info:
+            self.parse(schema, pyramid_request)
 
         assert exc_info.value.messages == {
             "state": ["Missing data for required field."]
         }
 
-    def test_its_invalid_if_state_is_missing_from_the_session(
-        self, schema, valid_request
+    def test_it_raises_if_the_state_jwt_is_expired(
+        self, schema, pyramid_request, _helpers
     ):
-        del valid_request.session["canvas_api_authorize_state"]
+        _helpers.decode_jwt.side_effect = ExpiredJWTError()
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(schema, valid_request)
+            self.parse(schema, pyramid_request)
 
-        assert exc_info.value.messages == {
-            "state": ["Invalid or missing state parameter."]
-        }
+        assert exc_info.value.messages == {"state": ["Expired `state` parameter"]}
 
-    def test_its_invalid_if_state_isnt_a_string(self, schema, valid_request):
-        valid_request.params["state"] = 23
-
-        with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(schema, valid_request)
-
-        assert exc_info.value.messages == {"state": ["Not a valid string."]}
-
-    def test_its_invalid_if_state_is_the_wrong_string(self, schema, valid_request):
-        valid_request.params["state"] = "the_wrong_string"
-
-        with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(schema, valid_request)
-
-        assert exc_info.value.messages == {
-            "state": ["Invalid or missing state parameter."]
-        }
-
-    def test_it_removes_the_state_param_after_validating_it(
-        self, schema, valid_request
+    def test_it_raises_if_the_state_jwt_is_invalid(
+        self, schema, pyramid_request, _helpers
     ):
-        parsed_args = parser.parse(schema, valid_request)
-
-        assert "canvas_api_authorize_state" not in valid_request.session
-
-    def test_its_invalid_if_state_is_null(self, schema, valid_request):
-        valid_request.params["state"] = None
+        _helpers.decode_jwt.side_effect = InvalidJWTError()
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(schema, valid_request)
+            self.parse(schema, pyramid_request)
 
-        assert exc_info.value.messages == {"state": ["Field may not be null."]}
+        assert exc_info.value.messages == {"state": ["Invalid `state` parameter"]}
 
-    def test_its_invalid_if_code_is_missing(self, schema, valid_request):
-        del valid_request.params["code"]
-
-        with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(schema, valid_request)
-
-        assert exc_info.value.messages == {"code": ["Missing data for required field."]}
-
-    def test_its_invalid_if_code_isnt_a_string(self, schema, valid_request):
-        valid_request.params["code"] = 23
+    def test_it_raises_if_the_csrf_token_doesnt_match_the_copy_in_the_session(
+        self, schema, pyramid_request
+    ):
+        pyramid_request.session["oauth2_csrf"] = "wrong"
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(schema, valid_request)
+            self.parse(schema, pyramid_request)
 
-        assert exc_info.value.messages == {"code": ["Not a valid string."]}
+        assert exc_info.value.messages == {"state": ["Invalid CSRF token"]}
 
-    def test_its_invalid_if_code_is_null(self, schema, valid_request):
-        valid_request.params["code"] = None
+    def test_it_raises_if_theres_no_csrf_token_in_the_session(
+        self, schema, pyramid_request
+    ):
+        del pyramid_request.session["oauth2_csrf"]
 
         with pytest.raises(ValidationError) as exc_info:
-            parsed_args = parser.parse(schema, valid_request)
+            self.parse(schema, pyramid_request)
 
-        assert exc_info.value.messages == {"code": ["Field may not be null."]}
+        assert exc_info.value.messages == {"state": ["Invalid CSRF token"]}
+
+    def test_it_removes_the_csrf_token_from_the_session(self, schema, pyramid_request):
+        self.parse(schema, pyramid_request)
+
+        assert "oauth2_csrf" not in pyramid_request.session
+
+    def test_it_returns_the_valid_state_and_authorization_code(
+        self, schema, pyramid_request
+    ):
+        parsed_params = self.parse(schema, pyramid_request)
+
+        assert parsed_params == {"code": "test_code", "state": "test_state"}
+
+    def parse(self, schema, request):
+        """Parse ``request`` with ``schema`` and return the parsed params."""
+        return parser.parse(schema, request, locations=["querystring"])
 
     @pytest.fixture
-    def schema(self, valid_request):
-        return instantiate_schema(CanvasOAuthCallbackSchema, valid_request)
+    def schema(self, pyramid_request):
+        return instantiate_schema(CanvasOAuthCallbackSchema, pyramid_request)
 
     @pytest.fixture
-    def valid_request(self):
-        """Return a minimal valid request.
+    def lti_user(self):
+        return LTIUser("test_user_id", "test_oauth_consumer_key")
 
-        All required fields are present and valid.
-        """
-        valid_request = testing.DummyRequest()
-        valid_request.params["code"] = "test_code"
-        valid_request.params["state"] = "test_state"
-        valid_request.session["canvas_api_authorize_state"] = "test_state"
-        return valid_request
+    @pytest.fixture
+    def pyramid_request(self, lti_user):
+        """Return a minimal valid OAuth 2 redirect request."""
+        pyramid_request = testing.DummyRequest()
+        pyramid_request.params["code"] = "test_code"
+        pyramid_request.params["state"] = "test_state"
+        pyramid_request.session["oauth2_csrf"] = "test_csrf"
+        pyramid_request.lti_user = lti_user
+        pyramid_request.registry.settings = {
+            "oauth2_state_secret": "test_oauth2_state_secret"
+        }
+        return pyramid_request
+
+    @pytest.fixture
+    def pyramid_config(self, pyramid_request):
+        # Override the global pyramid_config fixture with the minimum needed to
+        # make this test class pass.
+        settings = {"oauth2_state_secret": "test_oauth2_state_secret"}
+        with testing.testConfig(request=pyramid_request, settings=settings) as config:
+            config.include("pyramid_services")
+            yield config
+
+
+@pytest.fixture(autouse=True)
+def secrets(patch):
+    secrets = patch("lms.validation._oauth.secrets")
+    secrets.token_hex.return_value = "test_csrf"
+    return secrets
+
+
+@pytest.fixture(autouse=True)
+def _helpers(patch, lti_user):
+    _helpers = patch("lms.validation._oauth._helpers")
+    _helpers.decode_jwt.return_value = {"csrf": "test_csrf", "user": lti_user._asdict()}
+    return _helpers


### PR DESCRIPTION
Extend `CanvasOAuthCallbackSchema` to support reading the LTI user from an OAuth 2 `state` query parameter.

No code uses this yet, but the functionality has been added to `CanvasOAuthCallbackSchema`:

`CanvasOAuthCallbackSchema.state_param()` is a method that generates and returns a `state` param capable of authenticating the LTI user. The `state` param is a signed and timestamped JWT containing the current `request.lti_user` and a CSRF token that's also added to the session. A view should call `state_param()` to get the value for the `?state=<VALUE>` parameter for putting into a Canvas authorization endpoint URL before redirecting the browser to it (this will be done in the next PR).

`CanvasOAuthCallbackSchema.lti_user()` is a method that returns the `LTIUser` value from the current request's `state` param, assuming that `state` param was generated using `state_param()` (above). It
validates the JWT. An authentication policy should call `lti_user()` to authenticate `redirect_uri` requests (this will be done in the next PR).

The JWT and CSRF token are also verified before calling the view, when `CanvasOAuthCallbackSchema` is used as a schema to guard a view. The CSRF token is also removed from the session so that it can't be reused.