### PR TITLE
Separate JSON schemas into their own class and check content type

### DIFF
--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -3,15 +3,13 @@
 import marshmallow
 from webargs import fields
 
-from lms.validation._base import PyramidRequestSchema
+from lms.validation._base import JSONPyramidRequestSchema, PyramidRequestSchema
 
 __all__ = ["APIRecordSpeedgraderSchema", "APIReadResultSchema", "APIRecordResultSchema"]
 
 
-class APIRecordSpeedgraderSchema(PyramidRequestSchema):
+class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
     """Schema for validating Canvas Speedgrader submissions from the front end."""
-
-    locations = ["json"]
 
     document_url = fields.Str()
     """URL of the document for this assignment."""
@@ -47,10 +45,8 @@ class APIReadResultSchema(PyramidRequestSchema):
     """
 
 
-class APIRecordResultSchema(PyramidRequestSchema):
+class APIRecordResultSchema(JSONPyramidRequestSchema):
     """Schema for validating proxy requests to LTI Outcomes API for recording grades."""
-
-    locations = ["json"]
 
     lis_outcome_service_url = fields.Str(required=True)
     """URL provided by the LMS to submit grades or other results to."""

--- a/lms/validation/_base.py
+++ b/lms/validation/_base.py
@@ -101,7 +101,8 @@ class JSONPyramidRequestSchema(PyramidRequestSchema):
 
     @pre_load
     def check_content_type(self, data, **_):
-        """Check the request has content type 'application/json'.
+        """
+        Check the request has content type 'application/json'.
 
         :raise HTTPUnsupportedMediaType: If the content type is wrong
         """

--- a/lms/validation/_base.py
+++ b/lms/validation/_base.py
@@ -110,7 +110,7 @@ class JSONPyramidRequestSchema(PyramidRequestSchema):
 
         if content_type != "application/json":
             raise HTTPUnsupportedMediaType(
-                f"Require Content-Type=application/json, found {content_type}"
+                f"Unexpected content type. Expected 'application/json' but found '{content_type}'",
             )
 
         return data

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -45,6 +45,10 @@ def pyramid_request(db_session):
         "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES"
     )
 
+    # The DummyRequest request lacks a content_type property which the real
+    # request has
+    pyramid_request.content_type = None
+
     return pyramid_request
 
 

--- a/tests/unit/lms/validation/_base_test.py
+++ b/tests/unit/lms/validation/_base_test.py
@@ -9,7 +9,7 @@ from lms.validation._base import JSONPyramidRequestSchema
 
 
 class TestJSONPyramidRequestSchema:
-    class TestingSchema(JSONPyramidRequestSchema):
+    class ExampleSchema(JSONPyramidRequestSchema):
         key = fields.Str()
 
     def test_it_reads_from_json_content(self):
@@ -21,7 +21,7 @@ class TestJSONPyramidRequestSchema:
         )
         request.content_type = "application/json"
 
-        assert self.TestingSchema(request).parse() == data
+        assert self.ExampleSchema(request).parse() == data
 
     @pytest.mark.parametrize("content_type", (None, "text/html"))
     def test_it_fails_without_json_content_type_header(self, content_type):
@@ -29,4 +29,4 @@ class TestJSONPyramidRequestSchema:
         request.content_type = content_type
 
         with pytest.raises(HTTPUnsupportedMediaType):
-            self.TestingSchema(request).parse()
+            self.ExampleSchema(request).parse()

--- a/tests/unit/lms/validation/_base_test.py
+++ b/tests/unit/lms/validation/_base_test.py
@@ -1,0 +1,32 @@
+import json
+
+import pytest
+from marshmallow import fields
+from pyramid.httpexceptions import HTTPUnsupportedMediaType
+from pyramid.testing import DummyRequest
+
+from lms.validation._base import JSONPyramidRequestSchema
+
+
+class TestJSONPyramidRequestSchema:
+    class TestingSchema(JSONPyramidRequestSchema):
+        key = fields.Str()
+
+    def test_it_reads_from_json_content(self):
+        data = {"key": "value"}
+
+        request = DummyRequest(
+            body=json.dumps(data),
+            headers={"Content-Type": "application/json; charset=UTF-8"},
+        )
+        request.content_type = "application/json"
+
+        assert self.TestingSchema(request).parse() == data
+
+    @pytest.mark.parametrize("content_type", (None, "text/html"))
+    def test_it_fails_without_json_content_type_header(self, content_type):
+        request = DummyRequest(body=json.dumps({}))
+        request.content_type = content_type
+
+        with pytest.raises(HTTPUnsupportedMediaType):
+            self.TestingSchema(request).parse()


### PR DESCRIPTION
 * Raise an exception when JSON payloads have wrong content type
 * Added a content_type to the base pyramid request object
 * Lots of changes to validation/_api_test.py to use a new fixture
   * This fixture is a JSON request which...
   * Sets the content type
   * Encodes the JSON content
 * Added the content type and some variations to the base tests

----

# To review

* Easiest is probably to login to canvas as a student
* Open an assigment and pop it into a new window
* Use the dev tools to look at network requests
* Filter by 'submissions' and copy the contents as a curl request
* Modify the content type to something other than application/json