### PR TITLE
Add ability to have async RPC methods handlers

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/server/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server.js
@@ -61,7 +61,7 @@ export default class Server {
    * Receive a postMessage event and, if it's a JSON-RPC request from an
    * allowed origin, post back either a result or an error response.
    */
-  _receiveMessage(event) {
+  async _receiveMessage(event) {
     if (!this._allowedOrigins.includes(event.origin)) {
       return;
     }
@@ -76,7 +76,8 @@ export default class Server {
       origin: event.origin,
     });
 
-    event.source.postMessage(this._jsonRPCResponse(event.data), event.origin);
+    const result = await this._jsonRPCResponse(event.data);
+    event.source.postMessage(result, event.origin);
   }
 
   /**
@@ -99,7 +100,7 @@ export default class Server {
   /**
    * Return a JSON-RPC response object for the given JSON-RPC request object.
    */
-  _jsonRPCResponse(request) {
+  async _jsonRPCResponse(request) {
     // Return an error response if the request id is invalid.
     // id must be a string, number or null.
     const id = request.id;
@@ -123,6 +124,15 @@ export default class Server {
     }
 
     // Call the method and return the result response.
-    return { jsonrpc: '2.0', result: method(), id: request.id };
+    try {
+      const result = await method();
+      return { jsonrpc: '2.0', result: result, id: request.id };
+    } catch (e) {
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        error: { code: -32600, message: e.message },
+      };
+    }
   }
 }


### PR DESCRIPTION
Relates to https://github.com/hypothesis/client/pull/1843

**Add ability to have async RPC methods handlers** 

We need to add the ability for an RPC method to be async so it can fetch a result from the lms service and potentially block on the client (e.g groups). These changes allow the methods to return to the result asynchronously and delay the postMessage response according. 
