### PR TITLE
Get access tokens 3/n: Add CanvasAPIClient service

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -28,3 +28,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.launch_verifier.LaunchVerifier", name="launch_verifier"
     )
+    config.register_service_factory(
+        "lms.services.canvas_api.CanvasAPIClient", name="canvas_api_client"
+    )

--- a/lms/services/_helpers/__init__.py
+++ b/lms/services/_helpers/__init__.py
@@ -1,0 +1,4 @@
+from lms.services._helpers.canvas_api import CanvasAPIHelper
+
+
+__all__ = ["CanvasAPIHelper"]

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -1,0 +1,89 @@
+"""Helpers for working with the Canvas API."""
+from urllib.parse import urlparse, urlunparse
+
+import requests
+
+
+__all__ = ["CanvasAPIHelper"]
+
+
+class CanvasAPIHelper:
+    """
+    Methods for generating useful Canvas API values.
+
+    A lot of working with the Canvas API is generating correct values. For
+    example generating the token endpoint URL for the right Canvas instance, or
+    generating an access token request with the right URL, HTTP verb
+    parameters.
+
+    This helper handles generating these kinds of values so that the higher
+    level code can focus on what to *do* with the values instead.
+
+    Objects of this class are immutable, and none of their properties or
+    methods have any side effects.
+    """
+
+    def __init__(self, consumer_key, ai_getter, route_url):
+        """
+        Initialize a CanvasAPIHelper for the given ``consumer_key``.
+
+        :arg consumer_key: the consumer key of the application instance whose
+            Canvas instance's API we're going to be using
+        :type consumer_key: str
+
+        :arg ai_getter: the "ai_getter" service
+
+        :arg route_url: the :meth:`pyramid.request.Request.route_url()` method
+        :type route_url: callable
+        """
+        self._client_id = ai_getter.developer_key(consumer_key)
+        self._client_secret = ai_getter.developer_secret(consumer_key)
+        self._canvas_url = urlparse(ai_getter.lms_url(consumer_key)).netloc
+        self._redirect_uri = route_url("canvas_oauth_callback")
+
+    @property
+    def token_url(self):
+        """
+        Return the URL of the Canvas API's token endpoint.
+
+        This is the OAuth 2.0 endpoint that you post an authorization code to
+        in order to get an access token. See:
+
+        https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#post-login-oauth2-token
+
+        :rtype str:
+        """
+        return urlunparse(("https", self._canvas_url, "login/oauth2/token", "", "", ""))
+
+    def access_token_request(self, authorization_code):
+        """
+        Return a prepared access token request.
+
+        Return a prepared request object that, when sent, will make a
+        server-to-server request to the Canvas API's token endpoint in order to
+        exchange ``authorization_code`` for an access token.
+
+        The request can be sent like this::
+
+            >>> response = requests.Session().send(request)
+
+        For documentation of this request see:
+
+        https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#post-login-oauth2-token
+
+        :arg authorization_code: the authorization code received from the
+            browser after Canvas redirected the browser to our redirect_uri
+
+        :rtype: requests.PreparedRequest
+        """
+        return requests.Request(
+            "POST",
+            self.token_url,
+            params={
+                "grant_type": "authorization_code",
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+                "redirect_uri": self._redirect_uri,
+                "code": authorization_code,
+            },
+        ).prepare()

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -1,0 +1,69 @@
+import datetime
+
+import requests
+
+from lms.models import OAuth2Token
+from lms.services._helpers import CanvasAPIHelper
+
+
+__all__ = ["CanvasAPIClient"]
+
+
+class CanvasAPIClient:
+    def __init__(self, _context, request):
+        self._helper = CanvasAPIHelper(
+            request.lti_user.oauth_consumer_key,
+            request.find_service(name="ai_getter"),
+            request.route_url,
+        )
+        self._lti_user = request.lti_user
+        self._db = request.db
+
+    def get_token(self, authorization_code):
+        """
+        Get an access token for the current LTI user.
+
+        Posts to the Canvas API to get the access token and returns it.
+        """
+        access_token_request = self._helper.access_token_request(authorization_code)
+        access_token_response = requests.Session().send(access_token_request)
+
+        # TODO: Handle access token error responses.
+        # These aren't documented in the Canvas docs as far as I can see.
+        # They are documented in the OAuth 2 spec but I don't yet know if Canvas's
+        # error responses follow this:
+        # https://tools.ietf.org/html/rfc6749#section-5.2
+
+        # TODO: Validate access_token_response.
+
+        response_params = access_token_response.json()
+        access_token = response_params["access_token"]
+        refresh_token = response_params["refresh_token"]
+        expires_in = response_params["expires_in"]
+
+        return (access_token, refresh_token, expires_in)
+
+    def save_token(self, access_token, refresh_token=None, expires_in=None):
+        # Find the existing token in the DB.
+        token = (
+            self._db.query(OAuth2Token)
+            .filter_by(
+                consumer_key=self._lti_user.oauth_consumer_key,
+                user_id=self._lti_user.user_id,
+            )
+            .one_or_none()
+        )
+
+        # If there's no existing token in the DB then create a new one.
+        if token is None:
+            token = OAuth2Token()
+            self._db.add(token)
+
+        # Either update the existing token, or set the attributes of the newly
+        # created one.
+        token.consumer_key = self._lti_user.oauth_consumer_key
+        token.user_id = self._lti_user.user_id
+        token.access_token = access_token
+        token.refresh_token = refresh_token
+        token.expires_in = expires_in
+        token.received_at = datetime.datetime.utcnow()

