### PR TITLE
Add unique constraint to module_item_configurations

### DIFF
--- a/lms/migrations/versions/4ab4d06f7e3f_add_unique_constraint_to_module_item_.py
+++ b/lms/migrations/versions/4ab4d06f7e3f_add_unique_constraint_to_module_item_.py
@@ -1,0 +1,27 @@
+"""
+Add unique constraint to module_item_configurations.
+
+Revision ID: 4ab4d06f7e3f
+Revises: f36f9a0aadf4
+Create Date: 2019-05-28 14:08:38.790749
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4ab4d06f7e3f"
+down_revision = "f36f9a0aadf4"
+
+
+def upgrade():
+    op.create_unique_constraint(
+        "uq__module_item_configurations__resource_link_id",
+        "module_item_configurations",
+        ["resource_link_id", "tool_consumer_instance_guid"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "uq__module_item_configurations__resource_link_id", "module_item_configurations"
+    )

--- a/lms/models/module_item_configuration.py
+++ b/lms/models/module_item_configuration.py
@@ -6,6 +6,9 @@ class ModuleItemConfiguration(BASE):
     """Class that links a document url to a specific lms module (Not needed for canvas)."""
 
     __tablename__ = "module_item_configurations"
+    __table_args__ = (
+        sa.UniqueConstraint("resource_link_id", "tool_consumer_instance_guid"),
+    )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     resource_link_id = sa.Column(sa.String)


### PR DESCRIPTION
In practice no two module_item_configurations with the same
resource_link_id, tool_consumer_instance_guid and document_url are ever
created, and if a duplicate did get into the DB the code would
misbehave.

See:

https://github.com/hypothesis/lms/blob/3430effa15d8f8137db908f5c40ab1df5c85f908/lms/views/lti_launches.py#L70-L77

So add a DB constraint to make sure that this can't happen, and also to
speed up a common DB query by adding an index.