### PR TITLE
Remove unused SCSS vars

### DIFF
--- a/lms/static/styles/_variables.scss
+++ b/lms/static/styles/_variables.scss
@@ -1,6 +1,5 @@
 // Colors.
 $white: white;
-$black: black;
 
 $grey-1: #f2f2f2;
 $grey-2: #ececec;
@@ -11,7 +10,6 @@ $grey-6: #3f3f3f;
 $grey-7: #202020;
 
 $brand: #d00032;
-$highlight: #58cef4;
 
 // Typography.
 $sans-font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !default;

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -1,4 +1,3 @@
-$file-list-item-height: 40px;
 $file-list-icon-size: 24px;
 
 .FileList {

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -3,7 +3,6 @@
 
 
 $table-item-height: 40px;
-$table-icon-size: 24px;
 
 // Wrapper around the table. This is used because table elements do not support
 // setting the `height` or `overflow` properties directly.


### PR DESCRIPTION
Found via sass-unused [1]. I didn't remove _all_ unused variables
because some of them are elements of our standard font stack which just
happen not to be used in the LMS repo at present. We'll likely move
those to a shared package in future.

[1] https://github.com/robertknight/sass-unused