### PR TITLE
Launch views refactor 2/n: Raise CanvasAPIError if Canvas API request fails

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -5,6 +5,7 @@ from lms.services.exceptions import ConsumerKeyError
 from lms.services.exceptions import LTIOAuthError
 from lms.services.exceptions import HAPIError
 from lms.services.exceptions import HAPINotFoundError
+from lms.services.exceptions import CanvasAPIError
 
 __all__ = (
     "ServiceError",
@@ -14,6 +15,7 @@ __all__ = (
     "LTIOAuthError",
     "HAPIError",
     "HAPINotFoundError",
+    "CanvasAPIError",
 )
 
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -67,3 +67,42 @@ class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
 
 class HAPINotFoundError(HAPIError):  # pylint: disable=too-many-ancestors
     """A 404 error from an API request."""
+
+
+class CanvasAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
+    """
+    A problem with a Canvas API request.
+
+    This exception class is raised whenever a Canvas API request times out or
+    when an unsuccessful, invalid or unexpected response is received from the
+    Canvas API.
+
+    An CanvasAPIError is a 500 Internal Server Error response
+    (HTTPInternalServerError subclass) rather than, say, a 502 Bad Gateway
+    because Cloudflare intercepts gateway error responses and replaces our
+    error page with its own error page, and we don't want that.
+
+    Any arguments or keyword arguments other than ``response`` are passed
+    through to HTTPInternalServerError.
+
+    :param response: The response from the HTTP request to the h API
+    :type response: requests.Response
+    """
+
+    def __init__(self, *args, response=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.response = response
+
+    def __str__(self):
+        if self.response is None:
+            return super().__str__()
+
+        # Log the details of the Canvas API response. This goes to both Sentry
+        # and the application's logs. It's helpful for debugging to know how
+        # Canvas responded.
+        parts = [
+            str(self.response.status_code or ""),
+            self.response.reason,
+            self.response.text,
+        ]
+        return " ".join([part for part in parts if part])

--- a/tests/lms/services/canvas_api_test.py
+++ b/tests/lms/services/canvas_api_test.py
@@ -195,6 +195,18 @@ class TestCanvasAPIClient:
         with pytest.raises(CanvasAPIError, match="Not authorized"):
             canvas_api_client.public_url("test_file_id")
 
+    @pytest.mark.parametrize("method_under_test", ["list_files", "public_url"])
+    def test_it_raises_CanvasAPIError_if_we_dont_have_an_access_token(
+        self, canvas_api_client, method_under_test, requests
+    ):
+        method = getattr(canvas_api_client, method_under_test)
+
+        with pytest.raises(
+            CanvasAPIError,
+            match="We don't have a Canvas API access token for this user",
+        ):
+            method("test_file_or_course_id")
+
     @pytest.fixture
     def access_token(self, db_session, pyramid_request):
         access_token = OAuth2Token(


### PR DESCRIPTION
This causes the `public_url` API to raise `CanvasAPIError` if we don't yet have an access token (expired or otherwise) for the user (e.g. if this is the first time this user has launched a Canvas Files assignment).

And it makes both the `list_files` and `public_url` APIs raise `CanvasAPIError` if the Canvas API request fails to get a response (e.g. a network timeout) or sends an unsuccessful response (e.g. an authorization error).

There are plenty of error cases not covered yet, and the code and tests aren't factored how I want, but this will allow us to get on with the next stage which is to integrate the new OAuth2 authorization into the assignment launches.