### PR TITLE
Launch views refactor 3/n: Add new assignment launch views

### DIFF
--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -68,8 +68,8 @@ class LaunchVerifier:
                 dict(self._request.headers),
                 dict(self._request.params),
             )
-        except pylti.common.LTIException:
-            raise LTIOAuthError()
+        except pylti.common.LTIException as err:
+            raise LTIOAuthError() from err
         except KeyError:
             # pylti crashes if certain params (e.g. oauth_nonce) are missing
             # from the request.

--- a/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
@@ -1,0 +1,15 @@
+{% extends "lms:templates/base.html.jinja2" %}
+
+{% block content %}
+  <iframe width="100%" height="100%" src="{{ via_url }}"></iframe>
+{% endblock %}
+
+{% block scripts %}
+  <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson }}</script>
+  <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson }}</script>
+
+  {% for url in asset_urls("postmessage_json_rpc_server_js") %}
+    <script src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}
+

--- a/lms/templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2
@@ -1,0 +1,17 @@
+{% extends "lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2" %}
+
+{% block content %}
+  {% if via_url %}
+    {{ super() }}
+  {% else %}
+    <main class="modal-content">
+      <h1>Authorize Hypothesis</h1>
+
+      <p class="modal-text">
+        Hypothesis needs your authorization to access this assignment.
+      </p>
+
+      <button class="btn" type="submit">Authorize</button>
+  </main>
+  {% endif %}
+{% endblock %}

--- a/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
@@ -1,34 +1,24 @@
 {% extends "lms:templates/base.html.jinja2" %}
 
 {% block content %}
-  <p>Assignment is not configured. You need to choose a file:</p>
+  <div id="app"></div>
+{% endblock %}
 
-  <form method="POST" action="http://localhost:8001/module_item_configurations">
+{% block styles %}
+  {% for url in  asset_urls("file_picker_v2_css") %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}
 
-    <input type="hidden" id="authorization" name="authorization" value="{{ js_config.authorization_param }}">
-    <input type="hidden" id="resource_link_id" name="resource_link_id" value="{{ resource_link_id }}">
-    <input type="hidden" id="tool_consumer_instance_guid" name="tool_consumer_instance_guid" value="{{ tool_consumer_instance_guid }}">
-    <input type="hidden" id="oauth_consumer_key" name="oauth_consumer_key" value="{{ oauth_consumer_key }}">
-    <input type="hidden" id="user_id" name="user_id" value="{{ user_id }}">
-    <input type="hidden" id="context_id" name="context_id" value="{{ context_id }}">
+{% block scripts %}
+  {% for url in asset_urls("file_picker_v2_js") %}
+    <script async defer src="{{ url }}"></script>
+  {% endfor %}
 
-    <fieldset>
-      <legend>Which file should the assignment use?</legend>
-      <ul>
-        <li>
-          <label for="dummy">Dummy PDF File</label>
-          <input type="radio" checked id="dummy" name="document_url" value="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf">
-        </li>
-        <li>
-          <label for="document">PDF document</label>
-          <input type="radio" id="document" name="document_url" value="http://www.pdf995.com/samples/pdf.pdf">
-        </li>
-        <li>
-          <label for="simple">A Simple PDF File</label>
-          <input type="radio" id="simple" name="document_url" value="http://www.africau.edu/images/default/sample.pdf">
-        </li>
-      </ul>
-    </fieldset>
-    <button type="submit">Submit</button>
-  </form>
+  <script class="js-hypothesis-config" type="text/json">
+    {
+      "formAction": "{{ content_item_return_url }}",
+      "formFields": {{ form_fields | tojson }}
+    }
+  </script>
 {% endblock %}

