### PR TITLE
Part 3: Completing first test and introducing StepContexts

### DIFF
--- a/.behaverc
+++ b/.behaverc
@@ -1,0 +1,2 @@
+[behave]
+paths=tests/bdd/

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "make test              Run the unit tests"
 	@echo "make coverage          Print the unit test coverage report"
 	@echo "make functests         Run the functional tests"
+	@echo "make bddtests          Run the gherkin tests"
 	@echo "make docstrings        View all the docstrings locally as HTML"
 	@echo "make checkdocstrings   Crash if building the docstrings fails"
 	@echo "make pip-compile       Compile requirements.in to requirements.txt"
@@ -149,6 +150,10 @@ frontend-lint: node_modules/.uptodate
 .PHONY: backend-tests
 backend-tests: python
 	tox -q -e py36-tests
+
+.PHONY: bddtests
+bddtests: python
+	tox -q -e py36-bddtests
 
 .PHONY: frontend-tests
 frontend-tests: node_modules/.uptodate

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -1,0 +1,30 @@
+"""Entry point and hooks for behave."""
+
+from lms.app import create_app
+from tests.bdd.step_context import StepContextManager
+from tests.conftest import TEST_SETTINGS
+
+TEST_SETTINGS["session_cookie_secret"] = "notasecret"
+
+
+def before_all(context):
+    # This will actually take effect the next time you run the tests, but it
+    # still keeps you mostly up to date when developing
+    StepContextManager.before_all(context, app=create_app(None, **TEST_SETTINGS))
+
+
+def before_scenario(context, scenario):
+    try:
+        StepContextManager.before_scenario(context)
+    except Exception as e:
+        print('PUP', e)
+        raise
+
+
+def after_scenario(context, scenario):
+    try:
+        StepContextManager.after_scenario(context)
+    except Exception as e:
+        print('WUP', e)
+        raise
+

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -19,4 +19,3 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     StepContextManager.after_scenario(context)
-

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -14,17 +14,9 @@ def before_all(context):
 
 
 def before_scenario(context, scenario):
-    try:
-        StepContextManager.before_scenario(context)
-    except Exception as e:
-        print('PUP', e)
-        raise
+    StepContextManager.before_scenario(context)
 
 
 def after_scenario(context, scenario):
-    try:
-        StepContextManager.after_scenario(context)
-    except Exception as e:
-        print('WUP', e)
-        raise
+    StepContextManager.after_scenario(context)
 

--- a/tests/bdd/features/lti_certification/section_1_invalid_launch_requests.feature
+++ b/tests/bdd/features/lti_certification/section_1_invalid_launch_requests.feature
@@ -2,9 +2,40 @@ Feature: Section 1 - Invalid Launch Requests
 
   This section comprises tests using invalid launch requests.
 
+  Background:
+    Given fixtures are located in '/lti_certification_1_1/section_1'
+      And the OAuth 1 consumer key is 'Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3'
+      And the OAuth 1 shared secret is 'TEST_SECRET'
+      And I create an LMS DB 'ApplicationInstance'
+        | Field            | Value                                      |
+        | consumer_key     | Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3 |
+        | shared_secret    | TEST_SECRET                                |
+        | lms_url          | test_lms_url                               |
+        | requesters_email | test_requesters_email                      |
+      And I load the fixture 'most_common.ini' as 'params'
+
   @v1.0 @v1.1 @v1.2 @required
   Scenario: Test 1.1 - No resource_link_id provided
     # Expected result: Return user to the Tool Consumer with an error message
+
+    Given I update the fixture 'params' with
+	  | Key                     | Value               |
+	  | custom_link_setting_url | $LtiLink.custom.url |
+	  | resource_link_id        | *MISSING*           |
+
+      And I start a 'POST' request to 'http://localhost/lti_launches'
+      And I set the request header 'Accept' to 'text/html'
+      And I set the request header 'Content-Type' to 'application/x-www-form-urlencoded'
+      And I OAuth 1 sign the fixture 'params'
+      And I set the form parameters from the fixture 'params'
+
+     When I send the request to the app
+
+     Then the response status code is 302
+      And the response header 'Location' is the URL
+      And the fixture 'params' key 'launch_presentation_return_url' is the value
+      And the url matches the value
+      And the url query parameter 'lti_msg' matches '.*resource_link_id'
 
   @v1.0 @v1.1 @v1.2 @required
   Scenario: Test 1.2 - No resource_link_id or return URL provided

