### PR TITLE
Read the js_config object from the Pyramid context

### DIFF
--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -33,6 +33,10 @@
     </div>
 
     {% block scripts %}
+      {% if context.js_config %}
+        <script type="application/json" class="js-config">{{ context.js_config|tojson }}</script>
+      {% endif %}
+
       {% if context.rpc_server_config %}
         <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson }}</script>
         {% for url in asset_urls("postmessage_json_rpc_server_js") %}

--- a/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/unconfigured_basic_lti_launch.html.jinja2
@@ -11,17 +11,9 @@
 {% endblock %}
 
 {% block scripts %}
+  {{ super() }}
+
   {% for url in asset_urls("file_picker_v2_js") %}
     <script async defer src="{{ url }}"></script>
   {% endfor %}
-
-  <script class="js-config" type="text/json">
-    {
-      "formAction": "{{ content_item_return_url }}",
-      "formFields": {{ form_fields | tojson }},
-      "googleClientId": "{{ google_client_id }}",
-      "googleDeveloperKey": "{{ google_developer_key }}",
-      "lmsUrl": "{{ lms_url }}"
-    }
-  </script>
 {% endblock %}

--- a/lms/templates/content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection.html.jinja2
@@ -11,22 +11,8 @@
 {% endblock %}
 
 {% block scripts %}
+  {{ super() }}
   {% for url in asset_urls("file_picker_v2_js") %}
     <script async defer src="{{ url }}"></script>
   {% endfor %}
-
-  <script class="js-config" type="text/json">
-  {
-    "authToken": "{{ context.js_config.authToken }}",
-    "authUrl": "{{ request.route_url('canvas_api.authorize') }}",
-    "courseId": "{{ course_id }}",
-    "formAction": "{{ content_item_return_url }}",
-    "formFields": {{ form_fields | tojson }},
-    "googleClientId": "{{ google_client_id }}",
-    "googleDeveloperKey": "{{ google_developer_key }}",
-    "lmsName" : "Canvas",
-    "lmsUrl": "{{ lms_url }}",
-    "ltiLaunchUrl": "{{ lti_launch_url }}"
-  }
-  </script>
 {% endblock %}

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from lms.resources import LTILaunchResource
 from lms.services import CanvasAPIError
 from lms.services.canvas_api import CanvasAPIClient
 from lms.views.basic_lti_launch import BasicLTILaunchViews
@@ -9,20 +10,22 @@ from lms.views.basic_lti_launch import BasicLTILaunchViews
 
 class TestCanvasFileBasicLTILaunch:
     def test_it_gets_a_public_url_from_the_canvas_api(
-        self, canvas_api_client, pyramid_request
+        self, canvas_api_client, context, pyramid_request
     ):
         pyramid_request.params = {"file_id": "TEST_FILE_ID"}
 
-        BasicLTILaunchViews(pyramid_request).canvas_file_basic_lti_launch()
+        BasicLTILaunchViews(context, pyramid_request).canvas_file_basic_lti_launch()
 
         canvas_api_client.public_url.assert_called_once_with("TEST_FILE_ID")
 
     def test_it_passes_the_right_via_url_to_the_template(
-        self, canvas_api_client, pyramid_request, via_url
+        self, canvas_api_client, context, pyramid_request, via_url
     ):
         pyramid_request.params = {"file_id": "TEST_FILE_ID"}
 
