### PR TITLE
Marking Canvas LTI Launch View specific behavior and moving into sub-functions

### DIFF
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -319,7 +319,7 @@ class BasicLTILaunchViews:
         )
 
     def initialise_canvas_submission_params(self):
-        """ Add config used by UI to call Canvas `record_submission` API."""
+        """Add config used by UI to call Canvas `record_submission` API."""
         lis_result_sourcedid = self.request.params.get("lis_result_sourcedid")
         lis_outcome_service_url = self.request.params.get("lis_outcome_service_url")
 

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -367,7 +367,7 @@ class BasicLTILaunchViews:
             # of the experience can still work.
             display_name = "(Couldn't fetch student name)"
 
-        # TODO! - Could/should this be replaced with a LISSourcedId lookup?
+        # TODO! - Could/should this be replaced with a LISResultSourcedId lookup?
         self.context.hypothesis_config.update(
             {"focus": {"user": {"username": focused_user, "displayName": display_name}}}
         )

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -351,7 +351,7 @@ class BasicLTILaunchViews:
         # If the launch has been configured to focus on the annotations from
         # a particular user, translate that into Hypothesis client configuration.
 
-        # This parameter is only passed as a part of Canvas Speedgrader config
+        # This parameter is only passed as a part of Canvas SpeedGrader config
         # and is passed as a parameter to a URL which they call us back on.
         focused_user = self.request.params.get("focused_user")
         if not focused_user:

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -71,11 +71,16 @@ class TestBasicLTILaunch:
 
         assert "submissionParams" not in context.js_config
 
-    def test_it_configures_client_to_focus_on_user_if_param_set(
+    def test_it_configures_client_to_focus_on_user_if_in_canvas_and_param_set(
         self, context, pyramid_request, h_api
     ):
         context.hypothesis_config = {}
-        pyramid_request.params.update({"focused_user": "user123"})
+        pyramid_request.params.update(
+            {
+                "tool_consumer_info_product_family_code": "canvas",
+                "focused_user": "user123",
+            }
+        )
         h_api.get_user.return_value = HUser(
             authority="TEST_AUTHORITY", username="user123", display_name="Jim Smith"
         )
@@ -91,7 +96,12 @@ class TestBasicLTILaunch:
         self, context, pyramid_request, h_api
     ):
         context.hypothesis_config = {}
-        pyramid_request.params.update({"focused_user": "user123"})
+        pyramid_request.params.update(
+            {
+                "focused_user": "user123",
+                "tool_consumer_info_product_family_code": "canvas",
+            }
+        )
         h_api.get_user.side_effect = HAPIError("User does not exist")
 
         BasicLTILaunchViews(context, pyramid_request)


### PR DESCRIPTION
Moving some functions in the view `__init__` which are canvas specific into smaller sub-functions . 

This is a bit easier to read, but mostly it's to highlight the fact that they aren't general behavior that matters in anything other than a Canvas context. If that changes, we can change them.