### PR TITLE
Get access tokens 4/n: View code for getting access tokens

### DIFF
--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -42,9 +42,9 @@ def authorize(request):
     schema=CanvasOAuthCallbackSchema,
 )
 def oauth2_redirect(request):
-    access_code = request.parsed_params["code"]
-    state = request.parsed_params["state"]
-    return f"""Redirect received
-lti_user: {request.lti_user}
-access_code: {access_code}
-state: {state}"""
+    canvas_api_client = request.find_service(name="canvas_api_client")
+
+    authorization_code = request.parsed_params["code"]
+
+    token = canvas_api_client.get_token(authorization_code)
+    canvas_api_client.save_token(*token)


### PR DESCRIPTION
In the `redirect_uri` view (which is what receives the popup window redirect from Canvas containing the authorization code query param) exchange the authorization code for an access token in a server-server
request to the Canvas API.

The access token and its refresh token and expiry time get saved to the DB but otherwise they aren't used yet.

If the DB already contains an access token for this user (same consumer key and user_id) that token will be updated rather than saving a second one.