### PR TITLE
Remove test class inheritance

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,5 +10,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.49
+fail_under = 98.56
 skip_covered = True

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -6,8 +6,6 @@ from h_matchers import Any
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
 from lms.services import HAPIError
-from lms.services.h_api import HAPI
-from lms.validation.authentication._helpers._jwt import decode_jwt
 from lms.values import HUser, LTIUser
 from lms.views.basic_lti_launch import BasicLTILaunchViews
 
@@ -305,7 +303,7 @@ class TestDBConfiguredBasicLTILaunch:
         )
 
     def test_it_configures_frontend_grading(
-        self, context, pyramid_request, frontend_app, via_url, ModuleItemConfiguration,
+        self, context, pyramid_request, frontend_app
     ):
         db_configured_basic_lti_launch_caller(context, pyramid_request)
         frontend_app.configure_grading.assert_called_once_with(
@@ -328,13 +326,7 @@ class TestURLConfiguredBasicLTILaunch:
         )
 
     def test_it_configures_frontend_grading(
-        self,
-        context,
-        pyramid_request,
-        frontend_app,
-        lti_outcome_params,
-        via_url,
-        ModuleItemConfiguration,
+        self, context, pyramid_request, frontend_app, lti_outcome_params,
     ):
         pyramid_request.params = lti_outcome_params
 
@@ -365,7 +357,7 @@ class TestConfigureModuleItem:
         assert context.js_config.config["urls"]["via_url"] == via_url.return_value
 
     def test_it_configures_frontend_grading(
-        self, context, pyramid_request, frontend_app, via_url, ModuleItemConfiguration,
+        self, context, pyramid_request, frontend_app
     ):
         configure_module_item_caller(context, pyramid_request)
 
@@ -420,7 +412,7 @@ class TestUnconfiguredBasicLTILaunch:
         )
 
     @pytest.fixture
