### PR TITLE
Change LTIHService to look like it will with the bulk API

### DIFF
--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -94,9 +94,9 @@ class HAPI:
         except HAPINotFoundError:
             self.create_user(h_user, provider, provider_unique_id)
 
-    def create_group(self, group_id, group_name, creator):
+    def upsert_group(self, group_id, group_name, creator):
         """
-        Create a group in H.
+        Update or create a group in H.
 
         :param group_id: The id of the group
         :param group_name: The display name for the group

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -1,26 +1,10 @@
-from functools import wraps
+from collections import namedtuple
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
 
 from lms.services import HAPIError, HAPINotFoundError
 
-
-def lti_h_action(function):
-    """Disable an action if provisioning is not enabled and catch HAPIError."""
-
-    @wraps(function)
-    def wrapper(self, *args, **kwargs):
-        # Pylint doesn't understand that self is "us" in this context
-        if not self._context.provisioning_enabled:  # pylint: disable=protected-access
-            return None
-
-        try:
-            return function(self, *args, **kwargs)
-
-        except HAPIError as err:
-            raise HTTPInternalServerError(explanation=err.explanation) from err
-
-    return wrapper
+Group = namedtuple("Group", "name groupid")
 
 
 class LTIHService:
@@ -44,71 +28,65 @@ class LTIHService:
         self.h_api = request.find_service(name="h_api")
         self.group_info_service = request.find_service(name="group_info")
 
-    @lti_h_action
-    def add_user_to_group(self):
+    def single_group_sync(self):
         """
-        Add the Hypothesis user to the course group.
+        Sync standard data to H for an LTI launch.
 
-        Add the Hypothesis user corresponding to the current request's LTI
-        user, to the Hypothesis group corresponding to the current request's
-        LTI course.
-
-        Assumes that the Hypothesis user and group have already been created.
+        This will read a single group from the context object, upsert it, the
+        current user and make that user a member of the group.
         """
-
-        self.h_api.add_user_to_group(
-            h_user=self._context.h_user, group_id=self._context.h_groupid
+        self.sync(
+            groups=[
+                Group(name=self._context.h_group_name, groupid=self._context.h_groupid)
+            ]
         )
 
-    @lti_h_action
-    def upsert_h_user(self):
+    def sync(self, groups):
         """
-        Create or update the Hypothesis user for the request's LTI user.
+        Sync standard data to H for an LTI launch with the provided groups.
 
-        Update the h user's information from LTI data. If the user doesn't
-        exist yet, call the h API to create one.
+        This will upsert the provided list of groups, the current user and
+        make that user a member of each group.
+
+        :param groups: A list of Group objects.
+        :raises HTTPInternalServerError: If we cannot sync to H for any reason
         """
+
+        if not self._context.provisioning_enabled:  # pylint: disable=protected-access
+            return None
+
+        try:
+            return self._sync_to_h(groups)
+
+        except HAPIError as err:
+            raise HTTPInternalServerError(explanation=err.explanation) from err
+
+    def _sync_to_h(self, groups):
+        h_user = self._context.h_user
 
         self.h_api.upsert_user(
-            h_user=self._context.h_user,
+            h_user=h_user,
             provider=self._context.h_provider,
             provider_unique_id=self._context.h_provider_unique_id,
         )
 
-    @lti_h_action
-    def upsert_course_group(self):
-        """
-        Create or update the Hypothesis group for the request's LTI course.
+        for group in groups:
+            self._upsert_h_group(group, creator=self._context.h_user)
 
-        Call the h API to create a group for the LTI course, if one doesn't
-        exist already.
+            self.group_info_service.upsert(
+                authority_provided_id=self._context.h_authority_provided_id,
+                consumer_key=self._request.lti_user.oauth_consumer_key,
+                params=self._request.params,
+            )
 
