### PR TITLE
Add feature-flagged sync API

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -250,6 +250,7 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
                 # The auth token that the JavaScript code will use to
                 # authenticate itself to the API.
                 "authToken": self._auth_token(),
+                "sync": self._sync_api(),
             },
             # The URL that the JavaScript code will open if it needs the user to
             # authorize us to request a new Canvas access token.
@@ -363,7 +364,33 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
                     "authority": self._authority,
                     "enableShareLinks": False,
                     "grantToken": self._grant_token(api_url),
-                    "groups": [self._context.h_group.groupid(self._authority)],
+                    "groups": self._groups(),
                 }
             ]
+        }
+
+    def _groups(self):
+        if self._context.should_use_section_groups:
+            return "$rpc:requestGroups"
+        return [self._context.h_group.groupid(self._authority)]
+
+    def _sync_api(self):
+        if not self._context.should_use_section_groups:
+            return None
+
+        req = self._request
+
+        return {
+            "path": req.route_path("canvas_api.sync"),
+            "data": {
+                "lms": {
+                    "tool_consumer_instance_guid": req.params[
+                        "tool_consumer_instance_guid"
+                    ],
+                },
+                "course": {
+                    "context_id": req.params["context_id"],
+                    "custom_canvas_course_id": req.params["custom_canvas_course_id"],
+                },
+            },
         }

--- a/lms/resources/default.py
+++ b/lms/resources/default.py
@@ -9,6 +9,7 @@ class DefaultResource:  # pylint:disable=too-few-public-methods
         (Allow, "report_viewers", "view"),
         (Allow, "lti_user", "canvas_api"),
         (Allow, "lti_user", "lti_outcomes"),
+        (Allow, "lti_user", "sync_api"),
     ]
 
     def __init__(self, request):

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -66,43 +66,6 @@ class LTILaunchResource:
             authority_provided_id=authority_provided_id,
         )
 
-    def h_section_groupid(self, tool_consumer_instance_guid, context_id, section):
-        """
-        Return a unique h groupid for a given Canvas course section.
-
-        The groupid is deterministic and is unique to the course section.
-        Calling this function again with params representing the same course
-        section will always return the same groupid. Calling this function with
-        different params will always return a different groupid.
-
-        :param tool_consumer_instance_guid: the tool_consumer_instance_guid LTI
-            launch param from the Canvas instance that the section belongs to.
-            This is a unique identifier for the Canvas instance
-        :type tool_consumer_instance_guid: str
-
-        :param context_id: the context_id LTI launch param from the Canvas
-            course that the section belongs to. This is a unique identifier for
-            the course within the Canvas instance
-        :type context_id: str
-
-        :param section: a section dict as received from the Canvas API
-        :type section: dict
-        """
-        hash_object = hashlib.sha1()
-        hash_object.update(tool_consumer_instance_guid.encode())
-        hash_object.update(context_id.encode())
-        hash_object.update(section["id"].encode())
-        return f"group:section-{hash_object.hexdigest()}@{self._authority}"
-
-    @staticmethod
-    def h_section_group_name(section):
-        """
-        Return the h group name for the given Canvas course section.
-
-        :param section: a section dict as received from the Canvas API
-        """
-        return h_group_name(section["name"])
-
     @property
     def is_canvas(self):
         """Return True if Canvas is the LMS that launched us."""
