### PR TITLE
Don't disable all feature flags in cookie

### DIFF
--- a/lms/extensions/feature_flags/_helpers.py
+++ b/lms/extensions/feature_flags/_helpers.py
@@ -25,7 +25,7 @@ class FeatureFlagsCookieHelper:
         self._jwt_cookie_helper.set(response, flags)
 
     def get(self, flag):
-        return self.get_all().get(flag, False)
+        return self.get_all().get(flag, None)
 
     def get_all(self):
         return self._parse_flags(self._jwt_cookie_helper.get())

--- a/tests/lms/extensions/feature_flags/_helpers_test.py
+++ b/tests/lms/extensions/feature_flags/_helpers_test.py
@@ -64,7 +64,7 @@ class TestFeatureFlagsCookieHelper:
         jwt_cookie_helper.get.return_value = {"disallowed_flag": True}
         helper = FeatureFlagsCookieHelper(pyramid_request)
 
-        assert helper.get("disallowed_flag") is False
+        assert helper.get("disallowed_flag") is None
 
     def test_get_all_gets_all_the_flags_from_the_cookie(
         self, pyramid_request, JWTCookieHelper, jwt_cookie_helper
@@ -106,14 +106,14 @@ class TestFeatureFlagsCookieHelper:
 
         jwt_cookie_helper.set.assert_called_once_with(response, {})
 
-    def test_when_theres_no_flags_allowed_get_always_returns_False(
+    def test_when_theres_no_flags_allowed_get_always_returns_None(
         self, pyramid_request, jwt_cookie_helper
     ):
         pyramid_request.registry.settings["feature_flags_allowed_in_cookie"] = ""
         jwt_cookie_helper.get.return_value = {"test_flag_one": True}
         helper = FeatureFlagsCookieHelper(pyramid_request)
 
-        assert helper.get("test_flag_one") is False
+        assert helper.get("test_flag_one") is None
 
     def test_when_theres_no_flags_allowed_get_all_returns_an_empty_dict(
         self, pyramid_request, jwt_cookie_helper


### PR DESCRIPTION
The way the feature flags mechanism works is that it consults a list of
feature flag "providers" in this order:

- Config file
- Environment variable
- Cookie
- Query string

When queried about a particular feature flag each provider can return
None, True or False, and the *last* provider to return either True or
False is used. So for example the feature flags cookie can return True
to enable a feature that is disabled in the config file, because the
cookie is consulted after the config file.

Unfortunately the cookie provider was _always_ returning True or False,
rather than None, even for flags that the cookie has nothing to say
about because they aren't listed in FEATURE_FLAGS_ALLOWED_IN_COOKIE.
This resulted in the cookie always having the last say (other than the
query string) and always disabling any flags that had been enabled in
the config file or envvars.

Fix the cookie provider to return None rather than False if a cookie
isn't listed in FEATURE_FLAGS_ALLOWED_IN_COOKIE, so that it doesn't
override earlier providers' values for these flags.