### PR TITLE
Add support for getting sections from the Canvas API

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.22
+fail_under = 99.23
 skip_covered = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.23
+fail_under = 99.24
 skip_covered = True

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -146,7 +146,7 @@ class CanvasAPIHelper:
             (
                 "https",
                 self._canvas_url,
-                f"/api/v1/courses/{course_id}" "",
+                f"/api/v1/courses/{course_id}",
                 "",
                 "include[]=sections",
                 "",
@@ -180,7 +180,7 @@ class CanvasAPIHelper:
             (
                 "https",
                 self._canvas_url,
-                f"/api/v1/courses/{course_id}/sections" "",
+                f"/api/v1/courses/{course_id}/sections",
                 "",
                 "",
                 "",

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -191,6 +191,44 @@ class CanvasAPIHelper:
             "GET", url, headers={"Authorization": f"Bearer {access_token}"},
         ).prepare()
 
+    def users_sections_request(self, access_token, user_id, course_id):
+        """
+        Return a prepared "user's course sections" request.
+
+        Return a server-to-server request to the Canvas API that gets a list of
+        all the given user's (user_id) sections for the given course
+        (course_id).
+
+        For documentation of this request see:
+
+        https://canvas.instructure.com/doc/api/courses.html#method.courses.user
+
+        :arg access_token: the access token to authenticate the request with
+        :type access_token: str
+
+        :arg user_id: the Canvas user_id of the user whose sections you want
+        :type user_id: str
+
+        :arg course_id: the Canvas course_id of the course to look in
+        :type course_id: str
+
+        :rtype: requests.PreparedRequest
+        """
+        url = urlunparse(
+            (
+                "https",
+                self._canvas_url,
+                f"/api/v1/courses/{course_id}/users/{user_id}",
+                "",
+                "include[]=enrollments",
+                "",
+            )
+        )
+
+        return requests.Request(
+            "GET", url, headers={"Authorization": f"Bearer {access_token}"},
+        ).prepare()
+
     def list_files_request(self, access_token, course_id):
         """
         Return a prepared list files request.

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -157,6 +157,40 @@ class CanvasAPIHelper:
             "GET", url, headers={"Authorization": f"Bearer {access_token}"},
         ).prepare()
 
+    def course_sections_request(self, access_token, course_id):
+        """
+        Return a prepared "list course sections" request.
+
+        Return a server-to-server request to the Canvas API that gets a list of
+        all the sections for the given course (course_id).
+
+        For documentation of this request see:
+
+        https://canvas.instructure.com/doc/api/sections.html#method.sections.index
+
+        :arg access_token: the access token to authenticate the request with
+        :type access_token: str
+
+        :arg course_id: the Canvas course_id of the course to look in
+        :type course_id: str
+
+        :rtype: requests.PreparedRequest
+        """
+        url = urlunparse(
+            (
+                "https",
+                self._canvas_url,
+                f"/api/v1/courses/{course_id}/sections" "",
+                "",
+                "",
+                "",
+            )
+        )
+
+        return requests.Request(
+            "GET", url, headers={"Authorization": f"Bearer {access_token}"},
+        ).prepare()
+
     def list_files_request(self, access_token, course_id):
         """
         Return a prepared list files request.

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -10,6 +10,7 @@ from lms.validation import (
     CanvasCourseSectionsResponseSchema,
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
+    CanvasUsersSectionsResponseSchema,
 )
 from lms.validation.authentication import (
     CanvasAccessTokenResponseSchema,
@@ -123,6 +124,38 @@ class CanvasAPIClient:
         return self.send_with_refresh_and_retry(
             self._helper.course_sections_request(oauth2_token.access_token, course_id),
             CanvasCourseSectionsResponseSchema,
+            oauth2_token.refresh_token,
+        )
+
+    def users_sections(self, user_id, course_id):
+        """
+        Return all the given user's sections for the given course_id.
+
+        Send an HTTP request to the Canvas API to get the list of sections and
+        return it.
+
+        :arg user_id: the Canvas user_id of the user whose sections you want
+        :type user_id: str
+
+        :arg course_id: the Canvas course_id of the course to look in
+        :type course_id: str
+
+        :raise lms.services.CanvasAPIAccessTokenError: if we can't get the list
+            of sections because we don't have a working Canvas API access token
+            for the user
+        :raise lms.services.CanvasAPIServerError: if we do have an access token
+            but the Canvas API request fails for any other reason
+
+        :return: a list of raw section dicts as received from the Canvas API
+        :rtype: list(dict)
+        """
+        oauth2_token = self._oauth2_token
+
+        return self.send_with_refresh_and_retry(
+            self._helper.users_sections_request(
+                oauth2_token.access_token, user_id, course_id
+            ),
+            CanvasUsersSectionsResponseSchema,
             oauth2_token.refresh_token,
         )
 

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -7,6 +7,7 @@ from lms.services import CanvasAPIAccessTokenError
 from lms.services._helpers import CanvasAPIHelper
 from lms.validation import (
     CanvasAuthenticatedUsersSectionsResponseSchema,
+    CanvasCourseSectionsResponseSchema,
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
 )
@@ -95,6 +96,33 @@ class CanvasAPIClient:
                 oauth2_token.access_token, course_id
             ),
             CanvasAuthenticatedUsersSectionsResponseSchema,
+            oauth2_token.refresh_token,
+        )
+
+    def course_sections(self, course_id):
+        """
+        Return all the sections for the given course_id.
+
+        Send an HTTP request to the Canvas API to get the list of sections and
+        return it.
+
+        :arg course_id: the Canvas course_id of the course to look in
+        :type course_id: str
+
+        :raise lms.services.CanvasAPIAccessTokenError: if we can't get the list
+            of sections because we don't have a working Canvas API access token
+            for the user
+        :raise lms.services.CanvasAPIServerError: if we do have an access token
+            but the Canvas API request fails for any other reason
+
+        :return: a list of raw section dicts as received from the Canvas API
+        :rtype: list(dict)
+        """
+        oauth2_token = self._oauth2_token
+
+        return self.send_with_refresh_and_retry(
+            self._helper.course_sections_request(oauth2_token.access_token, course_id),
+            CanvasCourseSectionsResponseSchema,
             oauth2_token.refresh_token,
         )
 

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -55,6 +55,7 @@ from lms.validation._base import (
 )
 from lms.validation._canvas import (
     CanvasAuthenticatedUsersSectionsResponseSchema,
+    CanvasCourseSectionsResponseSchema,
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
 )

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -54,6 +54,7 @@ from lms.validation._base import (
     RequestsResponseSchema,
 )
 from lms.validation._canvas import (
+    CanvasAuthenticatedUsersSectionsResponseSchema,
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
 )

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -58,6 +58,7 @@ from lms.validation._canvas import (
     CanvasCourseSectionsResponseSchema,
     CanvasListFilesResponseSchema,
     CanvasPublicURLResponseSchema,
+    CanvasUsersSectionsResponseSchema,
 )
 from lms.validation._exceptions import LTIToolRedirect, ValidationError
 from lms.validation._lti_launch_params import (

--- a/lms/validation/_canvas.py
+++ b/lms/validation/_canvas.py
@@ -1,7 +1,39 @@
 """Schemas for Canvas API responses."""
-from webargs import fields
+from marshmallow import Schema, fields, post_load, validate
 
 from lms.validation._base import RequestsResponseSchema
+
+
+class CanvasAuthenticatedUsersSectionsResponseSchema(RequestsResponseSchema):
+    """
+    Schema for the Canvas API's "authenticated user's sections" responses.
+
+    Canvas doesn't have an "authenticated user's sections" API endpoint as
+    such, so we instead call its get course API
+    (https://canvas.instructure.com/doc/api/courses.html#method.courses.show)
+    with the ?include[]=sections query param and then extract only the part of
+    the response that we want (the list of sections with their names and IDs).
+    """
+
+    # A private nested schema for validating each individual section dict
+    # within the "sections" list in the Canvas API's response.
+    class _SectionSchema(Schema):
+        id = fields.Int(required=True)
+        name = fields.String(required=True)
+
+    sections = fields.List(
+        fields.Nested(_SectionSchema), validate=validate.Length(min=1), required=True
+    )
+
+    @post_load
+    def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
+        # Return the list of section dicts directly (rather than returning
+        # the wrapping {"sections": [<list_of_section_dicts>]} dict).
+        #
+        # If we get as far as this method then data["sections"] is guaranteed
+        # to be a list of one-or-more valid section dicts, so we don't need to
+        # code defensively here.
+        return data["sections"]
 
 
 class CanvasListFilesResponseSchema(RequestsResponseSchema):

--- a/tests/unit/lms/services/_helpers/canvas_api_test.py
+++ b/tests/unit/lms/services/_helpers/canvas_api_test.py
@@ -43,6 +43,18 @@ class TestCanvasAPIHelper:
             "&refresh_token=test_refresh_token"
         )
 
