### PR TITLE
Centralize and deduplicate service fixtures

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,14 @@ from pyramid import testing
 from pyramid.request import apply_request_extensions
 
 from lms.services.application_instance_getter import ApplicationInstanceGetter
+from lms.services.canvas_api import CanvasAPIClient
+from lms.services.grading_info import GradingInfoService
+from lms.services.group_info import GroupInfoService
+from lms.services.h_api import HAPI
 from lms.services.launch_verifier import LaunchVerifier
+from lms.services.lti_h import LTIHService
+from lms.services.lti_outcomes import LTIOutcomesClient
+from lms.services.oauth1 import OAuth1Service
 from lms.values import LTIUser
 from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
 
@@ -130,7 +137,7 @@ def db_session(db_engine):
         conn.close()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def ai_getter(pyramid_config):
     ai_getter = mock.create_autospec(
         ApplicationInstanceGetter, spec_set=True, instance=True
@@ -142,11 +149,74 @@ def ai_getter(pyramid_config):
     return ai_getter
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
+def canvas_api_client(pyramid_config):
+    canvas_api_client = mock.create_autospec(
+        CanvasAPIClient, spec_set=True, instance=True
+    )
+    canvas_api_client.get_token.return_value = (
+        "test_access_token",
+        "test_refresh_token",
+        3600,
+    )
+    pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
+    return canvas_api_client
+
+
+@pytest.fixture
 def launch_verifier(pyramid_config):
     launch_verifier = mock.create_autospec(LaunchVerifier, spec_set=True, instance=True)
     pyramid_config.register_service(launch_verifier, name="launch_verifier")
     return launch_verifier
+
+
+@pytest.fixture
+def grading_info_service(pyramid_config):
+    grading_info_service = mock.create_autospec(
+        GradingInfoService, instance=True, spec_set=True
+    )
+    grading_info_service.get_by_assignment.return_value = []
+    pyramid_config.register_service(grading_info_service, name="grading_info")
+    return grading_info_service
+
+
+@pytest.fixture
+def group_info_service(pyramid_config):
+    group_info_service = mock.create_autospec(
+        GroupInfoService, instance=True, spec_set=True
+    )
+    pyramid_config.register_service(group_info_service, name="group_info")
+    return group_info_service
+
+
+@pytest.fixture
+def h_api(patch, pyramid_config):
+    h_api = mock.create_autospec(HAPI, spec_set=True, instance=True)
+    pyramid_config.register_service(h_api, name="h_api")
+    return h_api
+
+
+@pytest.fixture
+def lti_h_service(pyramid_config):
+    lti_h_service = mock.create_autospec(LTIHService, instance=True, spec_set=True)
+    pyramid_config.register_service(lti_h_service, name="lti_h")
+    return lti_h_service
+
+
+@pytest.fixture
+def lti_outcomes_client(pyramid_config):
+    lti_outcomes_client = mock.create_autospec(
+        LTIOutcomesClient, instance=True, spec_set=True
+    )
+    pyramid_config.register_service(lti_outcomes_client, name="lti_outcomes_client")
+    return lti_outcomes_client
+
+
+@pytest.fixture
+def oauth1_service(pyramid_config):
+    oauth1_service = mock.create_autospec(OAuth1Service, instance=True, spec_set=True)
+    pyramid_config.register_service(oauth1_service, name="oauth1")
+    return oauth1_service
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -388,6 +388,9 @@ class TestLTILaunchResource:
         return pyramid_request
 
 
+pytestmark = pytest.mark.usefixtures("ai_getter")
+
+
 @pytest.fixture(autouse=True)
 def JSConfig(patch):
     return patch("lms.resources.lti_launch.JSConfig")

--- a/tests/unit/lms/services/canvas_api_test.py
+++ b/tests/unit/lms/services/canvas_api_test.py
@@ -475,6 +475,9 @@ class TestSendWithRefreshAndRetry:
         return patch("lms.services.canvas_api.CanvasAPIClient.get_refreshed_token")
 
 
+pytestmark = pytest.mark.usefixtures("ai_getter")
+
+
 @pytest.fixture(autouse=True)
 def application_instance(db_session, pyramid_request):
     """The ApplicationInstance that the test OAuth2Token's belong to."""
@@ -515,7 +518,7 @@ def CanvasPublicURLResponseSchema(patch):
 
 
 @pytest.fixture
-def canvas_api_client(pyramid_config, pyramid_request):
+def canvas_api_client(CanvasAPIHelper, pyramid_config, pyramid_request):
     return CanvasAPIClient(mock.sentinel.context, pyramid_request)
 
 

--- a/tests/unit/lms/services/launch_verifier_test.py
+++ b/tests/unit/lms/services/launch_verifier_test.py
@@ -204,3 +204,6 @@ def sign(pyramid_request):
     pyramid_request.params["oauth_signature"] = oauthlib_client.get_oauth_signature(
         oauthlib_request
     )
+
+
+pytestmark = pytest.mark.usefixtures("ai_getter")

--- a/tests/unit/lms/services/lti_outcomes_test.py
+++ b/tests/unit/lms/services/lti_outcomes_test.py
@@ -11,7 +11,6 @@ from requests import RequestException
 
 from lms.services.exceptions import LTIOutcomesAPIError
 from lms.services.lti_outcomes import LTIOutcomesClient
-from lms.services.oauth1 import OAuth1Service
 
 
 class TestLTIOutcomesClient:
@@ -88,7 +87,7 @@ class TestLTIOutcomesClient:
                 self.GRADING_ID, pre_record_hook=lambda *args, **kwargs: hook_result
             )
 
