### PR TITLE
Deduplicate exception classes

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -3,6 +3,7 @@ from lms.services.exceptions import LTILaunchVerificationError
 from lms.services.exceptions import NoConsumerKey
 from lms.services.exceptions import ConsumerKeyError
 from lms.services.exceptions import LTIOAuthError
+from lms.services.exceptions import ExternalRequestError
 from lms.services.exceptions import HAPIError
 from lms.services.exceptions import HAPINotFoundError
 from lms.services.exceptions import CanvasAPIError
@@ -13,6 +14,7 @@ __all__ = (
     "NoConsumerKey",
     "ConsumerKeyError",
     "LTIOAuthError",
+    "ExternalRequestError",
     "HAPIError",
     "HAPINotFoundError",
     "CanvasAPIError",

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,6 +1,3 @@
-from pyramid.httpexceptions import HTTPInternalServerError
-
-
 class ServiceError(Exception):
     """Base class for all :mod:`lms.services` exceptions."""
 
@@ -27,32 +24,25 @@ class LTIOAuthError(LTILaunchVerificationError):
     """Raised when OAuth signature verification of a launch request fails."""
 
 
-class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
+class HAPIError(ServiceError):
     """
     A problem with an h API request.
 
     This exception class is raised whenever an h API request times out or when
     an unsuccessful, invalid or unexpected response is received from the h API.
 
-    An HAPIError is a 500 Internal Server Error response (HTTPInternalServerError
-    subclass) rather than, say, a 502 Bad Gateway because Cloudflare intercepts
-    gateway error responses and replaces our error page with its own error
-    page, and we don't want that.
-
-    Any arguments or keyword arguments other than ``response`` are passed
-    through to HTTPInternalServerError.
-
     :param response: The response from the HTTP request to the h API
     :type response: requests.Response
     """
 
-    def __init__(self, *args, response=None, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, explanation=None, response=None):
+        super().__init__()
+        self.explanation = explanation
         self.response = response
 
     def __str__(self):
         if self.response is None:
-            return super().__str__()
+            return self.explanation
 
         # Log the details of the h API response. This goes to both Sentry and
         # the application's logs. It's helpful for debugging to know how h
@@ -65,11 +55,11 @@ class HAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
         return " ".join([part for part in parts if part])
 
 
-class HAPINotFoundError(HAPIError):  # pylint: disable=too-many-ancestors
+class HAPINotFoundError(HAPIError):
     """A 404 error from an API request."""
 
 
-class CanvasAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ancestors
+class CanvasAPIError(ServiceError):
     """
     A problem with a Canvas API request.
 
@@ -77,25 +67,18 @@ class CanvasAPIError(HTTPInternalServerError):  # pylint: disable=too-many-ances
     when an unsuccessful, invalid or unexpected response is received from the
     Canvas API.
 
-    An CanvasAPIError is a 500 Internal Server Error response
-    (HTTPInternalServerError subclass) rather than, say, a 502 Bad Gateway
-    because Cloudflare intercepts gateway error responses and replaces our
-    error page with its own error page, and we don't want that.
-
-    Any arguments or keyword arguments other than ``response`` are passed
-    through to HTTPInternalServerError.
-
     :param response: The response from the HTTP request to the h API
     :type response: requests.Response
     """
 
-    def __init__(self, *args, response=None, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, explanation=None, response=None):
+        super().__init__()
+        self.explanation = explanation
         self.response = response
 
     def __str__(self):
         if self.response is None:
-            return super().__str__()
+            return self.explanation
 
         # Log the details of the Canvas API response. This goes to both Sentry
         # and the application's logs. It's helpful for debugging to know how

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -24,12 +24,9 @@ class LTIOAuthError(LTILaunchVerificationError):
     """Raised when OAuth signature verification of a launch request fails."""
 
 
-class HAPIError(ServiceError):
+class ExternalRequestError(ServiceError):
     """
-    A problem with an h API request.
-
-    This exception class is raised whenever an h API request times out or when
-    an unsuccessful, invalid or unexpected response is received from the h API.
+    A problem with a network request to an external service.
 
     :param response: The response from the HTTP request to the h API
     :type response: requests.Response
@@ -44,48 +41,34 @@ class HAPIError(ServiceError):
         if self.response is None:
             return self.explanation
 
-        # Log the details of the h API response. This goes to both Sentry and
-        # the application's logs. It's helpful for debugging to know how h
-        # responded.
+        # Log the details of the response. This goes to both Sentry and the
+        # application's logs. It's helpful for debugging to know how the
+        # external service responded.
         parts = [
             str(self.response.status_code or ""),
             self.response.reason,
             self.response.text,
         ]
         return " ".join([part for part in parts if part])
+
+
+class HAPIError(ExternalRequestError):
+    """
+    A problem with an h API request.
+
+    Raised whenever an h API request times out or when an unsuccessful, invalid
+    or unexpected response is received from the h API.
+    """
 
 
 class HAPINotFoundError(HAPIError):
     """A 404 error from an API request."""
 
 
-class CanvasAPIError(ServiceError):
+class CanvasAPIError(ExternalRequestError):
     """
     A problem with a Canvas API request.
 
-    This exception class is raised whenever a Canvas API request times out or
-    when an unsuccessful, invalid or unexpected response is received from the
-    Canvas API.
-
-    :param response: The response from the HTTP request to the h API
-    :type response: requests.Response
+    Raised whenever a Canvas API request times out or when an unsuccessful,
+    invalid or unexpected response is received from the Canvas API.
     """
-
-    def __init__(self, explanation=None, response=None):
-        super().__init__()
-        self.explanation = explanation
-        self.response = response
-
-    def __str__(self):
-        if self.response is None:
-            return self.explanation
-
-        # Log the details of the Canvas API response. This goes to both Sentry
-        # and the application's logs. It's helpful for debugging to know how
-        # Canvas responded.
-        parts = [
-            str(self.response.status_code or ""),
-            self.response.reason,
-            self.response.text,
-        ]
-        return " ".join([part for part in parts if part])

--- a/tests/lms/services/exceptions_test.py
+++ b/tests/lms/services/exceptions_test.py
@@ -3,24 +3,24 @@ from unittest import mock
 import pytest
 from requests import Response
 
-from lms.services import HAPIError
+from lms.services import ExternalRequestError
 
 
-class TestHAPIError:
-    # If no ``response`` kwarg is given to HAPIError() then __str__() falls
-    # back on the HTTPInternalServerError base class's __str__() which is to
-    # use the given detail message string as the string representation of
-    # the exception.
+class TestExternalRequestError:
+    # If no ``response`` kwarg is given to ExternalRequestError() then
+    # __str__() falls back on the HTTPInternalServerError base class's
+    # __str__() which is to use the given detail message string as the string
+    # representation of the exception.
     def test_when_theres_no_response_uses_detail_message_as_str(self):
-        err = HAPIError("Connecting to Hypothesis failed")
+        err = ExternalRequestError("Connecting to Hypothesis failed")
 
         assert str(err) == "Connecting to Hypothesis failed"
 
-    # If a ``response`` arg is given to HAPIError() then it uses the
+    # If a ``response`` arg is given to ExternalRequestError() then it uses the
     # Response object's attributes to format a more informative string
     # representation of the exception. Not all Response objects necessarily
-    # have values for every attribute - certain attributes can be ``None``
-    # or the empty string, so ``__str__()`` needs to handle those.
+    # have values for every attribute - certain attributes can be ``None`` or
+    # the empty string, so ``__str__()`` needs to handle those.
     @pytest.mark.parametrize(
         "status_code,reason,text,expected",
         [
@@ -36,6 +36,6 @@ class TestHAPIError:
         response = mock.create_autospec(
             Response, instance=True, status_code=status_code, reason=reason, text=text
         )
-        err = HAPIError("Connecting to Hypothesis failed", response=response)
+        err = ExternalRequestError("Connecting to Hypothesis failed", response=response)
 
         assert str(err) == expected

--- a/tests/lms/views/api/canvas/files_test.py
+++ b/tests/lms/views/api/canvas/files_test.py
@@ -1,6 +1,9 @@
 import pytest
 from unittest import mock
 
+from pyramid.httpexceptions import HTTPInternalServerError
+
+from lms.services import CanvasAPIError
 from lms.services.canvas_api import CanvasAPIClient
 from lms.views.api.canvas.files import FilesAPIViews
 
@@ -17,6 +20,12 @@ class TestListFiles:
         FilesAPIViews(
             pyramid_request
         ).list_files() == canvas_api_client.list_files.return_value
+
+    def test_if_list_files_raises_it_500s(self, canvas_api_client, pyramid_request):
+        canvas_api_client.list_files.side_effect = CanvasAPIError("Oops")
+
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
+            FilesAPIViews(pyramid_request).list_files()
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -40,6 +49,12 @@ class TestViaURL:
         util.via_url.assert_called_once_with(
             pyramid_request, canvas_api_client.public_url.return_value
         )
+
+    def test_if_public_url_raises_it_500s(self, canvas_api_client, pyramid_request):
+        canvas_api_client.public_url.side_effect = CanvasAPIError("Oops")
+
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
+            FilesAPIViews(pyramid_request).via_url()
 
     def test_it_returns_the_via_url(self, pyramid_request, util):
         data = FilesAPIViews(pyramid_request).via_url()

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -125,7 +125,7 @@ class TestUpsertHUser:
 
 
 @pytest.mark.usefixtures("hapi_svc")
-class TestCreateCourseGroup:
+class TestUpsertCourseGroup:
     def test_it_does_nothing_if_the_feature_isnt_enabled(
         self, upsert_course_group, context, pyramid_request, wrapped, hapi_svc
     ):

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 import pytest
 
-from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
 
 from requests import Response
 
@@ -30,7 +30,7 @@ class TestUpsertHUser:
     ):
         hapi_svc.patch.side_effect = HAPIError("whatever")
 
-        with pytest.raises(HAPIError, match="whatever"):
+        with pytest.raises(HTTPInternalServerError, match="whatever"):
             upsert_h_user(context, pyramid_request)
 
     def test_it_raises_if_post_raises(
@@ -40,7 +40,7 @@ class TestUpsertHUser:
         hapi_svc.patch.side_effect = HAPINotFoundError("whatever")
         hapi_svc.post.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             upsert_h_user(context, pyramid_request)
 
     def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
@@ -157,7 +157,7 @@ class TestCreateCourseGroup:
         # view raises an exception and an error page is shown.
         hapi_svc.patch.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             upsert_course_group(context, pyramid_request)
 
     def test_if_the_group_doesnt_exist_it_creates_it(
@@ -177,6 +177,20 @@ class TestCreateCourseGroup:
             {"groupid": "test_groupid", "name": "test_group_name"},
             "acct:test_username@TEST_AUTHORITY",
         )
+
+    def test_it_raises_if_creating_the_group_fails(
+        self, upsert_course_group, context, pyramid_request, hapi_svc
+    ):
+        pyramid_request.lti_user = LTIUser(
+            user_id="TEST_USER_ID",
+            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            roles="instructor",
+        )
+        hapi_svc.patch.side_effect = HAPINotFoundError()
+        hapi_svc.put.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
+            upsert_course_group(context, pyramid_request)
 
     def test_if_the_group_doesnt_exist_and_the_user_isnt_allowed_to_create_groups_it_400s(
         self, upsert_course_group, context, pyramid_request, hapi_svc
@@ -244,7 +258,7 @@ class TestAddUserToGroup:
     ):
         hapi_svc.post.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             add_user_to_group(context, pyramid_request)
 
     def test_it_continues_to_the_wrapped_func(

--- a/tests/lms/views/decorators/legacy_h_api_test.py
+++ b/tests/lms/views/decorators/legacy_h_api_test.py
@@ -3,7 +3,7 @@
 from unittest import mock
 import pytest
 
-from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
 
 from requests import Response
 
@@ -31,7 +31,7 @@ class TestUpsertHUser:
     ):
         hapi_svc.patch.side_effect = HAPIError("whatever")
 
-        with pytest.raises(HAPIError, match="whatever"):
+        with pytest.raises(HTTPInternalServerError, match="whatever"):
             upsert_h_user(pyramid_request, mock.sentinel.jwt, context)
 
     def test_it_raises_if_post_raises(
@@ -41,7 +41,7 @@ class TestUpsertHUser:
         hapi_svc.patch.side_effect = HAPINotFoundError("whatever")
         hapi_svc.post.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             upsert_h_user(pyramid_request, mock.sentinel.jwt, context)
 
     def test_it_continues_to_the_wrapped_func_if_feature_not_enabled(
@@ -166,7 +166,7 @@ class TestCreateCourseGroup:
         # view raises an exception and an error page is shown.
         hapi_svc.patch.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             create_course_group(pyramid_request, mock.sentinel.jwt, context)
 
     def test_if_the_group_doesnt_exist_it_creates_it(
@@ -181,6 +181,15 @@ class TestCreateCourseGroup:
             {"groupid": "test_groupid", "name": "test_group_name"},
             "acct:test_username@TEST_AUTHORITY",
         )
+
+    def test_it_raises_if_creating_the_group_fails(
+        self, create_course_group, context, pyramid_request, hapi_svc
+    ):
+        hapi_svc.patch.side_effect = HAPINotFoundError()
+        hapi_svc.put.side_effect = HAPIError("Oops")
+
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
+            create_course_group(pyramid_request, mock.sentinel.jwt, context)
 
     def test_if_the_group_doesnt_exist_and_the_user_isnt_allowed_to_create_groups_it_400s(
         self, create_course_group, context, pyramid_request, hapi_svc
@@ -244,7 +253,7 @@ class TestAddUserToGroup:
     ):
         hapi_svc.post.side_effect = HAPIError("Oops")
 
-        with pytest.raises(HAPIError, match="Oops"):
+        with pytest.raises(HTTPInternalServerError, match="Oops"):
             add_user_to_group(pyramid_request, mock.sentinel.jwt, context)
 
     def test_it_continues_to_the_wrapped_func(


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/710.

Extract a base class `ExternalRequestError` to remove duplicate code
from `HAPIError` and `CanvasAPIError`.