### PR TITLE
Tweak pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+addopts = -q
+filterwarnings =
+    # Fail the tests if there are any warnings.
+    error
+
+    # Silence an imp warning that venusian is triggering.
+    ignore:^the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses$:DeprecationWarning:.*

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ whitelist_externals =
 commands =
     dev: {posargs:pserve conf/development.ini --reload}
     tests: sh bin/create-testdb
-    tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
+    tests: coverage run -m pytest {posargs:tests/unit/}
     functests: pytest {posargs:tests/functional/}
     bddtests: behave {posargs:tests/bdd/}
     lint: prospector


### PR DESCRIPTION
Centralise the pytest config in a `pytest.ini` file that applies to both
`make test` and `make functests` instead of repeating command line
options in the `pytest` commands in `tox.ini`.

The new `pytest.ini` fails the tests on warnings which was already being
done for `make test` but not for `make functests` which was printing out
a warning. `make functests` will now fail on warnings too, and the one
warning that it was already printing has been silenced.

The new `pytest.ini` also contains `-q`: less output is nicer when the
tests pass.