### PR TITLE
Fix LtiLaunches.created default value

### DIFF
--- a/lms/models/lti_launches.py
+++ b/lms/models/lti_launches.py
@@ -11,7 +11,7 @@ class LtiLaunches(BASE):
     __tablename__ = "lti_launches"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
-    created = sa.Column(sa.TIMESTAMP, default=datetime.utcnow())
+    created = sa.Column(sa.TIMESTAMP, default=datetime.utcnow)
     context_id = sa.Column(sa.String)
     lti_key = sa.Column(sa.String)
 

--- a/tests/unit/lms/models/lti_launches_test.py
+++ b/tests/unit/lms/models/lti_launches_test.py
@@ -1,10 +1,16 @@
+from datetime import datetime
+
 from lms.models import LtiLaunches
 
 
 class TestLTILaunches:
     def test_add_adds_an_lti_launch_record_to_the_db(self, db_session):
+        before = datetime.utcnow()
         LtiLaunches.add(db_session, "TEST_CONTEXT_ID", "TEST_OAUTH_CONSUMER_KEY")
 
         lti_launch = db_session.query(LtiLaunches).one()
+
+        after = datetime.utcnow()
         assert lti_launch.context_id == "TEST_CONTEXT_ID"
         assert lti_launch.lti_key == "TEST_OAUTH_CONSUMER_KEY"
+        assert lti_launch.created >= before <= after


### PR DESCRIPTION
Use the current time as the default value, not the time at which the app
started up.