### PR TITLE
Removing codecov and replacing it with a coverage ratchet value

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,11 +5,6 @@ source =
     lms
     tests/unit
 
-[paths]
-source =
-    src/
-    */site-packages/
-
 [report]
 show_missing = True
 precision = 2

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+parallel = True
+source =
+    lms
+    tests/unit
+
+[paths]
+source =
+    src/
+    */site-packages/
+
+[report]
+show_missing = True
+precision = 2
+fail_under = 96.11

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .pydeps
-.coverage*
+.coverage
+.coverage.*
 .tox
 .cache
 *.pyc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ node {
             try {
                 testApp(image: img, runArgs: "${runArgs} -e TEST_DATABASE_URL=${databaseUrl(postgresContainer)} -e CODECOV_TOKEN=${credentials('LMS_CODECOV_TOKEN')}") {
                     installDeps()
-                    run("make backend-tests coverage codecov")
+                    run("make backend-tests coverage")
                 }
             } finally {
                 postgresContainer.stop()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ node {
             postgresContainer = docker.image("postgres:11.5").run("-P -e POSTGRES_DB=lmstest")
 
             try {
-                testApp(image: img, runArgs: "${runArgs} -e TEST_DATABASE_URL=${databaseUrl(postgresContainer)} -e CODECOV_TOKEN=${credentials('LMS_CODECOV_TOKEN')}") {
+                testApp(image: img, runArgs: "${runArgs} -e TEST_DATABASE_URL=${databaseUrl(postgresContainer)}") {
                     installDeps()
                     run("make backend-tests coverage")
                 }

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ help:
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
 	@echo "make test              Run the unit tests"
 	@echo "make coverage          Print the unit test coverage report"
-	@echo "make codecov           Upload the coverage report to codecov.io"
 	@echo "make docstrings        View all the docstrings locally as HTML"
 	@echo "make checkdocstrings   Crash if building the docstrings fails"
 	@echo "make pip-compile       Compile requirements.in to requirements.txt"
@@ -73,10 +72,6 @@ test: backend-tests frontend-tests
 .PHONY: coverage
 coverage: python
 	tox -q -e py36-coverage
-
-.PHONY: codecov
-codecov: python
-	tox -q -e py36-codecov
 
 .PHONY: docstrings
 docstrings: python

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/hypothesis/lms.svg?branch=master)](https://travis-ci.org/hypothesis/lms)
-[![codecov](https://codecov.io/gh/hypothesis/lms/branch/master/graph/badge.svg)](https://codecov.io/gh/hypothesis/lms)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 # Hypothesis LMS App

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lms",
   "version": "1.0.0",
-  "description": "[![Build Status](https://travis-ci.org/hypothesis/lms.svg?branch=master)](https://travis-ci.org/hypothesis/lms) [![codecov](https://codecov.io/gh/hypothesis/lms/branch/master/graph/badge.svg)](https://codecov.io/gh/hypothesis/lms) [![Updates](https://pyup.io/repos/github/hypothesis/lms/shield.svg)](https://pyup.io/repos/github/hypothesis/lms/) [![Python 3](https://pyup.io/repos/github/hypothesis/lms/python-3-shield.svg)](https://pyup.io/repos/github/hypothesis/lms/)",
+  "description": "[![Build Status](https://travis-ci.org/hypothesis/lms.svg?branch=master)](https://travis-ci.org/hypothesis/lms) [![Updates](https://pyup.io/repos/github/hypothesis/lms/shield.svg)](https://pyup.io/repos/github/hypothesis/lms/) [![Python 3](https://pyup.io/repos/github/hypothesis/lms/python-3-shield.svg)](https://pyup.io/repos/github/hypothesis/lms/)",
   "main": "index.js",
   "directories": {
     "lib": "lib",

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
     checkformatting: black --check lms tests
     checkformatting: isort --recursive --quiet --check-only lms tests
     coverage: -coverage combine
-    coverage: coverage report --show-missing
+    coverage: coverage report
     docker-compose: docker-compose {posargs}
     {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envdir}/rst .
     docstrings: sphinx-autobuild -BqT -z lms -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml

--- a/tox.ini
+++ b/tox.ini
@@ -42,13 +42,11 @@ passenv =
     dev: SENTRY_ENVIRONMENT
     dev: USERNAME
     dev: VIA_URL
-    codecov: TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps =
     {tests,clean,coverage}: coverage
     {tests,lint}: httpretty
     {tests,lint,docstrings,checkdocstrings}: pytest
     {tests,lint,docstrings,checkdocstrings}: factory-boy
-    codecov: codecov
     lint: prospector==1.1.6.2
     {format,checkformatting}: black
     {format,checkformatting}: isort
@@ -75,7 +73,6 @@ commands =
     checkformatting: isort --recursive --quiet --check-only lms tests
     coverage: -coverage combine
     coverage: coverage report --show-missing
-    codecov: codecov -t {env:CODECOV_TOKEN}
     docker-compose: docker-compose {posargs}
     {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envdir}/rst .
     docstrings: sphinx-autobuild -BqT -z lms -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ whitelist_externals =
     tests: sh
 commands =
     tests: sh bin/create-testdb
-    tests: coverage run --source lms,tests/unit -m pytest -v -Werror {posargs:tests/unit/}
+    tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
     dev: {posargs:gunicorn --paste conf/development.ini}
     lint: prospector
     lint: prospector tests


### PR DESCRIPTION
`codecov` was apparently getting routinely ignored, and failing so instead the idea is to:

 * Introduce a fixed percentage coverage value
 * Any time the total coverage falls below this the build will fail
 * Every so often we will review the value and increase it to the current level (never decrease)

The idea is that for any particular project new patches must match the general level of quality of the project from a coverage point of view. Of course beating this is encouraged, and over time if we only ever revise the number upwards we should move toward 100% coverage without having a massive cliff edge of work to achieve it.