### PR TITLE
Fixing unbound response bug in error handling in LTI Outcomes service

### DIFF
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -191,6 +191,7 @@ def _send_request(outcomes_request_params, pox_body):
     )
 
     try:
+        response = None  # Bind the variable so we can refer to it in the catch
         response = requests.post(
             url=outcomes_request_params.lis_outcome_service_url,
             data=xml_body,
@@ -201,6 +202,7 @@ def _send_request(outcomes_request_params, pox_body):
         # there was an HTTP-related problem with the request. This exception
         # is a subclass of ``requests.exceptions.RequestError``.
         response.raise_for_status()
+
     except RequestException as err:
         # Handle any kind of ``RequestException``, be it an ``HTTPError`` or other
         # flavor of ``RequestException``.

--- a/tests/unit/lms/services/lti_outcomes_test.py
+++ b/tests/unit/lms/services/lti_outcomes_test.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 import httpretty
 import pytest
 from jinja2 import Template
+from requests import RequestException
 
 from lms.services.exceptions import LTIOutcomesAPIError
 from lms.services.lti_outcomes import (
@@ -209,6 +210,14 @@ class TestLTIOutcomesClient:
         with pytest.raises(LTIOutcomesAPIError):
             lti_outcomes_svc.read_result(lti_outcomes_params)
 
+    def test_it_gracefully_handles_RequestException(
+        self, requests, lti_outcomes_svc, lti_outcomes_params
+    ):
+        requests.post.side_effect = RequestException
+
+        with pytest.raises(LTIOutcomesAPIError):
+            lti_outcomes_svc.read_result(lti_outcomes_params)
+
     @pytest.fixture
     def request_xml(self):
         """Return parsed XML of last request."""
@@ -289,6 +298,10 @@ class TestLTIOutcomesClient:
     @pytest.fixture
     def lti_outcomes_svc(self, pyramid_request):
         return LTIOutcomesClient({}, pyramid_request)
+
+    @pytest.fixture
+    def requests(self, patch):
+        return patch("lms.services.lti_outcomes.requests")
 
 
 def element_text(xml, path):


### PR DESCRIPTION
We referred to a variable which can be undeclared by the time we get to it.

This fixes: https://github.com/hypothesis/lms/issues/1106