### PR TITLE
Remove U+FEFF BOM from lms/app.py

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -1,4 +1,4 @@
-﻿from lms.config import configure
+from lms.config import configure
 
 
 def configure_jinja2_assets(config):


### PR DESCRIPTION
Remove a bite order mark from `app.py`. This shouldn't be here and I'm hoping it was the cause of occasional isort crashes on app.py that I've been seeing