### PR TITLE
Fix `make lint` by pinning Prospector

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     {tests,lint,docstrings,checkdocstrings}: pytest
     {tests,lint,docstrings,checkdocstrings}: factory-boy
     codecov: codecov
-    lint: prospector
+    lint: prospector==1.1.6.2
     {format,checkformatting}: black
     {docstrings,checkdocstrings}: sphinx
     docstrings: sphinx-autobuild


### PR DESCRIPTION
Pin Prospector to the latest version that works.

Pinning it in `tox.ini` like this won't enable it to be automatically updated by Dependabot. For the work needed to enable Dependabot to handle this see https://github.com/hypothesis/lms/pull/691