### PR TITLE
WIP: Add LISResultSourcedId model, migration and tests

### DIFF
--- a/lms/migrations/versions/edab0e4610e0_add_the_lis_result_sourcedid_table.py
+++ b/lms/migrations/versions/edab0e4610e0_add_the_lis_result_sourcedid_table.py
@@ -1,0 +1,66 @@
+"""
+Add the lis_result_sourcedid table.
+
+This table allows us to stash Learner launch-parameter details for later use
+during grading
+
+Revision ID: edab0e4610e0
+Revises: 2fdc9b46320a
+Create Date: 2019-09-05 14:15:47.918403
+
+"""
+import datetime
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "edab0e4610e0"
+down_revision = "2fdc9b46320a"
+
+
+def upgrade():
+    op.create_table(
+        "lis_result_sourcedid",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column(
+            "created",
+            sa.DateTime(),
+            default=datetime.datetime.utcnow,
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            default=datetime.datetime.utcnow,
+            onupdate=datetime.datetime.utcnow,
+            nullable=False,
+        ),
+        sa.Column("lis_result_sourcedid", sa.UnicodeText(), nullable=False),
+        sa.Column("lis_outcome_service_url", sa.UnicodeText(), nullable=False),
+        sa.Column("lis_result_sourcedid", sa.UnicodeText(), nullable=False),
+        sa.Column(
+            "oauth_consumer_key",
+            sa.UnicodeText(),
+            sa.ForeignKey("application_instances.consumer_key"),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.UnicodeText(), nullable=False),
+        sa.Column("context_id", sa.UnicodeText(), nullable=False),
+        sa.Column("resource_link_id", sa.UnicodeText(), nullable=False),
+        sa.Column(
+            "tool_consumer_info_product_family_code", sa.UnicodeText(), nullable=True
+        ),
+        sa.Column("h_username", sa.UnicodeText(), nullable=False),
+        sa.Column("h_display_name", sa.UnicodeText(), nullable=False),
+        sa.UniqueConstraint(
+            "oauth_consumer_key", "user_id", "context_id", "resource_link_id"
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("lis_result_sourcedid")

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,4 +1,5 @@
 from lms.models.application_instance import ApplicationInstance
+from lms.models.lis_result_sourcedid import LISResultSourcedId
 from lms.models.lti_launches import LtiLaunches
 from lms.models.module_item_configuration import ModuleItemConfiguration
 from lms.models.oauth2_token import OAuth2Token
@@ -6,6 +7,7 @@ from lms.models.oauth2_token import OAuth2Token
 
 __all__ = (
     "ApplicationInstance",
+    "LISResultSourcedId",
     "LtiLaunches",
     "ModuleItemConfiguration",
     "OAuth2Token",

--- a/lms/models/lis_result_sourcedid.py
+++ b/lms/models/lis_result_sourcedid.py
@@ -1,0 +1,72 @@
+import datetime
+
+import sqlalchemy as sa
+
+from lms.db import BASE
+
+
+__all__ = ["LISResultSourcedId"]
+
+
+class LISResultSourcedId(BASE):
+    """
+    A record of a student's launch of a Hypothesis-configured LMS assignment.
+
+    For some institutions (at present, BlackBoardLearn), we need to persist
+    some information about students and launches to be able to provide grading
+    support for instructors/graders later on.
+
+    Data persisted here allows us to make use of APIs that support the LTI Basic
+    Outcomes spec and configure the Hypothesis client appropriately for grading.
+
+    The combination of ``oauth_consumer_key``, ``user_id``, ``context_id``,
+    and ``resource_link_id`` uniquely identifies a user-assignment
+    (``user_id``, ``resource_link_id``) launch within a particular course
+    (``context_id``) and application install (``oauth_consumer_key``). The
+    uniqueness constraint here indicates that we should only ever have one
+    record per user-assignment-course-install combination.
+
+    ``lis_result_sourcedid`` and ``lis_outcome_service_url`` allow us to
+    construct the right requests to outcome (i.e. grading) APIs when needed. As
+    these values can change over time (while user-assignment-course-install
+    remains static), records should be updated upon subsequent launches to make
+    sure these stay in sync—i.e. record should be created on first relevant
+    launch and updated on each subsequent relevant launch.
+
+    ``h_username`` and ``h_display_name`` allow us to configure the Hypothesis
+    client and this application's own interface when in grading mode, as we
+    won't have access to request parameters to derive this information when it
+    is, at last, needed.
+    """
+
+    __tablename__ = "lis_result_sourcedid"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "oauth_consumer_key", "user_id", "context_id", "resource_link_id"
+        ),
+    )
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+    created = sa.Column(
+        sa.DateTime(),
+        default=datetime.datetime.utcnow,
+        server_default=sa.func.now(),
+        nullable=False,
+    )
+    updated = sa.Column(
+        sa.DateTime(),
+        server_default=sa.func.now(),
+        default=datetime.datetime.utcnow,
+        onupdate=datetime.datetime.utcnow,
+        nullable=False,
+    )
+    lis_result_sourcedid = sa.Column(sa.UnicodeText(), nullable=False)
+    lis_outcome_service_url = sa.Column(sa.UnicodeText(), nullable=False)
+    oauth_consumer_key = sa.Column(sa.UnicodeText(), nullable=False)
+    user_id = sa.Column(sa.UnicodeText(), nullable=False)
+    context_id = sa.Column(sa.UnicodeText(), nullable=False)
+    resource_link_id = sa.Column(sa.UnicodeText(), nullable=False)
+    # The "family" of LMS tool, e.g. "BlackboardLearn" or "canvas"
+    tool_consumer_info_product_family_code = sa.Column(sa.UnicodeText(), nullable=True)
+    h_username = sa.Column(sa.UnicodeText(), nullable=False)
+    h_display_name = sa.Column(sa.UnicodeText(), nullable=False)

--- a/tests/lms/models/lis_result_sourcedid_test.py
+++ b/tests/lms/models/lis_result_sourcedid_test.py
@@ -1,0 +1,100 @@
+# import datetime
+
+import pytest
+import sqlalchemy.exc
+
+from lms.models import ApplicationInstance, LISResultSourcedId
+
+
+class TestLISResultSourcedId:
+    def test_it_persists_and_returns_attrs(
+        self, application_instance, db_session, lis_result_sourcedid
+    ):
+        db_session.add(lis_result_sourcedid)
+        lrs = db_session.query(LISResultSourcedId).one()
+
+        assert lrs.lis_result_sourcedid == "result_sourcedid"
+        assert lrs.lis_outcome_service_url == "https://somewhere.else"
+        assert lrs.oauth_consumer_key == application_instance.consumer_key
+        assert lrs.user_id == "339483948"
+        assert lrs.context_id == "random context"
+        assert lrs.resource_link_id == "random resource link id"
+        assert lrs.tool_consumer_info_product_family_code == "BlackboardLearn"
+        assert lrs.h_username == "blackboarduser1"
+        assert lrs.h_display_name == "Black Board User"
+
+    @pytest.mark.parametrize(
+        "non_nullable_field",
+        [
+            "lis_result_sourcedid",
+            "lis_outcome_service_url",
+            "oauth_consumer_key",
+            "user_id",
+            "context_id",
+            "resource_link_id",
+            "h_username",
+            "h_display_name",
+        ],
+    )
+    def test_it_enforces_non_nullable_field_presence(
+        self, db_session, lis_result_sourcedid, non_nullable_field
+    ):
+        setattr(lis_result_sourcedid, non_nullable_field, None)
+        db_session.add(lis_result_sourcedid)
+        with pytest.raises(
+            sqlalchemy.exc.IntegrityError,
+            match=f'null value in column "{non_nullable_field}" violates not-null constraint',
+        ):
+            db_session.flush()
+
+    def test_it_enforces_uniqueness_constraint(
+        self, lis_result_sourcedid, lis_result_duplicate_sourcedid, db_session
+    ):
+        db_session.add(lis_result_sourcedid)
+        db_session.add(lis_result_duplicate_sourcedid)
+
+        with pytest.raises(
+            sqlalchemy.exc.IntegrityError,
+            match="duplicate key value violates unique constraint",
+        ):
+            db_session.flush()
+
+    @pytest.fixture
+    def application_instance(self, db_session):
+        """The ApplicationInstance that the LISResultSourcedIds belong to"""
+        application_instance = ApplicationInstance(
+            consumer_key="test_consumer_key",
+            shared_secret="test_shared_secret",
+            lms_url="test_lms_url",
+            requesters_email="test_requesters_email",
+        )
+        db_session.add(application_instance)
+        return application_instance
+
+    @pytest.fixture
+    def lis_result_sourcedid(self, application_instance):
+        return LISResultSourcedId(
+            lis_result_sourcedid="result_sourcedid",
+            lis_outcome_service_url="https://somewhere.else",
+            oauth_consumer_key=application_instance.consumer_key,
+            user_id="339483948",
+            context_id="random context",
+            resource_link_id="random resource link id",
+            tool_consumer_info_product_family_code="BlackboardLearn",
+            h_username="blackboarduser1",
+            h_display_name="Black Board User",
+        )
+
+    @pytest.fixture
+    def lis_result_duplicate_sourcedid(self, application_instance):
+        return LISResultSourcedId(
+            lis_result_sourcedid="result_sourcedid_another",
+            lis_outcome_service_url="https://somewhere.else_yet",
+            oauth_consumer_key=application_instance.consumer_key,
+            user_id="339483948",
+            context_id="random context",
+            resource_link_id="random resource link id",
+            tool_consumer_info_product_family_code="BlackboardLearn",
+            h_username="blackboarduser1",
+            h_display_name="Black Board User",
+        )


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/946

This PR adds a new DB table, `lis_result_sourcedid`, and a model `LISResultSourcedId` for later use in supporting grading mode in Blackboard (and potentially other LMSes).