### PR TITLE
Enable validating requests-library responses using our validation schemas

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -1,19 +1,22 @@
 """
-Schemas for parsing and validating requests.
+Schemas for parsing and validating things.
 
-This package contains schemas that views can use to validate and parse
-requests. The idea is that the request is validated before the view is called.
-If validation fails an error response is sent back and the view is never
-called. If validation succeeds the parsed and validated parameters are made
-available to the view as ``request.parsed_params``. The view's own code can
-assume that all the parsed params are valid and that all required params are
-present.
+This package contains schemas for parsing and validating things like Pyramid
+requests, or :mod:`requests`-library responses.
 
-Usage::
+Validating Pyramid Requests
+---------------------------
 
-    from lms.validation import FOO_SCHEMA
+When validating Pyramid requests the idea is that the request is validated
+before the view is called.  If validation fails an error response is sent back
+and the view is never called. If validation succeeds the parsed and validated
+parameters are made available to the view as ``request.parsed_params``. The
+view's own code can assume that all the parsed params are valid and that all
+required params are present. Example::
 
-    @view_config(..., schema=FOO_SCHEMA)
+    from lms.validation import FooSchema
+
+    @view_config(..., schema=FooSchema)
     def foo_view(request):
         validated_arg_1 = request.parsed_params["validated_arg_1"]
         validated_arg_2 = request.parsed_params["validated_arg_2"]
@@ -23,6 +26,22 @@ Note that we're using our own view deriver (the ``schema`` argument to
 ``view_config``) to integrate our schemas and views, rather than using webargs's
 ``@use_args()`` / ``@use_kwargs()`` decorators. For the reasons for this see
 commit message f61a5ff3cae6b983e24db809d8e4b4933aca1e92.
+
+Validating requests-Library Responses
+-------------------------------------
+
+To validate a :mod:`requests`-library response you pass the response object to a
+suitable validation schema's ``__init__()`` method and then call the schema's
+``parse()`` method::
+
+    import requests
+
+    response = requests.get(...)
+
+    try:
+        parsed_params = BarSchema(response).parse()
+    except lms.validation.ValidationError as err:
+        ...
 """
 from lms.validation._exceptions import (
     ValidationError,

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -24,8 +24,6 @@ Note that we're using our own view deriver (the ``schema`` argument to
 ``@use_args()`` / ``@use_kwargs()`` decorators. For the reasons for this see
 commit message f61a5ff3cae6b983e24db809d8e4b4933aca1e92.
 """
-from webargs import pyramidparser
-
 from lms.validation._exceptions import (
     ValidationError,
     ExpiredSessionTokenError,
@@ -42,7 +40,6 @@ from lms.validation._module_item_configuration import ConfigureModuleItemSchema
 
 
 __all__ = (
-    "parser",
     "CanvasOAuthCallbackSchema",
     "BearerTokenSchema",
     "LaunchParamsSchema",
@@ -55,14 +52,6 @@ __all__ = (
     "InvalidStateParamError",
     "ExpiredStateParamError",
 )
-
-
-parser = pyramidparser.PyramidParser()
-
-
-@parser.error_handler
-def _handle_error(error, _req, _schema, _status_code, _headers):
-    raise ValidationError(messages=error.messages) from error
 
 
 def _validated_view(view, info):
@@ -89,9 +78,7 @@ def _validated_view(view, info):
             # Use the view's configured schema to validate the request,
             # and make the validated and parsed request params available as
             # request.parsed_params.
-            request.parsed_params = parser.parse(
-                info.options["schema"](request), request
-            )
+            request.parsed_params = info.options["schema"](request).parse()
 
             # Call the view normally.
             return view(context, request)

--- a/lms/validation/_bearer_token.py
+++ b/lms/validation/_bearer_token.py
@@ -17,7 +17,7 @@ from lms.values import LTIUser
 __all__ = ("BearerTokenSchema",)
 
 
-class BearerTokenSchema(marshmallow.Schema):
+class BearerTokenSchema(_helpers.PyramidRequestSchema):
     """
     Schema for our bearer token-based LTI authentication.
 
@@ -62,19 +62,9 @@ class BearerTokenSchema(marshmallow.Schema):
     oauth_consumer_key = marshmallow.fields.Str(required=True)
     roles = marshmallow.fields.Str(required=True)
 
-    class Meta:
-        """Marshmallow options for this schema."""
-
-        # Silence a strict=False deprecation warning from marshmallow.
-        # TODO: Remove this once we've upgraded to marshmallow 3.
-        strict = True
-
     def __init__(self, request):
-        super().__init__()
-        self._request = request
-        # Storing context needed for serialization or deserialization in
-        # self.context is a marshmallow convention.
-        self.context = {"secret": request.registry.settings["jwt_secret"]}
+        super().__init__(request)
+        self.context["secret"] = request.registry.settings["jwt_secret"]
 
     def authorization_param(self, lti_user):
         """
@@ -120,7 +110,9 @@ class BearerTokenSchema(marshmallow.Schema):
         """
         try:
             return parser.parse(
-                self, self._request, locations=["headers", "querystring", "form"]
+                self,
+                self.context["request"],
+                locations=["headers", "querystring", "form"],
             )
         except HTTPUnprocessableEntity as error:
             try:

--- a/lms/validation/_helpers/__init__.py
+++ b/lms/validation/_helpers/__init__.py
@@ -1,4 +1,5 @@
 """Private helpers for :mod:`lms.validation` code."""
+from lms.validation._helpers._base import PyramidRequestSchema
 from lms.validation._helpers._exceptions import (
     HelpersError,
     JWTError,
@@ -9,6 +10,7 @@ from lms.validation._helpers._jwt import decode_jwt, encode_jwt
 
 
 __all__ = [
+    "PyramidRequestSchema",
     "HelpersError",
     "JWTError",
     "ExpiredJWTError",

--- a/lms/validation/_helpers/__init__.py
+++ b/lms/validation/_helpers/__init__.py
@@ -1,5 +1,5 @@
 """Private helpers for :mod:`lms.validation` code."""
-from lms.validation._helpers._base import PyramidRequestSchema
+from lms.validation._helpers._base import PyramidRequestSchema, RequestsResponseSchema
 from lms.validation._helpers._exceptions import (
     HelpersError,
     JWTError,
@@ -11,6 +11,7 @@ from lms.validation._helpers._jwt import decode_jwt, encode_jwt
 
 __all__ = [
     "PyramidRequestSchema",
+    "RequestsResponseSchema",
     "HelpersError",
     "JWTError",
     "ExpiredJWTError",

--- a/lms/validation/_helpers/_base.py
+++ b/lms/validation/_helpers/_base.py
@@ -63,18 +63,19 @@ class RequestsResponseSchema(_BaseSchema):
 
         :raise lms.validation.ValidationError: if the response isn't valid
         """
-        response = self.context["response"]
-
         try:
-            response_params = response.json()
-        except ValueError as err:
-            raise ValidationError(
-                {"_schema": "response doesn't have a valid JSON body"}
-            ) from err
-
-        try:
-            result = self.load(response_params, *args, **kwargs)
+            result = self.load(self.context["response"], *args, **kwargs)
         except marshmallow.ValidationError as err:
             raise ValidationError(messages=err.messages) from err
 
         return result.data
+
+    @staticmethod
+    @marshmallow.pre_load
+    def _pre_load(response):
+        try:
+            return response.json()
+        except ValueError as err:
+            raise marshmallow.ValidationError(
+                "response doesn't have a valid JSON body"
+            ) from err

--- a/lms/validation/_helpers/_base.py
+++ b/lms/validation/_helpers/_base.py
@@ -1,0 +1,27 @@
+"""Base classes for validation schemas."""
+import marshmallow
+
+
+__all__ = ["PyramidRequestSchema"]
+
+
+class _BaseSchema(marshmallow.Schema):
+    """Base class for all schemas."""
+
+    class Meta:
+        """Marshmallow options for all schemas."""
+
+        # Silence a strict=False deprecation warning from marshmallow.
+        # TODO: Remove this once we've upgraded to marshmallow 3.
+        strict = True
+
+
+class PyramidRequestSchema(_BaseSchema):
+    """Base class for schemas that validate Pyramid requests."""
+
+    def __init__(self, request):
+        super().__init__()
+
+        # Storing context needed for serialization or deserialization in
+        # self.context is a marshmallow convention.
+        self.context = {"request": request}

--- a/lms/validation/_helpers/_base.py
+++ b/lms/validation/_helpers/_base.py
@@ -1,8 +1,14 @@
 """Base classes for validation schemas."""
 import marshmallow
+from webargs import pyramidparser
+
+from lms.validation._exceptions import ValidationError
 
 
 __all__ = ["PyramidRequestSchema"]
+
+
+_PYRAMID_PARSER = pyramidparser.PyramidParser()
 
 
 class _BaseSchema(marshmallow.Schema):
@@ -25,3 +31,20 @@ class PyramidRequestSchema(_BaseSchema):
         # Storing context needed for serialization or deserialization in
         # self.context is a marshmallow convention.
         self.context = {"request": request}
+
+    def parse(self, *args, **kwargs):
+        """
+        Parse and validate the request.
+
+        Use this schema to parse and validate ``self.context["request"]`` and
+        either return the successfully parsed params or raise a validation
+        error.
+
+        :raise lms.validation.ValidationError: if the request isn't valid
+        """
+        return _PYRAMID_PARSER.parse(self, self.context["request"], *args, **kwargs)
+
+
+@_PYRAMID_PARSER.error_handler
+def _handle_error(error, _req, _schema, _status_code, _headers):
+    raise ValidationError(messages=error.messages) from error

--- a/lms/validation/_launch_params.py
+++ b/lms/validation/_launch_params.py
@@ -1,10 +1,7 @@
 """Schema for validating LTI launch params."""
 import marshmallow
-from webargs.pyramidparser import parser
-from pyramid.httpexceptions import HTTPUnprocessableEntity
 
 from lms.services import LTILaunchVerificationError
-from lms.validation._exceptions import ValidationError
 from lms.validation._helpers import PyramidRequestSchema
 from lms.values import LTIUser
 
@@ -53,10 +50,7 @@ class LaunchParamsSchema(PyramidRequestSchema):
 
         :rtype: LTIUser
         """
-        try:
-            kwargs = parser.parse(self, self.context["request"], locations=["form"])
-        except HTTPUnprocessableEntity as err:
-            raise ValidationError(err.json) from err
+        kwargs = self.parse(locations=["form"])
 
         return LTIUser(
             kwargs["user_id"], kwargs["oauth_consumer_key"], kwargs.get("roles", "")

--- a/lms/validation/_launch_params.py
+++ b/lms/validation/_launch_params.py
@@ -5,13 +5,14 @@ from pyramid.httpexceptions import HTTPUnprocessableEntity
 
 from lms.services import LTILaunchVerificationError
 from lms.validation._exceptions import ValidationError
+from lms.validation._helpers import PyramidRequestSchema
 from lms.values import LTIUser
 
 
 __all__ = ("LaunchParamsSchema",)
 
 
-class LaunchParamsSchema(marshmallow.Schema):
+class LaunchParamsSchema(PyramidRequestSchema):
     """
     Schema for LTI launch params.
 
@@ -40,16 +41,8 @@ class LaunchParamsSchema(marshmallow.Schema):
     oauth_timestamp = marshmallow.fields.Str(required=True)
     oauth_version = marshmallow.fields.Str(required=True)
 
-    class Meta:
-        """Marshmallow options for this schema."""
-
-        # Silence a strict=False deprecation warning from marshmallow.
-        # TODO: Remove this once we've upgraded to marshmallow 3.
-        strict = True
-
     def __init__(self, request):
-        super().__init__()
-        self._request = request
+        super().__init__(request)
         self._launch_verifier = request.find_service(name="launch_verifier")
 
     def lti_user(self):
@@ -61,7 +54,7 @@ class LaunchParamsSchema(marshmallow.Schema):
         :rtype: LTIUser
         """
         try:
-            kwargs = parser.parse(self, self._request, locations=["form"])
+            kwargs = parser.parse(self, self.context["request"], locations=["form"])
         except HTTPUnprocessableEntity as err:
             raise ValidationError(err.json) from err
 

--- a/lms/validation/_module_item_configuration.py
+++ b/lms/validation/_module_item_configuration.py
@@ -1,26 +1,16 @@
 """Validation for the configure_module_item() view."""
 
-import marshmallow
 from webargs import fields
+
+from lms.validation._helpers import PyramidRequestSchema
 
 
 __all__ = ["ConfigureModuleItemSchema"]
 
 
-class ConfigureModuleItemSchema(marshmallow.Schema):
+class ConfigureModuleItemSchema(PyramidRequestSchema):
     """Schema for validating requests to the configure_module_item() view."""
 
     document_url = fields.Str(required=True)
     resource_link_id = fields.Str(required=True)
     tool_consumer_instance_guid = fields.Str(required=True)
-
-    class Meta:
-        """Marshmallow options for this schema."""
-
-        # Silence a strict=False deprecation warning from marshmallow.
-        # TODO: Remove this once we've upgraded to marshmallow 3.
-        strict = True
-
-    def __init__(self, request):
-        super().__init__()
-        self._request = request

--- a/lms/validation/_oauth.py
+++ b/lms/validation/_oauth.py
@@ -10,7 +10,7 @@ from lms.validation import _exceptions
 from lms.values import LTIUser
 
 
-class CanvasOAuthCallbackSchema(marshmallow.Schema):
+class CanvasOAuthCallbackSchema(_helpers.PyramidRequestSchema):
     """
     Schema for validating OAuth 2 redirect_uri requests from Canvas.
 
@@ -58,19 +58,9 @@ class CanvasOAuthCallbackSchema(marshmallow.Schema):
     code = fields.Str(required=True)
     state = fields.Str(required=True)
 
-    class Meta:
-        """Marshmallow options for this schema."""
-
-        # Silence a strict=False deprecation warning from marshmallow.
-        # TODO: Remove this once we've upgraded to marshmallow 3.
-        strict = True
-
     def __init__(self, request):
-        super().__init__()
-        self.context = {
-            "request": request,
-            "secret": request.registry.settings["oauth2_state_secret"],
-        }
+        super().__init__(request)
+        self.context["secret"] = request.registry.settings["oauth2_state_secret"]
 
     def state_param(self):
         """

--- a/tests/lms/validation/_module_item_configuration_test.py
+++ b/tests/lms/validation/_module_item_configuration_test.py
@@ -1,13 +1,13 @@
 from pyramid import testing
 import pytest
 
-from lms.validation import ConfigureModuleItemSchema, parser
+from lms.validation import ConfigureModuleItemSchema
 from lms.validation import ValidationError
 
 
 class TestConfigureModuleItemSchema:
     def test_that_validation_succeeds_for_valid_requests(self, pyramid_request, schema):
-        self.parse(schema, pyramid_request)
+        schema.parse()
 
     @pytest.mark.parametrize(
         "param", ["document_url", "resource_link_id", "tool_consumer_instance_guid"]
@@ -18,15 +18,11 @@ class TestConfigureModuleItemSchema:
         del pyramid_request.params[param]
 
         with pytest.raises(ValidationError) as exc_info:
-            self.parse(schema, pyramid_request)
+            schema.parse()
 
         assert exc_info.value.messages == dict(
             [(param, ["Missing data for required field."])]
         )
-
-    def parse(self, schema, request):
-        """Parse ``request`` with ``schema`` and return the parsed params."""
-        return parser.parse(schema, request, locations=["form"])
 
     @pytest.fixture
     def pyramid_request(self):


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/715>.

In various places we use the `requests` library to send requests to the Canvas API. `requests` will raise if we don't get a response (network error or timeout) or if the response is non-2xx. But after that we still need to validate that:

1. We can successfully parse the response body as JSON
2. The JSON contains all the required params that we need from the response
3. Each param has a valid value

Unfortunately `lms.validation` assumes that our validation schemas are all for validating Pyramid requests. So refactor `lms.validation` a little to also enable schemas that validate requests-library response objects:

1. Add `_BaseSchema` as the base class for _all_ validation schemas, just to remove some boilerplate that we were putting in every schema

2. Add `PyramidRequestSchema(_BaseSchema)` as the base class for all schemas for validating Pyramid request objects, and change all our existing schemas to inherit from it

3. Add `RequestsResponseSchema(_BaseSchema)` as the base class for future schemas that validate requests response objects, with a very similar API to that of `PyramidRequestSchema`