### PR TITLE
Add provider and provider_unique_id fields to HUser

### DIFF
--- a/lms/models/h_user.py
+++ b/lms/models/h_user.py
@@ -27,6 +27,12 @@ class HUser(NamedTuple):
     display_name: str = ""
     """The display name for the user, generated from the LMS user's display name."""
 
+    provider: str = ""
+    """The "provider" string to pass to the h API for this user."""
+
+    provider_unique_id: str = ""
+    """The "provider_unique_id" string to pass to the h API for this user."""
+
     @property
     def userid(self):
         return f"acct:{self.username}@{self.authority}"

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -31,17 +31,25 @@ class LTILaunchResource:
     def h_user(self):
         """Return the h user for the current request."""
 
+        # The h "provider" string for the current request.
+        provider = self._request.lti_user.tool_consumer_instance_guid
+
+        # The h "provider_unique_id" string for the current request.
+        provider_unique_id = self._request.lti_user.user_id
+
         def username():
             """Return the h username for the current request."""
             username_hash_object = hashlib.sha1()
-            username_hash_object.update(self.h_provider.encode())
-            username_hash_object.update(self.h_provider_unique_id.encode())
+            username_hash_object.update(provider.encode())
+            username_hash_object.update(provider_unique_id.encode())
             return username_hash_object.hexdigest()[:30]
 
         return HUser(
             authority=self._authority,
             username=username(),
             display_name=self._request.lti_user.display_name,
+            provider=provider,
+            provider_unique_id=provider_unique_id,
         )
 
     @property
@@ -144,16 +152,6 @@ class LTILaunchResource:
             name = name[: group_name_max_length - 1].rstrip() + "…"
 
         return name
-
-    @property
-    def h_provider(self):
-        """Return the h "provider" string for the current request."""
-        return self._request.lti_user.tool_consumer_instance_guid
-
-    @property
-    def h_provider_unique_id(self):
-        """Return the h provider_unique_id for the current request."""
-        return self._request.lti_user.user_id
 
     @property
     def is_canvas(self):

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -42,21 +42,22 @@ class HAPI:
             display_name=user_info["display_name"],
         )
 
-    def create_user(self, h_user, provider, provider_unique_id):
+    def create_user(self, h_user):
         """
         Create a user in H.
 
         :arg h_user: the user to be created in h
         :type h_user: HUser
-        :param provider: the "provider" string to send to h
-        :param provider_unique_id:  the "provider_unique_id" string to send to h
         """
         user_data = {
             "username": h_user.username,
             "display_name": h_user.display_name,
             "authority": self._authority,
             "identities": [
-                {"provider": provider, "provider_unique_id": provider_unique_id,}
+                {
+                    "provider": h_user.provider,
+                    "provider_unique_id": h_user.provider_unique_id,
+                }
             ],
         }
 
@@ -77,7 +78,7 @@ class HAPI:
             data={"display_name": h_user.display_name},
         )
 
-    def upsert_user(self, h_user, provider, provider_unique_id):
+    def upsert_user(self, h_user):
         """
         Create or update a user in H as appropriate.
 
@@ -86,13 +87,11 @@ class HAPI:
 
         :param h_user: the updated user value
         :type h_user: HUser
-        :param provider: the "provider" string to send to h
-        :param provider_unique_id:  the "provider_unique_id" string to send to h
         """
         try:
             self.update_user(h_user)
         except HAPINotFoundError:
