### PR TITLE
Remove an unnecessary routes fixture

### DIFF
--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -168,7 +168,7 @@ class TestCanvasFileBasicLTILaunch(ConfiguredLaunch):
 
         assert (
             context.js_config.config["authUrl"]
-            == "http://example.com/TEST_AUTHORIZE_URL"
+            == "http://example.com/api/canvas/authorize"
         )
         assert context.js_config.config["lmsName"] == "Canvas"
 
@@ -194,10 +194,6 @@ class TestCanvasFileBasicLTILaunch(ConfiguredLaunch):
 
     def make_request(self, context, pyramid_request):
         BasicLTILaunchViews(context, pyramid_request).canvas_file_basic_lti_launch()
-
-    @pytest.fixture(autouse=True)
-    def routes(self, pyramid_config):
-        pyramid_config.add_route("canvas_api.authorize", "/TEST_AUTHORIZE_URL")
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
This route is already added by a global fixture:

https://github.com/hypothesis/lms/blob/07c3af58a06011a0232df7e6daa5516ffbafbe91/tests/unit/conftest.py#L222-L233