### PR TITLE
Enable and disable sections in various circumstances

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -4,6 +4,8 @@ from datetime import datetime
 import sqlalchemy as sa
 from Crypto import Random
 from Crypto.Cipher import AES
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
 
 from lms.db import BASE
 
@@ -30,12 +32,23 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
         server_default=sa.sql.expression.true(),
         nullable=False,
     )
-    canvas_sections_enabled = sa.Column(
-        sa.Boolean(),
-        default=False,
-        server_default=sa.sql.expression.false(),
-        nullable=False,
-    )
+    _settings = sa.Column("settings", MutableDict.as_mutable(JSONB))
+
+    @property
+    def settings(self):
+        """
+        Get a settings object which can get and set grouped settings.
+
+        The object can be queried with `settings.get(group, key)` or
+        `settings.set(group, key, value)`.
+
+        :return: _ApplicationSettings object.
+        """
+
+        if self._settings is None:
+            self._settings = {}
+
+        return _ApplicationSettings(self._settings)
 
     #: A list of all the OAuth2Tokens for this application instance
     #: (each token belongs to a different user of this application
@@ -56,13 +69,7 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
 
     @classmethod
     def build_from_lms_url(  # pylint:disable=too-many-arguments
-        cls,
-        lms_url,
-        email,
-        developer_key,
-        developer_secret,
-        encryption_key,
-        canvas_sections_enabled,
+        cls, lms_url, email, developer_key, developer_secret, encryption_key, settings,
     ):
         """Instantiate ApplicationInstance with lms_url."""
         encrypted_secret = developer_secret
@@ -82,7 +89,7 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
             developer_secret=encrypted_secret,
             aes_cipher_iv=aes_iv,
             created=datetime.utcnow(),
-            canvas_sections_enabled=canvas_sections_enabled,
+            _settings=settings,
         )
 
 
@@ -105,3 +112,30 @@ def _encrypt_oauth_secret(oauth_secret, key, init_v):
     """Encrypt an oauth secrety via AES encryption."""
     cipher = AES.new(key, AES.MODE_CFB, init_v)
     return cipher.encrypt(oauth_secret)
