### PR TITLE
Allow sending same request with different access token

### DIFF
--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -130,7 +130,7 @@ class CanvasAPIHelper:
         ).prepare()
 
     @staticmethod
-    def validated_response(request, schema=None):
+    def validated_response(request, schema=None, access_token=None):
         """
         Send a Canvas API request and validate and return the response.
 
@@ -158,6 +158,9 @@ class CanvasAPIHelper:
 
         :rtype: requests.Response
         """
+        if access_token:
+            request.headers["Authorization"] = f"Bearer {access_token}"
+
         try:
             response = requests.Session().send(request)
             response.raise_for_status()


### PR DESCRIPTION
This is going to be needed so that if the request fails we can use the refresh token to get a new access token and then, after having saved the new access token to the DB for next time, re-try the original request with the new access token.