### PR TITLE
Catch and display errors reported by LMS backend API calls

### DIFF
--- a/lms/static/scripts/file_picker_v2/components/Dialog.js
+++ b/lms/static/scripts/file_picker_v2/components/Dialog.js
@@ -88,9 +88,11 @@ export default function Dialog({
           <h1 className="Dialog__title" id="Dialog__title">
             {title}
             <span className="u-stretch" />
-            <button className="Dialog__cancel-btn" onClick={onCancel}>
-              ✕
-            </button>
+            {onCancel && (
+              <button className="Dialog__cancel-btn" onClick={onCancel}>
+                ✕
+              </button>
+            )}
           </h1>
           {children}
           <div className="u-stretch" />

--- a/lms/static/scripts/file_picker_v2/components/ErrorDialog.js
+++ b/lms/static/scripts/file_picker_v2/components/ErrorDialog.js
@@ -1,33 +1,23 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
+import ErrorDisplay from './ErrorDisplay';
 import Dialog from './Dialog';
 
 /**
- * Informs the user that a problem occurred and provides them with useful links
- * to get help or report the issue.
+ * A dialog that informs the user about a problem that occurred and provides
+ * them with links to get help or report the issue.
  */
-export default function ErrorDialog({ title, error }) {
+export default function ErrorDialog({ onCancel, title, error }) {
   return (
-    <Dialog title="Something went wrong :(">
-      <p>{title}</p>
-      <p>
-        If you have a problem using Hypothesis LMS integration, please{' '}
-        <a
-          href="https://web.hypothes.is/help/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          visit our support page
-        </a>
-        .
-      </p>
-      <p>Problem details: {error.message}</p>
+    <Dialog title="Something went wrong :(" onCancel={onCancel}>
+      <ErrorDisplay message={title} error={error} />
     </Dialog>
   );
 }
 
 ErrorDialog.propTypes = {
+  onCancel: propTypes.func,
   title: propTypes.string.isRequired,
   error: propTypes.shape({
     message: propTypes.string.isRequired,

--- a/lms/static/scripts/file_picker_v2/components/ErrorDisplay.js
+++ b/lms/static/scripts/file_picker_v2/components/ErrorDisplay.js
@@ -1,0 +1,81 @@
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
+
+function emailLink({ address, subject = '', body = '' }) {
+  return `mailto:${address}?subject=${encodeURIComponent(
+    subject
+  )}&body=${encodeURIComponent(body)}`;
+}
+
+/**
+ * Displays details of an error, such as a failed API call and provide the user
+ * with information on how to get help with it.
+ */
+export default function ErrorDisplay({ message, error }) {
+  let details = '';
+  try {
+    if (error.details) {
+      details = JSON.stringify(error.details, null, 2 /* indent */);
+    }
+  } catch (e) {
+    // Ignored
+  }
+
+  const supportLink = emailLink({
+    address: 'support@hypothes.is',
+    subject: 'Hypothesis LMS support',
+    body: `
+
+Error message: ${error.message}
+
+Technical details:
+
+${details}
+    `,
+  });
+
+  return (
+    // nb. Wrapper `<div>` here exists to apply block layout to contents.
+    <div>
+      <p>
+        {message}: <i>{error.message}</i>
+      </p>
+      <p>
+        If the problem persists{' '}
+        <a href={supportLink} target="_blank" rel="noopener noreferrer">
+          send us an email
+        </a>{' '}
+        or <a href="https://web.hypothes.is/get-help/">open a support ticket</a>
+        . You can also visit our{' '}
+        <a
+          href="https://web.hypothes.is/help/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          help documents
+        </a>
+        .
+      </p>
+      {!!details && (
+        <details>
+          <pre className="ErrorDisplay__details">{details}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+ErrorDisplay.propTypes = {
+  /**
+   * A short message explaining that a problem happened.
+   */
+  message: propTypes.string.isRequired,
+
+  /**
+   * An `Error`-like object with details of the problem.
+   *
+   * This is assumed to have a string `message` property and may have a
+   * JSON-serializable `details` property.
+   */
+  error: propTypes.object.isRequired,
+};

--- a/lms/static/scripts/file_picker_v2/components/test/ErrorDialog-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/ErrorDialog-test.js
@@ -1,5 +1,6 @@
 import { createElement } from 'preact';
 import ErrorDialog from '../ErrorDialog';
+import ErrorDisplay from '../ErrorDisplay';
 
 import { shallow } from 'enzyme';
 
@@ -7,6 +8,10 @@ describe('ErrorDialog', () => {
   it('displays details of the error', () => {
     const err = new Error('Something went wrong');
     const wrapper = shallow(<ErrorDialog title="Oh no!" error={err} />);
-    assert.include(wrapper.debug(), 'Something went wrong');
+
+    assert.include(wrapper.find(ErrorDisplay).props(), {
+      message: 'Oh no!',
+      error: err,
+    });
   });
 });

--- a/lms/static/scripts/file_picker_v2/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/ErrorDisplay-test.js
@@ -1,0 +1,49 @@
+import { createElement } from 'preact';
+import { shallow } from 'enzyme';
+
+import ErrorDisplay from '../ErrorDisplay';
+
+describe('ErrorDisplay', () => {
+  it('displays a support link', () => {
+    const error = new Error('Canvas says no');
+    error.details = { someTechnicalDetail: 123 };
+
+    const wrapper = shallow(
+      <ErrorDisplay message="Failed to fetch files" error={error} />
+    );
+
+    const supportLink = wrapper
+      .find('a')
+      .filterWhere(n => n.text() === 'send us an email');
+    const href = new URL(supportLink.prop('href'));
+
+    assert.equal(href.protocol, 'mailto:');
+    assert.equal(href.pathname, 'support@hypothes.is');
+    assert.equal(href.searchParams.get('subject'), 'Hypothesis LMS support');
+    assert.include(href.searchParams.get('body'), 'Canvas says no');
+    assert.include(href.searchParams.get('body'), '"someTechnicalDetail": 123');
+  });
+
+  it('omits technical details if not provided', () => {
+    const error = { message: '' };
+
+    const wrapper = shallow(
+      <ErrorDisplay message="Something went wrong" error={error} />
+    );
+
+    const details = wrapper.find('pre');
+    assert.isFalse(details.exists());
+  });
+
+  it('displays technical details if provided', () => {
+    const error = { message: '', details: 'Note from server' };
+
+    const wrapper = shallow(
+      <ErrorDisplay message="Something went wrong" error={error} />
+    );
+
+    const details = wrapper.find('pre');
+    assert.isTrue(details.exists());
+    assert.include(details.text(), 'Note from server');
+  });
+});

--- a/lms/static/scripts/file_picker_v2/utils/api.js
+++ b/lms/static/scripts/file_picker_v2/utils/api.js
@@ -1,19 +1,64 @@
-export class AuthorizationError extends Error {
-  constructor() {
-    super('Authorization failed');
+/**
+ * Error returned when an API call fails with a 4xx or 5xx response and
+ * JSON body.
+ */
+export class ApiError extends Error {
+  constructor(status, data) {
+    const message = data.error_message || data.message || 'API call failed';
+    super(message);
+
+    /**
+     * HTTP response status.
+     *
+     * @type {number}
+     */
+    this.status = status;
+
+    /**
+     * Server-provided error message.
+     *
+     * May be `null` if the server did not provide any details about what the
+     * problem was.
+     *
+     * @type {string|null}
+     */
+    this.errorMessage = data.error_message || null;
+
+    /**
+     *
+     * @type {Object|undefined}
+     */
+    this.details = data.details;
   }
 }
 
-async function listFiles(authToken, courseId) {
-  const result = await fetch(`/api/canvas/courses/${courseId}/files`, {
+/**
+ * Make an API call to the LMS app backend.
+ *
+ * @param options
+ * @param {string} options.path
+ * @param {string} options.authToken
+ */
+async function apiCall({ path, authToken }) {
+  const result = await fetch(path, {
     headers: {
       Authorization: authToken,
     },
   });
-  if (result.status === 403) {
-    throw new AuthorizationError();
+  const data = await result.json();
+
+  if (result.status >= 400 && result.status < 600) {
+    throw new ApiError(result.status, data);
   }
-  return await result.json();
+
+  return data;
+}
+
+async function listFiles(authToken, courseId) {
+  return apiCall({
+    authToken,
+    path: `/api/canvas/courses/${courseId}/files`,
+  });
 }
 
 // Separate export from declaration to work around

--- a/lms/static/scripts/file_picker_v2/utils/api.js
+++ b/lms/static/scripts/file_picker_v2/utils/api.js
@@ -25,8 +25,13 @@ export class ApiError extends Error {
     this.errorMessage = data.error_message || null;
 
     /**
+     * Server-provided details of the error.
      *
-     * @type {Object|undefined}
+     * If provided, this will contain technical information about what the
+     * problem was on the backend. This may be useful when handling eg.
+     * support requests.
+     *
+     * @type {any}
      */
     this.details = data.details;
   }
@@ -36,7 +41,7 @@ export class ApiError extends Error {
  * Make an API call to the LMS app backend.
  *
  * @param options
- * @param {string} options.path
+ * @param {string} options.path - The `/api/...` path of the endpoint to call
  * @param {string} options.authToken
  */
 async function apiCall({ path, authToken }) {

--- a/lms/static/scripts/polyfills.js
+++ b/lms/static/scripts/polyfills.js
@@ -5,6 +5,7 @@ import 'core-js/features/promise';
 import 'core-js/features/array/from';
 import 'core-js/features/array/includes';
 import 'core-js/features/object/assign';
+import 'core-js/features/url';
 
 // window.fetch
 import 'whatwg-fetch';

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -1,0 +1,5 @@
+.ErrorDisplay__details {
+  overflow: scroll;
+  background-color: $grey-1;
+  border: 1px solid $grey-3;
+}

--- a/lms/static/styles/file-picker-app.scss
+++ b/lms/static/styles/file-picker-app.scss
@@ -18,6 +18,7 @@
 @import 'components/Table';
 
 // LMS file picker React components.
+@import 'components/ErrorDisplay';
 @import 'components/FileList';
 @import 'components/FilePickerApp';
 @import 'components/LMSFilePicker';


### PR DESCRIPTION
This PR implements handling of different types of error that can happen when fetching files from the LMS backend. There are three possibilities for the kind of error that may happen:

1. The server responds with a generic 400 error but no details
2. The server responds with a 4xx error and specific details
3. Some other error happens,  such as a network failure

In the first case, the frontend assumes an authorization error and displays the same authorization message and button text as when the dialog is shown for the first time. In the other cases,  the error details are displayed inline:

<img width="544" alt="lms-file-picker-try-again" src="https://user-images.githubusercontent.com/2458/60656245-09746380-9e47-11e9-8d5c-2866e89d35c7.png">

Clicking the "send us an email" link will open an email to support@hypothes.is with the details pre-filled. Clicking the "Try again" button will re-authorize and re-fetch files. In other words, exactly the same steps as when clicking the "Authorize" button when the dialog first appears. Note that in this PR, the authorization form is always displayed when the dialog is first shown. Fixing that will happen in a follow-up PR.

The new `ErrorDisplay` component used to display errors inline has also been added to the error dialog which is used when requests to the Google Drive Picker fail:

<img width="678" alt="google-picker-error-dialog" src="https://user-images.githubusercontent.com/2458/60500223-dc427c80-9cb1-11e9-8589-f505a54b4059.png">

I also fixed a bug where clicking "X" in this dialog did nothing.

See commit messages for implementation notes.