### PR TITLE
Skip Via 3 routing for Google Drive documents

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -1,7 +1,81 @@
 """Via-related view helpers."""
+import re
 from urllib.parse import parse_qsl, urlencode, urlparse
 
 __all__ = ["via_url"]
+
+# pylint: disable=too-few-public-methods
+
+
+class _ViaDoc:
+    """A doc we want to proxy with content type."""
+
+    GOOGLE_DRIVE_REGEX = re.compile(
+        r"^https://drive.google.com/uc\?id=(.*)&export=download$", re.IGNORECASE
+    )
+
+    def __init__(self, url, content_type=None):
+        self.url = url
+
+        if content_type is None and self.GOOGLE_DRIVE_REGEX.match(url):
+            content_type = "pdf"
+
+        self._content_type = content_type
+
+    @property
+    def is_pdf(self):
+        return self._content_type == "pdf"
+
+    @property
+    def is_html(self):
+        return self._content_type == "html"
+
+
+class _ViaClient:
+    """A small wrapper to make calling Via easier."""
+
+    def __init__(self, service_url, legacy_service_url, host_url, legacy_mode=False):
+        self.service_url = urlparse(service_url)
+        self.legacy_service_url = legacy_service_url
+
+        # Default via parameters
+        self.options = {
+            "via.client.openSidebar": "1",
+            "via.client.requestConfigFromFrame.origin": host_url,
+            "via.client.requestConfigFromFrame.ancestorLevel": "2",
+        }
+        self.legacy_mode = legacy_mode
+
+    def url_for(self, doc):
+        if not isinstance(doc, _ViaDoc):
+            raise TypeError(f"Expected doc to be a ViaDoc, not '{type(doc)}'")
+
+        if self.legacy_mode or doc.is_html:
+            return self._legacy_via_url(doc.url)
+
+        if doc.is_pdf:
+            return self._url_for("/pdf", doc.url)
+
+        return self._url_for("/route", doc.url)
+
+    def _url_for(self, path, doc_url):
+        options = {"url": doc_url}
+        options.update(self.options)
+
+        return self.service_url._replace(path=path, query=urlencode(options)).geturl()
+
+    def _legacy_via_url(self, doc_url):
+        parsed_url = urlparse(doc_url)
+
+        params = [
+            kv for kv in parse_qsl(parsed_url.query) if not kv[0].startswith("via.")
+        ]
+        params.extend(self.options.items())
+
+        return (
+            self.legacy_service_url
+            + parsed_url._replace(query=urlencode(params)).geturl()
+        )
 
 
 def via_url(request, document_url):
@@ -18,28 +92,9 @@ def via_url(request, document_url):
     :return: A URL string
     """
 
-    # Default via parameters
-    options = {
-        "via.client.openSidebar": "1",
-        "via.client.requestConfigFromFrame.origin": request.host_url,
-        "via.client.requestConfigFromFrame.ancestorLevel": "2",
-    }
-
-    if request.feature("use_legacy_via"):
-        return _legacy_via_url(
-            request.registry.settings["legacy_via_url"], document_url, options
-        )
-
-    options["url"] = document_url
-    via_service_url = urlparse(request.registry.settings["via_url"])
-
-    return via_service_url._replace(path="/route", query=urlencode(options)).geturl()
-
-
-def _legacy_via_url(via_service_url, document_url, options):
-    parsed_url = urlparse(document_url)
-
-    params = [kv for kv in parse_qsl(parsed_url.query) if not kv[0].startswith("via.")]
-    params.extend(options.items())
-
-    return via_service_url + parsed_url._replace(query=urlencode(params)).geturl()
+    return _ViaClient(
+        service_url=request.registry.settings["via_url"],
+        legacy_service_url=request.registry.settings["legacy_via_url"],
+        host_url=request.host_url,
+        legacy_mode=request.feature("use_legacy_via"),
+    ).url_for(_ViaDoc(document_url))

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -47,8 +47,7 @@ class _ViaClient:
         self.legacy_mode = legacy_mode
 
     def url_for(self, doc):
-        if not isinstance(doc, _ViaDoc):
-            raise TypeError(f"Expected doc to be a ViaDoc, not '{type(doc)}'")
+        assert isinstance(doc, _ViaDoc), "Provided doc is a ViaDoc"
 
         if self.legacy_mode or doc.is_html:
             return self._legacy_via_url(doc.url)

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -47,8 +47,6 @@ class _ViaClient:
         self.legacy_mode = legacy_mode
 
     def url_for(self, doc):
-        assert isinstance(doc, _ViaDoc), "Provided doc is a ViaDoc"
-
         if self.legacy_mode or doc.is_html:
             return self._legacy_via_url(doc.url)
 

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -53,6 +53,16 @@ class TestViaURL:
         if expected_extras:
             assert final_url == Any.url.containing_query(expected_extras)
 
+    def test_it_redirects_to_via3_view_pdf_directly_for_google_drive(
+        self, pyramid_request
+    ):
+        google_drive_url = "https://drive.google.com/uc?id=<SOME-ID>&export=download"
+        final_url = via_url(pyramid_request, google_drive_url)
+
+        assert final_url == Any.url.matching(
+            "http://test_via3_server.is/pdf"
+        ).containing_query({"url": google_drive_url})
+
     @pytest.mark.usefixtures("legacy_via_feature_flag")
     @pytest.mark.parametrize(
         "url", ("http://doc.example.com", "https://doc.example.com",)


### PR DESCRIPTION
Got a little fancy here and introduced a simple model class here to help re-use some of the logic. The idea is to make the central bit nice and declarative (if is_pdf do this).

The document object also paves the way for us to specify that something is a PDF for Canvas docs (in the next PR)

### What's happened here?

The logic has been split into some model object so represent:

 * The document 
 * Via itself, making URLs based the document

The document contains a "content_type" which you can set, but if you don't it will use the same regex we have in Via 3 to guess that the doc is a PDF when we see a Google Drive doc.

The objects are tested as blackbox private components of `via_url`.

### How to test

This is mostly about observing what URLs are constructed when we look at various docs by LMS. So here are some URLs to follow on the local Canvas instance, along with with the expected result. In each case filter by "via.client" in the dev tools:

Run "make dev" in superdev, then visit:

* https://hypothesis.instructure.com/courses/83/assignments/462 - Google drive localhost assignment
   - You should see a single call to "pdf?url=" showing Via 3 handling the PDF viewing
   - You should _not_ see a call to "route" showing we have skipped the routing
* https://hypothesis.instructure.com/courses/83/assignments/460 - HTML assignment
   - You should see "route?url=" showing Via 3 routing is in place
   - You should see "example.com?..." showing original flavour Via is handling the HTML
* https://hypothesis.instructure.com/courses/83/assignments/461 - PDF assignment
   - You should see a call to "route?url=" and "pdf?url=" showing Via 3 routing and viewing is in place