### PR TITLE
SpeedGrader 5/n - Workaround SpeedGrader launch URL encoding bug

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -57,7 +57,10 @@ from lms.validation._oauth import (
     CanvasAccessTokenResponseSchema,
     CanvasRefreshTokenResponseSchema,
 )
-from lms.validation._launch_params import LaunchParamsSchema
+from lms.validation._launch_params import (
+    LaunchParamsSchema,
+    URLConfiguredLaunchParamsSchema,
+)
 from lms.validation._bearer_token import BearerTokenSchema
 from lms.validation._module_item_configuration import ConfigureModuleItemSchema
 from lms.validation._canvas import (
@@ -74,6 +77,7 @@ __all__ = (
     "CanvasRefreshTokenResponseSchema",
     "BearerTokenSchema",
     "LaunchParamsSchema",
+    "URLConfiguredLaunchParamsSchema",
     "ConfigureModuleItemSchema",
     "CanvasListFilesResponseSchema",
     "CanvasPublicURLResponseSchema",

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -55,6 +55,14 @@ def record_submission(request):
     # theory require a grade).
     current_score = lti_outcomes_client.read_result(outcome_request_params)
     if current_score is None:
+        # **WARNING**
+        #
+        # Canvas has a bug with handling of percent-encoded characters in the
+        # the SpeedGrader launch URL. Code that responds to the launch will
+        # need to handle this for fields that may contain such chars (eg.
+        # the "url" field).
+        #
+        # See https://github.com/instructure/canvas-lms/issues/1486
         speedgrader_launch_params = {"focused_user": parsed_params["h_username"]}
         if parsed_params.get("document_url"):
             speedgrader_launch_params["url"] = parsed_params.get("document_url")

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -15,7 +15,11 @@ from pyramid.view import view_config, view_defaults
 
 from lms.models import ModuleItemConfiguration
 from lms.views.helpers import via_url
-from lms.validation import BearerTokenSchema, ConfigureModuleItemSchema
+from lms.validation import (
+    BearerTokenSchema,
+    ConfigureModuleItemSchema,
+    URLConfiguredLaunchParamsSchema,
+)
 from lms.views.decorators import (
     upsert_h_user,
     upsert_course_group,
@@ -133,7 +137,7 @@ class BasicLTILaunchViews:
 
         return {}
 
-    @view_config(url_configured=True)
+    @view_config(url_configured=True, schema=URLConfiguredLaunchParamsSchema)
     def url_configured_basic_lti_launch(self):
         """
         Respond to a URL-configured assignment launch.
@@ -145,7 +149,8 @@ class BasicLTILaunchViews:
         LMS, which passes it back to us in each launch request. All we have to
         do is pass the URL to Via.
         """
-        self._set_via_url(self.request.params["url"])
+        url = self.request.parsed_params["url"]
+        self._set_via_url(url)
 
         return {}
 

--- a/tests/lms/validation/_launch_params_test.py
+++ b/tests/lms/validation/_launch_params_test.py
@@ -2,7 +2,11 @@ import pytest
 from pyramid.httpexceptions import HTTPUnprocessableEntity
 
 from lms.services import LTILaunchVerificationError
-from lms.validation import LaunchParamsSchema, ValidationError
+from lms.validation import (
+    LaunchParamsSchema,
+    ValidationError,
+    URLConfiguredLaunchParamsSchema,
+)
 from lms.values import LTIUser
 
 
@@ -69,4 +73,69 @@ class TestLaunchParamsSchema:
             "oauth_version": "TEST_OAUTH_VERSION",
             "roles": "TEST_ROLES",
         }
+        return pyramid_request
+
+
+class TestURLConfiguredLaunchParamsSchema:
+    @pytest.mark.parametrize(
+        "url_param, expected_parsed_url",
+        [
+            (
+                "https%3A%2F%2Fexample.com%2Fpath%3Fparam%3Dvalue",
+                "https://example.com/path?param=value",
+            ),
+            (
+                "http%3A%2F%2Fexample.com%2Fpath%3Fparam%3Dvalue",
+                "http://example.com/path?param=value",
+            ),
+            (
+                "http%3a%2F%2Fexample.com%2Fpath%3Fparam%3Dvalue",
+                "http://example.com/path?param=value",
+            ),
+        ],
+    )
+    def test_it_decodes_url_if_percent_encoded(
+        self, schema, set_url, url_param, expected_parsed_url
+    ):
+        set_url(url_param)
+        params = schema.parse()
+        assert params["url"] == expected_parsed_url
+
+    @pytest.mark.parametrize(
+        "url_param",
+        [
+            "https://example.com/path?param=value",
+            "http://example.com/path?param=%25foo%25",
+        ],
+    )
+    def test_it_doesnt_decode_url_if_not_percent_encoded(
+        self, schema, set_url, url_param
+    ):
+        set_url(url_param)
+        params = schema.parse()
+        assert params["url"] == url_param
+
+    def test_it_raises_if_url_not_present(self, schema):
+        with pytest.raises(ValidationError) as exc_info:
+            schema.parse()
+
+        assert exc_info.value.messages == dict(
+            [("url", ["Missing data for required field."])]
+        )
+
+    @pytest.fixture
+    def set_url(self, pyramid_request):
+        def set_url_(url):
+            pyramid_request.GET["url"] = url
+            pyramid_request.POST["url"] = url
+
+        return set_url_
+
+    @pytest.fixture
+    def schema(self, pyramid_request):
+        return URLConfiguredLaunchParamsSchema(pyramid_request)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.content_type = "application/x-www-form-urlencoded"
         return pyramid_request

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -136,7 +136,8 @@ class TestURLConfiguredBasicLTILaunch:
     def test_it_configures_via_url(
         self, context, pyramid_request, lti_outcome_params, via_url
     ):
-        pyramid_request.params = {"url": "TEST_URL", **lti_outcome_params}
+        pyramid_request.params.update(**lti_outcome_params)
+        pyramid_request.parsed_params = {"url": "TEST_URL"}
 
         BasicLTILaunchViews(context, pyramid_request).url_configured_basic_lti_launch()
 


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/865 and https://github.com/hypothesis/lms/pull/867**

Query params in LTI launch URLs submitted to Canvas for use in SpeedGrader get
doubly-encoded so they are still percent-encoded after Pyramid/WSGI have parsed
the request. Implement a workaround by decoding the query param a second time in
the LTI Launch view and signpost the potential issue when generating the
SpeedGrader launch URL.

More generic solutions are possible, but they could have unexpected interactions
with different parts of the system. Therefore this PR just handles the one query
param where this is a problem.

Fixes https://github.com/hypothesis/lms/issues/869