### PR TITLE
Fix Dialog component overflow issue

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -4,7 +4,6 @@ import propTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Button from './Button';
-import { zIndexScale } from '../utils/style';
 
 /**
  * Accessibility notes:
@@ -68,17 +67,14 @@ export default function Dialog({
 
   return (
     <div
+      className="Dialog__background"
       role="dialog"
       aria-labelledby="Dialog__title"
       onKeyDown={handleKey}
       tabIndex="0"
       ref={rootEl}
     >
-      <div
-        className="Dialog__background"
-        style={{ zIndex: zIndexScale.dialogBackground }}
-      />
-      <div className="Dialog__container" style={{ zIndex: zIndexScale.dialog }}>
+      <div className="Dialog__dimension">
         <div
           className={classNames({
             Dialog__content: true,
@@ -100,6 +96,7 @@ export default function Dialog({
           </h1>
           {children}
           <div className="u-stretch" />
+          <div className="Dialog__fill" />
           <div className="Dialog__actions">
             {onCancel && (
               <Button

--- a/lms/static/scripts/frontend_apps/utils/style.js
+++ b/lms/static/scripts/frontend_apps/utils/style.js
@@ -1,4 +1,0 @@
-export const zIndexScale = {
-  dialogBackground: 1,
-  dialog: 2,
-};

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,39 +1,41 @@
-.Dialog__container {
+.Dialog__background {
   display: flex;
   flex-direction: column;
+  /* Center vertically and horizontally. */
   justify-content: center;
   align-items: center;
-  position: fixed;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
-}
 
-.Dialog__background {
-  background-color: black;
-  bottom: 0;
+  overflow: scroll;
+  background-color: rgba(0, 0, 0, 0.5);
+
+  /* Fill the space of the nearest positioned ancestor. */
+  position: absolute;
+  height: 100%;
+  width: 100%;
   left: 0;
-  opacity: 0.5;
-  position: fixed;
-  right: 0;
   top: 0;
 }
 
 .Dialog__content {
+  display: flex;
+  flex-direction: column;
   background-color: white;
   border-radius: 3px;
-  margin-left: auto;
-  margin-right: auto;
   padding: 20px;
+  /* Center the content horizontally in case it's width is overriden. */
+  margin-right: auto;
+  margin-left: auto;
 }
 
 .Dialog__title {
   display: flex;
   align-items: center;
   font-size: $title-font-size;
+}
+
+.Dialog__fill {
+  /* Choose an arbitrarily large flex-grow priority. */
+  flex-grow: 6;
 }
 
 .Dialog__cancel-btn {
@@ -69,4 +71,12 @@
       margin-left: 5px;
     }
   }
+}
+
+.Dialog__dimension {
+  /* Prevent the top of the content from getting cut off */
+  /* when the content height exceeds its ancestor's. */
+  /* See https://css-tricks.com/flexbox-truncated-text/ */
+  min-height: 0;
+  width: 75%;
 }

--- a/lms/static/styles/components/_LMSFilePicker.scss
+++ b/lms/static/styles/components/_LMSFilePicker.scss
@@ -1,8 +1,6 @@
 .LMSFilePicker__dialog {
-  display: flex;
-  flex-direction: column;
-  max-height: 100vh;
+  /* Prevent the Dialog from jumping size when changing state from fetching to fetched. */
+  min-height: 400px;
+  /* Avoid having the dialog be too wide. */
   max-width: 500px;
-  width: 80vw;
-  height: 400px;
 }

--- a/lms/static/styles/components/_URLPicker.scss
+++ b/lms/static/styles/components/_URLPicker.scss
@@ -1,7 +1,4 @@
 .URLPicker__dialog {
-  display: flex;
-  flex-direction: column;
-  width: 80vw;
+  /* Avoid having the dialog be too wide. */
   max-width: 500px;
-  max-height: 300px;
 }


### PR DESCRIPTION
Previously when the Dialog contents overflowed the height of the parent, they would get cut off.
![image](https://user-images.githubusercontent.com/30059933/63396817-45bf3d00-c37d-11e9-8409-f941ae77c4cb.png)


The Dialog configuration by its parent element and the Dialog html and css has been refactored to more concisely and explicitly express their intentions. 

Previous:
![image](https://user-images.githubusercontent.com/30059933/63396623-8c606780-c37c-11e9-9dbb-86770edc9671.png)

Current:
![image](https://user-images.githubusercontent.com/30059933/63396702-cf223f80-c37c-11e9-9519-7ea5dfb81704.png)

Current for soon to be new dialog (See other [PR](https://github.com/hypothesis/lms/pull/859)):
![image](https://user-images.githubusercontent.com/30059933/63397466-7902cb80-c37f-11e9-91e8-f3d38b4ee096.png)


