### PR TITLE
Combine `LTILaunchResource` h user properties into `h_user`

### DIFF
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -65,7 +65,7 @@ class BasicLTILaunchViews:
         ):
             self.context.js_config["submissionParams"] = {}
 
-            self._set_submission_param("h_username", context.h_username)
+            self._set_submission_param("h_username", context.h_user.username)
             self._set_submission_param(
                 "lis_result_sourcedid", params.get("lis_result_sourcedid")
             )

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -28,8 +28,8 @@ def upsert_h_user(wrapped):
         hapi_svc = request.find_service(name="hapi")
 
         user_data = {
-            "username": context.h_username,
-            "display_name": context.h_display_name,
+            "username": context.h_user.username,
+            "display_name": context.h_user.display_name,
             "authority": request.registry.settings["h_authority"],
             "identities": [
                 {
@@ -42,8 +42,8 @@ def upsert_h_user(wrapped):
         try:
             try:
                 hapi_svc.patch(
-                    f"users/{context.h_username}",
-                    {"display_name": context.h_display_name},
+                    f"users/{context.h_user.username}",
+                    {"display_name": context.h_user.display_name},
                 )
             except HAPINotFoundError:
                 # Call the h API to create the user in h if it doesn't exist already.
@@ -96,7 +96,7 @@ def upsert_course_group(wrapped):
                     hapi_svc.put(
                         f"groups/{context.h_groupid}",
                         {"groupid": context.h_groupid, "name": context.h_group_name},
-                        context.h_userid,
+                        context.h_user.userid,
                     )
                 else:
                     raise HTTPBadRequest("Instructor must launch assignment first.")
@@ -126,7 +126,7 @@ def add_user_to_group(wrapped):
 
         try:
             request.find_service(name="hapi").post(
-                f"groups/{context.h_groupid}/members/{context.h_userid}"
+                f"groups/{context.h_groupid}/members/{context.h_user.userid}"
             )
         except HAPIError as err:
             raise HTTPInternalServerError(explanation=err.explanation) from err

--- a/tests/lms/resources/_lti_launch_test.py
+++ b/tests/lms/resources/_lti_launch_test.py
@@ -143,10 +143,10 @@ class TestLTILaunchResource:
     def test_h_display_name(
         self, request_params, expected_display_name, pyramid_request
     ):
-        pyramid_request.params = request_params
+        pyramid_request.params.update(request_params)
 
         assert (
-            resources.LTILaunchResource(pyramid_request).h_display_name
+            resources.LTILaunchResource(pyramid_request).h_user.display_name
             == expected_display_name
         )
 
@@ -249,18 +249,18 @@ class TestLTILaunchResource:
         ):
             resources.LTILaunchResource(pyramid_request).h_provider_unique_id
 
-    def test_h_username_returns_a_30_char_string(self, pyramid_request):
+    def test_h_user_username_is_a_30_char_string(self, pyramid_request):
         pyramid_request.params = {
             "tool_consumer_instance_guid": "VCSy*G1u3:canvas-lms",
             "user_id": "4533***70d9",
         }
 
-        username = resources.LTILaunchResource(pyramid_request).h_username
+        username = resources.LTILaunchResource(pyramid_request).h_user.username
 
         assert isinstance(username, str)
         assert len(username) == 30
 
-    def test_h_username_raises_if_tool_consumer_instance_guid_is_missing(
+    def test_h_user_raises_if_tool_consumer_instance_guid_is_missing(
         self, pyramid_request
     ):
         pyramid_request.params = {"user_id": "4533***70d9"}
@@ -269,44 +269,25 @@ class TestLTILaunchResource:
             HTTPBadRequest,
             match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
         ):
-            resources.LTILaunchResource(pyramid_request).h_username
+            resources.LTILaunchResource(pyramid_request).h_user
 
-    def test_h_username_raises_if_user_id_is_missing(self, pyramid_request):
+    def test_h_user_raises_if_user_id_is_missing(self, pyramid_request):
         pyramid_request.params = {"tool_consumer_instance_guid": "VCSy*G1u3:canvas-lms"}
 
         with pytest.raises(
             HTTPBadRequest, match='Required parameter "user_id" missing from LTI params'
         ):
-            resources.LTILaunchResource(pyramid_request).h_username
+            resources.LTILaunchResource(pyramid_request).h_user
 
-    def test_h_userid(self, pyramid_request):
+    def test_h_user_userid(self, pyramid_request):
         pyramid_request.params = {
             "tool_consumer_instance_guid": "VCSy*G1u3:canvas-lms",
             "user_id": "4533***70d9",
         }
 
-        userid = resources.LTILaunchResource(pyramid_request).h_userid
+        userid = resources.LTILaunchResource(pyramid_request).h_user.userid
 
         assert userid == "acct:2569ad7b99f316ecc7dfee5c0c801c@TEST_AUTHORITY"
-
-    def test_h_userid_raises_if_tool_consumer_instance_guid_is_missing(
-        self, pyramid_request
-    ):
-        pyramid_request.params = {"user_id": "4533***70d9"}
-
-        with pytest.raises(
-            HTTPBadRequest,
-            match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
-        ):
-            resources.LTILaunchResource(pyramid_request).h_userid
-
-    def test_h_userid_raises_if_user_id_is_missing(self, pyramid_request):
-        pyramid_request.params = {"tool_consumer_instance_guid": "VCSy*G1u3:canvas-lms"}
-
-        with pytest.raises(
-            HTTPBadRequest, match='Required parameter "user_id" missing from LTI params'
-        ):
-            resources.LTILaunchResource(pyramid_request).h_userid
 
     def test_js_config_includes_the_urls(self, pyramid_request):
         js_config = resources.LTILaunchResource(pyramid_request).js_config

--- a/tests/lms/services/hapi_test.py
+++ b/tests/lms/services/hapi_test.py
@@ -12,6 +12,7 @@ from lms.resources import LTILaunchResource
 from lms.services.hapi import HypothesisAPIService
 from lms.services import HAPIError
 from lms.services import HAPINotFoundError
+from lms.values import HUser
 
 
 class TestAPIRequest:
@@ -145,7 +146,7 @@ class TestAPIRequest:
             LTILaunchResource,
             spec_set=True,
             instance=True,
-            h_userid="acct:seanh@TEST_AUTHORITY",
+            h_user=HUser(authority="TEST_AUTHORITY", username="seanh"),
         )
         return context
 

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -26,7 +26,7 @@ class TestBasicLTILaunch:
         BasicLTILaunchViews(context, pyramid_request)
 
         assert context.js_config["submissionParams"] == {
-            "h_username": context.h_username,
+            "h_username": context.h_user.username,
             "lis_result_sourcedid": "modelstudent-assignment1",
             "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
         }

--- a/tests/lms/views/decorators/h_api_test.py
+++ b/tests/lms/views/decorators/h_api_test.py
@@ -10,7 +10,7 @@ from lms.services import HAPINotFoundError
 from lms.views.decorators import h_api
 from lms.services.hapi import HypothesisAPIService
 from lms.resources import LTILaunchResource
-from lms.values import LTIUser
+from lms.values import HUser, LTIUser
 
 
 @pytest.mark.usefixtures("hapi_svc")
@@ -62,10 +62,8 @@ class TestUpsertHUser:
 
         hapi_svc.post.assert_not_called()
 
-    def test_it_raises_if_h_username_raises(
-        self, upsert_h_user, context, pyramid_request
-    ):
-        type(context).h_username = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
+    def test_it_raises_if_h_user_raises(self, upsert_h_user, context, pyramid_request):
+        type(context).h_user = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
 
         with pytest.raises(HTTPBadRequest, match="Oops"):
             upsert_h_user(context, pyramid_request)
@@ -289,11 +287,13 @@ def context():
         LTILaunchResource,
         spec_set=True,
         instance=True,
-        h_display_name="test_display_name",
+        h_user=HUser(
+            authority="TEST_AUTHORITY",
+            username="test_username",
+            display_name="test_display_name",
+        ),
         h_groupid="test_groupid",
         h_group_name="test_group_name",
-        h_username="test_username",
-        h_userid="acct:test_username@TEST_AUTHORITY",
         h_provider="test_provider",
         h_provider_unique_id="test_provider_unique_id",
         provisioning_enabled=True,


### PR DESCRIPTION
Combine `LTILaunchResource.h_{username, display_name, userid}`
properties into a single `h_user` property which returns an `HUser`.

This removes the duplication of logic for generating the userid from the
username and authority between `LTILaunchResource` and `HUser`. In
future it will also make it possible to add other convenience properties
to `HUser`.

This is a follow-up to [1]

[1] https://github.com/hypothesis/lms/pull/888#pullrequestreview-274807714