### PR TITLE
Remove unnecessary validation code from LTILaunchResource

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -15,8 +15,9 @@ class LTILaunchResource:
     Many methods and properties of this class are only meant to be called when
     request.parsed_params holds validated params from an LTI launch request and
     might crash otherwise. So you should only call these methods after the
-    request has been validated with LaunchParamsSchema (for example from views
-    that have schema=LaunchParamsSchema in their view config).
+    request has been validated with BasicLTILaunchSchema or similar (for
+    example from views that have schema=BasicLTILaunchSchema in their view
+    config).
     """
 
     __acl__ = [(Allow, "lti_user", "launch_lti_assignment")]

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -9,7 +9,15 @@ from lms.values import HUser
 
 
 class LTILaunchResource:
-    """Context resource for LTI launch requests."""
+    """
+    Context resource for LTI launch requests.
+
+    Many methods and properties of this class are only meant to be called when
+    request.parsed_params holds validated params from an LTI launch request and
+    might crash otherwise. So you should only call these methods after the
+    request has been validated with LaunchParamsSchema (for example from views
+    that have schema=LaunchParamsSchema in their view config).
+    """
 
     __acl__ = [(Allow, "lti_user", "launch_lti_assignment")]
 

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -32,7 +32,7 @@ class LTILaunchResource:
 
         def display_name():
             """Return the h display name for the current request."""
-            params = self._request.params
+            params = self._request.parsed_params
 
             display_name = params.get("lis_person_name_full", "").strip()
 
@@ -76,8 +76,10 @@ class LTILaunchResource:
         # and context_id uniquely identifies a course within an LMS. Together they
         # globally uniquely identify a course.
         hash_object = hashlib.sha1()
-        hash_object.update(self._request.params["tool_consumer_instance_guid"].encode())
-        hash_object.update(self._request.params["context_id"].encode())
+        hash_object.update(
+            self._request.parsed_params["tool_consumer_instance_guid"].encode()
+        )
+        hash_object.update(self._request.parsed_params["context_id"].encode())
         return hash_object.hexdigest()
 
     @property
@@ -135,7 +137,7 @@ class LTILaunchResource:
         generated name you'll get back an unsuccessful response from the Hypothesis
         API.
         """
-        return self._group_name(self._request.params["context_title"].strip())
+        return self._group_name(self._request.parsed_params["context_title"].strip())
 
     def h_section_group_name(self, section):
         """
@@ -159,23 +161,23 @@ class LTILaunchResource:
     @property
     def h_provider(self):
         """Return the h "provider" string for the current request."""
-        return self._request.params["tool_consumer_instance_guid"]
+        return self._request.parsed_params["tool_consumer_instance_guid"]
 
     @property
     def h_provider_unique_id(self):
         """Return the h provider_unique_id for the current request."""
-        return self._request.params["user_id"]
+        return self._request.parsed_params["user_id"]
 
     @property
     def is_canvas(self):
         """Return True if Canvas is the LMS that launched us."""
         if (
-            self._request.params.get("tool_consumer_info_product_family_code")
+            self._request.parsed_params.get("tool_consumer_info_product_family_code")
             == "canvas"
         ):
             return True
 
-        if "custom_canvas_course_id" in self._request.params:
+        if "custom_canvas_course_id" in self._request.parsed_params:
             return True
 
         return False
@@ -189,13 +191,13 @@ class LTILaunchResource:
     def provisioning_enabled(self):
         """Return True if provisioning is enabled for this request."""
         return self._ai_getter.provisioning_enabled(
-            self._request.params["oauth_consumer_key"]
+            self._request.parsed_params["oauth_consumer_key"]
         )
 
     @property
     def lms_url(self):
         """Return the ApplicationInstance.lms_url."""
-        oauth_consumer_key = self._request.params.get("oauth_consumer_key")
+        oauth_consumer_key = self._request.parsed_params.get("oauth_consumer_key")
         return self._ai_getter.lms_url(oauth_consumer_key)
 
     @property
@@ -209,4 +211,4 @@ class LTILaunchResource:
         seems to match). And of course custom_canvas_api_domain only works in
         Canvas.
         """
