### PR TITLE
Add "type" to group_info

### DIFF
--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -87,6 +87,7 @@ class GroupInfo(BASE):  # pylint:disable=too-few-public-methods
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("info", {})
         kwargs["info"].setdefault("instructors", [])
+        kwargs["info"].setdefault("type", None)
         super().__init__(*args, **kwargs)
 
     @property
@@ -96,6 +97,14 @@ class GroupInfo(BASE):  # pylint:disable=too-few-public-methods
     @instructors.setter
     def instructors(self, new_instructors):
         self.info["instructors"] = new_instructors
+
+    @property
+    def type(self):
+        return self.info["type"]
+
+    @type.setter
+    def type(self, new_type):
+        self.info["type"] = new_type
 
     def upsert_instructor(self, new_instructor):
         updated_instructors = []

--- a/lms/models/h_group.py
+++ b/lms/models/h_group.py
@@ -4,6 +4,7 @@ from typing import NamedTuple
 class HGroup(NamedTuple):
     name: str
     authority_provided_id: str
+    type: str = "course_group"
 
     def groupid(self, authority):
         return f"group:{self.authority_provided_id}@{authority}"

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -68,4 +68,4 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
                 dict(email=self._lti_user.email, **self._lti_user.h_user._asdict())
             )
 
-        group_info.info["type"] = type_
+        group_info.type = type_

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -19,7 +19,7 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
         self._db = request.db
         self._lti_user = request.lti_user
 
-    def upsert(self, authority_provided_id, consumer_key, params, type_):
+    def upsert(self, h_group, consumer_key, params):
         """
         Upsert a row into the ``group_info`` DB table.
 
@@ -34,27 +34,25 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
         Any keys in ``params`` that don't correspond to a ``GroupInfo`` column
         name will be ignored.
 
-        :param authority_provided_id: the ``authority_provided_id`` of the
-            ``GroupInfo`` to create or update
+        :param h_group: the group to upsert
+        :type h_group: lms.models.HGroup
 
         :param consumer_key: the ``GroupInfo.consumer_key`` value to set
 
         :param params: the other ``GroupInfo`` columns to set
         :type params: dict
 
-        :param type_: the type of the group, e.g. "course_group" or "section_group"
-        :type type_: str
-
         """
         group_info = (
             self._db.query(GroupInfo)
-            .filter_by(authority_provided_id=authority_provided_id)
+            .filter_by(authority_provided_id=h_group.authority_provided_id)
             .one_or_none()
         )
 
         if not group_info:
             group_info = GroupInfo(
-                authority_provided_id=authority_provided_id, consumer_key=consumer_key
+                authority_provided_id=h_group.authority_provided_id,
+                consumer_key=consumer_key,
             )
             self._db.add(group_info)
 
@@ -68,4 +66,4 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
                 dict(email=self._lti_user.email, **self._lti_user.h_user._asdict())
             )
 
-        group_info.type = type_
+        group_info.type = h_group.type

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -19,7 +19,7 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
         self._db = request.db
         self._lti_user = request.lti_user
 
-    def upsert(self, authority_provided_id, consumer_key, params):
+    def upsert(self, authority_provided_id, consumer_key, params, type_):
         """
         Upsert a row into the ``group_info`` DB table.
 
@@ -36,9 +36,15 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
 
         :param authority_provided_id: the ``authority_provided_id`` of the
             ``GroupInfo`` to create or update
+
         :param consumer_key: the ``GroupInfo.consumer_key`` value to set
+
         :param params: the other ``GroupInfo`` columns to set
         :type params: dict
+
+        :param type_: the type of the group, e.g. "course_group" or "section_group"
+        :type type_: str
+
         """
         group_info = (
             self._db.query(GroupInfo)
@@ -61,3 +67,5 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
             group_info.upsert_instructor(
                 dict(email=self._lti_user.email, **self._lti_user.h_user._asdict())
             )
+
+        group_info.info["type"] = type_

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -21,25 +21,24 @@ class GroupInfoService:  # pylint:disable=too-few-public-methods
 
     def upsert(self, h_group, consumer_key, params):
         """
-        Upsert a row into the ``group_info`` DB table.
+        Upsert a row into the `group_info` DB table.
 
-        Find the :class:`~lms.models.GroupInfo` with the given
-        ``authority_provided_id``, or create it if none exists.  Then update
-        the ``GroupInfo``'s ``consumer_key`` to the given ``consumer_key``, and
-        update its other columns from the items in ``params``.
+        Find the models.GroupInfo matching the given h_group or create it if
+        none exists. Then update the GroupInfo's consumer_key to the given
+        consumer_key, and update its other columns from the items in `params`.
 
-        ``params["id"]`` and ``params["authority_provided_id"]`` will be
-        ignored if present--these columns can't be updated.
+        params["id"], params["authority_provided_id"], and params["info"] will
+        be ignored if present--these columns can't be updated.
 
-        Any keys in ``params`` that don't correspond to a ``GroupInfo`` column
-        name will be ignored.
+        Any keys in `params` that don't correspond to a GroupInfo column name
+        will be ignored.
 
         :param h_group: the group to upsert
-        :type h_group: lms.models.HGroup
+        :type h_group: models.HGroup
 
-        :param consumer_key: the ``GroupInfo.consumer_key`` value to set
+        :param consumer_key: the GroupInfo.consumer_key value to set
 
-        :param params: the other ``GroupInfo`` columns to set
+        :param params: the other GroupInfo columns to set
         :type params: dict
 
         """

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -54,10 +54,9 @@ class LTIHService:  # pylint:disable=too-few-public-methods
         # Keep a note of the groups locally for reporting purposes.
         for h_group in h_groups:
             self._group_info_service.upsert(
-                authority_provided_id=h_group.authority_provided_id,
+                h_group=h_group,
                 consumer_key=self._lti_user.oauth_consumer_key,
                 params=group_info_params,
-                type_=h_group.type,
             )
 
     def _yield_commands(self, h_groups):

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -57,6 +57,7 @@ class LTIHService:  # pylint:disable=too-few-public-methods
                 authority_provided_id=h_group.authority_provided_id,
                 consumer_key=self._lti_user.oauth_consumer_key,
                 params=group_info_params,
+                type_=h_group.type,
             )
 
     def _yield_commands(self, h_groups):

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -38,7 +38,9 @@ def sync(request):
         hash_object.update(str(section["id"]).encode())
         authority_provided_id = hash_object.hexdigest()
 
