### PR TITLE
Add fallback error handler for `/api/*` routes

### DIFF
--- a/lms/views/api/error.py
+++ b/lms/views/api/error.py
@@ -41,3 +41,14 @@ def forbidden(request):
 def notfound(request):
     request.response.status_int = 404
     return {"message": _("Endpoint not found")}
+
+
+@exception_view_config(path_info="/api/*", context=Exception, renderer="json")
+def api_error(request):
+    """Fallback error handler for frontend API requests."""
+    request.response.status_int = 500
+
+    # Exception details are not reported here to avoid leaking internal information.
+    return {
+        "message": "A problem occurred while handling this request. Hypothesis has been notified."
+    }

--- a/tests/lms/views/api/error_test.py
+++ b/tests/lms/views/api/error_test.py
@@ -48,7 +48,7 @@ class TestForbidden:
         assert result["message"] == "You're not authorized to view this page"
 
 
-class TestApiError:
+class TestAPIError:
     def test_it(self, pyramid_request):
         json_data = error.api_error(pyramid_request)
 

--- a/tests/lms/views/api/error_test.py
+++ b/tests/lms/views/api/error_test.py
@@ -46,3 +46,13 @@ class TestForbidden:
         result = error.forbidden(pyramid_request)
 
         assert result["message"] == "You're not authorized to view this page"
+
+
+class TestApiError:
+    def test_it(self, pyramid_request):
+        json_data = error.api_error(pyramid_request)
+
+        assert pyramid_request.response.status_code == 500
+        assert json_data == {
+            "message": "A problem occurred while handling this request. Hypothesis has been notified."
+        }


### PR DESCRIPTION
Add a fallback error handler for `/api/*` routes so that unhandled
exceptions result in JSON rather than HTML responses, to be consistent
with the frontend's expectations.