### PR TITLE
Add view decorator to upsert LISResultSourcedId records

### DIFF
--- a/lms/services/lis_result_sourcedid.py
+++ b/lms/services/lis_result_sourcedid.py
@@ -9,47 +9,47 @@ class LISResultSourcedIdService:
     def __init__(self, _context, request):
         self._db = request.db
 
-    def upsert(self, validated_attrs):
+    def upsert(self, lis_info, h_user, lti_user):
         """
         Update an existing record or create a new one if none exists.
 
-        :arg validated_attrs: Valid attributes for associated
-            :class:`lms.models.LISResultSourcedId` record.
+        :arg lis_info: LIS-specific attrs
+        :type lis_info: :class:`lms.values.LISResultSourcedId`
+        :arg h_user: The h user this record is associated with
+        :type h_user: :class:`lms.values.HUser`
+        :arg lti_user: The LTI-provided user that this record is associated with
+        :type lti_user: :class:`lms.values.LTIUser`
         :return: The new or updated record
         :rtype: :class:`~lms.models.LISResultSourcedId`
         """
         lis_result_sourcedid = (
             self._db.query(LISResultSourcedId)
             .filter_by(
-                oauth_consumer_key=validated_attrs["oauth_consumer_key"],
-                user_id=validated_attrs["user_id"],
-                context_id=validated_attrs["context_id"],
-                resource_link_id=validated_attrs["resource_link_id"],
+                oauth_consumer_key=lti_user.oauth_consumer_key,
+                user_id=lti_user.user_id,
+                context_id=lis_info.context_id,
+                resource_link_id=lis_info.resource_link_id,
             )
             .one_or_none()
         )
 
         if lis_result_sourcedid is None:
             lis_result_sourcedid = LISResultSourcedId(
-                oauth_consumer_key=validated_attrs["oauth_consumer_key"],
-                user_id=validated_attrs["user_id"],
-                context_id=validated_attrs["context_id"],
-                resource_link_id=validated_attrs["resource_link_id"],
+                oauth_consumer_key=lti_user.oauth_consumer_key,
+                user_id=lti_user.user_id,
+                context_id=lis_info.context_id,
+                resource_link_id=lis_info.resource_link_id,
             )
             self._db.add(lis_result_sourcedid)
 
-        lis_result_sourcedid.lis_result_sourcedid = validated_attrs[
-            "lis_result_sourcedid"
-        ]
-        lis_result_sourcedid.lis_outcome_service_url = validated_attrs[
-            "lis_outcome_service_url"
-        ]
-        lis_result_sourcedid.h_username = validated_attrs["h_username"]
-        lis_result_sourcedid.h_display_name = validated_attrs["h_display_name"]
+        lis_result_sourcedid.lis_result_sourcedid = lis_info.lis_result_sourcedid
+        lis_result_sourcedid.lis_outcome_service_url = lis_info.lis_outcome_service_url
 
-        if "tool_consumer_info_product_family_code" in validated_attrs:
-            lis_result_sourcedid.tool_consumer_info_product_family_code = validated_attrs[
-                "tool_consumer_info_product_family_code"
-            ]
+        lis_result_sourcedid.h_username = h_user.username
+        lis_result_sourcedid.h_display_name = h_user.display_name
+
+        lis_result_sourcedid.tool_consumer_info_product_family_code = (
+            lis_info.tool_consumer_info_product_family_code
+        )
 
         return lis_result_sourcedid

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -26,6 +26,7 @@ from lms.views.decorators import (
     upsert_course_group,
     add_user_to_group,
     report_lti_launch,
+    upsert_lis_result_sourcedid,
 )
 
 
@@ -38,6 +39,8 @@ from lms.views.decorators import (
         add_user_to_group,
         # Report all LTI assignment launches to the /reports page.
         report_lti_launch,
+        # Create/update LIS Result SourcedId record for certain students
+        upsert_lis_result_sourcedid,
     ],
     permission="launch_lti_assignment",
     renderer="lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2",

--- a/lms/views/decorators/__init__.py
+++ b/lms/views/decorators/__init__.py
@@ -21,6 +21,7 @@ https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#n
 from lms.views.decorators.h_api import upsert_h_user
 from lms.views.decorators.h_api import upsert_course_group
 from lms.views.decorators.h_api import add_user_to_group
