### PR TITLE
Disable PyLint's "too few public methods" warning

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -37,6 +37,8 @@ disable=
     bad-continuation,
     line-too-long,
 
+    too-few-public-methods,
+
 good-names=
     # PyLint's default good names.
     i,j,k,ex,Run,_,

--- a/lms/assets.py
+++ b/lms/assets.py
@@ -7,7 +7,7 @@ from pyramid.settings import aslist
 from pyramid.static import static_view
 
 
-class _CachedFile:  # pylint:disable=too-few-public-methods
+class _CachedFile:
     """
     Parses content from a file and caches the result.
 

--- a/lms/config/settings.py
+++ b/lms/config/settings.py
@@ -7,7 +7,7 @@ class SettingError(Exception):
     pass
 
 
-class SettingGetter:  # pylint:disable=too-few-public-methods
+class SettingGetter:
     """Helper for getting values of settings from envvars or config file."""
 
     def __init__(self, settings):

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -12,7 +12,7 @@ from lms.db import BASE
 __all__ = ["ApplicationInstance"]
 
 
-class ApplicationInstance(BASE):  # pylint:disable=too-few-public-methods
+class ApplicationInstance(BASE):
     """Class to represent a single lms install."""
 
     __tablename__ = "application_instances"

--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -7,7 +7,7 @@ from lms.db import BASE
 __all__ = ["GradingInfo"]
 
 
-class GradingInfo(BASE):  # pylint:disable=too-few-public-methods
+class GradingInfo(BASE):
     """
     A record of a student's launch of a Hypothesis-configured LMS assignment.
 

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -7,7 +7,7 @@ from lms.db import BASE
 __all__ = ["GroupInfo"]
 
 
-class GroupInfo(BASE):  # pylint:disable=too-few-public-methods
+class GroupInfo(BASE):
     """
     Some info about an LMS group that was created in h.
 

--- a/lms/models/lti_launches.py
+++ b/lms/models/lti_launches.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from lms.db import BASE
 
 
-class LtiLaunches(BASE):  # pylint:disable=too-few-public-methods
+class LtiLaunches(BASE):
     """Track each LTI launch."""
 
     __tablename__ = "lti_launches"

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -8,7 +8,7 @@ from lms.db import BASE
 __all__ = ["OAuth2Token"]
 
 
-class OAuth2Token(BASE):  # pylint:disable=too-few-public-methods
+class OAuth2Token(BASE):
     """
     An OAuth 2.0 access token, refresh token and expiry time.
 

--- a/lms/resources/default.py
+++ b/lms/resources/default.py
@@ -2,7 +2,7 @@
 from pyramid.security import Allow
 
 
-class DefaultResource:  # pylint:disable=too-few-public-methods
+class DefaultResource:
     """The application's default root resource."""
 
     __acl__ = [

--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -24,7 +24,7 @@ class _SectionSchema(Schema):
     various schemas below for Canvas API responses that contain section dicts.
     """
 
-    class Meta:  # pylint:disable=too-few-public-methods
+    class Meta:
         unknown = EXCLUDE
 
     id = fields.Int(required=True)
@@ -409,7 +409,7 @@ class CanvasAPIClient(_CanvasAPIAuthenticatedClient):
         class _EnrollmentSchema(Schema):
             """Schema for extracting a section ID from an enrollment dict."""
 
-            class Meta:  # pylint:disable=too-few-public-methods
+            class Meta:
                 unknown = EXCLUDE
 
             course_section_id = fields.Int(required=True)

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -5,7 +5,7 @@ from lms.models import GroupInfo
 __all__ = ["GroupInfoService"]
 
 
-class GroupInfoService:  # pylint:disable=too-few-public-methods
+class GroupInfoService:
     """
     A service that upserts :class:`~lms.models.GroupInfo` records.
 

--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -12,7 +12,7 @@ from lms.services import (
 __all__ = ["LaunchVerifier"]
 
 
-class LaunchVerifier:  # pylint:disable=too-few-public-methods
+class LaunchVerifier:
     """LTI launch request verifier."""
 
     def __init__(self, _context, request):

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -4,7 +4,7 @@ from pyramid.httpexceptions import HTTPInternalServerError
 from lms.services import HAPIError
 
 
-class LTIHService:  # pylint:disable=too-few-public-methods
+class LTIHService:
     """
     Copy LTI users and courses to h users and groups.
 

--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -1,7 +1,7 @@
 from requests_oauthlib import OAuth1
 
 
-class OAuth1Service:  # pylint:disable=too-few-public-methods
+class OAuth1Service:
     """Provides OAuth1 convenience functions."""
 
     def __init__(self, _context, request):

--- a/lms/validation/_base.py
+++ b/lms/validation/_base.py
@@ -39,7 +39,7 @@ class PlainSchema(marshmallow.Schema):
     def __init__(self):
         super().__init__(many=self.many)
 
-    class Meta:  # pylint:disable=too-few-public-methods
+    class Meta:
         """Marshmallow options for all schemas."""
 
         # Drop unknown keys, instead of raising an error.

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -39,7 +39,7 @@ class BasicLTILaunchSchema(_CommonLTILaunchSchema):
     class URLSchema(Schema):
         """Schema containing only validation for the return URL."""
 
-        class Meta:  # pylint:disable=too-few-public-methods
+        class Meta:
             """Allow other values, as we are only here to validate the URL."""
 
             unknown = EXCLUDE

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -4,8 +4,6 @@ from urllib.parse import parse_qsl, urlencode, urlparse
 
 __all__ = ["via_url"]
 
-# pylint: disable=too-few-public-methods
-
 
 class _ViaDoc:
     """A doc we want to proxy with content type."""


### PR DESCRIPTION
This warning frequently triggers when we don't want it to / when we can't do anything about it: SQLAlchemy model classes, Pyramid services, inline Meta classes, etc.