### PR TITLE
Make requsetGroups call sync/ endpoint specified in js-config

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -17,6 +17,7 @@ session_cookie_secret = "notasecret"
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
 feature_flags_allowed_in_cookie = use_legacy_via
+feature_flags.section_groups = true
 
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -95,8 +95,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
   };
 
   // Helper to handle error events from api requests
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleError = useCallback(async (e, errorState) => {
+  const handleError = async (e, errorState) => {
     setFetched();
     if (e instanceof ApiError && !e.errorMessage) {
       setErrorState('error-authorizing');
@@ -104,7 +103,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
       setErrorMessage(e.errorMessage);
       setErrorState(errorState);
     }
-  });
+  };
 
   /**
    * Fetch the groups from the sync endpoint

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -200,7 +200,8 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
       // submission.
       handleError(e, 'error-report-submission');
     }
-  }, [authToken, canvas.speedGrader, contentUrl, handleError]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authToken, canvas.speedGrader, contentUrl]);
 
   useEffect(reportSubmission, [reportSubmission]);
 

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -109,16 +109,12 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
   /**
    * Fetch the groups from the sync endpoint
    */
-  const fetchGroups = async xxx_bypassfail_authToken => {
+  const fetchGroups = async () => {
     if (apiSync) {
-      let auth = authToken + 'invalid token!';
-      if (xxx_bypassfail_authToken) {
-        auth = xxx_bypassfail_authToken;
-      }
       try {
         setFetching();
         const groups = await apiCall({
-          authToken: auth,
+          authToken,
           path: apiSync.path,
           data: apiSync.data,
         });
@@ -135,7 +131,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
    *
    * This will typically be a PDF URL proxied through Via.
    */
-  const fetchContentUrl = async xxx_bypassfail_authToken => {
+  const fetchContentUrl = async () => {
     if (!viaCallbackUrl) {
       // If no "callback" URL was supplied for the frontend to use to fetch
       // the URL, then the backend must have provided the Via URL in the
@@ -144,14 +140,8 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
     }
     try {
       setFetching();
-      //setContentUrl(null); // unset any previous value
-      // temp code to test failed requets
-      let auth = authToken + 'invalid token!';
-      if (xxx_bypassfail_authToken) {
-        auth = xxx_bypassfail_authToken;
-      }
       const { via_url: contentUrl } = await apiCall({
-        authToken: auth,
+        authToken,
         path: viaCallbackUrl,
       });
       setFetched();
@@ -200,7 +190,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
       // submission.
       handleError(e, 'error-report-submission');
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authToken, canvas.speedGrader, contentUrl]);
 
   useEffect(reportSubmission, [reportSubmission]);

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -48,7 +48,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
   } = useContext(Config);
 
   // The current state of the error.
-  // One "error-fetched-url", "error-fetched-groups", "error-authorizing"
+  // One "error-fetch", "error-authorizing"
   const [errorState, setErrorState] = useState(null);
 
   // Any current error message to render to a dialog
@@ -125,7 +125,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
         rpcServer.resolveGroupFetch(groups);
         setFetched();
       } catch (e) {
-        handleError(e, 'error-fetch-groups');
+        handleError(e, 'error-fetch');
       }
     }
   };
@@ -157,7 +157,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
       setFetched();
       setContentUrl(contentUrl);
     } catch (e) {
-      handleError(e, 'error-fetch-url');
+      handleError(e, 'error-fetch');
     }
   };
 
@@ -274,8 +274,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
             </p>
           </Dialog>
         )}
