### PR TITLE
Using error view decorators and fixing html Validation errors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,4 +10,4 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 97.65
+fail_under = 97.69

--- a/lms/app.py
+++ b/lms/app.py
@@ -83,7 +83,6 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.routes")
     config.include("lms.assets")
     config.include("lms.views")
-    config.include("lms.views.error")
     config.include("lms.services")
     config.include("lms.validation")
     config.include("lms.tweens")

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -1,5 +1,6 @@
 import h_pyramid_sentry
 from pyramid import httpexceptions, i18n
+from pyramid.config import not_
 from pyramid.view import (
     exception_view_config,
     forbidden_view_config,
@@ -50,7 +51,7 @@ def http_server_error(exc, request):
 
 @exception_view_config(
     context=ValidationError,
-    accept="text/html",
+    path_info=not_("^/api/.*"),
     renderer="lms:templates/validation_error.html.jinja2",
 )
 def validation_error(exc, request):

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -20,13 +20,13 @@ def _http_error(exc, request):
 
 
 @notfound_view_config(renderer=DEFAULT_RENDERER)
-def notfound(request):
+def notfound(_, request):
     request.response.status_int = 404
     return {"message": _("Page not found")}
 
 
 @forbidden_view_config(renderer=DEFAULT_RENDERER)
-def forbidden(request):
+def forbidden(_, request):
     request.response.status_int = 403
     return {"message": _("You're not authorized to view this page")}
 
@@ -60,7 +60,7 @@ def validation_error(exc, request):
 
 
 @exception_view_config(context=Exception, renderer=DEFAULT_RENDERER)
-def error(request):
+def error(_, request):
     """
     Handle an unexpected exception.
 

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -1,22 +1,16 @@
 import h_pyramid_sentry
 from pyramid import httpexceptions, i18n
-from pyramid.view import forbidden_view_config, notfound_view_config
+from pyramid.view import (
+    exception_view_config,
+    forbidden_view_config,
+    notfound_view_config,
+)
 
 from lms.validation import ValidationError
 
 _ = i18n.TranslationStringFactory(__package__)
 
-
-@notfound_view_config(renderer="lms:templates/error.html.jinja2")
-def notfound(request):
-    request.response.status_int = 404
-    return {"message": _("Page not found")}
-
-
-@forbidden_view_config(renderer="lms:templates/error.html.jinja2")
-def forbidden(request):
-    request.response.status_int = 403
-    return {"message": _("You're not authorized to view this page")}
+DEFAULT_RENDERER = "lms:templates/error.html.jinja2"
 
 
 def _http_error(exc, request):
@@ -25,23 +19,47 @@ def _http_error(exc, request):
     return {"message": str(exc)}
 
 
+@notfound_view_config(renderer=DEFAULT_RENDERER)
+def notfound(request):
+    request.response.status_int = 404
+    return {"message": _("Page not found")}
+
+
+@forbidden_view_config(renderer=DEFAULT_RENDERER)
+def forbidden(request):
+    request.response.status_int = 403
+    return {"message": _("You're not authorized to view this page")}
+
+
+@exception_view_config(
+    context=httpexceptions.HTTPClientError, renderer=DEFAULT_RENDERER,
+)
 def http_client_error(exc, request):
     """Handle an HTTP 4xx (client error) exception."""
     return _http_error(exc, request)
 
 
+@exception_view_config(
+    context=httpexceptions.HTTPServerError, renderer=DEFAULT_RENDERER
+)
 def http_server_error(exc, request):
     """Handle an HTTP 5xx (server error) exception."""
     h_pyramid_sentry.report_exception()
     return _http_error(exc, request)
 
 
+@exception_view_config(
+    context=ValidationError,
+    accept="text/html",
+    renderer="lms:templates/validation_error.html.jinja2",
+)
 def validation_error(exc, request):
     """Handle a ValidationError."""
     request.response.status_int = exc.status_int
     return {"error": exc}
 
 
+@exception_view_config(context=Exception, renderer=DEFAULT_RENDERER)
 def error(request):
     """
     Handle an unexpected exception.
@@ -66,22 +84,3 @@ def error(request):
             "fix it."
         )
     }
-
-
-def includeme(config):
-    view_defaults = {"renderer": "lms:templates/error.html.jinja2"}
-
-    config.add_exception_view(
-        http_client_error, context=httpexceptions.HTTPClientError, **view_defaults
-    )
-    config.add_exception_view(
-        http_server_error, context=httpexceptions.HTTPServerError, **view_defaults
-    )
-    config.add_exception_view(error, context=Exception, **view_defaults)
-
-    validation_view_defaults = dict(view_defaults)
-    validation_view_defaults["renderer"] = "lms:templates/validation_error.html.jinja2"
-
-    config.add_exception_view(
-        validation_error, context=ValidationError, **validation_view_defaults
-    )

--- a/lms/views/error.py
+++ b/lms/views/error.py
@@ -20,13 +20,13 @@ def _http_error(exc, request):
 
 
 @notfound_view_config(renderer=DEFAULT_RENDERER)
-def notfound(_, request):
+def notfound(_exc, request):
     request.response.status_int = 404
     return {"message": _("Page not found")}
 
 
 @forbidden_view_config(renderer=DEFAULT_RENDERER)
-def forbidden(_, request):
+def forbidden(_exc, request):
     request.response.status_int = 403
     return {"message": _("You're not authorized to view this page")}
 
