### PR TITLE
Provide user with error details indicating an incorrect canvas url

### DIFF
--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -255,33 +255,22 @@ class LTILaunchResource:
 
     @property
     def lms_url(self):
+        """Return the ApplicationInstance.lms_url."""
+        oauth_consumer_key = self._request.params.get("oauth_consumer_key")
+        return self._ai_getter.lms_url(oauth_consumer_key)
+
+    @property
+    def custom_canvas_api_domain(self):
         """
-        Return a guess at the top-level URL of the LMS that's embedding us.
-
-        Return a guess at the URL of the top-level LMS page in which we're
-        embedded in an iframe.
-
-        This is used by our Google Picker integration: in order to launch
-        Google Picker within an iframe we need to pass it the top-level URL of
-        the tab the iframe is within, otherwise Google Picker refuses to launch.
+        Return the domain of the Canvas API.
 
         FIXME: Getting this from the custom_canvas_api_domain param isn't quite
         right. This is the domain of the Canvas API which isn't the same thing
         as the domain of the Canvas website (although in practice it always
         seems to match). And of course custom_canvas_api_domain only works in
         Canvas.
-
-        FIXME: Getting this from ApplicationInstance.lms_url isn't very good
-        because that URL is entered by users into our ``/welcome`` form and
-        isn't validated.
         """
