### PR TITLE
Fix js error when loading assignments outside of canvas

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -125,7 +125,7 @@ export default function BasicLtiLaunchApp() {
     // If a teacher launches an assignment or the LMS does not support reporting
     // outcomes or grading is not enabled for the assignment, then no submission
     // URL will be available.
-    if (!canvas.speedGrader.submissionParams) {
+    if (!canvas.speedGrader || !canvas.speedGrader.submissionParams) {
       return;
     }
 


### PR DESCRIPTION
The speedGrader object is undefined so it needs to be checked before referencing a key inside of it.

I  will need to add testing for this new bit, but would like to patch prod right away. I may need to take a deeper look at the changes over the last 2 days too. But I think this puts out fires for now
