### PR TITLE
Canvas API backend error handling 6/6: Send 400 Bad Request JSON responses to the frontend, on Canvas API failures

### DIFF
--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -3,7 +3,7 @@ import datetime
 from sqlalchemy.orm.exc import NoResultFound
 
 from lms.models import OAuth2Token
-from lms.services import CanvasAPIError
+from lms.services import CanvasAPIAccessTokenError
 from lms.services._helpers import CanvasAPIHelper
 from lms.validation import (
     CanvasAccessTokenResponseSchema,
@@ -84,9 +84,9 @@ class CanvasAPIClient:
         :arg course_id: the Canvas course_id of the course to look in
         :type course_id: str
 
-        :raise lms.services.CanvasAPIError: if we can't get the list of files
-            because we don't have a working Canvas API access token for the
-            user
+        :raise lms.services.CanvasAPIAccessTokenError: if we can't get the list
+            of files because we don't have a working Canvas API access token
+            for the user
         :raise lms.services.CanvasAPIServerError: if we do have an access token
             but the Canvas API request fails for any other reason
 
@@ -107,9 +107,9 @@ class CanvasAPIClient:
         :arg file_id: the ID of the Canvas file
         :type file_id: str
 
-        :raise lms.services.CanvasAPIError: if we can't get the public URL
-            because we don't have a working Canvas API access token for the
-            user
+        :raise lms.services.CanvasAPIAccessTokenError: if we can't get the
+            public URL because we don't have a working Canvas API access token
+            for the user
         :raise lms.services.CanvasAPIServerError: if we do have an access token
             but the Canvas API request fails for any other reason
 
@@ -125,7 +125,7 @@ class CanvasAPIClient:
         """
         Return the user's saved access token from the DB.
 
-        :raise lms.services.CanvasAPIError: if we don't have an access token
+        :raise lms.services.CanvasAPIAccessTokenError: if we don't have an access token
             for the user
         """
         try:
@@ -139,7 +139,7 @@ class CanvasAPIClient:
                 .access_token
             )
         except NoResultFound as err:
