### PR TITLE
Centralize JSConfig 3/n: Move the "mode" JavaScript setting into JSConfig

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -48,6 +48,11 @@ class JSConfig:
             # Our JSON-RPC server passes this to the Hypothesis client over
             # postMessage.
             "hypothesisClient": self._hypothesis_client,
+            # What "mode" to put the JavaScript code in.
+            # For example in "basic-lti-launch" mode the JavaScript code
+            # launches its BasicLtiLaunchApp, whereas in
+            # "content-item-selection" mode it launches its FilePickerApp.
+            "mode": "basic-lti-launch",
             # The config object for our JSON-RPC server.
             "rpcServer": {
                 "allowedOrigins": self._request.registry.settings[
@@ -59,6 +64,15 @@ class JSConfig:
             # here.
             "urls": self._urls,
         }
+
+    def enable_content_item_selection_mode(self):
+        """
+        Put the JavaScript code into "content item selection" mode.
+
+        This mode shows teachers an assignment configuration UI where they can
+        choose the document to be annotated for the assignment.
+        """
+        self.config["mode"] = "content-item-selection"
 
     def _auth_token(self):
         """Return the authToken setting."""

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -15,12 +15,10 @@ startRpcServer();
 const rootEl = document.querySelector('#app');
 const config = JSON.parse(document.querySelector('.js-config').textContent);
 
-const mode = config.mode || 'content-item-selection';
-
 render(
   <Config.Provider value={config}>
-    {mode === 'basic-lti-launch' && <BasicLtiLaunchApp />}
-    {mode === 'content-item-selection' && <FilePickerApp />}
+    {config.mode === 'basic-lti-launch' && <BasicLtiLaunchApp />}
+    {config.mode === 'content-item-selection' && <FilePickerApp />}
   </Config.Provider>,
   rootEl
 );

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -37,13 +37,6 @@ class BasicLTILaunchViews:
         self.context = context
         self.request = request
 
-        self.context.js_config.config.update(
-            {
-                # Configure the front-end mini-app to run.
-                "mode": "basic-lti-launch",
-            }
-        )
-
         if self.is_launched_by_canvas():
             self.initialise_canvas_submission_params()
             self.set_canvas_focused_user()
@@ -200,6 +193,7 @@ class BasicLTILaunchViews:
         we'll save it in our DB. Subsequent launches of the same assignment
         will then be DB-configured launches rather than unconfigured.
         """
+        self.context.js_config.enable_content_item_selection_mode()
 
         params = self._extract_lti_params(self.request)
 
@@ -211,7 +205,6 @@ class BasicLTILaunchViews:
         # Add the config needed by the JavaScript document selection code.
         self.context.js_config.config.update(
             {
-                "mode": "content-item-selection",
                 # It is assumed that this view is only used by LMSes for which
                 # we do not have an integration with the LMS's file storage.
                 # (currently only Canvas supports this).

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -51,6 +51,8 @@ def content_item_selection(context, request):
     lti_h_service.upsert_h_user()
     lti_h_service.upsert_course_group()
 
+    context.js_config.enable_content_item_selection_mode()
+
     context.js_config.config.update(
         {
             # The URL that the JavaScript code will open if it needs the user to

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -18,6 +18,11 @@ class TestJSConfig:
 
         assert config["a_key"] == "a_value"
 
+    def test_enable_content_item_selection_mode(self, js_config):
+        js_config.enable_content_item_selection_mode()
+
+        assert js_config.config["mode"] == "content-item-selection"
+
 
 class TestJSConfigAuthToken:
     """Unit tests for the "authToken" sub-dict of JSConfig."""

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -82,11 +82,6 @@ def configure_module_item_caller(context, pyramid_request):
 class TestBasicLTILaunchViewsInit:
     """Unit tests for BasicLTILaunchViews.__init__()."""
 
-    def test_it_configures_frontend(self, context, pyramid_request):
-        BasicLTILaunchViews(context, pyramid_request)
-
-        assert context.js_config.config["mode"] == "basic-lti-launch"
-
     def test_it_adds_report_submission_config_if_the_LMS_is_Canvas(
         self, context, canvas_request
     ):
@@ -344,7 +339,6 @@ class TestUnconfiguredBasicLTILaunch:
         BasicLTILaunchViews(context, pyramid_request).unconfigured_basic_lti_launch()
 
         assert context.js_config.config == {
-            "mode": "content-item-selection",
             "enableLmsFilePicker": False,
             "formAction": "http://example.com/module_item_configurations",
             "formFields": Any.dict(),
@@ -374,6 +368,11 @@ class TestUnconfiguredBasicLTILaunch:
                 "some_random_rubbish": "SOME_RANDOM_RUBBISH",
             }
         )
+
+    def test_it_enables_content_item_selection_mode(self, context, pyramid_request):
+        BasicLTILaunchViews(context, pyramid_request).unconfigured_basic_lti_launch()
+
+        context.js_config.enable_content_item_selection_mode.assert_called_once_with()
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -8,6 +8,11 @@ from lms.views.content_item_selection import content_item_selection
 
 
 class TestContentItemSelection:
+    def test_it_enables_content_item_selection_mode(self, context, pyramid_request):
+        content_item_selection(context, pyramid_request)
+
+        context.js_config.enable_content_item_selection_mode.assert_called_once_with()
+
     def test_it_sets_the_authUrl_javascript_config_setting(
         self, context, pyramid_request
     ):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/1522 for the tests to pass.

The "mode" config setting tells the JavaScript code whether it should do a normal assignment launch (`"basic-lti-launch"` mode) or whether it should show the UI for the teacher to configure the assignment (selecting the document for the assignment) (`"content-item-selection"` mode).

The mode is now changed to default to `"basic-lti-launch"` mode, and it gets explicitly changed to `"content-item-selection"` in two specific places.

Previously the default was `"content-item-selection"` (but this default was implemented in JavaScript not Python) and it had to be explicitly set to `"basic-lti-launch"` and then in one place it had to be explicitly set back to `"content-item-selection"` again _after_ changing it to `"basic-lti-launch"`.