### PR TITLE
Add LTIUser.roles value

### DIFF
--- a/lms/validation/_bearer_token.py
+++ b/lms/validation/_bearer_token.py
@@ -60,6 +60,7 @@ class BearerTokenSchema(marshmallow.Schema):
 
     user_id = marshmallow.fields.Str(required=True)
     oauth_consumer_key = marshmallow.fields.Str(required=True)
+    roles = marshmallow.fields.Str(required=True)
 
     class Meta:
         """Marshmallow options for this schema."""

--- a/lms/validation/_launch_params.py
+++ b/lms/validation/_launch_params.py
@@ -31,6 +31,7 @@ class LaunchParamsSchema(marshmallow.Schema):
     """
 
     user_id = marshmallow.fields.Str(required=True)
+    roles = marshmallow.fields.Str(required=True)
 
     oauth_consumer_key = marshmallow.fields.Str(required=True)
     oauth_nonce = marshmallow.fields.Str(required=True)
@@ -64,7 +65,9 @@ class LaunchParamsSchema(marshmallow.Schema):
         except HTTPUnprocessableEntity as err:
             raise ValidationError(err.json) from err
 
-        return LTIUser(kwargs["user_id"], kwargs["oauth_consumer_key"])
+        return LTIUser(
+            kwargs["user_id"], kwargs["oauth_consumer_key"], kwargs.get("roles", "")
+        )
 
     @marshmallow.validates_schema
     def _verify_oauth_1(self, _data):

--- a/lms/values.py
+++ b/lms/values.py
@@ -13,3 +13,6 @@ class LTIUser(NamedTuple):
 
     oauth_consumer_key: str
     """The oauth_consumer_key LTI launch parameter."""
+
+    roles: str
+    """The user's LTI roles."""

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -76,7 +76,7 @@ def upsert_course_group(wrapped):
         hapi_svc = request.find_service(name="hapi")
 
         is_instructor = any(
-            role in request.params["roles"].lower()
+            role in request.lti_user.roles.lower()
             for role in ("administrator", "instructor", "teachingassisstant")
         )
 

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -162,7 +162,7 @@ class AuthorizedToConfigureAssignments(Base):
     name = "authorized_to_configure_assignments"
 
     def __call__(self, context, request):
-        roles = request.params.get("roles", "").lower()
+        roles = request.lti_user.roles.lower()
         authorized = any(
             role in roles
             for role in ["administrator", "instructor", "teachingassistant"]

--- a/tests/lms/authentication/_helpers_test.py
+++ b/tests/lms/authentication/_helpers_test.py
@@ -10,11 +10,17 @@ class TestAuthenticatedUserID:
         "lti_user,expected_userid",
         [
             (
-                LTIUser("sam", "Hypothesisf301584250a2dece14f021ab8424018a"),
+                LTIUser(
+                    "sam", "Hypothesisf301584250a2dece14f021ab8424018a", "TEST_ROLES"
+                ),
                 "c2Ft:Hypothesisf301584250a2dece14f021ab8424018a",
             ),
             (
-                LTIUser("Sam:Smith", "Hypothesisf301584250a2dece14f021ab8424018a"),
+                LTIUser(
+                    "Sam:Smith",
+                    "Hypothesisf301584250a2dece14f021ab8424018a",
+                    "TEST_ROLES",
+                ),
                 "U2FtOlNtaXRo:Hypothesisf301584250a2dece14f021ab8424018a",
             ),
         ],

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -130,7 +130,9 @@ def pyramid_request(db_session):
     pyramid_request.feature = mock.create_autospec(
         lambda feature: False, return_value=False
     )
-    pyramid_request.lti_user = LTIUser("TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY")
+    pyramid_request.lti_user = LTIUser(
+        "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES"
+    )
 
     return pyramid_request
 

--- a/tests/lms/validation/_bearer_token_test.py
+++ b/tests/lms/validation/_bearer_token_test.py
@@ -94,6 +94,16 @@ class TestBearerTokenSchema:
             "oauth_consumer_key": ["Missing data for required field."]
         }
 
+    def test_it_raises_if_the_roles_param_is_missing(self, schema, _helpers):
+        del _helpers.decode_jwt.return_value["roles"]
+
+        with pytest.raises(ValidationError) as exc_info:
+            schema.lti_user()
+
+        assert exc_info.value.messages == {
+            "roles": ["Missing data for required field."]
+        }
+
     def test_serialize_and_deserialize_via_marshmallow_api(self, lti_user, schema):
         serialized = schema.dump(lti_user)
         deserialized = schema.load(serialized.data)
