### PR TITLE
Make the LMS file selection dialog user at smaller heights

### DIFF
--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -3,6 +3,13 @@ $file-list-icon-size: 24px;
 
 .FileList {
   position: relative;
+
+  display: flex;
+  flex-direction: column;
+
+  // Override the default minimum height of the table so that the file list
+  // is fully visible even if available height is very small.
+  min-height: 100px;
 }
 
 .FileList__spinner {

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -8,7 +8,6 @@ $table-icon-size: 24px;
 // Wrapper around the table. This is used because table elements do not support
 // setting the `height` or `overflow` properties directly.
 .Table__wrapper {
-  height: 7 * $table-item-height;
   overflow: auto;
   border: 1px solid var.$grey-6;
 


### PR DESCRIPTION
Enable the file selection dialog to work with a wider range of available
window heights by:

 - Removing the fixed 280px (7 * $table-item-height) height assigned to the
   table
 - Using a flex column layout to make the file list expand/shrink to fit
   its contents and overriding the default computed minimum height,
   which is based on the table's content, so that the table can shrink
   if necessary

This fixes an issue where the Canvas file picker dialog was getting cut
off in Canvas because the assignment selection iframe was only 340px
high. It now works:

<img width="690" alt="Screenshot 2020-02-03 12 38 53" src="https://user-images.githubusercontent.com/2458/73654181-f2b71900-4682-11ea-9401-7195f8fabdda.png">

Fixes #1416