### PR TITLE
Replace assignment launch code with new views

### DIFF
--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -31,6 +31,8 @@ class LTILaunch:
     USERNAME_MAX_LENGTH = 30
     """The maximum length of an h username."""
 
+    __acl__ = [(Allow, "lti_user", "launch_lti_assignment")]
+
     def __init__(self, request):
         """Return the context resource for an LTI launch request."""
         self._request = request

--- a/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
@@ -1,0 +1,15 @@
+{% extends "lms:templates/base.html.jinja2" %}
+
+{% block content %}
+  <iframe width="100%" height="100%" src="{{ via_url }}"></iframe>
+{% endblock %}
+
+{% block scripts %}
+  <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson }}</script>
+  <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson }}</script>
+
+  {% for url in asset_urls("postmessage_json_rpc_server_js") %}
+    <script src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}
+

--- a/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
@@ -1,0 +1,34 @@
+{% extends "lms:templates/base.html.jinja2" %}
+
+{% block content %}
+  <p>Assignment is not configured. You need to choose a file:</p>
+
+  <form method="POST" action="http://localhost:8001/module_item_configurations">
+
+    <input type="hidden" id="authorization" name="authorization" value="{{ js_config.authorization_param }}">
+    <input type="hidden" id="resource_link_id" name="resource_link_id" value="{{ resource_link_id }}">
+    <input type="hidden" id="tool_consumer_instance_guid" name="tool_consumer_instance_guid" value="{{ tool_consumer_instance_guid }}">
+    <input type="hidden" id="oauth_consumer_key" name="oauth_consumer_key" value="{{ oauth_consumer_key }}">
+    <input type="hidden" id="user_id" name="user_id" value="{{ user_id }}">
+    <input type="hidden" id="context_id" name="context_id" value="{{ context_id }}">
+
+    <fieldset>
+      <legend>Which file should the assignment use?</legend>
+      <ul>
+        <li>
+          <label for="dummy">Dummy PDF File</label>
+          <input type="radio" checked id="dummy" name="document_url" value="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf">
+        </li>
+        <li>
+          <label for="document">PDF document</label>
+          <input type="radio" id="document" name="document_url" value="http://www.pdf995.com/samples/pdf.pdf">
+        </li>
+        <li>
+          <label for="simple">A Simple PDF File</label>
+          <input type="radio" id="simple" name="document_url" value="http://www.africau.edu/images/default/sample.pdf">
+        </li>
+      </ul>
+    </fieldset>
+    <button type="submit">Submit</button>
+  </form>
+{% endblock %}

--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 
 
 def includeme(config):
     config.scan(__name__)
+    config.include("lms.views.predicates")

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -1,0 +1,195 @@
+"""
+Views for handling what the LTI spec calls "Basic LTI Launches".
+
+A Basic LTI Launch is the form submission POST request that an LMS sends us
+when it wants our app to launch an assignment, as opposed to other kinds of
+LTI launches such as the Content Item Selection launches that some LMS's
+send us while *creating* a new assignment.
+
+The spec requires Basic LTI Launch requests to have an ``lti_message_type``
+parameter with the value ``basic-lti-launch-request`` to distinguish them
+from other types of launch request (other "message types") but our code
+doesn't actually require basic launch requests to have this parameter.
+
+Note: The views in this module are currently used only when the new_oauth
+feature flag is on. They replace legacy views from ``lti_launches.py``
+that're still used when the feature flag is off.
+"""
+from pyramid.view import view_config, view_defaults
+
+from lms.models import ModuleItemConfiguration
+from lms.util import via_url
+from lms.views.decorators import (
+    upsert_h_user,
+    upsert_course_group,
+    add_user_to_group,
+    report_lti_launch,
+)
+
+
+@view_defaults(
+    decorator=[
+        # Before any LTI assignment launch create or update the Hypothesis user
+        # and group corresponding to the LTI user and course.
+        upsert_h_user,
+        upsert_course_group,
+        add_user_to_group,
+        # Report all LTI assignment launches to the /reports page.
+        report_lti_launch,
+    ],
+    feature_flag="new_oauth",
+    permission="launch_lti_assignment",
+    renderer="lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2",
+    request_method="POST",
+    route_name="lti_launches",
+)
+class BasicLTILaunchViews:
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(canvas_file=True)
+    def canvas_file_basic_lti_launch(self):
+        """
+        Respond to a Canvas file assignment launch.
+
+        Canvas file assignment launch requests have a ``file_id`` request
+        parameter, which is the Canvas instance's ID for the file. To display
+        the assignment we have to use this ``file_id`` to get a download URL
+        for the file from the Canvas API. We then pass that download URL to
+        Via. We have to re-do this file-ID-for-download-URL exchange on every
+        single launch because Canvas's download URLs are temporary.
+        """
+        canvas_api_client = self.request.find_service(name="canvas_api_client")
+        file_id = self.request.params["file_id"]
+
+        # TODO: Handle failures of the public_url request.
+        document_url = canvas_api_client.public_url(file_id)
+
+        return {"via_url": via_url(self.request, document_url)}
+
+    @view_config(db_configured=True)
+    def db_configured_basic_lti_launch(self):
+        """
+        Respond to a DB-configured assignment launch.
+
+        DB-configured assignment launch requests don't have any kind of file ID
+        or document URL in the request. Instead the document URL is stored in
+        our own DB. This happens with LMS's that don't support LTI content item
+        selection/deep linking, so they don't support storing the document URL
+        in the LMS and passing it back to us in each launch request. Instead we
+        retrieve the document URL from the DB and pass it to Via.
+        """
+        resource_link_id = self.request.params["resource_link_id"]
+        tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
+
+        # The ``db_configured=True`` view predicate ensures that this view
+        # won't be called if there isn't a matching ModuleItemConfiguration in
+        # the DB. So here we can safely assume that the ModuleItemConfiguration
+        # exists.
+        document_url = (
+            self.request.db.query(ModuleItemConfiguration)
+            .filter_by(
+                resource_link_id=resource_link_id,
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
+            )
+            .one()
+            .document_url
+        )
+
+        return {"via_url": via_url(self.request, document_url)}
+
+    @view_config(url_configured=True)
+    def url_configured_basic_lti_launch(self):
+        """
+        Respond to a URL-configured assignment launch.
+
+        URL-configured assignment launch requests have the document URL in the
+        ``url`` request parameter. This happens in LMS's that support LTI
+        content item selection/deep linking: the document URL is chosen during
+        content item selection (during assignment creation) and saved in the
+        LMS, which passes it back to us in each launch request. All we have to
+        do is pass the URL to Via.
+        """
+        return {"via_url": via_url(self.request, self.request.params["url"])}
+
+    @view_config(
+        authorized_to_configure_assignments=True,
+        configured=False,
+        decorator=[],  # Disable the default decorators just for this view.
+        renderer="lms:templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2",
+    )
+    def unconfigured_basic_lti_launch(self):
+        """
+        Respond to an unconfigured assignment launch.
+
+        Unconfigured assignment launch requests don't contain any document URL
+        or file ID because the assignment's document hasn't been chosen yet.
+        This happens in LMS's that don't support LTI content item
+        selection/deep linking. They go straight from assignment creation to
+        launching the assignment without the user having had a chance to choose
+        a document.
+
+        When this happens we show the user our document-selection form instead
+        of launching the assignment. The user will choose the document and
+        we'll save it in our DB. Subsequent launches of the same assignment
+        will then be DB-configured launches rather than unconfigured.
+        """
+        return {
+            "resource_link_id": self.request.params["resource_link_id"],
+            "tool_consumer_instance_guid": self.request.params[
+                "tool_consumer_instance_guid"
+            ],
+            "oauth_consumer_key": self.request.lti_user.oauth_consumer_key,
+            "user_id": self.request.lti_user.user_id,
+            "context_id": self.request.params["context_id"],
+        }
+
+    # pylint:disable=no-self-use
+    @view_config(
+        authorized_to_configure_assignments=False,
+        configured=False,
+        decorator=[],  # Disable the default decorators just for this view.
+        renderer="json",
+    )
+    def unconfigured_basic_lti_launch_not_authorized(self):
+        """
+        Respond to an unauthorized unconfigured assignment launch.
+
+        This happens when an assignment's document hasn't been chosen yet and
+        the assignment is launched by a user who isn't authorized to choose the
+        document (for example a learner rather than a teacher). We just show an
+        error page.
+        """
+        return {}
+
+    @view_config(
+        decorator=[],  # Disable the default decorators just for this view.
+        route_name="module_item_configurations",
+    )
+    def configure_module_item(self):
+        """
+        Respond to a configure module item request.
+
+        This happens after an unconfigured assignment launch. We show the user
+        our document selection form instead of launching the assignment, and
+        when the user chooses a document and submits the form this is the view
+        that receives that form submission.
+
+        We save the chosen document in the DB so that subsequent launches of
+        this same assignment will be DB-configured rather than unconfigured.
+        And we also send back the assignment launch page, passing the chosen
+        URL to Via, as the direct response to the content item form submission.
+        """
+        document_url = self.request.params["document_url"]
+
+        self.request.db.add(
+            ModuleItemConfiguration(
+                document_url=document_url,
+                resource_link_id=self.request.params["resource_link_id"],
+                tool_consumer_instance_guid=self.request.params[
+                    "tool_consumer_instance_guid"
+                ],
+            )
+        )
+
+        return {"via_url": via_url(self.request, document_url)}

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -7,15 +7,15 @@ from lms.util import lti_launch
 from lms.util.view_renderer import view_renderer
 from lms.util.associate_user import associate_user
 from lms.util.authorize_lms import authorize_lms
