### PR TITLE
Extract HUser creation from LTILaunchResource

### DIFF
--- a/lms/models/h_user.py
+++ b/lms/models/h_user.py
@@ -1,3 +1,4 @@
+import hashlib
 from typing import NamedTuple
 
 
@@ -32,6 +33,26 @@ class HUser(NamedTuple):
 
     provider_unique_id: str = ""
     """The "provider_unique_id" string to pass to the h API for this user."""
+
+    @classmethod
+    def from_lti_user(cls, lti_user, authority):
+        provider = lti_user.tool_consumer_instance_guid
+        provider_unique_id = lti_user.user_id
+
+        def username():
+            """Return the h username for the current request."""
+            username_hash_object = hashlib.sha1()
+            username_hash_object.update(provider.encode())
+            username_hash_object.update(provider_unique_id.encode())
+            return username_hash_object.hexdigest()[:30]
+
+        return cls(
+            authority=authority,
+            username=username(),
+            display_name=lti_user.display_name,
+            provider=provider,
+            provider_unique_id=provider_unique_id,
+        )
 
     @property
     def userid(self):

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -10,7 +10,7 @@ from lms.validation.authentication import BearerTokenSchema
 from lms.views.helpers import via_url
 
 
-class JSConfig:  # pylint:disable=too-few-public-methods
+class JSConfig:  # pylint:disable=too-few-public-methods,too-many-instance-attributes
     """The config for the app's JavaScript code."""
 
     def __init__(self, context, request):
@@ -24,6 +24,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         self._grading_info_service = request.find_service(name="grading_info")
         self._ai_getter = request.find_service(name="ai_getter")
         self._h_api = request.find_service(name="h_api")
+        self._lti_h = request.find_service(name="lti_h")
 
     def add_canvas_file_id(self, canvas_file_id):
         """
@@ -193,7 +194,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
 
         self._config["canvas"]["speedGrader"] = {
             "submissionParams": {
-                "h_username": self._context.h_user.username,
+                "h_username": self._lti_h.h_user.username,
                 "lis_result_sourcedid": lis_result_sourcedid,
                 "lis_outcome_service_url": lis_outcome_service_url,
                 **kwargs,
@@ -330,7 +331,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         claims = {
             "aud": urlparse(api_url).hostname,
             "iss": self._request.registry.settings["h_jwt_client_id"],
-            "sub": self._context.h_user.userid,
+            "sub": self._lti_h.h_user.userid,
             "nbf": now,
             "exp": now + datetime.timedelta(minutes=5),
         }

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -4,7 +4,6 @@ import hashlib
 
 from pyramid.security import Allow
 
-from lms.models import HUser
 from lms.resources._js_config import JSConfig
 
 
@@ -26,31 +25,6 @@ class LTILaunchResource:
         """Return the context resource for an LTI launch request."""
         self._request = request
         self._authority = self._request.registry.settings["h_authority"]
-
-    @property
-    def h_user(self):
-        """Return the h user for the current request."""
-
-        # The h "provider" string for the current request.
-        provider = self._request.lti_user.tool_consumer_instance_guid
-
-        # The h "provider_unique_id" string for the current request.
-        provider_unique_id = self._request.lti_user.user_id
-
-        def username():
-            """Return the h username for the current request."""
-            username_hash_object = hashlib.sha1()
-            username_hash_object.update(provider.encode())
-            username_hash_object.update(provider_unique_id.encode())
-            return username_hash_object.hexdigest()[:30]
-
-        return HUser(
-            authority=self._authority,
-            username=username(),
-            display_name=self._request.lti_user.display_name,
-            provider=provider,
-            provider_unique_id=provider_unique_id,
-        )
 
     @property
     def h_authority_provided_id(self):

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -35,6 +35,8 @@ class BasicLTILaunchViews:
         self.context = context
         self.request = request
 
+        self._lti_h = request.find_service(name="lti_h")
+
         self.context.js_config.maybe_set_focused_user()
 
     def sync_lti_data_to_h(self):
@@ -45,7 +47,7 @@ class BasicLTILaunchViews:
         and group corresponding to the LTI user and course.
         """
 
-        self.request.find_service(name="lti_h").single_group_sync()
+        self._lti_h.single_group_sync()
 
     def store_lti_data(self):
         """Store LTI launch data in our LMS database."""
