### PR TITLE
Delete test DB tables before running tests

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -81,8 +81,19 @@ BASE = declarative_base(
 SESSION = sessionmaker()
 
 
-def init(engine):
-    """Initialise the database tables."""
+def init(engine, drop=False):
+    """
+    Create all the database tables if they don't already exist.
+
+    If `drop=True` is given then delete all existing tables first and then
+    re-create them. Tests use this. If `drop=False` existing tables won't be
+    touched.
+
+    :param engine: the sqlalchemy Engine object
+    :param drop: whether or not to delete existing tables
+    """
+    if drop:
+        BASE.metadata.drop_all(engine)
     BASE.metadata.create_all(engine)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,13 @@ TEST_SETTINGS = {
 @pytest.fixture(scope="session")
 def db_engine():
     engine = sqlalchemy.create_engine(TEST_SETTINGS["sqlalchemy.url"])
-    db.init(engine)
+
+    # Delete all database tables and re-initialize the database schema based on
+    # the current models. Doing this at the beginning of each test run ensures
+    # that any schema changes made to the models since the last test run will
+    # be applied to the test DB schema before running the tests again.
+    db.init(engine, drop=True)
+
     return engine
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -11,15 +11,11 @@ TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(
 )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def auto_use_dn(db_engine):
-    # TODO - Is this right?
-    return db_engine
-
-
-def _clean_database(engine):
+@pytest.fixture(autouse=True)
+def clean_database(db_engine):
+    """Delete any data added by the previous test."""
     tables = reversed(db.BASE.metadata.sorted_tables)
-    with contextlib.closing(engine.connect()) as conn:
+    with contextlib.closing(db_engine.connect()) as conn:
         tx = conn.begin()
         tnames = ", ".join('"' + t.name + '"' for t in tables)
         conn.execute("TRUNCATE {};".format(tnames))
@@ -35,7 +31,6 @@ def pyramid_app():
 
 @pytest.fixture
 def app(pyramid_app, db_engine):
-    _clean_database(db_engine)
     db.init(db_engine)
 
     return TestApp(pyramid_app)


### PR DESCRIPTION
On master the BDD tests pollutes the test DB such that future runs of the unit
tests fail:

```terminal
$ make backend-tests
(the tests pass)
$ make bddtests
(the tests pass)
$ make backend-tests
(a bunch of assertions fail because there's unexpected data in the test DB)
```

The only way to fix this once its happened is to manually delete your test DB.

This is arguably a problem with the BDD tests: they don't seem to clean up after
themselves, whereas the functests and unit tests do.

But as a fix I've changed the functests and unit tests to delete all the test DB
tables at the beginning of a test run. Ensuring that the test DB is in a clean
state before you start a test run seems more robust than trying to always leave
the DB clean _after_ a test run no matter what happened.