### PR TITLE
Add GradingInfo factory

### DIFF
--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,3 +1,4 @@
+from tests.factories.grading_info import GradingInfo
 from tests.factories.h_group import HGroup
 from tests.factories.h_user import HUser
 from tests.factories.lti_user import LTIUser

--- a/tests/factories/_attributes.py
+++ b/tests/factories/_attributes.py
@@ -1,0 +1,11 @@
+"""Shared attributes used by test factories."""
+
+from factory import Faker
+
+OAUTH_CONSUMER_KEY = Faker("hexify", text="Hypothesis" + "^" * 32)
+
+USER_ID = Faker("hexify", text="^" * 40)
+
+H_USERNAME = Faker("hexify", text="^" * 30)
+
+H_DISPLAY_NAME = Faker("name")

--- a/tests/factories/grading_info.py
+++ b/tests/factories/grading_info.py
@@ -1,0 +1,29 @@
+from factory import Faker, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories._attributes import (
+    H_DISPLAY_NAME,
+    H_USERNAME,
+    OAUTH_CONSUMER_KEY,
+    USER_ID,
+)
+
+GradingInfo = make_factory(  # pylint:disable=invalid-name
+    models.GradingInfo,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    lis_result_sourcedid=Faker("numerify", text="test_lis_result_sourcedid_#"),
+    lis_outcome_service_url=Faker(
+        "numerify", text="https://example.com/test-lis-outcome-service-url-#"
+    ),
+    oauth_consumer_key=OAUTH_CONSUMER_KEY,
+    user_id=USER_ID,
+    context_id=Faker("hexify", text="^" * 32),
+    resource_link_id=Faker("hexify", text="^" * 32),
+    tool_consumer_info_product_family_code=Faker(
+        "random_element",
+        elements=["BlackBoardLearn", "moodle", "canvas", "sakai", "desire2learn",],
+    ),
+    h_username=H_USERNAME,
+    h_display_name=H_DISPLAY_NAME,
+)

--- a/tests/factories/h_user.py
+++ b/tests/factories/h_user.py
@@ -1,11 +1,12 @@
 import factory
 
 from lms import models
+from tests.factories._attributes import H_DISPLAY_NAME, H_USERNAME
 
 HUser = factory.make_factory(  # pylint:disable=invalid-name
     models.HUser,
-    username=factory.Faker("hexify", text="^" * 30),
-    display_name=factory.Faker("name"),
+    username=H_USERNAME,
+    display_name=H_DISPLAY_NAME,
     provider=factory.Faker("hexify", text="^" * 40),
     provider_unique_id=factory.Faker("hexify", text="^" * 40),
 )

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,11 +1,12 @@
 from factory import Faker, make_factory
 
 from lms import models
+from tests.factories._attributes import OAUTH_CONSUMER_KEY, USER_ID
 
 LTIUser = make_factory(  # pylint:disable=invalid-name
     models.LTIUser,
-    user_id=Faker("hexify", text="^" * 40),
-    oauth_consumer_key=Faker("hexify", text="Hypothesis" + "^" * 32),
+    user_id=USER_ID,
+    oauth_consumer_key=OAUTH_CONSUMER_KEY,
     roles=Faker("random_element", elements=["Learner", "Instructor"]),
     tool_consumer_instance_guid=Faker("hexify", text="^" * 40),
     display_name=Faker("name"),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,7 @@ from unittest import mock
 import httpretty
 import pytest
 import sqlalchemy
+from factory.alchemy import SQLAlchemyModelFactory
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 
@@ -135,12 +136,53 @@ def db_session(db_engine):
         ):  # pylint:disable=protected-access
             session.begin_nested()
 
+    set_factory_boy_sqlalchemy_session(session)
+
     try:
         yield session
     finally:
+        clear_factory_boy_sqlalchemy_session()
         session.close()
         trans.rollback()
         conn.close()
+
+
+def sqlalchemy_factory_classes():
+    # Return all the SQLAlchemy factory classes from tests.factories.
+    for factory_class in factories.__dict__.values():
+        try:
+            is_sqla_factory = issubclass(factory_class, SQLAlchemyModelFactory)
+        except TypeError:
+            is_sqla_factory = False
+
+        if is_sqla_factory:
+            yield factory_class
+
+
+def set_factory_boy_sqlalchemy_session(session):
+    # Set the Meta.sqlalchemy_session option on all our SQLAlchemy test factory
+    # classes. We can't do it in the normal Factory Boy way:
+    #
+    #     class MyFactory:
+    #         class Meta:
+    #             sqlalchemy_session = session
+    #
+    # Because we don't have `session` available to us at import time.
+    # So we have to do it this way instead.
+    #
+    # See:
+    # https://factoryboy.readthedocs.io/en/latest/orms.html#sqlalchemy
+    # https://factoryboy.readthedocs.io/en/latest/reference.html#factory.Factory._meta
+    for factory_class in sqlalchemy_factory_classes():
+        # pylint:disable=protected-access
+        factory_class._meta.sqlalchemy_session = session
+
+
+def clear_factory_boy_sqlalchemy_session():
+    # Delete the sqlalchemy session from all our test factories.
+    # Just in case, so we don't have references to the session hanging about.
+    for factory_class in sqlalchemy_factory_classes():
+        factory_class._meta.sqlalchemy_session = None  # pylint:disable=protected-access
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -1,3 +1,4 @@
+from operator import attrgetter
 from unittest import mock
 
 import pytest