-        return self._request.params.get("custom_canvas_api_domain")
+        return self._request.parsed_params.get("custom_canvas_api_domain")

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -63,7 +63,7 @@ from lms.validation._canvas import (
 from lms.validation._exceptions import LTIToolRedirect, ValidationError
 from lms.validation._lti_launch_params import (
     BasicLTILaunchSchema,
-    LaunchParamsURLConfiguredSchema,
+    URLConfiguredBasicLTILaunchSchema,
 )
 from lms.validation._module_item_configuration import ConfigureModuleItemSchema
 

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -62,7 +62,7 @@ from lms.validation._canvas import (
 )
 from lms.validation._exceptions import LTIToolRedirect, ValidationError
 from lms.validation._lti_launch_params import (
-    LaunchParamsSchema,
+    BasicLTILaunchSchema,
     LaunchParamsURLConfiguredSchema,
 )
 from lms.validation._module_item_configuration import ConfigureModuleItemSchema

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -63,6 +63,7 @@ from lms.validation._canvas import (
 from lms.validation._exceptions import LTIToolRedirect, ValidationError
 from lms.validation._lti_launch_params import (
     BasicLTILaunchSchema,
+    ContentItemSelectionLTILaunchSchema,
     URLConfiguredBasicLTILaunchSchema,
 )
 from lms.validation._module_item_configuration import ConfigureModuleItemSchema

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -7,7 +7,28 @@ from lms.validation._base import PyramidRequestSchema
 from lms.validation._exceptions import LTIToolRedirect
 
 
-class BasicLTILaunchSchema(PyramidRequestSchema):
+class _CommonLTILaunchSchema(PyramidRequestSchema):
+    """Fields common to different types of LTI launches."""
+
+    locations = ["form"]
+
+    context_id = fields.Str(required=True)
+    context_title = fields.Str(required=True)
+    lti_version = fields.Str(validate=OneOf(["LTI-1p0"]), required=True)
+    oauth_consumer_key = fields.Str(required=True)
+    tool_consumer_instance_guid = fields.Str(required=True)
+    user_id = fields.Str(required=True)
+
+    custom_canvas_api_domain = fields.Str()
+    custom_canvas_course_id = fields.Str()
+    launch_presentation_return_url = fields.Str()
+    lis_person_name_full = fields.Str()
+    lis_person_name_family = fields.Str()
+    lis_person_name_given = fields.Str()
+    tool_consumer_info_product_family_code = fields.Str()
+
+
+class BasicLTILaunchSchema(_CommonLTILaunchSchema):
     """
     Schema for basic LTI launch requests (i.e. assignment launches).
 
@@ -25,24 +46,10 @@ class BasicLTILaunchSchema(PyramidRequestSchema):
 
         launch_presentation_return_url = fields.URL()
 
-    context_id = fields.Str(required=True)
-    context_title = fields.Str(required=True)
     lti_message_type = fields.Str(
         validate=OneOf(["basic-lti-launch-request"]), required=True
     )
-    lti_version = fields.Str(validate=OneOf(["LTI-1p0"]), required=True)
-    oauth_consumer_key = fields.Str(required=True)
     resource_link_id = fields.Str(required=True)
-    tool_consumer_instance_guid = fields.Str(required=True)
-    user_id = fields.Str(required=True)
-
-    custom_canvas_api_domain = fields.Str()
-    custom_canvas_course_id = fields.Str()
-    launch_presentation_return_url = fields.Str()
-    lis_person_name_full = fields.Str()
-    lis_person_name_family = fields.Str()
-    lis_person_name_given = fields.Str()
-    tool_consumer_info_product_family_code = fields.Str()
 
     # If we have an error in one of these fields we should redirect back to
     # the calling LMS if possible
@@ -53,8 +60,6 @@ class BasicLTILaunchSchema(PyramidRequestSchema):
         "context_id",
         "context_title",
     }
-
-    locations = ["form"]
 
     def handle_error(self, error, data, *, many, **kwargs):
         """
@@ -114,3 +119,11 @@ class URLConfiguredBasicLTILaunchSchema(BasicLTILaunchSchema):
             _data["url"] = url
 
         return _data
+
+
+class ContentItemSelectionLTILaunchSchema(_CommonLTILaunchSchema):
+    """Schema for content item selection LTI launches."""
+
+    lti_message_type = fields.Str(
+        validate=OneOf(["ContentItemSelectionRequest"]), required=True
+    )

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -95,13 +95,8 @@ class BasicLTILaunchSchema(PyramidRequestSchema):
         super().handle_error(error, data, many=many, **kwargs)
 
 
-class LaunchParamsURLConfiguredSchema(BasicLTILaunchSchema):
-    """
-    Schema for an "URL-configured" Basic LTI Launch.
-
-    An URL-configured launch is one where the content URL is provided by a "url"
-    launch param.
-    """
+class URLConfiguredBasicLTILaunchSchema(BasicLTILaunchSchema):
+    """Schema for URL-configured basic LTI launches."""
 
     url = fields.Str(required=True)
 

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -7,9 +7,9 @@ from lms.validation._base import PyramidRequestSchema
 from lms.validation._exceptions import LTIToolRedirect
 
 
-class LaunchParamsSchema(PyramidRequestSchema):
+class BasicLTILaunchSchema(PyramidRequestSchema):
     """
-    Schema describing the minimum requirements for LTI launch parameters.
+    Schema for basic LTI launch requests (i.e. assignment launches).
 
     This *DOES NOT* contain all of the fields required for authentication.
     For that see `lms.validation.authentication.LaunchParamsAuthSchema`
@@ -75,7 +75,7 @@ class LaunchParamsSchema(PyramidRequestSchema):
             # Extract the launch_presentation_return_url and check it's a real
             # URL
             return_url = (
-                LaunchParamsSchema.URLSchema()
+                BasicLTILaunchSchema.URLSchema()
                 .load(data)
                 .get("launch_presentation_return_url")
             )
@@ -95,7 +95,7 @@ class LaunchParamsSchema(PyramidRequestSchema):
         super().handle_error(error, data, many=many, **kwargs)
 
 
-class LaunchParamsURLConfiguredSchema(LaunchParamsSchema):
+class LaunchParamsURLConfiguredSchema(BasicLTILaunchSchema):
     """
     Schema for an "URL-configured" Basic LTI Launch.
 

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -27,12 +27,22 @@ class LaunchParamsSchema(PyramidRequestSchema):
 
     context_id = fields.Str(required=True)
     context_title = fields.Str(required=True)
-    launch_presentation_return_url = fields.Str()
     lti_message_type = fields.Str(
         validate=OneOf(["basic-lti-launch-request"]), required=True
     )
     lti_version = fields.Str(validate=OneOf(["LTI-1p0"]), required=True)
+    oauth_consumer_key = fields.Str(required=True)
     resource_link_id = fields.Str(required=True)
+    tool_consumer_instance_guid = fields.Str(required=True)
+    user_id = fields.Str(required=True)
+
+    custom_canvas_api_domain = fields.Str()
+    custom_canvas_course_id = fields.Str()
+    launch_presentation_return_url = fields.Str()
+    lis_person_name_full = fields.Str()
+    lis_person_name_family = fields.Str()
+    lis_person_name_given = fields.Str()
+    tool_consumer_info_product_family_code = fields.Str()
 
     # If we have an error in one of these fields we should redirect back to
     # the calling LMS if possible

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -16,8 +16,8 @@ from pyramid.view import view_config, view_defaults
 
 from lms.models import LtiLaunches, ModuleItemConfiguration
 from lms.validation import (
+    BasicLTILaunchSchema,
     ConfigureModuleItemSchema,
-    LaunchParamsSchema,
     LaunchParamsURLConfiguredSchema,
 )
 from lms.validation.authentication import BearerTokenSchema
@@ -28,7 +28,7 @@ from lms.validation.authentication import BearerTokenSchema
     renderer="lms:templates/basic_lti_launch/basic_lti_launch.html.jinja2",
     request_method="POST",
     route_name="lti_launches",
-    schema=LaunchParamsSchema,
+    schema=BasicLTILaunchSchema,
 )
 class BasicLTILaunchViews:
     def __init__(self, context, request):

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -18,7 +18,7 @@ from lms.models import LtiLaunches, ModuleItemConfiguration
 from lms.validation import (
     BasicLTILaunchSchema,
     ConfigureModuleItemSchema,
-    LaunchParamsURLConfiguredSchema,
+    URLConfiguredBasicLTILaunchSchema,
 )
 from lms.validation.authentication import BearerTokenSchema
 
@@ -116,7 +116,7 @@ class BasicLTILaunchViews:
 
         return {}
 
-    @view_config(url_configured=True, schema=LaunchParamsURLConfiguredSchema)
+    @view_config(url_configured=True, schema=URLConfiguredBasicLTILaunchSchema)
     def url_configured_basic_lti_launch(self):
         """
         Respond to a URL-configured assignment launch.

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -36,6 +36,8 @@ https://canvas.instructure.com/doc/api/file.content_item.html
 """
 from pyramid.view import view_config
 
+from lms.validation import ContentItemSelectionLTILaunchSchema
+
 
 @view_config(
     authorized_to_configure_assignments=True,
@@ -43,6 +45,7 @@ from pyramid.view import view_config
     renderer="lms:templates/file_picker.html.jinja2",
     request_method="POST",
     route_name="content_item_selection",
+    schema=ContentItemSelectionLTILaunchSchema,
 )
 def content_item_selection(context, request):
     request.find_service(name="lti_h").single_group_sync()

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -57,19 +57,19 @@ class TestHDisplayName:
         ],
     )
     def test_it(self, name_parts, expected, pyramid_request):
