### PR TITLE
Add course name and assignment to LMSGrader

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -209,6 +209,8 @@ export default function BasicLtiLaunchApp() {
         <LMSGrader
           onChangeSelectedUser={changeSelectedUserKey}
           students={grading.students}
+          courseName={grading.courseName}
+          assignmentName={grading.assignmentName}
         >
           {iFrame}
         </LMSGrader>

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -16,6 +16,8 @@ import {
 
 export default function LMSGrader({
   children,
+  assignmentName,
+  courseName,
   students,
   onChangeSelectedUser,
 }) {
@@ -76,13 +78,14 @@ export default function LMSGrader({
     <div className="LMSGrader">
       <header>
         <ul className="LMSGrader__grading-components">
-          <li className="LMSGrader__assignment">
-            {
-              // placeholder for course name and assignment
-            }
+          <li className="LMSGrader__title">
+            <h1 className="LMSGrader__assignment">{assignmentName}</h1>
+            <h2 className="LMSGrader__name">{courseName}</h2>
           </li>
-          <li className="LMSGrader__student-count">{renderStudentCount()}</li>
           <li className="LMSGrader__student-picker">
+            <div className="LMSGrader__student-count">
+              {renderStudentCount()}
+            </div>
             <StudentSelector
               onSelectStudent={onSelectStudent}
               students={students}
@@ -105,8 +108,14 @@ export default function LMSGrader({
 LMSGrader.propTypes = {
   // iframe to pass along
   children: propTypes.node.isRequired,
+
+  // Assignment and course information
+  courseName: propTypes.string.isRequired,
+  assignmentName: propTypes.string.isRequired,
+
   // Callback to alert the parent component that a change has occurred and re-rendering may be needed.
   onChangeSelectedUser: propTypes.func.isRequired,
+
   // List of students to grade
   students: propTypes.array.isRequired,
 };

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -46,10 +46,21 @@ describe('LMSGrader', () => {
       <LMSGrader
         onChangeSelectedUser={fakeOnChange}
         students={fakeStudents}
+        courseName={'course name'}
+        assignmentName={'course assignment'}
         {...props}
       />
     );
   };
+
+  it('sets the assignment and course names', () => {
+    const wrapper = renderGrader();
+    assert.equal(
+      wrapper.find('.LMSGrader__assignment').text(),
+      'course assignment'
+    );
+    assert.equal(wrapper.find('.LMSGrader__name').text(), 'course name');
+  });
 
   it('creates a valid component with 2 students', () => {
     const wrapper = renderGrader();

--- a/lms/static/styles/components/_LMSGrader.scss
+++ b/lms/static/styles/components/_LMSGrader.scss
@@ -12,26 +12,45 @@
 }
 
 .LMSGrader__grading-components {
-  padding: 15px 15px;
-  margin: 0;
-  list-style: none;
   display: flex;
+  flex-flow: wrap;
+  justify-content: flex-end;
+  margin: 15px 15px 0 15px;
+  padding: 0;
+  list-style: none;
+  > li {
+    margin-bottom: 15px;
+  }
 }
 
 .LMSGrader__student-count {
-  display: flex;
-  flex-flow: column;
-  justify-content: space-around;
   margin: 10px;
   font-weight: 500;
 }
 
-.LMSGrader__assignment {
+.LMSGrader__title {
   flex-grow: 1;
 }
 
+.LMSGrader__assignment {
+  font-size: 18px;
+  margin: 0 0 10px 0;
+}
+
+.LMSGrader__name {
+  font-size: 16px;
+  margin: 0;
+}
+
+
 .LMSGrader__student-picker {
   display: flex;
+  flex-wrap: nowrap;
   align-items: center;
-  margin-right: 20px;
+}
+
+.LMSGrader__student-grade {
+  margin-left: 20px;
+  display: flex;
+  align-items: center;
 }


### PR DESCRIPTION
The course assignment is the larger `<h1>` tag here where as the name is the smaller `<h2>`. I felt that the more significant title would be the assignment as that is what always will change and the name perhaps may stay the same. 

![Screen Shot 2019-10-30 at 3 11 00 PM](https://user-images.githubusercontent.com/3939074/67902956-98f4ff00-fb27-11e9-8e4d-bd11efbe7587.png)


the config now expects the course name and assignment name to be nested in the config object:
```
...
   "grading":{ 
      "courseName": "foo",
      "courseAssignment": "bar",
      "students":[ 
         ...
      ]
   },
   "lmsGrader":true,
...
```

I also improved the css a bit so it looks better when shrinking the window and the grader components collapse/wrap in a reasonable way.

![Screen Shot 2019-10-30 at 3 11 10 PM](https://user-images.githubusercontent.com/3939074/67902945-92668780-fb27-11e9-9622-ff78368897a9.png)
