### PR TITLE
Fix a `make lint` crash by downgrading PyLint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     {tests,bddtests,functests,lint}: h-matchers>=1.2.5
     {bddtests,functests,lint}: webtest
     {bddtests,lint}: behave
-    lint: pylint
+    lint: pylint<2.5
     lint: pydocstyle
     lint: pycodestyle
     {format,checkformatting}: black


### PR DESCRIPTION
PyLint 2.5's new way of importing code doesn't work with our apps.
See:

https://github.com/PyCQA/pylint/blob/303b8d852e469379cd0f1a8891a018de5e39a966/ChangeLog#L83-L90
https://github.com/PyCQA/pylint/issues/3386
https://github.com/PyCQA/pylint/pull/3411
https://hypothes-is.slack.com/archives/C1MA4E9B9/p1587994973069200