### PR TITLE
Make get_by_assignment() return student dicts

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.16
+fail_under = 99.19
 skip_covered = True

--- a/lms/views/helpers/frontend_app.py
+++ b/lms/views/helpers/frontend_app.py
@@ -20,7 +20,7 @@ def configure_grading(request, js_config):
 
     js_config["lmsGrader"] = True
 
-    grading_infos = request.find_service(name="grading_info").get_by_assignment(
+    students = request.find_service(name="grading_info").get_students_by_assignment(
         oauth_consumer_key=request.lti_user.oauth_consumer_key,
         context_id=request.params.get("context_id"),
         resource_link_id=request.params.get("resource_link_id"),
@@ -30,15 +30,7 @@ def configure_grading(request, js_config):
         "courseName": request.params.get("context_title"),
         "assignmentName": request.params.get("resource_link_title"),
         # TODO! - Rename this in the front end?
-        "students": [
-            {
-                "userid": h_user.userid,
-                "displayName": h_user.display_name,
-                "LISResultSourcedId": grading_info.lis_result_sourcedid,
-                "LISOutcomeServiceUrl": grading_info.lis_outcome_service_url,
-            }
-            for (grading_info, h_user) in grading_infos
-        ],
+        "students": students,
     }
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -177,7 +177,7 @@ def grading_info_service(pyramid_config):
     grading_info_service = mock.create_autospec(
         GradingInfoService, instance=True, spec_set=True
     )
-    grading_info_service.get_by_assignment.return_value = []
+    grading_info_service.get_students_by_assignment.return_value = []
     pyramid_config.register_service(grading_info_service, name="grading_info")
     return grading_info_service
 

--- a/tests/unit/lms/app_test.py
+++ b/tests/unit/lms/app_test.py
@@ -1,6 +1,28 @@
+from unittest import mock
+
 import pytest
 
-from lms.app import create_app
+from lms.app import configure_jinja2_assets, create_app
+
+
+class TestConfigureJinja2Assets:
+    def test_it_adds_the_static_asset_url_generator_functions_to_the_template_env(
+        self, pyramid_config
+    ):
+        assets_env = pyramid_config.registry["assets_env"] = mock.Mock(
+            spec_set=["url", "urls"]
+        )
+
+        configure_jinja2_assets(pyramid_config)
+
+        assert (
+            pyramid_config.get_jinja2_environment().globals["asset_url"]
+            == assets_env.url
+        )
+        assert (
+            pyramid_config.get_jinja2_environment().globals["asset_urls"]
+            == assets_env.urls
+        )
 
 
 class TestCreateApp:

--- a/tests/unit/lms/views/helpers/frontend_app_test.py
+++ b/tests/unit/lms/views/helpers/frontend_app_test.py
@@ -1,21 +1,11 @@
-from unittest import mock
-
 import pytest
 
-from lms.models import GradingInfo
-from lms.values import HUser, LTIUser
+from lms.values import LTIUser
 from lms.views.helpers import frontend_app
 
 
 class TestConfigureGrading:
-    def test_it_enables_grading(self, grading_request):
-        js_config = {}
-
-        frontend_app.configure_grading(grading_request, js_config)
-
-        assert "lmsGrader" in js_config
-
-    def test_it_disables_grading_if_user_is_not_instructor(self, grading_request):
+    def test_it_doesnt_enable_grading_if_user_is_not_instructor(self, grading_request):
         js_config = {}
         grading_request.lti_user = LTIUser(
             "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "student"
@@ -25,7 +15,7 @@ class TestConfigureGrading:
 
         assert "lmsGrader" not in js_config
 
-    def test_it_disables_grading_if_grading_is_disabled_for_assignment(
+    def test_it_doesnt_enable_grading_if_grading_is_disabled_for_assignment(
         self, grading_request
     ):
         js_config = {}
@@ -35,89 +25,40 @@ class TestConfigureGrading:
 
         assert "lmsGrader" not in js_config
 
-    def test_it_fetches_grading_info_records(
-        self, grading_request, grading_info_service
-    ):
-        frontend_app.configure_grading(grading_request, {})
+    def test_it_enables_grading(self, grading_request, grading_info_service):
+        js_config = {}
 
-        grading_info_service.get_by_assignment.assert_called_once_with(
+        frontend_app.configure_grading(grading_request, js_config)
+
+        assert js_config["lmsGrader"] is True
+        grading_info_service.get_students_by_assignment.assert_called_once_with(
             oauth_consumer_key=grading_request.lti_user.oauth_consumer_key,
             context_id=grading_request.params["context_id"],
             resource_link_id=grading_request.params["resource_link_id"],
         )
+        assert js_config["grading"] == {
+            "courseName": "Test Course 101",
+            "assignmentName": "How to use Hypothesis",
+            "students": grading_info_service.get_students_by_assignment.return_value,
+        }
 
-    def test_it_sets_list_of_grading_info_on_config(self, grading_request):
-        js_config = {}
+    @pytest.fixture
+    def grading_request(self, pyramid_request):
+        pyramid_request.params[
+            "tool_consumer_info_product_family_code"
+        ] = "MyFakeLTITool"
+        pyramid_request.params[
+            "lis_outcome_service_url"
+        ] = "https://myfakeltitool.hypothes.is/grades"
 
-        frontend_app.configure_grading(grading_request, js_config)
-
-        assert "students" in js_config["grading"]
-        assert js_config["grading"]["students"] == []
-
-    def test_it_sets_js_properties_for_each_grading_info_record(
-        self, grading_info_service, grading_infos, grading_request
-    ):
-        js_config = {}
-        grading_info_service.get_by_assignment.return_value = grading_infos
-
-        frontend_app.configure_grading(grading_request, js_config)
-
-        assert len(js_config["grading"]["students"]) == 3
-        for propName in [
-            "userid",
-            "displayName",
-            "LISResultSourcedId",
-            "LISOutcomeServiceUrl",
-        ]:
-            assert propName in js_config["grading"]["students"][0]
-
-    def test_it_sets_course_and_assignment_names(self, grading_request):
-        js_config = {}
-        frontend_app.configure_grading(grading_request, js_config)
-
-        assert js_config["grading"]["courseName"] == "Test Course 101"
-        assert js_config["grading"]["assignmentName"] == "How to use Hypothesis"
+        pyramid_request.lti_user = LTIUser(
+            "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"
+        )
+        pyramid_request.params["context_id"] = "unique_course_id"
+        pyramid_request.params["context_title"] = "Test Course 101"
+        pyramid_request.params["resource_link_id"] = "unique_assignment_id"
+        pyramid_request.params["resource_link_title"] = "How to use Hypothesis"
+        return pyramid_request
 
 
 pytestmark = pytest.mark.usefixtures("grading_info_service")
-
-
-@pytest.fixture
-def grading_infos():
-    grading_infos = []
-
-    for index in range(3):
-        h_username = f"username_{index}"
-        h_display_name = f"Student {index}"
-        lis_result_sourcedid = f"lis_result_sourcedid_{index}"
-
-        grading_infos.append(
-            (
-                GradingInfo(
-                    h_username=h_username,
-                    h_display_name=h_display_name,
-                    lis_result_sourcedid=lis_result_sourcedid,
-                    lis_outcome_service_url="http://example.com/service_url",
-                ),
-                HUser("test_authority", h_username, h_display_name),
-            )
-        )
-
-    return grading_infos
-
-
-@pytest.fixture
-def grading_request(pyramid_request):
-    pyramid_request.params["tool_consumer_info_product_family_code"] = "MyFakeLTITool"
-    pyramid_request.params[
-        "lis_outcome_service_url"
-    ] = "https://myfakeltitool.hypothes.is/grades"
-
-    pyramid_request.lti_user = LTIUser(
-        "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"
-    )
-    pyramid_request.params["context_id"] = "unique_course_id"
-    pyramid_request.params["context_title"] = "Test Course 101"
-    pyramid_request.params["resource_link_id"] = "unique_assignment_id"
-    pyramid_request.params["resource_link_title"] = "How to use Hypothesis"
-    return pyramid_request


### PR DESCRIPTION
`GradingInfoService.get_by_assignment()` currently returns a list of
`(GradingInfo, HUser)` 2-tuples, one for each student who has launched
the assignment. There are two problems with this:

1. `frontend_app.py`, which is the only one place where
   `get_by_assignment()` is called, has to iterate over this list of
   2-tuples and turn them into the list of student dicts that's actually
   needed:

   https://github.com/hypothesis/lms/blob/0f34b1b080944fc07cbae85107a686f1b27a3728/lms/views/helpers/frontend_app.py#L33-L41

2. If you're then writing tests for this `frontend_app.py` code that use
   a mock `GradingInfoService` it's extremely awkward to mock
   `get_by_assignment()`'s list-of-matching-`(GradingInfo,
   HUser)`-2-tuples return value. You end up having to do something like
   this:

   ```python
   @pytest.fixture
   def grading_infos(self):
       return [
           mock.create_autospec(GradingInfo, instance=True, spec_set=True),
           mock.create_autospec(GradingInfo, instance=True, spec_set=True),
           mock.create_autospec(GradingInfo, instance=True, spec_set=True),
       ]

   @pytest.fixture
   def h_users(self):
       return [
           HUser("lms.hypothes.is", "test_h_username_1", "test_h_display_name_1"),
           HUser("lms.hypothes.is", "test_h_username_2", "test_h_display_name_2"),
           HUser("lms.hypothes.is", "test_h_username_3", "test_h_display_name_3"),
       ]

   @pytest.fixture
   def grading_info_service(
       self, grading_info_service, grading_infos, h_users,
   ):
       grading_info_service.get_by_assignment.return_value = [
           (grading_infos[0], h_users[0]),
           (grading_infos[1], h_users[1]),
           (grading_infos[2], h_users[2]),
       ]
       return grading_info_service
   ```

   And then you end up having to write assertions that look like this:

   ```python
   assert js_config.config["grading"]["students"] == [
       {
           "userid": h_users[0].userid,
           "displayName": h_users[0].display_name,
           "LISResultSourcedId": grading_infos[0].lis_result_sourcedid,
           "LISOutcomeServiceUrl": grading_infos[0].lis_outcome_service_url,
       },
       {
           "userid": h_users[1].userid,
           "displayName": h_users[1].display_name,
           "LISResultSourcedId": grading_infos[1].lis_result_sourcedid,
           "LISOutcomeServiceUrl": grading_infos[1].lis_outcome_service_url,
       },
       {
           "userid": h_users[2].userid,
           "displayName": h_users[2].display_name,
           "LISResultSourcedId": grading_infos[2].lis_result_sourcedid,
           "LISOutcomeServiceUrl": grading_infos[2].lis_outcome_service_url,
       },
   ]
   ```

This all goes away if `GradingInfoService.get_by_assignment()` just
returns the list of student dicts in the first place. Now
`frontend_app.py` just has to do this:

```python
js_config["grading"]["students"] = grading_info_svc.get_by_assignment(...)
```

And `frontend_app.py` tests using a mock `GradingInfoService` just have
to do this:

```python
assert js_config["grading"]["students"] == grading_info_svc.get_by_assignment.return_value
```