### PR TITLE
WIP- Rpc improvements

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,5 +1,5 @@
 import Server from './server';
-import { requestConfig } from './methods';
+import { requestConfig, groupsAsync } from './methods';
 
 let server = {}; // Singleton RPC server reference
 
@@ -9,6 +9,7 @@ let server = {}; // Singleton RPC server reference
 function startRpcServer() {
   server = new Server();
   server.register('requestConfig', requestConfig);
+  server.register('groupsAsync', groupsAsync);
 }
 
 /**

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,5 +1,5 @@
 import Server from './server';
-import { requestConfig, groupsAsync } from './methods';
+import { groupsAsync, requestConfig, requestFrame } from './methods';
 
 let server = {}; // Singleton RPC server reference
 
@@ -10,6 +10,7 @@ function startRpcServer() {
   server = new Server();
   server.register('requestConfig', requestConfig);
   server.register('groupsAsync', groupsAsync);
+  server.register('requestFrame', requestFrame);
 }
 
 /**

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -1,4 +1,4 @@
-import { requestConfig } from './methods';
+import { requestConfig, requestFrame } from './methods';
 
 describe('postmessage_json_rpc/methods#requestConfig', () => {
   let configEl;
@@ -20,5 +20,10 @@ describe('postmessage_json_rpc/methods#requestConfig', () => {
   it('returns the config object', async () => {
     const result = await requestConfig();
     assert.deepEqual(result, { foo: 'bar' });
+  });
+
+  it('returns the parameters passed to requestFrame', async () => {
+    const result = await requestFrame({ bar: 1 });
+    assert.deepEqual(result, { bar: 1 });
   });
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -17,7 +17,8 @@ describe('postmessage_json_rpc/methods#requestConfig', () => {
     configEl.parentNode.removeChild(configEl);
   });
 
-  it('returns the config object', () => {
-    assert.deepEqual(requestConfig(), { foo: 'bar' });
+  it('returns the config object', async () => {
+    const result = await requestConfig();
+    assert.deepEqual(result, { foo: 'bar' });
   });
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -16,6 +16,21 @@ export async function requestConfig() {
 }
 
 /**
+ * Method that is used to trace back to the sender which frame
+ * is the embedding ancestor frame. An acknowledgment of this
+ * request tells the sender that this frame is the controlling
+ * embedder frame.
+ *
+ * @param {Object} params - Parameter object to round trip. Use this
+ *  to store a unique index when performing discovery.
+ * @return {Promise<Object>} Successful promise returning the
+ *  passed in parameter object.
+ */
+export async function requestFrame(params) {
+  return Promise.resolve(params);
+}
+
+/**
  * Temporary method that blocks for a little while to simulate
  * waiting for canvas groups to be ready.
  *

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -9,8 +9,22 @@
 /**
  * Return a Hypothesis client config object for the current LTI request.
  */
-export function requestConfig() {
+export async function requestConfig() {
   const configEl = document.querySelector('.js-config');
   const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
-  return clientConfigObj;
+  return Promise.resolve(clientConfigObj);
+}
+
+/**
+ * Temporary method that blocks for a little while to simulate
+ * waiting for canvas groups to be ready.
+ *
+ * TODO: replace this with a real request to lms/
+ */
+export async function groupsAsync() {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve('groupsAsync resolved!');
+    }, 500);
+  });
 }

--- a/lms/static/scripts/postmessage_json_rpc/server/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server.js
@@ -29,7 +29,7 @@ export default class Server {
     // origins will be ignored.
     this._allowedOrigins = configObj.allowedOrigins;
 
-    // Add a postMessage event listener so we can recieve JSON-RPC requests.
+    // Add a postMessage event listener so we can receive JSON-RPC requests.
     this._boundReceiveMessage = this._receiveMessage.bind(this);
     window.addEventListener('message', this._boundReceiveMessage);
 
@@ -126,8 +126,13 @@ export default class Server {
 
     // Call the method and return the result response.
     try {
-      const result = await method();
-      return { jsonrpc: '2.0', result: result, id: request.id };
+      let result;
+      if (request.params && Array.isArray(request.params)) {
+        result = await method(...request.params);
+      } else {
+        result = await method();
+      }
+      return Promise.resolve({ jsonrpc: '2.0', result, id: request.id });
     } catch (e) {
       return Promise.resolve({
         jsonrpc: '2.0',


### PR DESCRIPTION
Relates to https://github.com/hypothesis/client/pull/1843

This PR covers  3 changes.

1. Add ability to have async rpc methods

We need to add the ability for an RPC method to be async so it can fetch a result from the lms service. These changes allow the methods to return to the result asynchronously and delay the postMessage response according. This includes the changes from this PR https://github.com/hypothesis/lms/pull/1494

2. Add requestFrame method
`requestFrame` is used to discover which ancestor is the embedding frame as opposed to guessing at which frame is the right ancestor each call.

3. Allow RPC server methods to accept parameters

This matches what the client RPC server can already do. Parameters must be in array format otherwise they are ignored.

e.g.
```
{
      jsonrpc: '2.0',
      id: 'test_id',
      method: 'registeredMethod',
      params: ['one' {two: 'two’}]
      timeout: 2000
};
```


Note: I will need to squash these commits into 3, some of the messages are outdated.