### PR TITLE
Remove authority from models.HUser

### DIFF
--- a/lms/models/h_user.py
+++ b/lms/models/h_user.py
@@ -10,13 +10,6 @@ class HUser(NamedTuple):
     usernames.
     """
 
-    authority: str
-    """
-    The authority which the user belongs to.
-
-    This should always match the h_authority setting.
-    """
-
     username: str
     """
     Generated username for h user.
@@ -33,6 +26,5 @@ class HUser(NamedTuple):
     provider_unique_id: str = ""
     """The "provider_unique_id" string to pass to the h API for this user."""
 
-    @property
-    def userid(self):
-        return f"acct:{self.username}@{self.authority}"
+    def userid(self, authority):
+        return f"acct:{self.username}@{authority}"

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -10,7 +10,7 @@ from lms.validation.authentication import BearerTokenSchema
 from lms.views.helpers import via_url
 
 
-class JSConfig:  # pylint:disable=too-few-public-methods
+class JSConfig:  # pylint:disable=too-many-instance-attributes
     """The config for the app's JavaScript code."""
 
     def __init__(self, context, request):
@@ -20,6 +20,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         self._consumer_key = (
             request.lti_user.oauth_consumer_key if request.lti_user else None
         )
+        self._authority = request.registry.settings["h_authority"]
 
         self._grading_info_service = request.find_service(name="grading_info")
         self._ai_getter = request.find_service(name="ai_getter")
@@ -312,7 +313,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
         # Yield a "student" dict for each GradingInfo.
         for grading_info in grading_infos:
             h_user = HUser(
-                authority=self._request.registry.settings["h_authority"],
+                authority=self._authority,
                 username=grading_info.h_username,
                 display_name=grading_info.h_display_name,
             )
@@ -371,7 +372,7 @@ class JSConfig:  # pylint:disable=too-few-public-methods
             "services": [
                 {
                     "apiUrl": api_url,
-                    "authority": self._request.registry.settings["h_authority"],
+                    "authority": self._authority,
                     "enableShareLinks": False,
                     "grantToken": self._grant_token(api_url),
                     "groups": [self._context.h_groupid],

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -313,12 +313,11 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
         # Yield a "student" dict for each GradingInfo.
         for grading_info in grading_infos:
             h_user = HUser(
-                authority=self._authority,
                 username=grading_info.h_username,
                 display_name=grading_info.h_display_name,
             )
             yield {
-                "userid": h_user.userid,
+                "userid": h_user.userid(self._authority),
                 "displayName": h_user.display_name,
                 "LISResultSourcedId": grading_info.lis_result_sourcedid,
                 "LISOutcomeServiceUrl": grading_info.lis_outcome_service_url,
@@ -331,7 +330,7 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
         claims = {
             "aud": urlparse(api_url).hostname,
             "iss": self._request.registry.settings["h_jwt_client_id"],
-            "sub": self._context.h_user.userid,
+            "sub": self._context.h_user.userid(self._authority),
             "nbf": now,
             "exp": now + datetime.timedelta(minutes=5),
         }

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -45,7 +45,6 @@ class LTILaunchResource:
             return username_hash_object.hexdigest()[:30]
 
         return HUser(
-            authority=self._authority,
             username=username(),
             display_name=self._request.lti_user.display_name,
             provider=provider,

--- a/tests/factories/h_user.py
+++ b/tests/factories/h_user.py
@@ -4,7 +4,6 @@ from lms import models
 
 HUser = factory.make_factory(  # pylint:disable=invalid-name
     models.HUser,
-    authority="lms.hypothes.is",
     username=factory.Faker("hexify", text="^" * 30),
     display_name=factory.Faker("name"),
     provider=factory.Faker("hexify", text="^" * 40),

--- a/tests/unit/lms/models/h_user_test.py
+++ b/tests/unit/lms/models/h_user_test.py
@@ -3,6 +3,6 @@ from tests import factories
 
 class TestHUser:
     def test_userid(self):
-        h_user = factories.HUser(username="test_username", authority="test_authority")
+        h_user = factories.HUser(username="test_username")
 
-        assert h_user.userid == "acct:test_username@test_authority"
+        assert h_user.userid("test_authority") == "acct:test_username@test_authority"

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -375,7 +375,7 @@ class TestJSConfigHypothesisClient:
     def test_it_disables_share_links(self, config):
         assert not config["services"][0]["enableShareLinks"]
 
-    def test_it_includes_grant_token(self, config, context):
+    def test_it_includes_grant_token(self, config, context, pyramid_request):
         before = int(datetime.datetime.now().timestamp())
 
         grant_token = config["services"][0]["grantToken"]
@@ -386,11 +386,14 @@ class TestJSConfigHypothesisClient:
             key="TEST_JWT_CLIENT_SECRET",
             audience="example.com",
         )
-        after = int(datetime.datetime.now().timestamp())
-        assert claims["iss"] == "TEST_JWT_CLIENT_ID"
-        assert claims["sub"] == context.h_user.userid
-        assert before <= claims["nbf"] <= after
         assert claims["exp"] > before
+        assert claims["iss"] == "TEST_JWT_CLIENT_ID"
+
+        authority = pyramid_request.registry.settings["h_authority"]
+        assert claims["sub"] == context.h_user.userid(authority)
+
+        after = int(datetime.datetime.now().timestamp())
+        assert before <= claims["nbf"] <= after
 
     def test_it_includes_the_group(self, config):
         groups = config["services"][0]["groups"]

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -175,7 +175,6 @@ class TestIsCanvas:
 class TestHUser:
     def test_it(self, pyramid_request):
         assert LTILaunchResource(pyramid_request).h_user == HUser(
-            authority=pyramid_request.registry.settings["h_authority"],
             username="16aa3b3e92cdfa53e5996d138a7013",
             display_name=pyramid_request.lti_user.display_name,
             provider="test_tool_consumer_instance_guid",


### PR DESCRIPTION
Remove the `authority` attribute from `models.HUser`, and change the
`userid()` property to a `userid(authority)` instance method.

This makes creating `HUser`'s easier because you don't need
`request.registry.settings["h_authority"]` to create one.

This comes at the cost of making getting an `HUser`'s `userid` more
difficult: you now need to pass in
`request.registry.settings["h_authority"]` to the `userid` method.
Previously you could have accessed `h_user.userid` without passing in
the authority, if you had been given an already-created `HUser` from
somewhere else. But if you had to create the `HUser` yourself then you
would have needed the `"h_authority"` setting to create it anyway.

In practice I think the code is overall simpler and more flexible if we
delay needing the `"h_authority"` setting until if and when it's needed:
if and when something needs the `userid`. It turns out only two places
at the "edges" of the code actually need the `userid`:

1. `JSConfig` needs it when generating the JavaScript config to be
   passed to the client

2. `HAPIService` needs it to pass to the h API

Rather than forcing `"h_authority"` to be needed whenever an `HUser` is
created. This way, code that doesn't need the `userid`, can create
`HUser`'s without ever needing the `"h_authority"` setting.

I think it also makes sense to remove the concept of authority from our
domain model. There is only ever one authority: the value of the
`request.registry.settings["h_authority"]` setting. All domain model
objects would always have the same authority. It's a setting, not part
of the domain model.