--- a/tests/bdd/step_context.py
+++ b/tests/bdd/step_context.py
@@ -1,0 +1,69 @@
+class StepContext:
+    """Step and tear down for an object powering step specific tasks."""
+
+    # Does this class always exist, or does it come and go?
+    ephemeral = False
+
+    # The key to use when attaching to the context
+    context_key = None
+
+    def __init__(self, **kwargs):
+        pass
+
+    def do_setup(self):
+        """Setup the class for work before the scenario."""
+        pass
+
+    def do_teardown(self):
+        """Clean up the class for work after the scenario."""
+        pass
+
+    @classmethod
+    def register(cls, context, **kwargs):
+        instance = cls(**kwargs)
+        setattr(context, cls.context_key, instance)
+
+        return instance
+
+    @classmethod
+    def setup(cls, context):
+        instance = cls.get_instance(context)
+        if instance:
+            instance.do_setup()
+
+    @classmethod
+    def teardown(cls, context):
+        if cls.ephemeral:
+            setattr(context, cls.context_key, None)
+            return
+
+        instance = cls.get_instance(context)
+        if instance:
+            instance.do_teardown()
+
+    @classmethod
+    def get_instance(cls, context):
+        try:
+            return getattr(context, cls.context_key)
+        except AttributeError:
+            return None
+
+
+class StepContextManager:
+    """Manage all sub-classes of StepContext at once."""
+
+    @classmethod
+    def before_all(cls, context, **kwargs):
+        for step_context in StepContext.__subclasses__():
+            if not step_context.ephemeral:
+                step_context.register(context, **kwargs)
+
+    @classmethod
+    def before_scenario(cls, context):
+        for step_context in StepContext.__subclasses__():
+            step_context.setup(context)
+
+    @classmethod
+    def after_scenario(cls, context):
+        for step_context in StepContext.__subclasses__():
+            step_context.teardown(context)

--- a/tests/bdd/steps/lms_db.py
+++ b/tests/bdd/steps/lms_db.py
@@ -1,0 +1,59 @@
+"""Insert LMS specific objects into the DB."""
+
+import sqlalchemy
+from behave import step
+from sqlalchemy.orm import sessionmaker
+
+from lms import db, models
+from tests.bdd.step_context import StepContext
+from tests.conftest import TEST_DATABASE_URL
+
+
+class LMSDBContext(StepContext):
+    context_key = "db"
+
+    def __init__(self, **kwargs):
+        self.engine = sqlalchemy.create_engine(TEST_DATABASE_URL)
+        self.session_maker = sessionmaker(bind=self.engine.connect())
+        db.init(self.engine)
+
+        self.session = None
+        self.modified_tables = None
+
+        self._initial_wipe()
+
+    def create_row(self, model_class, data):
+        model_class = getattr(models, model_class)
+        model = model_class(**data)
+        self.session.add(model)
+        self.session.commit()
+
+        self.modified_tables.append(model_class.__table__)
+
+    def wipe(self, tables):
+        if not tables:
+            return
+
+        table_names = ", ".join(f'"{table.name}"' for table in tables)
+        self.session.execute(f"TRUNCATE {table_names} CASCADE;")
+        self.session.commit()
+
+    def _initial_wipe(self):
+        self.session = self.session_maker()
+        try:
+            self.wipe(db.BASE.metadata.sorted_tables)
+        finally:
+            self.session.close()
+
+    def do_setup(self):
+        self.session = self.session_maker()
+        self.modified_tables = []
+
+    def do_teardown(self):
+        self.wipe(self.modified_tables)
+        self.session.close()
+
+
+@step("I create an LMS DB '{model_class}'")
+def create_row_from_fixture(context, model_class):
+    context.db.create_row(model_class, data={row[0]: row[1] for row in context.table})

