### PR TITLE
Fix creating assignments in non-Canvas LMS's

### DIFF
--- a/lms/validation/_module_item_configuration.py
+++ b/lms/validation/_module_item_configuration.py
@@ -15,3 +15,7 @@ class ConfigureModuleItemSchema(PyramidRequestSchema):
     document_url = fields.Str(required=True)
     resource_link_id = fields.Str(required=True)
     tool_consumer_instance_guid = fields.Str(required=True)
+    oauth_consumer_key = fields.Str(required=True)
+    user_id = fields.Str(required=True)
+    context_id = fields.Str(required=True)
+    context_title = fields.Str(required=True)

--- a/tests/unit/lms/validation/_module_item_configuration_test.py
+++ b/tests/unit/lms/validation/_module_item_configuration_test.py
@@ -29,6 +29,10 @@ class TestConfigureModuleItemSchema:
         pyramid_request = testing.DummyRequest()
         pyramid_request.params["document_url"] = "test_document_url"
         pyramid_request.params["resource_link_id"] = "test_resource_link_id"
+        pyramid_request.params["oauth_consumer_key"] = "test_oauth_consumer_key"
+        pyramid_request.params["user_id"] = "test_user_id"
+        pyramid_request.params["context_id"] = "test_context_id"
+        pyramid_request.params["context_title"] = "test_context_title"
         pyramid_request.params[
             "tool_consumer_instance_guid"
         ] = "test_tool_consumer_instance_guid"


### PR DESCRIPTION
A recent commit changed a bunch of code in `LTILaunchResource` to read
from `request.parsed_params` not `request.params`. This means the params
being read must be added to the validation schema that the view uses.

We forgot to update the `configure_module_item()` view and its
`ConfigureModuleItemSchema`.

Fixes https://github.com/hypothesis/lms/issues/1626