### PR TITLE
Fix `make devdata`

### DIFF
--- a/lms/scripts/devdata.py
+++ b/lms/scripts/devdata.py
@@ -28,6 +28,7 @@ class DevDataFactory:
     def __init__(self, request, devdata_):
         self.db = request.db
         self.tm = request.tm
+        request.tm.begin()
         self.devdata = devdata_
 
     def create_all(self):


### PR DESCRIPTION
We [changed lms to use explicit transaction management](https://github.com/hypothesis/lms/pull/1083) and that broke `make devdata`.

If someone wanted to move the `begin()` / `abort()` / `commit()` into a `try` / `except` / `else` in [`create_all()`](https://github.com/hypothesis/lms/blob/e81fcdc84f73cbf61879773de0584c2cfe44bc04/lms/scripts/devdata.py#L34-L53) that'd be better but it doesn't really matter for the `make devdata` script