@@ -109,7 +119,9 @@ class TestBearerTokenSchema:
     def lti_user(self):
         """The original LTIUser that was encoded as a JWT in the request."""
         return LTIUser(
-            user_id="TEST_USER_ID", oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY"
+            user_id="TEST_USER_ID",
+            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            roles="TEST_ROLES",
         )
 
     @pytest.fixture
@@ -133,5 +145,6 @@ def _helpers(patch):
     _helpers.decode_jwt.return_value = {
         "user_id": "TEST_USER_ID",
         "oauth_consumer_key": "TEST_OAUTH_CONSUMER_KEY",
+        "roles": "TEST_ROLES",
     }
     return _helpers

--- a/tests/lms/validation/_launch_params_test.py
+++ b/tests/lms/validation/_launch_params_test.py
@@ -10,7 +10,9 @@ class TestLaunchParamsSchema:
     def test_it_returns_the_lti_user_info(self, schema):
         lti_user = schema.lti_user()
 
-        assert lti_user == LTIUser("TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY")
+        assert lti_user == LTIUser(
+            "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES"
+        )
 
     def test_it_does_oauth_1_verification(self, launch_verifier, schema):
         schema.lti_user()
@@ -29,6 +31,7 @@ class TestLaunchParamsSchema:
         "missing_param",
         [
             "user_id",
+            "roles",
             "oauth_consumer_key",
             "oauth_nonce",
             "oauth_signature",
@@ -64,5 +67,6 @@ class TestLaunchParamsSchema:
             "oauth_signature_method": "TEST_OAUTH_SIGNATURE_METHOD",
             "oauth_timestamp": "TEST_OAUTH_TIMESTAMP",
             "oauth_version": "TEST_OAUTH_VERSION",
+            "roles": "TEST_ROLES",
         }
         return pyramid_request

--- a/tests/lms/validation/_oauth_test.py
+++ b/tests/lms/validation/_oauth_test.py
@@ -151,7 +151,7 @@ class TestCanvasOauthCallbackSchema:
 
     @pytest.fixture
     def lti_user(self):
-        return LTIUser("test_user_id", "test_oauth_consumer_key")
+        return LTIUser("test_user_id", "test_oauth_consumer_key", "test_roles")
 
     @pytest.fixture
     def pyramid_request(self, lti_user):

--- a/tests/lms/views/predicates/_lti_launch_test.py
+++ b/tests/lms/views/predicates/_lti_launch_test.py
@@ -4,6 +4,7 @@ from pyramid.testing import DummyRequest
 import pytest
 
 from lms.models import ModuleItemConfiguration
+from lms.values import LTIUser
 from lms.views.predicates import (
     DBConfigured,
     CanvasFile,
@@ -145,20 +146,24 @@ class TestAuthorizedToConfigureAssignments:
     )
     @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
     def test_when_user_is_authorized(self, roles, value, expected):
-        request = DummyRequest(params={"roles": roles})
+        request = DummyRequest()
+        request.lti_user = LTIUser(
+            user_id="TEST_USER_ID",
+            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            roles=roles,
+        )
         predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
 
         assert predicate(mock.sentinel.context, request) is expected
 
     @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
     def test_when_user_isnt_authorized(self, value, expected):
-        request = DummyRequest(params={"roles": "Learner"})
+        request = DummyRequest()
+        request.lti_user = LTIUser(
+            user_id="TEST_USER_ID",
+            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            roles="Learner",
+        )
         predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
 
         assert predicate(mock.sentinel.context, request) is expected
-
-    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
-    def test_when_theres_no_roles_param(self, value, expected):
-        predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
-
-        assert predicate(mock.sentinel.context, DummyRequest()) is expected


### PR DESCRIPTION
`LTIUser` objects are the values that get serialized into JWT authorization params that are then included in XHR requests, form submissions and OAuth 2 redirects, deserialized again, and used to authenticate the user making the request.

We have an upcoming need to know the user's LTI roles not just their `user_id` and `oauth_consumer_key`, so add a new field `LTIUser.roles`.

This of course will invalidate any existing authorization params out there in the wild in people's open tabs. Fortunately this is all still behind a feature flag so we're fine.