### PR TITLE
Fix a bug in CanvasAuthenticatedUsersSectionsResponseSchema

### DIFF
--- a/lms/validation/_canvas.py
+++ b/lms/validation/_canvas.py
@@ -21,6 +21,9 @@ class _SectionSchema(Schema):
     various schemas below for Canvas API responses that contain section dicts.
     """
 
+    class Meta:  # pylint:disable=too-few-public-methods
+        unknown = EXCLUDE
+
     id = fields.Int(required=True)
     name = fields.String(required=True)
 

--- a/tests/unit/lms/validation/_canvas_test.py
+++ b/tests/unit/lms/validation/_canvas_test.py
@@ -24,7 +24,7 @@ def canvas_authenticated_users_sections_response_schema():
     response_ = response()
     response_.json.return_value = {
         "sections": [
-            {"id": 101, "name": "section_name_1", "foo": "bar"},
+            {"id": 101, "name": "section_name_1", "unexpected": "ignored"},
             {"id": 102, "name": "section_name_2"},
             {"id": 103, "name": "section_name_3"},
         ]

--- a/tests/unit/lms/validation/_canvas_test.py
+++ b/tests/unit/lms/validation/_canvas_test.py
@@ -36,7 +36,7 @@ def canvas_course_sections_response_schema():
     """Return a CanvasCourseSectionsResponseSchema."""
     response_ = response()
     response_.json.return_value = [
-        {"id": 101, "name": "section_name_1", "foo": "bar"},
+        {"id": 101, "name": "section_name_1", "unexpected": "ignored"},
         {"id": 102, "name": "section_name_2"},
         {"id": 103, "name": "section_name_3"},
     ]

--- a/tests/unit/lms/validation/_canvas_test.py
+++ b/tests/unit/lms/validation/_canvas_test.py
@@ -24,7 +24,7 @@ def canvas_authenticated_users_sections_response_schema():
     response_ = response()
     response_.json.return_value = {
         "sections": [
-            {"id": 101, "name": "section_name_1"},
+            {"id": 101, "name": "section_name_1", "foo": "bar"},
             {"id": 102, "name": "section_name_2"},
             {"id": 103, "name": "section_name_3"},
         ]
@@ -36,7 +36,7 @@ def canvas_course_sections_response_schema():
     """Return a CanvasCourseSectionsResponseSchema."""
     response_ = response()
     response_.json.return_value = [
-        {"id": 101, "name": "section_name_1"},
+        {"id": 101, "name": "section_name_1", "foo": "bar"},
         {"id": 102, "name": "section_name_2"},
         {"id": 103, "name": "section_name_3"},
     ]


### PR DESCRIPTION
When the sections dicts returned by the Canvas API contained additional items that we don't care about (which they do, with the real Canvas API) `CanvasAuthenticatedUsersSectionsResponseSchema` was raising a validation error. Fix it to just ignore the additional items instead.