### PR TITLE
Centralize JSConfig 7/n: Move the focused_user into JSConfig

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,7 +16,7 @@ from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.services.oauth1 import OAuth1Service
-from lms.values import LTIUser
+from lms.values import HUser, LTIUser
 from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
 
 TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(
@@ -195,6 +195,11 @@ def group_info_service(pyramid_config):
 @pytest.fixture
 def h_api(pyramid_config):
     h_api = mock.create_autospec(HAPI, spec_set=True, instance=True)
+    h_api.get_user.return_value = HUser(
+        authority="lms.hypothes.is",
+        username="example_h_username",
+        display_name="example_h_display_name",
+    )
     pyramid_config.register_service(h_api, name="h_api")
     return h_api
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/1522 for the tests to pass.

`"focused_user"` is a JavaScript config setting that gets sent to the Hypothesis client and causes it to focus on one particular user, showing only that user's annotations. It's only used in Canvas SpeedGrader launches, to get the client to focus on the student who is being graded. The `"focused_user"` setting is _not_ used by our non-Canvas grading UX.

There's also a change in behaviour in this PR: it now configures the client to focus on a user whenever there's a `focused_user` launch param. Previously it only did this when the LMS was Canvas _and_ there was a `focused_user` launch param. The is-Canvas check was both unnecessary and incorrect:
    
* In practice the `focused_user` launch param only ever appears in Canvas SpeedGrader launches, so the presence of `focused_user` already tells us that we must be in Canvas, it's not necessary to additionally check by other means that we are in Canvas
    
* The user focusing behaviour is not desired in Canvas generally, only in Canvas SpeedGrader, so the check should be "is Canvas SpeedGrader?" not just "is Canvas?" Just checking for the `focused_user` param already achieves this
    
This also means that if we ever do add the focused_user param in any non-Canvas environments it will just work.
