### PR TITLE
Add missing speedGrader config test to BasicLtiLaunchApp-test.js

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -123,7 +123,7 @@ Dialog.propTypes = {
    * The "Cancel" button is added automatically if the `onCancel` prop is set.
    */
   buttons: propTypes.arrayOf(
-    propTypes.oneOf([propTypes.instanceOf(Button), propTypes.element])
+    propTypes.oneOfType([propTypes.instanceOf(Button), propTypes.element])
   ), // e.g. <button>
 
   /**


### PR DESCRIPTION
- Refactor BasicLtiLaunchApp-test to have a separate speed grader describe block.
- Fix <Dialog> propType warning

fixes https://github.com/hypothesis/lms/issues/1628