### PR TITLE
Reorganize some docstrings

### DIFF
--- a/lms/views/api/canvas/README.md
+++ b/lms/views/api/canvas/README.md
@@ -1,0 +1,32 @@
+Canvas Proxy API
+================
+
+This package implements a proxy API for the Canvas API, giving our frontend
+code access to the Canvas API:
+
+https://canvas.instructure.com/doc/api/
+
+Requests to this proxy API are authenticated using this app's authentication
+policies (for example: a JWT in an `Authorization` header) and this API
+therefore knows what LTI user is making the request. This API then makes
+server-to-server requests, authenticated using OAuth 2 access tokens, to the
+appropriate Canvas instance's files API and returns the results to the original
+proxy API caller:
+
+                         +---------+
+                         | Browser |
+                         +---------+
+                         |         ↑
+    1. List files request|         |
+       (JWT auth)        |         |4. Proxied list files response
+                         ↓         |
+                        +-----------+
+                        | Proxy API |
+                        +-----------+
+                         |         ↑
+    2. Proxied list files|         |
+       request (OAuth 2) |         |3. List files response
+                         ↓         |
+                      +---------------+
+                      |Real Canvas API|
+                      +---------------+

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -1,3 +1,14 @@
+"""
+Views for getting OAuth 2 access tokens for the Canvas API.
+
+This module provides views for doing an OAuth 2 flow to get a Canvas API access
+token for the current user:
+
+https://canvas.instructure.com/doc/api/file.oauth.html
+
+The received access tokens are saved to the DB and used by proxy API views to
+authenticated server-to-server requests to Canvas.
+"""
 from urllib.parse import urlencode, urlparse, urlunparse
 
 from pyramid.httpexceptions import HTTPFound, HTTPInternalServerError

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -1,34 +1,4 @@
-"""
-Proxy API for Canvas's Files API.
-
-Gives our frontend code access to Canvas's Files API:
-https://canvas.instructure.com/doc/api/files.html
-
-Requests to this proxy API are authenticated using this app's authentication
-policies (for example: a JWT in an ``Authorization`` header) and this API
-therefore knows what LTI user is making the request. This API then makes
-server-to-server requests, authenticated using OAuth 2 access tokens, to the
-appropriate Canvas instance's files API and returns the results to the original
-proxy API caller::
-
-                         +---------+
-                         | Browser |
-                         +---------+
-                         |         ↑
-    1. List files request|         |
-       (JWT auth)        |         |4. Proxied list files response
-                         ↓         |
-                        +-----------+
-                        | Proxy API |
-                        +-----------+
-                         |         ↑
-    2. Proxied list files|         |
-       request (OAuth 2) |         |3. List files response
-                         ↓         |
-                      +---------------+
-                      |Real Canvas API|
-                      +---------------+
-"""
+"""Proxy API views for files-related Canvas API endpoints."""
 from pyramid.view import view_config, view_defaults
 
 from lms.views import helpers


### PR DESCRIPTION
files.py, which is just for the files-related proxy API views, had a module docstring that really documented the entire proxy API package. Moved this to a README.md file and added new docstrings to files.py and authorize.py

Here's the new README.md rendered as the `views/api/canvas` folder's README on GitHub: https://github.com/hypothesis/lms/tree/canvasapi-docstrings/lms/views/api/canvas