### PR TITLE
Oauth2 redirect error handling

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -7,6 +7,7 @@ from lms.services.exceptions import ExternalRequestError
 from lms.services.exceptions import HAPIError
 from lms.services.exceptions import HAPINotFoundError
 from lms.services.exceptions import CanvasAPIError
+from lms.services.exceptions import CanvasAPIServerError
 
 __all__ = (
     "ServiceError",
@@ -18,6 +19,7 @@ __all__ = (
     "HAPIError",
     "HAPINotFoundError",
     "CanvasAPIError",
+    "CanvasAPIServerError",
 )
 
 

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from lms.models import OAuth2Token
 from lms.services import CanvasAPIError
+from lms.services.exceptions import CanvasAPIServerError
 from lms.services._helpers import CanvasAPIHelper
 
 
@@ -27,15 +28,20 @@ class CanvasAPIClient:
         Get an access token for the current LTI user.
 
         Posts to the Canvas API to get the access token and returns it.
+
+        :raise lms.services.CanvasAPIServerError: if the Canvas API request
+            fails for any reason
         """
         access_token_request = self._helper.access_token_request(authorization_code)
-        access_token_response = requests.Session().send(access_token_request)
 
-        # TODO: Handle access token error responses.
-        # These aren't documented in the Canvas docs as far as I can see.
-        # They are documented in the OAuth 2 spec but I don't yet know if Canvas's
-        # error responses follow this:
-        # https://tools.ietf.org/html/rfc6749#section-5.2
+        try:
+            access_token_response = requests.Session().send(access_token_request)
+            access_token_response.raise_for_status()
+        except RequestException as err:
+            raise CanvasAPIServerError(
+                explanation="Authorizing with Canvas failed",
+                response=getattr(err, "response", None),
+            ) from err
 
         # TODO: Validate access_token_response.
 

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -29,6 +29,10 @@ class CanvasAPIClient:
 
         Posts to the Canvas API to get the access token and returns it.
 
+        :arg authorization_code: The Canvas API OAuth 2.0 authorization code to
+            exchange for an access token
+        :type authorization_code: str
+
         :raise lms.services.CanvasAPIServerError: if the Canvas API request
             fails for any reason
         """

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -72,3 +72,12 @@ class CanvasAPIError(ExternalRequestError):
     Raised whenever a Canvas API request times out or when an unsuccessful,
     invalid or unexpected response is received from the Canvas API.
     """
+
+
+class CanvasAPIServerError(CanvasAPIError):
+    """
+    A server error during a Canvas API request.
+
+    Raised when a Canvas API request fails in an unexpected way: for example
+    the request times out, or we receive an unexpected response.
+    """

--- a/lms/static/styles/file-picker-app.scss
+++ b/lms/static/styles/file-picker-app.scss
@@ -11,6 +11,8 @@
 @import 'components/label';
 
 // Generic React components.
+// Note: Some of these are also used by server-rendered HTML templates, not
+// just by React code.
 @import 'components/Button';
 @import 'components/Dialog';
 @import 'components/Table';

--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -1,0 +1,33 @@
+{% extends "lms:templates/base.html.jinja2" %}
+
+{% block content %}
+  <div class="Dialog__background" style="z-index: 1;"></div>
+  <div class="Dialog__container" style="z-index: 2;">
+    <div class="Dialog__content LMSFilePicker__dialog">
+      <h1 class="Dialog__title">Authorization failed</h1>
+      <p>
+        Something went wrong when authorizing Hypothesis.
+      </p>
+      <div class="u-stretch"></div>
+      <div class="Dialog__actions">
+        <button class="Button Button--cancel"
+                type="button"
+                onclick="window.close()">
+          Cancel
+        </button>
+        <button class="Button"
+                type="button"
+                onclick="window.location.href = '{{ authorize_url }}'">
+          Try again
+        </button>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+
+{% block styles %}
+  {% for url in  asset_urls("file_picker_v2_css") %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}

--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -5,9 +5,14 @@
   <div class="Dialog__container" style="z-index: 2;">
     <div class="Dialog__content LMSFilePicker__dialog">
       <h1 class="Dialog__title">Authorization failed</h1>
-      <p>
-        Something went wrong when authorizing Hypothesis.
-      </p>
+
+      <p>Something went wrong when authorizing Hypothesis.</p>
+
+      <p>If the problem persists
+      <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support">send us an email</a>
+      or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener">open a support ticket</a>.
+      You can also visit our <a href="https://web.hypothes.is/help/" target="_blank"> help documents</a>.</p>
+
       <div class="u-stretch"></div>
       <div class="Dialog__actions">
         <button class="Button Button--cancel"

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -1,52 +1,51 @@
 from urllib.parse import urlencode, urlparse, urlunparse
 
 from pyramid.httpexceptions import HTTPFound
-from pyramid.view import view_config
+from pyramid.view import view_config, view_defaults
 
 from lms.validation import CanvasOAuthCallbackSchema
 
 
-@view_config(
-    route_name="canvas_api.authorize", request_method="GET", permission="canvas_api"
-)
-def authorize(request):
-    ai_getter = request.find_service(name="ai_getter")
-    consumer_key = request.lti_user.oauth_consumer_key
+@view_defaults(feature_flag="new_oauth", permission="canvas_api", request_method="GET")
+class CanvasAPIAuthorizeViews:
+    def __init__(self, request):
+        self.request = request
+        self.ai_getter = request.find_service(name="ai_getter")
+        self.canvas_api_client = request.find_service(name="canvas_api_client")
 
-    authorize_url = urlunparse(
-        (
-            "https",
-            urlparse(ai_getter.lms_url(consumer_key)).netloc,
-            "login/oauth2/auth",
-            "",
-            urlencode(
-                {
-                    "client_id": ai_getter.developer_key(consumer_key),
-                    "response_type": "code",
-                    "redirect_uri": request.route_url("canvas_oauth_callback"),
-                    "state": CanvasOAuthCallbackSchema(request).state_param(),
-                }
-            ),
-            "",
+    @view_config(route_name="canvas_api.authorize")
+    def authorize(self):
+        consumer_key = self.request.lti_user.oauth_consumer_key
+
+        authorize_url = urlunparse(
+            (
+                "https",
+                urlparse(self.ai_getter.lms_url(consumer_key)).netloc,
+                "login/oauth2/auth",
+                "",
+                urlencode(
+                    {
+                        "client_id": self.ai_getter.developer_key(consumer_key),
+                        "response_type": "code",
+                        "redirect_uri": self.request.route_url("canvas_oauth_callback"),
+                        "state": CanvasOAuthCallbackSchema(self.request).state_param(),
+                    }
+                ),
+                "",
+            )
         )
+
+        return HTTPFound(location=authorize_url)
+
+    @view_config(
+        route_name="canvas_oauth_callback",
+        renderer="lms:templates/api/canvas/oauth2_redirect.html.jinja2",
+        schema=CanvasOAuthCallbackSchema,
     )
+    def oauth2_redirect(self):
+        authorization_code = self.request.parsed_params["code"]
 
-    return HTTPFound(location=authorize_url)
+        token = self.canvas_api_client.get_token(authorization_code)
+        self.canvas_api_client.save_token(*token)
 
-
-@view_config(
-    feature_flag="new_oauth",
-    request_method="GET",
-    route_name="canvas_oauth_callback",
-    renderer="lms:templates/api/canvas/oauth2_redirect.html.jinja2",
-    schema=CanvasOAuthCallbackSchema,
-)
-def oauth2_redirect(request):
-    canvas_api_client = request.find_service(name="canvas_api_client")
-
-    authorization_code = request.parsed_params["code"]
-
-    token = canvas_api_client.get_token(authorization_code)
-    canvas_api_client.save_token(*token)
-
-    return {}
+        return {}

--- a/tests/lms/views/api/canvas/authorize_test.py
+++ b/tests/lms/views/api/canvas/authorize_test.py
@@ -69,8 +69,6 @@ class TestOAuth2Redirect:
     def test_it_gets_an_access_token_from_canvas(
         self, canvas_api_client, pyramid_request
     ):
-        pyramid_request.parsed_params = {"code": "test_authorization_code"}
-
         CanvasAPIAuthorizeViews(pyramid_request).oauth2_redirect()
 
         canvas_api_client.get_token.assert_called_once_with("test_authorization_code")
@@ -78,8 +76,6 @@ class TestOAuth2Redirect:
     def test_it_saves_the_access_token_to_the_db(
         self, canvas_api_client, pyramid_request
     ):
-        pyramid_request.parsed_params = {"code": "test_authorization_code"}
-
         CanvasAPIAuthorizeViews(pyramid_request).oauth2_redirect()
 
         canvas_api_client.save_token.assert_called_once_with(
@@ -87,11 +83,15 @@ class TestOAuth2Redirect:
         )
 
     def test_it_500s_if_get_token_raises(self, canvas_api_client, pyramid_request):
-        pyramid_request.parsed_params = {"code": "test_authorization_code"}
         canvas_api_client.get_token.side_effect = CanvasAPIServerError()
 
         with pytest.raises(HTTPInternalServerError):
             CanvasAPIAuthorizeViews(pyramid_request).oauth2_redirect()
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.parsed_params = {"code": "test_authorization_code"}
+        return pyramid_request
 
 
 class TestOAuth2RedirectError:


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/710> and <https://github.com/hypothesis/lms/pull/711>.

When we send the access token request to Canvas, catch any error
responses or network timeouts etc and show the user an error page with a
"Try again" button.

`CanvasAPIClient.get_token()` now raises `CanvasAPIServerError` if
there's a problem with the access token request.

The `oauth2_redirect()` view that calls `CanvasAPIClient.get_token()`
catches the `CanvasAPIServerError` and wraps it in an
`HTTPInternalServerError`.

This causes Pyramid to call the new `oauth2_redirect_error()` exception
view which renders a template with a "Try again" button that links back
to the original `authorize()` view to restart the flow.

The user is put into an infinite loop, within the popup window, of authorizing with Canvas and then seeing an error message from us with a <kbd>Try again</kbd> button, until the authorization succeeds or the user gives up.

![Peek 2019-06-18 16-33](https://user-images.githubusercontent.com/22498/59844056-d4014d80-9351-11e9-867c-aeabc6f45157.gif)
