### PR TITLE
Document JSConfig raised exceptions

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -23,6 +23,9 @@ class JSConfig:
         """
         Return the configuration for the app's JavaScript code.
 
+        :raise HTTPBadRequest: if a request param needed to generate the config
+            is missing
+
         :rtype: dict
         """
         # This is a lazy-computed property so that if it's going to raise an
@@ -86,7 +89,12 @@ class JSConfig:
     @property
     @functools.lru_cache()
     def _hypothesis_client(self):
-        """Return the config object for the Hypothesis client."""
+        """
+        Return the config object for the Hypothesis client.
+
+        :raise HTTPBadRequest: if a request param needed to generate the config
+            is missing
+        """
         # This is a lazy-computed property so that if it's going to raise an
         # exception that doesn't happen until someone actually reads it.
         # If it instead crashed in JSConfig.__init__() that would happen

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -18,22 +18,6 @@ class TestJSConfig:
 
         assert config["a_key"] == "a_value"
 
-    @pytest.mark.parametrize(
-        "context_property", ["provisioning_enabled", "h_user", "h_groupid"]
-    )
-    def test_it_raises_if_a_context_property_raises(
-        self, context, context_property, pyramid_request
-    ):
-        # Make reading context.<context_property> raise HTTPBadRequest.
-        setattr(
-            type(context),
-            context_property,
-            mock.PropertyMock(side_effect=HTTPBadRequest("example error message")),
-        )
-
-        with pytest.raises(HTTPBadRequest, match="example error message"):
-            JSConfig(context, pyramid_request).config
-
 
 class TestJSConfigAuthToken:
     """Unit tests for the "authToken" sub-dict of JSConfig."""
@@ -116,6 +100,22 @@ class TestJSConfigHypothesisClient:
         config.update({"a_key": "a_value"})
 
         assert config["a_key"] == "a_value"
+
+    @pytest.mark.parametrize(
+        "context_property", ["provisioning_enabled", "h_user", "h_groupid"]
+    )
+    def test_it_raises_if_a_context_property_raises(
+        self, context, context_property, pyramid_request
+    ):
+        # Make reading context.<context_property> raise HTTPBadRequest.
+        setattr(
+            type(context),
+            context_property,
+            mock.PropertyMock(side_effect=HTTPBadRequest("example error message")),
+        )
+
+        with pytest.raises(HTTPBadRequest, match="example error message"):
+            JSConfig(context, pyramid_request)._hypothesis_client
 
     @pytest.fixture
     def config(self, config):


### PR DESCRIPTION
Also move a general JSConfig test into `TestJSConfigHypothesisClient` to clarify which part of the code it is that raises.