### PR TITLE
Remove single_group_sync() and decouple LTIHService from LTILaunchResource (context)

### DIFF
--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -3,7 +3,7 @@ from pyramid.httpexceptions import HTTPInternalServerError
 from lms.services import HAPIError
 
 
-class LTIHService:
+class LTIHService:  # pylint:disable=too-few-public-methods
     """
     Copy LTI users and courses to h users and groups.
 
@@ -18,7 +18,6 @@ class LTIHService:
     """
 
     def __init__(self, _context, request):
-        self._context = request.context
         self._request = request
         self._lti_user = request.lti_user
         self._h_user = request.lti_user.h_user
@@ -26,15 +25,6 @@ class LTIHService:
         self._ai_getter = request.find_service(name="ai_getter")
         self._h_api = request.find_service(name="h_api")
         self._group_info_service = request.find_service(name="group_info")
-
-    def single_group_sync(self):
-        """
-        Sync standard data to H for an LTI launch.
-
-        This will read a single group from the context object, upsert it, the
-        current user and make that user a member of the group.
-        """
-        self.sync(groups=[self._context.h_group])
 
     def sync(self, groups):
         """
@@ -63,7 +53,7 @@ class LTIHService:
             self._h_api.upsert_group(group)
 
             self._group_info_service.upsert(
-                authority_provided_id=self._context.h_group.authority_provided_id,
+                authority_provided_id=group.authority_provided_id,
                 consumer_key=self._lti_user.oauth_consumer_key,
                 params=self._request.params,
             )

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -45,7 +45,7 @@ class BasicLTILaunchViews:
         and group corresponding to the LTI user and course.
         """
 
-        self.request.find_service(name="lti_h").single_group_sync()
+        self.request.find_service(name="lti_h").sync([self.context.h_group])
 
     def store_lti_data(self):
         """Store LTI launch data in our LMS database."""

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -48,7 +48,7 @@ from lms.validation import ContentItemSelectionLTILaunchSchema
     schema=ContentItemSelectionLTILaunchSchema,
 )
 def content_item_selection(context, request):
