### PR TITLE
Simplify frontend linting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -199,14 +199,3 @@ gulp.task('test', function(callback) {
 gulp.task('test-watch', function(callback) {
   runKarma('./lms/static/scripts/karma.config.js', {}, callback);
 });
-
-gulp.task('lint', function() {
-  // Adapted from usage example at https://www.npmjs.com/package/gulp-eslint
-  // `gulp-eslint` is loaded lazily so that it is not required during Docker image builds
-  var eslint = require('gulp-eslint');
-  return gulp
-    .src(['lms/static/scripts/**/*.js'])
-    .pipe(eslint())
-    .pipe(eslint.format())
-    .pipe(eslint.failAfterError());
-});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "gulp build",
     "checkformatting": "prettier --check lms/**/*.js scripts/**/*.js",
     "format": "prettier --list-different --write lms/**/*.js scripts/**/*.js",
-    "lint": "gulp lint",
+    "lint": "eslint lms/static/scripts",
     "test": "gulp test"
   },
   "repository": {
@@ -63,7 +63,6 @@
     "enzyme-adapter-preact-pure": "^2.0.0",
     "eslint": "^6.0.1",
     "eslint-config-hypothesis": "^2.0.0",
-    "gulp-eslint": "^6.0.0",
     "karma": "^4.2.0",
     "karma-browserify": "^6.0.0",
     "karma-chai": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2468,7 +2468,7 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^6.0.0, eslint@^6.0.1:
+eslint@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.0.1.tgz#4a32181d72cb999d6f54151df7d337131f81cda7"
   integrity sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==
@@ -3110,15 +3110,6 @@ gulp-cli@^2.2.0:
     semver-greatest-satisfied-range "^1.1.0"
     v8flags "^3.0.1"
     yargs "^7.1.0"
-
-gulp-eslint@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-eslint/-/gulp-eslint-6.0.0.tgz#7d402bb45f8a67652b868277011812057370a832"
-  integrity sha512-dCVPSh1sA+UVhn7JSQt7KEb4An2sQNbOdB3PA8UCfxsoPlAKjJHxYHGXdXC7eb+V1FAnilSFFqslPrq037l1ig==
-  dependencies:
-    eslint "^6.0.0"
-    fancy-log "^1.3.2"
-    plugin-error "^1.0.1"
 
 gulp@^4.0.2:
   version "4.0.2"
@@ -5102,15 +5093,6 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-
-plugin-error@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
-  dependencies:
-    ansi-colors "^1.0.1"
-    arr-diff "^4.0.0"
-    arr-union "^3.1.0"
-    extend-shallow "^3.0.2"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Running ESLint is a matter of running a single CLI command, so there is
no need to do it through Gulp.