### PR TITLE
Prevent reflow of grading components

### DIFF
--- a/lms/static/styles/components/_LMSGrader.scss
+++ b/lms/static/styles/components/_LMSGrader.scss
@@ -26,6 +26,13 @@
 .LMSGrader__student-count {
   margin: 10px;
   font-weight: 500;
+  /**
+   * Fixed width prevents this element from changing size 
+   * when the student index is changed. This prevents a 
+   * potential re-flow onto the next line.
+   */
+  width: 150px; 
+  text-align: right;
 }
 
 .LMSGrader__title {


### PR DESCRIPTION

Fix the width of the `LMSGrader__student-count` element to prevent a potential reflow of dom elements to the next line when changing students. 

This should cover us up to 3 digits of students. e.g. "Student 999 of 999" still fits in 150px.

In this example you can see how it breaks to a second line when changing from All Students to the first student, but after fixing the width, it no longer does that.
![reflow](https://user-images.githubusercontent.com/3939074/70827948-2e2e1900-1d9f-11ea-89ad-7d9e2fa19f80.gif)


fixes https://github.com/hypothesis/lms/issues/1194
