### PR TITLE
Implement content URL fetching at assignment launch for Canvas files

### DIFF
--- a/lms/static/scripts/file_picker_v2/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/file_picker_v2/components/BasicLtiLaunchApp.js
@@ -1,0 +1,138 @@
+import { Fragment, createElement } from 'preact';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'preact/hooks';
+
+import AuthWindow from '../utils/AuthWindow';
+import { Config } from '../config';
+import { ApiError, apiCall } from '../utils/api';
+
+import Button from './Button';
+import ErrorDisplay from './ErrorDisplay';
+import Spinner from './Spinner';
+
+/**
+ * Application displayed when an assignment is launched if the LMS backend
+ * is unable to directly render the content in an iframe. This happens when
+ * the content URL needs to be fetched from a remote source (eg. the LMS's
+ * file storage) first, which may require authorization from the user.
+ */
+export default function BasicLtiLaunchApp() {
+  const {
+    authToken,
+    authUrl,
+    lmsName,
+    urls: { via_url: viaUrl },
+  } = useContext(Config);
+
+  const [{ state, contentUrl, error }, setState] = useState({
+    // The current state of the screen.
+    // One of "fetching", "fetched-url", "authorizing" or "error".
+    //
+    // When the app is initially displayed it will attempt to fetch the content
+    // URL.
+    state: 'fetching-url',
+
+    // URL of assignment content. Set when state is "fetched-url".
+    contentUrl: null,
+
+    // Details of last error. Set when state is "error".
+    error: null,
+  });
+
+  /**
+   * Fetch the URL of the content to display in the iframe.
+   *
+   * This will typically be a PDF URL proxied through Via.
+   */
+  const fetchContentUrl = useCallback(async () => {
+    try {
+      setState({ state: 'fetching-url' });
+      const { via_url: contentUrl } = await apiCall({
+        authToken,
+        path: viaUrl,
+      });
+      setState({ state: 'fetched-url', contentUrl });
+    } catch (e) {
+      if (e instanceof ApiError && !e.errorMessage) {
+        setState({ state: 'authorizing' });
+      } else {
+        setState({ state: 'error', error: e });
+      }
+    }
+  }, [authToken, viaUrl]);
+
+  /**
+   * Fetch the assignment content URL when the app is initially displayed.
+   */
+  useEffect(() => {
+    fetchContentUrl();
+  }, [fetchContentUrl]);
+
+  // `AuthWindow` instance, set only when waiting for the user to approve
+  // the app's access to the user's files in the LMS.
+  const authWindow = useRef(null);
+
+  /**
+   * Request the user's authorization to access the content, then try fetching
+   * the content URL again.
+   */
+  const authorizeAndFetchUrl = useCallback(async () => {
+    setState({ state: 'authorizing' });
+
+    if (authWindow.current) {
+      authWindow.current.focus();
+      return;
+    }
+    authWindow.current = new AuthWindow({ authToken, authUrl, lmsName });
+
+    try {
+      await authWindow.current.authorize();
+      await fetchContentUrl();
+    } finally {
+      // eslint-disable-next-line require-atomic-updates
+      authWindow.current = null;
+    }
+  }, [authToken, authUrl, fetchContentUrl, lmsName]);
+
+  if (state === 'fetched-url') {
+    return <iframe width="100%" height="100%" src={contentUrl} />;
+  }
+
+  return (
+    <Fragment>
+      {state === 'fetching-url' && (
+        <Spinner className="BasicLtiLaunchApp__spinner" />
+      )}
+      {state === 'authorizing' && (
+        <div className="BasicLtiLaunchApp__form">
+          <h1 className="heading">Authorize Hypothesis</h1>
+          <p>Hypothesis needs your authorization to launch this assignment.</p>
+          <Button
+            onClick={authorizeAndFetchUrl}
+            className="BasicLtiLaunchApp__button"
+            label="Authorize"
+          />
+        </div>
+      )}
+      {state === 'error' && (
+        <div className="BasicLtiLaunchApp__form">
+          <h1 className="heading">Something went wrong</h1>
+          <ErrorDisplay
+            message="There was a problem fetching this file"
+            error={error}
+          />
+          <Button
+            onClick={authorizeAndFetchUrl}
+            className="BasicLtiLaunchApp__button"
+            label="Try again"
+          />
+        </div>
+      )}
+    </Fragment>
+  );
+}

