### PR TITLE
Render Hypothesis client config into page if set but empty

### DIFF
--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -33,18 +33,18 @@
     </div>
 
     {% block scripts %}
-      {% if context.js_config %}
+      {% if context.js_config is defined %}
         <script type="application/json" class="js-config">{{ context.js_config|tojson }}</script>
       {% endif %}
 
-      {% if context.rpc_server_config %}
+      {% if context.rpc_server_config is defined %}
         <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson }}</script>
         {% for url in asset_urls("postmessage_json_rpc_server_js") %}
           <script src="{{ url }}"></script>
         {% endfor %}
       {% endif %}
 
-      {% if context.hypothesis_config %}
+      {% if context.hypothesis_config is defined %}
         <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson }}</script>
       {% endif %}
     {% endblock %}


### PR DESCRIPTION
When provisioning is disabled, `context.hypothesis_config` is set to an
empty dictionary. Because this is a falsey value in Python, the config
was not rendered into the page, causing the client-side JS to fail.

Modify the base template to check for the existence of JS config related
values instead of falseyness.

The client continued to work when using the legacy (non-`new_oauth`)
mode because the new_lti_launch.html.jinja2 template had duplicated
logic to render this config into the page.

Fixes #755