--- a/tests/bdd/steps/oauth1.py
+++ b/tests/bdd/steps/oauth1.py
@@ -1,0 +1,75 @@
+"""Deal with OAuth 1 signing."""
+
+import time
+
+import oauthlib
+from behave import step
+
+from tests.bdd.step_context import StepContext
+
+
+class OAuth1Context(StepContext):
+    context_key = "oath_context"
+
+    def __init__(self, **kwargs):
+        self.consumer_key = None
+        self.shared_secret = None
+        self.client = None
+
+    def set_shared_secret(self, shared_secret):
+        self.shared_secret = shared_secret
+
+        self._make_client()
+
+    def set_consumer_key(self, consumer_key):
+        self.consumer_key = consumer_key
+
+        self._make_client()
+
+    def _make_client(self):
+        if self.shared_secret is None or self.consumer_key is None:
+            return
+
+        self.client = oauthlib.oauth1.Client(self.consumer_key, self.shared_secret)
+
+    def _make_nonce(self):
+        return "38d6db30e395417659d068164ca95169"
+
+    def sign_params(self, url, method, params):
+        if not self.client:
+            raise ValueError("You must set the consumer key and nonce first")
+
+        params.update(
+            {
+                "oauth_consumer_key": self.consumer_key,
+                "oauth_nonce": self._make_nonce(),
+                "oauth_timestamp": str(int(time.time())),
+            }
+        )
+        params["oauth_signature"] = self.client.get_oauth_signature(
+            oauthlib.common.Request(url, method, body=params)
+        )
+
+    def do_teardown(self):
+        self.context_key = None
+        self.shared_secret = None
+        self.client = None
+
+
+@step("the OAuth 1 consumer key is '{consumer_key}'")
+def set_oauth_consumer_key(context, consumer_key):
+    context.oath_context.set_consumer_key(consumer_key)
+
+
+@step("the OAuth 1 shared secret is '{shared_secret}'")
+def set_oauth_shared_secret(context, shared_secret):
+    context.oath_context.set_shared_secret(shared_secret)
+
+
+@step("I OAuth 1 sign the fixture '{fixture_name}'")
+def oauth_sign_params(context, fixture_name):
+    context.oath_context.sign_params(
+        url=context.the_request.get_url(),
+        method=context.the_request.get_method(),
+        params=context.the_fixture.get_fixture(fixture_name),
+    )

--- a/tests/bdd/steps/the_app.py
+++ b/tests/bdd/steps/the_app.py
@@ -1,0 +1,35 @@
+"""Make requests to a web-test application."""
+
+from behave import when
+from h_matchers import Any
+from webtest import TestApp
+
+from tests.bdd.step_context import StepContext
+from tests.bdd.steps.the_response import WebTestResponse
+
+
+class TheApp(StepContext):
+    context_key = "the_app"
+
+    def __init__(self, app, **kwargs):
+        self.app = TestApp(app)
+
+    def send_request(self, request):
+        # Translate requests.request into a test app call
+
+        method = getattr(self.app, request.method.lower())
+
+        return method(
+            url=request.url,
+            headers=request.headers,
+            params=request.data,
+            status=Any.int(),
+        )
+
+
+@when("I send the request to the app")
+def sent_request_to_app(context):
+    request = context.the_request.request
+    response = context.the_app.send_request(request)
+
+    WebTestResponse.register(context, response=response)

--- a/tests/bdd/steps/the_request.py
+++ b/tests/bdd/steps/the_request.py
@@ -1,0 +1,48 @@
+"""Form and manipulate HTTP requests."""
+
+from behave import given
+from requests import Request
+
+from tests.bdd.step_context import StepContext
+
+
+class TheRequest(StepContext):
+    context_key = "the_request"
+
+    def __init__(self, **kwargs):
+        self.request = None
+
+    def new_request(self, method, url):
+        self.request = Request(method, url)
+
+    def set_header(self, header, value):
+        self.request.headers[header] = value
+
+    def get_url(self):
+        return self.request.url
+
+    def get_method(self):
+        return self.request.method
+
+    def set_form_parameters(self, params):
+        self.request.data = params
+
+    def do_teardown(self):
+        self.request = None
+
+
+@given("I start a '{method}' request to '{url}'")
+def start_request(context, method, url):
+    context.the_request.new_request(method, url)
+
+
+@given("I set the request header '{header}' to '{value}'")
+def set_header(context, header, value):
+    context.the_request.set_header(header, value)
+
+
+@given("I set the form parameters from the fixture '{fixture_name}'")
+def set_form_parameters_from_fixture(context, fixture_name):
+    context.the_request.set_form_parameters(
+        context.the_fixture.get_fixture(fixture_name)
+    )

--- a/tests/bdd/steps/the_response.py
+++ b/tests/bdd/steps/the_response.py
@@ -1,0 +1,53 @@
+"""Make assertions about HTTP responses."""
+
+import re
+
+from behave import then
+
+from tests.bdd.step_context import StepContext
+from tests.bdd.steps.the_url import TheURL
+
+
+class WebTestResponse(StepContext):
+    context_key = "the_response"
+    ephemeral = True
+
+    def __init__(self, response, **kwargs):
+        self.response = response
+
+    def get_body(self):
+        return self.response.text
+
+    def get_headers(self):
+        return dict(self.response.headers)
+
+    def get_header(self, name):
+        return self.response.headers[name]
+
+    def status_code(self):
+        return self.response.status_code
+
+
+@then("the response status code is {status_code}")
+def the_response_status_code_is(context, status_code):
+    found_code = context.the_response.status_code()
+    if found_code != int(status_code):
+        raise AssertionError(
+            f"Expected status code '{status_code}' found '{found_code}'"
+        )
+
+
+@then("the response header '{header}' is the URL")
+def the_response_header_is_the_url(context, header):
+    value = context.the_response.get_header(header)
+
+    TheURL.register(context, url=value)
+
+
+@then("I dump the response")
+def dump_the_response(context):
+    response = context.the_response
+
+    print(f"Dump response: {response.status_code()}")
+    print(response.get_headers())
+    print(response.get_body())

