### PR TITLE
Move lms/config/resources.py into the right place

### DIFF
--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -87,7 +87,9 @@ def configure(settings):
 
     settings.update(env_settings)
 
-    config = Configurator(settings=settings, root_factory=".resources.Root")
+    config = Configurator(
+        settings=settings, root_factory="lms.resources.DefaultResource"
+    )
 
     # Security policies
     authz_policy = ACLAuthorizationPolicy()

--- a/lms/resources/__init__.py
+++ b/lms/resources/__init__.py
@@ -1,0 +1,14 @@
+"""
+The application's Pyramid traversal resources.
+
+See the traversal-related sections in the Pyramid docs:
+
+* https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hellotraversal.html
+* https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/muchadoabouttraversal.html
+* https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/traversal.html
+* https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html
+"""
+from lms.resources._default import DefaultResource
+from lms.resources._lti_launch import LTILaunchResource
+
+__all__ = ["DefaultResource", "LTILaunchResource"]

--- a/lms/resources/_default.py
+++ b/lms/resources/_default.py
@@ -1,0 +1,15 @@
+"""Default traversal resources."""
+from pyramid.security import Allow
+
+
+__all__ = ["DefaultResource"]
+
+
+class DefaultResource:
+    """The application'a default root resource."""
+
+    __acl__ = [(Allow, "report_viewers", "view"), (Allow, "lti_user", "canvas_api")]
+
+    def __init__(self, request):
+        """Return the default root resource object."""
+        self._request = request

--- a/lms/resources/_default.py
+++ b/lms/resources/_default.py
@@ -6,7 +6,7 @@ __all__ = ["DefaultResource"]
 
 
 class DefaultResource:
-    """The application'a default root resource."""
+    """The application's default root resource."""
 
     __acl__ = [(Allow, "report_viewers", "view"), (Allow, "lti_user", "canvas_api")]
 

--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -1,3 +1,4 @@
+"""Traversal resources for LTI launch views."""
 import datetime
 import hashlib
 import urllib
@@ -9,17 +10,10 @@ from pyramid.security import Allow
 from lms.util import lti_params_for
 
 
-class Root:
-    """The default root factory for the application."""
-
-    __acl__ = [(Allow, "report_viewers", "view"), (Allow, "lti_user", "canvas_api")]
-
-    def __init__(self, request):
-        """Return the default root resource object."""
-        self._request = request
+__all__ = ["LTILaunchResource"]
 
 
-class LTILaunch:
+class LTILaunchResource:
     """Context resource for LTI launch requests."""
 
     DISPLAY_NAME_MAX_LENGTH = 30

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from lms.config.resources import LTILaunch
-
-
 def includeme(config):
     config.add_route("index", "/")
     config.add_route("feature_flags_test", "/flags/test")
@@ -11,14 +7,20 @@ def includeme(config):
     config.add_route("reports", "/reports")
     config.add_route("config_xml", "/config_xml")
     config.add_route(
-        "module_item_configurations", "/module_item_configurations", factory=LTILaunch
+        "module_item_configurations",
+        "/module_item_configurations",
+        factory="lms.resources.LTILaunchResource",
     )
     config.add_route("canvas_proxy", "/canvas_proxy")
 
     # lms routes
-    config.add_route("lti_launches", "/lti_launches", factory=LTILaunch)
     config.add_route(
-        "content_item_selection", "/content_item_selection", factory=LTILaunch
+        "lti_launches", "/lti_launches", factory="lms.resources.LTILaunchResource"
+    )
+    config.add_route(
+        "content_item_selection",
+        "/content_item_selection",
+        factory="lms.resources.LTILaunchResource",
     )
 
     # Oauth
@@ -26,7 +28,7 @@ def includeme(config):
     config.add_route(
         "module_item_launch_oauth_callback",
         "/module_item_launch_oauth_callback",
-        factory=LTILaunch,
+        factory="lms.resources.LTILaunchResource",
     )
 
     # Assets

