### PR TITLE
Add factories.HUser

### DIFF
--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,1 +1,2 @@
+from tests.factories.h_user import HUser
 from tests.factories.lti_user import LTIUser

--- a/tests/factories/h_user.py
+++ b/tests/factories/h_user.py
@@ -1,0 +1,10 @@
+import factory
+
+from lms import models
+
+HUser = factory.make_factory(  # pylint:disable=invalid-name
+    models.HUser,
+    authority="lms.hypothes.is",
+    username=factory.Faker("hexify", text="^" * 30),
+    display_name=factory.Faker("name"),
+)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,6 @@ import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 
-from lms.models import HUser
 from lms.services.application_instance_getter import ApplicationInstanceGetter
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.grading_info import GradingInfoService
@@ -199,11 +198,7 @@ def group_info_service(pyramid_config):
 @pytest.fixture
 def h_api(pyramid_config):
     h_api = mock.create_autospec(HAPI, spec_set=True, instance=True)
-    h_api.get_user.return_value = HUser(
-        authority="lms.hypothes.is",
-        username="example_h_username",
-        display_name="example_h_display_name",
-    )
+    h_api.get_user.return_value = factories.HUser()
     pyramid_config.register_service(h_api, name="h_api")
     return h_api
 

--- a/tests/unit/lms/models/h_user_test.py
+++ b/tests/unit/lms/models/h_user_test.py
@@ -1,8 +1,8 @@
-from lms.models import HUser
+from tests import factories
 
 
 class TestHUser:
     def test_userid(self):
-        h_user = HUser("test_authority", "test_username")
+        h_user = factories.HUser(username="test_username", authority="test_authority")
 
         assert h_user.userid == "acct:test_username@test_authority"

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from h_matchers import Any
 
-from lms.models import GradingInfo, HUser
+from lms.models import GradingInfo
 from lms.resources import LTILaunchResource
 from lms.services.grading_info import GradingInfoService
 from tests import factories
@@ -185,9 +185,7 @@ def lti_user():
 
 @pytest.fixture
 def h_user():
-    return HUser(
-        authority="test_authority", username="seanh", display_name="Sample Student"
-    )
+    return factories.HUser()
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -14,6 +14,7 @@ from requests import (
 from lms.models import HUser
 from lms.services import HAPIError, HAPINotFoundError
 from lms.services.h_api import HAPI
+from tests import factories
 
 
 class TestHAPI:
@@ -62,7 +63,7 @@ class TestHAPI:
 
         _api_request.assert_called_once_with(
             "PATCH",
-            "users/sentinel.username",
+            f"users/{h_user.username}",
             data={"display_name": h_user.display_name},
         )
 
@@ -153,8 +154,7 @@ class TestHAPI:
         h_api.add_user_to_group(h_user, sentinel.group_id)
 
         _api_request.assert_called_once_with(
-            "POST",
-            "groups/sentinel.group_id/members/acct:sentinel.username@TEST_AUTHORITY",
+            "POST", f"groups/sentinel.group_id/members/{h_user.userid}",
         )
 
     def test__api_request(self, h_api, requests):
@@ -225,11 +225,7 @@ class TestHAPI:
 
     @pytest.fixture
     def h_user(self):
-        return HUser(
-            username=sentinel.username,
-            display_name=sentinel.display_name,
-            authority="TEST_AUTHORITY",
-        )
+        return factories.HUser()
 
     @pytest.fixture
     def h_api(self, pyramid_request):

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -4,9 +4,10 @@ from unittest.mock import create_autospec
 import pytest
 from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
 
-from lms.models import GroupInfo, HUser
+from lms.models import GroupInfo
 from lms.services import HAPIError
 from lms.services.lti_h import Group, LTIHService
+from tests import factories
 
 
 class TestSync:
@@ -165,11 +166,7 @@ def lti_h_svc(pyramid_request):
 
 @pytest.fixture
 def h_user():
-    return HUser(
-        authority="TEST_AUTHORITY",
-        username="test_username",
-        display_name="test_display_name",
-    )
+    return factories.HUser()
 
 
 @pytest.fixture


### PR DESCRIPTION
Similar to `factories.LTIUser`, this is going to reduce the amount of test refactoring needed when we add new required parameters to `models.HUser` in the future, and it also forces us to improve our tests:

Add `factories.HUser`, a test factory for `models.HUser`, and change all the tests to use it instead of creating `HUser` objects directly.

This forces us to improve the tests by not specifying specific field values for test `HUser` objects when the test doesn't care about the specific values, but still specifying specific values for certain fields when the test _does_ care about them.