### PR TITLE
Work around bug in PyLTI's handling of URL params with percent encoded characters

### DIFF
--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -63,7 +63,16 @@ class LaunchVerifier:
         try:
             valid = pylti.common.verify_request_common(
                 consumers,
-                self._request.url,
+                # We pass only the host + path of the URL (`request.path_url`)
+                # to `verify_request_common` in the `url` arg because:
+                #
+                # - Query params are also passed in `request.params` below
+                # - If query params are passed in both the URL and the `parameters`
+                #   dict, then the value from the URL is used
+                # - If values in the query param contain percent-encoded characters,
+                #   these are incorrectly _decoded_ in the result, whereas they
+                #   are handled correctly if passed in the `parameters` arg.
+                self._request.path_url,
                 self._request.method,
                 dict(self._request.headers),
                 dict(self._request.params),


### PR DESCRIPTION
Fix an OAuth 1.0 signature verification failure when handling an LTI
launch request where:

 - There is a "url" query param (aka. the launch request is "URL configured")
 - The "url" query param, _after decoding_, contains percent-encoded
   query parameters.

For example, given an LTI launch request with the following URL:

  "https://lms.hypothes.is/lti_launches?url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FG%25C3%25B6reme_National_park"

The LMS would generate an OAuth signature base string using the "url"
parameter "https://en.wikipedia.org/wiki/G%C3%B6reme_National_ark".

When our lms app received the request, it would parse the incoming
request so `request.params["url"]` was "https://en.wikipedia.org/wiki/G%C3%B6reme_National_ark".

However when PyLTI generates the signature base string for comparison,
it _decoded_ this value and used:

  "https://en.wikipedia.org/wiki/Göreme_National_Park"

The result is that the signatures did not match and the request aborted
with a 403 HTTP status.

Since this problem only affects parameters that PyLTI extracts from the
URL and not those passed to `verify_request_common` in the `parameters`
kwarg, and query params are present in both, the workaround here is to
exclude the query string + fragment from the value passed to
`verify_request_common` as the `url` argument.

Fixes #689