### PR TITLE
Fix via3 route and use more sensible feature flag name

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -16,7 +16,7 @@ session_cookie_secret = "notasecret"
 
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
-feature_flags_allowed_in_cookie = use_via3_url
+feature_flags_allowed_in_cookie = use_via3
 
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -25,11 +25,11 @@ def via_url(request, document_url):
         "via.config_frame_ancestor_level": "2",
     }
 
-    if request.feature("use_via3_url"):
+    if request.feature("use_via3"):
         options["url"] = document_url
         via3_url = urlparse(request.registry.settings["via3_url"])
 
-        return via3_url._replace(query=urlencode(options)).geturl()
+        return via3_url._replace(path='/route', query=urlencode(options)).geturl()
 
     return _legacy_via_url(request.registry.settings["via_url"], document_url, options)
 

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -29,7 +29,7 @@ def via_url(request, document_url):
         options["url"] = document_url
         via3_url = urlparse(request.registry.settings["via3_url"])
 
-        return via3_url._replace(path='/route', query=urlencode(options)).geturl()
+        return via3_url._replace(path="/route", query=urlencode(options)).geturl()
 
     return _legacy_via_url(request.registry.settings["via_url"], document_url, options)
 

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -57,9 +57,9 @@ class TestViaURL:
 
         final_url = via_url(pyramid_request, url)
 
-        assert final_url == Any.url.matching('http://test_via3_server.is/route').with_query(
-            dict(self.DEFAULT_OPTIONS, url=url)
-        )
+        assert final_url == Any.url.matching(
+            "http://test_via3_server.is/route"
+        ).with_query(dict(self.DEFAULT_OPTIONS, url=url))
 
     @pytest.fixture
     def via3_feature_flag(self, pyramid_request):

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -57,10 +57,10 @@ class TestViaURL:
 
         final_url = via_url(pyramid_request, url)
 
-        assert final_url == Any.url.with_host("test_via3_server.is").with_query(
+        assert final_url == Any.url.matching('http://test_via3_server.is/route').with_query(
             dict(self.DEFAULT_OPTIONS, url=url)
         )
 
     @pytest.fixture
     def via3_feature_flag(self, pyramid_request):
-        pyramid_request.feature = lambda feature: feature == "use_via3_url"
+        pyramid_request.feature = lambda feature: feature == "use_via3"


### PR DESCRIPTION
The previous change did not add the required `/route` to the URL for Via 3. Also changed the feature flag to be `use_via3` as I think that makes more sense than `use_via3_url`.

Feature flags are pretty bust in LMS, so to test this you either have to disable `feature_flags_allowed_in_cookie = use_via3`, or after this PR (https://github.com/hypothesis/lms/pull/1571) cookie flags will be disabled.