### PR TITLE
Record group info on LTI launch

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,4 +1,5 @@
 from lms.models.application_instance import ApplicationInstance
+from lms.models.group_info import GroupInfo
 from lms.models.lis_result_sourcedid import LISResultSourcedId
 from lms.models.lti_launches import LtiLaunches
 from lms.models.module_item_configuration import ModuleItemConfiguration
@@ -6,6 +7,7 @@ from lms.models.oauth2_token import OAuth2Token
 
 __all__ = (
     "ApplicationInstance",
+    "GroupInfo",
     "LISResultSourcedId",
     "LtiLaunches",
     "ModuleItemConfiguration",

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -38,6 +38,11 @@ class ApplicationInstance(BASE):
         "OAuth2Token", back_populates="application_instance"
     )
 
+    #: A list of all the GroupInfo's for this application instance.
+    group_infos = sa.orm.relationship(
+        "GroupInfo", back_populates="application_instance"
+    )
+
     @classmethod
     def build_from_lms_url(  # pylint:disable=too-many-arguments
         cls, lms_url, email, developer_key, developer_secret, encryption_key=None

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -1,0 +1,90 @@
+import sqlalchemy as sa
+
+from lms.db import BASE
+
+__all__ = ["GroupInfo"]
+
+
+class GroupInfo(BASE):
+    """
+    Some info about an LMS group that was created in h.
+
+    This info is stored purely for metrics/analytics purposes and shouldn't be
+    used for application logic. The app should treat the h API as the
+    "single-source of truth" about what h groups exist and what their IDs and
+    other properties are.
+    """
+
+    __tablename__ = "group_info"
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+
+    #: The authority_provided_id of the group in h.
+    #:
+    #: This corresponds to the ID part of the groupid that's used in h's groups
+    #: API. For example if the groupid is "group:SOME_ID@lms.hypothesis.is"
+    #: then the authority_provided_id is the "SOME_ID" part without the leading
+    #: "group:" or the trailing "@lms.hypothes.is".
+    #:
+    #: This also corresponds to the group.authority_provided_id column in h's
+    #: DB.
+    authority_provided_id = sa.Column(sa.UnicodeText(), nullable=False, unique=True)
+
+    #: The LTI consumer_key (oauth_consumer_key) of the application instance
+    #: that this access token belongs to.
+    consumer_key = sa.Column(
+        sa.String(),
+        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
+        nullable=False,
+    )
+
+    #: The ApplicationInstance that this group belongs to.
+    application_instance = sa.orm.relationship(
+        "ApplicationInstance", back_populates="group_infos"
+    )
+
+    #: The value of the context_id param this group was last launched with.
+    context_id = sa.Column(sa.UnicodeText())
+
+    #: The value of the context_title param this group was last launched with.
+    context_title = sa.Column(sa.UnicodeText())
+
+    #: The value of the context_label param this group was last launched with.
+    context_label = sa.Column(sa.UnicodeText())
+
+    #: The value of the tool_consumer_info_product_family_code param this group was last launched with.
+    tool_consumer_info_product_family_code = sa.Column(sa.UnicodeText())
+
+    #: The value of the tool_consumer_info_version param this group was last launched with.
+    tool_consumer_info_version = sa.Column(sa.UnicodeText())
+
+    #: The value of the tool_consumer_instance_name param this group was last launched with.
+    tool_consumer_instance_name = sa.Column(sa.UnicodeText())
+
+    #: The value of the tool_consumer_instance_description param this group was last launched with.
+    tool_consumer_instance_description = sa.Column(sa.UnicodeText())
+
+    #: The value of the tool_consumer_instance_url param this group was last launched with.
+    tool_consumer_instance_url = sa.Column(sa.UnicodeText())
+
+    #: The value of the tool_consumer_instance_contact_email param this group was last launched with.
+    tool_consumer_instance_contact_email = sa.Column(sa.UnicodeText())
+
+    #: The value of the tool_consumer_instance_guid param this group was last launched with.
+    tool_consumer_instance_guid = sa.Column(sa.UnicodeText())
+
+    #: The value of the custom_canvas_api_domain param this group was last launched with.
+    custom_canvas_api_domain = sa.Column(sa.UnicodeText())
+
+    #: The value of the custom_canvas_course_id param this group was last launched with.
+    custom_canvas_course_id = sa.Column(sa.UnicodeText())
+
+    def __str__(self):
+        return self.__repr__(_class_name="GroupInfo")
+
+    def __repr__(self, _class_name="lms.models.GroupInfo"):
+        return (
+            f"<{_class_name}"
+            f" authority_provided_id:'{self.authority_provided_id}'"
+            f" consumer_key:'{self.consumer_key}'>"
+        )

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -53,3 +53,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.lti_outcomes.LTIOutcomesClient", name="lti_outcomes_client"
     )