+from lms.views.decorators.lis_result_sourcedid import upsert_lis_result_sourcedid
 from lms.views.decorators.reports import report_lti_launch
 
 __all__ = (
@@ -28,4 +29,5 @@ __all__ = (
     "upsert_course_group",
     "add_user_to_group",
     "report_lti_launch",
+    "upsert_lis_result_sourcedid",
 )

--- a/lms/views/decorators/lis_result_sourcedid.py
+++ b/lms/views/decorators/lis_result_sourcedid.py
@@ -1,0 +1,45 @@
+"""View decorators for working with LISResultSourcedId data."""
+
+import functools
+
+from lms.validation import LISResultSourcedIdSchema, ValidationError
+
+__all__ = ["upsert_lis_result_sourcedid"]
+
+
+def upsert_lis_result_sourcedid(wrapped):
+    """Create or update a record of LIS result/outcome data for a student launch."""
+
+    @functools.wraps(wrapped)
+    def wrapper(context, request):
+        try:
+            lis_result_sourcedid = LISResultSourcedIdSchema(
+                request
+            ).lis_result_sourcedid_info()
+        except ValidationError:
+            # We're missing something we need in the request.
+            # This can happen if the user is not a student, or if the needed
+            # LIS data is not present on the request.
+            return wrapped(context, request)
+
+        is_instructor = any(
+            role in request.lti_user.roles.lower()
+            for role in ("administrator", "instructor", "teachingassisstant")
+        )
+
+        if (
+            is_instructor
+            or lis_result_sourcedid.tool_consumer_info_product_family_code
+            != "BlackboardLearn"
+        ):
+            # Don't create records for instructors, or for LMSes other than
+            # BlackboardLearn (at least for now)
+            return wrapped(context, request)
+
+        lis_result_svc = request.find_service(name="lis_result_sourcedid")
+        lis_result_svc.upsert(
+            lis_result_sourcedid, h_user=context.h_user, lti_user=request.lti_user
+        )
+        return wrapped(context, request)
+
+    return wrapper

--- a/tests/lms/services/lis_result_sourcedid_test.py
+++ b/tests/lms/services/lis_result_sourcedid_test.py
@@ -5,14 +5,14 @@ import pytest
 from lms.models import ApplicationInstance, LISResultSourcedId
 from lms.resources import LTILaunchResource
 from lms.services.lis_result_sourcedid import LISResultSourcedIdService
-from lms.values import HUser
+from lms import values
 
 
 class TestLISResultSourcedIdUpsert:
     def test_it_creates_new_record_if_no_matching_exists(
-        self, svc, validated_attrs, db_session
+        self, svc, lis_result_sourcedid_info, h_user, lti_user, db_session
     ):
-        lis_result_sourcedid = svc.upsert(validated_attrs)
+        lis_result_sourcedid = svc.upsert(lis_result_sourcedid_info, h_user, lti_user)
 
         persisted_lis_result_sourcedid = db_session.query(LISResultSourcedId).one()
 
@@ -20,26 +20,65 @@ class TestLISResultSourcedIdUpsert:
         assert persisted_lis_result_sourcedid is lis_result_sourcedid
         assert db_session.query(LISResultSourcedId).count() == 1
 
-    def test_it_sets_values_from_validated_attrs_when_new_record(
-        self, svc, validated_attrs, db_session
+    def test_it_sets_values_from_lis_info_when_new_record(
+        self, svc, lis_result_sourcedid_info, h_user, lti_user, db_session
     ):
-        lis_result_sourcedid = svc.upsert(validated_attrs)
+        lis_result_sourcedid = svc.upsert(lis_result_sourcedid_info, h_user, lti_user)
 
-        for key in validated_attrs:
-            assert getattr(lis_result_sourcedid, key) == validated_attrs[key]
+        for field in lis_result_sourcedid_info._fields:
+            assert getattr(lis_result_sourcedid, field) == getattr(
+                lis_result_sourcedid_info, field
+            )
+
+    def test_it_sets_values_from_h_user_when_new_record(
+        self, svc, lis_result_sourcedid_info, h_user, lti_user, db_session
+    ):
+        lis_result_sourcedid = svc.upsert(lis_result_sourcedid_info, h_user, lti_user)
+
+        assert lis_result_sourcedid.h_username == h_user.username
+        assert lis_result_sourcedid.h_display_name == h_user.display_name
+
+    def test_it_sets_values_from_lti_user_when_new_record(
+        self, svc, lis_result_sourcedid_info, h_user, lti_user, db_session
+    ):
+        lis_result_sourcedid = svc.upsert(lis_result_sourcedid_info, h_user, lti_user)
+
+        assert lis_result_sourcedid.oauth_consumer_key == lti_user.oauth_consumer_key
+        assert lis_result_sourcedid.user_id == lti_user.user_id
 
     def test_it_updates_existing_record_if_matching_exists(
-        self, svc, validated_attrs, lis_result_sourcedid, db_session
+        self,
+        svc,
+        lis_result_sourcedid_info,
+        h_user,
+        lti_user,
+        lis_result_sourcedid,
+        db_session,
     ):
-        validated_attrs["lis_result_sourcedid"] = "Something entirely different"
+        # Update a couple of attributes on the model...
+        h_user2 = h_user._replace(display_name="Someone Else")
+        lis_result_sourcedid_info_2 = lis_result_sourcedid_info._replace(
+            lis_result_sourcedid="something different"
+        )
+        # Note: Both fields from ``LTIUser`` would always be the same in any matching record
 
-        lis_result_sourcedid_updated = svc.upsert(validated_attrs)
+        lis_result_sourcedid_updated = svc.upsert(
+            lis_result_sourcedid_info_2, h_user2, lti_user
+        )
 
         assert lis_result_sourcedid_updated is lis_result_sourcedid
         assert (
-            lis_result_sourcedid_updated.lis_result_sourcedid
-            == "Something entirely different"
+            lis_result_sourcedid_updated.lis_result_sourcedid == "something different"
         )
+        assert lis_result_sourcedid.h_display_name == "Someone Else"
+
+    @pytest.fixture
+    def lti_user(self):
+        return values.LTIUser("TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES")
+
+    @pytest.fixture
+    def h_user(self):
+        return values.HUser(authority="TEST_AUTHORITY", username="seanh")
 
     @pytest.fixture
     def application_instance(self, db_session):
@@ -54,12 +93,9 @@ class TestLISResultSourcedIdUpsert:
         return application_instance
 
     @pytest.fixture
-    def context(self):
+    def context(self, h_user):
         context = mock.create_autospec(
-            LTILaunchResource,
-            spec_set=True,
-            instance=True,
-            h_user=HUser(authority="TEST_AUTHORITY", username="seanh"),
+            LTILaunchResource, spec_set=True, instance=True, h_user=h_user
         )
         return context
 
@@ -68,21 +104,37 @@ class TestLISResultSourcedIdUpsert:
         return LISResultSourcedIdService(context, pyramid_request)
 
     @pytest.fixture
-    def validated_attrs(self, application_instance):
-        return {
-            "lis_result_sourcedid": "result_sourcedid",
-            "lis_outcome_service_url": "https://somewhere.else",
-            "oauth_consumer_key": application_instance.consumer_key,
-            "user_id": "339483948",
-            "context_id": "random context",
-            "resource_link_id": "random resource link id",
-            "tool_consumer_info_product_family_code": "BlackboardLearn",
-            "h_username": "seanh",
-            "h_display_name": "Black Board User",
-        }
+    def lis_result_sourcedid_info(self, application_instance):
+        return values.LISResultSourcedId(
+            lis_result_sourcedid="result_sourcedid",
+            lis_outcome_service_url="https://somewhere.else",
+            context_id="random context",
+            resource_link_id="random resource link id",
+            tool_consumer_info_product_family_code="BlackboardLearn",
+        )
 
     @pytest.fixture
-    def lis_result_sourcedid(self, validated_attrs, db_session):
-        lis_result_sourcedid_ = LISResultSourcedId(**validated_attrs)
+    def lis_result_sourcedid(
+        self, lis_result_sourcedid_info, h_user, lti_user, db_session
+    ):
+        lis_result_sourcedid_ = LISResultSourcedId()
+        lis_result_sourcedid_.lis_result_sourcedid = (
+            lis_result_sourcedid_info.lis_result_sourcedid
+        )
+        lis_result_sourcedid_.lis_outcome_service_url = (
+            lis_result_sourcedid_info.lis_outcome_service_url
+        )
+        lis_result_sourcedid_.context_id = lis_result_sourcedid_info.context_id
+        lis_result_sourcedid_.resource_link_id = (
+            lis_result_sourcedid_info.resource_link_id
+        )
+        lis_result_sourcedid_.tool_consumer_info_product_family_code = (
+            lis_result_sourcedid_info.tool_consumer_info_product_family_code
+        )
+        lis_result_sourcedid_.h_username = h_user.username
+        lis_result_sourcedid_.h_display_name = h_user.display_name
+        lis_result_sourcedid_.oauth_consumer_key = lti_user.oauth_consumer_key
+        lis_result_sourcedid_.user_id = lti_user.user_id
+
         db_session.add(lis_result_sourcedid_)
         return lis_result_sourcedid_

--- a/tests/lms/views/decorators/lis_result_sourcedid_test.py
+++ b/tests/lms/views/decorators/lis_result_sourcedid_test.py
@@ -1,0 +1,196 @@
+from unittest import mock
+import pytest
+
+from lms.validation import ValidationError
+from lms.services.lis_result_sourcedid import LISResultSourcedIdService
+from lms.views import decorators
+
+from lms.resources import LTILaunchResource
+from lms import values
+
+
+@pytest.mark.usefixtures("lis_result_sourcedid_svc")
+class TestUpsertLISResultSourcedId:
+    def test_it_continues_to_wrapped_fn_if_validation_raises_ValidationError(
+        self,
+        upsert_lis_result_sourcedid,
+        context,
+        pyramid_request,
+        wrapped,
+        LISResultSourcedIdSchema,
+        lis_result_sourcedid_svc,
+    ):
+        LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.side_effect = ValidationError(
+            "foo"
+        )
+
+        returned = upsert_lis_result_sourcedid(context, pyramid_request)
+
+        assert returned == wrapped.return_value
+        LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.assert_called_once()
+        lis_result_sourcedid_svc.upsert.assert_not_called()
+        wrapped.assert_called_once_with(context, pyramid_request)
+
+    def test_it_raises_if_validation_raises_other_than_ValidationError(
+        self,
+        upsert_lis_result_sourcedid,
+        context,
+        pyramid_request,
+        wrapped,
+        LISResultSourcedIdSchema,
+        lis_result_sourcedid_svc,
+    ):
+        LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.side_effect = TypeError(
+            "foo"
+        )
+
+        with pytest.raises(TypeError, match="foo"):
+            upsert_lis_result_sourcedid(context, pyramid_request)
+            lis_result_sourcedid_svc.upsert.assert_not_called()
+            wrapped.assert_called_once_with(context, pyramid_request)
+
+    def test_it_continues_to_wrapped_fn_if_user_is_instructor(
+        self,
+        upsert_lis_result_sourcedid,
+        pyramid_request,
+        context,
+        wrapped,
+        LISResultSourcedIdSchema,
+        lis_result_sourcedid_svc,
+        lis_result_sourcedid_value,
+    ):
+        pyramid_request.lti_user = values.LTIUser(
+            "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"
+        )
+        LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
+            lis_result_sourcedid_value
+        )
+
+        upsert_lis_result_sourcedid(context, pyramid_request)
+
+        LISResultSourcedIdSchema(
+            pyramid_request
+        ).lis_result_sourcedid_info.assert_called_once()
+        wrapped.assert_called_once_with(context, pyramid_request)
+        lis_result_sourcedid_svc.upsert.assert_not_called()
+
+    def test_it_continues_to_wrapped_fn_if_LMS_not_blackboard(
+        self,
+        upsert_lis_result_sourcedid,
+        pyramid_request,
+        context,
+        lis_result_sourcedid_svc,
+        LISResultSourcedIdSchema,
+        lis_result_sourcedid_value,
+        wrapped,
+    ):
+        lis_result_sourcedid_value = lis_result_sourcedid_value._replace(
+            tool_consumer_info_product_family_code="NOTBLACKBOARD"
+        )
+        LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
+            lis_result_sourcedid_value
+        )
+
+        upsert_lis_result_sourcedid(context, pyramid_request)
+
+        LISResultSourcedIdSchema(
+            pyramid_request
+        ).lis_result_sourcedid_info.assert_called_once()
+        wrapped.assert_called_once_with(context, pyramid_request)
+        lis_result_sourcedid_svc.upsert.assert_not_called()
+
+    def test_it_upserts_lis_result_sourcedid(
+        self,
+        upsert_lis_result_sourcedid,
+        pyramid_request,
+        context,
+        wrapped,
+        LISResultSourcedIdSchema,
+        lis_result_sourcedid_svc,
+        lis_result_sourcedid_value,
+    ):
+        LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
+            lis_result_sourcedid_value
+        )
+
+        upsert_lis_result_sourcedid(context, pyramid_request)
+
+        lis_result_sourcedid_svc.upsert.assert_called_once_with(
+            lis_result_sourcedid_value, context.h_user, pyramid_request.lti_user
+        )
+        wrapped.assert_called_once_with(context, pyramid_request)
+
+    def test_it_raises_if_upsert_service_raises(
+        self,
+        upsert_lis_result_sourcedid,
+        pyramid_request,
+        context,
+        wrapped,
+        LISResultSourcedIdSchema,
+        lis_result_sourcedid_svc,
+        lis_result_sourcedid_value,
+    ):
+        LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
+            lis_result_sourcedid_value
+        )
+        lis_result_sourcedid_svc.upsert.side_effect = TypeError("service raised")
+
+        with pytest.raises(TypeError, match="service raised"):
+            upsert_lis_result_sourcedid(context, pyramid_request)
+
+            lis_result_sourcedid_svc.upsert.assert_not_called()
+            wrapped.assert_not_called()
+
+
+@pytest.fixture
+def context():
+    context = mock.create_autospec(
+        LTILaunchResource,
+        spec_set=True,
+        instance=True,
+        h_user=values.HUser(
+            authority="TEST_AUTHORITY",
+            username="test_username",
+            display_name="test_display_name",
+        ),
+    )
+    return context
+
+
+@pytest.fixture
+def lis_result_sourcedid_value():
+    return values.LISResultSourcedId(
+        lis_result_sourcedid="TEST LIS RESULT SOURCEDID",
+        lis_outcome_service_url="TEST LIS OUTCOME SERVICE URL",
+        context_id="TEST CONTEXT ID",
+        resource_link_id="TEST RESOURCE LINK ID",
+        tool_consumer_info_product_family_code="BlackboardLearn",
+    )
+
+
+@pytest.fixture
+def wrapped():
+    """The wrapped view callable."""
+
+    def view_callable_spec(context, request):
+        """Spec for the mock view callable."""
+
+    return mock.create_autospec(view_callable_spec, spec_set=True)
+
+
+@pytest.fixture
+def lis_result_sourcedid_svc(pyramid_config):
+    svc = mock.create_autospec(LISResultSourcedIdService, spec_set=True, instance=True)
+    pyramid_config.register_service(svc, name="lis_result_sourcedid")
+    return svc
+
+
+@pytest.fixture
+def upsert_lis_result_sourcedid(wrapped):
+    # Return the actual wrapper function so that tests can call it directly.
+    return decorators.upsert_lis_result_sourcedid(wrapped)
+
+
+@pytest.fixture
+def LISResultSourcedIdSchema(patch):
+    return patch("lms.views.decorators.lis_result_sourcedid.LISResultSourcedIdSchema")


### PR DESCRIPTION
This PR adds a view decorator that will upsert records into the `lis_result_sourcedid` tables for qualified requests (students of BlackBoard with required params on the request).

It also converts the upsert service to take three `NamedTuples` instead of a single `dict` for more rigorous typing/validation.

I'm marking it WIP simply because I'd like to do more "real" testing before deploying (e.g. on Canvas).

Fixes https://github.com/hypothesis/lms/issues/946