### PR TITLE
Move JS config into collaborator

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -1,0 +1,100 @@
+import datetime
+import urllib
+
+import jwt
+
+from lms.validation.authentication import BearerTokenSchema
+
+
+class JSConfig:
+    """The config for the app's JavaScript code."""
+
+    def __init__(self, context, request):
+        self._context = context
+        self._request = request
+
+    @property
+    def config(self):
+        """
+        Return the configuration for the app's JavaScript code.
+
+        This is a mutable config dict. It can be accessed, for example by
+        views, and they can mutate it or add their own view-specific config
+        settings. The modified config object will then be passed to the
+        JavaScript code in the response page.
+
+        :rtype: dict
+        """
+        return {
+            "authToken": self._auth_token,
+            "hypothesisClient": self._hypothesis_config,
+            "rpcServer": self._rpc_server_config,
+            "urls": self._urls,
+        }
+
+    @property
+    def _auth_token(self):
+        """Return the authToken setting."""
+        if not self._request.lti_user:
+            return None
+
+        return BearerTokenSchema(self._request).authorization_param(
+            self._request.lti_user
+        )
+
+    @property
+    def _hypothesis_config(self):
+        """
+        Return the Hypothesis client config object for the current request.
+
+        See: https://h.readthedocs.io/projects/client/en/latest/publishers/config/#configuring-the-client-using-json
+
+        """
+        if not self._context.provisioning_enabled:
+            return {}
+
+        client_id = self._request.registry.settings["h_jwt_client_id"]
+        client_secret = self._request.registry.settings["h_jwt_client_secret"]
+        api_url = self._request.registry.settings["h_api_url_public"]
+        audience = urllib.parse.urlparse(api_url).hostname
+
+        def grant_token():
+            now = datetime.datetime.utcnow()
+            claims = {
+                "aud": audience,
+                "iss": client_id,
+                "sub": self._context.h_user.userid,
+                "nbf": now,
+                "exp": now + datetime.timedelta(minutes=5),
+            }
+            return jwt.encode(claims, client_secret, algorithm="HS256")
+
+        return {
+            "services": [
+                {
+                    "apiUrl": api_url,
+                    "authority": self._request.registry.settings["h_authority"],
+                    "enableShareLinks": False,
+                    "grantToken": grant_token().decode("utf-8"),
+                    "groups": [self._context.h_groupid],
+                }
+            ]
+        }
+
+    @property
+    def _rpc_server_config(self):
+        """Return the config for the postMessage-JSON-RPC server."""
+        return {
+            "allowedOrigins": self._request.registry.settings["rpc_allowed_origins"],
+        }
+
+    @property
+    def _urls(self):
+        """
+        Return a dict of URLs for the frontend to use.
+
+        For example: API endpoints for the frontend to call would go in
+        here.
+
+        """
+        return {}

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -1,13 +1,11 @@
 """Traversal resources for LTI launch views."""
-import datetime
+import functools
 import hashlib
-import urllib
 
-import jwt
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.security import Allow
 
-from lms.validation.authentication import BearerTokenSchema
+from lms.resources._js_config import JSConfig
 from lms.values import HUser
 
 
@@ -30,7 +28,6 @@ class LTILaunchResource:
         self._request = request
         self._authority = self._request.registry.settings["h_authority"]
         self._ai_getter = self._request.find_service(name="ai_getter")
-        self._js_config = None
 
     @property
     def h_user(self):
@@ -162,82 +159,9 @@ class LTILaunchResource:
         return self._get_param("user_id")
 
     @property
+    @functools.lru_cache()
     def js_config(self):
