### PR TITLE
Add NamedTuple and validation for LISResultSourcedId

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -62,6 +62,7 @@ from lms.validation._launch_params import (
     URLConfiguredLaunchParamsSchema,
 )
 from lms.validation._bearer_token import BearerTokenSchema
+from lms.validation._lis_result_sourcedid import LISResultSourcedIdSchema
 from lms.validation._module_item_configuration import ConfigureModuleItemSchema
 from lms.validation._canvas import (
     CanvasListFilesResponseSchema,
@@ -77,6 +78,7 @@ __all__ = (
     "CanvasRefreshTokenResponseSchema",
     "BearerTokenSchema",
     "LaunchParamsSchema",
+    "LISResultSourcedIdSchema",
     "URLConfiguredLaunchParamsSchema",
     "ConfigureModuleItemSchema",
     "CanvasListFilesResponseSchema",

--- a/lms/validation/_lis_result_sourcedid.py
+++ b/lms/validation/_lis_result_sourcedid.py
@@ -1,0 +1,54 @@
+"""Schema for validating params required for LIS Outcomes."""
+import marshmallow
+
+from lms.validation._helpers import PyramidRequestSchema
+from lms.values import LISResultSourcedId
+
+
+__all__ = ["LISResultSourcedIdSchema"]
+
+
+class LISResultSourcedIdSchema(PyramidRequestSchema):
+    """
+    Schema for LIS Result/LMS Outcomes params.
+
+    Validates params for LMS Outcomes metadata. Usage via webargs::
+
+        >>> from webargs.pyramidparser import parser
+        >>>
+        >>> schema = LISResultSourcedIdSchema(request)
+        >>> parsed_params = parser.parse(schema, request)
+
+    Or to verify the request and get an :class:`~lms.values.LISResultSourcedId`
+    from the request's params::
+
+        >>> schema = LISResultSourcedIdSchema(request)
+        >>> schema.lis_result_sourcedid()
+        LISResultSourcedId(lis_result_sourcedid='...', ...)
+    """
+
+    lis_result_sourcedid = marshmallow.fields.Str(required=True)
+    lis_outcome_service_url = marshmallow.fields.Str(required=True)
+    context_id = marshmallow.fields.Str(required=True)
+    resource_link_id = marshmallow.fields.Str(required=True)
+    tool_consumer_info_product_family_code = marshmallow.fields.Str(missing="")
+
+    def lis_result_sourcedid_info(self):
+        """
+        Return an :class:`~lms.values.LISResultSourcedId`.
+
+        :raise ValidationError: if the request isn't a valid LIS Outcome launch
+        :rtype: LISResultSourcedId
+        """
+
+        parsed_params = self.parse(locations=["form"])
+
+        return LISResultSourcedId(
+            lis_result_sourcedid=parsed_params["lis_result_sourcedid"],
+            lis_outcome_service_url=parsed_params["lis_outcome_service_url"],
+            context_id=parsed_params["context_id"],
+            resource_link_id=parsed_params["resource_link_id"],
+            tool_consumer_info_product_family_code=parsed_params[
+                "tool_consumer_info_product_family_code"
+            ],
+        )

--- a/lms/values.py
+++ b/lms/values.py
@@ -2,7 +2,7 @@
 from typing import NamedTuple
 
 
-__all__ = ("LTIUser",)
+__all__ = ("LTIUser", "LISResultSourcedId")
 
 
 class LTIUser(NamedTuple):
@@ -47,3 +47,28 @@ class HUser(NamedTuple):
     @property
     def userid(self):
         return f"acct:{self.username}@{self.authority}"
+
+
+class LISResultSourcedId(NamedTuple):
+    """
+    LIS Outcome metadata for an LMS student user.
+
+    May be used—in combination with :class:`~lms.values.LTIUser` and
+    :class:`~lms.values.HUser` to populate an :class:`lms.models.LISResultSourcedId`
+    model.
+    """
+
+    lis_result_sourcedid: str
+    """The LIS Result Identifier associated with this launch."""
+
+    lis_outcome_service_url: str
+    """Service URL for communicating outcomes."""
+
+    context_id: str
+    """unique id of the course from which the user is accessing the app."""
+
+    resource_link_id: str
+    """unique id referencing the link, or "placement", of the app in the consumer."""
+
+    tool_consumer_info_product_family_code: str = ""
+    """The 'family' of LMS tool, e.g. 'BlackboardLearn' or 'canvas'."""

--- a/tests/lms/validation/_lis_result_sourcedid_test.py
+++ b/tests/lms/validation/_lis_result_sourcedid_test.py
@@ -1,0 +1,89 @@
+import pytest
+
+from lms.validation import LISResultSourcedIdSchema
+
+from pyramid.httpexceptions import HTTPUnprocessableEntity
+
+from lms.values import LISResultSourcedId as LISResultSourcedIdValue
+
+
+class TestLISResultSourcedIdSchema:
+    def test_it_parses_params_from_request(self, schema):
+        lis_result_sourcedid = schema.parse()
+
+        assert lis_result_sourcedid == {
+            "lis_result_sourcedid": "TEST LIS RESULT SOURCEDID",
+            "resource_link_id": "TEST RESOURCE LINK ID",
+            "lis_outcome_service_url": "TEST LIS OUTCOME SERVICE URL",
+            "context_id": "TEST CONTEXT ID",
+            "tool_consumer_info_product_family_code": "TEST PRODUCT FAMILY CODE",
+        }
+
+    def test_it_does_not_raise_if_optional_field_missing(
+        self, pyramid_outcome_request, schema
+    ):
+        del pyramid_outcome_request.POST["tool_consumer_info_product_family_code"]
+
+        lis_result_sourcedid = schema.parse()
+
+        assert lis_result_sourcedid == {
+            "tool_consumer_info_product_family_code": "",
+            "lis_result_sourcedid": "TEST LIS RESULT SOURCEDID",
+            "resource_link_id": "TEST RESOURCE LINK ID",
+            "lis_outcome_service_url": "TEST LIS OUTCOME SERVICE URL",
+            "context_id": "TEST CONTEXT ID",
+        }
+
+    @pytest.mark.parametrize(
+        "missing_param",
+        [
+            "lis_result_sourcedid",
+            "resource_link_id",
+            "lis_outcome_service_url",
+            "context_id",
+            "resource_link_id",
+        ],
+    )
+    def test_it_raises_if_a_required_param_is_missing(
+        self, missing_param, pyramid_outcome_request, schema
+    ):
+        del pyramid_outcome_request.POST[missing_param]
+
+        with pytest.raises(HTTPUnprocessableEntity) as exc_info:
+            schema.parse()
+
+        assert exc_info.value.messages == dict(
+            [(missing_param, ["Missing data for required field."])]
+        )
+
+    def test_it_returns_lis_result_sourcedid_info(self, schema):
+        lis_result_sourcedid = schema.lis_result_sourcedid_info()
+
+        assert isinstance(lis_result_sourcedid, LISResultSourcedIdValue)
+
+    def test_it_lis_result_sourcedid_info_does_not_raise_with_missing_optional_field(
+        self, schema, pyramid_outcome_request
+    ):
+        del pyramid_outcome_request.POST["tool_consumer_info_product_family_code"]
+
+        lis_result_sourcedid = schema.lis_result_sourcedid_info()
+
+        assert isinstance(lis_result_sourcedid, LISResultSourcedIdValue)
+
+    @pytest.fixture
+    def pyramid_outcome_request(self, pyramid_request):
+        """Pyramid ``request`` with needed params for valid outcome record."""
+        pyramid_request.POST.update(
+            {
+                "lis_result_sourcedid": "TEST LIS RESULT SOURCEDID",
+                "lis_outcome_service_url": "TEST LIS OUTCOME SERVICE URL",
+                "context_id": "TEST CONTEXT ID",
+                "resource_link_id": "TEST RESOURCE LINK ID",
+                "tool_consumer_info_product_family_code": "TEST PRODUCT FAMILY CODE",
+            }
+        )
+        return pyramid_request
+
+    @pytest.fixture
+    def schema(self, pyramid_outcome_request):
+        return LISResultSourcedIdSchema(pyramid_outcome_request)


### PR DESCRIPTION
This PR adds some validation for `lis_result_sourcedid` data. It adds a `NamedTuple` and a schema validation for the `request`.

Part of https://github.com/hypothesis/lms/issues/946