### PR TITLE
Combine the groupid and group_name methods

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -376,7 +376,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
                     "authority": self._request.registry.settings["h_authority"],
                     "enableShareLinks": False,
                     "grantToken": self._grant_token(api_url),
-                    "groups": [self._context.h_groupid],
+                    "groups": [self._context.h_course_group["groupid"]],
                 }
             ]
         }

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -57,7 +57,8 @@ class LTIHService:
         """
 
         self.h_api.add_user_to_group(
-            h_user=self._context.h_user, group_id=self._context.h_groupid
+            h_user=self._context.h_user,
+            group_id=self._context.h_course_group["groupid"],
         )
 
     @lti_h_action
@@ -93,8 +94,8 @@ class LTIHService:
         """
 
         self._upsert_h_group(
-            group_id=self._context.h_groupid,
-            group_name=self._context.h_group_name,
+            group_id=self._context.h_course_group["groupid"],
+            group_name=self._context.h_course_group["name"],
             creator=self._context.h_user,
         )
 

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -401,7 +401,7 @@ class TestJSConfigHypothesisClient:
         assert config["a_key"] == "a_value"
 
     @pytest.mark.parametrize(
-        "context_property", ["provisioning_enabled", "h_user", "h_groupid"]
+        "context_property", ["provisioning_enabled", "h_user", "h_course_group"]
     )
     def test_it_raises_if_a_context_property_raises(
         self, context, context_property, pyramid_request
@@ -468,7 +468,7 @@ def context():
         spec_set=True,
         instance=True,
         h_user=HUser("TEST_AUTHORITY", "example_username"),
-        h_groupid="example_groupid",
+        h_course_group={"groupid": "example_groupid", "name": "example_group_name"},
         is_canvas=True,
     )
 

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -219,8 +219,7 @@ def h_user():
 @pytest.fixture
 def context(h_user):
     class TestContext:
-        h_groupid = "test_groupid"
-        h_group_name = "test_group_name"
+        h_course_group = {"groupid": "test_groupid", "name": "test_group_name"}
         h_provider = "test_provider"
         h_provider_unique_id = "test_provider_unique_id"
         provisioning_enabled = True


### PR DESCRIPTION
Combine the `h_groupid` and `h_group_name` properties into a single
`h_course_group` property, and `h_section_groupid()` and
`h_section_group_name()` into a single `h_section_group()` method.

Fixes https://github.com/hypothesis/lms/issues/1382

In the future these might become plural: `h_course_groups` and
`h_section_groups()` returning lists of one or more groups (see
https://github.com/hypothesis/lms/issues/1407).

We may ultimately want an `h_groups()` method that decides whether a
course group or section groups is needed and returns one or the other.
Or we may want to leave that up to code elsewhere, to decide whether to
call `h_course_groups` or `h_section_groups()`. I'm not sure yet, so I'm
leaving them as separate methods for now.