### PR TITLE
JS config reorganization 4/n: grading

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -117,8 +117,8 @@ class JSConfig:  # pylint:disable=too-few-public-methods
             # "SpeedGrader" and we support that instead.
             return
 
-        self._config["lmsGrader"] = True
         self._config["grading"] = {
+            "enabled": True,
             "courseName": self._request.params.get("context_title"),
             "assignmentName": self._request.params.get("resource_link_title"),
             "students": list(self._get_students()),

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -58,7 +58,6 @@ export default function BasicLtiLaunchApp() {
     },
     authUrl,
     grading,
-    lmsGrader,
     submissionParams,
     // Content URL to show in the iframe.
     viaUrl,
@@ -197,7 +196,7 @@ export default function BasicLtiLaunchApp() {
       />
     );
 
-    if (lmsGrader) {
+    if (grading && grading.enabled) {
       // Use the LMS Grader.
       return (
         <LMSGrader

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -37,6 +37,7 @@ describe('BasicLtiLaunchApp', () => {
       },
       authUrl: 'https://lms.hypothes.is/authorize-lms',
       urls: {},
+      grading: {},
     };
     fakeApiCall = sinon.stub();
     FakeAuthWindow = sinon.stub().returns({
@@ -224,10 +225,10 @@ describe('BasicLtiLaunchApp', () => {
     assert.notCalled(fakeApiCall);
   });
 
-  context('when lmsGrader mode flag is true', () => {
+  context('when grading is enabled', () => {
     beforeEach(() => {
-      fakeConfig.lmsGrader = true;
       fakeConfig.grading = {
+        enabled: true,
         students: [{ userid: 'user1' }, { userid: 'user2' }],
       };
     });
@@ -248,15 +249,15 @@ describe('BasicLtiLaunchApp', () => {
       {
         name: 'LMS grader mode',
         content: () => {
-          // Turn on `lmsGrader` for this test. Note: fakeConfig won't
+          // Turn on grading for this test. Note: fakeConfig won't
           // reset for a successive axe test, so its important that this
           // test is the last one run in the test list. Otherwise
           // fakeConfig will need to be restored again as done in the
           // root level beforeEach() at the top of the file.
           fakeConfig = {
             ...fakeConfig,
-            lmsGrader: true,
             grading: {
+              enabled: true,
               students: [],
               courseName: 'courseName',
               assignmentName: 'assignmentName',

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -210,13 +210,13 @@ class TestMaybeEnableGrading:
     def test_it_adds_the_grading_settings(self, js_config, grading_info_service):
         js_config.maybe_enable_grading()
 
-        assert js_config.asdict()["lmsGrader"] is True
         grading_info_service.get_by_assignment.assert_called_once_with(
             context_id="test_course_id",
             oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
             resource_link_id="TEST_RESOURCE_LINK_ID",
         )
         assert js_config.asdict()["grading"] == {
+            "enabled": True,
             "assignmentName": "test_assignment_name",
             "courseName": "test_course_name",
             "students": [
@@ -237,7 +237,6 @@ class TestMaybeEnableGrading:
 
         js_config.maybe_enable_grading()
 
-        assert not js_config.asdict().get("lmsGrader")
         assert not js_config.asdict().get("grading")
 
     def test_it_does_nothing_if_theres_no_lis_outcome_service_url(
@@ -247,7 +246,6 @@ class TestMaybeEnableGrading:
 
         js_config.maybe_enable_grading()
 
-        assert not js_config.asdict().get("lmsGrader")
         assert not js_config.asdict().get("grading")
 
     def test_it_does_nothing_in_Canvas(self, context, js_config):
@@ -255,7 +253,6 @@ class TestMaybeEnableGrading:
 
         js_config.maybe_enable_grading()
 
-        assert not js_config.asdict().get("lmsGrader")
         assert not js_config.asdict().get("grading")
 
     @pytest.fixture


### PR DESCRIPTION
Part of <https://github.com/hypothesis/lms/issues/1565>. See <https://github.com/hypothesis/lms/issues/1435#issuecomment-598738736> for the JavaScript config object organization that we're ultimately driving towards.

This PR moves the `lmsGrader` setting into the already-existing `grading` sub-object of the JavaScript config object with the rest of the grading-related settings, and renames it to `enabled`. All grading settings are now gathered together in the `grading` sub-object.