### PR TITLE
Add RPC server requestGroups method with artificial delay in dev

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.21
+fail_under = 99.22
 skip_covered = True

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -1,6 +1,7 @@
 [app:main]
 use = call:lms.app:create_app
 debug = true
+dev = true
 
 pyramid.reload_templates = true
 pyramid.debug_authorization = false

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -2,6 +2,7 @@
 
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator, aslist
+from pyramid.settings import asbool
 
 from lms.config.settings import SettingError, SettingGetter
 
@@ -11,6 +12,8 @@ def configure(settings):
     sg = SettingGetter(settings)  # pylint:disable=invalid-name
 
     env_settings = {
+        # Whether or not we're in "dev" mode (as opposed to QA, production or tests).
+        "dev": sg.get("DEV", default=False),
         # The URL of the https://github.com/hypothesis/via instance to
         # integrate with.
         "via_url": sg.get("VIA_URL"),
@@ -61,6 +64,8 @@ def configure(settings):
         #     python3 -c 'import secrets; print(secrets.token_hex())'
         "oauth2_state_secret": sg.get("OAUTH2_STATE_SECRET"),
     }
+
+    env_settings["dev"] = asbool(env_settings["dev"])
 
     database_url = sg.get("DATABASE_URL")
     if database_url:

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -255,6 +255,8 @@ class JSConfig:  # pylint:disable=too-few-public-methods
             "authUrl": self._request.route_url("canvas_api.authorize"),
             # Some debug information, currently used in the Gherkin tests.
             "debug": self._debug(),
+            # Tell the JavaScript code whether we're in "dev" mode.
+            "dev": self._request.registry.settings["dev"],
             # The config object for the Hypothesis client.
             # Our JSON-RPC server passes this to the Hypothesis client over
             # postMessage.

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,5 +1,5 @@
 import Server from './server';
-import { requestConfig } from './methods';
+import { requestConfig, requestGroups } from './methods';
 
 let server = {}; // Singleton RPC server reference
 
@@ -9,6 +9,7 @@ let server = {}; // Singleton RPC server reference
 function startRpcServer() {
   server = new Server();
   server.register('requestConfig', requestConfig);
+  server.register('requestGroups', requestGroups);
 }
 
 /**

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -39,7 +39,7 @@ describe('postmessage_json_rpc/methods#requestGroups', () => {
     configEl.parentNode.removeChild(configEl);
   });
 
-  it('returns the list of groups', () => {
-    assert.deepEqual(requestGroups(), ['groupid1', 'groupid2']);
+  it('returns the list of groups', async () => {
+    assert.deepEqual(await requestGroups(), ['groupid1', 'groupid2']);
   });
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -1,4 +1,4 @@
-import { requestConfig } from './methods';
+import { requestConfig, requestGroups } from './methods';
 
 describe('postmessage_json_rpc/methods#requestConfig', () => {
   let configEl;
@@ -19,5 +19,27 @@ describe('postmessage_json_rpc/methods#requestConfig', () => {
 
   it('returns the config object', () => {
     assert.deepEqual(requestConfig(), { foo: 'bar' });
+  });
+});
+
+describe('postmessage_json_rpc/methods#requestGroups', () => {
+  let configEl;
+
+  beforeEach('inject the client config into the document', () => {
+    configEl = document.createElement('script');
+    configEl.setAttribute('type', 'application/json');
+    configEl.classList.add('js-config');
+    configEl.textContent = JSON.stringify({
+      hypothesisClient: { services: [{ groups: ['groupid1', 'groupid2'] }] },
+    });
+    document.body.appendChild(configEl);
+  });
+
+  afterEach('remove the client config from the document', () => {
+    configEl.parentNode.removeChild(configEl);
+  });
+
+  it('returns the list of groups', () => {
+    assert.deepEqual(requestGroups(), ['groupid1', 'groupid2']);
   });
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -14,3 +14,12 @@ export function requestConfig() {
   const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
   return clientConfigObj;
 }
+
+/**
+ * Return the groups for the Hypothesis client to show.
+ */
+export function requestGroups() {
+  const configEl = document.querySelector('.js-config');
+  const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
+  return clientConfigObj.services[0].groups;
+}

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -30,7 +30,11 @@ export async function requestGroups() {
   if (configObj.dev === true) {
     // Artifically sleep to simulate how long this will take when it needs to
     // send real API requests to get the groups.
-    await sleep(1900);
+    // The artificial delay is only inserted 50% of the time (at random) so we
+    // don't somehow accidentally end up relying on the slowness.
+    if (Math.random() < 0.5) {
+      await sleep(1900);
+    }
   }
 
   return configObj.hypothesisClient.services[0].groups;

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -18,8 +18,20 @@ export function requestConfig() {
 /**
  * Return the groups for the Hypothesis client to show.
  */
-export function requestGroups() {
-  const configEl = document.querySelector('.js-config');
-  const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
-  return clientConfigObj.services[0].groups;
+export async function requestGroups() {
+  const configObj = JSON.parse(
+    document.querySelector('.js-config').textContent
+  );
+
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  if (configObj.dev === true) {
+    // Artifically sleep to simulate how long this will take when it needs to
+    // send real API requests to get the groups.
+    await sleep(1900);
+  }
+
+  return configObj.hypothesisClient.services[0].groups;
 }

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -33,7 +33,7 @@ export async function requestGroups() {
     // The artificial delay is only inserted 50% of the time (at random) so we
     // don't somehow accidentally end up relying on the slowness.
     if (Math.random() < 0.5) {
-      await sleep(1900);
+      await sleep(4000);
     }
   }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def get_test_database_url(default):
 
 
 TEST_SETTINGS = {
+    "dev": False,
     "via_url": "http://TEST_VIA_SERVER.is/",
     "via3_url": "http://TEST_VIA3_SERVER.is/",
     "jwt_secret": "test_secret",

--- a/tests/unit/lms/config/__init___test.py
+++ b/tests/unit/lms/config/__init___test.py
@@ -47,6 +47,30 @@ class TestConfigure:
         with pytest.raises(SettingError, match="error message"):
             configure({})
 
+    def test_dev_defaults_to_False(self, setting_getter):
+        def get(envvar_name, *_args, **_kwargs):
+            if envvar_name == "DEV":
+                return None
+            return mock.DEFAULT
+
+        setting_getter.get.side_effect = get
+
+        configurator = configure({})
+
+        assert not configurator.registry.settings["dev"]
+
+    def test_dev_can_be_set_to_True(self, setting_getter):
+        def get(envvar_name, *_args, **_kwargs):
+            if envvar_name == "DEV":
+                return "true"
+            return mock.DEFAULT
+
+        setting_getter.get.side_effect = get
+
+        configurator = configure({})
+
+        assert configurator.registry.settings["dev"] is True
+
     def test_the_aes_secret_setting_is_the_LMS_SECRET_env_var_as_a_byte_string(
         self, setting_getter
     ):


### PR DESCRIPTION
Nothing actually calls this yet. But I have hacked the client to call it locally, and verified that it returns the list of one group ID.

Fixes https://github.com/hypothesis/lms/issues/1555