### PR TITLE
Configure Via to open external links in a new tab

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -43,6 +43,7 @@ class _ViaClient:
             "via.client.openSidebar": "1",
             "via.client.requestConfigFromFrame.origin": host_url,
             "via.client.requestConfigFromFrame.ancestorLevel": "2",
+            "via.external_link_mode": "new-tab",
         }
         self.legacy_mode = legacy_mode
 

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -12,6 +12,7 @@ class TestViaURL:
         # This is the `request.host_url`
         "via.client.requestConfigFromFrame.origin": "http://example.com",
         "via.client.requestConfigFromFrame.ancestorLevel": "2",
+        "via.external_link_mode": "new-tab",
     }
 
     def test_if_creates_the_correct_via_url(self, pyramid_request):


### PR DESCRIPTION
Set the `via.external_link_mode` query param in generated Via URLs to
ensure that non-fragment links in web pages open a new tab. This
prevents Via from navigating to a new page that then loads Hypothesis in
the "normal" mode rather than logged in an account/group that
corresponds to the LMS app.

See also https://github.com/hypothesis/via/pull/235.

Part of https://github.com/hypothesis/lms/issues/451.