### PR TITLE
wip - Add readyToReceive method

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,5 +1,5 @@
 import Server from './server';
-import { requestConfig } from './methods';
+import { readyToReceive, requestConfig } from './methods';
 
 let server = {}; // Singleton RPC server reference
 
@@ -9,6 +9,7 @@ let server = {}; // Singleton RPC server reference
 function startRpcServer() {
   server = new Server();
   server.register('requestConfig', requestConfig);
+  server.register('readyToReceive', readyToReceive);
 }
 
 /**
@@ -26,4 +27,15 @@ function getSidebarWindow() {
   return server.sidebarWindow;
 }
 
-export { startRpcServer, getSidebarWindow };
+/**
+ * Resolve the promise we created in the constructor with the saved
+ * sidebar frame and origin.
+ */
+function setSidebarResolved() {
+  server.resolveSidebarWindow({
+    frame: server.currentFrameEvent.source,
+    origin: server.currentFrameEvent.origin,
+  });
+}
+
+export { startRpcServer, getSidebarWindow, setSidebarResolved };

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -1,3 +1,5 @@
+import { setSidebarResolved } from './index';
+
 /**
  * Methods that're remotely callable by JSON-RPC over postMessage.
  *
@@ -13,4 +15,13 @@ export function requestConfig() {
   const configEl = document.querySelector('.js-config');
   const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
   return clientConfigObj;
+}
+
+/**
+ * The client sends this request when it's ready to receive incoming RPC
+ * requests.
+ */
+export function readyToReceive() {
+  setSidebarResolved();
+  return {};
 }

--- a/lms/static/scripts/postmessage_json_rpc/server/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/server.js
@@ -29,6 +29,10 @@ export default class Server {
     // origins will be ignored.
     this._allowedOrigins = configObj.allowedOrigins;
 
+    // Reference to the incoming RCP event so we can later use it to
+    // send RCP requests back to the client.
+    this.currentFrameEvent = null;
+
     // Add a postMessage event listener so we can recieve JSON-RPC requests.
     this._boundReceiveMessage = this._receiveMessage.bind(this);
     window.addEventListener('message', this._boundReceiveMessage);
@@ -37,7 +41,7 @@ export default class Server {
     this._registeredMethods = {};
 
     this.sidebarWindow = new Promise(resolve => {
-      this._resolveSidebarWindow = resolve;
+      this.resolveSidebarWindow = resolve;
     });
   }
 
@@ -69,12 +73,8 @@ export default class Server {
     if (!this._isJSONRPCRequest(event)) {
       return;
     }
-    // Resolve the promise we created in the constructor with the saved
-    // sidebar frame and origin.
-    this._resolveSidebarWindow({
-      frame: event.source,
-      origin: event.origin,
-    });
+    // Save the event reference.
+    this.currentFrameEvent = event;
 
     const result = await this._jsonRPCResponse(event.data);
     event.source.postMessage(result, event.origin);


### PR DESCRIPTION
readyToReceive calls setSidebarResolved which saves the current incoming frame event (from the client) and resolves a promise. This delays any outgoing RPC requests until the client sends the `readyToReceive` message first to prevent outgoing RCP requests from arriving too early and causing a timeout.