-        params = {
+        parsed_params = {
             f"lis_person_name_{field}": part
             for field, part in zip(["full", "given", "family"], name_parts)
             if part is not None
         }
 
-        pyramid_request.params.update(params)
+        pyramid_request.parsed_params.update(parsed_params)
 
         assert LTILaunchResource(pyramid_request).h_user.display_name == expected
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
             "user_id": "test_user_id",
         }
@@ -85,7 +85,7 @@ class TestHAuthorityProvidedID:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "context_id": "test_context_id",
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
         }
@@ -101,7 +101,7 @@ class TestHGroupID:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "context_id": "test_context_id",
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
         }
@@ -169,7 +169,7 @@ class TestHGroupName:
     def test_it_returns_group_names_based_on_context_titles(
         self, context_title, expected_group_name, pyramid_request
     ):
-        pyramid_request.params["context_title"] = context_title
+        pyramid_request.parsed_params["context_title"] = context_title
 
         assert LTILaunchResource(pyramid_request).h_group_name == expected_group_name
 
@@ -201,7 +201,7 @@ class TestHProvider:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
         }
         return pyramid_request
@@ -215,7 +215,7 @@ class TestHProviderUniqueID:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "user_id": "test_user_id",
         }
         return pyramid_request
@@ -223,7 +223,7 @@ class TestHProviderUniqueID:
 
 class TestIsCanvas:
     @pytest.mark.parametrize(
-        "params,is_canvas",
+        "parsed_params,is_canvas",
         [
             # For *some* launches Canvas includes a
             # `tool_consumer_info_product_family_code: canvas` and you can
@@ -243,8 +243,8 @@ class TestIsCanvas:
             ({}, False),
         ],
     )
