### PR TITLE
Tidy up JSConfig

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -14,6 +14,9 @@ class JSConfig:
         self._context = context
         self._request = request
 
+        # A dict of URLs for the frontend to use.
+        self._urls = {}
+
     @property
     @functools.lru_cache()
     def config(self):
@@ -119,14 +122,3 @@ class JSConfig:
             self._request.registry.settings["h_jwt_client_secret"],
             algorithm="HS256",
         ).decode("utf-8")
-
-    @property
-    def _urls(self):
-        """
-        Return a dict of URLs for the frontend to use.
-
-        For example: API endpoints for the frontend to call would go in
-        here.
-
-        """
-        return {}

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -23,13 +23,18 @@ class JSConfig:
         """
         Return the configuration for the app's JavaScript code.
 
-        This is a mutable config dict. It can be accessed, for example by
-        views, and they can mutate it or add their own view-specific config
-        settings. The modified config object will then be passed to the
-        JavaScript code in the response page.
-
         :rtype: dict
         """
+        # This is a lazy-computed property so that if it's going to raise an
+        # exception that doesn't happen until someone actually reads it.
+        # If it instead crashed in JSConfig.__init__() that would happen
+        # earlier in the request processing pipeline and could change the error
+        # response.
+        #
+        # We cache this property (@functools.lru_cache()) so that it's
+        # mutable. You can do self.config["foo"] = "bar" and the mutation will
+        # be preserved.
+
         return {
             # The auth token that the JavaScript code will use to authenticate
             # itself to our own backend's APIs.
@@ -81,12 +86,17 @@ class JSConfig:
     @property
     @functools.lru_cache()
     def _hypothesis_client(self):
-        """
-        Return the Hypothesis client config object for the current request.
+        """Return the config object for the Hypothesis client."""
+        # This is a lazy-computed property so that if it's going to raise an
+        # exception that doesn't happen until someone actually reads it.
+        # If it instead crashed in JSConfig.__init__() that would happen
+        # earlier in the request processing pipeline and could change the error
+        # response.
+        #
+        # We cache this property (@functools.lru_cache()) so that it's
+        # mutable. You can do self._hypothesis_client["foo"] = "bar" and the
+        # mutation will be preserved.
 
-        See: https://h.readthedocs.io/projects/client/en/latest/publishers/config/#configuring-the-client-using-json
-
-        """
         if not self._context.provisioning_enabled:
             return {}
 

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -28,14 +28,27 @@ class JSConfig:
         :rtype: dict
         """
         return {
-            "authToken": self._auth_token,
-            "debug": self._debug,
+            # The auth token that the JavaScript code will use to authenticate
+            # itself to our own backend's APIs.
+            "authToken": self._auth_token(),
+            # Some debug information, currently used in the Gherkin tests.
+            "debug": self._debug(),
+            # The config object for the Hypothesis client.
+            # Our JSON-RPC server passes this to the Hypothesis client over
+            # postMessage.
             "hypothesisClient": self._hypothesis_config,
-            "rpcServer": self._rpc_server_config,
+            # The config object for our JSON-RPC server.
+            "rpcServer": {
+                "allowedOrigins": self._request.registry.settings[
+                    "rpc_allowed_origins"
+                ],
+            },
+            # A dict of URLs for the frontend to use.
+            # For example: API endpoints for the frontend to call would go in
+            # here.
             "urls": self._urls,
         }
 
-    @property
     def _auth_token(self):
         """Return the authToken setting."""
         if not self._request.lti_user:
@@ -45,7 +58,6 @@ class JSConfig:
             self._request.lti_user
         )
 
-    @property
     def _debug(self):
         """
         Return some debug information.
@@ -77,6 +89,8 @@ class JSConfig:
         api_url = self._request.registry.settings["h_api_url_public"]
 
         return {
+            # For documentation of these Hypothesis client settings see:
+            # https://h.readthedocs.io/projects/client/en/latest/publishers/config/#configuring-the-client-using-json
             "services": [
                 {
                     "apiUrl": api_url,
@@ -105,13 +119,6 @@ class JSConfig:
             self._request.registry.settings["h_jwt_client_secret"],
             algorithm="HS256",
         ).decode("utf-8")
-
-    @property
-    def _rpc_server_config(self):
-        """Return the config for the postMessage-JSON-RPC server."""
-        return {
-            "allowedOrigins": self._request.registry.settings["rpc_allowed_origins"],
-        }
 
     @property
     def _urls(self):

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -39,7 +39,7 @@ class JSConfig:
             # The config object for the Hypothesis client.
             # Our JSON-RPC server passes this to the Hypothesis client over
             # postMessage.
-            "hypothesisClient": self._hypothesis_config,
+            "hypothesisClient": self._hypothesis_client,
             # The config object for our JSON-RPC server.
             "rpcServer": {
                 "allowedOrigins": self._request.registry.settings[
@@ -80,7 +80,7 @@ class JSConfig:
 
     @property
     @functools.lru_cache()
-    def _hypothesis_config(self):
+    def _hypothesis_client(self):
         """
         Return the Hypothesis client config object for the current request.
 

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -79,6 +79,7 @@ class JSConfig:
         return debug_info
 
     @property
+    @functools.lru_cache()
     def _hypothesis_config(self):
         """
         Return the Hypothesis client config object for the current request.

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -103,7 +103,7 @@ class JSConfig:
         }
 
     def _grant_token(self, api_url):
-        """Return an OAuth 2 the client can use to log in to h."""
+        """Return an OAuth 2 grant token the client can use to log in to h."""
         now = datetime.datetime.utcnow()
 
         claims = {


### PR DESCRIPTION
A bunch of small JSConfig tidy-ups to pave the way for coming JSConfig changes:

* More docstrings
* More code comments
* Change things that don't need to be `@property`'s to just methods
* Change things that don't need to be either `@property`'s or methods to just attributes or inline them into `config()`
* `JSConfig._hypothesis_config` is renamed to `_hypothesis_client` to match its name in the config dict, and has `@functools.lru_cache()` added to it because future `JSConfig` code is going to need to mutate `self._hypothesis_client` as a dict
