### PR TITLE
Fix a11y lint for ValidationMessage

### DIFF
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -145,14 +145,16 @@ export default function SubmitGradeForm({ disabled = false, student }) {
 
   return (
     <form className="SubmitGradeForm" autoComplete="off">
-      <ValidationMessage
-        message={validationMessage}
-        open={showValidationError}
-        onClose={() => {
-          // Sync up the state when the ValidationMessage is closed
-          setValidationError(false);
-        }}
-      />
+      {validationMessage && (
+        <ValidationMessage
+          message={validationMessage}
+          open={showValidationError}
+          onClose={() => {
+            // Sync up the state when the ValidationMessage is closed
+            setValidationError(false);
+          }}
+        />
+      )}
       <label className="SubmitGradeForm__label" htmlFor={gradeId}>
         Grade (Out of 10)
       </label>

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -22,7 +22,8 @@ export default function ValidationMessage({
   /**
    * Closes the validation error message and notifies parent
    */
-  const closeValidationError = () => {
+  const closeValidationError = e => {
+    e.preventDefault();
     setShowError(false);
     onClose();
   };
@@ -33,11 +34,9 @@ export default function ValidationMessage({
   });
 
   return (
-    // FIXME-A11Y
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-    <div onClick={closeValidationError} className={errorClass}>
+    <button onClick={closeValidationError} className={errorClass}>
       {message}
-    </div>
+    </button>
   );
 }
 

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -112,9 +112,9 @@ describe('SubmitGradeForm', () => {
   });
 
   context('validation messages', () => {
-    it('hides the validation message by default', () => {
+    it('does not render the validation message by default', () => {
       const wrapper = renderForm();
-      assert.isFalse(wrapper.find('ValidationMessage').prop('open'));
+      assert.isFalse(wrapper.find('ValidationMessage').exists());
     });
 
     it('shows the validation message when the validator returns an error', () => {

--- a/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
@@ -40,7 +40,7 @@ describe('ValidationMessage', () => {
       open: true,
       message: 'foo',
     });
-    wrapper.find('div').simulate('click');
+    wrapper.find('button').simulate('click');
     assert.isTrue(onCloseProp.calledOnce);
     assert.isTrue(wrapper.find('.ValidationMessage--closed').exists());
   });

--- a/lms/static/styles/components/_ValidationMessage.scss
+++ b/lms/static/styles/components/_ValidationMessage.scss
@@ -1,3 +1,6 @@
+@use "../mixins";
+
+
 @keyframes validationErrorOpen {
   from {
     width: 0;
@@ -21,6 +24,7 @@
 }
 
 .ValidationMessage {
+  @include mixins.input-focus;
   display: inline-block;
   position: absolute;
   z-index: 10;


### PR DESCRIPTION
This PR is exactly what was posted before, and we can continue the conversation here.

The first issue here is that a `<div>` cant have a click event. To fix that, I made it a `<button>` which created a second and more subtle a11y issue with axe validation of a parent component building this component without a `message` prop. It causes axe to complain about the button not having a readable message.

The fix was to make SubmitGradeForm selective about rendering ValidationMessage. It was not sufficient to isolate the condition directly into ValidationMessage -- this caused some unfortunate animation issues with css key frames that after many attempts, I could not work out nicely. This solution should be suffice for a11y and it renders nice. I think the one drawback is the condition inside of SubmitGradeForm `{validationMessage && ( ... `