### PR TITLE
Enable grading in all LMS's

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,4 +10,4 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 97.71
+fail_under = 97.70

--- a/lms/views/decorators/lis_result_sourcedid.py
+++ b/lms/views/decorators/lis_result_sourcedid.py
@@ -29,14 +29,6 @@ def upsert_lis_result_sourcedid(wrapped):
         if request.lti_user.is_instructor:
             should_upsert = False
 
-        # Don't upsert the lis_result_sourcedid if the LMS isn't either
-        # Blackboard Learn or Moodle.
-        if lis_result_sourcedid.tool_consumer_info_product_family_code not in (
-            "BlackboardLearn",
-            "moodle",
-        ):
-            should_upsert = False
-
         if should_upsert:
             lis_result_svc = request.find_service(name="lis_result_sourcedid")
             lis_result_svc.upsert(

--- a/lms/views/decorators/lis_result_sourcedid.py
+++ b/lms/views/decorators/lis_result_sourcedid.py
@@ -22,19 +22,27 @@ def upsert_lis_result_sourcedid(wrapped):
             # LIS data is not present on the request.
             return wrapped(context, request)
 
-        if (
-            request.lti_user.is_instructor
-            or lis_result_sourcedid.tool_consumer_info_product_family_code
-            != "BlackboardLearn"
-        ):
-            # Don't create records for instructors, or for LMSes other than
-            # BlackboardLearn (at least for now)
-            return wrapped(context, request)
+        # Whether or not we should upsert the lis_result_sourcedid.
+        should_upsert = True
 
-        lis_result_svc = request.find_service(name="lis_result_sourcedid")
-        lis_result_svc.upsert(
-            lis_result_sourcedid, h_user=context.h_user, lti_user=request.lti_user
-        )
+        # Don't upsert the lis_result_sourcedid if the user is an instructor.
+        if request.lti_user.is_instructor:
+            should_upsert = False
+
+        # Don't upsert the lis_result_sourcedid if the LMS isn't either
+        # Blackboard Learn or Moodle.
+        if lis_result_sourcedid.tool_consumer_info_product_family_code not in (
+            "BlackboardLearn",
+            "moodle",
+        ):
+            should_upsert = False
+
+        if should_upsert:
+            lis_result_svc = request.find_service(name="lis_result_sourcedid")
+            lis_result_svc.upsert(
+                lis_result_sourcedid, h_user=context.h_user, lti_user=request.lti_user
+            )
+
         return wrapped(context, request)
 
     return wrapper

--- a/lms/views/decorators/lis_result_sourcedid.py
+++ b/lms/views/decorators/lis_result_sourcedid.py
@@ -22,14 +22,7 @@ def upsert_lis_result_sourcedid(wrapped):
             # LIS data is not present on the request.
             return wrapped(context, request)
 
-        # Whether or not we should upsert the lis_result_sourcedid.
-        should_upsert = True
-
-        # Don't upsert the lis_result_sourcedid if the user is an instructor.
-        if request.lti_user.is_instructor:
-            should_upsert = False
-
-        if should_upsert:
+        if not request.lti_user.is_instructor:
             lis_result_svc = request.find_service(name="lis_result_sourcedid")
             lis_result_svc.upsert(
                 lis_result_sourcedid, h_user=context.h_user, lti_user=request.lti_user

--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -9,15 +9,10 @@ def configure_grading(request, js_config):
     """
     Insert any needed JS context to configure the front end for grading.
 
-    This is only enabled for instructors on Blackboard or Moodle for now. Note
-    that this is entirely distinct from Canvas Speedgrader, which provides its
-    own UI.
+    Note that this is entirely distinct from Canvas Speedgrader, which provides
+    its own UI.
     """
-    if (
-        request.lti_user.is_instructor
-        and _is_blackboard_or_moodle(request)
-        and _is_assignment_gradable(request)
-    ):
+    if request.lti_user.is_instructor and _is_assignment_gradable(request):
         js_config["lmsGrader"] = True
 
     js_config["grading"] = {
@@ -49,11 +44,6 @@ def configure_grading(request, js_config):
         )
 
     js_config["grading"]["students"] = students
-
-
-def _is_blackboard_or_moodle(request):
-    family_code = request.params.get("tool_consumer_info_product_family_code", "")
-    return family_code in ("BlackboardLearn", "moodle")
 
 
 def _is_assignment_gradable(request):

--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -9,12 +9,13 @@ def configure_grading(request, js_config):
     """
     Insert any needed JS context to configure the front end for grading.
 
-    This is only enabled for instructors on BlackBoard for now. Note that this
-    is entirely distinct from Canvas Speedgrader, which provides its own UI.
+    This is only enabled for instructors on Blackboard or Moodle for now. Note
+    that this is entirely distinct from Canvas Speedgrader, which provides its
+    own UI.
     """
     if (
         request.lti_user.is_instructor
-        and _is_blackboard(request)
+        and _is_blackboard_or_moodle(request)
         and _is_assignment_gradable(request)
     ):
         js_config["lmsGrader"] = True
@@ -50,9 +51,9 @@ def configure_grading(request, js_config):
     js_config["grading"]["students"] = students
 
 
-def _is_blackboard(request):
+def _is_blackboard_or_moodle(request):
     family_code = request.params.get("tool_consumer_info_product_family_code", "")
-    return family_code == "BlackboardLearn"
+    return family_code in ("BlackboardLearn", "moodle")
 
 
 def _is_assignment_gradable(request):

--- a/tests/unit/lms/models/lis_result_sourcedid_test.py
+++ b/tests/unit/lms/models/lis_result_sourcedid_test.py
@@ -17,9 +17,9 @@ class TestLISResultSourcedId:
         assert lrs.user_id == "339483948"
         assert lrs.context_id == "random context"
         assert lrs.resource_link_id == "random resource link id"
-        assert lrs.tool_consumer_info_product_family_code == "BlackboardLearn"
-        assert lrs.h_username == "blackboarduser1"
-        assert lrs.h_display_name == "Black Board User"
+        assert lrs.tool_consumer_info_product_family_code == "MyFakeLTITool"
+        assert lrs.h_username == "ltiuser1"
+        assert lrs.h_display_name == "My Fake LTI User"
 
     @pytest.mark.parametrize(
         "non_nullable_field",
@@ -78,9 +78,9 @@ class TestLISResultSourcedId:
             user_id="339483948",
             context_id="random context",
             resource_link_id="random resource link id",
-            tool_consumer_info_product_family_code="BlackboardLearn",
-            h_username="blackboarduser1",
-            h_display_name="Black Board User",
+            tool_consumer_info_product_family_code="MyFakeLTITool",
+            h_username="ltiuser1",
+            h_display_name="My Fake LTI User",
         )
 
     @pytest.fixture
@@ -92,7 +92,7 @@ class TestLISResultSourcedId:
             user_id="339483948",
             context_id="random context",
             resource_link_id="random resource link id",
-            tool_consumer_info_product_family_code="BlackboardLearn",
-            h_username="blackboarduser1",
-            h_display_name="Black Board User",
+            tool_consumer_info_product_family_code="MyFakeLTITool",
+            h_username="ltiuser1",
+            h_display_name="My Fake LTI User",
         )

--- a/tests/unit/lms/services/lis_result_sourcedid_test.py
+++ b/tests/unit/lms/services/lis_result_sourcedid_test.py
@@ -176,7 +176,7 @@ def lis_result_sourcedid_info(application_instance):
         lis_outcome_service_url="https://somewhere.else",
         context_id="random context",
         resource_link_id="random resource link id",
-        tool_consumer_info_product_family_code="BlackboardLearn",
+        tool_consumer_info_product_family_code="MyFakeLTITool",
     )
 
 

