### PR TITLE
Fix a11y for Dialog

### DIFF
--- a/lms/static/scripts/frontend_apps/common/dom.js
+++ b/lms/static/scripts/frontend_apps/common/dom.js
@@ -1,0 +1,23 @@
+/**
+ * Attach listeners for one or multiple events to an element and return a
+ * function that removes the listeners.
+ *
+ * @param {Element}
+ * @param {string[]} events
+ * @param {(event: Event) => any} listener
+ * @param {boolean} [options.useCapture]
+ * @return {function} Function which removes the event listeners.
+ */
+export function listen(element, events, listener, { useCapture = false } = {}) {
+  if (!Array.isArray(events)) {
+    events = [events];
+  }
+  events.forEach(event =>
+    element.addEventListener(event, listener, useCapture)
+  );
+  return () => {
+    events.forEach(event =>
+      element.removeEventListener(event, listener, useCapture)
+    );
+  };
+}

--- a/lms/static/scripts/frontend_apps/common/test/dom-test.js
+++ b/lms/static/scripts/frontend_apps/common/test/dom-test.js
@@ -1,0 +1,60 @@
+import { listen } from '../dom';
+
+describe('common/dom', () => {
+  const createElement = () => ({
+    addEventListener: sinon.stub(),
+    removeEventListener: sinon.stub(),
+  });
+
+  describe('listen', () => {
+    [true, false].forEach(useCapture => {
+      it('adds listeners for specified events', () => {
+        const element = createElement();
+        const handler = sinon.stub();
+
+        listen(element, ['click', 'mousedown'], handler, { useCapture });
+
+        assert.calledWith(
+          element.addEventListener,
+          'click',
+          handler,
+          useCapture
+        );
+        assert.calledWith(
+          element.addEventListener,
+          'mousedown',
+          handler,
+          useCapture
+        );
+      });
+    });
+
+    [true, false].forEach(useCapture => {
+      it('removes listeners when returned function is invoked', () => {
+        const element = createElement();
+        const handler = sinon.stub();
+
+        const removeListeners = listen(
+          element,
+          ['click', 'mousedown'],
+          handler,
+          { useCapture }
+        );
+        removeListeners();
+
+        assert.calledWith(
+          element.removeEventListener,
+          'click',
+          handler,
+          useCapture
+        );
+        assert.calledWith(
+          element.removeEventListener,
+          'mousedown',
+          handler,
+          useCapture
+        );
+      });
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/common/test/use-element-should-close-test.js
+++ b/lms/static/scripts/frontend_apps/common/test/use-element-should-close-test.js
@@ -1,0 +1,129 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { useRef } from 'preact/hooks';
+import { act } from 'preact/test-utils';
+import propTypes from 'prop-types';
+
+import useElementShouldClose from '../use-element-should-close';
+
+describe('useElementShouldClose', () => {
+  let handleClose;
+  let e;
+  const events = [
+    new Event('mousedown'),
+    new Event('click'),
+    ((e = new Event('keydown')), (e.key = 'Escape'), e),
+    new Event('focus'),
+  ];
+
+  // Create a fake component to mount in tests that uses the hook
+  function FakeComponent({ isOpen = true }) {
+    const myRef = useRef();
+    useElementShouldClose(myRef, isOpen, handleClose);
+    return (
+      <div ref={myRef}>
+        <button>Hi</button>
+      </div>
+    );
+  }
+
+  FakeComponent.propTypes = {
+    isOpen: propTypes.bool,
+  };
+
+  // Tests useElementShouldClose on a custom component directly
+  function FakeCompoundComponent({ isOpen = true }) {
+    function FakeCustomComponent() {
+      return (
+        <div>
+          <button>Hi</button>
+        </div>
+      );
+    }
+    const myRef = useRef();
+    useElementShouldClose(myRef, isOpen, handleClose);
+    return <FakeCustomComponent ref={myRef} />;
+  }
+
+  FakeCompoundComponent.propTypes = {
+    isOpen: propTypes.bool,
+  };
+
+  function createComponent(props) {
+    return mount(<FakeComponent isOpen={true} {...props} />);
+  }
+
+  function createCompoundComponent(props) {
+    return mount(<FakeCompoundComponent isOpen={true} {...props} />);
+  }
+
+  beforeEach(() => {
+    handleClose = sinon.stub();
+  });
+
+  // Run each set of tests twice, once for a regular node and a second
+  // time for a custom preact component
+  [
+    {
+      createWrapper: createComponent,
+      description: 'useElementShouldClose attached to a html node',
+    },
+    {
+      createWrapper: createCompoundComponent,
+      description: 'useElementShouldClose attached to a preact component',
+    },
+  ].forEach(test => {
+    context(test.description, () => {
+      events.forEach(event => {
+        it(`should invoke close callback once for events outside of element (${event.type})`, () => {
+          const wrapper = test.createWrapper();
+
+          act(() => {
+            document.body.dispatchEvent(event);
+          });
+          wrapper.update();
+
+          assert.calledOnce(handleClose);
+
+          // Update the component to change it and re-execute the hook
+          wrapper.setProps({ isOpen: false });
+
+          act(() => {
+            document.body.dispatchEvent(event);
+          });
+
+          // Cleanup of hook should have removed eventListeners, so the callback
+          // is not called again
+          assert.calledOnce(handleClose);
+        });
+      });
+
+      events.forEach(event => {
+        it(`should not invoke close callback on events outside of element if element closed (${event.type})`, () => {
+          const wrapper = test.createWrapper({ isOpen: false });
+
+          act(() => {
+            document.body.dispatchEvent(event);
+          });
+          wrapper.update();
+
+          assert.equal(handleClose.callCount, 0);
+        });
+      });
+
+      events.forEach(event => {
+        it(`should not invoke close callback on events inside of element (${event.type})`, () => {
+          const wrapper = test.createWrapper();
+          const button = wrapper.find('button');
+
+          act(() => {
+            button.getDOMNode().dispatchEvent(event);
+          });
+          wrapper.update();
+
+          assert.equal(handleClose.callCount, 0);
+        });
+      });
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/common/use-element-should-close.js
+++ b/lms/static/scripts/frontend_apps/common/use-element-should-close.js
@@ -1,0 +1,109 @@
+import { useEffect } from 'preact/hooks';
+
+import { listen } from './dom';
+
+/**
+ * @typedef Ref
+ * @prop current {Node} - HTML node
+ *
+ * A ref object attached to a HTML node.
+ */
+
+/**
+ * @typedef PreactRef
+ * @prop current {Object} - preact component object
+ *
+ * A ref object attached to a custom preact component.
+ */
+
+/**
+ * This hook adds appropriate `eventListener`s to the document when a target
+ * element (`closeableEl`) is open. Events such as `click` and `focus` on
+ * elements that fall outside of `closeableEl` in the document, or keypress
+ * events for the `esc` key, will invoke the provided `handleClose` function
+ * to indicate that `closeableEl` should be closed. This hook also performs
+ * cleanup to remove `eventListener`s when appropriate.
+ *
+ * Limitation: This will not work when attached to a custom component that has
+ * more than one element nested under a root <Fragment>
+ *
+ * @param {Ref|PreactRef} closeableEl - ref object:
+ *                                Reference to a DOM element or preat component
+ *                                that should be closed when DOM elements external
+ *                                to it are interacted with or `Esc` is pressed
+ * @param {bool} isOpen - Whether the element is currently open. This hook does
+ *                        not attach event listeners/do anything if it's not.
+ * @param {() => void} handleClose - A function that will do the actual closing
+ *                                   of `closeableEl`
+ */
+export default function useElementShouldClose(
+  closeableEl,
+  isOpen,
+  handleClose
+) {
+  /**
+   *  Helper to return the underlying node object whether
+   *  `closeableEl` is attached to an HTMLNode or Preact component.
+   *
+   *  @param {Preact ref} closeableEl
+   *  @returns {Node}
+   */
+
+  const getCurrentNode = closeableEl => {
+    // if base is present, assume its a preact component
+    const node = closeableEl.current.base
+      ? closeableEl.current.base
+      : closeableEl.current;
+    if (typeof node !== 'object') {
+      throw new Error('useElementShouldClose can not find a node reference');
+    }
+    return node;
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      return () => {};
+    }
+
+    // Close element when user presses Escape key, regardless of focus.
+    const removeKeypressListener = listen(document.body, ['keydown'], event => {
+      if (event.key === 'Escape') {
+        handleClose();
+      }
+    });
+
+    // Close element if user focuses an element outside of it via any means
+    // (key press, programmatic focus change).
+    const removeFocusListener = listen(
+      document.body,
+      'focus',
+      event => {
+        const current = getCurrentNode(closeableEl);
+        if (!current.contains(event.target)) {
+          handleClose();
+        }
+      },
+      { useCapture: true }
+    );
+
+    // Close element if user clicks outside of it, even if on an element which
+    // does not accept focus.
+    const removeClickListener = listen(
+      document.body,
+      ['mousedown', 'click'],
+      event => {
+        const current = getCurrentNode(closeableEl);
+        if (!current.contains(event.target)) {
+          handleClose();
+        }
+      },
+      { useCapture: true }
+    );
+
+    return () => {
+      removeKeypressListener();
+      removeClickListener();
+      removeFocusListener();
+    };
+  }, [closeableEl, isOpen, handleClose]);
+}

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -221,6 +221,7 @@ export default function BasicLtiLaunchApp() {
       {ltiLaunchState.state === 'authorizing' && (
         <Dialog
           title="Authorize Hypothesis"
+          role="alertdialog"
           buttons={[
             <Button
               onClick={authorizeAndFetchUrl}
@@ -238,6 +239,7 @@ export default function BasicLtiLaunchApp() {
           <Dialog
             title="Something went wrong"
             contentClass="BasicLtiLaunchApp__dialog"
+            role="alertdialog"
             buttons={[
               <Button
                 onClick={authorizeAndFetchUrl}
@@ -258,6 +260,7 @@ export default function BasicLtiLaunchApp() {
           <Dialog
             title="Something went wrong"
             contentClass="BasicLtiLaunchApp__dialog"
+            role="alertdialog"
           >
             <ErrorDisplay
               message="There was a problem submitting this Hypothesis assignment"

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -10,7 +10,11 @@ import Dialog from './Dialog';
  */
 export default function ErrorDialog({ onCancel, title, error }) {
   return (
-    <Dialog title="Something went wrong :(" onCancel={onCancel}>
+    <Dialog
+      role="alertdialog"
+      title="Something went wrong :("
+      onCancel={onCancel}
+    >
       <ErrorDisplay message={title} error={error} />
     </Dialog>
   );

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -35,14 +35,17 @@ describe('Dialog', () => {
 
   it('closes when Escape key is pressed', () => {
     const onCancel = sinon.stub();
-    const wrapper = mount(<Dialog title="Test dialog" onCancel={onCancel} />);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    mount(<Dialog title="Test dialog" onCancel={onCancel} />, {
+      attachTo: container,
+    });
 
-    wrapper
-      .find('div')
-      .first()
-      .simulate('keydown', { key: 'Escape' });
-
+    const event = new Event('keydown');
+    event.key = 'Escape';
+    document.body.dispatchEvent(event);
     assert.called(onCancel);
+    container.remove();
   });
 
   it('closes when close button is clicked', () => {
@@ -80,6 +83,7 @@ describe('Dialog', () => {
       </Dialog>,
       { attachTo: container }
     );
+
     assert.equal(
       document.activeElement,
       wrapper.find('[role="dialog"]').getDOMNode()


### PR DESCRIPTION
This is a continuation of this PR https://github.com/hypothesis/lms/pull/1481

In summary 
- Dialog may now have either a “dialog” or an “alertdialog” role depending what its used for.
- Dialog no longer has an `onKeyDown` handler. (a11y issue)
- `Escape` keyboard event is now handled with useElementShouldClose
- Add aria-modal=“true” prop to Dialog
- Dialog `id` prop is now generated with useUniqueId
- Expand Dialog `button` prop types for better accuracy

dom.js and use-elemenet-should-close.js are direct copies from the client added to a new common/ folder until we can get an imported package for such things. 

