### PR TITLE
Add option to use via2 service via feature flag

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -25,6 +25,7 @@ feature_flags_cookie_secret = "notasecret"
 oauth2_state_secret = "notasecret"
 
 via_url = http://localhost:9080
+via2_url = http://localhost:9081
 h_authority = lms.hypothes.is
 h_api_url_public = http://localhost:5000/api/
 h_api_url_private = http://localhost:5000/api/

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -15,6 +15,7 @@ def configure(settings):
         # The URL of the https://github.com/hypothesis/via instance to
         # integrate with.
         "via_url": sg.get("VIA_URL"),
+        "via2_url": sg.get("VIA2_URL"),
         "jwt_secret": sg.get("JWT_SECRET"),
         "google_client_id": sg.get("GOOGLE_CLIENT_ID"),
         "google_developer_key": sg.get("GOOGLE_DEVELOPER_KEY"),
@@ -67,6 +68,7 @@ def configure(settings):
         env_settings["sqlalchemy.url"] = database_url
 
     env_settings["via_url"] = _append_trailing_slash(env_settings["via_url"])
+    env_settings["via2_url"] = _append_trailing_slash(env_settings["via2_url"])
     env_settings["h_api_url_public"] = _append_trailing_slash(
         env_settings["h_api_url_public"]
     )

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -44,7 +44,11 @@ def via_url(request, document_url):
 
     query_string = parse.urlencode(query_string_as_list)
 
-    return request.registry.settings["via_url"] + parse.urlunparse(
+    via_service_url = request.registry.settings["via_url"]
+    if request.feature("use_via2_service"):
+        via_service_url = request.registry.settings["via2_url"]
+
+    return via_service_url + parse.urlunparse(
         (
             parts.scheme,
             parts.netloc,

--- a/tests/lms/config/__init___test.py
+++ b/tests/lms/config/__init___test.py
@@ -133,6 +133,20 @@ class TestConfigure:
 
         assert configurator.registry.settings["via_url"] == "https://via.hypothes.is/"
 
+    def test_trailing_slashes_are_appended_to_via2_url(self, setting_getter):
+        def side_effect(
+            envvar_name, *args, **kwargs
+        ):  # pylint: disable=unused-argument
+            if envvar_name == "VIA2_URL":
+                return "https://via2.hypothes.is"
+            return mock.DEFAULT
+
+        setting_getter.get.side_effect = side_effect
+
+        configurator = configure({})
+
+        assert configurator.registry.settings["via2_url"] == "https://via2.hypothes.is/"
+
     def test_trailing_slashes_are_appended_to_h_api_url_public(self, setting_getter):
         def side_effect(
             envvar_name, *args, **kwargs

--- a/tests/lms/conftest.py
+++ b/tests/lms/conftest.py
@@ -138,6 +138,7 @@ def pyramid_config(pyramid_request):
     settings = {
         "sqlalchemy.url": TEST_DATABASE_URL,
         "via_url": "http://TEST_VIA_SERVER.is/",
+        "via2_url": "http://TEST_VIA2_SERVER.is/",
         "jwt_secret": "test_secret",
         "google_client_id": "fake_client_id",
         "google_developer_key": "fake_developer_key",

--- a/tests/lms/views/helpers/_via_test.py
+++ b/tests/lms/views/helpers/_via_test.py
@@ -54,3 +54,12 @@ class TestViaURL:
         pyramid_request.feature = lambda feature: feature == "pdfjs2"
 
         assert "via.features=pdfjs2" in via_url(pyramid_request, "http://example.com")
+
+    def test_it_returns_via2_url_if_use_via2_service_feature_flag_is_set(
+        self, pyramid_request
+    ):
+        pyramid_request.feature = lambda feature: feature == "use_via2_service"
+
+        assert via_url(pyramid_request, "http://example.com").startswith(
+            "http://TEST_VIA2_SERVER.is/"
+        )


### PR DESCRIPTION
Add `use_via2_service` feature flag that when enabled, will use `https://via2.hypothes.is` instead of `https://via.hypothes.is` (or `https://qa-via2.hypothes.is` if on qa or `http://localhost:9081` if on dev). This is part of https://github.com/hypothesis/lms/issues/1030.