### PR TITLE
Pass correct `origin` value to Google Picker in new tabs

### DIFF
--- a/lms/static/scripts/file_picker_v2/components/FilePickerApp.js
+++ b/lms/static/scripts/file_picker_v2/components/FilePickerApp.js
@@ -59,7 +59,12 @@ export default function FilePickerApp({
     return new GooglePickerClient({
       developerKey: googleDeveloperKey,
       clientId: googleClientId,
-      origin: lmsUrl,
+
+      // If the form is being displayed inside an iframe, then the backend
+      // must provide the URL of the top-level frame to us so we can pass it
+      // to the Google Picker API. Otherwise we can use the URL of the current
+      // tab.
+      origin: window === window.top ? window.location.href : lmsUrl,
     });
   }, [googleDeveloperKey, googleClientId, lmsUrl]);
 


### PR DESCRIPTION
When the file picker form is rendered into a top-level tab instead of an
iframe, pass the URL of the current page instead of the LMS URL as the
"origin" parameter that is forwarded to the Google Picker API.

(_Note that testing this with a unit test is fiddly because `window` and `window.top` are "unforgeable" APIs. I could add some indirection here to solve that, but it seems a bit pointless for something so simple_)

Fixes #421