### PR TITLE
Remove some unnecessary __all__'s

### DIFF
--- a/.prospector.base.yaml
+++ b/.prospector.base.yaml
@@ -31,6 +31,10 @@ pep257:
             # "Multi-line docstring summary should start at the second line".
 pyflakes:
   run: true
+  disable:
+      - F401  # Unused import. We don't need pyflakes to detect these because
+              # pylint detects them, and pylint's unused import detection
+              # generates fewer false positives than pyflakes's.
 pylint:
   enable:
     - relative-import

--- a/lms/resources/__init__.py
+++ b/lms/resources/__init__.py
@@ -10,5 +10,3 @@ See the traversal-related sections in the Pyramid docs:
 """
 from lms.resources._default import DefaultResource
 from lms.resources._lti_launch import LTILaunchResource
-
-__all__ = ["DefaultResource", "LTILaunchResource"]

--- a/lms/resources/_default.py
+++ b/lms/resources/_default.py
@@ -1,8 +1,6 @@
 """Default traversal resources."""
 from pyramid.security import Allow
 
-__all__ = ["DefaultResource"]
-
 
 class DefaultResource:
     """The application's default root resource."""

--- a/lms/resources/_lti_launch.py
+++ b/lms/resources/_lti_launch.py
@@ -10,8 +10,6 @@ from pyramid.security import Allow
 from lms.validation.authentication import BearerTokenSchema
 from lms.values import HUser
 
-__all__ = ["LTILaunchResource"]
-
 
 class LTILaunchResource:
     """Context resource for LTI launch requests."""


### PR DESCRIPTION
Remove some `__all__`'s that aren't doing anything for us.

PEP 8 does say:

> "To better support introspection, modules should explicitly declare the names
> in their public API using the `__all__` attribute."

https://www.python.org/dev/peps/pep-0008/#public-and-internal-interfaces

But the `__all__`'s are a maintenance burden, they can potentially get
out of sync with the actual code if people forget to update them, and I
don't think they're doing much for us:

1. The only names in `_lti_launch.py` are `LTILaunchResource`, which is public,
   and imported names which are private. And the same section of PEP 8 also says:

   > "Imported names should always be considered an implementation detail ...
   > unless they are an explicitly documented part of the containing module's API,
   > such as `os.path` or a package's `__init__` module that exposes functionality
   > from submodules.

   So we don't need to distinguish that the imported names are private as they're
   considered so by default.

2. `_default.py`: same story as `_lti_launch.py`.

3. `__init__.py` contains _only_ import names:

   ```python
   from lms.resources._default import DefaultResource
   from lms.resources._lti_launch import LTILaunchResource
   ```

   These are being imported into the `__init__.py` because they're intended to
   be the `lms.resources` package's public API. You're supposed to do
   `from lms.resources import DefaultResource, LTILaunchResource` and **not**
   do `from lms.resources._lti_launch import LTILaunchResource`. This is made
   explicit by the leading underscore on `_lti_launch.py`. This both makes
   `lms.resources`'s public API simpler to use (just a flat namespace, not
   nested) and makes the organization of `lms.resources` into submodules a
   private implementation detail so that the package can be reorganized (e.g.
   breaking a big module up into smaller ones) without affecting user code.

   This is all good but the `__all__` in `__init__.py` still appears
   unnecessary. When PEP 8 says that imported names are private _"unless they
   are an explicitly documented part of the containing module's API, such as
   `os.path` or a package's `__init__` module that exposes functionality
   from submodules"_ it's not clear whether it's saying that the names imported
   into `__init__.py` would need to be explicitly declared as part of
   `__init__.py`'s public interface by adding them to `__init__.py`'s docstring
   or `__all__`, or whether just importing them into `__init__.py` is enough.

   But I think it's obvious that when a package's `__init__.py` is importing
   names from the package's submodule for clearly no other reason, that
   `__init__.py` is doing so to add those names to the package's interface.
   There's no need to also list the names in a docstring or `__all__`.

   PyLint even disables "unused import" warnings for `__init__.py` files by
   default: https://docs.pylint.org/en/1.6.0/features.html#id17

Elsewhere PEP 8 also says that modules designed for use via
`from M import *` should use `__all__` (`__all__` affects what names
`import *` imports) but our modules aren't intended to be used like
that.