+    config.register_service_factory(
+        "lms.services.group_info_upsert.GroupInfoUpsert", name="group_info_upsert"
+    )

--- a/lms/services/group_info_upsert.py
+++ b/lms/services/group_info_upsert.py
@@ -1,0 +1,45 @@
+"""A service that upserts :class:`lms.models.GroupInfo` records."""
+from lms.models import GroupInfo
+
+__all__ = ["GroupInfoUpsert"]
+
+
+class GroupInfoUpsert:
+    """
+    A callable that upserts :class:`lms.models.GroupInfo` records.
+
+    Usage:
+
+        group_info_upsert = request.find_service(name="group_info_upsert")
+        group_info_upsert(authority_provided_id, consumer_key, **kwargs)
+    """
+
+    def __init__(self, _context, request):
+        self._db = request.db
+
+    def __call__(self, authority_provided_id, consumer_key, **kwargs):
+        """
+        Upsert a row into the group_info DB table.
+
+        Find the existing group_info with the given ``authority_provided_id``
+        and update it with the given ``consumer_key`` and ``kwargs``.
+
+        If no group_info with the given ``authority_provided_id`` exists then
+        create one.
+        """
+        group_info = (
+            self._db.query(GroupInfo)
+            .filter_by(authority_provided_id=authority_provided_id)
+            .one_or_none()
+        )
+
+        if not group_info:
+            group_info = GroupInfo(
+                authority_provided_id=authority_provided_id, consumer_key=consumer_key
+            )
+            self._db.add(group_info)
+
+        group_info.consumer_key = consumer_key
+
+        for name, value in kwargs.items():
+            setattr(group_info, name, value)

--- a/lms/views/decorators/_helpers.py
+++ b/lms/views/decorators/_helpers.py
@@ -1,0 +1,26 @@
+__all__ = ["upsert_group_info"]
+
+
+def upsert_group_info(context, request):
+    """Create or update the GroupInfo for the given request."""
+    request.find_service(name="group_info_upsert")(
+        context.h_authority_provided_id,
+        request.lti_user.oauth_consumer_key,
+        **{
+            param: request.params.get(param)
+            for param in [
+                "context_id",
+                "context_title",
+                "context_label",
+                "tool_consumer_info_product_family_code",
+                "tool_consumer_info_version",
+                "tool_consumer_instance_name",
+                "tool_consumer_instance_description",
+                "tool_consumer_instance_url",
+                "tool_consumer_instance_contact_email",
+                "tool_consumer_instance_guid",
+                "custom_canvas_api_domain",
+                "custom_canvas_course_id",
+            ]
+        },
+    )

--- a/lms/views/decorators/h_api.py
+++ b/lms/views/decorators/h_api.py
@@ -5,8 +5,13 @@ import functools
 from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
 
 from lms.services import HAPIError, HAPINotFoundError
+from lms.views.decorators._helpers import upsert_group_info
 
-__all__ = ["upsert_h_user", "upsert_course_group", "add_user_to_group"]
+__all__ = [
+    "upsert_h_user",
+    "upsert_course_group",
+    "add_user_to_group",
+]
 
 
 def upsert_h_user(wrapped):
