### PR TITLE
LTI Certification 1.1 - Tests 1.5, 1.6 & 1.7

### DIFF
--- a/lms/validation/_exceptions.py
+++ b/lms/validation/_exceptions.py
@@ -5,9 +5,7 @@ from pyramid.httpexceptions import HTTPFound
 
 # pylint: disable=too-many-ancestors
 
-__all__ = [
-    "ValidationError",
-]
+__all__ = ["ValidationError", "LTIToolRedirect"]
 
 
 class ValidationError(

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -1,6 +1,11 @@
 from urllib.parse import unquote
 
+<<<<<<< HEAD
 from marshmallow import Schema, ValidationError, fields, post_load
+=======
+from marshmallow import fields, post_load
+from marshmallow.validate import OneOf
+>>>>>>> Implementing the validation for lti_version
 
 from lms.validation._exceptions import LTIToolRedirect
 from lms.validation._helpers import PyramidRequestSchema
@@ -21,10 +26,11 @@ class LaunchParamsSchema(PyramidRequestSchema):
 
     resource_link_id = fields.Str(required=True)
     launch_presentation_return_url = fields.Str()
+    lti_version = fields.Str(validate=OneOf(['LTI-1p0']), required=True)
 
     # If we have an error in one of these fields we should redirect back to
     # the calling LMS if possible
-    lti_redirect_fields = {"resource_link_id"}
+    lti_redirect_fields = {"resource_link_id", "lti_version"}
 
     locations = ["form"]
 

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -1,11 +1,7 @@
 from urllib.parse import unquote
 
-<<<<<<< HEAD
-from marshmallow import Schema, ValidationError, fields, post_load
-=======
-from marshmallow import fields, post_load
+from marshmallow import EXCLUDE, Schema, ValidationError, fields, post_load
 from marshmallow.validate import OneOf
->>>>>>> Implementing the validation for lti_version
 
 from lms.validation._exceptions import LTIToolRedirect
 from lms.validation._helpers import PyramidRequestSchema
@@ -22,11 +18,16 @@ class LaunchParamsSchema(PyramidRequestSchema):
     class URLSchema(Schema):
         """Schema containing only validation for the return URL."""
 
+        class Meta:
+            """Allow other values, as we are only here to validate the URL."""
+
+            unknown = EXCLUDE
+
         launch_presentation_return_url = fields.URL()
 
     resource_link_id = fields.Str(required=True)
     launch_presentation_return_url = fields.Str()
-    lti_version = fields.Str(validate=OneOf(['LTI-1p0']), required=True)
+    lti_version = fields.Str(validate=OneOf(["LTI-1p0"]), required=True)
 
     # If we have an error in one of these fields we should redirect back to
     # the calling LMS if possible

--- a/tests/functional/lti_certification/test_lti_certification_1_1.py
+++ b/tests/functional/lti_certification/test_lti_certification_1_1.py
@@ -31,7 +31,8 @@ class TestLTICertification(TestBaseClass):
         lti_params.pop("resource_link_id")
 
         self.assert_redirected_to_tool_with_message(
-            app, lti_params, message=Any.string.containing("resource_link_id"))
+            app, lti_params, message=Any.string.containing("resource_link_id")
+        )
 
     def test_1_2_nice_message_when_res_link_id_and_return_url_missing(
         self, app, lti_params
@@ -44,23 +45,32 @@ class TestLTICertification(TestBaseClass):
         self.assert_response_is_html(result)
         assert "resource_link_id" in result
 
-    def test_1_5_redirect_to_tool_consumer_when_lti_version_invalid(self, app, lti_params):
-        lti_params['lti_version'] = 'LTI-1'
+    def test_1_5_redirect_to_tool_consumer_when_lti_version_invalid(
+        self, app, lti_params
+    ):
+        lti_params["lti_version"] = "LTI-1"
 
         self.assert_redirected_to_tool_with_message(
-            app, lti_params, message=Any.string.containing("lti_version"))
+            app, lti_params, message=Any.string.containing("lti_version")
+        )
 
-    def test_1_6_redirect_to_tool_consumer_when_lti_version_wrong(self, app, lti_params):
-        lti_params['lti_version'] = 'LTI-2p0'
-
-        self.assert_redirected_to_tool_with_message(
-            app, lti_params, message=Any.string.containing("lti_version"))
-
-    def test_1_7_redirect_to_tool_consumer_when_lti_version_missing(self, app, lti_params):
-        lti_params.pop('lti_version')
+    def test_1_6_redirect_to_tool_consumer_when_lti_version_wrong(
+        self, app, lti_params
+    ):
+        lti_params["lti_version"] = "LTI-2p0"
 
         self.assert_redirected_to_tool_with_message(
-            app, lti_params, message=Any.string.containing("lti_version"))
+            app, lti_params, message=Any.string.containing("lti_version")
+        )
+
+    def test_1_7_redirect_to_tool_consumer_when_lti_version_missing(
+        self, app, lti_params
+    ):
+        lti_params.pop("lti_version")
+
+        self.assert_redirected_to_tool_with_message(
+            app, lti_params, message=Any.string.containing("lti_version")
+        )
 
     # ---------------------------------------------------------------------- #
     # Assertions

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -34,7 +34,18 @@ class TestLaunchParamsSchema:
         with pytest.raises(ValidationError):
             schema.parse()
 
-    def test_LTIToolRedirect_raise_when_res_link_missing_with_return_url(
+    def test_ValidationError_raised_when_res_link_missing_with_bad_return_url(
+        self, pyramid_request
+    ):
+        pyramid_request.params.pop("resource_link_id")
+        pyramid_request.params["launch_presentation_return_url"] = "broken"
+
+        schema = LaunchParamsSchema(pyramid_request)
+
+        with pytest.raises(ValidationError):
+            schema.parse()
+
+    def test_LTIToolRedirect_raised_when_res_link_missing_with_return_url(
         self, pyramid_request
     ):
         pyramid_request.params.pop("resource_link_id")
@@ -109,6 +120,8 @@ class TestURLConfiguredLaunchParamsSchema:
 @pytest.fixture
 def pyramid_request(pyramid_request):
     pyramid_request.content_type = "application/x-www-form-urlencoded"
-    pyramid_request.params.update({"resource_link_id": "DUMMY-LINK"})
+    pyramid_request.params.update(
+        {"resource_link_id": "DUMMY-LINK", "lti_version": "LTI-1p0"}
+    )
 
     return pyramid_request


### PR DESCRIPTION
Fixing a number of issues around the `lti_version` which can only be one value for LTI 1.1.

Addresses: 
* https://github.com/hypothesis/lms/issues/1113 - LTI version invalid
* https://github.com/hypothesis/lms/issues/1114 - LTI version wrong
* https://github.com/hypothesis/lms/issues/1117 - LTI version missing