### PR TITLE
Make get_by_assignment() return a list of 2-tuples

### DIFF
--- a/tests/unit/lms/views/helpers/frontend_app_test.py
+++ b/tests/unit/lms/views/helpers/frontend_app_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from lms.models import GradingInfo
 from lms.services.grading_info import GradingInfoService
-from lms.values import LTIUser
+from lms.values import HUser, LTIUser
 from lms.views.helpers import frontend_app
 
 
@@ -89,15 +89,26 @@ def grading_info_svc(pyramid_config):
 
 @pytest.fixture
 def grading_infos():
-    return [
-        GradingInfo(
-            h_username=f"username_{index}",
-            h_display_name=f"Student {index}",
-            lis_result_sourcedid=f"lis_result_sourcedid_{index}",
-            lis_outcome_service_url="http://example.com/service_url",
+    grading_infos = []
+
+    for index in range(3):
+        h_username = f"username_{index}"
+        h_display_name = f"Student {index}"
+        lis_result_sourcedid = f"lis_result_sourcedid_{index}"
+
+        grading_infos.append(
+            (
+                GradingInfo(
+                    h_username=h_username,
+                    h_display_name=h_display_name,
+                    lis_result_sourcedid=lis_result_sourcedid,
+                    lis_outcome_service_url="http://example.com/service_url",
+                ),
+                HUser("test_authority", h_username, h_display_name),
+            )
         )
-        for index in range(3)
-    ]
+
+    return grading_infos
 
 
 @pytest.fixture


### PR DESCRIPTION
Make `GradingInfoService.get_by_assignment()` return a list of
`(GradingInfo, HUser)` 2-tuples instead of just a list of
`GradingInfo`'s.

`get_by_assignment()` is called in only one place, and that calling code
immediately transforms `get_by_assignment()`'s list of `GradingInfo`'s
into a list of `(GradingInfo, HUser)` 2-tuples:

https://github.com/hypothesis/lms/blob/e801a012b4ca655338a35b678892e789edabad27/lms/views/helpers/frontend_app.py#L48-L57

Just have `get_by_assignment()` already return the 2-tuples itself,
simplifying the calling code.