--- a/tests/unit/lms/views/decorators/lis_result_sourcedid_test.py
+++ b/tests/unit/lms/views/decorators/lis_result_sourcedid_test.py
@@ -75,7 +75,7 @@ class TestUpsertLISResultSourcedId:
         wrapped.assert_called_once_with(context, pyramid_request)
         lis_result_sourcedid_svc.upsert.assert_not_called()
 
-    def test_it_continues_to_wrapped_fn_if_LMS_not_blackboard(
+    def test_it_continues_to_wrapped_fn_if_LMS_not_blackboard_or_moodle(
         self,
         upsert_lis_result_sourcedid,
         pyramid_request,
@@ -86,7 +86,7 @@ class TestUpsertLISResultSourcedId:
         wrapped,
     ):
         lis_result_sourcedid_value = lis_result_sourcedid_value._replace(
-            tool_consumer_info_product_family_code="NOTBLACKBOARD"
+            tool_consumer_info_product_family_code="NOT_BLACKBOARD_OR_MOODLE"
         )
         LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
             lis_result_sourcedid_value
@@ -100,7 +100,8 @@ class TestUpsertLISResultSourcedId:
         wrapped.assert_called_once_with(context, pyramid_request)
         lis_result_sourcedid_svc.upsert.assert_not_called()
 
-    def test_it_upserts_lis_result_sourcedid(
+    @pytest.mark.parametrize("product_family_code", ["BlackboardLearn", "moodle"])
+    def test_it_upserts_lis_result_sourcedid_if_LMS_is_blackboard_or_moodle(
         self,
         upsert_lis_result_sourcedid,
         pyramid_request,
@@ -109,7 +110,11 @@ class TestUpsertLISResultSourcedId:
         LISResultSourcedIdSchema,
         lis_result_sourcedid_svc,
         lis_result_sourcedid_value,
+        product_family_code,
     ):
+        lis_result_sourcedid_value = lis_result_sourcedid_value._replace(
+            tool_consumer_info_product_family_code=product_family_code
+        )
         LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
             lis_result_sourcedid_value
         )
@@ -131,6 +136,9 @@ class TestUpsertLISResultSourcedId:
         lis_result_sourcedid_svc,
         lis_result_sourcedid_value,
     ):
