### PR TITLE
Make JSConfig.config private

### DIFF
--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -34,7 +34,7 @@
 
     {% block scripts %}
       {% if context.js_config is defined %}
-        <script type="application/json" class="js-config">{{ context.js_config.config|tojson }}</script>
+        <script type="application/json" class="js-config">{{ context.js_config.asdict()|tojson }}</script>
       {% endif %}
     {% endblock %}
   </body>

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -281,9 +281,7 @@ pytestmark = pytest.mark.usefixtures("h_api", "grading_info_service", "lti_h_ser
 @pytest.fixture
 def context():
     context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
-    context.js_config = mock.create_autospec(
-        JSConfig, spec_set=True, instance=True, config={"urls": {}}
-    )
+    context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
     context.is_canvas = False
     return context
 

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -30,9 +30,7 @@ class TestContentItemSelection:
     @pytest.fixture
     def context(self):
         context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
-        context.js_config = mock.create_autospec(
-            JSConfig, spec_set=True, instance=True, config={}
-        )
+        context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
         return context
 
 


### PR DESCRIPTION
Change the mutable property JSConfig.config to a private, mutable
property JSConfig._config (it's still mutated by code within JSConfig).

Add a new JSConfig.asdict() method for the one place where code outside
of JSConfig needs to actually access the config dict (in the base
template, where it gets rendered to JSON).

Since the new asdict() just returns self._config anyway, this doesn't
make any real difference. But it might clarify the intent: code outside
of JSConfig isn't supposed to read or write the underlying config dict
anymore.