### PR TITLE
2 - Use new style via params "via.client.*"

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -20,9 +20,9 @@ def via_url(request, document_url):
 
     # Default via parameters
     options = {
-        "via.open_sidebar": "1",
-        "via.request_config_from_frame": request.host_url,
-        "via.config_frame_ancestor_level": "2",
+        "via.client.openSidebar": "1",
+        "via.client.requestConfigFromFrame.origin": request.host_url,
+        "via.client.requestConfigFromFrame.ancestorLevel": "2",
     }
 
     if request.feature("use_legacy_via"):

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -8,10 +8,10 @@ from lms.views.helpers import via_url
 
 class TestViaURL:
     DEFAULT_OPTIONS = {
-        "via.open_sidebar": "1",
+        "via.client.openSidebar": "1",
         # This is the `request.host_url`
-        "via.request_config_from_frame": "http://example.com",
-        "via.config_frame_ancestor_level": "2",
+        "via.client.requestConfigFromFrame.origin": "http://example.com",
+        "via.client.requestConfigFromFrame.ancestorLevel": "2",
     }
 
     def test_if_creates_the_correct_via_url(self, pyramid_request):
@@ -36,8 +36,8 @@ class TestViaURL:
                 # its own values.
                 {
                     "extra": "value",
-                    "via.open_sidebar": "IGNORED1",
-                    "via.request_config_from_frame": "IGNORED2",
+                    "via.client.openSidebar": "IGNORED1",
+                    "via.client.requestConfigFromFrame.origin": "IGNORED2",
                 },
                 "extra=value",
             ),


### PR DESCRIPTION
This enables new style params which are programatically understood and passed onto the client, instead of catered for individually.

This cannot be merged until the enabling PRs to make via and via3 accept this style have been put in place:

 * https://github.com/hypothesis/via3/pull/125
 * https://github.com/hypothesis/via/pull/228