### PR TITLE
JS config reorganization 3/n: filePicker

### DIFF
--- a/bin/qt
+++ b/bin/qt
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import subprocess
+
+
+def get_files():
+    files = (
+        subprocess.run(
+            ["git", "diff", "origin/master", "--name-only"],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        .stdout.decode("utf8")
+        .split()
+    )
+
+    files = [f for f in files if f.endswith(".py")]
+
+    for f in files:
+        if f.startswith("tests/"):
+            continue
+
+        test_file = "tests/unit/" + os.path.splitext(f)[0] + "_test.py"
+
+        if test_file not in files:
+            files.append(test_file)
+
+    files = [f for f in files if os.path.isfile(f)]
+
+    test_files = [f for f in files if f.startswith("tests/unit/")]
+    functest_files = [f for f in files if f.startswith("tests/functional/")]
+    all_test_files = test_files + functest_files
+    src_files = [f for f in files if f not in all_test_files]
+
+    return files, src_files, test_files, functest_files, all_test_files
+
+
+class Run:
+    def __init__(self, tox, verbose):
+        self._tox = tox
+        self._verbose = verbose
+
+    def __call__(self, env, cmd, files, options=""):
+        files = " ".join(files)
+
+        cmd_fmt = ".tox/{env}/bin/{cmd} {args}"
+        tox_fmt = "tox -qqe {env} --run-command '{cmd} {args}'"
+
+        if self._tox:
+            fmt = tox_fmt
+        else:
+            fmt = cmd_fmt
+
+        if options:
+            args = [options, files]
+        else:
+            args = [files]
+
+        cmd = fmt.format(env=env, cmd=cmd, args=" ".join(args))
+
+        if self._verbose:
+            print(cmd)
+
+        subprocess.run(cmd, shell=True, check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Format, lint and test only the files that have changed on this branch.",
+        epilog="By default commands are run directly rather than with tox. "
+        "This is faster but it can fail because it doesn't allow tox to "
+        "create virtualenvs and install and update dependencies. If you run "
+        "into a problem try running `%(prog)s -t` once to run the commands in "
+        "tox and see if that fixes it, then go back to running `%(prog)s` "
+        "without -t.",
+    )
+    parser.add_argument(
+        "-t",
+        "--tox",
+        action="store_true",
+        help="run commands in tox instead of directly",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+
+    args = parser.parse_args()
+
+    files, src_files, test_files, functest_files, all_test_files = get_files()
+
+    if files:
+        run = Run(args.tox, args.verbose)
+
+        run("format", "black", files)
+
+        if src_files:
+            run("lint", "pylint", src_files)
+            run("lint", "pycodestyle", src_files)
+            run("lint", "pydocstyle", src_files)
+
+        if all_test_files:
+            run("lint", "pylint", all_test_files, "--rcfile=tests/.pylintrc")
+
+        if test_files:
+            run("tests", "pytest", test_files)
+
+        if functest_files:
+            run("functests", "pytest", functest_files)
+
+
+if __name__ == "__main__":
+    main()

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -33,7 +33,7 @@ export default function FilePickerApp({
     filePicker: {
       formAction,
       formFields,
-      canvas: { enabled: enableCanvasFilePicker, ltiLaunchUrl, courseId },
+      canvas: { enabled: canvasEnabled, ltiLaunchUrl, courseId },
       google: {
         clientId: googleClientId,
         developerKey: googleDeveloperKey,
@@ -176,7 +176,7 @@ export default function FilePickerApp({
             label="Enter URL of web page or PDF"
             onClick={() => setActiveDialog('url')}
           />
-          {enableCanvasFilePicker && (
+          {canvasEnabled && (
             <Button
               className="FilePickerApp__source-button"
               label={`Select PDF from Canvas`}

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -30,18 +30,18 @@ export default function FilePickerApp({
   const {
     api: { authToken },
     authUrl,
-    courseId,
-    enableLmsFilePicker = false,
-    formAction,
-    formFields,
-    googleClientId,
-    googleDeveloperKey,
-    customCanvasApiDomain,
-    lmsUrl,
-    ltiLaunchUrl,
+    filePicker: {
+      formAction,
+      formFields,
+      canvas: { enabled: enableCanvasFilePicker, ltiLaunchUrl, courseId },
+      google: {
+        clientId: googleClientId,
+        developerKey: googleDeveloperKey,
+        origin: topLevelLmsUrl,
+      },
+    },
   } = useContext(Config);
 
-  const topLevelLmsUrl = customCanvasApiDomain || lmsUrl;
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
   const [url, setUrl] = useState(null);
   const [lmsFile, setLmsFile] = useState(null);
@@ -176,7 +176,7 @@ export default function FilePickerApp({
             label="Enter URL of web page or PDF"
             onClick={() => setActiveDialog('url')}
           />
-          {enableLmsFilePicker && (
+          {enableCanvasFilePicker && (
             <Button
               className="FilePickerApp__source-button"
               label={`Select PDF from Canvas`}

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -129,7 +129,6 @@ export default function FilePickerApp({
           authToken={authToken}
           authUrl={authUrl}
           courseId={courseId}
-          lmsUrl={lmsUrl}
           onCancel={cancelDialog}
           onSelectFile={selectLMSFile}
         />

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -37,7 +37,7 @@ export default function FilePickerApp({
       google: {
         clientId: googleClientId,
         developerKey: googleDeveloperKey,
-        origin: topLevelLmsUrl,
+        origin: googleOrigin,
       },
     },
   } = useContext(Config);
@@ -54,7 +54,7 @@ export default function FilePickerApp({
   // We do this eagerly to make the picker load faster if the user does click
   // on the "Select from Google Drive" button.
   const googlePicker = useMemo(() => {
-    if (!googleClientId || !googleDeveloperKey || !topLevelLmsUrl) {
+    if (!googleClientId || !googleDeveloperKey || !googleOrigin) {
       return null;
     }
     return new GooglePickerClient({
@@ -65,9 +65,9 @@ export default function FilePickerApp({
       // must provide the URL of the top-level frame to us so we can pass it
       // to the Google Picker API. Otherwise we can use the URL of the current
       // tab.
-      origin: window === window.top ? window.location.href : topLevelLmsUrl,
+      origin: window === window.top ? window.location.href : googleOrigin,
     });
-  }, [googleDeveloperKey, googleClientId, topLevelLmsUrl]);
+  }, [googleDeveloperKey, googleClientId, googleOrigin]);
 
   /**
    * Flag indicating whether the form should be auto-submitted on the next

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -33,7 +33,6 @@ export default function LMSFilePicker({
   authToken,
   authUrl,
   courseId,
-  lmsUrl,
   onCancel,
   onSelectFile,
 }) {
@@ -149,12 +148,7 @@ export default function LMSFilePicker({
       )}
       {dialogState.state === 'authorizing' && authorizationAttempted && (
         <ErrorDisplay
-          message={
-            <Fragment>
-              {`Failed to authorize with the Canvas instance at `}
-              <a href={`${lmsUrl}`}>{`${lmsUrl}`}</a>
-            </Fragment>
-          }
+          message={<Fragment>{`Failed to authorize with Canvas`}</Fragment>}
           error={new Error('')}
         />
       )}
@@ -193,11 +187,6 @@ LMSFilePicker.propTypes = {
    * ID of the course that the user is choosing a file for.
    */
   courseId: propTypes.string.isRequired,
-
-  /**
-   * The url of the LMS, eg. "https://foobar.instructure.com".
-   */
-  lmsUrl: propTypes.string.isRequired,
 
   /** Callback invoked if the user cancels file selection. */
   onCancel: propTypes.func.isRequired,

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -42,10 +42,15 @@ describe('FilePickerApp', () => {
   beforeEach(() => {
     fakeConfig = {
       api: {},
-      enableLmsFilePicker: true,
-      formAction: 'https://www.shinylms.com/',
-      formFields: { hidden_field: 'hidden_value' },
-      ltiLaunchUrl: 'https://lms.anno.co/lti_launch',
+      filePicker: {
+        formAction: 'https://www.shinylms.com/',
+        formFields: { hidden_field: 'hidden_value' },
+        canvas: {
+          enabled: true,
+          ltiLaunchUrl: 'https://lms.anno.co/lti_launch',
+        },
+        google: {},
+      },
     };
 
     container = document.createElement('div');
@@ -75,10 +80,13 @@ describe('FilePickerApp', () => {
 
     assert.equal(form.prop('action'), 'https://www.shinylms.com/');
 
-    Object.keys(fakeConfig.formFields).forEach(fieldName => {
+    Object.keys(fakeConfig.filePicker.formFields).forEach(fieldName => {
       const field = form.find(`input[name="${fieldName}"]`);
       assert.equal(field.length, 1);
-      assert.equal(field.prop('value'), fakeConfig.formFields[fieldName]);
+      assert.equal(
+        field.prop('value'),
+        fakeConfig.filePicker.formFields[fieldName]
+      );
     });
   });
 
@@ -87,14 +95,14 @@ describe('FilePickerApp', () => {
     assert.equal(wrapper.find('Button').length, 2);
   });
 
-  it('renders LMS file picker button if `enableLmsFilePicker` is true', () => {
-    fakeConfig.enableLmsFilePicker = true;
+  it('renders Canvas file picker button if Canvas file picker enabled', () => {
+    fakeConfig.filePicker.canvas.enabled = true;
     const wrapper = renderFilePicker();
     assert.isTrue(wrapper.exists('Button[label="Select PDF from Canvas"]'));
   });
 
-  it('does not render LMS file picker button if `enableLmsFilePicker` is false', () => {
-    fakeConfig.enableLmsFilePicker = false;
+  it('does not render Canvas file picker button if Canvas file picker not enabled', () => {
+    fakeConfig.filePicker.canvas.enabled = false;
     const wrapper = renderFilePicker();
     assert.isFalse(wrapper.exists('Button[label="Select PDF from Canvas"]'));
   });
@@ -130,7 +138,10 @@ describe('FilePickerApp', () => {
     assert.called(onSubmit);
     assert.deepEqual(
       getContentItem(wrapper),
-      contentItemForUrl(fakeConfig.ltiLaunchUrl, 'https://example.com')
+      contentItemForUrl(
+        fakeConfig.filePicker.canvas.ltiLaunchUrl,
+        'https://example.com'
+      )
     );
   });
 
@@ -158,15 +169,15 @@ describe('FilePickerApp', () => {
     assert.called(onSubmit);
     assert.deepEqual(
       getContentItem(wrapper),
-      contentItemForLmsFile(fakeConfig.ltiLaunchUrl, file)
+      contentItemForLmsFile(fakeConfig.filePicker.canvas.ltiLaunchUrl, file)
     );
   });
 
   describe('Google picker', () => {
     beforeEach(() => {
-      fakeConfig.googleClientId = 'goog-client-id';
-      fakeConfig.googleDeveloperKey = 'goog-developer-key';
-      fakeConfig.customCanvasApiDomain = 'https://test.chalkboard.com';
+      fakeConfig.filePicker.google.clientId = 'goog-client-id';
+      fakeConfig.filePicker.google.developerKey = 'goog-developer-key';
+      fakeConfig.filePicker.google.origin = 'https://test.chalkboard.com';
 
       const picker = FakeGooglePickerClient();
       picker.showPicker.resolves({
@@ -194,20 +205,9 @@ describe('FilePickerApp', () => {
     it('initializes Google Picker client when developer key is provided', () => {
       renderFilePicker();
       assert.calledWith(FakeGooglePickerClient, {
-        developerKey: fakeConfig.googleDeveloperKey,
-        clientId: fakeConfig.googleClientId,
-        origin: fakeConfig.customCanvasApiDomain,
-      });
-    });
-
-    it('Google Picker client origin falls back to lmsUrl if customCanvasApiDomain does not exist', () => {
-      fakeConfig.customCanvasApiDomain = null;
-      fakeConfig.lmsUrl = 'https://test.chalkboard2.com';
-      renderFilePicker();
-      assert.calledWith(FakeGooglePickerClient, {
-        developerKey: fakeConfig.googleDeveloperKey,
-        clientId: fakeConfig.googleClientId,
-        origin: fakeConfig.lmsUrl,
+        developerKey: fakeConfig.filePicker.google.developerKey,
+        clientId: fakeConfig.filePicker.google.clientId,
+        origin: fakeConfig.filePicker.google.origin,
       });
     });
 
@@ -245,7 +245,7 @@ describe('FilePickerApp', () => {
       assert.deepEqual(
         getContentItem(wrapper),
         contentItemForUrl(
-          fakeConfig.ltiLaunchUrl,
+          fakeConfig.filePicker.canvas.ltiLaunchUrl,
           'https://files.google.com/doc1'
         )
       );

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -175,9 +175,11 @@ describe('FilePickerApp', () => {
 
   describe('Google picker', () => {
     beforeEach(() => {
-      fakeConfig.filePicker.google.clientId = 'goog-client-id';
-      fakeConfig.filePicker.google.developerKey = 'goog-developer-key';
-      fakeConfig.filePicker.google.origin = 'https://test.chalkboard.com';
+      fakeConfig.filePicker.google = {
+        clientId: 'goog-client-id',
+        developerKey: 'goog-developer-key',
+        origin: 'https://test.chalkboard.com',
+      };
 
       const picker = FakeGooglePickerClient();
       picker.showPicker.resolves({

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -206,11 +206,7 @@ describe('FilePickerApp', () => {
 
     it('initializes Google Picker client when developer key is provided', () => {
       renderFilePicker();
-      assert.calledWith(FakeGooglePickerClient, {
-        developerKey: fakeConfig.filePicker.google.developerKey,
-        clientId: fakeConfig.filePicker.google.clientId,
-        origin: fakeConfig.filePicker.google.origin,
-      });
+      assert.calledWith(FakeGooglePickerClient, fakeConfig.filePicker.google);
     });
 
     it('shows "Select PDF from Google Drive" button if developer key is provided', () => {

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -27,7 +27,6 @@ describe('LMSFilePicker', () => {
         authToken="auth-token"
         authUrl="https://lms.anno.co/authorize-lms"
         courseId="test-course"
-        lmsUrl="https://hypothesis.dummylms.com"
         onAuthorized={sinon.stub()}
         onSelectFile={sinon.stub()}
         onCancel={sinon.stub()}
@@ -85,16 +84,14 @@ describe('LMSFilePicker', () => {
     assert.isTrue(wrapper.exists('FakeButton[label="Authorize"]'));
   });
 
-  it('shows the try again prompt with the `lmsUrl` after a failed authorization attempt', async () => {
+  it('shows the try again prompt after a failed authorization attempt', async () => {
     fakeListFiles.rejects(new ApiError('Not authorized', {}));
 
     const authWindowClosed = new Promise(resolve => {
       fakeAuthWindowInstance.close = resolve;
     });
 
-    const wrapper = renderFilePicker({
-      lmsUrl: 'https://example.com',
-    });
+    const wrapper = renderFilePicker();
     assert.called(fakeListFiles);
 
     try {
@@ -120,11 +117,7 @@ describe('LMSFilePicker', () => {
 
     const errorDetails = wrapper.find(ErrorDisplay);
     assert.isTrue(
-      errorDetails
-        .text()
-        .includes(
-          'Failed to authorize with the Canvas instance at https://example.com'
-        )
+      errorDetails.text().includes('Failed to authorize with Canvas')
     );
     assert.equal(errorDetails.props().error.message, '');
   });


### PR DESCRIPTION
Part of <https://github.com/hypothesis/lms/issues/1565>. See <https://github.com/hypothesis/lms/issues/1435#issuecomment-598738736> for the JavaScript config object organization that we're ultimately driving towards.

This PR moves all the file-picker related settings into a new `"filePicker"` sub-object and renames many of them. Canvas picker settings are in a `"canvas"` sub-sub-object and Google Picker settings in a `"google"` sub-sub-object.