### PR TITLE
Use dialog in basicLtiLaunch to display error messages

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -11,6 +11,7 @@ import AuthWindow from '../utils/AuthWindow';
 import { Config } from '../config';
 import { ApiError, apiCall } from '../utils/api';
 
+import Dialog from './Dialog';
 import Button from './Button';
 import ErrorDisplay from './ErrorDisplay';
 import Spinner from './Spinner';
@@ -189,34 +190,53 @@ export default function BasicLtiLaunchApp() {
         <Spinner className="BasicLtiLaunchApp__spinner" />
       )}
       {ltiLaunchState.state === 'authorizing' && (
-        <div className="BasicLtiLaunchApp__form">
-          <h1 className="heading">Authorize Hypothesis</h1>
-          <p>Hypothesis needs your authorization to launch this assignment.</p>
-          <Button
-            onClick={authorizeAndFetchUrl}
-            className="BasicLtiLaunchApp__button"
-            label="Authorize"
-          />
-        </div>
-      )}
-      {ltiLaunchState.state === 'error' && (
-        <div className="BasicLtiLaunchApp__form">
-          <h1 className="heading">Something went wrong</h1>
-          <ErrorDisplay
-            message="There was a problem loading this Hypothesis assignment"
-            error={ltiLaunchState.error}
-          />
-          {ltiLaunchState.failedAction === 'fetch-url' ? (
+        <Dialog
+          title="Authorize Hypothesis"
+          buttons={[
             <Button
               onClick={authorizeAndFetchUrl}
               className="BasicLtiLaunchApp__button"
-              label="Try again"
-            />
-          ) : (
-            <b>To fix this problem, try reloading the page.</b>
-          )}
-        </div>
+              label="Authorize"
+              key="authorize"
+            />,
+          ]}
+        >
+          <p>Hypothesis needs your authorization to launch this assignment.</p>
+        </Dialog>
       )}
+      {ltiLaunchState.state === 'error' &&
+        ltiLaunchState.failedAction === 'fetch-url' && (
+          <Dialog
+            title="Something went wrong"
+            contentClass="BasicLtiLaunchApp__dialog"
+            buttons={[
+              <Button
+                onClick={authorizeAndFetchUrl}
+                className="BasicLtiLaunchApp__button"
+                label="Try again"
+                key="retry"
+              />,
+            ]}
+          >
+            <ErrorDisplay
+              message="There was a problem fetching this Hypothesis assignment"
+              error={ltiLaunchState.error}
+            />
+          </Dialog>
+        )}
+      {ltiLaunchState.state === 'error' &&
+        ltiLaunchState.failedAction === 'report-submission' && (
+          <Dialog
+            title="Something went wrong"
+            contentClass="BasicLtiLaunchApp__dialog"
+          >
+            <ErrorDisplay
+              message="There was a problem submitting this Hypothesis assignment"
+              error={ltiLaunchState.error}
+            />
+            <b>To fix this problem, try reloading the page.</b>
+          </Dialog>
+        )}
     </Fragment>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'preact';
+import { Fragment, createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
@@ -13,6 +13,12 @@ describe('BasicLtiLaunchApp', () => {
   let FakeAuthWindow;
   let FakeErrorDisplay;
   let fakeConfig;
+  // eslint-disable-next-line react/prop-types
+  const FakeDialog = ({ buttons, children }) => (
+    <Fragment>
+      {buttons} {children}
+    </Fragment>
+  );
 
   const renderLtiLaunchApp = (props = {}) => {
     return mount(
@@ -43,6 +49,7 @@ describe('BasicLtiLaunchApp', () => {
     // shallow rendering because the modern context API doesn't seem to work
     // with shallow rendering yet
     $imports.$mock({
+      './Dialog': FakeDialog,
       './ErrorDisplay': FakeErrorDisplay,
       './Spinner': FakeSpinner,
 

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,19 +1,6 @@
-.BasicLtiLaunchApp__form {
-  margin-top: 10vh;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  position: relative;
-
-  margin-left: auto;
-  margin-right: auto;
+.BasicLtiLaunchApp__dialog {
+  width: 75%;
   max-width: 500px;
-  width: fit-content;
-}
-
-.BasicLtiLaunchApp__button {
-  margin-top: 20px;
-  align-self: flex-end;
 }
 
 .BasicLtiLaunchApp__spinner {
@@ -25,4 +12,3 @@
   left: calc(50% - #{$spinner-size / 2});
   top: 100px;
 }
-


### PR DESCRIPTION
This is a fix for https://github.com/hypothesis/lms/issues/768.

There are 3 states in this view that have been modified to use the Dialog component:
* a request for authorization
* a failure to fetch the assignment
* a failure to submit the assignment

The user's authorization is requested:
![image](https://user-images.githubusercontent.com/30059933/63453973-af336000-c3fe-11e9-9876-f824abaed77b.png)


Fetching the assignment fails:
![image](https://user-images.githubusercontent.com/30059933/63453016-8ca04780-c3fc-11e9-959c-a4b4f4c404a5.png)


A user's submission fails:
![image](https://user-images.githubusercontent.com/30059933/63453117-cbce9880-c3fc-11e9-92e4-c234f88868cf.png)

This is dependent on https://github.com/hypothesis/lms/pull/927.