### PR TITLE
Rollback DB session before calling exception views

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -42,6 +42,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.views.error")
     config.include("lms.services")
     config.include("lms.validation")
+    config.include("lms.tweens")
     config.add_static_view(name="export", path="lms:static/export")
     config.add_static_view(name="static", path="lms:static")
 

--- a/lms/tweens.py
+++ b/lms/tweens.py
@@ -1,0 +1,34 @@
+"""Custom Pyramid tweens."""
+from pyramid.tweens import EXCVIEW
+
+__all__ = ["rollback_db_session_tween_factory"]
+
+
+def rollback_db_session_tween_factory(handler, _registry):
+    """Return the rollback_db_session_tween."""
+
+    def rollback_db_session_tween(request):
+        """
+        Rollback the DB session before exception views are called.
+
+        Catch any exception raised by view processing and rollback the
+        sqlalchemy database session before exception view processing begins.
+
+        This means that code can access the DB session during exception view
+        processing without getting an InvalidRequestError from sqlalchemy
+        ("This Session's transaction has been rolled back due to a previous
+        exception during flush. To begin a new transaction with this Session,
+        first issue Session.rollback()"), even if exception view processing was
+        triggered by a sqlalchemy IntegrityError during view processing.
+        """
+        try:
+            return handler(request)
+        except Exception:
+            request.db.rollback()
+            raise
+
+    return rollback_db_session_tween
+
+
+def includeme(config):
+    config.add_tween("lms.tweens.rollback_db_session_tween_factory", under=EXCVIEW)

--- a/tests/lms/tweens_test.py
+++ b/tests/lms/tweens_test.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+import pytest
+from pyramid.tweens import EXCVIEW
+
+from lms.tweens import includeme, rollback_db_session_tween_factory
+
+
+class TestDBRollbackSessionOnExceptionTween:
+    def test_it_does_nothing_usually(self, handler, pyramid_request):
+        tween = rollback_db_session_tween_factory(handler, pyramid_request.registry)
+
+        tween(pyramid_request)
+
+        handler.assert_called_once_with(pyramid_request)
+        pyramid_request.db.rollback.assert_not_called()
+
+    def test_it_calls_db_rollback_on_exception(self, handler, pyramid_request):
+        handler.side_effect = IOError
+
+        tween = rollback_db_session_tween_factory(handler, pyramid_request.registry)
+
+        with pytest.raises(IOError):
+            tween(pyramid_request)
+
+        handler.assert_called_once_with(pyramid_request)
+        pyramid_request.db.rollback.assert_called_once_with()
+
+    @pytest.fixture
+    def handler(self):
+        return mock.create_autospec(lambda request: None)  # pragma: nocover
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.db = mock.MagicMock(spec_set=["rollback"])
+        return pyramid_request
+
+
+class TestIncludeMe:
+    def test_it_adds_rollback_db_session_tween(self, config):
+        includeme(config)
+
+        config.add_tween.assert_called_with(
+            "lms.tweens.rollback_db_session_tween_factory", under=EXCVIEW
+        )
+
+    @pytest.fixture
+    def config(self):
+        return mock.MagicMock(spec_set=["add_tween"])


### PR DESCRIPTION
Add a tween that rolls back the DB session before exception views are
called to prevent crashes when exception views try to access the DB.
This is the same as one we already have in h:

https://github.com/hypothesis/h/pull/5746