### PR TITLE
Reduce the number of parallel build tasks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,26 +27,12 @@ node {
 
     // Run each of the stages in parallel.
     parallel failFast: true,
-    "Formatting": {
-        stage("Formatting") {
-            testApp(image: img, runArgs: runArgs) {
-                installDeps()
-                run("make checkformatting")
-            }
-        }
-    },
-    "Docstrings": {
-        stage("Docstrings") {
-            testApp(image: img, runArgs: runArgs) {
-                installDeps()
-                run("make checkdocstrings")
-            }
-        }
-    },
     "Backend lint": {
         stage("Backend lint") {
             testApp(image: img, runArgs: runArgs) {
                 installDeps()
+                run("make checkformatting")
+                run("make checkdocstrings")
                 run("make backend-lint")
             }
         }
@@ -66,21 +52,13 @@ node {
             }
         }
     },
-    "Frontend lint": {
-        stage("Frontend lint") {
-            testApp(image: img, runArgs: runArgs) {
-                installDeps()
-                sh "apk add yarn"
-                run("make frontend-lint")
-            }
-        }
-    },
-    "Frontend tests": {
-        stage("Frontend tests") {
+    "Frontend lint + tests": {
+        stage("Frontend lint + tests") {
             workspace = pwd()
             // The frontend tests use a node Docker image because they're
             // incompatible with the hypothesis/lms image.
             docker.image("node:10-stretch").inside("${runArgs} -e HOME=${workspace}") {
+                sh "make frontend-lint"
                 sh "make frontend-tests"
             }
         }


### PR DESCRIPTION
Each build task spins up its own Docker container and, for the backend tasks, each container also installs build dependencies (build-base, python3-dev etc.). It appears that this has significant overhead and on our current Jenkins setup, builds are prone to failing as a result. Specifically, we're seeing quite a lot of timeouts when Jenkins is invoking `docker run` to run backend tests and when trying to kill containers after a successful test run. See my notes and linked issues [in this Slack message](https://hypothes-is.slack.com/archives/C1MA4E9B9/p1560333606006300).

Reduce the contention by combining the backend
lint/docstrings/formatting tasks into one, and the frontend lint + tests
into one.

~~I also added config to suppress some lint failures seen in a fresh build of `make backend-lint` with no pre-existing tox env for "py36-lint".~~ (_seanh addressed this in a separate PR_)