### PR TITLE
Allow "image/x-icon" as the MIME type for the favicon in tests

### DIFF
--- a/tests/lms/views/favicon_test.py
+++ b/tests/lms/views/favicon_test.py
@@ -5,4 +5,10 @@ def test_favicon(pyramid_request):
     response = favicon.favicon(pyramid_request)
 
     assert response.status_int == 200
-    assert response.headers["Content-Type"] == "image/vnd.microsoft.icon"
+    assert response.headers["Content-Type"] in (
+        # Python's default mime type for .ico files.
+        "image/vnd.microsoft.icon",
+        # Non-standard mime type that some systems will report.
+        # See https://en.wikipedia.org/wiki/Favicon#Standardization
+        "image/x-icon",
+    )


### PR DESCRIPTION
This is a non-standard MIME type but one that is widely used and may be
returned as the Content-Type for .ico files depending on the system's
mime type registry. This happens for example if Apache 2's mime types
are installed.

I'm sure there are many other ways of fixing this, or even removing the favicon view entirely in favour of using some other mechanism of serving a static resource. Better suggestions welcome.