### PR TITLE
Rename authorization param

### DIFF
--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -174,7 +174,7 @@ class LTILaunchResource:
             self._js_config = {"urls": {}}
 
             if self._request.lti_user:
-                self._js_config["authorization_param"] = BearerTokenSchema(
+                self._js_config["authToken"] = BearerTokenSchema(
                     self._request
                 ).authorization_param(self._request.lti_user)
 

--- a/lms/templates/content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection.html.jinja2
@@ -17,7 +17,7 @@
 
   <script class="js-config" type="text/json">
   {
-    "authToken": "{{ context.js_config.authorization_param }}",
+    "authToken": "{{ context.js_config.authToken }}",
     "authUrl": "{{ request.route_url('canvas_api.authorize') }}",
     "courseId": "{{ course_id }}",
     "formAction": "{{ content_item_return_url }}",

--- a/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
@@ -53,7 +53,7 @@
 
 <script class="js-config" type="text/json">
 {
-  "authToken": "{{ context.js_config.authorization_param }}",
+  "authToken": "{{ context.js_config.authToken }}",
   "authUrl": "{{ request.route_url('canvas_api.authorize') }}",
   "courseId": "{{ course_id }}",
   "formAction": "{{ content_item_return_url }}",

--- a/tests/lms/resources/_lti_launch_test.py
+++ b/tests/lms/resources/_lti_launch_test.py
@@ -349,7 +349,7 @@ class TestLTILaunchResource:
             pyramid_request.lti_user
         )
         assert (
-            js_config["authorization_param"]
+            js_config["authToken"]
             == bearer_token_schema.authorization_param.return_value
         )
 
@@ -361,7 +361,7 @@ class TestLTILaunchResource:
         js_config = resources.LTILaunchResource(pyramid_request).js_config
 
         BearerTokenSchema.assert_not_called()
-        assert "authorization_param" not in js_config
+        assert "authToken" not in js_config
 
     def test_hypothesis_config_raises_if_theres_no_oauth_consumer_key(
         self, lti_params_for, pyramid_request


### PR DESCRIPTION
Rename `authorization_param` in the `js-config` object to `authToken`. The new file picker JavaScript already reads `authToken` not `authorization_param`, and the naming style matches that of other JavaScript config settings.

Depends on https://github.com/hypothesis/lms/pull/694