-        return HGroup(h_group_name(section["name"]), authority_provided_id,)
+        return HGroup(
+            h_group_name(section["name"]), authority_provided_id, type="section_group"
+        )
 
     groups = [group(section) for section in sections]
 

--- a/tests/unit/lms/models/group_info_test.py
+++ b/tests/unit/lms/models/group_info_test.py
@@ -86,6 +86,16 @@ class TestGroupInfo:
 
         assert group_info.instructors == existing_instructors
 
+    def test_type_defaults_to_None(self):
+        assert GroupInfo().type is None
+
+    def test_set_and_get_type(self):
+        group_info = GroupInfo()
+
+        group_info.type = "test_type"
+
+        assert group_info.type == "test_type"
+
     @pytest.fixture
     def existing_instructors(self, group_info):
         group_info.instructors = factory.build_batch(

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -17,6 +17,7 @@ class TestGroupInfoUpsert:
             authority_provided_id=self.AUTHORITY,
             consumer_key=self.CONSUMER_KEY,
             params=params,
+            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)
@@ -24,6 +25,7 @@ class TestGroupInfoUpsert:
         assert group_info.consumer_key == self.CONSUMER_KEY
         assert group_info.context_title == params["context_title"]
         assert group_info.context_label == params["context_label"]
+        assert group_info.info["type"] == "course_group"
 
     def test_it_updates_an_existing_GroupInfo_if_one_already_exists(
         self, db_session, group_info_svc, params
@@ -43,6 +45,7 @@ class TestGroupInfoUpsert:
             authority_provided_id=self.AUTHORITY,
             consumer_key=self.CONSUMER_KEY,
             params=dict(params, context_title="NEW_TITLE"),
+            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)
@@ -50,6 +53,7 @@ class TestGroupInfoUpsert:
         assert group_info.consumer_key == self.CONSUMER_KEY
         assert group_info.context_label == params["context_label"]
         assert group_info.context_title == "NEW_TITLE"
+        assert group_info.info["type"] == "course_group"
 
     def test_it_ignores_non_metadata_params(self, db_session, group_info_svc, params):
         group_info_svc.upsert(
@@ -61,6 +65,7 @@ class TestGroupInfoUpsert:
                 authority_provided_id="IGNORE ME 2",
                 something_unrelated="IGNORED ME 3",
             ),
+            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)
@@ -76,6 +81,7 @@ class TestGroupInfoUpsert:
             authority_provided_id=self.AUTHORITY,
             consumer_key=self.CONSUMER_KEY,
             params={},
+            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)
@@ -95,6 +101,7 @@ class TestGroupInfoUpsert:
             authority_provided_id=self.AUTHORITY,
             consumer_key=self.CONSUMER_KEY,
             params={},
+            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from lms.models import ApplicationInstance, GroupInfo
 from lms.services.group_info import GroupInfoService
+from tests import factories
 
 
 class TestGroupInfoUpsert:
