### PR TITLE
Fixing the column name for feature flags UI

### DIFF
--- a/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
+++ b/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
@@ -26,8 +26,8 @@
         <table>
           <tr>
             <th>Flag</th>
-            <th>State</th>
-            <th><span title="The final state once all feature flag providers are applied">Effective</span></th>
+            <th><span title="The final state once all feature flag providers are applied">State</span></th>
+            <th>Default</th>
             <th>Off</th>
             <th>On</th>
           </tr>
@@ -37,7 +37,7 @@
                          <label for="{{ flag }}"><code>{{ flag }}</code></label>
                     </td>
                     <td>
-                        {{ "On" if effective[flag] else "Off" }}
+                        {{ "On" if state[flag] else "Off" }}
                     </td>
                     <td>
                         <input type="radio" name="{{ flag }}" value="" {% if not value %}checked{% endif %}>

--- a/lms/extensions/feature_flags/views/cookie_form.py
+++ b/lms/extensions/feature_flags/views/cookie_form.py
@@ -22,8 +22,8 @@ class CookieFormViews:
 
         return {
             "flags": flags,
-            # The final effective state of each feature flag
-            "effective": {flag: self._request.feature(flag) for flag in flags.keys()},
+            # The final state of each feature flag
+            "state": {flag: self._request.feature(flag) for flag in flags.keys()},
         }
 
     @view_config(request_method="POST")


### PR DESCRIPTION
 * Also renaming variable

I think this might be a good time to retest as well (as I had accidentally left the SameSite setting unset in the previous commit).

From what I can see this is broken locally with the exception of Firefox when running under 127.0.0.1 only (not 0.0.0.0).