### PR TITLE
Renaming LISResultSourcedId to GroupInfo

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,6 +1,6 @@
 from lms.models.application_instance import ApplicationInstance
+from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
-from lms.models.lis_result_sourcedid import LISResultSourcedId
 from lms.models.lti_launches import LtiLaunches
 from lms.models.module_item_configuration import ModuleItemConfiguration
 from lms.models.oauth2_token import OAuth2Token
@@ -8,7 +8,7 @@ from lms.models.oauth2_token import OAuth2Token
 __all__ = (
     "ApplicationInstance",
     "GroupInfo",
-    "LISResultSourcedId",
+    "GradingInfo",
     "LtiLaunches",
     "ModuleItemConfiguration",
     "OAuth2Token",

--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -4,10 +4,10 @@ import sqlalchemy as sa
 
 from lms.db import BASE
 
-__all__ = ["LISResultSourcedId"]
+__all__ = ["GradingInfo"]
 
 
-class LISResultSourcedId(BASE):
+class GradingInfo(BASE):
     """
     A record of a student's launch of a Hypothesis-configured LMS assignment.
 

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -42,8 +42,7 @@ def includeme(config):
         "lms.services.launch_verifier.LaunchVerifier", name="launch_verifier"
     )
     config.register_service_factory(
-        "lms.services.lis_result_sourcedid.LISResultSourcedIdService",
-        name="lis_result_sourcedid",
+        "lms.services.grading_info.GradingInfoService", name="grading_info",
     )
     config.register_service_factory(
         "lms.services.lti_outcomes.LTIOutcomesClient", name="lti_outcomes_client"

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -84,11 +84,11 @@ class BasicLTILaunchViews:
         lti_user = request.lti_user
 
         # TODO! - Change this test to `requires_student_navigation` rather than
-        # `is_launched_by_canvas`. LISResultSourcedId objects are stored to
+        # `is_launched_by_canvas`. GradingInfo objects are stored to
         # enable student navigation, which Canvas happens not to require.
         if not lti_user.is_instructor and not self.is_launched_by_canvas():
             # Create or update a record of LIS result data for a student launch
-            request.find_service(name="lis_result_sourcedid").upsert_from_request(
+            request.find_service(name="grading_info").upsert_from_request(
                 request, h_user=self.context.h_user, lti_user=lti_user
             )
 
@@ -361,7 +361,7 @@ class BasicLTILaunchViews:
             # of the experience can still work.
             display_name = "(Couldn't fetch student name)"
 
-        # TODO! - Could/should this be replaced with a LISResultSourcedId lookup?
+        # TODO! - Could/should this be replaced with a GradingInfo lookup?
         self.context.hypothesis_config.update(
             {"focus": {"user": {"username": focused_user, "displayName": display_name}}}
         )

--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -25,14 +25,15 @@ def configure_grading(request, js_config):
     js_config["grading"] = {
         "courseName": request.params.get("context_title"),
         "assignmentName": request.params.get("resource_link_title"),
+        # TODO! - Rename this in the front end?
         "students": [
             {
                 "userid": h_user.userid,
                 "displayName": h_user.display_name,
-                "LISResultSourcedId": student.lis_result_sourcedid,
-                "LISOutcomeServiceUrl": student.lis_outcome_service_url,
+                "LISResultSourcedId": grading_info.lis_result_sourcedid,
+                "LISOutcomeServiceUrl": grading_info.lis_outcome_service_url,
             }
-            for student, h_user in _students_for_assignment(
+            for grading_info, h_user in _grading_info_for_assignment(
                 context_id=request.params.get("context_id"),
                 resource_link_id=request.params.get("resource_link_id"),
                 request=request,
@@ -41,18 +42,18 @@ def configure_grading(request, js_config):
     }
 
 
-def _students_for_assignment(context_id, resource_link_id, request):
-    service = request.find_service(name="lis_result_sourcedid")
+def _grading_info_for_assignment(context_id, resource_link_id, request):
+    service = request.find_service(name="grading_info")
 
-    for student in service.fetch_students_by_assignment(
+    for grading_info in service.get_by_assignment(
         oauth_consumer_key=request.lti_user.oauth_consumer_key,
         context_id=context_id,
         resource_link_id=resource_link_id,
     ):
-        yield student, HUser(
+        yield grading_info, HUser(
             authority=request.registry.settings["h_authority"],
-            username=student.h_username,
-            display_name=student.h_display_name,
+            username=grading_info.h_username,
+            display_name=grading_info.h_display_name,
         )
 
 

--- a/tests/unit/lms/models/grading_info_test.py
+++ b/tests/unit/lms/models/grading_info_test.py
@@ -1,15 +1,15 @@
 import pytest
 import sqlalchemy.exc
 
-from lms.models import ApplicationInstance, LISResultSourcedId
+from lms.models import ApplicationInstance, GradingInfo
 
 
-class TestLISResultSourcedId:
+class TestGradingInfo:
     def test_it_persists_and_returns_attrs(
-        self, application_instance, db_session, lis_result_sourcedid
+        self, application_instance, db_session, grading_info
     ):
-        db_session.add(lis_result_sourcedid)
-        lrs = db_session.query(LISResultSourcedId).one()
+        db_session.add(grading_info)
+        lrs = db_session.query(GradingInfo).one()
 
         assert lrs.lis_result_sourcedid == "result_sourcedid"
         assert lrs.lis_outcome_service_url == "https://somewhere.else"
@@ -35,10 +35,10 @@ class TestLISResultSourcedId:
         ],
     )
     def test_it_enforces_non_nullable_field_presence(
-        self, db_session, lis_result_sourcedid, non_nullable_field
+        self, db_session, grading_info, non_nullable_field
     ):
-        setattr(lis_result_sourcedid, non_nullable_field, None)
-        db_session.add(lis_result_sourcedid)
+        setattr(grading_info, non_nullable_field, None)
+        db_session.add(grading_info)
         with pytest.raises(
             sqlalchemy.exc.IntegrityError,
             match=f'null value in column "{non_nullable_field}" violates not-null constraint',
@@ -46,10 +46,10 @@ class TestLISResultSourcedId:
             db_session.flush()
 
     def test_it_enforces_uniqueness_constraint(
-        self, lis_result_sourcedid, lis_result_duplicate_sourcedid, db_session
+        self, grading_info, grading_info_duplicate, db_session
     ):
-        db_session.add(lis_result_sourcedid)
-        db_session.add(lis_result_duplicate_sourcedid)
+        db_session.add(grading_info)
+        db_session.add(grading_info_duplicate)
 
         with pytest.raises(
             sqlalchemy.exc.IntegrityError,
@@ -59,7 +59,7 @@ class TestLISResultSourcedId:
 
     @pytest.fixture
     def application_instance(self, db_session):
-        """The ApplicationInstance that the LISResultSourcedIds belong to"""
+        """The ApplicationInstance that the GradingInfos belong to"""
         application_instance = ApplicationInstance(
             consumer_key="test_consumer_key",
             shared_secret="test_shared_secret",
@@ -70,29 +70,29 @@ class TestLISResultSourcedId:
         return application_instance
 
     @pytest.fixture
-    def lis_result_sourcedid(self, application_instance):
-        return LISResultSourcedId(
-            lis_result_sourcedid="result_sourcedid",
-            lis_outcome_service_url="https://somewhere.else",
-            oauth_consumer_key=application_instance.consumer_key,
-            user_id="339483948",
-            context_id="random context",
-            resource_link_id="random resource link id",
-            tool_consumer_info_product_family_code="MyFakeLTITool",
-            h_username="ltiuser1",
-            h_display_name="My Fake LTI User",
+    def grading_info(self, grading_info_params):
+        return GradingInfo(**grading_info_params)
+
+    @pytest.fixture
+    def grading_info_duplicate(self, grading_info_params):
+        return GradingInfo(
+            **dict(
+                grading_info_params,
+                lis_result_sourcedid="result_sourcedid_another",
+                lis_outcome_service_url="https://somewhere.else_yet",
+            )
         )
 
     @pytest.fixture
-    def lis_result_duplicate_sourcedid(self, application_instance):
-        return LISResultSourcedId(
-            lis_result_sourcedid="result_sourcedid_another",
-            lis_outcome_service_url="https://somewhere.else_yet",
-            oauth_consumer_key=application_instance.consumer_key,
-            user_id="339483948",
-            context_id="random context",
-            resource_link_id="random resource link id",
-            tool_consumer_info_product_family_code="MyFakeLTITool",
-            h_username="ltiuser1",
-            h_display_name="My Fake LTI User",
-        )
+    def grading_info_params(self, application_instance):
+        return {
+            "lis_result_sourcedid": "result_sourcedid",
+            "lis_outcome_service_url": "https://somewhere.else",
+            "oauth_consumer_key": application_instance.consumer_key,
+            "user_id": "339483948",
+            "context_id": "random context",
+            "resource_link_id": "random resource link id",
+            "tool_consumer_info_product_family_code": "MyFakeLTITool",
+            "h_username": "ltiuser1",
+            "h_display_name": "My Fake LTI User",
+        }

--- a/tests/unit/lms/services/__init___test.py
+++ b/tests/unit/lms/services/__init___test.py
@@ -3,10 +3,10 @@ import pytest
 from lms.services import includeme
 from lms.services.application_instance_getter import ApplicationInstanceGetter
 from lms.services.canvas_api import CanvasAPIClient
+from lms.services.grading_info import GradingInfoService
 from lms.services.group_info import GroupInfoService
 from lms.services.h_api import HAPI
 from lms.services.launch_verifier import LaunchVerifier
-from lms.services.lis_result_sourcedid import LISResultSourcedIdService
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 
@@ -19,7 +19,7 @@ class TestIncludeme:
             ("canvas_api_client", CanvasAPIClient),
             ("h_api", HAPI),
             ("launch_verifier", LaunchVerifier),
-            ("lis_result_sourcedid", LISResultSourcedIdService),
+            ("grading_info", GradingInfoService),
             ("lti_outcomes_client", LTIOutcomesClient),
             ("group_info", GroupInfoService),
             ("lti_h", LTIHService),


### PR DESCRIPTION
`LISResultSourcedId` is both confusing and misleading. The object is actually a compound of various pieces of data of which `lis_result_sourcedid` is only one. It's also completely hostile to understanding what the hell it is.

I've tried to fix everywhere referring to this but it's likely I've missed something. The LTI field is still called `lis_result_sourcedid` so that's still all over our code.