--- a/lms/static/scripts/file_picker_v2/components/ErrorDisplay.js
+++ b/lms/static/scripts/file_picker_v2/components/ErrorDisplay.js
@@ -36,7 +36,7 @@ ${details}
 
   return (
     // nb. Wrapper `<div>` here exists to apply block layout to contents.
-    <div>
+    <div className="ErrorDisplay">
       <p>
         {message}: <i>{error.message}</i>
       </p>

--- a/lms/static/scripts/file_picker_v2/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/BasicLtiLaunchApp-test.js
@@ -1,0 +1,165 @@
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
+
+import { Config } from '../../config';
+import { ApiError } from '../../utils/api';
+
+import BasicLtiLaunchApp, { $imports } from '../BasicLtiLaunchApp';
+
+describe('BasicLtiLaunchApp', () => {
+  let fakeApiCall;
+  let FakeAuthWindow;
+  let fakeConfig;
+
+  const renderLtiLaunchApp = (props = {}) => {
+    return mount(
+      <Config.Provider value={fakeConfig}>
+        <BasicLtiLaunchApp {...props} />
+      </Config.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    fakeConfig = {
+      authToken: 'dummyAuthToken',
+      authUrl: 'https://lms.hypothes.is/authorize-lms',
+      lmsName: 'Shiny LMS',
+      urls: {
+        via_url: 'https://lms.hypothes.is/api/files/1234',
+      },
+    };
+
+    fakeApiCall = sinon.stub();
+
+    FakeAuthWindow = sinon.stub().returns({
+      authorize: sinon.stub().resolves(null),
+    });
+
+    const FakeErrorDisplay = () => null;
+    const FakeSpinner = () => null;
+
+    // nb. We mock components manually rather than using Enzyme's
+    // shallow rendering because the modern context API doesn't seem to work
+    // with shallow rendering yet
+    $imports.$mock({
+      './ErrorDisplay': FakeErrorDisplay,
+      './Spinner': FakeSpinner,
+
+      '../utils/AuthWindow': FakeAuthWindow,
+      '../utils/api': {
+        apiCall: fakeApiCall,
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('attempts to fetch the content URL when mounted', async () => {
+    const wrapper = renderLtiLaunchApp();
+
+    await fakeApiCall.returnValues[0];
+
+    assert.calledWith(fakeApiCall, {
+      authToken: 'dummyAuthToken',
+      path: 'https://lms.hypothes.is/api/files/1234',
+    });
+    assert.isTrue(wrapper.exists('FakeSpinner'));
+  });
+
+  it('displays the content URL in an iframe if successfully fetched', async () => {
+    fakeApiCall.resolves({
+      via_url: 'https://via.hypothes.is/123',
+    });
+
+    const wrapper = renderLtiLaunchApp();
+
+    await fakeApiCall.returnValues[0];
+    wrapper.update();
+
+    const iframe = wrapper.find('iframe');
+    assert.isTrue(iframe.exists());
+    assert.include(iframe.props(), {
+      src: 'https://via.hypothes.is/123',
+    });
+  });
+
+  it('displays authorization prompt if content URL fetch fails with an `ApiError`', async () => {
+    // Make the initial URL fetch request reject with an unspecified `ApiError`.
+    fakeApiCall.rejects(new ApiError(400, {}));
+
+    const wrapper = renderLtiLaunchApp();
+    try {
+      await fakeApiCall.returnValues[0];
+    } catch (e) {
+      // Ignored
+    }
+
+    // Verify that an "Authorize" prompt is shown.
+    wrapper.update();
+    const authButton = wrapper.find('Button[label="Authorize"]');
+    assert.isTrue(authButton.exists());
+
+    // Click the "Authorize" button and verify that authorization is attempted.
+    fakeApiCall.reset();
+    fakeApiCall.resolves({ via_url: 'https://via.hypothes.is/123' });
+    authButton.prop('onClick')();
+    assert.called(FakeAuthWindow);
+
+    // Check that files are fetched after authorization completes.
+    await new Promise(resolve => {
+      setTimeout(resolve, 0);
+    });
+    wrapper.update();
+
+    assert.equal(
+      wrapper.find('iframe').prop('src'),
+      'https://via.hypothes.is/123'
+    );
+  });
+
+  [
+    {
+      description: 'a specific server error',
+      error: new ApiError(400, { error_message: 'Server error' }),
+    },
+    {
+      description: 'a network or other generic error',
+      error: new Error('Failed to fetch'),
+    },
+  ].forEach(({ description, error }) => {
+    it(`displays error details if content URL fetch fails with ${description}`, async () => {
+      // Make the initial URL fetch request reject with the given error.
+      fakeApiCall.rejects(error);
+
+      const wrapper = renderLtiLaunchApp();
+      try {
+        await fakeApiCall.returnValues[0];
+      } catch (e) {
+        // Ignored
+      }
+
+      // Verify that a "Try again" prompt is shown.
+      wrapper.update();
+      const tryAgainButton = wrapper.find('Button[label="Try again"]');
+      assert.isTrue(tryAgainButton.exists());
+
+      // Click the "Try again" button and verify that authorization is attempted.
+      fakeApiCall.reset();
+      fakeApiCall.resolves({ via_url: 'https://via.hypothes.is/123' });
+      tryAgainButton.prop('onClick')();
+      assert.called(FakeAuthWindow);
+
+      // Check that files are fetched after authorization completes.
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
+      wrapper.update();
+      assert.equal(
+        wrapper.find('iframe').prop('src'),
+        'https://via.hypothes.is/123'
+      );
+    });
+  });
+});

--- a/lms/static/scripts/file_picker_v2/index.js
+++ b/lms/static/scripts/file_picker_v2/index.js
@@ -1,14 +1,18 @@
 import { createElement, render } from 'preact';
 
 import { Config } from './config';
+import BasicLtiLaunchApp from './components/BasicLtiLaunchApp';
 import FilePickerApp from './components/FilePickerApp';
 
 const rootEl = document.querySelector('#app');
 const config = JSON.parse(document.querySelector('.js-config').textContent);
 
+const mode = config.mode || 'content-item-selection';
+
 render(
   <Config.Provider value={config}>
-    <FilePickerApp />
+    {mode === 'basic-lti-launch' && <BasicLtiLaunchApp />}
+    {mode === 'content-item-selection' && <FilePickerApp />}
   </Config.Provider>,
   rootEl
 );

--- a/lms/static/scripts/file_picker_v2/utils/api.js
+++ b/lms/static/scripts/file_picker_v2/utils/api.js
@@ -68,4 +68,4 @@ async function listFiles(authToken, courseId) {
 
 // Separate export from declaration to work around
 // https://github.com/robertknight/babel-plugin-mockable-imports/issues/9
-export { listFiles };
+export { apiCall, listFiles };

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,0 +1,28 @@
+.BasicLtiLaunchApp__form {
+  margin-top: 10vh;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  position: relative;
+
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 500px;
+  width: fit-content;
+}
+
+.BasicLtiLaunchApp__button {
+  margin-top: 20px;
+  align-self: flex-end;
+}
+
+.BasicLtiLaunchApp__spinner {
+  $spinner-size: 50px;
+
+  position: absolute;
+  width: $spinner-size;
+  height: $spinner-size;
+  left: calc(50% - #{$spinner-size / 2});
+  top: 100px;
+}
+

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -1,5 +1,11 @@
+.ErrorDisplay {
+  max-width: 100%;
+}
+
 .ErrorDisplay__details {
   overflow: scroll;
   background-color: $grey-1;
   border: 1px solid $grey-3;
+
+  max-width: 100%;
 }

--- a/lms/static/styles/components/_heading.scss
+++ b/lms/static/styles/components/_heading.scss
@@ -1,0 +1,3 @@
+.heading {
+  font-size: $title-font-size;
+}

--- a/lms/static/styles/file-picker-app.scss
+++ b/lms/static/styles/file-picker-app.scss
@@ -8,6 +8,7 @@
 @import 'typography';
 
 // HTML components.
+@import 'components/heading';
 @import 'components/label';
 
 // Generic React components.
@@ -17,7 +18,8 @@
 @import 'components/Dialog';
 @import 'components/Table';
 
-// LMS file picker React components.
+// React components.
+@import 'components/BasicLtiLaunchApp';
 @import 'components/ErrorDisplay';
 @import 'components/FileList';
 @import 'components/FilePickerApp';

--- a/lms/templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/canvas_file_basic_lti_launch.html.jinja2
@@ -1,1 +1,18 @@
 {% extends "lms:templates/base.html.jinja2" %}
+
+{% block content %}
+  <div style="width: 100%; height: 100%;" id="app"></div>
+{% endblock %}
+
+{% block styles %}
+  {% for url in  asset_urls("file_picker_v2_css") %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% for url in asset_urls("file_picker_v2_js") %}
+    <script async defer src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -66,6 +66,18 @@ class BasicLTILaunchViews:
         """
         file_id = self.request.params["file_id"]
 
+        self.context.js_config.update(
+            {
+                # Configure the front-end mini-app to run.
+                "mode": "basic-lti-launch",
+                # The URL that the JavaScript code will open if it needs the user to
+                # authorize us to request a new access token.
+                "authUrl": self.request.route_url("canvas_api.authorize"),
+                # Set the LMS name to use in user-facing messages.
+                "lmsName": "Canvas",
+            }
+        )
+
         self.context.js_config["urls"].update(
             {
                 "via_url": self.request.route_url(

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -9,6 +9,15 @@ from lms.views.basic_lti_launch import BasicLTILaunchViews
 
 
 class TestCanvasFileBasicLTILaunch:
+    def test_it_configures_frontend(self, context, pyramid_request):
+        pyramid_request.params = {"file_id": "TEST_FILE_ID"}
+
+        BasicLTILaunchViews(context, pyramid_request).canvas_file_basic_lti_launch()
+
+        assert context.js_config["mode"] == "basic-lti-launch"
+        assert context.js_config["authUrl"] == "http://example.com/TEST_AUTHORIZE_URL"
+        assert context.js_config["lmsName"] == "Canvas"
+
     def test_it_adds_the_via_url_to_the_javascript_config(
         self, context, pyramid_request
     ):
@@ -20,6 +29,10 @@ class TestCanvasFileBasicLTILaunch:
             context.js_config["urls"]["via_url"]
             == "http://example.com/api/canvas/files/TEST_FILE_ID/via_url"
         )
+
+    @pytest.fixture(autouse=True)
+    def routes(self, pyramid_config):
+        pyramid_config.add_route("canvas_api.authorize", "/TEST_AUTHORIZE_URL")
 
 
 class TestDBConfiguredBasicLTILaunch:


### PR DESCRIPTION
Implement a small client-side application which handles launching assignments that use Canvas files (or other LMS's files in future).

Initially the app renders a loading indicator and makes a request for the assignment content URL to the backend:

<img width="813" alt="basic-lti-launch-fetching" src="https://user-images.githubusercontent.com/2458/60670367-5c124780-9e68-11e9-8c80-525547a4b7b3.png">

When the URL is returned, the client app renders an iframe with that URL.

If the URL cannot be fetched because authorization is required, the client will prompt the user for authorization:

<img width="803" alt="basic-lti-auth-prompt" src="https://user-images.githubusercontent.com/2458/60670227-0f2e7100-9e68-11e9-9530-d3abbf992d46.png">

If an error occurs, that will be displayed to the user:

<img width="751" alt="basic-lti-launch-error" src="https://user-images.githubusercontent.com/2458/60670203-02aa1880-9e68-11e9-810c-5dd46b0376a5.png">

---

**Implementation notes:**

The implementation reuses many of the components from the file picker
app, so it is implemented as a new component in the file_picker_v2
bundle. As both apps are pretty small, I think I will keep to just the one bundle
for the moment, but I will give it a more generic name in a follow-up PR.