@@ -134,3 +97,11 @@ class LTILaunchResource:
         Canvas.
         """
         return self._request.parsed_params.get("custom_canvas_api_domain")
+
+    @property
+    def should_use_section_groups(self):
+        """Return True if section groups rather than a course group should be used."""
+        if not self.is_canvas:
+            return False
+
+        return self._request.feature("section_groups")

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -30,7 +30,8 @@ def includeme(config):
         "canvas_api.courses.files.list", "/api/canvas/courses/{course_id}/files"
     )
     config.add_route("canvas_api.files.via_url", "/api/canvas/files/{file_id}/via_url")
-    config.add_route("lti_api.submissions.record", "/api/lti/submissions")
+    config.add_route("canvas_api.sync", "/api/canvas/sync", request_method="POST")
 
+    config.add_route("lti_api.submissions.record", "/api/lti/submissions")
     config.add_route("lti_api.result.read", "/api/lti/result", request_method="GET")
     config.add_route("lti_api.result.record", "/api/lti/result", request_method="POST")

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -1,0 +1,46 @@
+import hashlib
+
+from pyramid.view import view_config
+
+from lms.models import HGroup, h_group_name
+
+
+@view_config(
+    route_name="canvas_api.sync",
+    request_method="POST",
+    renderer="json",
+    permission="sync_api",
+)
+def sync(request):
+    authority = request.registry.settings["h_authority"]
+    canvas_api_svc = request.find_service(name="canvas_api_client")
+    lti_h_svc = request.find_service(name="lti_h")
+
+    context_id = request.json["course"]["context_id"]
+    custom_canvas_course_id = request.json["course"]["custom_canvas_course_id"]
+    tool_consumer_instance_guid = request.json["lms"]["tool_consumer_instance_guid"]
+
+    if request.lti_user.is_learner:
+        # For learners we only want the client to show the sections that the
+        # student belongs to, so fetch only the user's sections.
+        sections = canvas_api_svc.authenticated_users_sections(custom_canvas_course_id)
+    else:
+        # For non-learners (e.g. instructors, teaching assistants) we want the
+        # client to show all of the course's sections.
+        sections = canvas_api_svc.course_sections(custom_canvas_course_id)
+
+    def group(section):
+        """Return an HGroup from the given Canvas section dict."""
+        hash_object = hashlib.sha1()
+        hash_object.update(tool_consumer_instance_guid.encode())
+        hash_object.update(context_id.encode())
+        hash_object.update(str(section["id"]).encode())
+        authority_provided_id = hash_object.hexdigest()
+
+        return HGroup(h_group_name(section["name"]), authority_provided_id,)
+
+    groups = [group(section) for section in sections]
+
+    lti_h_svc.sync(groups)
+
+    return [group.groupid(authority) for group in groups]

--- a/tests/unit/lms/models/h_group_test.py
+++ b/tests/unit/lms/models/h_group_test.py
@@ -23,5 +23,5 @@ def test_groupid():
         ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
     ),
 )
-def test_group_name(name, expected_result):
+def test_h_group_name(name, expected_result):
     assert h_group_name(name) == expected_result

--- a/tests/unit/lms/resources/default_test.py
+++ b/tests/unit/lms/resources/default_test.py
@@ -1,3 +1,4 @@
+import pytest
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from lms.resources import DefaultResource
@@ -43,3 +44,16 @@ class TestDefaultResource:
         resource = DefaultResource(pyramid_request)
 
         assert not pyramid_request.has_permission("canvas_api", resource)
+
+    @pytest.mark.parametrize(
+        "groupid,permission", [("lti_user", True), ("others", False)]
+    )
+    def test_sync_api_permission(
+        self, pyramid_config, pyramid_request, groupid, permission
+    ):
+        pyramid_config.testing_securitypolicy("some_lti_user", groupids=[groupid])
+        pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
+
+        resource = DefaultResource(pyramid_request)
+
+        assert pyramid_request.has_permission("sync_api", resource) == permission

--- a/tests/unit/lms/routes_test.py
+++ b/tests/unit/lms/routes_test.py
@@ -45,6 +45,9 @@ class TestIncludeMe:
             mock.call.add_route(
                 "canvas_api.files.via_url", "/api/canvas/files/{file_id}/via_url"
             ),
+            mock.call.add_route(
+                "canvas_api.sync", "/api/canvas/sync", request_method="POST"
+            ),
             mock.call.add_route("lti_api.submissions.record", "/api/lti/submissions"),
             mock.call.add_route(
                 "lti_api.result.read", "/api/lti/result", request_method="GET"

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -1,0 +1,95 @@
+import pytest
+
+from lms.views.api.canvas.sync import sync
+from tests import factories
+
+
+def test_sync_when_the_user_is_a_learner(
+    pyramid_request, canvas_api_client, lti_h_service
+):
+    pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Learner")
+
+    returned_groupids = sync(pyramid_request)
+
+    expected_groups = [
+        factories.HGroup(
+            name="Section 2",
+            authority_provided_id="d99674b9700f4a40a2b301d2949b61339c58236c",
+        )
+    ]
+    canvas_api_client.authenticated_users_sections.assert_called_once_with(
+        "test_custom_canvas_course_id"
+    )
+    assert_that_it_called_sync_and_returned_the_groupids(
+        lti_h_service, returned_groupids, expected_groups
+    )
+
+
+def test_sync_when_the_user_isnt_a_learner(
+    pyramid_request, canvas_api_client, lti_h_service
+):
+    pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Instructor")
+
+    returned_groupids = sync(pyramid_request)
+
+    expected_groups = [
+        factories.HGroup(
+            name="Section 1",
+            authority_provided_id="d0f36006728f2277f228b74c8a7f620305bfb3e7",
+        ),
+        factories.HGroup(
+            name="Section 2",
+            authority_provided_id="d99674b9700f4a40a2b301d2949b61339c58236c",
+        ),
+        factories.HGroup(
+            name="Section 3",
+            authority_provided_id="6a85e3651705dee4da0805b8985472343cbea94e",
+        ),
+    ]
+    canvas_api_client.course_sections.assert_called_once_with(
+        "test_custom_canvas_course_id"
+    )
+    assert_that_it_called_sync_and_returned_the_groupids(
+        lti_h_service, returned_groupids, expected_groups
+    )
+
+
+def assert_that_it_called_sync_and_returned_the_groupids(
+    lti_h_service, returned_groupids, expected_groups
+):
+    lti_h_service.sync.assert_called_once_with(expected_groups)
+    assert returned_groupids == [
+        f"group:{group.authority_provided_id}@TEST_AUTHORITY"
+        for group in expected_groups
+    ]
+
+
+pytestmark = pytest.mark.usefixtures("canvas_api_client", "lti_h_service")
+
+
+@pytest.fixture
+def canvas_api_client(canvas_api_client):
+    # The course has three sections named "Section 1", "Section 2" and "Section
+    # 3" (with IDs 1, 2 and 3).
+    canvas_api_client.course_sections.return_value = [
+        {"id": i, "name": f"Section {i}",} for i in range(1, 4)
+    ]
+
+    # The learner is only a member of section 2.
+    canvas_api_client.authenticated_users_sections.return_value = [
+        {"id": 2, "name": "Section 2"}
+    ]
+
+    return canvas_api_client
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.json = {
+        "course": {
+            "context_id": "test_context_id",
+            "custom_canvas_course_id": "test_custom_canvas_course_id",
+        },
+        "lms": {"tool_consumer_instance_guid": "test_tool_consumer_instance_guid",},
+    }
+    return pyramid_request


### PR DESCRIPTION
Add the new sync API and, if the `section_groups` feature flag is on, add the JavaScript config necessary to tell the frontend to call the sync API.

Fixes https://github.com/hypothesis/lms/issues/1566
Fixes https://github.com/hypothesis/lms/issues/1389

This PR does not include the frontend changes necessary to make it respond to the new config and actually call the sync API.

## What this PR does

1. Adds a `context.should_use_section_groups` boolean. For now, sections groups are enabled if you're in Canvas and you have the `section_groups` feature flag on.

1. Adds the new sync API: route, ACL and view.

   When called, the sync API fetches the sections from Canvas, generates groups from them, upserts the groups into h, and returns the list of groupids.

1. Adds new sync API settings to the JavaScript config.

   This tells the JS what path to call the sync API on, and what params to pass to it. The JS is dumb about calling the sync API: it just passes it the params the backend told it to pass. (This JS code that dumbly calls the sync API is _not in this PR_.)

   This new sync API config is only added to the JS config when sections are in use. Otherwise it's omitted (and the JS will just use the course group from the JS config and will not call the sync API).

1. When section groups are in use the `"groups"` in the JavaScript config object that we send **to the Hypothesis client** will be the string `"$rpc:requestGroups"` instead of the list of group IDs. This is what we have to do to tell the client to fetch the list of group IDs over postMessage-JSON-RPC.

   Note: this is the config for the Hypothesis client, that will be sent over postMessage-JSON-RPC to the Hypothesis client, it's _not_ the config for the LMS app's own frontend code.

   When section groups are not in use the `"groups"` config is what it was before: a list of one course group ID.

## How to test this PR

You can't really test this PR without the frontend changes that make it actually call the sync API, and pass the groups from the sync API to the client. And that frontend code isn't ready yet. But there is a hacky version of that frontend PR: https://github.com/hypothesis/lms/pull/1681

So the easiest way to test this PR is to cherry-pick #1681 onto this branch locally (`git cherry-pick make-the-frontend-call-the-sync-api`). That PR will both enable the `section_groups` feature flag by default in dev and change the frontend code to use the section groups. You can then launch assignments as teachers and students and see section groups in the client.

There are https://hypothesis.instructure.com/ test users on 1Password named **Sections 101 Teacher**, **Sections 101 Student 1**, **Sections 101 Student 2** and **Sections 101 Student 3** (the different students are members of different sections of the course). If you log in to Canvas as one of these users you'll see a test course named **Sections 101** that contains pre-created test sections.

- [ ] When launching an assignment as a teacher you should see all of the course's sections in the client's groups menu

- [ ] When launching an assignment as a student you should only see that student's sections, which may only be one section (or it might be more than one if the student belongs to multiple sections)

- [ ] If you delete all of the Canvas API access tokens from your LMS DB (`make sql` and then `delete from oauth2_token;`) and then launch any assignment, you should see that it asks you to authorize with Canvas and _then_ launches and shows the section groups.

  Previously this Canvas authorization would only have happened when launching a Canvas files assignment because only Canvas files assignments had to call the Canvas API. Now it'll happen with any type of assignment, since they all need to call the Canvas API to get the sections.

- [ ] In dev tools you should be able to see the sync API request and response containing the section group IDs

- [ ] You could also look at the groups being created in h's DB with `make sql` in h

- [ ] If you set `feature_flags.section_groups` to `false` in `development.ini` you should then see course groups again not section groups, and no sync API request in dev tools

## Known issues

1. When more than one section group is shown in the client, the groups menu includes buttons for leaving the groups: https://hypothes-is.slack.com/archives/C1M8NH76X/p1587752985223300 These buttons shouldn't be shown in the LMS context. We'll fix this in a separate PR

2. This will be totally broken in SpeedGrader. We'll fix that in later PRs