-        Groups can only be created if the LTI user is allowed to create
-        Hypothesis groups (for example instructors are allowed to create
-        groups).
+        for group in groups:
+            self.h_api.add_user_to_group(h_user=h_user, group_id=group.groupid)
 
-        If the group for the course hasn't been created yet, and if the user
-        isn't allowed to create groups (e.g. if they're just a student) then
-        show an error page instead of continuing with the LTI launch.
-        """
-
-        self._upsert_h_group(
-            group_id=self._context.h_groupid,
-            group_name=self._context.h_group_name,
-            creator=self._context.h_user,
-        )
-
-        self.group_info_service.upsert(
-            authority_provided_id=self._context.h_authority_provided_id,
-            consumer_key=self._request.lti_user.oauth_consumer_key,
-            params=self._request.params,
-        )
-
-    def _upsert_h_group(self, group_id, group_name, creator):
+    def _upsert_h_group(self, group, creator):
         """Update the group and create it if the user is an instructor."""
 
         try:
-            self.h_api.update_group(group_id=group_id, group_name=group_name)
+            self.h_api.update_group(group_id=group.groupid, group_name=group.name)
             return
 
         except HAPINotFoundError:
@@ -118,6 +96,6 @@ class LTIHService:
                 raise HTTPBadRequest("Instructor must launch assignment first.")
 
         # Try to create the group with the current instructor as its creator.
-        self.h_api.create_group(
-            group_id=group_id, group_name=group_name, creator=creator
+        self.h_api.upsert_group(
+            group_id=group.groupid, group_name=group.name, creator=creator
         )

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -45,10 +45,7 @@ class BasicLTILaunchViews:
         and group corresponding to the LTI user and course.
         """
 
-        lti_h_service = self.request.find_service(name="lti_h")
-        lti_h_service.upsert_h_user()
-        lti_h_service.upsert_course_group()
-        lti_h_service.add_user_to_group()
+        self.request.find_service(name="lti_h").single_group_sync()
 
     def store_lti_data(self):
         """Store LTI launch data in our LMS database."""

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -45,9 +45,7 @@ from pyramid.view import view_config
     route_name="content_item_selection",
 )
 def content_item_selection(context, request):
-    lti_h_service = request.find_service(name="lti_h")
-    lti_h_service.upsert_h_user()
-    lti_h_service.upsert_course_group()
+    request.find_service(name="lti_h").single_group_sync()
 
     context.js_config.enable_content_item_selection_mode(
         form_action=request.params["content_item_return_url"],

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -77,8 +77,8 @@ class TestHAPI:
             h_user, sentinel.provider, sentinel.provider_unique_id
         )
 
-    def test_create_group_works(self, h_api, h_user, _api_request):
-        h_api.create_group(sentinel.group_id, sentinel.group_name, h_user)
+    def test_upsert_group_works(self, h_api, h_user, _api_request):
+        h_api.upsert_group(sentinel.group_id, sentinel.group_name, h_user)
 
         _api_request.assert_called_once_with(
             "PUT",


### PR DESCRIPTION
_From linked ticket https://github.com/hypothesis/lms/issues/1567:_

> Currently our code in the views calls separate methods to upsert groups, users and user membership. This should all be collected together in a single interface to prepare for bulk calling.
> 
> At the end of this ticket:
> 
> There will be a fascade for bulk calling H
> This will accept all of the details to update in one go
> The code will have been altered to use it
> Internally it will use existing mechanisms to update H as we do now
> 

The word 'facade' is used here to indicate that although we are accepting data _as if_ we are the bulk API, we are not actually implementing any bulk processing at this point. The existing `LITHService` was chosen as the target.

This is to allow work to progress in tandem with the Bulk API work.

A lot of the tests and work here will get swept away when the guts of this change, so minimal efforts have been made to keep them working and preserve coverage.

Refactoring LTIHService so that:

1. It's interface now looks more like how it will look once it's using the bulk API library
2. The LMS app's actual end-to-end behaviour hasn't changed at all