### PR TITLE
Make LMS feature flag cookie settings tri-state

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -72,8 +72,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.add_feature_flag_providers(
         "lms.extensions.feature_flags.config_file_provider",
         "lms.extensions.feature_flags.envvar_provider",
-        # Cookie provision is currently broken. Disable until fixed
-        # "lms.extensions.feature_flags.cookie_provider",
+        "lms.extensions.feature_flags.cookie_provider",
         "lms.extensions.feature_flags.query_string_provider",
     )
 

--- a/lms/extensions/feature_flags/__init__.py
+++ b/lms/extensions/feature_flags/__init__.py
@@ -33,8 +33,7 @@ disabled.
 
 By default no sources are consulted and ``request.feature()`` always returns
 ``False``. You have to explicitly add the sources you want, in the order you
-want, by calling ``config.add_feature_flag_provider()`` or
-``add_feature_flag_providers()``.  For example::
+want, by calling ``add_feature_flag_providers()``. For example::
 
     config.add_feature_flag_providers(
         "lms.extensions.feature_flags.config_file_provider",
@@ -59,7 +58,7 @@ Enable or disable feature flags in the app's config file.
 
 Usage::
 
-    config.add_feature_flag_provider("lms.extensions.feature_flags.config_file_provider")
+    config.add_feature_flag_providers("lms.extensions.feature_flags.config_file_provider", ...)
 
 To enable or disable feature flags in your app's config file add
 ``feature_flags.* = true|false`` lines to the file, one line per feature flag.
@@ -76,7 +75,7 @@ Enable or disable feature flags using environment variables.
 
 Usage::
 
-    config.add_feature_flag_provider("lms.extensions.feature_flags.envvar_provider")
+    config.add_feature_flag_providers("lms.extensions.feature_flags.envvar_provider", ...)
 
 To enable or disable feature flags add ``FEATURE_FLAG_*=true|false``
 environment variables, one envvar per feature flag. For example::
@@ -91,7 +90,7 @@ Enable or disable feature flags using a browser cookie.
 
 Usage::
 
-    config.add_feature_flag_provider("lms.extensions.feature_flags.cookie_provider")
+    config.add_feature_flag_providers("lms.extensions.feature_flags.cookie_provider", ...)
 
 This will add a ``/flags`` page to your app that you can visit to enable or disable
 feature flags in your browser's feature flags cookie.
@@ -119,7 +118,7 @@ Enable or disable feature flags using URL query string parameters.
 
 Usage::
 
-    config.add_feature_flag_provider("lms.extensions.feature_flags.query_string_provider")
+    config.add_feature_flag_providers("lms.extensions.feature_flags.query_string_provider", ...)
 
 To enable or disable feature flags add ``?feature_flags.foo=true|false``
 parameters to the query string. For example::
@@ -172,19 +171,6 @@ def includeme(config):
         """
         return feature_flags.flag_is_active(request, feature_flag_name)
 
-    def add_feature_flag_provider(_config, feature_flag_provider):
-        """
-        Adapt feature_flags.add_provider().
-
-        Adapt feature_flags.add_provider() to enable it to be used as a Pyramid
-        config directive.
-
-        This enables things to call
-        config.add_feature_flag_provider(my_provider) and it'll call
-        feature_flags.add_provider(my_provider).
-        """
-        return feature_flags.add_provider(config.maybe_dotted(feature_flag_provider))
-
     def add_feature_flag_providers(_config, *providers):
         """Adapt feature_flags.add_providers()."""
         providers = [config.maybe_dotted(provider) for provider in providers]
@@ -193,9 +179,6 @@ def includeme(config):
     # Register the Pyramid request method and config directive. These are this
     # extension's public API.
     config.add_request_method(feature)
-    config.add_directive(
-        "add_feature_flag_provider", add_feature_flag_provider, action_wrap=False
-    )
     config.add_directive(
         "add_feature_flag_providers", add_feature_flag_providers, action_wrap=False
     )

--- a/lms/extensions/feature_flags/_feature_flags.py
+++ b/lms/extensions/feature_flags/_feature_flags.py
@@ -39,12 +39,13 @@ class FeatureFlags:
         otherwise. All feature flags are ``False`` by default (if no source
         toggles the feature flag either on or off, it will be off by default).
         """
-        results = [False]  # All feature flags are False by default.
-        results.extend(
-            [provider(request, feature_flag_name) for provider in self._providers]
-        )
-        results = [result for result in results if result is not None]
-        return results[-1]
+
+        for provider in reversed(self._providers):
+            enabled = provider(request, feature_flag_name)
+            if enabled is not None:
+                return enabled
+
+        return False
 
     def add_provider(self, provider):
         """Add a feature flag provider."""

--- a/lms/extensions/feature_flags/_feature_flags.py
+++ b/lms/extensions/feature_flags/_feature_flags.py
@@ -47,10 +47,6 @@ class FeatureFlags:
 
         return False
 
-    def add_provider(self, provider):
-        """Add a feature flag provider."""
-        self._providers.append(provider)
-
     def add_providers(self, *providers):
         """Add a list of feature flag providers."""
         self._providers.extend(providers)

--- a/lms/extensions/feature_flags/_helpers.py
+++ b/lms/extensions/feature_flags/_helpers.py
@@ -9,7 +9,7 @@ def as_tristate(value):
     """
     Coerce the given value to True, False or None.
 
-    Like Pyramid `as_bool` this will attempt to interpret the value given to
+    Like Pyramid's `asbool` this will attempt to interpret the value given to
     it as either True or False, but in addition allows for None types.
 
     The following items are considered as None:
@@ -18,13 +18,12 @@ def as_tristate(value):
      * None
      * "None" or "none"
 
-    All other values are handle as per `as_bool`.
+    All other values are handle as per `asbool`.
     """
     if value in {None, True, False}:
         return value
 
-    # Catch empty strings
-    if not value or (isinstance(value, str) and value.lower() == "none"):
+    if isinstance(value, str) and value.lower() in {"", "none"}:
         return None
 
     return asbool(value)
@@ -88,6 +87,7 @@ class JWTCookieHelper:
 
     def get(self):
         jwt_bytes = self._request.cookies.get(self._name, "")
+
         if not jwt_bytes:
             return {}
 

--- a/lms/extensions/feature_flags/_helpers.py
+++ b/lms/extensions/feature_flags/_helpers.py
@@ -79,10 +79,10 @@ class JWTCookieHelper:
             overwrite=True,
             # We want this cookie to be sent when the LMS app is loaded inside
             # an iframe, and thus in a third-party context, from within the LMS.
-            # samesite="None",
-            # # Setting `SameSite="None"` requires that we also set the `Secure`
-            # # flag per https://tools.ietf.org/html/draft-west-cookie-incrementalism-00#section-3.2.
-            # secure=True,
+            samesite="None",
+            # Setting `SameSite="None"` requires that we also set the `Secure`
+            # flag per https://tools.ietf.org/html/draft-west-cookie-incrementalism-00#section-3.2.
+            secure=True,
         )
 
     def get(self):

