### PR TITLE
Add a timeout to Canvas API requests

### DIFF
--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -179,7 +179,7 @@ class CanvasAPIHelper:
             request.headers["Authorization"] = f"Bearer {access_token}"
 
         try:
-            response = requests.Session().send(request)
+            response = requests.Session().send(request, timeout=3)
             response.raise_for_status()
         except RequestException as err:
             CanvasAPIError.raise_from(err)

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -179,7 +179,7 @@ class CanvasAPIHelper:
             request.headers["Authorization"] = f"Bearer {access_token}"
 
         try:
-            response = requests.Session().send(request, timeout=3)
+            response = requests.Session().send(request, timeout=9)
             response.raise_for_status()
         except RequestException as err:
             CanvasAPIError.raise_from(err)

--- a/tests/unit/lms/services/_helpers/canvas_api_test.py
+++ b/tests/unit/lms/services/_helpers/canvas_api_test.py
@@ -76,7 +76,7 @@ class TestValidatedResponse:
         helper.validated_response(prepared_request)
 
         requests.Session.assert_called_once_with()
-        requests_session.send.assert_called_once_with(prepared_request)
+        requests_session.send.assert_called_once_with(prepared_request, timeout=3)
 
     def test_if_given_an_access_token_it_inserts_an_Authorization_header(
         self, helper, prepared_request, requests_session

--- a/tests/unit/lms/services/_helpers/canvas_api_test.py
+++ b/tests/unit/lms/services/_helpers/canvas_api_test.py
@@ -76,7 +76,7 @@ class TestValidatedResponse:
         helper.validated_response(prepared_request)
 
         requests.Session.assert_called_once_with()
-        requests_session.send.assert_called_once_with(prepared_request, timeout=3)
+        requests_session.send.assert_called_once_with(prepared_request, timeout=9)
 
     def test_if_given_an_access_token_it_inserts_an_Authorization_header(
         self, helper, prepared_request, requests_session


### PR DESCRIPTION
Looking at New Relic, some Canvas API's seem to take up to a second to
respond sometimes, so I've made the timeout pretty generous at 3
seconds.