### PR TITLE
Adding testing for LTI 1.1 Certification - Parts 1.8 & 1.9

### DIFF
--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -28,10 +28,13 @@ class LaunchParamsSchema(PyramidRequestSchema):
     resource_link_id = fields.Str(required=True)
     launch_presentation_return_url = fields.Str()
     lti_version = fields.Str(validate=OneOf(["LTI-1p0"]), required=True)
+    lti_message_type = fields.Str(
+        validate=OneOf(["basic-lti-launch-request"]), required=True
+    )
 
     # If we have an error in one of these fields we should redirect back to
     # the calling LMS if possible
-    lti_redirect_fields = {"resource_link_id", "lti_version"}
+    lti_redirect_fields = {"resource_link_id", "lti_version", "lti_message_type"}
 
     locations = ["form"]
 

--- a/tests/functional/lti_certification/test_lti_certification_1_1.py
+++ b/tests/functional/lti_certification/test_lti_certification_1_1.py
@@ -72,6 +72,24 @@ class TestLTICertification(TestBaseClass):
             app, lti_params, message=Any.string.containing("lti_version")
         )
 
+    def test_1_8_redirect_to_tool_consumer_when_lti_mesage_type_invalid(
+        self, app, lti_params
+    ):
+        lti_params["lti_message_type"] = "a-basic-lti-launch-request"
+
+        self.assert_redirected_to_tool_with_message(
+            app, lti_params, message=Any.string.containing("lti_message_type")
+        )
+
+    def test_1_9_redirect_to_tool_consumer_when_lti_message_type_missing(
+        self, app, lti_params
+    ):
+        lti_params.pop("lti_message_type")
+
+        self.assert_redirected_to_tool_with_message(
+            app, lti_params, message=Any.string.containing("lti_message_type")
+        )
+
     # ---------------------------------------------------------------------- #
     # Assertions
 

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -121,7 +121,11 @@ class TestURLConfiguredLaunchParamsSchema:
 def pyramid_request(pyramid_request):
     pyramid_request.content_type = "application/x-www-form-urlencoded"
     pyramid_request.params.update(
-        {"resource_link_id": "DUMMY-LINK", "lti_version": "LTI-1p0"}
+        {
+            "resource_link_id": "DUMMY-LINK",
+            "lti_version": "LTI-1p0",
+            "lti_message_type": "basic-lti-launch-request",
+        }
     )
 
     return pyramid_request


### PR DESCRIPTION
From https://www.imsglobal.org/specs/ltiv1p1/implementation-guide (search "Basic Launch Data") the only acceptable value is "basic-lti-launch-request".

Addresses:

 * https://github.com/hypothesis/lms/issues/1118 - LTI message type invalid
 * https://github.com/hypothesis/lms/issues/1119 - LTI message type missing