### PR TITLE
Use legacy Via in dev by default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,13 +15,12 @@ There are three presentations for developers that describe what the Hypothesis L
 
 ### You will need
 
-* The LMS app integrates h, the Hypothesis client, Via 3, and Via, so you will need to
+* The LMS app integrates h, the Hypothesis client, and Via, so you will need to
   set up development environments for each of those before you can develop the
   LMS app:
 
   * https://h.readthedocs.io/en/latest/developing/install/
   * https://h.readthedocs.io/projects/client/en/latest/developers/developing/
-  * https://github.com/hypothesis/via3 (Serves PDF content)
   * https://github.com/hypothesis/via (Serves HTTP content)
 
 * [Git](https://git-scm.com/)

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -15,12 +15,12 @@ session_cookie_secret = "notasecret"
 
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
+feature_flags_allowed_in_cookie = use_via3_url
 
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"
 
-# Set the default to Via 3 for dev (original via: 9080)
-via_url = http://localhost:9082
+via_url = http://localhost:9080
 via3_url = http://localhost:9082
 
 h_authority = lms.hypothes.is


### PR DESCRIPTION
Change the dev env back to legacy Via instead of Via 3 by default.

You can still visit http://localhost:8001/flags and turn on the
use_via3_url feature flag to have it use Via 3 in dev instead.

When it's time to change the dev env backt o Via 3 by default again we
can simply revert this commit.