-    request.find_service(name="lti_h").single_group_sync()
+    request.find_service(name="lti_h").sync([context.h_group])
 
     context.js_config.enable_content_item_selection_mode(
         form_action=request.params["content_item_return_url"],

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -9,59 +9,52 @@ from lms.services.lti_h import LTIHService
 
 
 class TestSync:
-    def test_single_group_sync_calls_sync(self, lti_h_svc, context):
-        lti_h_svc.sync = create_autospec(lti_h_svc.sync)
-
-        lti_h_svc.single_group_sync()
-
-        lti_h_svc.sync.assert_called_once_with(groups=[context.h_group])
-
     def test_sync_does_nothing_if_provisioning_is_disabled(
-        self, ai_getter, lti_h_svc, h_api, context
+        self, ai_getter, lti_h_svc, h_api, h_group
     ):
         ai_getter.provisioning_enabled.return_value = False
 
-        lti_h_svc.sync(groups=[context.h_group])
+        lti_h_svc.sync(groups=[h_group])
 
         h_api.upsert_user.assert_not_called()
 
-    def test_sync_catches_HAPIErrors(self, h_api, lti_h_svc, context):
+    def test_sync_catches_HAPIErrors(self, h_api, lti_h_svc, h_group):
         h_api.upsert_user.side_effect = HAPIError
 
         with pytest.raises(HTTPInternalServerError):
-            lti_h_svc.sync(groups=[context.h_group])
+            lti_h_svc.sync(groups=[h_group])
 
 
 class TestGroupUpdating:
-    def test_it_upserts_the_group(self, h_api, lti_h_svc, context):
-        lti_h_svc.single_group_sync()
+    def test_it_upserts_the_group(self, h_api, lti_h_svc, h_group):
+        lti_h_svc.sync([h_group])
 
-        h_api.upsert_group.assert_called_once_with(context.h_group)
+        h_api.upsert_group.assert_called_once_with(h_group)
 
-    def test_it_raises_if_upserting_the_group_fails(self, h_api, lti_h_svc):
+    def test_it_raises_if_upserting_the_group_fails(self, h_api, lti_h_svc, h_group):
         h_api.upsert_group.side_effect = HAPIError("Oops")
 
         with pytest.raises(HTTPInternalServerError, match="Oops"):
-            lti_h_svc.single_group_sync()
+            lti_h_svc.sync([h_group])
 
     def test_it_upserts_the_GroupInfo_into_the_db(
-        self, params, group_info_service, context, lti_h_svc, pyramid_request
+        self, params, group_info_service, lti_h_svc, pyramid_request, h_group
     ):
-        lti_h_svc.single_group_sync()
+        lti_h_svc.sync([h_group])
 
         group_info_service.upsert.assert_called_once_with(
-            authority_provided_id=context.h_group.authority_provided_id,
+            authority_provided_id=h_group.authority_provided_id,
             consumer_key=pyramid_request.lti_user.oauth_consumer_key,
             params=params,
         )
 
     def test_it_doesnt_upsert_GroupInfo_into_the_db_if_upserting_the_group_fails(
-        self, group_info_service, h_api, lti_h_svc
+        self, group_info_service, h_api, lti_h_svc, h_group
     ):
         h_api.upsert_group.side_effect = HAPIError("Oops")
 
         try:
-            lti_h_svc.single_group_sync()
+            lti_h_svc.sync([h_group])
         except:  # pylint: disable=bare-except
             pass
 
@@ -80,38 +73,40 @@ class TestGroupUpdating:
 
 
 class TestUserUpserting:
-    def test_it_calls_h_api_for_user_update(self, h_api, lti_h_svc, h_user):
-        lti_h_svc.single_group_sync()
+    def test_it_calls_h_api_for_user_update(self, h_api, lti_h_svc, h_user, h_group):
+        lti_h_svc.sync([h_group])
 
         h_api.upsert_user.assert_called_once_with(h_user=h_user)
 
-    def test_it_raises_if_upsert_user_raises_unexpected_error(self, h_api, lti_h_svc):
+    def test_it_raises_if_upsert_user_raises_unexpected_error(
+        self, h_api, lti_h_svc, h_group
+    ):
         h_api.upsert_user.side_effect = HAPIError("whatever")
 
         with pytest.raises(HTTPInternalServerError, match="whatever"):
-            lti_h_svc.single_group_sync()
+            lti_h_svc.sync([h_group])
 
     def test_it_doesnt_use_the_h_api_if_feature_not_enabled(
-        self, ai_getter, h_api, lti_h_svc
+        self, ai_getter, h_api, lti_h_svc, h_group
     ):
         ai_getter.provisioning_enabled.return_value = False
 
-        lti_h_svc.single_group_sync()
+        lti_h_svc.sync([h_group])
 
         h_api.upsert_user.assert_not_called()
 
 
 class TestAddingUserToGroups:
-    def test_it_adds_the_user_to_the_group(self, h_api, lti_h_svc, h_user, context):
-        lti_h_svc.single_group_sync()
+    def test_it_adds_the_user_to_the_group(self, h_api, lti_h_svc, h_user, h_group):
+        lti_h_svc.sync([h_group])
 
-        h_api.add_user_to_group.assert_called_once_with(h_user, context.h_group)
+        h_api.add_user_to_group.assert_called_once_with(h_user, h_group)
 
-    def test_it_raises_if_post_raises(self, h_api, lti_h_svc):
+    def test_it_raises_if_post_raises(self, h_api, lti_h_svc, h_group):
         h_api.add_user_to_group.side_effect = HAPIError("Oops")
 
         with pytest.raises(HTTPInternalServerError, match="Oops"):
-            lti_h_svc.single_group_sync()
+            lti_h_svc.sync([h_group])
 
 
 pytestmark = pytest.mark.usefixtures("ai_getter", "h_api", "group_info_service")
@@ -128,15 +123,5 @@ def h_user(pyramid_request):
 
 
 @pytest.fixture
-def context():
-    class TestContext:
-        h_group = create_autospec(HGroup, instance=True, spec_set=True)
-
-    context = TestContext()
-    return context
-
-
-@pytest.fixture
-def pyramid_request(context, pyramid_request):
-    pyramid_request.context = context
-    return pyramid_request
+def h_group():
+    return create_autospec(HGroup, instance=True, spec_set=True)


### PR DESCRIPTION
This finishes decoupling `LTIHService` from `LTILaunchResource` (`self._context`) and means that `LTIHService` should now be callable by the sync API:

Remove `LTIHService.single_group_sync()` which was just a convenience method for doing `self.sync([self._context.h_group])`. Just have the views call `lti_h_svc.sync([context.h_group])` instead. The sync API view will call `lti_h_svc.sync([group_created_in_some_other_way])`