### PR TITLE
Fix `make pip-compile`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ deps =
     docker-compose: docker-compose
     {tests,bddtests,functests,lint}: -r requirements.txt
     dev: -r requirements-dev.in
-    pip-compile: pip-tools
+    pip-compile: pip-tools<5.0.0
 setenv =
     tests: JWT_SECRET = test_secret
     tests: VIA_URL = https://example.com/


### PR DESCRIPTION
This is broken with pip-tools 5, pin to an older version.