### PR TITLE
Use a machine user to create groups

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.24
+fail_under = 99.25
 skip_covered = True

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -94,19 +94,18 @@ class HAPI:
         except HAPINotFoundError:
             self.create_user(h_user, provider, provider_unique_id)
 
-    def upsert_group(self, group_id, group_name, creator):
+    def upsert_group(self, group_id, group_name):
         """
         Update or create a group in H.
 
         :param group_id: The id of the group
         :param group_name: The display name for the group
-        :param creator: The user creating the group
         """
         self._api_request(
             "PUT",
             f"groups/{group_id}",
             data={"groupid": group_id, "name": group_name},
-            headers={"X-Forwarded-User": creator.userid},
+            headers={"X-Forwarded-User": f"acct:lms@{self._authority}"},
         )
 
     def update_group(self, group_id, group_name):

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -121,19 +121,6 @@ class HAPI:
             )
             do_upsert_group()
 
-    def update_group(self, group_id, group_name):
-        """
-        Update a group in H.
-
-        Currently this only updates the name of the group.
-
-        :param group_id: The id of the group
-        :param group_name: The display name for the group
-        """
-        self._api_request(
-            "PATCH", f"groups/{group_id}", data={"name": group_name},
-        )
-
     def add_user_to_group(self, h_user, group_id):
         """
         Add the user as a member of the group.

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
+from pyramid.httpexceptions import HTTPInternalServerError
 
 from lms.services import HAPIError, HAPINotFoundError
 
@@ -75,14 +75,8 @@ class LTIHService:
                 self.h_api.update_group(group_id=group.groupid, group_name=group.name)
             except HAPINotFoundError:
                 # The group hasn't been created in h yet.
-                if not self._request.lti_user.is_instructor:
-                    raise HTTPBadRequest("Instructor must launch assignment first.")
-
-                # Try to create the group with the current instructor as its creator.
                 self.h_api.upsert_group(
-                    group_id=group.groupid,
-                    group_name=group.name,
-                    creator=self._context.h_user,
+                    group_id=group.groupid, group_name=group.name,
                 )
 
             self.group_info_service.upsert(

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from pyramid.httpexceptions import HTTPInternalServerError
 
-from lms.services import HAPIError, HAPINotFoundError
+from lms.services import HAPIError
 
 Group = namedtuple("Group", "name groupid")
 
@@ -71,13 +71,7 @@ class LTIHService:
         )
 
         for group in groups:
-            try:
-                self.h_api.update_group(group_id=group.groupid, group_name=group.name)
-            except HAPINotFoundError:
-                # The group hasn't been created in h yet.
-                self.h_api.upsert_group(
-                    group_id=group.groupid, group_name=group.name,
-                )
+            self.h_api.upsert_group(group_id=group.groupid, group_name=group.name)
 
             self.group_info_service.upsert(
                 authority_provided_id=self._context.h_authority_provided_id,

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -87,15 +87,12 @@ class LTIHService:
 
         try:
             self.h_api.update_group(group_id=group.groupid, group_name=group.name)
-            return
-
         except HAPINotFoundError:
             # The group hasn't been created in h yet.
-
             if not self._request.lti_user.is_instructor:
                 raise HTTPBadRequest("Instructor must launch assignment first.")
 
-        # Try to create the group with the current instructor as its creator.
-        self.h_api.upsert_group(
-            group_id=group.groupid, group_name=group.name, creator=creator
-        )
+            # Try to create the group with the current instructor as its creator.
+            self.h_api.upsert_group(
+                group_id=group.groupid, group_name=group.name, creator=creator
+            )

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -149,13 +149,6 @@ class TestHAPI:
             upsert_group_call,
         ]
 
-    def test_update_group_works(self, h_api, _api_request):
-        h_api.update_group(sentinel.group_id, sentinel.group_name)
-
-        _api_request.assert_called_once_with(
-            "PATCH", "groups/sentinel.group_id", data={"name": sentinel.group_name}
-        )
-
     def test_add_user_to_group(self, h_api, _api_request, h_user):
         h_api.add_user_to_group(h_user, sentinel.group_id)
 

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -77,14 +77,16 @@ class TestHAPI:
             h_user, sentinel.provider, sentinel.provider_unique_id
         )
 
-    def test_upsert_group_works(self, h_api, h_user, _api_request):
-        h_api.upsert_group(sentinel.group_id, sentinel.group_name, h_user)
+    def test_upsert_group_works(self, h_api, _api_request):
+        h_api.upsert_group(sentinel.group_id, sentinel.group_name)
 
         _api_request.assert_called_once_with(
             "PUT",
             "groups/sentinel.group_id",
             data={"groupid": sentinel.group_id, "name": sentinel.group_name},
-            headers=Any.dict.containing({"X-Forwarded-User": h_user.userid}),
+            headers=Any.dict.containing(
+                {"X-Forwarded-User": "acct:lms@TEST_AUTHORITY"}
+            ),
         )
 
     def test_update_group_works(self, h_api, _api_request):

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -66,7 +66,7 @@ class TestHAPI:
             data={"display_name": h_user.display_name},
         )
 
-    def test_upsert_calls_calls_create_if_update_fails(
+    def test_upsert_user_calls_create_if_update_fails(
         self, update_user, create_user, h_api, h_user
     ):
         update_user.side_effect = HAPINotFoundError()
@@ -77,17 +77,77 @@ class TestHAPI:
             h_user, sentinel.provider, sentinel.provider_unique_id
         )
 
-    def test_upsert_group_works(self, h_api, _api_request):
+    def test_upsert_group_works(self, h_api, _api_request, upsert_group_call):
         h_api.upsert_group(sentinel.group_id, sentinel.group_name)
 
-        _api_request.assert_called_once_with(
-            "PUT",
-            "groups/sentinel.group_id",
-            data={"groupid": sentinel.group_id, "name": sentinel.group_name},
-            headers=Any.dict.containing(
-                {"X-Forwarded-User": "acct:lms@TEST_AUTHORITY"}
-            ),
-        )
+        assert _api_request.call_args_list == [upsert_group_call]
+
+    def test_upsert_group_raises_if_creating_the_group_fails(
+        self, h_api, _api_request, upsert_group_call
+    ):
+        # If the first attempt to upsert the group fails with anything other
+        # than a 404, upsert_group() raises.
+        _api_request.side_effect = HAPIError("test_error_message")
+
+        with pytest.raises(HAPIError, match="test_error_message"):
+            h_api.upsert_group(sentinel.group_id, sentinel.group_name)
+
+        assert _api_request.call_args_list == [upsert_group_call]
+
+    def test_upsert_group_creates_the_lms_user_if_it_doesnt_exist(
+        self, h_api, _api_request, upsert_group_call, create_user_call
+    ):
+        # Make only the first h API call (the first attempt to upsert the
+        # group) fail.
+        _api_request.side_effect = [HAPINotFoundError(), None, None]
+
+        h_api.upsert_group(sentinel.group_id, sentinel.group_name)
+
+        # It should have tried to upsert the group once, then created the user,
+        # then tried again to upsert the group.
+        assert _api_request.call_args_list == [
+            upsert_group_call,
+            create_user_call,
+            upsert_group_call,
+        ]
+
+    def test_upsert_group_raises_if_creating_the_lms_user_fails(
+        self, h_api, _api_request, upsert_group_call, create_user_call
+    ):
+        # Make the first attempt to upsert the group fail because the lms user
+        # doesn't exist, and make the attempt to create the lms user also fail.
+        _api_request.side_effect = [
+            HAPINotFoundError(),
+            HAPIError("test_error_message"),
+            None,
+        ]
+
+        with pytest.raises(HAPIError, match="test_error_message"):
+            h_api.upsert_group(sentinel.group_id, sentinel.group_name)
+
+        # It should have tried to upsert the group once then tried to create
+        # the user (which failed).
+        assert _api_request.call_args_list == [upsert_group_call, create_user_call]
+
+    def test_upsert_group_raises_if_the_second_attempt_to_upsert_the_group_fails(
+        self, h_api, _api_request, upsert_group_call, create_user_call
+    ):
+        # Make both attempts to upsert the group fail, but let creating the lms
+        # user succeed.
+        _api_request.side_effect = [
+            HAPINotFoundError(),
+            None,
+            HAPIError("test_error_message"),
+        ]
+
+        with pytest.raises(HAPIError, match="test_error_message"):
+            h_api.upsert_group(sentinel.group_id, sentinel.group_name)
+
+        assert _api_request.call_args_list == [
+            upsert_group_call,
+            create_user_call,
+            upsert_group_call,
+        ]
 
     def test_update_group_works(self, h_api, _api_request):
         h_api.update_group(sentinel.group_id, sentinel.group_name)
@@ -196,6 +256,30 @@ class TestHAPI:
     def _api_request(self, h_api):
         with patch.object(h_api, "_api_request", autospec=True):
             yield h_api._api_request
+
+    @pytest.fixture
+    def upsert_group_call(self):
+        """Return the call that upsert_group() makes to _api_request() to try to upsert the group."""
+        return call(
+            "PUT",
+            "groups/sentinel.group_id",
+            data={"groupid": sentinel.group_id, "name": sentinel.group_name},
+            headers={"X-Forwarded-User": "acct:lms@TEST_AUTHORITY"},
+        )
+
+    @pytest.fixture
+    def create_user_call(self):
+        """Return the call that create_user() makes to _api_request() to create the lms user."""
+        return call(
+            "POST",
+            "users",
+            data={
+                "username": "lms",
+                "display_name": "",
+                "authority": "TEST_AUTHORITY",
+                "identities": [{"provider": "lms", "provider_unique_id": "lms"}],
+            },
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -56,7 +56,7 @@ class TestGroupUpdating:
             lti_h_svc.single_group_sync()
 
     def test_it_creates_the_group_if_it_doesnt_exist(
-        self, pyramid_request, h_api, lti_h_svc, h_user
+        self, pyramid_request, h_api, lti_h_svc
     ):
         pyramid_request.lti_user = LTIUser(
             user_id="TEST_USER_ID",
@@ -68,7 +68,7 @@ class TestGroupUpdating:
         lti_h_svc.single_group_sync()
 
         h_api.upsert_group.assert_called_once_with(
-            group_id="test_groupid", group_name="test_group_name", creator=h_user,
+            group_id="test_groupid", group_name="test_group_name"
         )
 
     def test_it_raises_if_creating_the_group_fails(
@@ -84,23 +84,6 @@ class TestGroupUpdating:
 
         with pytest.raises(HTTPInternalServerError, match="Oops"):
             lti_h_svc.single_group_sync()
-
-    def test_it_400s_with_missing_group_and_unpriviledged_user(
-        self, pyramid_request, h_api, lti_h_svc
-    ):
-        pyramid_request.lti_user = LTIUser(
-            user_id="TEST_USER_ID",
-            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
-            roles="learner",
-        )
-        h_api.update_group.side_effect = HAPINotFoundError()
-
-        with pytest.raises(
-            HTTPBadRequest, match="Instructor must launch assignment first"
-        ):
-            lti_h_svc.single_group_sync()
-
-        h_api.upsert_group.assert_not_called()
 
     def test_it_upserts_the_GroupInfo_into_the_db(
         self, params, group_info_service, context, lti_h_svc

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -55,7 +55,7 @@ class TestGroupUpdating:
         with pytest.raises(HTTPInternalServerError, match="Oops"):
             lti_h_svc.single_group_sync()
 
-    def test_it_creates_the_group_if_it_doesnt_exist(
+    def test_it_upserts_the_group_if_it_doesnt_exist(
         self, pyramid_request, h_api, lti_h_svc
     ):
         pyramid_request.lti_user = LTIUser(
@@ -71,7 +71,7 @@ class TestGroupUpdating:
             group_id="test_groupid", group_name="test_group_name"
         )
 
-    def test_it_raises_if_creating_the_group_fails(
+    def test_it_raises_if_upserting_the_group_fails(
         self, pyramid_request, h_api, lti_h_svc
     ):
         pyramid_request.lti_user = LTIUser(
@@ -96,7 +96,7 @@ class TestGroupUpdating:
             params=params,
         )
 
-    def test_it_doesnt_upsert_GroupInfo_into_the_db_if_creating_the_group_fails(
+    def test_it_doesnt_upsert_GroupInfo_into_the_db_if_upserting_the_group_fails(
         self, group_info_service, h_api, lti_h_svc
     ):
         h_api.update_group.side_effect = HAPINotFoundError()


### PR DESCRIPTION
Automatically create a machine user in h and use it as the group's creator when creating groups.

Fixes https://github.com/hypothesis/lms/issues/1400