### PR TITLE
Fix make dev

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ passenv =
     dev: GOOGLE_APP_ID
     dev: GOOGLE_CLIENT_ID
     dev: GOOGLE_DEVELOPER_KEY
+    dev: HOME
     dev: H_AUTHORITY
     dev: H_API_URL_PRIVATE
     dev: H_API_URL_PUBLIC


### PR DESCRIPTION
`make dev` is getting this error:

    mkdir: cannot create directory ‘/.pyenv’: Permission denied

because $HOME is not available inside tox so, when pyenv is run in tox,
it's trying to use /.pyenv instead of ~/.pyenv.

Fix this by making $HOME available to pyenv inside tox.

I'm not sure how this ever worked.