### PR TITLE
Fix some naming in tests

### DIFF
--- a/tests/unit/lms/validation/authentication/_launch_params_test.py
+++ b/tests/unit/lms/validation/authentication/_launch_params_test.py
@@ -7,7 +7,7 @@ from lms.validation.authentication import LaunchParamsAuthSchema
 from lms.values import LTIUser
 
 
-class TestLaunchParamsSchema:
+class TestLaunchParamsAuthSchema:
     def test_it_returns_the_lti_user_info(self, schema):
         lti_user = schema.lti_user()
 


### PR DESCRIPTION
The schema being tested here is called LaunchParamsAuthSchema / launch_params_auth_schema, not LaunchParamsSchema. Especially since there's actually another schema elsewhere in the code that _is_ called LaunchParamsSchema, it's best if the tests use the schema's full name here.