### PR TITLE
Add sections support to SpeedGrader launches

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -382,7 +382,7 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
 
         req = self._request
 
-        return {
+        sync_api_config = {
             "path": req.route_path("canvas_api.sync"),
             "data": {
                 "lms": {
@@ -401,3 +401,10 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
                 },
             },
         }
+
+        if "learner_canvas_user_id" in req.params:
+            sync_api_config["data"]["learner"] = {
+                "canvas_user_id": req.params["learner_canvas_user_id"],
+            }
+
+        return sync_api_config

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -198,6 +198,7 @@ class JSConfig:  # pylint:disable=too-many-instance-attributes
                 "h_username": self._h_user.username,
                 "lis_result_sourcedid": lis_result_sourcedid,
                 "lis_outcome_service_url": lis_outcome_service_url,
+                "learner_canvas_user_id": self._request.params["custom_canvas_user_id"],
                 **kwargs,
             },
         }

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -101,6 +101,17 @@ class LTILaunchResource:
     @property
     def canvas_sections_enabled(self):
         """Return True if Canvas sections is enabled for this request."""
-        ai_getter = self._request.find_service(name="ai_getter")
+        if not self.is_canvas:
+            return False
 
-        return self.is_canvas and ai_getter.canvas_sections_enabled()
+        ai_getter = self._request.find_service(name="ai_getter")
+        if not ai_getter.canvas_sections_enabled():
+            return False
+
+        params = self._request.params
+        if "focused_user" in params and "learner_canvas_user_id" not in params:
+            # This is a legacy SpeedGrader URL, submitted to Canvas before our
+            # Canvas course sections feature was released.
+            return False
+
+        return True

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -20,6 +20,9 @@ class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
     h_username = fields.Str(required=True)
     """h username generated for the active user."""
 
+    learner_canvas_user_id = fields.Str(required=True)
+    """Canvas user ID of the active user."""
+
     lis_outcome_service_url = fields.Str(required=True)
     """URL provided by the LMS to submit grades or other results to."""
 

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -17,18 +17,18 @@ def sync(request):
     lti_h_svc = request.find_service(name="lti_h")
 
     context_id = request.json["course"]["context_id"]
-    custom_canvas_course_id = request.json["course"]["custom_canvas_course_id"]
+    course_id = request.json["course"]["custom_canvas_course_id"]
     group_info = request.json["group_info"]
     tool_consumer_instance_guid = request.json["lms"]["tool_consumer_instance_guid"]
 
     if request.lti_user.is_learner:
         # For learners we only want the client to show the sections that the
         # student belongs to, so fetch only the user's sections.
-        sections = canvas_api_svc.authenticated_users_sections(custom_canvas_course_id)
+        sections = canvas_api_svc.authenticated_users_sections(course_id)
     else:
         # For non-learners (e.g. instructors, teaching assistants) we want the
         # client to show all of the course's sections.
-        sections = canvas_api_svc.course_sections(custom_canvas_course_id)
+        sections = canvas_api_svc.course_sections(course_id)
 
     def group(section):
         """Return an HGroup from the given Canvas section dict."""
@@ -38,12 +38,20 @@ def sync(request):
         hash_object.update(str(section["id"]).encode())
         authority_provided_id = hash_object.hexdigest()
 
-        return HGroup(
-            h_group_name(section["name"]), authority_provided_id, type="section_group"
-        )
+        if "name" in section:
+            name = h_group_name(section["name"])
+        else:
+            name = None
+
+        return HGroup(name, authority_provided_id, type="section_group")
 
     groups = [group(section) for section in sections]
-
     lti_h_svc.sync(groups, group_info)
+
+    if "learner" in request.json:
+        user_id = request.json["learner"]["canvas_user_id"]
+        learners_sections = canvas_api_svc.users_sections(user_id, course_id)
+        learners_groups = [group(section) for section in learners_sections]
+        return [group.groupid(authority) for group in learners_groups]
 
     return [group.groupid(authority) for group in groups]

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -110,7 +110,10 @@ class CanvasPreRecordHook:
 
     def get_speedgrader_launch_url(self):
         parsed_params = self.request.parsed_params
