### PR TITLE
Replace the fake public URL API with a real one

### DIFF
--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -13,7 +13,7 @@ class CanvasAPIHelper:
 
     A lot of working with the Canvas API is generating correct values. For
     example generating the token endpoint URL for the right Canvas instance, or
-    generating an access token request with the right URL, HTTP verb
+    generating an access token request with the right URL, HTTP verb and
     parameters.
 
     This helper handles generating these kinds of values so that the higher

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -115,7 +115,7 @@ class CanvasAPIHelper:
         :type access_token: str
 
         :arg file_id: the Canvas file ID of the file
-        :type course_id: str
+        :type file_id: str
 
         :rtype: requests.PreparedRequest
         """

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -100,6 +100,31 @@ class CanvasAPIHelper:
             headers={"Authorization": f"Bearer {access_token}"},
         ).prepare()
 
+    def public_url_request(self, access_token, file_id):
+        """
+        Return a prepared public URL request.
+
+        Return a server-to-server request to Canvas's file public URL API that
+        gets a public download URL for the file with ID ``file_id``.
+
+        For documentation of this request see:
+
+        https://canvas.instructure.com/doc/api/files.html#method.files.public_url
+
+        :arg access_token: the access token to authenticate the request with
+        :type access_token: str
+
+        :arg file_id: the Canvas file ID of the file
+        :type course_id: str
+
+        :rtype: requests.PreparedRequest
+        """
+        return requests.Request(
+            "GET",
+            self._public_url(file_id),
+            headers={"Authorization": f"Bearer {access_token}"},
+        ).prepare()
+
     @property
     def _token_url(self):
         """Return the URL of the Canvas API's token endpoint."""
@@ -114,6 +139,19 @@ class CanvasAPIHelper:
                 f"/api/v1/courses/{course_id}/files",
                 "",
                 urlencode({"content_types[]": "application/pdf", "per_page": 100}),
+                "",
+            )
+        )
+
+    def _public_url(self, file_id):
+        """Return a URL for Canvas's file public URL API."""
+        return urlunparse(
+            (
+                "https",
+                self._canvas_url,
+                f"/api/v1/files/{file_id}/public_url",
+                "",
+                "",
                 "",
             )
         )

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -46,16 +46,8 @@ class CanvasAPIHelper:
         """Return the URL of the Canvas API's token endpoint."""
         return urlunparse(("https", self._canvas_url, "login/oauth2/token", "", "", ""))
 
