### PR TITLE
Quieten pytest's output in `make test`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,8 +68,8 @@ whitelist_externals =
 commands =
     dev: {posargs:pserve conf/development.ini --reload}
     tests: sh bin/create-testdb
-    tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
-    functests: pytest {posargs:tests/functional/}
+    tests: coverage run -m pytest -q -Werror {posargs:tests/unit/}
+    functests: pytest -q {posargs:tests/functional/}
     bddtests: behave {posargs:tests/bdd/}
     lint: prospector
     lint: prospector tests


### PR DESCRIPTION
When the tests pass less output is nicer. Do the same for `make functests` also.