### PR TITLE
Replace test class inheritance with functions

### DIFF
--- a/tests/unit/lms/validation/_canvas_test.py
+++ b/tests/unit/lms/validation/_canvas_test.py
@@ -11,13 +11,106 @@ from lms.validation import (
 )
 
 
-class CommonResponseSchemaTests:
+def response():
+    """Return a mock ``requests`` HTTP response object."""
+    return mock.create_autospec(requests.Response, instance=True, spec_set=True)
+
+
+def canvas_list_files_response_schema():
+    """Return a CanvasListFilesResponseSchema."""
+    response_ = response()
+    response_.json.return_value = [
+        {
+            "content-type": "application/pdf",
+            "created_at": "2018-11-22T08:46:38Z",
+            "display_name": "TEST FILE 1",
+            "filename": "TEST_FILE_1.pdf",
+            "folder_id": 81,
+            "hidden": False,
+            "hidden_for_user": False,
+            "id": 188,
+            "lock_at": None,
+            "locked": False,
+            "locked_for_user": False,
+            "media_entry_id": None,
+            "mime_class": "pdf",
+            "modified_at": "2018-11-22T08:46:38Z",
+            "size": 2435546,
+            "thumbnail_url": None,
+            "unlock_at": None,
+            "updated_at": "2019-05-08T15:22:31Z",
+            "upload_status": "success",
+            "url": "TEST_URL_1",
+            "uuid": "TEST_UUID_1",
+            "workflow_state": "processing",
+        },
+        {
+            "content-type": "application/pdf",
+            "created_at": "2018-10-25T15:04:08Z",
+            "display_name": "TEST FILE 2",
+            "filename": "TEST_FILE_2.pdf",
+            "folder_id": 17,
+            "hidden": False,
+            "hidden_for_user": False,
+            "id": 181,
+            "lock_at": None,
+            "locked": False,
+            "locked_for_user": False,
+            "media_entry_id": None,
+            "mime_class": "pdf",
+            "modified_at": "2018-10-25T15:04:08Z",
+            "size": 1407214,
+            "thumbnail_url": None,
+            "unlock_at": None,
+            "updated_at": "2019-02-14T00:33:01Z",
+            "upload_status": "success",
+            "url": "TEST_URL_2",
+            "uuid": "TEST_UUID_2",
+            "workflow_state": "processing",
+        },
+        {
+            "content-type": "application/pdf",
+            "created_at": "2017-09-08T11:05:03Z",
+            "display_name": "TEST FILE 3",
+            "filename": "TEST_FILE_3.pdf",
+            "folder_id": 17,
+            "hidden": False,
+            "hidden_for_user": False,
+            "id": 97,
+            "lock_at": None,
+            "locked": False,
+            "locked_for_user": False,
+            "media_entry_id": None,
+            "mime_class": "pdf",
+            "modified_at": "2017-09-08T11:05:03Z",
+            "size": 265615,
+            "thumbnail_url": None,
+            "unlock_at": None,
+            "updated_at": "2018-10-19T17:16:50Z",
+            "upload_status": "success",
+            "url": "TEST_URL_3",
+            "uuid": "TEST_UUID_3",
+            "workflow_state": "processing",
+        },
+    ]
+    return CanvasListFilesResponseSchema(response_)
+
+
+def canvas_public_url_response_schema():
+    """Return a CanvasPublicURLResponseSchema."""
+    response_ = response()
+    response_.json.return_value = {
+        "public_url": "https://example-bucket.s3.amazonaws.com/example-namespace/attachments/1/example-filename?AWSAccessKeyId=example-key&Expires=1400000000&Signature=example-signature"
+    }
+    return CanvasPublicURLResponseSchema(response_)
+
+
+class TestCommon:
     def test_it_raises_ValidationError_if_the_response_json_has_the_wrong_format(
-        self, response, schema
+        self, schema
     ):
         # The decoded JSON value is a string rather than a list or object.
