### PR TITLE
Revert PR #1184

### DIFF
--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -7,7 +7,6 @@ import jwt
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.security import Allow
 
-from lms.validation import LaunchParamsSchema
 from lms.validation.authentication import BearerTokenSchema
 from lms.values import HUser
 
@@ -31,11 +30,6 @@ class LTILaunchResource:
     def __init__(self, request):
         """Return the context resource for an LTI launch request."""
         self._request = request
-
-        # Apply the schema to ensure we are checking LTI compatibility etc.
-        # TODO - Change things to actually use the parsed stuff
-        LaunchParamsSchema(request).parse()
-
         self._authority = self._request.registry.settings["h_authority"]
         self._ai_getter = self._request.find_service(name="ai_getter")
         self._hypothesis_config = None

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -15,7 +15,11 @@ from pyramid.view import view_config, view_defaults
 
 from lms.models import ModuleItemConfiguration
 from lms.services import HAPIError
-from lms.validation import ConfigureModuleItemSchema, LaunchParamsURLConfiguredSchema
+from lms.validation import (
+    ConfigureModuleItemSchema,
+    LaunchParamsSchema,
+    LaunchParamsURLConfiguredSchema,
+)
 from lms.validation.authentication import BearerTokenSchema
 from lms.views.decorators import (
     add_user_to_group,
@@ -43,6 +47,7 @@ from lms.views.helpers import frontend_app, via_url
     renderer="lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2",
     request_method="POST",
     route_name="lti_launches",
+    schema=LaunchParamsSchema,
 )
 class BasicLTILaunchViews:
     def __init__(self, context, request):

--- a/tests/unit/lms/resources/_lti_launch_test.py
+++ b/tests/unit/lms/resources/_lti_launch_test.py
@@ -9,12 +9,6 @@ from lms.resources import LTILaunchResource
 
 
 class TestLTILaunchResource:
-    def test_it_validates_the_request_params(self, pyramid_request, LaunchParamsSchema):
-        LTILaunchResource(pyramid_request)
-
-        LaunchParamsSchema.assert_called_once_with(pyramid_request)
-        LaunchParamsSchema.return_value.parse.assert_called_once_with()
-
     def test_it_allows_LTI_users_to_launch_LTI_assignments(
         self, pyramid_config, pyramid_request
     ):
@@ -512,8 +506,3 @@ def BearerTokenSchema(patch):
 @pytest.fixture
 def bearer_token_schema(BearerTokenSchema):
     return BearerTokenSchema.return_value
-
-
-@pytest.fixture(autouse=True)
-def LaunchParamsSchema(patch):
-    return patch("lms.resources._lti_launch.LaunchParamsSchema")


### PR DESCRIPTION
This reverts https://github.com/hypothesis/lms/pull/1184 because it
broke configuring assignments in non-Canvas LMS's.

Revert "Lint and formatting"

This reverts commit 5f1db52b8e42f82025f2b8590a773ebf3c0e6a47.

Revert "Fix some broken unit tests"

This reverts commit 578839e67ee6b3e1c8d930f793431ee4685ba325.

Revert "Adding the schema to the resource instead of the view"

This reverts commit f6e1d7cd9e95bb1b466da5ab31427657a695cbb4.