### PR TITLE
Change get_by_assignment() to just return GradingInfos

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.16
+fail_under = 99.19
 skip_covered = True

--- a/lms/services/grading_info.py
+++ b/lms/services/grading_info.py
@@ -2,7 +2,6 @@ from marshmallow import fields
 
 from lms.models import GradingInfo
 from lms.validation import PyramidRequestSchema, ValidationError
-from lms.values import HUser
 
 __all__ = ["GradingInfoService"]
 
@@ -26,11 +25,10 @@ class GradingInfoService:
 
     def get_by_assignment(self, oauth_consumer_key, context_id, resource_link_id):
         """
-        Return all the (GradingInfo, HUser) tuples for a given assignment.
+        Return all GradingInfo's for a given assignment.
 
-        The returned list will contain one (GradingInfo, HUser) tuple for each
-        student who has launched this assignment (and had GradingInfo data
-        persisted for them).
+        The returned list will contain one GradingInfo for each student who has
+        launched this assignment (and had GradingInfo data persisted for them).
 
         :param oauth_consumer_key: the assignment's oauth_consumer_key
             (identifies a deployment of our app in an LMS)
@@ -43,27 +41,12 @@ class GradingInfoService:
         :param resource_link_id: the assignment's resource_link_id
             (identifies the assignment within the LMS course)
         :type resource_link_id: str
-
-        :return: a list of all the (GradingInfo, HUser) tuples for the assignment
-        :rtype: list[(GradingInfo, HUser)]
         """
