### PR TITLE
Use pyramid_exclog in dev

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -7,11 +7,6 @@ pyramid.debug_authorization = false
 pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
-pyramid.includes = pyramid_debugtoolbar
-
-# By default, the toolbar only appears for clients from IP addresses
-# '127.0.0.1' and '::1'.
-# debugtoolbar.hosts = 127.0.0.1 ::1
 
 sqlalchemy.url = postgresql://postgres@localhost:5433/postgres
 

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -5,8 +5,6 @@ pipeline:
 
 [app:lms]
 use = call:lms.app:create_app
-pyramid.includes = pyramid_exclog
-exclog.extra_info = true
 
 [server:main]
 use: egg:gunicorn

--- a/lms/app.py
+++ b/lms/app.py
@@ -10,6 +10,15 @@ def configure_jinja2_assets(config):
 def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config = configure(settings=settings)
 
+    # Make sure that pyramid_exclog's tween runs under pyramid_tm's tween so
+    # that pyramid_exclog doesn't re-open the DB session after pyramid_tm has
+    # already closed it.
+    config.add_tween(
+        "pyramid_exclog.exclog_tween_factory", under="pyramid_tm.tm_tween_factory"
+    )
+    config.add_settings({"exclog.extra_info": True})
+    config.include("pyramid_exclog")
+
     config.include("pyramid_jinja2")
     config.include("pyramid_services")
     config.include("pyramid_tm")

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -1,8 +1,5 @@
-import os
-
 from pyramid import httpexceptions
 from pyramid import i18n
-from pyramid.settings import asbool
 from pyramid.view import forbidden_view_config, notfound_view_config
 import sentry_sdk
 
@@ -73,16 +70,6 @@ def error(request):
 
 
 def includeme(config):
-    debug = asbool(os.environ.get("DEBUG") or config.registry.settings.get("debug"))
-    if debug:
-        # Don't register the error pages in development environments.  Let
-        # pyramid_debugtoolbar show the traceback in the browser and terminal
-        # instead.
-        # If you want to test the error pages in your dev env you can set the
-        # environment variable DEBUG to false:
-        #     export DEBUG=false
-        return
-
     view_defaults = {"renderer": "lms:templates/error.html.jinja2"}
 
     config.add_exception_view(

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,5 @@
 -r requirements.txt
 -e .
 
-pyramid_debugtoolbar
 pyramid_ipython
 honcho

--- a/tests/lms/views/error_test.py
+++ b/tests/lms/views/error_test.py
@@ -127,7 +127,7 @@ class TestError:
         )
 
 
-@pytest.mark.usefixtures("os", "pyramid_config")
+@pytest.mark.usefixtures("pyramid_config")
 class TestIncludeMe:
     def test_it_adds_the_exception_views(self, pyramid_config):
         error.includeme(pyramid_config)
@@ -154,19 +154,6 @@ class TestIncludeMe:
                 renderer="lms:templates/validation_error.html.jinja2",
             ),
         ]
-
-    def test_it_doesnt_add_the_exception_views_in_debug_mode(self, os, pyramid_config):
-        os.environ["DEBUG"] = True
-
-        error.includeme(pyramid_config)
-
-        pyramid_config.add_exception_view.assert_not_called()
-
-    @pytest.fixture
-    def os(self, patch):
-        os = patch("lms.views.error.os")
-        os.environ = {"DEBUG": False}
-        return os
 
     @pytest.fixture
     def pyramid_config(self, pyramid_config):


### PR DESCRIPTION
Use pyramid_exclog to print exceptions and related information to the
terminal in dev, not just in production.

Also removed pyramid_debugtoolbar in dev, use pyramid_exclog's terminal
printing rather than pyramid_debugtoolbar's HTML interface for
debugging.

Also remove the logic that prevented error views from being registered
(and therefore nice error pages from being shown) in dev.

This makes dev the same as production when an error happens:

1. The proper error page will be rendered in the browser
2. The traceback and additional info will be printed to the terminal (in
   production this same output should appear in Papertrail)