--- a/lms/extensions/feature_flags/_static/feature-flags.css
+++ b/lms/extensions/feature_flags/_static/feature-flags.css
@@ -7,27 +7,18 @@ li {
   margin-bottom: 20px;
 }
 
-input[type=checkbox] {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    width: 30px;
-    height: 30px;
-    border: 2px solid black;
-    margin-right: 1em;
+table {
+    font-size: 1.2em;
+    border-collapse: collapse;
 }
 
-input[type=checkbox] , label {
-    vertical-align: middle;
+input[type=radio] {
+    transform: scale(1.5);
 }
 
-input[type=checkbox]:checked:after {
-    margin-left: 7px;
-    margin-top: -1px;
-    width: 8px;
-    height: 18px;
-    border: solid black;
-    border-width: 0 4px 4px 0;
-    transform: rotate(45deg);
-    content: "";
-    display: inline-block;
+table td, table th {
+    padding: 8px 16px;
+    text-align: center;
+
+    border:2px solid #ccc;
 }

--- a/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
+++ b/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
@@ -23,14 +23,38 @@
 
       <form class="feature_flags_form" action="{{ request.route_url('feature_flags_cookie_form') }}" method="post">
 
-        <ul>
-        {% for flag in flags %}
-          <li>
-            <input type="checkbox"{% if flags[flag] %} checked{% endif %} id="{{ flag }}" name="{{ flag }}">
-            <label for="{{ flag }}">{{ flag }}</label>
-          </li>
-        {% endfor %}
-        </ul>
+        <table>
+          <tr>
+            <th>Flag</th>
+            <th>State</th>
+            <th>Default</th>
+            <th>Off</th>
+            <th>On</th>
+          </tr>
+            {% for flag, value in flags.items() %}
+                <tr>
+                    <td>
+                         <label for="{{ flag }}"><code>{{ flag }}</code></label>
+                    </td>
+                    <td>
+                        {{ "On" if effective[flag] else "Off" }}
+                    </td>
+                    <td>
+                        <input type="radio" name="{{ flag }}" value="" {% if not value %}checked{% endif %}>
+                    </td>
+                    <td>
+                        <input type="radio" name="{{ flag }}" value="off" {% if value == False %}checked{% endif %}>
+                    </td>
+                    <td>
+                        <input type="radio" name="{{ flag }}" value="on" {% if value == True %}checked{% endif %}>
+                    </td>
+
+
+                </tr>
+            {% endfor %}
+        </table>
+
+        <br>
 
         <div class="form-controls">
           <div style="display:flex; flex-direction:column; align-items:flex-end;">

--- a/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
+++ b/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
@@ -27,7 +27,7 @@
           <tr>
             <th>Flag</th>
             <th>State</th>
-            <th>Default</th>
+            <th><span title="The final state once all feature flag providers are applied">Effective</span></th>
             <th>Off</th>
             <th>On</th>
           </tr>
@@ -48,8 +48,6 @@
                     <td>
                         <input type="radio" name="{{ flag }}" value="on" {% if value == True %}checked{% endif %}>
                     </td>
-
-
                 </tr>
             {% endfor %}
         </table>

--- a/lms/extensions/feature_flags/views/cookie_form.py
+++ b/lms/extensions/feature_flags/views/cookie_form.py
@@ -18,7 +18,12 @@ class CookieFormViews:
     @view_config(request_method="GET")
     def get(self):
         """Render the feature flags cookie form page."""
-        return {"flags": self._cookie_helper.get_all()}
+        flags = self._cookie_helper.get_all()
+
+        return {
+            "flags": flags,
+            "effective": {flag: self._request.feature(flag) for flag in flags.keys()},
+        }
 
     @view_config(request_method="POST")
     def post(self):

--- a/lms/extensions/feature_flags/views/cookie_form.py
+++ b/lms/extensions/feature_flags/views/cookie_form.py
@@ -22,6 +22,7 @@ class CookieFormViews:
 
         return {
             "flags": flags,
+            # The final effective state of each feature flag
             "effective": {flag: self._request.feature(flag) for flag in flags.keys()},
         }
 

--- a/tests/unit/lms/extensions/feature_flags/__init___test.py
+++ b/tests/unit/lms/extensions/feature_flags/__init___test.py
@@ -22,13 +22,6 @@ class TestIncludeMe:
             pyramid_request, "test_feature"
         )
 
-    def test_add_feature_flag_provider(self, pyramid_config, feature_flags):
-        includeme(pyramid_config)
-
-        pyramid_config.add_feature_flag_provider(mock.sentinel.provider)
-
-        feature_flags.add_provider.assert_called_once_with(mock.sentinel.provider)
-
     def test_add_feature_flag_providers(self, pyramid_config, feature_flags):
         includeme(pyramid_config)
 

--- a/tests/unit/lms/extensions/feature_flags/_feature_flags_test.py
+++ b/tests/unit/lms/extensions/feature_flags/_feature_flags_test.py
@@ -42,15 +42,11 @@ class TestFeatureFlags:
 
     def test_it_calls_providers_with_request_and_flag(self, pyramid_request):
         uncalled_provider = mock.MagicMock()
-        true_provider = mock.MagicMock()
-        true_provider.return_value = True
-        none_provider = mock.MagicMock()
-        none_provider.return_value = None
+        true_provider = mock.MagicMock(return_value=True)
+        none_provider = mock.MagicMock(return_value=None)
 
         feature_flags = FeatureFlags()
-        feature_flags.add_provider(uncalled_provider)
-        feature_flags.add_provider(true_provider)
-        feature_flags.add_provider(none_provider)
+        feature_flags.add_providers(uncalled_provider, true_provider, none_provider)
 
         feature_flags.flag_is_active(pyramid_request, "test_flag")
 

--- a/tests/unit/lms/extensions/feature_flags/_feature_flags_test.py
+++ b/tests/unit/lms/extensions/feature_flags/_feature_flags_test.py
@@ -41,13 +41,19 @@ class TestFeatureFlags:
         assert feature_flags.flag_is_active(pyramid_request, "test_flag") == result
 
     def test_it_calls_providers_with_request_and_flag(self, pyramid_request):
+        uncalled_provider = mock.MagicMock()
+        true_provider = mock.MagicMock()
+        true_provider.return_value = True
+        none_provider = mock.MagicMock()
+        none_provider.return_value = None
+
         feature_flags = FeatureFlags()
-        provider_1 = mock.MagicMock()
-        provider_2 = mock.MagicMock()
-        feature_flags.add_provider(provider_1)
-        feature_flags.add_provider(provider_2)
+        feature_flags.add_provider(uncalled_provider)
+        feature_flags.add_provider(true_provider)
+        feature_flags.add_provider(none_provider)
 
         feature_flags.flag_is_active(pyramid_request, "test_flag")
 
-        provider_1.assert_called_once_with(pyramid_request, "test_flag")
-        provider_2.assert_called_once_with(pyramid_request, "test_flag")
+        none_provider.assert_called_once_with(pyramid_request, "test_flag")
+        true_provider.assert_called_once_with(pyramid_request, "test_flag")
+        uncalled_provider.assert_not_called()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7131143/81844997-d6f7c480-9547-11ea-999f-120b47af1316.png)

### What this PR does

 * Re-enables the cookie feature flag provider
 * Adds a `as_tristate` function which is like the pyramid `asbool`, but also returns `None` for various null-like inputs
 * Uses this in the cookies to allow "default" type behavior using it
 * Updates the web interface to have a table (ugly but clear and functional) which allows you to change the value and also shows you the resulting state with other providers in the mix

Some refactors as well:

 * Make use of the `as_tristate` in the main providers file
 * Simplified the algorithm for applying all the providers to make it:
    * Much simpler
    * Fail fast if we get a value

### How to test

Although this is enabled, **it doesn't work locally** as we have to enable secure cookies to make it work in an iframe. You can see the page working an updating locally by:

 * Editing `lms/extensions/feature_flags/_helpers.py:JWTCookieHelper.set()` 
 * Comment out: ``` samesite="None",  secure=True,```
 * Go to: http://0.0.0.0:8001/flags
 * You can also enable a flag to see the interaction by editing `conf/development.ini` and adding `feature_flags.use_legacy_via = True`
 * This will let you see the default overriding behavior, and show that we no longer squash all other provider results

In QA you can test this by:

 * Creating a new assignment
 * Selecting URL type document and adding `https://qa-lms.hypothes.is/flags` as the link
 * You now have a handy dandy assignment which lets you set and view the current flag status in place