### PR TITLE
Move hypothesis_config into js_config

### DIFF
--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -192,7 +192,7 @@ class LTILaunchResource:
                     ],
                 },
                 # The config object for the Hypothesis client server.
-                "hypothesisClient": self._hypothesis_config,
+                "hypothesisClient": self._get_hypothesis_config(),
                 # URLs for the frontend to use (e.g. API endpoints for it to call).
                 "urls": {},
             }
@@ -204,8 +204,7 @@ class LTILaunchResource:
 
         return self._js_config
 
-    @property
-    def _hypothesis_config(self):
+    def _get_hypothesis_config(self):
         """
         Return the Hypothesis client config object for the current request.
 

--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -32,7 +32,6 @@ class LTILaunchResource:
         self._request = request
         self._authority = self._request.registry.settings["h_authority"]
         self._ai_getter = self._request.find_service(name="ai_getter")
-        self._hypothesis_config = None
         self._js_config = None
 
     @property
@@ -192,6 +191,8 @@ class LTILaunchResource:
                         "rpc_allowed_origins"
                     ],
                 },
+                # The config object for the Hypothesis client server.
+                "hypothesisClient": self._hypothesis_config,
                 # URLs for the frontend to use (e.g. API endpoints for it to call).
                 "urls": {},
             }
@@ -204,7 +205,7 @@ class LTILaunchResource:
         return self._js_config
 
     @property
-    def hypothesis_config(self):
+    def _hypothesis_config(self):
         """
         Return the Hypothesis client config object for the current request.
 
@@ -213,11 +214,6 @@ class LTILaunchResource:
         request, such as an authorization grant token for the client to use to
         log in to the Hypothesis account corresponding to the LTI user that the
         request comes from.
-
-        This is a mutable config dict. It can be accessed, for example by
-        views, as ``request.context.hypothesis_config``, and they can mutate it or add
-        their own view-specific config settings. The modified config object
-        will then be passed to the Hypothesis client.
 
         See: https://h.readthedocs.io/projects/client/en/latest/publishers/config/#configuring-the-client-using-json
 
@@ -241,20 +237,17 @@ class LTILaunchResource:
             }
             return jwt.encode(claims, client_secret, algorithm="HS256")
 
-        if self._hypothesis_config is None:
-            self._hypothesis_config = {
-                "services": [
-                    {
-                        "apiUrl": api_url,
-                        "authority": self._authority,
-                        "enableShareLinks": False,
-                        "grantToken": grant_token().decode("utf-8"),
-                        "groups": [self.h_groupid],
-                    }
-                ]
-            }
-
-        return self._hypothesis_config
+        return {
+            "services": [
+                {
+                    "apiUrl": api_url,
+                    "authority": self._authority,
+                    "enableShareLinks": False,
+                    "grantToken": grant_token().decode("utf-8"),
+                    "groups": [self.h_groupid],
+                }
+            ]
+        }
 
     @property
     def provisioning_enabled(self):

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -51,10 +51,10 @@ describe('BasicLtiLaunchApp', () => {
       },
     });
 
-    // fake js-hypothesis-config
+    // fake js-config
     fakeHypothesisConfig = sinon.stub(document, 'querySelector');
     fakeHypothesisConfig
