### PR TITLE
Migrate the old sass @import to @use

### DIFF
--- a/lms/static/styles/_mixins.scss
+++ b/lms/static/styles/_mixins.scss
@@ -1,3 +1,6 @@
+@use "variables" as *;
+
+
 // Typography
 // ----------
 @mixin font-small {

--- a/lms/static/styles/_mixins.scss
+++ b/lms/static/styles/_mixins.scss
@@ -1,18 +1,18 @@
-@use "variables" as *;
+@use "variables" as var;
 
 
 // Typography
 // ----------
 @mixin font-small {
-  font-size: $small-font-size;
-  line-height: $small-line-height;
+  font-size: var.$small-font-size;
+  line-height: var.$small-line-height;
   font-weight: 400;
   letter-spacing: 0.2px;
 }
 
 @mixin font-normal {
-  font-size: $normal-font-size;
-  line-height: $normal-line-height;
+  font-size: var.$normal-font-size;
+  line-height: var.$normal-line-height;
   font-weight: 400;
 }
 

--- a/lms/static/styles/_typography.scss
+++ b/lms/static/styles/_typography.scss
@@ -1,7 +1,7 @@
-@use "variables" as *;
+@use "variables" as var;
 
 
 .heading-1 {
-  font-size: $title-font-size;
+  font-size: var.$title-font-size;
   margin-bottom: 30px;
 }

--- a/lms/static/styles/_typography.scss
+++ b/lms/static/styles/_typography.scss
@@ -1,3 +1,6 @@
+@use "variables" as *;
+
+
 .heading-1 {
   font-size: $title-font-size;
   margin-bottom: 30px;

--- a/lms/static/styles/components/_Button.scss
+++ b/lms/static/styles/components/_Button.scss
@@ -1,5 +1,9 @@
+@use "../mixins";
+@use "../variables" as *;
+
+
 .Button {
-  @include font-normal;
+  @include mixins.font-normal;
 
   min-height: 30px;
 
@@ -44,7 +48,7 @@
   background-color: $brand;
 }
 
-@include touch-input {
+@include mixins.touch-input {
   .Button {
     min-height: $touch-target-size;
   }

--- a/lms/static/styles/components/_Button.scss
+++ b/lms/static/styles/components/_Button.scss
@@ -1,5 +1,5 @@
 @use "../mixins";
-@use "../variables" as *;
+@use "../variables" as var;
 
 
 .Button {
@@ -7,10 +7,10 @@
 
   min-height: 30px;
 
-  background-color: $grey-6;
+  background-color: var.$grey-6;
   border: none;
   border-radius: 2px;
-  color: $white;
+  color: var.$white;
   cursor: pointer;
   font-weight: bold;
   padding-left: 15px;
@@ -18,14 +18,14 @@
   white-space: nowrap;
 
   &:hover {
-    background-color: $brand;
+    background-color: var.$brand;
   }
 
   &[disabled] {
-    color: $grey-6;
-    background-color: $grey-2;
+    color: var.$grey-6;
+    background-color: var.$grey-2;
     &:hover {
-      background-color: $grey-2;
+      background-color: var.$grey-2;
     }
   }
 }
@@ -35,21 +35,21 @@
 }
 
 .Button--cancel {
-  color: $grey-6;
-  background-color: $grey-2;
+  color: var.$grey-6;
+  background-color: var.$grey-2;
 
   &:hover {
-    background-color: $grey-3;
-    color: $brand;
+    background-color: var.$grey-3;
+    color: var.$brand;
   }
 }
 
 .Button--danger {
-  background-color: $brand;
+  background-color: var.$brand;
 }
 
 @include mixins.touch-input {
   .Button {
-    min-height: $touch-target-size;
+    min-height: var.$touch-target-size;
   }
 }

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,4 +1,4 @@
-@use "../variables" as *;
+@use "../variables" as var;
 
 
 .Dialog__container {
@@ -36,13 +36,13 @@
 .Dialog__title {
   display: flex;
   align-items: center;
-  font-size: $title-font-size;
+  font-size: var.$title-font-size;
 }
 
 .Dialog__cancel-btn {
   border: 0;
   background: none;
-  color: $grey-6;
+  color: var.$grey-6;
 
   // Given the button a large hit target and ensure the 'X' label is large
   // enough to see easily and aligned with the right edge of the dialog.
@@ -57,7 +57,7 @@
   text-align: right;
 
   &:hover {
-    color: $brand;
+    color: var.$brand;
   }
 }
 

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,3 +1,6 @@
+@use "../variables" as *;
+
+
 .Dialog__container {
   display: flex;
   flex-direction: column;

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -1,4 +1,4 @@
-@use "../variables" as *;
+@use "../variables" as var;
 
 
 .ErrorDisplay {
@@ -7,8 +7,8 @@
 
 .ErrorDisplay__details {
   overflow: scroll;
-  background-color: $grey-1;
-  border: 1px solid $grey-3;
+  background-color: var.$grey-1;
+  border: 1px solid var.$grey-3;
 
   max-width: 100%;
 }

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -1,3 +1,6 @@
+@use "../variables" as *;
+
+
 .ErrorDisplay {
   max-width: 100%;
 }

--- a/lms/static/styles/components/_LMSGrader.scss
+++ b/lms/static/styles/components/_LMSGrader.scss
@@ -1,3 +1,6 @@
+@use "../variables" as *;
+
+
 .LMSGrader {
   display: flex;
   flex-direction: column;

--- a/lms/static/styles/components/_LMSGrader.scss
+++ b/lms/static/styles/components/_LMSGrader.scss
@@ -1,4 +1,4 @@
-@use "../variables" as *;
+@use "../variables" as var;
 
 
 .LMSGrader {
@@ -17,7 +17,7 @@
 }
 
 .LMSGrader__grading-components {
-  background-color: $grey-7;
+  background-color: var.$grey-7;
   padding: 0;
   margin: 0;
   list-style: none;

--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -1,3 +1,6 @@
+@use "../variables" as *;
+
+
 .StudentSelector {
   display: flex;
   button {

--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -1,4 +1,4 @@
-@use "../variables" as *;
+@use "../variables" as var;
 
 
 .StudentSelector {
@@ -7,16 +7,16 @@
     background-color: transparent;
     min-width: 80px;
     border: none;
-    background-color: $grey-6;
+    background-color: var.$grey-6;
     transition: background-color 0.2s, opacity 0.2s;
     outline: none;
     &:hover {
       cursor: pointer;
-      background-color: $grey-5;
+      background-color: var.$grey-5;
     }
     &:disabled {
       &:hover {
-        background-color: $grey-6;
+        background-color: var.$grey-6;
       }
       cursor: default;
       opacity: 0.5;

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -1,3 +1,7 @@
+@use "../mixins/focus";
+@use "../variables" as *;
+
+
 $table-item-height: 40px;
 $table-icon-size: 24px;
 
@@ -12,7 +16,7 @@ $table-icon-size: 24px;
 }
 
 .Table__table {
-  @include outline-on-keyboard-focus;
+  @include focus.outline-on-keyboard-focus;
 
   border-collapse: collapse;
   width: 100%;

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -1,5 +1,5 @@
 @use "../mixins/focus";
-@use "../variables" as *;
+@use "../variables" as var;
 
 
 $table-item-height: 40px;
@@ -10,7 +10,7 @@ $table-icon-size: 24px;
 .Table__wrapper {
   height: 7 * $table-item-height;
   overflow: auto;
-  border: 1px solid $grey-6;
+  border: 1px solid var.$grey-6;
 
   margin-top: 10px;
 }
@@ -20,7 +20,7 @@ $table-icon-size: 24px;
 
   border-collapse: collapse;
   width: 100%;
-  font-size: $normal-font-size;
+  font-size: var.$normal-font-size;
   table-layout: fixed;
 }
 
@@ -37,7 +37,7 @@ $table-icon-size: 24px;
 // be applied to the `thead` element, but there are bugs in Chrome and Edge.
 // See https://caniuse.com/#feat=css-sticky.
 .Table__head th {
-  background-color: $grey-6;
+  background-color: var.$grey-6;
   position: sticky;
   top: 0;
   font-weight: normal;
@@ -69,7 +69,7 @@ $table-icon-size: 24px;
       border-top: 1px solid white;
     }
 
-    background-color: $grey-6;
+    background-color: var.$grey-6;
     color: white;
   }
 

--- a/lms/static/styles/components/_heading.scss
+++ b/lms/static/styles/components/_heading.scss
@@ -1,6 +1,6 @@
-@use "../variables" as *;
+@use "../variables" as var;
 
 
 .heading {
-  font-size: $title-font-size;
+  font-size: var.$title-font-size;
 }

--- a/lms/static/styles/components/_heading.scss
+++ b/lms/static/styles/components/_heading.scss
@@ -1,3 +1,6 @@
+@use "../variables" as *;
+
+
 .heading {
   font-size: $title-font-size;
 }

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -1,35 +1,36 @@
-@import 'normalize.css/normalize';
+@use 'normalize.css/normalize';
 
-@import 'mixins';
-@import 'variables';
+@use 'mixins';
+@use 'variables' as *;
 
 // Additional mixins.
-@import 'mixins/focus';
+@use 'mixins/focus';
 
 // Shared classes.
-@import 'utils';
-@import 'typography';
+@use 'utils';
+@use 'typography';
 
 // HTML components.
-@import 'components/heading';
-@import 'components/label';
+@use 'components/heading';
+@use 'components/label';
 
 // Generic React components.
 // Note: Some of these are also used by server-rendered HTML templates, not
 // just by React code.
-@import 'components/Button';
-@import 'components/Dialog';
-@import 'components/Table';
+@use 'components/Button';
+@use 'components/Dialog';
+@use 'components/Table';
 
 // React components.
-@import 'components/BasicLtiLaunchApp';
-@import 'components/ErrorDisplay';
-@import 'components/FileList';
-@import 'components/FilePickerApp';
-@import 'components/LMSFilePicker';
-@import 'components/LMSGrader';
-@import 'components/StudentSelector';
-@import 'components/URLPicker';
+@use 'components/BasicLtiLaunchApp';
+@use 'components/ErrorDisplay';
+@use 'components/FileList';
+@use 'components/FilePickerApp';
+@use 'components/LMSFilePicker';
+@use 'components/LMSGrader';
+@use 'components/StudentSelector';
+@use 'components/URLPicker';
+
 
 // Element styles.
 body {


### PR DESCRIPTION
The diff of the compiled lms.css and frontend_app.css are identical before and after the conversion.

ran 
`sass-migrator module --migrate-deps lms/static/styles/frontend_apps.scss `

- Manually needed to convert the `normalize.css/normalize` as migration tool balked at that.
- Converted the @ use "../variables" to use the wildcard * namespace as its our convention for variables instead of prefixing the namespace when used.

e.g. 
`variables.$grey-2`
vs 
`$grey-2`

fixes #1054
