### PR TITLE
Don't subclass HTTPError in services

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,6 +1,3 @@
-from pyramid.httpexceptions import HTTPInternalServerError
-
-
 class ServiceError(Exception):
     """Base class for all :mod:`lms.services` exceptions."""
 
@@ -27,32 +24,25 @@ class LTIOAuthError(LTILaunchVerificationError):
     """Raised when OAuth signature verification of a launch request fails."""
 
 
-class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
+class HAPIError(ServiceError):
     """
     A problem with an h API request.
 
     This exception class is raised whenever an h API request times out or when
     an unsuccessful, invalid or unexpected response is received from the h API.
 
-    An HAPIError is a 500 Internal Server Error response (HTTPInternalServerError
-    subclass) rather than, say, a 502 Bad Gateway because Cloudflare intercepts
-    gateway error responses and replaces our error page with its own error
-    page, and we don't want that.
-
-    Any arguments or keyword arguments other than ``response`` are passed
-    through to HTTPInternalServerError.
-
     :param response: The response from the HTTP request to the h API
     :type response: requests.Response
     """
 
-    def __init__(self, *args, response=None, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, explanation=None, response=None):
+        super().__init__()
+        self.explanation = explanation
         self.response = response
 
     def __str__(self):
         if self.response is None:
-            return super().__str__()
+            return self.explanation
 
         # Log the details of the h API response. This goes to both Sentry and
         # the application's logs. It's helpful for debugging to know how h
@@ -65,11 +55,11 @@ class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
         return " ".join([part for part in parts if part])
 
 
-class HAPINotFoundError(HAPIError):  # pylint: disable=too-many-ancestors
+class HAPINotFoundError(HAPIError):
     """A 404 error from an API request."""
 
 
-class CanvasAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
+class CanvasAPIError(ServiceError):
     """
     A problem with a Canvas API request.
 
@@ -77,25 +67,18 @@ class CanvasAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ances
     when an unsuccessful, invalid or unexpected response is received from the
     Canvas API.
 
-    An CanvasAPIError is a 500 Internal Server Error response
-    (HTTPInternalServerError subclass) rather than, say, a 502 Bad Gateway
-    because Cloudflare intercepts gateway error responses and replaces our
-    error page with its own error page, and we don't want that.
-
-    Any arguments or keyword arguments other than ``response`` are passed
-    through to HTTPInternalServerError.
-
     :param response: The response from the HTTP request to the h API
     :type response: requests.Response
     """
 
-    def __init__(self, *args, response=None, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, explanation=None, response=None):
+        super().__init__()
+        self.explanation = explanation
         self.response = response
 
     def __str__(self):
         if self.response is None:
-            return super().__str__()
+            return self.explanation
 
         # Log the details of the Canvas API response. This goes to both Sentry
         # and the application's logs. It's helpful for debugging to know how

--- a/tests/lms/views/api/canvas/files_test.py
+++ b/tests/lms/views/api/canvas/files_test.py
@@ -1,6 +1,9 @@
 import pytest
 from unittest import mock
 
+from pyramid.httpexceptions import HTTPInternalServerError
+
+from lms.services import CanvasAPIError
 from lms.services.canvas_api import CanvasAPIClient
 from lms.views.api.canvas.files import FilesAPIViews
 
@@ -17,6 +20,12 @@ class TestListFiles:
         FilesAPIViews(
             pyramid_request
         ).list_files() == canvas_api_client.list_files.return_value
+
+    def test_if_list_files_raises_it_500s(self, canvas_api_client, pyramid_request):
+        canvas_api_client.list_files.side_effect = CanvasAPIError("Oops")
+
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
+            FilesAPIViews(pyramid_request).list_files()
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -40,6 +49,12 @@ class TestViaURL:
         util.via_url.assert_called_once_with(
             pyramid_request, canvas_api_client.public_url.return_value
         )
+
+    def test_if_public_url_raises_it_500s(self, canvas_api_client, pyramid_request):
+        canvas_api_client.public_url.side_effect = CanvasAPIError("Oops")
+
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
+            FilesAPIViews(pyramid_request).via_url()
 
     def test_it_returns_the_via_url(self, pyramid_request, util):
         data = FilesAPIViews(pyramid_request).via_url()

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -125,7 +125,7 @@ class TestUpsertHUser:
 
 
 @pytest.mark.usefixtures("hapi_svc")
-class TestCreateCourseGroup:
+class TestUpsertCourseGroup:
     def test_it_does_nothing_if_the_feature_isnt_enabled(
         self, upsert_course_group, context, pyramid_request, wrapped, hapi_svc
     ):

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 import pytest
 
-from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
 
 from requests import Response
 
@@ -30,7 +30,7 @@ class TestUpsertHUser:
     ):
         hapi_svc.patch.side_effect = HAPIError("whatever")
 
