### PR TITLE
Fix macOS fork child process crash

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ deps =
 setenv =
     tests: JWT_SECRET = test_secret
     tests: VIA_URL = https://example.com/
+    OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 whitelist_externals =
     tests: sh
 commands =


### PR DESCRIPTION
Fix a crash with the web process in macOS development environments that
outputs this error message:

    objc[11433]: +[__NSPlaceholderDate initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.

This is due to an issue with recent versions of macOS that breaks all
sorts of things (Python, Ruby, Postgres, ...). Googling the error
message, setting `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` in
every thread or post about it.

Some good posts about the issue are:

* https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
* https://www.wefearchange.org/2018/11/forkmacos.rst.html
* http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html

Fixes https://github.com/hypothesis/lms/issues/1348