### PR TITLE
Rename low-level h API service to `HAPIRequests`/`h_api_requests`

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -27,7 +27,7 @@ __all__ = (
 
 def includeme(config):
     config.register_service_factory(
-        "lms.services.hapi.HypothesisAPIService", name="hapi"
+        "lms.services.h_api_requests.HAPIRequests", name="h_api_requests"
     )
     config.register_service_factory(
         "lms.services.h_api_client.HAPIClient", name="h_api_client"

--- a/lms/services/h_api_client.py
+++ b/lms/services/h_api_client.py
@@ -13,7 +13,7 @@ class HAPIClient:
     """
 
     def __init__(self, _context, request):
-        self._hapi_svc = request.find_service(name="hapi")
+        self._h_api = request.find_service(name="h_api_requests")
         self._request = request
 
     def get_user(self, username):
@@ -27,7 +27,7 @@ class HAPIClient:
         userid = HUser(authority, username).userid
 
         # nb. Raises `HAPIError` if the request fails for any reason.
-        user_info = self._hapi_svc.get(path=f"users/{userid}").json()
+        user_info = self._h_api.get(path=f"users/{userid}").json()
 
         return HUser(
             authority=authority,

--- a/lms/services/h_api_requests.py
+++ b/lms/services/h_api_requests.py
@@ -8,10 +8,10 @@ from lms.services import HAPIError
 from lms.services import HAPINotFoundError
 
 
-__all__ = ["HypothesisAPIService"]
+__all__ = ["HAPIRequests"]
 
 
-class HypothesisAPIService:
+class HAPIRequests:
     """
     Low-level API service.
 
@@ -24,7 +24,7 @@ class HypothesisAPIService:
 
     def __init__(self, _context, request):
         """
-        Return a new HypothesisAPIService object.
+        Return a new HAPIRequests object.
 
         :arg _context: the Pyramid context resource
         :arg request: the Pyramid request

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -25,7 +25,7 @@ def upsert_h_user(wrapped):
         if not context.provisioning_enabled:
             return wrapped(context, request)
 
-        hapi_svc = request.find_service(name="hapi")
+        hapi_svc = request.find_service(name="h_api_requests")
 
         user_data = {
             "username": context.h_username,
@@ -77,7 +77,7 @@ def upsert_course_group(wrapped):
         if not context.provisioning_enabled:
             return wrapped(context, request)
 
-        hapi_svc = request.find_service(name="hapi")
+        hapi_svc = request.find_service(name="h_api_requests")
 
         is_instructor = any(
             role in request.lti_user.roles.lower()
@@ -125,7 +125,7 @@ def add_user_to_group(wrapped):
             return wrapped(context, request)
 
         try:
-            request.find_service(name="hapi").post(
+            request.find_service(name="h_api_requests").post(
                 f"groups/{context.h_groupid}/members/{context.h_userid}"
             )
         except HAPIError as err:

--- a/tests/lms/services/h_api_client_test.py
+++ b/tests/lms/services/h_api_client_test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from lms.services import HAPIError
-from lms.services.hapi import HypothesisAPIService
+from lms.services.h_api_requests import HAPIRequests
 from lms.services.h_api_client import HAPIClient
 from lms.values import HUser
 
@@ -35,6 +35,6 @@ class TestHAPIClient:
 
     @pytest.fixture
     def h_api(self, pyramid_config):
-        svc = mock.create_autospec(HypothesisAPIService, instance=True)
-        pyramid_config.register_service(svc, name="hapi")
+        svc = mock.create_autospec(HAPIRequests, instance=True)
+        pyramid_config.register_service(svc, name="h_api_requests")
         return svc

--- a/tests/lms/services/h_api_requests_test.py
+++ b/tests/lms/services/h_api_requests_test.py
@@ -9,7 +9,7 @@ from requests import Response
 from requests import TooManyRedirects
 
 from lms.resources import LTILaunchResource
-from lms.services.hapi import HypothesisAPIService
+from lms.services.h_api_requests import HAPIRequests
 from lms.services import HAPIError
 from lms.services import HAPINotFoundError
 
@@ -25,11 +25,11 @@ class TestAPIRequest:
         del pyramid_request.registry.settings[setting]
 
         with pytest.raises(KeyError, match=setting):
-            HypothesisAPIService(None, pyramid_request)
+            HAPIRequests(None, pyramid_request)
 
     @pytest.mark.parametrize("verb", ["DELETE", "GET", "PATCH", "POST", "PUT"])
     def test_it_sends_requests_to_the_h_api(self, pyramid_request, requests, svc, verb):
-        # Retrieve the method to call, e.g. HypothesisAPIService.delete() or .get().
+        # Retrieve the method to call, e.g. HAPIRequests.delete() or .get().
         method = getattr(svc, verb.lower())
 
         method("path")
@@ -151,8 +151,8 @@ class TestAPIRequest:
 
     @pytest.fixture(autouse=True)
     def requests(self, patch):
-        return patch("lms.services.hapi.requests")
+        return patch("lms.services.h_api_requests.requests")
 
     @pytest.fixture
     def svc(self, context, pyramid_request):
-        return HypothesisAPIService(context, pyramid_request)
+        return HAPIRequests(context, pyramid_request)

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -8,7 +8,7 @@ from requests import Response
 from lms.services import HAPIError
 from lms.services import HAPINotFoundError
 from lms.views.decorators import h_api
-from lms.services.hapi import HypothesisAPIService
+from lms.services.h_api_requests import HAPIRequests
 from lms.resources import LTILaunchResource
 from lms.values import LTIUser
 
@@ -322,12 +322,12 @@ def wrapped():
 
 @pytest.fixture
 def hapi_svc(patch, pyramid_config):
-    hapi_svc = mock.create_autospec(HypothesisAPIService, spec_set=True, instance=True)
+    hapi_svc = mock.create_autospec(HAPIRequests, spec_set=True, instance=True)
     hapi_svc.patch.return_value = mock.create_autospec(
         Response, instance=True, status_code=200, reason="OK", text=""
     )
     hapi_svc.post.return_value = mock.create_autospec(
         Response, instance=True, status_code=200, reason="OK", text=""
     )
-    pyramid_config.register_service(hapi_svc, name="hapi")
+    pyramid_config.register_service(hapi_svc, name="h_api_requests")
     return hapi_svc


### PR DESCRIPTION
Follow up on [1] by renaming the low-level h API service to
`HAPIRequests`, to contrast with the high-level h API service
`HAPIClient`.

[1] https://github.com/hypothesis/lms/pull/888#issuecomment-521261199