### PR TITLE
Centralize JSConfig 1/n: Move the "lmsName" config setting into JSConfig

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -48,6 +48,9 @@ class JSConfig:
             # Our JSON-RPC server passes this to the Hypothesis client over
             # postMessage.
             "hypothesisClient": self._hypothesis_client,
+            # The LMS name to use in user-facing messages.
+            # Shown on the "Select PDF from Canvas" button label.
+            "lmsName": "Canvas",
             # The config object for our JSON-RPC server.
             "rpcServer": {
                 "allowedOrigins": self._request.registry.settings[

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -106,8 +106,6 @@ class BasicLTILaunchViews:
                 # The URL that the JavaScript code will open if it needs the user to
                 # authorize us to request a new access token.
                 "authUrl": self.request.route_url("canvas_api.authorize"),
-                # Set the LMS name to use in user-facing messages.
-                "lmsName": "Canvas",
             }
         )
 

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -69,8 +69,6 @@ def content_item_selection(context, request):
             # Variables needed for initializing Google Picker.
             "googleClientId": request.registry.settings["google_client_id"],
             "googleDeveloperKey": request.registry.settings["google_developer_key"],
-            # Shown on the "Select PDF from Canvas" button label.
-            "lmsName": "Canvas",
             # The "content item selection" that we submit to the
             # content_item_return_url is actually an LTI launch URL with the
             # selected document URL or file_id as a query parameter. To construct

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -13,7 +13,10 @@ from lms.values import HUser
 class TestJSConfig:
     """General unit tests for JSConfig."""
 
-    def test_it_is_mutable(self, config):
+    def test_config(self, config):
+        assert config["lmsName"] == "Canvas"
+
+    def test_config_is_mutable(self, config):
         config.update({"a_key": "a_value"})
 
         assert config["a_key"] == "a_value"

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -235,7 +235,6 @@ class TestCanvasFileBasicLTILaunch:
             context.js_config.config["authUrl"]
             == "http://example.com/api/canvas/authorize"
         )
-        assert context.js_config.config["lmsName"] == "Canvas"
 
     def test_it_configures_via_callback_url(self, context, canvas_request):
         canvas_file_basic_lti_launch_caller(context, canvas_request)

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -43,13 +43,6 @@ class TestContentItemSelection:
         assert context.js_config.config["googleClientId"] == "fake_client_id"
         assert context.js_config.config["googleDeveloperKey"] == "fake_developer_key"
 
-    def test_it_sets_the_lmsName_javascript_config_setting(
-        self, context, pyramid_request
-    ):
-        content_item_selection(context, pyramid_request)
-
-        assert context.js_config.config["lmsName"] == "Canvas"
-
     def test_it_sets_the_ltiLaunchUrl_javascript_config_setting(
         self, context, pyramid_request
     ):


### PR DESCRIPTION
The `"lmsName"` setting is the `"Canvas"` string on the <kbd>Select PDF from Canvas</kbd> button when creating an assignment. It is always `"Canvas"`, never takes any other value.

This PR changes things so that this setting is now present in the JSConfig all the time whereas previously it was only present for certain views. But this doesn't do any harm.

An alternative approach to this one would be to remove the setting entirely, and just have the frontend code hardcode the single `"Canvas"` value instead of using a false setting that never changes.