### PR TITLE
Make the frontend call the sync API

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -17,6 +17,7 @@ session_cookie_secret = "notasecret"
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
 feature_flags_allowed_in_cookie = use_legacy_via
+feature_flags.section_groups = true
 
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -76,6 +76,14 @@ async function listFiles(authToken, courseId) {
   });
 }
 
+async function sync(authToken, config) {
+  return apiCall({
+    authToken,
+    path: config.path,
+    data: config.data,
+  });
+}
+
 // Separate export from declaration to work around
 // https://github.com/robertknight/babel-plugin-mockable-imports/issues/9
-export { apiCall, listFiles };
+export { apiCall, sync, listFiles };

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -15,27 +15,14 @@ export function requestConfig() {
   return clientConfigObj;
 }
 
+
+var groupsPromise = new Promise(function(resolve, reject) {
+  window.resolveGroupsPromise = resolve;
+});
+
 /**
  * Return the groups for the Hypothesis client to show.
  */
 export async function requestGroups() {
-  const configObj = JSON.parse(
-    document.querySelector('.js-config').textContent
-  );
-
-  function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  if (configObj.dev === true) {
-    // Artifically sleep to simulate how long this will take when it needs to
-    // send real API requests to get the groups.
-    // The artificial delay is only inserted 50% of the time (at random) so we
-    // don't somehow accidentally end up relying on the slowness.
-    if (Math.random() < 0.5) {
-      await sleep(4000);
-    }
-  }
-
-  return configObj.hypothesisClient.services[0].groups;
+  return await groupsPromise;
 }


### PR DESCRIPTION
Turn on the section_groups feature flag in dev and make the frontend send the sync API request, and send the groups from the sync API request to the client.

This is not a real PR. It's just a hacky demonstration / proof-of-concept. Do not merge