-        params = {"focused_user": parsed_params["h_username"]}
+        params = {
+            "focused_user": parsed_params["h_username"],
+            "learner_canvas_user_id": parsed_params["learner_canvas_user_id"],
+        }
 
         if parsed_params.get("document_url"):
             params["url"] = parsed_params.get("document_url")

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -348,12 +348,22 @@ class TestJSConfigAPISync:
             },
         }
 
+    @pytest.mark.usefixtures("section_groups_on", "learner_canvas_user_id")
+    def test_it_adds_learner_canvas_user_id_for_SpeedGrader_launches(self, sync):
+        assert sync["data"]["learner"] == {
+            "canvas_user_id": "test_learner_canvas_user_id",
+        }
+
     def test_its_None_if_section_groups_isnt_enabled(self, sync):
         assert sync is None
 
     @pytest.fixture
     def sync(self, config):
         return config["api"]["sync"]
+
+    @pytest.fixture
+    def learner_canvas_user_id(self, pyramid_request):
+        pyramid_request.params["learner_canvas_user_id"] = "test_learner_canvas_user_id"
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -155,6 +155,7 @@ class TestAddCanvasFileIDAddDocumentURLCommon:
             submission_params()["lis_result_sourcedid"]
             == "example_lis_result_sourcedid"
         )
+        assert submission_params()["learner_canvas_user_id"] == "test_user_id"
 
     def test_it_doesnt_set_the_speedGrader_settings_if_the_LMS_isnt_Canvas(
         self, context, method, js_config
@@ -502,6 +503,7 @@ def pyramid_request(pyramid_request):
             "lis_outcome_service_url": "example_lis_outcome_service_url",
             "context_id": "test_course_id",
             "custom_canvas_course_id": "test_course_id",
+            "custom_canvas_user_id": "test_user_id",
         }
     )
     return pyramid_request

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -101,7 +101,7 @@ class TestJSConfig:
         assert js_config == JSConfig.return_value
 
 
