### PR TITLE
Add service for interacting with `LISResultSourcedId` records

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -27,20 +27,24 @@ __all__ = (
 
 def includeme(config):
     config.register_service_factory(
-        "lms.services.h_api_requests.HAPIRequests", name="h_api_requests"
+        "lms.services.application_instance_getter.ApplicationInstanceGetter",
+        name="ai_getter",
+    )
+    config.register_service_factory(
+        "lms.services.canvas_api.CanvasAPIClient", name="canvas_api_client"
     )
     config.register_service_factory(
         "lms.services.h_api_client.HAPIClient", name="h_api_client"
     )
     config.register_service_factory(
-        "lms.services.application_instance_getter.ApplicationInstanceGetter",
-        name="ai_getter",
+        "lms.services.h_api_requests.HAPIRequests", name="h_api_requests"
     )
     config.register_service_factory(
         "lms.services.launch_verifier.LaunchVerifier", name="launch_verifier"
     )
     config.register_service_factory(
-        "lms.services.canvas_api.CanvasAPIClient", name="canvas_api_client"
+        "lms.services.lis_result_sourcedid.LISResultSourcedIdService",
+        name="lis_result_sourcedid",
     )
     config.register_service_factory(
         "lms.services.lti_outcomes.LTIOutcomesClient", name="lti_outcomes_client"

--- a/lms/services/lis_result_sourcedid.py
+++ b/lms/services/lis_result_sourcedid.py
@@ -1,0 +1,55 @@
+from lms.models import LISResultSourcedId
+
+__all__ = ["LISResultSourcedIdService"]
+
+
+class LISResultSourcedIdService:
+    """Methods for interacting with LISResultSourcedId records."""
+
+    def __init__(self, _context, request):
+        self._db = request.db
+
+    def upsert(self, validated_attrs):
+        """
+        Update an existing record or create a new one if none exists.
+
+        :arg validated_attrs: Valid attributes for associated
+            :class:`lms.models.LISResultSourcedId` record.
+        :return: The new or updated record
+        :rtype: :class:`~lms.models.LISResultSourcedId`
+        """
+        lis_result_sourcedid = (
+            self._db.query(LISResultSourcedId)
+            .filter_by(
+                oauth_consumer_key=validated_attrs["oauth_consumer_key"],
+                user_id=validated_attrs["user_id"],
+                context_id=validated_attrs["context_id"],
+                resource_link_id=validated_attrs["resource_link_id"],
+            )
+            .one_or_none()
+        )
+
+        if lis_result_sourcedid is None:
+            lis_result_sourcedid = LISResultSourcedId(
+                oauth_consumer_key=validated_attrs["oauth_consumer_key"],
+                user_id=validated_attrs["user_id"],
+                context_id=validated_attrs["context_id"],
+                resource_link_id=validated_attrs["resource_link_id"],
+            )
+            self._db.add(lis_result_sourcedid)
+
+        lis_result_sourcedid.lis_result_sourcedid = validated_attrs[
+            "lis_result_sourcedid"
+        ]
+        lis_result_sourcedid.lis_outcome_service_url = validated_attrs[
+            "lis_outcome_service_url"
+        ]
+        lis_result_sourcedid.h_username = validated_attrs["h_username"]
+        lis_result_sourcedid.h_display_name = validated_attrs["h_display_name"]
+
+        if "tool_consumer_info_product_family_code" in validated_attrs:
+            lis_result_sourcedid.tool_consumer_info_product_family_code = validated_attrs[
+                "tool_consumer_info_product_family_code"
+            ]
+
+        return lis_result_sourcedid

--- a/tests/lms/services/lis_result_sourcedid_test.py
+++ b/tests/lms/services/lis_result_sourcedid_test.py
@@ -1,0 +1,88 @@
+from unittest import mock
+
+import pytest
+
+from lms.models import ApplicationInstance, LISResultSourcedId
+from lms.resources import LTILaunchResource
+from lms.services.lis_result_sourcedid import LISResultSourcedIdService
+from lms.values import HUser
+
+
+class TestLISResultSourcedIdUpsert:
+    def test_it_creates_new_record_if_no_matching_exists(
+        self, svc, validated_attrs, db_session
+    ):
+        lis_result_sourcedid = svc.upsert(validated_attrs)
+
+        persisted_lis_result_sourcedid = db_session.query(LISResultSourcedId).one()
+
+        assert isinstance(lis_result_sourcedid, LISResultSourcedId)
+        assert persisted_lis_result_sourcedid is lis_result_sourcedid
+        assert db_session.query(LISResultSourcedId).count() == 1
+
+    def test_it_sets_values_from_validated_attrs_when_new_record(
+        self, svc, validated_attrs, db_session
+    ):
+        lis_result_sourcedid = svc.upsert(validated_attrs)
+
+        for key in validated_attrs:
+            assert getattr(lis_result_sourcedid, key) == validated_attrs[key]
+
+    def test_it_updates_existing_record_if_matching_exists(
+        self, svc, validated_attrs, lis_result_sourcedid, db_session
+    ):
+        validated_attrs["lis_result_sourcedid"] = "Something entirely different"
+
+        lis_result_sourcedid_updated = svc.upsert(validated_attrs)
+
+        assert lis_result_sourcedid_updated is lis_result_sourcedid
+        assert (
+            lis_result_sourcedid_updated.lis_result_sourcedid
+            == "Something entirely different"
+        )
+
+    @pytest.fixture
+    def application_instance(self, db_session):
+        """The ApplicationInstance that the LISResultSourcedIds belong to"""
+        application_instance = ApplicationInstance(
+            consumer_key="test_consumer_key",
+            shared_secret="test_shared_secret",
+            lms_url="test_lms_url",
+            requesters_email="test_requesters_email",
+        )
+        db_session.add(application_instance)
+        return application_instance
+
+    @pytest.fixture
+    def context(self):
+        context = mock.create_autospec(
+            LTILaunchResource,
+            spec_set=True,
+            instance=True,
+            h_user=HUser(authority="TEST_AUTHORITY", username="seanh"),
+        )
+        return context
+
+    @pytest.fixture
+    def svc(self, context, pyramid_request):
+        return LISResultSourcedIdService(context, pyramid_request)
+
+    @pytest.fixture
+    def validated_attrs(self, application_instance):
+        return {
+            "lis_result_sourcedid": "result_sourcedid",
+            "lis_outcome_service_url": "https://somewhere.else",
+            "oauth_consumer_key": application_instance.consumer_key,
+            "user_id": "339483948",
+            "context_id": "random context",
+            "resource_link_id": "random resource link id",
+            "tool_consumer_info_product_family_code": "BlackboardLearn",
+            "h_username": "seanh",
+            "h_display_name": "Black Board User",
+        }
+
+    @pytest.fixture
+    def lis_result_sourcedid(self, validated_attrs, db_session):
+        lis_result_sourcedid_ = LISResultSourcedId(**validated_attrs)
+        db_session.add(lis_result_sourcedid_)
+        return lis_result_sourcedid_


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/946

This PR adds a straightforward service for upserting rows into the `lti_result_sourcedid` table.

I've taken the route of assuming that callers will pre-validate the attributes, so the `upsert` service method is relatively "stupid" and doesn't do any sort of real thinking.

One thing to note! At one point during work on this, when alphabetizing the services, I inadvertently deleted the registration of the `canvas_api` service altogether—but _all of the tests still passed_. This seemed a little alarming to me, so I thought I'd mention it.