### PR TITLE
Separate ai_getter service from service factory

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -31,7 +31,7 @@ __all__ = (
 
 def includeme(config):
     config.register_service_factory(
-        "lms.services.application_instance_getter.ApplicationInstanceGetter",
+        "lms.services.application_instance_getter.application_instance_getter_service_factory",
         name="ai_getter",
     )
     config.register_service_factory(

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -10,9 +10,9 @@ __all__ = ["ApplicationInstanceGetter"]
 class ApplicationInstanceGetter:
     """Methods for getting properties from application instances."""
 
-    def __init__(self, _context, request):
-        self._db = request.db
-        self._aes_secret = request.registry.settings["aes_secret"]
+    def __init__(self, db, aes_secret):
+        self._db = db
+        self._aes_secret = aes_secret
 
     def developer_key(self, consumer_key):
         """
@@ -116,3 +116,9 @@ class ApplicationInstanceGetter:
             )
         except NoResultFound as err:
             raise ConsumerKeyError() from err
+
+
+def application_instance_getter_service_factory(_context, request):
+    return ApplicationInstanceGetter(
+        request.db, request.registry.settings["aes_secret"]
+    )

--- a/tests/unit/lms/services/__init___test.py
+++ b/tests/unit/lms/services/__init___test.py
@@ -1,7 +1,9 @@
 import pytest
 
 from lms.services import includeme
-from lms.services.application_instance_getter import ApplicationInstanceGetter
+from lms.services.application_instance_getter import (
+    application_instance_getter_service_factory,
+)
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.grading_info import GradingInfoService
 from lms.services.group_info import GroupInfoService
@@ -16,7 +18,7 @@ class TestIncludeme:
     @pytest.mark.parametrize(
         "name,service_class",
         (
-            ("ai_getter", ApplicationInstanceGetter),
+            ("ai_getter", application_instance_getter_service_factory),
             ("canvas_api_client", CanvasAPIClient),
             ("h_api", HAPI),
             ("launch_verifier", LaunchVerifier),

--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -5,7 +5,9 @@ import pytest
 from lms.models import ApplicationInstance
 from lms.models.application_instance import _build_aes_iv, _encrypt_oauth_secret
 from lms.services import ConsumerKeyError
-from lms.services.application_instance_getter import ApplicationInstanceGetter
+from lms.services.application_instance_getter import (
+    application_instance_getter_service_factory,
+)
 
 
 class TestApplicationInstanceGetter:
@@ -73,7 +75,9 @@ class TestApplicationInstanceGetter:
 
     @pytest.fixture
     def ai_getter(self, pyramid_request):
-        return ApplicationInstanceGetter(mock.sentinel.context, pyramid_request)
+        return application_instance_getter_service_factory(
+            mock.sentinel.context, pyramid_request
+        )
 
     @pytest.fixture(autouse=True)
     def test_application_instance(self, pyramid_request):


### PR DESCRIPTION
Separate `application_instance_getter_service_factory()` from the `ApplicationInstanceGetter` class itself.

This is because I'm expecting to have to register two different `ApplicationInstanceGetter` factories in two different contexts, in a future PR.

We have two different ways of doing pyramid_services in h and lms: in h the service class itself is "pure" and the factory is a separate function. In lms the service class's `__init__()` is used as the factory, so the service class itself has a dependency on `context` and `request`. I think h's way is better here and we should start migrating lms's services to it: it allows service classes to be decoupled from Pyramid, and it allows different service factories for the same service class to be registered in different contexts. Or you can have different classes that provide the same service, and a single service factory can contain if/else logic that instantiates different classes under different circumstances. Finally, it make constructing a service class directly easier, if you ever have reason to do that.