-    def test_it(self, pyramid_request, params, is_canvas):
-        pyramid_request.params = params
+    def test_it(self, pyramid_request, parsed_params, is_canvas):
+        pyramid_request.parsed_params = parsed_params
 
         assert LTILaunchResource(pyramid_request).is_canvas == is_canvas
 
@@ -260,7 +260,7 @@ class TestHUser:
     def test_it_raises_if_a_required_parameter_is_missing(
         self, pyramid_request, parameter
     ):
-        pyramid_request.params.pop(parameter)
+        pyramid_request.parsed_params.pop(parameter)
 
     def test_userid(self, pyramid_request):
         userid = LTILaunchResource(pyramid_request).h_user.userid
@@ -269,7 +269,7 @@ class TestHUser:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
             "user_id": "test_user_id",
         }
@@ -296,7 +296,7 @@ class TestProvisioningEnabled:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
         }
         return pyramid_request
@@ -309,7 +309,7 @@ class TestCustomCanvasAPIDomain:
         assert lti_launch.custom_canvas_api_domain == "test_custom_canvas_api_domain"
 
     def test_it_returns_None_if_not_defined(self, pyramid_request):
-        del pyramid_request.params["custom_canvas_api_domain"]
+        del pyramid_request.parsed_params["custom_canvas_api_domain"]
 
         lti_launch = LTILaunchResource(pyramid_request)
 