@@ -72,7 +77,7 @@ def upsert_course_group(wrapped):
     """
 
     @functools.wraps(wrapped)
-    def wrapper(context, request):
+    def wrapper(context, request):  # pylint:disable=too-many-branches
         if not context.provisioning_enabled:
             return wrapped(context, request)
 
@@ -101,6 +106,8 @@ def upsert_course_group(wrapped):
                     raise HTTPBadRequest("Instructor must launch assignment first.")
         except HAPIError as err:
             raise HTTPInternalServerError(explanation=err.explanation) from err
+        else:
+            upsert_group_info(context, request)
         return wrapped(context, request)
 
     return wrapper

--- a/tests/lms/models/group_info_test.py
+++ b/tests/lms/models/group_info_test.py
@@ -1,0 +1,82 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from lms.models import ApplicationInstance, GroupInfo
+
+
+class TestGroupInfo:
+    def test_persist_and_retrieve(self, application_instance, db_session, group_info):
+        db_session.add(group_info)
+
+        retrieved_group_info = db_session.query(GroupInfo).one()
+
+        assert retrieved_group_info.id
+        assert (
+            retrieved_group_info.authority_provided_id == "test_authority_provided_id"
+        )
+        assert retrieved_group_info.consumer_key == "test_consumer_key"
+
+    def test_application_instance_relation(
+        self, application_instance, db_session, group_info
+    ):
+        db_session.add(group_info)
+
+        retrieved_group_info = db_session.query(GroupInfo).one()
+
+        assert retrieved_group_info.application_instance == application_instance
+
+    def test_authority_provided_id_cant_be_None(
+        self, application_instance, db_session, group_info
+    ):
+        group_info.authority_provided_id = None
+        db_session.add(group_info)
+
+        with pytest.raises(
+            IntegrityError, match='"authority_provided_id" violates not-null constrain'
+        ):
+            db_session.flush()
+
+    def test_application_instance_cant_be_None(
+        self, application_instance, db_session, group_info
+    ):
+        group_info.application_instance = None
+        db_session.add(group_info)
+
+        with pytest.raises(
+            IntegrityError, match='"consumer_key" violates not-null constrain'
+        ):
+            db_session.flush()
+
+    def test___str__(self, db_session, group_info):
+        db_session.add(group_info)
+        db_session.flush()
+        assert (
+            str(group_info)
+            == "<GroupInfo authority_provided_id:'test_authority_provided_id' consumer_key:'test_consumer_key'>"
+        )
+
+    def test___repr__(self, db_session, group_info):
+        db_session.add(group_info)
+        db_session.flush()
+        assert (
+            repr(group_info)
+            == "<lms.models.GroupInfo authority_provided_id:'test_authority_provided_id' consumer_key:'test_consumer_key'>"
+        )
+
+    @pytest.fixture
+    def application_instance(self, db_session):
+        """The ApplicationInstance that the test GroupInfo belongs to."""
+        return ApplicationInstance(
+            consumer_key="test_consumer_key",
+            shared_secret="test_shared_secret",
+            lms_url="test_lms_url",
+            requesters_email="test_requesters_email",
+        )
+
+    @pytest.fixture
+    def group_info(self, application_instance):
+        """The GroupInfo object that's being tested."""
+        return GroupInfo(
+            authority_provided_id="test_authority_provided_id",
+            application_instance=application_instance,
+        )

--- a/tests/lms/resources/_lti_launch_test.py
+++ b/tests/lms/resources/_lti_launch_test.py
@@ -150,7 +150,7 @@ class TestLTILaunchResource:
             == expected_display_name
         )
 
-    def test_h_groupid_raises_if_theres_no_tool_consumer_instance_guid(
+    def test_h_authority_provided_id_raises_if_theres_no_tool_consumer_instance_guid(
         self, pyramid_request
     ):
         pyramid_request.params = {}
@@ -158,15 +158,23 @@ class TestLTILaunchResource:
             HTTPBadRequest,
             match='Required parameter "tool_consumer_instance_guid" missing from LTI params',
         ):
-            resources.LTILaunchResource(pyramid_request).h_groupid
+            resources.LTILaunchResource(pyramid_request).h_authority_provided_id
 
-    def test_h_groupid_raises_if_theres_no_context_id(self, pyramid_request):
+    def test_h_authority_provided_id_raises_if_theres_no_context_id(
+        self, pyramid_request
+    ):
         pyramid_request.params = {"tool_consumer_instance_guid": "test_guid"}
         with pytest.raises(
             HTTPBadRequest,
             match='Required parameter "context_id" missing from LTI params',
         ):
