### PR TITLE
JS config reorganization 5/n: canvas

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -31,7 +31,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         self._config["api"]["viaCallbackUrl"] = self._request.route_url(
             "canvas_api.files.via_url", file_id=canvas_file_id
         )
-        self._add_canvas_submission_params(canvas_file_id=canvas_file_id)
+        self._add_canvas_speedgrader_settings(canvas_file_id=canvas_file_id)
 
     def add_document_url(self, document_url):
         """
@@ -41,7 +41,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
             is missing
         """
         self._config["viaUrl"] = via_url(self._request, document_url)
-        self._add_canvas_submission_params(document_url=document_url)
+        self._add_canvas_speedgrader_settings(document_url=document_url)
 
     def asdict(self):
         """
@@ -160,7 +160,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
 
         self._hypothesis_client["focus"]["user"]["displayName"] = display_name
 
-    def _add_canvas_submission_params(self, **kwargs):
+    def _add_canvas_speedgrader_settings(self, **kwargs):
         """
         Add config used by the JS to call our record_canvas_speedgrader_submission API.
 
@@ -187,11 +187,13 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         if not lis_outcome_service_url:
             return
 
-        self._config["submissionParams"] = {
-            "h_username": self._context.h_user.username,
-            "lis_result_sourcedid": lis_result_sourcedid,
-            "lis_outcome_service_url": lis_outcome_service_url,
-            **kwargs,
+        self._config["canvas"]["speedGrader"] = {
+            "submissionParams": {
+                "h_username": self._context.h_user.username,
+                "lis_result_sourcedid": lis_result_sourcedid,
+                "lis_outcome_service_url": lis_outcome_service_url,
+                **kwargs,
+            },
         }
 
     def _auth_token(self):

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -253,6 +253,11 @@ class JSConfig:  # pylint:disable=too-few-public-methods
             # The URL that the JavaScript code will open if it needs the user to
             # authorize us to request a new Canvas access token.
             "authUrl": self._request.route_url("canvas_api.authorize"),
+            "canvas": {
+                # The URL that the JavaScript code will open if it needs the user to
+                # authorize us to request a new Canvas access token.
+                "authUrl": self._request.route_url("canvas_api.authorize"),
+            },
             # Some debug information, currently used in the Gherkin tests.
             "debug": self._debug(),
             # Tell the JavaScript code whether we're in "dev" mode.

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -59,7 +59,7 @@ export default function BasicLtiLaunchApp() {
     grading,
     // Content URL to show in the iframe.
     viaUrl,
-    canvas: { authUrl, speedGrader },
+    canvas,
   } = useContext(Config);
 
   const [ltiLaunchState, setLtiLaunchState] = useState({
@@ -125,7 +125,7 @@ export default function BasicLtiLaunchApp() {
     // If a teacher launches an assignment or the LMS does not support reporting
     // outcomes or grading is not enabled for the assignment, then no submission
     // URL will be available.
-    if (!speedGrader.submissionParams) {
+    if (!canvas.speedGrader.submissionParams) {
       return;
     }
 
@@ -138,7 +138,7 @@ export default function BasicLtiLaunchApp() {
       await apiCall({
         authToken,
         path: '/api/lti/submissions',
-        data: speedGrader.submissionParams,
+        data: canvas.speedGrader.submissionParams,
       });
     } catch (e) {
       // If reporting the submission failed, replace the content with an error.
@@ -151,7 +151,7 @@ export default function BasicLtiLaunchApp() {
         failedAction: 'report-submission',
       });
     }
-  }, [authToken, ltiLaunchState.state, speedGrader]);
+  }, [authToken, ltiLaunchState.state, canvas]);
 
   useEffect(reportSubmission, [reportSubmission]);
 
@@ -173,7 +173,7 @@ export default function BasicLtiLaunchApp() {
       authWindow.current.focus();
       return;
     }
