### PR TITLE
Add via.config_frame_ancestor_level to via_url

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -37,6 +37,7 @@ def via_url(request, document_url):
     ]
     query_string_as_list.append(("via.open_sidebar", "1"))
     query_string_as_list.append(("via.request_config_from_frame", request.host_url))
+    query_string_as_list.append(("via.config_frame_ancestor_level", 2))
     query_string = parse.urlencode(query_string_as_list)
 
     via_service_url = request.registry.settings["via_url"]

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -13,13 +13,15 @@ class TestViaURL:
                 "https://example.com",
                 "http://TEST_VIA_SERVER.is/https://example.com"
                 "?via.open_sidebar=1"
-                "&via.request_config_from_frame=http%3A%2F%2Fexample.com",
+                "&via.request_config_from_frame=http%3A%2F%2Fexample.com"
+                "&via.config_frame_ancestor_level=2",
             ),
             (
                 "http://example.com",
                 "http://TEST_VIA_SERVER.is/http://example.com"
                 "?via.open_sidebar=1"
-                "&via.request_config_from_frame=http%3A%2F%2Fexample.com",
+                "&via.request_config_from_frame=http%3A%2F%2Fexample.com"
+                "&via.config_frame_ancestor_level=2",
             ),
             # If the document URL already has query params it appends the Via
             # params and preserves the existing ones.
@@ -27,7 +29,8 @@ class TestViaURL:
                 "http://example.com?foo=FOO&bar=BAR",
                 "http://TEST_VIA_SERVER.is/http://example.com"
                 "?foo=FOO&bar=BAR&via.open_sidebar=1"
-                "&via.request_config_from_frame=http%3A%2F%2Fexample.com",
+                "&via.request_config_from_frame=http%3A%2F%2Fexample.com"
+                "&via.config_frame_ancestor_level=2",
             ),
             # If the document URL already has via.open_sidebar or
             # via.request_config_from_frame query params it replaces them with
@@ -36,7 +39,8 @@ class TestViaURL:
                 "http://example.com?thing=blah&via.open_sidebar=FOO&via.request_config_from_frame=BAR",
                 "http://TEST_VIA_SERVER.is/http://example.com"
                 "?thing=blah&via.open_sidebar=1"
-                "&via.request_config_from_frame=http%3A%2F%2Fexample.com",
+                "&via.request_config_from_frame=http%3A%2F%2Fexample.com"
+                "&via.config_frame_ancestor_level=2",
             ),
         ],
     )


### PR DESCRIPTION
This is needed to inform the client which ancestor frame to send RCP requests to. This PR needs to land before we can make any changes to via so it won't cause errors downstream.
