### PR TITLE
Expose the JSConfig instance directly

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 from urllib.parse import urlparse
 
 import jwt
@@ -14,6 +15,7 @@ class JSConfig:
         self._request = request
 
     @property
+    @functools.lru_cache()
     def config(self):
         """
         Return the configuration for the app's JavaScript code.

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -155,7 +155,7 @@ class LTILaunchResource:
     @property
     @functools.lru_cache()
     def js_config(self):
-        return JSConfig(self, self._request).config
+        return JSConfig(self, self._request)
 
     @property
     def provisioning_enabled(self):

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -34,7 +34,7 @@
 
     {% block scripts %}
       {% if context.js_config is defined %}
-        <script type="application/json" class="js-config">{{ context.js_config|tojson }}</script>
+        <script type="application/json" class="js-config">{{ context.js_config.config|tojson }}</script>
       {% endif %}
     {% endblock %}
   </body>

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -37,7 +37,7 @@ class BasicLTILaunchViews:
         self.context = context
         self.request = request
 
-        self.context.js_config.update(
+        self.context.js_config.config.update(
             {
                 # Configure the front-end mini-app to run.
                 "mode": "basic-lti-launch",
@@ -101,7 +101,7 @@ class BasicLTILaunchViews:
 
         file_id = self.request.params["file_id"]
 
-        self.context.js_config.update(
+        self.context.js_config.config.update(
             {
                 # The URL that the JavaScript code will open if it needs the user to
                 # authorize us to request a new access token.
@@ -113,7 +113,7 @@ class BasicLTILaunchViews:
 
         # Configure the frontend to make a callback to the API to fetch the
         # Via URL.
-        self.context.js_config["urls"].update(
+        self.context.js_config.config["urls"].update(
             {
                 "via_url_callback": self.request.route_url(
                     "canvas_api.files.via_url", file_id=file_id
@@ -140,7 +140,7 @@ class BasicLTILaunchViews:
         self.sync_lti_data_to_h()
         self.store_lti_data()
 
-        frontend_app.configure_grading(self.request, self.context.js_config)
+        frontend_app.configure_grading(self.request, self.context.js_config.config)
 
         resource_link_id = self.request.params["resource_link_id"]
         tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
@@ -172,7 +172,7 @@ class BasicLTILaunchViews:
         self.sync_lti_data_to_h()
         self.store_lti_data()
 
-        frontend_app.configure_grading(self.request, self.context.js_config)
+        frontend_app.configure_grading(self.request, self.context.js_config.config)
 
         url = self.request.parsed_params["url"]
         self._set_via_url(url)
@@ -209,7 +209,7 @@ class BasicLTILaunchViews:
         )
 
         # Add the config needed by the JavaScript document selection code.
-        self.context.js_config.update(
+        self.context.js_config.config.update(
             {
                 "mode": "content-item-selection",
                 # It is assumed that this view is only used by LMSes for which
@@ -293,13 +293,13 @@ class BasicLTILaunchViews:
         self.sync_lti_data_to_h()
         self.store_lti_data()
 
-        frontend_app.configure_grading(self.request, self.context.js_config)
+        frontend_app.configure_grading(self.request, self.context.js_config.config)
 
         return {}
 
     def _set_via_url(self, document_url):
         """Configure content URL which the frontend will render inside an iframe."""
-        self.context.js_config["urls"].update(
+        self.context.js_config.config["urls"].update(
             {"via_url": via_url(self.request, document_url)}
         )
         self.set_canvas_submission_param("document_url", document_url)
@@ -319,7 +319,7 @@ class BasicLTILaunchViews:
         # launched by a teacher, or when the submission-related params are
         # missing for some other reason.
         if lis_result_sourcedid and lis_outcome_service_url:
-            self.context.js_config["submissionParams"] = {
+            self.context.js_config.config["submissionParams"] = {
                 "h_username": self.context.h_user.username,
                 "lis_result_sourcedid": lis_result_sourcedid,
                 "lis_outcome_service_url": lis_outcome_service_url,
@@ -328,8 +328,8 @@ class BasicLTILaunchViews:
     def set_canvas_submission_param(self, name, value):
         """Update config for frontend's calls to `report_submisssion` API."""
 
-        if "submissionParams" in self.context.js_config:
-            self.context.js_config["submissionParams"][name] = value
+        if "submissionParams" in self.context.js_config.config:
+            self.context.js_config.config["submissionParams"][name] = value
 
     def set_canvas_focused_user(self):
         """Configure the Hypothesis client to focus on a particular user."""
@@ -354,6 +354,6 @@ class BasicLTILaunchViews:
             display_name = "(Couldn't fetch student name)"
 
         # TODO! - Could/should this be replaced with a GradingInfo lookup?
