### PR TITLE
Add grader to handle null grade values

### DIFF
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -46,7 +46,9 @@ const useFetchGrade = student => {
         const response = await fetchGrade({ student, authToken });
         if (!didCancel) {
           // Only set these values if we didn't cancel this request
-          setGrade(scaleGrade(response.currentScore, GRADE_MULTIPLIER));
+          if (response.currentScore) {
+            setGrade(scaleGrade(response.currentScore, GRADE_MULTIPLIER));
+          }
           setGradeLoading(false);
         }
       };

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -189,6 +189,13 @@ describe('SubmitGradeForm', () => {
   });
 
   context('when fetching a grade', () => {
+    it('sets the defaultValue prop to an empty string if the grade is falsey', async () => {
+      fakeFetchGrade.resolves({ currentScore: null });
+      const wrapper = renderForm();
+      await waitFor(() => !isFetchingGrade(wrapper));
+      assert.equal(wrapper.find('input').prop('defaultValue'), '');
+    });
+
     it("sets the input defaultValue prop to the student's grade", async () => {
       const wrapper = renderForm();
       await waitFor(() => !isFetchingGrade(wrapper));


### PR DESCRIPTION
When building the grader, I made the assumption that the currentGrade value from the service layer would always be a number, this was a false assumption. It can now handle a null or missing value. 

I was able to test this on blackboard by clearing out any previous student grades, then I was able to repro to error. Once I applied this fix, then that error was resolved and the UI worked.

Fixes https://github.com/hypothesis/lms/issues/1342