### PR TITLE
Add LTIUser test factory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import functools
 import os
 from unittest import mock
 
+import factory.random
 import pytest
 import sqlalchemy
 from sqlalchemy.orm import sessionmaker
@@ -71,3 +72,11 @@ def autopatcher(request, target, **kwargs):
 @pytest.fixture
 def patch(request):
     return functools.partial(autopatcher, request)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def factory_boy_random_seed():
+    # Set factory_boy's random seed so that it produces the same random values
+    # in each run of the tests.
+    # See: https://factoryboy.readthedocs.io/en/latest/index.html#reproducible-random-values
+    factory.random.reseed_random("hypothesis/lms")

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,1 @@
+from tests.factories.lti_user import LTIUser

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,0 +1,10 @@
+from factory import Faker, make_factory
+
+from lms import models
+
+LTIUser = make_factory(  # pylint:disable=invalid-name
+    models.LTIUser,
+    user_id=Faker("hexify", text="^" * 40),
+    oauth_consumer_key=Faker("hexify", text="Hypothesis" + "^" * 32),
+    roles=Faker("random_element", elements=["Learner", "Instructor"]),
+)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,7 @@ import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 
-from lms.models import HUser, LTIUser
+from lms.models import HUser
 from lms.services.application_instance_getter import ApplicationInstanceGetter
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.grading_info import GradingInfoService
@@ -17,6 +17,7 @@ from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.services.oauth1 import OAuth1Service
+from tests import factories
 from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
 
 TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(
@@ -54,15 +55,18 @@ def pyramid_request(db_session):
     pyramid_request.feature = mock.create_autospec(
         lambda feature: False, return_value=False  # pragma: no cover
     )
-    pyramid_request.lti_user = LTIUser(
-        "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES"
-    )
+    pyramid_request.lti_user = factories.LTIUser()
 
     # The DummyRequest request lacks a content_type property which the real
     # request has
     pyramid_request.content_type = None
 
     return pyramid_request
+
+
+@pytest.fixture
+def user_is_learner(pyramid_request):
+    pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Learner")
 
 
 def configure_jinja2_assets(config):

--- a/tests/unit/lms/authentication/_helpers_test.py
+++ b/tests/unit/lms/authentication/_helpers_test.py
@@ -1,8 +1,8 @@
 import pytest
 
 from lms.authentication._helpers import authenticated_userid, get_lti_user, groupfinder
-from lms.models import LTIUser
 from lms.validation import ValidationError
+from tests import factories
 
 
 class TestAuthenticatedUserID:
@@ -10,16 +10,16 @@ class TestAuthenticatedUserID:
         "lti_user,expected_userid",
         [
             (
-                LTIUser(
-                    "sam", "Hypothesisf301584250a2dece14f021ab8424018a", "TEST_ROLES"
+                factories.LTIUser(
+                    user_id="sam",
+                    oauth_consumer_key="Hypothesisf301584250a2dece14f021ab8424018a",
                 ),
                 "c2Ft:Hypothesisf301584250a2dece14f021ab8424018a",
             ),
             (
-                LTIUser(
-                    "Sam:Smith",
-                    "Hypothesisf301584250a2dece14f021ab8424018a",
-                    "TEST_ROLES",
+                factories.LTIUser(
+                    user_id="Sam:Smith",
+                    oauth_consumer_key="Hypothesisf301584250a2dece14f021ab8424018a",
                 ),
                 "U2FtOlNtaXRo:Hypothesisf301584250a2dece14f021ab8424018a",
             ),

--- a/tests/unit/lms/models/lti_user_test.py
+++ b/tests/unit/lms/models/lti_user_test.py
@@ -1,8 +1,6 @@
-from unittest import mock
-
 import pytest
 
-from lms.models import LTIUser
+from tests import factories
 
 
 class TestLTIUser:
@@ -16,11 +14,9 @@ class TestLTIUser:
         ],
     )
     def test_is_instructor(self, roles, is_instructor):
-        lti_user = LTIUser(
-            mock.sentinel.userid, mock.sentinel.oauth_consumer_key, roles
-        )
+        lti_user = factories.LTIUser(roles=roles)
 
-        assert lti_user.is_instructor == is_instructor
+        assert lti_user.is_instructor == is_instructor  # pylint:disable=no-member
 
     @pytest.mark.parametrize(
         "roles,is_learner",
@@ -32,8 +28,6 @@ class TestLTIUser:
         ],
     )
     def test_is_learner(self, roles, is_learner):
-        lti_user = LTIUser(
-            mock.sentinel.userid, mock.sentinel.oauth_consumer_key, roles
-        )
+        lti_user = factories.LTIUser(roles=roles)
 
         assert lti_user.is_learner == is_learner

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -198,12 +198,14 @@ class TestAddCanvasFileIDAddDocumentURLCommon:
 
 
 class TestMaybeEnableGrading:
-    def test_it_adds_the_grading_settings(self, js_config, grading_info_service):
+    def test_it_adds_the_grading_settings(
+        self, js_config, grading_info_service, pyramid_request
+    ):
         js_config.maybe_enable_grading()
 
         grading_info_service.get_by_assignment.assert_called_once_with(
             context_id="test_course_id",
-            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            oauth_consumer_key=pyramid_request.lti_user.oauth_consumer_key,
             resource_link_id="TEST_RESOURCE_LINK_ID",
         )
         assert js_config.asdict()["grading"] == {
@@ -221,7 +223,7 @@ class TestMaybeEnableGrading:
             ],
         }
 
