### PR TITLE
Add section group name method

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -122,8 +122,19 @@ class LTILaunchResource:
         :raise HTTPBadRequest: if an LTI param needed for generating the group
           name is missing
         """
-        name = self._get_param("context_title").strip()
+        return self._group_name(self._get_param("context_title").strip())
 
+    def h_section_group_name(self, section):
+        """
+        Return the h group name for the given Canvas course section.
+
+        :param section: a section dict as received from the Canvas API
+        """
+        return self._group_name(section["name"].strip())
+
+    @staticmethod
+    def _group_name(name):
+        """Return an h group name from the given course or section name."""
         # The maximum length of an h group name.
         group_name_max_length = 25
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -233,6 +233,25 @@ class TestHGroupName:
         assert LTILaunchResource(pyramid_request).h_group_name == expected_group_name
 
 
+class TestHSectionGroupName:
+    @pytest.mark.parametrize(
+        "section_name,group_name",
+        [
+            ("Test Section", "Test Section"),
+            (" Test Section ", "Test Section"),
+            ("Test   Section", "Test   Section"),
+            ("Object Oriented Polymorphism 101", "Object Oriented Polymorp…"),
+            ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
+        ],
+    )
+    def test_it(self, lti_launch, section_name, group_name):
+        # A section dict as received from the Canvas API (except this one only
+        # has the keys that we actually use).
+        section = {"name": section_name}
+
+        assert lti_launch.h_section_group_name(section) == group_name
+
+
 class TestHProvider:
     def test_it_just_returns_the_tool_consumer_instance_guid(self, pyramid_request):
         provider = LTILaunchResource(pyramid_request).h_provider


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/1411

The method of generating the name for a section group is just the same as how we currently [generate the names for course groups](https://github.com/hypothesis/lms/blob/cba173c7b75bda2700b1077cc07050ec68bf6059/lms/resources/lti_launch.py#L109-L133): just take the course/section name from Canvas, strip leading and trailing whitespace, and truncate it to 25 chars because that's as long as group names can be in h.

These group names do not need to be unique.

Background:

* [How to make test calls to the Canvas API](https://github.com/hypothesis/lms/wiki/How-to-Test-the-Canvas-API)

* [How to get all a course's sections from the Canvas API](https://github.com/hypothesis/lms/issues/1404) (`http GET 'https://hypothesis.instructure.com/api/v1/courses/<COURSE_ID>/sections' Authorization:'Bearer 9382~p5X***L9y'`)

* [How to get all _the authenticated user's_ sections for a course from the Canvas API](https://github.com/hypothesis/lms/issues/1403) (`http GET 'https://hypothesis.instructure.com/api/v1/courses/<COURSE_ID>?include[]=sections' Authorization:'Bearer 9382~c7I***A8v'`)

The sections that we get back from the Canvas API either look like this (when getting _all_ the sections for a course, which we will do for teacher launches):

```json
    {
        "course_id": 100,
        "created_at": "2020-01-06T16:08:26Z",
        "end_at": null,
        "id": 106,
        "integration_id": null,
        "name": "Sections 101",
        "nonxlist_course_id": null,
        "restrict_enrollments_to_section_dates": null,
        "sis_course_id": null,
        "sis_section_id": null,
        "start_at": null
    }
```

or like this (when getting just the authenticated user's sections for a course, which we will do for student launches):

```json
        {
            "end_at": null,
            "id": 106,
            "name": "Sections 101",
            "start_at": null
        }

```

In either case there's a `"name": "Sections 101"` field which is all we need.

We're also going to need a third way of getting sections for SpeedGrader--retrieving an arbitrary user's sections for a course (not _all_ sections in the course, and not the _authenticated_ user's sections, but _another_ user's sections): https://github.com/hypothesis/lms/issues/1405 I haven't figured out how to do that yet, but hopefully the `"name": "Sections 101"` field will still be there.
