### PR TITLE
Change RPC server methods to be async

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,5 +1,5 @@
 import Server from './server';
-import { requestConfig } from './methods';
+import { requestConfig, groupsAsync } from './methods';
 
 let server = {}; // Singleton RPC server reference
 
@@ -9,6 +9,7 @@ let server = {}; // Singleton RPC server reference
 function startRpcServer() {
   server = new Server();
   server.register('requestConfig', requestConfig);
+  server.register('groupsAsync', groupsAsync);
 }
 
 /**

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -17,7 +17,8 @@ describe('postmessage_json_rpc/methods#requestConfig', () => {
     configEl.parentNode.removeChild(configEl);
   });
 
-  it('returns the config object', () => {
-    assert.deepEqual(requestConfig(), { foo: 'bar' });
+  it('returns the config object', async () => {
+    const result = await requestConfig();
+    assert.deepEqual(result, { foo: 'bar' });
   });
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -9,8 +9,22 @@
 /**
  * Return a Hypothesis client config object for the current LTI request.
  */
-export function requestConfig() {
+export async function requestConfig() {
   const configEl = document.querySelector('.js-config');
   const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
-  return clientConfigObj;
+  return Promise.resolve(clientConfigObj);
+}
+
+/**
+ * Temporary method that blocks for a little while to simulate
+ * waiting for canvas groups to be ready.
+ *
+ * TODO: replace this with a real request to lms/
+ */
+export async function groupsAsync() {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve('groupsAsync resolved!');
+    }, 500);
+  });
 }


### PR DESCRIPTION
- We need to add the ability for an RPC method to be async so it can fetch a result from the lms service. These changes allow the methods to return to the result asynchronously and delay the postMessage response according.

- Move the _resolveSidebarWindow() call until after the _jsonRPCResponse returns. This ensures we have the frame ready only after we respond to the client that send it.