### PR TITLE
Sync close_the_sqlalchemy_session() with h's version

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -70,8 +70,11 @@ def _session(request):
     # See: https://github.com/Pylons/pyramid_tm/issues/40
     @request.add_finished_callback
     def close_the_sqlalchemy_session(_request):  # pylint: disable=unused-variable
-        if session.dirty:
-            log.warning("closing a dirty session")
+        connections = (
+            session.transaction._connections  # pylint:disable=protected-access
+        )
+        if len(connections) > 1:
+            log.warning("closing an unclosed DB session")
         session.close()
 
     return session

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -57,17 +57,13 @@ def _session(request):
 
     # pyramid_tm doesn't always close the database session for us.
     #
-    # For example if an exception view accesses the session and causes a new
-    # transaction to be opened, pyramid_tm won't close this connection because
-    # pyramid_tm's transaction has already ended before exception views are
-    # executed.
+    # If anything that executes later in the Pyramid request processing cycle
+    # than pyramid_tm tween egress opens a new DB session (for example a tween
+    # above the pyramid_tm tween, a response callback, or a NewResponse
+    # subscriber) then pyramid_tm won't close that DB session for us.
     #
-    # Connections opened by NewResponse and finished callbacks aren't closed by
-    # pyramid_tm either.
-    #
-    # So add our own callback here to make sure db sessions are always closed.
-    #
-    # See: https://github.com/Pylons/pyramid_tm/issues/40
+    # So as a precaution add our own callback here to make sure db sessions are
+    # always closed.
     @request.add_finished_callback
     def close_the_sqlalchemy_session(_request):  # pylint: disable=unused-variable
         connections = (

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -1,9 +1,14 @@
+import logging
+
 import sqlalchemy
 import zope.sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 __all__ = ("BASE", "init")
+
+
+log = logging.getLogger(__name__)
 
 
 BASE = declarative_base(
@@ -64,11 +69,9 @@ def _session(request):
     #
     # See: https://github.com/Pylons/pyramid_tm/issues/40
     @request.add_finished_callback
-    def close_the_sqlalchemy_session(request):  # pylint: disable=unused-variable
+    def close_the_sqlalchemy_session(_request):  # pylint: disable=unused-variable
         if session.dirty:
-            request.sentry.captureMessage(
-                "closing a dirty session", stack=True, extra={"dirty": session.dirty}
-            )
+            log.warning("closing a dirty session")
         session.close()
 
     return session


### PR DESCRIPTION
h has a [Pyramid finished callback](https://docs.pylonsproject.org/projects/pyramid/en/latest/api/request.html#pyramid.request.Request.add_finished_callback) called [`close_the_sqlalchemy_session()`](https://github.com/hypothesis/h/blob/5e27c4044c67dd6e786c93f8ae1b8ca2c692849b/h/db/__init__.py#L94-L122) that forcibly closes any unclosed DB sessions at the very end of request processing, and logs a warning because this should never happen.

lms also has a [copy of the same finished callback](https://github.com/hypothesis/lms/blob/2d17fdf8b70cabec857b715a91ad092bf9b180d3/lms/db/__init__.py#L53-L74).

This PR syncs lms's `close_the_sqlalchemy_session()` with h's:

1. Log "closing a dirty session" to Papertrail as a warning instead of reporting it to Sentry because sentry_sdk can try to read from the DB which will implicitly open a new DB connection that doesn't get closed. We have a Papertrail alert that sends an email and Slack message whenever this warning gets logged

2. Use the number of open DB connections to decide when to log the warning, not whether the session is dirty. We don't care whether the session is dirty (which just means that it contains modifications to existing DB rows, doesn't even track new rows that've been added). We care whether there's an unclosed connection, dirty or not

3. Update code comment to reflect the pyramid_tm 2 situation not pyramid_tm 1

See the individual commit messages for more details