### PR TITLE
Fix vertical rhythm of URL form

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -29,7 +29,7 @@ export default function URLPicker({ onCancel, onSelectURL }) {
       initialFocus={input}
     >
       <p>Enter the URL of any publicly available web page or PDF.</p>
-      <form ref={form} className="u-flex-row" onSubmit={submit}>
+      <form ref={form} className="URLPicker__form u-flex-row" onSubmit={submit}>
         <label className="label" htmlFor="url">
           URL:{' '}
         </label>

--- a/lms/static/styles/components/_URLPicker.scss
+++ b/lms/static/styles/components/_URLPicker.scss
@@ -5,3 +5,8 @@
   max-width: 500px;
   max-height: 300px;
 }
+
+.URLPicker__form {
+  margin-bottom: 1em;
+  margin-top: 1em;
+}


### PR DESCRIPTION
Before:

![Screenshot from 2019-07-09 18-11-18](https://user-images.githubusercontent.com/22498/60909455-2ad5b500-a276-11e9-807e-07679a7501d9.png)

After:

![Screenshot from 2019-07-09 18-12-11](https://user-images.githubusercontent.com/22498/60909465-30cb9600-a276-11e9-9d91-608eacce3639.png)

It seems like we might want a separate vertical rhythm CSS fle in which elements like titles, paragraphs, divs that contain buttons, forms, etc all have their top and bottom margins set to the same values (or multiples thereof). So far I'm just making individual fixes to components that I find problems with.