### PR TITLE
Add instructor info to group_info table

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -21,6 +21,9 @@ class LTIUser(NamedTuple):
     display_name: str
     """The user's display name."""
 
+    email: str = ""
+    """The user's email address."""
+
     @property
     def h_user(self):
         """Return a models.HUser generated from this LTIUser."""

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -17,6 +17,7 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
 
     def __init__(self, _context, request):
         self._db = request.db
+        self._lti_user = request.lti_user
 
     def upsert(self, authority_provided_id, consumer_key, params):
         """
@@ -52,4 +53,9 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
             self._db.add(group_info)
 
         group_info.consumer_key = consumer_key
-        group_info.update_from_dict(params, skip_keys={"authority_provided_id", "id"})
+        group_info.update_from_dict(
+            params, skip_keys={"authority_provided_id", "id", "info"}
+        )
+
+        if self._lti_user.is_instructor:
+            group_info.upsert_instructor(self._lti_user.h_user._asdict())

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -58,4 +58,6 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
         )
 
         if self._lti_user.is_instructor:
-            group_info.upsert_instructor(self._lti_user.h_user._asdict())
+            group_info.upsert_instructor(
+                dict(email=self._lti_user.email, **self._lti_user.h_user._asdict())
+            )

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -62,6 +62,7 @@ class BearerTokenSchema(PyramidRequestSchema):
     roles = marshmallow.fields.Str(required=True)
     tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
     display_name = marshmallow.fields.Str(required=True)
+    email = marshmallow.fields.Str()
 
     def __init__(self, request):
         super().__init__(request)

--- a/lms/validation/authentication/_launch_params.py
+++ b/lms/validation/authentication/_launch_params.py
@@ -34,6 +34,7 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
     lis_person_name_given = marshmallow.fields.Str(missing="")
     lis_person_name_family = marshmallow.fields.Str(missing="")
     lis_person_name_full = marshmallow.fields.Str(missing="")
+    lis_person_contact_email_primary = marshmallow.fields.Str(missing="")
 
     oauth_consumer_key = marshmallow.fields.Str(required=True)
     oauth_nonce = marshmallow.fields.Str(required=True)
@@ -66,6 +67,7 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
                 kwargs["lis_person_name_family"],
                 kwargs["lis_person_name_full"],
             ),
+            email=kwargs["lis_person_contact_email_primary"],
         )
 
     @marshmallow.validates_schema

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -69,6 +69,11 @@ def user_is_learner(pyramid_request):
     pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Learner")
 
 
+@pytest.fixture
+def user_is_instructor(pyramid_request):
+    pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Instructor")
+
+
 def configure_jinja2_assets(config):
     jinja2_env = config.get_jinja2_environment()
     jinja2_env.globals["asset_url"] = "http://example.com"

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -83,7 +83,9 @@ class TestGroupInfoUpsert:
     @pytest.fixture
     def params(self):
         return {
-            field.key: f"TEST_{field.key.upper()}" for field in GroupInfo.iter_columns()
+            field.key: f"TEST_{field.key.upper()}"
+            for field in GroupInfo.iter_columns()
+            if field.key not in ["info"]
         }
 
     @pytest.fixture

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -118,7 +118,7 @@ class TestGroupInfoUpsert:
         return {
             field.key: f"TEST_{field.key.upper()}"
             for field in GroupInfo.iter_columns()
-            if field.key not in ["info"]
+            if field.key != "info"
         }
 
     @pytest.fixture


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/1701

Depends on https://github.com/hypothesis/lms/pull/1704

Record info about instructors who launch our app in the `group_info`
table:

* Add a new JSON column `group_info.info`.

  So far this is a JSON object with a single top-level key "instructors"
  that contains a list of instructor dicts.

  `group_info.info` can be extended with more info (besides instructors)
  in future without a DB migration.

  The instructor dicts can also be extended to hold more field in future
  without a DB migration.

* Add a `GroupInfo.instructors` read-write property for convenience, and
  a `GroupInfo.upsert_instructor(dict)` method the creates-or-updates an
  instructor dict in a `GroupInfo`'s instructors list.

* When an instructor launches an assignment, have `GroupInfoService`
  upsert their user details into `GroupInfo.info["instructors"]` for
  each of the assignment's course or section groups