### PR TITLE
Move RPC server and client configs into base template

### DIFF
--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -32,6 +32,17 @@
       {% block content %}{% endblock %}
     </div>
 
-    {% block scripts %}{% endblock %}
+    {% block scripts %}
+      {% if context.rpc_server_config %}
+        <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson }}</script>
+        {% for url in asset_urls("postmessage_json_rpc_server_js") %}
+          <script src="{{ url }}"></script>
+        {% endfor %}
+      {% endif %}
+
+      {% if context.hypothesis_config %}
+        <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson }}</script>
+      {% endif %}
+    {% endblock %}
   </body>
 </html>

--- a/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
@@ -3,13 +3,3 @@
 {% block content %}
   <iframe width="100%" height="100%" src="{{ via_url }}"></iframe>
 {% endblock %}
-
-{% block scripts %}
-  <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson }}</script>
-  <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson }}</script>
-
-  {% for url in asset_urls("postmessage_json_rpc_server_js") %}
-    <script src="{{ url }}"></script>
-  {% endfor %}
-{% endblock %}
-


### PR DESCRIPTION
We're going to be needing the `js-rpc-server-config`,
`js-hypothesis-config` in pages that don't use the
`basic_lti_launch.html.jinja2` template or a sub-template thereof. But
currently these config objects are rendered by
`basic_lti_launch.html.jinja2` so are only available in pages based on
that template.

Move the `<script class="js-rpc-server-config">` and
`<script class="js-hypothesis-config">` objects out of the
`basic_lti_launch.html.jinja2` template and into the `base.html.jinja2`
template. Also move the `<script>` tags for the postMessage JSON RPC
server JavaScript with them.

This puts these JSON objects in the same place in the templates as the
existing `<script class="js-config">` object.

Rather than the inclusion of these objects in the page being conditional
on whether the view's template was `basic_lti_launch.html.jinja2` or a
sub-template thereof, their inclusion is now conditional on whether
`context.rpc_server_config` and `context.hypothesis_config` are defined,
using `{% if %}` statements in `base.html.jinja2`.