-class TestShouldUseSectionGroups:
+class TestCanvasSectionsEnabled:
     @pytest.mark.parametrize(
         "is_canvas,canvas_sections_enabled,expected_result",
         [
@@ -118,6 +118,27 @@ class TestShouldUseSectionGroups:
 
         with mock.patch.object(LTILaunchResource, "is_canvas", is_canvas):
             assert lti_launch.canvas_sections_enabled == expected_result
+
+    def test_it_enables_sections_for_SpeedGrader_launches(
+        self, lti_launch, ai_getter, pyramid_request
+    ):
+        ai_getter.canvas_sections_enabled.return_value = True
+        pyramid_request.params["focused_user"] = mock.sentinel.focused_user
+        pyramid_request.params[
+            "learner_canvas_user_id"
+        ] = mock.sentinel.learner_canvas_user_id
+
+        with mock.patch.object(LTILaunchResource, "is_canvas", True):
+            assert lti_launch.canvas_sections_enabled is True
+
+    def test_it_disables_sections_for_legacy_SpeedGrader_launches(
+        self, lti_launch, ai_getter, pyramid_request
+    ):
+        ai_getter.canvas_sections_enabled.return_value = True
+        pyramid_request.params["focused_user"] = mock.sentinel.focused_user
+
+        with mock.patch.object(LTILaunchResource, "is_canvas", True):
+            assert not lti_launch.canvas_sections_enabled
 
 
 pytestmark = pytest.mark.usefixtures("ai_getter")

--- a/tests/unit/lms/validation/_api_test.py
+++ b/tests/unit/lms/validation/_api_test.py
@@ -19,7 +19,13 @@ class TestAPIRecordSpeedgraderSchema:
         assert parsed_params == all_fields
 
     @pytest.mark.parametrize(
-        "field", ["h_username", "lis_outcome_service_url", "lis_result_sourcedid"]
+        "field",
+        [
+            "h_username",
+            "lis_outcome_service_url",
+            "lis_result_sourcedid",
+            "learner_canvas_user_id",
+        ],
     )
     def test_it_raises_if_required_fields_missing(
         self, json_request, all_fields, field
@@ -45,6 +51,7 @@ class TestAPIRecordSpeedgraderSchema:
             "document_url": "https://example.com",
             "canvas_file_id": "file123",
             "h_username": "user123",
+            "learner_canvas_user_id": "canvas_user_123",
             "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
             "lis_result_sourcedid": "modelstudent-assignment1",
         }

--- a/tests/unit/lms/views/api/lti_test.py
+++ b/tests/unit/lms/views/api/lti_test.py
@@ -72,6 +72,7 @@ class TestCanvasPreRecordHook:
     )
     def test_it_sets_expected_fields(self, pyramid_request, parsed_params, url_params):
         parsed_params["h_username"] = "h_username"
+        parsed_params["learner_canvas_user_id"] = "learner_canvas_user_id"
         pyramid_request.parsed_params = parsed_params
 
         result = CanvasPreRecordHook(pyramid_request)(
@@ -89,7 +90,11 @@ class TestCanvasPreRecordHook:
         assert launch_url.startswith("http://example.com/lti_launches?")
 
         query_string = parse_qs(urlparse(launch_url).query)
-        assert query_string == dict(url_params, focused_user=["h_username"])
+        assert query_string == dict(
+            url_params,
+            focused_user=["h_username"],
+            learner_canvas_user_id=["learner_canvas_user_id"],
+        )
 
 
 class TestReadResult:


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/1694

Depends on https://github.com/hypothesis/lms/pull/1731

## Intended Behaviour

This gets SpeedGrader working when sections is enabled: the client shows the section group(s) that the learner being graded belongs to, rather than showing the instructor's groups.

## Testing

* You'll need frontend sections support to test this:

  ```terminal
  git cherry-pick make-the-frontend-call-the-sync-api
  ```

* You may also want to turn the `canvas_sections_enabled` setting on and off for all application instances in your DB (which is just a quick and easy way to turn it on/off for the app instance you happen to currently be testing with):

  ```terminal
  tox -qe docker-compose -- exec postgres psql -U postgres -c 'update application_instances set canvas_sections_enabled = true;'
  ```

  ```terminal
  tox -qe docker-compose -- exec postgres psql -U postgres -c 'update application_instances set canvas_sections_enabled = false;'
  ```

* You need to understand that when a student launches an assignment it submits a SpeedGrader URL to Canvas _and does not re-submit the SpeedGrader URL if the student re-launches the assignment_. This means that if a student has launched an assignment and submitted a legacy SpeedGrader URL that student will have legacy SpeedGrader support for that assignment forever, and vice-versa

- [x] Legacy SpeedGrader submissions should still show course groups

  1. Log in to Canvas as a teacher and create a new assignment
  2. Change to the master branch, log in to Canvas as a student, and launch the new assignment. A legacy SpeedGrader URL is submitted to Canvas when the student launches the assignment
  3. Change back to this branch, log in to Canvas as a teacher, and launch the assignment in SpeedGrader. You should see the course group when grading the student

- [x] New submissions should show section groups.

  The "Sections 101" course and `eng+canvassections101*` users in 1Password are useful for testing this.

  1. Log in to Canvas as a teacher and create a new assignment
  2. Log in to Canvas as a student and launch the assignment
  3. Log in to Canvas as another student who has different section memberships, and launch the assignment
  4. Log in to Canvas as the teacher again and launch the assignment in SpeedGrader. When grading the first student you should see the first student's section group(s) only, when grading the second student you should see the second student's sections

- [x] Application instances with sections disabled should continue to use course groups.

  As well as legacy SpeedGrader URLs submitted to Canvas before this branch was deployed, there will also be SpeedGrader URLs that get submitted to Canvas after this branch is deployed and sections is released, but that belong to application instances that have sections disabled. These SpeedGrader submissions should continue to use course groups.

  1. Disable sections for your app instance:

     ```terminal
     tox -qe docker-compose -- exec postgres psql -U postgres -c 'update application_instances set canvas_sections_enabled = false;'
     ```

  2. Log in to Canvas as a teacher and create a new assignment
  3. Log in to Canvas as a student and launch the assignment
  4. Log in as the teacher again and launch the assignment in SpeedGrader. You should see the one course group when grading the student

## Known Issues

* Application instances that get upgraded from sections-disabled to sections-enabled can lose access to submitted student annotations in SpeedGrader.

  1. Disable sections for your app instance:

     ```terminal
     tox -qe docker-compose -- exec postgres psql -U postgres -c 'update application_instances set canvas_sections_enabled = false;'
     ```

  2. Log in to Canvas as a teacher and create a new assignment
  3. Log in to Canvas as a student and launch the assignment
  4. Enable sections for your app instance:

     ```terminal
     tox -qe docker-compose -- exec postgres psql -U postgres -c 'update application_instances set canvas_sections_enabled = true;'
     ```

  5. Log in as the teacher again and launch the assignment in SpeedGrader. You will see the student's section groups, rather than the course group, when grading the student. You can't see the student's previously submitted annotations because they were created in the course group.

## Implementation Notes

There are a few parts to this:

* In `JSConfig` we add a new `"learner_canvas_user_id"` to the `"submissionParams"` config dict.

  This causes the frontend to include the new `"learner_canvas_user_id"` when it makes requests to the backend's "record submission" API, which it does every time a learner launches an assignment.

  The param is actually named `"custom_canvas_user_id"` when we originally receive it in the launch request from Canvas. We can't use `"custom_canvas_user_id"` as a custom query param in SpeedGrader launches, though, because Canvas already uses this name for the _instructor's_ user ID in the form body of SpeedGrader launch requests.

  We do want the name to clarify that it's a Canvas user ID not an h user ID or an LTI user ID. And we also want the name to clarify that it's the user ID of the learner to be graded, not of the instructor who is launching us. Hence `"learner_canvas_user_id"`

* In the record-submission API we add support for this new `"learner_canvas_user_id"` param. We use it to add `"learner_canvas_user_id"` to the SpeedGrader launch URLs that we submit to Canvas as a new query param.

* Back in `JSConfig` again, we add a `"learner"` dict to the sync API request's data.

  This causes the frontend to include the new `"learner"` dict in the data when it calls the sync API. The `"learner"` dict is only added for SpeedGrader launches (launches that include the `"learner_canvas_user_id"` param).

* In the sync API view we add support for this new `"learner"` dict. When the learner dict is present we retrieve the user's sections from the Canvas API and return those to the client instead of the instructor's sections.

  Note that we still do retrieve the instructors sections, which is _all_ of the course's sections, as well and we sync them to h. This is because we need to make sure the instructor's user exists in h, the groups exist in h, and the instructor is a member of the groups, otherwise the launch could fail. (Also, we can't create the groups in h based on the learners-sections response from the Canvas API, because this particular Canvas API call only returns the section IDs not the names.)

  This unfortunately means that we're making two different requests to the Canvas API for every one SpeedGrader launch.

* Finally, we add backwards-compatibility support for legacy SpeedGrader URLs.

  There are SpeedGrader URLs in the wild (submitted to Canvas instances) from before the sections feature existed, and these URLs need to keep working. They need to show the course group rather than showing either the learner's or the instructor's section group(s).

  In `LTILaunchResource.canvas_sections_enabled()` we detect legacy SpeedGrader launches because they have the pre-existing (and still used) `focused_user` param but they lack the new `learner_canvas_user_id` param. We disable sections for these launches.