### PR TITLE
Add ConfigureModuleItemSchema

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -38,6 +38,7 @@ from lms.validation._exceptions import (
 from lms.validation._oauth import CanvasOAuthCallbackSchema
 from lms.validation._launch_params import LaunchParamsSchema
 from lms.validation._bearer_token import BearerTokenSchema
+from lms.validation._module_item_configuration import ConfigureModuleItemSchema
 from lms.validation._helpers import instantiate_schema
 
 
@@ -46,6 +47,7 @@ __all__ = (
     "CanvasOAuthCallbackSchema",
     "BearerTokenSchema",
     "LaunchParamsSchema",
+    "ConfigureModuleItemSchema",
     "ValidationError",
     "ExpiredSessionTokenError",
     "MissingSessionTokenError",

--- a/lms/validation/_module_item_configuration.py
+++ b/lms/validation/_module_item_configuration.py
@@ -1,0 +1,26 @@
+"""Validation for the configure_module_item() view."""
+
+import marshmallow
+from webargs import fields
+
+
+__all__ = ["ConfigureModuleItemSchema"]
+
+
+class ConfigureModuleItemSchema(marshmallow.Schema):
+    """Schema for validating requests to the configure_module_item() view."""
+
+    document_url = fields.Str(required=True)
+    resource_link_id = fields.Str(required=True)
+    tool_consumer_instance_guid = fields.Str(required=True)
+
+    class Meta:
+        """Marshmallow options for this schema."""
+
+        # Silence a strict=False deprecation warning from marshmallow.
+        # TODO: Remove this once we've upgraded to marshmallow 3.
+        strict = True
+
+    def __init__(self, request):
+        super().__init__()
+        self._request = request

--- a/tests/lms/validation/_module_item_configuration_test.py
+++ b/tests/lms/validation/_module_item_configuration_test.py
@@ -1,0 +1,44 @@
+from pyramid import testing
+import pytest
+
+from lms.validation import ConfigureModuleItemSchema, parser
+from lms.validation import ValidationError
+
+
+class TestConfigureModuleItemSchema:
+    def test_that_validation_succeeds_for_valid_requests(self, pyramid_request, schema):
+        self.parse(schema, pyramid_request)
+
+    @pytest.mark.parametrize(
+        "param", ["document_url", "resource_link_id", "tool_consumer_instance_guid"]
+    )
+    def test_that_validation_fails_if_a_required_param_is_missing(
+        self, param, pyramid_request, schema
+    ):
+        del pyramid_request.params[param]
+
+        with pytest.raises(ValidationError) as exc_info:
+            self.parse(schema, pyramid_request)
+
+        assert exc_info.value.messages == dict(
+            [(param, ["Missing data for required field."])]
+        )
+
+    def parse(self, schema, request):
+        """Parse ``request`` with ``schema`` and return the parsed params."""
+        return parser.parse(schema, request, locations=["form"])
+
+    @pytest.fixture
+    def pyramid_request(self):
+        """Return a minimal valid OAuth 2 redirect request."""
+        pyramid_request = testing.DummyRequest()
+        pyramid_request.params["document_url"] = "test_document_url"
+        pyramid_request.params["resource_link_id"] = "test_resource_link_id"
+        pyramid_request.params[
+            "tool_consumer_instance_guid"
+        ] = "test_tool_consumer_instance_guid"
+        return pyramid_request
+
+    @pytest.fixture
+    def schema(self, pyramid_request):
+        return ConfigureModuleItemSchema(pyramid_request)


### PR DESCRIPTION
This schema will be used to protect the `/module_item_configurations` route. When an unconfigured assignment is launched the content item form that's rendered gets submitted to `/module_item_configurations` so that the chosen document URL can be saved in the DB. This schema will be used to validate those form submissions.