### PR TITLE
Dialog css fixes

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -57,6 +57,13 @@ export default function Dialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const contentClasses = {
+    Dialog__content: true,
+  };
+  if (contentClasses) {
+    contentClasses[contentClass] = true;
+  }
+
   return (
     <div
       role={role}
@@ -70,12 +77,7 @@ export default function Dialog({
         style={{ zIndex: zIndexScale.dialogBackground }}
       />
       <div className="Dialog__container" style={{ zIndex: zIndexScale.dialog }}>
-        <div
-          className={classNames({
-            Dialog__content: true,
-            [contentClass]: true,
-          })}
-        >
+        <div className={classNames(contentClasses)}>
           <h1 className="Dialog__title" id={dialogTitleId}>
             {title}
             <span className="u-stretch" />

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -13,12 +13,15 @@ function emailLink({ address, subject = '', body = '' }) {
  */
 export default function ErrorDisplay({ message, error }) {
   let details = '';
-  try {
-    if (error.details) {
+
+  if (typeof error.details === 'object') {
+    try {
       details = JSON.stringify(error.details, null, 2 /* indent */);
+    } catch (e) {
+      // ignore
     }
-  } catch (e) {
-    // Ignored
+  } else {
+    details = error.details;
   }
 
   const supportLink = emailLink({

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -14,6 +14,15 @@ describe('Dialog', () => {
     assert.isTrue(wrapper.contains(<span>content</span>));
   });
 
+  it('adds `contentClass` value to class list', () => {
+    const wrapper = mount(
+      <Dialog contentClass="foo">
+        <span>content</span>
+      </Dialog>
+    );
+    assert.isTrue(wrapper.find('.Dialog__content').hasClass('foo'));
+  });
+
   it('renders buttons', () => {
     const wrapper = mount(
       <Dialog

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,8 +1,3 @@
-.BasicLtiLaunchApp__dialog {
-  width: 75%;
-  max-width: 500px;
-}
-
 .BasicLtiLaunchApp__spinner {
   $spinner-size: 50px;
 

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -3,14 +3,8 @@
 
 .Dialog__container {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   position: fixed;
-  left: 0;
   top: 0;
-  right: 0;
-  bottom: 0;
   width: 100%;
   height: 100%;
 }
@@ -26,10 +20,13 @@
 }
 
 .Dialog__content {
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  max-width: 700px;
   background-color: white;
   border-radius: 3px;
-  margin-left: auto;
-  margin-right: auto;
+  margin: auto;
   padding: 20px;
 }
 

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -2,13 +2,20 @@
 
 
 .ErrorDisplay {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow-y: scroll;
+  padding-right: 5px;
+  margin-bottom: 10px;
   max-width: 100%;
 }
 
 .ErrorDisplay__details {
-  overflow: scroll;
   background-color: var.$grey-1;
   border: 1px solid var.$grey-3;
-
+  white-space: pre-wrap;
   max-width: 100%;
+  padding: 10px;
+  margin-bottom: 0;
 }

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -14,6 +14,7 @@ $file-list-icon-size: 24px;
 
 .FileList__spinner {
   position: absolute;
+  margin: 15px;
   left: calc(50% - #{$file-list-icon-size / 2});
   top: calc(50% - #{$file-list-icon-size / 2});
 }

--- a/lms/static/styles/components/_LMSFilePicker.scss
+++ b/lms/static/styles/components/_LMSFilePicker.scss
@@ -1,8 +1,0 @@
-.LMSFilePicker__dialog {
-  display: flex;
-  flex-direction: column;
-  max-height: 100vh;
-  max-width: 500px;
-  width: 80vw;
-  height: 400px;
-}

--- a/lms/static/styles/components/_URLPicker.scss
+++ b/lms/static/styles/components/_URLPicker.scss
@@ -1,7 +1,0 @@
-.URLPicker__dialog {
-  display: flex;
-  flex-direction: column;
-  width: 80vw;
-  max-width: 500px;
-  max-height: 300px;
-}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -27,13 +27,11 @@
 @use 'components/ErrorDisplay';
 @use 'components/FileList';
 @use 'components/FilePickerApp';
-@use 'components/LMSFilePicker';
 @use 'components/LMSGrader';
 @use 'components/StudentSelector';
 @use 'components/SubmitGradeForm';
 @use 'components/ValidationMessage';
 @use 'components/SvgIcon';
-@use 'components/URLPicker';
 
 
 // Element styles.


### PR DESCRIPTION
- Increase max-width of dialogs to 700px
- Allow dialogs to expand to 90% of the height to take advantage of extra space
- Allow extremely long content in dialogs to scroll, but not hide any bottom buttons out of the view
- Coverage & delete some CSS settings among various dialogs used
- Fix bug where non-json error details text was not formatted pretty in <ErrorDisplay>
- Fix bug that set “undefined” class in <Dialog> when not passing a `contentClass` prop.