+        lis_result_sourcedid_value = lis_result_sourcedid_value._replace(
+            tool_consumer_info_product_family_code="moodle"
+        )
         LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
             lis_result_sourcedid_value
         )
@@ -164,7 +172,7 @@ def lis_result_sourcedid_value():
         lis_outcome_service_url="TEST LIS OUTCOME SERVICE URL",
         context_id="TEST CONTEXT ID",
         resource_link_id="TEST RESOURCE LINK ID",
-        tool_consumer_info_product_family_code="BlackboardLearn",
+        tool_consumer_info_product_family_code="FooLMS",
     )
 
 

--- a/tests/unit/lms/views/decorators/lis_result_sourcedid_test.py
+++ b/tests/unit/lms/views/decorators/lis_result_sourcedid_test.py
@@ -75,33 +75,7 @@ class TestUpsertLISResultSourcedId:
         wrapped.assert_called_once_with(context, pyramid_request)
         lis_result_sourcedid_svc.upsert.assert_not_called()
 
-    def test_it_continues_to_wrapped_fn_if_LMS_not_blackboard_or_moodle(
-        self,
-        upsert_lis_result_sourcedid,
-        pyramid_request,
-        context,
-        lis_result_sourcedid_svc,
-        LISResultSourcedIdSchema,
-        lis_result_sourcedid_value,
-        wrapped,
-    ):
-        lis_result_sourcedid_value = lis_result_sourcedid_value._replace(
-            tool_consumer_info_product_family_code="NOT_BLACKBOARD_OR_MOODLE"
-        )
-        LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
-            lis_result_sourcedid_value
-        )
-
-        upsert_lis_result_sourcedid(context, pyramid_request)
-
-        LISResultSourcedIdSchema(
-            pyramid_request
-        ).lis_result_sourcedid_info.assert_called_once()
-        wrapped.assert_called_once_with(context, pyramid_request)
-        lis_result_sourcedid_svc.upsert.assert_not_called()
-
-    @pytest.mark.parametrize("product_family_code", ["BlackboardLearn", "moodle"])
-    def test_it_upserts_lis_result_sourcedid_if_LMS_is_blackboard_or_moodle(
+    def test_it_upserts_lis_result_sourcedid(
         self,
         upsert_lis_result_sourcedid,
         pyramid_request,
@@ -110,11 +84,7 @@ class TestUpsertLISResultSourcedId:
         LISResultSourcedIdSchema,
         lis_result_sourcedid_svc,
         lis_result_sourcedid_value,
-        product_family_code,
     ):
-        lis_result_sourcedid_value = lis_result_sourcedid_value._replace(
-            tool_consumer_info_product_family_code=product_family_code
-        )
         LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
             lis_result_sourcedid_value
         )
@@ -136,9 +106,6 @@ class TestUpsertLISResultSourcedId:
         lis_result_sourcedid_svc,
         lis_result_sourcedid_value,
     ):
-        lis_result_sourcedid_value = lis_result_sourcedid_value._replace(
-            tool_consumer_info_product_family_code="moodle"
-        )
         LISResultSourcedIdSchema.return_value.lis_result_sourcedid_info.return_value = (
             lis_result_sourcedid_value
         )