-        grading_infos = self._db.query(GradingInfo).filter_by(
+        return self._db.query(GradingInfo).filter_by(
             oauth_consumer_key=oauth_consumer_key,
             context_id=context_id,
             resource_link_id=resource_link_id,
         )
-
-        return [
-            (
-                grading_info,
-                HUser(
-                    authority=self._authority,
-                    username=grading_info.h_username,
-                    display_name=grading_info.h_display_name,
-                ),
-            )
-            for grading_info in grading_infos
-        ]
 
     def upsert_from_request(self, request, h_user, lti_user):
         """

--- a/tests/unit/lms/app_test.py
+++ b/tests/unit/lms/app_test.py
@@ -1,6 +1,28 @@
+from unittest import mock
+
 import pytest
 
-from lms.app import create_app
+from lms.app import configure_jinja2_assets, create_app
+
+
+class TestConfigureJinja2Assets:
+    def test_it_adds_the_static_asset_url_generator_functions_to_the_template_env(
+        self, pyramid_config
+    ):
+        assets_env = pyramid_config.registry["assets_env"] = mock.Mock(
+            spec_set=["url", "urls"]
+        )
+
+        configure_jinja2_assets(pyramid_config)
+
+        assert (
+            pyramid_config.get_jinja2_environment().globals["asset_url"]
+            == assets_env.url
+        )
+        assert (
+            pyramid_config.get_jinja2_environment().globals["asset_urls"]
+            == assets_env.urls
+        )
 
 
 class TestCreateApp:

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -10,45 +10,71 @@ from lms.values import HUser, LTIUser
 
 
 class TestGetByAssignment:
-    def test_it_retrieves_matching_records(
-        self, svc, lti_params, grading_info, another_grading_info, lti_user,
-    ):
-
+    def test_it(self, svc, matching_grading_infos):
         grading_infos = svc.get_by_assignment(
-            oauth_consumer_key=lti_user.oauth_consumer_key,
-            context_id=lti_params["context_id"],
-            resource_link_id=lti_params["resource_link_id"],
+            "matching_oauth_consumer_key",
+            "matching_context_id",
+            "matching_resource_link_id",
         )
 
-        assert len(grading_infos) == 2
+        assert list(grading_infos) == matching_grading_infos
 
-    def test_it_returns_empty_list_if_no_matching_records(
-        self, svc, lti_params, lti_user
-    ):
-        grading_infos = svc.get_by_assignment(
-            oauth_consumer_key=lti_user.oauth_consumer_key,
-            context_id=lti_params["context_id"],
-            resource_link_id=lti_params["resource_link_id"],
-        )
-
-        assert not grading_infos
-
-    @pytest.fixture
-    def another_grading_info(self, lti_params, db_session):
-        another_grading_info = GradingInfo(**lti_params)
-
-        add_users(
-            another_grading_info,
-            h_user=HUser(
-                authority="TEST_AUTHORITY",
-                username="teststudent",
-                display_name="Another Test",
+    @pytest.mark.parametrize(
+        "oauth_consumer_key,context_id,resource_link_id",
+        [
+            (
+                "other_oauth_consumer_key",
+                "matching_context_id",
+                "matching_resource_link_id",
             ),
-            lti_user=LTIUser("TEST_USER_ID_2", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES"),
+            (
+                "matching_oauth_consumer_key",
+                "other_context_id",
+                "matching_resource_link_id",
+            ),
+            (
+                "matching_oauth_consumer_key",
+                "matching_context_id",
+                "other_resource_link_id",
+            ),
+            ("other_oauth_consumer_key", "other_context_id", "other_resource_link_id"),
+        ],
+    )
+    def test_it_returns_an_empty_list_if_there_are_no_matching_GradingInfos(
+        self, svc, oauth_consumer_key, context_id, resource_link_id
+    ):
+        grading_infos = svc.get_by_assignment(
+            oauth_consumer_key, context_id, resource_link_id
         )
 
-        db_session.add(another_grading_info)
-        return another_grading_info
+        assert list(grading_infos) == []
+
+    @pytest.fixture(autouse=True)
+    def matching_grading_infos(self, db_session):
+        """Some GradingInfo's that should match the DB query in the test above."""
+        matching_grading_infos = [self.grading_info("matching", i) for i in range(3)]
+        db_session.add_all(matching_grading_infos)
+        return matching_grading_infos
+
+    @pytest.fixture(autouse=True)
+    def noise_grading_infos(self, db_session):
+        """Some GradingInfo's that should *not* match the test query."""
+        noise_grading_infos = [self.grading_info("noise", i) for i in range(3)]
+        db_session.add_all(noise_grading_infos)
+        return noise_grading_infos
+
+    def grading_info(self, prefix, index):
+        return GradingInfo(
+            lis_result_sourcedid=f"{prefix}_lis_result_sourcedid_{index}",
+            lis_outcome_service_url=f"{prefix}_lis_outcomes_service_url_{index}",
+            oauth_consumer_key=f"{prefix}_oauth_consumer_key",
+            user_id=f"{prefix}_user_id_{index}",
+            context_id=f"{prefix}_context_id",
+            resource_link_id=f"{prefix}_resource_link_id",
+            tool_consumer_info_product_family_code=f"{prefix}_tool_consumer_info_product_family_code_{index}",
+            h_username=f"{prefix}_h_username_{index}",
+            h_display_name=f"{prefix}_h_display_name_{index}",
+        )
 
 
 class TestUpsertFromRequest:
@@ -72,14 +98,7 @@ class TestUpsertFromRequest:
         assert result.user_id == lti_user.user_id
 
     def test_it_updates_existing_record_if_matching_exists(
-        self,
-        svc,
-        pyramid_request,
-        h_user,
-        lti_user,
-        grading_info,
-        db_session,
-        lti_params,
+        self, svc, pyramid_request, h_user, lti_user, db_session,
     ):
         # Update a couple of attributes on the model...
         h_user = h_user._replace(display_name="Someone Else")
@@ -140,13 +159,13 @@ class TestUpsertFromRequest:
 
 @pytest.fixture
 def lti_user():
-    return LTIUser("TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES")
+    return LTIUser("test_user_id", "matching_oauth_consumer_key", "test_roles")
 
 
 @pytest.fixture
 def h_user():
     return HUser(
-        authority="TEST_AUTHORITY", username="seanh", display_name="Sample Student"
+        authority="test_authority", username="seanh", display_name="Sample Student"
     )
 
 
@@ -168,21 +187,3 @@ def lti_params():
         "resource_link_id": "random resource link id",
         "tool_consumer_info_product_family_code": "MyFakeLTITool",
     }