-        {(errorState === 'error-fetch-url' ||
-          errorState === 'error-fetch-groups') && (
+        {errorState === 'error-fetch' && (
           <Dialog
             title="Something went wrong"
             contentClass="BasicLtiLaunchApp__dialog"

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -10,14 +10,16 @@ import FilePickerApp from './components/FilePickerApp';
 import { startRpcServer } from '../postmessage_json_rpc/server';
 
 // Create an RPC Server and start listening to postMessage calls.
-startRpcServer();
+const rpcServer = startRpcServer();
 
 const rootEl = document.querySelector('#app');
 const config = JSON.parse(document.querySelector('.js-config').textContent);
 
 render(
   <Config.Provider value={config}>
-    {config.mode === 'basic-lti-launch' && <BasicLtiLaunchApp />}
+    {config.mode === 'basic-lti-launch' && (
+      <BasicLtiLaunchApp rpcServer={rpcServer} />
+    )}
     {config.mode === 'content-item-selection' && <FilePickerApp />}
   </Config.Provider>,
   rootEl

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,15 +1,26 @@
 import Server from './server';
-import { requestConfig, requestGroups } from './methods';
+import { requestConfig } from './methods';
 
 let server = {}; // Singleton RPC server reference
 
 /**
- * Create a new RPC server and pass in a the requestConfig object
+ * Create a new RPC server and register any methods it will support.
+ *
+ * @return {Server} - Instance of the server.
  */
 function startRpcServer() {
   server = new Server();
   server.register('requestConfig', requestConfig);
-  server.register('requestGroups', requestGroups);
+
+  const groupsPromise = new Promise(resolve => {
+    server.resolveGroupFetch = resolve;
+  });
+
+  server.register('requestGroups', async () => {
+    return await groupsPromise;
+  });
+
+  return server;
 }
 
 /**

--- a/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods-test.js
@@ -1,4 +1,4 @@
-import { requestConfig, requestGroups } from './methods';
+import { requestConfig, requestGroups, $imports } from './methods';
 
 describe('postmessage_json_rpc/methods#requestConfig', () => {
   let configEl;
@@ -24,13 +24,32 @@ describe('postmessage_json_rpc/methods#requestConfig', () => {
 
 describe('postmessage_json_rpc/methods#requestGroups', () => {
   let configEl;
+  let fakeApiCall;
 
   beforeEach('inject the client config into the document', () => {
+    fakeApiCall = sinon.stub();
+    $imports.$mock({
+      '../../frontend_apps/utils/api': {
+        apiCall: fakeApiCall,
+      },
+    });
+
     configEl = document.createElement('script');
     configEl.setAttribute('type', 'application/json');
     configEl.classList.add('js-config');
     configEl.textContent = JSON.stringify({
-      hypothesisClient: { services: [{ groups: ['groupid1', 'groupid2'] }] },
+      api: {
+        authToken: 'dummyAuthToken',
+        sync: {
+          data: {
+            course: {
+              context_id: '12345',
+              custom_canvas_course_id: '101',
+            },
+          },
+          path: '/api/sync',
+        },
+      },
     });
     document.body.appendChild(configEl);
   });
@@ -39,7 +58,17 @@ describe('postmessage_json_rpc/methods#requestGroups', () => {
     configEl.parentNode.removeChild(configEl);
   });
 
-  it('returns the list of groups', async () => {
-    assert.deepEqual(await requestGroups(), ['groupid1', 'groupid2']);
+  it('calls the remote endpoint specified in .js-config when `requestGroups` is called', async () => {
+    await requestGroups();
+    assert.calledWith(fakeApiCall, {
+      authToken: 'dummyAuthToken',
+      path: '/api/sync',
+      data: {
+        course: {
+          context_id: '12345',
+          custom_canvas_course_id: '101',
+        },
+      },
+    });
   });
 });

--- a/lms/static/scripts/postmessage_json_rpc/server/methods.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/methods.js
@@ -1,3 +1,5 @@
+import { apiCall } from '../../frontend_apps/utils/api';
+
 /**
  * Methods that're remotely callable by JSON-RPC over postMessage.
  *
@@ -16,26 +18,18 @@ export function requestConfig() {
 }
 
 /**
- * Return the groups for the Hypothesis client to show.
+ * In the case where groups are not available at load time, the groups must
+ * be fetched asynchronously using the api values found in the js-config
+ * object. In this case, call the remote endpoint and return the groups for
+ * the Hypothesis client.
  */
 export async function requestGroups() {
   const configObj = JSON.parse(
     document.querySelector('.js-config').textContent
   );
-
-  function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  if (configObj.dev === true) {
-    // Artifically sleep to simulate how long this will take when it needs to
-    // send real API requests to get the groups.
-    // The artificial delay is only inserted 50% of the time (at random) so we
-    // don't somehow accidentally end up relying on the slowness.
-    if (Math.random() < 0.5) {
-      await sleep(4000);
-    }
-  }
-
-  return configObj.hypothesisClient.services[0].groups;
+  return apiCall({
+    authToken: configObj.api.authToken,
+    path: configObj.api.sync.path,
+    data: configObj.api.sync.data,
+  });
 }


### PR DESCRIPTION
When requestGroups() RPC is called, it makes an API request to sync/ with the path and data from .js-config and returns the response (groups) to the client sidebar.

-------
![Screen Shot 2020-04-28 at 3 11 09 PM](https://user-images.githubusercontent.com/3939074/80542950-cf8ac580-8962-11ea-996f-a094471b8a17.png)

**To test**

use **eng+canvassections101teacher** account
https://hypothesis.instructure.com/login/canvas


To get this working, it may be best to cherry pick this commit onto `make-the-frontend-call-the-sync-api` and then set `feature_flags.section_groups = true` in development.ini

Note. this follows the POC here
https://github.com/hypothesis/lms/pull/1680

**Remaining work not covered by this PR:**

- It still waits until the client calls requsetGroups before it makes the api call adding a delay up to several seconds relative to when the LMS client first loads. Upon my testing, this varies from about **750ms to 2500ms** -- not insignificant.

- It does not retry the request if the auth fails. Instead the client only gets a toast notice that groups did not load. 


The reasons for the 2 shortcomings is that there is no simple way to throw an error and have a popup that allows the client to re-request auth because the RPC methods are decoupled from components. Secondly, we're not able to pre-call the sync/ method and then return a promise from the requestGroups call w/o using the global space to store the promise.  I think it may be time to build in a formal global store the LMS frontend.

If we did that, we would have structured way to set state that could trigger a popup in a component to re-request auth or even provide a more informative error message.  I think we could also pre-fetch the groups, add a subscribe listener to that store and block requestGroups (if needed) until the sync/ call returns.

For now, I just wanted to get bare bones working on the client.


Fixes part of https://github.com/hypothesis/lms/issues/1390
