### PR TITLE
Minor styling and bug fixes for grader

### DIFF
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -145,6 +145,7 @@ export default function SubmitGradeForm({ disabled = false, student }) {
    */
   const handleKeyDown = () => {
     setValidationError(false);
+    setGradeSaved(false);
   };
 
   return (
@@ -182,11 +183,11 @@ export default function SubmitGradeForm({ disabled = false, student }) {
           })}
         />
       </span>
-      <button
+      <input
+        type="submit"
         className="SubmitGradeForm__submit"
         disabled={disabled}
         onClick={onSubmitGrade}
-        type="submit"
       >
         <SvgIcon
           className="SubmitGradeForm__check-icon"
@@ -194,7 +195,7 @@ export default function SubmitGradeForm({ disabled = false, student }) {
           inline={true}
         />{' '}
         Submit Grade
-      </button>
+      </input>
       {!!submitGradeError && (
         <ErrorDialog
           title="Error"

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -34,9 +34,12 @@ export default function ValidationMessage({
   });
 
   return (
-    <button onClick={closeValidationError} className={errorClass}>
-      {message}
-    </button>
+    <input
+      type="button"
+      onClick={closeValidationError}
+      className={errorClass}
+      value={message}
+    />
   );
 }
 

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -71,26 +71,37 @@ describe('SubmitGradeForm', () => {
 
   it('does not disable the input field when the disable prop is missing', () => {
     const wrapper = renderForm();
-    assert.isFalse(wrapper.find('input').prop('disabled'));
+    assert.isFalse(
+      wrapper.find('input.SubmitGradeForm__grade').prop('disabled')
+    );
   });
 
   it('disables the submit button when the disable prop is true', () => {
     const wrapper = renderForm({ disabled: true });
-    assert.isTrue(wrapper.find('button').prop('disabled'));
+    assert.isTrue(wrapper.find('input[type="submit"]').prop('disabled'));
   });
 
   it("sets the input key to the student's LISResultSourcedId", () => {
     const wrapper = renderForm();
-    assert.equal(wrapper.find('input').key(), fakeStudent.LISResultSourcedId);
+    assert.equal(
+      wrapper.find('input.SubmitGradeForm__grade').key(),
+      fakeStudent.LISResultSourcedId
+    );
   });
 
   it('clears out the previous grade when changing students', async () => {
     const wrapper = renderForm();
     await waitFor(() => !isFetchingGrade(wrapper));
 
-    assert.equal(wrapper.find('input').prop('defaultValue'), 10);
+    assert.equal(
+      wrapper.find('.SubmitGradeForm__grade').prop('defaultValue'),
+      10
+    );
     wrapper.setProps({ student: fakeStudentAlt });
-    assert.equal(wrapper.find('input').prop('defaultValue'), '');
+    assert.equal(
+      wrapper.find('.SubmitGradeForm__grade').prop('defaultValue'),
+      ''
+    );
   });
 
   it('focuses the input field when changing students and fetching the grade', async () => {
@@ -124,7 +135,7 @@ describe('SubmitGradeForm', () => {
         },
       });
       const wrapper = renderForm();
-      wrapper.find('button').simulate('click');
+      wrapper.find('input[type="submit"]').simulate('click');
       assert.isTrue(wrapper.find('ValidationMessage').prop('open'));
       assert.equal(wrapper.find('ValidationMessage').prop('message'), 'err');
     });
@@ -136,8 +147,8 @@ describe('SubmitGradeForm', () => {
         },
       });
       const wrapper = renderForm();
-      wrapper.find('button').simulate('click');
-      wrapper.find('input').simulate('input');
+      wrapper.find('input[type="submit"]').simulate('click');
+      wrapper.find('input.SubmitGradeForm__grade').simulate('input');
       assert.isFalse(wrapper.find('ValidationMessage').prop('open'));
     });
   });
