### PR TITLE
Add Proxy API for submitting LTI Outcome Results

### DIFF
--- a/lms/resources/_default.py
+++ b/lms/resources/_default.py
@@ -8,7 +8,11 @@ __all__ = ["DefaultResource"]
 class DefaultResource:
     """The application's default root resource."""
 
-    __acl__ = [(Allow, "report_viewers", "view"), (Allow, "lti_user", "canvas_api")]
+    __acl__ = [
+        (Allow, "report_viewers", "view"),
+        (Allow, "lti_user", "canvas_api"),
+        (Allow, "lti_user", "lti_outcomes"),
+    ]
 
     def __init__(self, request):
         """Return the default root resource object."""

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -31,3 +31,5 @@ def includeme(config):
     )
     config.add_route("canvas_api.files.via_url", "/api/canvas/files/{file_id}/via_url")
     config.add_route("lti_api.submissions.record", "/api/lti/submissions")
+
+    config.add_route("lti_api.result.record", "/api/lti/result", request_method="POST")

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -68,11 +68,12 @@ from lms.validation._canvas import (
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
 )
-from lms.validation._api import APIRecordSpeedgraderSchema
+from lms.validation._api import APIRecordSpeedgraderSchema, APIRecordResultSchema
 
 
 __all__ = (
     "APIRecordSpeedgraderSchema",
+    "APIRecordResultSchema",
     "CanvasOAuthCallbackSchema",
     "CanvasAccessTokenResponseSchema",
     "CanvasRefreshTokenResponseSchema",

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -68,11 +68,11 @@ from lms.validation._canvas import (
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
 )
-from lms.validation._api import APIRecordSubmissionSchema
+from lms.validation._api import APIRecordSpeedgraderSchema
 
 
 __all__ = (
-    "APIRecordSubmissionSchema",
+    "APIRecordSpeedgraderSchema",
     "CanvasOAuthCallbackSchema",
     "CanvasAccessTokenResponseSchema",
     "CanvasRefreshTokenResponseSchema",

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -5,11 +5,11 @@ from webargs import fields
 from lms.validation._helpers import PyramidRequestSchema
 
 
-__all__ = ["APIRecordSubmissionSchema"]
+__all__ = ["APIRecordSpeedgraderSchema"]
 
 
-class APIRecordSubmissionSchema(PyramidRequestSchema):
-    """Schema for validating requests from the frontend to record submissions."""
+class APIRecordSpeedgraderSchema(PyramidRequestSchema):
+    """Schema for validating Canvas Speedgrader submissions from the front end."""
 
     locations = ["json"]
 

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -1,11 +1,12 @@
 """Schema for JSON APIs exposed to the frontend."""
 
+import marshmallow
 from webargs import fields
 
 from lms.validation._helpers import PyramidRequestSchema
 
 
-__all__ = ["APIRecordSpeedgraderSchema"]
+__all__ = ["APIRecordSpeedgraderSchema", "APIRecordResultSchema"]
 
 
 class APIRecordSpeedgraderSchema(PyramidRequestSchema):
@@ -29,4 +30,26 @@ class APIRecordSpeedgraderSchema(PyramidRequestSchema):
     """
     Opaque identifier provided by the LMS to identify a submission. This
     typically encodes the assignment context and LMS user.
+    """
+
+
+class APIRecordResultSchema(PyramidRequestSchema):
+    """Schema for validating proxy requests to LTI Outcomes API for recording grades."""
+
+    locations = ["json"]
+
+    lis_outcome_service_url = fields.Str(required=True)
+    """URL provided by the LMS to submit grades or other results to."""
+
+    lis_result_sourcedid = fields.Str(required=True)
+    """
+    Opaque identifier provided by the LMS to identify a submission. This
+    typically encodes the assignment context and LMS user.
+    """
+
+    score = fields.Number(
+        required=True, validate=marshmallow.validate.Range(min=0, max=1)
+    )
+    """
+    Score — i.e. grade — for this submission. A value between 0 and 1, inclusive.
     """

--- a/lms/views/api/error.py
+++ b/lms/views/api/error.py
@@ -7,9 +7,17 @@ from pyramid.view import (
 )
 
 from lms.services import CanvasAPIError, CanvasAPIAccessTokenError
-
+from lms.validation import ValidationError
 
 _ = i18n.TranslationStringFactory(__package__)
+
+
+@exception_view_config(context=ValidationError, renderer="json")
+def validation_error(context, request):
+    request.response.status_int = 422
+    # For frontend requests to proxy API endpoints, handle schema
+    # validation errors.
+    return {"error_message": context.explanation, "details": context.messages}
 
 
 @exception_view_config(context=CanvasAPIAccessTokenError, renderer="json")

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -3,7 +3,7 @@ from datetime import timezone
 
 from pyramid.view import view_config, view_defaults
 
-from lms.validation import APIRecordSpeedgraderSchema
+from lms.validation import APIRecordSpeedgraderSchema, APIRecordResultSchema
 from lms.services.lti_outcomes import LTIOutcomesRequestParams
 
 
@@ -27,6 +27,16 @@ class LTIOutcomesViews:
             lis_outcome_service_url=self.parsed_params["lis_outcome_service_url"],
             lis_result_sourcedid=self.parsed_params["lis_result_sourcedid"],
         )
+
+    @view_config(route_name="lti_api.result.record", schema=APIRecordResultSchema)
+    def record_result(self):
+        """Proxy result (grade/score) to LTI Outcomes Result API."""
+
+        self.request.find_service(name="lti_outcomes_client").record_result(
+            self.outcome_request_params, score=self.request.parsed_params["score"]
+        )
+
+        return {}
 
     @view_config(
         route_name="lti_api.submissions.record", schema=APIRecordSpeedgraderSchema

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -3,7 +3,7 @@ from datetime import timezone
 
 from pyramid.view import view_config, view_defaults
 
-from lms.validation import APIRecordSubmissionSchema
+from lms.validation import APIRecordSpeedgraderSchema
 from lms.services.lti_outcomes import LTIOutcomesRequestParams
 
 
@@ -29,7 +29,7 @@ class LTIOutcomesViews:
         )
 
     @view_config(
-        route_name="lti_api.submissions.record", schema=APIRecordSubmissionSchema
+        route_name="lti_api.submissions.record", schema=APIRecordSpeedgraderSchema
     )
     def record_canvas_speedgrader_submission(self):
         """

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -7,7 +7,7 @@ from lms.validation import APIRecordSpeedgraderSchema, APIRecordResultSchema
 from lms.services.lti_outcomes import LTIOutcomesRequestParams
 
 
-@view_defaults(request_method="POST", renderer="json")
+@view_defaults(request_method="POST", renderer="json", permission="lti_outcomes")
 class LTIOutcomesViews:
     """Views for proxy APIs interacting with LTI Outcome Management APIs."""
 

--- a/tests/lms/test_routes.py
+++ b/tests/lms/test_routes.py
@@ -45,4 +45,7 @@ class TestIncludeMe:
                 "canvas_api.files.via_url", "/api/canvas/files/{file_id}/via_url"
             ),
             mock.call.add_route("lti_api.submissions.record", "/api/lti/submissions"),
+            mock.call.add_route(
+                "lti_api.result.record", "/api/lti/result", request_method="POST"
+            ),
         ]

--- a/tests/lms/validation/_api_test.py
+++ b/tests/lms/validation/_api_test.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from lms.validation import ValidationError
-from lms.validation._api import APIRecordSpeedgraderSchema
+from lms.validation._api import APIRecordSpeedgraderSchema, APIRecordResultSchema
 
 
 class TestAPIRecordSpeedgraderSchema:
@@ -47,4 +47,57 @@ class TestAPIRecordSpeedgraderSchema:
             "h_username": "user123",
             "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
             "lis_result_sourcedid": "modelstudent-assignment1",
+        }
+
+
+class TestAPIRecordResultSchema:
+    def test_it_parses_request(self, pyramid_request, all_fields):
+        pyramid_request.body = json.dumps(all_fields)
+
+        schema = APIRecordResultSchema(pyramid_request)
+        parsed_params = schema.parse()
+
+        assert parsed_params == all_fields
+
+    @pytest.mark.parametrize(
+        "field", ["lis_outcome_service_url", "lis_result_sourcedid", "score"]
+    )
+    def test_it_raises_if_required_fields_missing(
+        self, pyramid_request, all_fields, field
+    ):
+        del all_fields[field]
+        pyramid_request.body = json.dumps(all_fields)
+
+        schema = APIRecordResultSchema(pyramid_request)
+
+        with pytest.raises(ValidationError):
+            schema.parse()
+
+    @pytest.mark.parametrize("bad_score", ["5", 5.0, 5, -1, 1.2, "fingers"])
+    def test_it_raises_if_score_invalid(self, pyramid_request, all_fields, bad_score):
+        all_fields["score"] = bad_score
+        pyramid_request.body = json.dumps(all_fields)
+
+        schema = APIRecordResultSchema(pyramid_request)
+
+        with pytest.raises(ValidationError):
+            schema.parse()
+
+    @pytest.mark.parametrize("good_score", ["0", "0.5", "1", "1.0", "0.0", 0.5, 1, 0])
+    def test_it_does_not_raise_with_valid_score_value(
+        self, pyramid_request, all_fields, good_score
+    ):
+        all_fields["score"] = good_score
+        pyramid_request.body = json.dumps(all_fields)
+
+        schema = APIRecordResultSchema(pyramid_request)
+
+        schema.parse()
+
+    @pytest.fixture
+    def all_fields(self):
+        return {
+            "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
+            "lis_result_sourcedid": "modelstudent-assignment1",
+            "score": 0.5,
         }

--- a/tests/lms/validation/_api_test.py
+++ b/tests/lms/validation/_api_test.py
@@ -3,14 +3,14 @@ import json
 import pytest
 
 from lms.validation import ValidationError
-from lms.validation._api import APIRecordSubmissionSchema
+from lms.validation._api import APIRecordSpeedgraderSchema
 
 
-class TestAPIRecordSubmissionSchema:
+class TestAPIRecordSpeedgraderSchema:
     def test_it_parses_request(self, pyramid_request, all_fields):
         pyramid_request.body = json.dumps(all_fields)
 
-        schema = APIRecordSubmissionSchema(pyramid_request)
+        schema = APIRecordSpeedgraderSchema(pyramid_request)
         parsed_params = schema.parse()
 
         assert parsed_params == all_fields
@@ -24,7 +24,7 @@ class TestAPIRecordSubmissionSchema:
         del all_fields[field]
         pyramid_request.body = json.dumps(all_fields)
 
-        schema = APIRecordSubmissionSchema(pyramid_request)
+        schema = APIRecordSpeedgraderSchema(pyramid_request)
 
         with pytest.raises(ValidationError):
             schema.parse()
@@ -36,7 +36,7 @@ class TestAPIRecordSubmissionSchema:
         del all_fields[field]
         pyramid_request.body = json.dumps(all_fields)
 
-        schema = APIRecordSubmissionSchema(pyramid_request)
+        schema = APIRecordSpeedgraderSchema(pyramid_request)
         schema.parse()
 
     @pytest.fixture

--- a/tests/lms/views/api/error_test.py
+++ b/tests/lms/views/api/error_test.py
@@ -1,5 +1,18 @@
 from lms.services import CanvasAPIError
 from lms.views.api import error
+from lms.validation import ValidationError
+
+
+class TestSchemaValidationError:
+    def test_it(self, pyramid_request):
+        json_data = error.validation_error(
+            ValidationError(messages="foobar"), pyramid_request
+        )
+        assert pyramid_request.response.status_code == 422
+        assert json_data == {
+            "error_message": "Unable to process the contained instructions",
+            "details": "foobar",
+        }
 
 
 class TestCanvasAPIAccessTokenError:

--- a/tests/lms/views/api/lti_test.py
+++ b/tests/lms/views/api/lti_test.py
@@ -10,7 +10,7 @@ from lms.services.lti_outcomes import LTIOutcomesClient, LTIOutcomesRequestParam
 from lms.services.application_instance_getter import ApplicationInstanceGetter
 
 
-class TestRecordSubmission:
+class TestRecordCanvasSpeedgraderSubmission:
     def test_it_passes_correct_params_to_read_current_score(
         self, pyramid_request, lti_outcomes_client
     ):
@@ -86,6 +86,33 @@ class TestRecordSubmission:
             # service.
             "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
             "lis_result_sourcedid": "modelstudent-assignment1",
+        }
+        return pyramid_request
+
+
+class TestRecordResult:
+    def test_it_records_result(self, pyramid_request, lti_outcomes_client):
+
+        LTIOutcomesViews(pyramid_request).record_result()
+
+        expected_outcome_params = LTIOutcomesRequestParams(
+            consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            shared_secret="oauth-secret",
+            lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
+            lis_result_sourcedid="modelstudent-assignment1",
+        )
+        lti_outcomes_client.record_result.assert_called_once_with(
+            expected_outcome_params, score=pyramid_request.parsed_params["score"]
+        )
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.parsed_params = {
+            # Metadata provided by LMS for requests to LTI Outcomes Management
+            # service.
+            "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
+            "lis_result_sourcedid": "modelstudent-assignment1",
+            "score": 0.5,
         }
         return pyramid_request
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/948

This PR adds a super-basic route and view to proxy over results (i.e. grades or scores) to an LTI-Outcomes-Management-compliant API. In this case our goal is to be able to submit BlackBoard Learn grades.

Also included here is a schema for validating requests to this endpoint.

How to test this (using `curl` or your preferred request-management software):

1. You'll need a properly-configured Blackboard Learn assignment pointing at your local instance of `lms`. Launch this assignment as at least one _student_ who is enrolled in the course prior to continuing.
1. Ensure that you have the `blackboard_grading` feature flag enabled in your context (i.e. browser session) and launch the assignment as an (associated) instructor.
1. If you view source/inspect, you can find the generated `js_config` for the launch (in a `script` tag with a class of `js-config`). From here, you'll want to take note of:
    1. The `AuthToken` value
    1. Choose a student for which to submit a grade and note their values for `LISResultSourcedId` and `LISOutcomeServiceUrl`.
1. Generate a `POST` request to `http://localhost:8001/api/lti/result`
    1. Set an `Authorization` header with the `AuthToken` value (do not include the prefix `Bearer `).
    1. Create a JSON body:
    ```
    {
        'lis_result_sourcedid': <LISResultSourcedId from above>,
        'lis_outcome_service_url': <LISOutcomeServiceUrl from above>,
        'score': <some value between 0 and 1>
    }
    ```
1. Let 'er rip

Screenshot of submitted grade showing up in Blackboard grading center:

![image](https://user-images.githubusercontent.com/439947/65544887-4306b900-dee2-11e9-8525-26a56f10d853.png)
