### PR TITLE
Add a feature flag to enable PDF.js v2

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -38,6 +38,10 @@ def via_url(request, document_url):
     ]
     query_string_as_list.append(("via.open_sidebar", "1"))
     query_string_as_list.append(("via.request_config_from_frame", request.host_url))
+
+    if request.feature("pdfjs2"):
+        query_string_as_list.append(("via.features", "pdfjs2"))
+
     query_string = parse.urlencode(query_string_as_list)
 
     return request.registry.settings["via_url"] + parse.urlunparse(

--- a/tests/lms/views/helpers/_via_test.py
+++ b/tests/lms/views/helpers/_via_test.py
@@ -49,3 +49,8 @@ class TestViaURL:
         pyramid_request.params["oauth_consumer_key"] = "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
         # fmt: on
         assert via_url(pyramid_request, document_url) == expected_via_url
+
+    def test_it_enables_via_features(self, pyramid_request):
+        pyramid_request.feature = lambda feature: feature == "pdfjs2"
+
+        assert "via.features=pdfjs2" in via_url(pyramid_request, "http://example.com")


### PR DESCRIPTION
When enabled, this flag in turn enables the "pdfjs2" Via feature flag,
which will cause Via to use PDF.js v2 when serving PDFs.