### PR TITLE
Use separate DBs for tests, functests and bddtests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,4 @@ omit =
 show_missing = True
 precision = 2
 fail_under = 98.46
+skip_covered = True

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ node {
             try {
                 testApp(image: img, runArgs: "${runArgs} -e TEST_DATABASE_URL=${databaseUrl(postgresContainer)}") {
                     installDeps()
-                    run("make backend-tests coverage functests-only bddtests")
+                    run("make backend-tests functests-only bddtests")
                 }
             } finally {
                 postgresContainer.stop()

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ help:
 	@echo "make format            Correctly format the code"
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
 	@echo "make test              Run the unit tests"
-	@echo "make coverage          Print the unit test coverage report"
 	@echo "make functests         Run the functional tests"
 	@echo "make bddtests          Run the gherkin tests"
 	@echo "make docstrings        View all the docstrings locally as HTML"
@@ -80,10 +79,6 @@ checkformatting: python
 
 .PHONY: test
 test: backend-tests frontend-tests
-
-.PHONY: coverage
-coverage: python
-	@tox -qe coverage
 
 .PHONY: functests
 functests: build/manifest.json functests-only
@@ -164,7 +159,7 @@ bddtests: python
 	@tox -qe bddtests
 
 .PHONY: sure
-sure: checkformatting lint test coverage functests bddtests
+sure: checkformatting lint test functests bddtests
 
 .PHONY: frontend-tests
 frontend-tests: node_modules/.uptodate

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ bddtests: python
 	@tox -qe bddtests
 
 .PHONY: sure
-sure: checkformatting lint test functests bddtests
+sure: checkformatting backend-lint frontend-lint backend-tests frontend-tests functests bddtests
 
 .PHONY: frontend-tests
 frontend-tests: node_modules/.uptodate

--- a/bin/create-db
+++ b/bin/create-db
@@ -4,5 +4,5 @@
 #
 # Usage:
 #
-#     create-testdb <DB_NAME>
+#     create-db <DB_NAME>
 make services args="exec postgres psql -U postgres -c 'CREATE DATABASE $1;'" > /dev/null 2>&1 || true

--- a/bin/create-testdb
+++ b/bin/create-testdb
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
 #
-# Create the "lms_test" database in Postgres, if it doesn't exist already.
-make services args='exec postgres psql -U postgres -c "CREATE DATABASE lms_test;"' > /dev/null 2>&1 || true
+# Create the given database in Postgres, if it doesn't exist already.
+#
+# Usage:
+#
+#     create-testdb <DB_NAME>
+make services args="exec postgres psql -U postgres -c 'CREATE DATABASE $1;'" > /dev/null 2>&1 || true

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -5,9 +5,11 @@ from pkg_resources import resource_filename
 from lms.app import create_app
 from tests.bdd.higher_order_gherkin import Injector
 from tests.bdd.step_context import StepContextManager
+from tests.bdd.steps.lms_db import test_database_url
 from tests.conftest import TEST_SETTINGS
 
-TEST_SETTINGS["session_cookie_secret"] = "notasecret"
+TEST_SETTINGS["sqlalchemy.url"] = test_database_url
+
 
 # Create the compiled step file before steps are read
 Injector.create_step_file(

--- a/tests/bdd/steps/lms_db.py
+++ b/tests/bdd/steps/lms_db.py
@@ -1,4 +1,5 @@
 """Insert LMS specific objects into the DB."""
+import os
 
 import sqlalchemy
 from behave import step
@@ -6,14 +7,18 @@ from sqlalchemy.orm import sessionmaker
 
 from lms import db, models
 from tests.bdd.step_context import StepContext
-from tests.conftest import TEST_DATABASE_URL
+from tests.conftest import get_test_database_url
+
+test_database_url = get_test_database_url(
+    default="postgresql://postgres@localhost:5433/lms_bddtests"
+)
 
 
 class LMSDBContext(StepContext):
     context_key = "db"
 
     def __init__(self, **kwargs):
-        self.engine = sqlalchemy.create_engine(TEST_DATABASE_URL)
+        self.engine = sqlalchemy.create_engine(test_database_url)
         self.session_maker = sessionmaker(bind=self.engine.connect())
         db.init(self.engine)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,22 +8,14 @@ from sqlalchemy.orm import sessionmaker
 
 from lms import db
 
-__all__ = [
-    "patch",
-    "db_engine",
-    "SESSION",
-    "TEST_DATABASE_URL",
-    "TEST_SETTINGS",
-]
-
 SESSION = sessionmaker()
-TEST_DATABASE_URL = os.environ.get(
-    "TEST_DATABASE_URL", "postgresql://postgres@localhost:5433/lms_test"
-)
 
-# Settings that will end up in pyramid_request.registry.settings.
+
+def get_test_database_url(default):
+    return os.environ.get("TEST_DATABASE_URL", default)
+
+
 TEST_SETTINGS = {
-    "sqlalchemy.url": TEST_DATABASE_URL,
     "via_url": "http://TEST_VIA_SERVER.is/",
     "via3_url": "http://TEST_VIA3_SERVER.is/",
     "jwt_secret": "test_secret",
@@ -48,12 +40,13 @@ TEST_SETTINGS = {
     "h_api_url_private": "https://example.com/private/api/",
     "rpc_allowed_origins": ["http://localhost:5000"],
     "oauth2_state_secret": "test_oauth2_state_secret",
+    "session_cookie_secret": "notasecret",
 }
 
 
 @pytest.fixture(scope="session")
 def db_engine():
-    engine = sqlalchemy.create_engine(TEST_DATABASE_URL)
+    engine = sqlalchemy.create_engine(TEST_SETTINGS["sqlalchemy.url"])
     db.init(engine)
     return engine
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -4,9 +4,11 @@ import pytest
 from webtest import TestApp
 
 from lms import db
-from tests.conftest import *
+from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
 
-TEST_SETTINGS["session_cookie_secret"] = "notasecret"
+TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(
+    default="postgresql://postgres@localhost:5433/lms_functests"
+)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,11 @@ from pyramid.request import apply_request_extensions
 from lms.services.application_instance_getter import ApplicationInstanceGetter
 from lms.services.launch_verifier import LaunchVerifier
 from lms.values import LTIUser
-from tests.conftest import *
+from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
+
+TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(
+    default="postgresql://postgres@localhost:5433/lms_test"
+)
 
 
 @pytest.fixture

--- a/tests/unit/lms/session_test.py
+++ b/tests/unit/lms/session_test.py
@@ -4,8 +4,6 @@ from lms.session import includeme
 
 
 def test_includeme(pyramid_config):
-    pyramid_config.registry.settings["session_cookie_secret"] = "test_secret"
-
     includeme(pyramid_config)
 
     session_factory = pyramid_config.registry.queryUtility(ISessionFactory)

--- a/tox.ini
+++ b/tox.ini
@@ -70,9 +70,9 @@ whitelist_externals =
     tests,functests,bddtests: sh
 commands =
     dev: {posargs:pserve conf/development.ini --reload}
-    tests: sh bin/create-testdb lms_test
-    functests: sh bin/create-testdb lms_functests
-    bddtests: sh bin/create-testdb lms_bddtests
+    tests: sh bin/create-db lms_test
+    functests: sh bin/create-db lms_functests
+    bddtests: sh bin/create-db lms_bddtests
     tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
     tests: -coverage combine
     tests: coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ passenv =
     dev: USERNAME
     dev: VIA_URL
 deps =
-    {tests,clean,coverage}: coverage
+    {tests,clean}: coverage
     {tests,bddtests,functests,lint}: httpretty
     {tests,bddtests,functests,lint,docstrings,checkdocstrings}: pytest
     {tests,functests,lint,docstrings,checkdocstrings}: factory-boy
@@ -62,12 +62,17 @@ deps =
 setenv =
     tests: JWT_SECRET = test_secret
     tests: VIA_URL = https://example.com/
+    tests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:5433/lms_test}
+    functests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:5433/lms_functests}
+    bddtests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:5433/lms_bddtests}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 whitelist_externals =
-    tests: sh
+    tests,functests,bddtests: sh
 commands =
     dev: {posargs:pserve conf/development.ini --reload}
-    tests: sh bin/create-testdb
+    tests: sh bin/create-testdb lms_test
+    functests: sh bin/create-testdb lms_functests
+    bddtests: sh bin/create-testdb lms_bddtests
     tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
     tests: -coverage combine
     tests: coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,9 @@ whitelist_externals =
 commands =
     dev: {posargs:pserve conf/development.ini --reload}
     tests: sh bin/create-testdb
-    tests: coverage run -m pytest {posargs:tests/unit/}
+    tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
+    tests: -coverage combine
+    tests: coverage report
     functests: pytest {posargs:tests/functional/}
     bddtests: behave {posargs:tests/bdd/}
     lint: prospector
@@ -77,8 +79,6 @@ commands =
     format: isort --recursive --quiet --atomic lms tests
     checkformatting: black --check lms tests
     checkformatting: isort --recursive --quiet --check-only lms tests
-    coverage: -coverage combine
-    coverage: coverage report
     docker-compose: docker-compose {posargs}
     {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envdir}/rst .
     docstrings: sphinx-autobuild -BqT -z lms -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml


### PR DESCRIPTION
Rather than all sharing a single lms-test DB have the tests, functests and
bddtests use separate lms-test, lms-functests and lms-bddtests DBs.

<del>I was noticing a problem that, when the three different tests are run together
in a single `make` command, something seemed to be sometimes leaving test data
behind in the DB that would cause later test runs to fail until the DB was
manually cleared. Was happening to me locally quite often. I didn't figure out
why. But this change seems to get rid of the problem.</del> -- this doesn't seem to fix that, I think the db_session fixture in the functests may be wrong

This also means that the tests, functests and bddtests can be run in parallel,
for example:

```terminal
$ make -j `nproc` sure
```

This takes the time to run `make sure` on my machine down from 1 min 30s to 42s.