### PR TITLE
Fix some test fixtures

### DIFF
--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -183,10 +183,6 @@ class ConfiguredLaunch:
         pyramid_config.register_service(lti_h_service, name="lti_h")
         return lti_h_service
 
-    @pytest.fixture(autouse=True)
-    def ModuleItemConfiguration(self, patch):
-        return patch("lms.views.basic_lti_launch.ModuleItemConfiguration")
-
 
 class TestCanvasFileBasicLTILaunch(ConfiguredLaunch):
     def test_it_configures_frontend(self, context, pyramid_request):
@@ -466,6 +462,11 @@ def BearerTokenSchema(patch):
 @pytest.fixture(autouse=True)
 def LtiLaunches(patch):
     return patch("lms.views.basic_lti_launch.LtiLaunches")
+
+
+@pytest.fixture(autouse=True)
+def ModuleItemConfiguration(patch):
+    return patch("lms.views.basic_lti_launch.ModuleItemConfiguration")
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -169,10 +169,6 @@ class ConfiguredLaunch:
 
         grading_info_service.upsert_from_request.assert_not_called()
 
-    @pytest.fixture
-    def frontend_app(self, patch):
-        return patch("lms.views.basic_lti_launch.frontend_app")
-
     @pytest.fixture(autouse=True)
     def grading_info_service(self, pyramid_config):
         grading_info_service = mock.create_autospec(
@@ -476,6 +472,11 @@ def lti_outcome_params():
         "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
         "tool_consumer_info_product_family_code": "canvas",
     }
+
+
+@pytest.fixture(autouse=True)
+def frontend_app(patch):
+    return patch("lms.views.basic_lti_launch.frontend_app")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -174,10 +174,6 @@ class ConfiguredLaunch:
         return patch("lms.views.basic_lti_launch.frontend_app")
 
     @pytest.fixture(autouse=True)
-    def via_url(self, patch):
-        return patch("lms.views.basic_lti_launch.via_url")
-
-    @pytest.fixture(autouse=True)
     def grading_info_service(self, pyramid_config):
         grading_info_service = mock.create_autospec(
             GradingInfoService, instance=True, spec_set=True
@@ -480,3 +476,8 @@ def lti_outcome_params():
         "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
         "tool_consumer_info_product_family_code": "canvas",
     }
+
+
+@pytest.fixture(autouse=True)
+def via_url(patch):
+    return patch("lms.views.basic_lti_launch.via_url")

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -183,10 +183,6 @@ class ConfiguredLaunch:
         pyramid_config.register_service(lti_h_service, name="lti_h")
         return lti_h_service
 
-    @pytest.fixture
-    def LtiLaunches(self, patch):
-        return patch("lms.views.basic_lti_launch.LtiLaunches")
-
     @pytest.fixture(autouse=True)
     def ModuleItemConfiguration(self, patch):
         return patch("lms.views.basic_lti_launch.ModuleItemConfiguration")
@@ -465,6 +461,11 @@ def lti_outcome_params():
 @pytest.fixture(autouse=True)
 def BearerTokenSchema(patch):
     return patch("lms.views.basic_lti_launch.BearerTokenSchema")
+
+
+@pytest.fixture(autouse=True)
+def LtiLaunches(patch):
+    return patch("lms.views.basic_lti_launch.LtiLaunches")
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix a bunch of `BasicLTILaunchViews` test fixtures that were either missing, were not autouse when they should be, or were not module-scope when they should be.

* This makes the tests more correct (all the tests are now unit tests for `basic_lti_launch_test.py`, which is what they're supposed to be according to our testing approach, whereas previously some of them were also testing code from other modules)

* It also brings the code in line with our general testing patterns: the unit tests for a module always patch imports of other modules _from our own codebase_, and import patch fixtures are always module-level and autouse

* It's going to make the test code easier to refactor. I'm going to need to move a bunch of tests around between different test classes. Module-level autouse fixtures will just work as I do this without any changes, whereas class-level and non-autouse fixtures would require much juggling as I refactor the tests.