### PR TITLE
Validate Canvas API access token responses

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -45,6 +45,7 @@ class ExternalRequestError(ServiceError):
         # application's logs. It's helpful for debugging to know how the
         # external service responded.
         parts = [
+            self.explanation + ":",
             str(self.response.status_code or ""),
             self.response.reason,
             self.response.text,

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -52,7 +52,10 @@ from lms.validation._exceptions import (
     ExpiredStateParamError,
     InvalidStateParamError,
 )
-from lms.validation._oauth import CanvasOAuthCallbackSchema
+from lms.validation._oauth import (
+    CanvasOAuthCallbackSchema,
+    CanvasAccessTokenResponseSchema,
+)
 from lms.validation._launch_params import LaunchParamsSchema
 from lms.validation._bearer_token import BearerTokenSchema
 from lms.validation._module_item_configuration import ConfigureModuleItemSchema
@@ -60,6 +63,7 @@ from lms.validation._module_item_configuration import ConfigureModuleItemSchema
 
 __all__ = (
     "CanvasOAuthCallbackSchema",
+    "CanvasAccessTokenResponseSchema",
     "BearerTokenSchema",
     "LaunchParamsSchema",
     "ConfigureModuleItemSchema",

--- a/lms/validation/_helpers/_base.py
+++ b/lms/validation/_helpers/_base.py
@@ -70,9 +70,8 @@ class RequestsResponseSchema(_BaseSchema):
 
         return result.data
 
-    @staticmethod
     @marshmallow.pre_load
-    def _pre_load(response):
+    def _pre_load(self, response):  # pylint: disable=no-self-use
         try:
             return response.json()
         except ValueError as err:

--- a/lms/validation/_oauth.py
+++ b/lms/validation/_oauth.py
@@ -10,6 +10,9 @@ from lms.validation import _exceptions
 from lms.values import LTIUser
 
 
+__all__ = ["CanvasOAuthCallbackSchema", "CanvasAccessTokenResponseSchema"]
+
+
 class CanvasOAuthCallbackSchema(_helpers.PyramidRequestSchema):
     """
     Schema for validating OAuth 2 redirect_uri requests from Canvas.
@@ -125,3 +128,16 @@ class CanvasOAuthCallbackSchema(_helpers.PyramidRequestSchema):
             raise _exceptions.ExpiredStateParamError() from err
         except InvalidJWTError as err:
             raise _exceptions.InvalidStateParamError() from err
+
+
+class CanvasAccessTokenResponseSchema(_helpers.RequestsResponseSchema):
+    """Schema for validating OAuth 2 access token responses from Canvas."""
+
+    access_token = fields.Str(required=True)
+    refresh_token = fields.Str()
+    expires_in = fields.Integer()
+
+    @marshmallow.validates("expires_in")
+    def validate_quantity(self, expires_in):  # pylint:disable=no-self-use
+        if not expires_in > 0:
+            raise marshmallow.ValidationError("expires_in must be greater than 0")

--- a/tests/lms/services/exceptions_test.py
+++ b/tests/lms/services/exceptions_test.py
@@ -24,10 +24,30 @@ class TestExternalRequestError:
     @pytest.mark.parametrize(
         "status_code,reason,text,expected",
         [
-            (400, "Bad Request", "Name too long", "400 Bad Request Name too long"),
-            (None, "Bad Request", "Name too long", "Bad Request Name too long"),
-            (400, None, "Name too long", "400 Name too long"),
-            (400, "Bad Request", "", "400 Bad Request"),
+            (
+                400,
+                "Bad Request",
+                "Name too long",
+                "Connecting to Hypothesis failed: 400 Bad Request Name too long",
+            ),
+            (
+                None,
+                "Bad Request",
+                "Name too long",
+                "Connecting to Hypothesis failed: Bad Request Name too long",
+            ),
+            (
+                400,
+                None,
+                "Name too long",
+                "Connecting to Hypothesis failed: 400 Name too long",
+            ),
+            (
+                400,
+                "Bad Request",
+                "",
+                "Connecting to Hypothesis failed: 400 Bad Request",
+            ),
         ],
     )
     def test_when_theres_a_response_it_uses_it_in_str(


### PR DESCRIPTION
Depends on ~~https://github.com/hypothesis/lms/pull/715~~, https://github.com/hypothesis/lms/pull/716, and ~~https://github.com/hypothesis/lms/pull/717~~.

This adds `CanvasAccessTokenResponseSchema`, our first `RequestsResponseSchema` subclass, and changes `CanvasAPIClient.get_token()` to validate the Canvas API's access token response with it.

`CanvasAPIClient.get_token()` raises `CanvasAPIServerError` if Canvas's response is invalid, and the relevant view already catches `CanvasAPIServerError`'s and turns them into a "Something went wrong, try again" page.