--- a/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
@@ -1,0 +1,34 @@
+{% extends "lms:templates/base.html.jinja2" %}
+
+{% block content %}
+  <p>Assignment is not configured. You need to choose a file:</p>
+
+  <form method="POST" action="http://localhost:8001/module_item_configurations">
+
+    <input type="hidden" id="authorization" name="authorization" value="{{ js_config.authorization_param }}">
+    <input type="hidden" id="resource_link_id" name="resource_link_id" value="{{ resource_link_id }}">
+    <input type="hidden" id="tool_consumer_instance_guid" name="tool_consumer_instance_guid" value="{{ tool_consumer_instance_guid }}">
+    <input type="hidden" id="oauth_consumer_key" name="oauth_consumer_key" value="{{ oauth_consumer_key }}">
+    <input type="hidden" id="user_id" name="user_id" value="{{ user_id }}">
+    <input type="hidden" id="context_id" name="context_id" value="{{ context_id }}">
+
+    <fieldset>
+      <legend>Which file should the assignment use?</legend>
+      <ul>
+        <li>
+          <label for="dummy">Dummy PDF File</label>
+          <input type="radio" checked id="dummy" name="document_url" value="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf">
+        </li>
+        <li>
+          <label for="document">PDF document</label>
+          <input type="radio" id="document" name="document_url" value="http://www.pdf995.com/samples/pdf.pdf">
+        </li>
+        <li>
+          <label for="simple">A Simple PDF File</label>
+          <input type="radio" id="simple" name="document_url" value="http://www.africau.edu/images/default/sample.pdf">
+        </li>
+      </ul>
+    </fieldset>
+    <button type="submit">Submit</button>
+  </form>
+{% endblock %}

--- a/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch_not_authorized.html.jinja2
+++ b/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch_not_authorized.html.jinja2
@@ -1,0 +1,12 @@
+{% extends "lms:templates/base.html.jinja2" %}
+
+{% block content %}
+  <main class="modal-content">
+    <h1>Hypothesis Assignment Isn't Configured</h1>
+
+    <p class="modal-text">
+      This assignment hasn't been configured yet.
+      An instructor needs to launch the assignment to configure it.
+    </p>
+  </main>
+{% endblock %}

--- a/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch_not_authorized.html.jinja2
+++ b/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch_not_authorized.html.jinja2
@@ -2,7 +2,7 @@
 
 {% block content %}
   <main class="modal-content">
-    <h1>Hypothesis Assignment Isn't Configured</h1>
+    <h1>Hypothesis assignment isn't configured</h1>
 
     <p class="modal-text">
       This assignment hasn't been configured yet.

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -20,7 +20,7 @@ from pyramid.view import view_config, view_defaults
 from lms.models import ModuleItemConfiguration
 from lms.services import CanvasAPIError
 from lms.util import via_url
-from lms.validation import BearerTokenSchema
+from lms.validation import BearerTokenSchema, ConfigureModuleItemSchema
 from lms.views.decorators import (
     upsert_h_user,
     upsert_course_group,
@@ -181,6 +181,7 @@ class BasicLTILaunchViews:
         authorized_to_configure_assignments=True,
         decorator=[],  # Disable the default decorators just for this view.
         route_name="module_item_configurations",
+        schema=ConfigureModuleItemSchema,
     )
     def configure_module_item(self):
         """
@@ -196,13 +197,13 @@ class BasicLTILaunchViews:
         And we also send back the assignment launch page, passing the chosen
         URL to Via, as the direct response to the content item form submission.
         """