--- a/tests/bdd/steps/the_url.py
+++ b/tests/bdd/steps/the_url.py
@@ -1,0 +1,45 @@
+"""Create, manipulate and make assertions about URLs."""
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+from behave import then
+
+from tests.bdd.step_context import StepContext
+
+
+class TheURL(StepContext):
+    context_key = "the_url"
+    ephemeral = True
+
+    def __init__(self, url, **kwargs):
+        self.raw_url = url
+        self.url = urlparse(url)
+        self.query = parse_qs(self.url.query)
+
+    def bare_url(self):
+        return self.url._replace(query=None).geturl()
+
+
+@then("the url matches '{bare_url}'")
+def the_url_matches(context, bare_url):
+    found_url = context.the_url.bare_url()
+
+    if found_url != bare_url:
+        raise AssertionError(f"Expected url '{bare_url}' found '{found_url}'")
+
+
+@then("the url matches the value")
+def the_url_matches_the_value(context):
+    the_url_matches(context, context.the_value)
+
+
+@then("the url query parameter '{param}' matches '{regex}'")
+def the_url_query_parameter_matches(context, param, regex):
+    value = context.the_url.query.get(param)
+    value = value[0]
+
+    if not re.compile(regex).match(value):
+        raise AssertionError(
+            f"Expected param '{param}' to match regex '{regex}', but found: '{value}'"
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -45,17 +45,18 @@ passenv =
 deps =
     {tests,clean,coverage}: coverage
     {tests,functests,lint}: httpretty
-    {tests,functests,lint,docstrings,checkdocstrings}: pytest
+    {tests,bddtests,functests,lint,docstrings,checkdocstrings}: pytest
     {tests,functests,lint,docstrings,checkdocstrings}: factory-boy
-    {tests,functests,lint,docstrings,checkdocstrings}: h-matchers>=1.2.0
-    {functests,lint,docstrings,checkdocstrings}: webtest
+    {tests,bddtests,functests,lint,docstrings,checkdocstrings}: h-matchers>=1.2.0
+    {bddtests,functests,lint,docstrings,checkdocstrings}: webtest
+    {bddtests,lint}: behave
     lint: prospector==1.1.6.2
     {format,checkformatting}: black
     {format,checkformatting}: isort
     {docstrings,checkdocstrings}: sphinx
     docstrings: sphinx-autobuild
     docker-compose: docker-compose
-    {tests,functests,lint,docstrings,checkdocstrings}: -r requirements.txt
+    {tests,bddtests,functests,lint,docstrings,checkdocstrings}: -r requirements.txt
     dev: -r requirements-dev.in
     pip-compile: pip-tools
 setenv =
@@ -64,10 +65,11 @@ setenv =
 whitelist_externals =
     tests: sh
 commands =
+    dev: {posargs:pserve conf/development.ini --reload}
     tests: sh bin/create-testdb
     tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
     functests: pytest {posargs:tests/functional/}
-    dev: {posargs:pserve conf/development.ini --reload}
+    bddtests: behave {posargs:tests/bdd/}
     lint: prospector
     lint: prospector tests
     format: black lms tests


### PR DESCRIPTION
## What is in this change?

 * The first test (1.1) has been completed
 * All the required mechanism to get behave working has been added
 * You can now run `make bddtests` to run these on the command line
 * The steps have been implemented in a very small re-usable style (not fewer more scenario specific steps)
 * A new concept of a 'StepContext' and 'StepContextManager' class have been introduced

## What are `StepContexts`?

 * These are responsible for keeping all state related to a set of steps
 * They are also responsible for setup and tear down of that state
 * They can register and de-register themselves from the global BDD context
 * This allows us to have clean managed fixtures which don't lank around between tests
 * They also cater for having one-time setup at the beginning of all tests

## What is the `StepContextManager`

 * This is aware of all `StepContext` objects have have been defined
 * This is in charge of executing registration, setup and tear down

## Why not use Behave fixtures?

Behave fixtures:
 
 * Don't really allow for this mixed singleton / setup tear down style
 * Have very scanty documentation
 * Are basically just context managers
 * It's possible we could stitch the two together, but ours are always ambiently available rather than being used per scenario.