### PR TITLE
Expose course and assignment name to frontend app

### DIFF
--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -15,7 +15,10 @@ def configure_grading(request, js_config):
     if request.lti_user.is_instructor and _is_blackboard(request):
         js_config["lmsGrader"] = True
 
-    js_config["grading"] = {}
+    js_config["grading"] = {
+        "courseName": request.params.get("context_title"),
+        "assignmentName": request.params.get("resource_link_title"),
+    }
 
     lis_result_sourcedid_svc = request.find_service(name="lis_result_sourcedid")
     lis_result_sourcedids = lis_result_sourcedid_svc.fetch_students_by_assignment(

--- a/tests/lms/views/helpers/frontend_app_test.py
+++ b/tests/lms/views/helpers/frontend_app_test.py
@@ -64,6 +64,13 @@ class TestConfigureGrading:
         ]:
             assert propName in js_config["grading"]["students"][0]
 
+    def test_it_sets_course_and_assignment_names(self, grading_request):
+        js_config = {}
+        frontend_app.configure_grading(grading_request, js_config)
+
+        assert js_config["grading"]["courseName"] == "Test Course 101"
+        assert js_config["grading"]["assignmentName"] == "How to use Hypothesis"
+
 
 @pytest.fixture
 def lis_result_sourcedid_svc(pyramid_config):
@@ -105,5 +112,7 @@ def grading_request(pyramid_request):
         "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"
     )
     pyramid_request.params["context_id"] = "unique_course_id"
+    pyramid_request.params["context_title"] = "Test Course 101"
     pyramid_request.params["resource_link_id"] = "unique_assignment_id"
+    pyramid_request.params["resource_link_title"] = "How to use Hypothesis"
     return pyramid_request


### PR DESCRIPTION
This is a counterpart to https://github.com/hypothesis/lms/pull/1089
which enables the course and assignment name to appear in the grading
bar.

Note that the assignment name is stored in the `assignmentName` config key. I've agreed with @LMS007 to update the prop/config key to match in #1089.

Fixes #1053