### PR TITLE
Elide long file names in the new file picker

### DIFF
--- a/lms/static/scripts/file_picker_v2/components/FileList.js
+++ b/lms/static/scripts/file_picker_v2/components/FileList.js
@@ -17,11 +17,11 @@ export default function FileList({
   const columns = [
     {
       label: 'Name',
-      className: 'FileList__name-col',
+      className: 'FileList__name-header',
     },
     {
       label: 'Last modified',
-      className: 'FileList__date-col',
+      className: 'FileList__date-header',
     },
   ];
 
@@ -35,7 +35,7 @@ export default function FileList({
         onUseItem={onUseFile}
         renderItem={file => (
           <Fragment>
-            <td>
+            <td className="FileList__name-col">
               <img
                 className="FileList__icon"
                 src="/static/images/file-pdf.svg"
@@ -44,7 +44,7 @@ export default function FileList({
                 {file.display_name}
               </a>
             </td>
-            <td className="FileList__date">
+            <td className="FileList__date-col">
               {file.updated_at && formatDate(file.updated_at)}
             </td>
           </Fragment>

--- a/lms/static/styles/components/_Button.scss
+++ b/lms/static/styles/components/_Button.scss
@@ -7,6 +7,7 @@
   border: none;
   border-radius: 2px;
   color: $white;
+  cursor: pointer;
   font-weight: bold;
   padding-left: 15px;
   padding-right: 15px;

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -11,12 +11,12 @@ $file-list-icon-size: 24px;
   top: calc(50% - #{$file-list-icon-size / 2});
 }
 
-.FileList__name-col {
+.FileList__name-header {
   text-align: left;
   padding-left: 10px;
 }
 
-.FileList__date-col {
+.FileList__date-header {
   width: 120px;
   text-align: left;
 }
@@ -29,6 +29,12 @@ $file-list-icon-size: 24px;
   vertical-align: middle;
 }
 
+.FileList__name-col {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .FileList__name {
   flex-grow: 1;
   text-decoration: none;
@@ -36,6 +42,6 @@ $file-list-icon-size: 24px;
   vertical-align: middle;
 }
 
-.FileList__date {
+.FileList__date-col {
   padding-right: 10px;
 }

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -15,6 +15,7 @@ $table-icon-size: 24px;
   border-collapse: collapse;
   width: 100%;
   font-size: $normal-font-size;
+  table-layout: fixed;
 }
 
 .Table__head {


### PR DESCRIPTION
Fix an issue with long file names in the new file picker, and update the cursor for buttons for consistency with the h website and client.

**Before:**

<img width="619" alt="Screenshot 2019-05-16 17 46 31" src="https://user-images.githubusercontent.com/2458/57872064-ca407380-7802-11e9-907a-9f6815b7f7d7.png">

**After:**

<img width="582" alt="Screenshot 2019-05-17 13 42 29" src="https://user-images.githubusercontent.com/2458/57929023-227e8080-78aa-11e9-8852-247713c26d3d.png">