-            self.create_user(h_user, provider, provider_unique_id)
+            self.create_user(h_user)
 
     def upsert_group(self, group_id, group_name):
         """
@@ -117,7 +116,7 @@ class HAPI:
             # If we get a 404 when trying to upsert a group that must mean
             # that the lms user doesn't exist in h yet.
             self.create_user(
-                HUser(self._authority, "lms"), provider="lms", provider_unique_id="lms",
+                HUser(self._authority, "lms", provider="lms", provider_unique_id="lms"),
             )
             do_upsert_group()
 

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -52,7 +52,7 @@ class HAPI:
         user_data = {
             "username": h_user.username,
             "display_name": h_user.display_name,
-            "authority": self._authority,
+            "authority": h_user.authority,
             "identities": [
                 {
                     "provider": h_user.provider,

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -66,11 +66,7 @@ class LTIHService:
     def _sync_to_h(self, groups):
         h_user = self._context.h_user
 
-        self._h_api.upsert_user(
-            h_user=h_user,
-            provider=self._context.h_provider,
-            provider_unique_id=self._context.h_provider_unique_id,
-        )
+        self._h_api.upsert_user(h_user=h_user)
 
         for group in groups:
             self._h_api.upsert_group(group_id=group.groupid, group_name=group.name)

--- a/tests/factories/h_user.py
+++ b/tests/factories/h_user.py
@@ -7,4 +7,6 @@ HUser = factory.make_factory(  # pylint:disable=invalid-name
     authority="lms.hypothes.is",
     username=factory.Faker("hexify", text="^" * 30),
     display_name=factory.Faker("name"),
+    provider=factory.Faker("hexify", text="^" * 40),
+    provider_unique_id=factory.Faker("hexify", text="^" * 40),
 )

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -144,34 +144,6 @@ class TestHSectionGroupName:
         assert lti_launch.h_section_group_name(section) == group_name
 
 
-class TestHProvider:
-    def test_it_just_returns_the_tool_consumer_instance_guid(self, pyramid_request):
-        provider = LTILaunchResource(pyramid_request).h_provider
-
-        assert provider == pyramid_request.lti_user.tool_consumer_instance_guid
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = {
-            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
-        }
-        return pyramid_request
-
-
-class TestHProviderUniqueID:
-    def test_it_just_returns_the_user_id(self, pyramid_request):
-        provider_unique_id = LTILaunchResource(pyramid_request).h_provider_unique_id
-
-        assert provider_unique_id == pyramid_request.lti_user.user_id
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = {
-            "user_id": "test_user_id",
-        }
-        return pyramid_request
-
-
 class TestIsCanvas:
     @pytest.mark.parametrize(
         "parsed_params,is_canvas",
@@ -206,6 +178,8 @@ class TestHUser:
             authority=pyramid_request.registry.settings["h_authority"],
             username="16aa3b3e92cdfa53e5996d138a7013",
             display_name=pyramid_request.lti_user.display_name,
+            provider="test_tool_consumer_instance_guid",
+            provider_unique_id="test_user_id",
         )
 
     @pytest.fixture

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -48,7 +48,7 @@ class TestHAPI:
             data={
                 "username": h_user.username,
                 "display_name": h_user.display_name,
-                "authority": "TEST_AUTHORITY",
+                "authority": h_user.authority,
                 "identities": [
                     {
                         "provider": h_user.provider,

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -40,7 +40,7 @@ class TestHAPI:
         assert user.display_name == sentinel.display_name
 
     def test_create_user_works(self, h_api, h_user, _api_request):
-        h_api.create_user(h_user, sentinel.provider, sentinel.provider_unique_id)
+        h_api.create_user(h_user)
 
         _api_request.assert_called_once_with(
             "POST",
@@ -51,8 +51,8 @@ class TestHAPI:
                 "authority": "TEST_AUTHORITY",
                 "identities": [
                     {
-                        "provider": sentinel.provider,
-                        "provider_unique_id": sentinel.provider_unique_id,
+                        "provider": h_user.provider,
+                        "provider_unique_id": h_user.provider_unique_id,
                     }
                 ],
             },
@@ -71,12 +71,10 @@ class TestHAPI:
         self, update_user, create_user, h_api, h_user
     ):
         update_user.side_effect = HAPINotFoundError()
-        h_api.upsert_user(h_user, sentinel.provider, sentinel.provider_unique_id)
+        h_api.upsert_user(h_user)
 
         update_user.assert_called_once_with(h_user)
-        create_user.assert_called_once_with(
-            h_user, sentinel.provider, sentinel.provider_unique_id
-        )
+        create_user.assert_called_once_with(h_user)
 
     def test_upsert_group_works(self, h_api, _api_request, upsert_group_call):
         h_api.upsert_group(sentinel.group_id, sentinel.group_name)

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -91,11 +91,7 @@ class TestUserUpserting:
     def test_it_calls_h_api_for_user_update(self, h_api, lti_h_svc, h_user):
         lti_h_svc.single_group_sync()
 
-        h_api.upsert_user.assert_called_once_with(
-            h_user=h_user,
-            provider="test_provider",
-            provider_unique_id="test_provider_unique_id",
-        )
+        h_api.upsert_user.assert_called_once_with(h_user=h_user)
 
     def test_it_raises_if_upsert_user_raises_unexpected_error(self, h_api, lti_h_svc):
         h_api.upsert_user.side_effect = HAPIError("whatever")
@@ -114,20 +110,6 @@ class TestUserUpserting:
 
     def test_it_raises_if_h_user_raises(self, context, lti_h_svc):
         type(context).h_user = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
-
-        with pytest.raises(HTTPBadRequest, match="Oops"):
-            lti_h_svc.single_group_sync()
-
-    def test_it_raises_if_h_provider_raises(self, context, lti_h_svc):
-        type(context).h_provider = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
-
-        with pytest.raises(HTTPBadRequest, match="Oops"):
-            lti_h_svc.single_group_sync()
-
-    def test_it_raises_if_provider_unique_id_raises(self, context, lti_h_svc):
-        type(context).h_provider_unique_id = mock.PropertyMock(
-            side_effect=HTTPBadRequest("Oops")
-        )
 
         with pytest.raises(HTTPBadRequest, match="Oops"):
             lti_h_svc.single_group_sync()
@@ -166,8 +148,6 @@ def context(h_user):
     class TestContext:
         h_groupid = "test_groupid"
         h_group_name = "test_group_name"
-        h_provider = "test_provider"
-        h_provider_unique_id = "test_provider_unique_id"
         h_authority_provided_id = "test_authority_provided_id"
 
     context = TestContext()


### PR DESCRIPTION
`LTILaunchResource` currently has three separate properties:

1. `LTILaunchResource.h_user`. Returns a `models.HUser` object.

2. `LTILaunchResource.h_provider`

3. `LTILaunchResource.h_provider_unique_id`

`h_provider` and `h_provider_unique_id` are really part of the `HUser`:
they're only really used by `LTILaunchResource.h_user`.

Add two new attributes `provider` and `provider_unique_id` to `models.HUser`,
change `LTILaunchResource.h_user` to set them, and delete
`LTILaunchResource.h_provider` and `LTILaunchResource.h_provider_unique_id`.

Code that was previously reading `context.h_provider` and
`context.h_provider_unique_id` can now read `context.h_user.provider`
and `context.h_user.provider_unique_id` instead.

This also simplifies the `HAPI` service as `HAPI.create_user()` and
`HAPI.upsert_user()` no longer need to take a separate `provider` and
`provider_unique_id` params in addition to the `h_user` param.

`provider` and `provider_unique_id` are added to as optional fields to `HUser` because there are a couple of places other than `LTILaunchResource` that create `HUser` objects and setting a `provider` and `provider_unique_id` doesn't make sense in those places.