### PR TITLE
Add GradingInfo.__repr__()

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -58,6 +58,15 @@ class BaseClass:
             if key in data:
                 setattr(self, key, data[key])
 
+    def __repr__(self):
+        return "{class_}({kwargs})".format(
+            class_=self.__class__.__name__,
+            kwargs=", ".join(
+                f"{kwarg}={repr(getattr(self, kwarg))}"
+                for kwarg in self.__table__.columns.keys()  # pylint:disable=no-member
+            ),
+        )
+
 
 BASE = declarative_base(
     # Create a default metadata object with naming conventions for indexes and

--- a/tests/unit/lms/db/__init___test.py
+++ b/tests/unit/lms/db/__init___test.py
@@ -52,6 +52,22 @@ class TestBase:
         with pytest.raises(TypeError):
             ModelClass().update_from_dict({}, skip_keys=["a"])
 
+    def test_repr(self):
+        model = ModelClass(id=23, column=46)
+
+        assert repr(model) == ("ModelClass(" "id=23, " "column=46)")
+
+    def test_repr_is_valid_python(self):
+        model = ModelClass(id=23, column=46)
+
+        deserialized_model = eval(repr(model))  # pylint:disable=eval-used
+
+        for attr in (
+            "id",
+            "column",
+        ):
+            assert getattr(deserialized_model, attr) == getattr(model, attr)
+
     @pytest.fixture
     def model(self):
         return ModelClass(id=1234, column="original_value")


### PR DESCRIPTION
Add a `__repr__()` to `GradingInfo`. I found this useful when debugging some test stuff.

Might be a nicer way of implementing it using [`reprlib`](https://github.com/hypothesis/lms/pull/new/add-GradingInfo-repr)?