### PR TITLE
Inline _h_display_name into h_user

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -14,9 +14,6 @@ from lms.values import HUser
 class LTILaunchResource:
     """Context resource for LTI launch requests."""
 
-    GROUP_NAME_MAX_LENGTH = 25
-    """The maximum length of an h group name."""
-
     __acl__ = [(Allow, "lti_user", "launch_lti_assignment")]
 
     def __init__(self, request):
@@ -130,8 +127,11 @@ class LTILaunchResource:
         """
         name = self._get_param("context_title").strip()
 
-        if len(name) > self.GROUP_NAME_MAX_LENGTH:
-            name = name[: self.GROUP_NAME_MAX_LENGTH - 1].rstrip() + "…"
+        # The maximum length of an h group name.
+        group_name_max_length = 25
+
+        if len(name) > group_name_max_length:
+            name = name[: group_name_max_length - 1].rstrip() + "…"
 
         return name
 

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -14,9 +14,6 @@ from lms.values import HUser
 class LTILaunchResource:
     """Context resource for LTI launch requests."""
 
-    DISPLAY_NAME_MAX_LENGTH = 30
-    """The maximum length of an h display name."""
-
     GROUP_NAME_MAX_LENGTH = 25
     """The maximum length of an h group name."""
 
@@ -63,10 +60,13 @@ class LTILaunchResource:
             if not display_name:
                 return "Anonymous"
 
-            if len(display_name) <= self.DISPLAY_NAME_MAX_LENGTH:
+            # The maximum length of an h display name.
+            display_name_max_length = 30
+
+            if len(display_name) <= display_name_max_length:
                 return display_name
 
-            return display_name[: self.DISPLAY_NAME_MAX_LENGTH - 1].rstrip() + "…"
+            return display_name[: display_name_max_length - 1].rstrip() + "…"
 
         return HUser(
             authority=self._authority, username=username(), display_name=display_name()

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -17,9 +17,6 @@ class LTILaunchResource:
     GROUP_NAME_MAX_LENGTH = 25
     """The maximum length of an h group name."""
 
-    USERNAME_MAX_LENGTH = 30
-    """The maximum length of an h username."""
-
     __acl__ = [(Allow, "lti_user", "launch_lti_assignment")]
 
     def __init__(self, request):
@@ -43,7 +40,7 @@ class LTILaunchResource:
             username_hash_object = hashlib.sha1()
             username_hash_object.update(self.h_provider.encode())
             username_hash_object.update(self.h_provider_unique_id.encode())
-            return username_hash_object.hexdigest()[: self.USERNAME_MAX_LENGTH]
+            return username_hash_object.hexdigest()[:30]
 
         def display_name():
             """Return the h display name for the current request."""

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -52,25 +52,21 @@ class LTILaunchResource:
             """Return the h display name for the current request."""
             params = self._request.params
 
-            full_name = (params.get("lis_person_name_full") or "").strip()
-            given_name = (params.get("lis_person_name_given") or "").strip()
-            family_name = (params.get("lis_person_name_family") or "").strip()
+            display_name = params.get("lis_person_name_full", "").strip()
 
-            if full_name:
-                display_name = full_name
-            else:
-                display_name = " ".join((given_name, family_name))
+            if not display_name:
+                given_name = params.get("lis_person_name_given", "").strip()
+                family_name = params.get("lis_person_name_family", "").strip()
 
-            display_name = display_name.strip()
+                display_name = " ".join((given_name, family_name)).strip()
 
-            display_name = display_name or "Anonymous"
+            if not display_name:
+                return "Anonymous"
 
-            if len(display_name) > self.DISPLAY_NAME_MAX_LENGTH:
-                display_name = (
-                    display_name[: self.DISPLAY_NAME_MAX_LENGTH - 1].rstrip() + "…"
-                )
+            if len(display_name) <= self.DISPLAY_NAME_MAX_LENGTH:
+                return display_name
 
-            return display_name
+            return display_name[: self.DISPLAY_NAME_MAX_LENGTH - 1].rstrip() + "…"
 
         return HUser(
             authority=self._authority, username=username(), display_name=display_name()


### PR DESCRIPTION
Like the previously inlined `_h_username`
(5c2d47a8f68aa5d5ff64487e06778bf271a1e363), `LTILaunch._h_display_name`
is another separate `@property` that's only used in one place: the
`LTILaunch.h_user` property. So inline `_h_display_name` into `h_user`
to make the code more readable and easier to refactor by making
`_h_display_name`'s limited scope more clear.

Note that the previously-inlined username code was just a single block
of code (with no empty lines) so it could just be inlined as a block of
code with a comment:

https://github.com/hypothesis/lms/blob/64478c3110544bcaefde8b90b0e7b685311e9ca7/lms/resources/_lti_launch.py#L45-L49

But `_h_display_name` is a longer method that contains multiple blocks
of code. If it were simply inlined into `_h_user` as lines of code with
a comment at the top it would be unclear which/how many blocks the
comment applied to, and I think the result would be an over-long and
quite unreadable method:

```python
@property
def h_user(self):
    params = self._request.params

    # Generate the h username for the current request.
    h_username_hash_object = hashlib.sha1()
    h_username_hash_object.update(self.h_provider.encode())
    h_username_hash_object.update(self.h_provider_unique_id.encode())
    h_username = h_username_hash_object.hexdigest()[: self.USERNAME_MAX_LENGTH]

    # Generate the h display name for the current request.
    full_name = (params.get("lis_person_name_full") or "").strip()
    given_name = (params.get("lis_person_name_given") or "").strip()
    family_name = (params.get("lis_person_name_family") or "").strip()

    if full_name:
        display_name = full_name
    else:
        display_name = " ".join((given_name, family_name))

    display_name = display_name.strip()

    display_name = display_name or "Anonymous"

    if len(display_name) > self.DISPLAY_NAME_MAX_LENGTH:
        display_name = (
            display_name[: self.DISPLAY_NAME_MAX_LENGTH - 1].rstrip() + "…"
        )

    return HUser(
        authority=self._authority,
        username=h_username,
        display_name=display_name,
    )
```

So instead I've inlined `_h_display_name` into `h_user` as a
`display_name()` inner function, I've also moved the username code into
a `username()` inner function as well at the same time, just to make the
method body more self-consistent:

```python
@property
def h_user(self):
    def username():
        """Return the h username for the current request."""
        ...

    def display_name():
        """Return the h display name for the current request."""
        ...

    return HUser(
        authority=self._authority, username=username(), display_name=display_name()
    )
```

I think this has a few advantages:

* It's clear exactly which blocks of code the inner function's name and
  docstring apply to
* The indentation helps to visually separate the different parts of the
  method
* Local variables are scoped