### PR TITLE
Rename the JSON config block that the LMS frontend app reads from

### DIFF
--- a/lms/static/scripts/file_picker_v2/index.js
+++ b/lms/static/scripts/file_picker_v2/index.js
@@ -4,9 +4,7 @@ import { Config } from './config';
 import FilePickerApp from './components/FilePickerApp';
 
 const rootEl = document.querySelector('#app');
-const config = JSON.parse(
-  document.querySelector('.js-hypothesis-config').textContent
-);
+const config = JSON.parse(document.querySelector('.js-config').textContent);
 
 render(
   <Config.Provider value={config}>

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -32,7 +32,6 @@
       {% block content %}{% endblock %}
     </div>
 
-    <script type="application/json" class="js-config">{{ js_config|tojson }}</script>
     {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
@@ -15,7 +15,7 @@
     <script async defer src="{{ url }}"></script>
   {% endfor %}
 
-  <script class="js-hypothesis-config" type="text/json">
+  <script class="js-config" type="text/json">
     {
       "formAction": "{{ content_item_return_url }}",
       "formFields": {{ form_fields | tojson }},

--- a/lms/templates/content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection.html.jinja2
@@ -15,7 +15,7 @@
     <script async defer src="{{ url }}"></script>
   {% endfor %}
 
-  <script class="js-hypothesis-config" type="text/json">
+  <script class="js-config" type="text/json">
   {
     "authToken": "{{ js_config.authorization_param }}",
     "authUrl": "{{ request.route_url('canvas_api.authorize') }}",

--- a/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
@@ -51,7 +51,7 @@
 <script async defer src="{{ url }}"></script>
 {% endfor %}
 
-<script class="js-hypothesis-config" type="text/json">
+<script class="js-config" type="text/json">
 {
   "authToken": "{{ js_config.authorization_param }}",
   "authUrl": "{{ request.route_url('canvas_api.authorize') }}",


### PR DESCRIPTION
This PR fixes a couple of things that were confusing about the JSON config that the LMS frontend / file picker app reads.

- The base template defined a "js-config" block, but this was not actually used anywhere
- The file picker app read its config from a "js-hypothesis-config" block, which was defined in each of the views that rendered the app. The "js-hypothesis-config" name is overloaded as elsewhere in the app it is used for configuration for the _Hypothesis client_