+    def test_authenticated_users_sections_request(self, helper):
+        request = helper.authenticated_users_sections_request(
+            "test_access_token", "test_course_id"
+        )
+
+        assert request.method == "GET"
+        assert request.headers["Authorization"] == "Bearer test_access_token"
+        assert request.url == (
+            "https://my-canvas-instance.com/api/v1/courses/test_course_id"
+            "?include%5B%5D=sections"
+        )
+
     def test_list_files_request(self, ai_getter, helper):
         request = helper.list_files_request("test_access_token", "test_course_id")
 

--- a/tests/unit/lms/services/_helpers/canvas_api_test.py
+++ b/tests/unit/lms/services/_helpers/canvas_api_test.py
@@ -55,6 +55,15 @@ class TestCanvasAPIHelper:
             "?include%5B%5D=sections"
         )
 
+    def test_course_sections_request(self, helper):
+        request = helper.course_sections_request("test_access_token", "test_course_id")
+
+        assert request.method == "GET"
+        assert request.headers["Authorization"] == "Bearer test_access_token"
+        assert request.url == (
+            "https://my-canvas-instance.com/api/v1/courses/test_course_id" "/sections"
+        )
+
     def test_list_files_request(self, ai_getter, helper):
         request = helper.list_files_request("test_access_token", "test_course_id")
 