-        """
-        Return the configuration for the app's JavaScript code.
-
-        This is a mutable config dict. It can be accessed, for example by
-        views, as ``request.context.js_config``, and they can mutate it or add
-        their own view-specific config settings. The modified config object
-        will then be passed to the JavaScript code in the response page.
-
-        :rtype: dict
-        """
-        if self._js_config is None:
-            # Initialize self._js_config for the first time.
-            self._js_config = {
-                # The config object for the postMessage-JSON-RPC server.
-                "rpcServer": {
-                    "allowedOrigins": self._request.registry.settings[
-                        "rpc_allowed_origins"
-                    ],
-                },
-                # The config object for the Hypothesis client server.
-                "hypothesisClient": self._get_hypothesis_config(),
-                # URLs for the frontend to use (e.g. API endpoints for it to call).
-                "urls": {},
-            }
-
-            if self._request.lti_user:
-                self._js_config["authToken"] = BearerTokenSchema(
-                    self._request
-                ).authorization_param(self._request.lti_user)
-
-        return self._js_config
-
-    def _get_hypothesis_config(self):
-        """
-        Return the Hypothesis client config object for the current request.
-
-        Return a dict suitable for dumping to JSON and using as a Hypothesis
-        client config object. Includes settings specific to the current LTI
-        request, such as an authorization grant token for the client to use to
-        log in to the Hypothesis account corresponding to the LTI user that the
-        request comes from.
-
-        See: https://h.readthedocs.io/projects/client/en/latest/publishers/config/#configuring-the-client-using-json
-
-        """
-        if not self.provisioning_enabled:
-            return {}
-
-        client_id = self._request.registry.settings["h_jwt_client_id"]
-        client_secret = self._request.registry.settings["h_jwt_client_secret"]
-        api_url = self._request.registry.settings["h_api_url_public"]
-        audience = urllib.parse.urlparse(api_url).hostname
-
-        def grant_token():
-            now = datetime.datetime.utcnow()
-            claims = {
-                "aud": audience,
-                "iss": client_id,
-                "sub": self.h_user.userid,
-                "nbf": now,
-                "exp": now + datetime.timedelta(minutes=5),
-            }
-            return jwt.encode(claims, client_secret, algorithm="HS256")
-
-        return {
-            "services": [
-                {
-                    "apiUrl": api_url,
-                    "authority": self._authority,
-                    "enableShareLinks": False,
-                    "grantToken": grant_token().decode("utf-8"),
-                    "groups": [self.h_groupid],
-                }
-            ]
-        }
+        return JSConfig(self, self._request).config
 
     @property
     def provisioning_enabled(self):

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -47,9 +47,7 @@ class TestJSConfigAuthToken:
         )
         assert authToken == bearer_token_schema.authorization_param.return_value
 
-    def test_it_is_None_for_non_lti_users(
-        self, authToken, BearerTokenSchema, context, pyramid_request
-    ):
+    def test_it_is_None_for_non_lti_users(self, context, pyramid_request):
         pyramid_request.lti_user = None
 
         assert JSConfig(context, pyramid_request).config["authToken"] is None
@@ -91,7 +89,7 @@ class TestJSConfigHypothesisClient:
         assert before <= claims["nbf"] <= after
         assert claims["exp"] > before
 
