### PR TITLE
Get access tokens 2/n: Add OAuth2Token model class

### DIFF
--- a/lms/migrations/versions/f36f9a0aadf4_add_oauth2_token_table.py
+++ b/lms/migrations/versions/f36f9a0aadf4_add_oauth2_token_table.py
@@ -28,7 +28,7 @@ def upgrade():
         sa.Column("refresh_token", sa.UnicodeText()),
         sa.Column("expires_in", sa.Integer()),
         sa.Column(
-            "created", sa.DateTime(), server_default=sa.func.now(), nullable=False
+            "received_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
         ),
         sa.UniqueConstraint(
             "user_id", "consumer_key", name="uq__oauth2_token__user_id"

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -9,6 +9,7 @@ from lms.models.oauth_state import (
     find_or_create_from_user,
     find_user_from_state,
 )
+from lms.models.oauth2_token import OAuth2Token
 from lms.models.tokens import Token, update_user_token
 from lms.models.users import User, build_from_lti_params
 
@@ -23,6 +24,7 @@ __all__ = (
     "find_user_from_state",
     "ModuleItemConfiguration",
     "OauthState",
+    "OAuth2Token",
     "Token",
     "update_user_token",
     "User",

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -42,6 +42,13 @@ class ApplicationInstance(BASE):
         nullable=False,
     )
 
+    #: A list of all the OAuth2Tokens for this application instance
+    #: (each token belongs to a different user of this application
+    #: instance's LMS).
+    access_tokens = sa.orm.relationship(
+        "OAuth2Token", back_populates="application_instance"
+    )
+
 
 def build_shared_secret():
     """Generate a shared secret."""

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -43,8 +43,19 @@ class OAuth2Token(BASE):
     #: Null if the authorization server didn't provide an expires_in number.
     expires_in = sa.Column(sa.Integer())
 
-    #: The time when this access token was created.
-    created = sa.Column(
+    #: The time when we received `access_token` and `expires_in`.
+    #:
+    #: This is the time when we received the `access_token` and
+    #: `expires_in` values above from the authorization server.
+    #:
+    #: It's needed to compute whether `expires_in` has elapsed and therefore
+    #: `access_token` has expired.
+    #:
+    #: If database rows are updated in place (rather than being deleted and
+    #: inserting new rows) then whenever `access_token` and `expires_in`
+    #: are updated with new values from the authorization server, `received_at`
+    #: should also be updated to the current time.
+    received_at = sa.Column(
         sa.DateTime,
         default=datetime.datetime.utcnow,
         server_default=sa.func.now(),
@@ -57,4 +68,4 @@ class OAuth2Token(BASE):
         )
 
     def __repr__(self):
-        return f"<lms.models.OAuth2Token user_id:'{self.user_id}' consumer_key:'{self.consumer_key}' access_token:'{self.access_token}' refresh_token:'{self.refresh_token}' expires_in:{self.expires_in}' created:'{self.created}'>"
+        return f"<lms.models.OAuth2Token user_id:'{self.user_id}' consumer_key:'{self.consumer_key}' access_token:'{self.access_token}' refresh_token:'{self.refresh_token}' expires_in:{self.expires_in}' received_at:'{self.received_at}'>"

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -1,0 +1,60 @@
+"""Database model for persisting OAuth 2 tokens."""
+import datetime
+
+import sqlalchemy as sa
+
+from lms.db import BASE
+
+
+class OAuth2Token(BASE):
+    """An OAuth 2.0 access token, refresh token and expiry time."""
+
+    __tablename__ = "oauth2_token"
+    __table_args__ = (sa.UniqueConstraint("user_id", "consumer_key"),)
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+
+    #: The LTI user_id of the LMS user who this access token belongs to.
+    user_id = sa.Column(sa.UnicodeText(), nullable=False)
+
+    #: The LTI consumer_key (oauth_consumer_key) of the application instance
+    #: that this access token belongs to.
+    consumer_key = sa.Column(
+        sa.String(),
+        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
+        nullable=False,
+    )
+
+    #: The ApplicationInstance that this access token belongs to.
+    application_instance = sa.orm.relationship(
+        "ApplicationInstance", back_populates="access_tokens"
+    )
+
+    #: The OAuth 2.0 access token, as received from the authorization server.
+    access_token = sa.Column(sa.UnicodeText(), nullable=False)
+
+    #: The OAuth 2.0 refresh token, as received from the authorization server.
+    #: This will be null if the authorization server didn't provide a refresh
+    #: token.
+    refresh_token = sa.Column(sa.UnicodeText())
+
+    #: The lifetime in seconds of the access token, as given to us by the
+    #: authorization server.
+    #: Null if the authorization server didn't provide an expires_in number.
+    expires_in = sa.Column(sa.Integer())
+
+    #: The time when this access token was created.
+    created = sa.Column(
+        sa.DateTime,
+        default=datetime.datetime.utcnow,
+        server_default=sa.func.now(),
+        nullable=False,
+    )
+
+    def __str__(self):
+        return (
+            f"<OAuth2Token user_id:'{self.user_id}' consumer_key:'{self.consumer_key}'>"
+        )
+
+    def __repr__(self):
+        return f"<lms.models.OAuth2Token user_id:'{self.user_id}' consumer_key:'{self.consumer_key}' access_token:'{self.access_token}' refresh_token:'{self.refresh_token}' expires_in:{self.expires_in}' created:'{self.created}'>"

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -7,7 +7,13 @@ from lms.db import BASE
 
 
 class OAuth2Token(BASE):
-    """An OAuth 2.0 access token, refresh token and expiry time."""
+    """
+    An OAuth 2.0 access token, refresh token and expiry time.
+
+    These are used when this app is acting as an OAuth 2 client and
+    communicating with APIs that require OAuth 2 access token authentication,
+    for example the Canvas API.
+    """
 
     __tablename__ = "oauth2_token"
     __table_args__ = (sa.UniqueConstraint("user_id", "consumer_key"),)

--- a/tests/lms/models/oauth2_token_test.py
+++ b/tests/lms/models/oauth2_token_test.py
@@ -17,7 +17,7 @@ class TestOAuth2Token:
                 access_token="test_access_token",
                 refresh_token="test_refresh_token",
                 expires_in=3600,
-                created=now,
+                received_at=now,
             )
         )
 
