### PR TITLE
Skip Via 3 routing for Canvas files, which are always PDFs

### DIFF
--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -31,5 +31,9 @@ class FilesAPIViews:
         public_url = self.canvas_api_client.public_url(
             self.request.matchdict["file_id"]
         )
-        via_url = helpers.via_url(self.request, public_url)
+
+        # Currently we only let users pick PDF files, so we can save a little
+        # time by specifying this, instead of Via having to work it out
+        via_url = helpers.via_url(self.request, public_url, content_type="pdf")
+
         return {"via_url": via_url}

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -75,7 +75,7 @@ class _ViaClient:
         )
 
 
-def via_url(request, document_url):
+def via_url(request, document_url, content_type=None):
     """
     Return the Via URL for annotating the given ``document_url``.
 
@@ -86,12 +86,15 @@ def via_url(request, document_url):
 
     :param request: Request object
     :param document_url: Document URL to present in Via
+    :param content_type: Either "pdf" or "html" if known, None if not
     :return: A URL string
     """
+
+    doc = _ViaDoc(document_url, content_type)
 
     return _ViaClient(
         service_url=request.registry.settings["via_url"],
         legacy_service_url=request.registry.settings["legacy_via_url"],
         host_url=request.host_url,
         legacy_mode=request.feature("use_legacy_via"),
-    ).url_for(_ViaDoc(document_url))
+    ).url_for(doc)

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -48,7 +48,9 @@ class TestViaURL:
         FilesAPIViews(pyramid_request).via_url()
 
         helpers.via_url.assert_called_once_with(
-            pyramid_request, canvas_api_client.public_url.return_value
+            pyramid_request,
+            canvas_api_client.public_url.return_value,
+            content_type="pdf",
         )
 
     # CanvasAPIError's are caught and handled by an exception view, so the

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -63,9 +63,18 @@ class TestViaURL:
             "http://test_via3_server.is/pdf"
         ).containing_query({"url": google_drive_url})
 
+    def test_it_redirects_to_via3_view_pdf_directly_if_content_type_is_pdf(
+        self, pyramid_request
+    ):
+        final_url = via_url(pyramid_request, "any url", content_type="pdf")
+
+        assert (
+            final_url == Any.url.matching("http://test_via3_server.is/pdf").with_query()
+        )
+
     @pytest.mark.usefixtures("legacy_via_feature_flag")
     @pytest.mark.parametrize(
-        "url", ("http://doc.example.com", "https://doc.example.com",)
+        "url", ("http://doc.example.com", "https://doc.example.com")
     )
     def test_it_passes_through_the_url(self, pyramid_request, url):
         final_url = via_url(pyramid_request, url)


### PR DESCRIPTION
This is a performance improvement which should be snappier for users and put less load on Via3.

This must be merged after: https://github.com/hypothesis/lms/pull/1685