### PR TITLE
Part 4: Adding the concept of Higher Order Gherkin - Steps defined in Gherkin

### DIFF
--- a/.behaverc
+++ b/.behaverc
@@ -1,2 +1,3 @@
 [behave]
 paths=tests/bdd/
+exclude_re=feature_steps

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -17,9 +17,6 @@ Injector.create_step_file(
 
 
 def before_all(context):
-    # This will actually take effect the next time you run the tests, but it
-    # still keeps you mostly up to date when developing
-
     StepContextManager.before_all(context, app=create_app(None, **TEST_SETTINGS))
 
 

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -1,15 +1,25 @@
 """Entry point and hooks for behave."""
 
+from pkg_resources import resource_filename
+
 from lms.app import create_app
+from tests.bdd.higher_order_gherkin import Injector
 from tests.bdd.step_context import StepContextManager
 from tests.conftest import TEST_SETTINGS
 
 TEST_SETTINGS["session_cookie_secret"] = "notasecret"
 
+# Create the compiled step file before steps are read
+Injector.create_step_file(
+    source_dir=resource_filename("tests", "bdd/steps/feature_steps/"),
+    target_file=resource_filename("tests", "bdd/steps/_compiled_feature_steps.py"),
+)
+
 
 def before_all(context):
     # This will actually take effect the next time you run the tests, but it
     # still keeps you mostly up to date when developing
+
     StepContextManager.before_all(context, app=create_app(None, **TEST_SETTINGS))
 
 

--- a/tests/bdd/features/lti_certification/section_1_invalid_launch_requests.feature
+++ b/tests/bdd/features/lti_certification/section_1_invalid_launch_requests.feature
@@ -3,16 +3,7 @@ Feature: Section 1 - Invalid Launch Requests
   This section comprises tests using invalid launch requests.
 
   Background:
-    Given fixtures are located in '/lti_certification_1_1/section_1'
-      And the OAuth 1 consumer key is 'Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3'
-      And the OAuth 1 shared secret is 'TEST_SECRET'
-      And I create an LMS DB 'ApplicationInstance'
-        | Field            | Value                                      |
-        | consumer_key     | Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3 |
-        | shared_secret    | TEST_SECRET                                |
-        | lms_url          | test_lms_url                               |
-        | requesters_email | test_requesters_email                      |
-      And I load the fixture 'most_common.ini' as 'params'
+    Given standard setup for LTI section 1
 
   @v1.0 @v1.1 @v1.2 @required
   Scenario: Test 1.1 - No resource_link_id provided
@@ -20,22 +11,12 @@ Feature: Section 1 - Invalid Launch Requests
 
     Given I update the fixture 'params' with
 	  | Key                     | Value               |
-	  | custom_link_setting_url | $LtiLink.custom.url |
 	  | resource_link_id        | *MISSING*           |
+      | custom_link_setting_url | $LtiLink.custom.url |
 
-      And I start a 'POST' request to 'http://localhost/lti_launches'
-      And I set the request header 'Accept' to 'text/html'
-      And I set the request header 'Content-Type' to 'application/x-www-form-urlencoded'
-      And I OAuth 1 sign the fixture 'params'
-      And I set the form parameters from the fixture 'params'
+     When I make an LTI launch request
 
-     When I send the request to the app
-
-     Then the response status code is 302
-      And the response header 'Location' is the URL
-      And the fixture 'params' key 'launch_presentation_return_url' is the value
-      And the url matches the value
-      And the url query parameter 'lti_msg' matches '.*resource_link_id'
+     Then the app redirects to the LTI tool with message matching '.*resource_link_id'
 
   @v1.0 @v1.1 @v1.2 @required
   Scenario: Test 1.2 - No resource_link_id or return URL provided

--- a/tests/bdd/higher_order_gherkin.py
+++ b/tests/bdd/higher_order_gherkin.py
@@ -1,9 +1,11 @@
 """Creates step definitions from feature files."""
 
+import os
 import re
 from glob import glob
 
 from behave.parser import parse_file
+from pkg_resources import resource_filename
 
 __ALL__ = ["Injector"]
 
@@ -86,12 +88,16 @@ class Renderer:
 
     @classmethod
     def render_steps(cls, feature_steps, source_dir):
+        # Make the source_dir relative to the project to prevent us from adding
+        # local file layout details
+        source_dir = os.path.relpath(source_dir, resource_filename("tests", "../"))
+
         python_code = (
-            f'"""\nThis code is auto-generated.\n\nFrom {source_dir}.\n"""'
+            f'"""\nThis code is auto-generated.\n\nFrom {source_dir}/.\n"""'
             "\n\nfrom behave import step\n"
         )
 
-        for feature_step in feature_steps:
+        for feature_step in sorted(feature_steps, key=lambda step: step.name):
             python_code += "\n\n" + cls.render_step(feature_step)
 
         return python_code

--- a/tests/bdd/higher_order_gherkin.py
+++ b/tests/bdd/higher_order_gherkin.py
@@ -1,0 +1,123 @@
+"""Creates step definitions from feature files."""
+
+import re
+from glob import glob
+
+from behave.parser import parse_file
+
+__ALL__ = ["Injector"]
+
+
+class FeatureStep:
+    """A step created from a feature file."""
+
+    def __init__(self, scenario, params, body):
+        self.scenario = scenario
+        self.params = params
+        self.body = body
+
+    @property
+    def name(self):
+        return self.scenario.name
+
+    @property
+    def filename(self):
+        return self.scenario.feature.filename
+
+    @property
+    def line_no(self):
+        return self.scenario.line
+
+
+class Injector:
+    """Inject feature generated steps into your code base."""
+
+    @classmethod
+    def create_step_file(cls, source_dir, target_file):
+        python_code = Renderer.render_steps(
+            cls._scan_dir(source_dir), source_dir=source_dir
+        )
+
+        with open(target_file, "w") as handle:
+            handle.write(python_code)
+
+    @classmethod
+    def _scan_dir(cls, target_dir):
+        for feature_file in glob(target_dir + "*.feature"):
+            yield from Parser.parse_feature_file(feature_file)
+
+
+class Parser:
+    """Parse feature files into steps."""
+
+    PARAM = re.compile("{([a-z_]+)}")
+
+    @classmethod
+    def parse_feature_file(cls, feature_file):
+        with open(feature_file) as handle:
+            lines = list(handle)
+
+        parsed = parse_file(feature_file)
+
+        start_points = [scenario.line for scenario in parsed.scenarios]
+        start_points.append(len(lines) + 1)
+
+        for pos, scenario in enumerate(parsed.scenarios):
+            start = scenario.line
+            end = start_points[pos + 1] - 1
+            body = "".join(lines[start:end]).rstrip()
+
+            yield FeatureStep(
+                scenario=scenario,
+                params=cls._parse_function_name(scenario.name),
+                body=body,
+            )
+
+    @classmethod
+    def _parse_function_name(cls, name):
+        return cls.PARAM.findall(name)
+
+
+class Renderer:
+    """Render steps into Python code."""
+
+    NOT_LOWER_CASE = re.compile("[^a-z]+")
+    FORMAT_REMOVER = re.compile(r"\.format\(\s+\)", re.MULTILINE)
+
+    @classmethod
+    def render_steps(cls, feature_steps, source_dir):
+        python_code = (
+            f'"""\nThis code is auto-generated.\n\nFrom {source_dir}.\n"""'
+            "\n\nfrom behave import step\n"
+        )
+
+        for feature_step in feature_steps:
+            python_code += "\n\n" + cls.render_step(feature_step)
+
+        return python_code
+
+    @classmethod
+    def render_step(cls, step):
+        signature = ", ".join(["context"] + step.params)
+        subs = ", ".join(f"{param}={param}" for param in step.params)
+        function_name = cls._function_name(step.name)
+
+        python_code = f"""@step("{step.name}")
+def {function_name}({signature}):
+    # From: {step.filename}: line {step.line_no - 1}
+    context.execute_steps(
+        \"\"\"
+{step.body}
+    \"\"\".format(
+            {subs}
+        )
+    )
+"""
+        python_code = cls.FORMAT_REMOVER.sub("", python_code)
+
+        return python_code
+
+    @classmethod
+    def _function_name(cls, name):
+        name = name.lower()
+        return cls.NOT_LOWER_CASE.sub("_", name.strip()).strip("_")

--- a/tests/bdd/steps/_compiled_feature_steps.py
+++ b/tests/bdd/steps/_compiled_feature_steps.py
@@ -1,10 +1,46 @@
 """
 This code is auto-generated.
 
-From /home/jon/projects/lms/tests/bdd/steps/feature_steps/.
+From tests/bdd/steps/feature_steps/.
 """
 
 from behave import step
+
+
+@step("I make an LTI launch request")
+def i_make_an_lti_launch_request(context):
+    # From: tests/bdd/steps/feature_steps/lti.feature: line 15
+    context.execute_steps(
+        """
+    Given I start an LTI launch request
+    And   I sign the LTI launch request
+
+    When I send the request to the app
+    """
+    )
+
+
+@step("I sign the LTI launch request")
+def i_sign_the_lti_launch_request(context):
+    # From: tests/bdd/steps/feature_steps/lti.feature: line 11
+    context.execute_steps(
+        """
+    Given I OAuth 1 sign the fixture 'params'
+      And I set the form parameters from the fixture 'params'
+    """
+    )
+
+
+@step("I start an LTI launch request")
+def i_start_an_lti_launch_request(context):
+    # From: tests/bdd/steps/feature_steps/lti.feature: line 6
+    context.execute_steps(
+        """
+    Given I start a 'POST' request to 'http://localhost/lti_launches'
+      And I set the request header 'Accept' to 'text/html'
+      And I set the request header 'Content-Type' to 'application/x-www-form-urlencoded'
+    """
+    )
 
 
 @step("standard authentication setup")
@@ -36,42 +72,6 @@ def standard_setup_for_lti_section_section(context, section):
     """.format(
             section=section
         )
-    )
-
-
-@step("I start an LTI launch request")
-def i_start_an_lti_launch_request(context):
-    # From: tests/bdd/steps/feature_steps/lti.feature: line 6
-    context.execute_steps(
-        """
-    Given I start a 'POST' request to 'http://localhost/lti_launches'
-      And I set the request header 'Accept' to 'text/html'
-      And I set the request header 'Content-Type' to 'application/x-www-form-urlencoded'
-    """
-    )
-
-
-@step("I sign the LTI launch request")
-def i_sign_the_lti_launch_request(context):
-    # From: tests/bdd/steps/feature_steps/lti.feature: line 11
-    context.execute_steps(
-        """
-    Given I OAuth 1 sign the fixture 'params'
-      And I set the form parameters from the fixture 'params'
-    """
-    )
-
-
-@step("I make an LTI launch request")
-def i_make_an_lti_launch_request(context):
-    # From: tests/bdd/steps/feature_steps/lti.feature: line 15
-    context.execute_steps(
-        """
-    Given I start an LTI launch request
-    And   I sign the LTI launch request
-
-    When I send the request to the app
-    """
     )
 
 

--- a/tests/bdd/steps/_compiled_feature_steps.py
+++ b/tests/bdd/steps/_compiled_feature_steps.py
@@ -1,0 +1,91 @@
+"""
+This code is auto-generated.
+
+From /home/jon/projects/lms/tests/bdd/steps/feature_steps/.
+"""
+
+from behave import step
+
+
+@step("standard authentication setup")
+def standard_authentication_setup(context):
+    # From: tests/bdd/steps/feature_steps/auth.feature: line 1
+    context.execute_steps(
+        """
+    Given the OAuth 1 consumer key is 'Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3'
+      And the OAuth 1 shared secret is 'TEST_SECRET'
+
+    Given I create an LMS DB 'ApplicationInstance'
+        | Field            | Value                                      |
+        | consumer_key     | Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3 |
+        | shared_secret    | TEST_SECRET                                |
+        | lms_url          | test_lms_url                               |
+        | requesters_email | test_requesters_email                      |
+    """
+    )
+
+
+@step("standard setup for LTI section {section}")
+def standard_setup_for_lti_section_section(context, section):
+    # From: tests/bdd/steps/feature_steps/lti.feature: line 1
+    context.execute_steps(
+        """
+    Given fixtures are located in '/lti_certification_1_1/section_{section}'
+      And standard authentication setup
+      And I load the fixture 'most_common.ini' as 'params'
+    """.format(
+            section=section
+        )
+    )
+
+
+@step("I start an LTI launch request")
+def i_start_an_lti_launch_request(context):
+    # From: tests/bdd/steps/feature_steps/lti.feature: line 6
+    context.execute_steps(
+        """
+    Given I start a 'POST' request to 'http://localhost/lti_launches'
+      And I set the request header 'Accept' to 'text/html'
+      And I set the request header 'Content-Type' to 'application/x-www-form-urlencoded'
+    """
+    )
+
+
+@step("I sign the LTI launch request")
+def i_sign_the_lti_launch_request(context):
+    # From: tests/bdd/steps/feature_steps/lti.feature: line 11
+    context.execute_steps(
+        """
+    Given I OAuth 1 sign the fixture 'params'
+      And I set the form parameters from the fixture 'params'
+    """
+    )
+
+
+@step("I make an LTI launch request")
+def i_make_an_lti_launch_request(context):
+    # From: tests/bdd/steps/feature_steps/lti.feature: line 15
+    context.execute_steps(
+        """
+    Given I start an LTI launch request
+    And   I sign the LTI launch request
+
+    When I send the request to the app
+    """
+    )
+
+
+@step("the app redirects to the LTI tool with message matching '{regex}'")
+def the_app_redirects_to_the_lti_tool_with_message_matching_regex(context, regex):
+    # From: tests/bdd/steps/feature_steps/lti.feature: line 21
+    context.execute_steps(
+        """
+     Then  the response status code is 302
+      And   the response header 'Location' is the URL
+      And   the fixture 'params' key 'launch_presentation_return_url' is the value
+      And   the url matches the value
+      And   the url query parameter 'lti_msg' matches '{regex}'
+    """.format(
+            regex=regex
+        )
+    )

--- a/tests/bdd/steps/feature_steps/auth.feature
+++ b/tests/bdd/steps/feature_steps/auth.feature
@@ -1,0 +1,12 @@
+Feature: Authentication steps
+  Scenario: standard authentication setup
+    Given the OAuth 1 consumer key is 'Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3'
+      And the OAuth 1 shared secret is 'TEST_SECRET'
+
+    Given I create an LMS DB 'ApplicationInstance'
+        | Field            | Value                                      |
+        | consumer_key     | Hypothesis4dd96539c449ca5c3d57cc3d778d6bf3 |
+        | shared_secret    | TEST_SECRET                                |
+        | lms_url          | test_lms_url                               |
+        | requesters_email | test_requesters_email                      |
+

--- a/tests/bdd/steps/feature_steps/lti.feature
+++ b/tests/bdd/steps/feature_steps/lti.feature
@@ -1,0 +1,27 @@
+Feature: Standard LTI setup
+  Scenario: standard setup for LTI section {section}
+    Given fixtures are located in '/lti_certification_1_1/section_{section}'
+      And standard authentication setup
+      And I load the fixture 'most_common.ini' as 'params'
+
+  Scenario: I start an LTI launch request
+    Given I start a 'POST' request to 'http://localhost/lti_launches'
+      And I set the request header 'Accept' to 'text/html'
+      And I set the request header 'Content-Type' to 'application/x-www-form-urlencoded'
+
+  Scenario: I sign the LTI launch request
+    Given I OAuth 1 sign the fixture 'params'
+      And I set the form parameters from the fixture 'params'
+
+  Scenario: I make an LTI launch request
+    Given I start an LTI launch request
+    And   I sign the LTI launch request
+
+    When I send the request to the app
+
+  Scenario: the app redirects to the LTI tool with message matching '{regex}'
+     Then  the response status code is 302
+      And   the response header 'Location' is the URL
+      And   the fixture 'params' key 'launch_presentation_return_url' is the value
+      And   the url matches the value
+      And   the url query parameter 'lti_msg' matches '{regex}'


### PR DESCRIPTION
# What does this do?

 * This introduces the higher order gherkin injector
 * This injector reads special feature step files
 * These are written in Gherkin but define steps not scenarios
 * These scenarios are parsed and written out to a python file
 * This python file is read by behave and interpreted as normal steps

# The problem

All steps and related functions exist on a continuum of scale:

 * __Small steps__ are:
   * :heavy_check_mark: Re-usable
   * :heavy_check_mark: Composable
   * :x: Hide the intent of the test 
   * :heavy_check_mark: Result in less code being written 
   * :x: Result in more gherkin being written
 * __Large steps__ are:
   * :x: Test specific
   * :x: Inflexible 
   * :heavy_check_mark: Reveal the intent of the test 
   * :x: Result in more code being written  
   * :heavy_check_mark: Result in less gherkin being written 

As steps bind 1:1 with a specific piece of code, there isn't much place for abstraction.

_Note_ - The PR before this picks the small steps trade-off

## The properties of an ideal solution

An ideal solution would combine the best of both worlds resulting in steps which have the following properties:

   * :heavy_check_mark: Re-usable
   * :heavy_check_mark: Composable
   * :heavy_check_mark: Reveal the intent of the test
   * :heavy_check_mark: Result in less code being written 
   * :heavy_check_mark: Result in less gherkin being written

# Higher Order Gherkin (HOG)

The central idea of HOG is to allow you to write step definitions in terms of other step definitions all in Gherkin. This is achieved by hijacking the feature file and re-interpreting scenarios as steps.

Steps defined in this way are called "Feature Steps".

## Features of this solution

 * You can define steps that call other steps all in Gherkin
 * These steps can refer to each other
 * These steps can accept parameters
 * Essentially we are introducing the idea of functions and composability to Gherkin
 * As the feature step files are fully valid Gherkin IDE's will highlight and help you autocomplete when writing them (once any dependent steps are compiled)
 * When run only the top level, most descriptive, steps are printed

## How you are intended to use it

 * Write small very generic steps (less python)
 * Write very high level descriptive BDD scenarios (less gherkin)
 * Bridge the gap between the two with "Feature Steps"

## An example

Here we define a new step `the app redirects to the LTI tool with message matching '{regex}'` in terms of other existing steps:
 
```
Scenario: the app redirects to the LTI tool with message matching '{regex}'
     Then the response status code is 302
      And the response header 'Location' is the URL
      And the fixture 'params' key 'launch_presentation_return_url' is the value
      And the url matches the value
      And the url query parameter 'lti_msg' matches '{regex}'
```

Now in our tests we can write:
```
Given the app redirects to the LTI tool with message matching 'some_value_here'
```

Which is much clearer than repeating the same chunk of Gherkin over and over.

## Caveats

 * The steps must be compiled before they can be used
 * IDE's will jump to the definition in the python code, not the feature step files
 * IDE's can only jump from the original gherkin to the compiled features step file, not from the sub-definitions in there to each other. This makes chasing through them a little more manual when debugging
  * Currently feature steps only support placeholders, not full regexes

## Future improvements

 * It would be nice to associate feature steps with specific features or sub-folders, instead of having one big bundle
 * It might be nice to render out a file structure that mimics the original feature step files to make associating them easier