@@ -14,10 +15,11 @@ class TestGroupInfoUpsert:
         self, db_session, group_info_svc, params
     ):
         group_info_svc.upsert(
-            authority_provided_id=self.AUTHORITY,
+            factories.HGroup(
+                authority_provided_id=self.AUTHORITY, type="course_group",
+            ),
             consumer_key=self.CONSUMER_KEY,
             params=params,
-            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)
@@ -42,10 +44,11 @@ class TestGroupInfoUpsert:
         )
 
         group_info_svc.upsert(
-            authority_provided_id=self.AUTHORITY,
+            factories.HGroup(
+                authority_provided_id=self.AUTHORITY, type="course_group",
+            ),
             consumer_key=self.CONSUMER_KEY,
             params=dict(params, context_title="NEW_TITLE"),
-            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)
@@ -57,7 +60,9 @@ class TestGroupInfoUpsert:
 
     def test_it_ignores_non_metadata_params(self, db_session, group_info_svc, params):
         group_info_svc.upsert(
-            authority_provided_id=self.AUTHORITY,
+            factories.HGroup(
+                authority_provided_id=self.AUTHORITY, type="course_group",
+            ),
             consumer_key=self.CONSUMER_KEY,
             params=dict(
                 params,
@@ -65,7 +70,6 @@ class TestGroupInfoUpsert:
                 authority_provided_id="IGNORE ME 2",
                 something_unrelated="IGNORED ME 3",
             ),
-            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)
@@ -78,10 +82,11 @@ class TestGroupInfoUpsert:
         self, db_session, group_info_svc, pyramid_request
     ):
         group_info_svc.upsert(
-            authority_provided_id=self.AUTHORITY,
+            factories.HGroup(
+                authority_provided_id=self.AUTHORITY, type="course_group",
+            ),
             consumer_key=self.CONSUMER_KEY,
             params={},
-            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)
@@ -98,10 +103,11 @@ class TestGroupInfoUpsert:
         self, db_session, group_info_svc
     ):
         group_info_svc.upsert(
-            authority_provided_id=self.AUTHORITY,
+            factories.HGroup(
+                authority_provided_id=self.AUTHORITY, type="course_group",
+            ),
             consumer_key=self.CONSUMER_KEY,
             params={},
-            type_="course_group",
         )
 
         group_info = self.get_inserted_group_info(db_session)

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -25,7 +25,7 @@ class TestGroupInfoUpsert:
         assert group_info.consumer_key == self.CONSUMER_KEY
         assert group_info.context_title == params["context_title"]
         assert group_info.context_label == params["context_label"]
-        assert group_info.info["type"] == "course_group"
+        assert group_info.type == "course_group"
 
     def test_it_updates_an_existing_GroupInfo_if_one_already_exists(
         self, db_session, group_info_svc, params
@@ -53,7 +53,7 @@ class TestGroupInfoUpsert:
         assert group_info.consumer_key == self.CONSUMER_KEY
         assert group_info.context_label == params["context_label"]
         assert group_info.context_title == "NEW_TITLE"
-        assert group_info.info["type"] == "course_group"
+        assert group_info.type == "course_group"
 
     def test_it_ignores_non_metadata_params(self, db_session, group_info_svc, params):
         group_info_svc.upsert(

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -78,10 +78,9 @@ class TestGroupInfoUpdating:
         lti_h_svc.sync([h_group], sentinel.params)
 
         group_info_service.upsert.assert_called_once_with(
-            authority_provided_id=h_group.authority_provided_id,
+            h_group=h_group,
             consumer_key=pyramid_request.lti_user.oauth_consumer_key,
             params=sentinel.params,
-            type_=h_group.type,
         )
 
     @pytest.fixture

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -81,6 +81,7 @@ class TestGroupInfoUpdating:
             authority_provided_id=h_group.authority_provided_id,
             consumer_key=pyramid_request.lti_user.oauth_consumer_key,
             params=sentinel.params,
+            type_=h_group.type,
         )
 
     @pytest.fixture

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -15,6 +15,7 @@ def test_sync_when_the_user_is_a_learner(
         factories.HGroup(
             name="Section 2",
             authority_provided_id="d99674b9700f4a40a2b301d2949b61339c58236c",
+            type="section_group",
         )
     ]
     canvas_api_client.authenticated_users_sections.assert_called_once_with(
@@ -36,14 +37,17 @@ def test_sync_when_the_user_isnt_a_learner(
         factories.HGroup(
             name="Section 1",
             authority_provided_id="d0f36006728f2277f228b74c8a7f620305bfb3e7",
+            type="section_group",
         ),
         factories.HGroup(
             name="Section 2",
             authority_provided_id="d99674b9700f4a40a2b301d2949b61339c58236c",
+            type="section_group",
         ),
         factories.HGroup(
             name="Section 3",
             authority_provided_id="6a85e3651705dee4da0805b8985472343cbea94e",
+            type="section_group",
         ),
     ]
     canvas_api_client.course_sections.assert_called_once_with(


### PR DESCRIPTION
Add a new `type` field to `group_info` that records whether a group is a course group or a section group.