### PR TITLE
Extract group_name() into model

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,7 +1,7 @@
 from lms.models.application_instance import ApplicationInstance
 from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
-from lms.models.h_group import HGroup
+from lms.models.h_group import HGroup, h_group_name
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
 from lms.models.lti_user import LTIUser, display_name

--- a/lms/models/h_group.py
+++ b/lms/models/h_group.py
@@ -7,3 +7,16 @@ class HGroup(NamedTuple):
 
     def groupid(self, authority):
         return f"group:{self.authority_provided_id}@{authority}"
+
+
+def h_group_name(name):
+    """Return an h-compatible group name from the given string."""
+    name = name.strip()
+
+    # The maximum length of an h group name.
+    group_name_max_length = 25
+
+    if len(name) > group_name_max_length:
+        name = name[: group_name_max_length - 1].rstrip() + "…"
+
+    return name

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -4,7 +4,7 @@ import hashlib
 
 from pyramid.security import Allow
 
-from lms.models import HGroup
+from lms.models import HGroup, h_group_name
 from lms.resources._js_config import JSConfig
 
 
@@ -62,7 +62,7 @@ class LTILaunchResource:
         authority_provided_id = hash_object.hexdigest()
 
         return HGroup(
-            name=self._group_name(self._request.parsed_params["context_title"].strip()),
+            name=h_group_name(self._request.parsed_params["context_title"]),
             authority_provided_id=authority_provided_id,
         )
 
@@ -94,24 +94,14 @@ class LTILaunchResource:
         hash_object.update(section["id"].encode())
         return f"group:section-{hash_object.hexdigest()}@{self._authority}"
 
-    def h_section_group_name(self, section):
+    @staticmethod
+    def h_section_group_name(section):
         """
         Return the h group name for the given Canvas course section.
 
         :param section: a section dict as received from the Canvas API
         """
-        return self._group_name(section["name"].strip())
-
-    @staticmethod
-    def _group_name(name):
-        """Return an h group name from the given course or section name."""
-        # The maximum length of an h group name.
-        group_name_max_length = 25
-
-        if len(name) > group_name_max_length:
-            name = name[: group_name_max_length - 1].rstrip() + "…"
-
-        return name
+        return h_group_name(section["name"])
 
     @property
     def is_canvas(self):

--- a/tests/unit/lms/models/h_group_test.py
+++ b/tests/unit/lms/models/h_group_test.py
@@ -1,6 +1,8 @@
 from unittest import mock
 
-from lms.models import HGroup
+import pytest
+
+from lms.models import HGroup, h_group_name
 
 
 def test_groupid():
@@ -9,3 +11,17 @@ def test_groupid():
     groupid = group.groupid("lms.hypothes.is")
 
     assert groupid == "group:test_authority_provided_id@lms.hypothes.is"
+
+
+@pytest.mark.parametrize(
+    "name,expected_result",
+    (
+        ("Test Course", "Test Course"),
+        (" Test Course ", "Test Course"),
+        ("Test   Course", "Test   Course"),
+        ("Object Oriented Polymorphism 101", "Object Oriented Polymorp…"),
+        ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
+    ),
+)
+def test_group_name(name, expected_result):
+    assert h_group_name(name) == expected_result


### PR DESCRIPTION
Extract the `_group_name()` helper method out of `LTILaunchResource` into the domain model. This reduces some test duplication, and also makes it so that future code outside of `LTILaunchResource` can call `models.h_group_name()` without duplicating any code.

Same approach as with `display_name()` for `models.LTIUser`