### PR TITLE
Add client validation utility

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/validation-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/validation-test.js
@@ -1,0 +1,35 @@
+import { translateToNumber, validateGrade } from '../validation';
+
+describe('validation', () => {
+  context('translateToNumber', () => {
+    it('translates the string to a number', async () => {
+      assert.isTrue(translateToNumber('1') === 1);
+    });
+
+    it('does not translate the empty string to a number', async () => {
+      assert.isTrue(typeof translateToNumber(' ') === 'string');
+    });
+
+    it('does not translate a non numerical string to a number', async () => {
+      assert.isTrue(typeof translateToNumber('a') === 'string');
+    });
+  });
+
+  context('validateGrade', () => {
+    it('fails validation if the value is not a number', async () => {
+      assert.equal(validateGrade('1'), 'Grade must be a valid number');
+    });
+
+    it('fails validation if the value is less than 0', async () => {
+      assert.equal(validateGrade(-1), 'Grade must be between 0 and 10');
+    });
+
+    it('fails validation if the value is greater than 10', async () => {
+      assert.equal(validateGrade(11), 'Grade must be between 0 and 10');
+    });
+
+    it('passes validation if its a valid number between 0 and 10', async () => {
+      assert.equal(validateGrade(1), undefined);
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/test/validation-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/validation-test.js
@@ -1,17 +1,21 @@
-import { translateToNumber, validateGrade } from '../validation';
+import { formatToNumber, validateGrade } from '../validation';
 
 describe('validation', () => {
-  context('translateToNumber', () => {
+  context('formatToNumber', () => {
     it('translates the string to a number', async () => {
-      assert.isTrue(translateToNumber('1') === 1);
+      assert.isTrue(formatToNumber('1') === 1);
     });
 
     it('does not translate the empty string to a number', async () => {
-      assert.isTrue(typeof translateToNumber(' ') === 'string');
+      assert.isTrue(typeof formatToNumber(' ') === 'string');
     });
 
     it('does not translate a non numerical string to a number', async () => {
-      assert.isTrue(typeof translateToNumber('a') === 'string');
+      assert.isTrue(typeof formatToNumber('a') === 'string');
+    });
+
+    it('translates the string to a number with leading and trailing spaces', async () => {
+      assert.isTrue(formatToNumber(' 1 ') === 1);
     });
   });
 

--- a/lms/static/scripts/frontend_apps/utils/validation.js
+++ b/lms/static/scripts/frontend_apps/utils/validation.js
@@ -5,14 +5,17 @@
  * @param {string} value - The value to attempt to translate
  * @return {number|string} - Translated value or original if not translated
  */
-function translateToNumber(value) {
-  if (value.toString().trim().length === 0) {
-    // don't translate a string with only tabs or spaces
-    return value;
+function formatToNumber(originalValue) {
+  // Remove any trailing or leading tabs or spaces
+  const value = originalValue.trim();
+  if (value.length === 0) {
+    // If its an empty string just return it so its
+    // not converted to a 0.
+    return originalValue;
   }
   const translated = Number(value);
   if (isNaN(translated)) {
-    return value;
+    return originalValue;
   } else {
     return translated;
   }
@@ -36,4 +39,4 @@ function validateGrade(value) {
   }
 }
 
-export { translateToNumber, validateGrade };
+export { formatToNumber, validateGrade };

--- a/lms/static/scripts/frontend_apps/utils/validation.js
+++ b/lms/static/scripts/frontend_apps/utils/validation.js
@@ -1,0 +1,39 @@
+/**
+ * Coerce a string value from an input field to an numeric value.
+ * If the value can't be properly cast, then it will remain a string.
+ *
+ * @param {string} value - The value to attempt to translate
+ * @return {number|string} - Translated value or original if not translated
+ */
+function translateToNumber(value) {
+  if (value.toString().trim().length === 0) {
+    // don't translate a string with only tabs or spaces
+    return value;
+  }
+  const translated = Number(value);
+  if (isNaN(translated)) {
+    return value;
+  } else {
+    return translated;
+  }
+}
+
+/**
+ * The validator will ensure the value is:
+ * - a numeric type
+ * - between or equal to the the range of [0 - 10]
+ * -
+ * @param {number} value - Value to test
+ * @return {string|undefined} - Returns an error message or undefined if valid.
+ */
+function validateGrade(value) {
+  if (typeof value !== 'number') {
+    return 'Grade must be a valid number';
+  } else if (value < 0 || value > 10) {
+    return 'Grade must be between 0 and 10';
+  } else {
+    return undefined;
+  }
+}
+
+export { translateToNumber, validateGrade };


### PR DESCRIPTION
*independent part of the grader PR for separate review*

Add two functions for validation of input fields
 - translateToNumber - Coerces a string value to a number (if it can)
 - validateGrade - Assets a number is both a numeric type and within the grade range [0-10]


simple use case
```
<input onClick={(e)=>{
  const notValid = validateGrade(translateToNumber(e.target.value));
  if (!notValid) {
    // value okay
  } else {
   alert(notValid);
 }
}}/>
```