-    def list_files_url(self, course_id):
-        """
-        Return a Canvas list files API URL for ``course_id``.
-
-        This is the API that returns a list of all the files in a course. See:
-
-        https://canvas.instructure.com/doc/api/files.html#method.files.api_index
-
-        :rtype: str
-        """
+    def _list_files_url(self, course_id):
+        """Return the Canvas list files API URL for ``course_id``."""
         return urlunparse(
             (
                 "https",
@@ -126,6 +118,6 @@ class CanvasAPIHelper:
         """
         return requests.Request(
             "GET",
-            self.list_files_url(course_id),
+            self._list_files_url(course_id),
             headers={"Authorization": f"Bearer {access_token}"},
         ).prepare()

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -21,6 +21,12 @@ class CanvasAPIHelper:
 
     Objects of this class are immutable, and none of their properties or
     methods have any side effects.
+
+    Many of the returned values are :class:`requests.PreparedRequest` objects.
+    These are HTTP requests prepared with the right URL, headers and params.
+    They can be sent like this::
+
+        >>> response = requests.Session().send(prepared_request)
     """
 
     def __init__(self, consumer_key, ai_getter, route_url):
@@ -45,13 +51,8 @@ class CanvasAPIHelper:
         """
         Return a prepared access token request.
 
-        Return a prepared request object that, when sent, will make a
-        server-to-server request to the Canvas API's token endpoint in order to
-        exchange ``authorization_code`` for an access token.
-
-        The request can be sent like this::
-
-            >>> response = requests.Session().send(request)
+        Return a server-to-server request to the Canvas API's token endpoint
+        that exchanges ``authorization_code`` for an access token.
 
         For documentation of this request see:
 
@@ -78,13 +79,8 @@ class CanvasAPIHelper:
         """
         Return a prepared list files request.
 
-        The returned request, when sent, will make a server-to-server request
-        to Canvas's list files API to get a list of the files belonging to
-        ``course_id``.
-
-        The request can be sent like this::
-
-            >>> response = requests.Session().send(request)
+        Return a server-to-server request to Canvas's list files API that gets
+        a list of the files belonging to ``course_id``.
 
         For documentation of this request see:
 

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -42,17 +42,8 @@ class CanvasAPIHelper:
         self._redirect_uri = route_url("canvas_oauth_callback")
 
     @property
-    def token_url(self):
-        """
-        Return the URL of the Canvas API's token endpoint.
-
-        This is the OAuth 2.0 endpoint that you post an authorization code to
-        in order to get an access token. See:
-
-        https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#post-login-oauth2-token
-
-        :rtype: str
-        """
+    def _token_url(self):
+        """Return the URL of the Canvas API's token endpoint."""
         return urlunparse(("https", self._canvas_url, "login/oauth2/token", "", "", ""))
 
     def list_files_url(self, course_id):
@@ -99,7 +90,7 @@ class CanvasAPIHelper:
         """
         return requests.Request(
             "POST",
-            self.token_url,
+            self._token_url,
             params={
                 "grant_type": "authorization_code",
                 "client_id": self._client_id,

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -41,24 +41,6 @@ class CanvasAPIHelper:
         self._canvas_url = urlparse(ai_getter.lms_url(consumer_key)).netloc
         self._redirect_uri = route_url("canvas_oauth_callback")
 
-    @property
-    def _token_url(self):
-        """Return the URL of the Canvas API's token endpoint."""
-        return urlunparse(("https", self._canvas_url, "login/oauth2/token", "", "", ""))
-
-    def _list_files_url(self, course_id):
-        """Return the Canvas list files API URL for ``course_id``."""
-        return urlunparse(
-            (
-                "https",
-                self._canvas_url,
-                f"/api/v1/courses/{course_id}/files",
-                "",
-                urlencode({"content_types[]": "application/pdf", "per_page": 100}),
-                "",
-            )
-        )
-
     def access_token_request(self, authorization_code):
         """
         Return a prepared access token request.
@@ -121,3 +103,21 @@ class CanvasAPIHelper:
             self._list_files_url(course_id),
             headers={"Authorization": f"Bearer {access_token}"},
         ).prepare()
+
+    @property
+    def _token_url(self):
+        """Return the URL of the Canvas API's token endpoint."""
+        return urlunparse(("https", self._canvas_url, "login/oauth2/token", "", "", ""))
+
+    def _list_files_url(self, course_id):
+        """Return the Canvas list files API URL for ``course_id``."""
+        return urlunparse(
+            (
+                "https",
+                self._canvas_url,
+                f"/api/v1/courses/{course_id}/files",
+                "",
+                urlencode({"content_types[]": "application/pdf", "per_page": 100}),
+                "",
+            )
+        )

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -99,6 +99,30 @@ class CanvasAPIClient:
 
         return [present_file(file_dict) for file_dict in list_files_response.json()]
 
+    def public_url(self, file_id):
+        """
+        Return a new public download URL for the file with the given ID.
+
+        Send an HTTP request to the Canvas API to get a new temporary public
+        download URL, and return the URL.
+
+        :arg file_id: the ID of the Canvas file
+        :type file_id: str
+
+        :rtype: str
+        """
+        public_url_request = self._helper.public_url_request(
+            self._access_token, file_id
+        )
+        public_url_response = requests.Session().send(public_url_request)
+
+        # TODO: Validate public_url_response
+        # TODO: Handle Canvas public URL API error responses (for example an
+        #       authorization error might require us to refresh the access
+        #       token and try again)
+
+        return public_url_response.json()["public_url"]
+
     @property
     def _access_token(self):
         """Return the user's saved access token from the DB."""

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -80,18 +80,9 @@ class CanvasAPIClient:
 
         :rtype: list(dict)
         """
-        # TODO: Handle the case where we don't have an access token yet
-        access_token = (
-            self._db.query(OAuth2Token)
-            .filter_by(
-                consumer_key=self._lti_user.oauth_consumer_key,
-                user_id=self._lti_user.user_id,
-            )
-            .one()
-            .access_token
+        list_files_request = self._helper.list_files_request(
+            self._access_token, course_id
         )
-
-        list_files_request = self._helper.list_files_request(access_token, course_id)
         list_files_response = requests.Session().send(list_files_request)
 
         # TODO: Validate list_files_response
@@ -107,3 +98,17 @@ class CanvasAPIClient:
             }
 
         return [present_file(file_dict) for file_dict in list_files_response.json()]
+
+    @property
+    def _access_token(self):
+        """Return the user's saved access token from the DB."""
+        # TODO: Handle the case where we don't have an access token yet
+        return (
+            self._db.query(OAuth2Token)
+            .filter_by(
+                consumer_key=self._lti_user.oauth_consumer_key,
+                user_id=self._lti_user.user_id,
+            )
+            .one()
+            .access_token
+        )

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -44,9 +44,10 @@ class FilesAPIViews:
         return self.canvas_api_client.list_files(self.request.matchdict["course_id"])
 
     @view_config(request_method="GET", route_name="canvas_api.files.public_url")
-    def public_url(self):  # pylint:disable=no-self-use
+    def public_url(self):
         """Return the public URL of the given file."""
-        # TODO: Replace the hardcoded URL with a real one received from Canvas.
         return {
-            "public_url": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+            "public_url": self.canvas_api_client.public_url(
+                self.request.matchdict["file_id"]
+            )
         }

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -29,31 +29,24 @@ proxy API caller::
                       |Real Canvas API|
                       +---------------+
 """
-from pyramid.view import view_config
+from pyramid.view import view_config, view_defaults
 
 
-@view_config(
-    permission="canvas_api",
-    renderer="json",
-    request_method="GET",
-    route_name="canvas_api.courses.files.list",
-)
-def list_files(request):
-    """Return the list of files in the given course."""
-    course_id = request.matchdict["course_id"]
-    canvas_api_client = request.find_service(name="canvas_api_client")
-    return canvas_api_client.list_files(course_id)
+@view_defaults(permission="canvas_api", renderer="json")
+class FilesAPIViews:
+    def __init__(self, request):
+        self.request = request
+        self.canvas_api_client = request.find_service(name="canvas_api_client")
 
+    @view_config(request_method="GET", route_name="canvas_api.courses.files.list")
+    def list_files(self):
+        """Return the list of files in the given course."""
+        return self.canvas_api_client.list_files(self.request.matchdict["course_id"])
 
-@view_config(
-    permission="canvas_api",
-    renderer="json",
-    request_method="GET",
-    route_name="canvas_api.files.public_url",
-)
-def public_url(_request):
-    """Return the public URL of the given file."""
-    # TODO: Replace the hardcoded URL with a real one received from Canvas.
-    return {
-        "public_url": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
-    }
+    @view_config(request_method="GET", route_name="canvas_api.files.public_url")
+    def public_url(self):  # pylint:disable=no-self-use
+        """Return the public URL of the given file."""
+        # TODO: Replace the hardcoded URL with a real one received from Canvas.
+        return {
+            "public_url": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+        }

--- a/tests/lms/services/_helpers/canvas_api_test.py
+++ b/tests/lms/services/_helpers/canvas_api_test.py
@@ -4,19 +4,6 @@ from lms.services._helpers.canvas_api import CanvasAPIHelper
 
 
 class TestCanvasAPIHelper:
-    def test_list_files_url(self, ai_getter, route_url):
-        helper = CanvasAPIHelper("test_consumer_key", ai_getter, route_url)
-
-        list_files_url = helper.list_files_url("test_course_id")
-
-        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
-        assert (
-            list_files_url
-            == "https://my-canvas-instance.com/api/v1/courses/test_course_id/files"
-            "?content_types%5B%5D=application%2Fpdf"
-            "&per_page=100"
-        )
-
     def test_access_token_request(self, ai_getter, route_url):
         helper = CanvasAPIHelper("test_consumer_key", ai_getter, route_url)
 

--- a/tests/lms/services/_helpers/canvas_api_test.py
+++ b/tests/lms/services/_helpers/canvas_api_test.py
@@ -11,6 +11,7 @@ class TestCanvasAPIHelper:
 
         ai_getter.developer_key.assert_called_once_with("test_consumer_key")
         ai_getter.developer_secret.assert_called_once_with("test_consumer_key")
+        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
         assert request.method == "POST"
         assert request.url == (
             "https://my-canvas-instance.com/login/oauth2/token"
@@ -26,6 +27,7 @@ class TestCanvasAPIHelper:
 
         request = helper.list_files_request("test_access_token", "test_course_id")
 
+        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
         assert request.method == "GET"
         assert request.url == (
             "https://my-canvas-instance.com/api/v1/courses/test_course_id/files"

--- a/tests/lms/services/_helpers/canvas_api_test.py
+++ b/tests/lms/services/_helpers/canvas_api_test.py
@@ -36,6 +36,18 @@ class TestCanvasAPIHelper:
             "&per_page=100"
         )
 
+    def test_public_url_request(self, ai_getter, route_url):
+        helper = CanvasAPIHelper("test_consumer_key", ai_getter, route_url)
+
+        request = helper.public_url_request("test_access_token", "test_file_id")
+
+        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
+        assert request.method == "GET"
+        assert request.headers["Authorization"] == "Bearer test_access_token"
+        assert request.url == (
+            "https://my-canvas-instance.com/api/v1/files/test_file_id/public_url"
+        )
+
     @pytest.fixture
     def ai_getter(self, ai_getter):
         ai_getter.developer_key.return_value = "test_developer_key"

--- a/tests/lms/services/_helpers/canvas_api_test.py
+++ b/tests/lms/services/_helpers/canvas_api_test.py
@@ -29,6 +29,7 @@ class TestCanvasAPIHelper:
 
         ai_getter.lms_url.assert_called_once_with("test_consumer_key")
         assert request.method == "GET"
+        assert request.headers["Authorization"] == "Bearer test_access_token"
         assert request.url == (
             "https://my-canvas-instance.com/api/v1/courses/test_course_id/files"
             "?content_types%5B%5D=application%2Fpdf"

--- a/tests/lms/services/_helpers/canvas_api_test.py
+++ b/tests/lms/services/_helpers/canvas_api_test.py
@@ -4,14 +4,6 @@ from lms.services._helpers.canvas_api import CanvasAPIHelper
 
 
 class TestCanvasAPIHelper:
-    def test_token_url(self, ai_getter, route_url):
-        helper = CanvasAPIHelper("test_consumer_key", ai_getter, route_url)
-
-        token_url = helper.token_url
-
-        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
-        assert token_url == "https://my-canvas-instance.com/login/oauth2/token"
-
     def test_list_files_url(self, ai_getter, route_url):
         helper = CanvasAPIHelper("test_consumer_key", ai_getter, route_url)
 

--- a/tests/lms/services/canvas_api_test.py
+++ b/tests/lms/services/canvas_api_test.py
@@ -161,7 +161,7 @@ class TestCanvasAPIClient:
     def test_public_url_returns_the_public_url(self, canvas_api_client):
         assert (
             canvas_api_client.public_url("test_file_id")
-            == "https://my-canvas-instance.com/files/1/download"
+            == "https://example-bucket.s3.amazonaws.com/example-namespace/attachments/1/example-filename?AWSAccessKeyId=example-key&Expires=1400000000&Signature=example-signature"
         )
 
     @pytest.fixture
@@ -289,7 +289,7 @@ class TestCanvasAPIClient:
     def public_url_response(self, requests):
         """Configure requests to send back public URL responses."""
         public_url_response = {
-            "public_url": "https://my-canvas-instance.com/files/1/download"
+            "public_url": "https://example-bucket.s3.amazonaws.com/example-namespace/attachments/1/example-filename?AWSAccessKeyId=example-key&Expires=1400000000&Signature=example-signature"
         }
         requests.Session.return_value.send.return_value.json.return_value = (
             public_url_response

--- a/tests/lms/views/api/canvas/files_test.py
+++ b/tests/lms/views/api/canvas/files_test.py
@@ -25,13 +25,22 @@ class TestListFiles:
 
 
 class TestPublicURL:
-    def test_it_returns_the_public_url(self, pyramid_request):
+    def test_it_gets_the_public_url_from_canvas(
+        self, canvas_api_client, pyramid_request
+    ):
+        FilesAPIViews(pyramid_request).public_url()
+
+        canvas_api_client.public_url.assert_called_once_with("test_file_id")
+
+    def test_it_returns_the_public_url(self, canvas_api_client, pyramid_request):
         data = FilesAPIViews(pyramid_request).public_url()
 
-        assert (
-            data["public_url"]
-            == "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
-        )
+        assert data["public_url"] == canvas_api_client.public_url.return_value
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.matchdict = {"file_id": "test_file_id"}
+        return pyramid_request
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lms/views/api/canvas/files_test.py
+++ b/tests/lms/views/api/canvas/files_test.py
@@ -2,27 +2,21 @@ import pytest
 from unittest import mock
 
 from lms.services.canvas_api import CanvasAPIClient
-from lms.views.api.canvas.files import list_files, public_url
+from lms.views.api.canvas.files import FilesAPIViews
 
 
 class TestListFiles:
     def test_it_gets_the_list_of_files_from_canvas(
         self, canvas_api_client, pyramid_request
     ):
-        list_files(pyramid_request)
+        FilesAPIViews(pyramid_request).list_files()
 
         canvas_api_client.list_files.assert_called_once_with("test_course_id")
 
     def test_it_returns_the_list_of_files(self, canvas_api_client, pyramid_request):
-        list_files(pyramid_request) == canvas_api_client.list_files.return_value
-
-    @pytest.fixture(autouse=True)
-    def canvas_api_client(self, pyramid_config):
-        canvas_api_client = mock.create_autospec(
-            CanvasAPIClient, spec_set=True, instance=True
-        )
-        pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
-        return canvas_api_client
+        FilesAPIViews(
+            pyramid_request
+        ).list_files() == canvas_api_client.list_files.return_value
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -32,9 +26,18 @@ class TestListFiles:
 
 class TestPublicURL:
     def test_it_returns_the_public_url(self, pyramid_request):
-        data = public_url(pyramid_request)
+        data = FilesAPIViews(pyramid_request).public_url()
 
         assert (
             data["public_url"]
             == "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
         )
+
+
+@pytest.fixture(autouse=True)
+def canvas_api_client(pyramid_config):
+    canvas_api_client = mock.create_autospec(
+        CanvasAPIClient, spec_set=True, instance=True
+    )
+    pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
+    return canvas_api_client


### PR DESCRIPTION
As with the other Canvas proxy APIs there's no error handling yet.

There are several individual refactoring commits first, and then the final commit does all the work of replacing the API.

Usage:

```
$ http GET "http://localhost:8001/api/canvas/files/180/public_url" Authorization:"Bearer ***"
HTTP/1.1 200 OK
Connection: close
Content-Length: 607
Content-Type: application/json

{
    "public_url": "https://instructure-uploads.s3.amazonaws.com/***"
}
```