-    def test_it_includes_the_group(self, pyramid_request, config):
+    def test_it_includes_the_group(self, config):
         groups = config["services"][0]["groups"]
 
         assert groups == ["example_groupid"]

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -1,0 +1,161 @@
+import datetime
+from unittest import mock
+
+import jwt
+import pytest
+from pyramid.httpexceptions import HTTPBadRequest
+
+from lms.resources import LTILaunchResource
+from lms.resources._js_config import JSConfig
+from lms.values import HUser
+
+
+class TestJSConfig:
+    """General unit tests for JSConfig."""
+
+    def test_it_is_mutable(self, config):
+        config.update({"a_key": "a_value"})
+
+        assert config["a_key"] == "a_value"
+
+    @pytest.mark.parametrize(
+        "context_property", ["provisioning_enabled", "h_user", "h_groupid"]
+    )
+    def test_it_raises_if_a_context_property_raises(
+        self, context, context_property, pyramid_request
+    ):
+        # Make reading context.<context_property> raise HTTPBadRequest.
+        setattr(
+            type(context),
+            context_property,
+            mock.PropertyMock(side_effect=HTTPBadRequest("example error message")),
+        )
+
+        with pytest.raises(HTTPBadRequest, match="example error message"):
+            JSConfig(context, pyramid_request).config
+
+
+class TestJSConfigAuthToken:
+    """Unit tests for the "authToken" sub-dict of JSConfig."""
+
+    def test_it(
+        self, authToken, bearer_token_schema, BearerTokenSchema, pyramid_request
+    ):
+        BearerTokenSchema.assert_called_once_with(pyramid_request)
+        bearer_token_schema.authorization_param.assert_called_once_with(
+            pyramid_request.lti_user
+        )
+        assert authToken == bearer_token_schema.authorization_param.return_value
+
+    def test_it_is_None_for_non_lti_users(
+        self, authToken, BearerTokenSchema, context, pyramid_request
+    ):
+        pyramid_request.lti_user = None
+
+        assert JSConfig(context, pyramid_request).config["authToken"] is None
+
+    @pytest.fixture
+    def authToken(self, config):
+        return config["authToken"]
+
+
+class TestJSConfigHypothesisClient:
+    """Unit tests for the "hypothesisClient" sub-dict of JSConfig."""
+
+    def test_it_contains_one_service_config(self, config):
+        assert len(config["services"]) == 1
+
+    def test_it_includes_the_api_url(self, config):
+        assert config["services"][0]["apiUrl"] == "https://example.com/api/"
+
+    def test_it_includes_the_authority(self, config):
+        assert config["services"][0]["authority"] == "TEST_AUTHORITY"
+
+    def test_it_disables_share_links(self, config):
+        assert config["services"][0]["enableShareLinks"] is False
+
+    def test_it_includes_grant_token(self, config):
+        before = int(datetime.datetime.now().timestamp())
+
+        grant_token = config["services"][0]["grantToken"]
+
+        claims = jwt.decode(
+            grant_token,
+            algorithms=["HS256"],
+            key="TEST_JWT_CLIENT_SECRET",
+            audience="example.com",
+        )
+        after = int(datetime.datetime.now().timestamp())
+        assert claims["iss"] == "TEST_JWT_CLIENT_ID"
+        assert claims["sub"] == "acct:example_username@TEST_AUTHORITY"
+        assert before <= claims["nbf"] <= after
+        assert claims["exp"] > before
+
+    def test_it_includes_the_group(self, pyramid_request, config):
+        groups = config["services"][0]["groups"]
+
+        assert groups == ["example_groupid"]
+
+    def test_it_is_empty_if_provisioning_feature_is_disabled(
+        self, context, pyramid_request
+    ):
+        context.provisioning_enabled = False
+
+        assert JSConfig(context, pyramid_request).config["hypothesisClient"] == {}
+
+    def test_it_is_mutable(self, config):
+        config.update({"a_key": "a_value"})
+
+        assert config["a_key"] == "a_value"
+
+    @pytest.fixture
+    def config(self, config):
+        return config["hypothesisClient"]
+
+
+class TestJSConfigRPCServer:
+    """Unit tests for the "rpcServer" sub-dict of JSConfig."""
+
+    def test_it(self, config):
+        assert config == {"allowedOrigins": ["http://localhost:5000"]}
+
+    @pytest.fixture
+    def config(self, config):
+        return config["rpcServer"]
+
+
+class TestJSConfigURLs:
+    """Unit tests for the "urls" sub-dict of JSConfig."""
+
+    def test_it(self, config):
+        assert config == {}
+
+    @pytest.fixture
+    def config(self, config):
+        return config["urls"]
+
+
+@pytest.fixture(autouse=True)
+def BearerTokenSchema(patch):
+    return patch("lms.resources._js_config.BearerTokenSchema")
+
+
+@pytest.fixture
+def bearer_token_schema(BearerTokenSchema):
+    return BearerTokenSchema.return_value
+
+
+@pytest.fixture
+def config(context, pyramid_request):
+    return JSConfig(context, pyramid_request).config
+
+
+@pytest.fixture
+def context():
+    return mock.create_autospec(
+        LTILaunchResource,
+        spec_set=True,
+        instance=True,
+        h_user=HUser("TEST_AUTHORITY", "example_username"),
+        h_groupid="example_groupid",
+    )


### PR DESCRIPTION
This just moves `LTILaunchResource.js_config` into a separate helper class that `LTILaunchResource` calls, without changing the public interface yet. User code still access the config dict directly as `context.js_config` (singleton) for now.