### PR TITLE
Launch views refactor 1/n: Add LTI launch view predicates

### DIFF
--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 def includeme(config):
     config.scan(__name__)
+    config.include("lms.views.predicates")

--- a/lms/views/predicates/__init__.py
+++ b/lms/views/predicates/__init__.py
@@ -1,0 +1,34 @@
+"""
+Custom Pyramid view predicates.
+
+See:
+
+https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#view-and-route-predicates
+"""
+from lms.views.predicates._lti_launch import (
+    DBConfigured,
+    CanvasFile,
+    URLConfigured,
+    Configured,
+    AuthorizedToConfigureAssignments,
+)
+
+
+__all__ = [
+    "DBConfigured",
+    "CanvasFile",
+    "URLConfigured",
+    "Configured",
+    "AuthorizedToConfigureAssignments",
+]
+
+
+def includeme(config):
+    for view_predicate_factory in (
+        DBConfigured,
+        CanvasFile,
+        URLConfigured,
+        Configured,
+        AuthorizedToConfigureAssignments,
+    ):
+        config.add_view_predicate(view_predicate_factory.name, view_predicate_factory)

--- a/lms/views/predicates/_helpers.py
+++ b/lms/views/predicates/_helpers.py
@@ -1,0 +1,43 @@
+"""Private helpers for view predicates."""
+from abc import ABCMeta, abstractmethod, abstractproperty
+
+
+__all__ = ["Base"]
+
+
+class Base(metaclass=ABCMeta):
+    """Abstract base class for custom view predicate classes."""
+
+    def __init__(self, value, config):
+        self.value = value
+        self.config = config
+
+    def text(self):
+        """
+        Return a string describing the behavior of this predicate.
+
+        Used by Pyramid in error messages.
+        """
+        return f"{self.name} = {self.value}"
+
+    def phash(self):
+        """
+        Return a string uniquely identifying this predicate's name and value.
+
+        Used by Pyramid for view configuration constraints handling.
+        """
+        return self.text()
+
+    @abstractproperty
+    def name(self):
+        """
+        Return the name of this predicate.
+
+        This is the string that is used as a keyword argument to Pyramid's
+        ``@view_config()`` in order to use this predicate on a view. It's also
+        used by ``text()`` and ``phash()``.
+        """
+
+    @abstractmethod
+    def __call__(self, context, request):
+        """Return ``True`` if ``request`` matches this predicate."""

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -1,0 +1,170 @@
+"""Predicates for use with LTI launch views."""
+from lms.models import ModuleItemConfiguration
+from lms.views.predicates._helpers import Base
+
+
+__all__ = [
+    "DBConfigured",
+    "CanvasFile",
+    "URLConfigured",
+    "Configured",
+    "AuthorizedToConfigureAssignments",
+]
+
+
+class DBConfigured(Base):
+    """
+    Allow invoking an LTI launch view only if the assignment is DB-configured.
+
+    Some LTI assignments are "DB-configured" meaning the assignment's
+    configuration (the URL of the document to be annotated for the assignment)
+    is stored in our own DB.
+
+    This happens with LMS's that don't support LTI "content item selection"
+    (also known as "deep linking"), so they don't support storing the
+    assignment configuration (document URL) in the LMS.
+
+    Pass ``db_configured=True`` to a view's configuration to allow invoking the
+    view only for requests whose assignment has its configuration stored in our
+    DB. Pass ``db_configured=False`` to allow invoking the view for assignments
+    that are *not* DB-configured.
+
+    For example::
+
+        @view_config(..., db_configured=True)
+        def db_configured_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "db_configured"
+
+    def __call__(self, context, request):
+        resource_link_id = request.params.get("resource_link_id")
+        tool_consumer_instance_guid = request.params.get("tool_consumer_instance_guid")
+
+        has_module_item_configuration = (
+            request.db.query(ModuleItemConfiguration)
+            .filter_by(
+                resource_link_id=resource_link_id,
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
+            )
+            .count()
+            > 0
+        )
+
+        return has_module_item_configuration == self.value
+
+
+class CanvasFile(Base):
+    """
+    Allow invoking an LTI launch view only for Canvas file assignments.
+
+    Pass ``canvas_file=True`` to a view config to allow invoking the view only
+    for Canvas file assignments, or ``canvas_file=False`` to allow it only for
+    other types of assignment. For example::
+
+        @view_config(..., canvas_file=True)
+        def canvas_file_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "canvas_file"
+
+    def __call__(self, context, request):
+        return ("canvas_file" in request.params) == self.value
+
+
+class URLConfigured(Base):
+    """
+    Allow invoking an LTI launch view only for URL-configured assignments.
+
+    "URL-configured" assignments are ones where the URL of the document to be
+    annotated (for example a public HTML or PDF URL, or a Google Drive URL) is
+    sent to us by the LMS in the ``url`` launch parameter.
+
+    This happens when the LMS supports content-item selection (a.k.a deep
+    linking) and the file to be annotated is *not* a Canvas file.
+
+    Pass ``url_configured=True`` to a view config to allow invoking the view
+    only for URL-configured assignments, or ``url_configured=False`` to allow
+    it only for non-URL-configured assignments. For example::
+
+        @view_config(..., url_configured=True)
+        def url_configured_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "url_configured"
+
+    def __call__(self, context, request):
+        return ("url" in request.params) == self.value
+
+
+class Configured(Base):
+    """
+    Allow invoking an LTI launch view only if the assignment is configured.
+
+    An *unconfigured* assignment is one for which the document URL to be
+    annotated hasn't been selected yet. Regardless of whether the selected
+    document URL is stored in the LMS or in our own DB, and regardless of what
+    kind of file the document URL locates (HTML, Canvas PDF, Google Drive,
+    ...). An unconfigured assignment is one whose document URL hasn't yet been
+    chosen by any means.
+
+    Pass ``configured=True`` to a view config to allow invoking the view only
+    for assignments that're already configured, or ``configured=False`` for
+    assignments that aren't yet configured. For example::
+
+        @view_config(..., configured=True)
+        def configured_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "configured"
+
+    def __init__(self, value, config):
+        super().__init__(value, config)
+        self.canvas_file = CanvasFile(True, config)
+        self.url_configured = URLConfigured(True, config)
+        self.db_configured = DBConfigured(True, config)
+
+    def __call__(self, context, request):
+        configured = any(
+            [
+                self.canvas_file(context, request),
+                self.url_configured(context, request),
+                self.db_configured(context, request),
+            ]
+        )
+        return configured == self.value
+
+
+class AuthorizedToConfigureAssignments(Base):
+    """
+    Allow a launch view if the user is authorized to configure assignments.
+
+    Only certain LTI users are allowed to configure assignments (to choose the
+    URL of the assignment's document). For example administrators and
+    instructors are allowed to, but learners aren't.
+
+    Pass ``authorized_to_configure_assignments=True`` to a view config to allow
+    invoking the view only if the user is authorized to configure assignments.
+    Pass ``authorized_to_configure_assignments=False`` to allow a view only for
+    users who *aren't* so authorized.
+
+    For example::
+
+        @view_config(..., authorized_to_configure_assignments=True)
+        def authorized_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "authorized_to_configure_assignments"
+
+    def __call__(self, context, request):
+        roles = request.params.get("roles", "").lower()
+        authorized = any(
+            role in roles
+            for role in ["administrator", "instructor", "teachingassistant"]
+        )
+        return authorized == self.value

--- a/tests/lms/views/predicates/_helpers_test.py
+++ b/tests/lms/views/predicates/_helpers_test.py
@@ -1,0 +1,65 @@
+import pytest
+
+from lms.views.predicates._helpers import Base
+
+
+class TestBase:
+    def test_subclasses_must_have_name(self):
+        class CustomPredicateFactory(Base):
+            def __call__(self, context, request):
+                """Does nothing."""
+
+        with pytest.raises(
+            TypeError,
+            match="Can't instantiate abstract class CustomPredicateFactory with abstract methods name",
+        ):
+            CustomPredicateFactory("test_value", "test_config")
+
+    def test_subclasses_must_have___call__(self):
+        class CustomPredicateFactory(Base):
+            name = "custom_predicate_factory"
+
+        with pytest.raises(
+            TypeError,
+            match="Can't instantiate abstract class CustomPredicateFactory with abstract methods __call__",
+        ):
+            CustomPredicateFactory("test_value", "test_config")
+
+    def test_value(self):
+        # It makes self.value available to subclasses.
+        assert (
+            CustomPredicateFactory("test_value", "test_config").get_value()
+            == "test_value"
+        )
+
+    def test_config(self):
+        # It makes self.config available to subclasses.
+        assert (
+            CustomPredicateFactory("test_value", "test_config").get_config()
+            == "test_config"
+        )
+
+    def test_text(self):
+        assert (
+            CustomPredicateFactory("test_value", "test_config").text()
+            == "custom_predicate_factory = test_value"
+        )
+
+    def test_phash(self):
+        assert (
+            CustomPredicateFactory("test_value", "test_config").phash()
+            == "custom_predicate_factory = test_value"
+        )
+
+
+class CustomPredicateFactory(Base):
+    name = "custom_predicate_factory"
+
+    def __call__(self, context, request):
+        """Does nothing."""
+
+    def get_value(self):
+        return self.value
+
+    def get_config(self):
+        return self.config

--- a/tests/lms/views/predicates/_lti_launch_test.py
+++ b/tests/lms/views/predicates/_lti_launch_test.py
@@ -1,0 +1,164 @@
+from unittest import mock
+
+from pyramid.testing import DummyRequest
+import pytest
+
+from lms.models import ModuleItemConfiguration
+from lms.views.predicates import (
+    DBConfigured,
+    CanvasFile,
+    URLConfigured,
+    Configured,
+    AuthorizedToConfigureAssignments,
+)
+
+
+class TestDBConfigured:
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_theres_a_matching_assignment_config_in_the_db(
+        self, pyramid_request, value, expected
+    ):
+        pyramid_request.params = {
+            "resource_link_id": "test_resource_link_id",
+            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
+        }
+        predicate = DBConfigured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_theres_no_matching_assignment_config_in_the_db(
+        self, pyramid_request, value, expected
+    ):
+        pyramid_request.params = {
+            "resource_link_id": "doesnt_match",
+            "tool_consumer_instance_guid": "doesnt_match",
+        }
+        predicate = DBConfigured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_request_params_are_missing(self, pyramid_request, value, expected):
+        pyramid_request.params = {}
+        predicate = DBConfigured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
+    @pytest.fixture(autouse=True)
+    def module_item_configuration(self, pyramid_request):
+        pyramid_request.db.add(
+            ModuleItemConfiguration(
+                resource_link_id="test_resource_link_id",
+                tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+                document_url="test_document_url",
+            )
+        )
+
+
+class TestCanvasFile:
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_canvas_file(self, value, expected):
+        request = DummyRequest(params={"canvas_file": 22})
+        predicate = CanvasFile(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_assignment_is_not_canvas_file(self, value, expected):
+        predicate = CanvasFile(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, DummyRequest()) is expected
+
+
+class TestURLConfigured:
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_url_configured(self, value, expected):
+        request = DummyRequest(params={"url": "https://example.com"})
+        predicate = URLConfigured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_assignment_is_not_url_configured(self, value, expected):
+        predicate = URLConfigured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, DummyRequest()) is expected
+
+
+class TestConfigured:
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_url_configured(self, pyramid_request, value, expected):
+        pyramid_request.params = {"url": "https://example.com"}
+        predicate = Configured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_canvas_file(self, pyramid_request, value, expected):
+        pyramid_request.params = {"canvas_file": 22}
+        predicate = Configured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_db_configured(self, pyramid_request, value, expected):
+        pyramid_request.db.add(
+            ModuleItemConfiguration(
+                resource_link_id="test_resource_link_id",
+                tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+                document_url="test_document_url",
+            )
+        )
+        predicate = Configured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_assignment_is_unconfigured(self, pyramid_request, value, expected):
+        pyramid_request.params = {}
+        predicate = Configured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params = {
+            "resource_link_id": "test_resource_link_id",
+            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
+        }
+        return pyramid_request
+
+
+class TestAuthorizedToConfigureAssignments:
+    @pytest.mark.parametrize(
+        "roles",
+        [
+            "administrator",
+            "Administrator",
+            "instructor",
+            "Instructor",
+            "teachingassistant",
+            "TeachingAssistant",
+            "Instructor,urn:lti:instrole:ims/lis/Administrator",
+        ],
+    )
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_user_is_authorized(self, roles, value, expected):
+        request = DummyRequest(params={"roles": roles})
+        predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_user_isnt_authorized(self, value, expected):
+        request = DummyRequest(params={"roles": "Learner"})
+        predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_theres_no_roles_param(self, value, expected):
+        predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, DummyRequest()) is expected

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ setenv =
     tests: JWT_SECRET = test_secret
     tests: VIA_URL = https://example.com/
 commands =
-    tests: coverage run --source lms,tests/lms -m pytest -Werror {posargs:tests/lms/}
+    tests: coverage run --source lms,tests/lms -m pytest -v -Werror {posargs:tests/lms/}
     dev: {posargs:gunicorn --paste conf/development.ini}
     lint: prospector
     lint: prospector tests


### PR DESCRIPTION
Add a few custom Pyramid view predicates intended to be used with future LTI launch views.

<del>I don't want to merge this quite yet until I've finished the view code that'll use it, but it can be reviewed now.</del>

Example of how these would be used to direct different `POST` requests to the same `/lti_launches` URL to different views, depending on the properties of the requests:

```python
@view_config(
    canvas_file=True,
    renderer="lms:templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2",
)
def canvas_file_basic_lti_launch(self):
    ...

@view_config(db_configured=True)
def db_configured_basic_lti_launch(self):
    ...

@view_config(url_configured=True)
def url_configured_basic_lti_launch(self):
    ...

@view_config(
    authorized_to_configure_assignments=True,
    configured=False,
    renderer="lms:templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2",
)
def unconfigured_basic_lti_launch(self):
    ...

@view_config(
    authorized_to_configure_assignments=False,
    configured=False,
    renderer="lms:templates/basic_lti_launch/unconfigured_basic_lti_launch_not_authorized.html.jinja2",
)
def unconfigured_basic_lti_launch_not_authorized(self):
    ...
```