### PR TITLE
Add report_lti_launch view decorator

### DIFF
--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -1,9 +1,35 @@
-# -*- coding: utf-8 -*-
+"""
+Custom view decorators.
 
-"""Python decorators meant to be used for decorating Pyramid view functions."""
+These are Pyramid view decorators, to be used with the ``decorators`` view
+config parameter. For example:
 
+    @view_config(
+        ...,
+        decorator=[
+            "lms.views.decorators.decorator_2",
+            "lms.views.decorators.decorator_1",
+        ]
+    )
+    def my_view(context, request):
+        ...
+
+For documentation see:
+
+https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#non-predicate-arguments
+"""
 from lms.views.decorators.h_api import upsert_h_user
 from lms.views.decorators.h_api import create_course_group
 from lms.views.decorators.h_api import add_user_to_group
+from lms.views.decorators.reports import report_lti_launch
 
-__all__ = ("upsert_h_user", "create_course_group", "add_user_to_group")
+__all__ = (
+    "report_lti_launch",
+    # Legacy view decorators. These are used as normal Python @decorators
+    # applied directly to the view function, rather than with Pyramid's
+    # decorators= view config parameter. See the docstring in
+    # lms/views/decorators/h_api.py for details.
+    "upsert_h_user",
+    "create_course_group",
+    "add_user_to_group",
+)

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """View decorators for working with the h API."""
 
 import functools

--- a/lms/views/decorators/reports.py
+++ b/lms/views/decorators/reports.py
@@ -1,0 +1,24 @@
+"""View decorators for reporting to the ``/reports`` page."""
+import datetime
+
+from lms.models.lti_launches import LtiLaunches
+
+
+def report_lti_launch(wrapped):
+    """
+    Report an LTI launch to the ``/reports`` page.
+
+    This decorator assumes that it's only used on LTI launch views.
+    """
+
+    def wrapper(context, request):
+        request.db.add(
+            LtiLaunches(
+                context_id=request.params.get("context_id"),
+                lti_key=request.params.get("oauth_consumer_key"),
+                created=datetime.datetime.utcnow(),
+            )
+        )
+        return wrapped(context, request)
+
+    return wrapper

--- a/tests/lms/views/decorators/reports_test.py
+++ b/tests/lms/views/decorators/reports_test.py
@@ -1,0 +1,40 @@
+from unittest import mock
+
+import pytest
+from pyramid.testing import DummyRequest
+
+from lms.models.lti_launches import LtiLaunches
+from lms.views.decorators.reports import report_lti_launch
+
+
+class TestReportLTILaunch:
+    def test_it_adds_an_lti_launch_record_to_the_db(self, pyramid_request, wrapped):
+        report_lti_launch(wrapped)(mock.sentinel.context, pyramid_request)
+
+        lti_launch = pyramid_request.db.query(LtiLaunches).one()
+        assert lti_launch.context_id == "TEST_CONTEXT_ID"
+        assert lti_launch.lti_key == "TEST_OAUTH_CONSUMER_KEY"
+
+    def test_it_calls_the_decorated_view(self, pyramid_request, wrapped):
+        result = report_lti_launch(wrapped)(mock.sentinel.context, pyramid_request)
+
+        wrapped.assert_called_once_with(mock.sentinel.context, pyramid_request)
+        assert result == wrapped.return_value
+
+    @pytest.fixture
+    def pyramid_request(self):
+        return DummyRequest(
+            params={
+                "context_id": "TEST_CONTEXT_ID",
+                "oauth_consumer_key": "TEST_OAUTH_CONSUMER_KEY",
+            }
+        )
+
+    @pytest.fixture
+    def wrapped(self):
+        """The wrapped view callable."""
+
+        def view_callable_spec(context, request):
+            """Spec for the mock view callable."""
+
+        return mock.create_autospec(view_callable_spec, spec_set=True)


### PR DESCRIPTION
This can be added to LTI launch views like so:

    @view_config(
        decorator="lms.views.decorators.report_lti_launch",
        ...
    )
    def my_lti_launch_view(context, request):

For details see the decorator parameter documented here:

https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html?highlight=decorator#non-predicate-arguments

It will add a row to the `lti_launches` DB table each time the view is
called. Rows from this table are the data used by the `/reports` page.

New views will use this instead of a helper function that the legacy
views used to append to the same table:

https://github.com/hypothesis/lms/blob/d06cae8bb0778867588c3f7e95c2050385a8776d/lms/views/lti_launches.py#L80-L93

Nothing uses the new view decorator yet.