### PR TITLE
Improve aesthetics and accessibility of file list

### DIFF
--- a/lms/static/scripts/file_picker_v2/components/Dialog.js
+++ b/lms/static/scripts/file_picker_v2/components/Dialog.js
@@ -89,7 +89,11 @@ export default function Dialog({
             {title}
             <span className="u-stretch" />
             {onCancel && (
-              <button className="Dialog__cancel-btn" onClick={onCancel}>
+              <button
+                aria-label="Close"
+                className="Dialog__cancel-btn"
+                onClick={onCancel}
+              >
                 ✕
               </button>
             )}

--- a/lms/static/scripts/file_picker_v2/components/FileList.js
+++ b/lms/static/scripts/file_picker_v2/components/FileList.js
@@ -40,6 +40,7 @@ export default function FileList({
               <img
                 className="FileList__icon"
                 src="/static/images/file-pdf.svg"
+                alt="PDF icon"
               />
               <a href="#" className="FileList__name">
                 {file.display_name}

--- a/lms/static/scripts/file_picker_v2/components/FileList.js
+++ b/lms/static/scripts/file_picker_v2/components/FileList.js
@@ -37,18 +37,15 @@ export default function FileList({
         onUseItem={onUseFile}
         renderItem={(file, isSelected) => (
           <Fragment>
-            <td className="FileList__name-col">
+            <td aria-label={file.display_name} className="FileList__name-col">
               <img
                 className={classnames(
                   'FileList__icon',
                   isSelected && 'is-selected'
                 )}
                 src="/static/images/file-pdf.svg"
-                alt="PDF icon"
               />
-              <a href="#" className="FileList__name">
-                {file.display_name}
-              </a>
+              <span className="FileList__name">{file.display_name}</span>
             </td>
             <td className="FileList__date-col">
               {file.updated_at && formatDate(file.updated_at)}

--- a/lms/static/scripts/file_picker_v2/components/FileList.js
+++ b/lms/static/scripts/file_picker_v2/components/FileList.js
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { Fragment, createElement } from 'preact';
 import propTypes from 'prop-types';
 
@@ -34,11 +35,14 @@ export default function FileList({
         selectedItem={selectedFile}
         onSelectItem={onSelectFile}
         onUseItem={onUseFile}
-        renderItem={file => (
+        renderItem={(file, isSelected) => (
           <Fragment>
             <td className="FileList__name-col">
               <img
-                className="FileList__icon"
+                className={classnames(
+                  'FileList__icon',
+                  isSelected && 'is-selected'
+                )}
                 src="/static/images/file-pdf.svg"
                 alt="PDF icon"
               />

--- a/lms/static/scripts/file_picker_v2/components/FileList.js
+++ b/lms/static/scripts/file_picker_v2/components/FileList.js
@@ -30,6 +30,7 @@ export default function FileList({
   return (
     <div className="FileList">
       <Table
+        accessibleLabel="File list"
         columns={columns}
         items={files}
         selectedItem={selectedFile}

--- a/lms/static/scripts/file_picker_v2/components/Table.js
+++ b/lms/static/scripts/file_picker_v2/components/Table.js
@@ -28,6 +28,7 @@ function nextItem(items, currentItem, step) {
  * An interactive table of items with a sticky header.
  */
 export default function Table({
+  accessibleLabel,
   columns,
   items,
   onSelectItem,
@@ -67,6 +68,7 @@ export default function Table({
   return (
     <div className="Table__wrapper">
       <table
+        aria-label={accessibleLabel}
         className="Table__table"
         tabIndex="0"
         role="grid"
@@ -110,6 +112,11 @@ export default function Table({
 }
 
 Table.propTypes = {
+  /**
+   * An accessible label for the table.
+   */
+  accessibleLabel: propTypes.string.isRequired,
+
   /**
    * The columns to display in this table.
    */

--- a/lms/static/scripts/file_picker_v2/components/Table.js
+++ b/lms/static/scripts/file_picker_v2/components/Table.js
@@ -58,7 +58,11 @@ export default function Table({
         <thead className="Table__head">
           <tr>
             {columns.map(column => (
-              <th key={column.label} className={column.className} scope="col">
+              <th
+                key={column.label}
+                className={classnames('Table__head-cell', column.className)}
+                scope="col"
+              >
                 {column.label}
               </th>
             ))}
@@ -76,7 +80,7 @@ export default function Table({
               onClick={() => onSelectItem(item)}
               onDblClick={() => onUseItem(item)}
             >
-              {renderItem(item)}
+              {renderItem(item, selectedItem === item)}
             </tr>
           ))}
         </tbody>
@@ -104,6 +108,9 @@ Table.propTypes = {
   /**
    * A function called to render each item. The result should be a list of
    * `<td>` elements (one per column) wrapped inside a Fragment.
+   *
+   * The function takes two arguments: The item to render and a boolean
+   * indicating whether the item is currently selected.
    */
   renderItem: propTypes.func.isRequired,
 

--- a/lms/static/scripts/file_picker_v2/components/Table.js
+++ b/lms/static/scripts/file_picker_v2/components/Table.js
@@ -71,6 +71,7 @@ export default function Table({
         <tbody className="Table__body">
           {items.map(item => (
             <tr
+              aria-selected={selectedItem === item}
               key={item.name}
               className={classnames({
                 Table__row: true,

--- a/lms/static/scripts/file_picker_v2/components/Table.js
+++ b/lms/static/scripts/file_picker_v2/components/Table.js
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import { createElement } from 'preact';
+import { useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 /**
@@ -34,6 +35,17 @@ export default function Table({
   renderItem,
   selectedItem,
 }) {
+  const rowRefs = useRef([]);
+
+  const focusAndSelectItem = item => {
+    const itemIndex = items.indexOf(item);
+    const rowEl = rowRefs.current[itemIndex];
+    if (rowEl) {
+      rowEl.focus();
+    }
+    onSelectItem(item);
+  };
+
   const onKeyDown = event => {
     let handled = false;
     if (event.key === 'Enter') {
@@ -41,10 +53,10 @@ export default function Table({
       onUseItem(selectedItem);
     } else if (event.key === 'ArrowUp') {
       handled = true;
-      onSelectItem(nextItem(items, selectedItem, -1));
+      focusAndSelectItem(nextItem(items, selectedItem, -1));
     } else if (event.key === 'ArrowDown') {
       handled = true;
-      onSelectItem(nextItem(items, selectedItem, 1));
+      focusAndSelectItem(nextItem(items, selectedItem, 1));
     }
     if (handled) {
       event.preventDefault();
@@ -54,7 +66,12 @@ export default function Table({
 
   return (
     <div className="Table__wrapper">
-      <table className="Table__table" tabIndex="0" onKeyDown={onKeyDown}>
+      <table
+        className="Table__table"
+        tabIndex="0"
+        role="grid"
+        onKeyDown={onKeyDown}
+      >
         <thead className="Table__head">
           <tr>
             {columns.map(column => (
@@ -69,7 +86,7 @@ export default function Table({
           </tr>
         </thead>
         <tbody className="Table__body">
-          {items.map(item => (
+          {items.map((item, index) => (
             <tr
               aria-selected={selectedItem === item}
               key={item.name}
@@ -80,6 +97,8 @@ export default function Table({
               onMouseDown={() => onSelectItem(item)}
               onClick={() => onSelectItem(item)}
               onDblClick={() => onUseItem(item)}
+              ref={node => (rowRefs.current[index] = node)}
+              tabIndex="-1"
             >
               {renderItem(item, selectedItem === item)}
             </tr>

--- a/lms/static/scripts/file_picker_v2/components/test/Table-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/Table-test.js
@@ -77,15 +77,24 @@ describe('Table', () => {
       onSelectItem,
       onUseItem,
     });
+    const rows = wrapper.find('tbody > tr').map(n => n.getDOMNode());
+    rows.forEach(row => (row.focus = sinon.stub()));
+
+    const assertKeySelectsItem = (key, index) => {
+      rows[index].focus.reset();
+      onSelectItem.reset();
+
+      wrapper.find('table').simulate('keydown', { key });
+
+      assert.calledWith(onSelectItem, items[index]);
+      assert.called(rows[index].focus);
+    };
 
     // Down arrow should select item below selected item.
-    wrapper.find('table').simulate('keydown', { key: 'ArrowDown' });
-    assert.calledWith(onSelectItem, items[2]);
+    assertKeySelectsItem('ArrowDown', 2);
 
     // Up arrow should select item above selected item.
-    onSelectItem.reset();
-    wrapper.find('table').simulate('keydown', { key: 'ArrowUp' });
-    assert.calledWith(onSelectItem, items[0]);
+    assertKeySelectsItem('ArrowUp', 0);
 
     // Enter should use selected item.
     onSelectItem.reset();
@@ -94,15 +103,11 @@ describe('Table', () => {
 
     // Up arrow should not change selection if first item is selected.
     wrapper.setProps({ selectedItem: items[0] });
-    onSelectItem.reset();
-    wrapper.find('table').simulate('keydown', { key: 'ArrowUp' });
-    assert.calledWith(onSelectItem, items[0]);
+    assertKeySelectsItem('ArrowUp', 0);
 
     // Down arrow should not change selection if last item is selected.
     wrapper.setProps({ selectedItem: items[items.length - 1] });
-    onSelectItem.reset();
-    wrapper.find('table').simulate('keydown', { key: 'ArrowDown' });
-    assert.calledWith(onSelectItem, items[items.length - 1]);
+    assertKeySelectsItem('ArrowDown', items.length - 1);
 
     // Other keys should do nothing.
     onSelectItem.reset();

--- a/lms/static/scripts/file_picker_v2/components/test/Table-test.js
+++ b/lms/static/scripts/file_picker_v2/components/test/Table-test.js
@@ -7,6 +7,7 @@ describe('Table', () => {
   const renderTable = (props = {}) =>
     mount(
       <Table
+        accessibleLabel="Test table"
         columns={[{ label: 'Item' }]}
         items={[]}
         renderItem={item => item}

--- a/lms/static/scripts/file_picker_v2/index.js
+++ b/lms/static/scripts/file_picker_v2/index.js
@@ -1,3 +1,7 @@
+// Polyfills.
+import 'focus-visible';
+
+// Setup app.
 import { createElement, render } from 'preact';
 
 import { Config } from './config';

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -27,6 +27,10 @@ $file-list-icon-size: 24px;
   width: $file-list-icon-size;
   height: $file-list-icon-size;
   vertical-align: middle;
+
+  &.is-selected {
+    filter: #{"invert()"}; // Quoted to avoid conflict with SASS mixin.
+  }
 }
 
 .FileList__name-col {
@@ -38,7 +42,7 @@ $file-list-icon-size: 24px;
 .FileList__name {
   flex-grow: 1;
   text-decoration: none;
-  color: black;
+  color: inherit;
   vertical-align: middle;
 }
 

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -29,7 +29,9 @@ $file-list-icon-size: 24px;
   vertical-align: middle;
 
   &.is-selected {
-    filter: #{"invert()"}; // Quoted to avoid conflict with SASS mixin.
+    // nb. Argument must be passed to `invert` even though "1" is the default
+    // to work around https://bugs.chromium.org/p/chromium/issues/detail?id=964696.
+    filter: #{"invert(1)"}; // Quoted to avoid conflict with SASS mixin.
   }
 }
 

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -12,12 +12,12 @@ $table-icon-size: 24px;
 }
 
 .Table__table {
+  @include outline-on-keyboard-focus;
+
   border-collapse: collapse;
   width: 100%;
   font-size: $normal-font-size;
   table-layout: fixed;
-
-  outline: none;
 }
 
 .Table__head {
@@ -58,6 +58,10 @@ $table-icon-size: 24px;
     border: none;
     vertical-align: middle;
   }
+
+  // Table rows provide their own selection indicator and rows are focused
+  // when selected.
+  outline: none;
 }
 
 .Table__row.is-selected {

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -54,6 +54,17 @@ $table-icon-size: 24px;
 
   height: $table-item-height;
 
+  &.is-selected {
+    // Add a border between the top item, when selected, and column headings to
+    // avoid them blending together.
+    &:first-child {
+      border-top: 1px solid white;
+    }
+
+    background-color: $grey-6;
+    color: white;
+  }
+
   & > td {
     border: none;
     vertical-align: middle;
@@ -62,9 +73,4 @@ $table-icon-size: 24px;
   // Table rows provide their own selection indicator and rows are focused
   // when selected.
   outline: none;
-}
-
-.Table__row.is-selected {
-  background-color: $grey-6;
-  color: white;
 }

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -16,10 +16,16 @@ $table-icon-size: 24px;
   width: 100%;
   font-size: $normal-font-size;
   table-layout: fixed;
+
+  outline: none;
 }
 
 .Table__head {
   color: white;
+
+  &-cell {
+    border: none;
+  }
 }
 
 // Sticky header for the table. On browsers that do not support `position: sticky`,
@@ -47,8 +53,14 @@ $table-icon-size: 24px;
   padding-right: 10px;
 
   height: $table-item-height;
+
+  & > td {
+    border: none;
+    vertical-align: middle;
+  }
 }
 
 .Table__row.is-selected {
-  background-color: $grey-3;
+  background-color: $grey-6;
+  color: white;
 }

--- a/lms/static/styles/file-picker-app.scss
+++ b/lms/static/styles/file-picker-app.scss
@@ -3,6 +3,9 @@
 @import 'mixins';
 @import 'variables';
 
+// Additional mixins.
+@import 'mixins/focus';
+
 // Shared classes.
 @import 'utils';
 @import 'typography';

--- a/lms/static/styles/mixins/focus.scss
+++ b/lms/static/styles/mixins/focus.scss
@@ -1,0 +1,23 @@
+/**
+ * Display an outline on an element only when it has keyboard focus.
+ *
+ * This requires the browser to support the :focus-visible pseudo-selector [1]
+ * or for the JS polyfill [2] to be loaded.
+ *
+ * [1] https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+ * [2] https://github.com/WICG/focus-visible
+ */
+@mixin outline-on-keyboard-focus {
+  // Selector for browsers using JS polyfill, which adds the "focus-visible"
+  // class to a keyboard-focused element.
+  &:focus:not(.focus-visible) {
+    outline: none;
+  }
+
+  // Selector for browsers with native :focus-visible support.
+  // (Do not combine with above, as an unsupported pseudo-class disables the
+  // entire selector)
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^1.6.1",
     "exorcist": "^1.0.1",
+    "focus-visible": "^5.0.1",
     "gulp": "^4.0.2",
     "gulplog": "^1.0.0",
     "jquery": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,6 +2842,11 @@ flush-write-stream@^1.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-visible@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.0.1.tgz#8bbe2d938bf88f067a252d72ac3a1cb2c3cb4767"
+  integrity sha512-xmuzsbC+LsF8iHlbBUvLsM6sfqyeUCAJTq3GK9JboFAdCqdDt/d4XoeE9jWT3cct2NFs/BKZ8IM8Yjkk1wgO3Q==
+
 follow-redirects@^1.0.0:
   version "1.5.8"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.8.tgz#1dbfe13e45ad969f813e86c00e5296f525c885a1"


### PR DESCRIPTION
This PR implements several improvements to the aesthetics and accessibility of the file list:

**General aesthetics and UX:**

- Use a much stronger visual highlight for selected rows
- Remove borders between cells. These were inherited from global styles in `lms.css`
- Remove the focus outline from the table, but only when not using keyboard input (see [:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) notes)
- Vertically center file names and labels

**Accessibility:**

- Add accessible labels to the dialog's "X" button and the whole table itself
- Add an the accessible label for the contents of the name column, so that screen readers just read the filename and don't try to describe the icon
- Identify the table as a [grid](https://www.w3.org/TR/wai-aria-practices/#grid) for a11y purposes. A "grid" is interactive whereas a plain table is typically for static data
- Sync keyboard focus with selected item in the table, so that screen readers will read out the selected row when navigating up and down

**File list with no row selected:**

<img width="521" alt="file-list-no-selection" src="https://user-images.githubusercontent.com/2458/60706627-c88d5500-9f01-11e9-8070-e07466bbf6d7.png">

**File list with top row selected:**

<img width="521" alt="file-list-first-row-selected" src="https://user-images.githubusercontent.com/2458/60706661-dcd15200-9f01-11e9-923e-a4303d995076.png">

**File list with middle row selected:**

<img width="528" alt="file-list-middle-row-selected" src="https://user-images.githubusercontent.com/2458/60706673-e22e9c80-9f01-11e9-9201-7bb1ee082374.png">

Fixes #742 
Fixes #743 