### PR TITLE
Get LMS unit tests to 100% percent code and branch coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.30
+fail_under = 99.31
 skip_covered = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.33
+fail_under = 100.00
 skip_covered = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.31
+fail_under = 99.33
 skip_covered = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.28
+fail_under = 99.30
 skip_covered = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.25
+fail_under = 99.26
 skip_covered = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ omit =
 [report]
 show_missing = True
 precision = 2
-fail_under = 99.26
+fail_under = 99.28
 skip_covered = True

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/hypothesis/lms.svg?branch=master)](https://travis-ci.org/hypothesis/lms)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![Coverage: 100%](https://img.shields.io/badge/Coverage-100%25-brightgreen)](https://github.com/hypothesis/lms/blob/master/.coveragerc#L18)
 
 # Hypothesis LMS App
 

--- a/lms/assets.py
+++ b/lms/assets.py
@@ -53,7 +53,7 @@ class _CachedFile:  # pylint:disable=too-few-public-methods
             return self._cached
 
         current_mtime = os.path.getmtime(self.path)
-        if not self._mtime or self._mtime < current_mtime:
+        if not self._mtime or self._mtime < current_mtime:  # pragma: no cover
             self._cached = self.loader(open(self.path))
             self._mtime = current_mtime
         return self._cached
@@ -76,7 +76,7 @@ class Environment:
 
     def __init__(
         self, assets_base_url, bundle_config_path, manifest_path, auto_reload=False
-    ):
+    ):  # pragma: no cover
         """
         Construct an Environment from the given configuration files.
 
@@ -94,12 +94,12 @@ class Environment:
             bundle_config_path, _load_bundles, auto_reload=auto_reload
         )
 
-    def files(self, bundle):
+    def files(self, bundle):  # pragma: no cover
         """Return the file paths for all files in a bundle."""
         bundles = self.bundles.load()
         return bundles[bundle]
 
-    def urls(self, bundle):
+    def urls(self, bundle):  # pragma: no cover
         """
         Return asset URLs for all files in a bundle.
 
@@ -110,14 +110,14 @@ class Environment:
 
         return [self.url(path) for path in bundles[bundle]]
 
-    def url(self, path):
+    def url(self, path):  # pragma: no cover
         """Return the cache-busted URL for an asset with a given path."""
         manifest = self.manifest.load()
         return "{}/{}".format(self.assets_base_url, manifest[path])
 
 
 def _add_cors_header(wrapped):
-    def wrapper(context, request):
+    def wrapper(context, request):  # pragma: no cover
         # Add a CORS header to the response because static assets from
         # the sidebar are loaded into pages served by a different origin:
         # The domain hosting the page into which the sidebar has been injected
@@ -133,7 +133,7 @@ def _add_cors_header(wrapped):
     return wrapper
 
 
-def _load_bundles(file_):
+def _load_bundles(file_):  # pragma: no cover
     """Read an asset bundle config from a file object."""
     parser = configparser.ConfigParser()
     parser.read_file(file_)
@@ -146,7 +146,7 @@ ASSETS_VIEW = _add_cors_header(
 )
 
 
