### PR TITLE
Fix dev server stopping and reloading

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -31,12 +31,6 @@ h_api_url_private = http://localhost:5000/api/
 rpc_allowed_origins = http://localhost:5000
 sentry_environment = dev
 
-[server:main]
-use: egg:gunicorn#main
-host: 0.0.0.0
-port: 8001
-timeout: 0
-
 ###
 # logging configuration
 # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -6,11 +6,6 @@ pipeline:
 [app:lms]
 use = call:lms.app:create_app
 
-[server:main]
-use: egg:gunicorn#main
-host: 0.0.0.0
-port: 8001
-
 [filter:proxy-prefix]
 use: egg:PasteDeploy#prefix
 

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:web]
-command=newrelic-admin run-program pserve conf/production.ini
+command=newrelic-admin run-program gunicorn --paste conf/production.ini --bind 0.0.0.0:8001
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,1 +1,3 @@
-import os
+reload = True
+timeout = 0
+bind = ":8001"

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ setenv =
 whitelist_externals =
     tests,functests,bddtests: sh
 commands =
-    dev: {posargs:pserve conf/development.ini --reload}
+    dev: {posargs:gunicorn --paste conf/development.ini}
     tests: sh bin/create-db lms_test
     functests: sh bin/create-db lms_functests
     bddtests: sh bin/create-db lms_bddtests


### PR DESCRIPTION
I've been having annoying issues with `make dev` and `make web` for a
while now:

1. Auto-reloading the web process on file changes doesn't seem to work
   reliably. While it often does work, changing files often seems to get
   the web process "stuck" and no longer working, requiring a manual
   Ctrl+c and restart

2. Stopping doesn't work well. When I hit Ctrl+c to stop `make dev` or
   `make web` it continues to print lines of logging to the terminal
   after my shell prompt has been rendered, messing up the command line.
   This also seems to break fish shell's interactive command line
   features (auto completion etc)

This used to work reliably.

I think the problems started happening when we switching from gunicorn
auto-reloading to pserve auto-reloading in
https://github.com/hypothesis/lms/pull/1219.

https://github.com/hypothesis/lms/pull/1219 fixed a problem that
gunicorn no longer reads settings from the `[server:main]` section of
the ini file. The fix was to run gunicorn via pserve, instead of running
gunicorn directly, so that pserve reads the settings and passes them to
gunicorn. And use pserve's autoreloading feature instead of gunicorn's.
This is the first approach recommended in the gunicorn docs about this:

https://docs.gunicorn.org/en/stable/run.html#paste-deployment

pserve appears to be the cause of all the problems above, however. Fix
the issues by changing back to running gunicorn directly (no pserve)
using gunicorn's builtin Paste/ini-file support, and use gunicorn
auto-reloading. Follow the _second_ method in the gunicorn docs, under
"To use the full power of Gunicorn’s reloading and hot code
upgrades...":

https://docs.gunicorn.org/en/stable/run.html#paste-deployment

Also fix production.ini and supervisord.conf to run gunicorn directly
instead of via pserve, as well.