### PR TITLE
Add new fields to LTIUser

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -3,7 +3,7 @@ from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
-from lms.models.lti_user import LTIUser
+from lms.models.lti_user import LTIUser, display_name
 from lms.models.module_item_configuration import ModuleItemConfiguration
 from lms.models.oauth2_token import OAuth2Token
 

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -13,6 +13,9 @@ class LTIUser(NamedTuple):
     roles: str
     """The user's LTI roles."""
 
+    tool_consumer_instance_guid: str
+    """Unique ID of the LMS instance that this user belongs to."""
+
     @property
     def is_instructor(self):
         """Whether this user is an instructor."""

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -16,14 +16,8 @@ class LTIUser(NamedTuple):
     tool_consumer_instance_guid: str
     """Unique ID of the LMS instance that this user belongs to."""
 
-    given_name: str
-    """The user's given name from the lis_person_name_given LTI param."""
-
-    family_name: str
-    """The user's family name from the lis_person_name_family LTI param."""
-
-    full_name: str
-    """The user's full name from the lis_person_name_full LTI param."""
+    display_name: str
+    """The user's display name."""
 
     @property
     def is_instructor(self):
@@ -37,3 +31,32 @@ class LTIUser(NamedTuple):
     def is_learner(self):
         """Whether this user is a learner."""
         return "learner" in self.roles.lower()
+
+
+def display_name(given_name, family_name, full_name):
+    """
+    Return an h-compatible display name the given name parts.
+
+    LTI 1.1 launch requests have separate given_name (lis_person_name_given),
+    family_name (lis_person_name_family) and full_name (lis_person_name_full)
+    parameters. This function returns a single display name string based on
+    these three separate names.
+    """
+    name = full_name.strip()
+
+    if not name:
+        given_name = given_name.strip()
+        family_name = family_name.strip()
+
+        name = " ".join((given_name, family_name)).strip()
+
+    if not name:
+        return "Anonymous"
+
+    # The maximum length of an h display name.
+    display_name_max_length = 30
+
+    if len(name) <= display_name_max_length:
+        return name
+
+    return name[: display_name_max_length - 1].rstrip() + "…"

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -16,6 +16,15 @@ class LTIUser(NamedTuple):
     tool_consumer_instance_guid: str
     """Unique ID of the LMS instance that this user belongs to."""
 
+    given_name: str
+    """The user's given name from the lis_person_name_given LTI param."""
+
+    family_name: str
+    """The user's family name from the lis_person_name_family LTI param."""
+
+    full_name: str
+    """The user's full name from the lis_person_name_full LTI param."""
+
     @property
     def is_instructor(self):
         """Whether this user is an instructor."""

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -40,13 +40,13 @@ class LTILaunchResource:
 
         def display_name():
             """Return the h display name for the current request."""
-            params = self._request.parsed_params
+            lti_user = self._request.lti_user
 
-            display_name = params.get("lis_person_name_full", "").strip()
+            display_name = lti_user.full_name.strip()
 
             if not display_name:
-                given_name = params.get("lis_person_name_given", "").strip()
-                family_name = params.get("lis_person_name_family", "").strip()
+                given_name = lti_user.given_name.strip()
+                family_name = lti_user.family_name.strip()
 
                 display_name = " ".join((given_name, family_name)).strip()
 
@@ -169,12 +169,12 @@ class LTILaunchResource:
     @property
     def h_provider(self):
         """Return the h "provider" string for the current request."""
-        return self._request.parsed_params["tool_consumer_instance_guid"]
+        return self._request.lti_user.tool_consumer_instance_guid
 
     @property
     def h_provider_unique_id(self):
         """Return the h provider_unique_id for the current request."""
-        return self._request.parsed_params["user_id"]
+        return self._request.lti_user.user_id
 
     @property
     def is_canvas(self):

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -38,31 +38,10 @@ class LTILaunchResource:
             username_hash_object.update(self.h_provider_unique_id.encode())
             return username_hash_object.hexdigest()[:30]
 