--- a/tests/lms/resources/_default_test.py
+++ b/tests/lms/resources/_default_test.py
@@ -1,0 +1,46 @@
+from pyramid.authorization import ACLAuthorizationPolicy
+import pytest
+
+from lms.resources import DefaultResource
+
+
+class TestDefaultResource:
+    def test_it_allows_report_viewers_to_view_the_reports_page(
+        self, pyramid_config, pyramid_request
+    ):
+        pyramid_config.testing_securitypolicy("jeremy", groupids=["report_viewers"])
+        pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
+
+        resource = DefaultResource(pyramid_request)
+
+        assert pyramid_request.has_permission("view", resource)
+
+    def test_it_doesnt_allow_others_to_view_the_reports_page(
+        self, pyramid_config, pyramid_request
+    ):
+        pyramid_config.testing_securitypolicy("someone_else", groupids=["others"])
+        pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
+
+        resource = DefaultResource(pyramid_request)
+
+        assert not pyramid_request.has_permission("view", resource)
+
+    def test_it_allows_lti_users_to_use_the_canvas_api(
+        self, pyramid_config, pyramid_request
+    ):
+        pyramid_config.testing_securitypolicy("some_lti_user", groupids=["lti_user"])
+        pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
+
+        resource = DefaultResource(pyramid_request)
+
+        assert pyramid_request.has_permission("canvas_api", resource)
+
+    def test_it_doesnt_allow_others_to_use_the_canvas_api(
+        self, pyramid_config, pyramid_request
+    ):
+        pyramid_config.testing_securitypolicy("someone_else", groupids=["others"])
+        pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
+
+        resource = DefaultResource(pyramid_request)
+
+        assert not pyramid_request.has_permission("canvas_api", resource)

--- a/tests/lms/resources/_lti_launch_test.py
+++ b/tests/lms/resources/_lti_launch_test.py
@@ -6,12 +6,12 @@ import pytest
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.httpexceptions import HTTPBadRequest
 
-from lms.config import resources
+from lms import resources
 from lms import models
 from lms.services import ConsumerKeyError
 
 
-class TestLTILaunch:
+class TestLTILaunchResource:
     def test_it_allows_LTI_users_to_launch_LTI_assignments(
         self, pyramid_config, pyramid_request
     ):
@@ -19,7 +19,7 @@ class TestLTILaunch:
         pyramid_config.testing_securitypolicy("TEST_USERNAME", groupids=["lti_user"])
         pyramid_config.set_authorization_policy(policy)
 
-        context = resources.LTILaunch(pyramid_request)
+        context = resources.LTILaunchResource(pyramid_request)
 
         assert pyramid_request.has_permission("launch_lti_assignment", context)
 
@@ -30,7 +30,7 @@ class TestLTILaunch:
         pyramid_config.testing_securitypolicy("TEST_USERNAME", groupids=["foo", "bar"])
         pyramid_config.set_authorization_policy(policy)
 
-        context = resources.LTILaunch(pyramid_request)
+        context = resources.LTILaunchResource(pyramid_request)
 
         assert not pyramid_request.has_permission("launch_lti_assignment", context)
 
@@ -40,7 +40,7 @@ class TestLTILaunch:
         lti_params_for.side_effect = HTTPBadRequest()
 
         with pytest.raises(HTTPBadRequest):
-            resources.LTILaunch(pyramid_request)
+            resources.LTILaunchResource(pyramid_request)
 
     @pytest.mark.parametrize(
         "request_params,expected_display_name",
@@ -157,7 +157,8 @@ class TestLTILaunch:
         lti_params_for.return_value = request_params
 
         assert (
-            resources.LTILaunch(pyramid_request).h_display_name == expected_display_name
+            resources.LTILaunchResource(pyramid_request).h_display_name
+            == expected_display_name
         )
 
     def test_h_groupid_raises_if_theres_no_tool_consumer_instance_guid(
@@ -168,7 +169,7 @@ class TestLTILaunch:
             HTTPBadRequest,
             match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
         ):
-            resources.LTILaunch(pyramid_request).h_groupid
+            resources.LTILaunchResource(pyramid_request).h_groupid
 
     def test_h_groupid_raises_if_theres_no_context_id(
         self, lti_params_for, pyramid_request
@@ -178,7 +179,7 @@ class TestLTILaunch:
             HTTPBadRequest,
             match='Required parameter "context_id" missing from LTI params',
         ):
-            resources.LTILaunch(pyramid_request).h_groupid
+            resources.LTILaunchResource(pyramid_request).h_groupid
 
     def test_h_groupid(self, lti_launch):
         assert (
@@ -208,7 +209,10 @@ class TestLTILaunch:
     ):
         lti_params_for.return_value = {"context_title": context_title}
 
-        assert resources.LTILaunch(pyramid_request).h_group_name == expected_group_name
+        assert (
+            resources.LTILaunchResource(pyramid_request).h_group_name
+            == expected_group_name
+        )
 
     def test_h_provider_just_returns_the_tool_consumer_instance_guid(
         self, lti_params_for, pyramid_request
@@ -217,7 +221,7 @@ class TestLTILaunch:
             "tool_consumer_instance_guid": "VCSy*G1u3:canvas-lms"
         }
 
-        provider = resources.LTILaunch(pyramid_request).h_provider
+        provider = resources.LTILaunchResource(pyramid_request).h_provider
 
         assert provider == "VCSy*G1u3:canvas-lms"
 
@@ -238,14 +242,16 @@ class TestLTILaunch:
             HTTPBadRequest,
             match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
         ):