-        self.context.js_config["hypothesisClient"].update(
+        self.context.js_config.config["hypothesisClient"].update(
             {"focus": {"user": {"username": focused_user, "displayName": display_name}}}
         )

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -51,7 +51,7 @@ def content_item_selection(context, request):
     lti_h_service.upsert_h_user()
     lti_h_service.upsert_course_group()
 
-    context.js_config.update(
+    context.js_config.config.update(
         {
             # The URL that the JavaScript code will open if it needs the user to
             # authorize us to request a new access token.
@@ -90,9 +90,9 @@ def content_item_selection(context, request):
     # course, as this is a required param of the API it'll call to get the list
     # of files in the course.
     if helpers.canvas_files_available(request):
-        context.js_config["enableLmsFilePicker"] = True
-        context.js_config["courseId"] = request.params["custom_canvas_course_id"]
+        context.js_config.config["enableLmsFilePicker"] = True
+        context.js_config.config["courseId"] = request.params["custom_canvas_course_id"]
     else:
-        context.js_config["enableLmsFilePicker"] = False
+        context.js_config.config["enableLmsFilePicker"] = False
 
     return {}

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -358,7 +358,7 @@ class TestLTILaunchResource:
         js_config = lti_launch.js_config
 
         JSConfig.assert_called_once_with(lti_launch, pyramid_request)
-        assert js_config == JSConfig.return_value.config
+        assert js_config == JSConfig.return_value
 
     def test_lms_url_return_the_ApplicationInstances_lms_url(
         self, ai_getter, pyramid_request

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from lms.resources import LTILaunchResource
+from lms.resources._js_config import JSConfig
 from lms.services.lti_h import LTIHService
 from lms.views.content_item_selection import content_item_selection
 
@@ -13,21 +14,24 @@ class TestContentItemSelection:
     ):
         content_item_selection(context, pyramid_request)
 
-        assert context.js_config["authUrl"] == "http://example.com/TEST_AUTHORIZE_URL"
+        assert (
+            context.js_config.config["authUrl"]
+            == "http://example.com/TEST_AUTHORIZE_URL"
+        )
 
     def test_it_sets_the_formAction_javascript_config_setting(
         self, context, pyramid_request
     ):
         content_item_selection(context, pyramid_request)
 
-        assert context.js_config["formAction"] == "TEST_CONTENT_ITEM_RETURN_URL"
+        assert context.js_config.config["formAction"] == "TEST_CONTENT_ITEM_RETURN_URL"
 
     def test_it_sets_the_formFields_javascript_config_setting(
         self, context, pyramid_request
     ):
         content_item_selection(context, pyramid_request)
 
-        assert context.js_config["formFields"] == {
+        assert context.js_config.config["formFields"] == {
             "lti_message_type": "ContentItemSelection",
             "lti_version": "TEST_LTI_VERSION",
         }
@@ -37,15 +41,15 @@ class TestContentItemSelection:
     ):
         content_item_selection(context, pyramid_request)
 
-        assert context.js_config["googleClientId"] == "fake_client_id"
-        assert context.js_config["googleDeveloperKey"] == "fake_developer_key"
+        assert context.js_config.config["googleClientId"] == "fake_client_id"
+        assert context.js_config.config["googleDeveloperKey"] == "fake_developer_key"
 
     def test_it_sets_the_lmsName_javascript_config_setting(
         self, context, pyramid_request
     ):
         content_item_selection(context, pyramid_request)
 
-        assert context.js_config["lmsName"] == "Canvas"
+        assert context.js_config.config["lmsName"] == "Canvas"
 
     def test_it_sets_the_ltiLaunchUrl_javascript_config_setting(
         self, context, pyramid_request
@@ -53,7 +57,7 @@ class TestContentItemSelection:
         content_item_selection(context, pyramid_request)
 
         assert (
-            context.js_config["ltiLaunchUrl"]
+            context.js_config.config["ltiLaunchUrl"]
             == "http://example.com/TEST_LTI_LAUNCH_URL"
         )
 
@@ -63,7 +67,7 @@ class TestContentItemSelection:
         content_item_selection(context, pyramid_request)
 
         helpers.canvas_files_available.assert_called_once_with(pyramid_request)
-        assert context.js_config["courseId"] == "TEST_CUSTOM_CANVAS_COURSE_ID"
+        assert context.js_config.config["courseId"] == "TEST_CUSTOM_CANVAS_COURSE_ID"
 
     @pytest.mark.parametrize("enable_picker", (True, False))
     def test_it_enables_lms_file_picker_if_canvas_files_available(
@@ -73,7 +77,7 @@ class TestContentItemSelection:
 
         content_item_selection(context, pyramid_request)
 
-        assert context.js_config["enableLmsFilePicker"] is enable_picker
+        assert context.js_config.config["enableLmsFilePicker"] is enable_picker
 
     def test_if_canvas_files_arent_available_for_this_application_instance_then_it_omits_course_id(
         self, context, helpers, pyramid_request
@@ -83,14 +87,14 @@ class TestContentItemSelection:
         content_item_selection(context, pyramid_request)
 
         helpers.canvas_files_available.assert_called_once_with(pyramid_request)
-        assert "courseId" not in context.js_config
+        assert "courseId" not in context.js_config.config
 
     def test_it_sets_the_lmsUrl_javascript_config_setting(
         self, context, pyramid_request
     ):
         content_item_selection(context, pyramid_request)
 
-        assert context.js_config["lmsUrl"] == context.lms_url
+        assert context.js_config.config["lmsUrl"] == context.lms_url
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -110,7 +114,9 @@ class TestContentItemSelection:
     @pytest.fixture
     def context(self):
         context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
-        context.js_config = {}
+        context.js_config = mock.create_autospec(
+            JSConfig, spec_set=True, instance=True, config={}
+        )
         return context
 
 


### PR DESCRIPTION
Expose JSConfig itself directly as context.js_config, rather than only
exposing JSConfig.config.

This is because we're going to be adding new methods to JSConfig for the
views to call, so they'll need access to it.

This means that view code that wants to access the config dict directly
now has to do `context.js_config.config`, but that will eventually be
going away as we phase out direct access to this dict.