-            resources.LTILaunchResource(pyramid_request).h_groupid
+            resources.LTILaunchResource(pyramid_request).h_authority_provided_id
+
+    def test_h_authority_provided_id(self, lti_launch):
+        assert (
+            lti_launch.h_authority_provided_id
+            == "d55a3c86dd79d390ec8dc6a8096d0943044ea268"
+        )
 
     def test_h_groupid(self, lti_launch):
         assert (

--- a/tests/lms/services/group_info_upsert_test.py
+++ b/tests/lms/services/group_info_upsert_test.py
@@ -1,0 +1,95 @@
+from unittest import mock
+
+import pytest
+
+from lms.models import ApplicationInstance, GroupInfo
+from lms.services.group_info_upsert import GroupInfoUpsert
+
+
+class TestGroupInfoUpsert:
+    def test_it_adds_a_new_GroupInfo_if_none_exists(
+        self, attrs, db_session, group_info_upsert
+    ):
+        group_info_upsert(**attrs)
+
+        group_info = (
+            db_session.query(GroupInfo)
+            .filter_by(authority_provided_id=attrs["authority_provided_id"])
+            .one()
+        )
+        assert group_info.consumer_key == attrs["consumer_key"]
+        assert group_info.context_title == attrs["context_title"]
+        assert group_info.context_label == attrs["context_label"]
+
+    def test_it_updates_an_existing_GroupInfo_if_one_already_exists(
+        self, attrs, db_session, group_info_upsert
+    ):
+        db_session.add(GroupInfo(**attrs))
+
+        group_info_upsert(**dict(attrs, context_title="NEW_TITLE"))
+
+        group_info = (
+            db_session.query(GroupInfo)
+            .filter_by(authority_provided_id=attrs["authority_provided_id"])
+            .one()
+        )
+        assert group_info.consumer_key == attrs["consumer_key"]
+        assert group_info.context_label == attrs["context_label"]
+        assert (
+            group_info.tool_consumer_instance_name
+            == attrs["tool_consumer_instance_name"]
+        )
+        assert group_info.context_title == "NEW_TITLE"
+
+    @pytest.fixture
+    def group_info_upsert(self, pyramid_config, pyramid_request):
+        """The group_info_upsert service that is being tested."""
+        return GroupInfoUpsert(mock.sentinel.context, pyramid_request)
+
+    @pytest.fixture
+    def attrs(self):
+        return {
+            "authority_provided_id": "TEST_AUTHORITY_PROVIDED_ID",
+            "consumer_key": "TEST_CONSUMER_KEY",
+            "context_title": "TEST_CONTEXT_TITLE",
+            "context_label": "TEST_CONTEXT_LABEL",
+            "tool_consumer_instance_name": "TEST_TOOL_CONSUMER_INSTANCE_NAME",
+        }
+
+    @pytest.fixture
+    def application_instance(self, pyramid_request):
+        """The application instance that the test group infos belong to."""
+        application_instance = ApplicationInstance(
+            consumer_key="TEST_CONSUMER_KEY",
+            developer_key="TEST_DEVELOPER_KEY",
+            lms_url="TEST_LMS_URL",
+            shared_secret="TEST_SHARED_SECRET",
+            requesters_email="TEST_EMAIL",
+        )
+        pyramid_request.db.add(application_instance)
+        return application_instance
+
+    @pytest.fixture(autouse=True)
+    def group_infos(self, application_instance, pyramid_request):
+        """Add some "noise" group infos."""
+        # Add some "noise" group infos to the DB for every test, to make the
+        # tests more realistic.
+        group_infos = [
+            GroupInfo(
+                authority_provided_id="NOISE_ID_1",
+                consumer_key="NOISE_CONSUMER_KEY_1",
+                application_instance=application_instance,
+            ),
+            GroupInfo(
+                authority_provided_id="NOISE_ID_2",
+                consumer_key="NOISE_CONSUMER_KEY_2",
+                application_instance=application_instance,
+            ),
+            GroupInfo(
+                authority_provided_id="NOISE_ID_3",
+                consumer_key="NOISE_CONSUMER_KEY_3",
+                application_instance=application_instance,
+            ),
+        ]
+        pyramid_request.db.add_all(group_infos)
+        return group_infos

--- a/tests/lms/views/decorators/_helpers_test.py
+++ b/tests/lms/views/decorators/_helpers_test.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+import pytest
+
+from lms.resources import LTILaunchResource
+from lms.services.group_info_upsert import GroupInfoUpsert
+from lms.views.decorators._helpers import upsert_group_info
+
+
+class TestUpsertGroupInfo:
+    def test_it(self, context, group_info_upsert, params, pyramid_request):
+        upsert_group_info(context, pyramid_request)
+
+        assert group_info_upsert.call_args_list == [
+            mock.call(
+                context.h_authority_provided_id, "TEST_OAUTH_CONSUMER_KEY", **params
+            )
+        ]
+
+    def test_it_defaults_to_None_if_request_params_are_missing(
+        self, context, group_info_upsert, params, pyramid_request
+    ):
+        pyramid_request.params = {}
+
+        upsert_group_info(context, pyramid_request)
+
+        assert group_info_upsert.call_args_list == [
+            mock.call(
+                context.h_authority_provided_id,
+                "TEST_OAUTH_CONSUMER_KEY",
+                **{param: None for param in params.keys()}
+            )
+        ]
+
+    @pytest.fixture
+    def context(self):
+        return mock.create_autospec(LTILaunchResource, instance=True, spec_set=True)
+
+    @pytest.fixture
+    def params(self):
+        return dict(
+            context_id="test_context_id",
+            context_title="test_context_title",
+            context_label="test_context_label",
+            tool_consumer_info_product_family_code="test_tool_consumer_info_product_family_code",
+            tool_consumer_info_version="test_tool_consumer_info_version",
+            tool_consumer_instance_name="test_tool_consumer_instance_name",
+            tool_consumer_instance_description="test_tool_consumer_instance_description",
+            tool_consumer_instance_url="test_tool_consumer_instance_url",
+            tool_consumer_instance_contact_email="test_tool_consumer_instance_contact_email",
+            tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+            custom_canvas_api_domain="test_custom_canvas_api_domain",
+            custom_canvas_course_id="test_custom_canvas_course_id",
+        )
+
+    @pytest.fixture(autouse=True)
+    def group_info_upsert(self, pyramid_config):
+        group_info_upsert = mock.create_autospec(
+            GroupInfoUpsert, instance=True, spec_set=True
+        )
+        pyramid_config.register_service(group_info_upsert, name="group_info_upsert")
+        return group_info_upsert
+
+    @pytest.fixture
+    def pyramid_request(self, params, pyramid_request):
+        pyramid_request.params = params
+        return pyramid_request


### PR DESCRIPTION
Depends on this DB migration: https://github.com/hypothesis/lms/pull/1087

The issue:

* This PR fixes <https://github.com/hypothesis/lms/issues/918>, which asks for a way to associate an LMS-created group found in the h DB with school/institution or LMS that the group belongs to

Testing:

* To test this PR you need to launch your local instance of the LMS app from an LMS such as Canvas. You can use the various pre-created "localhost" assignments in "Test Course 1" in https://hypothesis.instructure.com/courses/83 to do this. See https://github.com/hypothesis/lms/wiki/Testing-the-LTI-App-in-Canvas

Background:

* Whenever a teacher or student launches an assignment using our LMS app, the LMS app creates a group in h for the LMS course that the assignment belongs to. The h group has the same name as the LMS course
* There's a 1:1 mapping between LMS courses and h groups
* The LMS app uses [h's groups API](https://h.readthedocs.io/en/latest/api-reference/#tag/groups) to create the group
* One of the parameters that h's groups API supports is `groupid`. This is unique identifier for a group that is provided by the caller (in this case: the LMS app). The LMS app generates a unique ID based on the LMS course and other information it receives from the LMS, and passes it to the h API as the groupid parameter.
* An h groupid looks like this: `"group:<AUTHORITY_PROVIDED_ID>@<AUTHORITY>"`. In the case of the LMS app `<AUTHORITY>` is `lms.hypothes.is`. The `<AUTHORITY_PROVIDED_ID>` is unique within a given authority, and appending `@<AUTHORITY>` makes groupids globally unique
* The h DB actually [stores the `<AUTHORITY_PROVIDED_ID>` part only](https://github.com/hypothesis/h/blob/cfd3d2af55714273bf8984045f842c887ad2097b/h/models/group.py#L79-L82) in the groups table, _not_ the full `"group:<AUTHORITY_PROVIDED_ID>@<AUTHORITY>"`" groupid (the full groupid can be generated from the `authority` and `authority_provided_id` columns of h's `group` table
* The LMS app does not keep any record of what groups it has and has not created in h, or what the groupids of those groups are. It is always able to generate the groupid for the current course on every single launch, based on the LTI launch parameters that the LMS passes to us. And it always calls the h API to upsert a group with that ID, on every single launch. This is to avoid nasty synchronization issues between the h and LMS DBs. Groups and their IDs are stored in the h DB only. (Also, it _is_ necessary to update the group on every launch, not just to create it once, because the course might have been changed in the LMS. For example if the teacher changes the course's title, we update the name of the h group.)

What this PR does:

* This PR adds a new `group_info` table to the LMS DB which maps the groupids that the LMS app has generated to a bunch of information about the school/institution/LMS that the groupid was generated for
* On every LTI launch the LMS app upserts a row into the `group_info` table for this launch's groupid
* This `group_info` is for analytics purposes only and isn't ever read by the app except to upsert into it. It remains the case that, as far as the LMS app is concerned, the h DB is the only place where groups and their IDs exist, and the only source of truth about whether a given group has already been created or not

IntegrityErrors:

* If two concurrent requests try to create the same `group_info` row at the same time then one of them will fail with an IntegrityError. If this happens the failed request will be retried, and on the second attempt it will update the row rather than creating it, and will succeed

For example this diff will change the code to simulate conflicting concurrent requests:

```diff
diff --git a/lms/services/group_info_upsert.py b/lms/services/group_info_upsert.py
index 6a13feb8..70653c67 100644
--- a/lms/services/group_info_upsert.py
+++ b/lms/services/group_info_upsert.py
@@ -4,6 +4,9 @@ from lms.models import GroupInfo
 __all__ = ["GroupInfoUpsert"]
 
 
+FIRST_TIME = True
+
+
 class GroupInfoUpsert:
     """
     A callable that upserts :class:`lms.models.GroupInfo` records.
@@ -34,6 +37,21 @@ class GroupInfoUpsert:
         )
 
         if not group_info:
+            global FIRST_TIME
+
+            if FIRST_TIME:
+                FIRST_TIME = False
+                # A concurrent request adds a conflicting GroupInfo.
+                # This will cause the current request to raise an
+                # IntegrityError when pyramid_tm tries to commit the DB
+                # session.
+                self._db.add(
+                    GroupInfo(
+                        authority_provided_id=authority_provided_id,
+                        consumer_key=consumer_key,
+                    )
+                )
+
             group_info = GroupInfo(
                 authority_provided_id=authority_provided_id, consumer_key=consumer_key
             )
```

You'll then need to make sure there is no existing `group_info` row in your DB (since the IntegrityError cannot happen if the row already exists):

```
$ make sql
postgres=# delete from group_info;
```

Then launch one of the localhost Canvas assignments. The launch should succeed, and the group_info will have been created in the DB. The IntegrityError will be printed to the terminal but will be filtered out from Sentry reporting since it's retryable.

### Example SQL query

All LMS-created h groups in the h DB have a unique `authority_provided_id` that is provided to the h API by the LMS app when it creates or updates the group. To retrieve the `authority_provided_id`'s run this query **against the h DB**:

```sql
SELECT authority_provided_id FROM public.group WHERE authority = 'lms.hypothes.is' LIMIT 5;
```

Given an `authority_provided_id` from h you can run this query **against the lms DB** to get more info about the group:

```sql
SELECT * FROM group_info, application_instances
  WHERE group_info.authority_provided_id = '<AUTHORITY_PROVIDED_ID>'
  AND group_info.consumer_key = application_instances.consumer_key;
```

Output:

```
id                                     | 2
authority_provided_id                  | <AUTHORITY_PROVIDED_ID>
consumer_key                           | Hypothesis***
context_id                             | ***
context_title                          | Test Course 1
context_label                          | Test Course 1
tool_consumer_info_product_family_code | canvas
tool_consumer_info_version             | cloud
tool_consumer_instance_name            | University of Hypothesis
tool_consumer_instance_description     | 
tool_consumer_instance_url             | 
tool_consumer_instance_contact_email   | ***
tool_consumer_instance_guid            | ***:canvas-lms
custom_canvas_api_domain               | hypothesis.instructure.com
custom_canvas_course_id                | 83
id                                     | 1
consumer_key                           | Hypothesis***
shared_secret                          | ***
lms_url                                | https://hypothesis.instructure.com
requesters_email                       | ***
created                                | 2019-10-05 12:01:39.773757
developer_key                          | 
developer_secret                       | 
aes_cipher_iv                          | 
provisioning                           | t
```