-            raise CanvasAPIError(
+            raise CanvasAPIAccessTokenError(
                 explanation="We don't have a Canvas API access token for this user",
                 response=None,
             ) from err

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -29,11 +29,9 @@ proxy API caller::
                       |Real Canvas API|
                       +---------------+
 """
-from pyramid.httpexceptions import HTTPInternalServerError
 from pyramid.view import view_config, view_defaults
 
 from lms import util
-from lms.services import CanvasAPIError
 
 
 @view_defaults(permission="canvas_api", renderer="json")
@@ -44,23 +42,24 @@ class FilesAPIViews:
 
     @view_config(request_method="GET", route_name="canvas_api.courses.files.list")
     def list_files(self):
-        """Return the list of files in the given course."""
-        try:
-            return self.canvas_api_client.list_files(
-                self.request.matchdict["course_id"]
-            )
-        except CanvasAPIError as err:
-            raise HTTPInternalServerError(explanation=err.explanation) from err
+        """
+        Return the list of files in the given course.
+
+        :raise lms.services.CanvasAPIError: if the Canvas API request fails.
+            This exception is caught and handled by an exception view.
+        """
+        return self.canvas_api_client.list_files(self.request.matchdict["course_id"])
 
     @view_config(request_method="GET", route_name="canvas_api.files.via_url")
     def via_url(self):
-        """Return the Via URL for annotating the given Canvas file."""
-        try:
-            public_url = self.canvas_api_client.public_url(
-                self.request.matchdict["file_id"]
-            )
-        except CanvasAPIError as err:
-            raise HTTPInternalServerError(explanation=err.explanation) from err
+        """
+        Return the Via URL for annotating the given Canvas file.
 
+        :raise lms.services.CanvasAPIError: if the Canvas API request fails.
+            This exception is caught and handled by an exception view.
+        """
+        public_url = self.canvas_api_client.public_url(
+            self.request.matchdict["file_id"]
+        )
         via_url = util.via_url(self.request, public_url)
         return {"via_url": via_url}

--- a/lms/views/api/error.py
+++ b/lms/views/api/error.py
@@ -1,9 +1,34 @@
 """Error views for the API."""
 from pyramid import i18n
-from pyramid.view import forbidden_view_config, notfound_view_config
+from pyramid.view import (
+    exception_view_config,
+    forbidden_view_config,
+    notfound_view_config,
+)
+
+from lms.services import CanvasAPIError, CanvasAPIAccessTokenError
 
 
 _ = i18n.TranslationStringFactory(__package__)
+
+
+@exception_view_config(context=CanvasAPIAccessTokenError, renderer="json")
+def canvas_api_access_token_error(request):
+    request.response.status_int = 400
+    # For a CanvasAPIAccessTokenError we don't send any error message or
+    # details to the frontend because we don't want the frontend to show any
+    # error message to the user in this case. Just the 400 status so the
+    # frontend knows that the request failed, and that it should show the user
+    # an [Authorize] button so they can get a (new) access token and try again.
+    return {"error_message": None, "details": None}
+
+
+@exception_view_config(context=CanvasAPIError, renderer="json")
+def canvas_api_error(context, request):
+    request.response.status_int = 400
+    # Send the frontend an error message and details to show to the user for
+    # debugging.
+    return {"error_message": context.explanation, "details": context.details}
 
 
 @forbidden_view_config(path_info="/api/*", renderer="json")

--- a/tests/lms/services/canvas_api_test.py
+++ b/tests/lms/services/canvas_api_test.py
@@ -9,7 +9,7 @@ from requests import Response
 from requests import TooManyRedirects
 
 from lms.models import ApplicationInstance, OAuth2Token
-from lms.services import CanvasAPIError, CanvasAPIServerError
+from lms.services import CanvasAPIAccessTokenError, CanvasAPIServerError
 from lms.services.canvas_api import CanvasAPIClient
 from lms.validation import ValidationError
 
@@ -179,11 +179,11 @@ class TestListFiles:
 
         assert files == validated_response.parsed_params
 
-    def test_it_raises_CanvasAPIError_if_we_dont_have_an_access_token(
+    def test_it_raises_CanvasAPIAccessTokenError_if_we_dont_have_an_access_token(
         self, canvas_api_client
     ):
         with pytest.raises(
-            CanvasAPIError,
+            CanvasAPIAccessTokenError,
             match="We don't have a Canvas API access token for this user",
         ):
             canvas_api_client.list_files("test_course_id")
@@ -244,11 +244,11 @@ class TestPublicURL:
 
         assert url == "test_public_url"
 
-    def test_it_raises_CanvasAPIError_if_we_dont_have_an_access_token(
+    def test_it_raises_CanvasAPIAccessTokenError_if_we_dont_have_an_access_token(
         self, canvas_api_client
     ):
         with pytest.raises(
-            CanvasAPIError,
+            CanvasAPIAccessTokenError,
             match="We don't have a Canvas API access token for this user",
         ):
             canvas_api_client.public_url("test_file_id")

--- a/tests/lms/views/api/canvas/files_test.py
+++ b/tests/lms/views/api/canvas/files_test.py
@@ -1,8 +1,6 @@
 import pytest
 from unittest import mock
 
-from pyramid.httpexceptions import HTTPInternalServerError
-
 from lms.services import CanvasAPIError
 from lms.services.canvas_api import CanvasAPIClient
 from lms.views.api.canvas.files import FilesAPIViews
@@ -21,10 +19,14 @@ class TestListFiles:
             pyramid_request
         ).list_files() == canvas_api_client.list_files.return_value
 
-    def test_if_list_files_raises_it_500s(self, canvas_api_client, pyramid_request):
+    # CanvasAPIError's are caught and handled by an exception view, so the
+    # normal view just lets them raise.
+    def test_it_doesnt_catch_CanvasAPIErrors_from_list_files(
+        self, canvas_api_client, pyramid_request
+    ):
         canvas_api_client.list_files.side_effect = CanvasAPIError("Oops")
 
-        with pytest.raises(HTTPInternalServerError, match="Oops"):
+        with pytest.raises(CanvasAPIError, match="Oops"):
             FilesAPIViews(pyramid_request).list_files()
 
     @pytest.fixture
@@ -50,10 +52,14 @@ class TestViaURL:
             pyramid_request, canvas_api_client.public_url.return_value
         )
 
-    def test_if_public_url_raises_it_500s(self, canvas_api_client, pyramid_request):
+    # CanvasAPIError's are caught and handled by an exception view, so the
+    # normal view just lets them raise.
+    def test_doesnt_catch_CanvasAPIErrors_from_public_url(
+        self, canvas_api_client, pyramid_request
+    ):
         canvas_api_client.public_url.side_effect = CanvasAPIError("Oops")
 
-        with pytest.raises(HTTPInternalServerError, match="Oops"):
+        with pytest.raises(CanvasAPIError, match="Oops"):
             FilesAPIViews(pyramid_request).via_url()
 
     def test_it_returns_the_via_url(self, pyramid_request, util):

--- a/tests/lms/views/api/error_test.py
+++ b/tests/lms/views/api/error_test.py
@@ -1,4 +1,27 @@
+from lms.services import CanvasAPIError
 from lms.views.api import error
+
+
+class TestCanvasAPIAccessTokenError:
+    def test_it(self, pyramid_request):
+        json_data = error.canvas_api_access_token_error(pyramid_request)
+
+        assert pyramid_request.response.status_code == 400
+        assert json_data == {"error_message": None, "details": None}
+
+
+class TestCanvasAPIError:
+    def test_it(self, pyramid_request):
+        json_data = error.canvas_api_error(
+            CanvasAPIError(explanation="test_explanation", details={"foo": "bar"}),
+            pyramid_request,
+        )
+
+        assert pyramid_request.response.status_code == 400
+        assert json_data == {
+            "error_message": "test_explanation",
+            "details": {"foo": "bar"},
+        }
 
 
 class TestNotFound:


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/730.

I'll give this some manual testing once everything else is merged and this has been rebased, and will update the commit message which is incorrect about the details of the responses sent.

But this fixes the views to catch the service-level `CanvasAPIAccessTokenError` and `CanvasAPIError` that're sent whenever anything goes wrong with an access token or Canvas API request. The errors are turned into 400 Bad Request responses with JSON bodies, that should be suitable for the frontend to implement error handling behaviour.

## Testing

You can use this branch with everything on it to test: https://github.com/hypothesis/lms/pull/732

The easiest way to test this manually is to hack the code to send incorrect Canvas API requests in various ways, and observe the error responses that get sent back to our frontend in the browser's dev console.

### Incorrect `course_id` param (causes a 404 from Canvas)

```diff
diff --git a/lms/services/_helpers/canvas_api.py b/lms/services/_helpers/canvas_api.py
index c0b43a3..4b329a4 100644
--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -183,7 +183,7 @@ class CanvasAPIHelper:
             (
                 "https",
                 self._canvas_url,
-                f"/api/v1/courses/{course_id}/files",
+                f"/api/v1/courses/foo/files",
                 "",
                 urlencode({"content_types[]": "application/pdf", "per_page": 100}),
                 "",
```

In Canvas go to create a new assignment, choose _Select PDF from Canvas_, authorize, and then when the frontend tries to send the list_files proxy API request it'll get an error response.

The frontend won't respond correctly yet as it doesn't have error handling yet.

But in the dev tools you can see the 400 Bad Request JSON error with error_message and details, from the backend.

### Canvas API not responding

```diff
diff --git a/lms/services/_helpers/canvas_api.py b/lms/services/_helpers/canvas_api.py
index c0b43a3..1dacb62 100644
--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -182,7 +182,7 @@ class CanvasAPIHelper:
         return urlunparse(
             (
                 "https",
-                self._canvas_url,
+                "abcde.com",
                 f"/api/v1/courses/{course_id}/files",
                 "",
                 urlencode({"content_types[]": "application/pdf", "per_page": 100}),
```

Same thing: try to create a Canvas assignment and observe the error response in dev tools.

### Completely unexpected response (not even JSON) from Canvas

```diff
diff --git a/lms/services/_helpers/canvas_api.py b/lms/services/_helpers/canvas_api.py
index c0b43a3..8ae51b2 100644
--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -182,7 +182,7 @@ class CanvasAPIHelper:
         return urlunparse(
             (
                 "https",
-                self._canvas_url,
+                "example.com",
                 f"/api/v1/courses/{course_id}/files",
                 "",
                 urlencode({"content_types[]": "application/pdf", "per_page": 100}),
```

Same deal again.

### 200 OK JSON response from Canvas, but response body is not as we expected

Simulate this by hacking our validation schema to expect a param that Canvas doesn't send:

```diff
diff --git a/lms/validation/_canvas.py b/lms/validation/_canvas.py
index d462951..b28fd1e 100644
--- a/lms/validation/_canvas.py
+++ b/lms/validation/_canvas.py
@@ -19,6 +19,7 @@ class CanvasListFilesResponseSchema(RequestsResponseSchema):
     display_name = fields.Str(required=True)
     id = fields.Integer(required=True)
     updated_at = fields.String(required=True)
+    foo = fields.String(required=True)
 
 
 class CanvasPublicURLResponseSchema(RequestsResponseSchema):
```

### Our access token has expired or been deleted

```diff
diff --git a/lms/services/_helpers/canvas_api.py b/lms/services/_helpers/canvas_api.py
index c0b43a3..34d8362 100644
--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -101,7 +101,7 @@ class CanvasAPIHelper:
         return requests.Request(
             "GET",
             self._list_files_url(course_id),
-            headers={"Authorization": f"Bearer {access_token}"},
+            headers={"Authorization": f"Bearer foo"},
         ).prepare()
 
     def public_url_request(self, access_token, file_id):
```

In this case you'll see that our server's 400 Bad Request response contains no error message or details. This is because in the case of access token problems the frontend should just ask the user for a re-authorization, and not show them any error message.

### We don't have an access token for this user

```diff
diff --git a/lms/services/canvas_api.py b/lms/services/canvas_api.py
index f449856..7b11534 100644
--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -133,7 +133,7 @@ class CanvasAPIClient:
                 self._db.query(OAuth2Token)
                 .filter_by(
                     consumer_key=self._lti_user.oauth_consumer_key,
-                    user_id=self._lti_user.user_id,
+                    user_id="foo",
                 )
                 .one()
                 .access_token
```

Again there should be no error message or details in the response. <del>In fact there is an error message -- that's a mistake. I'll have to fix this one.</del> (fixed)