-        with pytest.raises(HAPIError, match="whatever"):
+        with pytest.raises(HTTPInternalServerError, match="whatever"):
             upsert_h_user(context, pyramid_request)
 
     def test_it_raises_if_post_raises(
@@ -40,7 +40,7 @@ class TestUpsertHUser:
         hapi_svc.patch.side_effect = HAPINotFoundError("whatever")
         hapi_svc.post.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             upsert_h_user(context, pyramid_request)
 
     def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
@@ -157,7 +157,7 @@ class TestCreateCourseGroup:
         # view raises an exception and an error page is shown.
         hapi_svc.patch.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             upsert_course_group(context, pyramid_request)
 
     def test_if_the_group_doesnt_exist_it_creates_it(
@@ -177,6 +177,20 @@ class TestCreateCourseGroup:
             {"groupid": "test_groupid", "name": "test_group_name"},
             "acct:test_username@TEST_AUTHORITY",
         )
+
+    def test_it_raises_if_creating_the_group_fails(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        pyramid_request.lti_user = LTIUser(
+            user_id="TEST_USER_ID",
+            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            roles="instructor",
+        )
+        hapi_svc.patch.side_effect = HAPINotFoundError()
+        hapi_svc.put.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
+            upsert_course_group(context, pyramid_request)
 
     def test_if_the_group_doesnt_exist_and_the_user_isnt_allowed_to_create_groups_it_400s(
         self, upsert_course_group, context, pyramid_request, hapi_svc
@@ -244,7 +258,7 @@ class TestAddUserToGroup:
     ):
         hapi_svc.post.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             add_user_to_group(context, pyramid_request)
 
     def test_it_continues_to_the_wrapped_func(

--- a/tests/lms/views/decorators/legacy_h_api_test.py
+++ b/tests/lms/views/decorators/legacy_h_api_test.py
@@ -3,7 +3,7 @@
 from unittest import mock
 import pytest
 
-from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
 
 from requests import Response
 
@@ -31,7 +31,7 @@ class TestUpsertHUser:
     ):
         hapi_svc.patch.side_effect = HAPIError("whatever")
 
-        with pytest.raises(HAPIError, match="whatever"):
+        with pytest.raises(HTTPInternalServerError, match="whatever"):
             upsert_h_user(pyramid_request, mock.sentinel.jwt, context)
 
     def test_it_raises_if_post_raises(
@@ -41,7 +41,7 @@ class TestUpsertHUser:
         hapi_svc.patch.side_effect = HAPINotFoundError("whatever")
         hapi_svc.post.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             upsert_h_user(pyramid_request, mock.sentinel.jwt, context)
 
     def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
@@ -166,7 +166,7 @@ class TestCreateCourseGroup:
         # view raises an exception and an error page is shown.
         hapi_svc.patch.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             create_course_group(pyramid_request, mock.sentinel.jwt, context)
 
     def test_if_the_group_doesnt_exist_it_creates_it(
@@ -181,6 +181,15 @@ class TestCreateCourseGroup:
             {"groupid": "test_groupid", "name": "test_group_name"},
             "acct:test_username@TEST_AUTHORITY",
         )
+
+    def test_it_raises_if_creating_the_group_fails(
+        self, create_course_group, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.patch.side_effect = HAPINotFoundError()
+        hapi_svc.put.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
+            create_course_group(pyramid_request, mock.sentinel.jwt, context)
 
     def test_if_the_group_doesnt_exist_and_the_user_isnt_allowed_to_create_groups_it_400s(
         self, create_course_group, context, pyramid_request, hapi_svc
@@ -244,7 +253,7 @@ class TestAddUserToGroup:
     ):
         hapi_svc.post.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             add_user_to_group(pyramid_request, mock.sentinel.jwt, context)
 
     def test_it_continues_to_the_wrapped_func(


### PR DESCRIPTION
Change `lms.services.HAPIError`, `HAPINotFoundError` and
`CanvasAPIError` into simple `Exception` subclasses rather than
subclassing `HTTPInternalServerError`.

The reason for subclassing `HTTPInternalServerError` was that views that
call services that raise these errors could just call them blindly, not
catching the services exceptions that might be raised, and since the
services exceptions were `HTTPError`s they would cause the correct 500
Internal Server Error responses to be sent.

While this does simplify view code and tests by removing
exception-wrapping from views, it causes some problems:

We want services exceptions to all be subclasses of
`lms.services.ServiceError`. This is so that some code calling a
services method can just catch `ServiceError` and this will catch any
error deliberately raised by services code (but won't catch unexpected
exceptions, those will be uncaught and cause a crash, which is what we
want for an unexpected exception). Since specific subclasses are used an
`except` that only wants to handle a specific kind of service error can
just catch a specific `ServiceError` subclass or classes (and can
optionally be followed by a catch-all `except ServiceError`).

If service classes are going to be `ServiceError` subclasses and also
`HTTPInternalServerError` subclasses, then we get into multiple
inheritance and cooperating classes, some of them third-party classes,
and things become tricky and tightly coupled to Pyramid.

Also, being simple `Exception` classes makes services errors simpler and
makes it easier to have those errors extend and reuse each other, by not
bringing in the complications of Pyramid's `HTTPError`s and their fields
and behaviours.

While having the views catch `ServiceError`s and re-raise them as
`HTTPError`s is more view code, it also makes it explicit in the views
that they may raise a 500, rather than this being an implicit
consequence of calling services code.

Finally, HTTP considerations and Pyramid belong in the views layer, not
the services layer.