### PR TITLE
Various a11y lint fixes

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -39,14 +39,13 @@ export default function FileList({
         renderItem={(file, isSelected) => (
           <Fragment>
             <td aria-label={file.display_name} className="FileList__name-col">
-              {/* FIXME-A11Y */}
-              {/* eslint-disable-next-line jsx-a11y/alt-text */}
               <img
                 className={classnames(
                   'FileList__icon',
                   isSelected && 'is-selected'
                 )}
                 src="/static/images/file-pdf.svg"
+                alt="PDF icon"
               />
               <span className="FileList__name">{file.display_name}</span>
             </td>

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -152,9 +152,7 @@ export default function LMSFilePicker({
         <ErrorDisplay
           message={
             <Fragment>
-              {/* FIXME-A11Y */}
-              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-              <a>{`Failed to authorize with the ${lmsName} instance at `}</a>
+              {`Failed to authorize with the ${lmsName} instance at `}
               <a href={`${lmsUrl}`}>{`${lmsUrl}`}</a>
             </Fragment>
           }

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -59,8 +59,12 @@ export default function StudentSelector({
 
     return (
       <span className="StudentsSelector__students">
-        {/* FIXME-A11Y */}
-        {/* eslint-disable-next-line jsx-a11y/no-onchange */}
+        {/* 
+        This lint issue may have arisen from browser inconsistency issues with 
+        `onChange` which have since been fixed. See browser compatibility note here:
+        https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event#annotations:xeC6ClQsEequhUdih2lXzw
+        */}
+        {/* eslint-disable-next-line jsx-a11y/no-onchange*/}
         <select
           className="StudentsSelector__students-select"
           onChange={e => {

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -14,6 +14,7 @@ import ErrorDialog from './ErrorDialog';
 import Spinner from './Spinner';
 import SvgIcon from './SvgIcon';
 import { fetchGrade, submitGrade } from '../utils/grader-service';
+import { useUniqueId } from '../utils/hooks';
 import { trustMarkup } from '../utils/trusted';
 import { formatToNumber, scaleGrade, validateGrade } from '../utils/validation';
 import ValidationMessage from './ValidationMessage';
@@ -90,6 +91,8 @@ export default function SubmitGradeForm({ disabled = false, student }) {
   const [showValidationError, setValidationError] = useState(false);
   // The actual validation error message.
   const [validationMessage, setValidationMessageMessage] = useState('');
+  // Unique id attribute for <input>
+  const gradeId = useUniqueId('SubmitGradeForm__grade:');
 
   const { authToken } = useContext(Config);
 
@@ -150,7 +153,7 @@ export default function SubmitGradeForm({ disabled = false, student }) {
           setValidationError(false);
         }}
       />
-      <label className="SubmitGradeForm__label" htmlFor="lms-grade">
+      <label className="SubmitGradeForm__label" htmlFor={gradeId}>
         Grade (Out of 10)
       </label>
       <span className="SubmitGradeForm__grade-wrapper">
@@ -159,9 +162,9 @@ export default function SubmitGradeForm({ disabled = false, student }) {
             'is-saved': gradeSaved,
           })}
           disabled={disabled}
-          id="lms-grade"
+          id={gradeId}
           ref={inputRef}
-          onKeyDown={handleKeyDown}
+          onInput={handleKeyDown}
           type="input"
           defaultValue={grade}
           key={student.LISResultSourcedId}

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -98,7 +98,6 @@ describe('StudentSelector', () => {
     );
   });
 
-  // FIXME-A11Y
   it.skip(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -137,7 +137,7 @@ describe('SubmitGradeForm', () => {
       });
       const wrapper = renderForm();
       wrapper.find('button').simulate('click');
-      wrapper.find('input').simulate('keydown', { key: 'k' });
+      wrapper.find('input').simulate('input');
       assert.isFalse(wrapper.find('ValidationMessage').prop('open'));
     });
   });
@@ -239,11 +239,16 @@ describe('SubmitGradeForm', () => {
     });
   });
 
-  // FIXME-A11Y
-  it.skip(
+  it(
     'should pass a11y checks',
-    checkAccessibility({
-      content: () => renderForm(),
-    })
+    checkAccessibility(
+      {
+        content: () => renderForm(),
+      },
+      {
+        name: 'when disabled',
+        content: () => renderForm({ disabled: true }),
+      }
+    )
   );
 });

--- a/lms/static/scripts/frontend_apps/utils/hooks.js
+++ b/lms/static/scripts/frontend_apps/utils/hooks.js
@@ -1,0 +1,21 @@
+import { useState } from 'preact/hooks';
+
+// Global counter used to create a unique ids
+let idCounter = 0;
+
+/**
+ * Creates a unique id attribute value. Each time useUniqueId() is called,
+ * the numerical suffix value increments by 1.
+ *
+ * @param {string} prefix
+ * @return {string}
+ */
+function useUniqueId(prefix) {
+  const [localId] = useState(() => {
+    ++idCounter;
+    return idCounter;
+  });
+  return `${prefix}${localId}`;
+}
+
+export { useUniqueId };

--- a/lms/static/scripts/frontend_apps/utils/test/hooks-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/hooks-test.js
@@ -1,0 +1,9 @@
+import { useUniqueId } from '../hooks';
+
+describe('hooks', () => {
+  it('generates unique ids each time useUniqueId is called', () => {
+    const id1 = useUniqueId('prefix:');
+    const id2 = useUniqueId('prefix:');
+    assert.notEqual(id1, id2);
+  });
+});

--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -11,14 +11,13 @@
 }
 
 .StudentSelector-change-student {
+  @include mixins.input-focus;
   min-width: 60px;
   height: 40px;
   border: none;
   background-color: var.$grey-2;
   border: 1px solid var.$grey-3;
   transition: background-color 0.2s, border-color 0.2s;
-  
-  @include mixins.input-focus;
   
   &:hover {
     cursor: pointer;
@@ -33,6 +32,7 @@
 }
 
 .StudentsSelector__students {
+  @include mixins.input-focus;
   position: relative;
 
   &-select {
@@ -43,8 +43,6 @@
     border-radius: 0;
     height: 40px;
     padding: 5px 35px 5px 20px;
-
-    @include mixins.input-focus;
 
     &::-ms-expand {
       /* Remove default select arrow in IE11 */

--- a/lms/static/styles/components/_SubmitGradeForm.scss
+++ b/lms/static/styles/components/_SubmitGradeForm.scss
@@ -72,6 +72,7 @@
   }
 
   &__grade {
+    @include mixins.input-focus;
     text-align: center;
     width: 60px;
     height: 40px;
@@ -90,8 +91,6 @@
     &:disabled {
       opacity: 0.5;
     }
-
-    @include mixins.input-focus;
   }
 }
 


### PR DESCRIPTION
This is by no means complete, but getting there. I still see lots of areas we could improve and converge on in terms of CSS, but I'd rather reserve that work in the pattern lib than duplicate whats been done on the client.

In this PR:
- Change ValidationMessage to be a button and give is a focus state
-Change SubmitGradeForm to listen to onInput instead of onKeydown to dismiss validation message
- Give SubmitGradeForm a unique id counter for axe validation
- Add onBlur to StudentSelector.js
- Remove erroneous `<a>` tag in LMSFilePicker
- Add informative comment about enableLmsFilePicker prop
- Fix missing alt attribute in FileList

