### PR TITLE
Prevent select icon from capturing click event

### DIFF
--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -55,6 +55,7 @@
   &-icon {
     position: absolute;
     transform: translateY(-50%);
+    pointer-events: none;
     top: 50%;
     right: 5px;
     color: var.$grey-4;


### PR DESCRIPTION
Prior to this css fix, the arrow icon would capture the click event and prevent the select list from opening.
