### PR TITLE
Stub out readyToReceive RPC method

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -1,23 +1,27 @@
 import { requestConfig } from './methods';
 
-describe('postmessage_json_rpc/methods#requestConfig', () => {
-  let configEl;
+describe('postmessage_json_rpc/methods', () => {
+  describe('requestConfig', () => {
+    let configEl;
 
-  beforeEach('inject the client config into the document', () => {
-    configEl = document.createElement('script');
-    configEl.setAttribute('type', 'application/json');
-    configEl.classList.add('js-config');
-    configEl.textContent = JSON.stringify({
-      hypothesisClient: { foo: 'bar' },
+    beforeEach('inject the client config into the document', () => {
+      configEl = document.createElement('script');
+      configEl.setAttribute('type', 'application/json');
+      configEl.classList.add('js-config');
+      configEl.textContent = JSON.stringify({
+        hypothesisClient: { foo: 'bar' },
+      });
+      document.body.appendChild(configEl);
     });
-    document.body.appendChild(configEl);
+
+    afterEach('remove the client config from the document', () => {
+      configEl.parentNode.removeChild(configEl);
+    });
+
+    it('returns the config object', () => {
+      assert.deepEqual(requestConfig(), { foo: 'bar' });
+    });
   });
 
-  afterEach('remove the client config from the document', () => {
-    configEl.parentNode.removeChild(configEl);
-  });
-
-  it('returns the config object', () => {
-    assert.deepEqual(requestConfig(), { foo: 'bar' });
-  });
+  describe('readyToReceive', () => {});
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -14,3 +14,14 @@ export function requestConfig() {
   const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
   return clientConfigObj;
 }
+
+/**
+ * The client sends this request when it's ready to receive incoming RPC
+ * requests.
+ */
+export function readyToReceive() {
+  // TOOD: resolve promise to unblock any outgoing rpc
+  // requests that were waiting.
+  // e.g. server._resolveSidebarWindow
+  return {};
+}


### PR DESCRIPTION
New method to allow delaying outgoing RPC requests to the client until its ready to receive them. Implementation details will need to happen after client changes, therefore this method is only a stub.

relates to https://github.com/hypothesis/client/pull/1885