### PR TITLE
Disable cookie feature flags until it's fixed

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -72,7 +72,8 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.add_feature_flag_providers(
         "lms.extensions.feature_flags.config_file_provider",
         "lms.extensions.feature_flags.envvar_provider",
-        "lms.extensions.feature_flags.cookie_provider",
+        # TODO: Cookie provision is currently broken. Disable until fixed
+        # "lms.extensions.feature_flags.cookie_provider",
         "lms.extensions.feature_flags.query_string_provider",
     )
 

--- a/lms/app.py
+++ b/lms/app.py
@@ -72,7 +72,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.add_feature_flag_providers(
         "lms.extensions.feature_flags.config_file_provider",
         "lms.extensions.feature_flags.envvar_provider",
-        # TODO: Cookie provision is currently broken. Disable until fixed
+        # Cookie provision is currently broken. Disable until fixed
         # "lms.extensions.feature_flags.cookie_provider",
         "lms.extensions.feature_flags.query_string_provider",
     )


### PR DESCRIPTION
Currently due to two different issues cookie based feature flags are disabling the feature flag feature across LMS:

 * Feature flags are effected in an order. If a later flag provider disables a flag it is turned off
 * Due to the lack of tri-state in cookie flags (https://github.com/hypothesis/lms/issues/790) it can only turn flags on or off
 * Due to a bug where cookie flags are always off, any cookie flags are always disabled