### PR TITLE
Add use_via2_html_rewriter feature flag

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -40,6 +40,8 @@ def via_url(request, document_url):
     query_string = parse.urlencode(query_string_as_list)
 
     via_service_url = request.registry.settings["via_url"]
+    if request.feature("use_via2_html_rewriter"):
+        via_service_url += "html/"
 
     return via_service_url + parse.urlunparse(
         (

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -49,3 +49,12 @@ class TestViaURL:
         pyramid_request.params["oauth_consumer_key"] = "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
         # fmt: on
         assert via_url(pyramid_request, document_url) == expected_via_url
+
+    def test_it_returns_via2_html_rewriter_url_if_use_via2_html_rewriter_feature_flag_is_set(
+        self, pyramid_request
+    ):
+        pyramid_request.feature = lambda feature: feature == "use_via2_html_rewriter"
+
+        assert via_url(pyramid_request, "http://example.com").startswith(
+            "http://TEST_VIA_SERVER.is/html/"
+        )


### PR DESCRIPTION
When enabled it will append html/ to the via2 service url which is
the path to the html rewriter endpoint in the via2 service.

Note this PR also requires updating the env var FEATURE_FLAGS_ALLOWED_IN_COOKIE to include the new feature flag.