-        response.json.return_value = "wrong_format"
-        schema.context["response"] = response
+        schema.context["response"].json.return_value = "wrong_format"
 
         with pytest.raises(ValidationError) as exc_info:
             schema.parse()
@@ -25,11 +118,10 @@ class CommonResponseSchemaTests:
         assert exc_info.value.messages == {"_schema": ["Invalid input type."]}
 
     def test_it_raises_ValidationError_if_the_response_body_isnt_valid_json(
-        self, response, schema
+        self, schema
     ):
         # Calling response.json() will raise JSONDecodeError.
-        response.json.side_effect = lambda: json.loads("invalid")
-        schema.context["response"] = response
+        schema.context["response"].json.side_effect = lambda: json.loads("invalid")
 
         with pytest.raises(ValidationError) as exc_info:
             schema.parse()
@@ -38,8 +130,14 @@ class CommonResponseSchemaTests:
             "_schema": ["response doesn't have a valid JSON body"]
         }
 
+    @pytest.fixture(
+        params=[canvas_list_files_response_schema, canvas_public_url_response_schema,]
+    )
+    def schema(self, request):
+        return request.param()
 
-class TestCanvasListFilesResponseSchema(CommonResponseSchemaTests):
+
+class TestCanvasListFilesResponseSchema:
     def test_it_returns_the_list_of_files(self, schema):
         parsed_params = schema.parse()
 
@@ -61,10 +159,8 @@ class TestCanvasListFilesResponseSchema(CommonResponseSchemaTests):
             },
         ]
 
-    def test_it_returns_an_empty_list_if_there_are_no_files(
-        self, schema, list_files_response
-    ):
-        list_files_response.json.return_value = []
+    def test_it_returns_an_empty_list_if_there_are_no_files(self, schema):
+        schema.context["response"].json.return_value = []
 
         parsed_params = schema.parse()
 
@@ -72,9 +168,9 @@ class TestCanvasListFilesResponseSchema(CommonResponseSchemaTests):
 
     @pytest.mark.parametrize("field_name", ["display_name", "id", "updated_at"])
     def test_it_raises_ValidationError_if_a_file_is_missing_a_required_field(
-        self, field_name, schema, list_files_response
+        self, field_name, schema
     ):
-        del list_files_response.json.return_value[1][field_name]
+        del schema.context["response"].json.return_value[1][field_name]
 
         with pytest.raises(ValidationError) as exc_info:
             schema.parse()
@@ -84,10 +180,10 @@ class TestCanvasListFilesResponseSchema(CommonResponseSchemaTests):
         }
 
     def test_it_raises_ValidationError_if_one_of_the_objects_in_the_response_json_has_the_wrong_format(
-        self, schema, list_files_response
+        self, schema
     ):
         # One item in the list is not an object.