-        def display_name():
-            """Return the h display name for the current request."""
-            lti_user = self._request.lti_user
-
-            display_name = lti_user.full_name.strip()
-
-            if not display_name:
-                given_name = lti_user.given_name.strip()
-                family_name = lti_user.family_name.strip()
-
-                display_name = " ".join((given_name, family_name)).strip()
-
-            if not display_name:
-                return "Anonymous"
-
-            # The maximum length of an h display name.
-            display_name_max_length = 30
-
-            if len(display_name) <= display_name_max_length:
-                return display_name
-
-            return display_name[: display_name_max_length - 1].rstrip() + "…"
-
         return HUser(
-            authority=self._authority, username=username(), display_name=display_name()
+            authority=self._authority,
+            username=username(),
+            display_name=self._request.lti_user.display_name,
         )
 
     @property

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -60,6 +60,7 @@ class BearerTokenSchema(PyramidRequestSchema):
     user_id = marshmallow.fields.Str(required=True)
     oauth_consumer_key = marshmallow.fields.Str(required=True)
     roles = marshmallow.fields.Str(required=True)
+    tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
 
     def __init__(self, request):
         super().__init__(request)

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -61,9 +61,7 @@ class BearerTokenSchema(PyramidRequestSchema):
     oauth_consumer_key = marshmallow.fields.Str(required=True)
     roles = marshmallow.fields.Str(required=True)
     tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
-    given_name = marshmallow.fields.Str(required=True)
-    family_name = marshmallow.fields.Str(required=True)
-    full_name = marshmallow.fields.Str(required=True)
+    display_name = marshmallow.fields.Str(required=True)
 
     def __init__(self, request):
         super().__init__(request)

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -61,6 +61,9 @@ class BearerTokenSchema(PyramidRequestSchema):
     oauth_consumer_key = marshmallow.fields.Str(required=True)
     roles = marshmallow.fields.Str(required=True)
     tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
+    given_name = marshmallow.fields.Str(required=True)
+    family_name = marshmallow.fields.Str(required=True)
+    full_name = marshmallow.fields.Str(required=True)
 
     def __init__(self, request):
         super().__init__(request)

--- a/lms/validation/authentication/_launch_params.py
+++ b/lms/validation/authentication/_launch_params.py
@@ -31,6 +31,9 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
     user_id = marshmallow.fields.Str(required=True)
     roles = marshmallow.fields.Str(required=True)
     tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
+    lis_person_name_given = marshmallow.fields.Str(missing="")
+    lis_person_name_family = marshmallow.fields.Str(missing="")
+    lis_person_name_full = marshmallow.fields.Str(missing="")
 
     oauth_consumer_key = marshmallow.fields.Str(required=True)
     oauth_nonce = marshmallow.fields.Str(required=True)
@@ -58,6 +61,9 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
             kwargs["oauth_consumer_key"],
             kwargs["roles"],
             kwargs["tool_consumer_instance_guid"],
+            kwargs["lis_person_name_given"],
+            kwargs["lis_person_name_family"],
+            kwargs["lis_person_name_full"],
         )
 
     @marshmallow.validates_schema

--- a/lms/validation/authentication/_launch_params.py
+++ b/lms/validation/authentication/_launch_params.py
@@ -30,6 +30,7 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
 
     user_id = marshmallow.fields.Str(required=True)
     roles = marshmallow.fields.Str(required=True)
+    tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
 
     oauth_consumer_key = marshmallow.fields.Str(required=True)
     oauth_nonce = marshmallow.fields.Str(required=True)
