### PR TITLE
LMSGrader can submit grades

### DIFF
--- a/lms/static/images/check.svg
+++ b/lms/static/images/check.svg
@@ -1,0 +1,2 @@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false" class="Icon Icon--check"><g fill-rule="evenodd"><rect fill="none" stroke="none" x="0" y="0" width="16" height="16"></rect><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 3L6 13 3 8"></path></g></svg>

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -3,6 +3,7 @@ import propTypes from 'prop-types';
 import { useEffect, useState } from 'preact/hooks';
 
 import StudentSelector from './StudentSelector';
+import SubmitGradeForm from './SubmitGradeForm';
 import {
   updateClientConfig,
   removeClientConfig,
@@ -64,6 +65,13 @@ export default function LMSGrader({
     setCurrentStudentIndex(studentIndex);
   };
 
+  /**
+   * Return the current student, or an empty object if there is none
+   */
+  const getCurrentStudent = () => {
+    return students[currentStudentIndex] ? students[currentStudentIndex] : {};
+  };
+
   return (
     <div className="LMSGrader">
       <header>
@@ -81,7 +89,12 @@ export default function LMSGrader({
               selectedStudentIndex={currentStudentIndex}
             />
           </li>
-          <li className="LMSGrader__student-grade" />
+          <li className="LMSGrader__student-grade">
+            <SubmitGradeForm
+              student={getCurrentStudent()}
+              disabled={currentStudentIndex < 0}
+            />
+          </li>
         </ul>
       </header>
       {children}

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -1,0 +1,130 @@
+import { createElement } from 'preact';
+import classNames from 'classnames';
+import propTypes from 'prop-types';
+import { useContext, useEffect, useState, useRef } from 'preact/hooks';
+
+import { Config } from '../config';
+import { submitGrade } from '../utils/grader-service';
+import { formatToNumber, validateGrade } from '../utils/validation';
+import ErrorDialog from './ErrorDialog';
+import Spinner from './Spinner';
+import SvgIcon from './SvgIcon';
+import { trustMarkup } from '../utils/trusted';
+import ValidationMessage from './ValidationMessage';
+
+/**
+ * A form with a single input field and submit button for an instructor to
+ * save a students grade.
+ */
+
+export default function SubmitGradeForm({ disabled = false, student }) {
+  const [showError, setShowError] = useState(false); // Is there a validation error message to show?
+  const [gradeErrorMessage, setGradeErrorMessage] = useState(''); // The actual validation error message.
+
+  const [networkError, setNetworkError] = useState(''); // if there is an error when submitting grade
+  const [requestStatus, setRequestStatus] = useState(''); // ajax request state, one of ('', 'fetching', 'error', 'done')
+
+  const { authToken } = useContext(Config);
+
+  useEffect(() => {
+    setRequestStatus(''); // clear out network status
+  }, [student]);
+
+  // Used to handle keyboard input effects.
+  const refInput = useRef(null);
+
+  /**
+   * Validate the grade and if it passes, then submit the grade to to `onSubmitGrade`
+   */
+  const onSubmitGrade = async event => {
+    event.preventDefault();
+    const value = formatToNumber(refInput.current.value);
+    const validationError = validateGrade(value);
+
+    if (validationError) {
+      setGradeErrorMessage(validationError);
+      setShowError(true);
+    } else {
+      try {
+        setRequestStatus('fetching');
+        // Divide value by 10 because the lms service layer expects grade to be a value between [0-1] but
+        // we treat this on the UI to be between [0-10].
+        await submitGrade({ student, grade: value / 10, authToken });
+        setRequestStatus('done');
+      } catch (e) {
+        setRequestStatus('error');
+        setNetworkError(e.errorMessage ? e.errorMessage : 'Unknown error');
+      }
+    }
+  };
+
+  /**
+   * If any input is detected, close the ValidationMessage.
+   */
+  const handleKeyDown = () => {
+    setShowError(false);
+  };
+
+  return (
+    <form className="SubmitGradeForm" autoComplete="off">
+      <ValidationMessage
+        message={gradeErrorMessage}
+        open={showError}
+        onClose={() => {
+          // Sync up the state when the ValidationMessage is closed
+          setShowError(false);
+        }}
+      />
+      <label className="SubmitGradeForm__label" htmlFor="lms-grade">
+        Grade (Out of 10)
+      </label>
+      <input
+        className={classNames('SubmitGradeForm__grade', {
+          'SubmitGradeForm__grade--saved': requestStatus === 'done',
+        })}
+        disabled={disabled}
+        id="lms-grade"
+        ref={refInput}
+        onKeyDown={handleKeyDown}
+        type="input"
+        defaultValue={''} // TODO: stub until we pull the grade from the service
+        key={student.LISResultSourcedId}
+      />
+      <button
+        className="SubmitGradeForm__submit"
+        disabled={disabled}
+        onClick={onSubmitGrade}
+        type="submit"
+      >
+        <SvgIcon
+          className="SubmitGradeForm__check-icon"
+          src={trustMarkup(require('../../../images/check.svg'))}
+          inline="true"
+        />{' '}
+        Submit Grade
+      </button>
+      {requestStatus === 'error' && (
+        <ErrorDialog
+          title="Error"
+          error={{ message: networkError }}
+          onCancel={() => {
+            setRequestStatus('');
+          }}
+        />
+      )}
+      {requestStatus === 'fetching' && (
+        <div className="SubmitGradeForm__loading-backdrop">
+          <Spinner className="SubmitGradeForm__spinner" />
+        </div>
+      )}
+    </form>
+  );
+}
+
+SubmitGradeForm.propTypes = {
+  // Disables the the entire form.
+  disabled: propTypes.bool,
+  // Grade for the current student.SubmitGradeForm.propTypes
+
+  student: propTypes.object.isRequired,
+};

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -1,0 +1,49 @@
+import { createElement } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import classNames from 'classnames';
+import propTypes from 'prop-types';
+
+/**
+ * Shows a single validation error message that can be open or closed.
+ * A user can also close the message by clicking on it.
+ */
+
+export default function ValidationMessage({
+  message,
+  open = false,
+  onClose = () => {},
+}) {
+  const [showError, setShowError] = useState(open);
+
+  useEffect(() => {
+    setShowError(open);
+  }, [open]);
+
+  /**
+   * Closes the validation error message and notifies parent
+   */
+  const closeValidationError = () => {
+    setShowError(false);
+    onClose();
+  };
+
+  const errorClass = classNames('ValidationMessage', {
+    'ValidationMessage--open': showError,
+    'ValidationMessage--closed': !showError,
+  });
+
+  return (
+    <div onClick={closeValidationError} className={errorClass}>
+      {message}
+    </div>
+  );
+}
+
+ValidationMessage.propTypes = {
+  // Error message text
+  message: propTypes.string.isRequired,
+  // Should this be open or closed
+  open: propTypes.bool,
+  // Optional callback when the error message closes itself via onClick
+  onClose: propTypes.function,
+};

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -8,10 +8,14 @@ describe('LMSGrader', () => {
     {
       userid: 'student1',
       displayName: 'Student 1',
+      LISResultSourcedId: 1,
+      LISOutcomeServiceUrl: '',
     },
     {
       userid: 'student1',
       displayName: 'Student 2',
+      LISResultSourcedId: 2,
+      LISOutcomeServiceUrl: '',
     },
   ];
   const fakeUpdateClientConfig = sinon.spy();
@@ -49,7 +53,10 @@ describe('LMSGrader', () => {
 
   it('creates a valid component with 2 students', () => {
     const wrapper = renderGrader();
-    assert.equal(wrapper.text(), '2 Students');
+    assert.equal(
+      wrapper.find('.LMSGrader__student-count').text(),
+      '2 Students'
+    );
   });
 
   it('set the selected student count to "Student 2 of 2" when the index changers to 1', () => {
@@ -60,8 +67,10 @@ describe('LMSGrader', () => {
         .props()
         .onSelectStudent(1); // second student
     });
-    wrapper.update();
-    assert.equal(wrapper.text(), 'Student 2 of 2');
+    assert.equal(
+      wrapper.find('.LMSGrader__student-count').text(),
+      'Student 2 of 2'
+    );
   });
 
   it('passes a default value of "0" to onChangeSelectedUser when no a student is selected', () => {

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -1,0 +1,135 @@
+import { Fragment, createElement } from 'preact';
+import { shallow } from 'enzyme';
+
+import SubmitGradeForm, { $imports } from '../SubmitGradeForm';
+
+describe('SubmitGradeForm', () => {
+  const fakeStudent = {
+    userid: 'student1',
+    displayName: 'Student 1',
+    LISResultSourcedId: 1,
+    LISOutcomeServiceUrl: '',
+  };
+  const renderForm = (props = {}) => {
+    return shallow(<SubmitGradeForm student={fakeStudent} {...props} />);
+  };
+
+  // eslint-disable-next-line react/prop-types
+  const FakeErrorDialog = ({ children }) => {
+    return <Fragment>{children}</Fragment>;
+  };
+
+  // eslint-disable-next-line react/prop-types
+  const FakeSpinner = ({ children }) => {
+    return <Fragment>{children}</Fragment>;
+  };
+
+  // eslint-disable-next-line react/prop-types
+  const FakeValidationMessage = ({ children }) => {
+    return <Fragment>{children}</Fragment>;
+  };
+
+  const fakeSubmitGrade = sinon.stub().resolves([]);
+  const fakeValidateGrade = sinon.stub();
+  const fakeFormatToNumber = sinon.stub();
+
+  beforeEach(() => {
+    $imports.$mock({
+      './ErrorDialog': FakeErrorDialog,
+      './Spinner': FakeSpinner,
+      './ValidationMessage': FakeValidationMessage,
+      '../utils/grader-service': {
+        submitGrade: fakeSubmitGrade,
+      },
+      '../utils/validation': {
+        formatToNumber: fakeFormatToNumber,
+        validateGrade: fakeValidateGrade,
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('does not disable the input field when the disable prop is missing', () => {
+    const wrapper = renderForm();
+    assert.isFalse(wrapper.find('input').prop('disabled'));
+  });
+
+  it('disables the submit button when the disable prop is true', () => {
+    const wrapper = renderForm({ disabled: true });
+    assert.isTrue(wrapper.find('button').prop('disabled'));
+  });
+
+  it("sets the input key to the student's LISResultSourcedId", () => {
+    const wrapper = renderForm();
+    assert.equal(wrapper.find('input').key(), fakeStudent.LISResultSourcedId);
+  });
+
+  context('validation messages', () => {
+    it('hides the validation message by default', () => {
+      const wrapper = renderForm();
+      assert.isFalse(wrapper.find(FakeValidationMessage).prop('open'));
+    });
+
+    it('shows the validation message when the validator returns an error', () => {
+      $imports.$mock({
+        '../utils/validation': {
+          validateGrade: sinon.stub().returns('err'),
+        },
+      });
+      const wrapper = renderForm();
+      wrapper.find('button').simulate('click');
+      assert.isTrue(wrapper.find(FakeValidationMessage).prop('open'));
+      assert.equal(wrapper.find(FakeValidationMessage).prop('message'), 'err');
+    });
+
+    it('hides the validation message after it was opened when input is detected', () => {
+      $imports.$mock({
+        '../utils/validation': {
+          validateGrade: sinon.stub().returns('err'),
+        },
+      });
+      const wrapper = renderForm();
+      wrapper.find('button').simulate('click');
+      wrapper.find('input').simulate('keydown', { key: 'k' });
+      assert.isFalse(wrapper.find(FakeValidationMessage).prop('open'));
+    });
+  });
+
+  context('when requests are sent', () => {
+    it('shows the loading spinner when submitting a grade', () => {
+      const wrapper = renderForm();
+      wrapper.find('button').simulate('click');
+      assert.isTrue(wrapper.find(FakeSpinner).exists());
+    });
+
+    it('shows the error dialog when the grade request throws an error', () => {
+      const wrapper = renderForm();
+      fakeSubmitGrade.throws({ errorMessage: '' });
+      wrapper.find('button').simulate('click');
+      wrapper.update();
+      assert.isTrue(wrapper.find(FakeErrorDialog).exists());
+    });
+
+    it('sets the `SubmitGradeForm__grade--saved` class when the grade has posted', async () => {
+      const wrapper = renderForm();
+      fakeSubmitGrade.resolves();
+      wrapper.find('button').simulate('click');
+      await fakeSubmitGrade.resolves();
+      wrapper.update();
+      assert.isTrue(
+        wrapper.find('input').hasClass('SubmitGradeForm__grade--saved')
+      );
+    });
+
+    it('closes the spinner after the grade has posted', async () => {
+      const wrapper = renderForm();
+      wrapper.find('button').simulate('click');
+      await fakeSubmitGrade.resolves();
+      wrapper.update();
+      assert.isFalse(wrapper.find(FakeSpinner).exists());
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
@@ -1,0 +1,37 @@
+import { createElement } from 'preact';
+import { shallow } from 'enzyme';
+
+import ValidationMessage from '../ValidationMessage';
+
+describe('ValidationMessage', () => {
+  const renderMessage = (props = {}) => {
+    return shallow(<ValidationMessage {...props} />);
+  };
+
+  it('renders closed by default', () => {
+    const wrapper = renderMessage();
+    assert.isTrue(wrapper.find('.ValidationMessage--closed').exists());
+  });
+
+  it('renders open when passing `open=true` prop', () => {
+    const wrapper = renderMessage({ open: true });
+    assert.isTrue(wrapper.find('.ValidationMessage--open').exists());
+  });
+
+  it('sets the message from the `message` prop', () => {
+    const wrapper = renderMessage({ message: 'some error' });
+    assert.equal(wrapper.text(), 'some error');
+  });
+
+  it('closes the message and calls `onClose` prop when clicked', () => {
+    const onCloseProp = sinon.stub();
+    const wrapper = renderMessage({
+      onClose: onCloseProp,
+      open: true,
+      message: 'foo',
+    });
+    wrapper.simulate('click');
+    assert.isTrue(onCloseProp.calledOnce);
+    assert.isTrue(wrapper.find('.ValidationMessage--closed').exists());
+  });
+});

--- a/lms/static/styles/_mixins.scss
+++ b/lms/static/styles/_mixins.scss
@@ -32,3 +32,11 @@
     @content;
   }
 }
+// Used to apply standard outline focus state styling to buttons and input fields
+@mixin input-focus {
+  &:focus {
+    outline: 1px solid var.$grey-5;
+    outline-offset: -1px;
+    outline-style: solid
+  }
+}

--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -1,3 +1,4 @@
+@use "../mixins";
 @use "../variables" as var;
 
 
@@ -17,12 +18,8 @@
   border: 1px solid var.$grey-3;
   transition: background-color 0.2s, border-color 0.2s;
   
-  &:focus {
-    outline: 1px solid var.$grey-5;
-    outline-offset: -1px;
-    outline-style: solid
-  }
-
+  @include mixins.input-focus;
+  
   &:hover {
     cursor: pointer;
     background-color: var.$grey-2;
@@ -44,11 +41,7 @@
   height: 40px;
   padding: 5px 20px;
 
-  &:focus {
-    outline: 1px solid var.$grey-5;
-    outline-offset: -1px;
-    outline-style: solid
-  }
+  @include mixins.input-focus;
 
   &::-ms-expand {
     /* Remove default select arrow in IE11 */

--- a/lms/static/styles/components/_SubmitGradeForm.scss
+++ b/lms/static/styles/components/_SubmitGradeForm.scss
@@ -1,0 +1,101 @@
+@use "../mixins";
+@use "../variables" as var;
+
+
+@keyframes gradeSaved {
+  from {
+    background-color: #58bf4b;
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+
+.SubmitGradeForm {
+  display: flex;
+  position: relative;
+  white-space: nowrap;
+
+  &__check-icon {
+    color: var.$grey-5;
+  }
+
+  &__submit {
+    height: 40px;
+    width: 150px;
+    font-weight: 500;
+    border: 1px solid var.$grey-3;
+    background-color: var.$grey-1;
+    transition: 0.2s;
+
+    &:focus {
+      border-color: var.$grey-5;
+    }
+
+    &:hover {
+      cursor: pointer;
+      background-color: var.$grey-2;
+    }
+
+    &:disabled {
+      background-color: var.$grey-1;
+      cursor: default;
+      opacity: 0.5;
+    }
+
+    &:focus {
+      @include mixins.input-focus;
+    }
+  }
+
+  &__label {
+    display: flex;
+    flex-flow: column;
+    justify-content: space-around;
+    margin: 10px;
+    font-weight: 500;
+  }
+
+  &__grade {
+    text-align: center;
+    width: 60px;
+    height: 40px;
+    border: 1px solid var.$grey-3;
+    border-right: none;
+
+    // Animation for successful grade submit
+    animation-duration: 2.0s;
+    animation-timing-function: ease-out;
+    animation-fill-mode: forwards;
+    
+    &--saved {
+      animation-name: gradeSaved;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+    }
+
+    @include mixins.input-focus;
+  }
+}
+
+.SubmitGradeForm__loading-backdrop {
+  background-color: white;
+  bottom: 0;
+  left: 0;
+  opacity: 0.5;
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+
+.SubmitGradeForm__spinner {
+  $spinner-size: 100px;
+  position: absolute;
+  width: $spinner-size;
+  height: $spinner-size;
+  left: calc(50% - #{$spinner-size});
+  top: calc(50% - #{$spinner-size});
+}

--- a/lms/static/styles/components/_ValidationMessage.scss
+++ b/lms/static/styles/components/_ValidationMessage.scss
@@ -1,0 +1,46 @@
+@keyframes validationErrorOpen {
+  from {
+    width: 0;
+    opacity: 0;
+  }
+  to {
+    width: 300px;
+    opacity: 0.9;
+  }
+}
+
+@keyframes validationErrorClose {
+  from {
+    width: 300px;
+    opacity: 1;
+  }
+  to {
+    width: 0px;
+    opacity: 0;
+  }
+}
+
+.ValidationMessage {
+  display: inline-block;
+  position: absolute;
+  z-index: 10;
+  box-shadow: 0 0 10px rgba(0,0,0,0.3);
+  padding: 0 10px;
+  right: 210px;
+  line-height: 40px;
+  background-color: #c2002d;
+  color: white;
+  white-space: nowrap;
+  overflow: hidden;
+  animation-duration: 0.3s;
+  animation-fill-mode: forwards;
+  &:hover {
+    cursor: pointer;
+  }
+}
+.ValidationMessage--open {
+  animation-name: validationErrorOpen;
+}
+.ValidationMessage--closed {
+  animation-name: validationErrorClose;
+}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -29,6 +29,8 @@
 @use 'components/LMSFilePicker';
 @use 'components/LMSGrader';
 @use 'components/StudentSelector';
+@use 'components/SubmitGradeForm';
+@use 'components/ValidationMessage';
 @use 'components/SvgIcon';
 @use 'components/URLPicker';
 


### PR DESCRIPTION
LMSGrader can submit grades (simplified)

- Similar to the first PR, but simplified in that there is no special handling for keyboard input or any detection to disable the submit button. This simplified the PR a bit and testing a-lot-a-bit :)

- Adds new component SubmitGradeForm which is responsible for validating the grade and submitting it to the service.

- Successful grades will force the SubmitGradeForm input to animate green for 2 seconds letting the instructor know the grade was saved. (UX is just a suggestion here, but some affordance is useful for saves)

- Any error should be caught by the client error validation and won't allow the grade to be submitted.

- Service errors would ideally be rare in this case, but if they occur they will render in a dialog just like the file picker.

