### PR TITLE
Factor out lti_outcome_params fixture

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,5 +10,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.56
+fail_under = 98.68
 skip_covered = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,8 +7,13 @@ source =
 omit =
     lms/scripts/*
 
+    # Don't bother covering these files as they just contain feature flags test
+    # views, not really user-facing code.
+    lms/extensions/feature_flags/views/test.py
+    lms/views/feature_flags_test.py
+
 [report]
 show_missing = True
 precision = 2
-fail_under = 98.68
+fail_under = 99.16
 skip_covered = True

--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -10,15 +10,14 @@ from lms.models import ApplicationInstance
 )
 def create_application_instance(request):
     """Create application instance in the databse and respond with key and secret."""
-    # Check to make sure that both developer key and secret are present. If not set to None.
+
+    # Default developer_key and developer_secret to None rather than letting
+    # them be empty strings.
     developer_key = request.params["developer_key"].strip()
     developer_secret = request.params["developer_secret"].strip()
-    if developer_key == "":
-        developer_key = None
 
-    if developer_secret == "":
-        developer_secret = None
-
+    # If either one of developer_key or developer_secret is missing, then we
+    # don't save the other one either.
     if not developer_key or not developer_secret:
         developer_key = None
         developer_secret = None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -45,6 +45,7 @@ def pyramid_request(db_session):
             "user_id": "TEST_USER_ID",
             "roles": "Instructor",
             "tool_consumer_instance_guid": "TEST_GUID",
+            "tool_consumer_info_product_family_code": "whiteboard",
             "content_item_return_url": "https://www.example.com",
             "lti_version": "TEST",
             "resource_link_id": "TEST_RESOURCE_LINK_ID",

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -87,12 +87,10 @@ class TestBasicLTILaunchViewsInit:
 
         assert context.js_config.config["mode"] == "basic-lti-launch"
 
-    def test_it_adds_report_submission_config_if_required_params_present(
-        self, context, pyramid_request, lti_outcome_params
+    def test_it_adds_report_submission_config_if_the_LMS_is_Canvas(
+        self, context, canvas_request
     ):
-        pyramid_request.params.update(lti_outcome_params)
-
-        BasicLTILaunchViews(context, pyramid_request)
+        BasicLTILaunchViews(context, canvas_request)
 
         assert context.js_config.config["submissionParams"] == {
             "h_username": context.h_user.username,
@@ -109,9 +107,8 @@ class TestBasicLTILaunchViewsInit:
         ],
     )
     def test_it_doesnt_add_report_submission_config_if_required_param_missing(
-        self, context, pyramid_request, lti_outcome_params, key
+        self, context, pyramid_request, key
     ):
-        pyramid_request.params.update(lti_outcome_params)
         del pyramid_request.params[key]
 
         BasicLTILaunchViews(context, pyramid_request)
@@ -119,32 +116,22 @@ class TestBasicLTILaunchViewsInit:
         assert "submissionParams" not in context.js_config.config
 
     def test_it_doesnt_add_report_submission_config_if_lms_not_canvas(
-        self, context, pyramid_request, lti_outcome_params
+        self, context, pyramid_request
     ):
-        pyramid_request.params.update(lti_outcome_params)
-        pyramid_request.params.update(
-            {"tool_consumer_info_product_family_code": "whiteboard"}
-        )
-
         BasicLTILaunchViews(context, pyramid_request)
 
         assert "submissionParams" not in context.js_config.config
 
     def test_it_configures_client_to_focus_on_user_if_in_canvas_and_param_set(
-        self, context, pyramid_request, h_api
+        self, context, canvas_request, h_api
     ):
         context.js_config.config["hypothesisClient"] = {}
-        pyramid_request.params.update(
-            {
-                "tool_consumer_info_product_family_code": "canvas",
-                "focused_user": "user123",
-            }
-        )
+        canvas_request.params["focused_user"] = "user123"
         h_api.get_user.return_value = HUser(
             authority="TEST_AUTHORITY", username="user123", display_name="Jim Smith"
         )
 
-        BasicLTILaunchViews(context, pyramid_request)
+        BasicLTILaunchViews(context, canvas_request)
 
         h_api.get_user.assert_called_once_with("user123")
         assert context.js_config.config["hypothesisClient"]["focus"] == {
@@ -152,18 +139,13 @@ class TestBasicLTILaunchViewsInit:
         }
 
     def test_it_uses_placeholder_display_name_for_focused_user_if_api_call_fails(
-        self, context, pyramid_request, h_api
+        self, context, canvas_request, h_api
     ):
         context.js_config.config["hypothesisClient"] = {}
-        pyramid_request.params.update(
-            {
-                "focused_user": "user123",
-                "tool_consumer_info_product_family_code": "canvas",
-            }
-        )
+        canvas_request.params["focused_user"] = "user123"
         h_api.get_user.side_effect = HAPIError("User does not exist")
 
-        BasicLTILaunchViews(context, pyramid_request)
+        BasicLTILaunchViews(context, canvas_request)
 
         h_api.get_user.assert_called_once_with("user123")
         assert context.js_config.config["hypothesisClient"]["focus"] == {
@@ -219,11 +201,9 @@ class TestCommon:
         grading_info_service.upsert_from_request.assert_not_called()
 
     def test_it_does_not_call_grading_info_upsert_if_canvas(
-        self, context, pyramid_request, grading_info_service, view_caller
+        self, context, canvas_request, grading_info_service, view_caller
     ):
-        pyramid_request.params["tool_consumer_info_product_family_code"] = "canvas"
-
-        view_caller(context, pyramid_request)
+        view_caller(context, canvas_request)
 
         grading_info_service.upsert_from_request.assert_not_called()
 
@@ -248,8 +228,8 @@ class TestCommon:
 
 
 class TestCanvasFileBasicLTILaunch:
-    def test_it_configures_frontend(self, context, pyramid_request):
-        canvas_file_basic_lti_launch_caller(context, pyramid_request)
+    def test_it_configures_frontend(self, context, canvas_request):
+        canvas_file_basic_lti_launch_caller(context, canvas_request)
 
         assert (
             context.js_config.config["authUrl"]
@@ -257,20 +237,16 @@ class TestCanvasFileBasicLTILaunch:
         )
         assert context.js_config.config["lmsName"] == "Canvas"
 
-    def test_it_configures_via_callback_url(self, context, pyramid_request):
-        canvas_file_basic_lti_launch_caller(context, pyramid_request)
+    def test_it_configures_via_callback_url(self, context, canvas_request):
+        canvas_file_basic_lti_launch_caller(context, canvas_request)
 
         assert (
             context.js_config.config["urls"]["via_url_callback"]
             == "http://example.com/api/canvas/files/TEST_FILE_ID/via_url"
         )
 
-    def test_it_configures_submission_params(
-        self, context, pyramid_request, lti_outcome_params
-    ):
-        pyramid_request.params.update(lti_outcome_params)
-
-        canvas_file_basic_lti_launch_caller(context, pyramid_request)
+    def test_it_configures_submission_params(self, context, canvas_request):
+        canvas_file_basic_lti_launch_caller(context, canvas_request)
 
         assert (
             context.js_config.config["submissionParams"]["canvas_file_id"]
@@ -280,22 +256,16 @@ class TestCanvasFileBasicLTILaunch:
 
 class TestDBConfiguredBasicLTILaunch:
     def test_it_configures_via_url(
-        self,
-        context,
-        pyramid_request,
-        lti_outcome_params,
-        via_url,
-        ModuleItemConfiguration,
+        self, context, canvas_request, via_url, ModuleItemConfiguration,
     ):
-        pyramid_request.params.update(lti_outcome_params)
         ModuleItemConfiguration.get_document_url.return_value = "TEST_DOCUMENT_URL"
 
-        db_configured_basic_lti_launch_caller(context, pyramid_request)
+        db_configured_basic_lti_launch_caller(context, canvas_request)
 
         ModuleItemConfiguration.get_document_url.assert_called_once_with(
-            pyramid_request.db, "TEST_GUID", "TEST_RESOURCE_LINK_ID",
+            canvas_request.db, "TEST_GUID", "TEST_RESOURCE_LINK_ID",
         )
-        via_url.assert_called_once_with(pyramid_request, "TEST_DOCUMENT_URL")
+        via_url.assert_called_once_with(canvas_request, "TEST_DOCUMENT_URL")
         assert context.js_config.config["urls"]["via_url"] == via_url.return_value
         assert (
             context.js_config.config["submissionParams"]["document_url"]
@@ -312,24 +282,18 @@ class TestDBConfiguredBasicLTILaunch:
 
 
 class TestURLConfiguredBasicLTILaunch:
-    def test_it_configures_via_url(
-        self, context, pyramid_request, lti_outcome_params, via_url
-    ):
-        pyramid_request.params.update(lti_outcome_params)
+    def test_it_configures_via_url(self, context, canvas_request, via_url):
+        url_configured_basic_lti_launch_caller(context, canvas_request)
 
-        url_configured_basic_lti_launch_caller(context, pyramid_request)
-
-        via_url.assert_called_once_with(pyramid_request, "TEST_URL")
+        via_url.assert_called_once_with(canvas_request, "TEST_URL")
         assert context.js_config.config["urls"]["via_url"] == via_url.return_value
         assert (
             context.js_config.config["submissionParams"]["document_url"] == "TEST_URL"
         )
 
     def test_it_configures_frontend_grading(
-        self, context, pyramid_request, frontend_app, lti_outcome_params,
+        self, context, pyramid_request, frontend_app
     ):
-        pyramid_request.params = lti_outcome_params
-
         url_configured_basic_lti_launch_caller(context, pyramid_request)
 
         frontend_app.configure_grading.assert_called_once_with(
@@ -445,17 +409,20 @@ def context():
 
 
 @pytest.fixture
-def lti_outcome_params():
-    # Request params needed for calls to the LMS's Outcome Management service,
-    # present when a student launches an assignment.
-    #
-    # These params are typically not present when a teacher launches an
-    # assignment.
-    return {
-        "lis_result_sourcedid": "modelstudent-assignment1",
-        "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
-        "tool_consumer_info_product_family_code": "canvas",
-    }
+def pyramid_request(pyramid_request):
+    pyramid_request.params.update(
+        {
+            "lis_result_sourcedid": "modelstudent-assignment1",
+            "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
+        }
+    )
+    return pyramid_request
+
+
+@pytest.fixture
+def canvas_request(pyramid_request):
+    pyramid_request.params["tool_consumer_info_product_family_code"] = "canvas"
+    return pyramid_request
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/views/test_application_instance.py
+++ b/tests/unit/lms/views/test_application_instance.py
@@ -1,9 +1,54 @@
+import pytest
+
 from lms.models import ApplicationInstance
-from lms.views.application_instances import create_application_instance
+from lms.views.application_instances import create_application_instance, new_application_instance
 
 
-class TestApplicationInstance:
+class TestCreateApplicationInstance:
     def test_it_creates_an_application_instance(self, pyramid_request):
+        create_application_instance(pyramid_request)
+
+        ai = pyramid_request.db.query(ApplicationInstance).one()
+        assert ai.lms_url == "canvas.example.com"
+        assert ai.requesters_email == "email@example.com"
+        assert ai.developer_key is None
+        assert ai.developer_secret is None
+
+    def test_it_saves_the_Canvas_developer_key_and_secret_if_given(
+        self, pyramid_request
+    ):
+        pyramid_request.params["developer_key"] = "example_key"
+        pyramid_request.params["developer_secret"] = "example_secret"
+
+        create_application_instance(pyramid_request)
+
+        ai = pyramid_request.db.query(ApplicationInstance).one()
+        assert ai.developer_key == "example_key"
+        assert ai.developer_secret
+
+    @pytest.mark.parametrize(
+        "developer_key,developer_secret",
+        [
+            # A developer key is given but no secret. Neither should be saved.
+            ("example_key", ""),
+            # A developer secret is given but no key. Neither should be saved.
+            ("", "example_secret"),
+        ],
+    )
+    def test_if_developer_key_or_secret_is_missing_it_doesnt_save_either(
+        self, pyramid_request, developer_key, developer_secret
+    ):
+        pyramid_request.params["developer_key"] = developer_key
+        pyramid_request.params["developer_secret"] = developer_secret
+
+        create_application_instance(pyramid_request)
+
+        ai = pyramid_request.db.query(ApplicationInstance).one()
+        assert ai.developer_key is None
+        assert ai.developer_secret is None
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
         pyramid_request.method = "POST"
         pyramid_request.params = {
             "lms_url": "canvas.example.com",
@@ -11,15 +56,9 @@ class TestApplicationInstance:
             "developer_key": "",
             "developer_secret": "",
         }
-        initial_count = (
-            pyramid_request.db.query(ApplicationInstance)
-            .filter(ApplicationInstance.lms_url == pyramid_request.params["lms_url"])
-            .count()
-        )
-        create_application_instance(pyramid_request)
-        new_count = (
-            pyramid_request.db.query(ApplicationInstance)
-            .filter(ApplicationInstance.lms_url == pyramid_request.params["lms_url"])
-            .count()
-        )
-        assert new_count == initial_count + 1
+        return pyramid_request
+
+
+class TestNewApplicationInstance:
+    def test_it(self, pyramid_request):
+        assert new_application_instance(pyramid_request) == {}

--- a/tests/unit/lms/views/test_application_instance.py
+++ b/tests/unit/lms/views/test_application_instance.py
@@ -1,7 +1,10 @@
 import pytest
 
 from lms.models import ApplicationInstance
-from lms.views.application_instances import create_application_instance, new_application_instance
+from lms.views.application_instances import (
+    create_application_instance,
+    new_application_instance,
+)
 
 
 class TestCreateApplicationInstance:


### PR DESCRIPTION
In preparation for replacing the lti_outcome_params fixture (in a future
PR) remove some unnecessary uses of it.

This reduced coverage so I increased it again by omitting some files
that really don't need to be tested.