@@ -29,7 +29,7 @@ class TestOAuth2Token:
         assert token.access_token == "test_access_token"
         assert token.refresh_token == "test_refresh_token"
         assert token.expires_in == 3600
-        assert token.created == now
+        assert token.received_at == now
 
     def test_user_id_cant_be_None(self, db_session, init_kwargs):
         del init_kwargs["user_id"]
@@ -101,7 +101,7 @@ class TestOAuth2Token:
 
         assert token.expires_in is None
 
-    def test_created_defaults_to_now(
+    def test_received_at_defaults_to_now(
         self, application_instance, db_session, init_kwargs
     ):
         token = OAuth2Token(**init_kwargs)
@@ -109,7 +109,7 @@ class TestOAuth2Token:
 
         db_session.flush()
 
-        assert isinstance(token.created, datetime.datetime)
+        assert isinstance(token.received_at, datetime.datetime)
 
     def test___str__(self, init_kwargs):
         token = OAuth2Token(**init_kwargs)
@@ -125,12 +125,12 @@ class TestOAuth2Token:
         )
         init_kwargs["refresh_token"] = "test_refresh_token"
         init_kwargs["expires_in"] = 3600
-        init_kwargs["created"] = now
+        init_kwargs["received_at"] = now
         token = OAuth2Token(**init_kwargs)
 
         assert (
             repr(token)
-            == "<lms.models.OAuth2Token user_id:'test_user_id' consumer_key:'test_consumer_key' access_token:'test_access_token' refresh_token:'test_refresh_token' expires_in:3600' created:'2019-05-15 11:11:09'>"
+            == "<lms.models.OAuth2Token user_id:'test_user_id' consumer_key:'test_consumer_key' access_token:'test_access_token' refresh_token:'test_refresh_token' expires_in:3600' received_at:'2019-05-15 11:11:09'>"
         )
 
     @pytest.fixture