-            resources.LTILaunch(pyramid_request).h_provider
+            resources.LTILaunchResource(pyramid_request).h_provider
 
     def test_h_provider_unique_id_just_returns_the_user_id(
         self, lti_params_for, pyramid_request
     ):
         lti_params_for.return_value = {"user_id": "4533***70d9"}
 
-        provider_unique_id = resources.LTILaunch(pyramid_request).h_provider_unique_id
+        provider_unique_id = resources.LTILaunchResource(
+            pyramid_request
+        ).h_provider_unique_id
 
         assert provider_unique_id == "4533***70d9"
 
@@ -258,7 +264,7 @@ class TestLTILaunch:
         with pytest.raises(
             HTTPBadRequest, match='Required parameter "user_id" missing from LTI params'
         ):
-            resources.LTILaunch(pyramid_request).h_provider_unique_id
+            resources.LTILaunchResource(pyramid_request).h_provider_unique_id
 
     def test_h_username_returns_a_30_char_string(self, pyramid_request, lti_params_for):
         lti_params_for.return_value = {
@@ -266,7 +272,7 @@ class TestLTILaunch:
             "user_id": "4533***70d9",
         }
 
-        username = resources.LTILaunch(pyramid_request).h_username
+        username = resources.LTILaunchResource(pyramid_request).h_username
 
         assert isinstance(username, str)
         assert len(username) == 30
@@ -280,7 +286,7 @@ class TestLTILaunch:
             HTTPBadRequest,
             match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
         ):
-            resources.LTILaunch(pyramid_request).h_username
+            resources.LTILaunchResource(pyramid_request).h_username
 
     def test_h_username_raises_if_user_id_is_missing(
         self, lti_params_for, pyramid_request
@@ -292,7 +298,7 @@ class TestLTILaunch:
         with pytest.raises(
             HTTPBadRequest, match='Required parameter "user_id" missing from LTI params'
         ):
-            resources.LTILaunch(pyramid_request).h_username
+            resources.LTILaunchResource(pyramid_request).h_username
 
     def test_h_userid(self, pyramid_request, lti_params_for):
         lti_params_for.return_value = {
@@ -300,7 +306,7 @@ class TestLTILaunch:
             "user_id": "4533***70d9",
         }
 
-        userid = resources.LTILaunch(pyramid_request).h_userid
+        userid = resources.LTILaunchResource(pyramid_request).h_userid
 
         assert userid == "acct:2569ad7b99f316ecc7dfee5c0c801c@TEST_AUTHORITY"
 
@@ -313,7 +319,7 @@ class TestLTILaunch:
             HTTPBadRequest,
             match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
         ):
-            resources.LTILaunch(pyramid_request).h_userid
+            resources.LTILaunchResource(pyramid_request).h_userid
 
     def test_h_userid_raises_if_user_id_is_missing(
         self, lti_params_for, pyramid_request
@@ -325,7 +331,7 @@ class TestLTILaunch:
         with pytest.raises(
             HTTPBadRequest, match='Required parameter "user_id" missing from LTI params'
         ):
-            resources.LTILaunch(pyramid_request).h_userid
+            resources.LTILaunchResource(pyramid_request).h_userid
 
     def test_hypothesis_config_raises_if_theres_no_oauth_consumer_key(
         self, lti_params_for, pyramid_request
@@ -336,7 +342,7 @@ class TestLTILaunch:
             HTTPBadRequest,
             match='Required parameter "oauth_consumer_key" missing from LTI params',
         ):
-            resources.LTILaunch(pyramid_request).hypothesis_config
+            resources.LTILaunchResource(pyramid_request).hypothesis_config
 
     def test_hypothesis_config_raises_if_theres_no_tool_consumer_instance_guid(
         self, lti_params_for, pyramid_request
@@ -349,7 +355,7 @@ class TestLTILaunch:
             HTTPBadRequest,
             match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
         ):
-            resources.LTILaunch(pyramid_request).hypothesis_config
+            resources.LTILaunchResource(pyramid_request).hypothesis_config
 
     def test_hypothesis_config_contains_one_service_config(self, lti_launch):
         assert len(lti_launch.hypothesis_config["services"]) == 1
@@ -429,18 +435,18 @@ class TestLTILaunch:
         self, lti_params_for, pyramid_request
     ):
         del lti_params_for.return_value["oauth_consumer_key"]
