### PR TITLE
Fix a11y lint in BasicLtiLaunchApp

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -189,13 +189,12 @@ export default function BasicLtiLaunchApp() {
 
   if (ltiLaunchState.state === 'fetched-url') {
     const iFrame = (
-      // FIXME-A11Y
-      // eslint-disable-next-line jsx-a11y/iframe-has-title
       <iframe
         width="100%"
         height="100%"
         className="js-via-iframe"
         src={ltiLaunchState.contentUrl}
+        title="Course content with Hypothesis annotation viewer"
       />
     );
 

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -239,11 +239,32 @@ describe('BasicLtiLaunchApp', () => {
     });
   });
 
-  // FIXME-A11Y
-  it.skip(
+  it(
     'should pass a11y checks',
-    checkAccessibility({
-      content: () => renderLtiLaunchApp(),
-    })
+    checkAccessibility([
+      {
+        content: () => renderLtiLaunchApp(),
+      },
+      {
+        name: 'LMS grader mode',
+        content: () => {
+          // Turn on `lmsGrader` for this test. Note: fakeConfig won't
+          // reset for a successive axe test, so its important that this
+          // test is the last one run in the test list. Otherwise
+          // fakeConfig will need to be restored again as done in the
+          // root level beforeEach() at the top of the file.
+          fakeConfig = {
+            ...fakeConfig,
+            lmsGrader: true,
+            grading: {
+              students: [],
+              courseName: 'courseName',
+              assignmentName: 'assignmentName',
+            },
+          };
+          return renderLtiLaunchApp();
+        },
+      },
+    ])
   );
 });


### PR DESCRIPTION
- Add title on iframe
- Add LMS Grader mode axe test (as this felt reasonable) Note: There are also a number of Dialogs that popup inside BasicLtiLaunchApp that are not reflected in `checkAccessibility` here, as Dialog shall have its own accessibility tests that reflect those relative states.