### PR TITLE
Don't use deprecated yield_fixture

### DIFF
--- a/tests/functional/api/basic_lti_launch.py
+++ b/tests/functional/api/basic_lti_launch.py
@@ -101,7 +101,7 @@ class TestBasicLTILaunch(TestBaseClass):
     def lti_params(self):
         return self.json_fixture("lti_params/good_params.json")
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def http_intercept(self, _http_intercept):
         """
         Monkey-patch Python's socket core module to mock all HTTP responses.
@@ -114,7 +114,7 @@ class TestBasicLTILaunch(TestBaseClass):
         yield
         httpretty.reset()
 
-    @pytest.yield_fixture(scope="session")
+    @pytest.fixture(scope="session")
     def _http_intercept(self):
         # Mock all calls to the H API
         httpretty.register_uri(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -74,7 +74,7 @@ def configure_jinja2_assets(config):
     jinja2_env.globals["js_config"] = {}
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def pyramid_config(pyramid_request):
     """
     Return a test Pyramid config (Configurator) object.
@@ -104,7 +104,7 @@ def pyramid_config(pyramid_request):
         yield config
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def db_session(db_engine):
     """
     Yield the SQLAlchemy session object.


### PR DESCRIPTION
yield_fixture is deprecated:

https://docs.pytest.org/en/latest/yieldfixture.html

The one yield_fixture that this commit does not remove, has already been
removed by this open PR:

https://github.com/hypothesis/lms/pull/1612