### PR TITLE
Part 1: Adding LTI BDD Fixtures with base cases

### DIFF
--- a/tests/bdd/bin/analyse_lti_params.py
+++ b/tests/bdd/bin/analyse_lti_params.py
@@ -1,0 +1,138 @@
+"""
+Analyse the params files for each section and make suggestions.
+
+This script will read all the ini files from the LTI specification tool and
+attempt to work out an 'most_common' baseline file to use for the section.
+
+It will then generate differences and make suggestions for configuring each
+test in that section.
+"""
+import os.path
+from collections import Counter, defaultdict
+from glob import glob
+
+from tests.bdd.steps.the_fixture import TheFixture
+
+
+def list_ini_files(fixture):
+    for file_name in sorted(glob(fixture.get_path("src/*.*.ini"))):
+        yield os.path.join("src", os.path.basename(file_name))
+
+
+def load_ini(fixture, filename):
+    values = fixture.load_ini(filename, "dummy")
+
+    bad_keys = {
+        "oauth_consumer_key",
+        "oauth_nonce",
+        "oauth_signature",
+        "oauth_timestamp",
+        "oauth_consumer_secret",
+    }
+
+    final = {}
+    for key, value in values.items():
+        if key in bad_keys:
+            continue
+
+        final[key] = value
+
+    return final
+
+
+def generate_most_common_values(fixture, threshold):
+    value_counts = defaultdict(Counter)
+    files = 0
+
+    for filename in list_ini_files(fixture):
+        files += 1
+
+        values = load_ini(fixture, filename)
+
+        for key, value in values.items():
+            value_counts[key].update({value: 1})
+
+    cutoff = files * threshold
+
+    for key, counts in value_counts.items():
+        for value, count in counts.most_common(1):
+            if count < cutoff:
+                print(
+                    f"Skipping {key}={value} as it has too few occurences: {count}/{files}"
+                )
+            else:
+                yield key, value
+
+
+def write_ini(filename, values):
+    with open(filename, "w") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def dump_ini(values):
+    for key, value in values.items():
+        print(f"{key}={value}")
+
+
+def write_most_common_file(fixture, threshold):
+    most_common = dict(generate_most_common_values(fixture, threshold))
+    filename = fixture.get_path("most_common.ini")
+    write_ini(filename, most_common)
+
+    return most_common
+
+
+def generate_diff(fixture, most_common, filename):
+    values = load_ini(fixture, filename)
+
+    most_common_keys = set(most_common.keys())
+    value_keys = set(values.keys())
+
+    for missing_key in most_common_keys - value_keys:
+        yield missing_key, "*MISSING*"
+
+    for key, value in values.items():
+        if key not in most_common or most_common[key] != value:
+            yield key, value
+
+
+def write_table(data):
+    max_key = max(len(key) for key in data.keys())
+    max_value = max(len(value) for value in data.values())
+
+    print("\tGiven I update the fixture 'params' with")
+    print(f"      | {'Key':<{max_key}} | {'Value':<{max_value}} |")
+    for key, value in sorted(data.items()):
+        print(f"      | {key:<{max_key}} | {value:<{max_value}} |")
+
+
+def generate_param_values(fixture, most_common):
+    for filename in list_ini_files(fixture):
+        print(f"\n# For {filename}\n")
+
+        diff = dict(generate_diff(fixture, most_common, filename))
+        if diff:
+            if len(diff) == 1:
+                key = list(diff.keys())[0]
+                value = list(diff.values())[0]
+                print(f"\tGiven I set the fixture 'params' key '{key}' to '{value}'")
+            else:
+                write_table(diff)
+                print()
+                dump_ini(diff)
+        else:
+            print("No detectable difference! - Maybe OAuth params?")
+
+
+if __name__ == "__main__":
+    for section, threshold in {1: 0.5, 2: 0.75, 3: 0.75, 4: 0.5}.items():
+        fixture = TheFixture()
+        fixture.set_base_dir(f"/lti_certification_1_1/section_{section}")
+
+        print(f"\nSection {section} --------------------------------------\n")
+        print("\nGenerating most_common fixture...\n")
+        most_common = write_most_common_file(fixture, threshold)
+
+        print("\nDifferences from the most_common...\n")
+        generate_param_values(fixture, most_common)

--- a/tests/bdd/bin/analyse_lti_params.py
+++ b/tests/bdd/bin/analyse_lti_params.py
@@ -1,11 +1,21 @@
 """
-Analyse the params files for each section and make suggestions.
+Make a file of the most common params for each section listing differences.
 
 This script will read all the ini files from the LTI specification tool and
-attempt to work out an 'most_common' baseline file to use for the section.
+attempt to work out an 'most_common' baseline file to use for the section and
+generate a file called ``most_common.ini`` for it.
 
 It will then generate differences and make suggestions for configuring each
-test in that section.
+test in that section and print them out in:
+
+ * A gherkin style: for direct inclusion in scenarios
+ * An ini style: for creating smaller fixture files
+
+Nothing will happen with this output: it's up to you to use it or not as you
+see fit.
+
+This is only used as a helper when writing the tests and doesn't form part of
+the final system.
 """
 import os.path
 from collections import Counter, defaultdict