--- a/tests/lms/services/_helpers/canvas_api_test.py
+++ b/tests/lms/services/_helpers/canvas_api_test.py
@@ -1,0 +1,43 @@
+import pytest
+
+from lms.services._helpers.canvas_api import CanvasAPIHelper
+
+
+class TestCanvasAPIHelper:
+    def test_token_url(self, ai_getter, route_url):
+        helper = CanvasAPIHelper("test_consumer_key", ai_getter, route_url)
+
+        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
+        assert helper.token_url == "https://my-canvas-instance.com/login/oauth2/token"
+
+    def test_access_token_request(self, ai_getter, route_url):
+        helper = CanvasAPIHelper("test_consumer_key", ai_getter, route_url)
+
+        request = helper.access_token_request("test_authorization_code")
+
+        ai_getter.developer_key.assert_called_once_with("test_consumer_key")
+        ai_getter.developer_secret.assert_called_once_with("test_consumer_key")
+        assert request.method == "POST"
+        assert request.url == (
+            "https://my-canvas-instance.com/login/oauth2/token"
+            "?grant_type=authorization_code"
+            "&client_id=test_developer_key"
+            "&client_secret=test_developer_secret"
+            "&redirect_uri=http%3A%2F%2Fexample.com%2Fcanvas_oauth_callback"
+            "&code=test_authorization_code"
+        )
+
+    @pytest.fixture
+    def ai_getter(self, ai_getter):
+        ai_getter.developer_key.return_value = "test_developer_key"
+        ai_getter.developer_secret.return_value = "test_developer_secret"
+        ai_getter.lms_url.return_value = "https://my-canvas-instance.com/"
+        return ai_getter
+
+    @pytest.fixture
+    def route_url(self, pyramid_request):
+        return pyramid_request.route_url
+
+    @pytest.fixture(autouse=True)
+    def routes(self, pyramid_config):
+        pyramid_config.add_route("canvas_oauth_callback", "/canvas_oauth_callback")

