### PR TITLE
Patch `propTypes.{element, node}` to work with Preact elements

### DIFF
--- a/lms/static/scripts/bootstrap.js
+++ b/lms/static/scripts/bootstrap.js
@@ -3,6 +3,10 @@ sinon.assert.expose(assert, { prefix: null });
 
 // Configure Enzyme for UI tests.
 require('preact/debug');
+import { patchPropTypes } from './frontend_apps/utils/prop-types';
+import propTypes from 'prop-types';
+patchPropTypes(propTypes);
+
 import { configure } from 'enzyme';
 import { Adapter } from 'enzyme-adapter-preact-pure';
 configure({ adapter: new Adapter() });

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -76,7 +76,8 @@ ErrorDisplay.propTypes = {
   /**
    * A short message explaining that a problem happened.
    */
-  message: propTypes.string.isRequired,
+  message: propTypes.oneOfType([propTypes.string, propTypes.element])
+    .isRequired,
 
   /**
    * An `Error`-like object with details of the problem.

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -58,7 +58,9 @@ describe('LMSGrader', () => {
         courseName={'course name'}
         assignmentName={'course assignment'}
         {...props}
-      />
+      >
+        <div title="The assignment content iframe" />
+      </LMSGrader>
     );
   };
 

--- a/lms/static/scripts/frontend_apps/utils/prop-types.js
+++ b/lms/static/scripts/frontend_apps/utils/prop-types.js
@@ -1,0 +1,93 @@
+import { isValidElement } from 'preact';
+
+/**
+ * Function that checks the prop `name` in `props` has an expected type or
+ * throws otherwise.
+ *
+ * @typedef {(props: Object, name: string, component: string) => any} CheckPropFunction
+ */
+
+/**
+ * Take a prop type checker function and return a checker where the prop is
+ * optional. The optional checker has an `isRequired` property that requires the
+ * prop.
+ *
+ * This matches how the standard prop types work (eg. `propTypes.object` is
+ * optional, `propTypes.object.isRequired` is required).
+ *
+ * @param {CheckPropFunction} checkPropType
+ * @return {CheckPropFunction}
+ */
+function checkOptionalProp(checkPropType) {
+  const check = (props, propName, componentName) => {
+    if (!(propName in props)) {
+      return null;
+    }
+    return checkPropType(props, propName, componentName);
+  };
+  check.isRequired = checkPropType;
+  return check;
+}
+
+/**
+ * Check that a prop is a Preact element (ie. the result of a call to `createElement`
+ * or a JSX element (`<div .../>`, `<Widget .../>`).
+ *
+ * This is the same as `propTypes.element`, but for Preact elements.
+ *
+ * @param {Object} props
+ * @param {string} propName
+ * @param {string} componentName
+ */
+function checkElementProp(props, propName, componentName) {
+  if (!isValidElement(props[propName])) {
+    return new Error(
+      `Expected prop "${propName}" supplied to ${componentName} to be a Preact element`
+    );
+  }
+  return null;
+}
+
+export const element = checkOptionalProp(checkElementProp);
+
+/**
+ * Check that a prop is a renderable value (ie. string, boolean, null or element)
+ *
+ * This is the same as `propTypes.node`, but for Preact nodes.
+ *
+ * @param {Object} props
+ * @param {string} propName
+ * @param {string} componentName
+ */
+function checkNodeProp(props, propName, componentName) {
+  const value = props[propName];
+  if (
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    value === null ||
+    isValidElement(value)
+  ) {
+    return null;
+  }
+  return new Error(
+    `Expected prop "${propName}" supplied to ${componentName} to be a renderable value (string, boolean, element etc.)`
+  );
+}
+
+export const node = checkOptionalProp(checkNodeProp);
+
+/**
+ * Patch `propTypes.{element, node}` to work with Preact (rather than React)
+ * elements.
+ *
+ * @example
+ *
+ * ```
+ * import propTypes from 'propTypes';
+ * patchPropTypes(propTypes);
+ * ```
+ */
+export function patchPropTypes(propTypes) {
+  propTypes.element = element;
+  propTypes.node = node;
+}

--- a/lms/static/scripts/frontend_apps/utils/test/prop-types-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/prop-types-test.js
@@ -1,0 +1,55 @@
+import { createElement } from 'preact';
+
+import { element, node } from '../prop-types';
+
+describe('prop-types', () => {
+  describe('element', () => {
+    function TestComponent() {
+      return null;
+    }
+
+    [<div key="foo" />, <TestComponent key="bar" />].forEach(validElement => {
+      it('returns `null` passed a valid element', () => {
+        const props = { aProp: validElement };
+        assert.equal(element(props, 'aProp', 'TestComponent'), null);
+      });
+    });
+
+    ['foo', {}, false, undefined, null].forEach(invalidElement => {
+      it('returns an Error if passed an invalid element', () => {
+        const props = { aProp: invalidElement };
+
+        const result = element(props, 'aProp', 'TestComponent');
+
+        assert.instanceOf(result, Error);
+        assert.equal(
+          result.message,
+          'Expected prop "aProp" supplied to TestComponent to be a Preact element'
+        );
+      });
+    });
+  });
+
+  describe('node', () => {
+    [<div key="foo" />, 'test', false].forEach(validNode => {
+      it('returns `null` if passed a valid node', () => {
+        const props = { aProp: validNode };
+        assert.equal(node(props, 'aProp', 'TestComponent'), null);
+      });
+    });
+
+    [{}, undefined].forEach(invalidNode => {
+      it('returns an Error if passed an invalid node', () => {
+        const props = { aProp: invalidNode };
+
+        const result = node(props, 'aProp', 'TestComponent');
+
+        assert.instanceOf(result, Error);
+        assert.equal(
+          result.message,
+          'Expected prop "aProp" supplied to TestComponent to be a renderable value (string, boolean, element etc.)'
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is the second part of https://github.com/hypothesis/lms/issues/1463. It fixes the remaining propTypes-related warnings when running lms frontend tests.

Several components make use of `propTypes.{element, node}` to validate that a prop contains a JSX element or a value that can appear in a JSX expression (string, boolean, null).

This fails validation checks because `propTypes.{element, node}` only work with React elements but not Preact ones. The Preact docs don't specify a preferred way to resolve this so I'm asking the community.

In the meantime, this resolves the related warnings by adding two custom prop type checkers which do the same thing and patches `propTypes.{element, node}` to use them.

---

- [x] Check with Preact devs / community whether there is a better solution (_Not that I found so far. That might change later_)
- [x] Add tests for our custom checkers, if we still end up using them