### PR TITLE
Sort students by last, then first name

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -1,6 +1,6 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import { call as rpcCall } from '../../postmessage_json_rpc/client';
 import { getSidebarWindow } from '../../postmessage_json_rpc/server';
@@ -24,23 +24,24 @@ export default function LMSGrader({
 
   // A sorted list of students. Students are sorted by
   // displayName.
-  const [students] = useState(() => {
+  const students = useMemo(() => {
+    function compareNames(name1 = '', name2 = '') {
+      if (name1.toLowerCase() < name2.toLowerCase()) {
+        return -1;
+      } else if (name1.toLowerCase() > name2.toLowerCase()) {
+        return 1;
+      } else {
+        return 0;
+      }
+    }
     // Make a copy
     const students_ = [...unorderedStudents];
+
     students_.sort((student1, student2) => {
-      function compareNames(name1, name2) {
-        if (name1.toLowerCase() < name2.toLowerCase()) {
-          return -1;
-        } else if (name1.toLowerCase() > name2.toLowerCase()) {
-          return 1;
-        } else {
-          return 0;
-        }
-      }
       return compareNames(student1.displayName, student2.displayName);
     });
     return students_;
-  });
+  }, [unorderedStudents]);
 
   /**
    * Makes an RPC call to the sidebar to change to the focused user.

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -22,62 +22,11 @@ export default function LMSGrader({
   // No initial current student selected
   const [currentStudentIndex, setCurrentStudentIndex] = useState(-1);
 
-  /**
-   * Create a name object for a given displayName for a
-   * student to facilitate sorting. This object contains
-   * a firstName and optional lastName as well as a new
-   * displayName as "{last}, {first}"
-   *
-   * @return {object}
-   * e.g.
-   * {
-   *  displayName: <string>
-   *  firstName: <string>
-   *  lastName: <string|null>
-   * }
-   */
-  const makeNames = name => {
-    const parts = name.split(' ');
-    if (parts.length <= 1) {
-      // No separator, don't mutate displayName
-      return {
-        displayName: name,
-        firstName: name,
-        lastName: null,
-      };
-    } else {
-      const first = parts[0];
-      // If there is more than two separators, just lump any beyond
-      // the first into the last name.
-      const last = parts.slice(1).join(' ');
-      let displayName;
-      if (last) {
-        displayName = `${last}, ${first}`;
-      } else {
-        displayName = first;
-      }
-      return {
-        displayName,
-        firstName: first,
-        lastName: last,
-      };
-    }
-  };
-
   // A sorted list of students. Students are sorted by
-  //  1. last name
-  //  2. first name
-  // Not all students may have a last name and in which
-  // case their first name is used to sort by.
+  // displayName.
   const [students] = useState(() => {
-    // First, create a first and last name for each student
-    // so we can compare on those values.
-    const students_ = unorderedStudents.map(s => {
-      return {
-        ...s,
-        ...makeNames(s.displayName),
-      };
-    });
+    // Make a copy
+    const students_ = [...unorderedStudents];
     students_.sort((student1, student2) => {
       function compareNames(name1, name2) {
         if (name1.toLowerCase() < name2.toLowerCase()) {
@@ -88,22 +37,7 @@ export default function LMSGrader({
           return 0;
         }
       }
-      // Compare last name, then first name. If there is no last name
-      // then compare first name.
-      let result = compareNames(
-        student1.lastName ? student1.lastName : student1.firstName,
-        student2.lastName ? student2.lastName : student2.firstName
-      );
-      if (result === 0) {
-        // Tie breaker (if needed)
-        // If we previously compared on first name, then the second compare
-        // shall use an empty string, otherwise use the first name.
-        result = compareNames(
-          student1.lastName ? student1.firstName : '',
-          student2.lastName ? student2.firstName : ''
-        );
-      }
-      return result;
+      return compareNames(student1.displayName, student2.displayName);
     });
     return students_;
   });

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -22,8 +22,7 @@ export default function LMSGrader({
   // No initial current student selected
   const [currentStudentIndex, setCurrentStudentIndex] = useState(-1);
 
-  // A sorted list of students. Students are sorted by
-  // displayName.
+  // Students sorted by displayName
   const students = useMemo(() => {
     function compareNames(name1 = '', name2 = '') {
       if (name1.toLowerCase() < name2.toLowerCase()) {

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -17,10 +17,96 @@ export default function LMSGrader({
   children,
   assignmentName,
   courseName,
-  students,
+  students: unorderedStudents,
 }) {
   // No initial current student selected
   const [currentStudentIndex, setCurrentStudentIndex] = useState(-1);
+
+  /**
+   * Create a name object for a given displayName for a
+   * student to facilitate sorting. This object contains
+   * a firstName and optional lastName as well as a new
+   * displayName as "{last}, {first}"
+   *
+   * @return {object}
+   * e.g.
+   * {
+   *  displayName: <string>
+   *  firstName: <string>
+   *  lastName: <string|null>
+   * }
+   */
+  const makeNames = name => {
+    const parts = name.split(' ');
+    if (parts.length <= 1) {
+      // No separator, don't mutate displayName
+      return {
+        displayName: name,
+        firstName: name,
+        lastName: null,
+      };
+    } else {
+      const first = parts[0];
+      // If there is more than two separators, just lump any beyond
+      // the first into the last name.
+      const last = parts.slice(1).join(' ');
+      let displayName;
+      if (last) {
+        displayName = `${last}, ${first}`;
+      } else {
+        displayName = first;
+      }
+      return {
+        displayName,
+        firstName: first,
+        lastName: last,
+      };
+    }
+  };
+
+  // A sorted list of students. Students are sorted by
+  //  1. last name
+  //  2. first name
+  // Not all students may have a last name and in which
+  // case their first name is used to sort by.
+  const [students] = useState(() => {
+    // First, create a first and last name for each student
+    // so we can compare on those values.
+    const students_ = unorderedStudents.map(s => {
+      return {
+        ...s,
+        ...makeNames(s.displayName),
+      };
+    });
+    students_.sort((student1, student2) => {
+      function compareNames(name1, name2) {
+        if (name1.toLowerCase() < name2.toLowerCase()) {
+          return -1;
+        } else if (name1.toLowerCase() > name2.toLowerCase()) {
+          return 1;
+        } else {
+          return 0;
+        }
+      }
+      // Compare last name, then first name. If there is no last name
+      // then compare first name.
+      let result = compareNames(
+        student1.lastName ? student1.lastName : student1.firstName,
+        student2.lastName ? student2.lastName : student2.firstName
+      );
+      if (result === 0) {
+        // Tie breaker (if needed)
+        // If we previously compared on first name, then the second compare
+        // shall use an empty string, otherwise use the first name.
+        result = compareNames(
+          student1.lastName ? student1.firstName : '',
+          student2.lastName ? student2.firstName : ''
+        );
+      }
+      return result;
+    });
+    return students_;
+  });
 
   /**
    * Makes an RPC call to the sidebar to change to the focused user.

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -89,22 +89,19 @@ describe('LMSGrader', () => {
         displayName: 'Student Beta',
       },
       {
-        displayName: 'stu Beta',
-      },
-      {
         displayName: 'Students Beta',
       },
       {
         displayName: 'Beta',
       },
       {
+        displayName: 'student Beta',
+      },
+      {
         displayName: 'Student Delta',
       },
       {
         displayName: 'Student Alpha',
-      },
-      {
-        displayName: 'Student Alpha Longer Last Name',
       },
       {
         displayName: 'Alpha',
@@ -119,14 +116,13 @@ describe('LMSGrader', () => {
       });
     assert.match(
       [
-        'Alpha', // no last name
-        'Alpha, Student',
-        'Alpha Longer Last Name, Student', // multiple last name words
-        'Beta', // no last name
-        'Beta, stu', // lowercase won't matter
-        'Beta, Student',
-        'Beta, Students',
-        'Delta, Student',
+        'Alpha',
+        'Beta',
+        'Student Alpha',
+        'Student Beta',
+        'student Beta',
+        'Student Delta',
+        'Students Beta',
       ],
       orderedStudentNames
     );
@@ -176,8 +172,8 @@ describe('LMSGrader', () => {
         'changeFocusModeUser',
         [
           {
-            username: 'acct:student1@authority',
-            displayName: '1, Student',
+            username: fakeStudents[0].userid,
+            displayName: fakeStudents[0].displayName,
           },
         ]
       )

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -97,7 +97,7 @@ describe('LMSGrader', () => {
     );
   });
 
-  it('orders the students by last name (if it exists), then first name', () => {
+  it('orders the students by displayName', () => {
     // Un-order students
     fakeStudents = [
       {
@@ -140,7 +140,7 @@ describe('LMSGrader', () => {
     );
   });
 
-  it('updates the order if the `students` change', () => {
+  it('updates the order if the `students` prop changes', () => {
     // Un-order students
     fakeStudents = [
       {
@@ -168,7 +168,7 @@ describe('LMSGrader', () => {
     assert.match(['Beta', 'Gamma'], orderedStudentNames);
   });
 
-  it('sorts an undefined displayName first', () => {
+  it('puts students with empty displayNames at the beginning of sorted students', () => {
     // Un-order students
     fakeStudents = [
       {

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -6,20 +6,7 @@ import LMSGrader, { $imports } from '../LMSGrader';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('LMSGrader', () => {
-  const fakeStudents = [
-    {
-      userid: 'acct:student1@authority',
-      displayName: 'Student 1',
-      LISResultSourcedId: 1,
-      LISOutcomeServiceUrl: '',
-    },
-    {
-      userid: 'acct:student2@authority',
-      displayName: 'Student 2',
-      LISResultSourcedId: 2,
-      LISOutcomeServiceUrl: '',
-    },
-  ];
+  let fakeStudents;
   let fakeOnChange;
   let fakeRpcCall;
   const fakeSidebarWindow = sinon.stub().resolves({
@@ -33,6 +20,20 @@ describe('LMSGrader', () => {
   };
 
   beforeEach(() => {
+    fakeStudents = [
+      {
+        userid: 'acct:student1@authority',
+        displayName: 'Student 1',
+        LISResultSourcedId: 1,
+        LISOutcomeServiceUrl: '',
+      },
+      {
+        userid: 'acct:student2@authority',
+        displayName: 'Student 2',
+        LISResultSourcedId: 2,
+        LISOutcomeServiceUrl: '',
+      },
+    ];
     fakeOnChange = sinon.spy();
     fakeRpcCall = sinon.spy();
     $imports.$mock({
@@ -81,6 +82,56 @@ describe('LMSGrader', () => {
     );
   });
 
+  it('orders the students by last name (if it exists), then first name', () => {
+    // Un-order students
+    fakeStudents = [
+      {
+        displayName: 'Student Beta',
+      },
+      {
+        displayName: 'stu Beta',
+      },
+      {
+        displayName: 'Students Beta',
+      },
+      {
+        displayName: 'Beta',
+      },
+      {
+        displayName: 'Student Delta',
+      },
+      {
+        displayName: 'Student Alpha',
+      },
+      {
+        displayName: 'Student Alpha Longer Last Name',
+      },
+      {
+        displayName: 'Alpha',
+      },
+    ];
+    const wrapper = renderGrader();
+    const orderedStudentNames = wrapper
+      .find('FakeStudentSelector')
+      .prop('students')
+      .map(s => {
+        return s.displayName;
+      });
+    assert.match(
+      [
+        'Alpha', // no last name
+        'Alpha, Student',
+        'Alpha Longer Last Name, Student', // multiple last name words
+        'Beta', // no last name
+        'Beta, stu', // lowercase won't matter
+        'Beta, Student',
+        'Beta, Students',
+        'Delta, Student',
+      ],
+      orderedStudentNames
+    );
+  });
+
   it('set the selected student count to "Student 2 of 2" when the index changers to 1', async () => {
     const wrapper = renderGrader();
     act(() => {
@@ -125,8 +176,8 @@ describe('LMSGrader', () => {
         'changeFocusModeUser',
         [
           {
-            username: fakeStudents[0].userid,
-            displayName: fakeStudents[0].displayName,
+            username: 'acct:student1@authority',
+            displayName: '1, Student',
           },
         ]
       )


### PR DESCRIPTION
The client attempts to discover a last name based off the displayName, but if it does not exist, then it sorts by first name.

Additionally if there are more separators, then every word past the first is assumed to be part of the last name. This may be a false assumption but its a best effort with only having a displayName.

Finally, the displayName is changed from the service layer to show the last then first. e.g. “{last}, {first}”

---------
I thought this was going to be a bit more straight forward, nothing with LMS ever is! :)
So we have to make some assumptions here and handle all the edge cases. We really don't know what the first or last names are so I went ahead with some general assumptions that hopefully are mostly right or at least make some sense when ordering.

To test, try this assignment.
https://blackboard.hypothes.is/webapps/blackboard/execute/blti/launchLink?course_id=_16_1&content_id=_214_1

It only has 2 students because we only have 2 student accounts, but the unit test should have all the edge cases

![students](https://user-images.githubusercontent.com/3939074/81124892-746d4b80-8eeb-11ea-8d18-bd6b81b8337e.gif)

fixes https://github.com/hypothesis/lms/issues/1629