### PR TITLE
Upgrade Jenkins to Postgres 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ node {
     "Backend tests": {
         stage("Backend tests") {
             // Run the Postgres test DB in a Docker container.
-            postgresContainer = docker.image("postgres:9.4").run("-P -e POSTGRES_DB=lmstest")
+            postgresContainer = docker.image("postgres:11.5").run("-P -e POSTGRES_DB=lmstest")
 
             try {
                 testApp(image: img, runArgs: "${runArgs} -e TEST_DATABASE_URL=${databaseUrl(postgresContainer)} -e CODECOV_TOKEN=${credentials('LMS_CODECOV_TOKEN')}") {


### PR DESCRIPTION
In preparation for switching our production RDS database to Postgres 11,
change Jenkins CI to run tests in PG 11.

See also https://github.com/hypothesis/h/pull/5824. Unlike h, we don't have Travis so this change means there will be no CI tests running in PG 9.4 any more once this lands. I personally think that's not likely to be an issue given the relatively low volume of transactions, data and schema simplicity in the lms app (ie. no exotic PG-specific features are used).