### PR TITLE
Canvas API backend error handling 1/6: Add CanvasAPIError factory

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -7,6 +7,7 @@ from lms.services.exceptions import ExternalRequestError
 from lms.services.exceptions import HAPIError
 from lms.services.exceptions import HAPINotFoundError
 from lms.services.exceptions import CanvasAPIError
+from lms.services.exceptions import CanvasAPIAccessTokenError
 from lms.services.exceptions import CanvasAPIServerError
 
 __all__ = (
@@ -19,6 +20,7 @@ __all__ = (
     "HAPIError",
     "HAPINotFoundError",
     "CanvasAPIError",
+    "CanvasAPIAccessTokenError",
     "CanvasAPIServerError",
 )
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -28,8 +28,14 @@ class ExternalRequestError(ServiceError):
     """
     A problem with a network request to an external service.
 
-    :param response: The response from the HTTP request to the h API
-    :type response: requests.Response
+    :arg explanation: A short error message for displaying to the user
+    :type explanation: str
+
+    :arg response: The external service's response to our HTTP request, if any
+    :type response: requests.Response or ``None``
+
+    :arg details: Additional details about what went wrong, for debugging
+    :type details: JSON-serializable dict or ``None``
     """
 
     def __init__(self, explanation=None, response=None, details=None):

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -75,6 +75,19 @@ class CanvasAPIError(ExternalRequestError):
     """
 
 
+class CanvasAPIAccessTokenError(CanvasAPIError):
+    """
+    A problem with a Canvas API access token.
+
+    Raised when a Canvas API request fails because we don't have an access
+    token for the user, or our access token is expired and can't be refreshed,
+    or our access token is otherwise not working.
+
+    If we can put the user through the OAuth grant flow to get a new access
+    token and then re-try the request, it might succeed.
+    """
+
+
 class CanvasAPIServerError(CanvasAPIError):
     """
     A server error during a Canvas API request.

--- a/tests/lms/services/exceptions_test.py
+++ b/tests/lms/services/exceptions_test.py
@@ -1,9 +1,17 @@
+import json
 from unittest import mock
 
+import httpretty
 import pytest
-from requests import Response
+import requests
 
-from lms.services import ExternalRequestError
+from lms.services import (
+    CanvasAPIError,
+    CanvasAPIAccessTokenError,
+    CanvasAPIServerError,
+    ExternalRequestError,
+)
+from lms.validation import ValidationError
 
 
 class TestExternalRequestError:
@@ -54,8 +62,143 @@ class TestExternalRequestError:
         self, status_code, reason, text, expected
     ):
         response = mock.create_autospec(
-            Response, instance=True, status_code=status_code, reason=reason, text=text
+            requests.Response,
+            instance=True,
+            status_code=status_code,
+            reason=reason,
+            text=text,
         )
         err = ExternalRequestError("Connecting to Hypothesis failed", response=response)
 
         assert str(err) == expected
