### PR TITLE
Dialog css fixes (off test branch)

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -57,6 +57,13 @@ export default function Dialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const contentClasses = {
+    Dialog__content: true,
+  };
+  if (contentClass) {
+    contentClasses[contentClass] = true;
+  }
+
   return (
     <div
       role={role}
@@ -70,12 +77,7 @@ export default function Dialog({
         style={{ zIndex: zIndexScale.dialogBackground }}
       />
       <div className="Dialog__container" style={{ zIndex: zIndexScale.dialog }}>
-        <div
-          className={classNames({
-            Dialog__content: true,
-            [contentClass]: true,
-          })}
-        >
+        <div className={classNames(contentClasses)}>
           <h1 className="Dialog__title" id={dialogTitleId}>
             {title}
             <span className="u-stretch" />

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -1,7 +1,6 @@
 import { createElement } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
-import classNames from 'classnames';
 
 import Button from './Button';
 import useElementShouldClose from '../common/use-element-should-close';
@@ -57,13 +56,6 @@ export default function Dialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const contentClasses = {
-    Dialog__content: true,
-  };
-  if (contentClass) {
-    contentClasses[contentClass] = true;
-  }
-
   return (
     <div
       role={role}
@@ -77,7 +69,11 @@ export default function Dialog({
         style={{ zIndex: zIndexScale.dialogBackground }}
       />
       <div className="Dialog__container" style={{ zIndex: zIndexScale.dialog }}>
-        <div className={classNames(contentClasses)}>
+        <div
+          className={
+            'Dialog__content' + (contentClass ? ` ${contentClass}` : '')
+          }
+        >
           <h1 className="Dialog__title" id={dialogTitleId}>
             {title}
             <span className="u-stretch" />

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -1,6 +1,7 @@
 import { createElement } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
+import classNames from 'classnames';
 
 import Button from './Button';
 import useElementShouldClose from '../common/use-element-should-close';
@@ -69,11 +70,7 @@ export default function Dialog({
         style={{ zIndex: zIndexScale.dialogBackground }}
       />
       <div className="Dialog__container" style={{ zIndex: zIndexScale.dialog }}>
-        <div
-          className={
-            'Dialog__content' + (contentClass ? ` ${contentClass}` : '')
-          }
-        >
+        <div className={classNames('Dialog__content', contentClass)}>
           <h1 className="Dialog__title" id={dialogTitleId}>
             {title}
             <span className="u-stretch" />

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -67,8 +67,11 @@ ${details}
         .
       </p>
       {!!details && (
-        <details>
-          <pre className="ErrorDisplay__details">{details}</pre>
+        <details className="ErrorDisplay__details">
+          <summary className="ErrorDisplay__details-summary">
+            Error Details
+          </summary>
+          <pre className="ErrorDisplay__details-content">{details}</pre>
         </details>
       )}
     </div>

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -13,12 +13,15 @@ function emailLink({ address, subject = '', body = '' }) {
  */
 export default function ErrorDisplay({ message, error }) {
   let details = '';
-  try {
-    if (error.details) {
+
+  if (typeof error.details === 'object') {
+    try {
       details = JSON.stringify(error.details, null, 2 /* indent */);
+    } catch (e) {
+      // ignore
     }
-  } catch (e) {
-    // Ignored
+  } else {
+    details = error.details;
   }
 
   const supportLink = emailLink({

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -14,6 +14,15 @@ describe('Dialog', () => {
     assert.isTrue(wrapper.contains(<span>content</span>));
   });
 
+  it('adds `contentClass` value to class list', () => {
+    const wrapper = mount(
+      <Dialog contentClass="foo">
+        <span>content</span>
+      </Dialog>
+    );
+    assert.isTrue(wrapper.find('.Dialog__content').hasClass('foo'));
+  });
+
   it('renders buttons', () => {
     const wrapper = mount(
       <Dialog

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,8 +1,3 @@
-.BasicLtiLaunchApp__dialog {
-  width: 75%;
-  max-width: 500px;
-}
-
 .BasicLtiLaunchApp__spinner {
   $spinner-size: 50px;
 

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,3 +1,4 @@
+@use "../mixins/focus";
 @use "../variables" as var;
 
 
@@ -37,6 +38,7 @@
 }
 
 .Dialog__cancel-btn {
+  @include focus.outline-on-keyboard-focus;
   border: 0;
   background: none;
   color: var.$grey-6;
@@ -65,6 +67,7 @@
   margin-top: 10px;
 
   .Button {
+    @include focus.outline-on-keyboard-focus;
     &:not(:first-child) {
       margin-left: 5px;
     }

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -3,14 +3,8 @@
 
 .Dialog__container {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   position: fixed;
-  left: 0;
   top: 0;
-  right: 0;
-  bottom: 0;
   width: 100%;
   height: 100%;
 }
@@ -26,10 +20,13 @@
 }
 
 .Dialog__content {
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  max-width: 700px;
   background-color: white;
   border-radius: 3px;
-  margin-left: auto;
-  margin-right: auto;
+  margin: auto;
   padding: 20px;
 }
 

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -1,3 +1,4 @@
+@use "../mixins/focus";
 @use "../variables" as var;
 
 
@@ -9,16 +10,23 @@
   padding-right: 5px;
   margin-bottom: 10px;
   max-width: 100%;
-  details {
+  
+  &__details {  
     padding: 4px; // fix for focus halo w/ overflow scroll
+    &-summary {
+      &:hover {
+        cursor: pointer;
+      }
+      @include focus.outline-on-keyboard-focus;
+    }
   }
-}
 
-.ErrorDisplay__details {
-  background-color: var.$grey-1;
-  border: 1px solid var.$grey-3;
-  white-space: pre-wrap;
-  max-width: 100%;
-  padding: 10px;
-  margin-bottom: 0;
+  &__details-content {
+    background-color: var.$grey-1;
+    border: 1px solid var.$grey-3;
+    white-space: pre-wrap;
+    max-width: 100%;
+    padding: 10px;
+    margin-bottom: 0;
+  }
 }

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -2,13 +2,23 @@
 
 
 .ErrorDisplay {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow-y: scroll;
+  padding-right: 5px;
+  margin-bottom: 10px;
   max-width: 100%;
+  details {
+    padding: 4px; // fix for focus halo w/ overflow scroll
+  }
 }
 
 .ErrorDisplay__details {
-  overflow: scroll;
   background-color: var.$grey-1;
   border: 1px solid var.$grey-3;
-
+  white-space: pre-wrap;
   max-width: 100%;
+  padding: 10px;
+  margin-bottom: 0;
 }

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -14,6 +14,7 @@ $file-list-icon-size: 24px;
 
 .FileList__spinner {
   position: absolute;
+  margin: 15px;
   left: calc(50% - #{$file-list-icon-size / 2});
   top: calc(50% - #{$file-list-icon-size / 2});
 }

--- a/lms/static/styles/components/_LMSFilePicker.scss
+++ b/lms/static/styles/components/_LMSFilePicker.scss
@@ -1,8 +1,0 @@
-.LMSFilePicker__dialog {
-  display: flex;
-  flex-direction: column;
-  max-height: 100vh;
-  max-width: 500px;
-  width: 80vw;
-  height: 400px;
-}

--- a/lms/static/styles/components/_URLPicker.scss
+++ b/lms/static/styles/components/_URLPicker.scss
@@ -1,7 +1,0 @@
-.URLPicker__dialog {
-  display: flex;
-  flex-direction: column;
-  width: 80vw;
-  max-width: 500px;
-  max-height: 300px;
-}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -27,13 +27,11 @@
 @use 'components/ErrorDisplay';
 @use 'components/FileList';
 @use 'components/FilePickerApp';
-@use 'components/LMSFilePicker';
 @use 'components/LMSGrader';
 @use 'components/StudentSelector';
 @use 'components/SubmitGradeForm';
 @use 'components/ValidationMessage';
 @use 'components/SvgIcon';
-@use 'components/URLPicker';
 
 
 // Element styles.

--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -6,39 +6,41 @@
     <div class="Dialog__content LMSFilePicker__dialog">
       {% if invalid_scope %}
         <h1 class="Dialog__title">Developer Key Scopes Missing</h1>
+        <div class="ErrorDisplay">
+          <p>
+            A Canvas admin needs to edit Hypothesis's developer key and add these
+            scopes:
+          </p>
 
-        <p>
-          A Canvas admin needs to edit Hypothesis's developer key and add these
-          scopes:
-        </p>
+          <ol>
+            {% for scope in scopes %}
+              <li><code>{{ scope }}</code></li>
+            {% endfor %}
+          </ol>
 
-        <ol>
-          {% for scope in scopes %}
-            <li><code>{{ scope }}</code></li>
-          {% endfor %}
-        </ol>
+          <p>For more information see:
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App">Canvas API Endpoints Used 
+  y the Hypothesis LMS App</a>.
+          </p>
+        {% else %}
+          <h1 class="Dialog__title">Authorization Failed</h1>
 
-        <p>For more information see:
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App">Canvas API Endpoints Used 
-y the Hypothesis LMS App</a>.
-        </p>
-      {% else %}
-        <h1 class="Dialog__title">Authorization Failed</h1>
+          <p>Something went wrong when authorizing Hypothesis.</p>
+        {% endif %}
 
-        <p>Something went wrong when authorizing Hypothesis.</p>
-      {% endif %}
+        <p>To get help from Hypothesis
+        <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support" target="_blank" rel="noopener noreferrer">send us an email</a>
+        or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener noreferrer">open a support ticket</a>.
+        You can also visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer"> help documents</a>.</p>
 
-      <p>To get help from Hypothesis
-      <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support" target="_blank" rel="noopener noreferrer">send us an email</a>
-      or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener noreferrer">open a support ticket</a>.
-      You can also visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer"> help documents</a>.</p>
-
-      {% if details %}
-        <details>
-          <p>The error message from Canvas was:</p>
-          <pre class="ErrorDisplay__details">{{ details }}</pre>
-        </details>
-      {% endif %}
+        {% if details %}
+          <details class="ErrorDisplay__details">
+            <summary class="ErrorDisplay__details-summary">Error Details</summary>
+            <p>The error message from Canvas was:</p>
+            <pre class="ErrorDisplay__details-content">{{ details }}</pre>
+          </details>
+        {% endif %}
+      </div>
 
       <div class="u-stretch"></div>
       <div class="Dialog__actions">


### PR DESCRIPTION
- Increase max-width of dialogs to 700px
- Allow dialogs to expand to 90% of the height to take advantage of extra space
- Allow extremely long content in dialogs to scroll, but not hide any bottom buttons out of the view
- Coverage & delete some CSS settings among various dialogs used
- Fix bug where non-json error details text was not formatted pretty in <ErrorDisplay>
- Fix bug that set “undefined” class in <Dialog> when not passing a `contentClass` prop.

------------------

fixes https://github.com/hypothesis/lms/issues/1728
fixes https://github.com/hypothesis/lms/issues/1727

There are a lot of actual changes here that are best viewed when contrasting the old dialogs with the new ones. That is very difficult to do in a fully working LMS app so I made a little cheat branch to help -- https://github.com/hypothesis/lms/tree/dialog-testing-branch. 

The `config.mode` value _(hard coded in index.js)_ will force the demo component seen here. Then, switch to **_this_**  branch and open the same assignment in a second tab. Don't close the first tab and then you can compare the differences.


### Differences between dialogs (Left: current, Right: new)



![Screen Shot 2020-05-26 at 5 20 04 PM](https://user-images.githubusercontent.com/3939074/82962472-2e008f00-9f75-11ea-8e5f-fcc2b149404d.png)

Changing the display to flex changes how the items' margins layout, but this imo is minor.

--------

![Screen Shot 2020-05-26 at 5 22 25 PM](https://user-images.githubusercontent.com/3939074/82962602-833ca080-9f75-11ea-8884-4fb2cd9fc909.png)

Removing min-width 500px allows some dialogs to shrink a bit more;

--------

![FilePickerApp](https://user-images.githubusercontent.com/3939074/82962292-a581ee80-9f74-11ea-9843-75f21fd30f02.gif)

Dialogs don't have extra whitespace due to removal of fixed height.

--------

![SimpleErrorDialog](https://user-images.githubusercontent.com/3939074/82962296-a74bb200-9f74-11ea-8f4b-79bb6a6e0965.gif)

Previously, really long content would not be in view on small screens. Now the content is scrollable, and if there are buttons on the bottle, then they don't move off screen.

--------

![Dialog - ErrorDisplay (button)](https://user-images.githubusercontent.com/3939074/82962280-a0bd3a80-9f74-11ea-9de1-d82b29bf33fc.gif)

The ErrorDisplay component was not able to render details very well. It munged white space together and render it as a single line.

--------


![Dialog - ErrorDisplay (json)](https://user-images.githubusercontent.com/3939074/82962284-a31f9480-9f74-11ea-979c-a79005cdc4c9.gif)

The details can still render json appropriately. Bumped the max-width to 700 for all dialogs, I feel like that helps.

--------
![Dialog - ErrorDisplay (text)](https://user-images.githubusercontent.com/3939074/82962287-a3b82b00-9f74-11ea-9182-71b2583537d0.gif)


![FilePicker](https://user-images.githubusercontent.com/3939074/82962291-a450c180-9f74-11ea-98eb-f35689be12d3.gif)

max-width 700 gives a bit more space for filenames, and the changes above applied to this dialog allows a lot more files to be seen at the same time. Additionally the errors that render in this component no longer take up the same whitespace and now dynamically adjust to the content of the error. Also adjusted the position of the spinner to a look a bit more vertically centered.

--------

![Screen Shot 2020-05-27 at 3 48 48 PM](https://user-images.githubusercontent.com/3939074/83079878-a75db780-a031-11ea-8dc3-9eb5196479f4.png)





