### PR TITLE
Move LTILaunchResource.h_user to request.lti_user.h_user

### DIFF
--- a/lms/models/h_user.py
+++ b/lms/models/h_user.py
@@ -1,3 +1,4 @@
+import hashlib
 from typing import NamedTuple
 
 
@@ -28,3 +29,22 @@ class HUser(NamedTuple):
 
     def userid(self, authority):
         return f"acct:{self.username}@{authority}"
+
+    @classmethod
+    def from_lti_user(cls, lti_user):
+        provider = lti_user.tool_consumer_instance_guid
+        provider_unique_id = lti_user.user_id
+
+        def username():
+            """Return the h username for the current request."""
+            username_hash_object = hashlib.sha1()
+            username_hash_object.update(provider.encode())
+            username_hash_object.update(provider_unique_id.encode())
+            return username_hash_object.hexdigest()[:30]
+
+        return cls(
+            username=username(),
+            display_name=lti_user.display_name,
+            provider=provider,
+            provider_unique_id=provider_unique_id,
+        )

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -1,5 +1,7 @@
 from typing import NamedTuple
 
+from lms.models import HUser
+
 
 class LTIUser(NamedTuple):
     """An LTI user."""
@@ -18,6 +20,11 @@ class LTIUser(NamedTuple):
 
     display_name: str
     """The user's display name."""
+
+    @property
+    def h_user(self):
+        """Return a models.HUser generated from this LTIUser."""
+        return HUser.from_lti_user(self)
 
     @property
     def is_instructor(self):

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -4,7 +4,6 @@ import hashlib
 
 from pyramid.security import Allow
 
-from lms.models import HUser
 from lms.resources._js_config import JSConfig
 
 
@@ -26,30 +25,6 @@ class LTILaunchResource:
         """Return the context resource for an LTI launch request."""
         self._request = request
         self._authority = self._request.registry.settings["h_authority"]
-
-    @property
-    def h_user(self):
-        """Return the h user for the current request."""
-
-        # The h "provider" string for the current request.
-        provider = self._request.lti_user.tool_consumer_instance_guid
-
-        # The h "provider_unique_id" string for the current request.
-        provider_unique_id = self._request.lti_user.user_id
-
-        def username():
-            """Return the h username for the current request."""
-            username_hash_object = hashlib.sha1()
-            username_hash_object.update(provider.encode())
-            username_hash_object.update(provider_unique_id.encode())
-            return username_hash_object.hexdigest()[:30]
-
-        return HUser(
-            username=username(),
-            display_name=self._request.lti_user.display_name,
-            provider=provider,
-            provider_unique_id=provider_unique_id,
-        )
 
     @property
     def h_authority_provided_id(self):

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -25,6 +25,7 @@ class LTIHService:
         self._context = request.context
         self._request = request
         self._lti_user = request.lti_user
+        self._h_user = request.lti_user.h_user
 
         self._ai_getter = request.find_service(name="ai_getter")
         self._h_api = request.find_service(name="h_api")
@@ -64,9 +65,7 @@ class LTIHService:
             raise HTTPInternalServerError(explanation=err.explanation) from err
 
     def _sync_to_h(self, groups):
-        h_user = self._context.h_user
-
-        self._h_api.upsert_user(h_user=h_user)
+        self._h_api.upsert_user(h_user=self._h_user)
 
         for group in groups:
             self._h_api.upsert_group(group_id=group.groupid, group_name=group.name)
@@ -78,4 +77,4 @@ class LTIHService:
             )
 
         for group in groups:
-            self._h_api.add_user_to_group(h_user=h_user, group_id=group.groupid)
+            self._h_api.add_user_to_group(h_user=self._h_user, group_id=group.groupid)

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -64,7 +64,7 @@ class BasicLTILaunchViews:
         if not lti_user.is_instructor and not self.context.is_canvas:
             # Create or update a record of LIS result data for a student launch
             request.find_service(name="grading_info").upsert_from_request(
-                request, h_user=self.context.h_user, lti_user=lti_user
+                request, h_user=lti_user.h_user, lti_user=lti_user
             )
 
     @view_config(canvas_file=True)

--- a/tests/unit/lms/models/h_user_test.py
+++ b/tests/unit/lms/models/h_user_test.py
@@ -1,3 +1,4 @@
+from lms.models import HUser
 from tests import factories
 
 
@@ -6,3 +7,16 @@ class TestHUser:
         h_user = factories.HUser(username="test_username")
 
         assert h_user.userid("test_authority") == "acct:test_username@test_authority"
+
+    def test_from_lti_user(self):
+        lti_user = factories.LTIUser(
+            tool_consumer_instance_guid="test_tool_consumer_instance_guid",
+            user_id="test_user_id",
+        )
+
+        assert HUser.from_lti_user(lti_user) == HUser(
+            username="16aa3b3e92cdfa53e5996d138a7013",
+            display_name=lti_user.display_name,
+            provider=lti_user.tool_consumer_instance_guid,
+            provider_unique_id=lti_user.user_id,
+        )

