### PR TITLE
Update dev docs to reflect new via2 dependency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,12 +16,13 @@ There are three presentations for developers that describe what the Hypothesis L
 
 ### You will need
 
-* The LMS app integrates h, the Hypothesis client and Via, so you will need to
+* The LMS app integrates h, the Hypothesis client, Via2, and Via, so you will need to
   set up development environments for each of those before you can develop the
   LMS app:
 
   * https://h.readthedocs.io/en/latest/developing/install/
   * https://h.readthedocs.io/projects/client/en/latest/developers/developing/
+  * https://github.com/hypothesis/proxy-server (Via2 redirects to Via for non-PDF content.)
   * https://github.com/hypothesis/via
 
 * [Git](https://git-scm.com/)


### PR DESCRIPTION
The lms app is dependent on both via and via2 now. It talks directly to via2 and uses via2 to serve pdfs and via2 redirects to via for all other types of content. Update the docs to reflect this change.