### PR TITLE
Moving the pip-compile to tox and it's own env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ checkdocstrings: python
 
 .PHONY: pip-compile
 pip-compile: python
-	tox -q -e py36-dev -- pip-compile --output-file requirements.txt requirements.in
+	tox -q -e py36-pip-compile
 
 .PHONY: docker
 docker:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,6 @@
 -r requirements.txt
 -e .
 
-pip-tools
 pyramid_debugtoolbar
 pyramid_ipython
 honcho

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ deps =
     docker-compose: docker-compose
     {tests,lint,docstrings,checkdocstrings}: -r requirements.txt
     dev: -r requirements-dev.in
+    pip-compile: pip-tools
 setenv =
     tests: JWT_SECRET = test_secret
     tests: VIA_URL = https://example.com/
@@ -76,4 +77,5 @@ commands =
     docstrings: sphinx-autobuild -BqT -z lms -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envdir}/rst {envdir}/dirhtml
     clean: coverage erase
+    pip-compile: pip-compile
 sitepackages = {env:SITE_PACKAGES:false}


### PR DESCRIPTION
Moving pip-compile command out of Make and the dev requirements to be a separate tox command. This means the dev env is very slightly smaller, the compile env is much smaller and we are following the more layered approach (make on tox, not instead).