### PR TITLE
Remove PDF.js v2 feature flag

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -37,10 +37,6 @@ def via_url(request, document_url):
     ]
     query_string_as_list.append(("via.open_sidebar", "1"))
     query_string_as_list.append(("via.request_config_from_frame", request.host_url))
-
-    if request.feature("pdfjs2"):
-        query_string_as_list.append(("via.features", "pdfjs2"))
-
     query_string = parse.urlencode(query_string_as_list)
 
     via_service_url = request.registry.settings["via_url"]

--- a/tests/lms/views/helpers/_via_test.py
+++ b/tests/lms/views/helpers/_via_test.py
@@ -50,11 +50,6 @@ class TestViaURL:
         # fmt: on
         assert via_url(pyramid_request, document_url) == expected_via_url
 
-    def test_it_enables_via_features(self, pyramid_request):
-        pyramid_request.feature = lambda feature: feature == "pdfjs2"
-
-        assert "via.features=pdfjs2" in via_url(pyramid_request, "http://example.com")
-
     def test_it_returns_via2_url_if_use_via2_service_feature_flag_is_set(
         self, pyramid_request
     ):


### PR DESCRIPTION
This is now always-enabled in Via / the new proxy implementation.

Fixes #1055