@@ -64,7 +66,7 @@ class BasicLTILaunchViews:
         if not lti_user.is_instructor and not self.context.is_canvas:
             # Create or update a record of LIS result data for a student launch
             request.find_service(name="grading_info").upsert_from_request(
-                request, h_user=self.context.h_user, lti_user=lti_user
+                request, h_user=self._lti_h.h_user, lti_user=lti_user
             )
 
     @view_config(canvas_file=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -205,7 +205,9 @@ def h_api(pyramid_config):
 
 @pytest.fixture
 def lti_h_service(pyramid_config):
-    lti_h_service = mock.create_autospec(LTIHService, instance=True, spec_set=True)
+    lti_h_service = mock.create_autospec(
+        LTIHService, instance=True, spec_set=True, h_user=factories.HUser()
+    )
     pyramid_config.register_service(lti_h_service, name="lti_h")
     return lti_h_service
 

--- a/tests/unit/lms/models/h_user_test.py
+++ b/tests/unit/lms/models/h_user_test.py
@@ -1,3 +1,4 @@
+from lms.models import HUser
 from tests import factories
 
 
@@ -6,3 +7,17 @@ class TestHUser:
         h_user = factories.HUser(username="test_username", authority="test_authority")
 
         assert h_user.userid == "acct:test_username@test_authority"
+
+    def test_from_lti_user(self):
+        lti_user = factories.LTIUser(
+            tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+            user_id="test_user_id",
+        )
+
+        assert HUser.from_lti_user(lti_user, "lms.hypothes.is") == HUser(
+            authority="lms.hypothes.is",
+            username="16aa3b3e92cdfa53e5996d138a7013",
+            display_name=lti_user.display_name,
+            provider=lti_user.tool_consumer_instance_guid,
+            provider_unique_id=lti_user.user_id,
+        )

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -3,9 +3,7 @@ from unittest import mock
 import pytest
 from pyramid.authorization import ACLAuthorizationPolicy
 
-from lms.models import HUser
 from lms.resources import LTILaunchResource
-from tests import factories
 
 
 class TestACL:
@@ -170,25 +168,6 @@ class TestIsCanvas:
         pyramid_request.parsed_params = parsed_params
 
         assert LTILaunchResource(pyramid_request).is_canvas == is_canvas
-
-
-class TestHUser:
-    def test_it(self, pyramid_request):
-        assert LTILaunchResource(pyramid_request).h_user == HUser(
-            authority=pyramid_request.registry.settings["h_authority"],
-            username="16aa3b3e92cdfa53e5996d138a7013",
-            display_name=pyramid_request.lti_user.display_name,
-            provider="test_tool_consumer_instance_guid",
-            provider_unique_id="test_user_id",
-        )
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.lti_user = factories.LTIUser(
-            tool_consumer_instance_guid="test_tool_consumer_instance_guid",
-            user_id="test_user_id",
-        )
-        return pyramid_request
 
 
 class TestCustomCanvasAPIDomain:

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -114,12 +114,14 @@ class TestCommon:
 
     @pytest.mark.usefixtures("user_is_learner")
     def test_it_calls_grading_info_upsert(
-        self, context, pyramid_request, grading_info_service, view_caller
+        self, context, pyramid_request, grading_info_service, lti_h_service, view_caller
     ):
         view_caller(context, pyramid_request)
 
         grading_info_service.upsert_from_request.assert_called_once_with(
-            pyramid_request, h_user=context.h_user, lti_user=pyramid_request.lti_user
+            pyramid_request,
+            h_user=lti_h_service.h_user,
+            lti_user=pyramid_request.lti_user,
         )
 
     def test_it_does_not_call_grading_info_upsert_if_instructor(


### PR DESCRIPTION
Extract `HUser` creation out of `LTILaunchResource`. This is so that
requests outside of an `LTILaunchResource` context (e.g. API requests) can
create `HUsers`.

First, add a new classmethod `models.HUser.from_lti_user(lti_user,
authority)` that returns a new `HUser` based on a given `LTIUser` and the
`"h_authority"` setting. Move most of the code that was previously
`LTILaunchResource.h_user()` into this new classmethod.

Next, add a new property `LTIHService.h_user` which returns the `HUser` for
the current request, just: `models.HUser.from_lti_user(request.lti_user,
request.registry.settings["h_authority")`. That replaces the remaining
code in `LTILaunchResource.h_user`. Code can now access
`request.find_service(name="lti_h").h_user` instead of `context.h_user`.
`LTILaunchResource.h_user` can be deleted.

Finally, change all the places that were reading `context.h_user` to read
`request.find_service(name="lti_h").h_user` instead: `LTIHService` itself (now reads `self.h_user`)
`JSConfig`, and `BasicLTILaunchViews`.