### PR TITLE
Automate installing docker-compose and creating the lms_test DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ help:
 	@echo "                       dependencies, etc)"
 
 .PHONY: services
+services: args?=up -d
 services:
-	docker-compose up -d
+	@tox -q -e docker-compose -- $(args)
 
 .PHONY: dev
 dev: build/manifest.json python
@@ -47,7 +48,7 @@ shell: python
 
 .PHONY: sql
 sql:
-	docker-compose exec postgres psql --pset expanded=auto -U postgres
+	@tox -q -e docker-compose -- exec postgres psql --pset expanded=auto -U postgres
 
 .PHONY: lint
 lint: backend-lint frontend-lint

--- a/README.markdown
+++ b/README.markdown
@@ -37,8 +37,6 @@ There are three presentations for developers that describe what the Hypothesis L
   Follow the [instructions on the Docker website](https://docs.docker.com/install/)
   to install "Docker Engine - Community".
 
-* [Docker Compose](https://docs.docker.com/compose/install/)
-
 * [pyenv](https://github.com/pyenv/pyenv)
   Follow the instructions in the pyenv README to install it.
   The Homebrew method works best on macOS.
@@ -179,7 +177,7 @@ linting, code formatting, Python and SQL shells, etc.
 
 Create the `lms_test` database by running:
 
-    docker-compose exec postgres psql -U postgres -c "CREATE DATABASE lms_test;"
+    make services args='exec postgres psql -U postgres -c "CREATE DATABASE lms_test;"'
 
 You should now be able to run the tests successfully by typing:
 

--- a/README.markdown
+++ b/README.markdown
@@ -173,11 +173,7 @@ it crash for some reason.
 `make help` to see all the commands that're available for running the tests,
 linting, code formatting, Python and SQL shells, etc.
 
-### Create the test DB and run the tests
-
-Create the `lms_test` database by running:
-
-    make services args='exec postgres psql -U postgres -c "CREATE DATABASE lms_test;"'
+### Run the tests
 
 You should now be able to run the tests successfully by typing:
 

--- a/bin/create-testdb
+++ b/bin/create-testdb
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+#
+# Create the "lms_test" database in Postgres, if it doesn't exist already.
+make services args='exec postgres psql -U postgres -c "CREATE DATABASE lms_test;"' > /dev/null 2>&1 || true

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ deps =
     {format,checkformatting}: black
     {docstrings,checkdocstrings}: sphinx
     docstrings: sphinx-autobuild
+    docker-compose: docker-compose
     {tests,lint,docstrings,checkdocstrings}: -r requirements.txt
     dev: -r requirements-dev.in
 setenv =
@@ -66,6 +67,7 @@ commands =
     coverage: -coverage combine
     coverage: coverage report --show-missing
     codecov: codecov -t {env:CODECOV_TOKEN}
+    docker-compose: docker-compose {posargs}
     {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envdir}/rst .
     docstrings: sphinx-autobuild -BqT -z lms -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envdir}/rst {envdir}/dirhtml

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,10 @@ deps =
 setenv =
     tests: JWT_SECRET = test_secret
     tests: VIA_URL = https://example.com/
+whitelist_externals =
+    tests: sh
 commands =
+    tests: sh bin/create-testdb
     tests: coverage run --source lms,tests/lms -m pytest -v -Werror {posargs:tests/lms/}
     dev: {posargs:gunicorn --paste conf/development.ini}
     lint: prospector


### PR DESCRIPTION
Just copying two things that we've already had in h for a while, over to lms: install docker-compose automatically in tox so that developers don't have to go hunting through the Docker docs trying to find out how to install it on their system. And create the test DB automatically.