### PR TITLE
jenkins workspace cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,7 @@ node {
                 }
             } finally {
                 postgresContainer.stop()
+                cleanWs()
             }
         }
     },


### PR DESCRIPTION
This commit adds a directive to use the workspace cleanup plugin as the last step in the build stage