### PR TITLE
Delete old access tokens when getting a new one

### DIFF
--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -76,6 +76,7 @@ class CanvasAPIHelper:
                 "client_secret": self._client_secret,
                 "redirect_uri": self._redirect_uri,
                 "code": authorization_code,
+                "replace_tokens": True,
             },
         ).prepare()
 

--- a/tests/lms/services/_helpers/canvas_api_test.py
+++ b/tests/lms/services/_helpers/canvas_api_test.py
@@ -32,6 +32,7 @@ class TestCanvasAPIHelper:
             "&client_secret=test_developer_secret"
             "&redirect_uri=http%3A%2F%2Fexample.com%2Fcanvas_oauth_callback"
             "&code=test_authorization_code"
+            "&replace_tokens=True"
         )
 
     def test_refresh_token_request(self, ai_getter, helper, route_url):


### PR DESCRIPTION
Delete old Canvas API access tokens when getting a new one, by passing
the `replace_tokens` parameter to Canvas's access token endpoint. See:

https://canvas.instructure.com/doc/api/file.oauth.html#oauth2-flow-3

This does two things:

## Deletes access tokens created by previous versions of this app

Previous versions of this app have asked for a new access token on every
single launch of the app and not used the `replace_tokens` parameter.
This creates one access token in the user's account for every time they
have launched our app.

The user's list of access tokens in Canvas could list hundreds or
thousands of access tokens from our app, and Canvas provides no way for
either a student or admin to bulk delete access tokens. They have to be
deleted one by one, requiring two clicks per token.

See:

https://community.canvaslms.com/docs/DOC-16005-42121018197
https://community.canvaslms.com/docs/DOC-10806-4214724194

There's also no way to programmatically delete them using the API since
neither we nor the student have a list of all the actual access token
strings to post to the DELETE API
(https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#delete-login-oauth2-token)
and the DELETE API doesn't work for expired (more than one hour old)
access tokens anyway (you would need to also have the associated refresh
token to first refresh and then delete the access token).

By adding the `replace_tokens` parameter, the next time the user creates
or launches a Canvas file assignment and we ask them for a new access
token we will also delete all the existing access tokens in that user's
account. Since the `new_oauth` feature uses a new DB table for storing
access tokens, every user will be asked for a new access token once when
we release the feature, the next time they create or launch a Canvas
file assignment, giving us a chance to delete the old tokens.

If a user never creates or launches a Canvas file assignment using the
same developer key again then we won't get a chance to delete the access
tokens, but I don't think there's much we can do about that.

## Prevents creating multiple access tokens again

Although the app with the `new_oauth` flag enabled always reuses access
tokens and uses refresh tokens instead of asking for a new access token
every time, it _does_ ask for a new access token whenever something goes
wrong. For example if a network outage causes Canvas API requests to
temporarily fail.

This is the best approach since giving the user a way to try the whole
thing again from the very start (starting with getting a fresh access
token) gives them the best chance of being able to get past the problem.
For example this will work if an access token has been deleted from
Canvas but still exists in our DB. Or if an access token has somehow
become corrupted in our DB. Etc.

But it can result in multiple access tokens being created in the user's
account.

By adding `replace_tokens` we ensure that more than one access token is
never created.