### PR TITLE
Rename the h_api decorators to legacy_*

### DIFF
--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -7,15 +7,15 @@ from lms.util import lti_launch
 from lms.util.view_renderer import view_renderer
 from lms.util.associate_user import associate_user
 from lms.util.authorize_lms import authorize_lms
-from lms.views.decorators import upsert_h_user
-from lms.views.decorators import create_course_group
+from lms.views.decorators import legacy_upsert_h_user
+from lms.views.decorators import legacy_create_course_group
 from lms.views.helpers import canvas_files_available
 
 
 @view_config(route_name="content_item_selection", request_method="POST")
 @lti_launch
-@upsert_h_user
-@create_course_group
+@legacy_upsert_h_user
+@legacy_create_course_group
 @associate_user
 @authorize_lms(
     authorization_base_endpoint="login/oauth2/auth",

--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -18,18 +18,19 @@ For documentation see:
 
 https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#non-predicate-arguments
 """
-from lms.views.decorators.h_api import upsert_h_user
-from lms.views.decorators.h_api import create_course_group
-from lms.views.decorators.h_api import add_user_to_group
 from lms.views.decorators.reports import report_lti_launch
+
+from lms.views.decorators.legacy_h_api import legacy_upsert_h_user
+from lms.views.decorators.legacy_h_api import legacy_create_course_group
+from lms.views.decorators.legacy_h_api import legacy_add_user_to_group
 
 __all__ = (
     "report_lti_launch",
     # Legacy view decorators. These are used as normal Python @decorators
     # applied directly to the view function, rather than with Pyramid's
     # decorators= view config parameter. See the docstring in
-    # lms/views/decorators/h_api.py for details.
-    "upsert_h_user",
-    "create_course_group",
-    "add_user_to_group",
+    # lms/views/decorators/legacy_h_api.py for details.
+    "legacy_upsert_h_user",
+    "legacy_create_course_group",
+    "legacy_add_user_to_group",
 )

--- a/lms/views/decorators/legacy_h_api.py
+++ b/lms/views/decorators/legacy_h_api.py
@@ -7,7 +7,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 from lms.services import HAPINotFoundError
 
 
-def upsert_h_user(wrapped):  # noqa: MC0001
+def legacy_upsert_h_user(wrapped):  # noqa: MC0001
     """
     Update or create a Hypothesis LTI user.
 
@@ -18,7 +18,7 @@ def upsert_h_user(wrapped):  # noqa: MC0001
     The wrapped view must take ``request`` and ``jwt`` arguments::
 
       @view_config(...)
-      @upsert_h_user
+      @legacy_upsert_h_user
       def my_view(request, jwt):
           ...
 
@@ -78,7 +78,7 @@ def upsert_h_user(wrapped):  # noqa: MC0001
     return wrapper
 
 
-def create_course_group(wrapped):
+def legacy_create_course_group(wrapped):
     """
     Create a Hypothesis group for the LTI course, if one doesn't exist already.
 
@@ -95,7 +95,7 @@ def create_course_group(wrapped):
     The decorated view must take ``request`` and ``jwt`` arguments::
 
       @view_config(...)
-      @create_course_group
+      @legacy_create_course_group
       def my_view(request, jwt):
           ...
 
@@ -125,7 +125,7 @@ def create_course_group(wrapped):
     return wrapper
 
 
-def add_user_to_group(wrapped):
+def legacy_add_user_to_group(wrapped):
     @functools.wraps(wrapped)
     def wrapper(request, jwt, context=None):
         context = context or request.context

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -14,9 +14,9 @@ from lms.util.canvas_api import CanvasApi, GET
 from lms.util.authorize_lms import authorize_lms, save_token
 from lms.util import via_url
 from lms.models.tokens import find_token_by_user_id
-from lms.views.decorators import upsert_h_user
-from lms.views.decorators import create_course_group
-from lms.views.decorators import add_user_to_group
+from lms.views.decorators import legacy_upsert_h_user
+from lms.views.decorators import legacy_create_course_group
+from lms.views.decorators import legacy_add_user_to_group
 
 
 def can_configure_module_item(roles):
@@ -204,9 +204,9 @@ def should_launch(request):
 
 @view_config(route_name="lti_launches", request_method="POST")
 @lti_launch
-@upsert_h_user
-@create_course_group
-@add_user_to_group
+@legacy_upsert_h_user
+@legacy_create_course_group
+@legacy_add_user_to_group
 @associate_user
 @authorize_lms(
     authorization_base_endpoint="login/oauth2/auth",

--- a/tests/lms/views/decorators/legacy_h_api_test.py
+++ b/tests/lms/views/decorators/legacy_h_api_test.py
@@ -9,7 +9,7 @@ from requests import Response
 
 from lms.services import HAPIError
 from lms.services import HAPINotFoundError
-from lms.views.decorators import h_api
+from lms.views.decorators import legacy_h_api
 from lms.services.hapi import HypothesisAPIService
 from lms.config.resources import LTILaunch
 
@@ -122,7 +122,7 @@ class TestUpsertHUser:
     @pytest.fixture
     def upsert_h_user(self, wrapped):
         # Return the actual wrapper function so that tests can call it directly.
-        return h_api.upsert_h_user(wrapped)
+        return legacy_h_api.legacy_upsert_h_user(wrapped)
 
 
 @pytest.mark.usefixtures("hapi_svc")
@@ -206,7 +206,7 @@ class TestCreateCourseGroup:
     @pytest.fixture
     def create_course_group(self, wrapped):
         # Return the actual wrapper function so that tests can call it directly.
-        return h_api.create_course_group(wrapped)
+        return legacy_h_api.legacy_create_course_group(wrapped)
 
 
 @pytest.mark.usefixtures("hapi_svc")
@@ -258,7 +258,7 @@ class TestAddUserToGroup:
     @pytest.fixture
     def add_user_to_group(self, wrapped):
         # Return the actual wrapper function so that tests can call it directly.
-        return h_api.add_user_to_group(wrapped)
+        return legacy_h_api.legacy_add_user_to_group(wrapped)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
New versions of these decorators are going to be made that work as proper Pyramid view decorators, and these now `legacy_*` ones will eventually be deleted.