### PR TITLE
Specify query string as the place to look for the Canvas OAuth schema

### DIFF
--- a/lms/validation/authentication/_oauth.py
+++ b/lms/validation/authentication/_oauth.py
@@ -67,6 +67,7 @@ class CanvasOAuthCallbackSchema(PyramidRequestSchema):
     session so that it can't be reused.
     """
 
+    locations = ["querystring"]
     code = fields.Str(required=True)
     state = fields.Str(required=True)
 


### PR DESCRIPTION
This is to head off problems with defaults changing in webargs.