### PR TITLE
Get rid of save_token()

### DIFF
--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -48,13 +48,11 @@ class CanvasAPIAuthorizeViews:
         canvas_api_client = self.request.find_service(name="canvas_api_client")
 
         try:
-            token = canvas_api_client.get_token(authorization_code)
+            canvas_api_client.get_token(authorization_code)
         except CanvasAPIServerError as err:
             raise HTTPInternalServerError(
                 "Authorizing with the Canvas API failed"
             ) from err
-
-        canvas_api_client.save_token(*token)
 
         return {}
 

--- a/tests/lms/views/api/canvas/authorize_test.py
+++ b/tests/lms/views/api/canvas/authorize_test.py
@@ -73,15 +73,6 @@ class TestOAuth2Redirect:
 
         canvas_api_client.get_token.assert_called_once_with("test_authorization_code")
 
-    def test_it_saves_the_access_token_to_the_db(
-        self, canvas_api_client, pyramid_request
-    ):
-        CanvasAPIAuthorizeViews(pyramid_request).oauth2_redirect()
-
-        canvas_api_client.save_token.assert_called_once_with(
-            *canvas_api_client.get_token.return_value
-        )
-
     def test_it_500s_if_get_token_raises(self, canvas_api_client, pyramid_request):
         canvas_api_client.get_token.side_effect = CanvasAPIServerError()
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/747 for CI to pass.

Simplify CanvasAPIClient by getting rid of the separate save_token()
method, and just having get_token() save the token. So instead of:

    token = canvas_api_client.get_token()
    canvas_api_client.save_token(token)

It's now just:

    canvas_api_client.get_token()
