### PR TITLE
Don't list all students if grading is disabled

### DIFF
--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -41,7 +41,7 @@ def configure_grading(request, js_config):
     }
 
 
-def _find_students_for_assignment(context_id, resource_link_id, request):
+def _students_for_assignment(context_id, resource_link_id, request):
     service = request.find_service(name="lis_result_sourcedid")
 
     for student in service.fetch_students_by_assignment(

--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -12,42 +12,48 @@ def configure_grading(request, js_config):
     Note that this is entirely distinct from Canvas Speedgrader, which provides
     its own UI.
     """
+
     if (
-        request.lti_user.is_instructor
-        and _is_assignment_gradable(request)
-        and request.params.get("tool_consumer_info_product_family_code") != "canvas"
+        not request.lti_user.is_instructor
+        or not _is_assignment_gradable(request)
+        or request.params.get("tool_consumer_info_product_family_code") == "canvas"
     ):
-        js_config["lmsGrader"] = True
+        return
 
-        js_config["grading"] = {
-            "courseName": request.params.get("context_title"),
-            "assignmentName": request.params.get("resource_link_title"),
-        }
+    js_config["lmsGrader"] = True
 
-        lis_result_sourcedid_svc = request.find_service(name="lis_result_sourcedid")
-        lis_result_sourcedids = lis_result_sourcedid_svc.fetch_students_by_assignment(
-            oauth_consumer_key=request.lti_user.oauth_consumer_key,
-            context_id=request.params.get("context_id"),
-            resource_link_id=request.params.get("resource_link_id"),
+    js_config["grading"] = {
+        "courseName": request.params.get("context_title"),
+        "assignmentName": request.params.get("resource_link_title"),
+        "students": [
+            {
+                "userid": h_user.userid,
+                "displayName": h_user.display_name,
+                "LISResultSourcedId": student.lis_result_sourcedid,
+                "LISOutcomeServiceUrl": student.lis_outcome_service_url,
+            }
+            for student, h_user in _find_students_for_assignment(
+                context_id=request.params.get("context_id"),
+                resource_link_id=request.params.get("resource_link_id"),
+                request=request,
+            )
+        ],
+    }
+
+
+def _find_students_for_assignment(context_id, resource_link_id, request):
+    service = request.find_service(name="lis_result_sourcedid")
+
+    for student in service.fetch_students_by_assignment(
+        oauth_consumer_key=request.lti_user.oauth_consumer_key,
+        context_id=context_id,
+        resource_link_id=resource_link_id,
+    ):
+        yield student, HUser(
+            authority=request.registry.settings["h_authority"],
+            username=student.h_username,
+            display_name=student.h_display_name,
         )
-        students = []
-        for student in lis_result_sourcedids:
-            # Using ``HUser`` NamedTuple to get at the ``userid`` prop
-            h_user = HUser(
-                authority=request.registry.settings["h_authority"],
-                username=student.h_username,
-                display_name=student.h_display_name,
-            )
-            students.append(
-                {
-                    "userid": h_user.userid,
-                    "displayName": h_user.display_name,
-                    "LISResultSourcedId": student.lis_result_sourcedid,
-                    "LISOutcomeServiceUrl": student.lis_outcome_service_url,
-                }
-            )
-
-        js_config["grading"]["students"] = students
 
 
 def _is_assignment_gradable(request):

--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -32,7 +32,7 @@ def configure_grading(request, js_config):
                 "LISResultSourcedId": student.lis_result_sourcedid,
                 "LISOutcomeServiceUrl": student.lis_outcome_service_url,
             }
-            for student, h_user in _find_students_for_assignment(
+            for student, h_user in _students_for_assignment(
                 context_id=request.params.get("context_id"),
                 resource_link_id=request.params.get("resource_link_id"),
                 request=request,

--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -19,35 +19,35 @@ def configure_grading(request, js_config):
     ):
         js_config["lmsGrader"] = True
 
-    js_config["grading"] = {
-        "courseName": request.params.get("context_title"),
-        "assignmentName": request.params.get("resource_link_title"),
-    }
+        js_config["grading"] = {
+            "courseName": request.params.get("context_title"),
+            "assignmentName": request.params.get("resource_link_title"),
+        }
 
-    lis_result_sourcedid_svc = request.find_service(name="lis_result_sourcedid")
-    lis_result_sourcedids = lis_result_sourcedid_svc.fetch_students_by_assignment(
-        oauth_consumer_key=request.lti_user.oauth_consumer_key,
-        context_id=request.params.get("context_id"),
-        resource_link_id=request.params.get("resource_link_id"),
-    )
-    students = []
-    for student in lis_result_sourcedids:
-        # Using ``HUser`` NamedTuple to get at the ``userid`` prop
-        h_user = HUser(
-            authority=request.registry.settings["h_authority"],
-            username=student.h_username,
-            display_name=student.h_display_name,
+        lis_result_sourcedid_svc = request.find_service(name="lis_result_sourcedid")
+        lis_result_sourcedids = lis_result_sourcedid_svc.fetch_students_by_assignment(
+            oauth_consumer_key=request.lti_user.oauth_consumer_key,
+            context_id=request.params.get("context_id"),
+            resource_link_id=request.params.get("resource_link_id"),
         )
-        students.append(
-            {
-                "userid": h_user.userid,
-                "displayName": h_user.display_name,
-                "LISResultSourcedId": student.lis_result_sourcedid,
-                "LISOutcomeServiceUrl": student.lis_outcome_service_url,
-            }
-        )
+        students = []
+        for student in lis_result_sourcedids:
+            # Using ``HUser`` NamedTuple to get at the ``userid`` prop
+            h_user = HUser(
+                authority=request.registry.settings["h_authority"],
+                username=student.h_username,
+                display_name=student.h_display_name,
+            )
+            students.append(
+                {
+                    "userid": h_user.userid,
+                    "displayName": h_user.display_name,
+                    "LISResultSourcedId": student.lis_result_sourcedid,
+                    "LISOutcomeServiceUrl": student.lis_outcome_service_url,
+                }
+            )
 
-    js_config["grading"]["students"] = students
+        js_config["grading"]["students"] = students
 
 
 def _is_assignment_gradable(request):


### PR DESCRIPTION
 * Previously if grading is disabled, we still run the whole block
 * This means we look up all students for every call
 * This will be generating lots of unnecessary DB calls

This has two commits:

 * The first is a straight indent of the code to show the tests passing
 * The second is a refactor for an early return and to create the config separately from lookup