### PR TITLE
Add some convenience variables

### DIFF
--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -24,6 +24,7 @@ class LTIHService:
     def __init__(self, _context, request):
         self._context = request.context
         self._request = request
+        self._lti_user = request.lti_user
 
         self.h_api = request.find_service(name="h_api")
         self.group_info_service = request.find_service(name="group_info")
@@ -75,7 +76,7 @@ class LTIHService:
 
             self.group_info_service.upsert(
                 authority_provided_id=self._context.h_authority_provided_id,
-                consumer_key=self._request.lti_user.oauth_consumer_key,
+                consumer_key=self._lti_user.oauth_consumer_key,
                 params=self._request.params,
             )
 

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -222,11 +222,8 @@ class TestMaybeEnableGrading:
             ],
         }
 
-    def test_it_does_nothing_if_the_user_isnt_an_instructor(
-        self, js_config, pyramid_request
-    ):
-        pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Learner")
-
+    @pytest.mark.usefixtures("learner_request")
+    def test_it_does_nothing_if_the_user_isnt_an_instructor(self, js_config):
         js_config.maybe_enable_grading()
 
         assert not js_config.asdict().get("grading")
@@ -485,6 +482,12 @@ def pyramid_request(pyramid_request):
     pyramid_request.params[
         "lis_outcome_service_url"
     ] = "example_lis_outcome_service_url"
+    return pyramid_request
+
+
+@pytest.fixture
+def learner_request(pyramid_request):
+    pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Learner")
     return pyramid_request
 
 


### PR DESCRIPTION
Just make some code more concise by adding a few convenience variables
to `self`.

One test had to be fixed up because it was replacing `request.lti_user`
with a new object _after_ the request had already been passed to
`JSConfig`, but `JSConfig` now reads `request.lti_user` in its
`__init__()` so it still had the old `lti_user`. The fix makes the test
more correct anyway.