### PR TITLE
Include scope in canvas auth request

### DIFF
--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -28,6 +28,7 @@ class CanvasAPIAuthorizeViews:
                         "response_type": "code",
                         "redirect_uri": self.request.route_url("canvas_oauth_callback"),
                         "state": CanvasOAuthCallbackSchema(self.request).state_param(),
+                        "scope": "url:GET|/api/v1/courses/:course_id/files url:GET|/api/v1/files/:id/public_url",
                     }
                 ),
                 "",

--- a/tests/lms/views/api/canvas/authorize_test.py
+++ b/tests/lms/views/api/canvas/authorize_test.py
@@ -51,6 +51,15 @@ class TestAuthorize:
             "http://example.com/canvas_oauth_callback"
         ]
 
+    def test_it_includes_the_scope_in_a_query_param(self, pyramid_request):
+        response = CanvasAPIAuthorizeViews(pyramid_request).authorize()
+
+        query_params = parse_qs(urlparse(response.location).query)
+
+        assert query_params["scope"] == [
+            "url:GET|/api/v1/courses/:course_id/files url:GET|/api/v1/files/:id/public_url"
+        ]
+
     def test_it_includes_the_state_in_a_query_param(
         self, pyramid_request, CanvasOAuthCallbackSchema, canvas_oauth_callback_schema
     ):


### PR DESCRIPTION
This is a partial fix for https://github.com/hypothesis/lms/issues/806.