### PR TITLE
Replace shallow rendering with mocking of imported components

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -8,11 +8,11 @@ import { ApiError } from '../../utils/api';
 import BasicLtiLaunchApp, { $imports } from '../BasicLtiLaunchApp';
 
 import { waitFor, waitForElement } from './util';
+import mockImportedComponents from './mock-imported-components';
 
 describe('BasicLtiLaunchApp', () => {
   let fakeApiCall;
   let FakeAuthWindow;
-  let FakeErrorDisplay;
   let fakeConfig;
   let fakeHypothesisConfig;
 
@@ -22,11 +22,6 @@ describe('BasicLtiLaunchApp', () => {
       {buttons} {children}
     </Fragment>
   );
-
-  // eslint-disable-next-line react/prop-types
-  const FakeLMSGrader = ({ children }) => {
-    return <Fragment>{children}</Fragment>;
-  };
 
   const renderLtiLaunchApp = (props = {}) => {
     return mount(
@@ -50,17 +45,9 @@ describe('BasicLtiLaunchApp', () => {
       authorize: sinon.stub().resolves(null),
     });
 
-    FakeErrorDisplay = () => null;
-    const FakeSpinner = () => null;
-
-    // nb. We mock components manually rather than using Enzyme's
-    // shallow rendering because the modern context API doesn't seem to work
-    // with shallow rendering yet
+    $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './Dialog': FakeDialog,
-      './ErrorDisplay': FakeErrorDisplay,
-      './LMSGrader': FakeLMSGrader,
-      './Spinner': FakeSpinner,
 
       '../utils/AuthWindow': FakeAuthWindow,
       '../utils/api': {
@@ -111,7 +98,7 @@ describe('BasicLtiLaunchApp', () => {
         authToken: 'dummyAuthToken',
         path: 'https://lms.hypothes.is/api/files/1234',
       });
-      assert.isTrue(wrapper.exists('FakeSpinner'));
+      assert.isTrue(wrapper.exists('Spinner'));
     });
 
     it('displays the content URL in an iframe if successfully fetched', async () => {
@@ -217,7 +204,7 @@ describe('BasicLtiLaunchApp', () => {
 
     // Wait for the API call to fail and check that an error is displayed.
     const wrapper = renderLtiLaunchApp();
-    const errorDisplay = await waitForElement(wrapper, FakeErrorDisplay);
+    const errorDisplay = await waitForElement(wrapper, 'ErrorDisplay');
     assert.equal(errorDisplay.prop('error'), error);
 
     // There should be no "Try again" button in this context, instead we just
@@ -251,7 +238,7 @@ describe('BasicLtiLaunchApp', () => {
 
     it('renders the LMSGrader component', () => {
       const wrapper = renderLtiLaunchApp();
-      const LMSGrader = wrapper.find('FakeLMSGrader');
+      const LMSGrader = wrapper.find('LMSGrader');
       assert.isTrue(LMSGrader.exists());
     });
 
@@ -259,7 +246,7 @@ describe('BasicLtiLaunchApp', () => {
       const wrapper = renderLtiLaunchApp();
       act(() => {
         wrapper
-          .find(FakeLMSGrader)
+          .find('LMSGrader')
           .props()
           .onChangeSelectedUser('new_key');
       });

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
@@ -1,15 +1,23 @@
 import { createElement } from 'preact';
-import ErrorDialog from '../ErrorDialog';
-import ErrorDisplay from '../ErrorDisplay';
+import { mount } from 'enzyme';
 
-import { shallow } from 'enzyme';
+import ErrorDialog, { $imports } from '../ErrorDialog';
+import mockImportedComponents from './mock-imported-components';
 
 describe('ErrorDialog', () => {
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
   it('displays details of the error', () => {
     const err = new Error('Something went wrong');
-    const wrapper = shallow(<ErrorDialog title="Oh no!" error={err} />);
+    const wrapper = mount(<ErrorDialog title="Oh no!" error={err} />);
 
-    assert.include(wrapper.find(ErrorDisplay).props(), {
+    assert.include(wrapper.find('ErrorDisplay').props(), {
       message: 'Oh no!',
       error: err,
     });

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -1,14 +1,23 @@
 import { createElement } from 'preact';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
-import ErrorDisplay from '../ErrorDisplay';
+import ErrorDisplay, { $imports } from '../ErrorDisplay';
+import mockImportedComponents from './mock-imported-components';
 
 describe('ErrorDisplay', () => {
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
   it('displays a support link', () => {
     const error = new Error('Canvas says no');
     error.details = { someTechnicalDetail: 123 };
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <ErrorDisplay message="Failed to fetch files" error={error} />
     );
 
@@ -27,7 +36,7 @@ describe('ErrorDisplay', () => {
   it('omits technical details if not provided', () => {
     const error = { message: '' };
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <ErrorDisplay message="Something went wrong" error={error} />
     );
 
@@ -38,7 +47,7 @@ describe('ErrorDisplay', () => {
   it('displays technical details if provided', () => {
     const error = { message: '', details: 'Note from server' };
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <ErrorDisplay message="Something went wrong" error={error} />
     );
 

--- a/lms/static/scripts/frontend_apps/components/test/FileList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FileList-test.js
@@ -1,7 +1,8 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { createElement } from 'preact';
 
-import FileList from '../FileList';
+import FileList, { $imports } from '../FileList';
+import mockImportedComponents from './mock-imported-components';
 
 describe('FileList', () => {
   const testFiles = [
@@ -13,7 +14,15 @@ describe('FileList', () => {
   ];
 
   const renderFileList = (props = {}) =>
-    shallow(<FileList files={testFiles} {...props} />);
+    mount(<FileList files={testFiles} {...props} />);
+
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
 
   it('renders a table with "Name" and "Last modified" columns', () => {
     const wrapper = renderFileList();
@@ -27,7 +36,7 @@ describe('FileList', () => {
   it('renders files with an icon, file name and date', () => {
     const wrapper = renderFileList();
     const renderItem = wrapper.find('Table').prop('renderItem');
-    const itemWrapper = shallow(<div>{renderItem(testFiles[0])}</div>);
+    const itemWrapper = mount(<div>{renderItem(testFiles[0])}</div>);
     const formattedDate = new Date(testFiles[0]).toLocaleDateString();
     assert.equal(
       itemWrapper

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -10,8 +10,8 @@ import {
   contentItemForUrl,
 } from '../../utils/content-item';
 import { PickerCanceledError } from '../../utils/google-picker-client';
-import Button from '../Button';
 import FilePickerApp, { $imports } from '../FilePickerApp';
+import mockImportedComponents from './mock-imported-components';
 
 function interact(wrapper, callback) {
   act(callback);
@@ -19,11 +19,6 @@ function interact(wrapper, callback) {
 }
 
 describe('FilePickerApp', () => {
-  const FakeErrorDialog = () => null;
-  const FakeLMSFilePicker = () => null;
-  const FakeSpinner = () => null;
-  const FakeURLPicker = () => null;
-
   let container;
   let fakeConfig;
   let FakeGooglePickerClient;
@@ -60,14 +55,8 @@ describe('FilePickerApp', () => {
       enablePublicViewing: sinon.stub(),
     });
 
-    // nb. We mock these components manually rather than using Enzyme's
-    // shallow rendering because the modern context API doesn't seem to work
-    // with shallow rendering yet
+    $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      './ErrorDialog': FakeErrorDialog,
-      './LMSFilePicker': FakeLMSFilePicker,
-      './URLPicker': FakeURLPicker,
-      './Spinner': FakeSpinner,
       '../utils/google-picker-client': {
         GooglePickerClient: FakeGooglePickerClient,
       },
@@ -94,7 +83,7 @@ describe('FilePickerApp', () => {
 
   it('renders buttons to choose assignment source', () => {
     const wrapper = renderFilePicker();
-    assert.equal(wrapper.find(Button).length, 2);
+    assert.equal(wrapper.find('Button').length, 2);
   });
 
   it('renders LMS file picker button if `enableLmsFilePicker` is true', () => {
@@ -112,9 +101,9 @@ describe('FilePickerApp', () => {
   it('renders initial form with no dialog visible', () => {
     const wrapper = renderFilePicker();
 
-    assert.isFalse(wrapper.exists(FakeLMSFilePicker));
-    assert.isFalse(wrapper.exists(FakeURLPicker));
-    assert.equal(wrapper.find(Button).length, 2);
+    assert.isFalse(wrapper.exists('LMSFilePicker'));
+    assert.isFalse(wrapper.exists('URLPicker'));
+    assert.equal(wrapper.find('Button').length, 2);
   });
 
   it('shows URL selection dialog when "Enter URL" button is clicked', () => {
@@ -125,14 +114,14 @@ describe('FilePickerApp', () => {
       btn.props().onClick();
     });
 
-    assert.isTrue(wrapper.exists(FakeURLPicker));
+    assert.isTrue(wrapper.exists('URLPicker'));
   });
 
   it('submits a URL when a URL is selected', () => {
     const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
     const wrapper = renderFilePicker({ defaultActiveDialog: 'url', onSubmit });
 
-    const picker = wrapper.find(FakeURLPicker);
+    const picker = wrapper.find('URLPicker');
     interact(wrapper, () => {
       picker.props().onSelectURL('https://example.com');
     });
@@ -152,7 +141,7 @@ describe('FilePickerApp', () => {
       btn.props().onClick();
     });
 
-    assert.isTrue(wrapper.exists(FakeLMSFilePicker));
+    assert.isTrue(wrapper.exists('LMSFilePicker'));
   });
 
   it('submits an LMS file when an LMS file is selected', () => {
@@ -160,7 +149,7 @@ describe('FilePickerApp', () => {
     const wrapper = renderFilePicker({ defaultActiveDialog: 'lms', onSubmit });
     const file = { id: 123 };
 
-    const picker = wrapper.find(FakeLMSFilePicker);
+    const picker = wrapper.find('LMSFilePicker');
     interact(wrapper, () => {
       picker.props().onSelectFile(file);
     });
@@ -263,9 +252,9 @@ describe('FilePickerApp', () => {
 
     it('shows loading indicator while waiting for user to pick file', () => {
       const wrapper = renderFilePicker();
-      assert.isFalse(wrapper.exists(FakeSpinner));
+      assert.isFalse(wrapper.exists('Spinner'));
       clickGoogleDriveButton(wrapper);
-      assert.isTrue(wrapper.exists(FakeSpinner));
+      assert.isTrue(wrapper.exists('Spinner'));
     });
 
     it('shows error message if Google Picker fails to load', async () => {
@@ -281,7 +270,7 @@ describe('FilePickerApp', () => {
       }
 
       wrapper.setProps({}); // Force re-render.
-      const errDialog = wrapper.find(FakeErrorDialog);
+      const errDialog = wrapper.find('ErrorDialog');
       assert.equal(errDialog.length, 1);
       assert.equal(errDialog.prop('error'), err);
     });
@@ -299,11 +288,11 @@ describe('FilePickerApp', () => {
       }
 
       wrapper.setProps({}); // Force re-render.
-      const errDialog = wrapper.find(FakeErrorDialog);
+      const errDialog = wrapper.find('ErrorDialog');
       const onCancel = errDialog.prop('onCancel');
       assert.isFunction(onCancel);
       interact(wrapper, onCancel);
-      assert.isFalse(wrapper.exists(FakeErrorDialog));
+      assert.isFalse(wrapper.exists('ErrorDialog'));
     });
 
     it('does not show error message if user cancels picker', async () => {
@@ -318,7 +307,7 @@ describe('FilePickerApp', () => {
       }
 
       wrapper.setProps({}); // Force re-render.
-      assert.isFalse(wrapper.exists(FakeErrorDialog));
+      assert.isFalse(wrapper.exists('ErrorDialog'));
     });
 
     it('hides loading indicator if user cancels picker', async () => {
@@ -333,7 +322,7 @@ describe('FilePickerApp', () => {
       }
 
       wrapper.setProps({}); // Force re-render.
-      assert.isFalse(wrapper.exists(FakeSpinner));
+      assert.isFalse(wrapper.exists('Spinner'));
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -1,7 +1,8 @@
 import { createElement } from 'preact';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
-import StudentSelector from '../StudentSelector';
+import StudentSelector, { $imports } from '../StudentSelector';
+import mockImportedComponents from './mock-imported-components';
 
 describe('StudentSelector', () => {
   const renderSelector = (props = {}) => {
@@ -18,7 +19,7 @@ describe('StudentSelector', () => {
       },
     ];
 
-    return shallow(
+    return mount(
       <StudentSelector
         onSelectStudent={fakeOnSelectStudent}
         selectedStudentIndex={fakeSelectedStudentIndex}
@@ -27,6 +28,14 @@ describe('StudentSelector', () => {
       />
     );
   };
+
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
 
   it('shall have "All Students" as the default option', () => {
     const wrapper = renderSelector({ selectedStudentIndex: -1 });

--- a/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
@@ -1,12 +1,21 @@
 import { createElement } from 'preact';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
-import ValidationMessage from '../ValidationMessage';
+import ValidationMessage, { $imports } from '../ValidationMessage';
+import mockImportedComponents from './mock-imported-components';
 
 describe('ValidationMessage', () => {
   const renderMessage = (props = {}) => {
-    return shallow(<ValidationMessage {...props} />);
+    return mount(<ValidationMessage {...props} />);
   };
+
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
 
   it('renders closed by default', () => {
     const wrapper = renderMessage();
@@ -30,7 +39,7 @@ describe('ValidationMessage', () => {
       open: true,
       message: 'foo',
     });
-    wrapper.simulate('click');
+    wrapper.find('div').simulate('click');
     assert.isTrue(onCloseProp.calledOnce);
     assert.isTrue(wrapper.find('.ValidationMessage--closed').exists());
   });

--- a/lms/static/scripts/frontend_apps/components/test/mock-imported-components.js
+++ b/lms/static/scripts/frontend_apps/components/test/mock-imported-components.js
@@ -1,0 +1,65 @@
+/**
+ * Return true if `value` "looks like" a React/Preact component.
+ */
+function isComponent(value) {
+  return (
+    typeof value === 'function' &&
+    // eslint-disable-next-line
+    value.hasOwnProperty('propTypes') &&
+    value.name.match(/^[A-Z]/)
+  );
+}
+
+/**
+ * Return the display name of a component, minus the names of any wrappers
+ * (eg. `withServices(OriginalName)` becomes `OriginalName`).
+ *
+ * @param {Function} component - A Preact component
+ * @return {string}
+ */
+function getDisplayName(component) {
+  let displayName =
+    component.displayName || component.name || 'UnknownComponent';
+
+  const wrappedComponentMatch = displayName.match(/\([A-Z][A-Za-z0-9]+\)/);
+  if (wrappedComponentMatch) {
+    displayName = wrappedComponentMatch[0].slice(1, -1);
+  }
+
+  return displayName;
+}
+
+/**
+ * Helper for use with `babel-plugin-mockable-imports` that mocks components
+ * imported by a file.
+ *
+ * Mocked components will have the same display name as the original component,
+ * minus any wrappers (eg. `Widget` and `withServices(Widget)` both become
+ * `Widget`). They will render only their children, as if they were just a
+ * `Fragment`.
+ *
+ * @example
+ *   beforeEach(() => {
+ *     ComponentUnderTest.$imports.$mock(mockImportedComponents());
+ *
+ *     // Add additional mocks or overrides here.
+ *   });
+ *
+ *   afterEach(() => {
+ *     ComponentUnderTest.$imports.$restore();
+ *   });
+ *
+ * @return {Function} - A function that can be passed to `$imports.$mock`.
+ */
+export default function mockImportedComponents() {
+  return (source, symbol, value) => {
+    if (!isComponent(value)) {
+      return null;
+    }
+
+    const mock = props => props.children;
+    mock.displayName = getDisplayName(value);
+
+    return mock;
+  };
+}


### PR DESCRIPTION
Change UI tests to follow the pattern introduced in https://github.com/hypothesis/client/pull/1470 of using `mount` rather than `shallow` Enzyme rendering for all tests, but with imported components mocked using a `mockImportedComponents` helper.

This makes the tests more consistent, and removes some manual boilerplate for mocking components.

Some of the `SubmitGradeForm` tests broke due to waiting for async tasks to complete in a brittle way (see [related discussion in issue #1095](https://github.com/hypothesis/lms/pull/1095)). This commit resolves that by making the tests wait for the same loading indicators that the user sees in order to determine whether network requests have completed or not. This makes use of a `waitFor` utility that I had introduced previously but forgotten about when looking at #1095.