### PR TITLE
Add new h_api view decorators

### DIFF
--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -18,6 +18,9 @@ For documentation see:
 
 https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#non-predicate-arguments
 """
+from lms.views.decorators.h_api import upsert_h_user
+from lms.views.decorators.h_api import upsert_course_group
+from lms.views.decorators.h_api import add_user_to_group
 from lms.views.decorators.reports import report_lti_launch
 
 from lms.views.decorators.legacy_h_api import legacy_upsert_h_user
@@ -25,6 +28,9 @@ from lms.views.decorators.legacy_h_api import legacy_create_course_group
 from lms.views.decorators.legacy_h_api import legacy_add_user_to_group
 
 __all__ = (
+    "upsert_h_user",
+    "upsert_course_group",
+    "add_user_to_group",
     "report_lti_launch",
     # Legacy view decorators. These are used as normal Python @decorators
     # applied directly to the view function, rather than with Pyramid's

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -1,0 +1,126 @@
+"""View decorators for working with the h API."""
+
+import functools
+
+from pyramid.httpexceptions import HTTPBadRequest
+
+from lms.services import HAPINotFoundError
+
+
+__all__ = ["upsert_h_user", "upsert_course_group", "add_user_to_group"]
+
+
+def upsert_h_user(wrapped):
+    """
+    Create or update the Hypothesis user for the request's LTI user.
+
+    Update the h user's information from LTI data. If the user doesn't exist
+    yet, call the h API to create one.
+
+    Assumes that it's only used on LTI launch views.
+    """
+
+    @functools.wraps(wrapped)
+    def wrapper(context, request):
+        if not context.provisioning_enabled:
+            return wrapped(context, request)
+
+        hapi_svc = request.find_service(name="hapi")
+
+        user_data = {
+            "username": context.h_username,
+            "display_name": context.h_display_name,
+            "authority": request.registry.settings["h_authority"],
+            "identities": [
+                {
+                    "provider": context.h_provider,
+                    "provider_unique_id": context.h_provider_unique_id,
+                }
+            ],
+        }
+
+        try:
+            hapi_svc.patch(
+                f"users/{context.h_username}", {"display_name": context.h_display_name}
+            )
+        except HAPINotFoundError:
+            # Call the h API to create the user in h if it doesn't exist already.
+            hapi_svc.post("users", user_data)
+
+        return wrapped(context, request)
+
+    return wrapper
+
+
+def upsert_course_group(wrapped):
+    """
+    Create or update the Hypothesis group for the request's LTI course.
+
+    Call the h API to create a group for the LTI course, if one doesn't exist
+    already.
+
+    Groups can only be created if the LTI user is allowed to create Hypothesis
+    groups (for example instructors are allowed to create groups). If the group
+    for the course hasn't been created yet, and if the user isn't allowed to
+    create groups (e.g. if they're just a student) then show an error page
+    instead of continuing with the LTI launch.
+
+    Assumes that it's only used on LTI launch views.
+    """
+
+    @functools.wraps(wrapped)
+    def wrapper(context, request):
+        if not context.provisioning_enabled:
+            return wrapped(context, request)
+
+        hapi_svc = request.find_service(name="hapi")
+
+        is_instructor = any(
+            role in request.params["roles"].lower()
+            for role in ("administrator", "instructor", "teachingassisstant")
+        )
+
+        try:
+            hapi_svc.patch(
+                f"groups/{context.h_groupid}", {"name": context.h_group_name}
+            )
+        except HAPINotFoundError:
+            # The group hasn't been created in h yet.
+            if is_instructor:
+                # Try to create the group with the current instructor as its creator.
+                hapi_svc.put(
+                    f"groups/{context.h_groupid}",
+                    {"groupid": context.h_groupid, "name": context.h_group_name},
+                    context.h_userid,
+                )
+            else:
+                raise HTTPBadRequest("Instructor must launch assignment first.")
+        return wrapped(context, request)
+
+    return wrapper
+
+
+def add_user_to_group(wrapped):
+    """
+    Add the Hypothesis user to the course group.
+
+    Add the Hypothesis user corresponding to the current request's LTI user, to
+    the Hypothesis group corresponding to the current request's LTI course.
+
+    Assumes that the Hypothesis user and group have already been created.
+
+    Assumes that it's only used on LTI launch views.
+    """
+
+    @functools.wraps(wrapped)
+    def wrapper(context, request):
+        if not context.provisioning_enabled:
+            return wrapped(context, request)
+
+        request.find_service(name="hapi").post(
+            f"groups/{context.h_groupid}/members/{context.h_userid}"
+        )
+
+        return wrapped(context, request)
+
+    return wrapper

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -1,0 +1,310 @@
+from unittest import mock
+import pytest
+
+from pyramid.httpexceptions import HTTPBadRequest
+
+from requests import Response
+
+from lms.services import HAPIError
+from lms.services import HAPINotFoundError
+from lms.views.decorators import h_api
+from lms.services.hapi import HypothesisAPIService
+from lms.config.resources import LTILaunch
+
+
+@pytest.mark.usefixtures("hapi_svc")
+class TestUpsertHUser:
+    def test_it_invokes_patch_for_user_update(
+        self, upsert_h_user, context, pyramid_request, hapi_svc
+    ):
+
+        upsert_h_user(context, pyramid_request)
+
+        hapi_svc.patch.assert_called_once_with(
+            "users/test_username", {"display_name": "test_display_name"}
+        )
+
+    def test_it_raises_if_patch_raises_unexpected_error(
+        self, upsert_h_user, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.patch.side_effect = HAPIError("whatever")
+
+        with pytest.raises(HAPIError, match="whatever"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_raises_if_post_raises(
+        self, upsert_h_user, context, pyramid_request, hapi_svc
+    ):
+        # It will only invoke POST if PATCH raises HAPINotFoundError
+        hapi_svc.patch.side_effect = HAPINotFoundError("whatever")
+        hapi_svc.post.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HAPIError, match="Oops"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
+        self, upsert_h_user, context, pyramid_request, wrapped
+    ):
+        context.provisioning_enabled = False
+
+        returned = upsert_h_user(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    def test_it_doesnt_use_the_h_api_if_feature_not_enabled(
+        self, upsert_h_user, context, hapi_svc, pyramid_request
+    ):
+        context.provisioning_enabled = False
+
+        upsert_h_user(context, pyramid_request)
+
+        hapi_svc.post.assert_not_called()
+
+    def test_it_raises_if_h_username_raises(
+        self, upsert_h_user, context, pyramid_request
+    ):
+        type(context).h_username = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
+
+        with pytest.raises(HTTPBadRequest, match="Oops"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_raises_if_h_provider_raises(
+        self, upsert_h_user, context, pyramid_request
+    ):
+        type(context).h_provider = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
+
+        with pytest.raises(HTTPBadRequest, match="Oops"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_raises_if_provider_unique_id_raises(
+        self, upsert_h_user, context, pyramid_request
+    ):
+        type(context).h_provider_unique_id = mock.PropertyMock(
+            side_effect=HTTPBadRequest("Oops")
+        )
+
+        with pytest.raises(HTTPBadRequest, match="Oops"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_creates_the_user_in_h_if_it_does_not_exist(
+        self, upsert_h_user, context, hapi_svc, pyramid_request
+    ):
+        hapi_svc.patch.side_effect = HAPINotFoundError("whatever")
+
+        upsert_h_user(context, pyramid_request)
+
+        hapi_svc.post.assert_called_once_with(
+            "users",
+            {
+                "username": "test_username",
+                "display_name": "test_display_name",
+                "authority": "TEST_AUTHORITY",
+                "identities": [
+                    {
+                        "provider": "test_provider",
+                        "provider_unique_id": "test_provider_unique_id",
+                    }
+                ],
+            },
+        )
+
+    def test_it_continues_to_the_wrapped_function(
+        self, upsert_h_user, context, pyramid_request, wrapped
+    ):
+        returned = upsert_h_user(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    @pytest.fixture
+    def upsert_h_user(self, wrapped):
+        # Return the actual wrapper function so that tests can call it directly.
+        return h_api.upsert_h_user(wrapped)
+
+
+@pytest.mark.usefixtures("hapi_svc")
+class TestCreateCourseGroup:
+    def test_it_does_nothing_if_the_feature_isnt_enabled(
+        self, upsert_course_group, context, pyramid_request, wrapped, hapi_svc
+    ):
+        # If the auto provisioning feature isn't enabled for this application
+        # instance then upsert_course_group() doesn't do anything - just calls the
+        # wrapped view.
+        context.provisioning_enabled = False
+
+        returned = upsert_course_group(context, pyramid_request)
+
+        hapi_svc.patch.assert_not_called()
+        hapi_svc.put.assert_not_called()
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    def test_it_calls_the_group_update_api(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        upsert_course_group(context, pyramid_request)
+
+        hapi_svc.patch.assert_called_once_with(
+            "groups/test_groupid", {"name": "test_group_name"}
+        )
+
+    def test_it_raises_if_updating_the_group_fails(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        # If the group update API call fails for any non-404 reason then the
+        # view raises an exception and an error page is shown.
+        hapi_svc.patch.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HAPIError, match="Oops"):
+            upsert_course_group(context, pyramid_request)
+
+    def test_if_the_group_doesnt_exist_it_creates_it(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.patch.side_effect = HAPINotFoundError()
+
+        upsert_course_group(context, pyramid_request)
+
+        hapi_svc.put.assert_called_once_with(
+            "groups/test_groupid",
+            {"groupid": "test_groupid", "name": "test_group_name"},
+            "acct:test_username@TEST_AUTHORITY",
+        )
+
+    def test_if_the_group_doesnt_exist_and_the_user_isnt_allowed_to_create_groups_it_400s(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.patch.side_effect = HAPINotFoundError()
+        pyramid_request.params["roles"] = "Learner"
+
+        with pytest.raises(
+            HTTPBadRequest, match="Instructor must launch assignment first"
+        ):
+            upsert_course_group(context, pyramid_request)
+
+        hapi_svc.put.assert_not_called()
+
+    def test_it_calls_and_returns_the_wrapped_view(
+        self, upsert_course_group, context, pyramid_request, wrapped
+    ):
+        returned = upsert_course_group(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    @pytest.fixture
+    def upsert_course_group(self, wrapped):
+        # Return the actual wrapper function so that tests can call it directly.
+        return h_api.upsert_course_group(wrapped)
+
+
+@pytest.mark.usefixtures("hapi_svc")
+class TestAddUserToGroup:
+    def test_it_doesnt_post_to_the_api_if_feature_not_enabled(
+        self, add_user_to_group, context, pyramid_request, hapi_svc
+    ):
+        context.provisioning_enabled = False
+
+        add_user_to_group(context, pyramid_request)
+
+        hapi_svc.post.assert_not_called()
+
+    def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
+        self, add_user_to_group, context, pyramid_request, wrapped
+    ):
+        context.provisioning_enabled = False
+
+        returned = add_user_to_group(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    def test_it_adds_the_user_to_the_group(
+        self, add_user_to_group, context, pyramid_request, hapi_svc
+    ):
+        add_user_to_group(context, pyramid_request)
+
+        hapi_svc.post.assert_called_once_with(
+            "groups/test_groupid/members/acct:test_username@TEST_AUTHORITY"
+        )
+
+    def test_it_raises_if_post_raises(
+        self, add_user_to_group, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.post.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HAPIError, match="Oops"):
+            add_user_to_group(context, pyramid_request)
+
+    def test_it_continues_to_the_wrapped_func(
+        self, add_user_to_group, context, pyramid_request, wrapped
+    ):
+        returned = add_user_to_group(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    @pytest.fixture
+    def add_user_to_group(self, wrapped):
+        # Return the actual wrapper function so that tests can call it directly.
+        return h_api.add_user_to_group(wrapped)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params[
+            "tool_consumer_instance_guid"
+        ] = "test_tool_consumer_instance_guid"
+        pyramid_request.params["context_id"] = "test_context_id"
+        return pyramid_request
+
+
+@pytest.fixture
+def context():
+    context = mock.create_autospec(
+        LTILaunch,
+        spec_set=True,
+        instance=True,
+        h_display_name="test_display_name",
+        h_groupid="test_groupid",
+        h_group_name="test_group_name",
+        h_username="test_username",
+        h_userid="acct:test_username@TEST_AUTHORITY",
+        h_provider="test_provider",
+        h_provider_unique_id="test_provider_unique_id",
+        provisioning_enabled=True,
+    )
+    return context
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.params.update(
+        {
+            "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
+            "tool_consumer_instance_guid": "TEST_GUID",
+            "context_id": "TEST_CONTEXT",
+            "roles": "Instructor,urn:lti:instrole:ims/lis/Administrator",
+        }
+    )
+    pyramid_request.db = mock.MagicMock()
+    return pyramid_request
+
+
+@pytest.fixture
+def wrapped():
+    """Return the wrapped view function."""
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def hapi_svc(patch, pyramid_config):
+    hapi_svc = mock.create_autospec(HypothesisAPIService, spec_set=True, instance=True)
+    hapi_svc.patch.return_value = mock.create_autospec(
+        Response, instance=True, status_code=200, reason="OK", text=""
+    )
+    hapi_svc.post.return_value = mock.create_autospec(
+        Response, instance=True, status_code=200, reason="OK", text=""
+    )
+    pyramid_config.register_service(hapi_svc, name="hapi")
+    return hapi_svc


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/640

These are the same decorators (and the same tests) as `lms.views.decorators.legacy_h_api`, but rewritten to work as Pyramid view decorators instead of plain Python `@decorator`s.

The new decorators aren't used yet, but will be used by upcoming new Pyramid views.

I renamed one of the decorators from `create_course_group()` to `upsert_course_group()` to match with `upsert_h_user()`, and also updated its docstring. The previous `create_course_group()` decorator (now `legacy_create_course_group()`)'s name was out of date since the decorator had been updated to *create or update* the course group.

There was a little bit of validation in the legacy decorators (get a param from the request, and if the param is missing do a 400). I've removed this from the new decorators. The new decorators won't be called until after the request has passed a validation schema, so they can assume that the request has all required parameters.