-def includeme(config):
+def includeme(config):  # pragma: no cover
     config.add_view(route_name="assets", view=ASSETS_VIEW)
 
     assets_env = Environment(

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -103,7 +103,7 @@ def make_engine(settings):
     return sqlalchemy.create_engine(settings["sqlalchemy.url"])
 
 
-def _session(request):
+def _session(request):  # pragma: no cover
     engine = request.registry["sqlalchemy.engine"]
     session = SESSION(bind=engine)
 

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -46,14 +46,13 @@ class BaseClass:
         if skip_keys is None:
             skip_keys = {"id"}
 
-        columns = {col.key for col in self.iter_columns()}
-        if skip_keys:
-            if not isinstance(skip_keys, set):
-                raise TypeError(
-                    f"Expected a set of keys to skip but found '{type(skip_keys)}'"
-                )
+        if not isinstance(skip_keys, set):
+            raise TypeError(
+                f"Expected a set of keys to skip but found '{type(skip_keys)}'"
+            )
 
-            columns -= skip_keys
+        columns = {col.key for col in self.iter_columns()}
+        columns -= skip_keys
 
         for key in columns:
             if key in data:

--- a/lms/services/grading_info.py
+++ b/lms/services/grading_info.py
@@ -70,7 +70,6 @@ class GradingInfoService:
             return
 
         grading_info = self._find_or_create(
-            GradingInfo,
             oauth_consumer_key=lti_user.oauth_consumer_key,
             user_id=lti_user.user_id,
             context_id=parsed_params["context_id"],
@@ -82,11 +81,11 @@ class GradingInfoService:
 
         grading_info.update_from_dict(parsed_params)
 
-    def _find_or_create(self, model_class, **query):
-        result = self._db.query(model_class).filter_by(**query).one_or_none()
+    def _find_or_create(self, **query):
+        result = self._db.query(GradingInfo).filter_by(**query).one_or_none()
 
         if result is None:
-            result = model_class(**query)
+            result = GradingInfo(**query)
             self._db.add(result)
 
         return result

--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -1,3 +1,3 @@
-def includeme(config):
+def includeme(config):  # pragma: no cover
     config.scan(__name__)
     config.include("lms.views.predicates")

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -114,8 +114,8 @@ class CanvasPreRecordHook:
 
         if parsed_params.get("document_url"):
             params["url"] = parsed_params.get("document_url")
-
-        elif parsed_params.get("canvas_file_id"):
+        else:
+            assert parsed_params.get("canvas_file_id")
             params["canvas_file"] = "true"
             params["file_id"] = parsed_params["canvas_file_id"]
 

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -115,7 +115,10 @@ class CanvasPreRecordHook:
         if parsed_params.get("document_url"):
             params["url"] = parsed_params.get("document_url")
         else:
-            assert parsed_params.get("canvas_file_id")
+            assert parsed_params.get("canvas_file_id"), (
+                "All Canvas launches should have either a 'document_url' or "
+                "a 'canvas_file_id' parameter."
+            )
             params["canvas_file"] = "true"
             params["file_id"] = parsed_params["canvas_file_id"]
 

--- a/tests/unit/lms/config/__init___test.py
+++ b/tests/unit/lms/config/__init___test.py
@@ -94,6 +94,18 @@ class TestConfigure:
 
         assert configurator.registry.settings["aes_secret"] == b"test_lms_secret_"
 
+    def test_aes_secret_is_None_when_theres_no_LMS_SECRET(self, setting_getter):
+        def side_effect(envvar_name, *_args, **_kwargs):
+            if envvar_name == "LMS_SECRET":
+                return None
+            return mock.DEFAULT
+
+        setting_getter.get.side_effect = side_effect
+
+        configurator = configure({})
+
+        assert configurator.registry.settings["aes_secret"] is None
+
     def test_LMS_SECRET_cant_contain_non_ascii_chars(self, setting_getter):
         def side_effect(
             envvar_name, *args, **kwargs

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -100,16 +100,11 @@ class TestUpsertFromRequest:
     def test_it_updates_existing_record_if_matching_exists(
         self, svc, pyramid_request, h_user, lti_user, db_session,
     ):
-        grading_info = GradingInfo(
-            lis_result_sourcedid="lis_result_sourcedid",
-            lis_outcome_service_url="lis_outcomes_service_url",
+        grading_info = make_grading_info(
             oauth_consumer_key=lti_user.oauth_consumer_key,
             user_id=lti_user.user_id,
             context_id=pyramid_request.params["context_id"],
             resource_link_id=pyramid_request.params["resource_link_id"],
-            tool_consumer_info_product_family_code="tool_consumer_info_product_family_code",
-            h_username="h_username",
-            h_display_name="h_display_name",
         )
         db_session.add(grading_info)
         h_user = h_user._replace(
@@ -164,6 +159,23 @@ class TestUpsertFromRequest:
         pyramid_request.POST.update(lti_params)
 
         return pyramid_request
+
+
+def make_grading_info(**kwargs):
+    """Return a GradingInfo with defaults for fields not given in kwargs."""
+    fields = dict(
+        lis_result_sourcedid="lis_result_sourcedid",
+        lis_outcome_service_url="lis_outcomes_service_url",
+        oauth_consumer_key="oauth_consumer_key",
+        user_id="user_id",
+        context_id="context_id",
+        resource_link_id="resource_link_id",
+        tool_consumer_info_product_family_code="tool_consumer_info_product_family_code",
+        h_username="h_username",
+        h_display_name="h_display_name",
+    )
+    fields.update(**kwargs)
+    return GradingInfo(**fields)
 
 
 @pytest.fixture

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -53,11 +53,7 @@ class TestBasicLTILaunchSchema:
 
     @pytest.mark.parametrize(
         "required_param",
-        [
-            "oauth_consumer_key",
-            "tool_consumer_instance_guid",
-            "user_id",
-        ],
+        ["oauth_consumer_key", "tool_consumer_instance_guid", "user_id"],
     )
     def test_it_raises_ValidationError_if_a_non_reportable_field_is_missing(
         self, pyramid_request, required_param


### PR DESCRIPTION
I keep accidentally reducing coverage by deleting lines, causing the coverage test to fail, which wastes developer time. Also if I really have added lines with no coverage, I have to look for my lines in amongst the not-covered-on-master lines in the coverage report.

Fix both issues by getting coverage to 100%.

In some cases to increase coverage I fixed broken tests or added missing tests, or fixed bad code. See individual commit messages for details.

In the final commit I covered a handful of things that aren't worth testing or would be a big pain to test with `# pragma: no cover` comments. The 100% coverage is a practical benefit in itself, for the reasons above.