+
+
+class TestRaiseFrom:
+    @pytest.mark.parametrize(
+        "status,expected_status,expected_exception_class,expected_exception_string",
+        [
+            # A 401 Unauthorized response from Canvas, because our access token was
+            # expired or deleted.
+            (
+                401,
+                "401 Unauthorized",
+                CanvasAPIAccessTokenError,
+                "401 Client Error: Unauthorized for url: https://example.com/",
+            ),
+            # A 400 Bad Request response from Canvas, because we sent an invalid
+            # parameter or something.
+            (
+                400,
+                "400 Bad Request",
+                CanvasAPIServerError,
+                "400 Client Error: Bad Request for url: https://example.com/",
+            ),
+            # An unexpected error response from Canvas.
+            (
+                500,
+                "500 Internal Server Error",
+                CanvasAPIServerError,
+                "500 Server Error: Internal Server Error for url: https://example.com/",
+            ),
+        ],
+    )
+    def test_it_raises_the_right_CanvasAPIError_subclass_for_different_Canvas_responses(
+        self,
+        status,
+        expected_status,
+        expected_exception_class,
+        expected_exception_string,
+    ):
+        cause = self._requests_exception(status=status)
+
+        with pytest.raises(
+            expected_exception_class, match="Calling the Canvas API failed"
+        ) as exc_info:
+            CanvasAPIError.raise_from(cause)
+
+        raised_exception = exc_info.value
+        assert raised_exception.__cause__ == cause
+        assert raised_exception.response == cause.response
+        assert raised_exception.details == {
+            "exception": expected_exception_string,
+            "validation_errors": None,
+            "response": {"status": expected_status, "body": '{"foo": "bar"}'},
+        }
+
+    @pytest.mark.parametrize(
+        "cause,expected_exception_string",
+        [
+            (requests.RequestException(), "RequestException()"),
+            (requests.ConnectionError(), "ConnectionError()"),
+            (requests.TooManyRedirects(), "TooManyRedirects()"),
+            (requests.ConnectTimeout(), "ConnectTimeout()"),
+            (requests.ReadTimeout(), "ReadTimeout()"),
+        ],
+    )
+    def test_it_raises_CanvasAPIServerError_for_all_other_requests_errors(
+        self, cause, expected_exception_string
+    ):
+        with pytest.raises(
+            CanvasAPIServerError, match="Calling the Canvas API failed"
+        ) as exc_info:
+            CanvasAPIError.raise_from(cause)
+
+        raised_exception = exc_info.value
+        assert raised_exception.__cause__ == cause
+        # For these kinds of errors no response (either successful or
+        # unsuccessful) was ever received from Canvas (for example: the network
+        # request timed out) so there's nothing to set as the response
+        # property.
+        assert raised_exception.response is None
+        assert raised_exception.details == {
+            "exception": expected_exception_string,
+            "response": None,
+            "validation_errors": None,
+        }
+
+    def test_it_raises_CanvasAPIServerError_for_a_successful_but_invalid_response(
+        self, canvas_api_invalid_response
+    ):
+        cause = ValidationError("The response was invalid.")
+        cause.response = canvas_api_invalid_response
+
+        with pytest.raises(
+            CanvasAPIServerError, match="Calling the Canvas API failed"
+        ) as exc_info:
+            CanvasAPIError.raise_from(cause)
+
+        raised_exception = exc_info.value
+        assert raised_exception.__cause__ == cause
+        assert raised_exception.response == canvas_api_invalid_response
+        assert raised_exception.details == {
+            "exception": "Unable to process the contained instructions",
+            "response": {"body": "Invalid", "status": "200 OK"},
+            "validation_errors": "The response was invalid.",
+        }
+
+    @pytest.fixture
+    def canvas_api_invalid_response(self):
+        """Return a successful (200 OK) response with an invalid body."""
+        httpretty.register_uri(
+            httpretty.GET, "https://example.com", priority=1, status=200, body="Invalid"
+        )
+        return requests.get("https://example.com")
+
+    @staticmethod
+    def _requests_exception(**kwargs):
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://example.com",
+            priority=1,
+            body=json.dumps({"foo": "bar"}),
+            **kwargs
+        )
+
+        response = requests.get("https://example.com")
+
+        try:
+            response.raise_for_status()
+        except requests.RequestException as err:
+            return err
+
+        assert False, "We should never get here"


### PR DESCRIPTION
Given an exception caused by an attempted Canvas API request, there's
quite a lot of logic about how we wrap that exception in the appropriate
lms.services.CanvasAPIError subclass:

* The exception may be a requests exception representing a 401
  Unauthorized response from Canvas, in which case we wrap it in a
  CanvasAPIAccessTokenError.

* Any other exception (a requests exception representing a 400 Bad
  Request response from Canvas, or a 500 Server Error from Canvas, or a
  network error, or a validation error when validating Canvas's
  response, ...) gets wrapped in a CanvasAPIServerError.

* In cases where a response was actually received from Canvas it's set
  as the exception's `response` attribute, otherwise `response` is
  `None`

* The exception has a `details` attribute containing a string
  representation of the wrapped exception and the validation errors
  and/or response that caused it

Move all this exception-creating logic into a new
CanvasAPIError.raise_from() factory.

The CanvasAPIError's raised here will eventually bubble up to error
views which will turn them into appropriate JSON responses for our
frontend code to receive.