--- a/tests/unit/lms/services/_helpers/canvas_api_test.py
+++ b/tests/unit/lms/services/_helpers/canvas_api_test.py
@@ -61,7 +61,19 @@ class TestCanvasAPIHelper:
         assert request.method == "GET"
         assert request.headers["Authorization"] == "Bearer test_access_token"
         assert request.url == (
-            "https://my-canvas-instance.com/api/v1/courses/test_course_id" "/sections"
+            "https://my-canvas-instance.com/api/v1/courses/test_course_id/sections"
+        )
+
+    def test_users_sections_request(self, helper):
+        request = helper.users_sections_request(
+            "test_access_token", "test_user_id", "test_course_id"
+        )
+
+        assert request.method == "GET"
+        assert request.headers["Authorization"] == "Bearer test_access_token"
+        assert request.url == (
+            "https://my-canvas-instance.com/api/v1/courses/test_course_id/users/test_user_id"
+            "?include%5B%5D=enrollments"
         )
 
     def test_list_files_request(self, ai_getter, helper):

--- a/tests/unit/lms/services/canvas_api_test.py
+++ b/tests/unit/lms/services/canvas_api_test.py
@@ -198,6 +198,7 @@ class TestGetRefreshedToken:
         return old_oauth2_token
 
 
+@pytest.mark.usefixtures("send_with_refresh_and_retry")
 class TestAuthenticatedUsersSections:
     """Unit tests for CanvasAPIClient.authenticated_users_sections()."""
 
@@ -257,13 +258,66 @@ class TestAuthenticatedUsersSections:
         ):
             canvas_api_client.authenticated_users_sections("test_course_id")
 
