### PR TITLE
Move debug settings into JSConfig

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,5 +10,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.46
+fail_under = 98.49
 skip_covered = True

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -27,6 +27,7 @@ class JSConfig:
         """
         return {
             "authToken": self._auth_token,
+            "debug": self._debug,
             "hypothesisClient": self._hypothesis_config,
             "rpcServer": self._rpc_server_config,
             "urls": self._urls,
@@ -41,6 +42,24 @@ class JSConfig:
         return BearerTokenSchema(self._request).authorization_param(
             self._request.lti_user
         )
+
+    @property
+    def _debug(self):
+        """
+        Return some debug information.
+
+        Currently used in the Gherkin tests.
+        """
+        debug_info = {}
+
+        if self._request.lti_user:
+            debug_info["tags"] = [
+                "role:instructor"
+                if self._request.lti_user.is_instructor
+                else "role:learner"
+            ]
+
+        return debug_info
 
     @property
     def _hypothesis_config(self):

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -41,14 +41,6 @@ class BasicLTILaunchViews:
             {
                 # Configure the front-end mini-app to run.
                 "mode": "basic-lti-launch",
-                # Add debug information (currently used in the gherkin tests)
-                "debug": {
-                    "tags": [
-                        "role:instructor"
-                        if request.lti_user.is_instructor
-                        else "role:learner"
-                    ]
-                },
             }
         )
 

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -386,7 +386,6 @@ class TestUnconfiguredBasicLTILaunch:
 
         assert context.js_config == {
             "mode": "content-item-selection",
-            "debug": Any.dict(),
             "enableLmsFilePicker": False,
             "formAction": "http://example.com/module_item_configurations",
             "formFields": Any.dict(),


### PR DESCRIPTION
Move the `"debug"` settings that some views add to the JS config into the `JSConfig` class. For simplicity these are now just added for every request, not just some, which does no harm.

Just moving the code, not redesigning it.

Details:
    
`BasicLTILaunchViews` inserts some debug info, used by the Gherkin tests, into the JavaScript config:

https://github.com/hypothesis/lms/blob/a59fc96fd2c80aa7e015bb668c78e5041e3c5a46/lms/views/basic_lti_launch.py#L44-L51
    
Move this JavaScript config mutation into the `JSConfig` class and make it unconditional: the debug info is now added to the `JSConfig` for all requests (that have a `JSConfig`). The less variation of the `JSConfig` between different requests the better.