### PR TITLE
Use explicit transaction manager

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -1,4 +1,6 @@
-﻿from lms.config import configure
+import pyramid_tm
+
+from lms.config import configure
 
 
 def configure_jinja2_assets(config):
@@ -21,6 +23,19 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
 
     config.include("pyramid_jinja2")
     config.include("pyramid_services")
+
+    # Use pyramid_tm's explicit transaction manager.
+    #
+    # This means that trying to access a request's transaction after pyramid_tm
+    # has closed the request's transaction will crash, rather than implicitly
+    # opening a new transaction that doesn't get closed (and potentially
+    # leaking open DB connections).
+    #
+    # This is recommended in the pyramid_tm docs:
+    #
+    # https://docs.pylonsproject.org/projects/pyramid_tm/en/latest/#custom-transaction-managers
+    config.registry.settings["tm.manager_hook"] = pyramid_tm.explicit_manager
+
     config.include("pyramid_tm")
 
     config.include("lms.authentication")


### PR DESCRIPTION
Use pyramid_tm's explicit transaction manager.

This means that trying to access a request's transaction after
pyramid_tm has closed the request's transaction will crash, rather than
implicitly opening a new transaction that doesn't get closed (and
potentially leaking open DB connections).

This is recommended in the pyramid_tm docs:

https://docs.pylonsproject.org/projects/pyramid_tm/en/latest/#custom-transaction-managers

We *don't* use the explicit transaction manager in h because h already
has too much code that implicitly relies on implicit transaction
management. We would have to rewrite all that code to use explicit
transaction management, which might introduce bugs.

But in lms we can get away with enabling explicit transaction management
so do it now, before it's too late like it is for h.

Note that just because we're using explicit transaction management
doesn't mean we can never leak unclosed DB connections: you can still
explicitly open a new transaction and fail to close it. We don't ever
explicitly open new transactions in lms currently (and as far as I know
no libraries that we use do either) but something could be added in
future. So our close_the_sqlalchemy_session() finished callback is still
a good thing to have.