--- a/tests/unit/lms/views/helpers/frontend_app_test.py
+++ b/tests/unit/lms/views/helpers/frontend_app_test.py
@@ -10,7 +10,7 @@ from lms.views.helpers import frontend_app
 
 @pytest.mark.usefixtures("lis_result_sourcedid_svc")
 class TestConfigureGrading:
-    def test_it_enables_grading_(self, grading_request):
+    def test_it_enables_grading(self, grading_request):
         js_config = {}
 
         frontend_app.configure_grading(grading_request, js_config)

--- a/tests/unit/lms/views/helpers/frontend_app_test.py
+++ b/tests/unit/lms/views/helpers/frontend_app_test.py
@@ -10,7 +10,13 @@ from lms.views.helpers import frontend_app
 
 @pytest.mark.usefixtures("lis_result_sourcedid_svc")
 class TestConfigureGrading:
-    def test_it_enables_grading_if_criteria_met(self, grading_request):
+    @pytest.mark.parametrize("product_family_code", ["BlackboardLearn", "moodle"])
+    def test_it_enables_grading_if_criteria_met(
+        self, grading_request, product_family_code
+    ):
+        grading_request.params[
+            "tool_consumer_info_product_family_code"
+        ] = product_family_code
         js_config = {}
 
         frontend_app.configure_grading(grading_request, js_config)
@@ -27,9 +33,13 @@ class TestConfigureGrading:
 
         assert "lmsGrader" not in js_config
 
-    def test_it_disables_grading_if_lms_is_not_blackboard(self, grading_request):
+    def test_it_disables_grading_if_lms_is_not_blackboard_or_moodle(
+        self, grading_request
+    ):
         js_config = {}
-        grading_request.params["tool_consumer_info_product_family_code"] = "Moodle"
+        grading_request.params[
+            "tool_consumer_info_product_family_code"
+        ] = "NOT_BLACKBOARD_OR_MOODLE"
 
         frontend_app.configure_grading(grading_request, js_config)
 

--- a/tests/unit/lms/views/helpers/frontend_app_test.py
+++ b/tests/unit/lms/views/helpers/frontend_app_test.py
@@ -10,13 +10,7 @@ from lms.views.helpers import frontend_app
 
 @pytest.mark.usefixtures("lis_result_sourcedid_svc")
 class TestConfigureGrading:
-    @pytest.mark.parametrize("product_family_code", ["BlackboardLearn", "moodle"])
-    def test_it_enables_grading_if_criteria_met(
-        self, grading_request, product_family_code
-    ):
-        grading_request.params[
-            "tool_consumer_info_product_family_code"
-        ] = product_family_code
+    def test_it_enables_grading_(self, grading_request):
         js_config = {}
 
         frontend_app.configure_grading(grading_request, js_config)
@@ -28,18 +22,6 @@ class TestConfigureGrading:
         grading_request.lti_user = LTIUser(
             "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "student"
         )
-
-        frontend_app.configure_grading(grading_request, js_config)
-
-        assert "lmsGrader" not in js_config
-
-    def test_it_disables_grading_if_lms_is_not_blackboard_or_moodle(
-        self, grading_request
-    ):
-        js_config = {}
-        grading_request.params[
-            "tool_consumer_info_product_family_code"
-        ] = "NOT_BLACKBOARD_OR_MOODLE"
 
         frontend_app.configure_grading(grading_request, js_config)
 

--- a/tests/unit/lms/views/helpers/frontend_app_test.py
+++ b/tests/unit/lms/views/helpers/frontend_app_test.py
@@ -118,10 +118,10 @@ def lis_result_sourcedids():
 
 @pytest.fixture
 def grading_request(pyramid_request):
-    pyramid_request.params["tool_consumer_info_product_family_code"] = "BlackboardLearn"
+    pyramid_request.params["tool_consumer_info_product_family_code"] = "MyFakeLTITool"
     pyramid_request.params[
         "lis_outcome_service_url"
-    ] = "https://blackboard.hypothes.is/grades"
+    ] = "https://myfakeltitool.hypothes.is/grades"
 
     pyramid_request.lti_user = LTIUser(
         "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"


### PR DESCRIPTION
Remove the "only in Blackboard" gates from our grading feature so that it's now enabled in all LMS's.

It has been tested in Blackboard (and already released to the public), Moodle and Brightspace.