### PR TITLE
Add a method which filters and checks for duplicate sections

### DIFF
--- a/lms/services/canvas_api.py
+++ b/lms/services/canvas_api.py
@@ -485,7 +485,8 @@ class CanvasAPIClient(_CanvasAPIAuthenticatedClient):
 
     @classmethod
     def _ensure_sections_unique(cls, sections):
-        """Ensure that sections returned by Canvas are unique.
+        """
+        Ensure that sections returned by Canvas are unique.
 
         We _suspect_ that Canvas may on occasion return the same section twice
         or more. In the case this happens, and the name is the same we remove


### PR DESCRIPTION
We filter exact duplicates and fail on sections with different names.

This is to attempt to help with the _suspected_ cause of some failures with the Bulk API which it looks like could only be caused by sending two identical ids. 

This is most likely because Canvas sends us back the same data twice. Another, astronomically less likely, possibility is that we have a SHA-1 clash.