### PR TITLE
Disable grading UI if evaluation is disabled for assignment

### DIFF
--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -12,7 +12,11 @@ def configure_grading(request, js_config):
     This is only enabled for instructors on BlackBoard for now. Note that this
     is entirely distinct from Canvas Speedgrader, which provides its own UI.
     """
-    if request.lti_user.is_instructor and _is_blackboard(request):
+    if (
+        request.lti_user.is_instructor
+        and _is_blackboard(request)
+        and _is_assignment_gradable(request)
+    ):
         js_config["lmsGrader"] = True
 
     js_config["grading"] = {
@@ -49,3 +53,17 @@ def configure_grading(request, js_config):
 def _is_blackboard(request):
     family_code = request.params.get("tool_consumer_info_product_family_code", "")
     return family_code == "BlackboardLearn"
+
+
+def _is_assignment_gradable(request):
+    # When an instructor launches an LTI assignment, Blackboard sets the
+    # `lis_outcome_service_url` form param if evaluation is enabled or omits it otherwise.
+    #
+    # When extending the generic LTI grader to support other LMSes, we may need
+    # a different method to detect whether grading is enabled for a given
+    # assignment.
+    #
+    # The URL here is not actually used to submit grades. Instead that URL
+    # is passed to us when a _student_ launches the assignment and recorded for
+    # use when an instructor launches the assignment.
+    return "lis_outcome_service_url" in request.params

--- a/tests/lms/views/helpers/frontend_app_test.py
+++ b/tests/lms/views/helpers/frontend_app_test.py
@@ -10,19 +10,38 @@ from lms.views.helpers import frontend_app
 
 @pytest.mark.usefixtures("lis_result_sourcedid_svc")
 class TestConfigureGrading:
-    def test_it_sets_grading_config_if_qualified_request(self, grading_request):
+    def test_it_enables_grading_if_criteria_met(self, grading_request):
         js_config = {}
 
         frontend_app.configure_grading(grading_request, js_config)
 
         assert "lmsGrader" in js_config
 
-    def test_it_does_not_set_grading_config_if_unqualified_request(
-        self, pyramid_request
+    def test_it_disables_grading_if_user_is_not_instructor(self, grading_request):
+        js_config = {}
+        grading_request.lti_user = LTIUser(
+            "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "student"
+        )
+
+        frontend_app.configure_grading(grading_request, js_config)
+
+        assert "lmsGrader" not in js_config
+
+    def test_it_disables_grading_if_lms_is_not_blackboard(self, grading_request):
+        js_config = {}
+        grading_request.params["tool_consumer_info_product_family_code"] = "Moodle"
+
+        frontend_app.configure_grading(grading_request, js_config)
+
+        assert "lmsGrader" not in js_config
+
+    def test_it_disables_grading_if_grading_is_disabled_for_assignment(
+        self, grading_request
     ):
         js_config = {}
+        del grading_request.params["lis_outcome_service_url"]
 
-        frontend_app.configure_grading(pyramid_request, js_config)
+        frontend_app.configure_grading(grading_request, js_config)
 
         assert "lmsGrader" not in js_config
 
@@ -108,6 +127,10 @@ def lis_result_sourcedids():
 @pytest.fixture
 def grading_request(pyramid_request):
     pyramid_request.params["tool_consumer_info_product_family_code"] = "BlackboardLearn"
+    pyramid_request.params[
+        "lis_outcome_service_url"
+    ] = "https://blackboard.hypothes.is/grades"
+
     pyramid_request.lti_user = LTIUser(
         "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"
     )


### PR DESCRIPTION
When configuring an assignment in Blackboard there is an "Enable
evaluation" option. When this is _On_, LTI launch requests for
_instructors_ have a `lis_outcome_service_url` param in the request.
When it is _Off_ they do not.

As far as I know, the LTI specs do not say anything about whether this
param should be included in requests when instructors launch an
assignment, and the URL is not actually used at all in that context, but it is
nevertheless the only obvious indicator in the LTI launch request of
whether evaluation is enabled. Therefore, we may need to take a different approach
entirely in other LMSes.

Fixes #1034

---

**Important testing caveat**

When testing this I found that evaluation could only be disabled when creating an assignment. Disabling evaluation afterwards did not work, the state got reset after clicking "Submit". Enabling evaluation for an assignment after creating it did work however.