### PR TITLE
Move rpc_server_config into js_config

### DIFF
--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -185,7 +185,16 @@ class LTILaunchResource:
         """
         if self._js_config is None:
             # Initialize self._js_config for the first time.
-            self._js_config = {"urls": {}}
+            self._js_config = {
+                # The config object for the postMessage-JSON-RPC server.
+                "rpcServer": {
+                    "allowedOrigins": self._request.registry.settings[
+                        "rpc_allowed_origins"
+                    ],
+                },
+                # URLs for the frontend to use (e.g. API endpoints for it to call).
+                "urls": {},
+            }
 
             if self._request.lti_user:
                 self._js_config["authToken"] = BearerTokenSchema(
@@ -246,12 +255,6 @@ class LTILaunchResource:
             }
 
         return self._hypothesis_config
-
-    @property
-    def rpc_server_config(self):
-        """Return the config object for the JSON-RPC server."""
-        allowed_origins = self._request.registry.settings["rpc_allowed_origins"]
-        return {"allowedOrigins": allowed_origins}
 
     @property
     def provisioning_enabled(self):

--- a/lms/static/scripts/postmessage_json_rpc/server/server-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server-test.js
@@ -15,9 +15,11 @@ describe('postmessage_json_rpc/server#Server', () => {
   beforeEach('inject the server config into the document', () => {
     configEl = document.createElement('script');
     configEl.setAttribute('type', 'application/json');
-    configEl.classList.add('js-rpc-server-config');
+    configEl.classList.add('js-lms-config');
     configEl.textContent = JSON.stringify({
-      allowedOrigins: ['http://localhost:9876'],
+      rpcServer: {
+        allowedOrigins: ['http://localhost:9876'],
+      },
     });
     document.body.appendChild(configEl);
   });

--- a/lms/static/scripts/postmessage_json_rpc/server/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server.js
@@ -4,8 +4,10 @@
  * On creation the server automatically finds and reads its config settings
  * from a JSON config object in the document. For example:
  *
- *     <script type="application/json" class="js-rpc-server-config">
- *       { allowedOrigins: ["https://hypothes.is"] }
+ *     <script type="application/json" class="js-lms-config">
+ *       {
+ *         rpcServer: { allowedOrigins: ["https://hypothes.is"] }
+ *       }
  *     </script>
  *
  * After constructing a server you have to call its register() method to
@@ -20,8 +22,8 @@
  */
 export default class Server {
   constructor() {
-    const configEl = document.getElementsByClassName('js-rpc-server-config')[0];
-    const configObj = JSON.parse(configEl.textContent);
+    const configEl = document.getElementsByClassName('js-lms-config')[0];
+    const configObj = JSON.parse(configEl.textContent).rpcServer;
 
     // JSON-RPC messages that don't come from one of these allowed window
     // origins will be ignored.

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -38,10 +38,6 @@
         <script type="application/json" class="js-lms-config">{{ context.js_config|tojson }}</script>
       {% endif %}
 
-      {% if context.rpc_server_config is defined %}
-        <script type="application/json" class="js-rpc-server-config">{{ context.rpc_server_config|tojson }}</script>
-      {% endif %}
-
       {% if context.hypothesis_config is defined %}
         {# passes config to the sidebar #}
         <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson }}</script>

--- a/tests/unit/lms/resources/_lti_launch_test.py
+++ b/tests/unit/lms/resources/_lti_launch_test.py
@@ -303,6 +303,11 @@ class TestLTILaunchResource:
 
         assert userid == "acct:2569ad7b99f316ecc7dfee5c0c801c@TEST_AUTHORITY"
 
+    def test_js_config_includes_the_rpc_server_config(self, lti_launch):
+        assert lti_launch.js_config["rpcServer"] == {
+            "allowedOrigins": ["http://localhost:5000"]
+        }
+
     def test_js_config_includes_the_urls(self, pyramid_request):
         js_config = LTILaunchResource(pyramid_request).js_config
 
@@ -415,11 +420,6 @@ class TestLTILaunchResource:
         lti_launch.hypothesis_config.update({"a_key": "a_value"})
 
         assert lti_launch.hypothesis_config["a_key"] == "a_value"
-
-    def test_rpc_server_config(self, lti_launch):
-        assert lti_launch.rpc_server_config == {
-            "allowedOrigins": ["http://localhost:5000"]
-        }
 
     def test_provisioning_enabled_checks_whether_provisioning_is_enabled_for_the_request(
         self, ai_getter, lti_launch, pyramid_request


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/1386.

We want to simplify our JavaScript config by merging multiple separate
JavaScript config objects into one nested object.

How it currently works (before this commit)
-------------------------------------------

The backend currently has an `LTILaunchResource.rpc_server_config`
property:
https://github.com/hypothesis/lms/blob/1f10d599e5e2502a4bfbde023da35e852729788e/lms/resources/_lti_launch.py#L250-L254

The `rpc_server_config` property contains the config settings for the
JavaScript JSON-RPC server:
https://github.com/hypothesis/lms/blob/master/lms/static/scripts/postmessage_json_rpc/server/server.js

It gets rendered into the HTML as `"js-rpc-server-config"`:
https://github.com/hypothesis/lms/blob/1f10d599e5e2502a4bfbde023da35e852729788e/lms/templates/base.html.jinja2#L41-L43

The JSON-RPC server then reads this config from the HTML:
https://github.com/hypothesis/lms/blob/1f10d599e5e2502a4bfbde023da35e852729788e/lms/static/scripts/postmessage_json_rpc/server/server.js#L23

What this commit changes
------------------------

This commit merges `LTILaunchResource.rpc_server_config` into the
`LTILaunchResource.js_config` property, which is the "general" config
object for the frontend code.

The settings that were previously rpc_server_config are now an
`"rpc_server"` sub-dict within the dict that `js_config` returns.

The `"js-rpc-server-config"` object is no longer rendered into the HTML,
since the `"rpc_server"` config is now part of the `"js-lms-config"` that
already gets rendered:
https://github.com/hypothesis/lms/blob/1f10d599e5e2502a4bfbde023da35e852729788e/lms/templates/base.html.jinja2#L36-L39

Finally, the JSON-RPC server itself (`server.js`) is changed to read its
config from `js-lms-config["rpc_server"]` rather than from the old
`js-rpc-server-config`.

And a couple of tests need updating.

How to test this
----------------

Launch any assignment in Canvas and test that you're logged into your
Canvas account in the Hypothesis client. If the JSON-RPC server's config
wasn't working, you wouldn't be.