-        list_files_response.json.return_value = (
+        schema.context["response"].json.return_value = (
             [
                 {
                     "display_name": "TEST FILE 1",
@@ -109,94 +205,11 @@ class TestCanvasListFilesResponseSchema(CommonResponseSchemaTests):
         assert exc_info.value.messages == {0: {"_schema": ["Invalid input type."]}}
 
     @pytest.fixture
-    def schema(self, list_files_response):
-        return CanvasListFilesResponseSchema(list_files_response)
-
-    @pytest.fixture(autouse=True)
-    def list_files_response(self, response):
-        """
-        Return a Canvas list files API response.
-
-        Same fields and format as real Canvas list files API responses.
-        """
-        response.json.return_value = [
-            {
-                "content-type": "application/pdf",
-                "created_at": "2018-11-22T08:46:38Z",
-                "display_name": "TEST FILE 1",
-                "filename": "TEST_FILE_1.pdf",
-                "folder_id": 81,
-                "hidden": False,
-                "hidden_for_user": False,
-                "id": 188,
-                "lock_at": None,
-                "locked": False,
-                "locked_for_user": False,
-                "media_entry_id": None,
-                "mime_class": "pdf",
-                "modified_at": "2018-11-22T08:46:38Z",
-                "size": 2435546,
-                "thumbnail_url": None,
-                "unlock_at": None,
-                "updated_at": "2019-05-08T15:22:31Z",
-                "upload_status": "success",
-                "url": "TEST_URL_1",
-                "uuid": "TEST_UUID_1",
-                "workflow_state": "processing",
-            },
-            {
-                "content-type": "application/pdf",
-                "created_at": "2018-10-25T15:04:08Z",
-                "display_name": "TEST FILE 2",
-                "filename": "TEST_FILE_2.pdf",
-                "folder_id": 17,
-                "hidden": False,
-                "hidden_for_user": False,
-                "id": 181,
-                "lock_at": None,
-                "locked": False,
-                "locked_for_user": False,
-                "media_entry_id": None,
-                "mime_class": "pdf",
-                "modified_at": "2018-10-25T15:04:08Z",
-                "size": 1407214,
-                "thumbnail_url": None,
-                "unlock_at": None,
-                "updated_at": "2019-02-14T00:33:01Z",
-                "upload_status": "success",
-                "url": "TEST_URL_2",
-                "uuid": "TEST_UUID_2",
-                "workflow_state": "processing",
-            },
-            {
-                "content-type": "application/pdf",
-                "created_at": "2017-09-08T11:05:03Z",
-                "display_name": "TEST FILE 3",
-                "filename": "TEST_FILE_3.pdf",
-                "folder_id": 17,
-                "hidden": False,
-                "hidden_for_user": False,
-                "id": 97,
-                "lock_at": None,
-                "locked": False,
-                "locked_for_user": False,
-                "media_entry_id": None,
-                "mime_class": "pdf",
-                "modified_at": "2017-09-08T11:05:03Z",
-                "size": 265615,
-                "thumbnail_url": None,
-                "unlock_at": None,
-                "updated_at": "2018-10-19T17:16:50Z",
-                "upload_status": "success",
-                "url": "TEST_URL_3",
-                "uuid": "TEST_UUID_3",
-                "workflow_state": "processing",
-            },
-        ]
-        return response
+    def schema(self):
+        return canvas_list_files_response_schema()
 
 
-class TestCanvasPublicURLResponseSchema(CommonResponseSchemaTests):
+class TestCanvasPublicURLResponseSchema:
     def test_it_returns_the_public_url(self, schema):
         parsed_params = schema.parse()
 
@@ -204,10 +217,8 @@ class TestCanvasPublicURLResponseSchema(CommonResponseSchemaTests):
             "public_url": "https://example-bucket.s3.amazonaws.com/example-namespace/attachments/1/example-filename?AWSAccessKeyId=example-key&Expires=1400000000&Signature=example-signature"
         }
 
-    def test_it_raises_ValidationError_if_the_public_url_is_missing(
-        self, schema, public_url_response
-    ):
-        del public_url_response.json.return_value["public_url"]
+    def test_it_raises_ValidationError_if_the_public_url_is_missing(self, schema):
+        del schema.context["response"].json.return_value["public_url"]
 
         with pytest.raises(ValidationError) as exc_info:
             schema.parse()
@@ -218,9 +229,9 @@ class TestCanvasPublicURLResponseSchema(CommonResponseSchemaTests):
 
     @pytest.mark.parametrize("invalid_url", [23, True, ["a", "b", "c"], {}])
     def test_it_raises_ValidationError_if_the_public_url_has_the_wrong_type(
-        self, schema, public_url_response, invalid_url
+        self, schema, invalid_url
     ):
-        public_url_response.json.return_value["public_url"] = invalid_url
+        schema.context["response"].json.return_value["public_url"] = invalid_url
 
         with pytest.raises(ValidationError) as exc_info:
             schema.parse()
@@ -228,18 +239,5 @@ class TestCanvasPublicURLResponseSchema(CommonResponseSchemaTests):
         assert exc_info.value.messages == {"public_url": ["Not a valid string."]}
 
     @pytest.fixture
-    def schema(self, public_url_response):
-        return CanvasPublicURLResponseSchema(public_url_response)
-
-    @pytest.fixture(autouse=True)
-    def public_url_response(self, response):
-        response.json.return_value = {
-            "public_url": "https://example-bucket.s3.amazonaws.com/example-namespace/attachments/1/example-filename?AWSAccessKeyId=example-key&Expires=1400000000&Signature=example-signature"
-        }
-        return response
-
-
-@pytest.fixture
-def response():
-    """Return a ``requests`` HTTP response object."""
-    return mock.create_autospec(requests.Response, instance=True, spec_set=True)
+    def schema(self):
+        return canvas_public_url_response_schema()

--- a/tests/unit/lms/validation/_canvas_test.py
+++ b/tests/unit/lms/validation/_canvas_test.py
@@ -131,7 +131,7 @@ class TestCommon:
         }
 
     @pytest.fixture(
-        params=[canvas_list_files_response_schema, canvas_public_url_response_schema,]
+        params=[canvas_list_files_response_schema, canvas_public_url_response_schema]
     )
     def schema(self, request):
         return request.param()


### PR DESCRIPTION
Replace some test class inheritance with shared test helper functions
and a parametrized fixture. This is simpler, more idiomatic in pytest,
and keeps test classes simple and independent and decoupled from each
other which makes the tests easier to understand and to change.

The same as done elsewhere, e.g. https://github.com/hypothesis/lms/pull/1502

The way this worked previously was that `CommonResponseSchemaTests` was
not itself a test class (it doesn't begin with `Test` so pytest won't
find it and run it) but it was used as a base class for
`TestCanvasListFilesResponseSchema` and
`TestCanvasPublicURLResponseSchema` which therefore both inherited
`CommonResponseSchemaTests`'s test methods.
`CommonResponseSchemaTests`'s tests then made use of a `schema` fixture
which `CommonResponseSchemaTests` itself didn't provide. Rather, each of
`TestCanvasListFilesResponseSchema` and
`TestCanvasPublicURLResponseSchema` provided a `schema` fixture and so
`CommonResponseSchemaTests`'s would get the appropriate `schema` fixture
depending on which base class was currently being run.

The way this works now is that:

* We have two factory functions (not pytest fixtures just normal
  functions) for creating a `CanvasListFilesResponseSchema` or
  `CanvasPublicURLResponseSchema` object to be tested:

      def canvas_list_files_response_schema():
          ...

      def canvas_public_url_response_schema():
          ...

  These create a mock response object that looks like a Canvas list
  files or public_url response respectively and then create and return a
  `CanvasListFilesResponseSchema` or `CanvasPublicURLResponseSchema`
  configured with the mock response.

* Each of `TestCanvasListFilesResponseSchema` and
  `TestCanvasPublicURLResponseSchema` has a `schema` fixture that wraps
  the appropriate factory function. This is just for convenience, so
  individual test methods don't have to call the factory function
  themselves:

      class TestCanvasListFilesResponseSchema:

          ...

      @pytest.fixture
      def schema(self):
          return canvas_list_files_response_schema()

      class TestCanvasPublicURLResponseSchema:

          ...

      @pytest.fixture
      def schema(self):
          return canvas_public_url_response_schema()

* `TestCanvasListFilesResponseSchema` and
  `TestCanvasPublicURLResponseSchema` no longer subclass
  `CommonResponseSchemaTests`. Instead, `CommonResponseSchemaTests` has
  been renamed to `TestCommon` so that pytest will pick it up as a test
  class, and it has a parametrized `schema` fixture that calls each of
  the two factory functions in turn:

      class TestCommon:

          ...

      @pytest.fixture(params=[
          canvas_list_files_response_schema,
          canvas_public_url_response_schema,
      ])
      def schema(self, request):
          return request.param()

* Finally, there used to be a `response` fixture that tests could use if
  they wanted to modify the response that had been passed to the schema
  under test to be validated. That's been removed and tests just access
  the response via `schema.context["response"]` instead, which is
  simpler.