### PR TITLE
Centralize JSConfig 1/n: Remove the lmsName JavaScript setting

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -51,7 +51,6 @@ export default function BasicLtiLaunchApp() {
   const {
     authToken,
     authUrl,
-    lmsName,
     grading,
     lmsGrader,
     submissionParams,
@@ -176,7 +175,7 @@ export default function BasicLtiLaunchApp() {
       authWindow.current.focus();
       return;
     }
-    authWindow.current = new AuthWindow({ authToken, authUrl, lmsName });
+    authWindow.current = new AuthWindow({ authToken, authUrl });
 
     try {
       await authWindow.current.authorize();
@@ -185,7 +184,7 @@ export default function BasicLtiLaunchApp() {
       // eslint-disable-next-line require-atomic-updates
       authWindow.current = null;
     }
-  }, [authToken, authUrl, fetchContentUrl, lmsName]);
+  }, [authToken, authUrl, fetchContentUrl]);
 
   if (ltiLaunchState.state === 'fetched-url') {
     const iFrame = (

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -36,7 +36,6 @@ export default function FilePickerApp({
     formFields,
     googleClientId,
     googleDeveloperKey,
-    lmsName,
     customCanvasApiDomain,
     lmsUrl,
     ltiLaunchUrl,
@@ -122,13 +121,7 @@ export default function FilePickerApp({
   let dialog;
   switch (activeDialog) {
     case 'url':
-      dialog = (
-        <URLPicker
-          lmsName={lmsName}
-          onCancel={cancelDialog}
-          onSelectURL={selectURL}
-        />
-      );
+      dialog = <URLPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
       break;
     case 'lms':
       dialog = (
@@ -136,7 +129,6 @@ export default function FilePickerApp({
           authToken={authToken}
           authUrl={authUrl}
           courseId={courseId}
-          lmsName={lmsName}
           lmsUrl={lmsUrl}
           onCancel={cancelDialog}
           onSelectFile={selectLMSFile}
@@ -188,7 +180,7 @@ export default function FilePickerApp({
           {enableLmsFilePicker && (
             <Button
               className="FilePickerApp__source-button"
-              label={`Select PDF from ${lmsName}`}
+              label={`Select PDF from Canvas`}
               onClick={() => setActiveDialog('lms')}
             />
           )}

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -33,7 +33,6 @@ export default function LMSFilePicker({
   authToken,
   authUrl,
   courseId,
-  lmsName,
   lmsUrl,
   onCancel,
   onSelectFile,
@@ -79,7 +78,7 @@ export default function LMSFilePicker({
       return;
     }
 
-    authWindow.current = new AuthWindow({ authToken, authUrl, lmsName });
+    authWindow.current = new AuthWindow({ authToken, authUrl });
 
     try {
       await authWindow.current.authorize();
@@ -90,7 +89,7 @@ export default function LMSFilePicker({
       // eslint-disable-next-line require-atomic-updates
       authWindow.current = null;
     }
-  }, [fetchFiles, authToken, authUrl, lmsName]);
+  }, [fetchFiles, authToken, authUrl]);
 
   // On the initial load, fetch files or prompt to authorize if we know that
   // authorization will be required.
@@ -152,7 +151,7 @@ export default function LMSFilePicker({
         <ErrorDisplay
           message={
             <Fragment>
-              {`Failed to authorize with the ${lmsName} instance at `}
+              {`Failed to authorize with the Canvas instance at `}
               <a href={`${lmsUrl}`}>{`${lmsUrl}`}</a>
             </Fragment>
           }
@@ -162,7 +161,7 @@ export default function LMSFilePicker({
       {dialogState.state === 'authorizing' && !authorizationAttempted && (
         <p>
           To select a file, you must authorize Hypothesis to access your files
-          in {lmsName}.
+          in Canvas.
         </p>
       )}
       {(dialogState.state === 'fetching' ||
@@ -194,11 +193,6 @@ LMSFilePicker.propTypes = {
    * ID of the course that the user is choosing a file for.
    */
   courseId: propTypes.string.isRequired,
-
-  /**
-   * The name of the LMS to display in API controls, eg. "Canvas".
-   */
-  lmsName: propTypes.string.isRequired,
 
   /**
    * The url of the LMS, eg. "https://foobar.instructure.com".

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -34,7 +34,6 @@ describe('BasicLtiLaunchApp', () => {
     fakeConfig = {
       authToken: 'dummyAuthToken',
       authUrl: 'https://lms.hypothes.is/authorize-lms',
-      lmsName: 'Shiny LMS',
       urls: {},
     };
     fakeApiCall = sinon.stub();

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -44,7 +44,6 @@ describe('FilePickerApp', () => {
       enableLmsFilePicker: true,
       formAction: 'https://www.shinylms.com/',
       formFields: { hidden_field: 'hidden_value' },
-      lmsName: 'Shiny LMS',
       ltiLaunchUrl: 'https://lms.anno.co/lti_launch',
     };
 
@@ -90,13 +89,13 @@ describe('FilePickerApp', () => {
   it('renders LMS file picker button if `enableLmsFilePicker` is true', () => {
     fakeConfig.enableLmsFilePicker = true;
     const wrapper = renderFilePicker();
-    assert.isTrue(wrapper.exists('Button[label="Select PDF from Shiny LMS"]'));
+    assert.isTrue(wrapper.exists('Button[label="Select PDF from Canvas"]'));
   });
 
   it('does not render LMS file picker button if `enableLmsFilePicker` is false', () => {
     fakeConfig.enableLmsFilePicker = false;
     const wrapper = renderFilePicker();
-    assert.isFalse(wrapper.exists('Button[label="Select PDF from Shiny LMS"]'));
+    assert.isFalse(wrapper.exists('Button[label="Select PDF from Canvas"]'));
   });
 
   it('renders initial form with no dialog visible', () => {
@@ -134,10 +133,10 @@ describe('FilePickerApp', () => {
     );
   });
 
-  it('shows LMS file dialog when "Select PDF from <LMS Name>" is clicked', () => {
+  it('shows LMS file dialog when "Select PDF from Canvas" is clicked', () => {
     const wrapper = renderFilePicker();
 
-    const btn = wrapper.find('Button[label="Select PDF from Shiny LMS"]');
+    const btn = wrapper.find('Button[label="Select PDF from Canvas"]');
     interact(wrapper, () => {
       btn.props().onClick();
     });

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -27,7 +27,6 @@ describe('LMSFilePicker', () => {
         authToken="auth-token"
         authUrl="https://lms.anno.co/authorize-lms"
         courseId="test-course"
-        lmsName="Dummy LMS"
         lmsUrl="https://hypothesis.dummylms.com"
         onAuthorized={sinon.stub()}
         onSelectFile={sinon.stub()}
@@ -94,7 +93,6 @@ describe('LMSFilePicker', () => {
     });
 
     const wrapper = renderFilePicker({
-      lmsName: 'Canvas',
       lmsUrl: 'https://example.com',
     });
     assert.called(fakeListFiles);

--- a/lms/static/scripts/frontend_apps/utils/AuthWindow.js
+++ b/lms/static/scripts/frontend_apps/utils/AuthWindow.js
@@ -4,10 +4,9 @@ import queryString from 'query-string';
  * Manages an LMS authentication popup window.
  */
 export default class AuthWindow {
-  constructor({ authToken, authUrl, lmsName }) {
+  constructor({ authToken, authUrl }) {
     this._authToken = authToken;
     this._authUrl = authUrl;
-    this._lmsName = lmsName;
   }
 
   close() {
@@ -43,7 +42,7 @@ export default class AuthWindow {
     const authUrl = `${this._authUrl}?${authQuery}`;
     this._authWin = window.open(
       authUrl,
-      `Allow access to ${this._lmsName} files`,
+      `Allow access to Canvas files`,
       settings
     );
 

--- a/lms/static/scripts/frontend_apps/utils/test/AuthWindow-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/AuthWindow-test.js
@@ -19,7 +19,6 @@ describe('AuthWindow', () => {
     return new AuthWindow({
       authToken: 'auth-token',
       authUrl: 'https://lms.anno.co/authorize',
-      lmsName: 'Shiny LMS',
     });
   }
 
@@ -30,7 +29,7 @@ describe('AuthWindow', () => {
       assert.calledWith(
         window.open,
         'https://lms.anno.co/authorize?authorization=auth-token',
-        'Allow access to Shiny LMS files'
+        'Allow access to Canvas files'
       );
     });
 

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -91,13 +91,6 @@ class BasicLTILaunchViews:
 
         file_id = self.request.params["file_id"]
 
-        self.context.js_config.config.update(
-            {
-                # Set the LMS name to use in user-facing messages.
-                "lmsName": "Canvas",
-            }
-        )
-
         # Configure the frontend to make a callback to the API to fetch the
         # Via URL.
         self.context.js_config.config["urls"].update(

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -68,8 +68,6 @@ def content_item_selection(context, request):
             # Variables needed for initializing Google Picker.
             "googleClientId": request.registry.settings["google_client_id"],
             "googleDeveloperKey": request.registry.settings["google_developer_key"],
-            # Shown on the "Select PDF from Canvas" button label.
-            "lmsName": "Canvas",
             # The "content item selection" that we submit to the
             # content_item_return_url is actually an LTI launch URL with the
             # selected document URL or file_id as a query parameter. To construct

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -228,11 +228,6 @@ class TestCommon:
 
 @pytest.mark.usefixtures("is_canvas")
 class TestCanvasFileBasicLTILaunch:
-    def test_it_configures_frontend(self, context, pyramid_request):
-        canvas_file_basic_lti_launch_caller(context, pyramid_request)
-
-        assert context.js_config.config["lmsName"] == "Canvas"
-
     def test_it_configures_via_callback_url(self, context, pyramid_request):
         canvas_file_basic_lti_launch_caller(context, pyramid_request)
 

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -38,13 +38,6 @@ class TestContentItemSelection:
         assert context.js_config.config["googleClientId"] == "fake_client_id"
         assert context.js_config.config["googleDeveloperKey"] == "fake_developer_key"
 
-    def test_it_sets_the_lmsName_javascript_config_setting(
-        self, context, pyramid_request
-    ):
-        content_item_selection(context, pyramid_request)
-
-        assert context.js_config.config["lmsName"] == "Canvas"
-
     def test_it_sets_the_ltiLaunchUrl_javascript_config_setting(
         self, context, pyramid_request
     ):


### PR DESCRIPTION
This setting is only ever set to "Canvas". Simplify both the backend and
frontend code by just using "Canvas" as a hardcoded string and removing
the setting.