-    @pytest.mark.usefixtures("learner_request")
+    @pytest.mark.usefixtures("user_is_learner")
     def test_it_does_nothing_if_the_user_isnt_an_instructor(self, js_config):
         js_config.maybe_enable_grading()
 
@@ -481,12 +483,6 @@ def pyramid_request(pyramid_request):
     pyramid_request.params[
         "lis_outcome_service_url"
     ] = "example_lis_outcome_service_url"
-    return pyramid_request
-
-
-@pytest.fixture
-def learner_request(pyramid_request):
-    pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Learner")
     return pyramid_request
 
 

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -3,9 +3,10 @@ from unittest import mock
 import pytest
 from h_matchers import Any
 
-from lms.models import GradingInfo, HUser, LTIUser
+from lms.models import GradingInfo, HUser
 from lms.resources import LTILaunchResource
 from lms.services.grading_info import GradingInfoService
+from tests import factories
 
 
 class TestGetByAssignment:
@@ -158,7 +159,7 @@ class TestUpsertFromRequest:
 
 @pytest.fixture
 def lti_user():
-    return LTIUser("test_user_id", "matching_oauth_consumer_key", "test_roles")
+    return factories.LTIUser(oauth_consumer_key="matching_oauth_consumer_key")
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -52,13 +52,13 @@ class TestGroupUpdating:
             lti_h_svc.single_group_sync()
 
     def test_it_upserts_the_GroupInfo_into_the_db(
-        self, params, group_info_service, context, lti_h_svc
+        self, params, group_info_service, context, lti_h_svc, pyramid_request
     ):
         lti_h_svc.single_group_sync()
 
         group_info_service.upsert.assert_called_once_with(
             authority_provided_id=context.h_authority_provided_id,
-            consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            consumer_key=pyramid_request.lti_user.oauth_consumer_key,
             params=params,
         )
 

--- a/tests/unit/lms/validation/authentication/_oauth_test.py
+++ b/tests/unit/lms/validation/authentication/_oauth_test.py
@@ -4,7 +4,6 @@ import pytest
 import requests
 from pyramid import testing
 
-from lms.models import LTIUser
 from lms.validation import ValidationError
 from lms.validation.authentication import (
     ExpiredJWTError,
@@ -18,6 +17,7 @@ from lms.validation.authentication._oauth import (
     CanvasOAuthCallbackSchema,
     CanvasRefreshTokenResponseSchema,
 )
+from tests import factories
 
 
 class TestCanvasOauthCallbackSchema:
@@ -257,4 +257,4 @@ def _jwt(patch, lti_user):
 
 @pytest.fixture
 def lti_user():
-    return LTIUser("test_user_id", "test_oauth_consumer_key", "test_roles")
+    return factories.LTIUser()

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -2,10 +2,10 @@ from unittest import mock
 
 import pytest
 
-from lms.models import LTIUser
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
 from lms.views.basic_lti_launch import BasicLTILaunchViews
+from tests import factories
 
 
 def canvas_file_basic_lti_launch_caller(context, pyramid_request):
@@ -112,6 +112,7 @@ class TestCommon:
             pyramid_request.params["oauth_consumer_key"],
         )
 
+    @pytest.mark.usefixtures("user_is_learner")
     def test_it_calls_grading_info_upsert(
         self, context, pyramid_request, grading_info_service, view_caller
     ):
@@ -124,7 +125,7 @@ class TestCommon:
     def test_it_does_not_call_grading_info_upsert_if_instructor(
         self, context, pyramid_request, grading_info_service, view_caller
     ):
-        pyramid_request.lti_user = LTIUser("USER_ID", "OAUTH_STUFF", roles="instructor")
+        pyramid_request.lti_user = factories.LTIUser(roles="instructor")
 
         view_caller(context, pyramid_request)
 

--- a/tests/unit/lms/views/predicates/_lti_launch_test.py
+++ b/tests/unit/lms/views/predicates/_lti_launch_test.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 from pyramid.testing import DummyRequest
 
