### PR TITLE
Merge h_authority_provided_id, h_groupid and h_group_name into h_group

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,6 +1,7 @@
 from lms.models.application_instance import ApplicationInstance
 from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
+from lms.models.h_group import HGroup
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
 from lms.models.lti_user import LTIUser, display_name

--- a/lms/models/h_group.py
+++ b/lms/models/h_group.py
@@ -1,0 +1,9 @@
+from typing import NamedTuple
+
+
+class HGroup(NamedTuple):
+    name: str
+    authority_provided_id: str
+
+    def groupid(self, authority):
+        return f"group:{self.authority_provided_id}@{authority}"

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -363,7 +363,7 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
                     "authority": self._authority,
                     "enableShareLinks": False,
                     "grantToken": self._grant_token(api_url),
-                    "groups": [self._context.h_groupid],
+                    "groups": [self._context.h_group.groupid(self._authority)],
                 }
             ]
         }

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -89,20 +89,17 @@ class HAPI:
         except HAPINotFoundError:
             self.create_user(h_user)
 
-    def upsert_group(self, group_id, group_name):
-        """
-        Update or create a group in H.
-
-        :param group_id: The id of the group
-        :param group_name: The display name for the group
-        """
+    def upsert_group(self, group):
+        """Update or create a group in h."""
 
         def do_upsert_group():
             """Send an upsert group request to h."""
+            groupid = group.groupid(self._authority)
+
             self._api_request(
                 "PUT",
-                f"groups/{group_id}",
-                data={"groupid": group_id, "name": group_name},
+                f"groups/{groupid}",
+                data={"groupid": groupid, "name": group.name},
                 headers={"X-Forwarded-User": f"acct:lms@{self._authority}"},
             )
 
@@ -114,16 +111,18 @@ class HAPI:
             self.create_user(HUser("lms", provider="lms", provider_unique_id="lms"))
             do_upsert_group()
 
-    def add_user_to_group(self, h_user, group_id):
+    def add_user_to_group(self, h_user, h_group):
         """
         Add the user as a member of the group.
 
         :param h_user: the user to add to the group
         :type h_user: HUser
-        :param group_id: The id of the group
+        :param h_group: the group to add the user to
+        :type h_group: HGroup
         """
         self._api_request(
-            "POST", f"groups/{group_id}/members/{h_user.userid(self._authority)}"
+            "POST",
+            f"groups/{h_group.groupid(self._authority)}/members/{h_user.userid(self._authority)}",
         )
 
     def _api_request(self, method, path, data=None, headers=None):

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -43,7 +43,7 @@ class LTIHService:
         This will upsert the provided list of groups, the current user and
         make that user a member of each group.
 
-        :param groups: A list of models.Group objects.
+        :param groups: A list of models.HGroup objects.
         :raises HTTPInternalServerError: If we cannot sync to H for any reason
         """
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,2 +1,3 @@
+from tests.factories.h_group import HGroup
 from tests.factories.h_user import HUser
 from tests.factories.lti_user import LTIUser

--- a/tests/factories/h_group.py
+++ b/tests/factories/h_group.py
@@ -1,0 +1,9 @@
+from factory import Faker, Sequence, make_factory
+
+from lms import models
+
+HGroup = make_factory(  # pylint:disable=invalid-name
+    models.HGroup,
+    name=Sequence(lambda n: f"Test Group {n}"),
+    authority_provided_id=Faker("hexify", text="^" * 40),
+)

--- a/tests/unit/lms/models/h_group_test.py
+++ b/tests/unit/lms/models/h_group_test.py
@@ -1,0 +1,11 @@
+from unittest import mock
+
+from lms.models import HGroup
+
+
+def test_groupid():
+    group = HGroup(mock.sentinel.name, "test_authority_provided_id")
+
+    groupid = group.groupid("lms.hypothes.is")
+
+    assert groupid == "group:test_authority_provided_id@lms.hypothes.is"


### PR DESCRIPTION
Add a new `models.HGroup` domain model class with
`authority_provided_id`, `groupid` and `group_name` attributes and
combine the three separate `LTILaunchResource` properties
`h_authority_provided_id`, `h_groupid` and `h_group_name` into a single
`h_group` property that returns an `HGroup`.