-      .withArgs('.js-hypothesis-config')
+      .withArgs('.js-config')
       .returns({ text: JSON.stringify({}) });
   });
 

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -6,8 +6,10 @@ describe('postmessage_json_rpc/methods#requestConfig', () => {
   beforeEach('inject the client config into the document', () => {
     configEl = document.createElement('script');
     configEl.setAttribute('type', 'application/json');
-    configEl.classList.add('js-hypothesis-config');
-    configEl.textContent = JSON.stringify({ foo: 'bar' });
+    configEl.classList.add('js-config');
+    configEl.textContent = JSON.stringify({
+      hypothesisClient: { foo: 'bar' },
+    });
     document.body.appendChild(configEl);
   });
 

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -10,6 +10,7 @@
  * Return a Hypothesis client config object for the current LTI request.
  */
 export function requestConfig() {
-  const configEl = document.querySelector('.js-hypothesis-config');
-  return JSON.parse(configEl.textContent);
+  const configEl = document.querySelector('.js-config');
+  const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
+  return clientConfigObj;
 }

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -34,13 +34,7 @@
 
     {% block scripts %}
       {% if context.js_config is defined %}
-        {# passes config to the preact LMS app #}
         <script type="application/json" class="js-config">{{ context.js_config|tojson }}</script>
-      {% endif %}
-
-      {% if context.hypothesis_config is defined %}
-        {# passes config to the sidebar #}
-        <script type="application/json" class="js-hypothesis-config">{{ context.hypothesis_config|tojson }}</script>
       {% endif %}
     {% endblock %}
   </body>

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -362,6 +362,6 @@ class BasicLTILaunchViews:
             display_name = "(Couldn't fetch student name)"
 
         # TODO! - Could/should this be replaced with a GradingInfo lookup?
-        self.context.hypothesis_config.update(
+        self.context.js_config["hypothesisClient"].update(
             {"focus": {"user": {"username": focused_user, "displayName": display_name}}}
         )

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -74,7 +74,7 @@ class TestBasicLTILaunch:
     def test_it_configures_client_to_focus_on_user_if_in_canvas_and_param_set(
         self, context, pyramid_request, h_api
     ):
-        context.hypothesis_config = {}
+        context.js_config["hypothesisClient"] = {}
         pyramid_request.params.update(
             {
                 "tool_consumer_info_product_family_code": "canvas",
@@ -88,14 +88,14 @@ class TestBasicLTILaunch:
         BasicLTILaunchViews(context, pyramid_request)
 
         h_api.get_user.assert_called_once_with("user123")
-        assert context.hypothesis_config["focus"] == {
+        assert context.js_config["hypothesisClient"]["focus"] == {
             "user": {"username": "user123", "displayName": "Jim Smith"}
         }
 
     def test_it_uses_placeholder_display_name_for_focused_user_if_api_call_fails(
         self, context, pyramid_request, h_api
     ):
-        context.hypothesis_config = {}
+        context.js_config["hypothesisClient"] = {}
         pyramid_request.params.update(
             {
                 "focused_user": "user123",
@@ -107,7 +107,7 @@ class TestBasicLTILaunch:
         BasicLTILaunchViews(context, pyramid_request)
 
         h_api.get_user.assert_called_once_with("user123")
-        assert context.hypothesis_config["focus"] == {
+        assert context.js_config["hypothesisClient"]["focus"] == {
             "user": {
                 "username": "user123",
                 "displayName": "(Couldn't fetch student name)",


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/1386.

We want to simplify our JavaScript config by merging multiple separate
JavaScript config objects into one nested object, so move the separate
`LTILaunchResource.hypothesis_config` property into
`LTILaunchResource.js_config` as a `"hypothesisClient"` sub-dict.

How it currently works (before this commit)
-------------------------------------------

The backend currently has an `LTILaunchResource.hypothesis_config`
property:
https://github.com/hypothesis/lms/blob/0abc66323919997cd76d5109021e9eafafe5c336/lms/resources/_lti_launch.py#L206-L257

The `hypothesis_config` property contains the config settings that the
JSON-RPC server will pass to the Hypothesis client.

It gets rendered into the HTML as `"js-hypothesis-config"`:
https://github.com/hypothesis/lms/blob/0abc66323919997cd76d5109021e9eafafe5c336/lms/templates/base.html.jinja2#L41-L44

The JSON-RPC server then reads this config from the HTML:
https://github.com/hypothesis/lms/blob/0abc66323919997cd76d5109021e9eafafe5c336/lms/static/scripts/postmessage_json_rpc/server/methods.js#L13-L14

What this commit changes
------------------------

This commit moves `LTILaunchResource.hypothesis_config` into the
`LTILaunchResource.js_config` property, which is the "general" config
object for the frontend code.

The settings that were previously the separate `hypothesis_config` property are
now a `"hypothesisClient"` sub-dict within the dict that `js_config` returns.

The `"js-hypothesis-config"` object is no longer rendered into the HTML,
since the `"hypothesisClient"` config is now part of the
`"js-config"` that already gets rendered:
https://github.com/hypothesis/lms/blob/1f10d599e5e2502a4bfbde023da35e852729788e/lms/templates/base.html.jinja2#L36-L39

Finally, the JSON-RPC server itself (`methods.js`) is changed to read
the client's config from `js-config["hypothesisClient"]` rather than
from the old `js-hypothesis-config`.

And a couple of tests need updating.

How to test this
----------------

Launch any assignment in Canvas and test that you're logged into your
Canvas account in the Hypothesis client. If the JSON-RPC server's config
wasn't working, you wouldn't be.