### PR TITLE
Pulling all Canvas specific grading logic from the services to the views

### DIFF
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -50,15 +50,17 @@ class LTIOutcomesClient:
         """
         Set the score or content URL for a student submission to an assignment.
 
-        This method also accepts a callback hook which will be passed the
-        `score` and the `request_body` which it can modify and must return.
+        This method also accepts an optional callable hook which will be passed
+        the `score` and the `request_body` which it can modify and must return.
+        This allows support for extensions (or custom replacements) to the
+        standard LTI outcomes body.
 
         :param lis_result_sourcedid: The submission id
         :param score:
             Float value between 0 and 1.0.
             Defined as required by the LTI spec but is optional in Canvas if
             an `lti_launch_url` is set.
-        :param pre_record_hook: The call back
+        :param pre_record_hook: Hook to allow modification of the request
         """
 
         request = {"resultRecord": {"sourcedGUID": {"sourcedId": lis_result_sourcedid}}}

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -45,26 +45,20 @@ class LTIOutcomesClient:
             return None
 
     def record_result(  # pylint:disable=no-self-use
-        self, lis_result_sourcedid, score=None, **canvas_extras,
+        self, lis_result_sourcedid, score=None, pre_record_hook=None,
     ):
         """
         Set the score or content URL for a student submission to an assignment.
+
+        This method also accepts a callback hook which will be passed the
+        `score` and the `request_body` which it can modify and must return.
 
         :param lis_result_sourcedid: The submission id
         :param score:
             Float value between 0 and 1.0.
             Defined as required by the LTI spec but is optional in Canvas if
             an `lti_launch_url` is set.
-        :param lti_launch_url:
-            A URL where the student's work on this submission can be viewed.
-            This is only used in Canvas.
-        :param submitted_at:
-        :type datetime.datetime:
-            A `datetime.datetime` that indicates when the submission was
-            created. This is only used in Canvas and is displayed in the
-            SpeedGrader as the submission date. If the submission date matches
-            an existing submission then the existing submission is updated
-            rather than creating a new submission.
+        :param pre_record_hook: The call back
         """
 
         request = {"resultRecord": {"sourcedGUID": {"sourcedId": lis_result_sourcedid}}}
@@ -74,25 +68,15 @@ class LTIOutcomesClient:
                 "resultScore": {"language": "en", "textString": score}
             }
 
-        # Canvas specific adaptations
-        self._canvas_request_modification(request, **canvas_extras)
+        if pre_record_hook:
+            request = pre_record_hook(score=score, request_body=request)
+
+            if not isinstance(request, dict):
+                raise TypeError(
+                    "The pre-record hook must return the request body as a dict"
+                )
 
         self._send_request({"replaceResultRequest": request})
-
-    @classmethod
-    def _canvas_request_modification(
-        cls, request, lti_launch_url=None, submitted_at=None, **_
-    ):
-        # For details of Canvas extensions see:
-        # https://erau.instructure.com/doc/api/file.assignment_tools.html
-
-        if lti_launch_url:
-            request["resultRecord"].setdefault("result", {})["resultData"] = {
-                "ltiLaunchUrl": lti_launch_url
-            }
-
-        if submitted_at:
-            request["submissionDetails"] = {"submittedAt": submitted_at.isoformat()}
 
     def _send_request(self, request_body):
         """

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -76,7 +76,7 @@ class LTIOutcomesViews:
 
         # If we already have a score, then we've already recorded this info
         if self.lti_outcomes_client.read_result(lis_result_sourcedid):
-            return
+            return None
 
         self.lti_outcomes_client.record_result(
             lis_result_sourcedid, pre_record_hook=CanvasPreRecordHook(self.request)


### PR DESCRIPTION
Must be merged after https://github.com/hypothesis/lms/pull/1298.

This works by having a callback we pass into the record function which allows us to modify the request.

Some interesting insights as a result of putting the code in the same place so we can see it:

  * We were treating the `ltiLaunchUrl` and `submittedAt` values as independent
    * In truth you get both or you don't get called
  * We were treating the `submittedAt` value like a variable
    * In truth we always set the exact same value

None of this is obvious when the code dealing with this was in two places.