-    def pyramid_request(self, context, pyramid_request):
+    def pyramid_request(self, pyramid_request):
         pyramid_request.params = {
             "user_id": "TEST_USER_ID",
             "resource_link_id": "TEST_RESOURCE_LINK_ID",

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -12,6 +12,75 @@ from lms.values import HUser, LTIUser
 from lms.views.basic_lti_launch import BasicLTILaunchViews
 
 
+def canvas_file_basic_lti_launch_caller(context, pyramid_request):
+    """
+    Call BasicLTILaunchViews.canvas_file_basic_lti_launch().
+
+    Set up the appropriate conditions and then call
+    BasicLTILaunchViews.canvas_file_basic_lti_launch(), and return whatever
+    BasicLTILaunchViews.canvas_file_basic_lti_launch() returns.
+    """
+    # The file_id param is always present when canvas_file_basic_lti_launch()
+    # is called. The canvas_file=True view predicate ensures this.
+    pyramid_request.params["file_id"] = "TEST_FILE_ID"
+
+    views = BasicLTILaunchViews(context, pyramid_request)
+
+    return views.canvas_file_basic_lti_launch()
+
+
+def db_configured_basic_lti_launch_caller(context, pyramid_request):
+    """
+    Call BasicLTILaunchViews.db_configured_basic_lti_launch().
+
+    Set up the appropriate conditions and then call
+    BasicLTILaunchViews.db_configured_basic_lti_launch(), and return whatever
+    BasicLTILaunchViews.db_configured_basic_lti_launch() returns.
+    """
+    views = BasicLTILaunchViews(context, pyramid_request)
+    return views.db_configured_basic_lti_launch()
+
+
+def url_configured_basic_lti_launch_caller(context, pyramid_request):
+    """
+    Call BasicLTILaunchViews.url_configured_basic_lti_launch().
+
+    Set up the appropriate conditions and then call
+    BasicLTILaunchViews.url_configured_basic_lti_launch(), and return whatever
+    BasicLTILaunchViews.url_configured_basic_lti_launch() returns.
+    """
+    # The `url` parsed param is always present when
+    # url_configured_basic_lti_launch() is called. The url_configured=True view
+    # predicate and LaunchParamsURLConfiguredSchema ensure this.
+    pyramid_request.parsed_params = {"url": "TEST_URL"}
+
+    views = BasicLTILaunchViews(context, pyramid_request)
+
+    return views.url_configured_basic_lti_launch()
+
+
+def configure_module_item_caller(context, pyramid_request):
+    """
+    Call BasicLTILaunchViews.configure_module_item().
+
+    Set up the appropriate conditions and then call
+    BasicLTILaunchViews.configure_module_item(), and return whatever
+    BasicLTILaunchViews.configure_module_item() returns.
+    """
+    # The document_url, resource_link_id and tool_consumer_instance_guid parsed
+    # params are always present when configure_module_item() is called.
+    # ConfigureModuleItemSchema ensures this.
+    pyramid_request.parsed_params = {
+        "document_url": "TEST_DOCUMENT_URL",
+        "resource_link_id": "TEST_RESOURCE_LINK_ID",
+        "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+    }
+
+    views = BasicLTILaunchViews(context, pyramid_request)
+
+    return views.configure_module_item()
+
+
 class TestBasicLTILaunchViewsInit:
     """Unit tests for BasicLTILaunchViews.__init__()."""
 
@@ -107,11 +176,17 @@ class TestBasicLTILaunchViewsInit:
         }
 
 
-class ConfiguredLaunch:
-    def make_request(self, context, pyramid_request):  # pragma: no cover
-        raise NotImplementedError("Child tests must implement this function")
+class TestCommon:
+    """
+    Tests common to multiple (but not all) BasicLTILaunchViews views.
 
-    def test_it_reports_lti_launches(self, context, pyramid_request, LtiLaunches):
+    See the parametrized `view_caller` fixture below for the list of view
+    methods that these tests apply to.
+    """
+
+    def test_it_reports_lti_launches(
+        self, context, pyramid_request, LtiLaunches, view_caller
+    ):
         pyramid_request.params.update(
             {
                 "context_id": "TEST_CONTEXT_ID",
@@ -119,7 +194,7 @@ class ConfiguredLaunch:
             }
         )
 
-        self.make_request(context, pyramid_request)
+        view_caller(context, pyramid_request)
 
         LtiLaunches.add.assert_called_once_with(
             pyramid_request.db,
@@ -128,36 +203,55 @@ class ConfiguredLaunch:
         )
 
     def test_it_calls_grading_info_upsert(
-        self, context, pyramid_request, grading_info_service
+        self, context, pyramid_request, grading_info_service, view_caller
     ):
-        self.make_request(context, pyramid_request)
+        view_caller(context, pyramid_request)
 
         grading_info_service.upsert_from_request.assert_called_once_with(
             pyramid_request, h_user=context.h_user, lti_user=pyramid_request.lti_user
         )
 
     def test_it_does_not_call_grading_info_upsert_if_instructor(
-        self, context, pyramid_request, grading_info_service
+        self, context, pyramid_request, grading_info_service, view_caller
     ):
         pyramid_request.lti_user = LTIUser("USER_ID", "OAUTH_STUFF", roles="instructor")
 
-        self.make_request(context, pyramid_request)
+        view_caller(context, pyramid_request)
 
         grading_info_service.upsert_from_request.assert_not_called()
 
     def test_it_does_not_call_grading_info_upsert_if_canvas(
-        self, context, pyramid_request, grading_info_service
+        self, context, pyramid_request, grading_info_service, view_caller
     ):
         pyramid_request.params["tool_consumer_info_product_family_code"] = "canvas"
 
-        self.make_request(context, pyramid_request)
+        view_caller(context, pyramid_request)
 
         grading_info_service.upsert_from_request.assert_not_called()
 
+    @pytest.fixture(
+        params=[
+            canvas_file_basic_lti_launch_caller,
+            db_configured_basic_lti_launch_caller,
+            url_configured_basic_lti_launch_caller,
+            configure_module_item_caller,
+        ]
+    )
+    def view_caller(self, request):
+        """
+        Return a function that calls the view method to be tested.
 
-class TestCanvasFileBasicLTILaunch(ConfiguredLaunch):
+        This is a parametrized fixture. A test that uses this fixture will be
+        run multiple times, once for each parametrized version of this fixture.
+
+        See https://docs.pytest.org/en/latest/fixture.html#parametrizing-fixtures
+        """
+        return request.param
+
+
+class TestCanvasFileBasicLTILaunch:
     def test_it_configures_frontend(self, context, pyramid_request):
-        self.make_request(context, pyramid_request)
+        canvas_file_basic_lti_launch_caller(context, pyramid_request)
 
         assert (
             context.js_config.config["authUrl"]
@@ -166,7 +260,7 @@ class TestCanvasFileBasicLTILaunch(ConfiguredLaunch):
         assert context.js_config.config["lmsName"] == "Canvas"
 
     def test_it_configures_via_callback_url(self, context, pyramid_request):
-        self.make_request(context, pyramid_request)
+        canvas_file_basic_lti_launch_caller(context, pyramid_request)
 
         assert (
             context.js_config.config["urls"]["via_url_callback"]
@@ -178,26 +272,15 @@ class TestCanvasFileBasicLTILaunch(ConfiguredLaunch):
     ):
         pyramid_request.params.update(lti_outcome_params)
 
-        self.make_request(context, pyramid_request)
+        canvas_file_basic_lti_launch_caller(context, pyramid_request)
 
         assert (
             context.js_config.config["submissionParams"]["canvas_file_id"]
             == "TEST_FILE_ID"
         )
 
-    def make_request(self, context, pyramid_request):
-        BasicLTILaunchViews(context, pyramid_request).canvas_file_basic_lti_launch()
 
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
-            # file_id is always required by canvas_file_basic_lti_launch.
-            "file_id": "TEST_FILE_ID",
-        }
-        return pyramid_request
-
-
-class TestDBConfiguredBasicLTILaunch(ConfiguredLaunch):
+class TestDBConfiguredBasicLTILaunch:
     def test_it_configures_via_url(
         self,
         context,
@@ -209,7 +292,7 @@ class TestDBConfiguredBasicLTILaunch(ConfiguredLaunch):
         pyramid_request.params.update(lti_outcome_params)
         ModuleItemConfiguration.get_document_url.return_value = "TEST_DOCUMENT_URL"
 
-        self.make_request(context, pyramid_request)
+        db_configured_basic_lti_launch_caller(context, pyramid_request)
 
         ModuleItemConfiguration.get_document_url.assert_called_once_with(
             pyramid_request.db, "TEST_GUID", "TEST_RESOURCE_LINK_ID",
@@ -224,22 +307,19 @@ class TestDBConfiguredBasicLTILaunch(ConfiguredLaunch):
     def test_it_configures_frontend_grading(
         self, context, pyramid_request, frontend_app, via_url, ModuleItemConfiguration,
     ):
-        self.make_request(context, pyramid_request)
+        db_configured_basic_lti_launch_caller(context, pyramid_request)
         frontend_app.configure_grading.assert_called_once_with(
             pyramid_request, context.js_config.config
         )
 
-    def make_request(self, context, pyramid_request):
-        BasicLTILaunchViews(context, pyramid_request).db_configured_basic_lti_launch()
 
-
-class TestURLConfiguredBasicLTILaunch(ConfiguredLaunch):
+class TestURLConfiguredBasicLTILaunch:
     def test_it_configures_via_url(
         self, context, pyramid_request, lti_outcome_params, via_url
     ):
         pyramid_request.params.update(lti_outcome_params)
 
-        self.make_request(context, pyramid_request)
+        url_configured_basic_lti_launch_caller(context, pyramid_request)
 
         via_url.assert_called_once_with(pyramid_request, "TEST_URL")
         assert context.js_config.config["urls"]["via_url"] == via_url.return_value
@@ -258,27 +338,18 @@ class TestURLConfiguredBasicLTILaunch(ConfiguredLaunch):
     ):
         pyramid_request.params = lti_outcome_params
 
-        self.make_request(context, pyramid_request)
+        url_configured_basic_lti_launch_caller(context, pyramid_request)
 
         frontend_app.configure_grading.assert_called_once_with(
             pyramid_request, context.js_config.config
         )
 
-    def make_request(self, context, pyramid_request):
-        BasicLTILaunchViews(context, pyramid_request).url_configured_basic_lti_launch()
 
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        # url_configured_basic_lti_launch() always needs url.
-        pyramid_request.parsed_params = {"url": "TEST_URL"}
-        return pyramid_request
-
-
-class TestConfigureModuleItem(ConfiguredLaunch):
+class TestConfigureModuleItem:
     def test_it_saves_the_assignments_document_url_to_the_db(
         self, context, pyramid_request, ModuleItemConfiguration
     ):
-        self.make_request(context, pyramid_request)
+        configure_module_item_caller(context, pyramid_request)
 
         ModuleItemConfiguration.set_document_url.assert_called_once_with(
             pyramid_request.db,
@@ -288,7 +359,7 @@ class TestConfigureModuleItem(ConfiguredLaunch):
         )
 
     def test_it_configures_via_url(self, context, pyramid_request, via_url):
-        self.make_request(context, pyramid_request)
+        configure_module_item_caller(context, pyramid_request)
 
         via_url.assert_called_once_with(pyramid_request, "TEST_DOCUMENT_URL")
         assert context.js_config.config["urls"]["via_url"] == via_url.return_value
@@ -296,24 +367,11 @@ class TestConfigureModuleItem(ConfiguredLaunch):
     def test_it_configures_frontend_grading(
         self, context, pyramid_request, frontend_app, via_url, ModuleItemConfiguration,
     ):
-        self.make_request(context, pyramid_request)
+        configure_module_item_caller(context, pyramid_request)
 
         frontend_app.configure_grading.assert_called_once_with(
             pyramid_request, context.js_config.config
         )
-
-    def make_request(self, context, pyramid_request):
-        BasicLTILaunchViews(context, pyramid_request).configure_module_item()
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = {
-            "document_url": "TEST_DOCUMENT_URL",
-            "resource_link_id": "TEST_RESOURCE_LINK_ID",
-            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
-        }
-
-        return pyramid_request
 
 
 class TestUnconfiguredBasicLTILaunch:

--- a/tests/unit/lms/views/predicates/__init___test.py
+++ b/tests/unit/lms/views/predicates/__init___test.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+from lms.views.predicates import includeme
+from lms.views.predicates._lti_launch import (
+    AuthorizedToConfigureAssignments,
+    CanvasFile,
+    Configured,
+    DBConfigured,
+    URLConfigured,
+)
+
+
+def test_includeme_adds_the_view_predicates():
+    config = mock.Mock(spec_set=["add_view_predicate"])
+
+    includeme(config)
+
+    assert config.add_view_predicate.call_args_list == [
+        mock.call("db_configured", DBConfigured),
+        mock.call("canvas_file", CanvasFile),
+        mock.call("url_configured", URLConfigured),
+        mock.call("configured", Configured),
+        mock.call(
+            "authorized_to_configure_assignments", AuthorizedToConfigureAssignments
+        ),
+    ]


### PR DESCRIPTION
Factor out some test class inheritance in `basic_lti_launch_test.py`
that was being used to run one base class of tests against a few
different view methods.
Replace this with a pytest parametrized fixture instead.

Test class inheritance is un-idiomatic in pytest and I think it might be
incompatible with some pytest features. I also found it quite confusing
(I didn't spot the inheritance, and it sent me spinning for a while) and
my experience with test class inheritance (in past lives when I worked
on projects that used nosetests) is that it usually leads to test
maintenance horror by tightly coupling test classes to each other, and
by making code harder to understand as you have to refer to multiple
classes to follow it. The main problem though is that the inheritance
and coupling is making it hard for me to refactor these tests in the way
that I need to, because I need to split and join test classes, move
tests between classes, etc.

Replace the inheritance with a simpler and more explicit fixture-based
approach that makes the tests much easier to maintain and to refactor
as the test classes are now all separate from each other,
and is more idiomatic in pytest.

## How these test classes worked before

* Each of the test classes `TestCanvasFileBasicLTILaunch`,
  `TestDBConfiguredBasicLTILaunch`, `TestURLConfiguredBasicLTILaunch` and
  `TestConfigureModuleItem` had a `make_request(context, pyramid_request)`
  method that would call the appropriate view method.

* Each of the four test classes also overrode the `pyramid_request`
  fixture and added the request params necessary to call that view method.
  For example `canvas_file_basic_lti_launch()` only works if `"file_id"`
  is in `request.params` (and only ever gets called if `"file_id"` is in
  `request.params`), and so on.

* Tests common to all four view methods were in a base class named
  `ConfiguredLaunch`. `ConfiguredLaunch` would not itself be picked up
  by pytest as a test class (name doesn't start with "Test"). Rather,
  each of `TestCanvasFileBasicLTILaunch`,
  `TestDBConfiguredBasicLTILaunch`, `TestURLConfiguredBasicLTILaunch`
  and `TestConfigureModuleItem` inherited from `ConfiguredLaunch` and so
  inherited the test methods in `ConfiguredLaunch`.

* `ConfiguredLaunch`'s test methods called `self.make_request(context,
  request)` in order to call the view method under test, and by
  inheritance this would be the `make_request` of
  `TestCanvasFileBasicLTILaunch`, `TestDBConfiguredBasicLTILaunch`,
  `TestURLConfiguredBasicLTILaunch` or `TestConfigureModuleItem`
  depending on which test class was being run, so `ConfiguredLaunch`'s
  tests would all get run for all four view methods.

* `ConfiguredLaunch` wasn't a great name since these tests are also run
  against the `configure_module_item()` view which is an _un_-configured
  launch

## How these test classes work now

* For each view method there's a "caller" function at the top of
  `basic_lti_launch_test.py` that sets up the necessary request params
  and then calls the view:

  ```python
  def canvas_file_basic_lti_launch_caller(context, pyramid_request):
      pyramid_request.params["file_id"] = "TEST_FILE_ID"
      views = BasicLTILaunchViews(context, pyramid_request)
      return views.canvas_file_basic_lti_launch()

  def db_configured_basic_lti_launch_caller(context, pyramid_request):
      ...

  def url_configured_basic_lti_launch_caller(context, pyramid_request):
      ...

  def configure_module_item_caller(context, pyramid_request):
      ...
  ```

* The four test classes no longer have their `make_request()` methods
  nor their `pyramid_request` fixtures, as both things are now done by
  the caller function. Each test class calls the appropriate caller function
  when it wants to call the view.

* The tests common to all four view methods are in a `TestCommon` class
  that uses a `view_caller` parametrized fixture to run all of its tests
  four times:

  ```python
  class TestCommon:
      def test_something(self, context, pyramid_request, view_caller):
          ...

          view_caller(context, pyramid_request)

          ...

    @pytest.fixture(
        params=[
            canvas_file_basic_lti_launch_caller,
            db_configured_basic_lti_launch_caller,
            url_configured_basic_lti_launch_caller,
            configure_module_item_caller,
        ]
    )
    def view_caller(self, request):
        return request.param
  ```

* Module-level functions are the appropriate place for these caller functions, which are helper functions shared by multiple test classes in the module. Same as how shared pytest fixtures or any other shared helper functions would be module-level functions, if they were used by multiple test classes. The test classes don't use each other in any way, but they can all use the module-level helpers and fixtures.

* This is simple and explicit, there's no inheritance, and the test
  classes are decoupled from each other
