### PR TITLE
Fix file icons for selected files displaying above sticky header

### DIFF
--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -39,6 +39,10 @@ $table-icon-size: 24px;
   font-weight: normal;
   padding-top: 5px;
   padding-bottom: 5px;
+
+  // Ensure the header is displayed above content in the table when it is
+  // scrolled, including any content which establishes a new stacking context.
+  z-index: 1;
 }
 
 .Table__body {


### PR DESCRIPTION
File icons for selected files have a CSS `filter` effect applied. This
creates a new stacking context which caused them to be painted on top of
the `position: sticky` table headers when the content was scrolled.

Fix this by applying a z-index to the table header.

See also https://github.com/hypothesis/lms/issues/759

**Before:**

<img width="542" alt="table-header-before" src="https://user-images.githubusercontent.com/2458/61134845-6495fe00-a4b8-11e9-83c9-12c3971afa8a.png">

**After:**

<img width="537" alt="table-header-after" src="https://user-images.githubusercontent.com/2458/61134856-69f34880-a4b8-11e9-817b-3f63519ec542.png">

Related technical notes on MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context