### PR TITLE
Set `SameSite=None` attribute on feature flag cookie

### DIFF
--- a/lms/extensions/feature_flags/_helpers.py
+++ b/lms/extensions/feature_flags/_helpers.py
@@ -55,7 +55,12 @@ class JWTCookieHelper:
             jwt_bytes,
             max_age=31536000,  # One year in seconds.
             overwrite=True,
-            secure=not self._request.registry.settings.get("debug", False),
+            # We want this cookie to be sent when the LMS app is loaded inside
+            # an iframe, and thus in a third-party context, from within the LMS.
+            samesite="None",
+            # Setting `SameSite="None"` requires that we also set the `Secure`
+            # flag per https://tools.ietf.org/html/draft-west-cookie-incrementalism-00#section-3.2.
+            secure=True,
         )
 
     def get(self):


### PR DESCRIPTION
Feature flag cookies are set in a first-party context from the `/flags`
form but we want them to be send when the LMS app is loaded in an
iframe, in a third-party context, inside the LMS.

Per the recipes at [1] and [2], this requires setting `SameSite=None; Secure` on
the cookie. This requirement is expected to be enforced in Chrome starting in February 2020 with Chrome 80: https://www.chromium.org/updates/same-site.

[1] https://web.dev/samesite-cookie-recipes/
[2] https://tools.ietf.org/html/draft-west-cookie-incrementalism-00#section-3.2

**Important caveat**

The `Secure` flag means that this cookie will no longer be sent over plain
HTTP connections. That will not be a problem in QA and prod but unless browsers implement
an exception for localhost, which I'm not aware they do, this will make this method of setting
feature flags unavailable in development if serving the lms app over HTTP. In that case a different
method of enabling the flag will have to be used.

As a result, if you are testing this by running the lms app with `make dev` and trying to set the flag at http://localhost:8001/flags, when you submit the form the 302 response will include the correct `Set-Cookie` header but Chrome will show a warning indicator next to it and on hover show a message indicating that it has been ignored.

This means that the `/flags` page effectively breaks if you are testing over HTTP, but you can verify that the correct `Set-Cookie` header was returned at least. 

