### PR TITLE
Don't fetch Canvas file URLs on launch

### DIFF
--- a/lms/templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2
@@ -1,17 +1,1 @@
-{% extends "lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2" %}
-
-{% block content %}
-  {% if via_url %}
-    {{ super() }}
-  {% else %}
-    <main class="modal-content">
-      <h1>Authorize Hypothesis</h1>
-
-      <p class="modal-text">
-        Hypothesis needs your authorization to access this assignment.
-      </p>
-
-      <button class="btn" type="submit">Authorize</button>
-  </main>
-  {% endif %}
-{% endblock %}
+{% extends "lms:templates/base.html.jinja2" %}

--- a/lms/templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2
@@ -1,1 +1,0 @@
-{% extends "lms:templates/base.html.jinja2" %}

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -49,10 +49,7 @@ class BasicLTILaunchViews:
         self.context = context
         self.request = request
 
-    @view_config(
-        canvas_file=True,
-        renderer="lms:templates/base.html.jinja2",
-    )
+    @view_config(canvas_file=True, renderer="lms:templates/base.html.jinja2")
     def canvas_file_basic_lti_launch(self):
         """
         Respond to a Canvas file assignment launch.

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -18,7 +18,6 @@ that're still used when the feature flag is off.
 from pyramid.view import view_config, view_defaults
 
 from lms.models import ModuleItemConfiguration
-from lms.services import CanvasAPIError
 from lms.util import via_url
 from lms.validation import BearerTokenSchema, ConfigureModuleItemSchema
 from lms.views.decorators import (
@@ -65,15 +64,17 @@ class BasicLTILaunchViews:
         Via. We have to re-do this file-ID-for-download-URL exchange on every
         single launch because Canvas's download URLs are temporary.
         """
-        canvas_api_client = self.request.find_service(name="canvas_api_client")
         file_id = self.request.params["file_id"]
 
-        try:
-            document_url = canvas_api_client.public_url(file_id)
-        except CanvasAPIError:
-            return {}
+        self.context.js_config["urls"].update(
+            {
+                "via_url": self.request.route_url(
+                    "canvas_api.files.via_url", file_id=file_id
+                )
+            }
+        )
 
-        return {"via_url": via_url(self.request, document_url)}
+        return {}
 
     @view_config(db_configured=True)
     def db_configured_basic_lti_launch(self):

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -51,7 +51,7 @@ class BasicLTILaunchViews:
 
     @view_config(
         canvas_file=True,
-        renderer="lms:templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2",
+        renderer="lms:templates/base.html.jinja2",
     )
     def canvas_file_basic_lti_launch(self):
         """


### PR DESCRIPTION
Fix `canvas_file_basic_lti_launch()` to not fetch the Canvas file's
public URL from the Canvas API as part of the initial response to the
launch request. Instead add the proxy API URL that will return the
Canvas file's URL to the `"urls"` in the JavaScript config object.

The idea is that JavaScript code will make an XHR request to the
`via_url` proxy API and use the Canvas file URL from the response to
inject the Via iframe into the DOM.

This means that the server's response to the initial launch request can
be fast as it doesn't need to talk the the Canvas API, and all requests
to the Canvas API are kept within the `/api/canvas/` proxy API views.

For more reasoning see
https://github.com/hypothesis/lms/issues/622#issuecomment-499909135