@@ -41,6 +51,10 @@ def load_ini(fixture, filename):
 
 
 def generate_most_common_values(fixture, threshold):
+    # Create a dict which will automatically create a Counter object if you
+    # refer to a key. We will use this to store the param as the key, then
+    # store each different value we see along with how many times we have seen
+    # it for each param.
     value_counts = defaultdict(Counter)
     files = 0
 
@@ -55,6 +69,7 @@ def generate_most_common_values(fixture, threshold):
     cutoff = files * threshold
 
     for key, counts in value_counts.items():
+        # Pick out only the most common value for this param
         for value, count in counts.most_common(1):
             if count < cutoff:
                 print(
@@ -126,6 +141,10 @@ def generate_param_values(fixture, most_common):
 
 
 if __name__ == "__main__":
+    # These values for thresholds were arrived at by experimentation. Some of
+    # the sections are more similar than others. Basically I played with the
+    # numbers until I started seeing nice results.
+
     for section, threshold in {1: 0.5, 2: 0.75, 3: 0.75, 4: 0.5}.items():
         fixture = TheFixture()
         fixture.set_base_dir(f"/lti_certification_1_1/section_{section}")

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/most_common.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/most_common.ini
@@ -1,0 +1,32 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_signature_method=HMAC-SHA1
+oauth_version=1.0
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456
+resource_link_id=rli-1234

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.1.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.1.ini
@@ -1,0 +1,35 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=$LtiLink.custom.url
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=03bbb457a6be8805761813e214a1045e
+oauth_signature=jVGLePWbVkwpzuH3/zf6kztuZdU=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818460
+oauth_version=1.0
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.2.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.2.ini
@@ -1,0 +1,35 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=$LtiLink.custom.url
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=8ae010da0c29108cd1f4691a23ca8054
+oauth_signature=gpnhb9aJfHDsJflgngxecH2nVjs=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818497
+oauth_version=1.0
+resource_link_title=Link 1234
+resourcelinkid=rli-1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.3.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.3.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3-1573818543
+oauth_nonce=f96836a1db42382f7304977db7dc840e
+oauth_signature=iuapCjL6Ls2ZOZSK0f4QbQxX8Ik=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818543
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.4.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.4.ini
@@ -1,0 +1,37 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_consumer_secret=95639298c6f62fb18562e6189dd61f4743a78b5cb061d08780570049236b7a8a-1573818616
+oauth_nonce=6eb9f0a364af4ef72e91cac187356d81
+oauth_signature=uHmjroaCVDEEdnOk2jAalr4CJ5k=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818616
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.5.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.5.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=1ee55abdaab6688af9c7139497bcfc45
+oauth_signature=fN8jdLz0TfgC51rrKr15WVig0kQ=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818628
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.6.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.6.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-2p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=880b9ebbfeb96992a5d3915187f817ed
+oauth_signature=o9bgha4FEPdY5Pat2BSOLMQpC1U=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818644
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.7.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.7.ini
@@ -1,0 +1,35 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=6628068e492f579ec8cffeb7b1861ff1
+oauth_signature=9wxNPxk6w08vHgpFZi+lsFiFqCA=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818659
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.8.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.8.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/a-basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=a-basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=ea8b3680e379c044ec9ba1ad2a7173a8
+oauth_signature=NYdPZb66+1cRVKgF19fNkHXs6tc=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818676
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.9.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_1/src/1.9.ini
@@ -1,0 +1,35 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=4e979f8bfeddc7f845e0f55602a95b94
+oauth_signature=WewwXOhdWQYpTF82V6yi00yp1wk=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818691
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_2/most_common.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_2/most_common.ini
@@ -1,0 +1,22 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_signature_method=HMAC-SHA1
+oauth_version=1.0
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance

--- a/tests/bdd/fixtures/lti_certification_1_1/section_2/src/2.1.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_2/src/2.1.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=8e70bb8c6a3f7b9f0855f9646c720118
+oauth_signature=752Po3mFLN4gbPOU24YZAZf8Xuo=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573818979
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_2/src/2.2.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_2/src/2.2.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-5678/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=529d74f08e523f5a12eeb760153719df
+oauth_signature=Zv97jXSBftl0v2genUfeJ/IR2Vo=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819065
+oauth_version=1.0
+resource_link_id=rli-5678
+resource_link_title=Link 5678
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_2/src/2.3.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_2/src/2.3.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=bob@school.edu
+lis_person_name_family=Person
+lis_person_name_full=Bob R. Person
+lis_person_name_given=Bob
+lis_person_sourcedid=school.edu:bob
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=86c67ad92ee12a365f513cd7e468857f
+oauth_signature=2ue5m9Ic/k+U/xcX/EDhroap9c0=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819075
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Learner
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=654321

--- a/tests/bdd/fixtures/lti_certification_1_1/section_2/src/2.4.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_2/src/2.4.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-5678/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=bob@school.edu
+lis_person_name_family=Person
+lis_person_name_full=Bob R. Person
+lis_person_name_given=Bob
+lis_person_sourcedid=school.edu:bob
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=65ed2e441aad1e439c9d9b51327a2e41
+oauth_signature=TaIo0b/QIjrXsFsKXmrMRpV0WXM=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819088
+oauth_version=1.0
+resource_link_id=rli-5678
+resource_link_title=Link 5678
+roles=Learner
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=654321

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/most_common.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/most_common.ini
@@ -1,0 +1,25 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_signature_method=HMAC-SHA1
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.1.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.1.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=ef13ad9683a4c3120a4b95e5661fc5e3
+oauth_signature=do18AvVKEAWfw4CCGGo2C0KgQ3A=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819126
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=urn:lti:role:ims/lis/Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.2.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.2.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=75bd35cd7b7ac30efa47dd6666745df7
+oauth_signature=3FSxsXzsjnhkUkn2zFR+SBvOyq0=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819203
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=urn:non:ims/something/Else,Instructor,urn:lti:instrole:ims/lis/Alumni
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.3.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.3.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=7673130d5f89a732e77d4d314ff0c1fc
+oauth_signature=EHfx1wQ6fkjeQrhavzVJTOLjG2g=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819220
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=urn:non:ims/something/Else,urn:lti:role:ims/lis/Instructor,urn:lti:instrole:ims/lis/Alumni
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.4.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.4.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=bob@school.edu
+lis_person_name_family=Person
+lis_person_name_full=Bob R. Person
+lis_person_name_given=Bob
+lis_person_sourcedid=school.edu:bob
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=4e4366a1fbd393865243e432f77fa1de
+oauth_signature=uX8UI+JJ/5YHubQKHBEgU3mPDnc=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819255
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=urn:non:ims/something/Else,urn:lti:role:ims/lis/Learner,urn:lti:instrole:ims/lis/Alumni
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=654321

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.5.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.5.ini
@@ -1,0 +1,36 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=bob@school.edu
+lis_person_name_family=Person
+lis_person_name_full=Bob R. Person
+lis_person_name_given=Bob
+lis_person_sourcedid=school.edu:bob
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=738a0157c6827103da12d0e2371b8368
+oauth_signature=exDx/BjPQlVzEsJpU/SYoJRr4T4=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819287
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=urn:non:ims/something/Else
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=654321

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.6.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.6.ini
@@ -1,0 +1,31 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=5c6923ee46f5ff919f5826a90b940d28
+oauth_signature=Aklm7xqUoGCz6mSeT09/bTlLq5I=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819350
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=urn:lti:instrole:ims/lis/Learner
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=user-2001

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.7.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.7.ini
@@ -1,0 +1,31 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=85687667419972152b56365e8ac65510
+oauth_signature=5v3LVaoDjUeFWEDyWg+G9ddVe7c=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819365
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=urn:lti:instrole:ims/lis/Alumni
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=user-2001

--- a/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.8.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_3/src/3.8.ini
@@ -1,0 +1,31 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=b980ee0c3ec55e62840335ce737e68d7
+oauth_signature=LTrUNHKzufnBzAs9k/FCie+Z4y8=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819409
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=NotALearner
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=user-2001

--- a/tests/bdd/fixtures/lti_certification_1_1/section_4/most_common.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_4/most_common.ini
@@ -1,0 +1,25 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_signature_method=HMAC-SHA1
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance

--- a/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.1.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.1.ini
@@ -1,0 +1,33 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=sally@school.edu
+lis_person_sourcedid=school.edu:sally
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=aab0bbe4d34653bcf5525f97e61d01da
+oauth_signature=1E24vllao8EUkuvIki3XvETNyLU=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819619
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Learner
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=543216

--- a/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.2.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.2.ini
@@ -1,0 +1,35 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=seven@school.edu
+lis_person_name_family=Seven
+lis_person_name_given=Luck
+lis_person_sourcedid=school.edu:seven
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=6f55fbe1542219500371d5f9402c74b3
+oauth_signature=wDma05HLsdT3N9i/DYEKDuLpuFA=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819632
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Learner
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=777777

--- a/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.3.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.3.ini
@@ -1,0 +1,34 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_contact_email_primary=sally@school.edu
+lis_person_name_full=Sally R. Person
+lis_person_sourcedid=school.edu:sally
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=b73024964142f729715ddd5850a4b10d
+oauth_signature=BHxl3e33MmgxPErytDiNmAqSg6s=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819654
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Learner
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=543216

--- a/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.4.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.4.ini
@@ -1,0 +1,32 @@
+context_id=con-182
+context_label=SI182
+context_title=Design of Personal Environments
+context_type=CourseSection
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_course_section_sourcedid=id-182
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=ac21f48eef814869e69650129c679c8c
+oauth_signature=LPL+7dPWEr7EkY/azkdlDr9XqcE=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819675
+oauth_version=1.0
+resource_link_id=rli-1234
+resource_link_title=Link 1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.5.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.5.ini
@@ -1,0 +1,27 @@
+context_id=con-182
+custom_context_memberships_url=https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_context_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_link_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/links/rli-1234/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=d6c493564547bfe6f0f3121b1ebe34a5
+oauth_signature=biwtMkyAoXtR0dV1gqVwrb9+i/E=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819692
+oauth_version=1.0
+resource_link_id=rli-1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.6.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.6.ini
@@ -1,0 +1,28 @@
+custom_context_memberships_url=$ToolProxyBinding.memberships.url
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lis_person_contact_email_primary=jane@school.edu
+lis_person_name_family=Lastname
+lis_person_name_full=Jane Q. Lastname
+lis_person_name_given=Jane
+lis_person_sourcedid=school.edu:jane
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=c3cb124130f9865074f00a55a2b88e58
+oauth_signature=VmGjLeP0Lg8m5JPyvbg1fj6nAj8=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819704
+oauth_version=1.0
+resource_link_id=rli-1234
+roles=Instructor
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance
+user_id=123456

--- a/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.7.ini
+++ b/tests/bdd/fixtures/lti_certification_1_1/section_4/src/4.7.ini
@@ -1,0 +1,21 @@
+custom_context_memberships_url=$ToolProxyBinding.memberships.url
+custom_system_setting_url=https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3/custom?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+custom_tc_profile_url=https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a3BwZGwzZGhvdGRsdHBkcDV2dWh1aDQzYzE%3D
+launch_presentation_document_target=iframe
+launch_presentation_locale=en_US
+launch_presentation_return_url=https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request
+lti_message_type=basic-lti-launch-request
+lti_version=LTI-1p0
+oauth_callback=about:blank
+oauth_consumer_key=Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3
+oauth_nonce=bad62b4ed2dcab3d3c0c4ea0344f600d
+oauth_signature=74YZdPOcJX+MhVGnTYgcu6DjQrA=
+oauth_signature_method=HMAC-SHA1
+oauth_timestamp=1573819742
+oauth_version=1.0
+resource_link_id=rli-1234
+tool_consumer_info_product_family_code=imsglc
+tool_consumer_info_version=1.1
+tool_consumer_instance_description=IMS Testing Description
+tool_consumer_instance_guid=IMS Testing
+tool_consumer_instance_name=IMS Testing Instance

--- a/tests/bdd/steps/the_fixture.py
+++ b/tests/bdd/steps/the_fixture.py
@@ -1,0 +1,46 @@
+"""Load and manipulate fixtures."""
+
+import os.path
+
+from pkg_resources import resource_filename
+
+
+class TheFixture:
+    context_key = "the_fixture"
+
+    def __init__(self, **kwargs):
+        self.base_dir = None
+        self.fixtures = {}
+
+    def set_base_dir(self, base_dir):
+        base_dir = base_dir.lstrip("/")
+        path = os.path.join("bdd/fixtures", base_dir)
+
+        self.base_dir = resource_filename("tests", path)
+
+        if not os.path.isdir(self.base_dir):
+            raise EnvironmentError(f"Cannot find fixture dir: {self.base_dir}")
+
+    def set_fixture(self, name, value):
+        self.fixtures[name] = value
+
+        return value
+
+    def get_fixture(self, name):
+        return self.fixtures[name]
+
+    def load_ini(self, filename, fixture_name):
+        values = {}
+        with open(self.get_path(filename)) as handle:
+            for line in handle:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+
+                key, value = line.split("=", 1)
+                values[key] = value
+
+        return self.set_fixture(fixture_name, values)
+
+    def get_path(self, filename):
+        return os.path.join(self.base_dir, filename)


### PR DESCRIPTION
Adding a dump of the raw params from the LTI cert 1.1 - Tests 1.x - 4.x along with a script to create base fixtures from the individual cases.

The idea here is to create a 'base' upon which each test is a variation. This isn't to save space etc, but instead to make it easier to see what each test is trying to prove.