### PR TITLE
Change the public_url API to via_url

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -44,6 +44,4 @@ def includeme(config):
     config.add_route(
         "canvas_api.courses.files.list", "/api/canvas/courses/{course_id}/files"
     )
-    config.add_route(
-        "canvas_api.files.public_url", "/api/canvas/files/{file_id}/public_url"
-    )
+    config.add_route("canvas_api.files.via_url", "/api/canvas/files/{file_id}/via_url")

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -31,6 +31,8 @@ proxy API caller::
 """
 from pyramid.view import view_config, view_defaults
 
+from lms import util
+
 
 @view_defaults(permission="canvas_api", renderer="json")
 class FilesAPIViews:
@@ -43,11 +45,11 @@ class FilesAPIViews:
         """Return the list of files in the given course."""
         return self.canvas_api_client.list_files(self.request.matchdict["course_id"])
 
-    @view_config(request_method="GET", route_name="canvas_api.files.public_url")
-    def public_url(self):
-        """Return the public URL of the given file."""
-        return {
-            "public_url": self.canvas_api_client.public_url(
-                self.request.matchdict["file_id"]
-            )
-        }
+    @view_config(request_method="GET", route_name="canvas_api.files.via_url")
+    def via_url(self):
+        """Return the Via URL for annotating the given Canvas file."""
+        public_url = self.canvas_api_client.public_url(
+            self.request.matchdict["file_id"]
+        )
+        via_url = util.via_url(self.request, public_url)
+        return {"via_url": via_url}

--- a/tests/lms/views/api/canvas/files_test.py
+++ b/tests/lms/views/api/canvas/files_test.py
@@ -24,18 +24,27 @@ class TestListFiles:
         return pyramid_request
 
 
-class TestPublicURL:
+class TestViaURL:
     def test_it_gets_the_public_url_from_canvas(
         self, canvas_api_client, pyramid_request
     ):
-        FilesAPIViews(pyramid_request).public_url()
+        FilesAPIViews(pyramid_request).via_url()
 
         canvas_api_client.public_url.assert_called_once_with("test_file_id")
 
-    def test_it_returns_the_public_url(self, canvas_api_client, pyramid_request):
-        data = FilesAPIViews(pyramid_request).public_url()
+    def test_it_gets_the_via_url_for_the_public_url(
+        self, canvas_api_client, pyramid_request, util
+    ):
+        FilesAPIViews(pyramid_request).via_url()
 
-        assert data["public_url"] == canvas_api_client.public_url.return_value
+        util.via_url.assert_called_once_with(
+            pyramid_request, canvas_api_client.public_url.return_value
+        )
+
+    def test_it_returns_the_via_url(self, pyramid_request, util):
+        data = FilesAPIViews(pyramid_request).via_url()
+
+        assert data["via_url"] == util.via_url.return_value
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -50,3 +59,8 @@ def canvas_api_client(pyramid_config):
     )
     pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
     return canvas_api_client
+
+
+@pytest.fixture(autouse=True)
+def util(patch):
+    return patch("lms.views.api.canvas.files.util")


### PR DESCRIPTION
Rather than returning the public URL of a Canvas file and making the
frontend construct the Via URL from it, our proxy API should return the
Via URL for the Canvas file complete with https://via.hypothes.is/
prefix and query parameters. The frontend code can just use this Via URL
directly.