### PR TITLE
Refactor a parametrize and a feature flag fixture

### DIFF
--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -69,26 +69,45 @@ class TestApplicationInstanceGetter:
         assert not ai_getter.provisioning_enabled()
 
     @pytest.mark.parametrize(
-        "section_groups_feature_flag,developer_key,canvas_sections_enabled,expected_result",
+        "params",
         [
-            (True, "test_developer_key", True, True),
-            (False, "test_developer_key", True, False),
-            (True, None, True, False),
-            (True, "test_developer_key", False, False),
-            (False, None, False, False),
+            dict(
+                feature_flag=True,
+                developer_key="test_developer_key",
+                canvas_sections_enabled=True,
+                expected_result=True,
+            ),
+            dict(
+                feature_flag=False,
+                developer_key="test_developer_key",
+                canvas_sections_enabled=True,
+                expected_result=False,
+            ),
+            dict(
+                feature_flag=True,
+                developer_key=None,
+                canvas_sections_enabled=True,
+                expected_result=False,
+            ),
+            dict(
+                feature_flag=True,
+                developer_key="test_developer_key",
+                canvas_sections_enabled=False,
+                expected_result=False,
+            ),
+            dict(
+                feature_flag=False,
+                developer_key=None,
+                canvas_sections_enabled=False,
+                expected_result=False,
+            ),
         ],
     )
     def test_canvas_sections_enabled(
-        self,
-        pyramid_request,
-        test_application_instance,
-        section_groups_feature_flag,
-        developer_key,
-        canvas_sections_enabled,
-        expected_result,
+        self, pyramid_request, test_application_instance, params,
     ):
         def feature(flag):
-            if section_groups_feature_flag:
+            if params["feature_flag"]:
                 return flag == "section_groups"
             return False
 
@@ -96,13 +115,13 @@ class TestApplicationInstanceGetter:
         ai_getter = application_instance_getter_service_factory(
             mock.sentinel.context, pyramid_request
         )
-        test_application_instance.developer_key = developer_key
+        test_application_instance.developer_key = params["developer_key"]
         # pylint: disable=protected-access
         test_application_instance._settings = {
-            "canvas": {"sections_enabled": canvas_sections_enabled}
+            "canvas": {"sections_enabled": params["canvas_sections_enabled"]}
         }
 
-        assert ai_getter.canvas_sections_enabled() == expected_result
+        assert ai_getter.canvas_sections_enabled() == params["expected_result"]
 
     @pytest.mark.usefixtures(
         "unknown_consumer_key", "section_groups_feature_flag_enabled"

--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -71,41 +71,23 @@ class TestApplicationInstanceGetter:
     @pytest.mark.parametrize(
         "params",
         [
-            dict(
-                feature_flag=True,
-                developer_key="test_developer_key",
-                canvas_sections_enabled=True,
-                expected_result=True,
-            ),
-            dict(
-                feature_flag=False,
-                developer_key="test_developer_key",
-                canvas_sections_enabled=True,
-                expected_result=False,
-            ),
-            dict(
-                feature_flag=True,
-                developer_key=None,
-                canvas_sections_enabled=True,
-                expected_result=False,
-            ),
-            dict(
-                feature_flag=True,
-                developer_key="test_developer_key",
-                canvas_sections_enabled=False,
-                expected_result=False,
-            ),
-            dict(
-                feature_flag=False,
-                developer_key=None,
-                canvas_sections_enabled=False,
-                expected_result=False,
-            ),
+            dict(),
+            dict(feature_flag=False, expected_result=False),
+            dict(developer_key=None, expected_result=False),
+            dict(canvas_sections_enabled=False, expected_result=False),
         ],
     )
     def test_canvas_sections_enabled(
         self, pyramid_request, test_application_instance, params,
     ):
+        default_params = dict(
+            feature_flag=True,
+            developer_key="test_developer_key",
+            canvas_sections_enabled=True,
+            expected_result=True,
+        )
+        params = dict(default_params, **params)
+
         if params["feature_flag"]:
             enable_section_groups_feature_flag(pyramid_request)
 

--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -106,12 +106,9 @@ class TestApplicationInstanceGetter:
     def test_canvas_sections_enabled(
         self, pyramid_request, test_application_instance, params,
     ):
-        def feature(flag):
-            if params["feature_flag"]:
-                return flag == "section_groups"
-            return False
+        if params["feature_flag"]:
+            enable_section_groups_feature_flag(pyramid_request)
 
-        pyramid_request.feature.side_effect = feature
         ai_getter = application_instance_getter_service_factory(
             mock.sentinel.context, pyramid_request
         )
@@ -195,9 +192,16 @@ class TestApplicationInstanceGetter:
         )
         return pyramid_request
 
-    @pytest.fixture
-    def section_groups_feature_flag_enabled(self, pyramid_request):
-        def feature(flag):
-            return flag == "section_groups"
 
-        pyramid_request.feature.side_effect = feature
+def enable_section_groups_feature_flag(pyramid_request):
+    """
+    Enable the "section_groups" feature flag.
+
+    Also disables all other feature flags.
+    """
+    pyramid_request.feature.side_effect = lambda flag: flag == "section_groups"
+
+
+@pytest.fixture
+def section_groups_feature_flag_enabled(pyramid_request):
+    enable_section_groups_feature_flag(pyramid_request)


### PR DESCRIPTION
1. Make an `@parametrize` easier to read by having it use a params dict instead of long tuples, and by having it have default values for the items in the params dict so that each parametrized case only needs to contain the values the differ from the defaults. This is going to help with future changes to this test which are going to need to add more parameters and more cases: it'll now be possible to add these without making readability even worse.

2. Add a module level `enable_section_groups_feature_flag()` helper function and `section_groups_feature_flag_enabled` fixture. These just make it easier for tests that need to turn the flag on and off. In the future we're going to have to add more such tests to this module.