@@ -17,7 +18,9 @@ class TestGetByAssignment:
             "matching_resource_link_id",
         )
 
-        assert list(grading_infos) == matching_grading_infos
+        assert sorted(grading_infos, key=attrgetter("id")) == sorted(
+            matching_grading_infos, key=attrgetter("id")
+        )
 
     @pytest.mark.parametrize(
         "oauth_consumer_key,context_id,resource_link_id",
@@ -50,31 +53,19 @@ class TestGetByAssignment:
         assert list(grading_infos) == []
 
     @pytest.fixture(autouse=True)
-    def matching_grading_infos(self, db_session):
+    def matching_grading_infos(self):
         """Add some GradingInfo's that should match the DB query in the test above."""
-        matching_grading_infos = [self.grading_info("matching", i) for i in range(3)]
-        db_session.add_all(matching_grading_infos)
-        return matching_grading_infos
+        return factories.GradingInfo.create_batch(
+            size=3,
+            oauth_consumer_key="matching_oauth_consumer_key",
+            context_id="matching_context_id",
+            resource_link_id="matching_resource_link_id",
+        )
 
     @pytest.fixture(autouse=True)
-    def noise_grading_infos(self, db_session):
+    def noise_grading_infos(self):
         """Add some GradingInfo's that should *not* match the test query."""
-        noise_grading_infos = [self.grading_info("noise", i) for i in range(3)]
-        db_session.add_all(noise_grading_infos)
-        return noise_grading_infos
-
-    def grading_info(self, prefix, index):
-        return GradingInfo(
-            lis_result_sourcedid=f"{prefix}_lis_result_sourcedid_{index}",
-            lis_outcome_service_url=f"{prefix}_lis_outcomes_service_url_{index}",
-            oauth_consumer_key=f"{prefix}_oauth_consumer_key",
-            user_id=f"{prefix}_user_id_{index}",
-            context_id=f"{prefix}_context_id",
-            resource_link_id=f"{prefix}_resource_link_id",
-            tool_consumer_info_product_family_code=f"{prefix}_tool_consumer_info_product_family_code_{index}",
-            h_username=f"{prefix}_h_username_{index}",
-            h_display_name=f"{prefix}_h_display_name_{index}",
-        )
+        return factories.GradingInfo.create_batch(3)
 
 
 class TestUpsertFromRequest:
@@ -98,15 +89,14 @@ class TestUpsertFromRequest:
         assert result.user_id == lti_user.user_id
 
     def test_it_updates_existing_record_if_matching_exists(
-        self, svc, pyramid_request, h_user, lti_user, db_session,
+        self, svc, pyramid_request, h_user, lti_user
     ):
-        grading_info = make_grading_info(
+        grading_info = factories.GradingInfo(
             oauth_consumer_key=lti_user.oauth_consumer_key,
             user_id=lti_user.user_id,
             context_id=pyramid_request.params["context_id"],
             resource_link_id=pyramid_request.params["resource_link_id"],
         )
-        db_session.add(grading_info)
         h_user = h_user._replace(
             username="updated_user_name", display_name="updated_display_name"
         )
@@ -159,23 +149,6 @@ class TestUpsertFromRequest:
         pyramid_request.POST.update(lti_params)
 
         return pyramid_request
-
-
-def make_grading_info(**kwargs):
-    """Return a GradingInfo with defaults for fields not given in kwargs."""
-    fields = dict(
-        lis_result_sourcedid="lis_result_sourcedid",
-        lis_outcome_service_url="lis_outcomes_service_url",
-        oauth_consumer_key="oauth_consumer_key",
-        user_id="user_id",
-        context_id="context_id",
-        resource_link_id="resource_link_id",
-        tool_consumer_info_product_family_code="tool_consumer_info_product_family_code",
-        h_username="h_username",
-        h_display_name="h_display_name",
-    )
-    fields.update(**kwargs)
-    return GradingInfo(**fields)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add a test factory for `models.GradingInfo`. Since this is the first test factory for a DB model to be added to LMS, it requires integrating Factory Boy with the DB session.

When you do `factories.GradingInfo()` (or `factories.GradingInfo.create_batch(n)`) it automatically adds them to the DB session for you.

I haven't tested but I don't think this would work in an `@parametrize` because, even though the factory classes are just imported directly not accessed via a `factories` fixture like in h, the DB session won't have been set up at the time the `@parametrize` gets evaluated so it'll crash.

_But_ you can do `factories.GradingInfo.build()` or `build_batch(n)` which just creates `GradingInfo`'s without adding them to the DB. This means that your test can use the factory without using the DB if it doesn't actually need the DB (which would be a speed advantage if we weren't always initializing the DB for every test anyway) and it will also probably work in an `@parametrize` (though I haven't tried it).

Also, you could use `factories.GradingInfo.build()` in an `@parametrize` and then, if you also needed the object to be in the DB, add it manually with `db_session.add()` in your test.