### PR TITLE
Reorganize `lms.views.api.lti` into a view class

### DIFF
--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -1,83 +1,93 @@
 import datetime
 from datetime import timezone
 
-from pyramid.view import view_config
+from pyramid.view import view_config, view_defaults
 
 from lms.validation import APIRecordSubmissionSchema
 from lms.services.lti_outcomes import LTIOutcomesRequestParams
 
 
-@view_config(
-    request_method="POST",
-    route_name="lti_api.submissions.record",
-    renderer="json",
-    schema=APIRecordSubmissionSchema,
-)
-def record_submission(request):
-    """
-    Record info to facilitate later grading of an assignment.
+@view_defaults(request_method="POST", renderer="json")
+class LTIOutcomesViews:
+    """Views for proxy APIs interacting with LTI Outcome Management APIs."""
 
-    When a learner launches an assignment the LMS provides metadata that can
-    be later used to submit a score to the LMS using LTI Outcome Management
-    APIs. In Canvas, extensions to that API allow a custom LTI launch URL to be
-    submitted for use by the SpeedGrader [1].
+    def __init__(self, request):
+        self.request = request
+        self.parsed_params = self.request.parsed_params
+        self.lti_outcomes_client = self.request.find_service(name="lti_outcomes_client")
 
-    Currently this view only supports SpeedGrader-based grading in Canvas by
-    submitting an LTI Launch URL to Canvas. In future it will need to persist the
-    metadata to facilitate grading in other LMSes via a different UI.
+        lti_user = self.request.lti_user
 
-    This work _could_ be done by the backend during an LTI launch, but as it
-    involves potentially slow requests to the external LMS, it is triggered
-    asynchronously by the frontend while the assignment is loading.
-
-    [1] https://canvas.instructure.com/doc/api/file.assignment_tools.html
-    """
-
-    lti_user = request.lti_user
-    parsed_params = request.parsed_params
-
-    shared_secret = request.find_service(name="ai_getter").shared_secret(
-        lti_user.oauth_consumer_key
-    )
-    outcome_request_params = LTIOutcomesRequestParams(
-        consumer_key=lti_user.oauth_consumer_key,
-        shared_secret=shared_secret,
-        lis_outcome_service_url=parsed_params["lis_outcome_service_url"],
-        lis_result_sourcedid=parsed_params["lis_result_sourcedid"],
-    )
-
-    lti_outcomes_client = request.find_service(name="lti_outcomes_client")
-
-    # Send the SpeedGrader LTI launch URL to the Canvas instance, if we haven't
-    # already created a submission OR if the existing submission has not been
-    # graded (Canvas's result-reading API doesn't allow us to distinguish
-    # absence of a submission from an ungraded submission. Non-Canvas LMSes in
-    # theory require a grade).
-    current_score = lti_outcomes_client.read_result(outcome_request_params)
-    if current_score is None:
-        # **WARNING**
-        #
-        # Canvas has a bug with handling of percent-encoded characters in the
-        # the SpeedGrader launch URL. Code that responds to the launch will
-        # need to handle this for fields that may contain such chars (eg.
-        # the "url" field).
-        #
-        # See https://github.com/instructure/canvas-lms/issues/1486
-        speedgrader_launch_params = {"focused_user": parsed_params["h_username"]}
-        if parsed_params.get("document_url"):
-            speedgrader_launch_params["url"] = parsed_params.get("document_url")
-        elif parsed_params.get("canvas_file_id"):
-            speedgrader_launch_params["canvas_file"] = "true"
-            speedgrader_launch_params["file_id"] = parsed_params["canvas_file_id"]
-
-        speedgrader_launch_url = request.route_url(
-            "lti_launches", _query=speedgrader_launch_params
+        shared_secret = self.request.find_service(name="ai_getter").shared_secret(
+            lti_user.oauth_consumer_key
+        )
+        self.outcome_request_params = LTIOutcomesRequestParams(
+            consumer_key=lti_user.oauth_consumer_key,
+            shared_secret=shared_secret,
+            lis_outcome_service_url=self.parsed_params["lis_outcome_service_url"],
+            lis_result_sourcedid=self.parsed_params["lis_result_sourcedid"],
         )
 
-        lti_outcomes_client.record_result(
-            outcome_request_params,
-            lti_launch_url=speedgrader_launch_url,
-            submitted_at=datetime.datetime(2001, 1, 1, tzinfo=timezone.utc),
-        )
+    @view_config(
+        route_name="lti_api.submissions.record", schema=APIRecordSubmissionSchema
+    )
+    def record_canvas_speedgrader_submission(self):
+        """
+        Record info to allow later grading of an assignment via Canvas Speedgrader.
 
-    return {}
+        When a learner launches an assignment the LMS provides metadata that can
+        be later used to submit a score to the LMS using LTI Outcome Management
+        APIs. In Canvas, extensions to that API allow a custom LTI launch URL to be
+        submitted for use by the SpeedGrader [1].
+
+        This view only supports SpeedGrader-based grading in Canvas by
+        submitting an LTI Launch URL to Canvas.
+
+        This work _could_ be done by the backend during an LTI launch, but as it
+        involves potentially slow requests to the external LMS, it is triggered
+        asynchronously by the frontend while the assignment is loading.
+
+        [1] https://canvas.instructure.com/doc/api/file.assignment_tools.html
+        """
+
+        # Send the SpeedGrader LTI launch URL to the Canvas instance, if we haven't
+        # already created a submission OR if the existing submission has not been
+        # graded (Canvas's result-reading API doesn't allow us to distinguish
+        # absence of a submission from an ungraded submission. Non-Canvas LMSes in
+        # theory require a grade).
+        current_score = self.lti_outcomes_client.read_result(
+            self.outcome_request_params
+        )
+        if current_score is None:
+            # **WARNING**
+            #
+            # Canvas has a bug with handling of percent-encoded characters in the
+            # the SpeedGrader launch URL. Code that responds to the launch will
+            # need to handle this for fields that may contain such chars (eg.
+            # the "url" field).
+            #
+            # See https://github.com/instructure/canvas-lms/issues/1486
+            speedgrader_launch_params = {
+                "focused_user": self.parsed_params["h_username"]
+            }
+            if self.parsed_params.get("document_url"):
+                speedgrader_launch_params["url"] = self.parsed_params.get(
+                    "document_url"
+                )
+            elif self.parsed_params.get("canvas_file_id"):
+                speedgrader_launch_params["canvas_file"] = "true"
+                speedgrader_launch_params["file_id"] = self.parsed_params[
+                    "canvas_file_id"
+                ]
+
+            speedgrader_launch_url = self.request.route_url(
+                "lti_launches", _query=speedgrader_launch_params
+            )
+
+            self.lti_outcomes_client.record_result(
+                self.outcome_request_params,
+                lti_launch_url=speedgrader_launch_url,
+                submitted_at=datetime.datetime(2001, 1, 1, tzinfo=timezone.utc),
+            )
+
+        return {}

--- a/tests/lms/views/api/lti_test.py
+++ b/tests/lms/views/api/lti_test.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 
 import pytest
 
-from lms.views.api.lti import record_submission
+from lms.views.api.lti import LTIOutcomesViews
 from lms.services.lti_outcomes import LTIOutcomesClient, LTIOutcomesRequestParams
 from lms.services.application_instance_getter import ApplicationInstanceGetter
 
@@ -14,7 +14,7 @@ class TestRecordSubmission:
     def test_it_passes_correct_params_to_read_current_score(
         self, pyramid_request, lti_outcomes_client
     ):
-        record_submission(pyramid_request)
+        LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
 
         lti_outcomes_client.read_result.assert_called_once_with(
             LTIOutcomesRequestParams(
@@ -30,7 +30,7 @@ class TestRecordSubmission:
     ):
         lti_outcomes_client.read_result.return_value = 0.5
 
-        record_submission(pyramid_request)
+        LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
 
         lti_outcomes_client.record_result.assert_not_called()
 
@@ -54,7 +54,7 @@ class TestRecordSubmission:
         )
         lti_outcomes_client.read_result.return_value = None
 
-        record_submission(pyramid_request)
+        LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
 
         expected_outcome_params = LTIOutcomesRequestParams(
             consumer_key="TEST_OAUTH_CONSUMER_KEY",


### PR DESCRIPTION
This small PR factors out things common to various LTI Outcomes Management proxy API views and renames things specific to Canvas/Speedgrader for clarity. This makes way for another view to be added here to support BlackBoard grading.

Part of https://github.com/hypothesis/lms/issues/948