### PR TITLE
Rename js-lms-config back to just js-config

### DIFF
--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -13,7 +13,7 @@ import { startRpcServer } from '../postmessage_json_rpc/server';
 startRpcServer();
 
 const rootEl = document.querySelector('#app');
-const config = JSON.parse(document.querySelector('.js-lms-config').textContent);
+const config = JSON.parse(document.querySelector('.js-config').textContent);
 
 const mode = config.mode || 'content-item-selection';
 

--- a/lms/static/scripts/postmessage_json_rpc/server/server-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server-test.js
@@ -15,7 +15,7 @@ describe('postmessage_json_rpc/server#Server', () => {
   beforeEach('inject the server config into the document', () => {
     configEl = document.createElement('script');
     configEl.setAttribute('type', 'application/json');
-    configEl.classList.add('js-lms-config');
+    configEl.classList.add('js-config');
     configEl.textContent = JSON.stringify({
       rpcServer: {
         allowedOrigins: ['http://localhost:9876'],

--- a/lms/static/scripts/postmessage_json_rpc/server/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server.js
@@ -4,7 +4,7 @@
  * On creation the server automatically finds and reads its config settings
  * from a JSON config object in the document. For example:
  *
- *     <script type="application/json" class="js-lms-config">
+ *     <script type="application/json" class="js-config">
  *       {
  *         rpcServer: { allowedOrigins: ["https://hypothes.is"] }
  *       }
@@ -22,7 +22,7 @@
  */
 export default class Server {
   constructor() {
-    const configEl = document.getElementsByClassName('js-lms-config')[0];
+    const configEl = document.getElementsByClassName('js-config')[0];
     const configObj = JSON.parse(configEl.textContent).rpcServer;
 
     // JSON-RPC messages that don't come from one of these allowed window

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -35,7 +35,7 @@
     {% block scripts %}
       {% if context.js_config is defined %}
         {# passes config to the preact LMS app #}
-        <script type="application/json" class="js-lms-config">{{ context.js_config|tojson }}</script>
+        <script type="application/json" class="js-config">{{ context.js_config|tojson }}</script>
       {% endif %}
 
       {% if context.hypothesis_config is defined %}


### PR DESCRIPTION
This means that we once again have an `LTILaunchResource.js_config`
property and a matching `js-config` CSS class.

Note that the `js-` prefix is a pattern used to denote CSS classes that
exist for the purpose of enabling JavaScript to find things rather than
for styling, see:

https://github.com/hypothesis/frontend-toolkit/blob/master/docs/css-style-guide.md#classes-used-in-code

I'm not going to change that as it's a pattern used in frontend code
throughout all our apps (and it's a good idea too).

I think the addition of "-lms-" was meant to help distinguish this
config object from the other js-hypothesis-config and
js-rpc-server-config objects, but neither of those exists any more.