### PR TITLE
Use legacy Via in dev

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -19,7 +19,7 @@ feature_flags_cookie_secret = "notasecret"
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"
 
-via_url = http://localhost:9081
+via_url = http://localhost:9080
 h_authority = lms.hypothes.is
 h_api_url_public = http://localhost:5000/api/
 h_api_url_private = http://localhost:5000/api/


### PR DESCRIPTION
Until the Via 2 / proxy-server dev env has been sorted out. See:

https://github.com/hypothesis/proxy-server/issues/11
https://github.com/hypothesis/proxy-server/issues/12
https://github.com/hypothesis/proxy-server/issues/13