### PR TITLE
Add `blackboard_grading` feature flag, JS config

### DIFF
--- a/lms/services/lis_result_sourcedid.py
+++ b/lms/services/lis_result_sourcedid.py
@@ -8,6 +8,38 @@ class LISResultSourcedIdService:
 
     def __init__(self, _context, request):
         self._db = request.db
+        self._authority = request.registry.settings["h_authority"]
+
+    def fetch_students_by_assignment(
+        self, oauth_consumer_key, context_id, resource_link_id
+    ):
+        """
+        Fetch data for students having LIS result records for an assignment.
+
+        Retrieve all :class:`~lms.models.LISResultSourcedId`s that match this
+        assignment (each unique combination of (``oauth_consumer_key``,
+        ``context_id``, ``resource_link_id``) corresponds to an assignment).
+        There should be one record per applicable student who has launched this
+        assignment (and had ``LISresultSourcedId`` data persisted for them).
+
+        :arg oauth_consumer_key: Which LMS application install the request
+                                 corresponds to.
+        :type oauth_consumer_key: str
+        :arg context_id: LTI parameter indicating the course
+        :type context_id: str
+        :arg resource_link_id: LTI parameter (roughly) equating to an assignment
+        :type resource_link_id: str
+        :rtype: list[:class:`lms.models.LISResultSourcedId`]
+        """
+        return (
+            self._db.query(LISResultSourcedId)
+            .filter_by(
+                oauth_consumer_key=oauth_consumer_key,
+                context_id=context_id,
+                resource_link_id=resource_link_id,
+            )
+            .all()
+        )
 
     def upsert(self, lis_info, h_user, lti_user):
         """

--- a/lms/values.py
+++ b/lms/values.py
@@ -17,6 +17,14 @@ class LTIUser(NamedTuple):
     roles: str
     """The user's LTI roles."""
 
+    @property
+    def is_instructor(self):
+        """Whether this user is an instructor."""
+        return any(
+            role in self.roles.lower()
+            for role in ("administrator", "instructor", "teachingassistant")
+        )
+
 
 class HUser(NamedTuple):
     """

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -28,6 +28,7 @@ from lms.views.decorators import (
     report_lti_launch,
     upsert_lis_result_sourcedid,
 )
+from lms.views.helpers import frontend_app
 
 
 @view_defaults(
@@ -131,6 +132,10 @@ class BasicLTILaunchViews:
         in the LMS and passing it back to us in each launch request. Instead we
         retrieve the document URL from the DB and pass it to Via.
         """
+        # Configure front-end grading if feature is enabled
+        if self.request.feature("blackboard_grading"):
+            frontend_app.configure_grading(self.request, self.context.js_config)
+
         resource_link_id = self.request.params["resource_link_id"]
         tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
 
