### PR TITLE
Removing an unneccessary value object from the LIS service

### DIFF
--- a/lms/services/lis_result_sourcedid.py
+++ b/lms/services/lis_result_sourcedid.py
@@ -56,7 +56,7 @@ class LISResultSourcedIdService:
         :type lti_user: :class:`lms.values.LTIUser`
         """
         try:
-            lis_info = LISResultSourcedIdSchema(request).lis_result_sourcedid_info()
+            params = LISResultSourcedIdSchema(request).parse()
 
         except ValidationError:
             # We're missing something we need in the request.
@@ -68,18 +68,14 @@ class LISResultSourcedIdService:
             LISResultSourcedId,
             oauth_consumer_key=lti_user.oauth_consumer_key,
             user_id=lti_user.user_id,
-            context_id=lis_info.context_id,
-            resource_link_id=lis_info.resource_link_id,
+            context_id=params["context_id"],
+            resource_link_id=params["resource_link_id"],
         )
 
         lis_result_sourcedid.h_username = h_user.username
         lis_result_sourcedid.h_display_name = h_user.display_name
 
-        lis_result_sourcedid.lis_result_sourcedid = lis_info.lis_result_sourcedid
-        lis_result_sourcedid.lis_outcome_service_url = lis_info.lis_outcome_service_url
-        lis_result_sourcedid.tool_consumer_info_product_family_code = (
-            lis_info.tool_consumer_info_product_family_code
-        )
+        lis_result_sourcedid.update_from_dict(params)
 
     def _find_or_create(self, model_class, **query):
         result = self._db.query(model_class).filter_by(**query).one_or_none()

--- a/lms/validation/_lis_result_sourcedid.py
+++ b/lms/validation/_lis_result_sourcedid.py
@@ -2,7 +2,6 @@
 import marshmallow
 
 from lms.validation._helpers import PyramidRequestSchema
-from lms.values import LISResultSourcedId
 
 __all__ = ["LISResultSourcedIdSchema"]
 
@@ -31,23 +30,3 @@ class LISResultSourcedIdSchema(PyramidRequestSchema):
     context_id = marshmallow.fields.Str(required=True)
     resource_link_id = marshmallow.fields.Str(required=True)
     tool_consumer_info_product_family_code = marshmallow.fields.Str(missing="")
-
-    def lis_result_sourcedid_info(self):
-        """
-        Return an :class:`~lms.values.LISResultSourcedId`.
-
-        :raise ValidationError: if the request isn't a valid LIS Outcome launch
-        :rtype: LISResultSourcedId
-        """
-
-        parsed_params = self.parse(locations=["form"])
-
-        return LISResultSourcedId(
-            lis_result_sourcedid=parsed_params["lis_result_sourcedid"],
-            lis_outcome_service_url=parsed_params["lis_outcome_service_url"],
-            context_id=parsed_params["context_id"],
-            resource_link_id=parsed_params["resource_link_id"],
-            tool_consumer_info_product_family_code=parsed_params[
-                "tool_consumer_info_product_family_code"
-            ],
-        )

--- a/lms/values.py
+++ b/lms/values.py
@@ -1,7 +1,7 @@
 """Immutable value objects for use throughout the app."""
 from typing import NamedTuple
 
-__all__ = ("LTIUser", "LISResultSourcedId")
+__all__ = ("LTIUser", "HUser")
 
 
 class LTIUser(NamedTuple):
@@ -54,28 +54,3 @@ class HUser(NamedTuple):
     @property
     def userid(self):
         return f"acct:{self.username}@{self.authority}"
-
-
-class LISResultSourcedId(NamedTuple):
-    """
-    LIS Outcome metadata for an LMS student user.
-
-    May be used—in combination with :class:`~lms.values.LTIUser` and
-    :class:`~lms.values.HUser` to populate an :class:`lms.models.LISResultSourcedId`
-    model.
-    """
-
-    lis_result_sourcedid: str
-    """The LIS Result Identifier associated with this launch."""
-
-    lis_outcome_service_url: str
-    """Service URL for communicating outcomes."""
-
-    context_id: str
-    """unique id of the course from which the user is accessing the app."""
-
-    resource_link_id: str
-    """unique id referencing the link, or "placement", of the app in the consumer."""
-
-    tool_consumer_info_product_family_code: str = ""
-    """The 'family' of LMS tool, e.g. 'BlackboardLearn' or 'canvas'."""

--- a/tests/unit/lms/validation/_lis_result_sourcedid_test.py
+++ b/tests/unit/lms/validation/_lis_result_sourcedid_test.py
@@ -2,7 +2,6 @@ import pytest
 from pyramid.httpexceptions import HTTPUnprocessableEntity
 
 from lms.validation import LISResultSourcedIdSchema
-from lms.values import LISResultSourcedId as LISResultSourcedIdValue
 
 
 class TestLISResultSourcedIdSchema:
@@ -54,19 +53,14 @@ class TestLISResultSourcedIdSchema:
             [(missing_param, ["Missing data for required field."])]
         )
 
-    def test_it_returns_lis_result_sourcedid_info(self, schema):
-        lis_result_sourcedid = schema.lis_result_sourcedid_info()
-
-        assert isinstance(lis_result_sourcedid, LISResultSourcedIdValue)
-
     def test_it_lis_result_sourcedid_info_does_not_raise_with_missing_optional_field(
         self, schema, pyramid_outcome_request
     ):
         del pyramid_outcome_request.POST["tool_consumer_info_product_family_code"]
 
-        lis_result_sourcedid = schema.lis_result_sourcedid_info()
+        lis_result_sourcedid = schema.parse()
 
-        assert isinstance(lis_result_sourcedid, LISResultSourcedIdValue)
+        assert isinstance(lis_result_sourcedid, dict)
 
     @pytest.fixture
     def pyramid_outcome_request(self, pyramid_request):


### PR DESCRIPTION
A dict will do fine.

Spawned from: https://github.com/hypothesis/lms/pull/1247 as an attempt to split that up into more palatable chunks.

This removes the value object only, as it was only used locally.