### PR TITLE
Remove Via 3 and Via 2 feature flags and settings

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -21,7 +21,6 @@ oauth2_state_secret = "notasecret"
 
 # Set the default to Via 3 for dev (original via: 9080)
 via_url = http://localhost:9082
-via3_url = http://localhost:9082
 
 h_authority = lms.hypothes.is
 h_api_url_public = http://localhost:5000/api/

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -14,7 +14,6 @@ def configure(settings):
         # The URL of the https://github.com/hypothesis/via instance to
         # integrate with.
         "via_url": sg.get("VIA_URL"),
-        "via3_url": sg.get("VIA3_URL"),
         "jwt_secret": sg.get("JWT_SECRET"),
         "google_client_id": sg.get("GOOGLE_CLIENT_ID"),
         "google_developer_key": sg.get("GOOGLE_DEVELOPER_KEY"),
@@ -67,7 +66,6 @@ def configure(settings):
         env_settings["sqlalchemy.url"] = database_url
 
     env_settings["via_url"] = _append_trailing_slash(env_settings["via_url"])
-    env_settings["via3_url"] = _append_trailing_slash(env_settings["via3_url"])
     env_settings["h_api_url_public"] = _append_trailing_slash(
         env_settings["h_api_url_public"]
     )

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -40,10 +40,6 @@ def via_url(request, document_url):
     query_string = parse.urlencode(query_string_as_list)
 
     via_service_url = request.registry.settings["via_url"]
-    if request.feature("use_via3_url"):
-        via_service_url = request.registry.settings["via3_url"]
-    if request.feature("use_via2_html_rewriter"):
-        via_service_url += "html/"
 
     return via_service_url + parse.urlunparse(
         (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ TEST_DATABASE_URL = os.environ.get(
 TEST_SETTINGS = {
     "sqlalchemy.url": TEST_DATABASE_URL,
     "via_url": "http://TEST_VIA_SERVER.is/",
-    "via3_url": "http://TEST_VIA3_SERVER.is/",
     "jwt_secret": "test_secret",
     "google_client_id": "fake_client_id",
     "google_developer_key": "fake_developer_key",

--- a/tests/unit/lms/config/__init___test.py
+++ b/tests/unit/lms/config/__init___test.py
@@ -133,20 +133,6 @@ class TestConfigure:
 
         assert configurator.registry.settings["via_url"] == "https://via.hypothes.is/"
 
-    def test_trailing_slashes_are_appended_to_via3_url(self, setting_getter):
-        def side_effect(
-            envvar_name, *args, **kwargs
-        ):  # pylint: disable=unused-argument
-            if envvar_name == "VIA3_URL":
-                return "https://via3.hypothes.is"
-            return mock.DEFAULT
-
-        setting_getter.get.side_effect = side_effect
-
-        configurator = configure({})
-
-        assert configurator.registry.settings["via3_url"] == "https://via3.hypothes.is/"
-
     def test_trailing_slashes_are_appended_to_h_api_url_public(self, setting_getter):
         def side_effect(
             envvar_name, *args, **kwargs

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -49,21 +49,3 @@ class TestViaURL:
         pyramid_request.params["oauth_consumer_key"] = "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
         # fmt: on
         assert via_url(pyramid_request, document_url) == expected_via_url
-
-    def test_it_returns_via3_url_if_use_via3_url_feature_flag_is_set(
-        self, pyramid_request
-    ):
-        pyramid_request.feature = lambda feature: feature == "use_via3_url"
-
-        assert via_url(pyramid_request, "http://example.com").startswith(
-            "http://TEST_VIA3_SERVER.is/"
-        )
-
-    def test_it_returns_via2_html_rewriter_url_if_use_via2_html_rewriter_feature_flag_is_set(
-        self, pyramid_request
-    ):
-        pyramid_request.feature = lambda feature: feature == "use_via2_html_rewriter"
-
-        assert via_url(pyramid_request, "http://example.com").startswith(
-            "http://TEST_VIA_SERVER.is/html/"
-        )


### PR DESCRIPTION
It now just uses whatever version of Via is in the `via_url` setting all the time. Fixes https://github.com/hypothesis/via3/issues/80