### PR TITLE
Add `make pylint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ sql: python
 .PHONY: lint
 lint: backend-lint frontend-lint
 
+.PHONY: pylint
+pylint:
+	@tox -qe pylint
+
 .PHONY: format
 format: backend-format frontend-format
 

--- a/pylintrc.code
+++ b/pylintrc.code
@@ -1,0 +1,54 @@
+[MASTER]
+# Use multiple processes to speed up PyLint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+load-plugins=pylint.extensions.bad_builtin,
+             pylint.extensions.check_elif,
+             pylint.extensions.comparetozero,
+             pylint.extensions.docparams,
+             pylint.extensions.emptystring,
+             pylint.extensions.mccabe,
+             pylint.extensions.overlapping_exceptions,
+             pylint.extensions.redefined_variable_type,
+
+[MESSAGES CONTROL]
+disable=
+    # Docstrings are encouraged but we don't want to enforce that everything
+    # must have a docstring.
+    missing-docstring,
+
+    # We don't always want to have to put a `:return:` in a docstring.
+    missing-return-doc,
+
+    # We don't always want to have to put an `:rtype:` in a docstring.
+    missing-return-type-doc,
+
+    # We don't want to have to document the type of every parameter with a
+    # `:type:` in the docstring.
+    missing-type-doc,
+
+    # We use isort to sort and group our imports, so we don't need PyLint to
+    # check them for us.
+    ungrouped-imports,
+
+    # We use Black to format our code automatically, so we don't need PyLint to
+    # check formatting for us.
+    bad-continuation,
+    line-too-long,
+
+good-names=
+    # PyLint's default good names.
+    i,j,k,ex,Run,_,
+
+    # The standard name used for the pyramid_tm transaction manager.
+    tm,
+
+    # request.db.
+    db,
+
+[REPORTS]
+output-format=colorized
+# Deactivate the evaluation score: we don't care about it, we just enforce that
+# there are zero PyLint messages.
+score=no

--- a/pylintrc.tests
+++ b/pylintrc.tests
@@ -1,0 +1,80 @@
+[MASTER]
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+load-plugins=pylint.extensions.bad_builtin,
+             pylint.extensions.check_elif,
+             pylint.extensions.comparetozero,
+             pylint.extensions.docparams,
+             pylint.extensions.emptystring,
+             pylint.extensions.overlapping_exceptions,
+             pylint.extensions.redefined_variable_type,
+
+[MESSAGES CONTROL]
+disable=
+    # Docstrings are encouraged but we don't want to enforce that everything
+    # must have a docstring.
+    missing-docstring,
+
+    # We don't always want to have to put a `:return:` in a docstring.
+    missing-return-doc,
+
+    # We don't always want to have to put an `:rtype:` in a docstring.
+    missing-return-type-doc,
+
+    # We don't want to have to document the type of every parameter with a
+    # `:type:` in the docstring.
+    missing-type-doc,
+
+    # We use isort to sort and group our imports, so we don't need PyLint to
+    # check them for us.
+    ungrouped-imports,
+
+    # We use Black to format our code automatically, so we don't need PyLint to
+    # check formatting for us.
+    bad-continuation,
+    line-too-long,
+
+    # Because of how pytest fixtures work it's frequently necessary for
+    # parameters to redefine outer names.
+    redefined-outer-name,
+
+    # Lots of test methods don't use self, but we still want to group our tests
+    # into classes.
+    no-self-use,
+    too-few-public-methods,
+    too-many-public-methods,
+
+    too-many-arguments,
+
+# Just disable PyLint's name style checking for the tests, because we
+# frequently use lots of argument names that don't conform.
+# For example we frequently create pytest fixtures that aren't named in
+# snake_case, such as a fixture that returns a mock of the FooBar class would
+# be named FooBar in CamelCase.
+argument-naming-style=any
+class-naming-style=any
+function-naming-style=any
+method-naming-style=any
+
+good-names=
+    # PyLint's default good names.
+    i,j,k,ex,Run,_,
+
+    # The standard name used for the pyramid_tm transaction manager.
+    tm,
+
+    # request.db.
+    db,
+
+    pytestmark,
+
+    # Name used for mocks of the standard os module.
+    os,
+
+[REPORTS]
+output-format=colorized
+# Deactivate the evaluation score: we don't care about it, we just enforce that
+# there are zero PyLint messages.
+score=no

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,37 @@ requires =
 tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false
 
+[pycodestyle]
+ignore =
+    # Disable pycodestyle errors and warnings that we don't care about because
+    # Black formats our code for us.
+    E203,  # Whitespace before ':',
+    E231,  # Missing whitespace after ',',
+    E501,  # Line too long,
+    W503,  # Line break before binary operator,
+
+    # Bare except. PyLint finds these for us so we don't need pycodestyle to.
+    E722,
+
+[pydocstyle]
+ignore =
+    # Missing docstrings.
+    D100,D101,D102,D103,D104,D105,D106,D107,
+
+    # "No blank lines allowed after function docstring" conflicts with
+    # the Black code formatter, which insists on inserting blank lines after
+    # function docstrings.
+    D202,
+
+    # "1 blank line required before class docstring" conflicts with another
+    # pydocstyle rule D211 "No blank lines allowed before class docstring".
+    D203,
+
+    # Multi-line docstring summary should start at the first line, this
+    # conflicts with another pycodestyle rule "Multi-line docstring summary
+    # should start at the second line".
+    D212,
+
 [testenv]
 skip_install = true
 passenv =
@@ -44,19 +75,22 @@ passenv =
     dev: VIA_URL
 deps =
     {tests,clean}: coverage
-    {tests,bddtests,functests,lint}: httpretty
-    {tests,bddtests,functests,lint,docstrings,checkdocstrings}: pytest
-    {tests,functests,lint,docstrings,checkdocstrings}: factory-boy
-    {tests,bddtests,functests,lint,docstrings,checkdocstrings}: h-matchers>=1.2.0
-    {bddtests,functests,lint,docstrings,checkdocstrings}: webtest
-    {bddtests,lint}: behave
+    {tests,bddtests,functests,lint,pylint}: httpretty
+    {tests,bddtests,functests,lint,pylint,docstrings,checkdocstrings}: pytest
+    {tests,functests,lint,pylint,docstrings,checkdocstrings}: factory-boy
+    {tests,bddtests,functests,lint,pylint,docstrings,checkdocstrings}: h-matchers>=1.2.0
+    {bddtests,functests,lint,pylint,docstrings,checkdocstrings}: webtest
+    {bddtests,lint,pylint}: behave
     lint: prospector==1.1.6.2
+    pylint: pylint
+    pylint: pydocstyle
+    pylint: pycodestyle
     {format,checkformatting}: black
     {format,checkformatting}: isort
     {docstrings,checkdocstrings}: sphinx
     docstrings: sphinx-autobuild
     docker-compose: docker-compose
-    {tests,bddtests,functests,lint,docstrings,checkdocstrings}: -r requirements.txt
+    {tests,bddtests,functests,lint,pylint,docstrings,checkdocstrings}: -r requirements.txt
     dev: -r requirements-dev.in
     pip-compile: pip-tools
 setenv =
@@ -80,6 +114,10 @@ commands =
     bddtests: behave {posargs:tests/bdd/}
     lint: prospector
     lint: prospector tests
+    pylint: pylint --rcfile=pylintrc.code lms
+    pylint: pylint --rcfile=pylintrc.tests tests
+    pylint: pydocstyle lms tests
+    pylint: pycodestyle lms tests
     format: black lms tests
     format: isort --recursive --quiet --atomic lms tests
     checkformatting: black --check lms tests


### PR DESCRIPTION
Add a new `make pylint` command that runs pylint, pydocstyle and
pycodestyle directly, instead of running prospector.

The old, prospector-based `make lint` command still exists and is still
used by `make sure` and by CI. `make pylint` isn't actually used by
anything yet.

`make pylint` is currently failing because of lots of unfixed pylint
warnings in the code and tests.

In the future, once the tests are fixed, `make lint` will be removed and
`make pylint` will become `make lint`.

The `pylintrc` file had to be named `pylintrc.code` to prevent
prospector from picking it up (which would cause prospector to hang
forever). It'll be renamed to just `pylintrc` once prospector is gone.

Usage
-----

* `make pylint` will pylint the code and tests and also run pycodestyle
  and pydocstyle, and also create venvs for all these tools and install
  them, update the versions of the dependencies that pylint is checking
  against, etc. This is what CI and `make sure` will run in future.

* `tox -qe pylint --run-command 'pylint lms'` will still allow tox to do
  everything, but just run pylint over the code only and not run
  everything else. Faster. Any of the other individual commands can be
  run this way as well. You can also lint just certain directories or
  files this way.

* `.tox/pylint/bin/pylint lms` will run tox's copy of pylint but without
  any tox involvement at all. Even faster, but you lose all tox's help.
  E.g. you may be linting against old versions of the app's
  dependencies.  Again, you can run any of the commands this way, and
  can use it to lint only certain files or dirs. Won't work unless you
  have run one of the two above commands first so that tox's copy of
  pylint exists. There's literally no simpler or faster way to run
  pylint than this, since you're literally just running it directly
  without tox or make.

* `/PATH/TO/YOUR/pylint --rcfile=pylintrc.code ...` run your own
  installed copy of pylint (maybe just `pylint` if it's on your
  `$PATH`). No reason this won't work, and it will pick up our config.