### PR TITLE
SpeedGrader 3/n - Call API view to record a submission when a student starts an assignment

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -6,6 +6,16 @@ import { ApiError } from '../../utils/api';
 
 import BasicLtiLaunchApp, { $imports } from '../BasicLtiLaunchApp';
 
+/**
+ * Return a Promise that resolves on the next turn of the event loop.
+ *
+ * This gives any pending async microtasks a chance to execute.
+ * See https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/.
+ */
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve));
+}
+
 describe('BasicLtiLaunchApp', () => {
   let fakeApiCall;
   let FakeAuthWindow;
@@ -79,7 +89,7 @@ describe('BasicLtiLaunchApp', () => {
     it('attempts to fetch the content URL when mounted', async () => {
       const wrapper = renderLtiLaunchApp();
 
-      await fakeApiCall.returnValues[0];
+      await nextTick();
 
       assert.calledWith(fakeApiCall, {
         authToken: 'dummyAuthToken',
@@ -95,7 +105,7 @@ describe('BasicLtiLaunchApp', () => {
 
       const wrapper = renderLtiLaunchApp();
 
-      await fakeApiCall.returnValues[0];
+      await nextTick();
       wrapper.update();
 
       const iframe = wrapper.find('iframe');
@@ -110,11 +120,7 @@ describe('BasicLtiLaunchApp', () => {
       fakeApiCall.rejects(new ApiError(400, {}));
 
       const wrapper = renderLtiLaunchApp();
-      try {
-        await fakeApiCall.returnValues[0];
-      } catch (e) {
-        // Ignored
-      }
+      await nextTick();
 
       // Verify that an "Authorize" prompt is shown.
       wrapper.update();
@@ -154,11 +160,7 @@ describe('BasicLtiLaunchApp', () => {
         fakeApiCall.rejects(error);
 
         const wrapper = renderLtiLaunchApp();
-        try {
-          await fakeApiCall.returnValues[0];
-        } catch (e) {
-          // Ignored
-        }
+        await nextTick();
 
         // Verify that a "Try again" prompt is shown.
         wrapper.update();
@@ -172,9 +174,7 @@ describe('BasicLtiLaunchApp', () => {
         assert.called(FakeAuthWindow);
 
         // Check that files are fetched after authorization completes.
-        await new Promise(resolve => {
-          setTimeout(resolve, 0);
-        });
+        await nextTick();
         wrapper.update();
         assert.equal(
           wrapper.find('iframe').prop('src'),

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -43,20 +43,28 @@ export class ApiError extends Error {
  * @param options
  * @param {string} options.path - The `/api/...` path of the endpoint to call
  * @param {string} options.authToken
+ * @param {Object} [options.data] - JSON-serializable body of the request
  */
-async function apiCall({ path, authToken }) {
+async function apiCall({ path, authToken, data }) {
+  let body;
+  if (data !== undefined) {
+    body = JSON.stringify(data);
+  }
+
   const result = await fetch(path, {
+    method: data === undefined ? 'GET' : 'POST',
+    body,
     headers: {
       Authorization: authToken,
     },
   });
-  const data = await result.json();
+  const resultJson = await result.json();
 
   if (result.status >= 400 && result.status < 600) {
-    throw new ApiError(result.status, data);
+    throw new ApiError(result.status, resultJson);
   }
 
-  return data;
+  return resultJson;
 }
 
 async function listFiles(authToken, courseId) {

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -1,4 +1,4 @@
-import { ApiError, listFiles } from '../api';
+import { ApiError, apiCall, listFiles } from '../api';
 
 describe('api', () => {
   let fakeResponse;
@@ -17,10 +17,44 @@ describe('api', () => {
     window.fetch.restore();
   });
 
+  describe('apiCall', () => {
+    it('makes a GET request if no body is provided', async () => {
+      await apiCall({ path: '/api/test', authToken: 'auth' });
+
+      assert.calledWith(window.fetch, '/api/test', {
+        method: 'GET',
+        body: undefined,
+        headers: {
+          Authorization: 'auth',
+        },
+      });
+    });
+
+    it('makes a POST request if a body is provided', async () => {
+      const data = { param: 'value' };
+      await apiCall({ path: '/api/test', authToken: 'auth', data });
+
+      assert.calledWith(window.fetch, '/api/test', {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: {
+          Authorization: 'auth',
+        },
+      });
+    });
+
+    it("returns the response's JSON content", async () => {
+      const result = await apiCall({ path: '/api/test', authToken: 'auth' });
+      assert.deepEqual(result, await fakeResponse.json());
+    });
+  });
+
   describe('listFiles', () => {
     it('fetches file data from the backend', async () => {
       const response = listFiles('auth-token', 'course-id');
       assert.calledWith(window.fetch, '/api/canvas/courses/course-id/files', {
+        method: 'GET',
+        body: undefined,
         headers: {
           Authorization: 'auth-token',
         },


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/865**

Call `record_submission` API from frontend during LTI launch

When an assignment is launched by a student/learner, call the
`record_submission` API view provided by the backend to register a
grading LTI launch URL for the current (user, assignment) in Canvas.

This behavior is currently only enabled when the student has the "speedgrader"
feature flag enabled and when the LMS is Canvas.

 - Support making POST requests to API with JSON bodies from frontend

 - Pass params for call to `record_submission` API call to frontend in
   JS config under `submissionParams` key

 - If `submissionParams` key is present in JS config, call
   `record_submission` API from frontend during an LTI launch. This
   happens after the content URL is fetched, but concurrently with the
   content iframe loading.

 - If the frontend call to record a submission fails, replace the iframe
   content with an error, to prevent confusion where the student does
   the work but SpeedGrader does not show a submission.

   The initial error view is currently very basic, it just asks the user
   to reload the page.

 - Tweak the wording of the error display to make it more obvious that
   it comes from Hypothesis and also to make it more generic, as there
   are now different error conditions that can cause it to be displayed.

---

**Testing**

1. Create an assignment using Hypothesis when logged into Canvas as a teacher
2. Launch the assignment when logged in as a teacher - no call to `/api/lti/submissions` should be made
3. Launch the assignment when logged in as a student and the "speedgrader" flag off - no call to /api/lti/submissions` should be made
4. Launch the assignment when logged in as a student and the "speedgrader" flag is on - a call to `POST /api/lti/submissions` should be made with `h_username`, `lis_result_sourcedid` and `lis_outcome_service_url` params in the JSON request
5. Modify the `record_submission` API view to make it throw an exception (`raise Exception("failed")`) will do. When the assignment is launched, it may show the iframe briefly but will then show an error dialog. This is not a very polished error in this PR.
6. Repeat steps (1) and (3) in a non-Canvas LMS, no call to `/api/lti/submissions` should be made