### PR TITLE
Centralize JSConfig 6/n: Move via_url, via_url_callback, and submissionParams into JSConfig

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.19
+fail_under = 99.18
 skip_covered = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.18
+fail_under = 99.21
 skip_covered = True

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -112,6 +112,10 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         lis_result_sourcedid = self._request.params.get("lis_result_sourcedid")
         lis_outcome_service_url = self._request.params.get("lis_outcome_service_url")
 
+        # Don't set the Canvas submission params in non-Canvas LMS's.
+        if not self._context.is_canvas:
+            return
+
         # When a Canvas assignment is launched by a teacher or other
         # non-gradeable user there's no lis_result_sourcedid in the LTI
         # launch params.

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -70,6 +70,37 @@ class JSConfig:  # pylint:disable=too-few-public-methods
             "urls": self._urls,
         }
 
+    def add_canvas_submission_params(self):
+        """
+        Add config used by the JS to call our record_canvas_speedgrader_submission API.
+
+        :raise HTTPBadRequest: if a request param needed to generate the config
+            is missing
+        """
+        lis_result_sourcedid = self._request.params.get("lis_result_sourcedid")
+        lis_outcome_service_url = self._request.params.get("lis_outcome_service_url")
+
+        # When a Canvas assignment is launched by a teacher or other
+        # non-gradeable user there's no lis_result_sourcedid in the LTI
+        # launch params.
+        # Don't post submission to Canvas for these cases.
+        if not lis_result_sourcedid:
+            return
+
+        # When a Canvas assignment isn't gradeable there's no
+        # lis_outcome_service_url.
+        # Don't post submission to Canvas for these cases.
+        if not lis_outcome_service_url:
+            return
+
+        self.config.setdefault("submissionParams", {}).update(
+            {
+                "h_username": self._context.h_user.username,
+                "lis_result_sourcedid": lis_result_sourcedid,
+                "lis_outcome_service_url": lis_outcome_service_url,
+            }
+        )
+
     def enable_content_item_selection_mode(self):
         """
         Put the JavaScript code into "content item selection" mode.

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -37,7 +37,7 @@ class BasicLTILaunchViews:
         self.request = request
 
         if self.context.is_canvas:
-            self.initialise_canvas_submission_params()
+            self.context.js_config.add_canvas_submission_params()
 
         self.context.js_config.maybe_set_focused_user()
 
@@ -283,21 +283,6 @@ class BasicLTILaunchViews:
             {"via_url": via_url(self.request, document_url)}
         )
         self.set_canvas_submission_param("document_url", document_url)
-
-    def initialise_canvas_submission_params(self):
-        """Add config used by UI to call Canvas `record_submission` API."""
-        lis_result_sourcedid = self.request.params.get("lis_result_sourcedid")
-        lis_outcome_service_url = self.request.params.get("lis_outcome_service_url")
-
-        # Don't try to submit assignments to Canvas when the assignment is
-        # launched by a teacher, or when the submission-related params are
-        # missing for some other reason.
-        if lis_result_sourcedid and lis_outcome_service_url:
-            self.context.js_config.config["submissionParams"] = {
-                "h_username": self.context.h_user.username,
-                "lis_result_sourcedid": lis_result_sourcedid,
-                "lis_outcome_service_url": lis_outcome_service_url,
-            }
 
     def set_canvas_submission_param(self, name, value):
         """Update config for frontend's calls to `report_submisssion` API."""

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -84,6 +84,15 @@ class TestAddCanvasFileIDAddDocumentURLCommon:
             == "example_lis_result_sourcedid"
         )
 
+    def test_it_doesnt_set_the_canvas_submission_params_if_the_LMS_isnt_Canvas(
+        self, context, method, js_config
+    ):
+        context.is_canvas = False
+
+        method("canvas_file_id_or_document_url")
+
+        assert "submissionParams" not in js_config.config
+
     def test_it_doesnt_set_the_canvas_submission_params_if_theres_no_lis_result_sourcedid(
         self, method, js_config, pyramid_request
     ):
@@ -317,6 +326,7 @@ def context():
         instance=True,
         h_user=HUser("TEST_AUTHORITY", "example_username"),
         h_groupid="example_groupid",
