### PR TITLE
POC: Automate make services more bash-like example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ help:
 .PHONY: services
 services: args?=up -d
 services: python
-	@tox -qe docker-compose -- $(args)
+	@./bin/services/are-up || (tox -qe docker-compose -- $(args) && ./bin/services/wait-until-up)
 
 .PHONY: dev
 dev: build/manifest.json python

--- a/bin/services/are-up
+++ b/bin/services/are-up
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Check the status
+docker exec -it lms_postgres_1 /opt/hypothesis/is-ready 1>/dev/null 2>/dev/null;

--- a/bin/services/postgres/is-ready
+++ b/bin/services/postgres/is-ready
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Run a command which will exit cleanly if PostgreSQL is accepting connections
+psql -U postgres -c 'select 1';

--- a/bin/services/wait-until-up
+++ b/bin/services/wait-until-up
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+while ! ./bin/services/are-up
+do
+  echo "Waiting for services..."
+  sleep 0.01
+done
+
+echo "Services up"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     image: postgres:11.5-alpine
     ports:
       - '127.0.0.1:5433:5432'
+    volumes:
+      - ./bin/services/postgres:/opt/hypothesis

--- a/tox.ini
+++ b/tox.ini
@@ -68,11 +68,14 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 whitelist_externals =
     tests,functests,bddtests: sh
-commands =
-    dev: {posargs:pserve conf/development.ini --reload}
+    dev,tests,functests,bddtests: make
+commands_pre =
+    {dev,tests,functests,bddtests}: make -C {toxinidir} services
     tests: sh bin/create-db lms_test
     functests: sh bin/create-db lms_functests
     bddtests: sh bin/create-db lms_bddtests
+commands =
+    dev: {posargs:pserve conf/development.ini --reload}
     tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
     tests: -coverage combine
     tests: coverage report


### PR DESCRIPTION
This is far more bash oriented and relies on the fact that all bash commands have a return status.

This allows us to do things like `if /bin/services/are-up; then...` Which makes the scripts very short and concise.