### PR TITLE
Dialog css fixes

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -70,12 +70,7 @@ export default function Dialog({
         style={{ zIndex: zIndexScale.dialogBackground }}
       />
       <div className="Dialog__container" style={{ zIndex: zIndexScale.dialog }}>
-        <div
-          className={classNames({
-            Dialog__content: true,
-            [contentClass]: true,
-          })}
-        >
+        <div className={classNames('Dialog__content', contentClass)}>
           <h1 className="Dialog__title" id={dialogTitleId}>
             {title}
             <span className="u-stretch" />

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -13,12 +13,15 @@ function emailLink({ address, subject = '', body = '' }) {
  */
 export default function ErrorDisplay({ message, error }) {
   let details = '';
-  try {
-    if (error.details) {
+
+  if (typeof error.details === 'object') {
+    try {
       details = JSON.stringify(error.details, null, 2 /* indent */);
+    } catch (e) {
+      // ignore
     }
-  } catch (e) {
-    // Ignored
+  } else {
+    details = error.details;
   }
 
   const supportLink = emailLink({
@@ -64,8 +67,11 @@ ${details}
         .
       </p>
       {!!details && (
-        <details>
-          <pre className="ErrorDisplay__details">{details}</pre>
+        <details className="ErrorDisplay__details">
+          <summary className="ErrorDisplay__details-summary">
+            Error Details
+          </summary>
+          <pre className="ErrorDisplay__details-content">{details}</pre>
         </details>
       )}
     </div>

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -14,6 +14,15 @@ describe('Dialog', () => {
     assert.isTrue(wrapper.contains(<span>content</span>));
   });
 
+  it('adds `contentClass` value to class list', () => {
+    const wrapper = mount(
+      <Dialog contentClass="foo">
+        <span>content</span>
+      </Dialog>
+    );
+    assert.isTrue(wrapper.find('.Dialog__content').hasClass('foo'));
+  });
+
   it('renders buttons', () => {
     const wrapper = mount(
       <Dialog

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,8 +1,3 @@
-.BasicLtiLaunchApp__dialog {
-  width: 75%;
-  max-width: 500px;
-}
-
 .BasicLtiLaunchApp__spinner {
   $spinner-size: 50px;
 

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,16 +1,11 @@
+@use "../mixins/focus";
 @use "../variables" as var;
 
 
 .Dialog__container {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   position: fixed;
-  left: 0;
   top: 0;
-  right: 0;
-  bottom: 0;
   width: 100%;
   height: 100%;
 }
@@ -26,10 +21,13 @@
 }
 
 .Dialog__content {
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  max-width: 700px;
   background-color: white;
   border-radius: 3px;
-  margin-left: auto;
-  margin-right: auto;
+  margin: auto;
   padding: 20px;
 }
 
@@ -40,6 +38,7 @@
 }
 
 .Dialog__cancel-btn {
+  @include focus.outline-on-keyboard-focus;
   border: 0;
   background: none;
   color: var.$grey-6;
@@ -68,6 +67,7 @@
   margin-top: 10px;
 
   .Button {
+    @include focus.outline-on-keyboard-focus;
     &:not(:first-child) {
       margin-left: 5px;
     }

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -24,7 +24,8 @@
   display: flex;
   flex-direction: column;
   max-height: 90vh;
-  max-width: 700px;
+  max-width: 700px; // default for older browsers
+  max-width: min(700px, 90vw);
   background-color: white;
   border-radius: 3px;
   margin: auto;
@@ -45,17 +46,14 @@
 
   // Given the button a large hit target and ensure the 'X' label is large
   // enough to see easily and aligned with the right edge of the dialog.
-  padding: 0;
+  // Add negative margins so that the button does not force the dialog to 
+  // grow in height.
   font-size: 20px;
-  line-height: 20px;
-  width: 40px;
-  height: 40px;
-  margin-top: -15px;
-  margin-bottom: -15px;
-  margin-right: 0;
-  text-align: right;
+  padding: 5px;
+  margin: -10px 0px;
 
   &:hover {
+    cursor: pointer;
     color: var.$brand;
   }
 }

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -12,12 +12,12 @@
   max-width: 100%;
   
   &__details {  
-    padding: 4px; // fix for focus halo w/ overflow scroll
+    padding: 4px; // prevents focus ring from getting cut off
     &-summary {
+      @include focus.outline-on-keyboard-focus;
       &:hover {
         cursor: pointer;
       }
-      @include focus.outline-on-keyboard-focus;
     }
   }
 

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -1,14 +1,32 @@
+@use "../mixins/focus";
 @use "../variables" as var;
 
 
 .ErrorDisplay {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow-y: scroll;
+  padding-right: 5px;
+  margin-bottom: 10px;
   max-width: 100%;
-}
+  
+  &__details {  
+    padding: 4px; // fix for focus halo w/ overflow scroll
+    &-summary {
+      &:hover {
+        cursor: pointer;
+      }
+      @include focus.outline-on-keyboard-focus;
+    }
+  }
 
-.ErrorDisplay__details {
-  overflow: scroll;
-  background-color: var.$grey-1;
-  border: 1px solid var.$grey-3;
-
-  max-width: 100%;
+  &__details-content {
+    background-color: var.$grey-1;
+    border: 1px solid var.$grey-3;
+    white-space: pre-wrap;
+    max-width: 100%;
+    padding: 10px;
+    margin-bottom: 0;
+  }
 }

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -14,6 +14,7 @@ $file-list-icon-size: 24px;
 
 .FileList__spinner {
   position: absolute;
+  margin: 15px;
   left: calc(50% - #{$file-list-icon-size / 2});
   top: calc(50% - #{$file-list-icon-size / 2});
 }

--- a/lms/static/styles/components/_LMSFilePicker.scss
+++ b/lms/static/styles/components/_LMSFilePicker.scss
@@ -1,8 +1,0 @@
-.LMSFilePicker__dialog {
-  display: flex;
-  flex-direction: column;
-  max-height: 100vh;
-  max-width: 500px;
-  width: 80vw;
-  height: 400px;
-}

--- a/lms/static/styles/components/_URLPicker.scss
+++ b/lms/static/styles/components/_URLPicker.scss
@@ -1,7 +1,0 @@
-.URLPicker__dialog {
-  display: flex;
-  flex-direction: column;
-  width: 80vw;
-  max-width: 500px;
-  max-height: 300px;
-}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -26,13 +26,11 @@
 @use 'components/ErrorDisplay';
 @use 'components/FileList';
 @use 'components/FilePickerApp';
-@use 'components/LMSFilePicker';
 @use 'components/LMSGrader';
 @use 'components/StudentSelector';
 @use 'components/SubmitGradeForm';
 @use 'components/ValidationMessage';
 @use 'components/SvgIcon';
-@use 'components/URLPicker';
 
 
 // Element styles.

--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -6,39 +6,41 @@
     <div class="Dialog__content LMSFilePicker__dialog">
       {% if invalid_scope %}
         <h1 class="Dialog__title">Developer Key Scopes Missing</h1>
+        <div class="ErrorDisplay">
+          <p>
+            A Canvas admin needs to edit Hypothesis's developer key and add these
+            scopes:
+          </p>
 
-        <p>
-          A Canvas admin needs to edit Hypothesis's developer key and add these
-          scopes:
-        </p>
+          <ol>
+            {% for scope in scopes %}
+              <li><code>{{ scope }}</code></li>
+            {% endfor %}
+          </ol>
 
-        <ol>
-          {% for scope in scopes %}
-            <li><code>{{ scope }}</code></li>
-          {% endfor %}
-        </ol>
+          <p>For more information see:
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App">Canvas API Endpoints Used 
+  y the Hypothesis LMS App</a>.
+          </p>
+        {% else %}
+          <h1 class="Dialog__title">Authorization Failed</h1>
 
-        <p>For more information see:
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App">Canvas API Endpoints Used 
-y the Hypothesis LMS App</a>.
-        </p>
-      {% else %}
-        <h1 class="Dialog__title">Authorization Failed</h1>
+          <p>Something went wrong when authorizing Hypothesis.</p>
+        {% endif %}
 
-        <p>Something went wrong when authorizing Hypothesis.</p>
-      {% endif %}
+        <p>To get help from Hypothesis
+        <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support" target="_blank" rel="noopener noreferrer">send us an email</a>
+        or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener noreferrer">open a support ticket</a>.
+        You can also visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer"> help documents</a>.</p>
 
-      <p>To get help from Hypothesis
-      <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support" target="_blank" rel="noopener noreferrer">send us an email</a>
-      or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener noreferrer">open a support ticket</a>.
-      You can also visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer"> help documents</a>.</p>
-
-      {% if details %}
-        <details>
-          <p>The error message from Canvas was:</p>
-          <pre class="ErrorDisplay__details">{{ details }}</pre>
-        </details>
-      {% endif %}
+        {% if details %}
+          <details class="ErrorDisplay__details">
+            <summary class="ErrorDisplay__details-summary">Error Details</summary>
+            <p>The error message from Canvas was:</p>
+            <pre class="ErrorDisplay__details-content">{{ details }}</pre>
+          </details>
+        {% endif %}
+      </div>
 
       <div class="u-stretch"></div>
       <div class="Dialog__actions">

--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -19,8 +19,10 @@
           </ol>
 
           <p>For more information see:
-          <a target="_blank" rel="noopener noreferrer" href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App">Canvas API Endpoints Used 
-  y the Hypothesis LMS App</a>.
+          <a target="_blank"
+             rel="noopener noreferrer"
+             href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
+          >Canvas API Endpoints Used by the Hypothesis LMS App</a>.
           </p>
         {% else %}
           <h1 class="Dialog__title">Authorization Failed</h1>

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -3,6 +3,7 @@
   <head>
     <meta charset=utf-8>
     <meta name="google-site-verification" content="gaQfw17MvkfgMs1jAeZAEv0kuJTMS28lvH21_rQKBPY" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Hypothesis{% endblock %}</title>
     {% block base_styles %}
     {% for url in asset_urls("lms_css") %}


### PR DESCRIPTION
- Increase max-width of dialogs to 700px
- Allow dialogs to expand to 90% of the height to take advantage of extra space
- Allow extremely long content in dialogs to scroll, but not hide any bottom buttons out of the view
- Coverage & delete some CSS settings among various dialogs used
- Fix bug where non-json error details text was not formatted pretty in <ErrorDisplay>
- Fix bug that set “undefined” class in <Dialog> when not passing a `contentClass` prop.
- Add new DisplayError classes to oauth_redirect_error template

--------

Cherry picked changes in this PR against master, rather than demo branch. this is the PR to be merged, rather than the following: https://github.com/hypothesis/lms/pull/1780


To demo, use `eng+canvasteacher@hypothes.is` account. The test assignments, with various error are already set up for that account.