-    authWindow.current = new AuthWindow({ authToken, authUrl });
+    authWindow.current = new AuthWindow({ authToken, canvas.authUrl });
 
     try {
       await authWindow.current.authorize();
@@ -182,7 +182,7 @@ export default function BasicLtiLaunchApp() {
       // eslint-disable-next-line require-atomic-updates
       authWindow.current = null;
     }
-  }, [authToken, authUrl, fetchContentUrl]);
+  }, [authToken, canvas, fetchContentUrl]);
 
   if (ltiLaunchState.state === 'fetched-url') {
     const iFrame = (

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -173,7 +173,7 @@ export default function BasicLtiLaunchApp() {
       authWindow.current.focus();
       return;
     }
-    authWindow.current = new AuthWindow({ authToken, canvas.authUrl });
+    authWindow.current = new AuthWindow({ authToken, authUrl: canvas.authUrl });
 
     try {
       await authWindow.current.authorize();

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -57,10 +57,9 @@ export default function BasicLtiLaunchApp() {
       viaCallbackUrl,
     },
     grading,
-    submissionParams,
     // Content URL to show in the iframe.
     viaUrl,
-    canvas: { authUrl },
+    canvas: { authUrl, speedGrader },
   } = useContext(Config);
 
   const [ltiLaunchState, setLtiLaunchState] = useState({
@@ -126,7 +125,7 @@ export default function BasicLtiLaunchApp() {
     // If a teacher launches an assignment or the LMS does not support reporting
     // outcomes or grading is not enabled for the assignment, then no submission
     // URL will be available.
-    if (!submissionParams) {
+    if (!speedGrader.submissionParams) {
       return;
     }
 
@@ -139,7 +138,7 @@ export default function BasicLtiLaunchApp() {
       await apiCall({
         authToken,
         path: '/api/lti/submissions',
-        data: submissionParams,
+        data: speedGrader.submissionParams,
       });
     } catch (e) {
       // If reporting the submission failed, replace the content with an error.
@@ -152,7 +151,7 @@ export default function BasicLtiLaunchApp() {
         failedAction: 'report-submission',
       });
     }
-  }, [authToken, ltiLaunchState.state, submissionParams]);
+  }, [authToken, ltiLaunchState.state, speedGrader]);
 
   useEffect(reportSubmission, [reportSubmission]);
 

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -56,11 +56,11 @@ export default function BasicLtiLaunchApp() {
       // to third party APIs (eg. the LMS's file storage).
       viaCallbackUrl,
     },
-    authUrl,
     grading,
     submissionParams,
     // Content URL to show in the iframe.
     viaUrl,
+    canvas: { authUrl },
   } = useContext(Config);
 
   const [ltiLaunchState, setLtiLaunchState] = useState({

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -29,7 +29,6 @@ export default function FilePickerApp({
   const formEl = useRef();
   const {
     api: { authToken },
-    authUrl,
     filePicker: {
       formAction,
       formFields,
@@ -40,6 +39,7 @@ export default function FilePickerApp({
         origin: googleOrigin,
       },
     },
+    canvas: { authUrl },
   } = useContext(Config);
 
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -39,7 +39,7 @@ export default function FilePickerApp({
         origin: googleOrigin,
       },
     },
-    canvas: { authUrl },
+    canvas,
   } = useContext(Config);
 
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
@@ -127,7 +127,7 @@ export default function FilePickerApp({
       dialog = (
         <LMSFilePicker
           authToken={authToken}
-          authUrl={authUrl}
+          authUrl={canvas.authUrl}
           courseId={courseId}
           onCancel={cancelDialog}
           onSelectFile={selectLMSFile}

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -35,7 +35,7 @@ describe('BasicLtiLaunchApp', () => {
       api: {
         authToken: 'dummyAuthToken',
       },
-      authUrl: 'https://lms.hypothes.is/authorize-lms',
+      canvas: { authUrl: 'https://lms.hypothes.is/authorize-lms' },
       urls: {},
       grading: {},
     };

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -35,7 +35,10 @@ describe('BasicLtiLaunchApp', () => {
       api: {
         authToken: 'dummyAuthToken',
       },
-      canvas: { authUrl: 'https://lms.hypothes.is/authorize-lms' },
+      canvas: {
+        authUrl: 'https://lms.hypothes.is/authorize-lms',
+        speedGrader: {},
+      },
       urls: {},
       grading: {},
     };
@@ -174,7 +177,7 @@ describe('BasicLtiLaunchApp', () => {
   });
 
   it('reports the submission in the LMS when the content iframe starts loading', async () => {
-    fakeConfig.submissionParams = {
+    fakeConfig.canvas.speedGrader.submissionParams = {
       lis_result_sourcedid: 'modelstudent-assignment1',
     };
 
@@ -184,7 +187,7 @@ describe('BasicLtiLaunchApp', () => {
     assert.calledWith(fakeApiCall, {
       authToken: 'dummyAuthToken',
       path: '/api/lti/submissions',
-      data: fakeConfig.submissionParams,
+      data: fakeConfig.canvas.speedGrader.submissionParams,
     });
 
     // After the successful API call, the iframe should still be rendered.
@@ -193,7 +196,7 @@ describe('BasicLtiLaunchApp', () => {
   });
 
   it('displays an error if reporting the submission fails', async () => {
-    fakeConfig.submissionParams = {
+    fakeConfig.canvas.speedGrader.submissionParams = {
       lis_result_sourcedid: 'modelstudent-assignment1',
     };
     const error = new ApiError(400, {});
@@ -217,7 +220,7 @@ describe('BasicLtiLaunchApp', () => {
   it('does not report a submission if teacher launches assignment', async () => {
     // When a teacher launches the assignment, there will typically be no
     // `submissionParams` config provided by the backend.
-    fakeConfig.submissionParams = undefined;
+    fakeConfig.canvas.speedGrader.submissionParams = undefined;
 
     renderLtiLaunchApp();
     await new Promise(resolve => setTimeout(resolve, 0));

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -51,6 +51,7 @@ describe('FilePickerApp', () => {
         },
         google: {},
       },
+      canvas: {},
     };
 
     container = document.createElement('div');

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -16,7 +16,7 @@ class TestJSConfig:
     """General unit tests for JSConfig."""
 
     def test_auth_url(self, config):
-        assert config["authUrl"] == "http://example.com/api/canvas/authorize"
+        assert config["canvas"]["authUrl"] == "http://example.com/api/canvas/authorize"
 
 
 class TestEnableContentItemSelectionMode:


### PR DESCRIPTION
Part of <https://github.com/hypothesis/lms/issues/1565>. See <https://github.com/hypothesis/lms/issues/1435#issuecomment-598738736> for the JavaScript config object organization that we're ultimately driving towards.

This PR moves Canvas-specific settings into a `"canvas"` sub-object. `authUrl` is now `canvas.authUrl`, and `submissionParams` is now `canvas.speedGrader.submissionParams`.