### PR TITLE
Revert PR #1187

### DIFF
--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -7,7 +7,6 @@ import jwt
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.security import Allow
 
-from lms.validation import LaunchParamsSchema
 from lms.validation.authentication import BearerTokenSchema
 from lms.values import HUser
 
@@ -31,21 +30,6 @@ class LTILaunchResource:
     def __init__(self, request):
         """Return the context resource for an LTI launch request."""
         self._request = request
-
-        # *If* the "lti_launches" route is being requested then apply schema
-        # validation now, before the view decorators on the "lti_launches"
-        # route's views get called, because those view decorators call methods
-        # that assume that the request's params are valid.
-        #
-        # FIXME: We shouldn't be calling the schema here. It should be added to
-        # the "lti_launches" route's views with
-        # @view_config(..., schema=LaunchParamsSchema) instead. But before we
-        # can do that we need to get rid of the view decorators on those views,
-        # because the view decorators get called *before* the view schema and
-        # they assume the request params are already validated.
-        if request.matched_route.name == "lti_launches":
-            LaunchParamsSchema(request).parse()
-
         self._authority = self._request.registry.settings["h_authority"]
         self._ai_getter = self._request.find_service(name="ai_getter")
         self._hypothesis_config = None

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -15,7 +15,11 @@ from pyramid.view import view_config, view_defaults
 
 from lms.models import ModuleItemConfiguration
 from lms.services import HAPIError
-from lms.validation import ConfigureModuleItemSchema, LaunchParamsURLConfiguredSchema
+from lms.validation import (
+    ConfigureModuleItemSchema,
+    LaunchParamsSchema,
+    LaunchParamsURLConfiguredSchema,
+)
 from lms.validation.authentication import BearerTokenSchema
 from lms.views.decorators import (
     add_user_to_group,
@@ -43,6 +47,7 @@ from lms.views.helpers import frontend_app, via_url
     renderer="lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2",
     request_method="POST",
     route_name="lti_launches",
+    schema=LaunchParamsSchema,
 )
 class BasicLTILaunchViews:
     def __init__(self, context, request):

--- a/tests/unit/lms/resources/_lti_launch_test.py
+++ b/tests/unit/lms/resources/_lti_launch_test.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest import mock
 
 import jwt
 import pytest
@@ -10,21 +9,6 @@ from lms.resources import LTILaunchResource
 
 
 class TestLTILaunchResource:
-    def test_it_validates_the_request_params(self, pyramid_request, LaunchParamsSchema):
-        LTILaunchResource(pyramid_request)
-
-        LaunchParamsSchema.assert_called_once_with(pyramid_request)
-        LaunchParamsSchema.return_value.parse.assert_called_once_with()
-
-    def test_it_doesnt_validate_if_route_isnt_lti_launches(
-        self, pyramid_request, LaunchParamsSchema
-    ):
-        pyramid_request.matched_route.name = "module_item_configurations"
-
-        LTILaunchResource(pyramid_request)
-
-        LaunchParamsSchema.assert_not_called()
-
     def test_it_allows_LTI_users_to_launch_LTI_assignments(
         self, pyramid_config, pyramid_request
     ):
@@ -511,8 +495,6 @@ class TestLTILaunchResource:
             # Mandatory parameters for an LTI request to succeed
             "resource_link_id": "DUMMY-ID",
         }
-        pyramid_request.matched_route = mock.Mock(spec_set=["name"])
-        pyramid_request.matched_route.name = "lti_launches"
         return pyramid_request
 
 
@@ -524,8 +506,3 @@ def BearerTokenSchema(patch):
 @pytest.fixture
 def bearer_token_schema(BearerTokenSchema):
     return BearerTokenSchema.return_value
-
-
-@pytest.fixture(autouse=True)
-def LaunchParamsSchema(patch):
-    return patch("lms.resources._lti_launch.LaunchParamsSchema")


### PR DESCRIPTION
Revert https://github.com/hypothesis/lms/pull/1187 (validating launch
params in the resource instead of the view).

It turns out that Pyramid intitalises the resource before it does
authentication. If the resource does the validation then an
unauthenticated request can receive a validation error instead of an
authentication error (if the request also contained other invalid
params). This is wrong: authentication should happen before validation.

Revert "Don't validate launch params if not "lti_launches" route"

This reverts commit 73cd18fd8eac23194dd2fd69196334f8377e7a26.

Revert "Lint and formatting"

This reverts commit 321ebce516e43c0e10875f360a8bee4c696d1f36.

Revert "Fix some broken unit tests"

This reverts commit c435e553c6f40e996e7c1b7cad90a4d78ab31c76.

Revert "Adding the schema to the resource instead of the view"

This reverts commit 8995b4e6f6cf4e208baceae8354d78cd7f9f4e2c.