@@ -60,7 +60,7 @@ def validation_error(exc, request):
 
 
 @exception_view_config(context=Exception, renderer=DEFAULT_RENDERER)
-def error(_, request):
+def error(_exc, request):
     """
     Handle an unexpected exception.
 

--- a/tests/unit/lms/authentication/__init___test.py
+++ b/tests/unit/lms/authentication/__init___test.py
@@ -1,5 +1,4 @@
 import pytest
-from pyramid import testing
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.interfaces import IAuthenticationPolicy
 

--- a/tests/unit/lms/authentication/_policy_test.py
+++ b/tests/unit/lms/authentication/_policy_test.py
@@ -1,10 +1,8 @@
-import base64
 from unittest import mock
 
 import pytest
 
 from lms.authentication._policy import AuthenticationPolicy
-from lms.values import LTIUser
 
 
 class TestAuthenticationPolicy:

--- a/tests/unit/lms/config/settings_test.py
+++ b/tests/unit/lms/config/settings_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lms.config.settings import SettingError, SettingGetter
+from lms.config.settings import SettingGetter
 
 
 @pytest.mark.usefixtures("os_fixture")

--- a/tests/unit/lms/resources/_default_test.py
+++ b/tests/unit/lms/resources/_default_test.py
@@ -1,4 +1,3 @@
-import pytest
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from lms.resources import DefaultResource

--- a/tests/unit/lms/services/_helpers/canvas_api_test.py
+++ b/tests/unit/lms/services/_helpers/canvas_api_test.py
@@ -4,11 +4,7 @@ import pytest
 from requests import ConnectionError, HTTPError, ReadTimeout, Request, TooManyRedirects
 
 from lms.services._helpers.canvas_api import CanvasAPIHelper
-from lms.services.exceptions import (
-    CanvasAPIAccessTokenError,
-    CanvasAPIError,
-    CanvasAPIServerError,
-)
+from lms.services.exceptions import CanvasAPIError
 from lms.validation import ValidationError
 from lms.validation._helpers import PyramidRequestSchema
 

--- a/tests/unit/lms/services/canvas_api_test.py
+++ b/tests/unit/lms/services/canvas_api_test.py
@@ -1,13 +1,10 @@
-import datetime
 from unittest import mock
 
 import pytest
-from requests import ConnectionError, HTTPError, ReadTimeout, Response, TooManyRedirects
 
 from lms.models import ApplicationInstance, OAuth2Token
 from lms.services import CanvasAPIAccessTokenError, CanvasAPIServerError
 from lms.services.canvas_api import CanvasAPIClient
-from lms.validation import ValidationError
 
 
 class TestGetToken:

--- a/tests/unit/lms/validation/__init___test.py
+++ b/tests/unit/lms/validation/__init___test.py
@@ -1,8 +1,6 @@
 from unittest import mock
 
-import marshmallow
 import pytest
-import webargs
 from pyramid.interfaces import IViewDerivers
 
 from lms.validation import ValidationError, _validated_view, includeme

--- a/tests/unit/lms/views/error_test.py
+++ b/tests/unit/lms/views/error_test.py
@@ -17,7 +17,7 @@ class ExceptionViewTest:
 
     def handle(self, pyramid_request):
         if self.exception is None:
-            return type(self).view(pyramid_request)
+            return type(self).view(mock.sentinel.exception, pyramid_request)
 
         return type(self).view(self.exception, pyramid_request)
 

--- a/tests/unit/lms/views/error_test.py
+++ b/tests/unit/lms/views/error_test.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
 import pytest
-from h_matchers import Any
-from pyramid.httpexceptions import HTTPBadRequest, HTTPClientError, HTTPServerError
+from pyramid.httpexceptions import HTTPBadRequest, HTTPServerError
 
 from lms.validation import ValidationError
 from lms.views import error

--- a/tests/unit/lms/views/error_test.py
+++ b/tests/unit/lms/views/error_test.py
@@ -103,45 +103,6 @@ class TestError(ExceptionViewTest):
     }
 
 
-@pytest.mark.usefixtures("pyramid_config")
-class TestIncludeMe:
-    def test_it_adds_the_exception_views(self, pyramid_config):
-        error.includeme(pyramid_config)
-
-        assert (
-            pyramid_config.add_exception_view.call_args_list
-            == Any.list.containing(
-                [
-                    mock.call(
-                        error.http_client_error,
-                        context=HTTPClientError,
-                        renderer="lms:templates/error.html.jinja2",
-                    ),
-                    mock.call(
-                        error.http_server_error,
-                        context=HTTPServerError,
-                        renderer="lms:templates/error.html.jinja2",
-                    ),
-                    mock.call(
-                        error.error,
-                        context=Exception,
-                        renderer="lms:templates/error.html.jinja2",
-                    ),
-                    mock.call(
-                        error.validation_error,
-                        context=ValidationError,
-                        renderer="lms:templates/validation_error.html.jinja2",
-                    ),
-                ]
-            ).only()
-        )
-
-    @pytest.fixture
-    def pyramid_config(self, pyramid_config):
-        pyramid_config.add_exception_view = mock.MagicMock()
-        return pyramid_config
-
-
 @pytest.fixture(autouse=True)
 def h_pyramid_sentry(patch):
     return patch("lms.views.error.h_pyramid_sentry")


### PR DESCRIPTION
Previously we would return JSON for ValidationErrors regardless. We now specify what should happen if the user requests "text/html".

As a part of this I ran a cleaner over the imports in the tests as I remembered I'd left an un-used import. It cleaned out quite a few others too.
