### PR TITLE
state param auth 5/n: Use authenticatable state param

### DIFF
--- a/lms/authentication/_helpers.py
+++ b/lms/authentication/_helpers.py
@@ -1,6 +1,11 @@
 import base64
 
-from lms.validation import LaunchParamsSchema, BearerTokenSchema, ValidationError
+from lms.validation import (
+    LaunchParamsSchema,
+    BearerTokenSchema,
+    CanvasOAuthCallbackSchema,
+    ValidationError,
+)
 
 
 def authenticated_userid(lti_user):
@@ -36,6 +41,11 @@ def get_lti_user(request):
 
     try:
         return BearerTokenSchema(request).lti_user()
+    except ValidationError:
+        pass
+
+    try:
+        return CanvasOAuthCallbackSchema(request).lti_user()
     except ValidationError:
         return None
 

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -1,4 +1,3 @@
-import secrets
 from urllib.parse import urlencode, urlparse, urlunparse
 
 from pyramid.httpexceptions import HTTPFound
@@ -14,8 +13,6 @@ def authorize(request):
     ai_getter = request.find_service(name="ai_getter")
     consumer_key = request.lti_user.oauth_consumer_key
 
-    state = request.session["canvas_api_authorize_state"] = secrets.token_hex()
-
     authorize_url = urlunparse(
         (
             "https",
@@ -27,7 +24,7 @@ def authorize(request):
                     "client_id": ai_getter.developer_key(consumer_key),
                     "response_type": "code",
                     "redirect_uri": request.route_url("canvas_oauth_callback"),
-                    "state": state,
+                    "state": CanvasOAuthCallbackSchema(request).state_param(),
                 }
             ),
             "",

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -45,5 +45,6 @@ def oauth2_redirect(request):
     access_code = request.parsed_params["code"]
     state = request.parsed_params["state"]
     return f"""Redirect received
+lti_user: {request.lti_user}
 access_code: {access_code}
 state: {state}"""


### PR DESCRIPTION
<https://github.com/hypothesis/lms/pull/604> extended `CanvasOAuthCallbackSchema` to be able to serialize and deserialize OAuth 2 `state` param values that are signed and timestamped JWTs containing the `LTIUser` value and a CSRF token. This PR:

1. Has the `authorize()` (the view that redirects the popup window to Canvas's authorize page) use one of these JWTs as the `state` query param it passes to Canvas

2. Has the authentication policy use the `state` param to set `request.authenticated_userid`, `request.effective_principals`, and `request.lti_user`.

## Testing

* Turn on the new_oauth feature flag
* Turn off debug mode: `export DEBUG="false"
* Launch the app in Canvas, open the popup window, and authorize. After Canvas redirects back to our redirect_uri it'll now show the authenticated LTIUser (authenticated via the state param) in the popup window
* If you reload the popup window (<kbd><kbd>Ctrl</kbd>+<kbd>r</kbd></kbd>) you'll see a validation error because the CSRF token has been removed from the cookie
* If you open http://localhost:8001/canvas_oauth_callback directly in a tab you'll get validation errors, e.g.
  * http://localhost:8001/canvas_oauth_callback
  * http://localhost:8001/canvas_oauth_callback?code=foo
  * http://localhost:8001/canvas_oauth_callback?state=bar
  * http://localhost:8001/canvas_oauth_callback?code=foo&state=bar
* Launch the app in Canvas, open the popup window, don't click <kbd>Authorize</kbd> yet, delete the session cookie from your browser, then click <kbd>Authorize</kbd>, and you'll get a validation error