### PR TITLE
Specify the content type when sending JSON payloads

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -58,7 +58,7 @@ async function apiCall({ path, authToken, data }) {
   const result = await fetch(path, {
     method: data === undefined ? 'GET' : 'POST',
     body,
-    headers: headers,
+    headers,
   });
   const resultJson = await result.json();
 

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -47,16 +47,18 @@ export class ApiError extends Error {
  */
 async function apiCall({ path, authToken, data }) {
   let body;
+  const headers = {
+    Authorization: authToken,
+  };
   if (data !== undefined) {
     body = JSON.stringify(data);
+    headers['Content-Type'] = 'application/json; charset=UTF-8';
   }
 
   const result = await fetch(path, {
     method: data === undefined ? 'GET' : 'POST',
     body,
-    headers: {
-      Authorization: authToken,
-    },
+    headers: headers,
   });
   const resultJson = await result.json();
 

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -39,6 +39,7 @@ describe('api', () => {
         body: JSON.stringify(data),
         headers: {
           Authorization: 'auth',
+          'Content-Type': 'application/json; charset=UTF-8',
         },
       });
     });


### PR DESCRIPTION
This is a good idea, but mostly motivated by webargs no-longer accepting JSON content without it.

This is for: https://github.com/hypothesis/lms/issues/1441