### PR TITLE
Remove unnecessary __str__ and __repr__ methods

### DIFF
--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -5,7 +5,7 @@ from lms.db import BASE
 __all__ = ["GroupInfo"]
 
 
-class GroupInfo(BASE):
+class GroupInfo(BASE):  # pylint:disable=too-few-public-methods
     """
     Some info about an LMS group that was created in h.
 
@@ -78,13 +78,3 @@ class GroupInfo(BASE):
 
     #: The value of the custom_canvas_course_id param this group was last launched with.
     custom_canvas_course_id = sa.Column(sa.UnicodeText())
-
-    def __str__(self):
-        return self.__repr__(_class_name="GroupInfo")
-
-    def __repr__(self, _class_name="lms.models.GroupInfo"):
-        return (
-            f"<{_class_name}"
-            f" authority_provided_id:'{self.authority_provided_id}'"
-            f" consumer_key:'{self.consumer_key}'>"
-        )

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -8,7 +8,7 @@ from lms.db import BASE
 __all__ = ["OAuth2Token"]
 
 
-class OAuth2Token(BASE):
+class OAuth2Token(BASE):  # pylint:disable=too-few-public-methods
     """
     An OAuth 2.0 access token, refresh token and expiry time.
 
@@ -69,19 +69,3 @@ class OAuth2Token(BASE):
         server_default=sa.func.now(),
         nullable=False,
     )
-
-    def __str__(self):
-        return (
-            f"<OAuth2Token user_id:'{self.user_id}' consumer_key:'{self.consumer_key}'>"
-        )
-
-    def __repr__(self):
-        return (
-            "<lms.models.OAuth2Token"
-            f" user_id:'{self.user_id}'"
-            f" consumer_key:'{self.consumer_key}'"
-            f" access_token:'{self.access_token}'"
-            f" refresh_token:'{self.refresh_token}'"
-            f" expires_in:{self.expires_in}'"
-            f" received_at:'{self.received_at}'>"
-        )

--- a/tests/unit/lms/models/group_info_test.py
+++ b/tests/unit/lms/models/group_info_test.py
@@ -43,22 +43,6 @@ class TestGroupInfo:
         ):
             db_session.flush()
 
-    def test___str__(self, db_session, group_info):
-        db_session.add(group_info)
-        db_session.flush()
-        assert (
-            str(group_info)
-            == "<GroupInfo authority_provided_id:'test_authority_provided_id' consumer_key:'test_consumer_key'>"
-        )
-
-    def test___repr__(self, db_session, group_info):
-        db_session.add(group_info)
-        db_session.flush()
-        assert (
-            repr(group_info)
-            == "<lms.models.GroupInfo authority_provided_id:'test_authority_provided_id' consumer_key:'test_consumer_key'>"
-        )
-
     @pytest.fixture(autouse=True)
     def application_instance(self):
         """Return the ApplicationInstance that the test GroupInfo belongs to."""

--- a/tests/unit/lms/models/oauth2_token_test.py
+++ b/tests/unit/lms/models/oauth2_token_test.py
@@ -105,28 +105,6 @@ class TestOAuth2Token:
 
         assert isinstance(token.received_at, datetime.datetime)
 
-    def test___str__(self, init_kwargs):
-        token = OAuth2Token(**init_kwargs)
-
-        assert (
-            str(token)
-            == "<OAuth2Token user_id:'test_user_id' consumer_key:'test_consumer_key'>"
-        )
-
-    def test___repr__(self, init_kwargs):
-        now = datetime.datetime(
-            year=2019, month=5, day=15, hour=11, minute=11, second=9
-        )
-        init_kwargs["refresh_token"] = "test_refresh_token"
-        init_kwargs["expires_in"] = 3600
-        init_kwargs["received_at"] = now
-        token = OAuth2Token(**init_kwargs)
-
-        assert (
-            repr(token)
-            == "<lms.models.OAuth2Token user_id:'test_user_id' consumer_key:'test_consumer_key' access_token:'test_access_token' refresh_token:'test_refresh_token' expires_in:3600' received_at:'2019-05-15 11:11:09'>"
-        )
-
     @pytest.fixture(autouse=True)
     def application_instance(self, db_session):
         """Return the ApplicationInstance that the test OAuth2Token's belong to."""


### PR DESCRIPTION
All SQLAlchemy models already inherit a `__repr__()` from the base
class, so these aren't necessary. `__str__()` seems to fall back to just
using `__repr__()` too which is fine.

https://github.com/hypothesis/lms/blob/809b24db432e8bd61ebd294b06e7c5372b5e0456/lms/db/__init__.py#L61-L68