### PR TITLE
Fix the error page when our Canvas developer key lacks required scopes

### DIFF
--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -8,7 +8,7 @@
 
       <p>Something went wrong when authorizing Hypothesis.</p>
 
-      <p>If the problem persists
+      <p>To get help from Hypothesis
       <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support" target="_blank" rel="noopener noreferrer">send us an email</a>
       or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener noreferrer">open a support ticket</a>.
       You can also visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer"> help documents</a>.</p>

--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -15,16 +15,23 @@
 
       <div class="u-stretch"></div>
       <div class="Dialog__actions">
-        <button class="Button Button--cancel"
-                type="button"
-                onclick="window.close()">
-          Cancel
-        </button>
-        <button class="Button"
-                type="button"
-                onclick="window.location.href = '{{ authorize_url }}'">
-          Try again
-        </button>
+        {% if authorize_url %}
+          <button class="Button Button--cancel" type="button"
+                  onclick="window.close()">
+            Cancel
+          </button>
+          <button class="Button"
+                  type="button"
+                  onclick="window.location.href = '{{ authorize_url }}'">
+            Try again
+          </button>
+        {% else %}
+          <button class="Button"
+                  type="button"
+                  onclick="window.close()">
+            Close
+          </button>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -4,14 +4,41 @@
   <div class="Dialog__background" style="z-index: 1;"></div>
   <div class="Dialog__container" style="z-index: 2;">
     <div class="Dialog__content LMSFilePicker__dialog">
-      <h1 class="Dialog__title">Authorization failed</h1>
+      {% if invalid_scope %}
+        <h1 class="Dialog__title">Developer Key Scopes Missing</h1>
 
-      <p>Something went wrong when authorizing Hypothesis.</p>
+        <p>
+          A Canvas admin needs to edit Hypothesis's developer key and add these
+          scopes:
+        </p>
+
+        <ol>
+          {% for scope in scopes %}
+            <li><code>{{ scope }}</code></li>
+          {% endfor %}
+        </ol>
+
+        <p>For more information see:
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App">Canvas API Endpoints Used 
+y the Hypothesis LMS App</a>.
+        </p>
+      {% else %}
+        <h1 class="Dialog__title">Authorization Failed</h1>
+
+        <p>Something went wrong when authorizing Hypothesis.</p>
+      {% endif %}
 
       <p>To get help from Hypothesis
       <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support" target="_blank" rel="noopener noreferrer">send us an email</a>
       or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener noreferrer">open a support ticket</a>.
       You can also visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer"> help documents</a>.</p>
+
+      {% if details %}
+        <details>
+          <p>The error message from Canvas was:</p>
+          <pre class="ErrorDisplay__details">{{ details }}</pre>
+        </details>
+      {% endif %}
 
       <div class="u-stretch"></div>
       <div class="Dialog__actions">

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -73,8 +73,6 @@ class CanvasAPIAuthorizeViews:
         route_name="canvas_api.authorize",
     )
     def oauth2_redirect_error(self):
-        self.request.response.status_code = 500
-
         authorization_param = (
             BearerTokenSchema(self.request).authorization_param(self.request.lti_user),
         )

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -89,11 +89,6 @@ class TestOAuth2Redirect:
 
 
 class TestOAuth2RedirectError:
-    def test_it_sets_the_response_status_code_to_500(self, pyramid_request):
-        CanvasAPIAuthorizeViews(pyramid_request).oauth2_redirect_error()
-
-        assert pyramid_request.response.status_code == 500
-
     def test_it_passes_authorize_url_to_the_template(
         self, BearerTokenSchema, bearer_token_schema, pyramid_request
     ):

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -105,6 +105,17 @@ class TestOAuth2RedirectError:
             == "http://example.com/api/canvas/authorize?authorization=TEST_AUTHORIZATION_PARAM"
         )
 
+    def test_it_doesnt_pass_authorize_url_if_theres_no_authorized_user(
+        self, pyramid_request
+    ):
+        pyramid_request.lti_user = None
+
+        template_variables = CanvasAPIAuthorizeViews(
+            pyramid_request
+        ).oauth2_redirect_error()
+
+        assert "authorize_url" not in template_variables
+
 
 @pytest.fixture(autouse=True)
 def BearerTokenSchema(patch):


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/1718