@@ -318,7 +318,7 @@ class TestCustomCanvasAPIDomain:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "custom_canvas_api_domain": "test_custom_canvas_api_domain",
         }
         return pyramid_request
@@ -348,7 +348,7 @@ class TestLMSURL:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
         }
         return pyramid_request
@@ -365,3 +365,9 @@ def lti_launch(pyramid_request):
 @pytest.fixture(autouse=True)
 def JSConfig(patch):
     return patch("lms.resources.lti_launch.JSConfig")
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.parsed_params = {}
+    return pyramid_request

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -256,12 +256,6 @@ class TestHUser:
         assert isinstance(username, str)
         assert len(username) == 30
 
-    @pytest.mark.parametrize("parameter", ["tool_consumer_instance_guid", "user_id"])
-    def test_it_raises_if_a_required_parameter_is_missing(
-        self, pyramid_request, parameter
-    ):
-        pyramid_request.parsed_params.pop(parameter)
-
     def test_userid(self, pyramid_request):
         userid = LTILaunchResource(pyramid_request).h_user.userid
 

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -3,6 +3,7 @@ from h_matchers import Any
 
 from lms.validation import (
     BasicLTILaunchSchema,
+    ContentItemSelectionLTILaunchSchema,
     LTIToolRedirect,
     URLConfiguredBasicLTILaunchSchema,
     ValidationError,
@@ -120,6 +121,100 @@ class TestURLConfiguredBasicLTILaunchSchema:
     @pytest.fixture
     def schema(self, pyramid_request):
         return URLConfiguredBasicLTILaunchSchema(pyramid_request)
+
+
+class TestContentItemSelectionLTILaunchSchema:
+    def test_it(self, schema):
+        parsed_params = schema.parse()
+
+        assert parsed_params == {
+            "context_id": "test_context_id",
+            "context_title": "test_context_title",
+            "lti_message_type": "ContentItemSelectionRequest",
+            "lti_version": "LTI-1p0",
+            "oauth_consumer_key": "test_oauth_consumer_key",
+            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
+            "user_id": "test_user_id",
+            "custom_canvas_api_domain": "test_custom_canvas_api_domain",
+            "custom_canvas_course_id": "test_custom_canvas_course_id",
+            "launch_presentation_return_url": "test_launch_presentation_return_url",
+            "lis_person_name_full": "test_lis_person_name_full",
+            "lis_person_name_family": "test_lis_person_name_family",
+            "lis_person_name_given": "test_lis_person_name_given",
+            "tool_consumer_info_product_family_code": "test_tool_consumer_info_product_family_code",
+        }
+
+    @pytest.mark.parametrize(
+        "missing_param",
+        [
+            "context_id",
+            "context_title",
+            "lti_message_type",
+            "lti_version",
+            "oauth_consumer_key",
+            "tool_consumer_instance_guid",
+            "user_id",
+        ],
+    )
+    def test_required_params(self, schema, pyramid_request, missing_param):
+        del pyramid_request.params[missing_param]
+
+        with pytest.raises(ValidationError) as exc_info:
+            schema.parse()
+
+        assert exc_info.value.messages == dict(
+            ((missing_param, ["Missing data for required field."]),)
+        )
+
+    @pytest.mark.parametrize(
+        "invalid_params,expected_error_messages",
+        [
+            (
+                {"lti_version": "invalid version",},
+                {"lti_version": ["Must be one of: LTI-1p0."]},
+            ),
+            (
+                {"lti_message_type": "invalid message type",},
+                {"lti_message_type": ["Must be one of: ContentItemSelectionRequest."]},
+            ),
+        ],
+    )
+    def test_invalid_params(
+        self, schema, pyramid_request, invalid_params, expected_error_messages
+    ):
+        pyramid_request.params.update(invalid_params)
+
+        with pytest.raises(ValidationError) as exc_info:
+            schema.parse()
+
+        assert exc_info.value.messages == expected_error_messages
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params.clear()
+        pyramid_request.params.update(
+            {
+                "context_id": "test_context_id",
+                "context_title": "test_context_title",
+                "lti_message_type": "ContentItemSelectionRequest",
+                "lti_version": "LTI-1p0",
+                "oauth_consumer_key": "test_oauth_consumer_key",
+                "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
+                "user_id": "test_user_id",
+                "custom_canvas_api_domain": "test_custom_canvas_api_domain",
+                "custom_canvas_course_id": "test_custom_canvas_course_id",
+                "launch_presentation_return_url": "test_launch_presentation_return_url",
+                "lis_person_name_full": "test_lis_person_name_full",
+                "lis_person_name_family": "test_lis_person_name_family",
+                "lis_person_name_given": "test_lis_person_name_given",
+                "tool_consumer_info_product_family_code": "test_tool_consumer_info_product_family_code",
+            }
+        )
+        return pyramid_request
+
+    @pytest.fixture
+    def schema(self, pyramid_request):
+        return ContentItemSelectionLTILaunchSchema(pyramid_request)
 
 
 @pytest.fixture

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -2,18 +2,18 @@ import pytest
 from h_matchers import Any
 
 from lms.validation import (
-    LaunchParamsSchema,
+    BasicLTILaunchSchema,
     LaunchParamsURLConfiguredSchema,
     LTIToolRedirect,
     ValidationError,
 )
 
 
-class TestLaunchParamsSchema:
+class TestBasicLTILaunchSchema:
     def test_it_works_with_good_params(self, pyramid_request):
         pyramid_request.params["launch_presentation_return_url"] = "http://example.com"
 
-        schema = LaunchParamsSchema(pyramid_request)
+        schema = BasicLTILaunchSchema(pyramid_request)
         params = schema.parse()
 
         assert params == Any.dict.containing({"resource_link_id": Any.string()})
@@ -21,7 +21,7 @@ class TestLaunchParamsSchema:
     def test_it_allows_bad_urls_if_there_are_no_other_errors(self, pyramid_request):
         pyramid_request.params["launch_presentation_return_url"] = "goofyurl"
 
-        schema = LaunchParamsSchema(pyramid_request)
+        schema = BasicLTILaunchSchema(pyramid_request)
         schema.parse()
 
         # Still alive!
@@ -29,7 +29,7 @@ class TestLaunchParamsSchema:
     def test_ValidationError_raised_when_res_link_missing(self, pyramid_request):
         pyramid_request.params.pop("resource_link_id")
 
-        schema = LaunchParamsSchema(pyramid_request)
+        schema = BasicLTILaunchSchema(pyramid_request)
 
         with pytest.raises(ValidationError):
             schema.parse()
@@ -40,7 +40,7 @@ class TestLaunchParamsSchema:
         pyramid_request.params.pop("resource_link_id")
         pyramid_request.params["launch_presentation_return_url"] = "broken"
 
-        schema = LaunchParamsSchema(pyramid_request)
+        schema = BasicLTILaunchSchema(pyramid_request)
 
         with pytest.raises(ValidationError) as exc_info:
             schema.parse()
@@ -56,7 +56,7 @@ class TestLaunchParamsSchema:
         pyramid_request.params.pop("resource_link_id")
         pyramid_request.params["launch_presentation_return_url"] = "http://example.com"
 
-        schema = LaunchParamsSchema(pyramid_request)
+        schema = BasicLTILaunchSchema(pyramid_request)
 
         with pytest.raises(LTIToolRedirect):
             schema.parse()

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -124,25 +124,10 @@ class TestURLConfiguredBasicLTILaunchSchema:
 
 
 class TestContentItemSelectionLTILaunchSchema:
-    def test_it(self, schema):
+    def test_it(self, schema, valid_params):
         parsed_params = schema.parse()
 
-        assert parsed_params == {
-            "context_id": "test_context_id",
-            "context_title": "test_context_title",
-            "lti_message_type": "ContentItemSelectionRequest",
-            "lti_version": "LTI-1p0",
-            "oauth_consumer_key": "test_oauth_consumer_key",
-            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
-            "user_id": "test_user_id",
-            "custom_canvas_api_domain": "test_custom_canvas_api_domain",
-            "custom_canvas_course_id": "test_custom_canvas_course_id",
-            "launch_presentation_return_url": "test_launch_presentation_return_url",
-            "lis_person_name_full": "test_lis_person_name_full",
-            "lis_person_name_family": "test_lis_person_name_family",
-            "lis_person_name_given": "test_lis_person_name_given",
-            "tool_consumer_info_product_family_code": "test_tool_consumer_info_product_family_code",
-        }
+        assert parsed_params == valid_params
 
     @pytest.mark.parametrize(
         "missing_param",
@@ -190,26 +175,28 @@ class TestContentItemSelectionLTILaunchSchema:
         assert exc_info.value.messages == expected_error_messages
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
+    def valid_params(self):
+        return {
+            "context_id": "test_context_id",
+            "context_title": "test_context_title",
+            "lti_message_type": "ContentItemSelectionRequest",
+            "lti_version": "LTI-1p0",
+            "oauth_consumer_key": "test_oauth_consumer_key",
+            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
+            "user_id": "test_user_id",
+            "custom_canvas_api_domain": "test_custom_canvas_api_domain",
+            "custom_canvas_course_id": "test_custom_canvas_course_id",
+            "launch_presentation_return_url": "test_launch_presentation_return_url",
+            "lis_person_name_full": "test_lis_person_name_full",
+            "lis_person_name_family": "test_lis_person_name_family",
+            "lis_person_name_given": "test_lis_person_name_given",
+            "tool_consumer_info_product_family_code": "test_tool_consumer_info_product_family_code",
+        }
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request, valid_params):
         pyramid_request.params.clear()
-        pyramid_request.params.update(
-            {
-                "context_id": "test_context_id",
-                "context_title": "test_context_title",
-                "lti_message_type": "ContentItemSelectionRequest",
-                "lti_version": "LTI-1p0",
-                "oauth_consumer_key": "test_oauth_consumer_key",
-                "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
-                "user_id": "test_user_id",
-                "custom_canvas_api_domain": "test_custom_canvas_api_domain",
-                "custom_canvas_course_id": "test_custom_canvas_course_id",
-                "launch_presentation_return_url": "test_launch_presentation_return_url",
-                "lis_person_name_full": "test_lis_person_name_full",
-                "lis_person_name_family": "test_lis_person_name_family",
-                "lis_person_name_given": "test_lis_person_name_given",
-                "tool_consumer_info_product_family_code": "test_tool_consumer_info_product_family_code",
-            }
-        )
+        pyramid_request.params.update(valid_params)
         return pyramid_request
 
     @pytest.fixture

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -3,8 +3,8 @@ from h_matchers import Any
 
 from lms.validation import (
     BasicLTILaunchSchema,
-    LaunchParamsURLConfiguredSchema,
     LTIToolRedirect,
+    URLConfiguredBasicLTILaunchSchema,
     ValidationError,
 )
 
@@ -62,7 +62,7 @@ class TestBasicLTILaunchSchema:
             schema.parse()
 
 
-class TestURLConfiguredLaunchParamsSchema:
+class TestURLConfiguredBasicLTILaunchSchema:
     @pytest.mark.parametrize(
         "url_param, expected_parsed_url",
         [
@@ -119,7 +119,7 @@ class TestURLConfiguredLaunchParamsSchema:
 
     @pytest.fixture
     def schema(self, pyramid_request):
-        return LaunchParamsURLConfiguredSchema(pyramid_request)
+        return URLConfiguredBasicLTILaunchSchema(pyramid_request)
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -47,7 +47,7 @@ def url_configured_basic_lti_launch_caller(context, pyramid_request):
     """
     # The `url` parsed param is always present when
     # url_configured_basic_lti_launch() is called. The url_configured=True view
-    # predicate and LaunchParamsURLConfiguredSchema ensure this.
+    # predicate and URLConfiguredBasicLTILaunchSchema ensure this.
     pyramid_request.parsed_params = {"url": "TEST_URL"}
 
     views = BasicLTILaunchViews(context, pyramid_request)


### PR DESCRIPTION
`LTILaunchResource` has a `_get_param()` helper that returns a param
from `request.params` or raises `HTTPBadRequest` if the param doesn't
exist:
https://github.com/hypothesis/lms/blob/4442b8f48afc3df7c11d496a3b1487603b5fea03/lms/resources/lti_launch.py#L247-L254

This legacy validation (it pre-dates the `lms.validation` package and the introduction of marshmallow) happening in the wrong place and at the wrong time is problematic for a bunch of reasons, and is really getting in the way of necessary refactoring needed to introduce the sync API. See the commit message of <https://github.com/hypothesis/lms/pull/1615/commits/4e54d571fbbe99e5c140b89f300ccdd435c6ed00> for details.

Fortunately this validation within `LTILaunchResource` also turns out to be unnecessary because most of the views that use `LTILaunchResource` now have validation schemas attached to them that validate all these fields before `LTILaunchResource`'s methods are ever called. So the legacy validation can simply be deleted.

The only exception was the `content_item_selection()` view which uses `LTILaunchResource` but has no validation schema. A simple schema just had to be added for this view.

This PR:

* Deletes the legacy validation code from `LTILaunchResource`: https://github.com/hypothesis/lms/pull/1615/commits/4e54d571fbbe99e5c140b89f300ccdd435c6ed00
  * Changes `LTILaunchResource` to read `request.parsed_params` (the parsed and validated params) instead of reading the raw `request.params`: https://github.com/hypothesis/lms/pull/1615/commits/dff239bcb776d24eb5cc363d61100736f56d52e3
* Adds `ContentItemSelectionLTILaunchSchema` for the `content_item_selection()` view: https://github.com/hypothesis/lms/pull/1615/commits/d95ca4a38504fc4c91571dc05c4279aef0a50c80
  * Renames `LaunchParamsSchema` to `BasicLTILaunchSchema` (https://github.com/hypothesis/lms/pull/1615/commits/8cf32315800516d8b40bdc9317b3ab7d4f62678d) and `LaunchParamsURLConfiguredSchema` to `URLConfiguredBasicLTILaunchSchema` (https://github.com/hypothesis/lms/pull/1615/commits/39e43fc97f9b30eaf0749ce9644f2c340fa93a91). Making the three different LTI launch schemas have a consistent naming pattern, and making the names describe exactly what the schemas are for. There are multiple different types of LTI launch, and these are three different schemas for different types:
    * LTI launches with `"lti_message_type" = "basic-lti-launch-request"`: use `BasicLTILaunchSchema`
      * URL-configured LTI launches with `"lti_message_type" = "basic-lti-launch-request"`: (a specific sub-set of basic LTI launches): use `URLConfiguredBasicLTILaunchSchema`

    * LTI launches with `"lti_message_type" = "ContentItemSelectionRequest"`: use `ContentItemSelectionLTILaunchSchema`