### PR TITLE
BasicLtiLaunchApp UI improvments

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -303,7 +303,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
 
   return (
     <span className="BasicLtiLaunchApp">
-      <Spinner hide={!showSpinner} className="BasicLtiLaunchApp__spinner" />
+      {showSpinner && <Spinner className="BasicLtiLaunchApp__spinner" />}
       {errorDialog}
       {content}
     </span>

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -117,8 +117,6 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
         handleError(e, 'error-fetch');
       }
     }
-    // ignore errorState changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiSync, authToken, rpcServer]);
 
   /**
@@ -146,8 +144,6 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
     } finally {
       decFetchCount();
     }
-    // ignore errorState changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authToken, viaCallbackUrl]);
 
   /**

--- a/lms/static/scripts/frontend_apps/components/Spinner.js
+++ b/lms/static/scripts/frontend_apps/components/Spinner.js
@@ -1,4 +1,4 @@
-import { createElement } from 'preact';
+import { createElement, Fragment } from 'preact';
 import propTypes from 'prop-types';
 
 import SvgIcon from './SvgIcon';
@@ -6,16 +6,21 @@ import { trustMarkup } from '../utils/trusted';
 /**
  * A spinning loading indicator.
  */
-export default function Spinner({ className }) {
+export default function Spinner({ className, hide }) {
   return (
-    <SvgIcon
-      className={className}
-      src={trustMarkup(require('../../../images/spinner.svg'))}
-      inline={true}
-    />
+    <Fragment>
+      {!hide && (
+        <SvgIcon
+          className={className}
+          src={trustMarkup(require('../../../images/spinner.svg'))}
+          inline={true}
+        />
+      )}
+    </Fragment>
   );
 }
 
 Spinner.propTypes = {
   className: propTypes.string,
+  hide: propTypes.bool,
 };

--- a/lms/static/scripts/frontend_apps/components/Spinner.js
+++ b/lms/static/scripts/frontend_apps/components/Spinner.js
@@ -1,26 +1,22 @@
-import { createElement, Fragment } from 'preact';
+import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import SvgIcon from './SvgIcon';
 import { trustMarkup } from '../utils/trusted';
+
 /**
  * A spinning loading indicator.
  */
-export default function Spinner({ className, hide }) {
+export default function Spinner({ className }) {
   return (
-    <Fragment>
-      {!hide && (
-        <SvgIcon
-          className={className}
-          src={trustMarkup(require('../../../images/spinner.svg'))}
-          inline={true}
-        />
-      )}
-    </Fragment>
+    <SvgIcon
+      className={className}
+      src={trustMarkup(require('../../../images/spinner.svg'))}
+      inline={true}
+    />
   );
 }
 
 Spinner.propTypes = {
   className: propTypes.string,
-  hide: propTypes.bool,
 };

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -31,6 +31,17 @@ describe('BasicLtiLaunchApp', () => {
     );
   };
 
+  function spinnerVisible(wrapper) {
+    return waitForElement(wrapper, 'Spinner');
+  }
+
+  function spinnerHidden(wrapper) {
+    return waitFor(() => {
+      wrapper.update();
+      return !wrapper.exists('Spinner');
+    });
+  }
+
   function contentHidden(wrapper) {
     return waitForElement(wrapper, '.BasicLtiLaunchApp__content.is-hidden');
   }
@@ -141,16 +152,14 @@ describe('BasicLtiLaunchApp', () => {
 
     it('attempts to fetch the content URL when mounted', async () => {
       const wrapper = renderLtiLaunchApp();
-      // Initially show the spinner
-      await waitForElement(wrapper, 'Spinner[hide=false]');
+      await spinnerVisible(wrapper);
       await waitFor(() => fakeApiCall.called);
 
       assert.calledWith(fakeApiCall, {
         authToken: 'dummyAuthToken',
         path: 'https://lms.hypothes.is/api/files/1234',
       });
-      // Spinner shall be hidden
-      await waitForElement(wrapper, 'Spinner[hide=true]');
+      await spinnerHidden(wrapper);
     });
 
     it('displays the content URL in an iframe if successfully fetched', async () => {
@@ -171,8 +180,7 @@ describe('BasicLtiLaunchApp', () => {
       fakeApiCall.rejects(new ApiError(400, {}));
 
       const wrapper = renderLtiLaunchApp();
-      // Spinner initially shown
-      await waitForElement(wrapper, 'Spinner[hide=false]');
+      await spinnerVisible(wrapper);
       // Verify that an "Authorize" prompt is shown.
       const authButton = await waitForElement(
         wrapper,
@@ -188,10 +196,8 @@ describe('BasicLtiLaunchApp', () => {
       assert.called(FakeAuthWindow);
 
       // Check that files are fetched after authorization completes.
-      //const iframe = await waitForElement(wrapper, 'iframe');
       await contentVisible(wrapper);
-      // Clears the spinner
-      await waitForElement(wrapper, 'Spinner[hide=true]');
+      await spinnerHidden(wrapper);
       assert.equal(
         wrapper.find('iframe').prop('src'),
         'https://via.hypothes.is/123'
@@ -213,8 +219,7 @@ describe('BasicLtiLaunchApp', () => {
         fakeApiCall.rejects(error);
 
         const wrapper = renderLtiLaunchApp();
-        // Spinner initially shown
-        await waitForElement(wrapper, 'Spinner[hide=false]');
+        await spinnerVisible(wrapper);
 
         // Verify that a "Try again" prompt is shown.
         const tryAgainButton = await waitForElement(
@@ -230,8 +235,7 @@ describe('BasicLtiLaunchApp', () => {
 
         // Check that files are fetched after authorization completes.
         await contentVisible(wrapper);
-        // Spinner shall be hidden
-        await waitForElement(wrapper, 'Spinner[hide=true]');
+        await spinnerHidden(wrapper);
         assert.equal(
           wrapper.find('iframe').prop('src'),
           'https://via.hypothes.is/123'
@@ -386,13 +390,13 @@ describe('BasicLtiLaunchApp', () => {
       const wrapper = renderLtiLaunchApp();
       // Spinner should not go away if only the groups resolves
       groupsCallResolve(['group1', 'group2']);
-      await waitForElement(wrapper, 'Spinner[hide=false]');
+      await spinnerVisible(wrapper);
 
       // Spinner shall hide after content url resolves
       contentUrlResolve({
         via_url: 'https://via.hypothes.is/123',
       });
-      await waitForElement(wrapper, 'Spinner[hide=true]');
+      await spinnerHidden(wrapper);
       await contentVisible(wrapper);
     });
 

--- a/lms/static/scripts/frontend_apps/components/test/Spinner-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Spinner-test.js
@@ -6,6 +6,11 @@ import Spinner from '../Spinner';
 describe('Spinner', () => {
   it('renders a spinner', () => {
     const wrapper = mount(<Spinner className="loading-thingie" />);
-    assert.isTrue(wrapper.exists('SvgIcon.loading-thingie'));
+    assert.isTrue(wrapper.exists('SvgIcon.loading-thingie:not("is-hidden")'));
+  });
+
+  it('renders a spinner hidden', () => {
+    const wrapper = mount(<Spinner hide={true} className="loading-thingie" />);
+    assert.isFalse(wrapper.exists('SvgIcon'));
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/Spinner-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Spinner-test.js
@@ -6,11 +6,6 @@ import Spinner from '../Spinner';
 describe('Spinner', () => {
   it('renders a spinner', () => {
     const wrapper = mount(<Spinner className="loading-thingie" />);
-    assert.isTrue(wrapper.exists('SvgIcon.loading-thingie:not("is-hidden")'));
-  });
-
-  it('renders a spinner hidden', () => {
-    const wrapper = mount(<Spinner hide={true} className="loading-thingie" />);
-    assert.isFalse(wrapper.exists('SvgIcon'));
+    assert.isTrue(wrapper.exists('SvgIcon.loading-thingie'));
   });
 });

--- a/lms/static/scripts/test-util/wait.js
+++ b/lms/static/scripts/test-util/wait.js
@@ -61,22 +61,3 @@ export function waitForElement(wrapper, selector, timeout = 10) {
     `"${selector}" to render`
   );
 }
-
-/**
- * Wait up to `timeout` ms for an element to be removed.
- *
- * @param {CommonWrapper} wrapper - Root Enzyme wrapper
- * @param {string|Function} selector - Selector string or function to pass to `wrapper.find`
- * @param {number} timeout
- * @return {Promise<CommonWrapper>}
- */
-export function waitForElementToBeRemoved(wrapper, selector, timeout = 10) {
-  return waitFor(
-    () => {
-      wrapper.update();
-      return wrapper.find(selector).length === 0;
-    },
-    timeout,
-    `"${selector}" to render`
-  );
-}

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -12,3 +12,9 @@
   left: calc(50% - #{$spinner-size / 2});
   top: 100px;
 }
+
+.BasicLtiLaunchApp__content {
+  &.is-hidden {
+    visibility: hidden;
+  }
+}


### PR DESCRIPTION
- Don’t show spinner if there is an error
- Don’t show spinner when /sync is pending
- Render the <iframe> no matter what, but hidden if content URL is null or there is an error
- Remove waitForElementToBeRemoved as its no longer needed
- Various test adjustments for the above
- Fix several false negative tests
- Add `hide` prop to Spinner for easier negative testing
----

One shortcoming is it will override an error if another comes in. In order to prevent that, it will need some rethinking about `errorState`, but I think this is a minor and in most cases, the same error will be produced (auth error).  

fixes https://github.com/hypothesis/lms/issues/1748
