### PR TITLE
Run gunicorn and gulp in one terminal with Honcho

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ help:
 	@echo "make help              Show this help message"
 	@echo 'make services          Run the services that `make dev` requires'
 	@echo "                       (Postgres) in Docker"
-	@echo "make dev               Run the app in the development server"
+	@echo "make dev               Run the entire app (web server and other processes)"
+	@echo "make web               Run the web server on its own (useful for debugging the "
+	@echo "                       Python code with pdb)"
+	@echo "make assets            Run the assets build on its own, with live reloading "
+	@echo '                       (goes well with `make web` and useful for debugging '
+	@echo "                       gulp)"
 	@echo "make shell             Launch a Python shell in the dev environment"
 	@echo "make sql               Connect to the dev database with a psql shell"
 	@echo "make lint              Run the code linter(s) and print any warnings"
@@ -29,7 +34,15 @@ services:
 
 .PHONY: dev
 dev: build/manifest.json
+	tox -q -e py36-dev -- honcho start ${processes}
+
+.PHONY: web
+web:
 	tox -q -e py36-dev
+
+.PHONY: assets
+assets:
+	$(GULP) watch
 
 .PHONY: shell
 shell:

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web:    make web
+assets: make assets

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,3 +4,4 @@
 pip-tools
 pyramid_debugtoolbar
 pyramid_ipython
+honcho


### PR DESCRIPTION
Change `make dev` to run both gunicorn (development web server) and `gulp watch` (frontend assets build) in one terminal, using Honcho to interleave the stdouts of both processes into the one terminal. (honcho is added as a new dev dependency and will be automatically installed by tox.)

The end result is that you just run `make dev` as before but it'll now run both gunicorn and gulp. You no longer need to run gulp separately yourself.

Also:

* `make web` is a new command that now does what `make dev` used to do: runs the web server on its own, so you can debug it 

* `make assets` is a new command that runs `gulp watch` on its own so you can debug it

* Procfile is honcho's config file, which configures `honcho start` to run `make web` and `make assets` simultaneously in one terminal.

  Procfile calls Makefile to run `make web` and `make assets`. This avoids duplicating the actual tox and gulp commands that underlie `make web` and `make assets`. Makefile remains the single source of truth for these underlying commands.

* `make dev` is now just a wrapper for `honcho start`: it calls `honcho start` to run `make web` and `make assets` simultaneously

Debugging
---------

Unfortunately Honcho does mean that, when running `make dev`, neither the gunicorn or the gulp process is connected to your terminal's stdin: Honcho is. This means that you can't interactively debug gunicorn or gulp. For example you can't debug the Python code with pdb. Even if Honcho could echo your stdin to the gunicorn process (which it can't) it wouldn't be much fun to try to interact with pdb in a terminal while gulp's stdout is being printed to the same terminal.

That's why `make web` and `make assets` are here as separate commands from `make dev`: if you want to use an interactive debugger with the gunicorn or gulp process, you should open two terminal tabs or windows and run `make web` in one and `make assets` in the other. Starting the processes in this way is less convenient than `make dev` but it means that each process is running in its own terminal and on its own (no Honcho), so you can debug in peace.

Running only some processes
---------------------------

You can also tell `make dev` which processes to start, instead of starting all of them:

    $ make dev processes=web
    $ make dev processes=assets
    $ make dev processes='web assets'

This is just an alias for `honcho start [PROCESS...]`. This isn't particularly interesting in an app that only has two Honcho processes but might be more useful in an app with more processes, for example to run all of the processes bar one (so that you can then run that one process separately and debug it).

(It might be convenient if you could use `-` to _subtract_ processes. So `make dev processes=-web` would run all the processes in Procfile _except_ the web one, and you could then run `make web` separately. Honcho doesn't support this AFAIK.)

Running Honcho directly
-----------------------

Although `make dev` is intended to act as a wrapper, you can of course also run Honcho directly. To have tox install Honcho for you and then run tox's version of Honcho via tox directly (bypassing make):

    $ tox -qe py36-dev -- honcho --help

Or to run Honcho directly bypassing both tox and make:

    $ .tox/py36-dev/bin/honcho --help

That does require you to have run `make dev` or `make web` or something previously, so that `.tox/py36-dev/` will exist and honcho will have been installed in it.

If you have installed honcho yourself and it's on your $PATH you can bypass both make and tox and just run honcho directly:

    $ honcho start ...

and this will work with our Procfile.