### PR TITLE
SpeedGrader 2/n - Add an API endpoint for frontend to trigger submitting of grading LTI launch URL to Canvas

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -30,3 +30,4 @@ def includeme(config):
         "canvas_api.courses.files.list", "/api/canvas/courses/{course_id}/files"
     )
     config.add_route("canvas_api.files.via_url", "/api/canvas/files/{file_id}/via_url")
+    config.add_route("lti_api.submissions.record", "/api/lti/submissions")

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -64,11 +64,11 @@ from lms.validation._canvas import (
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
 )
-from lms.validation._api import ApiRecordSubmissionSchema
+from lms.validation._api import APIRecordSubmissionSchema
 
 
 __all__ = (
-    "ApiRecordSubmissionSchema",
+    "APIRecordSubmissionSchema",
     "CanvasOAuthCallbackSchema",
     "CanvasAccessTokenResponseSchema",
     "CanvasRefreshTokenResponseSchema",

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -64,9 +64,11 @@ from lms.validation._canvas import (
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
 )
+from lms.validation._api import ApiRecordSubmissionSchema
 
 
 __all__ = (
+    "ApiRecordSubmissionSchema",
     "CanvasOAuthCallbackSchema",
     "CanvasAccessTokenResponseSchema",
     "CanvasRefreshTokenResponseSchema",

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -1,0 +1,40 @@
+"""Schema for JSON APIs exposed to the frontend."""
+
+from webargs import fields
+
+from lms.validation._helpers import PyramidRequestSchema
+
+
+__all__ = ["ApiRecordSubmissionSchema"]
+
+
+class ApiRecordSubmissionSchema(PyramidRequestSchema):
+    """Schema for validating requests from the frontend to record submissions."""
+
+    locations = ["json"]
+
+    document_url = fields.Str()
+    """
+    URL of the document for this assignment.
+    """
+
+    canvas_file_id = fields.Str()
+    """
+    ID of the Canvas file for this assignment.
+    """
+
+    h_username = fields.Str(required=True)
+    """
+    h username generated for the active user.
+    """
+
+    lis_outcome_service_url = fields.Str(required=True)
+    """
+    URL provided by the LMS to submit grades or other results to.
+    """
+
+    lis_result_sourcedid = fields.Str(required=True)
+    """
+    Opaque identifier provided by the LMS to identify a submission. This
+    typically encodes the assignment context and LMS user.
+    """

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -5,33 +5,25 @@ from webargs import fields
 from lms.validation._helpers import PyramidRequestSchema
 
 
-__all__ = ["ApiRecordSubmissionSchema"]
+__all__ = ["APIRecordSubmissionSchema"]
 
 
-class ApiRecordSubmissionSchema(PyramidRequestSchema):
+class APIRecordSubmissionSchema(PyramidRequestSchema):
     """Schema for validating requests from the frontend to record submissions."""
 
     locations = ["json"]
 
     document_url = fields.Str()
-    """
-    URL of the document for this assignment.
-    """
+    """URL of the document for this assignment."""
 
     canvas_file_id = fields.Str()
-    """
-    ID of the Canvas file for this assignment.
-    """
+    """ID of the Canvas file for this assignment."""
 
     h_username = fields.Str(required=True)
-    """
-    h username generated for the active user.
-    """
+    """h username generated for the active user."""
 
     lis_outcome_service_url = fields.Str(required=True)
-    """
-    URL provided by the LMS to submit grades or other results to.
-    """
+    """URL provided by the LMS to submit grades or other results to."""
 
     lis_result_sourcedid = fields.Str(required=True)
     """

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -1,0 +1,75 @@
+import datetime
+from datetime import timezone
+
+from pyramid.view import view_config
+
+from lms.validation import ApiRecordSubmissionSchema
+from lms.services.lti_outcomes import LTIOutcomesRequestParams
+
+
+@view_config(
+    request_method="POST",
+    route_name="lti_api.submissions.record",
+    renderer="json",
+    schema=ApiRecordSubmissionSchema,
+)
+def record_submission(request):
+    """
+    Record info to facilitate later grading of an assignment.
+
+    When a learner launches an assignment the LMS provides metadata that can
+    be later used to submit a score to the LMS using LTI Outcome Management
+    APIs. In Canvas, extensions to that API allow a custom LTI launch URL to be
+    submitted for use by the SpeedGrader [1].
+
+    Currently this view only supports SpeedGrader-based grading in Canvas by
+    submitting an LTI Launch URL to Canvas. In future it will need to persist the
+    metadata to facilitate grading in other LMSes via a different UI.
+
+    This work _could_ be done by the backend during an LTI launch, but as it
+    involves potentially slow requests to the external LMS, it is triggered
+    asynchronously by the frontend while the assignment is loading.
+
+    [1] https://canvas.instructure.com/doc/api/file.assignment_tools.html
+    """
+
+    lti_user = request.lti_user
+    parsed_params = request.parsed_params
+
+    shared_secret = request.find_service(name="ai_getter").shared_secret(
+        lti_user.oauth_consumer_key
+    )
+    outcome_request_params = LTIOutcomesRequestParams(
+        consumer_key=lti_user.oauth_consumer_key,
+        shared_secret=shared_secret,
+        lis_outcome_service_url=parsed_params["lis_outcome_service_url"],
+        lis_result_sourcedid=parsed_params["lis_result_sourcedid"],
+    )
+
+    lti_outcomes_client = request.find_service(name="lti_outcomes_client")
+
+    # Send the SpeedGrader LTI launch URL to the Canvas instance, if we haven't
+    # already created a submission OR if the existing submission has not been
+    # graded (Canvas's result-reading API doesn't allow us to distinguish
+    # absence of a submission from an ungraded submission. Non-Canvas LMSes in
+    # theory require a grade).
+    current_score = lti_outcomes_client.read_result(outcome_request_params)
+    if current_score is None:
+        speedgrader_launch_params = {"focused_user": parsed_params["h_username"]}
+        if parsed_params.get("document_url"):
+            speedgrader_launch_params["url"] = parsed_params.get("document_url")
+        elif parsed_params.get("canvas_file_id"):
+            speedgrader_launch_params["canvas_file"] = "true"
+            speedgrader_launch_params["file_id"] = parsed_params["canvas_file_id"]
+
+        speedgrader_launch_url = request.route_url(
+            "lti_launches", _query=speedgrader_launch_params
+        )
+
+        lti_outcomes_client.record_result(
+            outcome_request_params,
+            lti_launch_url=speedgrader_launch_url,
+            submitted_at=datetime.datetime(2001, 1, 1, tzinfo=timezone.utc),
+        )
+
+    return {}

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -3,7 +3,7 @@ from datetime import timezone
 
 from pyramid.view import view_config
 
-from lms.validation import ApiRecordSubmissionSchema
+from lms.validation import APIRecordSubmissionSchema
 from lms.services.lti_outcomes import LTIOutcomesRequestParams
 
 
@@ -11,7 +11,7 @@ from lms.services.lti_outcomes import LTIOutcomesRequestParams
     request_method="POST",
     route_name="lti_api.submissions.record",
     renderer="json",
-    schema=ApiRecordSubmissionSchema,
+    schema=APIRecordSubmissionSchema,
 )
 def record_submission(request):
     """

--- a/tests/lms/test_routes.py
+++ b/tests/lms/test_routes.py
@@ -44,4 +44,5 @@ class TestIncludeMe:
             mock.call.add_route(
                 "canvas_api.files.via_url", "/api/canvas/files/{file_id}/via_url"
             ),
+            mock.call.add_route("lti_api.submissions.record", "/api/lti/submissions"),
         ]

--- a/tests/lms/validation/_api_test.py
+++ b/tests/lms/validation/_api_test.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+
+from lms.validation import ValidationError
+from lms.validation._api import ApiRecordSubmissionSchema
+
+
+class TestApiRecordSubmissionSchema:
+    def test_it_parses_request(self, pyramid_request, all_fields):
+        pyramid_request.body = json.dumps(all_fields)
+
+        schema = ApiRecordSubmissionSchema(pyramid_request)
+        parsed_params = schema.parse()
+
+        assert parsed_params == all_fields
+
+    @pytest.mark.parametrize(
+        "field", ["h_username", "lis_outcome_service_url", "lis_result_sourcedid"]
+    )
+    def test_it_raises_if_required_fields_missing(
+        self, pyramid_request, all_fields, field
+    ):
+        del all_fields[field]
+        pyramid_request.body = json.dumps(all_fields)
+
+        schema = ApiRecordSubmissionSchema(pyramid_request)
+
+        with pytest.raises(ValidationError):
+            schema.parse()
+
+    @pytest.mark.parametrize("field", ["document_url", "canvas_file_id"])
+    def test_it_doesnt_raise_if_optional_fields_missing(
+        self, pyramid_request, all_fields, field
+    ):
+        del all_fields[field]
+        pyramid_request.body = json.dumps(all_fields)
+
+        schema = ApiRecordSubmissionSchema(pyramid_request)
+        schema.parse()
+
+    @pytest.fixture
+    def all_fields(self):
+        return {
+            "document_url": "https://example.com",
+            "canvas_file_id": "file123",
+            "h_username": "user123",
+            "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
+            "lis_result_sourcedid": "modelstudent-assignment1",
+        }

--- a/tests/lms/validation/_api_test.py
+++ b/tests/lms/validation/_api_test.py
@@ -3,14 +3,14 @@ import json
 import pytest
 
 from lms.validation import ValidationError
-from lms.validation._api import ApiRecordSubmissionSchema
+from lms.validation._api import APIRecordSubmissionSchema
 
 
-class TestApiRecordSubmissionSchema:
+class TestAPIRecordSubmissionSchema:
     def test_it_parses_request(self, pyramid_request, all_fields):
         pyramid_request.body = json.dumps(all_fields)
 
-        schema = ApiRecordSubmissionSchema(pyramid_request)
+        schema = APIRecordSubmissionSchema(pyramid_request)
         parsed_params = schema.parse()
 
         assert parsed_params == all_fields
@@ -24,7 +24,7 @@ class TestApiRecordSubmissionSchema:
         del all_fields[field]
         pyramid_request.body = json.dumps(all_fields)
 
-        schema = ApiRecordSubmissionSchema(pyramid_request)
+        schema = APIRecordSubmissionSchema(pyramid_request)
 
         with pytest.raises(ValidationError):
             schema.parse()
@@ -36,7 +36,7 @@ class TestApiRecordSubmissionSchema:
         del all_fields[field]
         pyramid_request.body = json.dumps(all_fields)
 
-        schema = ApiRecordSubmissionSchema(pyramid_request)
+        schema = APIRecordSubmissionSchema(pyramid_request)
         schema.parse()
 
     @pytest.fixture

--- a/tests/lms/views/api/lti_test.py
+++ b/tests/lms/views/api/lti_test.py
@@ -1,0 +1,111 @@
+import datetime
+from datetime import timezone
+from unittest import mock
+from urllib.parse import urlencode
+
+import pytest
+
+from lms.views.api.lti import record_submission
+from lms.services.lti_outcomes import LTIOutcomesClient, LTIOutcomesRequestParams
+from lms.services.application_instance_getter import ApplicationInstanceGetter
+
+
+class TestRecordSubmission:
+    def test_it_passes_correct_params_to_read_current_score(
+        self, pyramid_request, lti_outcomes_client
+    ):
+        record_submission(pyramid_request)
+
+        lti_outcomes_client.read_result.assert_called_once_with(
+            LTIOutcomesRequestParams(
+                consumer_key="TEST_OAUTH_CONSUMER_KEY",
+                shared_secret="oauth-secret",
+                lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
+                lis_result_sourcedid="modelstudent-assignment1",
+            )
+        )
+
+    def test_it_does_not_record_result_if_score_already_exists(
+        self, pyramid_request, lti_outcomes_client
+    ):
+        lti_outcomes_client.read_result.return_value = 0.5
+
+        record_submission(pyramid_request)
+
+        lti_outcomes_client.record_result.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "document_url,canvas_file_id,lti_launch_doc_params",
+        [
+            ("https://example.com", None, {"url": "https://example.com"}),
+            (None, "file123", {"canvas_file": "true", "file_id": "file123"}),
+        ],
+    )
+    def test_it_records_result_if_no_score_exists(
+        self,
+        pyramid_request,
+        lti_outcomes_client,
+        document_url,
+        canvas_file_id,
+        lti_launch_doc_params,
+    ):
+        pyramid_request.parsed_params.update(
+            {"document_url": document_url, "canvas_file_id": canvas_file_id}
+        )
+        lti_outcomes_client.read_result.return_value = None
+
+        record_submission(pyramid_request)
+
+        expected_outcome_params = LTIOutcomesRequestParams(
+            consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            shared_secret="oauth-secret",
+            lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
+            lis_result_sourcedid="modelstudent-assignment1",
+        )
+        expected_submitted_at = datetime.datetime(2001, 1, 1, tzinfo=timezone.utc)
+        expected_launch_url = "http://example.com/lti_launches?" + urlencode(
+            {"focused_user": "user123", **lti_launch_doc_params}
+        )
+        lti_outcomes_client.record_result.assert_called_once_with(
+            expected_outcome_params,
+            lti_launch_url=expected_launch_url,
+            submitted_at=expected_submitted_at,
+        )
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.parsed_params = {
+            # Information that is needed to construct the LTI launch URL for
+            # Canvas's SpeedGrader.
+            "h_username": "user123",
+            # In practice, only one of `document_url` or `cnavas_file_id` will
+            # be set.
+            "document_url": "https://example.com",
+            "canvas_file_id": "file456",
+            # Metadata provided by LMS for requests to LTI Outcomes Management
+            # service.
+            "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
+            "lis_result_sourcedid": "modelstudent-assignment1",
+        }
+        return pyramid_request
+
+
+@pytest.fixture(autouse=True)
+def lti_outcomes_client(pyramid_config):
+    svc = mock.create_autospec(LTIOutcomesClient, instance=True, spec_set=True)
+    pyramid_config.register_service(svc, name="lti_outcomes_client")
+    return svc
+
+
+@pytest.fixture(autouse=True)
+def ai_getter(pyramid_config):
+    svc = mock.create_autospec(ApplicationInstanceGetter, instance=True, spec_set=True)
+
+    def shared_secret(consumer_key):
+        if consumer_key != "TEST_OAUTH_CONSUMER_KEY":
+            raise Exception("Incorrect consumer key")
+        return "oauth-secret"
+
+    svc.shared_secret.side_effect = shared_secret
+    pyramid_config.register_service(svc, name="ai_getter")
+    return svc


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/864**

Add an API endpoint to record a grading LTI launch URL in SpeedGrader

Add an API endpoint that the frontend will use to record a
grading-oriented LTI launch URL in Canvas's SpeedGrader for use when a teacher
grades the current user's annotations on an assignment.

This operation will be triggered by the frontend rather than by the
backend during the /lti_launches request, where all the necessary
information is already available, because it involves making (possibly
slow) calls to the external LMS. Instead these potentially slow
operations can happen concurrently with the assignment loading in the
user's browser.

 - Add `/api/lti/submissions` endpoint to record SpeedGrader Launch URL
 - Add schema to validate JSON body of requests to this endpoint