### PR TITLE
Decouple LTIHService from LTILaunchResource.provisioning_enabled

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -44,7 +44,7 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
     )
 
     @classmethod
-    def get(cls, db, consumer_key):
+    def get_by_consumer_key(cls, db, consumer_key):
         """Return the ApplicationInstance with the given consumer_key or None."""
         return db.query(cls).filter_by(consumer_key=consumer_key).one_or_none()
 

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -44,6 +44,11 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
     )
 
     @classmethod
+    def get(cls, db, consumer_key):
+        """Return the ApplicationInstance with the given consumer_key or None."""
+        return db.query(cls).filter_by(consumer_key=consumer_key).one_or_none()
+
+    @classmethod
     def build_from_lms_url(  # pylint:disable=too-many-arguments
         cls, lms_url, email, developer_key, developer_secret, encryption_key=None
     ):

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -81,7 +81,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
             # When we're being launched in an iframe within the LMS our JavaScript
             # needs to pass this URL (which is the URL of the top-most page) to Google
             # Picker, otherwise Picker refuses to launch inside an iframe.
-            return self._context.custom_canvas_api_domain or self._context.lms_url
+            return self._context.custom_canvas_api_domain or self._ai_getter.lms_url()
 
         self._config["filePicker"] = {
             "formAction": form_action,

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -214,7 +214,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
             return False
 
         try:
-            developer_key = self._ai_getter.developer_key(self._consumer_key)
+            developer_key = self._ai_getter.developer_key()
         except ConsumerKeyError:
             return False
 

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -360,7 +360,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         # mutable. You can do self._hypothesis_client["foo"] = "bar" and the
         # mutation will be preserved.
 
-        if not self._context.provisioning_enabled:
+        if not self._ai_getter.provisioning_enabled():
             return {}
 
         api_url = self._request.registry.settings["h_api_url_public"]

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -197,11 +197,6 @@ class LTILaunchResource:
         return JSConfig(self, self._request)
 
     @property
-    def provisioning_enabled(self):
-        """Return True if provisioning is enabled for this request."""
-        return self._ai_getter.provisioning_enabled()
-
-    @property
     def lms_url(self):
         """Return the ApplicationInstance.lms_url."""
         return self._ai_getter.lms_url()

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -199,15 +199,12 @@ class LTILaunchResource:
     @property
     def provisioning_enabled(self):
         """Return True if provisioning is enabled for this request."""
-        return self._ai_getter.provisioning_enabled(
-            self._request.parsed_params["oauth_consumer_key"]
-        )
+        return self._ai_getter.provisioning_enabled()
 
     @property
     def lms_url(self):
         """Return the ApplicationInstance.lms_url."""
-        oauth_consumer_key = self._request.parsed_params.get("oauth_consumer_key")
-        return self._ai_getter.lms_url(oauth_consumer_key)
+        return self._ai_getter.lms_url()
 
     @property
     def custom_canvas_api_domain(self):

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -26,7 +26,6 @@ class LTILaunchResource:
         """Return the context resource for an LTI launch request."""
         self._request = request
         self._authority = self._request.registry.settings["h_authority"]
-        self._ai_getter = self._request.find_service(name="ai_getter")
 
     @property
     def h_user(self):
@@ -195,11 +194,6 @@ class LTILaunchResource:
     @functools.lru_cache()
     def js_config(self):
         return JSConfig(self, self._request)
-
-    @property
-    def lms_url(self):
-        """Return the ApplicationInstance.lms_url."""
-        return self._ai_getter.lms_url()
 
     @property
     def custom_canvas_api_domain(self):

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -13,21 +13,6 @@ from lms.services.exceptions import (
     ServiceError,
 )
 
-__all__ = (
-    "ServiceError",
-    "LTILaunchVerificationError",
-    "NoConsumerKey",
-    "ConsumerKeyError",
-    "LTIOAuthError",
-    "ExternalRequestError",
-    "HAPIError",
-    "HAPINotFoundError",
-    "CanvasAPIError",
-    "CanvasAPIAccessTokenError",
-    "CanvasAPIServerError",
-    "LTIOutcomesAPIError",
-)
-
 
 def includeme(config):
     config.register_service_factory(

--- a/lms/services/_helpers/canvas_api.py
+++ b/lms/services/_helpers/canvas_api.py
@@ -32,22 +32,18 @@ class CanvasAPIHelper:
         >>> response = requests.Session().send(prepared_request)
     """
 
-    def __init__(self, consumer_key, ai_getter, route_url):
+    def __init__(self, ai_getter, route_url):
         """
         Initialize a CanvasAPIHelper for the given ``consumer_key``.
-
-        :arg consumer_key: the consumer key of the application instance whose
-            Canvas instance's API we're going to be using
-        :type consumer_key: str
 
         :arg ai_getter: the "ai_getter" service
 
         :arg route_url: the :meth:`pyramid.request.Request.route_url()` method
         :type route_url: callable
         """
-        self._client_id = ai_getter.developer_key(consumer_key)
-        self._client_secret = ai_getter.developer_secret(consumer_key)
-        self._canvas_url = urlparse(ai_getter.lms_url(consumer_key)).netloc
+        self._client_id = ai_getter.developer_key()
+        self._client_secret = ai_getter.developer_secret()
+        self._canvas_url = urlparse(ai_getter.lms_url()).netloc
         self._redirect_uri = route_url("canvas_oauth_callback")
 
     def access_token_request(self, authorization_code):

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -25,7 +25,7 @@ class ApplicationInstanceGetter:
         :return: the matching Canvas API developer key or ``None``
         :rtype: str or ``None``
         """
-        return self._get().developer_key
+        return self._get_by_consumer_key().developer_key
 
     def developer_secret(self):
         """
@@ -36,7 +36,7 @@ class ApplicationInstanceGetter:
         :return: the matching Canvas API developer secret or ``None``
         :rtype: str or ``None``
         """
-        application_instance = self._get()
+        application_instance = self._get_by_consumer_key()
 
         if application_instance.developer_secret is None:
             return None
@@ -55,7 +55,7 @@ class ApplicationInstanceGetter:
         :return: the matching LMS URL
         :rtype: str
         """
-        return self._get().lms_url
+        return self._get_by_consumer_key().lms_url
 
     def provisioning_enabled(self):
         """
@@ -65,7 +65,7 @@ class ApplicationInstanceGetter:
         request, ``False`` otherwise.
         """
         try:
-            provisioning = self._get().provisioning
+            provisioning = self._get_by_consumer_key().provisioning
         except ConsumerKeyError:
             provisioning = False
         return provisioning
@@ -81,10 +81,10 @@ class ApplicationInstanceGetter:
         :return: the request's shared secret
         :rtype: str
         """
-        return self._get().shared_secret
+        return self._get_by_consumer_key().shared_secret
 
     @lru_cache(maxsize=1)
-    def _get(self):
+    def _get_by_consumer_key(self):
         """
         Return the ApplicationInstance with the given consumer_key or ``None``.
 
@@ -93,7 +93,7 @@ class ApplicationInstanceGetter:
         :return: the matching ApplicationInstance or ``None``
         :rtype: :cls:`lms.models.ApplicationInstance` or ``None``
         """
-        application_instance = models.ApplicationInstance.get(
+        application_instance = models.ApplicationInstance.get_by_consumer_key(
             self._db, self._consumer_key
         )
 

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -107,5 +107,5 @@ def application_instance_getter_service_factory(_context, request):
     return ApplicationInstanceGetter(
         request.db,
         request.registry.settings["aes_secret"],
-        request.params.get("oauth_consumer_key"),
+        request.lti_user.oauth_consumer_key,
     )

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -1,9 +1,8 @@
 from functools import lru_cache
 
 from Crypto.Cipher import AES
-from sqlalchemy.orm.exc import NoResultFound
 
-from lms.models import ApplicationInstance
+from lms import models
 from lms.services import ConsumerKeyError
 
 __all__ = ["ApplicationInstanceGetter"]
@@ -94,14 +93,14 @@ class ApplicationInstanceGetter:
         :return: the matching ApplicationInstance or ``None``
         :rtype: :cls:`lms.models.ApplicationInstance` or ``None``
         """
-        try:
-            return (
-                self._db.query(ApplicationInstance)
-                .filter(ApplicationInstance.consumer_key == self._consumer_key)
-                .one()
-            )
-        except NoResultFound as err:
-            raise ConsumerKeyError() from err
+        application_instance = models.ApplicationInstance.get(
+            self._db, self._consumer_key
+        )
+
+        if application_instance is None:
+            raise ConsumerKeyError()
+
+        return application_instance
 
 
 def application_instance_getter_service_factory(_context, request):

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -10,37 +10,32 @@ __all__ = ["ApplicationInstanceGetter"]
 class ApplicationInstanceGetter:
     """Methods for getting properties from application instances."""
 
-    def __init__(self, db, aes_secret):
+    def __init__(self, db, aes_secret, consumer_key):
         self._db = db
         self._aes_secret = aes_secret
+        self._consumer_key = consumer_key
 
-    def developer_key(self, consumer_key):
+    def developer_key(self):
         """
-        Return the Canvas developer key for the given consumer_key, or None.
+        Return the Canvas developer key for the current request, or None.
 
-        :arg consumer_key: the consumer key to search for
-        :type consumer_key: str
-
-        :raise ConsumerKeyError: if the consumer key isn't in the database
+        :raise ConsumerKeyError: if the request's consumer key isn't in the DB
 
         :return: the matching Canvas API developer key or ``None``
         :rtype: str or ``None``
         """
-        return self._get(consumer_key).developer_key
+        return self._get().developer_key
 
-    def developer_secret(self, consumer_key):
+    def developer_secret(self):
         """
-        Return the Canvas developer secret for the given consumer_key, or None.
+        Return the Canvas developer secret for the current request or None.
 
-        :arg consumer_key: the consumer key to search for
-        :type consumer_key: str
-
-        :raise ConsumerKeyError: if the consumer key isn't in the database
+        :raise ConsumerKeyError: if the request's consumer key isn't in the DB
 
         :return: the matching Canvas API developer secret or ``None``
         :rtype: str or ``None``
         """
-        application_instance = self._get(consumer_key)
+        application_instance = self._get()
 
         if application_instance.developer_secret is None:
             return None
@@ -50,58 +45,46 @@ class ApplicationInstanceGetter:
         )
         return cipher.decrypt(application_instance.developer_secret)
 
-    def lms_url(self, consumer_key):
+    def lms_url(self):
         """
-        Return the LMS URL for the given LTI consumer_key.
+        Return the LMS URL for the current request.
 
-        :arg consumer_key: the consumer key to search for
-        :type consumer_key: str
-
-        :raise ConsumerKeyError: if the consumer key isn't in the database
+        :raise ConsumerKeyError: if the request's consumer key isn't in the DB
 
         :return: the matching LMS URL
         :rtype: str
         """
-        return self._get(consumer_key).lms_url
+        return self._get().lms_url
 
-    def provisioning_enabled(self, consumer_key):
+    def provisioning_enabled(self):
         """
-        Return ``True`` if provisioning is enabled for the given consumer key.
+        Return ``True`` if provisioning is enabled for the current request.
 
-        Return ``True`` if the provisioning feature is enabled for the given
-        consumer key, ``False`` otherwise.
-
-        :arg consumer_key: the consumer key to search for
-        :type consumer_key: str
+        Return ``True`` if the provisioning feature is enabled for the current
+        request, ``False`` otherwise.
         """
         try:
-            provisioning = self._get(consumer_key).provisioning
+            provisioning = self._get().provisioning
         except ConsumerKeyError:
             provisioning = False
         return provisioning
 
-    def shared_secret(self, consumer_key):
+    def shared_secret(self):
         """
-        Return the LTI/OAuth 1 shared secret for the given LTI consumer_key.
+        Return the LTI/OAuth 1 shared secret for the current request.
 
         This is called the ``oauth_consumer_secret`` in the OAuth 1.0 spec.
 
-        :arg consumer_key: the consumer key to search for
-        :type consumer_key: str
+        :raise ConsumerKeyError: if the request's consumer key isn't in the DB
 
-        :raise ConsumerKeyError: if the consumer key isn't in the database
-
-        :return: the matching shared secret
+        :return: the request's shared secret
         :rtype: str
         """
-        return self._get(consumer_key).shared_secret
+        return self._get().shared_secret
 
-    def _get(self, consumer_key):
+    def _get(self):
         """
         Return the ApplicationInstance with the given consumer_key or ``None``.
-
-        :arg consumer_key: the consumer key to search for
-        :type consumer_key: str
 
         :raise ConsumerKeyError: if the consumer key isn't in the database
 
@@ -111,7 +94,7 @@ class ApplicationInstanceGetter:
         try:
             return (
                 self._db.query(ApplicationInstance)
-                .filter(ApplicationInstance.consumer_key == consumer_key)
+                .filter(ApplicationInstance.consumer_key == self._consumer_key)
                 .one()
             )
         except NoResultFound as err:
@@ -120,5 +103,7 @@ class ApplicationInstanceGetter:
 
 def application_instance_getter_service_factory(_context, request):
     return ApplicationInstanceGetter(
-        request.db, request.registry.settings["aes_secret"]
+        request.db,
+        request.registry.settings["aes_secret"],
+        request.params.get("oauth_consumer_key"),
     )

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from Crypto.Cipher import AES
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -82,6 +84,7 @@ class ApplicationInstanceGetter:
         """
         return self._get().shared_secret
 
+    @lru_cache(maxsize=1)
     def _get(self):
         """
         Return the ApplicationInstance with the given consumer_key or ``None``.

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -23,9 +23,7 @@ __all__ = ["CanvasAPIClient"]
 class CanvasAPIClient:
     def __init__(self, _context, request):
         self._helper = CanvasAPIHelper(
-            request.lti_user.oauth_consumer_key,
-            request.find_service(name="ai_getter"),
-            request.route_url,
+            request.find_service(name="ai_getter"), request.route_url,
         )
         self._consumer_key = request.lti_user.oauth_consumer_key
         self._user_id = request.lti_user.user_id

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,19 +1,3 @@
-__all__ = [
-    "ServiceError",
-    "LTILaunchVerificationError",
-    "NoConsumerKey",
-    "ConsumerKeyError",
-    "LTIOAuthError",
-    "ExternalRequestError",
-    "HAPIError",
-    "HAPINotFoundError",
-    "CanvasAPIError",
-    "CanvasAPIAccessTokenError",
-    "CanvasAPIServerError",
-    "LTIOutcomesAPIError",
-]
-
-
 class ServiceError(Exception):
     """Base class for all :mod:`lms.services` exceptions."""
 

--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -55,7 +55,7 @@ class LaunchVerifier:  # pylint:disable=too-few-public-methods
         except KeyError:
             raise NoConsumerKey()
 
-        application_instance = models.ApplicationInstance.get(
+        application_instance = models.ApplicationInstance.get_by_consumer_key(
             self._request.db, consumer_key
         )
 

--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -55,9 +55,7 @@ class LaunchVerifier:  # pylint:disable=too-few-public-methods
             raise NoConsumerKey()
 
         try:
-            shared_secret = self._request.find_service(name="ai_getter").shared_secret(
-                consumer_key
-            )
+            shared_secret = self._request.find_service(name="ai_getter").shared_secret()
         except ConsumerKeyError:  # pylint: disable=try-except-raise
             raise
 

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -26,6 +26,7 @@ class LTIHService:
         self._request = request
         self._lti_user = request.lti_user
 
+        self._ai_getter = request.find_service(name="ai_getter")
         self._h_api = request.find_service(name="h_api")
         self._group_info_service = request.find_service(name="group_info")
 
@@ -53,7 +54,7 @@ class LTIHService:
         :raises HTTPInternalServerError: If we cannot sync to H for any reason
         """
 
-        if not self._context.provisioning_enabled:  # pylint: disable=protected-access
+        if not self._ai_getter.provisioning_enabled():
             return None
 
         try:

--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -19,7 +19,7 @@ class OAuth1Service:  # pylint:disable=too-few-public-methods
         """
 
         consumer_key = self.request.lti_user.oauth_consumer_key
-        shared_secret = self.ai_getter_service.shared_secret(consumer_key)
+        shared_secret = self.ai_getter_service.shared_secret()
 
         return OAuth1(
             client_key=consumer_key,

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -26,16 +26,15 @@ class CanvasAPIAuthorizeViews:
 
     @view_config(permission="canvas_api", route_name="canvas_api.authorize")
     def authorize(self):
-        consumer_key = self.request.lti_user.oauth_consumer_key
         authorize_url = urlunparse(
             (
                 "https",
-                urlparse(self.ai_getter.lms_url(consumer_key)).netloc,
+                urlparse(self.ai_getter.lms_url()).netloc,
                 "login/oauth2/auth",
                 "",
                 urlencode(
                     {
-                        "client_id": self.ai_getter.developer_key(consumer_key),
+                        "client_id": self.ai_getter.developer_key(),
                         "response_type": "code",
                         "redirect_uri": self.request.route_url("canvas_oauth_callback"),
                         "state": CanvasOAuthCallbackSchema(self.request).state_param(),

--- a/tests/unit/lms/models/test_application_instance.py
+++ b/tests/unit/lms/models/test_application_instance.py
@@ -67,7 +67,9 @@ class TestApplicationInstance:
         db_session.add(application_instance)
 
         assert (
-            ApplicationInstance.get(db_session, application_instance.consumer_key)
+            ApplicationInstance.get_by_consumer_key(
+                db_session, application_instance.consumer_key
+            )
             == application_instance
         )
 
@@ -75,7 +77,10 @@ class TestApplicationInstance:
     def test_get_returns_None_if_theres_no_matching_ApplicationInstance(
         self, db_session
     ):
-        assert ApplicationInstance.get(db_session, "unknown_consumer_key") is None
+        assert (
+            ApplicationInstance.get_by_consumer_key(db_session, "unknown_consumer_key")
+            is None
+        )
 
     @pytest.fixture
     def application_instance(self):

--- a/tests/unit/lms/models/test_application_instance.py
+++ b/tests/unit/lms/models/test_application_instance.py
@@ -61,6 +61,22 @@ class TestApplicationInstance:
         with pytest.raises(IntegrityError, match="requesters_email"):
             db_session.flush()
 
+    def test_get_returns_the_matching_ApplicationInstance(
+        self, db_session, application_instance
+    ):
+        db_session.add(application_instance)
+
+        assert (
+            ApplicationInstance.get(db_session, application_instance.consumer_key)
+            == application_instance
+        )
+
+    @pytest.mark.usefixtures("application_instance")
+    def test_get_returns_None_if_theres_no_matching_ApplicationInstance(
+        self, db_session
+    ):
+        assert ApplicationInstance.get(db_session, "unknown_consumer_key") is None
+
     @pytest.fixture
     def application_instance(self):
         """Return an ApplicationInstance with minimal required attributes."""

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -398,9 +398,7 @@ class TestJSConfigHypothesisClient:
 
         assert config["a_key"] == "a_value"
 
-    @pytest.mark.parametrize(
-        "context_property", ["provisioning_enabled", "h_user", "h_groupid"]
-    )
+    @pytest.mark.parametrize("context_property", ["h_user", "h_groupid"])
     def test_it_raises_if_a_context_property_raises(
         self, context, context_property, pyramid_request
     ):
@@ -487,9 +485,8 @@ def pyramid_request(pyramid_request):
 
 
 @pytest.fixture
-def provisioning_disabled(context):
-    """Modify context so that context.provisioning_enabled is False."""
-    context.provisioning_enabled = False
+def provisioning_disabled(ai_getter):
+    ai_getter.provisioning_enabled.return_value = False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -41,7 +41,7 @@ class TestEnableContentItemSelectionMode:
         }
 
     def test_google_picker_origin_falls_back_to_lms_url_if_theres_no_custom_canvas_api_domain(
-        self, context, js_config
+        self, ai_getter, context, js_config
     ):
         context.custom_canvas_api_domain = None
 
@@ -49,7 +49,11 @@ class TestEnableContentItemSelectionMode:
             mock.sentinel.form_action, mock.sentinel.form_fields
         )
 
-        assert js_config.asdict()["filePicker"]["google"]["origin"] == context.lms_url
+        ai_getter.lms_url.assert_called_once_with()
+        assert (
+            js_config.asdict()["filePicker"]["google"]["origin"]
+            == ai_getter.lms_url.return_value
+        )
 
     def test_it_doesnt_enable_the_canvas_file_picker_if_the_lms_isnt_Canvas(
         self, context, js_config,

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -302,27 +302,6 @@ class TestJSConfig:
         assert js_config == JSConfig.return_value
 
 
-class TestLMSURL:
-    def test_it_returns_the_ApplicationInstances_lms_url(
-        self, ai_getter, pyramid_request
-    ):
-        lti_launch = LTILaunchResource(pyramid_request)
-
-        lms_url = lti_launch.lms_url
-        ai_getter.lms_url.assert_called_once_with()
-        assert lms_url == ai_getter.lms_url.return_value
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = {
-            "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
-        }
-        return pyramid_request
-
-
-pytestmark = pytest.mark.usefixtures("ai_getter")
-
-
 @pytest.fixture
 def lti_launch(pyramid_request):
     return LTILaunchResource(pyramid_request)

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -276,9 +276,7 @@ class TestProvisioningEnabled:
     ):
         lti_launch.provisioning_enabled  # pylint:disable=pointless-statement
 
-        ai_getter.provisioning_enabled.assert_called_once_with(
-            "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
-        )
+        ai_getter.provisioning_enabled.assert_called_once_with()
 
     @pytest.mark.parametrize("expected", [True, False])
     def test_it_returns_based_on_ai_getter_provisiioning(
@@ -335,9 +333,7 @@ class TestLMSURL:
         lti_launch = LTILaunchResource(pyramid_request)
 
         lms_url = lti_launch.lms_url
-        ai_getter.lms_url.assert_called_once_with(
-            "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef"
-        )
+        ai_getter.lms_url.assert_called_once_with()
         assert lms_url == ai_getter.lms_url.return_value
 
     @pytest.fixture

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -270,30 +270,6 @@ class TestHUser:
         return pyramid_request
 
 
-class TestProvisioningEnabled:
-    def test_it_checks_whether_provisioning_is_enabled_for_the_request(
-        self, ai_getter, lti_launch
-    ):
-        lti_launch.provisioning_enabled  # pylint:disable=pointless-statement
-
-        ai_getter.provisioning_enabled.assert_called_once_with()
-
-    @pytest.mark.parametrize("expected", [True, False])
-    def test_it_returns_based_on_ai_getter_provisiioning(
-        self, expected, ai_getter, lti_launch
-    ):
-        ai_getter.provisioning_enabled.return_value = expected
-
-        assert lti_launch.provisioning_enabled is expected
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = {
-            "oauth_consumer_key": "Hypothesise3f14c1f7e8c89f73cefacdd1d80d0ef",
-        }
-        return pyramid_request
-
-
 class TestCustomCanvasAPIDomain:
     def test_it_returns_the_custom_canvas_api_domain(self, pyramid_request):
         lti_launch = LTILaunchResource(pyramid_request)

--- a/tests/unit/lms/services/_helpers/canvas_api_test.py
+++ b/tests/unit/lms/services/_helpers/canvas_api_test.py
@@ -14,9 +14,9 @@ class TestCanvasAPIHelper:
     def test_access_token_request(self, ai_getter, helper):
         request = helper.access_token_request("test_authorization_code")
 
-        ai_getter.developer_key.assert_called_once_with("test_consumer_key")
-        ai_getter.developer_secret.assert_called_once_with("test_consumer_key")
-        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
+        ai_getter.developer_key.assert_called_once_with()
+        ai_getter.developer_secret.assert_called_once_with()
+        ai_getter.lms_url.assert_called_once_with()
         assert request.method == "POST"
         assert request.url == (
             "https://my-canvas-instance.com/login/oauth2/token"
@@ -31,9 +31,9 @@ class TestCanvasAPIHelper:
     def test_refresh_token_request(self, ai_getter, helper):
         request = helper.refresh_token_request("test_refresh_token")
 
-        ai_getter.developer_key.assert_called_once_with("test_consumer_key")
-        ai_getter.developer_secret.assert_called_once_with("test_consumer_key")
-        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
+        ai_getter.developer_key.assert_called_once_with()
+        ai_getter.developer_secret.assert_called_once_with()
+        ai_getter.lms_url.assert_called_once_with()
         assert request.method == "POST"
         assert request.url == (
             "https://my-canvas-instance.com/login/oauth2/token"
@@ -79,7 +79,7 @@ class TestCanvasAPIHelper:
     def test_list_files_request(self, ai_getter, helper):
         request = helper.list_files_request("test_access_token", "test_course_id")
 
-        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
+        ai_getter.lms_url.assert_called_once_with()
         assert request.method == "GET"
         assert request.headers["Authorization"] == "Bearer test_access_token"
         assert request.url == (
@@ -91,7 +91,7 @@ class TestCanvasAPIHelper:
     def test_public_url_request(self, ai_getter, helper):
         request = helper.public_url_request("test_access_token", "test_file_id")
 
-        ai_getter.lms_url.assert_called_once_with("test_consumer_key")
+        ai_getter.lms_url.assert_called_once_with()
         assert request.method == "GET"
         assert request.headers["Authorization"] == "Bearer test_access_token"
         assert request.url == (
@@ -206,7 +206,7 @@ def ai_getter(ai_getter):
 
 @pytest.fixture
 def helper(ai_getter, route_url):
-    return CanvasAPIHelper("test_consumer_key", ai_getter, route_url)
+    return CanvasAPIHelper(ai_getter, route_url)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -85,7 +85,7 @@ class TestApplicationInstanceGetter:
     @pytest.fixture(autouse=True)
     def test_application_instance(self, pyramid_request):
         application_instance = ApplicationInstance(
-            consumer_key="TEST_CONSUMER_KEY",
+            consumer_key=pyramid_request.lti_user.oauth_consumer_key,
             developer_key="TEST_DEVELOPER_KEY",
             lms_url="TEST_LMS_URL",
             shared_secret="TEST_SHARED_SECRET",
@@ -126,12 +126,8 @@ class TestApplicationInstanceGetter:
         return application_instances
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.params.clear()
-        pyramid_request.params["oauth_consumer_key"] = "TEST_CONSUMER_KEY"
-        return pyramid_request
-
-    @pytest.fixture
     def unknown_consumer_key(self, pyramid_request):
-        pyramid_request.params["oauth_consumer_key"] = "UNKNOWN_CONSUMER_KEY"
+        pyramid_request.lti_user = pyramid_request.lti_user._replace(
+            oauth_consumer_key="UNKNOWN_CONSUMER_KEY"
+        )
         return pyramid_request

--- a/tests/unit/lms/services/canvas_api_test.py
+++ b/tests/unit/lms/services/canvas_api_test.py
@@ -24,9 +24,7 @@ class TestGetToken:
 
         # It initializes canvas_api_helper correctly.
         CanvasAPIHelper.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key,
-            ai_getter,
-            pyramid_request.route_url,
+            ai_getter, pyramid_request.route_url,
         )
 
         # It gets the access token request from canvas_api_helper.
@@ -110,9 +108,7 @@ class TestGetRefreshedToken:
 
         # It initializes canvas_api_helper correctly.
         CanvasAPIHelper.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key,
-            ai_getter,
-            pyramid_request.route_url,
+            ai_getter, pyramid_request.route_url,
         )
 
         # It gets the refresh token request from canvas_api_helper.
@@ -219,9 +215,7 @@ class TestAuthenticatedUsersSections:
 
         # It initializes canvas_api_helper.
         CanvasAPIHelper.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key,
-            ai_getter,
-            pyramid_request.route_url,
+            ai_getter, pyramid_request.route_url,
         )
 
         # It gets the prepared request.
@@ -280,9 +274,7 @@ class TestCourseSections:
 
         # It initializes canvas_api_helper.
         CanvasAPIHelper.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key,
-            ai_getter,
-            pyramid_request.route_url,
+            ai_getter, pyramid_request.route_url,
         )
 
         # It gets the prepared request.
@@ -341,9 +333,7 @@ class TestUsersSections:
 
         # It initializes canvas_api_helper.
         CanvasAPIHelper.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key,
-            ai_getter,
-            pyramid_request.route_url,
+            ai_getter, pyramid_request.route_url,
         )
 
         # It gets the prepared request.
@@ -400,9 +390,7 @@ class TestListFiles:
 
         # It initializes canvas_api_helper correctly.
         CanvasAPIHelper.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key,
-            ai_getter,
-            pyramid_request.route_url,
+            ai_getter, pyramid_request.route_url,
         )
 
         # It gets the PreparedRequest from the helper.
@@ -463,9 +451,7 @@ class TestPublicURL:
 
         # It initializes canvas_api_helper correctly.
         CanvasAPIHelper.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key,
-            ai_getter,
-            pyramid_request.route_url,
+            ai_getter, pyramid_request.route_url,
         )
 
         # It gets the PreparedRequest from the helper.

--- a/tests/unit/lms/services/launch_verifier_test.py
+++ b/tests/unit/lms/services/launch_verifier_test.py
@@ -28,7 +28,7 @@ class TestVerifyLaunchRequest:
     def test_it_gets_the_shared_secret_from_the_db(self, ai_getter, launch_verifier):
         launch_verifier.verify()
 
-        ai_getter.shared_secret.assert_called_once_with("TEST_OAUTH_CONSUMER_KEY")
+        ai_getter.shared_secret.assert_called_once_with()
 
     def test_it_raises_if_the_consumer_key_isnt_in_the_db(
         self, launch_verifier, ai_getter

--- a/tests/unit/lms/services/launch_verifier_test.py
+++ b/tests/unit/lms/services/launch_verifier_test.py
@@ -7,6 +7,7 @@ import oauthlib.oauth1
 import pytest
 from pylti.common import LTIException
 
+from lms.models import ApplicationInstance
 from lms.services import ConsumerKeyError, LTIOAuthError, NoConsumerKey
 from lms.services.launch_verifier import LaunchVerifier
 
@@ -213,7 +214,7 @@ def sign(pyramid_request):
 @pytest.fixture(autouse=True)
 def models(patch):
     models = patch("lms.services.launch_verifier.models")
-    models.ApplicationInstance.get_by_consumer_key.return_value = mock.Mock(
-        shared_secret="TEST_SECRET"
+    models.ApplicationInstance.get_by_consumer_key.return_value = mock.create_autospec(
+        ApplicationInstance, instance=True, spec_set=True, shared_secret="TEST_SECRET"
     )
     return models

--- a/tests/unit/lms/services/launch_verifier_test.py
+++ b/tests/unit/lms/services/launch_verifier_test.py
@@ -30,14 +30,14 @@ class TestVerifyLaunchRequest:
     ):
         launch_verifier.verify()
 
-        models.ApplicationInstance.get.assert_called_once_with(
+        models.ApplicationInstance.get_by_consumer_key.assert_called_once_with(
             pyramid_request.db, "TEST_OAUTH_CONSUMER_KEY"
         )
 
     def test_it_raises_if_the_consumer_key_isnt_in_the_db(
         self, launch_verifier, models
     ):
-        models.ApplicationInstance.get.return_value = None
+        models.ApplicationInstance.get_by_consumer_key.return_value = None
 
         with pytest.raises(ConsumerKeyError):
             launch_verifier.verify()
@@ -213,5 +213,7 @@ def sign(pyramid_request):
 @pytest.fixture(autouse=True)
 def models(patch):
     models = patch("lms.services.launch_verifier.models")
-    models.ApplicationInstance.get.return_value = mock.Mock(shared_secret="TEST_SECRET")
+    models.ApplicationInstance.get_by_consumer_key.return_value = mock.Mock(
+        shared_secret="TEST_SECRET"
+    )
     return models

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -18,9 +18,9 @@ class TestSync:
         lti_h_svc.sync.assert_called_once_with(groups=[group])
 
     def test_sync_does_nothing_if_provisioning_is_disabled(
-        self, context, lti_h_svc, h_api, group
+        self, ai_getter, lti_h_svc, h_api, group
     ):
-        context.provisioning_enabled = False
+        ai_getter.provisioning_enabled.return_value = False
 
         lti_h_svc.sync(groups=[group])
 
@@ -103,9 +103,9 @@ class TestUserUpserting:
             lti_h_svc.single_group_sync()
 
     def test_it_doesnt_use_the_h_api_if_feature_not_enabled(
-        self, context, h_api, lti_h_svc
+        self, ai_getter, h_api, lti_h_svc
     ):
-        context.provisioning_enabled = False
+        ai_getter.provisioning_enabled.return_value = False
 
         lti_h_svc.single_group_sync()
 
@@ -155,7 +155,7 @@ class TestAddingUserToGroups:
         return pyramid_request
 
 
-pytestmark = pytest.mark.usefixtures("h_api", "group_info_service")
+pytestmark = pytest.mark.usefixtures("ai_getter", "h_api", "group_info_service")
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -14,9 +14,7 @@ class TestAuthorize:
         response = CanvasAPIAuthorizeViews(pyramid_request).authorize()
 
         assert response.status_code == 302
-        ai_getter.lms_url.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key
-        )
+        ai_getter.lms_url.assert_called_once_with()
         assert response.location.startswith(
             f"{ai_getter.lms_url.return_value}/login/oauth2/auth"
         )
@@ -28,9 +26,7 @@ class TestAuthorize:
 
         query_params = parse_qs(urlparse(response.location).query)
 
-        ai_getter.developer_key.assert_called_once_with(
-            pyramid_request.lti_user.oauth_consumer_key
-        )
+        ai_getter.developer_key.assert_called_once_with()
         assert query_params["client_id"] == [str(ai_getter.developer_key.return_value)]
 
     def test_it_includes_the_response_type_in_a_query_param(self, pyramid_request):


### PR DESCRIPTION
Simplify `ApplicationInstanceGetter` and decouple `LTIHService` from `LTILaunchResource.provisioning_enabled`. This is part of decoupling `LTIHService` from `LTILaunchResource` entirely, so that `LTIHService` can be used in other request contexts (specifically: so that it can be used in new sync API requests).

* Change `ApplicationInstanceGetter` to receive `request.params["oauth_consumer_key"]` from pyramid_services rather than requiring it to be passed in to each method. This changes `ApplicationInstanceGetter.foo(consumer_key)` to just `ApplicationInstanceGetter.foo()` simplifying code that uses it

* Remove `LTILaunchResource.provisioning_enabled` and `LTILaunchResource.lms_url`. These were just wrappers for `ApplicationInstanceGetter` that injected `request.params["oauth_consumer_key"]`. Since `ApplicationInstanceGetter`'s factory now injects the consumer key, these no longer add anything. Change using code to use `ApplicationInstanceGetter` directly instead. This reduces code such as `LTIHService`'s dependency on `LTILaunchResource` which moves it closer to being usable in other request contexts.

We could go one step further and expose the request's `ApplicationInstance` model itself directly, perhaps as `request.application_instance`. But this is far enough for what I need to achieve right now, which is just to decouple `LTIHService` from `LTILaunchResource`