@@ -158,6 +163,10 @@ class BasicLTILaunchViews:
         LMS, which passes it back to us in each launch request. All we have to
         do is pass the URL to Via.
         """
+        # Configure front-end grading if feature is enabled
+        if self.request.feature("blackboard_grading"):
+            frontend_app.configure_grading(self.request, self.context.js_config)
+
         url = self.request.parsed_params["url"]
         self._set_via_url(url)
 

--- a/lms/views/decorators/lis_result_sourcedid.py
+++ b/lms/views/decorators/lis_result_sourcedid.py
@@ -22,13 +22,8 @@ def upsert_lis_result_sourcedid(wrapped):
             # LIS data is not present on the request.
             return wrapped(context, request)
 
-        is_instructor = any(
-            role in request.lti_user.roles.lower()
-            for role in ("administrator", "instructor", "teachingassisstant")
-        )
-
         if (
-            is_instructor
+            request.lti_user.is_instructor
             or lis_result_sourcedid.tool_consumer_info_product_family_code
             != "BlackboardLearn"
         ):

--- a/lms/views/helpers/__init__.py
+++ b/lms/views/helpers/__init__.py
@@ -1,6 +1,7 @@
 from lms.views.helpers._authentication import check_password
 from lms.views.helpers._canvas_files import canvas_files_available
+from lms.views.helpers import frontend_app
 from lms.views.helpers._via import via_url
 
 
-__all__ = ["check_password", "canvas_files_available", "via_url"]
+__all__ = ["check_password", "canvas_files_available", "frontend_app", "via_url"]

--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -1,0 +1,48 @@
+"""Helpers for configuring the front-end JavaScript application."""
+
+from lms.values import HUser
+
+__all__ = ("configure_grading",)
+
+
+def configure_grading(request, js_config):
+    """
+    Insert any needed JS context to configure the front end for grading.
+
+    This is only enabled for instructors on BlackBoard for now. Note that this
+    is entirely distinct from Canvas Speedgrader, which provides its own UI.
+    """
+    if request.lti_user.is_instructor and _is_blackboard(request):
+        js_config["lmsGrader"] = True
+
+    js_config["grading"] = {}
+
+    lis_result_sourcedid_svc = request.find_service(name="lis_result_sourcedid")
+    lis_result_sourcedids = lis_result_sourcedid_svc.fetch_students_by_assignment(
+        oauth_consumer_key=request.lti_user.oauth_consumer_key,
+        context_id=request.params.get("context_id"),
+        resource_link_id=request.params.get("resource_link_id"),
+    )
+    students = []
+    for student in lis_result_sourcedids:
+        # Using ``HUser`` NamedTuple to get at the ``userid`` prop
+        h_user = HUser(
+            authority=request.registry.settings["h_authority"],
+            username=student.h_username,
+            display_name=student.h_display_name,
+        )
+        students.append(
+            {
+                "userid": h_user.userid,
+                "displayName": h_user.display_name,
+                "LISResultSourcedId": student.lis_result_sourcedid,
+                "LISOutcomeServiceUrl": student.lis_outcome_service_url,
+            }
+        )
+
+    js_config["grading"]["students"] = students
+
+
+def _is_blackboard(request):
+    family_code = request.params.get("tool_consumer_info_product_family_code", "")
+    return family_code == "BlackboardLearn"

--- a/tests/lms/views/helpers/frontend_app_test.py
+++ b/tests/lms/views/helpers/frontend_app_test.py
@@ -1,0 +1,109 @@
+from unittest import mock
+
+import pytest
+
+from lms.models import LISResultSourcedId
+from lms.services.lis_result_sourcedid import LISResultSourcedIdService
+from lms.values import LTIUser
+from lms.views.helpers import frontend_app
+
+
+@pytest.mark.usefixtures("lis_result_sourcedid_svc")
+class TestConfigureGrading:
+    def test_it_sets_grading_config_if_qualified_request(self, grading_request):
+        js_config = {}
+
+        frontend_app.configure_grading(grading_request, js_config)
+
+        assert "lmsGrader" in js_config
+
+    def test_it_does_not_set_grading_config_if_unqualified_request(
+        self, pyramid_request
+    ):
+        js_config = {}
+
+        frontend_app.configure_grading(pyramid_request, js_config)
+
+        assert "lmsGrader" not in js_config
+
+    def test_it_fetches_lis_student_records(
+        self, grading_request, lis_result_sourcedid_svc
+    ):
+        frontend_app.configure_grading(grading_request, {})
+
+        lis_result_sourcedid_svc.fetch_students_by_assignment.assert_called_once_with(
+            oauth_consumer_key=grading_request.lti_user.oauth_consumer_key,
+            context_id=grading_request.params["context_id"],
+            resource_link_id=grading_request.params["resource_link_id"],
+        )
+
+    def test_it_sets_list_of_students_on_config(self, grading_request):
+        js_config = {}
+
+        frontend_app.configure_grading(grading_request, js_config)
+
+        assert "students" in js_config["grading"]
+        assert js_config["grading"]["students"] == []
+
+    def test_it_sets_js_properties_for_each_student_record(
+        self, lis_result_sourcedid_svc, lis_result_sourcedids, grading_request
+    ):
+        js_config = {}
+        lis_result_sourcedid_svc.fetch_students_by_assignment.return_value = (
+            lis_result_sourcedids
+        )
+
+        frontend_app.configure_grading(grading_request, js_config)
+
+        assert len(js_config["grading"]["students"]) == 3
+        for propName in [
+            "userid",
+            "displayName",
+            "LISResultSourcedId",
+            "LISOutcomeServiceUrl",
+        ]:
+            assert propName in js_config["grading"]["students"][0]
+
+
+@pytest.fixture
+def lis_result_sourcedid_svc(pyramid_config):
+    svc = mock.create_autospec(LISResultSourcedIdService, instance=True)
+    pyramid_config.register_service(svc, name="lis_result_sourcedid")
+    svc.fetch_students_by_assignment.return_value = []
+    return svc
+
+
+@pytest.fixture
+def lis_result_sourcedids():
+    lis_result_1 = LISResultSourcedId(
+        h_username="foobar",
+        h_display_name="A Student",
+        lis_result_sourcedid="sourcedid_1",
+        lis_outcome_service_url="http://fakeo",
+    )
+
+    lis_result_2 = LISResultSourcedId(
+        h_username="deadbeef",
+        h_display_name="Another Student",
+        lis_result_sourcedid="sourcedid_2",
+        lis_outcome_service_url="http://fakeo",
+    )
+
+    lis_result_3 = LISResultSourcedId(
+        h_username="feedbee",
+        h_display_name="Yet More Student",
+        lis_result_sourcedid="sourcedid_3",
+        lis_outcome_service_url="http://fakeo",
+    )
+    return [lis_result_1, lis_result_2, lis_result_3]
+
+
+@pytest.fixture
+def grading_request(pyramid_request):
+    pyramid_request.params["tool_consumer_info_product_family_code"] = "BlackboardLearn"
+    pyramid_request.lti_user = LTIUser(
+        "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"
+    )
+    pyramid_request.params["context_id"] = "unique_course_id"
+    pyramid_request.params["resource_link_id"] = "unique_assignment_id"
+    return pyramid_request


### PR DESCRIPTION
This PR does a few things related to grading configuration for Blackboard grading:

* It adds a new feature flag, `blackboard_grading`
* When that feature flag is active AND a request comes from Blackboard AND the current user is an instructor, JS configuration is added for the frontend app to consume
* A service method has been added to retrieve relevant student-LIS Result records for the applicable assignment (these are added to the JS config).

To accomplish this, a bit of shuffling around has happened, as I'm trying to yank some of the logic out of the view layer.

Part of https://github.com/hypothesis/lms/issues/949