-        lms_url = self._request.params.get("custom_canvas_api_domain")
-
-        if not lms_url:
-            oauth_consumer_key = self._request.params.get("oauth_consumer_key")
-            lms_url = self._ai_getter.lms_url(oauth_consumer_key)
-
-        return lms_url
+        return self._request.params.get("custom_canvas_api_domain")
 
     def _get_param(self, param_name):
         """Return the named param from the request or raise a 400."""

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -38,6 +38,7 @@ export default function FilePickerApp({
     googleDeveloperKey,
     lmsName,
     lmsUrl,
+    registeredLmsUrl,
     ltiLaunchUrl,
   } = useContext(Config);
 
@@ -135,6 +136,7 @@ export default function FilePickerApp({
           authUrl={authUrl}
           courseId={courseId}
           lmsName={lmsName}
+          registeredLmsUrl={registeredLmsUrl}
           onCancel={cancelDialog}
           onSelectFile={selectLMSFile}
         />

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -37,11 +37,12 @@ export default function FilePickerApp({
     googleClientId,
     googleDeveloperKey,
     lmsName,
+    customCanvasApiDomain,
     lmsUrl,
-    registeredLmsUrl,
     ltiLaunchUrl,
   } = useContext(Config);
 
+  const topLevelLmsUrl = customCanvasApiDomain || lmsUrl;
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
   const [url, setUrl] = useState(null);
   const [lmsFile, setLmsFile] = useState(null);
@@ -54,7 +55,7 @@ export default function FilePickerApp({
   // We do this eagerly to make the picker load faster if the user does click
   // on the "Select from Google Drive" button.
   const googlePicker = useMemo(() => {
-    if (!googleClientId || !googleDeveloperKey || !lmsUrl) {
+    if (!googleClientId || !googleDeveloperKey || !topLevelLmsUrl) {
       return null;
     }
     return new GooglePickerClient({
@@ -65,9 +66,9 @@ export default function FilePickerApp({
       // must provide the URL of the top-level frame to us so we can pass it
       // to the Google Picker API. Otherwise we can use the URL of the current
       // tab.
-      origin: window === window.top ? window.location.href : lmsUrl,
+      origin: window === window.top ? window.location.href : topLevelLmsUrl,
     });
-  }, [googleDeveloperKey, googleClientId, lmsUrl]);
+  }, [googleDeveloperKey, googleClientId, topLevelLmsUrl]);
 
   /**
    * Flag indicating whether the form should be auto-submitted on the next
@@ -136,7 +137,7 @@ export default function FilePickerApp({
           authUrl={authUrl}
           courseId={courseId}
           lmsName={lmsName}
-          registeredLmsUrl={registeredLmsUrl}
+          lmsUrl={lmsUrl}
           onCancel={cancelDialog}
           onSelectFile={selectLMSFile}
         />

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -34,7 +34,7 @@ export default function LMSFilePicker({
   authUrl,
   courseId,
   lmsName,
-  registeredLmsUrl,
+  lmsUrl,
   onCancel,
   onSelectFile,
 }) {
@@ -73,7 +73,6 @@ export default function LMSFilePicker({
   // fetch files.
   const authorizeAndFetchFiles = useCallback(async () => {
     setDialogState({ ...INITIAL_DIALOG_STATE, state: 'authorizing' });
-    setAuthorizationAttempted(true);
 
     if (authWindow.current) {
       authWindow.current.focus();
@@ -86,6 +85,7 @@ export default function LMSFilePicker({
       await authWindow.current.authorize();
       await fetchFiles();
     } finally {
+      setAuthorizationAttempted(true);
       authWindow.current.close();
       // eslint-disable-next-line require-atomic-updates
       authWindow.current = null;
@@ -150,10 +150,12 @@ export default function LMSFilePicker({
       )}
       {dialogState.state === 'authorizing' && authorizationAttempted && (
         <ErrorDisplay
-          message=<Fragment>
-            <a>{`Failed to authorize with the ${lmsName} instance at `}</a>
-            <a href={`${registeredLmsUrl}`}>{`${registeredLmsUrl}`}</a>
-          </Fragment>
+          message={
+            <Fragment>
+              <a>{`Failed to authorize with the ${lmsName} instance at `}</a>
+              <a href={`${lmsUrl}`}>{`${lmsUrl}`}</a>
+            </Fragment>
+          }
           error={new Error('')}
         />
       )}
@@ -201,7 +203,7 @@ LMSFilePicker.propTypes = {
   /**
    * The url of the LMS, eg. "https://foobar.instructure.com".
    */
-  registeredLmsUrl: propTypes.string.isRequired,
+  lmsUrl: propTypes.string.isRequired,
 
   /** Callback invoked if the user cancels file selection. */
   onCancel: propTypes.func.isRequired,

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -176,7 +176,7 @@ describe('FilePickerApp', () => {
     beforeEach(() => {
       fakeConfig.googleClientId = 'goog-client-id';
       fakeConfig.googleDeveloperKey = 'goog-developer-key';
-      fakeConfig.lmsUrl = 'https://test.chalkboard.com';
+      fakeConfig.customCanvasApiDomain = 'https://test.chalkboard.com';
 
       const picker = FakeGooglePickerClient();
       picker.showPicker.resolves({
@@ -202,6 +202,17 @@ describe('FilePickerApp', () => {
     }
 
     it('initializes Google Picker client when developer key is provided', () => {
+      renderFilePicker();
+      assert.calledWith(FakeGooglePickerClient, {
+        developerKey: fakeConfig.googleDeveloperKey,
+        clientId: fakeConfig.googleClientId,
+        origin: fakeConfig.customCanvasApiDomain,
+      });
+    });
+
+    it('Google Picker client origin falls back to lmsUrl if customCanvasApiDomain does not exist', () => {
+      fakeConfig.customCanvasApiDomain = null;
+      fakeConfig.lmsUrl = 'https://test.chalkboard2.com';
       renderFilePicker();
       assert.calledWith(FakeGooglePickerClient, {
         developerKey: fakeConfig.googleDeveloperKey,

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -221,10 +221,8 @@ class BasicLTILaunchViews:
                 "googleDeveloperKey": self.request.registry.settings[
                     "google_developer_key"
                 ],
+                "customCanvasApiDomain": self.context.custom_canvas_api_domain,
                 "lmsUrl": self.context.lms_url,
-                "registeredLmsUrl": self.request.find_service(name="ai_getter").lms_url(
-                    oauth_consumer_key
-                ),
             }
         )
 

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -222,6 +222,9 @@ class BasicLTILaunchViews:
                     "google_developer_key"
                 ],
                 "lmsUrl": self.context.lms_url,
+                "registeredLmsUrl": self.request.find_service(name="ai_getter").lms_url(
+                    oauth_consumer_key
+                ),
             }
         )
 

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -79,10 +79,8 @@ def content_item_selection(context, request):
             # When we're being launched in an iframe within the LMS our JavaScript
             # needs to pass this URL (which is the URL of the top-most page) to Google
             # Picker, otherwise Picker refuses to launch inside an iframe.
+            "customCanvasApiDomain": context.custom_canvas_api_domain,
             "lmsUrl": context.lms_url,
-            "registeredLmsUrl": request.find_service(name="ai_getter").lms_url(
-                request.lti_user.oauth_consumer_key
-            ),
         }
     )
 

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -80,6 +80,9 @@ def content_item_selection(context, request):
             # needs to pass this URL (which is the URL of the top-most page) to Google
             # Picker, otherwise Picker refuses to launch inside an iframe.
             "lmsUrl": context.lms_url,
+            "registeredLmsUrl": request.find_service(name="ai_getter").lms_url(
+                request.lti_user.oauth_consumer_key
+            ),
         }
     )
 

--- a/tests/lms/resources/_lti_launch_test.py
+++ b/tests/lms/resources/_lti_launch_test.py
@@ -436,16 +436,26 @@ class TestLTILaunchResource:
         with pytest.raises(HTTPBadRequest):
             lti_launch.provisioning_enabled
 
-    def test_lms_url_returns_the_custom_canvas_api_domain(self, pyramid_request):
+    def test_custom_canvas_api_domain_returns_the_custom_canvas_api_domain(
+        self, pyramid_request
+    ):
         pyramid_request.params[
             "custom_canvas_api_domain"
         ] = "test_custom_canvas_api_domain"
 
         lti_launch = resources.LTILaunchResource(pyramid_request)
 
-        assert lti_launch.lms_url == "test_custom_canvas_api_domain"
+        assert lti_launch.custom_canvas_api_domain == "test_custom_canvas_api_domain"
 
-    def test_lms_url_falls_back_on_the_ApplicationInstances_lms_url(
+    def test_custom_canvas_api_url_returns_None_if_not_defined(
+        self, ai_getter, pyramid_request
+    ):
+        lti_launch = resources.LTILaunchResource(pyramid_request)
+
+        custom_canvas_api_url = lti_launch.custom_canvas_api_domain
+        assert custom_canvas_api_url is None
+
+    def test_lms_url_return_the_ApplicationInstances_lms_url(
         self, ai_getter, pyramid_request
     ):
         lti_launch = resources.LTILaunchResource(pyramid_request)

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -260,6 +260,7 @@ class TestUnconfiguredBasicLTILaunch:
             "googleClientId": "TEST_GOOGLE_CLIENT_ID",
             "googleDeveloperKey": "TEST_GOOGLE_DEVELOPER_KEY",
             "lmsUrl": context.lms_url,
+            "registeredLmsUrl": "https://example.com",
             "urls": {},
         }
 

--- a/tests/lms/views/basic_lti_launch_test.py
+++ b/tests/lms/views/basic_lti_launch_test.py
@@ -259,8 +259,8 @@ class TestUnconfiguredBasicLTILaunch:
             },
             "googleClientId": "TEST_GOOGLE_CLIENT_ID",
             "googleDeveloperKey": "TEST_GOOGLE_DEVELOPER_KEY",
+            "customCanvasApiDomain": context.custom_canvas_api_domain,
             "lmsUrl": context.lms_url,
-            "registeredLmsUrl": "https://example.com",
             "urls": {},
         }
 


### PR DESCRIPTION
This is a fix for https://github.com/hypothesis/lms/issues/767. This is dependent on https://github.com/hypothesis/lms/pull/939.

To test:
1. Create an lms instance in the lms database that points to https://example.com rather than the correct canvas url. 
2. Try to create a new assignment by selecting a file from canvas.
3. It will prompt you to "authorize Hypothesis to access your files in Canvas". Click authorize.
4. A pop up will appear that opens example.com. Close this.
5. You should see:
![image](https://user-images.githubusercontent.com/30059933/64267079-9b9df400-ceea-11e9-8400-9baa8658040e.png)


