### PR TITLE
SpeedGrader 4/n - Basic implementation of focusing on a user in SpeedGrader

### DIFF
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -68,6 +68,12 @@ class BasicLTILaunchViews:
                 "lis_outcome_service_url", params.get("lis_outcome_service_url")
             )
 
+        # If the launch has been configured to focus on the annotations from
+        # a particular user, translate that into Hypothesis client configuration.
+        focused_user = self.request.params.get("focused_user")
+        if focused_user:
+            self.context.hypothesis_config.update({"query": f"user:{focused_user}"})
+
     @view_config(canvas_file=True)
     def canvas_file_basic_lti_launch(self):
         """

--- a/tests/lms/resources/_lti_launch_test.py
+++ b/tests/lms/resources/_lti_launch_test.py
@@ -1,14 +1,11 @@
 import datetime
 import jwt
 
-from unittest import mock
 import pytest
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.httpexceptions import HTTPBadRequest
 
 from lms import resources
-from lms import models
-from lms.services import ConsumerKeyError
 
 
 class TestLTILaunchResource:
@@ -341,6 +338,11 @@ class TestLTILaunchResource:
         BearerTokenSchema.assert_not_called()
         assert "authToken" not in js_config
 
+    def test_views_can_mutate_js_config(self, lti_launch):
+        lti_launch.js_config.update({"a_key": "a_value"})
+
+        assert lti_launch.js_config["a_key"] == "a_value"
+
     def test_hypothesis_config_raises_if_theres_no_oauth_consumer_key(
         self, pyramid_request
     ):
@@ -412,6 +414,11 @@ class TestLTILaunchResource:
         ai_getter.provisioning_enabled.return_value = False
 
         assert lti_launch.hypothesis_config == {}
+
+    def test_views_can_mutate_hypothesis_config(self, lti_launch):
+        lti_launch.hypothesis_config.update({"a_key": "a_value"})
+
+        assert lti_launch.hypothesis_config["a_key"] == "a_value"
 
     def test_rpc_server_config(self, lti_launch):
         assert lti_launch.rpc_server_config == {

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -68,6 +68,16 @@ class TestBasicLTILaunch:
 
         assert "submissionParams" not in context.js_config
 
+    def test_it_configures_client_to_focus_on_user_if_param_set(
+        self, context, pyramid_request
+    ):
+        context.hypothesis_config = {}
+        pyramid_request.params.update({"focused_user": "user123"})
+
+        BasicLTILaunchViews(context, pyramid_request)
+
+        assert context.hypothesis_config["query"] == "user:user123"
+
 
 class TestCanvasFileBasicLTILaunch:
     def test_it_configures_frontend(self, context, pyramid_request):


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/865 and https://github.com/hypothesis/lms/pull/867**

This PR implements focusing on the target student in SpeedGrader in the most basic possible way, by pre-filling the search bar with `user:<username>` where `<username>` is the auto-generated hex digit string that serves as the username for provisioned users in the LMS app.

- Make `context.hypothesis_config` mutable in LTI launch views, so that custom configuration can be passed to the client in grading launches
- Respond to the `focused_user` LTI launch param added in https://github.com/hypothesis/lms/pull/865 by adding `{"query":"user:<username>"}` to the Hypothesis client's configuration