### PR TITLE
Hide "Select PDF from Canvas" button if Canvas files is not available

### DIFF
--- a/lms/static/scripts/file_picker_v2/components/FilePickerApp.js
+++ b/lms/static/scripts/file_picker_v2/components/FilePickerApp.js
@@ -32,6 +32,7 @@ export default function FilePickerApp({
     authToken,
     authUrl,
     courseId,
+    enableLmsFilePicker = false,
     formAction,
     formFields,
     googleClientId,
@@ -181,11 +182,13 @@ export default function FilePickerApp({
           label="Enter URL of web page or PDF"
           onClick={() => setActiveDialog('url')}
         />
-        <Button
-          className="FilePickerApp__source-button"
-          label={`Select PDF from ${lmsName}`}
-          onClick={() => setActiveDialog('lms')}
-        />
+        {enableLmsFilePicker && (
+          <Button
+            className="FilePickerApp__source-button"
+            label={`Select PDF from ${lmsName}`}
+            onClick={() => setActiveDialog('lms')}
+          />
+        )}
         {googlePicker && (
           <Button
             className="FilePickerApp__source-button"

--- a/lms/static/scripts/file_picker_v2/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/FilePickerApp-test.js
@@ -41,6 +41,7 @@ describe('FilePickerApp', () => {
 
   beforeEach(() => {
     fakeConfig = {
+      enableLmsFilePicker: true,
       formAction: 'https://www.shinylms.com/',
       formFields: { hidden_field: 'hidden_value' },
       lmsName: 'Shiny LMS',
@@ -81,6 +82,23 @@ describe('FilePickerApp', () => {
       assert.equal(field.length, 1);
       assert.equal(field.prop('value'), fakeConfig.formFields[fieldName]);
     });
+  });
+
+  it('renders buttons to choose assignment source', () => {
+    const wrapper = renderFilePicker();
+    assert.equal(wrapper.find(Button).length, 2);
+  });
+
+  it('renders LMS file picker button if `enableLmsFilePicker` is true', () => {
+    fakeConfig.enableLmsFilePicker = true;
+    const wrapper = renderFilePicker();
+    assert.isTrue(wrapper.exists('Button[label="Select PDF from Shiny LMS"]'));
+  });
+
+  it('does not render LMS file picker button if `enableLmsFilePicker` is false', () => {
+    fakeConfig.enableLmsFilePicker = false;
+    const wrapper = renderFilePicker();
+    assert.isFalse(wrapper.exists('Button[label="Select PDF from Shiny LMS"]'));
   });
 
   it('renders initial form with no dialog visible', () => {

--- a/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
+++ b/lms/templates/content_item_selection/new_content_item_selection.html.jinja2
@@ -47,24 +47,11 @@
 
 {% block scripts %}
 {% if request.feature("new_oauth") %}
+{{ super() }}
+
 {% for url in asset_urls("file_picker_v2_js") %}
 <script async defer src="{{ url }}"></script>
 {% endfor %}
-
-<script class="js-config" type="text/json">
-{
-  "authToken": "{{ context.js_config.authToken }}",
-  "authUrl": "{{ request.route_url('canvas_api.authorize') }}",
-  "courseId": "{{ course_id }}",
-  "formAction": "{{ content_item_return_url }}",
-  "formFields": {{ form_fields | tojson }},
-  "googleClientId": "{{ google_client_id }}",
-  "googleDeveloperKey": "{{ google_developer_key }}",
-  "lmsName" : "Canvas",
-  "lmsUrl": "{{ lms_url }}",
-  "ltiLaunchUrl": "{{ lti_launch_url }}"
-}
-</script>
 
 {% else %}
 <script type="text/javascript">

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -142,6 +142,10 @@ class BasicLTILaunchViews:
         # Add the config needed by the JavaScript document selection code.
         self.context.js_config.update(
             {
+                # It is assumed that this view is only used by LMSes for which
+                # we do not have an integration with the LMS's file storage.
+                # (currently only Canvas supports this).
+                "enableLmsFilePicker": False,
                 "formAction": self.request.route_url("module_item_configurations"),
                 "formFields": {
                     "authorization": BearerTokenSchema(

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -94,6 +94,9 @@ def content_item_selection(context, request):
     # course, as this is a required param of the API it'll call to get the list
     # of files in the course.
     if helpers.canvas_files_available(request):
+        context.js_config["enableLmsFilePicker"] = True
         context.js_config["courseId"] = request.params["custom_canvas_course_id"]
+    else:
+        context.js_config["enableLmsFilePicker"] = False
 
     return {}

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -78,6 +78,7 @@ class TestUnconfiguredBasicLTILaunch:
             pyramid_request.lti_user
         )
         assert context.js_config == {
+            "enableLmsFilePicker": False,
             "formAction": "http://example.com/module_item_configurations",
             "formFields": {
                 "authorization": bearer_token_schema.authorization_param.return_value,

--- a/tests/lms/views/content_item_selection_test.py
+++ b/tests/lms/views/content_item_selection_test.py
@@ -64,6 +64,16 @@ class TestContentItemSelection:
         helpers.canvas_files_available.assert_called_once_with(pyramid_request)
         assert context.js_config["courseId"] == "TEST_CUSTOM_CANVAS_COURSE_ID"
 
+    @pytest.mark.parametrize("enable_picker", (True, False))
+    def test_it_enables_lms_file_picker_if_canvas_files_available(
+        self, context, helpers, pyramid_request, enable_picker
+    ):
+        helpers.canvas_files_available.return_value = enable_picker
+
+        content_item_selection(context, pyramid_request)
+
+        assert context.js_config["enableLmsFilePicker"] is enable_picker
+
     def test_if_canvas_files_arent_available_for_this_application_instance_then_it_omits_course_id(
         self, context, helpers, pyramid_request
     ):


### PR DESCRIPTION
 - Add `enableLmsFilePicker` config option to file picker JS app and set
   it in the `content_item_selection` view

   It would have been possible to just test for the presence of the existing
   `courseId` config field which is only set when the Canvas files API is
   available. However I opted to use a separate, more explicit flag instead, as
   it is possible that a field like "courseId" might be set for other
   reasons in future, and that other LMSes may use different conditions
   to enable or disable the LMS file picker.

 - Change `new_content_item_selection` template to use the `js-config`
   JSON script tag rendering provided by the base template instead of
   duplicating it. All the necessary config was already present in that
   tag.

Resolves one of the tasks in #624