### PR TITLE
Split up a test class into multiple test classes

### DIFF
--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -219,11 +219,8 @@ class TestHGroupName:
         "context_title,expected_group_name",
         (
             ("Test Course", "Test Course"),
-            (" Test Course", "Test Course"),
-            ("Test Course ", "Test Course"),
             (" Test Course ", "Test Course"),
             ("Test   Course", "Test   Course"),
-            ("Object Oriented Programming 101", "Object Oriented Programm…"),
             ("Object Oriented Polymorphism 101", "Object Oriented Polymorp…"),
             ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
         ),


### PR DESCRIPTION
`LTILaunchResource` is too large and as a result its test class is too large. We have cards coming up that will involve necessarily splitting `LTILaunchResource` up into multiple classes. For now, and in preparation, split its tests up into one test class per method.

This makes the tests easier to add to which we'll be doing soon.

Also removes some duplication from the tests by moving code into class-level fixtures.

Also clarifies the tests by having each test class have its own `pyramid_request` fixture, so you can see which request params each method being tested actually depends on.