### PR TITLE
A separate OAuth1 service to cut down on passing parameters about

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -51,3 +51,4 @@ def includeme(config):
         "lms.services.group_info.GroupInfoService", name="group_info"
     )
     config.register_service_factory("lms.services.lti_h.LTIHService", name="lti_h")
+    config.register_service_factory("lms.services.oauth1.OAuth1Service", name="oauth1")

--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -1,0 +1,32 @@
+from requests_oauthlib import OAuth1
+
+
+class OAuth1Service:
+    """Provides OAuth1 convenience functions."""
+
+    def __init__(self, _context, request):
+        self.request = request
+        self.ai_getter_service = request.find_service(name="ai_getter")
+
+    def get_client(self):
+        """
+        Get an OAUth1 client that can be used to sign HTTP requests.
+
+        To sign a request with the client pass it as the `auth` parameter to
+        `requests.post()`.
+
+        :rtype: OAuth1
+        """
+
+        consumer_key = self.request.lti_user.oauth_consumer_key
+        shared_secret = self.ai_getter_service.shared_secret(consumer_key)
+
+        return OAuth1(
+            client_key=consumer_key,
+            client_secret=shared_secret,
+            signature_method="HMAC-SHA1",
+            signature_type="auth_header",
+            # Include the body when signing the request, this defaults to
+            # `False` for non-form encoded bodies.
+            force_include_body=True,
+        )

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -20,14 +20,7 @@ class LTIOutcomesViews:
         self.parsed_params = self.request.parsed_params
         self.lti_outcomes_client = self.request.find_service(name="lti_outcomes_client")
 
-        lti_user = self.request.lti_user
-
-        shared_secret = self.request.find_service(name="ai_getter").shared_secret(
-            lti_user.oauth_consumer_key
-        )
         self.outcome_request_params = LTIOutcomesRequestParams(
-            consumer_key=lti_user.oauth_consumer_key,
-            shared_secret=shared_secret,
             lis_outcome_service_url=self.parsed_params["lis_outcome_service_url"],
             lis_result_sourcedid=self.parsed_params["lis_result_sourcedid"],
         )

--- a/tests/unit/lms/services/__init___test.py
+++ b/tests/unit/lms/services/__init___test.py
@@ -9,6 +9,7 @@ from lms.services.h_api import HAPI
 from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
+from lms.services.oauth1 import OAuth1Service
 
 
 class TestIncludeme:
@@ -23,6 +24,7 @@ class TestIncludeme:
             ("lti_outcomes_client", LTIOutcomesClient),
             ("group_info", GroupInfoService),
             ("lti_h", LTIHService),
+            ("oauth1", OAuth1Service),
         ),
     )
     def test_it_has_the_expected_service(self, name, service_class, pyramid_config):

--- a/tests/unit/lms/services/oauth1_test.py
+++ b/tests/unit/lms/services/oauth1_test.py
@@ -1,0 +1,53 @@
+from unittest import mock
+
+import pytest
+from requests import Request
+
+from lms.services.oauth1 import OAuth1Service
+
+
+class TestOAuth1Service:
+    def test_we_configure_OAuth1_correctly(self, service, OAuth1):
+        service.get_client()
+
+        OAuth1.assert_called_once_with(
+            client_key="TEST_OAUTH_CONSUMER_KEY",
+            client_secret="TEST_SECRET",
+            signature_method="HMAC-SHA1",
+            signature_type="auth_header",
+            force_include_body=True,
+        )
+
+    def test_we_can_be_used_to_sign_a_request(self, service):
+        request = Request(
+            "POST",
+            url="http://example.com",
+            data={"param": "value"},
+            auth=service.get_client(),
+        )
+
+        request = request.prepare()
+
+        auth_header = request.headers["Authorization"].decode("iso-8859-1")
+
+        assert auth_header.startswith("OAuth")
+        assert 'oauth_version="1.0"' in auth_header
+        assert 'oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY"' in auth_header
+        assert 'oauth_signature_method="HMAC-SHA1"' in auth_header
+
+        # This currently doesn't verify the signature, it only checks that
+        # one is present.
+        assert "oauth_signature=" in auth_header
+
+    @pytest.fixture
+    def service(self, context, pyramid_request):
+        return OAuth1Service(context, pyramid_request)
+
+    @pytest.fixture
+    def context(self):
+        # We don't use context, so it doesn't matter what it is
+        return mock.sentinel.context
+
+    @pytest.fixture
+    def OAuth1(self, patch):
+        return patch("lms.services.oauth1.OAuth1")