--- a/tests/lms/models/oauth2_token_test.py
+++ b/tests/lms/models/oauth2_token_test.py
@@ -1,0 +1,159 @@
+import datetime
+
+import pytest
+import sqlalchemy.exc
+
+from lms.models import OAuth2Token, ApplicationInstance
+
+
+class TestOAuth2Token:
+    def test_persist_and_retrieve_all_attrs(self, application_instance, db_session):
+        now = datetime.datetime.utcnow()
+
+        db_session.add(
+            OAuth2Token(
+                user_id="test_user_id",
+                consumer_key=application_instance.consumer_key,
+                access_token="test_access_token",
+                refresh_token="test_refresh_token",
+                expires_in=3600,
+                created=now,
+            )
+        )
+
+        token = db_session.query(OAuth2Token).one()
+        assert token.user_id == "test_user_id"
+        assert token.consumer_key == "test_consumer_key"
+        assert token.consumer_key == application_instance.consumer_key
+        assert token.application_instance == application_instance
+        assert token.access_token == "test_access_token"
+        assert token.refresh_token == "test_refresh_token"
+        assert token.expires_in == 3600
+        assert token.created == now
+
+    def test_user_id_cant_be_None(self, db_session, init_kwargs):
+        del init_kwargs["user_id"]
+        db_session.add(OAuth2Token(**init_kwargs))
+
+        with pytest.raises(
+            sqlalchemy.exc.IntegrityError,
+            match='null value in column "user_id" violates not-null constraint',
+        ):
+            db_session.flush()
+
+    def test_consumer_key_cant_be_None(self, db_session, init_kwargs):
+        del init_kwargs["consumer_key"]
+        db_session.add(OAuth2Token(**init_kwargs))
+
+        with pytest.raises(
+            sqlalchemy.exc.IntegrityError,
+            match='null value in column "consumer_key" violates not-null constraint',
+        ):
+            db_session.flush()
+
+    def test_setting_consumer_key_sets_application_instance(
+        self, application_instance, db_session, init_kwargs
+    ):
+        token = OAuth2Token(**init_kwargs)
+        db_session.add(token)
+        db_session.flush()
+
+        assert token.application_instance == application_instance
+
+    def test_setting_application_instance_sets_consumer_key(
+        self, application_instance, db_session, init_kwargs
+    ):
+        del init_kwargs["consumer_key"]
+        init_kwargs["application_instance"] = application_instance
+        token = OAuth2Token(**init_kwargs)
+        db_session.add(token)
+        db_session.flush()
+
+        assert token.consumer_key == application_instance.consumer_key
+
+    def test_access_token_cant_be_None(self, db_session, init_kwargs):
+        del init_kwargs["access_token"]
+        db_session.add(OAuth2Token(**init_kwargs))
+
+        with pytest.raises(
+            sqlalchemy.exc.IntegrityError,
+            match='null value in column "access_token" violates not-null constraint',
+        ):
+            db_session.flush()
+
+    def test_refresh_token_defaults_to_None(
+        self, application_instance, db_session, init_kwargs
+    ):
+        token = OAuth2Token(**init_kwargs)
+        db_session.add(token)
+
+        db_session.flush()
+
+        assert token.refresh_token is None
+
+    def test_expires_in_defaults_to_None(
+        self, application_instance, db_session, init_kwargs
+    ):
+        token = OAuth2Token(**init_kwargs)
+        db_session.add(token)
+
+        db_session.flush()
+
+        assert token.expires_in is None
+
+    def test_created_defaults_to_now(
+        self, application_instance, db_session, init_kwargs
+    ):
+        token = OAuth2Token(**init_kwargs)
+        db_session.add(token)
+
+        db_session.flush()
+
+        assert isinstance(token.created, datetime.datetime)
+
+    def test___str__(self, init_kwargs):
+        token = OAuth2Token(**init_kwargs)
+
+        assert (
+            str(token)
+            == "<OAuth2Token user_id:'test_user_id' consumer_key:'test_consumer_key'>"
+        )
+
+    def test___repr__(self, init_kwargs):
+        now = datetime.datetime(
+            year=2019, month=5, day=15, hour=11, minute=11, second=9
+        )
+        init_kwargs["refresh_token"] = "test_refresh_token"
+        init_kwargs["expires_in"] = 3600
+        init_kwargs["created"] = now
+        token = OAuth2Token(**init_kwargs)
+
+        assert (
+            repr(token)
+            == "<lms.models.OAuth2Token user_id:'test_user_id' consumer_key:'test_consumer_key' access_token:'test_access_token' refresh_token:'test_refresh_token' expires_in:3600' created:'2019-05-15 11:11:09'>"
+        )
+
+    @pytest.fixture
+    def application_instance(self, db_session):
+        """The ApplicationInstance that the test OAuth2Token's belong to."""
+        application_instance = ApplicationInstance(
+            consumer_key="test_consumer_key",
+            shared_secret="test_shared_secret",
+            lms_url="test_lms_url",
+            requesters_email="test_requesters_email",
+        )
+        db_session.add(application_instance)
+        return application_instance
+
+    @pytest.fixture
+    def init_kwargs(self, application_instance):
+        """
+        The **minimum** kwargs needed to init a valid OAuth2Token.
+
+        No optional kwargs or kwargs with default values are included here.
+        """
+        return dict(
+            user_id="test_user_id",
+            access_token="test_access_token",
+            consumer_key=application_instance.consumer_key,
+        )


### PR DESCRIPTION
A model class for storing OAuth 2 access tokens along with their optional refresh tokens and expiry times, keyed by application instance (consumer key) and LTI `user_id`.

This will eventually replace the `Token` model class which is going to be deleted.