### PR TITLE
Swap Via 3 to be the default with legacy Via as a feature flag

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,12 +15,13 @@ There are three presentations for developers that describe what the Hypothesis L
 
 ### You will need
 
-* The LMS app integrates h, the Hypothesis client, and Via, so you will need to
+* The LMS app integrates h, the Hypothesis client, Via 3, and Via, so you will need to
   set up development environments for each of those before you can develop the
   LMS app:
 
   * https://h.readthedocs.io/en/latest/developing/install/
   * https://h.readthedocs.io/projects/client/en/latest/developers/developing/
+  * https://github.com/hypothesis/via3 (Serves PDF content)
   * https://github.com/hypothesis/via (Serves HTTP content)
 
 * [Git](https://git-scm.com/)

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -16,13 +16,14 @@ session_cookie_secret = "notasecret"
 
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
-feature_flags_allowed_in_cookie = use_via3
+feature_flags_allowed_in_cookie = use_legacy_via
 
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"
 
-via_url = http://localhost:9080
-via3_url = http://localhost:9082
+# Set the default to Via 3 for dev (original via: 9080)
+via_url = http://localhost:9082
+legacy_via_url = http://localhost:9080
 
 h_authority = lms.hypothes.is
 h_api_url_public = http://localhost:5000/api/

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -17,7 +17,7 @@ def configure(settings):
         # The URL of the https://github.com/hypothesis/via instance to
         # integrate with.
         "via_url": sg.get("VIA_URL"),
-        "via3_url": sg.get("VIA3_URL"),
+        "legacy_via_url": sg.get("LEGACY_VIA_URL"),
         "jwt_secret": sg.get("JWT_SECRET"),
         "google_client_id": sg.get("GOOGLE_CLIENT_ID"),
         "google_developer_key": sg.get("GOOGLE_DEVELOPER_KEY"),
@@ -72,7 +72,9 @@ def configure(settings):
         env_settings["sqlalchemy.url"] = database_url
 
     env_settings["via_url"] = _append_trailing_slash(env_settings["via_url"])
-    env_settings["via3_url"] = _append_trailing_slash(env_settings["via3_url"])
+    env_settings["legacy_via_url"] = _append_trailing_slash(
+        env_settings["legacy_via_url"]
+    )
     env_settings["h_api_url_public"] = _append_trailing_slash(
         env_settings["h_api_url_public"]
     )

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -25,21 +25,21 @@ def via_url(request, document_url):
         "via.config_frame_ancestor_level": "2",
     }
 
-    if request.feature("use_via3"):
-        options["url"] = document_url
-        via3_url = urlparse(request.registry.settings["via3_url"])
+    if request.feature("use_legacy_via"):
+        return _legacy_via_url(
+            request.registry.settings["legacy_via_url"], document_url, options
+        )
 
-        return via3_url._replace(path="/route", query=urlencode(options)).geturl()
+    options["url"] = document_url
+    via_service_url = urlparse(request.registry.settings["via_url"])
 
-    return _legacy_via_url(request.registry.settings["via_url"], document_url, options)
+    return via_service_url._replace(path="/route", query=urlencode(options)).geturl()
 
 
 def _legacy_via_url(via_service_url, document_url, options):
-    parsed_query = urlparse(document_url)
+    parsed_url = urlparse(document_url)
 
-    params = [
-        kv for kv in parse_qsl(parsed_query.query) if not kv[0].startswith("via.")
-    ]
+    params = [kv for kv in parse_qsl(parsed_url.query) if not kv[0].startswith("via.")]
     params.extend(options.items())
 
-    return via_service_url + parsed_query._replace(query=urlencode(params)).geturl()
+    return via_service_url + parsed_url._replace(query=urlencode(params)).geturl()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,8 @@ def get_test_database_url(default):
 
 TEST_SETTINGS = {
     "dev": False,
-    "via_url": "http://TEST_VIA_SERVER.is/",
-    "via3_url": "http://TEST_VIA3_SERVER.is/",
+    "legacy_via_url": "http://TEST_LEGACY_VIA_SERVER.is/",
+    "via_url": "http://TEST_VIA3_SERVER.is/",
     "jwt_secret": "test_secret",
     "google_client_id": "fake_client_id",
     "google_developer_key": "fake_developer_key",

--- a/tests/unit/lms/config/__init___test.py
+++ b/tests/unit/lms/config/__init___test.py
@@ -148,20 +148,6 @@ class TestConfigure:
             envvar_name, *args, **kwargs
         ):  # pylint: disable=unused-argument
             if envvar_name == "VIA_URL":
-                return "https://via.hypothes.is"
-            return mock.DEFAULT
-
-        setting_getter.get.side_effect = side_effect
-
-        configurator = configure({})
-
-        assert configurator.registry.settings["via_url"] == "https://via.hypothes.is/"
-
-    def test_trailing_slashes_are_appended_to_via3_url(self, setting_getter):
-        def side_effect(
-            envvar_name, *args, **kwargs
-        ):  # pylint: disable=unused-argument
-            if envvar_name == "VIA3_URL":
                 return "https://via3.hypothes.is"
             return mock.DEFAULT
 
@@ -169,7 +155,24 @@ class TestConfigure:
 
         configurator = configure({})
 
-        assert configurator.registry.settings["via3_url"] == "https://via3.hypothes.is/"
+        assert configurator.registry.settings["via_url"] == "https://via3.hypothes.is/"
+
+    def test_trailing_slashes_are_appended_to_legacy_via_url(self, setting_getter):
+        def side_effect(
+            envvar_name, *args, **kwargs
+        ):  # pylint: disable=unused-argument
+            if envvar_name == "LEGACY_VIA_URL":
+                return "https://via.hypothes.is"
+            return mock.DEFAULT
+
+        setting_getter.get.side_effect = side_effect
+
+        configurator = configure({})
+
+        assert (
+            configurator.registry.settings["legacy_via_url"]
+            == "https://via.hypothes.is/"
+        )
 
     def test_trailing_slashes_are_appended_to_h_api_url_public(self, setting_getter):
         def side_effect(


### PR DESCRIPTION
You can now enable legacy Via with:

```bash
export FEATURE_FLAG_USE_LEGACY_VIA=true
```
----

This requires rebasing after a few other things:

 * https://github.com/hypothesis/lms/pull/1572
 * https://github.com/hypothesis/lms/pull/1571