### PR TITLE
Fix floating point precision with grade

### DIFF
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -15,7 +15,7 @@ import Spinner from './Spinner';
 import SvgIcon from './SvgIcon';
 import { fetchGrade, submitGrade } from '../utils/grader-service';
 import { trustMarkup } from '../utils/trusted';
-import { formatToNumber, validateGrade } from '../utils/validation';
+import { formatToNumber, scaleGrade, validateGrade } from '../utils/validation';
 import ValidationMessage from './ValidationMessage';
 
 // Grades are always stored as a value between [0-1] on the service layer.
@@ -46,7 +46,7 @@ const useFetchGrade = student => {
         const response = await fetchGrade({ student, authToken });
         if (!didCancel) {
           // Only set these values if we didn't cancel this request
-          setGrade(response.currentScore * GRADE_MULTIPLIER);
+          setGrade(scaleGrade(response.currentScore, GRADE_MULTIPLIER));
           setGradeLoading(false);
         }
       };

--- a/lms/static/scripts/frontend_apps/utils/test/validation-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/validation-test.js
@@ -1,7 +1,7 @@
-import { formatToNumber, validateGrade } from '../validation';
+import { formatToNumber, scaleGrade, validateGrade } from '../validation';
 
-describe('validation', () => {
-  context('formatToNumber', () => {
+describe('#validation', () => {
+  describe('formatToNumber', () => {
     it('translates the string to a number', async () => {
       assert.isTrue(formatToNumber('1') === 1);
     });
@@ -19,7 +19,7 @@ describe('validation', () => {
     });
   });
 
-  context('validateGrade', () => {
+  describe('#validateGrade', () => {
     it('fails validation if the value is not a number', async () => {
       assert.equal(validateGrade('1'), 'Grade must be a valid number');
     });
@@ -34,6 +34,26 @@ describe('validation', () => {
 
     it('passes validation if its a valid number between 0 and 10', async () => {
       assert.equal(validateGrade(1), undefined);
+    });
+  });
+
+  describe('#scaleGrade', () => {
+    const GRADE_MULTIPLIER = 10;
+    it('scales the grade by 10', async () => {
+      assert.equal(scaleGrade(0.5, GRADE_MULTIPLIER), 5);
+    });
+    it('does not lose precision', async () => {
+      // note: 0.33 * 10 = 3.3000000000000003
+      assert.equal(scaleGrade(0.33, GRADE_MULTIPLIER), 3.3);
+    });
+    it('rounds to same number of significate figures', async () => {
+      assert.equal(scaleGrade(0.9999, GRADE_MULTIPLIER), 9.999);
+    });
+    it('does not scale 0', async () => {
+      assert.equal(scaleGrade(0, GRADE_MULTIPLIER), 0);
+    });
+    it('does not care about trailing zeros', async () => {
+      assert.equal(scaleGrade(0.9, GRADE_MULTIPLIER), 9);
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/validation.js
+++ b/lms/static/scripts/frontend_apps/utils/validation.js
@@ -39,4 +39,28 @@ function validateGrade(value) {
   }
 }
 
-export { formatToNumber, validateGrade };
+/**
+ * Return a scaled grade rounded to the same precision
+ * as the original grade. This method eliminates precision
+ * errors with floating point scaling.
+ *
+ * e.g. 0.66 will scale to 6.6 with a multiplier of 10
+ *      0.667 will scale to 6.67  with a multiplier of 10
+ *
+ * @param {number} grade
+ * @param {number} multiplier
+ * @return {number}
+ */
+function scaleGrade(grade, multiplier) {
+  const sGrade = grade.toString();
+  if (sGrade.indexOf('.') < 0) {
+    // no decimal value, just returns the scaled value
+    return grade * multiplier;
+  } else {
+    const decimalDigitsLength = sGrade.split('.')[1].length;
+    // scale and round to one less the number of decimal digits the grade had
+    return (grade * multiplier).toFixed(decimalDigitsLength - 1);
+  }
+}
+
+export { formatToNumber, scaleGrade, validateGrade };


### PR DESCRIPTION
I noticed this bug when submitted a grade of 3.3. When you multiple 0.33 by 10 in js, you end up with a floating point precision problem that looks like this 3.3000000000000003. This fix converts all grades to a string, checks the least significate digits and rounds to that precision. 

To replicate this bug, just submit a grade of 3.3, and refresh and you'll see 3.3000000000000003