-    def test_it_signs_request_with_oauth1(self, svc, requests, oauth1_svc):
+    def test_it_signs_request_with_oauth1(self, svc, requests, oauth1_service):
         requests.post.side_effect = OSError()
 
         # We don't care if this actually does anything afterwards, so just
@@ -100,7 +99,7 @@ class TestLTIOutcomesClient:
             url=Any(),
             data=Any(),
             headers=Any(),
-            auth=oauth1_svc.get_client.return_value,
+            auth=oauth1_service.get_client.return_value,
         )
 
     def test_requests_fail_if_http_status_is_error(self, svc, respond_with):
@@ -223,12 +222,9 @@ class TestLTIOutcomesClient:
     def svc(self, pyramid_request):
         return LTIOutcomesClient({}, pyramid_request)
 
-    @pytest.fixture(autouse=True)
-    def oauth1_svc(self, pyramid_config):
-        svc = mock.create_autospec(OAuth1Service, instance=True, spec_set=True)
-        pyramid_config.register_service(svc, name="oauth1")
-        return svc
-
     @pytest.fixture
     def requests(self, patch):
         return patch("lms.services.lti_outcomes.requests")
+
+
+pytestmark = pytest.mark.usefixtures("oauth1_service")

--- a/tests/unit/lms/services/oauth1_test.py
+++ b/tests/unit/lms/services/oauth1_test.py
@@ -51,3 +51,6 @@ class TestOAuth1Service:
     @pytest.fixture
     def OAuth1(self, patch):
         return patch("lms.services.oauth1.OAuth1")
+
+
+pytestmark = pytest.mark.usefixtures("ai_getter")

--- a/tests/unit/lms/validation/authentication/_launch_params_test.py
+++ b/tests/unit/lms/validation/authentication/_launch_params_test.py
@@ -71,3 +71,6 @@ class TestLaunchParamsSchema:
             "roles": "TEST_ROLES",
         }
         return pyramid_request
+
+
+pytestmark = pytest.mark.usefixtures("launch_verifier")

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -5,7 +5,6 @@ import pytest
 from pyramid.httpexceptions import HTTPInternalServerError
 
 from lms.services import CanvasAPIServerError
-from lms.services.canvas_api import CanvasAPIClient
 from lms.views.api.canvas.authorize import CanvasAPIAuthorizeViews
 
 
@@ -118,20 +117,6 @@ class TestOAuth2RedirectError:
 
 
 @pytest.fixture(autouse=True)