--- a/tests/unit/lms/models/lti_user_test.py
+++ b/tests/unit/lms/models/lti_user_test.py
@@ -5,6 +5,14 @@ from tests import factories
 
 
 class TestLTIUser:
+    def test_h_user(self, HUser):
+        lti_user = factories.LTIUser()
+
+        h_user = lti_user.h_user
+
+        HUser.from_lti_user.assert_called_once_with(lti_user)
+        assert h_user == HUser.from_lti_user.return_value
+
     @pytest.mark.parametrize(
         "roles,is_instructor",
         [
@@ -68,3 +76,8 @@ def test_display_name(
     display_name_ = display_name(given_name, family_name, full_name)
 
     assert display_name_ == expected_display_name
+
+
+@pytest.fixture(autouse=True)
+def HUser(patch):
+    return patch("lms.models.lti_user.HUser")

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -3,9 +3,7 @@ from unittest import mock
 import pytest
 from pyramid.authorization import ACLAuthorizationPolicy
 
-from lms.models import HUser
 from lms.resources import LTILaunchResource
-from tests import factories
 
 
 class TestACL:
@@ -170,24 +168,6 @@ class TestIsCanvas:
         pyramid_request.parsed_params = parsed_params
 
         assert LTILaunchResource(pyramid_request).is_canvas == is_canvas
-
-
-class TestHUser:
-    def test_it(self, pyramid_request):
-        assert LTILaunchResource(pyramid_request).h_user == HUser(
-            username="16aa3b3e92cdfa53e5996d138a7013",
-            display_name=pyramid_request.lti_user.display_name,
-            provider="test_tool_consumer_instance_guid",
-            provider_unique_id="test_user_id",
-        )
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.lti_user = factories.LTIUser(
-            tool_consumer_instance_guid="test_tool_consumer_instance_guid",
-            user_id="test_user_id",
-        )
-        return pyramid_request
 
 
 class TestCustomCanvasAPIDomain:

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -1,13 +1,11 @@
-from unittest import mock
 from unittest.mock import create_autospec
 
 import pytest
-from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
+from pyramid.httpexceptions import HTTPInternalServerError
 
 from lms.models import GroupInfo
 from lms.services import HAPIError
 from lms.services.lti_h import Group, LTIHService
-from tests import factories
 
 
 class TestSync:
@@ -108,12 +106,6 @@ class TestUserUpserting:
 
         h_api.upsert_user.assert_not_called()
 
-    def test_it_raises_if_h_user_raises(self, context, lti_h_svc):
-        type(context).h_user = mock.PropertyMock(side_effect=HTTPBadRequest("Oops"))
-
-        with pytest.raises(HTTPBadRequest, match="Oops"):
-            lti_h_svc.single_group_sync()
-
 
 class TestAddingUserToGroups:
     def test_it_adds_the_user_to_the_group(self, h_api, lti_h_svc, h_user):
@@ -139,19 +131,18 @@ def lti_h_svc(pyramid_request):
 
 
 @pytest.fixture
-def h_user():
-    return factories.HUser()
+def h_user(pyramid_request):
+    return pyramid_request.lti_user.h_user
 
 
 @pytest.fixture
-def context(h_user):
+def context():
     class TestContext:
         h_groupid = "test_groupid"
         h_group_name = "test_group_name"
         h_authority_provided_id = "test_authority_provided_id"
 
     context = TestContext()
-    context.h_user = h_user  # pylint:disable=attribute-defined-outside-init
     return context
 
 

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -119,7 +119,9 @@ class TestCommon:
         view_caller(context, pyramid_request)
 
         grading_info_service.upsert_from_request.assert_called_once_with(
-            pyramid_request, h_user=context.h_user, lti_user=pyramid_request.lti_user
+            pyramid_request,
+            h_user=pyramid_request.lti_user.h_user,
+            lti_user=pyramid_request.lti_user,
         )
 
     def test_it_does_not_call_grading_info_upsert_if_instructor(


### PR DESCRIPTION
Move the `LTILaunchResource.h_user` (`context.h_user`) property, which
returns the `HUser` for the current request, to
`request.lti_user.h_user`:

1. Add a new factory classmethod `models.HUser.from_lti_user(lti_user)`
   that constructs an `HUser` from an `LTIUser`

2. As a convenience add a new instance property `models.LTIUser.h_user`
   which is the `HUser` for the given `LTIUser`

3. This means that instead of `context.lti_user` which only works when
   the context is an `LTILaunchResource`, code can now do
   `request.lti_user.h_user` instead, which works whenever
   `request.lti_user` isn't `None`. So code that uses the `h_user` is
   now decoupled from `LTILaunchResource` and can be used in other
   contexts.

4. Delete `LTILaunchResource.h_user` now that it's no longer used