### PR TITLE
Read authorization param from form fields

### DIFF
--- a/lms/validation/_bearer_token.py
+++ b/lms/validation/_bearer_token.py
@@ -97,10 +97,12 @@ class BearerTokenSchema(marshmallow.Schema):
         authorization param, decodes the JWT, validates the JWT's payload, and
         returns an :class:`~lms.values.LTIUser` from the payload.
 
-        The authorization param must be in an HTTP header
-        ``Authorization: Bearer <ENCODED_JWT>`` in the request. In the future
-        we may add support for reading the authorization param from other parts
-        of the request, such as from form fields or JSON parameters.
+        The authorization param can be in an HTTP header
+        ``Authorization: Bearer <ENCODED_JWT>``, in a query string parameter
+        ``?authorization=Bearer%20<ENCODED_JWT>``, or in a form field
+        ``authorization=Bearer+<ENCODED_JWT>``. In the future we may add
+        support for reading the authorization param from other parts of the
+        request, such as from JSON body fields.
 
         :raise ExpiredSessionTokenError: if the request's Authorization header
           contains an expired JWT
@@ -117,7 +119,7 @@ class BearerTokenSchema(marshmallow.Schema):
         """
         try:
             return parser.parse(
-                self, self._request, locations=["headers", "querystring"]
+                self, self._request, locations=["headers", "querystring", "form"]
             )
         except HTTPUnprocessableEntity as error:
             try:


### PR DESCRIPTION
Support reading authorization JWTs from form fields, as well as from
headers and query strings.

We'll need this in future as we're going to have a need for
authenticating form submissions (and using a form field seems nicer than
a query string on the form's `action` URL).

I didn't add a test for this because I couldn't find a way to create a
test that would fail if only "querystring" (and not "form") was in the
`locations=[...]` list and then would pass when "form" was added. Adding
the `authorization` param to the dummy request's `.params` will work
with either "querystring" or "form" or both, for example.