### PR TITLE
Add "launch_lti_assignment" permission to LTI users

### DIFF
--- a/lms/config/resources.py
+++ b/lms/config/resources.py
@@ -31,6 +31,8 @@ class LTILaunch:
     USERNAME_MAX_LENGTH = 30
     """The maximum length of an h username."""
 
+    __acl__ = [(Allow, "lti_user", "launch_lti_assignment")]
+
     def __init__(self, request):
         """Return the context resource for an LTI launch request."""
         self._request = request


### PR DESCRIPTION
This enables protecting a view like this:

    @view_config(..., permission="launch_lti_assignment")
    def my_view(request):
        ...

and the view will only be callable by verified LTI users. This is going to be used to protect upcoming new assignment launch views.