### PR TITLE
Fix the new Google Picker in non-Canvas LMS's

### DIFF
--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -18,9 +18,9 @@ def configure(settings):
         # integrate with.
         "via_url": sg.get("VIA_URL", required=True),
         "jwt_secret": sg.get("JWT_SECRET", required=True),
-        "google_client_id": sg.get("GOOGLE_CLIENT_ID"),
-        "google_developer_key": sg.get("GOOGLE_DEVELOPER_KEY"),
-        "google_app_id": sg.get("GOOGLE_APP_ID"),
+        "google_client_id": sg.get("GOOGLE_CLIENT_ID", required=True),
+        "google_developer_key": sg.get("GOOGLE_DEVELOPER_KEY", required=True),
+        "google_app_id": sg.get("GOOGLE_APP_ID", required=True),
         "lms_secret": sg.get("LMS_SECRET"),
         "hashed_pw": sg.get("HASHED_PW"),
         "salt": sg.get("SALT"),

--- a/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
@@ -18,7 +18,10 @@
   <script class="js-hypothesis-config" type="text/json">
     {
       "formAction": "{{ content_item_return_url }}",
-      "formFields": {{ form_fields | tojson }}
+      "formFields": {{ form_fields | tojson }},
+      "googleClientId": "{{ google_client_id }}",
+      "googleDeveloperKey": "{{ google_developer_key }}",
+      "lmsUrl": "{{ lms_url }}"
     }
   </script>
 {% endblock %}

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -135,10 +135,24 @@ class BasicLTILaunchViews:
         we'll save it in our DB. Subsequent launches of the same assignment
         will then be DB-configured launches rather than unconfigured.
         """
+        oauth_consumer_key = self.request.lti_user.oauth_consumer_key
+
+        lms_url = self.request.params.get("custom_canvas_api_domain")
+
+        if not lms_url:
+            lms_url = self.request.find_service(name="ai_getter").lms_url(
+                oauth_consumer_key
+            )
+
         return {
             "content_item_return_url": self.request.route_url(
                 "module_item_configurations"
             ),
+            "google_client_id": self.request.registry.settings["google_client_id"],
+            "google_developer_key": self.request.registry.settings[
+                "google_developer_key"
+            ],
+            "lms_url": lms_url,
             "form_fields": {
                 "authorization": BearerTokenSchema(self.request).authorization_param(
                     self.request.lti_user
@@ -147,7 +161,7 @@ class BasicLTILaunchViews:
                 "tool_consumer_instance_guid": self.request.params[
                     "tool_consumer_instance_guid"
                 ],
-                "oauth_consumer_key": self.request.lti_user.oauth_consumer_key,
+                "oauth_consumer_key": oauth_consumer_key,
                 "user_id": self.request.lti_user.user_id,
                 "context_id": self.request.params["context_id"],
             },


### PR DESCRIPTION
## Make the Google deployment settings required

There are only two deployments of this app - lms.hypothes.is and qa-lms.hypothes.is - and both of those have the Google Drive-related environment variables set. This app isn't intended to be used by third parties. So there's no need for the Google Drive-related settings to be optional, and the code can be simpler if it assumes that these settings are always present.

In development environments, if the developer wants to test the app without going to the trouble of creating a Google Drive client, they can just set these envvars to placeholder values as the README already says to do. Everything will work fine except that clicking on the **Select PDF from Google Drive** won't work.

We could make this even easier for developers by providing placeholder values in `development.ini` but that isn't done for any of the other settings yet.

## Fix the new Google Drive support in non-Canvas LMS's

In LMS's that don't support content-item selection, so they use the unconfigured assignment launch view to configure an assignment's document, pass the necessary config settings for Google Drive support to
the frontend so that the Google Drive button works.