### PR TITLE
LTI Outcomes: Removing the value object and replacing with a single value

### DIFF
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -1,4 +1,3 @@
-from typing import NamedTuple
 from xml.parsers.expat import ExpatError
 
 import requests
@@ -7,22 +6,7 @@ from requests import RequestException
 
 from lms.services.exceptions import LTIOutcomesAPIError
 
-__all__ = ["LTIOutcomesClient", "LTIOutcomesRequestParams"]
-
-
-class LTIOutcomesRequestParams(NamedTuple):
-    """Common parameters used by all LTI Outcomes Management requests."""
-
-    lis_outcome_service_url: str
-    """URL to submit requests to, provided by the LMS during an LTI launch."""
-
-    lis_result_sourcedid: str
-    """
-    Opaque identifier for a particular submission.
-
-    This is provided by the LMS during an LTI launch and identifies the user
-    and assignment that the launch refers to.
-    """
+__all__ = ["LTIOutcomesClient"]
 
 
 class LTIOutcomesClient:
@@ -34,26 +18,25 @@ class LTIOutcomesClient:
 
     def __init__(self, _context, request):
         self.oauth1_service = request.find_service(name="oauth1")
+        self.service_url = request.parsed_params["lis_outcome_service_url"]
 
-    def read_result(self, outcomes_request_params):  # pylint:disable=no-self-use
+    def read_result(self, lis_result_sourced_id):  # pylint:disable=no-self-use
         """
         Return the last-submitted score for a given submission.
 
+        :param lis_result_sourced_id: The submission id
         :return: The last-submitted score or `None` if no score has been
                  submitted.
         """
 
         result = self._send_request(
-            outcomes_request_params,
-            request_body={
+            {
                 "readResultRequest": {
                     "resultRecord": {
-                        "sourcedGUID": {
-                            "sourcedId": outcomes_request_params.lis_result_sourcedid
-                        }
+                        "sourcedGUID": {"sourcedId": lis_result_sourced_id}
                     }
                 }
-            },
+            }
         )
 
         try:
@@ -64,19 +47,20 @@ class LTIOutcomesClient:
             return None
 
     def record_result(  # pylint:disable=no-self-use
-        self, outcomes_request_params, score=None, **canvas_extras,
+        self, lis_result_sourced_id, score=None, **canvas_extras,
     ):
         """
-        Record a score or grading view launch URL for an assignment in the LMS.
+        Set the score or content URL for a student submission to an assignment.
 
-        :arg score:
+        :param lis_result_sourced_id: The submission id
+        :param score:
             Float value between 0 and 1.0.
             Defined as required by the LTI spec but is optional in Canvas if
             an `lti_launch_url` is set.
-        :arg lti_launch_url:
+        :param lti_launch_url:
             A URL where the student's work on this submission can be viewed.
             This is only used in Canvas.
-        :arg submitted_at:
+        :param submitted_at:
         :type datetime.datetime:
             A `datetime.datetime` that indicates when the submission was
             created. This is only used in Canvas and is displayed in the
@@ -86,11 +70,7 @@ class LTIOutcomesClient:
         """
 
         request = {
-            "resultRecord": {
-                "sourcedGUID": {
-                    "sourcedId": outcomes_request_params.lis_result_sourcedid
-                }
-            }
+            "resultRecord": {"sourcedGUID": {"sourcedId": lis_result_sourced_id}}
         }
 
         if score:
@@ -101,9 +81,7 @@ class LTIOutcomesClient:
         # Canvas specific adaptations
         self._canvas_request_modification(request, **canvas_extras)
 
