### PR TITLE
JS config reorganization 1/n: viaUrl

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -43,7 +43,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
         """
-        self._config["urls"]["via_url"] = via_url(self._request, document_url)
+        self._config["via_url"] = via_url(self._request, document_url)
         self._add_canvas_submission_params(document_url=document_url)
 
     def asdict(self):

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -43,7 +43,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
         """
-        self._config["via_url"] = via_url(self._request, document_url)
+        self._config["viaUrl"] = via_url(self._request, document_url)
         self._add_canvas_submission_params(document_url=document_url)
 
     def asdict(self):

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -55,13 +55,13 @@ export default function BasicLtiLaunchApp() {
     lmsGrader,
     submissionParams,
     urls: {
-      // Content URL to show in the iframe.
-      via_url: viaUrl,
       // API callback to use to fetch the URL to show in the iframe. This is
       // needed if resolving the content URL involves potentially slow calls
       // to third party APIs (eg. the LMS's file storage).
       via_url_callback: viaUrlCallback,
     },
+    // Content URL to show in the iframe.
+    via_url: viaUrl,
   } = useContext(Config);
 
   const [ltiLaunchState, setLtiLaunchState] = useState({

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -61,7 +61,7 @@ export default function BasicLtiLaunchApp() {
       via_url_callback: viaUrlCallback,
     },
     // Content URL to show in the iframe.
-    via_url: viaUrl,
+    viaUrl,
   } = useContext(Config);
 
   const [ltiLaunchState, setLtiLaunchState] = useState({

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -64,7 +64,7 @@ describe('BasicLtiLaunchApp', () => {
 
   context('when a content URL is provided in the config', () => {
     beforeEach(() => {
-      fakeConfig.urls.via_url = 'https://via.hypothes.is/123';
+      fakeConfig.via_url = 'https://via.hypothes.is/123';
     });
 
     it('displays the content URL in an iframe', () => {

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -64,7 +64,7 @@ describe('BasicLtiLaunchApp', () => {
 
   context('when a content URL is provided in the config', () => {
     beforeEach(() => {
-      fakeConfig.via_url = 'https://via.hypothes.is/123';
+      fakeConfig.viaUrl = 'https://via.hypothes.is/123';
     });
 
     it('displays the content URL in an iframe', () => {

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -120,7 +120,7 @@ class TestAddDocumentURL:
         js_config.add_document_url("example_document_url")
 
         via_url.assert_called_once_with(pyramid_request, "example_document_url")
-        assert js_config.asdict()["via_url"] == via_url.return_value
+        assert js_config.asdict()["viaUrl"] == via_url.return_value
 
     def test_it_sets_the_document_url(self, js_config):
         js_config.add_document_url("example_document_url")

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -120,7 +120,7 @@ class TestAddDocumentURL:
         js_config.add_document_url("example_document_url")
 
         via_url.assert_called_once_with(pyramid_request, "example_document_url")
-        assert js_config.asdict()["urls"]["via_url"] == via_url.return_value
+        assert js_config.asdict()["via_url"] == via_url.return_value
 
     def test_it_sets_the_document_url(self, js_config):
         js_config.add_document_url("example_document_url")


### PR DESCRIPTION
Part of <https://github.com/hypothesis/lms/issues/1565>. See <https://github.com/hypothesis/lms/issues/1435#issuecomment-598738736> for the JavaScript config object organization that we're ultimately driving towards.

This PR moves `urls.via_url` to a top-level setting and renames it to `viaUrl`. The `urls` sub-object will eventually be going away.