### PR TITLE
Validate launch params in resource instead of view, take 2

### DIFF
--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -32,9 +32,19 @@ class LTILaunchResource:
         """Return the context resource for an LTI launch request."""
         self._request = request
 
-        # Apply the schema to ensure we are checking LTI compatibility etc.
-        # TODO - Change things to actually use the parsed stuff
-        LaunchParamsSchema(request).parse()
+        # *If* the "lti_launches" route is being requested then apply schema
+        # validation now, before the view decorators on the "lti_launches"
+        # route's views get called, because those view decorators call methods
+        # that assume that the request's params are valid.
+        #
+        # FIXME: We shouldn't be calling the schema here. It should be added to
+        # the "lti_launches" route's views with
+        # @view_config(..., schema=LaunchParamsSchema) instead. But before we
+        # can do that we need to get rid of the view decorators on those views,
+        # because the view decorators get called *before* the view schema and
+        # they assume the request params are already validated.
+        if request.matched_route.name == "lti_launches":
+            LaunchParamsSchema(request).parse()
 
         self._authority = self._request.registry.settings["h_authority"]
         self._ai_getter = self._request.find_service(name="ai_getter")

--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -7,6 +7,7 @@ import jwt
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.security import Allow
 
+from lms.validation import LaunchParamsSchema
 from lms.validation.authentication import BearerTokenSchema
 from lms.values import HUser
 
@@ -30,6 +31,11 @@ class LTILaunchResource:
     def __init__(self, request):
         """Return the context resource for an LTI launch request."""
         self._request = request
+
+        # Apply the schema to ensure we are checking LTI compatibility etc.
+        # TODO - Change things to actually use the parsed stuff
+        LaunchParamsSchema(request).parse()
+
         self._authority = self._request.registry.settings["h_authority"]
         self._ai_getter = self._request.find_service(name="ai_getter")
         self._hypothesis_config = None

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -15,11 +15,7 @@ from pyramid.view import view_config, view_defaults
 
 from lms.models import ModuleItemConfiguration
 from lms.services import HAPIError
-from lms.validation import (
-    ConfigureModuleItemSchema,
-    LaunchParamsSchema,
-    LaunchParamsURLConfiguredSchema,
-)
+from lms.validation import ConfigureModuleItemSchema, LaunchParamsURLConfiguredSchema
 from lms.validation.authentication import BearerTokenSchema
 from lms.views.decorators import (
     add_user_to_group,
@@ -46,7 +42,7 @@ from lms.views.helpers import frontend_app, via_url
     permission="launch_lti_assignment",
     renderer="lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2",
     request_method="POST",
-    route_name="lti_launches"
+    route_name="lti_launches",
 )
 class BasicLTILaunchViews:
     def __init__(self, context, request):

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -46,8 +46,7 @@ from lms.views.helpers import frontend_app, via_url
     permission="launch_lti_assignment",
     renderer="lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2",
     request_method="POST",
-    route_name="lti_launches",
-    schema=LaunchParamsSchema,
+    route_name="lti_launches"
 )
 class BasicLTILaunchViews:
     def __init__(self, context, request):

--- a/tests/unit/lms/resources/_lti_launch_test.py
+++ b/tests/unit/lms/resources/_lti_launch_test.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 import jwt
 import pytest
@@ -14,6 +15,15 @@ class TestLTILaunchResource:
 
         LaunchParamsSchema.assert_called_once_with(pyramid_request)
         LaunchParamsSchema.return_value.parse.assert_called_once_with()
+
+    def test_it_doesnt_validate_if_route_isnt_lti_launches(
+        self, pyramid_request, LaunchParamsSchema
+    ):
+        pyramid_request.matched_route.name = "module_item_configurations"
+
+        LTILaunchResource(pyramid_request)
+
+        LaunchParamsSchema.assert_not_called()
 
     def test_it_allows_LTI_users_to_launch_LTI_assignments(
         self, pyramid_config, pyramid_request
@@ -501,6 +511,8 @@ class TestLTILaunchResource:
             # Mandatory parameters for an LTI request to succeed
             "resource_link_id": "DUMMY-ID",
         }
+        pyramid_request.matched_route = mock.Mock(spec_set=["name"])
+        pyramid_request.matched_route.name = "lti_launches"
         return pyramid_request
 
 

--- a/tests/unit/lms/resources/_lti_launch_test.py
+++ b/tests/unit/lms/resources/_lti_launch_test.py
@@ -9,6 +9,12 @@ from lms.resources import LTILaunchResource
 
 
 class TestLTILaunchResource:
+    def test_it_validates_the_request_params(self, pyramid_request, LaunchParamsSchema):
+        LTILaunchResource(pyramid_request)
+
+        LaunchParamsSchema.assert_called_once_with(pyramid_request)
+        LaunchParamsSchema.return_value.parse.assert_called_once_with()
+
     def test_it_allows_LTI_users_to_launch_LTI_assignments(
         self, pyramid_config, pyramid_request
     ):
@@ -506,3 +512,8 @@ def BearerTokenSchema(patch):
 @pytest.fixture
 def bearer_token_schema(BearerTokenSchema):
     return BearerTokenSchema.return_value
+
+
+@pytest.fixture(autouse=True)
+def LaunchParamsSchema(patch):
+    return patch("lms.resources._lti_launch.LaunchParamsSchema")


### PR DESCRIPTION
Re-instates the reverted https://github.com/hypothesis/lms/pull/1184 but with an additional commit to avoid breaking module item configurations.