--- a/tests/lms/services/canvas_api_test.py
+++ b/tests/lms/services/canvas_api_test.py
@@ -1,0 +1,127 @@
+import datetime
+from unittest import mock
+
+import pytest
+import requests as _requests
+
+from lms.models import ApplicationInstance, OAuth2Token
+from lms.services.canvas_api import CanvasAPIClient
+
+
+class TestCanvasAPIClient:
+    def test_get_token_sends_an_access_token_request(
+        self,
+        ai_getter,
+        access_token_request,
+        canvas_api_client,
+        CanvasAPIHelper,
+        canvas_api_helper,
+        pyramid_request,
+        requests,
+    ):
+        canvas_api_client.get_token("test_authorization_code")
+
+        # It initializes canvas_api_helper correctly.
+        CanvasAPIHelper.assert_called_once_with(
+            pyramid_request.lti_user.oauth_consumer_key,
+            ai_getter,
+            pyramid_request.route_url,
+        )
+
+        # It gets the access token request from canvas_api_helper.
+        canvas_api_helper.access_token_request.assert_called_once_with(
+            "test_authorization_code"
+        )
+
+        # It sends the access token request.
+        requests.Session.assert_called_once_with()
+        requests.Session.return_value.send.assert_called_once_with(access_token_request)
+
+    def test_get_token_returns_the_token_tuple(self, canvas_api_client):
+        token = canvas_api_client.get_token("test_authorization_code")
+
+        assert token == ("test_access_token", "test_refresh_token", 3600)
+
+    def test_save_token_updates_an_existing_token_in_the_db(
+        self, before, canvas_api_client, db_session, pyramid_request
+    ):
+        existing_token = OAuth2Token(
+            user_id=pyramid_request.lti_user.user_id,
+            consumer_key=pyramid_request.lti_user.oauth_consumer_key,
+            access_token="old_access_token",
+        )
+        db_session.add(existing_token)
+
+        canvas_api_client.save_token("new_access_token", "new_refresh_token", 3600)
+
+        assert (
+            existing_token.consumer_key == pyramid_request.lti_user.oauth_consumer_key
+        )
+        assert existing_token.user_id == pyramid_request.lti_user.user_id
+        assert existing_token.access_token == "new_access_token"
+        assert existing_token.refresh_token == "new_refresh_token"
+        assert existing_token.expires_in == 3600
+        assert existing_token.received_at >= before
+
+    def test_save_token_adds_a_new_token_to_the_db_if_none_exists(
+        self, before, canvas_api_client, db_session, pyramid_request
+    ):
+        canvas_api_client.save_token("new_access_token", "new_refresh_token", 3600)
+
+        token = db_session.query(OAuth2Token).one()
+        assert token.consumer_key == pyramid_request.lti_user.oauth_consumer_key
+        assert token.user_id == pyramid_request.lti_user.user_id
+        assert token.access_token == "new_access_token"
+        assert token.refresh_token == "new_refresh_token"
+        assert token.expires_in == 3600
+        assert token.received_at >= before
+
+    @pytest.fixture
+    def canvas_api_client(self, pyramid_config, pyramid_request):
+        return CanvasAPIClient(mock.sentinel.context, pyramid_request)
+
+    @pytest.fixture(autouse=True)
+    def application_instance(self, db_session, pyramid_request):
+        """The ApplicationInstance that the test OAuth2Token's belong to."""
+        application_instance = ApplicationInstance(
+            consumer_key=pyramid_request.lti_user.oauth_consumer_key,
+            shared_secret="test_shared_secret",
+            lms_url="test_lms_url",
+            requesters_email="test_requesters_email",
+        )
+        db_session.add(application_instance)
+        return application_instance
+
+    @pytest.fixture
+    def before(self):
+        """A time before the test method was called."""
+        return datetime.datetime.utcnow()
+
+
+@pytest.fixture(autouse=True)
+def CanvasAPIHelper(patch):
+    return patch("lms.services.canvas_api.CanvasAPIHelper")
+
+
+@pytest.fixture
+def canvas_api_helper(CanvasAPIHelper):
+    return CanvasAPIHelper.return_value
+
+
+@pytest.fixture
+def access_token_request(canvas_api_helper):
+    return canvas_api_helper.access_token_request.return_value
+
+
+@pytest.fixture(autouse=True)
+def requests(patch):
+    requests = patch("lms.services.canvas_api.requests")
+    requests.Session.return_value.send.return_value = mock.create_autospec(
+        _requests.Response, instance=True, spec_set=True
+    )
+    requests.Session.return_value.send.return_value.json.return_value = {
+        "access_token": "test_access_token",
+        "refresh_token": "test_refresh_token",
+        "expires_in": 3600,
+    }
+    return requests


### PR DESCRIPTION
... with code for sending an access token request to the Canvas API and returning the response.

Handling error responses from the Canvas API is not supported yet.