+        is_canvas=True,
     )
 
 

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -69,7 +69,7 @@ class TestAddDocumentURL:
 
 
 class TestAddCanvasFileIDAddDocumentURLCommon:
-    """Tests commont to both add_canvas_file_id() and add_document_url()."""
+    """Tests common to both add_canvas_file_id() and add_document_url()."""
 
     def test_it_sets_the_canvas_submission_params(self, method, js_config):
         method("canvas_file_id_or_document_url")

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -51,13 +51,11 @@ class TestAddCanvasFileID:
 class TestAddDocumentURL:
     """Unit tests for JSConfig.add_document_url()."""
 
-    def test_it_adds_the_via_url(self, js_config):
+    def test_it_adds_the_via_url(self, js_config, pyramid_request, via_url):
         js_config.add_document_url("example_document_url")
 
-        assert (
-            js_config.config["urls"]["via_url"]
-            == "http://TEST_VIA_SERVER.is/example_document_url?via.open_sidebar=1&via.request_config_from_frame=http%3A%2F%2Fexample.com"
-        )
+        via_url.assert_called_once_with(pyramid_request, "example_document_url")
+        assert js_config.config["urls"]["via_url"] == via_url.return_value
 
     def test_it_sets_the_document_url(self, js_config):
         js_config.add_document_url("example_document_url")
@@ -349,3 +347,8 @@ def pyramid_request(pyramid_request):
 def provisioning_disabled(context):
     """Modify context so that context.provisioning_enabled is False."""
     context.provisioning_enabled = False
+
+
+@pytest.fixture(autouse=True)
+def via_url(patch):
+    return patch("lms.resources._js_config.via_url")


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/1522 for the tests to pass.
Depends on https://github.com/hypothesis/lms/pull/1520.

This PR has two separate commits, and moves a bunch of JavaScript config settings out of the views and into `JSConfig`:

* `"via_url"` is the URL for the Via iframe that the JavaScript injects into the page.

  The Via URL contains the URL of the document to be annotated (in the path part of the Via URL).

  Where the document URL that's needed to construct the Via URL comes from varies between different types of assignments: for DB-configured assignments it's retrieved from the `module_item_configurations` table in the DB; for URL-configured assignment it's retrieved form the `"url"` LTI launch request param; for the `configure_module_item()` view it comes from a `"document_url"` request param.

  So it remains the view's job to retrieve the document URL, as each view does that differently. But the view now just passes that document URL to `context.js_config.add_document_url(document_url)` and `JSConfig` does the rest.

* `"via_url_callback"` is the URL of the proxy API that JavaScript calls in order to get the Via URL in order to inject the Via iframe.

  This setting  is used instead of the `"via_url"` setting when the Via URL isn't already known at page load time: when launching a Canvas files assignment. The `"via_url_callback"` contains the Canvas file ID. The `canvas_file_basic_lti_launch()` view now retrieves the Canvas file ID from the `"file_id"` request param and then just passes it to `context.js_config.add_canvas_file_id(canvas_file_id)` which does the rest.

* So each view calls either `add_document_url(document_url)` or `add_canvas_file_id(canvas_file_id)` but not both.

* Regardless of whether  `add_document_url(document_url)` or `add_canvas_file_id(canvas_file_id)` was called `JSConfig` then automatically sets a bunch of Canvas-only "submission params" that are common to `add_document_url()` and `add_canvas_file_id()` . These params are used by the JavaScript to make a request to a proxy API that submits a SpeedGrader launch URL to Canvas when a student launches an assignment. These all go in a `"submissionParams"` sub-dict of the JS config dict:

  * `["submissionParams"]["h_username"`]
  * `["submissionParams"]["lis_result_sourcedid"`]
  * `["submissionParams"]["lis_outcome_service_url"`]
  * Either `["submissionParams"]["document_url"`] or `["submissionParams"]["canvas_file_id"`] depending on the type of assignment

  The JavaScript passes these four to the backend's [`record_speedgrader_submission`](https://github.com/hypothesis/lms/blob/064f2884941d46bed41ab50fbef71aea89f3f4bf/lms/views/api/lti.py#L47-L85) API, which uses them to construct a SpeedGrader launch URL and submit it to Canvas.