-
-
-def add_users(grading_info, h_user, lti_user):
-    grading_info.h_username = h_user.username
-    grading_info.h_display_name = h_user.display_name
-
-    grading_info.oauth_consumer_key = lti_user.oauth_consumer_key
-    grading_info.user_id = lti_user.user_id
-
-
-@pytest.fixture
-def grading_info(lti_params, h_user, lti_user, db_session):
-    grading_info = GradingInfo(**lti_params)
-
-    add_users(grading_info, h_user, lti_user)
-
-    db_session.add(grading_info)
-    return grading_info

--- a/tests/unit/lms/views/helpers/frontend_app_test.py
+++ b/tests/unit/lms/views/helpers/frontend_app_test.py
@@ -3,19 +3,12 @@ from unittest import mock
 import pytest
 
 from lms.models import GradingInfo
-from lms.values import HUser, LTIUser
+from lms.values import LTIUser
 from lms.views.helpers import frontend_app
 
 
 class TestConfigureGrading:
-    def test_it_enables_grading(self, grading_request):
-        js_config = {}
-
-        frontend_app.configure_grading(grading_request, js_config)
-
-        assert "lmsGrader" in js_config
-
-    def test_it_disables_grading_if_user_is_not_instructor(self, grading_request):
+    def test_it_doesnt_enable_grading_if_user_is_not_instructor(self, grading_request):
         js_config = {}
         grading_request.lti_user = LTIUser(
             "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "student"
@@ -25,7 +18,7 @@ class TestConfigureGrading:
 
         assert "lmsGrader" not in js_config
 
-    def test_it_disables_grading_if_grading_is_disabled_for_assignment(
+    def test_it_doesnt_enable_grading_if_grading_is_disabled_for_assignment(
         self, grading_request
     ):
         js_config = {}
@@ -35,89 +28,64 @@ class TestConfigureGrading:
 
         assert "lmsGrader" not in js_config
 
-    def test_it_fetches_grading_info_records(
-        self, grading_request, grading_info_service
-    ):
-        frontend_app.configure_grading(grading_request, {})
+    def test_it_enables_grading(self, grading_request, grading_info_service):
+        js_config = {}
 
+        frontend_app.configure_grading(grading_request, js_config)
+
+        assert js_config["lmsGrader"] is True
         grading_info_service.get_by_assignment.assert_called_once_with(
             oauth_consumer_key=grading_request.lti_user.oauth_consumer_key,
             context_id=grading_request.params["context_id"],
             resource_link_id=grading_request.params["resource_link_id"],
         )
+        assert js_config["grading"] == {
+            "courseName": "Test Course 101",
+            "assignmentName": "How to use Hypothesis",
+            "students": [
+                {
+                    "LISOutcomeServiceUrl": f"test_lis_outcomes_service_url_{i}",
+                    "LISResultSourcedId": f"test_lis_result_sourcedid_{i}",
+                    "displayName": f"test_h_display_name_{i}",
+                    "userid": f"acct:test_h_username_{i}@TEST_AUTHORITY",
+                }
+                for i in range(3)
+            ],
+        }
 
-    def test_it_sets_list_of_grading_info_on_config(self, grading_request):
-        js_config = {}
+    @pytest.fixture
+    def grading_info_service(self, grading_info_service):
+        grading_info_service.get_by_assignment.return_value = [
+            mock.create_autospec(
+                GradingInfo,
+                instance=True,
+                spec_set=True,
+                lis_result_sourcedid=f"test_lis_result_sourcedid_{i}",
+                lis_outcome_service_url=f"test_lis_outcomes_service_url_{i}",
+                h_username=f"test_h_username_{i}",
+                h_display_name=f"test_h_display_name_{i}",
+            )
+            for i in range(3)
+        ]
+        return grading_info_service
 
-        frontend_app.configure_grading(grading_request, js_config)
+    @pytest.fixture
+    def grading_request(self, pyramid_request):
+        pyramid_request.params[
+            "tool_consumer_info_product_family_code"
+        ] = "MyFakeLTITool"
+        pyramid_request.params[
+            "lis_outcome_service_url"
+        ] = "https://myfakeltitool.hypothes.is/grades"
 
-        assert "students" in js_config["grading"]
-        assert js_config["grading"]["students"] == []
-
-    def test_it_sets_js_properties_for_each_grading_info_record(
-        self, grading_info_service, grading_infos, grading_request
-    ):
-        js_config = {}
-        grading_info_service.get_by_assignment.return_value = grading_infos
-
-        frontend_app.configure_grading(grading_request, js_config)
-
-        assert len(js_config["grading"]["students"]) == 3
-        for propName in [
-            "userid",
-            "displayName",
-            "LISResultSourcedId",
-            "LISOutcomeServiceUrl",
-        ]:
-            assert propName in js_config["grading"]["students"][0]
-
-    def test_it_sets_course_and_assignment_names(self, grading_request):
-        js_config = {}
-        frontend_app.configure_grading(grading_request, js_config)
-
-        assert js_config["grading"]["courseName"] == "Test Course 101"
-        assert js_config["grading"]["assignmentName"] == "How to use Hypothesis"
+        pyramid_request.lti_user = LTIUser(
+            "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"
+        )
+        pyramid_request.params["context_id"] = "unique_course_id"
+        pyramid_request.params["context_title"] = "Test Course 101"
+        pyramid_request.params["resource_link_id"] = "unique_assignment_id"
+        pyramid_request.params["resource_link_title"] = "How to use Hypothesis"
+        return pyramid_request
 
 
 pytestmark = pytest.mark.usefixtures("grading_info_service")
-
-
-@pytest.fixture
-def grading_infos():
-    grading_infos = []
-
-    for index in range(3):
-        h_username = f"username_{index}"
-        h_display_name = f"Student {index}"
-        lis_result_sourcedid = f"lis_result_sourcedid_{index}"
-
-        grading_infos.append(
-            (
-                GradingInfo(
-                    h_username=h_username,
-                    h_display_name=h_display_name,
-                    lis_result_sourcedid=lis_result_sourcedid,
-                    lis_outcome_service_url="http://example.com/service_url",
-                ),
-                HUser("test_authority", h_username, h_display_name),
-            )
-        )
-
-    return grading_infos
-
-
-@pytest.fixture
-def grading_request(pyramid_request):
-    pyramid_request.params["tool_consumer_info_product_family_code"] = "MyFakeLTITool"
-    pyramid_request.params[
-        "lis_outcome_service_url"
-    ] = "https://myfakeltitool.hypothes.is/grades"
-
-    pyramid_request.lti_user = LTIUser(
-        "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "instructor"
-    )
-    pyramid_request.params["context_id"] = "unique_course_id"
-    pyramid_request.params["context_title"] = "Test Course 101"
-    pyramid_request.params["resource_link_id"] = "unique_assignment_id"
-    pyramid_request.params["resource_link_title"] = "How to use Hypothesis"
-    return pyramid_request


### PR DESCRIPTION
Change `GradingInfoService.get_by_assignment()` to just return
`GradingInfo` objects instead of `(GradingInfo, HUser)` 2-tuples.

The calling code (in `frontend_app.py`) is now responsible for creating
the `HUser` object corresponding to each `GradingInfo` which it needs to
do in order to create the "student" dicts that it puts into the JS
config.

Overall this ends up making the tests for both `GradingInfoService` and
`frontend_app.py` simpler, and is a better division of work between the
two.