-def canvas_api_client(pyramid_config):
-    canvas_api_client = mock.create_autospec(
-        CanvasAPIClient, spec_set=True, instance=True
-    )
-    canvas_api_client.get_token.return_value = (
-        "test_access_token",
-        "test_refresh_token",
-        3600,
-    )
-    pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
-    return canvas_api_client
-
-
-@pytest.fixture(autouse=True)
 def BearerTokenSchema(patch):
     return patch("lms.views.api.canvas.authorize.BearerTokenSchema")
 
@@ -153,3 +138,6 @@ def canvas_oauth_callback_schema(CanvasOAuthCallbackSchema):
     schema = CanvasOAuthCallbackSchema.return_value
     schema.state_param.return_value = "test_state"
     return schema
+
+
+pytestmark = pytest.mark.usefixtures("ai_getter", "canvas_api_client")

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 
 from lms.services import CanvasAPIError
-from lms.services.canvas_api import CanvasAPIClient
 from lms.views.api.canvas.files import FilesAPIViews
 
 
@@ -75,14 +74,8 @@ class TestViaURL:
 
 
 @pytest.fixture(autouse=True)
-def canvas_api_client(pyramid_config):
-    canvas_api_client = mock.create_autospec(
-        CanvasAPIClient, spec_set=True, instance=True
-    )
-    pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
-    return canvas_api_client
-
-
-@pytest.fixture(autouse=True)
 def helpers(patch):
     return patch("lms.views.api.canvas.files.helpers")
+
+
+pytestmark = pytest.mark.usefixtures("canvas_api_client")

--- a/tests/unit/lms/views/api/lti_test.py
+++ b/tests/unit/lms/views/api/lti_test.py
@@ -6,7 +6,6 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from h_matchers import Any
 
-from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.views.api.lti import CanvasPreRecordHook, LTIOutcomesViews
 
 
@@ -140,8 +139,4 @@ class TestRecordResult:
         return pyramid_request
 
 
-@pytest.fixture(autouse=True)
-def lti_outcomes_client(pyramid_config):
-    svc = mock.create_autospec(LTIOutcomesClient, instance=True, spec_set=True)
-    pyramid_config.register_service(svc, name="lti_outcomes_client")
-    return svc
+pytestmark = pytest.mark.usefixtures("lti_outcomes_client")

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -6,9 +6,7 @@ from h_matchers import Any
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
 from lms.services import HAPIError
-from lms.services.grading_info import GradingInfoService
 from lms.services.h_api import HAPI
-from lms.services.lti_h import LTIHService
 from lms.validation.authentication._helpers._jwt import decode_jwt
 from lms.values import HUser, LTIUser
 from lms.views.basic_lti_launch import BasicLTILaunchViews
@@ -115,12 +113,6 @@ class TestBasicLTILaunch:
             }
         }
 
-    @pytest.fixture
-    def h_api(self, pyramid_config):
-        svc = mock.create_autospec(HAPI, instance=True, spec_set=True)
-        pyramid_config.register_service(svc, name="h_api")
-        return svc
-
 
 class ConfiguredLaunch:
     def make_request(self, context, pyramid_request):  # pragma: no cover
@@ -168,20 +160,6 @@ class ConfiguredLaunch:
         self.make_request(context, pyramid_request)
 
         grading_info_service.upsert_from_request.assert_not_called()
-
-    @pytest.fixture(autouse=True)
-    def grading_info_service(self, pyramid_config):
-        grading_info_service = mock.create_autospec(
-            GradingInfoService, instance=True, spec_set=True
-        )
-        pyramid_config.register_service(grading_info_service, name="grading_info")
-        return grading_info_service
-
-    @pytest.fixture(autouse=True)
-    def lti_h_service(self, pyramid_config):
-        lti_h_service = mock.create_autospec(LTIHService, instance=True, spec_set=True)
-        pyramid_config.register_service(lti_h_service, name="lti_h")
-        return lti_h_service
 
 
 class TestCanvasFileBasicLTILaunch(ConfiguredLaunch):
