### PR TITLE
Read the sections enabled from course, not AI getter

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -98,9 +98,8 @@ class LTILaunchResource:
         """
         return self._request.parsed_params.get("custom_canvas_api_domain")
 
-    @property
-    def _canvas_sections_supported(self):
-        """Return True if Canvas sections is enabled for this request."""
+    def canvas_sections_supported(self):
+        """Return True if Canvas sections is supported for this request."""
         if not self.is_canvas:
             return False
 
@@ -114,11 +113,11 @@ class LTILaunchResource:
 
     @property
     def canvas_sections_enabled(self):
-        if not self._canvas_sections_supported:
+        """Return True if Canvas sections is enabled for this request."""
+
+        if not self.canvas_sections_supported():
             return False
 
-        return (
-            self._request.find_service(name="ai_getter")
-            .settings()
-            .get("canvas", "sections_enabled")
-        )
+        course_id = self.h_group.authority_provided_id
+        course = self._request.find_service(name="course").get_or_create(course_id)
+        return course.settings.get("canvas", "sections_enabled")


### PR DESCRIPTION
This also made some changes to make testing easier:

 * Made the canvas_sections_supported public
 * Also stopped it being a property (to make it easier to mock)

Rewrote the canvas_sections_enabled tests to be canvas_sections_supported
tests.

## To test

 * Run `make sql`
     * Run `delete * from course`

### Sections enabled

 * Goto: https://hypothesis.instructure.com/courses/125/assignments/873 (sections enabled course)
     * You should see sections
 * Run `select * from course;`
     * You should see `{"canvas": {"sections_enabled": true}`
* Run `update course set settings='{"canvas": {"sections_enabled": false}}';`
* Refresh the page
   * You should see a single course group

### Sections disabled

* Goto: https://hypothesis.instructure.com/courses/124/assignments/885 (sections disabled course)
   * You should see a single course group
 * Run `select * from course;`
     * You should another row with `{"canvas": {"sections_enabled": false}`
