### PR TITLE
A11y dialog fixes

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,5 +1,5 @@
 import Server from './server';
-import { requestConfig } from './methods';
+import { requestConfig, groupsAsync } from './methods';
 
 let server = {}; // Singleton RPC server reference
 
@@ -9,6 +9,7 @@ let server = {}; // Singleton RPC server reference
 function startRpcServer() {
   server = new Server();
   server.register('requestConfig', requestConfig);
+  server.register('groupsAsync', groupsAsync);
 }
 
 /**

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,5 +1,5 @@
 import Server from './server';
-import { requestConfig, groupsAsync } from './methods';
+import { groupsAsync, requestConfig, requestFrame } from './methods';
 
 let server = {}; // Singleton RPC server reference
 
@@ -10,6 +10,7 @@ function startRpcServer() {
   server = new Server();
   server.register('requestConfig', requestConfig);
   server.register('groupsAsync', groupsAsync);
+  server.register('requestFrame', requestFrame);
 }
 
 /**

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -1,4 +1,4 @@
-import { requestConfig } from './methods';
+import { requestConfig, requestFrame } from './methods';
 
 describe('postmessage_json_rpc/methods#requestConfig', () => {
   let configEl;
@@ -20,5 +20,10 @@ describe('postmessage_json_rpc/methods#requestConfig', () => {
   it('returns the config object', async () => {
     const result = await requestConfig();
     assert.deepEqual(result, { foo: 'bar' });
+  });
+
+  it('returns the parameters passed to requestFrame', async () => {
+    const result = await requestFrame({ bar: 1 });
+    assert.deepEqual(result, { bar: 1 });
   });
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -17,7 +17,8 @@ describe('postmessage_json_rpc/methods#requestConfig', () => {
     configEl.parentNode.removeChild(configEl);
   });
 
-  it('returns the config object', () => {
-    assert.deepEqual(requestConfig(), { foo: 'bar' });
+  it('returns the config object', async () => {
+    const result = await requestConfig();
+    assert.deepEqual(result, { foo: 'bar' });
   });
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -16,6 +16,21 @@ export async function requestConfig() {
 }
 
 /**
+ * Method that is used to trace back to the sender which frame
+ * is the embedding ancestor frame. An acknowledgment of this
+ * request tells the sender that this frame is the controlling
+ * embedder frame.
+ *
+ * @param {Object} params - Parameter object to round trip. Use this
+ *  to store a unique index when performing discovery.
+ * @return {Promise<Object>} Successful promise returning the
+ *  passed in parameter object.
+ */
+export async function requestFrame(params) {
+  return Promise.resolve(params);
+}
+
+/**
  * Temporary method that blocks for a little while to simulate
  * waiting for canvas groups to be ready.
  *

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -9,8 +9,22 @@
 /**
  * Return a Hypothesis client config object for the current LTI request.
  */
-export function requestConfig() {
+export async function requestConfig() {
   const configEl = document.querySelector('.js-config');
   const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
-  return clientConfigObj;
+  return Promise.resolve(clientConfigObj);
+}
+
+/**
+ * Temporary method that blocks for a little while to simulate
+ * waiting for canvas groups to be ready.
+ *
+ * TODO: replace this with a real request to lms/
+ */
+export async function groupsAsync() {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve('groupsAsync resolved!');
+    }, 500);
+  });
 }

--- a/lms/static/scripts/postmessage_json_rpc/server/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server.js
@@ -29,7 +29,7 @@ export default class Server {
     // origins will be ignored.
     this._allowedOrigins = configObj.allowedOrigins;
 
-    // Add a postMessage event listener so we can recieve JSON-RPC requests.
+    // Add a postMessage event listener so we can receive JSON-RPC requests.
     this._boundReceiveMessage = this._receiveMessage.bind(this);
     window.addEventListener('message', this._boundReceiveMessage);
 
@@ -69,10 +69,6 @@ export default class Server {
     if (!this._isJSONRPCRequest(event)) {
       return;
     }
-
-    const result = await this._jsonRPCResponse(event.data);
-    event.source.postMessage(result, event.origin);
-
     // Resolve the promise we created in the constructor with the saved
     // sidebar frame and origin.
     this._resolveSidebarWindow({
@@ -129,8 +125,13 @@ export default class Server {
 
     // Call the method and return the result response.
     try {
-      const result = await method();
-      return { jsonrpc: '2.0', result: result, id: request.id };
+      let result;
+      if (request.params && Array.isArray(request.params)) {
+        result = await method(...request.params);
+      } else {
+        result = await method();
+      }
+      return Promise.resolve({ jsonrpc: '2.0', result, id: request.id });
     } catch (e) {
       return {
         jsonrpc: '2.0',

--- a/lms/static/scripts/postmessage_json_rpc/server/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server.js
@@ -69,6 +69,10 @@ export default class Server {
     if (!this._isJSONRPCRequest(event)) {
       return;
     }
+
+    const result = await this._jsonRPCResponse(event.data);
+    event.source.postMessage(result, event.origin);
+
     // Resolve the promise we created in the constructor with the saved
     // sidebar frame and origin.
     this._resolveSidebarWindow({


### PR DESCRIPTION
This diff covers 3 main things

1. The first commit is just pulling in 2 files from the client that I feel are valuable for a11y changes related to Dialog.js. But additionally, I think these modules will have repeated use in LMS. I think we'll eventually splinter off modules like this into a npm package that we can import. But for now, I'm just dumping them all into a subfolder called /common. The intent is that everything in common/ will be replaced with a package down the road. I do believe there are a few other stray modules in LMS that have been copied over (including the rpc stuff) and the intent is that they will all move the common. The RPC stuff will be a bit more involved because they have diverged a bit from the client to LMS, so I'll need to get the common parts of those in sync again first before moving them over.

2. Fix the a11y lint issues with Dialog. I took a close look at the models from w3 against what we had and eventually went with this model.
https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/alertdialog.html

All my instincts told me we should not be placing focus on the wrapper and instead lean on aria- labels. I did test this with screen readers and all seems okay. We diverge a bit from aforementioned example in that we only allow the dialog to close if an `onCancel` callback is provided. I think that is totally reasonable because we don't really have a valid state to dismiss the dialog when things need authorization or the UI is in an error state and needs a full reload. I also decide that `alertdialog` was more appropriate here than just `dialog` based on the mozilla docs:

> The difference with regular dialogs is that the alertdialog role should only used when an alert, error, or warning occurs. In other words, when a dialog's information and controls require the user's immediate attention alertdialog should be used instead of dialog. It is up to the developer to make this distinction though.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alertdialog_role

3. Fix a minor lint issue in BasicLtiLaunchApp.js  to add a `title` (open to other text ideas )


TODO: change the docs at the top of Dialog.js to reflect the changes if these are approved.