@@ -52,7 +53,12 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
         """
         kwargs = self.parse(locations=["form"])
 
-        return LTIUser(kwargs["user_id"], kwargs["oauth_consumer_key"], kwargs["roles"])
+        return LTIUser(
+            kwargs["user_id"],
+            kwargs["oauth_consumer_key"],
+            kwargs["roles"],
+            kwargs["tool_consumer_instance_guid"],
+        )
 
     @marshmallow.validates_schema
     def _verify_oauth_1(self, _data, **_kwargs):

--- a/lms/validation/authentication/_launch_params.py
+++ b/lms/validation/authentication/_launch_params.py
@@ -2,7 +2,7 @@
 
 import marshmallow
 
-from lms.models import LTIUser
+from lms.models import LTIUser, display_name
 from lms.services import LTILaunchVerificationError
 from lms.validation._base import PyramidRequestSchema
 
@@ -57,13 +57,15 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
         kwargs = self.parse(locations=["form"])
 
         return LTIUser(
-            kwargs["user_id"],
-            kwargs["oauth_consumer_key"],
-            kwargs["roles"],
-            kwargs["tool_consumer_instance_guid"],
-            kwargs["lis_person_name_given"],
-            kwargs["lis_person_name_family"],
-            kwargs["lis_person_name_full"],
+            user_id=kwargs["user_id"],
+            oauth_consumer_key=kwargs["oauth_consumer_key"],
+            roles=kwargs["roles"],
+            tool_consumer_instance_guid=kwargs["tool_consumer_instance_guid"],
+            display_name=display_name(
+                kwargs["lis_person_name_given"],
+                kwargs["lis_person_name_family"],
+                kwargs["lis_person_name_full"],
+            ),
         )
 
     @marshmallow.validates_schema

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,4 +1,4 @@
-from factory import Faker, make_factory
+from factory import Faker, LazyAttribute, make_factory
 
 from lms import models
 
@@ -8,4 +8,7 @@ LTIUser = make_factory(  # pylint:disable=invalid-name
     oauth_consumer_key=Faker("hexify", text="Hypothesis" + "^" * 32),
     roles=Faker("random_element", elements=["Learner", "Instructor"]),
     tool_consumer_instance_guid=Faker("hexify", text="^" * 40),
+    given_name=Faker("first_name"),
+    family_name=Faker("last_name"),
+    full_name=LazyAttribute(lambda o: f"{o.given_name} {o.family_name}"),
 )

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,4 +1,4 @@
-from factory import Faker, LazyAttribute, make_factory
+from factory import Faker, make_factory
 
 from lms import models
 
@@ -8,7 +8,5 @@ LTIUser = make_factory(  # pylint:disable=invalid-name
     oauth_consumer_key=Faker("hexify", text="Hypothesis" + "^" * 32),
     roles=Faker("random_element", elements=["Learner", "Instructor"]),
     tool_consumer_instance_guid=Faker("hexify", text="^" * 40),
-    given_name=Faker("first_name"),
-    family_name=Faker("last_name"),
-    full_name=LazyAttribute(lambda o: f"{o.given_name} {o.family_name}"),
+    display_name=Faker("name"),
 )

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -7,4 +7,5 @@ LTIUser = make_factory(  # pylint:disable=invalid-name
     user_id=Faker("hexify", text="^" * 40),
     oauth_consumer_key=Faker("hexify", text="Hypothesis" + "^" * 32),
     roles=Faker("random_element", elements=["Learner", "Instructor"]),
+    tool_consumer_instance_guid=Faker("hexify", text="^" * 40),
 )

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -347,6 +347,7 @@ class TestJSConfigAuthToken:
 class TestJSConfigDebug:
     """Unit tests for the "debug" sub-dict of JSConfig."""
 
+    @pytest.mark.usefixtures("user_is_learner")
     def test_it_contains_debugging_info_about_the_users_role(self, config):
         assert "role:learner" in config["tags"]
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -216,48 +216,10 @@ class TestHUser:
 
         assert userid == "acct:16aa3b3e92cdfa53e5996d138a7013@TEST_AUTHORITY"
 
-    @pytest.mark.parametrize(
-        "full_name,given_name,family_name,expected_display_name",
-        [
-            # It returns the full name if there is one.
-            ("full", "given", "family", "full"),
-            # If there's no full name it concatenates given and family names.
-            ("", "given", "family", "given family"),
-            (" ", "given", "family", "given family"),
-            # If there's no full name or given name it uses just the family name.
-            (" ", "", "family", "family"),
-            # If there's no full name or family name it uses just the given name.
-            ("", "given", "", "given"),
-            (" ", "given", " ", "given"),
-            # If there's nothing else it just returns "Anonymous".
-            ("", "", "", "Anonymous"),
-            (" ", " ", " ", "Anonymous"),
-            # Test white space stripping
-            (" full  ", "", "", "full"),
-            ("", "  given ", "", "given"),
-            ("", "", "  family ", "family"),
-            ("", "  given  ", "  family  ", "given family"),
-            # Test truncation
-            ("x" * 100, "", "", "x" * 29 + "…"),
-            ("", "x" * 100, "", "x" * 29 + "…"),
-            ("", "", "x" * 100, "x" * 29 + "…"),
-            ("", "given" * 3, "family" * 3, "givengivengiven familyfamilyf…"),
-        ],
-    )
-    def test_display_name(
-        self,
-        full_name,
-        given_name,
-        family_name,
-        expected_display_name,
-        pyramid_request,
-        lti_launch,
-    ):
-        pyramid_request.lti_user = factories.LTIUser(
-            full_name=full_name, given_name=given_name, family_name=family_name,
-        )
+    def test_display_name(self, pyramid_request):
+        display_name = LTILaunchResource(pyramid_request).h_user.display_name
 
-        assert lti_launch.h_user.display_name == expected_display_name
+        assert display_name == pyramid_request.lti_user.display_name
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -26,56 +26,6 @@ class TestACL:
         assert bool(has_permission) is expected
 
 
-class TestHDisplayName:
-    @pytest.mark.parametrize(
-        "full_name,given_name,family_name,expected_display_name",
-        [
-            # It returns the full name if there is one.
-            ("full", "given", "family", "full"),
-            # If there's no full name it concatenates given and family names.
-            ("", "given", "family", "given family"),
-            (" ", "given", "family", "given family"),
-            # If there's no full name or given name it uses just the family name.
-            (" ", "", "family", "family"),
-            # If there's no full name or family name it uses just the given name.
-            ("", "given", "", "given"),
-            (" ", "given", " ", "given"),
-            # If there's nothing else it just returns "Anonymous".
-            ("", "", "", "Anonymous"),
-            (" ", " ", " ", "Anonymous"),
-            # Test white space stripping
-            (" full  ", "", "", "full"),
-            ("", "  given ", "", "given"),
-            ("", "", "  family ", "family"),
-            ("", "  given  ", "  family  ", "given family"),
-            # Test truncation
-            ("x" * 100, "", "", "x" * 29 + "…"),
-            ("", "x" * 100, "", "x" * 29 + "…"),
-            ("", "", "x" * 100, "x" * 29 + "…"),
-            ("", "given" * 3, "family" * 3, "givengivengiven familyfamilyf…"),
-        ],
-    )
-    def test_it(
-        self, full_name, given_name, family_name, expected_display_name, pyramid_request
-    ):
-        pyramid_request.lti_user = factories.LTIUser(
-            full_name=full_name, given_name=given_name, family_name=family_name,
-        )
-
-        assert (
-            LTILaunchResource(pyramid_request).h_user.display_name
-            == expected_display_name
-        )
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = {
-            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
-            "user_id": "test_user_id",
-        }
-        return pyramid_request
-
-
 class TestHAuthorityProvidedID:
     def test_it(self, lti_launch):
         assert (
@@ -265,6 +215,49 @@ class TestHUser:
         userid = LTILaunchResource(pyramid_request).h_user.userid
 
         assert userid == "acct:16aa3b3e92cdfa53e5996d138a7013@TEST_AUTHORITY"
+
+    @pytest.mark.parametrize(
+        "full_name,given_name,family_name,expected_display_name",
+        [
+            # It returns the full name if there is one.
+            ("full", "given", "family", "full"),
+            # If there's no full name it concatenates given and family names.
+            ("", "given", "family", "given family"),
+            (" ", "given", "family", "given family"),
+            # If there's no full name or given name it uses just the family name.
+            (" ", "", "family", "family"),
+            # If there's no full name or family name it uses just the given name.
+            ("", "given", "", "given"),
+            (" ", "given", " ", "given"),
+            # If there's nothing else it just returns "Anonymous".
+            ("", "", "", "Anonymous"),
+            (" ", " ", " ", "Anonymous"),
+            # Test white space stripping
+            (" full  ", "", "", "full"),
+            ("", "  given ", "", "given"),
+            ("", "", "  family ", "family"),
+            ("", "  given  ", "  family  ", "given family"),
+            # Test truncation
+            ("x" * 100, "", "", "x" * 29 + "…"),
+            ("", "x" * 100, "", "x" * 29 + "…"),
+            ("", "", "x" * 100, "x" * 29 + "…"),
+            ("", "given" * 3, "family" * 3, "givengivengiven familyfamilyf…"),
+        ],
+    )
+    def test_display_name(
+        self,
+        full_name,
+        given_name,
+        family_name,
+        expected_display_name,
+        pyramid_request,
+        lti_launch,
+    ):
+        pyramid_request.lti_user = factories.LTIUser(
+            full_name=full_name, given_name=given_name, family_name=family_name,
+        )
+
+        assert lti_launch.h_user.display_name == expected_display_name
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from pyramid.authorization import ACLAuthorizationPolicy
 
+from lms.models import HUser
 from lms.resources import LTILaunchResource
 from tests import factories
 
@@ -200,33 +201,19 @@ class TestIsCanvas:
 
 
 class TestHUser:
-    def test_username_is_a_30_char_string(self, pyramid_request):
-        username = LTILaunchResource(pyramid_request).h_user.username
-
-        assert isinstance(username, str)
-        assert len(username) == 30
-
-    def test_userid(self, pyramid_request):
-        pyramid_request.lti_user = factories.LTIUser(
-            user_id="test_user_id",
-            tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+    def test_it(self, pyramid_request):
+        assert LTILaunchResource(pyramid_request).h_user == HUser(
+            authority=pyramid_request.registry.settings["h_authority"],
+            username="16aa3b3e92cdfa53e5996d138a7013",
+            display_name=pyramid_request.lti_user.display_name,
         )
-
-        userid = LTILaunchResource(pyramid_request).h_user.userid
-
-        assert userid == "acct:16aa3b3e92cdfa53e5996d138a7013@TEST_AUTHORITY"
-
-    def test_display_name(self, pyramid_request):
-        display_name = LTILaunchResource(pyramid_request).h_user.display_name
-
-        assert display_name == pyramid_request.lti_user.display_name
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = {
-            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
-            "user_id": "test_user_id",
-        }
+        pyramid_request.lti_user = factories.LTIUser(
+            tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+            user_id="test_user_id",
+        )
         return pyramid_request
 
 

--- a/tests/unit/lms/validation/authentication/_launch_params_test.py
+++ b/tests/unit/lms/validation/authentication/_launch_params_test.py
@@ -12,7 +12,10 @@ class TestLaunchParamsAuthSchema:
         lti_user = schema.lti_user()
 
         assert lti_user == LTIUser(
-            "TEST_USER_ID", "TEST_OAUTH_CONSUMER_KEY", "TEST_ROLES"
+            "TEST_USER_ID",
+            "TEST_OAUTH_CONSUMER_KEY",
+            "TEST_ROLES",
+            "TEST_TOOL_CONSUMER_INSTANCE_GUID",
         )
 
     def test_it_does_oauth_1_verification(self, launch_verifier, schema):
@@ -33,6 +36,7 @@ class TestLaunchParamsAuthSchema:
         [
             "user_id",
             "roles",
+            "tool_consumer_instance_guid",
             "oauth_consumer_key",
             "oauth_nonce",
             "oauth_signature",
@@ -69,6 +73,7 @@ class TestLaunchParamsAuthSchema:
             "oauth_timestamp": "TEST_OAUTH_TIMESTAMP",
             "oauth_version": "TEST_OAUTH_VERSION",
             "roles": "TEST_ROLES",
+            "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
         }
         return pyramid_request
 

--- a/tests/unit/lms/validation/authentication/_launch_params_test.py
+++ b/tests/unit/lms/validation/authentication/_launch_params_test.py
@@ -8,31 +8,26 @@ from lms.validation.authentication import LaunchParamsAuthSchema
 
 
 class TestLaunchParamsAuthSchema:
-    def test_it_returns_the_lti_user_info(self, schema):
+    def test_it_returns_the_lti_user_info(self, schema, display_name):
         lti_user = schema.lti_user()
 
+        display_name.assert_called_once_with(
+            "TEST_GIVEN_NAME", "TEST_FAMILY_NAME", "TEST_FULL_NAME",
+        )
         assert lti_user == LTIUser(
-            "TEST_USER_ID",
-            "TEST_OAUTH_CONSUMER_KEY",
-            "TEST_ROLES",
-            "TEST_TOOL_CONSUMER_INSTANCE_GUID",
-            "TEST_GIVEN_NAME",
-            "TEST_FAMILY_NAME",
-            "TEST_FULL_NAME",
+            user_id="TEST_USER_ID",
+            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            roles="TEST_ROLES",
+            tool_consumer_instance_guid="TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            display_name=display_name.return_value,
         )
 
     @pytest.mark.usefixtures("no_user_info")
-    def test_user_info_fields_default_to_empty_strings(self, schema):
-        lti_user = schema.lti_user()
+    def test_user_info_fields_default_to_empty_strings(self, schema, display_name):
+        schema.lti_user()
 
-        assert lti_user == LTIUser(
-            "TEST_USER_ID",
-            "TEST_OAUTH_CONSUMER_KEY",
-            "TEST_ROLES",
-            "TEST_TOOL_CONSUMER_INSTANCE_GUID",
-            "",
-            "",
-            "",
+        display_name.assert_called_once_with(
+            "", "", "",
         )
 
     def test_it_does_oauth_1_verification(self, launch_verifier, schema):
@@ -105,3 +100,8 @@ class TestLaunchParamsAuthSchema:
 
 
 pytestmark = pytest.mark.usefixtures("launch_verifier")
+
+
+@pytest.fixture(autouse=True)
+def display_name(patch):
+    return patch("lms.validation.authentication._launch_params.display_name")

--- a/tests/unit/lms/validation/authentication/_launch_params_test.py
+++ b/tests/unit/lms/validation/authentication/_launch_params_test.py
@@ -16,6 +16,23 @@ class TestLaunchParamsAuthSchema:
             "TEST_OAUTH_CONSUMER_KEY",
             "TEST_ROLES",
             "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            "TEST_GIVEN_NAME",
+            "TEST_FAMILY_NAME",
+            "TEST_FULL_NAME",
+        )
+
+    @pytest.mark.usefixtures("no_user_info")
+    def test_user_info_fields_default_to_empty_strings(self, schema):
+        lti_user = schema.lti_user()
+
+        assert lti_user == LTIUser(
+            "TEST_USER_ID",
+            "TEST_OAUTH_CONSUMER_KEY",
+            "TEST_ROLES",
+            "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            "",
+            "",
+            "",
         )
 
     def test_it_does_oauth_1_verification(self, launch_verifier, schema):
@@ -74,8 +91,17 @@ class TestLaunchParamsAuthSchema:
             "oauth_version": "TEST_OAUTH_VERSION",
             "roles": "TEST_ROLES",
             "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
+            "lis_person_name_given": "TEST_GIVEN_NAME",
+            "lis_person_name_family": "TEST_FAMILY_NAME",
+            "lis_person_name_full": "TEST_FULL_NAME",
         }
         return pyramid_request
+
+    @pytest.fixture
+    def no_user_info(self, pyramid_request):
+        del pyramid_request.POST["lis_person_name_given"]
+        del pyramid_request.POST["lis_person_name_family"]
+        del pyramid_request.POST["lis_person_name_full"]
 
 
 pytestmark = pytest.mark.usefixtures("launch_verifier")


### PR DESCRIPTION
Add a few more fields to `models.LTIUser` (the `request.lti_user` object). Specifically, this adds all the fields necessary to generate a `models.HUser` object from _just_ a `models.LTIUser` object, and future PRs will refactor the `HUser`-generating code to do just that.