### PR TITLE
JS config reorganization 2/n: api 

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -17,9 +17,6 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         self._context = context
         self._request = request
 
-        # A dict of URLs for the frontend to use.
-        self._urls = {}
-
         self._grading_info_service = request.find_service(name="grading_info")
         self._ai_getter = request.find_service(name="ai_getter")
         self._h_api = request.find_service(name="h_api")
@@ -31,7 +28,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
         """
-        self._config["urls"]["via_url_callback"] = self._request.route_url(
+        self._config["api"]["viaCallbackUrl"] = self._request.route_url(
             "canvas_api.files.via_url", file_id=canvas_file_id
         )
         self._add_canvas_submission_params(canvas_file_id=canvas_file_id)
@@ -276,10 +273,6 @@ class JSConfig:  # pylint:disable=too-few-public-methods
                     "rpc_allowed_origins"
                 ],
             },
-            # A dict of URLs for the frontend to use.
-            # For example: API endpoints for the frontend to call would go in
-            # here.
-            "urls": self._urls,
         }
 
     def _debug(self):

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -247,9 +247,13 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         # be preserved.
 
         return {
-            # The auth token that the JavaScript code will use to authenticate
-            # itself to our own backend's APIs.
-            "authToken": self._auth_token(),
+            # Settings to do with the API that the backend provides for the
+            # frontend to call.
+            "api": {
+                # The auth token that the JavaScript code will use to
+                # authenticate itself to the API.
+                "authToken": self._auth_token(),
+            },
             # The URL that the JavaScript code will open if it needs the user to
             # authorize us to request a new Canvas access token.
             "authUrl": self._request.route_url("canvas_api.authorize"),

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -49,24 +49,24 @@ const INITIAL_LTI_LAUNCH_STATE = {
  */
 export default function BasicLtiLaunchApp() {
   const {
-    api: { authToken },
+    api: {
+      authToken,
+      // API callback to use to fetch the URL to show in the iframe. This is
+      // needed if resolving the content URL involves potentially slow calls
+      // to third party APIs (eg. the LMS's file storage).
+      viaCallbackUrl,
+    },
     authUrl,
     grading,
     lmsGrader,
     submissionParams,
-    urls: {
-      // API callback to use to fetch the URL to show in the iframe. This is
-      // needed if resolving the content URL involves potentially slow calls
-      // to third party APIs (eg. the LMS's file storage).
-      via_url_callback: viaUrlCallback,
-    },
     // Content URL to show in the iframe.
     viaUrl,
   } = useContext(Config);
 
   const [ltiLaunchState, setLtiLaunchState] = useState({
     ...INITIAL_LTI_LAUNCH_STATE,
-    state: viaUrlCallback ? 'fetching-url' : 'fetched-url',
+    state: viaCallbackUrl ? 'fetching-url' : 'fetched-url',
     contentUrl: viaUrl ? viaUrl : null,
   });
 
@@ -76,7 +76,7 @@ export default function BasicLtiLaunchApp() {
    * This will typically be a PDF URL proxied through Via.
    */
   const fetchContentUrl = useCallback(async () => {
-    if (!viaUrlCallback) {
+    if (!viaCallbackUrl) {
       // If no "callback" URL was supplied for the frontend to use to fetch
       // the URL, then the backend must have provided the Via URL in the
       // initial request, which we'll just use directly.
@@ -90,7 +90,7 @@ export default function BasicLtiLaunchApp() {
       });
       const { via_url: contentUrl } = await apiCall({
         authToken,
-        path: viaUrlCallback,
+        path: viaCallbackUrl,
       });
       setLtiLaunchState({
         ...INITIAL_LTI_LAUNCH_STATE,
@@ -112,7 +112,7 @@ export default function BasicLtiLaunchApp() {
         });
       }
     }
-  }, [authToken, viaUrlCallback]);
+  }, [authToken, viaCallbackUrl]);
 
   /**
    * Fetch the assignment content URL when the app is initially displayed.

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -49,7 +49,7 @@ const INITIAL_LTI_LAUNCH_STATE = {
  */
 export default function BasicLtiLaunchApp() {
   const {
-    authToken,
+    api: { authToken },
     authUrl,
     grading,
     lmsGrader,

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -28,7 +28,7 @@ export default function FilePickerApp({
 }) {
   const formEl = useRef();
   const {
-    authToken,
+    api: { authToken },
     authUrl,
     courseId,
     enableLmsFilePicker = false,

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -30,7 +30,9 @@ const GRADE_MULTIPLIER = 10;
  * and error status of that fetch request.
  */
 const useFetchGrade = student => {
-  const { authToken } = useContext(Config);
+  const {
+    api: { authToken },
+  } = useContext(Config);
   const [grade, setGrade] = useState('');
   const [gradeLoading, setGradeLoading] = useState(false);
 
@@ -94,7 +96,9 @@ export default function SubmitGradeForm({ disabled = false, student }) {
   // Unique id attribute for <input>
   const gradeId = useUniqueId('SubmitGradeForm__grade:');
 
-  const { authToken } = useContext(Config);
+  const {
+    api: { authToken },
+  } = useContext(Config);
 
   // Used to handle keyboard input changes for the grade input field.
   const inputRef = useRef(null);

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -82,8 +82,7 @@ describe('BasicLtiLaunchApp', () => {
 
   context('when a content URL callback is provided in the config', () => {
     beforeEach(() => {
-      fakeConfig.urls.via_url_callback =
-        'https://lms.hypothes.is/api/files/1234';
+      fakeConfig.api.viaCallbackUrl = 'https://lms.hypothes.is/api/files/1234';
     });
 
     it('attempts to fetch the content URL when mounted', async () => {

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -32,7 +32,9 @@ describe('BasicLtiLaunchApp', () => {
 
   beforeEach(() => {
     fakeConfig = {
-      authToken: 'dummyAuthToken',
+      api: {
+        authToken: 'dummyAuthToken',
+      },
       authUrl: 'https://lms.hypothes.is/authorize-lms',
       urls: {},
     };

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -41,6 +41,7 @@ describe('FilePickerApp', () => {
 
   beforeEach(() => {
     fakeConfig = {
+      api: {},
       enableLmsFilePicker: true,
       formAction: 'https://www.shinylms.com/',
       formFields: { hidden_field: 'hidden_value' },

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -4,4 +4,4 @@ import { createContext } from 'preact';
  * Configuration object for the file picker application, read from a JSON
  * script tag injected into the page by the backend.
  */
-export const Config = createContext({});
+export const Config = createContext({ api: {} });

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -334,7 +334,7 @@ class TestJSConfigAuthToken:
 
     @pytest.fixture
     def authToken(self, config):
-        return config["authToken"]
+        return config["api"]["authToken"]
 
 
 class TestJSConfigDebug:

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -96,11 +96,11 @@ class TestEnableContentItemSelectionMode:
 class TestAddCanvasFileID:
     """Unit tests for JSConfig.add_canvas_file_id()."""
 
-    def test_it_adds_the_via_url_callback_url(self, js_config):
+    def test_it_adds_the_viaCallbackUrl(self, js_config):
         js_config.add_canvas_file_id("example_canvas_file_id")
 
         assert (
-            js_config.asdict()["urls"]["via_url_callback"]
+            js_config.asdict()["api"]["viaCallbackUrl"]
             == "http://example.com/api/canvas/files/example_canvas_file_id/via_url"
         )
 
@@ -429,17 +429,6 @@ class TestJSConfigRPCServer:
     @pytest.fixture
     def config(self, config):
         return config["rpcServer"]
-
-
-class TestJSConfigURLs:
-    """Unit tests for the "urls" sub-dict of JSConfig."""
-
-    def test_it(self, config):
-        assert config == {}
-
-    @pytest.fixture
-    def config(self, config):
-        return config["urls"]
 
 
 pytestmark = pytest.mark.usefixtures("ai_getter", "grading_info_service", "h_api")


### PR DESCRIPTION
Part of <https://github.com/hypothesis/lms/issues/1565>. See <https://github.com/hypothesis/lms/issues/1435#issuecomment-598738736> for the JavaScript config object organization that we're ultimately driving towards.

This PR introduces the new `"api"` sub-object and moves the `"via_url_callback"` setting into it, and renames it to `"viaCallbackUrl"`. The previously top-level `"authToken"` setting also moves under `"api"` (this is the token for authenticating API requests).