### PR TITLE
Move via_url() to view-specific helpers

### DIFF
--- a/lms/util/__init__.py
+++ b/lms/util/__init__.py
@@ -6,7 +6,6 @@ from lms.util.canvas_api import canvas_api, GET, POST
 from lms.util.jwt import jwt
 from lms.util._lti_launch import lti_launch
 from lms.util.lti import lti_params_for
-from lms.util.via import via_url
 from lms.util.view_renderer import view_renderer
 
 __all__ = (
@@ -18,7 +17,6 @@ __all__ = (
     "lti_launch",
     "lti_params_for",
     "save_token",
-    "via_url",
     "view_renderer",
     "GET",
     "POST",

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -31,7 +31,7 @@ proxy API caller::
 """
 from pyramid.view import view_config, view_defaults
 
-from lms import util
+from lms.views import helpers
 
 
 @view_defaults(permission="canvas_api", renderer="json")
@@ -61,5 +61,5 @@ class FilesAPIViews:
         public_url = self.canvas_api_client.public_url(
             self.request.matchdict["file_id"]
         )
-        via_url = util.via_url(self.request, public_url)
+        via_url = helpers.via_url(self.request, public_url)
         return {"via_url": via_url}

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -18,7 +18,7 @@ that're still used when the feature flag is off.
 from pyramid.view import view_config, view_defaults
 
 from lms.models import ModuleItemConfiguration
-from lms.util import via_url
+from lms.views.helpers import via_url
 from lms.validation import BearerTokenSchema, ConfigureModuleItemSchema
 from lms.views.decorators import (
     upsert_h_user,

--- a/lms/views/helpers/__init__.py
+++ b/lms/views/helpers/__init__.py
@@ -1,4 +1,5 @@
 from lms.views.helpers._canvas_files import canvas_files_available
+from lms.views.helpers._via import via_url
 
 
-__all__ = ("canvas_files_available",)
+__all__ = ["canvas_files_available", "via_url"]

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -1,4 +1,8 @@
+"""Via-related view helpers."""
 from urllib import parse
+
+
+__all__ = ["via_url"]
 
 
 def via_url(request, document_url):

--- a/tests/lms/views/api/canvas/files_test.py
+++ b/tests/lms/views/api/canvas/files_test.py
@@ -44,11 +44,11 @@ class TestViaURL:
         canvas_api_client.public_url.assert_called_once_with("test_file_id")
 
     def test_it_gets_the_via_url_for_the_public_url(
-        self, canvas_api_client, pyramid_request, util
+        self, canvas_api_client, pyramid_request, helpers
     ):
         FilesAPIViews(pyramid_request).via_url()
 
-        util.via_url.assert_called_once_with(
+        helpers.via_url.assert_called_once_with(
             pyramid_request, canvas_api_client.public_url.return_value
         )
 
@@ -62,10 +62,10 @@ class TestViaURL:
         with pytest.raises(CanvasAPIError, match="Oops"):
             FilesAPIViews(pyramid_request).via_url()
 
-    def test_it_returns_the_via_url(self, pyramid_request, util):
+    def test_it_returns_the_via_url(self, pyramid_request, helpers):
         data = FilesAPIViews(pyramid_request).via_url()
 
-        assert data["via_url"] == util.via_url.return_value
+        assert data["via_url"] == helpers.via_url.return_value
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -83,5 +83,5 @@ def canvas_api_client(pyramid_config):
 
 
 @pytest.fixture(autouse=True)
-def util(patch):
-    return patch("lms.views.api.canvas.files.util")
+def helpers(patch):
+    return patch("lms.views.api.canvas.files.helpers")

--- a/tests/lms/views/helpers/_via_test.py
+++ b/tests/lms/views/helpers/_via_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lms.util import via_url
+from lms.views.helpers import via_url
 
 
 class TestViaURL:


### PR DESCRIPTION
Tests will be failing because legacy views need to be deleted