**Note**: You'll want to delete all your Canvas API access tokens from your dev DB when testing this, to force it to open the authorization popup window to try to get a new token. Run: `tox -qe docker-compose -- exec postgres psql -U postgres -c 'delete from oauth2_token;'`

**Note**: We currently only use the Canvas API for Canvas Files assignments, so you'll want to launch a Canvas Files test assignment to test this.

When creating or launching a Canvas Files assignment, if we don't already have a working Canvas API access token for the user, we open a popup window to get the user to authorize us with Canvas and save a new access token to the DB.

There are two ways that this authorization popup window dance can fail:

1. Canvas might redirect the popup window back to us successfully with an authorization code in a query param but, when we try to exchange the authorization code for an access token this server-to-server request to the Canvas API fails.

   The easiest way to simulate this is to hack our `access_token_request()` function to send invalid requests to Canvas, which will force an error response from the Canvas API. For example:

   ```diff
   diff --git a/lms/services/_helpers/canvas_api.py b/lms/services/_helpers/canvas_api.py
   index 66fc16bb..1b54206c 100644
   --- a/lms/services/_helpers/canvas_api.py
   +++ b/lms/services/_helpers/canvas_api.py
   @@ -68,7 +68,7 @@ class CanvasAPIHelper:
                params={
                    "grant_type": "authorization_code",
                    "client_id": self._client_id,
   -                "client_secret": self._client_secret,
   +                "client_secret": "wrong",
                    "redirect_uri": self._redirect_uri,
                    "code": authorization_code,
                    "replace_tokens": True,
   ```

   When this happens the popup window will show an error page with a generic error message and <kbd>Cancel</kbd> (closes window) and <kbd>Try again</kbd> (redirects the popup window back to Canvas again) buttons:

   ![Screenshot from 2020-05-05 19-50-41](https://user-images.githubusercontent.com/22498/81103992-c1f8b100-8f09-11ea-9ff1-397b52432e62.png)

   **This error page is pre-existing behavior**, it's preserved by this PR but wasn't created by this PR.

2. If our Canvas developer key is missing one or more of the Canvas API scopes that we request, then Canvas redirects the popup window back to us with an error message instead of the authorization code in the query params. Previously we would crash when this happened (https://github.com/hypothesis/lms/issues/1718), now we show an error page.

   To simulate this you need to remove a required scope from our test dev key. Log in to <https://hypothesis.instructure.com/> as an admin and edit the "localhost (make devdata)" developer key (<kbd>Admin</kbd> &rarr; <kbd>University of Hypothesis</kbd> &rarr; <kbd>Developer keys</kbd> &rarr; <kbd>Show all keys</kbd>, then find the "localhost (make devdata)" key and click its <kbd>Edit</kbd> icon):

   1. Toggle <kbd>Enforce Scopes</kbd> on
   2. Un-check one of the scopes that our app needs. For example <samp>Courses > url:GET|/api/v1/files/:id/public_url</samp>
   3. Click <kbd>Save</kbd>

   **Note:** this will edit the shared localhost dev key for everyone, it'll break localhost Canvas testing for everyone.

   Then try to launch a Hypothesis assignment and you should see an error page with a specific error message listing the scopes we need. This error page just has a <kbd>Close</kbd> button, no <kbd>Try again</kbd>, because we've unavoidably lost the login session within the popup window. (The app in the underlying Canvas tab from whence the popup window came will still be working fine though.)

   ![Screenshot from 2020-05-05 19-56-09](https://user-images.githubusercontent.com/22498/81104479-7abef000-8f0a-11ea-9de1-e669faca5f80.png)

## Known Issue

There's a CSS issue when you expand the **Details**. I'll try to get a frontend dev to fix this in a follow-up PR:

![Screenshot from 2020-05-05 19-56-40](https://user-images.githubusercontent.com/22498/81104554-9d510900-8f0a-11ea-8281-b80e00c1e627.png)