+
+
+class _ApplicationSettings:
+    """Model for accessing and updating application settings."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def get(self, group, key):
+        """
+        Get a specific settings or None if it doesn't exist.
+
+        :param group: The name of the group of settings
+        :param key: The key in that group
+        :return: The value or None
+        """
+        return self.data.get(group, {}).get(key)
+
+    def set(self, group, key, value):
+        """
+        Set a specific setting in a group.
+
+        :param group: The name of the group of settings
+        :param key: The key in that group
+        :param value: The value to set
+        """
+        self.data.setdefault(group, {})[key] = value

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -56,12 +56,12 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
 
     @classmethod
     def build_from_lms_url(  # pylint:disable=too-many-arguments
-        cls, lms_url, email, developer_key, developer_secret, encryption_key=None
+        cls, lms_url, email, developer_key, developer_secret, encryption_key
     ):
         """Instantiate ApplicationInstance with lms_url."""
         encrypted_secret = developer_secret
         aes_iv = None
-        if encryption_key is not None and developer_secret and developer_key:
+        if developer_secret and developer_key:
             aes_iv = _build_aes_iv()
             encrypted_secret = _encrypt_oauth_secret(
                 developer_secret, encryption_key, aes_iv

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -56,7 +56,13 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
 
     @classmethod
     def build_from_lms_url(  # pylint:disable=too-many-arguments
-        cls, lms_url, email, developer_key, developer_secret, encryption_key
+        cls,
+        lms_url,
+        email,
+        developer_key,
+        developer_secret,
+        encryption_key,
+        canvas_sections_enabled,
     ):
         """Instantiate ApplicationInstance with lms_url."""
         encrypted_secret = developer_secret
@@ -76,6 +82,7 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
             developer_secret=encrypted_secret,
             aes_cipher_iv=aes_iv,
             created=datetime.utcnow(),
+            canvas_sections_enabled=canvas_sections_enabled,
         )
 
 

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -30,6 +30,12 @@ class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
         server_default=sa.sql.expression.true(),
         nullable=False,
     )
+    canvas_sections_enabled = sa.Column(
+        sa.Boolean(),
+        default=False,
+        server_default=sa.sql.expression.false(),
+        nullable=False,
+    )
 
     #: A list of all the OAuth2Tokens for this application instance
     #: (each token belongs to a different user of this application

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -370,12 +370,12 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
         }
 
     def _groups(self):
-        if self._context.should_use_section_groups:
+        if self._context.canvas_sections_enabled:
             return "$rpc:requestGroups"
         return [self._context.h_group.groupid(self._authority)]
 
     def _sync_api(self):
-        if not self._context.should_use_section_groups:
+        if not self._context.canvas_sections_enabled:
             return None
 
         req = self._request

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -106,7 +106,7 @@ class LTILaunchResource:
 
         ai_getter = self._request.find_service(name="ai_getter")
 
-        if not ai_getter.canvas_sections_enabled():
+        if not ai_getter.developer_key() or not ai_getter.canvas_sections_enabled():
             return False
 
         return self._request.feature("section_groups")

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -104,4 +104,9 @@ class LTILaunchResource:
         if not self.is_canvas:
             return False
 
+        ai_getter = self._request.find_service(name="ai_getter")
+
+        if not ai_getter.canvas_sections_enabled():
+            return False
+
         return self._request.feature("section_groups")

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -99,14 +99,8 @@ class LTILaunchResource:
         return self._request.parsed_params.get("custom_canvas_api_domain")
 
     @property
-    def should_use_section_groups(self):
-        """Return True if section groups rather than a course group should be used."""
-        if not self.is_canvas:
-            return False
-
+    def canvas_sections_enabled(self):
+        """Return True if Canvas sections is enabled for this request."""
         ai_getter = self._request.find_service(name="ai_getter")
 
-        if not ai_getter.developer_key() or not ai_getter.canvas_sections_enabled():
-            return False
-
-        return self._request.feature("section_groups")
+        return self.is_canvas and ai_getter.canvas_sections_enabled()

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -70,6 +70,12 @@ class ApplicationInstanceGetter:
             provisioning = False
         return provisioning
 
+    def canvas_sections_enabled(self):
+        try:
+            return self._get_by_consumer_key().canvas_sections_enabled
+        except ConsumerKeyError:
+            return False
+
     def shared_secret(self):
         """
         Return the LTI/OAuth 1 shared secret for the current request.

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -81,7 +81,10 @@ class ApplicationInstanceGetter:
         except ConsumerKeyError:
             return False
 
