### PR TITLE
Remove an unused provisioning_enabled fixture

### DIFF
--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -168,7 +168,6 @@ def context(h_user):
         h_group_name = "test_group_name"
         h_provider = "test_provider"
         h_provider_unique_id = "test_provider_unique_id"
-        provisioning_enabled = True
         h_authority_provided_id = "test_authority_provided_id"
 
     context = TestContext()


### PR DESCRIPTION
LTIHService doesn't use context.provisioning_enabled