### PR TITLE
Add resource_link_id param to pyramid_request fixture

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -47,6 +47,7 @@ def pyramid_request(db_session):
             "tool_consumer_instance_guid": "TEST_GUID",
             "content_item_return_url": "https://www.example.com",
             "lti_version": "TEST",
+            "resource_link_id": "TEST_RESOURCE_LINK_ID",
         }
     )
     pyramid_request.feature = mock.create_autospec(

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -223,9 +223,7 @@ class TestDBConfiguredBasicLTILaunch(ConfiguredLaunch):
         self.make_request(context, pyramid_request)
 
         ModuleItemConfiguration.get_document_url.assert_called_once_with(
-            pyramid_request.db,
-            "TEST_TOOL_CONSUMER_INSTANCE_GUID",
-            "TEST_RESOURCE_LINK_ID",
+            pyramid_request.db, "TEST_GUID", "TEST_RESOURCE_LINK_ID",
         )
         via_url.assert_called_once_with(pyramid_request, "TEST_DOCUMENT_URL")
         assert context.js_config.config["urls"]["via_url"] == via_url.return_value
@@ -244,16 +242,6 @@ class TestDBConfiguredBasicLTILaunch(ConfiguredLaunch):
 
     def make_request(self, context, pyramid_request):
         BasicLTILaunchViews(context, pyramid_request).db_configured_basic_lti_launch()
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
-            # db_configured_basic_lti_launch() always needs resource_link_id
-            # and tool_consumer_instance_guid.
-            "resource_link_id": "TEST_RESOURCE_LINK_ID",
-            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
-        }
-        return pyramid_request
 
 
 class TestURLConfiguredBasicLTILaunch(ConfiguredLaunch):
@@ -279,11 +267,7 @@ class TestURLConfiguredBasicLTILaunch(ConfiguredLaunch):
         via_url,
         ModuleItemConfiguration,
     ):
-        pyramid_request.params = {
-            "resource_link_id": "TEST_RESOURCE_LINK_ID",
-            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
-            **lti_outcome_params,
-        }
+        pyramid_request.params = lti_outcome_params
 
         self.make_request(context, pyramid_request)
 


### PR DESCRIPTION
Rather than individual tests adding this standard LTI launch param to
pyramid_request.params just add it to the global pyramid_request fixture
as we already do for other standard params.

Also removed some unnecessary setting of the tool_consumer_instance_guid
param in tests: this param is _already_ present in the global
pyramid_request fixture.