### PR TITLE
Centralize JSConfig 4/n: Move the "authUrl" JavaScript setting into JSConfig

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -42,6 +42,9 @@ class JSConfig:
             # The auth token that the JavaScript code will use to authenticate
             # itself to our own backend's APIs.
             "authToken": self._auth_token(),
+            # The URL that the JavaScript code will open if it needs the user to
+            # authorize us to request a new Canvas access token.
+            "authUrl": self._request.route_url("canvas_api.authorize"),
             # Some debug information, currently used in the Gherkin tests.
             "debug": self._debug(),
             # The config object for the Hypothesis client.

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -96,9 +96,6 @@ class BasicLTILaunchViews:
 
         self.context.js_config.config.update(
             {
-                # The URL that the JavaScript code will open if it needs the user to
-                # authorize us to request a new access token.
-                "authUrl": self.request.route_url("canvas_api.authorize"),
                 # Set the LMS name to use in user-facing messages.
                 "lmsName": "Canvas",
             }

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -55,9 +55,6 @@ def content_item_selection(context, request):
 
     context.js_config.config.update(
         {
-            # The URL that the JavaScript code will open if it needs the user to
-            # authorize us to request a new access token.
-            "authUrl": request.route_url("canvas_api.authorize"),
             # The URL that we'll POST the ContentItemSelection form submission
             # (containing the user's selected document) to.
             "formAction": request.params["content_item_return_url"],

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -13,6 +13,9 @@ from lms.values import HUser
 class TestJSConfig:
     """General unit tests for JSConfig."""
 
+    def test_auth_url(self, config):
+        assert config["authUrl"] == "http://example.com/api/canvas/authorize"
+
     def test_it_is_mutable(self, config):
         config.update({"a_key": "a_value"})
 

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -226,10 +226,6 @@ class TestCanvasFileBasicLTILaunch:
     def test_it_configures_frontend(self, context, canvas_request):
         canvas_file_basic_lti_launch_caller(context, canvas_request)
 
-        assert (
-            context.js_config.config["authUrl"]
-            == "http://example.com/api/canvas/authorize"
-        )
         assert context.js_config.config["lmsName"] == "Canvas"
 
     def test_it_configures_via_callback_url(self, context, canvas_request):

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -13,16 +13,6 @@ class TestContentItemSelection:
 
         context.js_config.enable_content_item_selection_mode.assert_called_once_with()
 
-    def test_it_sets_the_authUrl_javascript_config_setting(
-        self, context, pyramid_request
-    ):
-        content_item_selection(context, pyramid_request)
-
-        assert (
-            context.js_config.config["authUrl"]
-            == "http://example.com/TEST_AUTHORIZE_URL"
-        )
-
     def test_it_sets_the_formAction_javascript_config_setting(
         self, context, pyramid_request
     ):


### PR DESCRIPTION
The `"authUrl"` setting is the URL of the popup window that the
JavaScript code opens when it needs the user to get us a new Canvas API
access token by (re-)authorizing us with Canvas. It's actually a URL of
the LMS app itself, not a Canvas URL, but it redirects the popup window
to the appropriate Canvas URL.

This setting should probably be named something else given that it's
actually specific to the Canvas API.

It also belongs in the `"urls"` JavaScript setting (which is a dict of
all the URLs the JavaScript code needs to know about) not as its own
top-level setting.

But this PR limits itself to moving the `"authUrl"` setting into the
`JSConfig` class.

This change means that `"authUrl"` exists in the JS config all the time
not just some of the time, which does no harm.