-        document_url = self.request.params["document_url"]
+        document_url = self.request.parsed_params["document_url"]
 
         self.request.db.add(
             ModuleItemConfiguration(
                 document_url=document_url,
-                resource_link_id=self.request.params["resource_link_id"],
-                tool_consumer_instance_guid=self.request.params[
+                resource_link_id=self.request.parsed_params["resource_link_id"],
+                tool_consumer_instance_guid=self.request.parsed_params[
                     "tool_consumer_instance_guid"
                 ],
             )

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -20,6 +20,7 @@ from pyramid.view import view_config, view_defaults
 from lms.models import ModuleItemConfiguration
 from lms.services import CanvasAPIError
 from lms.util import via_url
+from lms.validation import BearerTokenSchema
 from lms.views.decorators import (
     upsert_h_user,
     upsert_course_group,
@@ -141,13 +142,21 @@ class BasicLTILaunchViews:
         will then be DB-configured launches rather than unconfigured.
         """
         return {
-            "resource_link_id": self.request.params["resource_link_id"],
-            "tool_consumer_instance_guid": self.request.params[
-                "tool_consumer_instance_guid"
-            ],
-            "oauth_consumer_key": self.request.lti_user.oauth_consumer_key,
-            "user_id": self.request.lti_user.user_id,
-            "context_id": self.request.params["context_id"],
+            "content_item_return_url": self.request.route_url(
+                "module_item_configurations"
+            ),
+            "form_fields": {
+                "authorization": BearerTokenSchema(self.request).authorization_param(
+                    self.request.lti_user
+                ),
+                "resource_link_id": self.request.params["resource_link_id"],
+                "tool_consumer_instance_guid": self.request.params[
+                    "tool_consumer_instance_guid"
+                ],
+                "oauth_consumer_key": self.request.lti_user.oauth_consumer_key,
+                "user_id": self.request.lti_user.user_id,
+                "context_id": self.request.params["context_id"],
+            },
         }
 
     # pylint:disable=no-self-use

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -178,6 +178,7 @@ class BasicLTILaunchViews:
         return {}
 
     @view_config(
+        authorized_to_configure_assignments=True,
         decorator=[],  # Disable the default decorators just for this view.
         route_name="module_item_configurations",
     )

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -93,14 +93,8 @@ class BasicLTILaunchViews:
         # won't be called if there isn't a matching ModuleItemConfiguration in
         # the DB. So here we can safely assume that the ModuleItemConfiguration
         # exists.
-        document_url = (
-            self.request.db.query(ModuleItemConfiguration)
-            .filter_by(
-                resource_link_id=resource_link_id,
-                tool_consumer_instance_guid=tool_consumer_instance_guid,
-            )
-            .one()
-            .document_url
+        document_url = ModuleItemConfiguration.get_document_url(
+            self.request.db, tool_consumer_instance_guid, resource_link_id
         )
 
         return {"via_url": via_url(self.request, document_url)}
@@ -199,14 +193,11 @@ class BasicLTILaunchViews:
         """
         document_url = self.request.parsed_params["document_url"]
 
-        self.request.db.add(
-            ModuleItemConfiguration(
-                document_url=document_url,
-                resource_link_id=self.request.parsed_params["resource_link_id"],
-                tool_consumer_instance_guid=self.request.parsed_params[
-                    "tool_consumer_instance_guid"
-                ],
-            )
+        ModuleItemConfiguration.set_document_url(
+            self.request.db,
+            self.request.parsed_params["tool_consumer_instance_guid"],
+            self.request.parsed_params["resource_link_id"],
+            document_url,
         )
 
         return {"via_url": via_url(self.request, document_url)}

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -1,0 +1,201 @@
+"""
+Views for handling what the LTI spec calls "Basic LTI Launches".
+
+A Basic LTI Launch is the form submission POST request that an LMS sends us
+when it wants our app to launch an assignment, as opposed to other kinds of
+LTI launches such as the Content Item Selection launches that some LMS's
+send us while *creating* a new assignment.
+
+The spec requires Basic LTI Launch requests to have an ``lti_message_type``
+parameter with the value ``basic-lti-launch-request`` to distinguish them
+from other types of launch request (other "message types") but our code
+doesn't actually require basic launch requests to have this parameter.
+
+Note: The views in this module are currently used only when the new_oauth
+feature flag is on. They replace legacy views from ``lti_launches.py``
+that're still used when the feature flag is off.
+"""
+from pyramid.view import view_config, view_defaults
+
+from lms.models import ModuleItemConfiguration
+from lms.services import CanvasAPIError
+from lms.util import via_url
+from lms.views.decorators import (
+    upsert_h_user,
+    upsert_course_group,
+    add_user_to_group,
+    report_lti_launch,
+)
+
+
+@view_defaults(
+    decorator=[
+        # Before any LTI assignment launch create or update the Hypothesis user
+        # and group corresponding to the LTI user and course.
+        upsert_h_user,
+        upsert_course_group,
+        add_user_to_group,
+        # Report all LTI assignment launches to the /reports page.
+        report_lti_launch,
+    ],
+    feature_flag="new_oauth",
+    permission="launch_lti_assignment",
+    renderer="lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2",
+    request_method="POST",
+    route_name="lti_launches",
+)
+class BasicLTILaunchViews:
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(
+        canvas_file=True,
+        renderer="lms:templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2",
+    )
+    def canvas_file_basic_lti_launch(self):
+        """
+        Respond to a Canvas file assignment launch.
+
+        Canvas file assignment launch requests have a ``file_id`` request
+        parameter, which is the Canvas instance's ID for the file. To display
+        the assignment we have to use this ``file_id`` to get a download URL
+        for the file from the Canvas API. We then pass that download URL to
+        Via. We have to re-do this file-ID-for-download-URL exchange on every
+        single launch because Canvas's download URLs are temporary.
+        """
+        canvas_api_client = self.request.find_service(name="canvas_api_client")
+        file_id = self.request.params["file_id"]
+
+        try:
+            document_url = canvas_api_client.public_url(file_id)
+        except CanvasAPIError:
+            return {}
+
+        return {"via_url": via_url(self.request, document_url)}
+
+    @view_config(db_configured=True)
+    def db_configured_basic_lti_launch(self):
+        """
+        Respond to a DB-configured assignment launch.
+
+        DB-configured assignment launch requests don't have any kind of file ID
+        or document URL in the request. Instead the document URL is stored in
+        our own DB. This happens with LMS's that don't support LTI content item
+        selection/deep linking, so they don't support storing the document URL
+        in the LMS and passing it back to us in each launch request. Instead we
+        retrieve the document URL from the DB and pass it to Via.
+        """
+        resource_link_id = self.request.params["resource_link_id"]
+        tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
+
+        # The ``db_configured=True`` view predicate ensures that this view
+        # won't be called if there isn't a matching ModuleItemConfiguration in
+        # the DB. So here we can safely assume that the ModuleItemConfiguration
+        # exists.
+        document_url = (
+            self.request.db.query(ModuleItemConfiguration)
+            .filter_by(
+                resource_link_id=resource_link_id,
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
+            )
+            .one()
+            .document_url
+        )
+
+        return {"via_url": via_url(self.request, document_url)}
+
+    @view_config(url_configured=True)
+    def url_configured_basic_lti_launch(self):
+        """
+        Respond to a URL-configured assignment launch.
+
+        URL-configured assignment launch requests have the document URL in the
+        ``url`` request parameter. This happens in LMS's that support LTI
+        content item selection/deep linking: the document URL is chosen during
+        content item selection (during assignment creation) and saved in the
+        LMS, which passes it back to us in each launch request. All we have to
+        do is pass the URL to Via.
+        """
+        return {"via_url": via_url(self.request, self.request.params["url"])}
+
+    @view_config(
+        authorized_to_configure_assignments=True,
+        configured=False,
+        decorator=[],  # Disable the class's default decorators just for this view.
+        renderer="lms:templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2",
+    )
+    def unconfigured_basic_lti_launch(self):
+        """
+        Respond to an unconfigured assignment launch.
+
+        Unconfigured assignment launch requests don't contain any document URL
+        or file ID because the assignment's document hasn't been chosen yet.
+        This happens in LMS's that don't support LTI content item
+        selection/deep linking. They go straight from assignment creation to
+        launching the assignment without the user having had a chance to choose
+        a document.
+
+        When this happens we show the user our document-selection form instead
+        of launching the assignment. The user will choose the document and
+        we'll save it in our DB. Subsequent launches of the same assignment
+        will then be DB-configured launches rather than unconfigured.
+        """
+        return {
+            "resource_link_id": self.request.params["resource_link_id"],
+            "tool_consumer_instance_guid": self.request.params[
+                "tool_consumer_instance_guid"
+            ],
+            "oauth_consumer_key": self.request.lti_user.oauth_consumer_key,
+            "user_id": self.request.lti_user.user_id,
+            "context_id": self.request.params["context_id"],
+        }
+
+    # pylint:disable=no-self-use
+    @view_config(
+        authorized_to_configure_assignments=False,
+        configured=False,
+        decorator=[],  # Disable the class's default decorators just for this view.
+        renderer="lms:templates/basic_lti_launch/unconfigured_basic_lti_launch_not_authorized.html.jinja2",
+    )
+    def unconfigured_basic_lti_launch_not_authorized(self):
+        """
+        Respond to an unauthorized unconfigured assignment launch.
+
+        This happens when an assignment's document hasn't been chosen yet and
+        the assignment is launched by a user who isn't authorized to choose the
+        document (for example a learner rather than a teacher). We just show an
+        error page.
+        """
+        return {}
+
+    @view_config(
+        decorator=[],  # Disable the default decorators just for this view.
+        route_name="module_item_configurations",
+    )
+    def configure_module_item(self):
+        """
+        Respond to a configure module item request.
+
+        This happens after an unconfigured assignment launch. We show the user
+        our document selection form instead of launching the assignment, and
+        when the user chooses a document and submits the form this is the view
+        that receives that form submission.
+
+        We save the chosen document in the DB so that subsequent launches of
+        this same assignment will be DB-configured rather than unconfigured.
+        And we also send back the assignment launch page, passing the chosen
+        URL to Via, as the direct response to the content item form submission.
+        """
+        document_url = self.request.params["document_url"]
+
+        self.request.db.add(
+            ModuleItemConfiguration(
+                document_url=document_url,
+                resource_link_id=self.request.params["resource_link_id"],
+                tool_consumer_instance_guid=self.request.params[
+                    "tool_consumer_instance_guid"
+                ],
+            )
+        )
+
+        return {"via_url": via_url(self.request, document_url)}

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -159,9 +159,14 @@ class AuthorizedToConfigureAssignments(Base):
     name = "authorized_to_configure_assignments"
 
     def __call__(self, context, request):
-        roles = request.lti_user.roles.lower()
+        if request.lti_user:
+            roles = request.lti_user.roles.lower()
+        else:
+            roles = ""
+
         authorized = any(
             role in roles
             for role in ["administrator", "instructor", "teachingassistant"]
         )
+
         return authorized == self.value

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -125,7 +125,7 @@ class TestUnconfiguredBasicLTILaunchNotAuthorized:
 
 class TestConfigureModuleItem:
     def test_it_saves_the_assignments_document_url_to_the_db(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "document_url": "TEST_DOCUMENT_URL",
             "resource_link_id": "TEST_RESOURCE_LINK_ID",
             "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
@@ -144,7 +144,7 @@ class TestConfigureModuleItem:
     def test_it_passes_the_right_via_url_to_the_template(
         self, pyramid_request, via_url
     ):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "document_url": "TEST_DOCUMENT_URL",
             "resource_link_id": "TEST_RESOURCE_LINK_ID",
             "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -1,0 +1,137 @@
+from unittest import mock
+
+import pytest
+
+from lms.models import ModuleItemConfiguration
+from lms.services.canvas_api import CanvasAPIClient
+from lms.views.basic_lti_launch import BasicLTILaunchViews
+
+
+class TestCanvasFileBasicLTILaunch:
+    def test_it_gets_a_public_url_from_the_canvas_api(
+        self, canvas_api_client, pyramid_request
+    ):
+        pyramid_request.params = {"file_id": "TEST_FILE_ID"}
+
+        BasicLTILaunchViews(pyramid_request).canvas_file_basic_lti_launch()
+
+        canvas_api_client.public_url.assert_called_once_with("TEST_FILE_ID")
+
+    def test_it_passes_the_right_via_url_to_the_template(
+        self, canvas_api_client, pyramid_request, via_url
+    ):
+        pyramid_request.params = {"file_id": "TEST_FILE_ID"}
+
+        data = BasicLTILaunchViews(pyramid_request).canvas_file_basic_lti_launch()
+
+        via_url.assert_called_once_with(
+            pyramid_request, canvas_api_client.public_url.return_value
+        )
+        assert data["via_url"] == via_url.return_value
+
+    @pytest.fixture(autouse=True)
+    def canvas_api_client(self, pyramid_config):
+        canvas_api_client = mock.create_autospec(
+            CanvasAPIClient, spec_set=True, instance=True
+        )
+        pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
+        return canvas_api_client
+
+
+class TestDBConfiguredBasicLTILaunch:
+    def test_it_passes_the_right_via_url_to_the_template(
+        self, pyramid_request, via_url
+    ):
+        pyramid_request.params = {
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+        }
+        pyramid_request.db.add(
+            ModuleItemConfiguration(
+                resource_link_id="TEST_RESOURCE_LINK_ID",
+                tool_consumer_instance_guid="TEST_TOOL_CONSUMER_INSTANCE_GUID",
+                document_url="TEST_DOCUMENT_URL",
+            )
+        )
+
+        data = BasicLTILaunchViews(pyramid_request).db_configured_basic_lti_launch()
+
+        via_url.assert_called_once_with(pyramid_request, "TEST_DOCUMENT_URL")
+        assert data["via_url"] == via_url.return_value
+
+
+class TestURLConfiguredBasicLTILaunch:
+    def test_it_passes_the_right_via_url_to_the_template(
+        self, pyramid_request, via_url
+    ):
+        pyramid_request.params = {"url": "TEST_URL"}
+
+        data = BasicLTILaunchViews(pyramid_request).url_configured_basic_lti_launch()
+
+        via_url.assert_called_once_with(pyramid_request, "TEST_URL")
+        assert data["via_url"] == via_url.return_value
+
+
+class TestUnconfiguredBasicLTILaunch:
+    def test_it_returns_the_right_template_data(self, pyramid_request):
+        pyramid_request.params = {
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            "context_id": "TEST_CONTEXT_ID",
+        }
+        data = BasicLTILaunchViews(pyramid_request).unconfigured_basic_lti_launch()
+
+        assert data == {
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            "oauth_consumer_key": "TEST_OAUTH_CONSUMER_KEY",
+            "user_id": "TEST_USER_ID",
+            "context_id": "TEST_CONTEXT_ID",
+        }
+
+
+class TestUnconfiguredBasicLTILaunchNotAuthorized:
+    def test_it_returns_the_right_template_data(self, pyramid_request):
+        data = BasicLTILaunchViews(
+            pyramid_request
+        ).unconfigured_basic_lti_launch_not_authorized()
+
+        assert data == {}
+
+
+class TestConfigureModuleItem:
+    def test_it_saves_the_assignments_document_url_to_the_db(self, pyramid_request):
+        pyramid_request.params = {
+            "document_url": "TEST_DOCUMENT_URL",
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+        }
+
+        BasicLTILaunchViews(pyramid_request).configure_module_item()
+
+        mic = (
+            pyramid_request.db.query(ModuleItemConfiguration).filter_by(
+                resource_link_id="TEST_RESOURCE_LINK_ID",
+                tool_consumer_instance_guid="TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            )
+        ).one_or_none()
+        assert mic and mic.document_url == "TEST_DOCUMENT_URL"
+
+    def test_it_passes_the_right_via_url_to_the_template(
+        self, pyramid_request, via_url
+    ):
+        pyramid_request.params = {
+            "document_url": "TEST_DOCUMENT_URL",
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+        }
+
+        data = BasicLTILaunchViews(pyramid_request).configure_module_item()
+
+        via_url.assert_called_once_with(pyramid_request, "TEST_DOCUMENT_URL")
+        assert data["via_url"] == via_url.return_value
+
+
+@pytest.fixture(autouse=True)
+def via_url(patch):
+    return patch("lms.views.basic_lti_launch.via_url")

--- a/tests/lms/views/predicates/_lti_launch_test.py
+++ b/tests/lms/views/predicates/_lti_launch_test.py
@@ -178,6 +178,14 @@ class TestAuthorizedToConfigureAssignments:
 
         assert predicate(mock.sentinel.context, request) is expected
 
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_theres_no_lti_user(self, value, expected):
+        request = DummyRequest()
+        request.lti_user = None
+        predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, request) is expected
+
 
 @pytest.fixture(autouse=True)
 def ModuleItemConfiguration(patch):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/639, https://github.com/hypothesis/lms/pull/644 and https://github.com/hypothesis/lms/pull/645.

Add new views and templates for handling LTI assignment launches when the `new_oauth` feature flag is on.