### PR TITLE
Add unique section groupid function

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -106,6 +106,34 @@ class LTILaunchResource:
         """
         return f"group:{self.h_authority_provided_id}@{self._authority}"
 
+    def h_section_groupid(self, tool_consumer_instance_guid, context_id, section):
+        """
+        Return a unique h groupid for a given Canvas course section.
+
+        The groupid is deterministic and is unique to the course section.
+        Calling this function again with params representing the same course
+        section will always return the same groupid. Calling this function with
+        different params will always return a different groupid.
+
+        :param tool_consumer_instance_guid: the tool_consumer_instance_guid LTI
+            launch param from the Canvas instance that the section belongs to.
+            This is a unique identifier for the Canvas instance
+        :type tool_consumer_instance_guid: str
+
+        :param context_id: the context_id LTI launch param from the Canvas
+            course that the section belongs to. This is a unique identifier for
+            the course within the Canvas instance
+        :type context_id: str
+
+        :param section: a section dict as received from the Canvas API
+        :type section: dict
+        """
+        hash_object = hashlib.sha1()
+        hash_object.update(tool_consumer_instance_guid.encode())
+        hash_object.update(context_id.encode())
+        hash_object.update(section["id"].encode())
+        return f"group:section-{hash_object.hexdigest()}@{self._authority}"
+
     @property
     def h_group_name(self):
         """

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -210,6 +210,53 @@ class TestHGroupID:
         return pyramid_request
 
 
+class TestHSectionGroupID:
+    @pytest.mark.parametrize(
+        "settings,args,expected_groupid",
+        (
+            (
+                {},
+                {},
+                "group:section-298e68dd4befff42f9a9ff7edffc542b2ba1f782@TEST_AUTHORITY",
+            ),
+            (
+                {},
+                {
+                    "tool_consumer_instance_guid": "DIFFERENT_tool_consumer_instance_guid"
+                },
+                "group:section-e690bef466ef1d42587ae88b6b76f553d5e718e7@TEST_AUTHORITY",
+            ),
+            (
+                {},
+                {"context_id": "DIFFERENT_context_id"},
+                "group:section-1ca5d17b0eab0e02784964c21aca33d99167402f@TEST_AUTHORITY",
+            ),
+            (
+                {},
+                {"section": {"id": "DIFFERENT_section_id"}},
+                "group:section-15348ff2dbeb6e250d029c363007b8357bde7eea@TEST_AUTHORITY",
+            ),
+            (
+                {"h_authority": "DIFFERENT_authority"},
+                {},
+                "group:section-298e68dd4befff42f9a9ff7edffc542b2ba1f782@DIFFERENT_authority",
+            ),
+        ),
+    )
+    def test_it(
+        self, settings, args, expected_groupid, pyramid_request,
+    ):
+        pyramid_request.registry.settings.update(**settings)
+        lti_launch_resource = LTILaunchResource(pyramid_request)
+        args.setdefault("tool_consumer_instance_guid", "tool_consumer_instance_guid")
+        args.setdefault("context_id", "context_id")
+        args.setdefault("section", {"id": "section_id"})
+
+        groupid = lti_launch_resource.h_section_groupid(**args)
+
+        assert groupid == expected_groupid
+
+
 class TestHGroupName:
     def test_it_raises_if_theres_no_context_title(self, lti_launch):
         with pytest.raises(HTTPBadRequest):


### PR DESCRIPTION
Add a method, `h_section_groupid()`, for deterministically generating a unique h groupid for a Canvas course section.

Fixes https://github.com/hypothesis/lms/issues/1410

See https://github.com/hypothesis/lms/issues/1410#issuecomment-603248954 for the design of the IDs