### PR TITLE
Always attempt to fetch files when the LMS file picker is shown

### DIFF
--- a/lms/static/scripts/file_picker_v2/components/Dialog.js
+++ b/lms/static/scripts/file_picker_v2/components/Dialog.js
@@ -88,9 +88,11 @@ export default function Dialog({
           <h1 className="Dialog__title" id="Dialog__title">
             {title}
             <span className="u-stretch" />
-            <button className="Dialog__cancel-btn" onClick={onCancel}>
-              ✕
-            </button>
+            {onCancel && (
+              <button className="Dialog__cancel-btn" onClick={onCancel}>
+                ✕
+              </button>
+            )}
           </h1>
           {children}
           <div className="u-stretch" />

--- a/lms/static/scripts/file_picker_v2/components/ErrorDialog.js
+++ b/lms/static/scripts/file_picker_v2/components/ErrorDialog.js
@@ -1,33 +1,23 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
+import ErrorDisplay from './ErrorDisplay';
 import Dialog from './Dialog';
 
 /**
- * Informs the user that a problem occurred and provides them with useful links
- * to get help or report the issue.
+ * A dialog that informs the user about a problem that occurred and provides
+ * them with links to get help or report the issue.
  */
-export default function ErrorDialog({ title, error }) {
+export default function ErrorDialog({ onCancel, title, error }) {
   return (
-    <Dialog title="Something went wrong :(">
-      <p>{title}</p>
-      <p>
-        If you have a problem using Hypothesis LMS integration, please{' '}
-        <a
-          href="https://web.hypothes.is/help/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          visit our support page
-        </a>
-        .
-      </p>
-      <p>Problem details: {error.message}</p>
+    <Dialog title="Something went wrong :(" onCancel={onCancel}>
+      <ErrorDisplay message={title} error={error} />
     </Dialog>
   );
 }
 
 ErrorDialog.propTypes = {
+  onCancel: propTypes.func,
   title: propTypes.string.isRequired,
   error: propTypes.shape({
     message: propTypes.string.isRequired,

--- a/lms/static/scripts/file_picker_v2/components/ErrorDisplay.js
+++ b/lms/static/scripts/file_picker_v2/components/ErrorDisplay.js
@@ -1,0 +1,81 @@
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
+
+function emailLink({ address, subject = '', body = '' }) {
+  return `mailto:${address}?subject=${encodeURIComponent(
+    subject
+  )}&body=${encodeURIComponent(body)}`;
+}
+
+/**
+ * Displays details of an error, such as a failed API call and provide the user
+ * with information on how to get help with it.
+ */
+export default function ErrorDisplay({ message, error }) {
+  let details = '';
+  try {
+    if (error.details) {
+      details = JSON.stringify(error.details, null, 2 /* indent */);
+    }
+  } catch (e) {
+    // Ignored
+  }
+
+  const supportLink = emailLink({
+    address: 'support@hypothes.is',
+    subject: 'Hypothesis LMS support',
+    body: `
+
+Error message: ${error.message}
+
+Technical details:
+
+${details}
+    `,
+  });
+
+  return (
+    // nb. Wrapper `<div>` here exists to apply block layout to contents.
+    <div>
+      <p>
+        {message}: <i>{error.message}</i>
+      </p>
+      <p>
+        If the problem persists{' '}
+        <a href={supportLink} target="_blank" rel="noopener noreferrer">
+          send us an email
+        </a>{' '}
+        or <a href="https://web.hypothes.is/get-help/">open a support ticket</a>
+        . You can also visit our{' '}
+        <a
+          href="https://web.hypothes.is/help/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          help documents
+        </a>
+        .
+      </p>
+      {!!details && (
+        <details>
+          <pre className="ErrorDisplay__details">{details}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+ErrorDisplay.propTypes = {
+  /**
+   * A short message explaining that a problem happened.
+   */
+  message: propTypes.string.isRequired,
+
+  /**
+   * An `Error`-like object with details of the problem.
+   *
+   * This is assumed to have a string `message` property and may have a
+   * JSON-serializable `details` property.
+   */
+  error: propTypes.object.isRequired,
+};

--- a/lms/static/scripts/file_picker_v2/components/FilePickerApp.js
+++ b/lms/static/scripts/file_picker_v2/components/FilePickerApp.js
@@ -24,7 +24,6 @@ import URLPicker from './URLPicker';
  */
 export default function FilePickerApp({
   defaultActiveDialog = null,
-  isLmsFileAccessAuthorized: authorized,
   onSubmit,
 }) {
   const formEl = useRef();
@@ -45,7 +44,6 @@ export default function FilePickerApp({
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
   const [url, setUrl] = useState(null);
   const [lmsFile, setLmsFile] = useState(null);
-  const [lmsFilesAuthorized, setLmsFilesAuthorized] = useState(authorized);
   const [isLoadingIndicatorVisible, setLoadingIndicatorVisible] = useState(
     false
   );
@@ -77,8 +75,6 @@ export default function FilePickerApp({
     setLmsFile(file);
     submit(true);
   };
-
-  const lmsAuthorized = () => setLmsFilesAuthorized(true);
 
   const selectURL = url => {
     setActiveDialog(null);
@@ -133,9 +129,7 @@ export default function FilePickerApp({
           authToken={authToken}
           authUrl={authUrl}
           courseId={courseId}
-          isAuthorized={lmsFilesAuthorized}
           lmsName={lmsName}
-          onAuthorized={lmsAuthorized}
           onCancel={cancelDialog}
           onSelectFile={selectLMSFile}
         />
@@ -223,13 +217,4 @@ FilePickerApp.propTypes = {
 
   /** Callback invoked when the form is submitted. */
   onSubmit: propTypes.func,
-
-  /**
-   * A hint as to whether the user has authorized the Hypothesis LMS app to
-   * access their files in the LMS.
-   *
-   * If `false`, an authorization prompt will be shown in a popup window if
-   * the user clicks on the "Select file from {LMS name}" button.
-   */
-  isLmsFileAccessAuthorized: propTypes.bool,
 };

--- a/lms/static/scripts/file_picker_v2/components/LMSFilePicker.js
+++ b/lms/static/scripts/file_picker_v2/components/LMSFilePicker.js
@@ -21,9 +21,7 @@ export default function LMSFilePicker({
   authToken,
   authUrl,
   courseId,
-  isAuthorized,
   lmsName,
-  onAuthorized,
   onCancel,
   onSelectFile,
 }) {
@@ -31,7 +29,7 @@ export default function LMSFilePicker({
   const [{ state, files, error }, setState] = useState({
     // The current state of the dialog, one of:
     // "fetching", "fetched", "authorizing" or "error".
-    state: isAuthorized ? 'fetching' : 'authorizing',
+    state: 'fetching',
 
     // List of fetched files. Set when state is "fetched".
     files: null,
@@ -80,16 +78,12 @@ export default function LMSFilePicker({
     try {
       await authWindow.current.authorize();
       await fetchFiles();
-
-      if (onAuthorized) {
-        onAuthorized();
-      }
     } finally {
       authWindow.current.close();
       // eslint-disable-next-line require-atomic-updates
       authWindow.current = null;
     }
-  }, [fetchFiles, authToken, authUrl, lmsName, onAuthorized]);
+  }, [fetchFiles, authToken, authUrl, lmsName]);
 
   // On the initial load, fetch files or prompt to authorize if we know that
   // authorization will be required.
@@ -177,12 +171,6 @@ LMSFilePicker.propTypes = {
   courseId: propTypes.string.isRequired,
 
   /**
-   * A hint as to whether the backend believes the user has authorized our
-   * LMS app's access to the user's files in the LMS.
-   */
-  isAuthorized: propTypes.bool,
-
-  /**
    * The name of the LMS to display in API controls, eg. "Canvas".
    */
   lmsName: propTypes.string.isRequired,
@@ -195,11 +183,4 @@ LMSFilePicker.propTypes = {
    * a selection.
    */
   onSelectFile: propTypes.func.isRequired,
-
-  /**
-   * Callback invoked when authorization succeeds. The parent component can
-   * use this to update the `isAuthorized` hint if the dialog is closed and
-   * then later shown again.
-   */
-  onAuthorized: propTypes.func,
 };

--- a/lms/static/scripts/file_picker_v2/components/test/ErrorDialog-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/ErrorDialog-test.js
@@ -1,5 +1,6 @@
 import { createElement } from 'preact';
 import ErrorDialog from '../ErrorDialog';
+import ErrorDisplay from '../ErrorDisplay';
 
 import { shallow } from 'enzyme';
 
@@ -7,6 +8,10 @@ describe('ErrorDialog', () => {
   it('displays details of the error', () => {
     const err = new Error('Something went wrong');
     const wrapper = shallow(<ErrorDialog title="Oh no!" error={err} />);
-    assert.include(wrapper.debug(), 'Something went wrong');
+
+    assert.include(wrapper.find(ErrorDisplay).props(), {
+      message: 'Oh no!',
+      error: err,
+    });
   });
 });

--- a/lms/static/scripts/file_picker_v2/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/ErrorDisplay-test.js
@@ -1,0 +1,49 @@
+import { createElement } from 'preact';
+import { shallow } from 'enzyme';
+
+import ErrorDisplay from '../ErrorDisplay';
+
+describe('ErrorDisplay', () => {
+  it('displays a support link', () => {
+    const error = new Error('Canvas says no');
+    error.details = { someTechnicalDetail: 123 };
+
+    const wrapper = shallow(
+      <ErrorDisplay message="Failed to fetch files" error={error} />
+    );
+
+    const supportLink = wrapper
+      .find('a')
+      .filterWhere(n => n.text() === 'send us an email');
+    const href = new URL(supportLink.prop('href'));
+
+    assert.equal(href.protocol, 'mailto:');
+    assert.equal(href.pathname, 'support@hypothes.is');
+    assert.equal(href.searchParams.get('subject'), 'Hypothesis LMS support');
+    assert.include(href.searchParams.get('body'), 'Canvas says no');
+    assert.include(href.searchParams.get('body'), '"someTechnicalDetail": 123');
+  });
+
+  it('omits technical details if not provided', () => {
+    const error = { message: '' };
+
+    const wrapper = shallow(
+      <ErrorDisplay message="Something went wrong" error={error} />
+    );
+
+    const details = wrapper.find('pre');
+    assert.isFalse(details.exists());
+  });
+
+  it('displays technical details if provided', () => {
+    const error = { message: '', details: 'Note from server' };
+
+    const wrapper = shallow(
+      <ErrorDisplay message="Something went wrong" error={error} />
+    );
+
+    const details = wrapper.find('pre');
+    assert.isTrue(details.exists());
+    assert.include(details.text(), 'Note from server');
+  });
+});

--- a/lms/static/scripts/file_picker_v2/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/LMSFilePicker-test.js
@@ -57,38 +57,8 @@ describe('LMSFilePicker', () => {
     $imports.$restore();
   });
 
-  it('shows an LMS authorization window when mounted if the user has not authorized', () => {
-    const authorized = new Promise(() => {});
-    FakeAuthWindow.returns({
-      authorize: sinon.stub().callsFake(() => authorized),
-      close: () => {},
-    });
-
+  it('fetches files when the dialog first appears', async () => {
     const wrapper = renderFilePicker();
-    assert.called(FakeAuthWindow);
-    assert.called(FakeAuthWindow.returnValues[0].authorize);
-
-    const authMessage = wrapper
-      .find('p')
-      .filterWhere(el => el.text().match(/you must authorize/));
-    assert.equal(authMessage.length, 1);
-
-    const authBtn = wrapper.find('FakeButton[label="Authorize"]');
-    assert.equal(authBtn.length, 1);
-  });
-
-  it('calls `onAuthorized` when authorization completes', done => {
-    const onAuthorized = sinon.stub();
-    renderFilePicker({ isAuthorized: false, onAuthorized });
-    setTimeout(() => {
-      assert.called(onAuthorized);
-      done();
-    }, 0);
-  });
-
-  it('fetches files once authorization completes', async () => {
-    const wrapper = renderFilePicker();
-    await FakeAuthWindow.returnValues[0].authorize.returnValues[0];
     assert.called(fakeListFiles);
     const expectedFiles = await fakeListFiles.returnValues[0];
     wrapper.update();
@@ -99,7 +69,7 @@ describe('LMSFilePicker', () => {
   it('shows the authorization prompt if fetching files fails with an ApiError that has no `errorMessage`', async () => {
     fakeListFiles.rejects(new ApiError('Not authorized', {}));
 
-    const wrapper = renderFilePicker({ isAuthorized: true });
+    const wrapper = renderFilePicker();
     assert.called(fakeListFiles);
 
     try {
@@ -128,7 +98,7 @@ describe('LMSFilePicker', () => {
       fakeListFiles.rejects(error);
 
       // When the dialog is initially displayed, it should try to fetch files.
-      const wrapper = renderFilePicker({ isAuthorized: true });
+      const wrapper = renderFilePicker();
       assert.called(fakeListFiles);
 
       try {
@@ -166,14 +136,27 @@ describe('LMSFilePicker', () => {
     });
   });
 
-  it('closes the authorization window when canceling the dialog', () => {
+  it('closes the authorization window if open when canceling the dialog', async () => {
+    // Make the initial file list request fail, to trigger a prompt to authorize.
+    fakeListFiles.rejects(new ApiError('Not authorized', {}));
+
     const closePopup = sinon.stub();
     FakeAuthWindow.returns({
       authorize: sinon.stub().resolves(null),
       close: closePopup,
     });
 
+    // Click the "Authorize" button to show the authorization popup.
     const wrapper = renderFilePicker();
+    try {
+      await fakeListFiles.returnValues[0];
+    } catch (e) {
+      // Ignored
+    }
+    wrapper.update();
+    wrapper.find('FakeButton[label="Authorize"]').prop('onClick')();
+
+    // Dismiss the LMS file picker. This should close the auth popup.
     wrapper
       .find(FakeDialog)
       .props()
@@ -182,14 +165,14 @@ describe('LMSFilePicker', () => {
     assert.called(closePopup);
   });
 
-  it('does not show an authorization window when mounted if the user has authorized', () => {
-    const wrapper = renderFilePicker({ isAuthorized: true });
+  it('does not show an authorization window when mounted', () => {
+    const wrapper = renderFilePicker();
     assert.notCalled(FakeAuthWindow);
-    assert.isFalse(wrapper.exists('Button[label="Authorize"]'));
+    assert.isFalse(wrapper.exists('FakeButton[label="Authorize"]'));
   });
 
   it('fetches and displays files from the LMS', async () => {
-    const wrapper = renderFilePicker({ isAuthorized: true });
+    const wrapper = renderFilePicker();
     assert.called(fakeListFiles);
 
     const expectedFiles = await fakeListFiles.returnValues[0];
@@ -200,7 +183,7 @@ describe('LMSFilePicker', () => {
   });
 
   it('shows a loading indicator while fetching files', async () => {
-    const wrapper = renderFilePicker({ isAuthorized: true });
+    const wrapper = renderFilePicker();
     assert.isTrue(wrapper.find(FakeFileList).prop('isLoading'));
 
     await fakeListFiles.returnValues[0];
@@ -210,7 +193,7 @@ describe('LMSFilePicker', () => {
   });
 
   it('maintains selected file state', () => {
-    const wrapper = renderFilePicker({ isAuthorized: true });
+    const wrapper = renderFilePicker();
     const file = { id: 123 };
 
     act(() => {
@@ -227,7 +210,7 @@ describe('LMSFilePicker', () => {
   it('invokes `onSelectFile` when user chooses a file', () => {
     const onSelectFile = sinon.stub();
     const file = { id: 123 };
-    const wrapper = renderFilePicker({ isAuthorized: true, onSelectFile });
+    const wrapper = renderFilePicker({ onSelectFile });
     wrapper
       .find(FakeFileList)
       .props()
@@ -236,7 +219,7 @@ describe('LMSFilePicker', () => {
   });
 
   it('shows disabled "Select" button when no file is selected', () => {
-    const wrapper = renderFilePicker({ isAuthorized: true });
+    const wrapper = renderFilePicker();
     assert.equal(
       wrapper.find('FakeButton[label="Select"]').prop('disabled'),
       true
@@ -244,7 +227,7 @@ describe('LMSFilePicker', () => {
   });
 
   it('shows enabled "Select" button when a file is selected', () => {
-    const wrapper = renderFilePicker({ isAuthorized: true });
+    const wrapper = renderFilePicker();
     act(() => {
       wrapper
         .find(FakeFileList)
@@ -261,7 +244,7 @@ describe('LMSFilePicker', () => {
   it('chooses selected file when uses clicks "Select" button', () => {
     const onSelectFile = sinon.stub();
     const file = { id: 123 };
-    const wrapper = renderFilePicker({ isAuthorized: true, onSelectFile });
+    const wrapper = renderFilePicker({ onSelectFile });
 
     act(() => {
       wrapper

--- a/lms/static/scripts/file_picker_v2/utils/api.js
+++ b/lms/static/scripts/file_picker_v2/utils/api.js
@@ -1,19 +1,64 @@
-export class AuthorizationError extends Error {
-  constructor() {
-    super('Authorization failed');
+/**
+ * Error returned when an API call fails with a 4xx or 5xx response and
+ * JSON body.
+ */
+export class ApiError extends Error {
+  constructor(status, data) {
+    const message = data.error_message || data.message || 'API call failed';
+    super(message);
+
+    /**
+     * HTTP response status.
+     *
+     * @type {number}
+     */
+    this.status = status;
+
+    /**
+     * Server-provided error message.
+     *
+     * May be `null` if the server did not provide any details about what the
+     * problem was.
+     *
+     * @type {string|null}
+     */
+    this.errorMessage = data.error_message || null;
+
+    /**
+     *
+     * @type {Object|undefined}
+     */
+    this.details = data.details;
   }
 }
 
-async function listFiles(authToken, courseId) {
-  const result = await fetch(`/api/canvas/courses/${courseId}/files`, {
+/**
+ * Make an API call to the LMS app backend.
+ *
+ * @param options
+ * @param {string} options.path
+ * @param {string} options.authToken
+ */
+async function apiCall({ path, authToken }) {
+  const result = await fetch(path, {
     headers: {
       Authorization: authToken,
     },
   });
-  if (result.status === 403) {
-    throw new AuthorizationError();
+  const data = await result.json();
+
+  if (result.status >= 400 && result.status < 600) {
+    throw new ApiError(result.status, data);
   }
-  return await result.json();
+
+  return data;
+}
+
+async function listFiles(authToken, courseId) {
+  return apiCall({
+    authToken,
+    path: `/api/canvas/courses/${courseId}/files`,
+  });
 }
 
 // Separate export from declaration to work around

--- a/lms/static/scripts/file_picker_v2/utils/api.js
+++ b/lms/static/scripts/file_picker_v2/utils/api.js
@@ -25,8 +25,13 @@ export class ApiError extends Error {
     this.errorMessage = data.error_message || null;
 
     /**
+     * Server-provided details of the error.
      *
-     * @type {Object|undefined}
+     * If provided, this will contain technical information about what the
+     * problem was on the backend. This may be useful when handling eg.
+     * support requests.
+     *
+     * @type {any}
      */
     this.details = data.details;
   }
@@ -36,7 +41,7 @@ export class ApiError extends Error {
  * Make an API call to the LMS app backend.
  *
  * @param options
- * @param {string} options.path
+ * @param {string} options.path - The `/api/...` path of the endpoint to call
  * @param {string} options.authToken
  */
 async function apiCall({ path, authToken }) {

--- a/lms/static/scripts/polyfills.js
+++ b/lms/static/scripts/polyfills.js
@@ -5,6 +5,7 @@ import 'core-js/features/promise';
 import 'core-js/features/array/from';
 import 'core-js/features/array/includes';
 import 'core-js/features/object/assign';
+import 'core-js/features/url';
 
 // window.fetch
 import 'whatwg-fetch';

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -1,0 +1,5 @@
+.ErrorDisplay__details {
+  overflow: scroll;
+  background-color: $grey-1;
+  border: 1px solid $grey-3;
+}

--- a/lms/static/styles/file-picker-app.scss
+++ b/lms/static/styles/file-picker-app.scss
@@ -18,6 +18,7 @@
 @import 'components/Table';
 
 // LMS file picker React components.
+@import 'components/ErrorDisplay';
 @import 'components/FileList';
 @import 'components/FilePickerApp';
 @import 'components/LMSFilePicker';


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/741**

Instead of expecting the server to provide a hint as to whether the user has authorized the H LMS app to access their LMS files, just try to fetch files when the file picker is shown and display a prompt to authorize if that fails.

As a result, the user is no longer prompted to authorize if they have already authorized the LMS in a previous session.