### PR TITLE
Centralize JSConfig 5/n: Move is_canvas into LTILaunchResource

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -153,6 +153,14 @@ class LTILaunchResource:
         return self._get_param("user_id")
 
     @property
+    def is_canvas(self):
+        """Return True if Canvas is the LMS that launched us."""
+        return (
+            self._request.params.get("tool_consumer_info_product_family_code")
+            == "canvas"
+        )
+
+    @property
     @functools.lru_cache()
     def js_config(self):
         return JSConfig(self, self._request)

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -37,7 +37,7 @@ class BasicLTILaunchViews:
         self.context = context
         self.request = request
 
-        if self.is_launched_by_canvas():
+        if self.context.is_canvas:
             self.initialise_canvas_submission_params()
             self.set_canvas_focused_user()
 
@@ -68,7 +68,7 @@ class BasicLTILaunchViews:
 
         lti_user = request.lti_user
 
-        if not lti_user.is_instructor and not self.is_launched_by_canvas():
+        if not lti_user.is_instructor and not self.context.is_canvas:
             # Create or update a record of LIS result data for a student launch
             request.find_service(name="grading_info").upsert_from_request(
                 request, h_user=self.context.h_user, lti_user=lti_user
@@ -290,12 +290,6 @@ class BasicLTILaunchViews:
             {"via_url": via_url(self.request, document_url)}
         )
         self.set_canvas_submission_param("document_url", document_url)
-
-    def is_launched_by_canvas(self):
-        return (
-            self.request.params.get("tool_consumer_info_product_family_code")
-            == "canvas"
-        )
 
     def initialise_canvas_submission_params(self):
         """Add config used by UI to call Canvas `record_submission` API."""

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -258,6 +258,19 @@ class TestLTILaunchResource:
             # pylint:disable=expression-not-assigned
             LTILaunchResource(pyramid_request).h_provider_unique_id
 
+    @pytest.mark.parametrize(
+        "tool_consumer_info_product_family_code,is_canvas",
+        [("canvas", True), ("whiteboard", False)],
+    )
+    def test_is_canvas(
+        self, pyramid_request, tool_consumer_info_product_family_code, is_canvas
+    ):
+        pyramid_request.params[
+            "tool_consumer_info_product_family_code"
+        ] = tool_consumer_info_product_family_code
+
+        assert LTILaunchResource(pyramid_request).is_canvas == is_canvas
+
     def test_h_user_username_is_a_30_char_string(self, pyramid_request):
         pyramid_request.params.update(
             {


### PR DESCRIPTION
Move `BasicLTILaunchViews.is_launched_by_canvas()` to
`LTILaunchResource.is_canvas` (a property).

This is necessary because future `JSConfig` code is going to need to
know whether the LMS is Canvas, and `JSConfig` can't access a
`BasicLTILaunchViews` method.

One thing that both `BasicLTILaunchViews` and `JSConfig` have access to
is the `LTILaunchResource` context, so they can both read
`context.is_canvas`.

Whether or not the LMS is Canvas also seems fitting as part of the
"context".

This is also in line with keeping views thin in general. One of the
reasons for keeping code out of views is that view code isn't reusable.
Context code is usable by the context itself, context helpers like
`JSConfig`, views, services that receive the context, etc.