-        data = BasicLTILaunchViews(pyramid_request).canvas_file_basic_lti_launch()
+        data = BasicLTILaunchViews(
+            context, pyramid_request
+        ).canvas_file_basic_lti_launch()
 
         via_url.assert_called_once_with(
             pyramid_request, canvas_api_client.public_url.return_value
@@ -30,7 +33,7 @@ class TestCanvasFileBasicLTILaunch:
         assert data["via_url"] == via_url.return_value
 
     def test_if_getting_the_public_url_from_Canvas_fails_it_doesnt_return_a_via_url(
-        self, canvas_api_client, pyramid_request
+        self, canvas_api_client, context, pyramid_request
     ):
         # If no via_url is passed to the template then the template renders a
         # "Hypothesis needs your authorization" message instead of a Via
@@ -38,7 +41,9 @@ class TestCanvasFileBasicLTILaunch:
         canvas_api_client.public_url.side_effect = CanvasAPIError("Failed")
         pyramid_request.params = {"file_id": "TEST_FILE_ID"}
 
-        data = BasicLTILaunchViews(pyramid_request).canvas_file_basic_lti_launch()
+        data = BasicLTILaunchViews(
+            context, pyramid_request
+        ).canvas_file_basic_lti_launch()
 
         assert data == {}
 
@@ -53,7 +58,7 @@ class TestCanvasFileBasicLTILaunch:
 
 class TestDBConfiguredBasicLTILaunch:
     def test_it_passes_the_right_via_url_to_the_template(
-        self, pyramid_request, via_url, ModuleItemConfiguration
+        self, context, pyramid_request, via_url, ModuleItemConfiguration
     ):
         pyramid_request.params = {
             "resource_link_id": "TEST_RESOURCE_LINK_ID",
@@ -61,7 +66,9 @@ class TestDBConfiguredBasicLTILaunch:
         }
         ModuleItemConfiguration.get_document_url.return_value = "TEST_DOCUMENT_URL"
 
-        data = BasicLTILaunchViews(pyramid_request).db_configured_basic_lti_launch()
+        data = BasicLTILaunchViews(
+            context, pyramid_request
+        ).db_configured_basic_lti_launch()
 
         ModuleItemConfiguration.get_document_url.assert_called_once_with(
             pyramid_request.db,
@@ -74,19 +81,21 @@ class TestDBConfiguredBasicLTILaunch:
 
 class TestURLConfiguredBasicLTILaunch:
     def test_it_passes_the_right_via_url_to_the_template(
-        self, pyramid_request, via_url
+        self, context, pyramid_request, via_url
     ):
         pyramid_request.params = {"url": "TEST_URL"}
 
-        data = BasicLTILaunchViews(pyramid_request).url_configured_basic_lti_launch()
+        data = BasicLTILaunchViews(
+            context, pyramid_request
+        ).url_configured_basic_lti_launch()
 
         via_url.assert_called_once_with(pyramid_request, "TEST_URL")
         assert data["via_url"] == via_url.return_value
 
 
 class TestUnconfiguredBasicLTILaunch:
-    def test_it_returns_the_right_template_data(
-        self, BearerTokenSchema, bearer_token_schema, pyramid_request
+    def test_it_sets_the_right_javascript_config_settings(
+        self, BearerTokenSchema, bearer_token_schema, context, pyramid_request
     ):
         pyramid_request.params[
             "custom_canvas_api_domain"
@@ -96,18 +105,15 @@ class TestUnconfiguredBasicLTILaunch:
             "google_developer_key"
         ] = "TEST_GOOGLE_DEVELOPER_KEY"
 
-        data = BasicLTILaunchViews(pyramid_request).unconfigured_basic_lti_launch()
+        BasicLTILaunchViews(context, pyramid_request).unconfigured_basic_lti_launch()
 
         BearerTokenSchema.assert_called_once_with(pyramid_request)
         bearer_token_schema.authorization_param.assert_called_once_with(
             pyramid_request.lti_user
         )
-        assert data == {
-            "content_item_return_url": "http://example.com/module_item_configurations",
-            "google_client_id": "TEST_GOOGLE_CLIENT_ID",
-            "google_developer_key": "TEST_GOOGLE_DEVELOPER_KEY",
-            "lms_url": "TEST_CUSTOM_CANVAS_API_DOMAIN",
-            "form_fields": {
+        assert context.js_config == {
+            "formAction": "http://example.com/module_item_configurations",
+            "formFields": {
                 "authorization": bearer_token_schema.authorization_param.return_value,
                 "resource_link_id": "TEST_RESOURCE_LINK_ID",
                 "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
@@ -115,18 +121,21 @@ class TestUnconfiguredBasicLTILaunch:
                 "user_id": "TEST_USER_ID",
                 "context_id": "TEST_CONTEXT_ID",
             },
+            "googleClientId": "TEST_GOOGLE_CLIENT_ID",
+            "googleDeveloperKey": "TEST_GOOGLE_DEVELOPER_KEY",
+            "lmsUrl": "TEST_CUSTOM_CANVAS_API_DOMAIN",
         }
 
     def test_if_theres_no_custom_canvas_api_domain_it_falls_back_on_the_application_instances_lms_url(
-        self, ai_getter, pyramid_request
+        self, ai_getter, context, pyramid_request
     ):
-        data = BasicLTILaunchViews(pyramid_request).unconfigured_basic_lti_launch()
+        BasicLTILaunchViews(context, pyramid_request).unconfigured_basic_lti_launch()
 
         ai_getter.lms_url.assert_called_once_with("TEST_OAUTH_CONSUMER_KEY")
-        assert data["lms_url"] == ai_getter.lms_url.return_value
+        assert context.js_config["lmsUrl"] == ai_getter.lms_url.return_value
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
+    def pyramid_request(self, context, pyramid_request):
         pyramid_request.params = {
             "resource_link_id": "TEST_RESOURCE_LINK_ID",
             "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
@@ -136,9 +145,9 @@ class TestUnconfiguredBasicLTILaunch:
 
 
 class TestUnconfiguredBasicLTILaunchNotAuthorized:
-    def test_it_returns_the_right_template_data(self, pyramid_request):
+    def test_it_returns_the_right_template_data(self, context, pyramid_request):
         data = BasicLTILaunchViews(
-            pyramid_request
+            context, pyramid_request
         ).unconfigured_basic_lti_launch_not_authorized()
 
         assert data == {}
@@ -146,7 +155,7 @@ class TestUnconfiguredBasicLTILaunchNotAuthorized:
 
 class TestConfigureModuleItem:
     def test_it_saves_the_assignments_document_url_to_the_db(
-        self, pyramid_request, ModuleItemConfiguration
+        self, context, pyramid_request, ModuleItemConfiguration
     ):
         pyramid_request.parsed_params = {
             "document_url": "TEST_DOCUMENT_URL",
@@ -154,7 +163,7 @@ class TestConfigureModuleItem:
             "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
         }
 
-        BasicLTILaunchViews(pyramid_request).configure_module_item()
+        BasicLTILaunchViews(context, pyramid_request).configure_module_item()
 
         ModuleItemConfiguration.set_document_url.assert_called_once_with(
             pyramid_request.db,
@@ -164,7 +173,7 @@ class TestConfigureModuleItem:
         )
 
     def test_it_passes_the_right_via_url_to_the_template(
-        self, pyramid_request, via_url
+        self, context, pyramid_request, via_url
     ):
         pyramid_request.parsed_params = {
             "document_url": "TEST_DOCUMENT_URL",
@@ -172,7 +181,7 @@ class TestConfigureModuleItem:
             "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
         }
 
-        data = BasicLTILaunchViews(pyramid_request).configure_module_item()
+        data = BasicLTILaunchViews(context, pyramid_request).configure_module_item()
 
         via_url.assert_called_once_with(pyramid_request, "TEST_DOCUMENT_URL")
         assert data["via_url"] == via_url.return_value
@@ -186,6 +195,13 @@ def BearerTokenSchema(patch):
 @pytest.fixture
 def bearer_token_schema(BearerTokenSchema):
     return BearerTokenSchema.return_value
+
+
+@pytest.fixture
+def context():
+    context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
+    context.js_config = {}
+    return context
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lms/views/test_lti_launches.py
+++ b/tests/lms/views/test_lti_launches.py
@@ -121,6 +121,7 @@ def lti_launch_request(lti_launch_request):
         LTILaunchResource,
         spec_set=True,
         instance=True,
+        js_config={},
         rpc_server_config={},
         hypothesis_config={},
         provisioning_enabled=True,


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/694, https://github.com/hypothesis/lms/pull/693 and https://github.com/hypothesis/lms/pull/695.

Read the JavaScript config object `<script type="application/json" class="js-config">` from the Pyramid context object (`LTILaunchResource.js_config`) instead of rendering it directly in templates.
    
This makes the generation and rendering of js-config consistent with that of js-rpc-server-config and js-hypothesis-config, and means that the js-config object is generated in unit-tested Python code rather than in untested template code. js-config can be modified on a per-view basis by having the Python view mutate `request.context.js_config`.
    
1. Have `base.html.jinja2` render `context.js_config` into the page, as it already does with `context.rpc_server_config` and `context.hypothesis_config`
    
2. `unconfigured_basic_lti_launch.html.jinja2` and `content_item_selection.html.jinja2` no longer need to render their own `js-config` objects directly
    
3. The `unconfigured_basic_lti_launch()` and `content_item_selection()` views now mutate `request.context.js_config`, adding the view-specific JavaScript file picker settings that those views need (these view-specific settings were previously rendered by the view's templates, `unconfigured_basic_lti_launch.html.jinja2` and `content_item_selection.html.jinja2`)