--- a/tests/unit/lms/views/api/lti_test.py
+++ b/tests/unit/lms/views/api/lti_test.py
@@ -5,22 +5,18 @@ from urllib.parse import urlencode
 
 import pytest
 
-from lms.services.application_instance_getter import ApplicationInstanceGetter
 from lms.services.lti_outcomes import LTIOutcomesClient, LTIOutcomesRequestParams
 from lms.views.api.lti import LTIOutcomesViews
 
 
 class TestRecordCanvasSpeedgraderSubmission:
     def test_it_passes_correct_params_to_read_current_score(
-        self, ai_getter, pyramid_request, lti_outcomes_client
+        self, pyramid_request, lti_outcomes_client
     ):
         LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
 
-        ai_getter.shared_secret.assert_called_once_with("TEST_OAUTH_CONSUMER_KEY")
         lti_outcomes_client.read_result.assert_called_once_with(
             LTIOutcomesRequestParams(
-                consumer_key="TEST_OAUTH_CONSUMER_KEY",
-                shared_secret=ai_getter.shared_secret.return_value,
                 lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
                 lis_result_sourcedid="modelstudent-assignment1",
             )
@@ -44,7 +40,6 @@ class TestRecordCanvasSpeedgraderSubmission:
     )
     def test_it_records_result_if_no_score_exists(
         self,
-        ai_getter,
         pyramid_request,
         lti_outcomes_client,
         document_url,
@@ -58,10 +53,7 @@ class TestRecordCanvasSpeedgraderSubmission:
 
         LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
 
-        ai_getter.shared_secret.assert_called_once_with("TEST_OAUTH_CONSUMER_KEY")
         expected_outcome_params = LTIOutcomesRequestParams(
-            consumer_key="TEST_OAUTH_CONSUMER_KEY",
-            shared_secret=ai_getter.shared_secret.return_value,
             lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
             lis_result_sourcedid="modelstudent-assignment1",
         )
@@ -94,16 +86,10 @@ class TestRecordCanvasSpeedgraderSubmission:
 
 
 class TestReadResult:
-    def test_it_proxies_to_read_result(
-        self, ai_getter, pyramid_request, lti_outcomes_client
-    ):
-
+    def test_it_proxies_to_read_result(self, pyramid_request, lti_outcomes_client):
         LTIOutcomesViews(pyramid_request).read_result()
 
-        ai_getter.shared_secret.assert_called_once_with("TEST_OAUTH_CONSUMER_KEY")
         expected_outcome_params = LTIOutcomesRequestParams(
-            consumer_key="TEST_OAUTH_CONSUMER_KEY",
-            shared_secret=ai_getter.shared_secret.return_value,
             lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
             lis_result_sourcedid="modelstudent-assignment1",
         )
@@ -128,14 +114,10 @@ class TestReadResult:
 
 
 class TestRecordResult:
-    def test_it_records_result(self, ai_getter, pyramid_request, lti_outcomes_client):
-
+    def test_it_records_result(self, pyramid_request, lti_outcomes_client):
         LTIOutcomesViews(pyramid_request).record_result()
 
-        ai_getter.shared_secret.assert_called_once_with("TEST_OAUTH_CONSUMER_KEY")
         expected_outcome_params = LTIOutcomesRequestParams(
-            consumer_key="TEST_OAUTH_CONSUMER_KEY",
-            shared_secret=ai_getter.shared_secret.return_value,
             lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
             lis_result_sourcedid="modelstudent-assignment1",
         )
@@ -159,11 +141,4 @@ class TestRecordResult:
 def lti_outcomes_client(pyramid_config):
     svc = mock.create_autospec(LTIOutcomesClient, instance=True, spec_set=True)
     pyramid_config.register_service(svc, name="lti_outcomes_client")
-    return svc
-
-
-@pytest.fixture(autouse=True)
-def ai_getter(pyramid_config):
-    svc = mock.create_autospec(ApplicationInstanceGetter, instance=True, spec_set=True)
-    pyramid_config.register_service(svc, name="ai_getter")
     return svc


### PR DESCRIPTION
 * The new OAuth1 service now encapsulates the secret and oauth key
 * This pulls it out of the objects which everyone was passing about
 * This is part of the work to eliminate the LTIOutcomesRequestParams object