-from lms.views.decorators import upsert_h_user
-from lms.views.decorators import create_course_group
+from lms.views.decorators import legacy_upsert_h_user
+from lms.views.decorators import legacy_create_course_group
 from lms.views.helpers import canvas_files_available
 
 
 @view_config(route_name="content_item_selection", request_method="POST")
 @lti_launch
-@upsert_h_user
-@create_course_group
+@legacy_upsert_h_user
+@legacy_create_course_group
 @associate_user
 @authorize_lms(
     authorization_base_endpoint="login/oauth2/auth",

--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -18,18 +18,19 @@ For documentation see:
 
 https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#non-predicate-arguments
 """
-from lms.views.decorators.h_api import upsert_h_user
-from lms.views.decorators.h_api import create_course_group
-from lms.views.decorators.h_api import add_user_to_group
 from lms.views.decorators.reports import report_lti_launch
+
+from lms.views.decorators.legacy_h_api import legacy_upsert_h_user
+from lms.views.decorators.legacy_h_api import legacy_create_course_group
+from lms.views.decorators.legacy_h_api import legacy_add_user_to_group
 
 __all__ = (
     "report_lti_launch",
     # Legacy view decorators. These are used as normal Python @decorators
     # applied directly to the view function, rather than with Pyramid's
     # decorators= view config parameter. See the docstring in
-    # lms/views/decorators/h_api.py for details.
-    "upsert_h_user",
-    "create_course_group",
-    "add_user_to_group",
+    # lms/views/decorators/legacy_h_api.py for details.
+    "legacy_upsert_h_user",
+    "legacy_create_course_group",
+    "legacy_add_user_to_group",
 )

--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -18,6 +18,9 @@ For documentation see:
 
 https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#non-predicate-arguments
 """
+from lms.views.decorators.h_api import upsert_h_user
+from lms.views.decorators.h_api import upsert_course_group
+from lms.views.decorators.h_api import add_user_to_group
 from lms.views.decorators.reports import report_lti_launch
 
 from lms.views.decorators.legacy_h_api import legacy_upsert_h_user
@@ -25,6 +28,9 @@ from lms.views.decorators.legacy_h_api import legacy_create_course_group
 from lms.views.decorators.legacy_h_api import legacy_add_user_to_group
 
 __all__ = (
+    "upsert_h_user",
+    "upsert_course_group",
+    "add_user_to_group",
     "report_lti_launch",
     # Legacy view decorators. These are used as normal Python @decorators
     # applied directly to the view function, rather than with Pyramid's

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -1,0 +1,126 @@
+"""View decorators for working with the h API."""
+
+import functools
+
+from pyramid.httpexceptions import HTTPBadRequest
+
+from lms.services import HAPINotFoundError
+
+
+__all__ = ["upsert_h_user", "upsert_course_group", "add_user_to_group"]
+
+
+def upsert_h_user(wrapped):
+    """
+    Create or update the Hypothesis user for the request's LTI user.
+
+    Update the h user's information from LTI data. If the user doesn't exist
+    yet, call the h API to create one.
+
+    Assumes that it's only used on LTI launch views.
+    """
+
+    @functools.wraps(wrapped)
+    def wrapper(context, request):
+        if not context.provisioning_enabled:
+            return wrapped(context, request)
+
+        hapi_svc = request.find_service(name="hapi")
+
+        user_data = {
+            "username": context.h_username,
+            "display_name": context.h_display_name,
+            "authority": request.registry.settings["h_authority"],
+            "identities": [
+                {
+                    "provider": context.h_provider,
+                    "provider_unique_id": context.h_provider_unique_id,
+                }
+            ],
+        }
+
+        try:
+            hapi_svc.patch(
+                f"users/{context.h_username}", {"display_name": context.h_display_name}
+            )
+        except HAPINotFoundError:
+            # Call the h API to create the user in h if it doesn't exist already.
+            hapi_svc.post("users", user_data)
+
+        return wrapped(context, request)
+
+    return wrapper
+
+
+def upsert_course_group(wrapped):
+    """
+    Create or update the Hypothesis group for the request's LTI course.
+
+    Call the h API to create a group for the LTI course, if one doesn't exist
+    already.
+
+    Groups can only be created if the LTI user is allowed to create Hypothesis
+    groups (for example instructors are allowed to create groups). If the group
+    for the course hasn't been created yet, and if the user isn't allowed to
+    create groups (e.g. if they're just a student) then show an error page
+    instead of continuing with the LTI launch.
+
+    Assumes that it's only used on LTI launch views.
+    """
+
+    @functools.wraps(wrapped)
+    def wrapper(context, request):
+        if not context.provisioning_enabled:
+            return wrapped(context, request)
+
+        hapi_svc = request.find_service(name="hapi")
+
+        is_instructor = any(
+            role in request.params["roles"].lower()
+            for role in ("administrator", "instructor", "teachingassisstant")
+        )
+
+        try:
+            hapi_svc.patch(
+                f"groups/{context.h_groupid}", {"name": context.h_group_name}
+            )
+        except HAPINotFoundError:
+            # The group hasn't been created in h yet.
+            if is_instructor:
+                # Try to create the group with the current instructor as its creator.
+                hapi_svc.put(
+                    f"groups/{context.h_groupid}",
+                    {"groupid": context.h_groupid, "name": context.h_group_name},
+                    context.h_userid,
+                )
+            else:
+                raise HTTPBadRequest("Instructor must launch assignment first.")
+        return wrapped(context, request)
+
+    return wrapper
+
+
+def add_user_to_group(wrapped):
+    """
+    Add the Hypothesis user to the course group.
+
+    Add the Hypothesis user corresponding to the current request's LTI user, to
+    the Hypothesis group corresponding to the current request's LTI course.
+
+    Assumes that the Hypothesis user and group have already been created.
+
+    Assumes that it's only used on LTI launch views.
+    """
+
+    @functools.wraps(wrapped)
+    def wrapper(context, request):
+        if not context.provisioning_enabled:
+            return wrapped(context, request)
+
+        request.find_service(name="hapi").post(
+            f"groups/{context.h_groupid}/members/{context.h_userid}"
+        )
+
+        return wrapped(context, request)
+
+    return wrapper

--- a/lms/views/decorators/legacy_h_api.py
+++ b/lms/views/decorators/legacy_h_api.py
@@ -7,7 +7,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 from lms.services import HAPINotFoundError
 
 
-def upsert_h_user(wrapped):  # noqa: MC0001
+def legacy_upsert_h_user(wrapped):  # noqa: MC0001
     """
     Update or create a Hypothesis LTI user.
 
@@ -18,7 +18,7 @@ def upsert_h_user(wrapped):  # noqa: MC0001
     The wrapped view must take ``request`` and ``jwt`` arguments::
 
       @view_config(...)
-      @upsert_h_user
+      @legacy_upsert_h_user
       def my_view(request, jwt):
           ...
 
@@ -78,7 +78,7 @@ def upsert_h_user(wrapped):  # noqa: MC0001
     return wrapper
 
 
-def create_course_group(wrapped):
+def legacy_create_course_group(wrapped):
     """
     Create a Hypothesis group for the LTI course, if one doesn't exist already.
 
@@ -95,7 +95,7 @@ def create_course_group(wrapped):
     The decorated view must take ``request`` and ``jwt`` arguments::
 
       @view_config(...)
-      @create_course_group
+      @legacy_create_course_group
       def my_view(request, jwt):
           ...
 
@@ -125,7 +125,7 @@ def create_course_group(wrapped):
     return wrapper
 
 
-def add_user_to_group(wrapped):
+def legacy_add_user_to_group(wrapped):
     @functools.wraps(wrapped)
     def wrapper(request, jwt, context=None):
         context = context or request.context

--- a/lms/views/lti_launches.py
+++ b/lms/views/lti_launches.py
@@ -14,9 +14,9 @@ from lms.util.canvas_api import CanvasApi, GET
 from lms.util.authorize_lms import authorize_lms, save_token
 from lms.util import via_url
 from lms.models.tokens import find_token_by_user_id
-from lms.views.decorators import upsert_h_user
-from lms.views.decorators import create_course_group
-from lms.views.decorators import add_user_to_group
+from lms.views.decorators import legacy_upsert_h_user
+from lms.views.decorators import legacy_create_course_group
+from lms.views.decorators import legacy_add_user_to_group
 
 
 def can_configure_module_item(roles):
@@ -204,9 +204,9 @@ def should_launch(request):
 
 @view_config(route_name="lti_launches", request_method="POST")
 @lti_launch
-@upsert_h_user
-@create_course_group
-@add_user_to_group
+@legacy_upsert_h_user
+@legacy_create_course_group
+@legacy_add_user_to_group
 @associate_user
 @authorize_lms(
     authorization_base_endpoint="login/oauth2/auth",

--- a/lms/views/predicates/__init__.py
+++ b/lms/views/predicates/__init__.py
@@ -1,0 +1,32 @@
+"""
+Custom Pyramid view predicates.
+
+See:
+
+https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#view-and-route-predicates
+"""
+from lms.views.predicates._lti_launch import IsDBConfigured
+from lms.views.predicates._lti_launch import IsCanvasFile
+from lms.views.predicates._lti_launch import IsURLConfigured
+from lms.views.predicates._lti_launch import IsConfigured
+from lms.views.predicates._lti_launch import UserIsAuthorizedToConfigureAssignments
+
+
+__all__ = [
+    "IsDBConfigured",
+    "IsCanvasFile",
+    "IsURLConfigured",
+    "IsConfigured",
+    "UserIsAuthorizedToConfigureAssignments",
+]
+
+
+def includeme(config):
+    for view_predicate_factory in (
+        IsDBConfigured,
+        IsCanvasFile,
+        IsURLConfigured,
+        IsConfigured,
+        UserIsAuthorizedToConfigureAssignments,
+    ):
+        config.add_view_predicate(view_predicate_factory.name, view_predicate_factory)

--- a/lms/views/predicates/_helpers.py
+++ b/lms/views/predicates/_helpers.py
@@ -1,0 +1,43 @@
+"""Private helpers for view predicates."""
+from abc import ABCMeta, abstractmethod, abstractproperty
+
+
+__all__ = ["Base"]
+
+
+class Base(metaclass=ABCMeta):
+    """Abstract base class for custom view predicate classes."""
+
+    def __init__(self, value, config):
+        self.value = value
+        self.config = config
+
+    def text(self):
+        """
+        Return a string describing the behavior of this predicate.
+
+        Used by Pyramid in error messages.
+        """
+        return f"{self.name} = {self.value}"
+
+    def phash(self):
+        """
+        Return a string uniquely identifying this predicate's name and value.
+
+        Used by Pyramid for view configuration constraints handling.
+        """
+        return self.text()
+
+    @abstractproperty
+    def name(self):
+        """
+        Return the name of this predicate.
+
+        This is the string that is used as a keyword argument to Pyramid's
+        ``@view_config()`` in order to use this predicate on a view. It's also
+        used by ``text()`` and ``phash()``.
+        """
+
+    @abstractmethod
+    def __call__(self, context, request):
+        """Return ``True`` if ``request`` matches this predicate."""

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -1,0 +1,170 @@
+"""Predicates for use with LTI launch views."""
+from lms.models import ModuleItemConfiguration
+from lms.views.predicates._helpers import Base
+
+
+__all__ = [
+    "IsDBConfigured",
+    "IsCanvasFile",
+    "IsURLConfigured",
+    "IsConfigured",
+    "UserIsAuthorizedToConfigureAssignments",
+]
+
+
+class IsDBConfigured(Base):
+    """
+    Allow invoking an LTI launch view only if the assignment is DB-configured.
+
+    Some LTI assignments are "DB-configured" meaning the assignment's
+    configuration (the URL of the document to be annotated for the assignment)
+    is stored in our own DB.
+
+    This happens with LMS's that don't support LTI "content item selection"
+    (also known as "deep linking"), so they don't support storing the
+    assignment configuration (document URL) in the LMS.
+
+    Pass ``db_configured=True`` to a view's configuration to allow invoking the
+    view only for requests whose assignment has its configuration stored in our
+    DB. Pass ``db_configured=False`` to allow invoking the view for assignments
+    that are *not* DB-configured.
+
+    For example::
+
+        authorized_assignment_launch_viewview_config(..., db_configured=True)
+        def db_configured_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "db_configured"
+
+    def __call__(self, context, request):
+        resource_link_id = request.params.get("resource_link_id")
+        tool_consumer_instance_guid = request.params.get("tool_consumer_instance_guid")
+
+        has_module_item_configuration = (
+            request.db.query(ModuleItemConfiguration)
+            .filter_by(
+                resource_link_id=resource_link_id,
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
+            )
+            .count()
+            > 0
+        )
+
+        return has_module_item_configuration == self.value
+
+
+class IsCanvasFile(Base):
+    """
+    Allow invoking an LTI launch view only for Canvas file assignments.
+
+    Pass ``canvas_file=True`` to a view config to allow invoking the view only
+    for Canvas file assignments, or ``canvas_file=False`` to allow it only for
+    other types of assignment. For example::
+
+        @view_config(..., canvas_file=True)
+        def canvas_file_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "canvas_file"
+
+    def __call__(self, context, request):
+        return ("canvas_file" in request.params) == self.value
+
+
+class IsURLConfigured(Base):
+    """
+    Allow invoking an LTI launch view only for URL-configured assignments.
+
+    "URL-configured" assignments are ones where the URL of the document to be
+    annotated (for example a public HTML or PDF URL, or a Google Drive URL) is
+    sent to us by the LMS in the ``url`` launch parameter.
+
+    This happens when the LMS supports content-item selection (a.k.a deep
+    linking) and the file to be annotated is *not* a Canvas file.
+
+    Pass ``url_configured=True`` to a view config to allow invoking the view
+    only for URL-configured assignments, or ``url_configured=False`` to allow
+    it only for non-URL-configired assignments. For example::
+
+        @view_config(..., url_configured=True)
+        def url_configured_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "url_configured"
+
+    def __call__(self, context, request):
+        return ("url" in request.params) == self.value
+
+
+class IsConfigured(Base):
+    """
+    Allow invoking an LTI launch view only if the assignment is configured.
+
+    An *unconfigured* assignment is one for which the document URL to be
+    annotated hasn't been selected yet. Regardless of whether the selected
+    document URL is stored in the LMS or in our own DB, and regardless of what
+    kind of file the document URL locates (HTML, Canvas PDF, Google Drive,
+    ...). An unconfigured assignment is one whose document URL hasn't yet been
+    chosen by any means.
+
+    Pass ``configured=True`` to a view config to allow invoking the view only
+    for assignments that're already configured, or ``configured=False`` for
+    assignments that aren't yet configured. For example::
+
+        @view_config(..., configured=True)
+        def configured_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "configured"
+
+    def __init__(self, value, config):
+        super().__init__(value, config)
+        self.canvas_file = IsCanvasFile(True, config)
+        self.url_configured = IsURLConfigured(True, config)
+        self.db_configured = IsDBConfigured(True, config)
+
+    def __call__(self, context, request):
+        configured = any(
+            [
+                self.canvas_file(context, request),
+                self.url_configured(context, request),
+                self.db_configured(context, request),
+            ]
+        )
+        return configured == self.value
+
+
+class UserIsAuthorizedToConfigureAssignments(Base):
+    """
+    Allow a launch view if the user is authorized to configure assignments.
+
+    Only certain LTI users are allowed to configure assignments (to choose the
+    URL of the assignment's document). For example administrators and
+    instructors are allowed to, but learners aren't.
+
+    Pass ``authorized_to_configure_assignments=True`` to a view config to allow
+    invoking the view only if the user is authorized to configure assignments.
+    Pass ``authorized_to_configure_assignments=False`` to allow a view only for
+    users who *aren't* so authorized.
+
+    For example::
+
+        @view_config(..., authorized_to_configure_assignments=True)
+        def authorized_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "authorized_to_configure_assignments"
+
+    def __call__(self, context, request):
+        roles = request.params.get("roles", "").lower()
+        authorized = any(
+            role in roles
+            for role in ["administrator", "instructor", "teachingassisstant"]
+        )
+        return authorized == self.value

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -1,0 +1,137 @@
+from unittest import mock
+
+import pytest
+
+from lms.models import ModuleItemConfiguration
+from lms.services.canvas_api import CanvasAPIClient
+from lms.views.basic_lti_launch import BasicLTILaunchViews
+
+
+class TestCanvasFileBasicLTILaunch:
+    def test_it_gets_a_public_url_from_the_canvas_api(
+        self, canvas_api_client, pyramid_request
+    ):
+        pyramid_request.params = {"file_id": "TEST_FILE_ID"}
+
+        BasicLTILaunchViews(pyramid_request).canvas_file_basic_lti_launch()
+
+        canvas_api_client.public_url.assert_called_once_with("TEST_FILE_ID")
+
+    def test_it_passes_the_right_via_url_to_the_template(
+        self, canvas_api_client, pyramid_request, via_url
+    ):
+        pyramid_request.params = {"file_id": "TEST_FILE_ID"}
+
+        data = BasicLTILaunchViews(pyramid_request).canvas_file_basic_lti_launch()
+
+        via_url.assert_called_once_with(
+            pyramid_request, canvas_api_client.public_url.return_value
+        )
+        assert data["via_url"] == via_url.return_value
+
+    @pytest.fixture(autouse=True)
+    def canvas_api_client(self, pyramid_config):
+        canvas_api_client = mock.create_autospec(
+            CanvasAPIClient, spec_set=True, instance=True
+        )
+        pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
+        return canvas_api_client
+
+
+class TestDBConfiguredBasicLTILaunch:
+    def test_it_passes_the_right_via_url_to_the_template(
+        self, pyramid_request, via_url
+    ):
+        pyramid_request.params = {
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+        }
+        pyramid_request.db.add(
+            ModuleItemConfiguration(
+                resource_link_id="TEST_RESOURCE_LINK_ID",
+                tool_consumer_instance_guid="TEST_TOOL_CONSUMER_INSTANCE_GUID",
+                document_url="TEST_DOCUMENT_URL",
+            )
+        )
+
+        data = BasicLTILaunchViews(pyramid_request).db_configured_basic_lti_launch()
+
+        via_url.assert_called_once_with(pyramid_request, "TEST_DOCUMENT_URL")
+        assert data["via_url"] == via_url.return_value
+
+
+class TestURLConfiguredBasicLTILaunch:
+    def test_it_passes_the_right_via_url_to_the_template(
+        self, pyramid_request, via_url
+    ):
+        pyramid_request.params = {"url": "TEST_URL"}
+
+        data = BasicLTILaunchViews(pyramid_request).url_configured_basic_lti_launch()
+
+        via_url.assert_called_once_with(pyramid_request, "TEST_URL")
+        assert data["via_url"] == via_url.return_value
+
+
+class TestUnconfiguredBasicLTILaunch:
+    def test_it_returns_the_right_template_data(self, pyramid_request):
+        pyramid_request.params = {
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            "context_id": "TEST_CONTEXT_ID",
+        }
+        data = BasicLTILaunchViews(pyramid_request).unconfigured_basic_lti_launch()
+
+        assert data == {
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            "oauth_consumer_key": "TEST_OAUTH_CONSUMER_KEY",
+            "user_id": "TEST_USER_ID",
+            "context_id": "TEST_CONTEXT_ID",
+        }
+
+
+class TestUnconfiguredBasicLTILaunchNotAuthorized:
+    def test_it_returns_the_right_template_data(self, pyramid_request):
+        data = BasicLTILaunchViews(
+            pyramid_request
+        ).unconfigured_basic_lti_launch_not_authorized()
+
+        assert data == {}
+
+
+class TestConfigureModuleItem:
+    def test_it_saves_the_assignments_document_url_to_the_db(self, pyramid_request):
+        pyramid_request.params = {
+            "document_url": "TEST_DOCUMENT_URL",
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+        }
+
+        BasicLTILaunchViews(pyramid_request).configure_module_item()
+
+        mic = (
+            pyramid_request.db.query(ModuleItemConfiguration).filter_by(
+                resource_link_id="TEST_RESOURCE_LINK_ID",
+                tool_consumer_instance_guid="TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            )
+        ).one_or_none()
+        assert mic and mic.document_url == "TEST_DOCUMENT_URL"
+
+    def test_it_passes_the_right_via_url_to_the_template(
+        self, pyramid_request, via_url
+    ):
+        pyramid_request.params = {
+            "document_url": "TEST_DOCUMENT_URL",
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+        }
+
+        data = BasicLTILaunchViews(pyramid_request).configure_module_item()
+
+        via_url.assert_called_once_with(pyramid_request, "TEST_DOCUMENT_URL")
+        assert data["via_url"] == via_url.return_value
+
+
+@pytest.fixture(autouse=True)
+def via_url(patch):
+    return patch("lms.views.basic_lti_launch.via_url")

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -1,0 +1,310 @@
+from unittest import mock
+import pytest
+
+from pyramid.httpexceptions import HTTPBadRequest
+
+from requests import Response
+
+from lms.services import HAPIError
+from lms.services import HAPINotFoundError
+from lms.views.decorators import h_api
+from lms.services.hapi import HypothesisAPIService
+from lms.config.resources import LTILaunch
+
+
+@pytest.mark.usefixtures("hapi_svc")
+class TestUpsertHUser:
+    def test_it_invokes_patch_for_user_update(
+        self, upsert_h_user, context, pyramid_request, hapi_svc
+    ):
+
+        upsert_h_user(context, pyramid_request)
+
+        hapi_svc.patch.assert_called_once_with(
+            "users/test_username", {"display_name": "test_display_name"}
+        )
+
+    def test_it_raises_if_patch_raises_unexpected_error(
+        self, upsert_h_user, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.patch.side_effect = HAPIError("whatever")
+
+        with pytest.raises(HAPIError, match="whatever"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_raises_if_post_raises(
+        self, upsert_h_user, context, pyramid_request, hapi_svc
+    ):
+        # It will only invoke POST if PATCH raises HAPINotFoundError
+        hapi_svc.patch.side_effect = HAPINotFoundError("whatever")
+        hapi_svc.post.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HAPIError, match="Oops"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
+        self, upsert_h_user, context, pyramid_request, wrapped
+    ):
+        context.provisioning_enabled = False
+
+        returned = upsert_h_user(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    def test_it_doesnt_use_the_h_api_if_feature_not_enabled(
+        self, upsert_h_user, context, hapi_svc, pyramid_request
+    ):
+        context.provisioning_enabled = False
+
+        upsert_h_user(context, pyramid_request)
+
+        hapi_svc.post.assert_not_called()
+
+    def test_it_raises_if_h_username_raises(
+        self, upsert_h_user, context, pyramid_request
+    ):
+        type(context).h_username = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
+
+        with pytest.raises(HTTPBadRequest, match="Oops"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_raises_if_h_provider_raises(
+        self, upsert_h_user, context, pyramid_request
+    ):
+        type(context).h_provider = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
+
+        with pytest.raises(HTTPBadRequest, match="Oops"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_raises_if_provider_unique_id_raises(
+        self, upsert_h_user, context, pyramid_request
+    ):
+        type(context).h_provider_unique_id = mock.PropertyMock(
+            side_effect=HTTPBadRequest("Oops")
+        )
+
+        with pytest.raises(HTTPBadRequest, match="Oops"):
+            upsert_h_user(context, pyramid_request)
+
+    def test_it_creates_the_user_in_h_if_it_does_not_exist(
+        self, upsert_h_user, context, hapi_svc, pyramid_request
+    ):
+        hapi_svc.patch.side_effect = HAPINotFoundError("whatever")
+
+        upsert_h_user(context, pyramid_request)
+
+        hapi_svc.post.assert_called_once_with(
+            "users",
+            {
+                "username": "test_username",
+                "display_name": "test_display_name",
+                "authority": "TEST_AUTHORITY",
+                "identities": [
+                    {
+                        "provider": "test_provider",
+                        "provider_unique_id": "test_provider_unique_id",
+                    }
+                ],
+            },
+        )
+
+    def test_it_continues_to_the_wrapped_function(
+        self, upsert_h_user, context, pyramid_request, wrapped
+    ):
+        returned = upsert_h_user(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    @pytest.fixture
+    def upsert_h_user(self, wrapped):
+        # Return the actual wrapper function so that tests can call it directly.
+        return h_api.upsert_h_user(wrapped)
+
+
+@pytest.mark.usefixtures("hapi_svc")
+class TestCreateCourseGroup:
+    def test_it_does_nothing_if_the_feature_isnt_enabled(
+        self, upsert_course_group, context, pyramid_request, wrapped, hapi_svc
+    ):
+        # If the auto provisioning feature isn't enabled for this application
+        # instance then upsert_course_group() doesn't do anything - just calls the
+        # wrapped view.
+        context.provisioning_enabled = False
+
+        returned = upsert_course_group(context, pyramid_request)
+
+        hapi_svc.patch.assert_not_called()
+        hapi_svc.put.assert_not_called()
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    def test_it_calls_the_group_update_api(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        upsert_course_group(context, pyramid_request)
+
+        hapi_svc.patch.assert_called_once_with(
+            "groups/test_groupid", {"name": "test_group_name"}
+        )
+
+    def test_it_raises_if_updating_the_group_fails(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        # If the group update API call fails for any non-404 reason then the
+        # view raises an exception and an error page is shown.
+        hapi_svc.patch.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HAPIError, match="Oops"):
+            upsert_course_group(context, pyramid_request)
+
+    def test_if_the_group_doesnt_exist_it_creates_it(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.patch.side_effect = HAPINotFoundError()
+
+        upsert_course_group(context, pyramid_request)
+
+        hapi_svc.put.assert_called_once_with(
+            "groups/test_groupid",
+            {"groupid": "test_groupid", "name": "test_group_name"},
+            "acct:test_username@TEST_AUTHORITY",
+        )
+
+    def test_if_the_group_doesnt_exist_and_the_user_isnt_allowed_to_create_groups_it_400s(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.patch.side_effect = HAPINotFoundError()
+        pyramid_request.params["roles"] = "Learner"
+
+        with pytest.raises(
+            HTTPBadRequest, match="Instructor must launch assignment first"
+        ):
+            upsert_course_group(context, pyramid_request)
+
+        hapi_svc.put.assert_not_called()
+
+    def test_it_calls_and_returns_the_wrapped_view(
+        self, upsert_course_group, context, pyramid_request, wrapped
+    ):
+        returned = upsert_course_group(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    @pytest.fixture
+    def upsert_course_group(self, wrapped):
+        # Return the actual wrapper function so that tests can call it directly.
+        return h_api.upsert_course_group(wrapped)
+
+
+@pytest.mark.usefixtures("hapi_svc")
+class TestAddUserToGroup:
+    def test_it_doesnt_post_to_the_api_if_feature_not_enabled(
+        self, add_user_to_group, context, pyramid_request, hapi_svc
+    ):
+        context.provisioning_enabled = False
+
+        add_user_to_group(context, pyramid_request)
+
+        hapi_svc.post.assert_not_called()
+
+    def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
+        self, add_user_to_group, context, pyramid_request, wrapped
+    ):
+        context.provisioning_enabled = False
+
+        returned = add_user_to_group(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    def test_it_adds_the_user_to_the_group(
+        self, add_user_to_group, context, pyramid_request, hapi_svc
+    ):
+        add_user_to_group(context, pyramid_request)
+
+        hapi_svc.post.assert_called_once_with(
+            "groups/test_groupid/members/acct:test_username@TEST_AUTHORITY"
+        )
+
+    def test_it_raises_if_post_raises(
+        self, add_user_to_group, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.post.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HAPIError, match="Oops"):
+            add_user_to_group(context, pyramid_request)
+
+    def test_it_continues_to_the_wrapped_func(
+        self, add_user_to_group, context, pyramid_request, wrapped
+    ):
+        returned = add_user_to_group(context, pyramid_request)
+
+        wrapped.assert_called_once_with(context, pyramid_request)
+        assert returned == wrapped.return_value
+
+    @pytest.fixture
+    def add_user_to_group(self, wrapped):
+        # Return the actual wrapper function so that tests can call it directly.
+        return h_api.add_user_to_group(wrapped)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params[
+            "tool_consumer_instance_guid"
+        ] = "test_tool_consumer_instance_guid"
+        pyramid_request.params["context_id"] = "test_context_id"
+        return pyramid_request
+
+
+@pytest.fixture
+def context():
+    context = mock.create_autospec(
+        LTILaunch,
+        spec_set=True,
+        instance=True,
+        h_display_name="test_display_name",
+        h_groupid="test_groupid",
+        h_group_name="test_group_name",
+        h_username="test_username",
+        h_userid="acct:test_username@TEST_AUTHORITY",
+        h_provider="test_provider",
+        h_provider_unique_id="test_provider_unique_id",
+        provisioning_enabled=True,
+    )
+    return context
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.params.update(
+        {
+            "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
+            "tool_consumer_instance_guid": "TEST_GUID",
+            "context_id": "TEST_CONTEXT",
+            "roles": "Instructor,urn:lti:instrole:ims/lis/Administrator",
+        }
+    )
+    pyramid_request.db = mock.MagicMock()
+    return pyramid_request
+
+
+@pytest.fixture
+def wrapped():
+    """Return the wrapped view function."""
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def hapi_svc(patch, pyramid_config):
+    hapi_svc = mock.create_autospec(HypothesisAPIService, spec_set=True, instance=True)
+    hapi_svc.patch.return_value = mock.create_autospec(
+        Response, instance=True, status_code=200, reason="OK", text=""
+    )
+    hapi_svc.post.return_value = mock.create_autospec(
+        Response, instance=True, status_code=200, reason="OK", text=""
+    )
+    pyramid_config.register_service(hapi_svc, name="hapi")
+    return hapi_svc

--- a/tests/lms/views/decorators/legacy_h_api_test.py
+++ b/tests/lms/views/decorators/legacy_h_api_test.py
@@ -9,7 +9,7 @@ from requests import Response
 
 from lms.services import HAPIError
 from lms.services import HAPINotFoundError
-from lms.views.decorators import h_api
+from lms.views.decorators import legacy_h_api
 from lms.services.hapi import HypothesisAPIService
 from lms.config.resources import LTILaunch
 
@@ -122,7 +122,7 @@ class TestUpsertHUser:
     @pytest.fixture
     def upsert_h_user(self, wrapped):
         # Return the actual wrapper function so that tests can call it directly.
-        return h_api.upsert_h_user(wrapped)
+        return legacy_h_api.legacy_upsert_h_user(wrapped)
 
 
 @pytest.mark.usefixtures("hapi_svc")
@@ -206,7 +206,7 @@ class TestCreateCourseGroup:
     @pytest.fixture
     def create_course_group(self, wrapped):
         # Return the actual wrapper function so that tests can call it directly.
-        return h_api.create_course_group(wrapped)
+        return legacy_h_api.legacy_create_course_group(wrapped)
 
 
 @pytest.mark.usefixtures("hapi_svc")
@@ -258,7 +258,7 @@ class TestAddUserToGroup:
     @pytest.fixture
     def add_user_to_group(self, wrapped):
         # Return the actual wrapper function so that tests can call it directly.
-        return h_api.add_user_to_group(wrapped)
+        return legacy_h_api.legacy_add_user_to_group(wrapped)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/lms/views/predicates/_helpers_test.py
+++ b/tests/lms/views/predicates/_helpers_test.py
@@ -1,0 +1,65 @@
+import pytest
+
+from lms.views.predicates._helpers import Base
+
+
+class TestBase:
+    def test_subclasses_must_have_name(self):
+        class CustomPredicateFactory(Base):
+            def __call__(self, context, request):
+                """Does nothing."""
+
+        with pytest.raises(
+            TypeError,
+            match="Can't instantiate abstract class CustomPredicateFactory with abstract methods name",
+        ):
+            CustomPredicateFactory("test_value", "test_config")
+
+    def test_subclasses_must_have___call__(self):
+        class CustomPredicateFactory(Base):
+            name = "custom_predicate_factory"
+
+        with pytest.raises(
+            TypeError,
+            match="Can't instantiate abstract class CustomPredicateFactory with abstract methods __call__",
+        ):
+            CustomPredicateFactory("test_value", "test_config")
+
+    def test_value(self):
+        # It makes self.value available to subclasses.
+        assert (
+            CustomPredicateFactory("test_value", "test_config").get_value()
+            == "test_value"
+        )
+
+    def test_config(self):
+        # It makes self.config available to subclasses.
+        assert (
+            CustomPredicateFactory("test_value", "test_config").get_config()
+            == "test_config"
+        )
+
+    def test_text(self):
+        assert (
+            CustomPredicateFactory("test_value", "test_config").text()
+            == "custom_predicate_factory = test_value"
+        )
+
+    def test_phash(self):
+        assert (
+            CustomPredicateFactory("test_value", "test_config").phash()
+            == "custom_predicate_factory = test_value"
+        )
+
+
+class CustomPredicateFactory(Base):
+    name = "custom_predicate_factory"
+
+    def __call__(self, context, request):
+        """Does nothing."""
+
+    def get_value(self):
+        return self.value
+
+    def get_config(self):
+        return self.config

--- a/tests/lms/views/predicates/_lti_launch_test.py
+++ b/tests/lms/views/predicates/_lti_launch_test.py
@@ -1,0 +1,264 @@
+from unittest import mock
+
+from pyramid.testing import DummyRequest
+import pytest
+
+from lms.models import ModuleItemConfiguration
+from lms.views.predicates import (
+    IsDBConfigured,
+    IsCanvasFile,
+    IsURLConfigured,
+    IsConfigured,
+    UserIsAuthorizedToConfigureAssignments,
+)
+
+
+class TestIsDBConfigured:
+    def test_when_theres_a_matching_assignment_config_in_the_db(self, pyramid_request):
+        pyramid_request.params = {
+            "resource_link_id": "test_resource_link_id",
+            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
+        }
+
+        assert (
+            IsDBConfigured(True, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is True
+        )
+        assert (
+            IsDBConfigured(False, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is False
+        )
+
+    def test_when_theres_no_matching_assignment_config_in_the_db(self, pyramid_request):
+        pyramid_request.params = {
+            "resource_link_id": "doesnt_match",
+            "tool_consumer_instance_guid": "doesnt_match",
+        }
+
+        assert (
+            IsDBConfigured(True, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is False
+        )
+        assert (
+            IsDBConfigured(False, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is True
+        )
+
+    def test_when_request_params_are_missing(self, pyramid_request):
+        pyramid_request.params = {}
+
+        assert (
+            IsDBConfigured(True, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is False
+        )
+        assert (
+            IsDBConfigured(False, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is True
+        )
+
+    @pytest.fixture(autouse=True)
+    def module_item_configuration(self, pyramid_request):
+        pyramid_request.db.add(
+            ModuleItemConfiguration(
+                resource_link_id="test_resource_link_id",
+                tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+                document_url="test_document_url",
+            )
+        )
+
+
+class TestIsCanvasFile:
+    def test_when_assignment_is_canvas_file(self):
+        request = DummyRequest(params={"canvas_file": 22})
+
+        assert (
+            IsCanvasFile(True, mock.sentinel.config)(mock.sentinel.context, request)
+            is True
+        )
+        assert (
+            IsCanvasFile(False, mock.sentinel.config)(mock.sentinel.context, request)
+            is False
+        )
+
+    def test_when_assignment_is_not_canvas_file(self):
+        assert (
+            IsCanvasFile(True, mock.sentinel.config)(
+                mock.sentinel.context, DummyRequest()
+            )
+            is False
+        )
+        assert (
+            IsCanvasFile(False, mock.sentinel.config)(
+                mock.sentinel.context, DummyRequest()
+            )
+            is True
+        )
+
+
+class TestIsURLConfigured:
+    def test_when_assignment_is_url_configured(self):
+        request = DummyRequest(params={"url": "https://example.com"})
+
+        assert (
+            IsURLConfigured(True, mock.sentinel.config)(mock.sentinel.context, request)
+            is True
+        )
+        assert (
+            IsURLConfigured(False, mock.sentinel.config)(mock.sentinel.context, request)
+            is False
+        )
+
+    def test_when_assignment_is_not_url_configured(self):
+        assert (
+            IsURLConfigured(True, mock.sentinel.config)(
+                mock.sentinel.context, DummyRequest()
+            )
+            is False
+        )
+        assert (
+            IsURLConfigured(False, mock.sentinel.config)(
+                mock.sentinel.context, DummyRequest()
+            )
+            is True
+        )
+
+
+class TestIsConfigured:
+    def test_when_assignment_is_url_configured(self, pyramid_request):
+        pyramid_request.params = {"url": "https://example.com"}
+
+        assert (
+            IsConfigured(True, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is True
+        )
+        assert (
+            IsConfigured(False, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is False
+        )
+
+    def test_when_assignment_is_canvas_file(self, pyramid_request):
+        pyramid_request.params = {"canvas_file": 22}
+
+        assert (
+            IsConfigured(True, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is True
+        )
+        assert (
+            IsConfigured(False, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is False
+        )
+
+    def test_when_assignment_is_db_configured(self, pyramid_request):
+        pyramid_request.db.add(
+            ModuleItemConfiguration(
+                resource_link_id="test_resource_link_id",
+                tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+                document_url="test_document_url",
+            )
+        )
+
+        assert (
+            IsConfigured(True, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is True
+        )
+        assert (
+            IsConfigured(False, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is False
+        )
+
+    def test_when_assignment_is_unconfigured(self, pyramid_request):
+        pyramid_request.params = {}
+
+        assert (
+            IsConfigured(True, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is False
+        )
+        assert (
+            IsConfigured(False, mock.sentinel.config)(
+                mock.sentinel.context, pyramid_request
+            )
+            is True
+        )
+
+    @pytest.fixture
+    def pyramid_request(self):
+        return DummyRequest(
+            params={
+                "resource_link_id": "test_resource_link_id",
+                "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
+            }
+        )
+
+
+class TestUserIsAuthorizedToConfigureAssignments:
+    def test_when_user_is_authorized(self):
+        request = DummyRequest(params={"roles": "Instructor"})
+
+        assert (
+            UserIsAuthorizedToConfigureAssignments(True, mock.sentinel.config)(
+                mock.sentinel.context, request
+            )
+            is True
+        )
+        assert (
+            UserIsAuthorizedToConfigureAssignments(False, mock.sentinel.config)(
+                mock.sentinel.context, request
+            )
+            is False
+        )
+
+    def test_when_user_isnt_authorized(self):
+        request = DummyRequest(params={"roles": "Learner"})
+
+        assert (
+            UserIsAuthorizedToConfigureAssignments(True, mock.sentinel.config)(
+                mock.sentinel.context, request
+            )
+            is False
+        )
+        assert (
+            UserIsAuthorizedToConfigureAssignments(False, mock.sentinel.config)(
+                mock.sentinel.context, request
+            )
+            is True
+        )
+
+    def test_when_theres_no_roles_param(self):
+        assert (
+            UserIsAuthorizedToConfigureAssignments(True, mock.sentinel.config)(
+                mock.sentinel.context, DummyRequest()
+            )
+            is False
+        )
+        assert (
+            UserIsAuthorizedToConfigureAssignments(False, mock.sentinel.config)(
+                mock.sentinel.context, DummyRequest()
+            )
+            is True
+        )


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/639, https://github.com/hypothesis/lms/pull/640 and https://github.com/hypothesis/lms/pull/642.

This completely replaces all the assignment launching code with new views and templates, when the `new_oauth` feature flag is on. The new views will enable us to add the new behaviours that's needed to use the new OAuth 2.0 and Canvas Files stuff when launching assignments. It's also just much simpler code that'll be easier to work with.

The new views don't have any validation yet and will crash on missing or invalid parameters. But, unlike with the old view code, validation schemas can be added to them. That'll be coming in a later PR.