-from lms.models import LTIUser
 from lms.views.predicates import (
     AuthorizedToConfigureAssignments,
     CanvasFile,
@@ -11,6 +10,7 @@ from lms.views.predicates import (
     DBConfigured,
     URLConfigured,
 )
+from tests import factories
 
 
 class TestDBConfigured:
@@ -157,11 +157,7 @@ class TestAuthorizedToConfigureAssignments:
     @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
     def test_when_user_is_authorized(self, roles, value, expected):
         request = DummyRequest()
-        request.lti_user = LTIUser(
-            user_id="TEST_USER_ID",
-            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
-            roles=roles,
-        )
+        request.lti_user = factories.LTIUser(roles=roles)
         predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
 
         assert predicate(mock.sentinel.context, request) is expected
@@ -169,11 +165,7 @@ class TestAuthorizedToConfigureAssignments:
     @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
     def test_when_user_isnt_authorized(self, value, expected):
         request = DummyRequest()
-        request.lti_user = LTIUser(
-            user_id="TEST_USER_ID",
-            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
-            roles="Learner",
-        )
+        request.lti_user = factories.LTIUser(roles="Learner")
         predicate = AuthorizedToConfigureAssignments(value, mock.sentinel.config)
 
         assert predicate(mock.sentinel.context, request) is expected

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
     {tests,clean}: coverage
     {tests,bddtests,functests,lint}: httpretty
     {tests,bddtests,functests,lint}: pytest
-    {tests,functests,lint}: factory-boy
+    {tests,functests,lint,bddtests}: factory-boy
     {tests,bddtests,functests,lint}: h-matchers>=1.2.4
     {bddtests,functests,lint}: webtest
     {bddtests,lint}: behave


### PR DESCRIPTION
In a future PR I need to add a new required argument to `LTIUser()`, which will mean updating everywhere that `LTIUser()` is called. `LTIUser()` is only called in a few places in the code, but it's called in many places in the tests, and those would all need to be updated.

Instead, add an `LTIUser` test factory so that `LTIUser()`'s arguments can be changed in future without having to change a lot of test code. Instead of calling `values.LTIUser(...)` and having to pass every required param every time, tests now call `factories.LTIUser()` with no arguments and the factory generates values for all of `values.LTIUser()`'s parameters. Or, if the test needs to pass a specific value for one of `LTIUser`'s params, it does `factories.LTIUser(some_param="some_value")`, passing only the arguments it cares about, and the factory generates the rest.

This means that required arguments can be added to `LTIUser()` and only the test factory needs to be updated. Individual tests won't need to change.

The factory also brings some other improvements to the test code:

* Fixes "too much information" problems in tests. A lot of tests are doing `LTIUser("TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES")` when the test doesn't actually care about any of those arguments. This is noise, and makes the tests less clear. When the tests actually do care about the value of one of the arguments, it obscures it.

  Tests can now do `factories.LTIUser()` or, if one of the arguments is actually relevant to the test, then include just that argument: `factories.LTIUser(oauth_consumer_key="...")`.

* Fixes "too little information" problems in tests. Often tests are using a distant `LTIUser` fixture (such as `pyramid_request.lti_user` in the global `pyramid_request` fixture) and are either explicitly reliant on that `LTIUser`s fields (e.g. they'll contain things like `some_service.some_method.assert_called_once_with("TEST_OAUTH_CONSUMER_KEY")` or, worse, the tests is implicitly reliant on the `LTIUser` having a particular attribute value like `"TEST_OAUTH_CONSUMER_KEY"` but that value isn't mentioned anywhere in the test at all. In both cases, the tests are depending on an `LTIUser` having been created with certain arguments, but creating the `LTIUser` with those arguments doesn't happen in the test. This again makes the tests less clear.

  Because `factories.LTIUser()` randomly generates new arguments to pass to `LTIUser` every time it's called, it's no longer possible to write tests that invisibly rely on fixed arguments having been passed to `LTIUser`. Tests either have to call `factories.LTIUser(...)` and pass specific values for arguments that the test depends on, or else the test needs to access things like `pyramid_request.lti_user.oauth_consumer_key` instead of just hard-coding `"TEST_OAUTH_CONSUMER_KEY"`.

* Establishes a pattern. Test factories are a best practice for the reasons above and others (e.g. they tend to result in more realistic values being used in tests, which can find bugs that wouldn't be found otherwise). Adding a `tests.factories` package establishes this best practice as a pattern that more tests can follow in future. Since the test factories are always used as `factories.Foo()` you can always see when a test factory is used, and since test factories all behave in broadly the same way you already know what's going on and probably don't need to look up the factory code.

* The test factory is implemented correctly once and reusable throughout all of the tests, which saves test fixture duplication and avoids buggy or less-than-ideal test fixture behaviour when different tests all implement their own ways of creating test objects.

  Correctly means things like generating realistic-looking values, generating randomised values so that tests can't invisibly depend on hard-coded values, using predictable randomness so flakey tests aren't produced, generating unique values when uniqueness is required (doesn't apply to `LTIUser`), providing a consistent way for individual tests to override just the values they care about, etc.