-        return bool(app_instance.developer_key and app_instance.canvas_sections_enabled)
+        return bool(
+            app_instance.developer_key
+            and app_instance.settings.get("canvas", "sections_enabled")
+        )
 
     def shared_secret(self):
         """

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -20,15 +20,21 @@ from lms.validation.authentication import BearerTokenSchema, CanvasOAuthCallback
 
 @view_defaults(request_method="GET", route_name="canvas_oauth_callback")
 class CanvasAPIAuthorizeViews:
-
-    #: The Canvas API scopes that we request.
-    scopes = (
-        "url:GET|/api/v1/courses/:course_id/files",
-        "url:GET|/api/v1/files/:id/public_url",
-    )
-
     def __init__(self, request):
         self.request = request
+
+        #: The Canvas API scopes that we request.
+        self.scopes = (
+            "url:GET|/api/v1/courses/:course_id/files",
+            "url:GET|/api/v1/files/:id/public_url",
+        )
+
+        if request.feature("section_groups"):
+            self.scopes = self.scopes + (
+                "url:GET|/api/v1/courses/:id",
+                "url:GET|/api/v1/courses/:course_id/sections",
+                "url:GET|/api/v1/courses/:course_id/users/:id",
+            )
 
     @view_config(permission="canvas_api", route_name="canvas_api.authorize")
     def authorize(self):

--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -28,6 +28,7 @@ def create_application_instance(request):
         developer_key,
         developer_secret,
         request.registry.settings["aes_secret"],
+        canvas_sections_enabled=developer_key and request.feature("section_groups"),
     )
     request.db.add(instance)
 

--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -28,7 +28,13 @@ def create_application_instance(request):
         developer_key,
         developer_secret,
         request.registry.settings["aes_secret"],
-        canvas_sections_enabled=developer_key and request.feature("section_groups"),
+        settings={
+            "canvas": {
+                "sections_enabled": bool(
+                    developer_key and request.feature("section_groups")
+                )
+            }
+        },
     )
     request.db.add(instance)
 

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -2,6 +2,9 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from lms.models import ApplicationInstance
+from lms.models.application_instance import _ApplicationSettings
+
+# pylint: disable=protected-access
 
 
 class TestApplicationInstance:
@@ -33,31 +36,23 @@ class TestApplicationInstance:
 
         assert application_instance.provisioning is not None
 
-    def test_canvas_sections_enabled_defaults_to_False(
-        self, db_session, application_instance
-    ):
-        db_session.add(application_instance)
+    def test_settings_defaults_to_an_empty_dict(self, application_instance):
+        settings = application_instance.settings
 
-        db_session.flush()
+        assert isinstance(settings, _ApplicationSettings)
+        assert settings.data == {}
 
-        assert not application_instance.canvas_sections_enabled
+    def test_settings_can_be_retrieved(self, application_instance):
+        application_instance._settings = {"group": {"key": "value"}}
 
-    def test_canvas_sections_can_be_enabled(self, db_session, application_instance):
-        application_instance.canvas_sections_enabled = True
-        db_session.add(application_instance)
-        db_session.flush()
+        assert application_instance.settings.get("group", "key") == "value"
 
-        assert application_instance.canvas_sections_enabled is True
+    def test_can_update_settings(self, application_instance):
+        application_instance._settings = {"group": {"key": "value"}}
 
-    def test_canvas_sections_enabled_is_not_nullable(
-        self, db_session, application_instance
-    ):
-        application_instance.canvas_sections_enabled = None
-        db_session.add(application_instance)
+        application_instance.settings.set("group", "key", "new_value")
 
-        db_session.flush()
-
-        assert application_instance.canvas_sections_enabled is not None
+        assert application_instance._settings["group"]["key"] == "new_value"
 
     def test_consumer_key_cant_be_null(self, db_session, application_instance):
         application_instance.consumer_key = None
@@ -117,3 +112,30 @@ class TestApplicationInstance:
             lms_url="TEST_LMS_URL",
             requesters_email="TEST_EMAIL",
         )
+
+
+class TestApplicationSettings:
+    @pytest.mark.parametrize(
+        "group,key,expected_value",
+        (
+            ("group", "key", "old_value"),
+            ("NEW", "key", None),
+            ("group", "NEW", None),
+            ("NEW", "NEW", None),
+        ),
+    )
+    def test_settings_can_be_retrieved(self, settings, group, key, expected_value):
+        assert settings.get(group, key) == expected_value
+
+    @pytest.mark.parametrize(
+        "group,key",
+        (("group", "key"), ("NEW", "key"), ("group", "NEW"), ("NEW", "NEW")),
+    )
+    def test_can_update_settings(self, settings, group, key):
+        settings.set(group, key, "new_value")
+
+        assert settings.get(group, key) == "new_value"
+
+    @pytest.fixture
+    def settings(self):
+        return _ApplicationSettings({"group": {"key": "old_value"}})

--- a/tests/unit/lms/models/test_application_instance.py
+++ b/tests/unit/lms/models/test_application_instance.py
@@ -33,6 +33,32 @@ class TestApplicationInstance:
 
         assert application_instance.provisioning is not None
 
+    def test_canvas_sections_enabled_defaults_to_False(
+        self, db_session, application_instance
+    ):
+        db_session.add(application_instance)
+
+        db_session.flush()
+
+        assert not application_instance.canvas_sections_enabled
+
+    def test_canvas_sections_can_be_enabled(self, db_session, application_instance):
+        application_instance.canvas_sections_enabled = True
+        db_session.add(application_instance)
+        db_session.flush()
+
+        assert application_instance.canvas_sections_enabled is True
+
+    def test_canvas_sections_enabled_is_not_nullable(
+        self, db_session, application_instance
+    ):
+        application_instance.canvas_sections_enabled = None
+        db_session.add(application_instance)
+
+        db_session.flush()
+
+        assert application_instance.canvas_sections_enabled is not None
+
     def test_consumer_key_cant_be_null(self, db_session, application_instance):
         application_instance.consumer_key = None
         db_session.add(application_instance)

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -485,13 +485,13 @@ def context():
         instance=True,
         h_group=mock.create_autospec(HGroup, instance=True, spec_set=True),
         is_canvas=True,
-        should_use_section_groups=False,
+        canvas_sections_enabled=False,
     )
 
 
 @pytest.fixture
 def section_groups_on(context):
-    context.should_use_section_groups = True
+    context.canvas_sections_enabled = True
 
 
 @pytest.fixture

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -105,11 +105,12 @@ class TestShouldUseSectionGroups:
     @pytest.mark.parametrize(
         "params",
         [
-            # If we're in Canvas and sections is enabled for the application
-            # instance then sections should be enabled.
+            # If we're in Canvas and the application instance has a developer
+            # key with sections enabled then sections should be enabled.
             dict(
                 is_canvas=True,
                 is_feature_flag_enabled=True,
+                developer_key=mock.sentinel.developer_key,
                 is_canvas_sections_enabled=True,
                 should_use_section_groups=True,
             ),
@@ -117,6 +118,7 @@ class TestShouldUseSectionGroups:
             dict(
                 is_canvas=True,
                 is_feature_flag_enabled=False,
+                developer_key=mock.sentinel.developer_key,
                 is_canvas_sections_enabled=True,
                 should_use_section_groups=False,
             ),
@@ -124,6 +126,7 @@ class TestShouldUseSectionGroups:
             dict(
                 is_canvas=False,
                 is_feature_flag_enabled=True,
+                developer_key=mock.sentinel.developer_key,
                 is_canvas_sections_enabled=True,
                 should_use_section_groups=False,
             ),
@@ -132,7 +135,17 @@ class TestShouldUseSectionGroups:
             dict(
                 is_canvas=True,
                 is_feature_flag_enabled=True,
+                developer_key=mock.sentinel.developer_key,
                 is_canvas_sections_enabled=False,
+                should_use_section_groups=False,
+            ),
+            # If the application instance doesn't have a developer key then
+            # sections should be disabled.
+            dict(
+                is_canvas=True,
+                is_feature_flag_enabled=True,
+                developer_key=None,
+                is_canvas_sections_enabled=True,
                 should_use_section_groups=False,
             ),
         ],
@@ -141,6 +154,7 @@ class TestShouldUseSectionGroups:
         self, lti_launch, pyramid_request, params, ai_getter,
     ):
         pyramid_request.feature.return_value = params["is_feature_flag_enabled"]
+        ai_getter.developer_key.return_value = params["developer_key"]
         ai_getter.canvas_sections_enabled.return_value = params[
             "is_canvas_sections_enabled"
         ]

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -103,67 +103,21 @@ class TestJSConfig:
 
 class TestShouldUseSectionGroups:
     @pytest.mark.parametrize(
-        "params",
+        "is_canvas,canvas_sections_enabled,expected_result",
         [
-            # If we're in Canvas and the application instance has a developer
-            # key with sections enabled then sections should be enabled.
-            dict(
-                is_canvas=True,
-                is_feature_flag_enabled=True,
-                developer_key=mock.sentinel.developer_key,
-                is_canvas_sections_enabled=True,
-                should_use_section_groups=True,
-            ),
-            # If the feature flag is disabled then sections should be disabled.
-            dict(
-                is_canvas=True,
-                is_feature_flag_enabled=False,
-                developer_key=mock.sentinel.developer_key,
-                is_canvas_sections_enabled=True,
-                should_use_section_groups=False,
-            ),
-            # If we're not in Canvas then sections should be disabled.
-            dict(
-                is_canvas=False,
-                is_feature_flag_enabled=True,
-                developer_key=mock.sentinel.developer_key,
-                is_canvas_sections_enabled=True,
-                should_use_section_groups=False,
-            ),
-            # If sections is disabled for the application instance then
-            # sections should be disabled.
-            dict(
-                is_canvas=True,
-                is_feature_flag_enabled=True,
-                developer_key=mock.sentinel.developer_key,
-                is_canvas_sections_enabled=False,
-                should_use_section_groups=False,
-            ),
-            # If the application instance doesn't have a developer key then
-            # sections should be disabled.
-            dict(
-                is_canvas=True,
-                is_feature_flag_enabled=True,
-                developer_key=None,
-                is_canvas_sections_enabled=True,
-                should_use_section_groups=False,
-            ),
+            (True, True, True),
+            (False, True, False),
+            (True, False, False),
+            (False, False, False),
         ],
     )
     def test_it(
-        self, lti_launch, pyramid_request, params, ai_getter,
+        self, lti_launch, ai_getter, is_canvas, canvas_sections_enabled, expected_result
     ):
-        pyramid_request.feature.return_value = params["is_feature_flag_enabled"]
-        ai_getter.developer_key.return_value = params["developer_key"]
-        ai_getter.canvas_sections_enabled.return_value = params[
-            "is_canvas_sections_enabled"
-        ]
+        ai_getter.canvas_sections_enabled.return_value = canvas_sections_enabled
 
-        with mock.patch.object(LTILaunchResource, "is_canvas", params["is_canvas"]):
-            assert (
-                lti_launch.should_use_section_groups
-                == params["should_use_section_groups"]
-            )
+        with mock.patch.object(LTILaunchResource, "is_canvas", is_canvas):
+            assert lti_launch.canvas_sections_enabled == expected_result
 
 
 pytestmark = pytest.mark.usefixtures("ai_getter")

--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -97,7 +97,10 @@ class TestApplicationInstanceGetter:
             mock.sentinel.context, pyramid_request
         )
         test_application_instance.developer_key = developer_key
-        test_application_instance.canvas_sections_enabled = canvas_sections_enabled
+        # pylint: disable=protected-access
+        test_application_instance._settings = {
+            "canvas": {"sections_enabled": canvas_sections_enabled}
+        }
 
         assert ai_getter.canvas_sections_enabled() == expected_result
 

--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -68,6 +68,20 @@ class TestApplicationInstanceGetter:
     def test_provisioning_returns_False_if_consumer_key_unknown(self, ai_getter):
         assert not ai_getter.provisioning_enabled()
 
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_canvas_sections_enabled_returns_the_canvas_sections_enabled(
+        self, ai_getter, flag, test_application_instance
+    ):
+        test_application_instance.canvas_sections_enabled = flag
+
+        assert ai_getter.canvas_sections_enabled() == flag
+
+    @pytest.mark.usefixtures("unknown_consumer_key")
+    def test_canvas_sections_enabled_returns_False_if_consumer_key_unknown(
+        self, ai_getter
+    ):
+        assert not ai_getter.canvas_sections_enabled()
+
     def test_shared_secret_returns_the_shared_secret(self, ai_getter):
         assert ai_getter.shared_secret() == "TEST_SHARED_SECRET"
 

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -42,28 +42,26 @@ class TestAuthorize:
             "http://example.com/canvas_oauth_callback"
         ]
 
-    def test_it_includes_the_scope_in_a_query_param(self, views):
+    def test_it_includes_the_scopes_in_a_query_param(self, views):
         response = views.authorize()
 
         query_params = parse_qs(urlparse(response.location).query)
 
-        assert query_params["scope"] == [
-            "url:GET|/api/v1/courses/:course_id/files url:GET|/api/v1/files/:id/public_url"
-        ]
-
-    @pytest.mark.usefixtures("sections_enabled")
-    def test_it_requests_sections_scopes_if_the_sections_feature_flag_is_on(
-        self, views
-    ):
-        response = views.authorize()
-
-        query_params = parse_qs(urlparse(response.location).query)
         assert query_params["scope"] == [
             "url:GET|/api/v1/courses/:course_id/files "
             "url:GET|/api/v1/files/:id/public_url "
             "url:GET|/api/v1/courses/:id "
             "url:GET|/api/v1/courses/:course_id/sections "
             "url:GET|/api/v1/courses/:course_id/users/:id"
+        ]
+
+    @pytest.mark.usefixtures("sections_disabled")
+    def test_it_doesnt_request_sections_scopes_if_sections_is_disabled(self, views):
+        response = views.authorize()
+
+        query_params = parse_qs(urlparse(response.location).query)
+        assert query_params["scope"] == [
+            "url:GET|/api/v1/courses/:course_id/files url:GET|/api/v1/files/:id/public_url"
         ]
 
     def test_it_includes_the_state_in_a_query_param(
@@ -170,15 +168,6 @@ class TestOAuth2RedirectError:
         assert template_variables["scopes"] == (
             "url:GET|/api/v1/courses/:course_id/files",
             "url:GET|/api/v1/files/:id/public_url",
-        )
-
-    @pytest.mark.usefixtures("sections_enabled")
-    def test_it_passes_sections_scopes_if_the_feature_flag_is_on(self, views):
-        template_variables = views.oauth2_redirect_error()
-
-        assert template_variables["scopes"] == (
-            "url:GET|/api/v1/courses/:course_id/files",
-            "url:GET|/api/v1/files/:id/public_url",
             "url:GET|/api/v1/courses/:id",
             "url:GET|/api/v1/courses/:course_id/sections",
             "url:GET|/api/v1/courses/:course_id/users/:id",
@@ -215,11 +204,8 @@ def canvas_oauth_callback_schema(CanvasOAuthCallbackSchema):
 
 
 @pytest.fixture
-def sections_enabled(pyramid_request):
-    def feature(flag):
-        return flag == "section_groups"
-
-    pyramid_request.feature.side_effect = feature
+def sections_disabled(ai_getter):
+    ai_getter.canvas_sections_enabled.return_value = False
 
 
 pytestmark = pytest.mark.usefixtures("ai_getter", "canvas_api_client")

--- a/tests/unit/lms/views/test_application_instance.py
+++ b/tests/unit/lms/views/test_application_instance.py
@@ -50,6 +50,27 @@ class TestCreateApplicationInstance:
         assert application_instance.developer_key is None
         assert application_instance.developer_secret is None
 
+    @pytest.mark.parametrize(
+        "developer_key,feature_flag,canvas_sections_enabled",
+        [
+            ("test_developer_key", True, True),
+            ("test_developer_key", False, False),
+            ("", True, False),
+            ("", False, False),
+        ],
+    )
+    def test_it_sets_canvas_sections_enabled(
+        self, pyramid_request, developer_key, feature_flag, canvas_sections_enabled
+    ):
+        pyramid_request.params["developer_key"] = developer_key
+        pyramid_request.params["developer_secret"] = "test_developer_secret"
+        pyramid_request.feature.return_value = feature_flag
+
+        create_application_instance(pyramid_request)
+
+        application_instance = pyramid_request.db.query(ApplicationInstance).one()
+        assert application_instance.canvas_sections_enabled == canvas_sections_enabled
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.method = "POST"

--- a/tests/unit/lms/views/test_application_instance.py
+++ b/tests/unit/lms/views/test_application_instance.py
@@ -69,7 +69,10 @@ class TestCreateApplicationInstance:
         create_application_instance(pyramid_request)
 
         application_instance = pyramid_request.db.query(ApplicationInstance).one()
-        assert application_instance.canvas_sections_enabled == canvas_sections_enabled
+        assert (
+            bool(application_instance.settings.get("canvas", "sections_enabled"))
+            == canvas_sections_enabled
+        )
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/unit/lms/views/test_reports.py
+++ b/tests/unit/lms/views/test_reports.py
@@ -26,7 +26,7 @@ class TestReports:
 
         def build_ai_from_pair(pair):
             return ApplicationInstance.build_from_lms_url(
-                pair[0], pair[1], None, None, None
+                pair[0], pair[1], None, None, None, None
             )
 
         app_instances = [


### PR DESCRIPTION
Depends on this DB migration: https://github.com/hypothesis/lms/pull/1730/

## Intended Behaviour

1. Pre-existing application instances (either created before the DB migration is run and before this branch is deployed; _or_ created after the DB migration and deploying this branch but before the `"section_groups"` feature flag is enabled) should **not** get the sections feature.

2. Pre-existing application instances that have a developer key should continue to get the Canvas Files feature but **not** get the sections feature.

   These pre-existing instances shouldn't request the sections API scopes, so they should keep working with a scoped dev key that only has the Files scopes.

   If the dev key lacks even the Files scopes then these instances will show an error page when you try to create or launch a Canvas Files assignment. The error page will tell the user that we need both the Files **and** Sections scopes.

3. **New** application instances (created after the DB migration has been run, this branch has been deployed, and the feature flag has been turned on) should get both the Files and Sections features.

   These new instances will always request both the Files and Sections scopes, and will show an error page if any of the scopes are missing. The error page will show whenever anyone tries to create or launch any assignment, and will ask for both the Files and Sections scopes.

4. New app instances that don't have a developer key won't get either the files or sections features.

## Testing

* To test this you need to cherry-pick frontend sections support:

  ```terminal
  git cherry-pick make-the-frontend-call-the-sync-api
  ```

* You'll want to repeatedly delete all the OAuth 2 tokens from your DB when testing this, to force it to re-authorize with Canvas (changing the developer key's scopes in Canvas also often forces a re-authorize, but not always):

   ```terminal
  tox -qe docker-compose -- exec postgres psql -U postgres -c 'delete from oauth2_token;'
  ```

### Test Cases

* App instances created before the DB migration:

  The `"section_groups"` feature flag should be **off** when creating the app instances for this test, and then using the app instances should be tested with the flag both **off** and **on**.

  Create the app instances on the master branch without the DB migration having been run so there's no `ApplicationInstance.canvas_sections_enabled` column. Then run the DB migration, then switch to this branch, and then test the app instance's behaviour.

  - App instance created without a developer key:
    - [x] Should work with no Canvas files or sections feature
  - App instance created with a developer key:
    - [x] Should have the Canvas files feature but not sections
    - [x] Should work with a scoped dev key even if the key lacks the sections scopes
    - [x] With a scoped dev key that lacks the _files_ scopes, should show an error page asking for both the sections and files scopes
  - [x] All of the above should work with the feature flag both off and on

* App instances created after the DB migration, but before the feature flag has been turned on:

  The `"section_groups"` feature flag should be **off** when creating the app instances for this test, and then using the app instances should be tested with the flag both **off** and **on**.

  Use this branch for the entire test (before creating the app instances and testing them).

  - App instance created without a developer key:
    - [x] Should work with no Canvas files or sections feature
  - App instance created with a developer key:
    - [x] Should have the Canvas files feature but not sections
    - [x] Should work with a scoped dev key even if the key lacks the sections scopes
    - [x] With a scoped dev key that lacks the _files_ scopes, should show an error page asking for both the sections and files scopes
  - [x] All of the above should work with the feature flag both off and on

* App instances created after the DB migration and after the feature flag has been turned on:

    The `"section_groups"` feature flag should be **on** for this test.

  Use this branch for the entire test (before creating the app instances and testing them).

  - App instance created without a developer key:
    - [x] Should work with no Canvas files or sections feature
  - App instance created with a developer key:
    - [x] Should have both the Canvas files and sections features
    - [x] Should work with a scoped dev key as long as the key has both the files and sections scopes
    - [x] With a scoped dev key that lacks the sections scopes, should show an error page asking for both the sections and files scopes
    - [x] With a scoped dev key that lacks the files scopes, should show an error page asking for both the sections and files scopes

## Implementation

1. Adds a new boolean DB column `ApplicationInstance.canvas_sections_enabled`. This is exactly the same as the existing `ApplicationInstance.provisioning`, which also toggles a feature

2. _If the `"section_groups"` feature flag is on_ enables sections by default for new application instances that have a developer key.

   Fixes https://github.com/hypothesis/lms/issues/1724.

   This is done when the `/welcome` form is submitted. Logic is added to the `create_application_instance()` view (which is the view that receives the form submission) to set `canvas_sections_enabled` to `True` if the feature flag is on and a dev key was submitted.

3. Disables sections if the application instance doesn't have a developer key. Fixes https://github.com/hypothesis/lms/issues/1695

4. Disables sections for pre-existing application instances.

   Fixes https://github.com/hypothesis/lms/issues/1697.

   This is done in two ways:

   1. The DB migration in https://github.com/hypothesis/lms/pull/1730/ will set `canvas_sections_enabled` to `False` for all preexisting rows
   2. The logic in the `create_application_instance()` view mentioned above will set `canvas_sections_enabled` to `False` for all new application instances created after the DB migration, as long as the `"section_groups"` feature flag is off. (Once the flag is on `create_application_instance()` starts setting `canvas_sections_enabled` to `True` for new instances.)

5. Adds the new Canvas API scopes that we need for sections, to the list of scopes that we request from the Canvas API.

   This will trigger the recently implemented scopes error page, if the dev key lacks any of the new scopes.

   Fixes https://github.com/hypothesis/lms/issues/1696

   The new scopes have already been documented here https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App

6. Does not request the sections scopes from the Canvas API if the application instance doesn't have the `canvas_sections_enabled` flag on. Even if the app instance does have a developer key. Instead requests the Files scopes only.

   This is so that preexisting app instances that have scoped dev keys with only the Files scopes, can continue working with only the Files feature (not Sections), and won't start showing an error page because we're now requesting the Sections scopes and the dev key doesn't have them.