@@ -429,6 +407,9 @@ class TestUnconfiguredBasicLTILaunchNotAuthorized:
         ).unconfigured_basic_lti_launch_not_authorized()
 
         assert data == {}
+
+
+pytestmark = pytest.mark.usefixtures("h_api", "grading_info_service", "lti_h_service")
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
-from lms.services.lti_h import LTIHService
 from lms.views.content_item_selection import content_item_selection
 
 
@@ -120,15 +119,11 @@ class TestContentItemSelection:
         return context
 
 
+pytestmark = pytest.mark.usefixtures("lti_h_service")
+
+
 @pytest.fixture(autouse=True)
 def helpers(patch):
     helpers = patch("lms.views.content_item_selection.helpers")
     helpers.canvas_files_available.return_value = True
     return helpers
-
-
-@pytest.fixture(autouse=True)
-def lti_h_service(pyramid_config):
-    lti_h_service = mock.create_autospec(LTIHService, instance=True, spec_set=True)
-    pyramid_config.register_service(lti_h_service, name="lti_h")
-    return lti_h_service

--- a/tests/unit/lms/views/helpers/frontend_app_test.py
+++ b/tests/unit/lms/views/helpers/frontend_app_test.py
@@ -3,12 +3,10 @@ from unittest import mock
 import pytest
 
 from lms.models import GradingInfo
-from lms.services.grading_info import GradingInfoService
 from lms.values import HUser, LTIUser
 from lms.views.helpers import frontend_app
 
 
-@pytest.mark.usefixtures("grading_info_svc")
 class TestConfigureGrading:
     def test_it_enables_grading(self, grading_request):
         js_config = {}
@@ -37,10 +35,12 @@ class TestConfigureGrading:
 
         assert "lmsGrader" not in js_config
 
-    def test_it_fetches_grading_info_records(self, grading_request, grading_info_svc):
+    def test_it_fetches_grading_info_records(
+        self, grading_request, grading_info_service
+    ):
         frontend_app.configure_grading(grading_request, {})
 
-        grading_info_svc.get_by_assignment.assert_called_once_with(
+        grading_info_service.get_by_assignment.assert_called_once_with(
             oauth_consumer_key=grading_request.lti_user.oauth_consumer_key,
             context_id=grading_request.params["context_id"],
             resource_link_id=grading_request.params["resource_link_id"],
@@ -55,10 +55,10 @@ class TestConfigureGrading:
         assert js_config["grading"]["students"] == []
 
     def test_it_sets_js_properties_for_each_grading_info_record(
-        self, grading_info_svc, grading_infos, grading_request
+        self, grading_info_service, grading_infos, grading_request
     ):
         js_config = {}
-        grading_info_svc.get_by_assignment.return_value = grading_infos
+        grading_info_service.get_by_assignment.return_value = grading_infos
 
         frontend_app.configure_grading(grading_request, js_config)
 
@@ -79,12 +79,7 @@ class TestConfigureGrading:
         assert js_config["grading"]["assignmentName"] == "How to use Hypothesis"
 
 
-@pytest.fixture
-def grading_info_svc(pyramid_config):
-    svc = mock.create_autospec(GradingInfoService, instance=True)
-    pyramid_config.register_service(svc, name="grading_info")
-    svc.get_by_assignment.return_value = []
-    return svc
+pytestmark = pytest.mark.usefixtures("grading_info_service")
 
 
 @pytest.fixture


### PR DESCRIPTION
This adds fixtures to `tests/unit/conftest.py` for mock services for all
our services. We're now mocking all the services correctly in one place,
rather than mocks for particular services being distributed throughout
the tests and having inconsistencies in fixture naming. This also
removes some duplication where we had multiple fixtures in different
test files for mocking the same service.

Individual tests can of course override and modify or replace these global fixtures
in the usual way.

These are not autouse fixtures because that would cause every one of
these fixtures to be executed, including runnning
`mock.create_autospec()` which is slow, for every single test, and that
slows down a full test run significantly. Instead, modules that need
given services to be mocked declare that using a `pytestmark` attribute.
This is equivalent to having a module-level autouse fixture, but for a
fixture that isn't defined in the module.