-    @pytest.fixture(autouse=True)
-    def send_with_refresh_and_retry(self, canvas_api_client):
-        send_with_refresh_and_retry = mock.create_autospec(
-            canvas_api_client.send_with_refresh_and_retry
+
+@pytest.mark.usefixtures("send_with_refresh_and_retry")
+class TestCourseSections:
+    """Unit tests for CanvasAPIClient.course_sections()."""
+
+    @pytest.mark.usefixtures("access_token")
+    def test_it(
+        self,
+        ai_getter,
+        canvas_api_client,
+        CanvasAPIHelper,
+        canvas_api_helper,
+        send_with_refresh_and_retry,
+        CanvasCourseSectionsResponseSchema,
+        pyramid_request,
+    ):
+        sections = canvas_api_client.course_sections("test_course_id")
+
+        # It initializes canvas_api_helper.
+        CanvasAPIHelper.assert_called_once_with(
+            pyramid_request.lti_user.oauth_consumer_key,
+            ai_getter,
+            pyramid_request.route_url,
         )
-        canvas_api_client.send_with_refresh_and_retry = send_with_refresh_and_retry
-        return send_with_refresh_and_retry
+
+        # It gets the prepared request.
+        canvas_api_helper.course_sections_request.assert_called_once_with(
+            "test_access_token", "test_course_id"
+        )
+
+        # It sends the prepared request.
+        send_with_refresh_and_retry.assert_called_once_with(
+            canvas_api_helper.course_sections_request.return_value,
+            CanvasCourseSectionsResponseSchema,
+            "test_refresh_token",
+        )
+
+        # It returns the sections.
+        assert sections == send_with_refresh_and_retry.return_value
+
+    def test_it_raises_if_we_dont_have_an_access_token(self, canvas_api_client):
+        with pytest.raises(
+            CanvasAPIAccessTokenError,
+            match="We don't have a Canvas API access token for this user",
+        ):
+            canvas_api_client.course_sections("test_course_id")
+
+    @pytest.mark.usefixtures("access_token")
+    @pytest.mark.parametrize(
+        "ExceptionClass", [CanvasAPIAccessTokenError, CanvasAPIServerError]
+    )
+    def test_it_raises_if_the_request_fails(
+        self, canvas_api_client, send_with_refresh_and_retry, ExceptionClass,
+    ):
+        send_with_refresh_and_retry.side_effect = ExceptionClass("test_error_message")
+
+        with pytest.raises(
+            ExceptionClass, match="test_error_message",
+        ):
+            canvas_api_client.course_sections("test_course_id")
 
 
 class TestListFiles:
@@ -575,6 +629,11 @@ def CanvasAuthenticatedUsersSectionsResponseSchema(patch):
 
 
 @pytest.fixture
+def CanvasCourseSectionsResponseSchema(patch):
+    return patch("lms.services.canvas_api.CanvasCourseSectionsResponseSchema")
+
+
+@pytest.fixture
 def CanvasListFilesResponseSchema(patch):
     return patch("lms.services.canvas_api.CanvasListFilesResponseSchema")
 
@@ -597,3 +656,12 @@ def CanvasAPIHelper(patch):
 @pytest.fixture
 def canvas_api_helper(CanvasAPIHelper):
     return CanvasAPIHelper.return_value
+
+
+@pytest.fixture
+def send_with_refresh_and_retry(canvas_api_client):
+    send_with_refresh_and_retry = mock.create_autospec(
+        canvas_api_client.send_with_refresh_and_retry
+    )
+    canvas_api_client.send_with_refresh_and_retry = send_with_refresh_and_retry
+    return send_with_refresh_and_retry


### PR DESCRIPTION
Add support for getting sections from the Canvas API in various ways.

Fixes https://github.com/hypothesis/lms/issues/1403

Fixes https://github.com/hypothesis/lms/issues/1404

Fixes https://github.com/hypothesis/lms/issues/1405

Note that there are no proxy API views/endpoints for these new Canvas API calls. There are only service methods for making the calls. These APIs aren't meant to be called by our frontend code directly. They'll be called by our backend code as appropriate (in response to sync API calls from the frontend)

There are three different circumstances under which we're going to need to retrieve sections from the Canvas API, in three different ways:

1. When a teacher (or any non-student) launches an assignment we want them to see the section groups for _all_ of the course sections in the Hypothesis client.

   We need to retrieve the full list of all of the course's sections including both the section IDs and names, so that we can both create those section groups in h and configure the client to show them. 

   The list of sections might change at any time (sections can be added, deleted or renamed in Canvas at any time) so we need to retrieve the list of sections and upsert the section groups into h on every launch.

   For this case we use **Canvas's sections API**, which has an endpoint for listing sections by course: https://canvas.instructure.com/doc/api/sections.html#method.sections.index

2. When a student launches an assignment we only want the client to show the section groups for the Canvas course sections that the student currently belongs to.

   We need to retrieve the student's sections including both the section IDs and names, so that we can both create those section groups in h and configure the client to show them.

   The list of sections might change at any time (sections can be added, deleted or renamed in Canvas at any time, and students can also be added to and removed from sections at any time) so we need to retrieve the list of sections and upsert the section groups into h on every launch.

   For this case we have to use **Canvas' _courses_ API** with `?include[]=sections` param.
This allow us to retrieve **the authenticated user's** sections only and not other sections. And since the student is the authenticated user, this works: https://canvas.instructure.com/doc/api/courses.html#method.courses.show

3. When a teacher launches an assignment in SpeedGrader then the teacher is the authenticated user but we want the client to show the section groups for the sections of the student who is currently being graded.

   In this case we can probably get away with not upserting the section groups into h. We can assume that all of the section groups will already exist in h or at least that if the student now belongs to any new sections that don't exist in h yet, the student can't have created any annotations in those groups yet so it would be okay not to show those groups in SpeedGrader.

   If we don't need to upsert the groups into h then we don't need the section names.

   We do need the section IDs, in order to configure the client to show those groups.

   If a student got removed from a section (or a section got deleted) after the student had already made some annotations for the assignment in that section group, those annotations would no longer show up in SpeedGrader. This would probably be acceptable, it's pretty edge casey.

   For this case we're using the **courses API endpoint** for getting information about a given user in the context of a given course: https://canvas.instructure.com/doc/api/courses.html#method.courses.user And we're using the `?include[]=enrollments` param to ask Canvas to include the student's enrollments in the course in that info. Students seem to have one course enrollment per course section they belong to. And the enrollment dicts contain `"course_section_id"` fields which are the section IDs. They do not contain the section names.

   I don't know of any way to get both the section IDs and names for all of an arbitrary user (not the authenticated user)'s sections for a course, without stitching together data from multiple different Canvas API endpoints.