### PR TITLE
Automate and remove "make services"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 .PHONY: help
 help:
 	@echo "make help              Show this help message"
-	@echo 'make services          Run the services that `make dev` requires'
-	@echo "                       (Postgres) in Docker"
 	@echo "make dev               Run the entire app (web server and other processes)"
 	@echo "make web               Run the web server on its own (useful for debugging the "
 	@echo "                       Python code with pdb)"
@@ -25,11 +23,6 @@ help:
 	@echo "make run-docker        Run the app's Docker image locally"
 	@echo "make clean             Delete development artefacts (cached files, "
 	@echo "                       dependencies, etc)"
-
-.PHONY: services
-services: args?=up -d
-services: python
-	@tox -qe docker-compose -- $(args)
 
 .PHONY: dev
 dev: build/manifest.json python

--- a/README.markdown
+++ b/README.markdown
@@ -56,12 +56,6 @@ installation process:
 
     cd lms
 
-### Run the services with Docker Compose
-
-Start the services that the LMS app requires using Docker Compose:
-
-    make services
-
 ### Create the development data and settings
 
 Create the database contents and environment variable settings needed to get lms

--- a/bin/create-db
+++ b/bin/create-db
@@ -5,6 +5,4 @@
 # Usage:
 #
 #     create-db <DB_NAME>
-tox -qqe docker-compose \
-    --run-command "docker-compose exec postgres psql -U postgres -c 'CREATE DATABASE $1;'" \
-    > /dev/null 2>&1 || true
+docker exec -it lms_postgres_1 psql -U postgres -c "CREATE DATABASE $1;" > /dev/null 2>&1 || true

--- a/bin/create-db
+++ b/bin/create-db
@@ -5,4 +5,6 @@
 # Usage:
 #
 #     create-db <DB_NAME>
-make services args="exec postgres psql -U postgres -c 'CREATE DATABASE $1;'" > /dev/null 2>&1 || true
+tox -qqe docker-compose \
+    --run-command "docker-compose exec postgres psql -U postgres -c 'CREATE DATABASE $1;'" \
+    > /dev/null 2>&1 || true

--- a/bin/start-services
+++ b/bin/start-services
@@ -6,6 +6,7 @@ Usage:
 
     bin/start_services
 """
+import os
 from time import sleep
 import subprocess
 import sys
@@ -60,6 +61,9 @@ def main():
 
 
 if __name__ == "__main__":
+    if "JENKINS_URL" in os.environ:
+        sys.exit()
+
     try:
         main()
     except RuntimeError as err:

--- a/bin/start-services
+++ b/bin/start-services
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""
+Start the services (if they aren't already running) and wait for them to start responding.
+
+Usage:
+
+    bin/start_services
+"""
+from time import sleep
+import subprocess
+import sys
+from subprocess import CalledProcessError, PIPE
+
+
+def is_postgres_running():
+    """Return True if Postgres is responding."""
+    try:
+        subprocess.run(
+            [
+                "docker",
+                "exec",
+                "-it",
+                "lms_postgres_1",
+                "psql",
+                "-U",
+                "postgres",
+                "-c",
+                "select 1",
+            ],
+            stdout=PIPE,
+            stderr=PIPE,
+            check=True,
+        )
+    except CalledProcessError:
+        return False
+
+    return True
+
+
+def wait_for_postgres():
+    for _ in range(50):
+        if is_postgres_running():
+            return
+        sleep(0.1)
+
+    raise RuntimeError("Starting Postgres failed")
+
+
+def start_containers():
+    subprocess.run(
+        ["tox", "-qq", "-e", "docker-compose", "--run-command", "docker-compose up -d"],
+        check=True,
+    )
+
+
+def main():
+    if not is_postgres_running():
+        start_containers()
+        wait_for_postgres()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except RuntimeError as err:
+        sys.exit(err)

--- a/tox.ini
+++ b/tox.ini
@@ -68,11 +68,13 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 whitelist_externals =
     tests,functests,bddtests: sh
-commands =
-    dev: {posargs:pserve conf/development.ini --reload}
+commands_pre =
+    {dev,tests,functests,bddtests}: {toxinidir}/bin/start-services
     tests: sh bin/create-db lms_test
     functests: sh bin/create-db lms_functests
     bddtests: sh bin/create-db lms_bddtests
+commands =
+    dev: {posargs:pserve conf/development.ini --reload}
     tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
     tests: -coverage combine
     tests: coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ tox_pyenv_fallback = false
 skip_install = true
 passenv =
     HOME
+    JENKINS_URL
     {tests,functests,bddtests}: TEST_DATABASE_URL
     {tests,functests}: PYTEST_ADDOPTS
     dev: SESSION_COOKIE_SECRET


### PR DESCRIPTION
Whenever you run a command that needs the DB (dev server, tests, functests, bddtests, ...) have it start the Postgres container automatically if it isn't already running. Works whether you're running `make` commands or running `tox` commands directly.

This will check off _you shouldn't have to run make services manually_ on the dev env roadmap: https://github.com/hypothesis/product-backlog/issues/1044

The same solution will also work for h, but we'll need to add support for Elasticsearch and RabbitMQ.

When the containers are already running the script adds very little overhead:

```terminal
$ time bin/start-services

________________________________________________________
Executed in  258.44 millis    fish           external 
   usr time   58.97 millis    0.00 micros   58.97 millis 
   sys time   34.13 millis  1451.00 micros   32.68 millis 
```

Some handy commands for testing this:

Stop the docker container:

    tox -qqe docker-compose --run-command 'docker-compose stop'

Stop the container and also delete your DB:

    tox -qqe docker-compose --run-command 'docker-compose down'

Run just a couple of tests:

    tox -qq --run-command 'pytest tests/unit/lms/app_test.py'