### PR TITLE
Upgrade the dev env to Postgres 11.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   postgres:
-    image: postgres:9.4-alpine
+    image: postgres:11.5-alpine
     ports:
       - '127.0.0.1:5433:5432'


### PR DESCRIPTION
11.5 is the version of Postgres that we're currently using in
production.

For developers:

* Before you `git pull` this commit, backup your DB to a `dump.sql` file:

      .tox/docker-compose/bin/docker-compose exec postgres pg_dump -U postgres postgres > dump.sql

* If you already have `make services` running then `make dev` will
  continue using Postgres 9.4 and your existing data

* But the next time you run `make services`, though, it will recreate
  your DB as a Postgres 11.5 DB. At this point your DB will be broken
  because it's a Postgres 11.5 DB with Postgres 9.4 contents. `make dev`
  will fail.

* You need to delete your DB contents and allow them to be created from
  scratch again, to get it working:

      make services args='down'
      make services

* You now have a working Postgres 11.5 DB but its contents are empty.

* You can restore the standard dev data by running `make devdata`

* **Or** you can restore your entire DB contents from the `dump.sql`
file that you made above by running:

      .tox/docker-compose/bin/docker-compose exec -T postgres psql -U postgres < dump.sql

* You can test whether you've successfully upgraded to 11.5 by running:

      .tox/docker-compose/bin/docker-compose exec postgres psql -U postgres -d postgres -c 'select version();'

See also:

* [How can I backup and restore my development database?](https://stackoverflow.com/c/hypothesis/questions/188/189)

* [How do I use docker-compose?](https://stackoverflow.com/c/hypothesis/questions/186)
 upgrade-to-postgres-11.5-in-dev (#5897)