### PR TITLE
Increase padding on StudentSelector and its icon

### DIFF
--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -42,7 +42,7 @@
     border-right: none;
     border-radius: 0;
     height: 40px;
-    padding: 5px 25px 5px 20px;
+    padding: 5px 35px 5px 20px;
 
     @include mixins.input-focus;
 
@@ -57,7 +57,7 @@
     transform: translateY(-50%);
     pointer-events: none;
     top: 50%;
-    right: 5px;
+    right: 10px;
     color: var.$grey-4;
   }
 }


### PR DESCRIPTION
This provides an extra 5px of whitespace left and right of the arrow icon per slack discussion

https://hypothes-is.slack.com/archives/C1M8NH76X/p1572998090025600?thread_ts=1572950850.013500&cid=C1M8NH76X

![Screen Shot 2019-11-05 at 4 00 30 PM](https://user-images.githubusercontent.com/3939074/68256656-942bc180-ffe5-11e9-8a7e-a8d4972e64fc.png)