-        lti_launch = resources.LTILaunch(pyramid_request)
+        lti_launch = resources.LTILaunchResource(pyramid_request)
 
         with pytest.raises(HTTPBadRequest):
             lti_launch.provisioning_enabled
 
     @pytest.fixture
     def lti_launch(self, pyramid_request):
-        return resources.LTILaunch(pyramid_request)
+        return resources.LTILaunchResource(pyramid_request)
 
     @pytest.fixture(autouse=True)
     def lti_params_for(self, patch):
-        lti_params_for = patch("lms.config.resources.lti_params_for")
+        lti_params_for = patch("lms.resources._lti_launch.lti_params_for")
         lti_params_for.return_value = {
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
             "context_id": "test_context_id",

--- a/tests/lms/services/hapi_test.py
+++ b/tests/lms/services/hapi_test.py
@@ -8,7 +8,7 @@ from requests import ReadTimeout
 from requests import Response
 from requests import TooManyRedirects
 
-from lms.config.resources import LTILaunch
+from lms.resources import LTILaunchResource
 from lms.services.hapi import HypothesisAPIService
 from lms.services import HAPIError
 from lms.services import HAPINotFoundError
@@ -142,7 +142,7 @@ class TestAPIRequest:
     @pytest.fixture
     def context(self):
         context = mock.create_autospec(
-            LTILaunch,
+            LTILaunchResource,
             spec_set=True,
             instance=True,
             h_userid="acct:seanh@TEST_AUTHORITY",

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -9,7 +9,7 @@ from lms.services import HAPIError
 from lms.services import HAPINotFoundError
 from lms.views.decorators import h_api
 from lms.services.hapi import HypothesisAPIService
-from lms.config.resources import LTILaunch
+from lms.resources import LTILaunchResource
 from lms.values import LTIUser
 
 
@@ -272,7 +272,7 @@ class TestAddUserToGroup:
 @pytest.fixture
 def context():
     context = mock.create_autospec(
-        LTILaunch,
+        LTILaunchResource,
         spec_set=True,
         instance=True,
         h_display_name="test_display_name",

--- a/tests/lms/views/decorators/legacy_h_api_test.py
+++ b/tests/lms/views/decorators/legacy_h_api_test.py
@@ -11,7 +11,7 @@ from lms.services import HAPIError
 from lms.services import HAPINotFoundError
 from lms.views.decorators import legacy_h_api
 from lms.services.hapi import HypothesisAPIService
-from lms.config.resources import LTILaunch
+from lms.resources import LTILaunchResource
 
 
 @pytest.mark.usefixtures("hapi_svc")
@@ -272,7 +272,7 @@ class TestAddUserToGroup:
 @pytest.fixture
 def context():
     context = mock.create_autospec(
-        LTILaunch,
+        LTILaunchResource,
         spec_set=True,
         instance=True,
         h_display_name="test_display_name",

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -4,7 +4,7 @@ import pytest
 
 from lms.views.lti_launches import lti_launches
 from lms.exceptions import MissingLTILaunchParamError
-from lms.config.resources import LTILaunch
+from lms.resources import LTILaunchResource
 from tests.lms.conftest import unwrap
 
 
@@ -118,7 +118,7 @@ def lti_launch_request(lti_launch_request):
     lti_launch_request.params["resource_link_id"] = "test_link_id"
 
     lti_launch_request.context = mock.create_autospec(
-        LTILaunch,
+        LTILaunchResource,
         spec_set=True,
         instance=True,
         rpc_server_config={},


### PR DESCRIPTION
For some reason the app's Pyramid resources were put in a `resources.py` module in `lms/config/` even though they have nothing to do with config.

Extract these into a `lms/resources/` package.

Also renamed `Root` to `DefaultResource` and `LTILaunch` to `LTILaunchResource`. This makes it more obvious what these classes are and makes them easier to grep for.

Also add tests for `DefaultResource`.