@@ -145,7 +156,7 @@ describe('SubmitGradeForm', () => {
   context('when submitting a grade', () => {
     it('shows the loading spinner when submitting a grade', () => {
       const wrapper = renderForm();
-      wrapper.find('button').simulate('click');
+      wrapper.find('input[type="submit"]').simulate('click');
       assert.isTrue(
         wrapper.find('.SubmitGradeForm__loading-backdrop Spinner').exists()
       );
@@ -154,33 +165,49 @@ describe('SubmitGradeForm', () => {
     it('shows the error dialog when the grade request throws an error', () => {
       const wrapper = renderForm();
       fakeSubmitGrade.throws({ errorMessage: '' });
-      wrapper.find('button').simulate('click');
+      wrapper.find('input[type="submit"]').simulate('click');
       assert.isTrue(wrapper.find('ErrorDialog').exists());
     });
 
     it('sets the `is-saved` class when the grade has posted', async () => {
       const wrapper = renderForm();
 
-      wrapper.find('button').simulate('click');
+      wrapper.find('input[type="submit"]').simulate('click');
       await waitFor(() => !isFetchingGrade(wrapper));
 
-      assert.isTrue(wrapper.find('input').hasClass('is-saved'));
+      assert.isTrue(
+        wrapper.find('input.SubmitGradeForm__grade').hasClass('is-saved')
+      );
+    });
+
+    it('removes the `is-saved` class after keyboard input', async () => {
+      const wrapper = renderForm();
+
+      wrapper.find('input[type="submit"]').simulate('click');
+      await waitFor(() => !isFetchingGrade(wrapper));
+
+      wrapper.find('input.SubmitGradeForm__grade').simulate('input');
+      assert.isFalse(
+        wrapper.find('input.SubmitGradeForm__grade').hasClass('is-saved')
+      );
     });
 
     it('removes the `SubmitGradeForm__grade--saved` class after the student prop changes', async () => {
       const wrapper = renderForm();
 
-      wrapper.find('button').simulate('click');
+      wrapper.find('input[type="submit"]').simulate('click');
       wrapper.setProps({ student: fakeStudentAlt });
 
       assert.isFalse(
-        wrapper.find('input').hasClass('SubmitGradeForm__grade--saved')
+        wrapper
+          .find('input.SubmitGradeForm__grade')
+          .hasClass('SubmitGradeForm__grade--saved')
       );
     });
 
     it('closes the spinner after the grade has posted', async () => {
       const wrapper = renderForm();
-      wrapper.find('button').simulate('click');
+      wrapper.find('input[type="submit"]').simulate('click');
 
       await waitFor(() => {
         wrapper.update();
@@ -194,14 +221,20 @@ describe('SubmitGradeForm', () => {
       fakeFetchGrade.resolves({ currentScore: null });
       const wrapper = renderForm();
       await waitFor(() => !isFetchingGrade(wrapper));
-      assert.equal(wrapper.find('input').prop('defaultValue'), '');
+      assert.equal(
+        wrapper.find('input.SubmitGradeForm__grade').prop('defaultValue'),
+        ''
+      );
     });
 
     it("sets the input defaultValue prop to the student's grade", async () => {
       const wrapper = renderForm();
       await waitFor(() => !isFetchingGrade(wrapper));
       // note, grade is scaled by 10
-      assert.equal(wrapper.find('input').prop('defaultValue'), 10);
+      assert.equal(
+        wrapper.find('input.SubmitGradeForm__grade').prop('defaultValue'),
+        10
+      );
     });
 
     it('sets the class on the <Spinner> component `active` while the grade is fetching', () => {

--- a/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
@@ -30,7 +30,7 @@ describe('ValidationMessage', () => {
 
   it('sets the message from the `message` prop', () => {
     const wrapper = renderMessage({ message: 'some error' });
-    assert.equal(wrapper.text(), 'some error');
+    assert.equal(wrapper.find('input').props().value, 'some error');
   });
 
   it('closes the message and calls `onClose` prop when clicked', () => {
@@ -40,7 +40,7 @@ describe('ValidationMessage', () => {
       open: true,
       message: 'foo',
     });
-    wrapper.find('button').simulate('click');
+    wrapper.find('input').simulate('click');
     assert.isTrue(onCloseProp.calledOnce);
     assert.isTrue(wrapper.find('.ValidationMessage--closed').exists());
   });

--- a/lms/static/styles/_mixins.scss
+++ b/lms/static/styles/_mixins.scss
@@ -32,14 +32,6 @@
     @content;
   }
 }
-// Used to apply standard outline focus state styling to buttons and input fields
-@mixin input-focus {
-  &:focus {
-    outline: 1px solid var.$grey-5;
-    outline-offset: -1px;
-    outline-style: solid
-  }
-}
 
 // Creates a spinner style with a provided $size and $color. The spinner
 // will be positioned in the center of its parent as long as that element is

--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -1,4 +1,4 @@
-@use "../mixins";
+@use "../mixins/focus";
 @use "../variables" as var;
 
 
@@ -11,7 +11,7 @@
 }
 
 .StudentSelector-change-student {
-  @include mixins.input-focus;
+  @include focus.outline-on-keyboard-focus;
   min-width: 60px;
   height: 40px;
   border: none;
@@ -32,10 +32,11 @@
 }
 
 .StudentsSelector__students {
-  @include mixins.input-focus;
+  @include focus.outline-on-keyboard-focus;
   position: relative;
 
   &-select {
+    @include focus.outline-on-keyboard-focus;
     appearance: none;
     border: 1px solid var.$grey-3;
     border-left: none;

--- a/lms/static/styles/components/_SubmitGradeForm.scss
+++ b/lms/static/styles/components/_SubmitGradeForm.scss
@@ -1,4 +1,5 @@
 @use "../mixins";
+@use "../mixins/focus";
 @use "../variables" as var;
 
 @keyframes SubmitGradeForm__fadeAway {
@@ -32,16 +33,14 @@
   }
 
   &__submit {
+    @include focus.outline-on-keyboard-focus;
+    
     height: 40px;
     width: 150px;
     font-weight: 500;
     border: 1px solid var.$grey-3;
     background-color: var.$grey-2;
     transition: background-color 0.2s;
-
-    &:focus {
-      border-color: var.$grey-5;
-    }
 
     &:hover {
       cursor: pointer;
@@ -52,10 +51,6 @@
       background-color: var.$grey-1;
       cursor: default;
       opacity: 0.5;
-    }
-
-    &:focus {
-      @include mixins.input-focus;
     }
   }
 
@@ -72,7 +67,7 @@
   }
 
   &__grade {
-    @include mixins.input-focus;
+    @include focus.outline-on-keyboard-focus;
     text-align: center;
     width: 60px;
     height: 40px;

--- a/lms/static/styles/components/_ValidationMessage.scss
+++ b/lms/static/styles/components/_ValidationMessage.scss
@@ -1,4 +1,4 @@
-@use "../mixins";
+@use "../mixins/focus";
 
 
 @keyframes validationErrorOpen {
@@ -24,7 +24,7 @@
 }
 
 .ValidationMessage {
-  @include mixins.input-focus;
+  @include focus.outline-on-keyboard-focus;
   display: inline-block;
   position: absolute;
   z-index: 10;
@@ -36,6 +36,7 @@
   color: white;
   white-space: nowrap;
   overflow: hidden;
+  border: none;
   animation-duration: 0.3s;
   animation-fill-mode: forwards;
   &:hover {


### PR DESCRIPTION
- Remove custom focus styling on grader buttons.  Use `:focus-visible` instead.

- Fix bug where the success background color (green) only changed on the first submit, but not on successive submits.

- Fix  bug where submitting grade via keyboard `Enter` didn’t work after an error. This was due to the fact that 2 <buttons> were inside the same <form> (the second was the error validation). The error needs to stay in the DOM for animation purposes. The fix is to use <input> with type=“submit” vs type=“button” so it know which one to default to.