-        self._send_request(
-            outcomes_request_params, request_body={"replaceResultRequest": request}
-        )
+        self._send_request({"replaceResultRequest": request})
 
     @classmethod
     def _canvas_request_modification(
@@ -120,7 +98,7 @@ class LTIOutcomesClient:
         if submitted_at:
             request["submissionDetails"] = {"submittedAt": submitted_at.isoformat()}
 
-    def _send_request(self, outcomes_request_params, request_body):
+    def _send_request(self, request_body):
         """
         Send a signed request to an LMS's Outcome Management Service endpoint.
 
@@ -137,7 +115,7 @@ class LTIOutcomesClient:
 
         try:
             response = requests.post(
-                url=outcomes_request_params.lis_outcome_service_url,
+                url=self.service_url,
                 data=xml_body,
                 headers={"Content-Type": "application/xml"},
                 auth=self.oauth1_service.get_client(),

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -20,11 +20,11 @@ class LTIOutcomesClient:
         self.oauth1_service = request.find_service(name="oauth1")
         self.service_url = request.parsed_params["lis_outcome_service_url"]
 
-    def read_result(self, lis_result_sourced_id):  # pylint:disable=no-self-use
+    def read_result(self, lis_result_sourcedid):  # pylint:disable=no-self-use
         """
         Return the last-submitted score for a given submission.
 
-        :param lis_result_sourced_id: The submission id
+        :param lis_result_sourcedid: The submission id
         :return: The last-submitted score or `None` if no score has been
                  submitted.
         """
@@ -32,9 +32,7 @@ class LTIOutcomesClient:
         result = self._send_request(
             {
                 "readResultRequest": {
-                    "resultRecord": {
-                        "sourcedGUID": {"sourcedId": lis_result_sourced_id}
-                    }
+                    "resultRecord": {"sourcedGUID": {"sourcedId": lis_result_sourcedid}}
                 }
             }
         )
@@ -47,12 +45,12 @@ class LTIOutcomesClient:
             return None
 
     def record_result(  # pylint:disable=no-self-use
-        self, lis_result_sourced_id, score=None, **canvas_extras,
+        self, lis_result_sourcedid, score=None, **canvas_extras,
     ):
         """
         Set the score or content URL for a student submission to an assignment.
 
-        :param lis_result_sourced_id: The submission id
+        :param lis_result_sourcedid: The submission id
         :param score:
             Float value between 0 and 1.0.
             Defined as required by the LTI spec but is optional in Canvas if
@@ -69,9 +67,7 @@ class LTIOutcomesClient:
             rather than creating a new submission.
         """
 
-        request = {
-            "resultRecord": {"sourcedGUID": {"sourcedId": lis_result_sourced_id}}
-        }
+        request = {"resultRecord": {"sourcedGUID": {"sourcedId": lis_result_sourcedid}}}
 
         if score:
             request["resultRecord"]["result"] = {

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -3,7 +3,6 @@ from datetime import timezone
 
 from pyramid.view import view_config, view_defaults
 
-from lms.services.lti_outcomes import LTIOutcomesRequestParams
 from lms.validation import (
     APIReadResultSchema,
     APIRecordResultSchema,
@@ -20,17 +19,13 @@ class LTIOutcomesViews:
         self.parsed_params = self.request.parsed_params
         self.lti_outcomes_client = self.request.find_service(name="lti_outcomes_client")
 
-        self.outcome_request_params = LTIOutcomesRequestParams(
-            lis_outcome_service_url=self.parsed_params["lis_outcome_service_url"],
-            lis_result_sourcedid=self.parsed_params["lis_result_sourcedid"],
-        )
-
     @view_config(route_name="lti_api.result.record", schema=APIRecordResultSchema)
     def record_result(self):
         """Proxy result (grade/score) to LTI Outcomes Result API."""
 
-        self.request.find_service(name="lti_outcomes_client").record_result(
-            self.outcome_request_params, score=self.request.parsed_params["score"]
+        self.lti_outcomes_client.record_result(
+            self.parsed_params["lis_result_sourcedid"],
+            score=self.parsed_params["score"],
         )
 
         return {}
@@ -43,9 +38,9 @@ class LTIOutcomesViews:
     def read_result(self):
         """Proxy request for current result (grade/score) to LTI Outcomes Result API."""
 
-        current_score = self.request.find_service(
-            name="lti_outcomes_client"
-        ).read_result(self.outcome_request_params)
+        current_score = self.lti_outcomes_client.read_result(
+            self.parsed_params["lis_result_sourcedid"]
+        )
 
         return {"currentScore": current_score}
 
@@ -76,9 +71,11 @@ class LTIOutcomesViews:
         # graded (Canvas's result-reading API doesn't allow us to distinguish
         # absence of a submission from an ungraded submission. Non-Canvas LMSes in
         # theory require a grade).
-        current_score = self.lti_outcomes_client.read_result(
-            self.outcome_request_params
-        )
+
+        lis_result_sourced_id = self.parsed_params["lis_result_sourcedid"]
+
+        current_score = self.lti_outcomes_client.read_result(lis_result_sourced_id)
+
         if current_score is None:
             # **WARNING**
             #
@@ -106,7 +103,7 @@ class LTIOutcomesViews:
             )
 
             self.lti_outcomes_client.record_result(
-                self.outcome_request_params,
+                lis_result_sourced_id,
                 lti_launch_url=speedgrader_launch_url,
                 submitted_at=datetime.datetime(2001, 1, 1, tzinfo=timezone.utc),
             )

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -72,9 +72,9 @@ class LTIOutcomesViews:
         # absence of a submission from an ungraded submission. Non-Canvas LMSes in
         # theory require a grade).
 
-        lis_result_sourced_id = self.parsed_params["lis_result_sourcedid"]
+        lis_result_sourcedid = self.parsed_params["lis_result_sourcedid"]
 
-        current_score = self.lti_outcomes_client.read_result(lis_result_sourced_id)
+        current_score = self.lti_outcomes_client.read_result(lis_result_sourcedid)
 
         if current_score is None:
             # **WARNING**
@@ -103,7 +103,7 @@ class LTIOutcomesViews:
             )
 
             self.lti_outcomes_client.record_result(
-                lis_result_sourced_id,
+                lis_result_sourcedid,
                 lti_launch_url=speedgrader_launch_url,
                 submitted_at=datetime.datetime(2001, 1, 1, tzinfo=timezone.utc),
             )

--- a/tests/unit/lms/views/api/lti_test.py
+++ b/tests/unit/lms/views/api/lti_test.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 
 import pytest
 
-from lms.services.lti_outcomes import LTIOutcomesClient, LTIOutcomesRequestParams
+from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.views.api.lti import LTIOutcomesViews
 
 
@@ -16,10 +16,7 @@ class TestRecordCanvasSpeedgraderSubmission:
         LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
 
         lti_outcomes_client.read_result.assert_called_once_with(
-            LTIOutcomesRequestParams(
-                lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
-                lis_result_sourcedid="modelstudent-assignment1",
-            )
+            "modelstudent-assignment1"
         )
 
     def test_it_does_not_record_result_if_score_already_exists(
@@ -53,16 +50,12 @@ class TestRecordCanvasSpeedgraderSubmission:
 
         LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
 
-        expected_outcome_params = LTIOutcomesRequestParams(
-            lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
-            lis_result_sourcedid="modelstudent-assignment1",
-        )
         expected_submitted_at = datetime.datetime(2001, 1, 1, tzinfo=timezone.utc)
         expected_launch_url = "http://example.com/lti_launches?" + urlencode(
             {"focused_user": "user123", **lti_launch_doc_params}
         )
         lti_outcomes_client.record_result.assert_called_once_with(
-            expected_outcome_params,
+            "modelstudent-assignment1",
             lti_launch_url=expected_launch_url,
             submitted_at=expected_submitted_at,
         )
@@ -89,11 +82,9 @@ class TestReadResult:
     def test_it_proxies_to_read_result(self, pyramid_request, lti_outcomes_client):
         LTIOutcomesViews(pyramid_request).read_result()
 
-        expected_outcome_params = LTIOutcomesRequestParams(
-            lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
-            lis_result_sourcedid="modelstudent-assignment1",
+        lti_outcomes_client.read_result.assert_called_once_with(
+            "modelstudent-assignment1"
         )
-        lti_outcomes_client.read_result.assert_called_once_with(expected_outcome_params)
 
     def test_it_returns_current_score(self, pyramid_request, lti_outcomes_client):
         lti_outcomes_client.read_result.return_value = 0.5
@@ -117,12 +108,8 @@ class TestRecordResult:
     def test_it_records_result(self, pyramid_request, lti_outcomes_client):
         LTIOutcomesViews(pyramid_request).record_result()
 
-        expected_outcome_params = LTIOutcomesRequestParams(
-            lis_outcome_service_url="https://hypothesis.shinylms.com/outcomes",
-            lis_result_sourcedid="modelstudent-assignment1",
-        )
         lti_outcomes_client.record_result.assert_called_once_with(
-            expected_outcome_params, score=pyramid_request.parsed_params["score"]
+            "modelstudent-assignment1", score=pyramid_request.parsed_params["score"]
         )
 
     @pytest.fixture


### PR DESCRIPTION
Generally the service URL doesn't change for an installation. Therefore
the only variable variable here is 'lis_result_sourcedid'.

This simplifies the callers a lot, which still making it obvious where
the critical part of information is coming from.