### PR TITLE
SpeedGrader 1/n - Add a service for sending LTI Outcomes Management requests

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -39,3 +39,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.canvas_api.CanvasAPIClient", name="canvas_api_client"
     )
+    config.register_service_factory(
+        "lms.services.lti_outcomes.LTIOutcomesClient", name="lti_outcomes_client"
+    )

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -192,14 +192,13 @@ def _send_request(outcomes_request_params, pox_body):
     )
 
     # Execute request and check HTTP status.
-    response = requests.post(
-        url=outcomes_request_params.lis_outcome_service_url,
-        data=xml_body,
-        headers={"Content-Type": "application/xml"},
-        auth=oauth_client,
-    )
-
     try:
+        response = requests.post(
+            url=outcomes_request_params.lis_outcome_service_url,
+            data=xml_body,
+            headers={"Content-Type": "application/xml"},
+            auth=oauth_client,
+        )
         response.raise_for_status()
     except RequestException as err:
         raise ExternalRequestError(

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -1,0 +1,235 @@
+from typing import NamedTuple
+from xml.etree import ElementTree
+
+from jinja2 import Template
+import requests
+from requests_oauthlib import OAuth1
+
+from lms.services.exceptions import ExternalRequestError, ServiceError
+
+
+__all__ = ["LTIOutcomesClient", "LTIOutcomesRequestParams"]
+
+LTI_OUTCOME_SERVICE_XML_NS = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0"
+
+# Envelope for LTI Outcome Service requests sent to the LMS
+#
+# See https://www.imsglobal.org/specs/ltiomv1p0/specification for specs for all
+# messages.
+#
+# nb. To be a valid XML document it is important that the template has no
+# whitespace at the start.
+LTI_OUTCOME_REQUEST_TEMPLATE = Template(
+    """<?xml version="1.0" encoding="UTF-8"?>
+<imsx_POXEnvelopeRequest xmlns="http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
+  <imsx_POXHeader>
+    <imsx_POXRequestHeaderInfo>
+      <imsx_version>V1.0</imsx_version>
+      <imsx_messageIdentifier>999999123</imsx_messageIdentifier>
+    </imsx_POXRequestHeaderInfo>
+  </imsx_POXHeader>
+  <imsx_POXBody>
+    {{ body }}
+  </imsx_POXBody>
+</imsx_POXEnvelopeRequest>
+"""
+)
+
+# Template for a `replaceResult` XML message to send to the LMS.
+REPLACE_RESULT_REQUEST_TEMPLATE = Template(
+    """
+<replaceResultRequest>
+  <resultRecord>
+    <sourcedGUID>
+      <sourcedId>{{ lis_result_sourcedid | e }}</sourcedId>
+    </sourcedGUID>
+    <result>
+      {% if score %}
+      <resultScore>
+        <language>en</language>
+        <textString>{{ score | e }}</textString>
+      </resultScore>
+      {% endif %}
+      {% if lti_launch_url %}
+      <resultData>
+        <ltiLaunchUrl>{{ lti_launch_url | e }}</ltiLaunchUrl>
+      </resultData>
+      {% endif %}
+    </result>
+  </resultRecord>
+  {% if submitted_at %}
+  <submissionDetails>
+    <submittedAt>{{ submitted_at.isoformat() }}</submittedAt>
+  </submissionDetails>
+  {% endif %}
+</replaceResultRequest>
+"""
+)
+
+# Template for a `readResult` XML message to send to the LMS.
+READ_RESULT_REQUEST_TEMPLATE = Template(
+    """
+<readResultRequest>
+  <resultRecord>
+    <sourcedGUID>
+      <sourcedId>{{ lis_result_sourcedid | e }}</sourcedId>
+    </sourcedGUID>
+  </resultRecord>
+</readResultRequest>
+"""
+)
+
+
+class LTIOutcomesRequestParams(NamedTuple):
+    """Common parameters used by all LTI Outcomes Management requests."""
+
+    consumer_key: str
+    """
+    OAuth 1.0 consumer key used to sign the request.
+    """
+
+    shared_secret: str
+    """
+    OAuth 1.0 shared secret used to sign the request.
+    """
+
+    lis_outcome_service_url: str
+    """
+    URL to submit requests to, provided by the LMS during an LTI launch.
+    """
+
+    lis_result_sourcedid: str
+    """
+    Opaque identifier for a particular submission.
+
+    This is provided by the LMS during an LTI launch and identifies the user
+    and assignment that the launch refers to.
+    """
+
+
+class LTIOutcomesClient:
+    """
+    Service for making requests to an LMS's Outcomes Management endpoint.
+
+    See https://www.imsglobal.org/specs/ltiomv1p0/specification.
+    """
+
+    def __init__(self, _context, request):
+        pass
+
+    def read_result(self, outcomes_request_params):  # noqa
+        """
+        Return the last-submitted score for a given submission.
+
+        :return: The last-submitted score or `None` if no score has been submitted.
+        """
+        body = READ_RESULT_REQUEST_TEMPLATE.render(
+            lis_result_sourcedid=outcomes_request_params.lis_result_sourcedid
+        )
+
+        result = _send_request(outcomes_request_params, body)
+
+        try:
+            score = find_element(
+                result, ["readResultResponse", "result", "resultScore", "textString"]
+            )
+            if score is None:
+                return None
+            return float(score.text)
+        except (ValueError, TypeError):
+            return None
+
+    def record_result(  # noqa
+        self,
+        outcomes_request_params,
+        score=None,
+        lti_launch_url=None,
+        submitted_at=None,
+    ):
+        """
+        Record a score or grading view launch URL for an assignment in the LMS.
+
+        :param score:
+            Float value between 0 and 1.0.
+            Defined as required by the LTI spec but is optional in Canvas if
+            an `lti_launch_url` is set.
+        :param lti_launch_url:
+            A URL where the student's work on this submission can be viewed.
+            This is only used in Canvas.
+        :param submitted_at:
+            A `datetime.datetime` that indicates when the submission was created.
+            This is only used in Canvas and is displayed in the SpeedGrader
+            as the submission date.
+            If the submission date matches an existing submission then the
+            existing submission is updated rather than creating a new submission.
+        """
+        body = REPLACE_RESULT_REQUEST_TEMPLATE.render(
+            lis_result_sourcedid=outcomes_request_params.lis_result_sourcedid,
+            score=score,
+            lti_launch_url=lti_launch_url,
+            submitted_at=submitted_at,
+        )
+
+        _send_request(outcomes_request_params, body)
+
+
+def _send_request(outcomes_request_params, pox_body):
+    """
+    Send a signed request to an LMS's Outcome Management Service endpoint.
+
+    :param pox_body: The content of the `imsx_POXBody` element in the request
+    :return: Parsed XML response
+    :rtype: ElementTree.Element
+    """
+
+    xml_body = LTI_OUTCOME_REQUEST_TEMPLATE.render(body=pox_body)
+
+    # Sign request using OAuth 1.0.
+    oauth_client = OAuth1(
+        client_key=outcomes_request_params.consumer_key,
+        client_secret=outcomes_request_params.shared_secret,
+        signature_method="HMAC-SHA1",
+        signature_type="auth_header",
+        # Include the body when signing the request, this defaults to `False`
+        # for non-form encoded bodies.
+        force_include_body=True,
+    )
+
+    # Execute request and check HTTP status.
+    response = requests.post(
+        url=outcomes_request_params.lis_outcome_service_url,
+        data=xml_body,
+        headers={"Content-Type": "application/xml"},
+        auth=oauth_client,
+    )
+
+    try:
+        response.raise_for_status()
+    except Exception as e:
+        raise ExternalRequestError(
+            "Error calling LTI Outcomes service", response
+        ) from e
+
+    # Parse response and check status code embedded in XML.
+    try:
+        xml = ElementTree.fromstring(response.text)
+    except ElementTree.ParseError as e:
+        raise ExternalRequestError(
+            "Unable to parse XML response from LTI Outcomes service", response
+        ) from e
+
+    status = find_element(xml, ["imsx_statusInfo", "imsx_codeMajor"])
+    if status is None:
+        raise ServiceError("Failed to read status from LTI outcome response")
+
+    if status.text != "success":
+        raise ServiceError("LTI outcome request failed")
+
+    return xml
+
+
+def find_element(xml_element, path):
+    """Extract element from LTI Outcomes Management XML response."""
+    xml_ns = LTI_OUTCOME_SERVICE_XML_NS
+    xpath = "/".join([f"{{{xml_ns}}}{name}" for name in path])
+    return xml_element.find(f".//{xpath}")

--- a/tests/lms/services/lti_outcomes_test.py
+++ b/tests/lms/services/lti_outcomes_test.py
@@ -1,0 +1,315 @@
+import datetime
+from xml.etree import ElementTree
+
+import httpretty
+from jinja2 import Template
+import pytest
+
+from lms.services.exceptions import ExternalRequestError, ServiceError
+from lms.services.lti_outcomes import (
+    LTIOutcomesClient,
+    LTIOutcomesRequestParams,
+    find_element,
+)
+
+LTI_OUTCOME_RESPONSE_TEMPLATE = Template(
+    """<?xml version="1.0" encoding="UTF-8"?>
+<imsx_POXEnvelopeResponse
+  xmlns="http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0"
+>
+  <imsx_POXHeader>
+    <imsx_POXResponseHeaderInfo>
+      <imsx_version>V1.0</imsx_version>
+      <imsx_messageIdentifier>1313355158804</imsx_messageIdentifier>
+      {% if not exclude_status %}
+      <imsx_statusInfo>
+        <imsx_codeMajor>{{ status_code|default('success') }}</imsx_codeMajor>
+        <imsx_severity>status</imsx_severity>
+        <imsx_description>Result read</imsx_description>
+        <imsx_messageRefIdentifier>999999123</imsx_messageRefIdentifier>
+        <imsx_operationRefIdentifier>readResult</imsx_operationRefIdentifier>
+      </imsx_statusInfo>
+      {% endif %}
+    </imsx_POXResponseHeaderInfo>
+  </imsx_POXHeader>
+  <imsx_POXBody>
+    <readResultResponse>
+      <result>
+        <resultScore>
+          <language>en</language>
+          {% if not exclude_score %}
+          <textString>{{ score }}</textString>
+          {% endif %}
+        </resultScore>
+      </result>
+    </readResultResponse>
+  </imsx_POXBody>
+</imsx_POXEnvelopeResponse>"""
+)
+
+
+class TestLTIOutcomesClient:
+    def test_read_result_sends_expected_request(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response, request_xml
+    ):
+        configure_response({"score": 0.95})
+
+        lti_outcomes_svc.read_result(lti_outcomes_params)
+
+        xml = request_xml()
+        check_header(xml)
+        sourcedid = element_text(
+            xml,
+            [
+                "imsx_POXBody",
+                "readResultRequest",
+                "resultRecord",
+                "sourcedGUID",
+                "sourcedId",
+            ],
+        )
+        assert sourcedid == lti_outcomes_params.lis_result_sourcedid
+
+    def test_read_result_returns_float_score(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response
+    ):
+        configure_response({"score": 0.95})
+
+        score = lti_outcomes_svc.read_result(lti_outcomes_params)
+
+        assert score == 0.95
+
+    def test_read_result_returns_none_if_no_score(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response
+    ):
+        configure_response({"exclude_score": True})
+
+        score = lti_outcomes_svc.read_result(lti_outcomes_params)
+
+        assert score is None
+
+    @pytest.mark.parametrize("score_text", ["", "not-a-float"])
+    def test_read_result_returns_none_if_score_not_a_float(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response, score_text
+    ):
+        configure_response({"score": score_text})
+
+        score = lti_outcomes_svc.read_result(lti_outcomes_params)
+
+        assert score is None
+
+    def test_record_result_sends_sourcedid(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response, request_xml
+    ):
+        configure_response({})
+
+        lti_outcomes_svc.record_result(lti_outcomes_params)
+        xml = request_xml()
+
+        check_header(xml)
+        sourcedid = element_text(
+            xml, ["replaceResultRequest", "resultRecord", "sourcedGUID", "sourcedId"]
+        )
+        assert sourcedid == lti_outcomes_params.lis_result_sourcedid
+
+    def test_record_result_sends_score(
+        self,
+        lti_outcomes_params,
+        lti_outcomes_svc,
+        configure_response,
+        record_result_request_fields,
+    ):
+        configure_response({})
+
+        lti_outcomes_svc.record_result(lti_outcomes_params, score=0.5)
+
+        assert record_result_request_fields() == {"score": "0.5"}
+
+    def test_record_result_sends_launch_url(
+        self,
+        lti_outcomes_params,
+        lti_outcomes_svc,
+        configure_response,
+        record_result_request_fields,
+    ):
+        configure_response({})
+        lti_launch_url = "https://lms.hypothes.is/lti_launches"
+
+        lti_outcomes_svc.record_result(
+            lti_outcomes_params, lti_launch_url=lti_launch_url
+        )
+
+        assert record_result_request_fields() == {"lti_launch_url": lti_launch_url}
+
+    def test_record_result_sends_submitted_at(
+        self,
+        lti_outcomes_params,
+        lti_outcomes_svc,
+        configure_response,
+        record_result_request_fields,
+    ):
+        configure_response({})
+        submitted_at = datetime.datetime(2010, 1, 1)
+
+        lti_outcomes_svc.record_result(lti_outcomes_params, submitted_at=submitted_at)
+
+        assert record_result_request_fields() == {
+            "submitted_at": submitted_at.isoformat()
+        }
+
+    def test_it_signs_request_with_oauth1(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response
+    ):
+        configure_response({})
+
+        lti_outcomes_svc.record_result(lti_outcomes_params)
+
+        request = httpretty.last_request()
+        auth_header = request.headers["Authorization"]
+
+        # nb. This currently doesn't verify the signature, it only checks that
+        # one is present.
+        assert auth_header.startswith("OAuth")
+        assert 'oauth_version="1.0"' in auth_header
+        assert 'oauth_consumer_key="lms_consumer_key"' in auth_header
+        assert 'oauth_signature_method="HMAC-SHA1"' in auth_header
+        assert "oauth_signature=" in auth_header
+
+    def test_requests_fail_if_http_status_is_error(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response
+    ):
+        configure_response({}, status=400)
+
+        with pytest.raises(ExternalRequestError):
+            lti_outcomes_svc.read_result(lti_outcomes_params)
+
+    def test_requests_fail_if_body_not_xml(self, lti_outcomes_params, lti_outcomes_svc):
+        httpretty.register_uri(
+            httpretty.POST,
+            lti_outcomes_params.lis_outcome_service_url,
+            body='{"not":"xml"}',
+            content_type="application/json",
+            priority=1,
+        )
+        with pytest.raises(ExternalRequestError):
+            lti_outcomes_svc.read_result(lti_outcomes_params)
+
+    def test_requests_fail_if_no_status(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response
+    ):
+        configure_response({"exclude_status": True})
+        with pytest.raises(ServiceError):
+            lti_outcomes_svc.read_result(lti_outcomes_params)
+
+    def test_requests_fail_if_status_is_not_success(
+        self, lti_outcomes_params, lti_outcomes_svc, configure_response
+    ):
+        configure_response({"status_code": "failure"})
+
+        with pytest.raises(ServiceError):
+            lti_outcomes_svc.read_result(lti_outcomes_params)
+
+    @pytest.fixture
+    def request_xml(self):
+        """Return parsed XML of last request."""
+
+        def xml():
+            request = httpretty.last_request()
+            return ElementTree.fromstring(request.body)
+
+        return xml
+
+    @pytest.fixture
+    def record_result_request_fields(self, request_xml):
+        """Return a dict of fields that were set in the last-sent `replaceResult` request."""
+
+        def get_fields():
+            xml = request_xml()
+            fields = {}
+            score = element_text(
+                xml,
+                [
+                    "replaceResultRequest",
+                    "resultRecord",
+                    "result",
+                    "resultScore",
+                    "textString",
+                ],
+            )
+            if score is not None:
+                fields["score"] = score
+
+            lti_launch_url = element_text(
+                xml,
+                [
+                    "replaceResultRequest",
+                    "resultRecord",
+                    "result",
+                    "resultData",
+                    "ltiLaunchUrl",
+                ],
+            )
+            if lti_launch_url is not None:
+                fields["lti_launch_url"] = lti_launch_url
+
+            submitted_at = element_text(
+                xml, ["replaceResultRequest", "submissionDetails", "submittedAt"]
+            )
+            if submitted_at is not None:
+                fields["submitted_at"] = submitted_at
+
+            return fields
+
+        return get_fields
+
+    @pytest.fixture
+    def configure_response(self, lti_outcomes_params):
+        def configure(template_params, status=200):
+            response_body = LTI_OUTCOME_RESPONSE_TEMPLATE.render(**template_params)
+            httpretty.register_uri(
+                httpretty.POST,
+                lti_outcomes_params.lis_outcome_service_url,
+                body=response_body,
+                content_type="application/xml",
+                priority=1,
+                status=status,
+            )
+
+        return configure
+
+    @pytest.fixture
+    def lti_outcomes_params(self):
+        return LTIOutcomesRequestParams(
+            consumer_key="lms_consumer_key",
+            shared_secret="lms_shared_secret",
+            lis_outcome_service_url="https://hypothesis.foolms.com/lti/outcomes",
+            lis_result_sourcedid="modelstudent-assignment123",
+        )
+
+    @pytest.fixture
+    def lti_outcomes_svc(self, pyramid_request):
+        return LTIOutcomesClient({}, pyramid_request)
+
+
+def element_text(xml, path):
+    element = find_element(xml, path)
+    if element is None:
+        return None
+    return element.text
+
+
+def check_header(xml):
+    """Check standard header fields of an LTI Outcomes Management request body."""
+    assert (
+        element_text(
+            xml, ["imsx_POXHeader", "imsx_POXRequestHeaderInfo", "imsx_version"]
+        )
+        == "V1.0"
+    )
+    assert (
+        element_text(
+            xml,
+            ["imsx_POXHeader", "imsx_POXRequestHeaderInfo", "imsx_messageIdentifier"],
+        )
+        == "999999123"
+    )


### PR DESCRIPTION
Add an `lti_outcomes_client` service which provides a client for reading/writing grading
information to an LMS's LTI Outcomes Management service [1], along with Canvas-specific extensions. Currently only the endpoints for reading the current score and replacing the score for an assignment are implemented, as these are the only ones needed for initial grading support.

This will be used for the initial SpeedGrader integration to record a
submission when a learner launches an assignment.

Strictly speaking the "service" could just be a utility class as it doesn't actually make use of any request parameters at the moment. I thought originally it would.

[1] https://www.imsglobal.org/specs/ltiomv1p0/specification