### PR TITLE
VitalSource integration prototype

### DIFF
--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -62,6 +62,10 @@ def configure(settings):
         # like this:
         #     python3 -c 'import secrets; print(secrets.token_hex())'
         "oauth2_state_secret": sg.get("OAUTH2_STATE_SECRET"),
+        # Default OAuth 1.0 key and secret for VitalSource LTI launches
+        "vitalsource_launch_key": sg.get("VITALSOURCE_LAUNCH_KEY"),
+        "vitalsource_launch_secret": sg.get("VITALSOURCE_LAUNCH_SECRET"),
+        "vitalsource_api_key": sg.get("VITALSOURCE_API_KEY"),
     }
 
     env_settings["dev"] = asbool(env_settings["dev"])

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -75,6 +75,17 @@ class JSConfig:
             self._config["viaUrl"] = via_url(self._request, document_url)
             self._add_canvas_speedgrader_settings(document_url=document_url)
 
+    def add_vitalsource_launch_url(self, book_id, cfi=None):
+        vitalsource_svc = self._request.find_service(name="vitalsource")
+        launch_url, launch_params = vitalsource_svc.get_launch_params(
+            book_id, cfi, self._request.lti_user
+        )
+        self._config["vitalSource"] = {
+            "launchUrl": launch_url,
+            "launchParams": launch_params,
+        }
+        # TODO - Add SpeedGrader settings for Canvas.
+
     def asdict(self):
         """
         Return the configuration for the app's JavaScript code.

--- a/lms/resources/default.py
+++ b/lms/resources/default.py
@@ -8,6 +8,7 @@ class DefaultResource:
     __acl__ = [
         (Allow, "report_viewers", "view"),
         (Allow, "lti_user", "api"),
+        (Allow, "lti_user", "vitalsource_api"),
     ]
 
     def __init__(self, request):

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -67,3 +67,7 @@ def includeme(config):
     config.add_route("lti_api.submissions.record", "/api/lti/submissions")
     config.add_route("lti_api.result.read", "/api/lti/result", request_method="GET")
     config.add_route("lti_api.result.record", "/api/lti/result", request_method="POST")
+    config.add_route("vitalsource_api.books.list", "/api/vitalsource/books")
+    config.add_route(
+        "vitalsource_api.books.toc", "/api/vitalsource/books/{book_id}/toc"
+    )

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -48,3 +48,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.assignment.factory", name="assignment"
     )
+    config.register_service_factory(
+        "lms.services.vitalsource.VitalSourceService", name="vitalsource"
+    )

--- a/lms/services/vitalsource.py
+++ b/lms/services/vitalsource.py
@@ -1,0 +1,65 @@
+import oauthlib
+from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
+
+
+class VitalSourceService:
+    def __init__(self, _context, request):
+        self._oauth_key = request.registry.settings["vitalsource_launch_key"]
+        self._oauth_secret = request.registry.settings["vitalsource_launch_secret"]
+
+    def get_launch_params(self, book_id, cfi, lti_user):
+        """
+        Launch the VitalSource book viewer using an LTI launch.
+
+        See https://developer.vitalsource.com/hc/en-us/articles/215612237-POST-LTI-Create-a-Bookshelf-Launch
+        """
+
+        launch_url = f"https://bc.vitalsource.com/books/{book_id}"
+
+        if cfi:
+            book_location = "/cfi" + cfi
+
+        launch_params = self._launch_params(
+            # TODO - Set the real user ID and roles here.
+            user_id="teststudent",
+            roles="Learner",
+            # user_id=lti_user.user_id,
+            # roles=lti_user.roles,
+            # TODO - Set the context ID here
+            context_id="testcourse",
+            location=book_location,
+        )
+        self._sign_form_params(launch_url, launch_params)
+
+        return (launch_url, launch_params)
+
+    def _sign_form_params(self, url, params):
+        client = oauthlib.oauth1.Client(
+            self._oauth_key,
+            self._oauth_secret,
+            signature_method=SIGNATURE_HMAC_SHA1,
+            signature_type=SIGNATURE_TYPE_BODY,
+        )
+        params.update(client.get_oauth_params(oauthlib.common.Request(url, "POST")))
+        oauth_request = oauthlib.common.Request(url, "POST", body=params)
+        params["oauth_signature"] = client.get_oauth_signature(oauth_request)
+        return params
+
+    def _launch_params(self, user_id, roles, context_id, location=None):
+        # See https://developer.vitalsource.com/hc/en-us/articles/206156238-General-LTI-Usage
+        params = {
+            # User data. These should be proxied from the LTI launch.
+            "user_id": user_id,
+            "roles": roles,
+            "context_id": context_id,
+            # Static VitalSource launch parameters.
+            "launch_presentation_document_target": "window",
+            # Standard LTI launch parameters.
+            "lti_version": "LTI-1p0",
+            "lti_message_type": "basic-lti-launch-request",
+        }
+
+        if location:
+            params["custom_book_location"] = location
+
+        return params

--- a/lms/services/vitalsource.py
+++ b/lms/services/vitalsource.py
@@ -14,6 +14,11 @@ class VitalSourceService:
         See https://developer.vitalsource.com/hc/en-us/articles/215612237-POST-LTI-Create-a-Bookshelf-Launch
         """
 
+        if not self._oauth_key:
+            raise ValueError('VitalSource launch key has not been set')
+        if not self._oauth_secret:
+            raise ValueError('VitalSource launch secret has not been set')
+
         launch_url = f"https://bc.vitalsource.com/books/{book_id}"
 
         if cfi:

--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -12,5 +12,25 @@
  * @prop {string} updated_at - An ISO 8601 date string
  */
 
+/**
+ * Metadata for an ebook that is available to annotate.
+ *
+ * @typedef Book
+ * @prop {string} id
+ * @prop {string} title
+ * @prop {string} cover_image - URL of a cover image for the book
+ */
+
+/**
+ * Metadata for a chapter within an ebook.
+ *
+ * @typedef Chapter
+ * @prop {string} cfi -
+ *   An EPUB CFI indicating the location of the chapter within the book.
+ *   See http://idpf.org/epub/linking/cfi/.
+ * @prop {string} page
+ * @prop {string} title
+ */
+
 // Make TS treat this file as a module.
 export {};

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -16,6 +16,7 @@ import AuthWindow from '../utils/AuthWindow';
 import LMSGrader from './LMSGrader';
 import LaunchErrorDialog from './LaunchErrorDialog';
 import Spinner from './Spinner';
+import VitalSourceBookViewer from './VitalSourceBookViewer';
 
 /**
  * @typedef {import('../services/client-rpc').ClientRpc} ClientRpc
@@ -59,6 +60,7 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
     // Content URL to show in the iframe.
     viaUrl,
     canvas,
+    vitalSource: vitalSourceConfig,
   } = useContext(Config);
 
   // Indicates what the application was doing when the error indicated by
@@ -87,7 +89,7 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
 
   // Show the assignment when the contentUrl has resolved and errorState
   // is falsely
-  const showIframe = contentUrl && !errorState;
+  const showIframe = (contentUrl || vitalSourceConfig) && !errorState;
 
   const showSpinner = fetchCount > 0 && !errorState;
 
@@ -281,7 +283,12 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
 
   // Construct the <iframe> content
   let iFrameWrapper;
-  const iFrame = (
+  const iFrame = vitalSourceConfig ? (
+    <VitalSourceBookViewer
+      launchUrl={vitalSourceConfig.launchUrl}
+      launchParams={vitalSourceConfig.launchParams}
+    />
+  ) : (
     <iframe
       className="BasicLtiLaunchApp__iframe"
       src={contentUrl || ''}

--- a/lms/static/scripts/frontend_apps/components/BookList.js
+++ b/lms/static/scripts/frontend_apps/components/BookList.js
@@ -1,0 +1,57 @@
+import { createElement } from 'preact';
+
+import Table from './Table';
+
+/**
+ * @typedef {import('../api-types').Book} Book
+ */
+
+/**
+ * @typedef BookListProps
+ * @prop {Book[]} books
+ * @prop {boolean} isLoading
+ * @prop {Book|null} selectedBook
+ * @prop {(b: Book) => any} onSelectBook
+ * @prop {(b: Book) => any} onUseBook
+ */
+
+/**
+ * @param {BookListProps} props
+ */
+export default function BookList({
+  books,
+  isLoading = false,
+  selectedBook,
+  onSelectBook,
+  onUseBook,
+}) {
+  const columns = [
+    {
+      label: 'Title',
+    },
+  ];
+
+  return (
+    <div className="BookList">
+      <Table
+        accessibleLabel="Book list"
+        columns={columns}
+        contentLoading={isLoading}
+        items={books}
+        onSelectItem={onSelectBook}
+        onUseItem={onUseBook}
+        renderItem={book => <td>{book.title}</td>}
+        selectedItem={selectedBook}
+      />
+      {selectedBook && (
+        <div className="BookList__cover-container">
+          <img
+            className="BookList__cover"
+            alt="Book cover"
+            src={selectedBook.cover_image}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/ChapterList.js
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.js
@@ -1,0 +1,56 @@
+import { Fragment, createElement } from 'preact';
+
+import Table from './Table';
+
+/**
+ * @typedef {import('../api-types').Chapter} Chapter
+ */
+
+/**
+ * @typedef ChapterListProps
+ * @prop {Chapter[]} chapters - List of available chapters
+ * @prop {boolean} [isLoading] - Whether to show a loading indicator
+ * @prop {Chapter|null} selectedChapter - The chapter within `chapters` which is currently selected
+ * @prop {(c: Chapter) => any} [onSelectChapter] -
+ *   Callback invoked when the user clicks on a chapter
+ * @prop {(c: Chapter) => any} [onUseChapter] -
+ *   Callback invoked when the user double-clicks a chapter
+ */
+
+/**
+ * @param {ChapterListProps} props
+ */
+export default function ChapterList({
+  chapters,
+  isLoading = false,
+  selectedChapter,
+  onSelectChapter,
+  onUseChapter,
+}) {
+  const columns = [
+    {
+      label: 'Title',
+    },
+    {
+      label: 'Page',
+    },
+  ];
+
+  return (
+    <Table
+      accessibleLabel="Table of Contents"
+      columns={columns}
+      contentLoading={isLoading}
+      items={chapters}
+      onSelectItem={onSelectChapter}
+      onUseItem={onUseChapter}
+      selectedItem={selectedChapter}
+      renderItem={chapter => (
+        <Fragment>
+          <td aria-label={chapter.title}>{chapter.title}</td>
+          <td>{chapter.page}</td>
+        </Fragment>
+      )}
+    />
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -1,4 +1,4 @@
-import { createElement, Fragment } from 'preact';
+import { Fragment, createElement } from 'preact';
 import { useEffect, useLayoutEffect, useRef } from 'preact/hooks';
 import classNames from 'classnames';
 
@@ -24,6 +24,12 @@ import { useUniqueId } from '../utils/hooks';
  *   A callback to invoke when the user cancels the dialog. If provided, a
  *   "Cancel" button will be displayed.
  * @prop {string} [cancelLabel] - Label for the cancel button
+ * @prop {(() => any)|null} [onBack] -
+ *   Callback to go to the previous step in a multi-step dialog. If provided a
+ *   "Back" button will be displayed.
+ * @prop {string} [minWidth] - CSS length that sets the minimum width of the dialog
+ * @prop {string} [minHeight] - CSS length that sets the minimum height of the dialog
+ * @prop {boolean} [stretchContent]
  */
 
 /**
@@ -54,11 +60,15 @@ export default function Dialog({
   children,
   contentClass,
   initialFocus,
+  onBack,
   onCancel,
   cancelLabel = 'Cancel',
   role = 'dialog',
   title,
   buttons,
+  minWidth,
+  minHeight,
+  stretchContent = false,
 }) {
   const dialogTitleId = useUniqueId('dialog-title');
   const dialogDescriptionId = useUniqueId('dialog-description');
@@ -99,6 +109,14 @@ export default function Dialog({
     }
   }, [dialogDescriptionId]);
 
+  const contentStyle = /** @type {Object.<string,string>} */ ({});
+  if (minWidth) {
+    contentStyle.minWidth = minWidth;
+  }
+  if (minHeight) {
+    contentStyle.minHeight = minHeight;
+  }
+
   return (
     <Fragment>
       <div
@@ -113,6 +131,7 @@ export default function Dialog({
           aria-labelledby={dialogTitleId}
           aria-modal={true}
           className={classNames('Dialog__content', contentClass)}
+          style={contentStyle}
         >
           <h1 className="Dialog__title" id={dialogTitleId}>
             {title}
@@ -128,8 +147,14 @@ export default function Dialog({
             )}
           </h1>
           {children}
-          <div className="u-stretch" />
+          {!stretchContent && <div className="u-stretch" />}
           <div className="Dialog__actions">
+            {onBack && (
+              <Fragment>
+                <Button onClick={onBack} label="← Back" />
+                <div className="u-stretch" />
+              </Fragment>
+            )}
             {onCancel && (
               <Button
                 className="Button--cancel"

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -2,6 +2,8 @@ import classnames from 'classnames';
 import { createElement } from 'preact';
 import { useRef } from 'preact/hooks';
 
+import Spinner from './Spinner';
+
 /**
  * Return the next item to select when advancing the selection by `step` items
  * forwards (if positive) or backwards (if negative).
@@ -31,7 +33,7 @@ function nextItem(items, currentItem, step) {
 /**
  * @typedef TableColumn
  * @prop {string} label - Header label for the column
- * @prop {string} className - Additional classes for the column's `<th>` element
+ * @prop {string} [className] - Additional classes for the column's `<th>` element
  */
 
 /**
@@ -39,6 +41,7 @@ function nextItem(items, currentItem, step) {
  * @typedef TableProps
  * @prop {string} accessibleLabel - An accessible label for the table
  * @prop {TableColumn[]} columns - The columns to display in this table
+ * @prop {boolean} [contentLoading] - Whether to show a loading spinner in place of the content
  * @prop {Item[]} items -
  *   The items to display in this table, one per row. `renderItem` defines how
  *   information from each item is represented as a series of table cells.
@@ -62,6 +65,7 @@ function nextItem(items, currentItem, step) {
 export default function Table({
   accessibleLabel,
   columns,
+  contentLoading = false,
   items,
   onSelectItem,
   onUseItem,
@@ -104,7 +108,7 @@ export default function Table({
   return (
     <div
       className={classnames({
-        Table__wrapper: true,
+        Table__viewport: true,
         'has-files': items.length > 0,
       })}
     >
@@ -148,6 +152,11 @@ export default function Table({
           ))}
         </tbody>
       </table>
+      {contentLoading && (
+        <div className="Table__spinner">
+          <Spinner />
+        </div>
+      )}
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/VitalSourceBookViewer.js
+++ b/lms/static/scripts/frontend_apps/components/VitalSourceBookViewer.js
@@ -1,0 +1,43 @@
+import { createElement } from 'preact';
+import { useEffect, useRef } from 'preact/hooks';
+
+/**
+ * @typedef VitalSourceBookViewerProps
+ * @prop {string} launchUrl
+ * @prop {Object.<string,string>} launchParams
+ */
+
+/**
+ * @param {VitalSourceBookViewerProps} props
+ */
+export default function VitalSourceBookViewer({ launchParams, launchUrl }) {
+  const iframe = useRef(/** @type {HTMLIFrameElement|null} */ (null));
+
+  useEffect(() => {
+    const iframeDoc = /** @type {Document} */ (iframe.current.contentDocument);
+    const launchForm = iframeDoc.createElement('form');
+
+    launchForm.method = 'POST';
+    launchForm.action = launchUrl;
+
+    Object.entries(launchParams).forEach(([key, value]) => {
+      const field = iframeDoc.createElement('input');
+      field.type = 'hidden';
+      field.name = key;
+      field.value = value;
+      launchForm.appendChild(field);
+    });
+    iframeDoc.body.appendChild(launchForm);
+    launchForm.submit();
+  }, [launchParams, launchUrl]);
+
+  return (
+    <iframe
+      ref={iframe}
+      width="100%"
+      height="100%"
+      title="Course content with Hypothesis annotation viewer"
+      src="about:blank"
+    />
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/VitalSourcePicker.js
+++ b/lms/static/scripts/frontend_apps/components/VitalSourcePicker.js
@@ -1,0 +1,123 @@
+import { createElement } from 'preact';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+
+import { apiCall } from '../utils/api';
+
+import BookList from './BookList';
+import Button from './Button';
+import ChapterList from './ChapterList';
+import Dialog from './Dialog';
+import ErrorDisplay from './ErrorDisplay';
+
+/**
+ * @typedef {import('../api-types').Chapter} Chapter
+ * @typedef {import('../api-types').Book} Book
+ *
+ * @typedef VitalSourcePickerProps
+ * @prop {string} authToken
+ * @prop {() => any} onCancel
+ * @prop {(b: Book, c: Chapter) => any} onSelectBook
+ */
+
+/**
+ * A dialog that allows the user to select a book from VitalSource
+ *
+ * @param {VitalSourcePickerProps} props
+ */
+export default function VitalSourcePicker({
+  authToken,
+  onCancel,
+  onSelectBook,
+}) {
+  const [bookList, setBookList] = useState(/** @type {Book[]|null} */ (null));
+  const [tableOfContents, setTableOfContents] = useState(
+    /** @type {Chapter[]|null} */ (null)
+  );
+  const [book, setBook] = useState(/** @type {Book|null} */ (null));
+  const [chapter, setChapter] = useState(/** @type {Chapter|null} */ (null));
+  const [step, setStep] = useState(
+    /** @type {'select-book'|'select-chapter'} */ ('select-book')
+  );
+  const [error, setError] = useState(/** @type {Error|null} */ (null));
+
+  const confirmBook = useCallback(book => {
+    setBook(book);
+    setTableOfContents(null);
+    setStep('select-chapter');
+  }, []);
+
+  const confirmChapter = useCallback(
+    chapter => {
+      onSelectBook(/** @type {Book} */ (book), chapter);
+    },
+    [book, onSelectBook]
+  );
+
+  useEffect(() => {
+    if (step === 'select-book' && !bookList) {
+      apiCall({ authToken, path: '/api/vitalsource/books' })
+        .then(setBookList)
+        .catch(setError);
+    } else if (step === 'select-chapter' && !tableOfContents) {
+      const currentBook = /** @type {Book} */ (book);
+      apiCall({
+        authToken,
+        path: `/api/vitalsource/books/${currentBook.id}/toc`,
+      })
+        .then(setTableOfContents)
+        .catch(setError);
+    }
+  }, [authToken, book, bookList, step, tableOfContents]);
+
+  const canSubmit =
+    (step === 'select-book' && book) || (step === 'select-chapter' && chapter);
+
+  const goBack = () => {
+    setStep('select-book');
+    setChapter(null);
+  };
+
+  return (
+    <Dialog
+      onBack={step !== 'select-book' ? goBack : null}
+      onCancel={onCancel}
+      title="Select book from VitalSource"
+      buttons={[
+        <Button
+          key="submit"
+          label={step === 'select-book' ? 'Select book' : 'Select chapter'}
+          disabled={!canSubmit}
+          onClick={() => {
+            if (step === 'select-book') {
+              confirmBook(book);
+            } else if (step === 'select-chapter') {
+              confirmChapter(chapter);
+            }
+          }}
+        />,
+      ]}
+      minWidth="75vw"
+      minHeight="70vh"
+    >
+      {step === 'select-book' && !error && (
+        <BookList
+          books={bookList || []}
+          isLoading={!bookList}
+          selectedBook={book}
+          onSelectBook={setBook}
+          onUseBook={confirmBook}
+        />
+      )}
+      {step === 'select-chapter' && !error && (
+        <ChapterList
+          chapters={tableOfContents || []}
+          isLoading={!tableOfContents}
+          selectedChapter={chapter}
+          onSelectChapter={setChapter}
+          onUseChapter={confirmChapter}
+        />
+      )}
+      {error && <ErrorDisplay message="Unable to fetch books" error={error} />}
+    </Dialog>
+  );
+}

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -42,6 +42,14 @@ import { createContext } from 'preact';
  */
 
 /**
+ * Data needed to display the VitalSource book viewer.
+ *
+ * @typedef VitalsourceConfig
+ * @prop {string} launchUrl
+ * @prop {Object.<string,string>} launchParams
+ */
+
+/**
  * Configuration for the content/file picker app shown while configuring an
  * assignment.
  *
@@ -93,6 +101,7 @@ import { createContext } from 'preact';
  *   @prop {string[]} rpcServer.allowedOrigins
  * @prop {string} viaUrl
  * @prop {CanvasAuthErrorConfig} canvasOAuth2RedirectError
+ * @prop {VitalsourceConfig} [vitalSource]
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -1,13 +1,12 @@
 /**
  * @typedef {import('../api-types').File} File
+ * @typedef {import('../api-types').Book} Book
+ * @typedef {import('../api-types').Chapter} Chapter
  */
 
 import { stringify } from 'querystring';
 
 /**
- * Return a JSON-LD `ContentItem` representation of the LTI activity launch
- * URL for a given document URL.
- *
  * @param {string} ltiLaunchUrl
  * @param {Object.<string,string>} params - Query parameters for the generated URL
  */
@@ -46,5 +45,19 @@ export function contentItemForLmsFile(ltiLaunchUrl, file) {
   return contentItemWithParams(ltiLaunchUrl, {
     canvas_file: 'true',
     file_id: file.id,
+  });
+}
+
+/**
+ * @param {string} ltiLaunchUrl
+ * @param {Object} item
+ *   @param {Book} item.book
+ *   @param {Chapter} item.chapter
+ */
+export function contentItemForVitalSourceBook(ltiLaunchUrl, { book, chapter }) {
+  return contentItemWithParams(ltiLaunchUrl, {
+    vitalsource_book: 'true',
+    book_id: book.id,
+    cfi: chapter.cfi,
   });
 }

--- a/lms/static/styles/components/_BookList.scss
+++ b/lms/static/styles/components/_BookList.scss
@@ -1,0 +1,22 @@
+.BookList {
+  display: flex;
+  flex-direction: row;
+}
+
+.BookList__cover {
+  width: 160px;
+  height: auto;
+}
+
+.BookList__cover-container {
+  margin-left: 5px;
+
+  // Align top of cover image with top edge of table.
+  margin-top: 10px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  background-color: #eee;
+}

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,6 +1,14 @@
 @use "../mixins/focus";
 @use "../variables" as var;
 
+// Mixin used to make more of the viewport's vertical space available to the
+// dialog content in small viewports.
+@mixin small-screen {
+  @media (max-height: 450px) {
+    @content;
+  }
+}
+
 .Dialog__container {
   display: flex;
   position: fixed;
@@ -30,12 +38,21 @@
   border-radius: 3px;
   margin: auto;
   padding: 20px;
+
+  @include small-screen {
+    max-height: 98vh;
+    padding: 10px;
+  }
 }
 
 .Dialog__title {
   display: flex;
   align-items: center;
   font-size: var.$title-font-size;
+
+  @include small-screen {
+    margin: 0.4em 0;
+  }
 }
 
 .Dialog__cancel-btn {

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -5,11 +5,13 @@ $table-item-height: 40px;
 
 // Wrapper around the table. This is used because table elements do not support
 // setting the `height` or `overflow` properties directly.
-.Table__wrapper {
+.Table__viewport {
   overflow: auto;
   border: 1px solid var.$grey-6;
-
   margin-top: 10px;
+  contain: size;
+  flex-grow: 1;
+  min-height: 200px;
 
   &.has-files {
     // This very specific value is so that when the table contains <=3 items
@@ -86,4 +88,12 @@ $table-item-height: 40px;
   // Table rows provide their own selection indicator and rows are focused
   // when selected.
   outline: none;
+}
+
+.Table__spinner {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -14,6 +14,7 @@
 
 // Preact components
 @use 'components/BasicLtiLaunchApp';
+@use 'components/BookList';
 @use 'components/Dialog';
 @use 'components/ErrorDisplay';
 @use 'components/FileList';

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -1,0 +1,75 @@
+import requests
+from pyramid.view import view_config, view_defaults
+
+
+@view_defaults(permission="vitalsource_api", renderer="json")
+class VitalSourceAPIViews:
+    def __init__(self, request):
+        self.request = request
+        self._api_key = request.registry.settings["vitalsource_api_key"]
+
+        if not self._api_key:
+            raise Exception("VitalSource API key is not set")
+
+    @view_config(request_method="GET", route_name="vitalsource_api.books.list")
+    def list_books(self):
+        """
+        List the books available to the current user.
+        """
+        # data = self._call_vitalsource_api("products")
+        # items = data["items"]
+
+        # FIXME - Fetch just the one book from the VS catalog that is set up
+        # for Hypothesis. A configuration issue on their end is causing "products"
+        # to return other books as well.
+        data = self._call_vitalsource_api("products/HYPOTHESIS-TESTING")
+        items = [data]
+
+        items.sort(key=lambda item: item["title"].lower())
+
+        # The "products" API can return individual books which have a VBID
+        # and collections (called "packages") which do not. Ignore packages
+        # for now.
+        items = [item for item in items if item["vbid"]]
+
+        def _format_item(item):
+            return {
+                "id": item["vbid"],
+                "title": item["title"],
+                "cover_image": item["resource_links"].get("cover_image"),
+            }
+
+        return [_format_item(item) for item in items]
+
+    @view_config(request_method="GET", route_name="vitalsource_api.books.toc")
+    def book_toc(self):
+        """
+        Get the chapters for the current book.
+        """
+        book_id = self.request.matchdict["book_id"]
+        data = self._call_vitalsource_api(f"products/{book_id}/toc")
+
+        def _format_item(item):
+            return {
+                "title": item["title"],
+                "cfi": item.get("cfi"),
+                "page": item.get("page"),
+            }
+
+        return [_format_item(item) for item in data["table_of_contents"]]
+
+    def _call_vitalsource_api(self, path, params={}):
+        response = requests.get(
+            f"https://api.vitalsource.com/v4/{path}",
+            headers={
+                "Accept": "application/json",
+                "X-VitalSource-API-Key": self._api_key,
+            },
+            params=params,
+        )
+
+        # TODO - Translate into standard API error.
+        response.raise_for_status()
+
+        # TODO - Validate response structure against expected schema.
+        return response.json()

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -16,14 +16,8 @@ class VitalSourceAPIViews:
         """
         List the books available to the current user.
         """
-        # data = self._call_vitalsource_api("products")
-        # items = data["items"]
-
-        # FIXME - Fetch just the one book from the VS catalog that is set up
-        # for Hypothesis. A configuration issue on their end is causing "products"
-        # to return other books as well.
-        data = self._call_vitalsource_api("products/HYPOTHESIS-TESTING")
-        items = [data]
+        data = self._call_vitalsource_api("products")
+        items = data["items"]
 
         items.sort(key=lambda item: item["title"].lower())
 

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -105,6 +105,19 @@ class BasicLTILaunchViews:
         )
         return self.basic_lti_launch(grading_supported=False)
 
+    @view_config(vitalsource_book=True)
+    def vitalsource_lti_launch(self):
+        """
+        Respond to a VitalSource book launch.
+        """
+        self.sync_lti_data_to_h()
+        self.store_lti_data()
+        self.context.js_config.maybe_enable_grading()
+        self.context.js_config.add_vitalsource_launch_url(
+            self.request.params["book_id"], self.request.params.get("cfi")
+        )
+        return {}
+
     @view_config(db_configured=True)
     def db_configured_basic_lti_launch(self):
         """

--- a/lms/views/predicates/__init__.py
+++ b/lms/views/predicates/__init__.py
@@ -13,8 +13,8 @@ from lms.views.predicates._lti_launch import (
     Configured,
     DBConfigured,
     URLConfigured,
+    VitalSourceBook,
 )
-
 
 def includeme(config):
     for view_predicate_factory in (
@@ -23,6 +23,7 @@ def includeme(config):
         BrightspaceCopied,
         CanvasFile,
         URLConfigured,
+        VitalSourceBook,
         Configured,
         AuthorizedToConfigureAssignments,
     ):

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -178,6 +178,13 @@ class CanvasFile(Base):
         return ("canvas_file" in request.params) == self.value
 
 
+class VitalSourceBook(Base):
+    name = "vitalsource_book"
+
+    def __call__(self, context, request):
+        return ("vitalsource_book" in request.params) == self.value
+
+
 class URLConfigured(Base):
     """
     Allow invoking an LTI launch view only for URL-configured assignments.
@@ -229,19 +236,19 @@ class Configured(Base):
     def __init__(self, value, config):
         super().__init__(value, config)
         self.canvas_file = CanvasFile(True, config)
-        self.url_configured = URLConfigured(True, config)
         self.db_configured = DBConfigured(True, config)
         self.blackboard_copied = BlackboardCopied(True, config)
         self.brightspace_copied = BrightspaceCopied(True, config)
+        self.vitalsource_book = VitalSourceBook(True, config)
 
     def __call__(self, context, request):
         configured = any(
             [
                 self.canvas_file(context, request),
-                self.url_configured(context, request),
                 self.db_configured(context, request),
                 self.blackboard_copied(context, request),
                 self.brightspace_copied(context, request),
+                self.vitalsource_book(context, request),
             ]
         )
         return configured == self.value

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,9 @@ passenv =
     dev: SENTRY_ENVIRONMENT
     dev: USERNAME
     dev: VIA_URL
+    dev: VITALSOURCE_API_KEY
+    dev: VITALSOURCE_LAUNCH_KEY
+    dev: VITALSOURCE_LAUNCH_SECRET
 deps =
     dev: -e .
     dev: -r requirements/dev.txt


### PR DESCRIPTION
This PR contains the current prototype of an integration with VitalSource. It adds a new type of assignment content (a VitalSource book) alongside the three existing types (URL, Google Drive, Canvas/LMS file storage):

<img width="850" alt="Screenshot 2020-06-04 19 03 47" src="https://user-images.githubusercontent.com/2458/83794849-7f57ff00-a696-11ea-9f02-f2157facae34.png">

When the user selects "_Select a book from VitalSource_" we need to display some UI to select the book and content within it. This currently uses an existing course browser UI that VS has:

<img width="898" alt="Screenshot 2020-06-04 19 04 16" src="https://user-images.githubusercontent.com/2458/83794926-a1ea1800-a696-11ea-8b84-e1c47ab00e18.png">

It is currently TBD whether we continue to use this UI or use a data API and build a custom UI for browsing the content (if that's possible). Depending on the LMS, we may be very space constrained in this view. In the current prototype there is obviously a lot of space taken up by the dialog border which can be eliminated, but still, we won't have a lot of space to work with.

We need to somehow capture the book that was selected and the location within it. Currently the _Select_ button just saves a hardcoded book ID.

When an assignment using VitalSource is launched, instead of rendering an iframe that loads a web page or PDF proxied through Via,  we instead render an iframe that displays the VitalSource book viewer:

<img width="1130" alt="Screenshot 2020-06-04 19 02 40" src="https://user-images.githubusercontent.com/2458/83795122-e83f7700-a696-11ea-901f-65e0b00fa933.png">

The Hypothesis viewer is currently embedded in the viewer with the default configuration, hence it isn't using account integration.

Authentication for both VitalSource's book viewer and content selection web apps are handled via an LTI launch:

1. Our LTI tool frontend renders an iframe with a local URL (`/vitalsource/book_launch` or `/vitalsource/book_selection_launch`)
2. This URL renders a tiny web page with an HTML form which has hidden parameters for an LTI launch, which is automatically submitted as soon as the page loads. This process is similar to how Canvas launches us
3. When the form is submitted, VS's web app verifies the LTI launch parameters and then shows their viewer with Hypothesis embedded.

----

**TODO items**

1. Update the Hypothesis configuration in the viewer so that it fetches configuration from the parent iframe.
2. Decide on an approach for the book + chapter selection (API vs. existing VS UI for browsing books)
3. The VS viewer currently always loads the _production_ Hypothesis client, whereas for other assignment types it will load the local development, QA or prod clients as appropriate. We need to figure out how we'll handle this.
4. We need to make sure the client captures appropriate document location metadata so that we can re-anchor annotations reliably in future
5. We need to figure out how to enable the client to navigate the viewer to annotations that are on different pages than the one that is currently visible.
6. The prototype currently uses a single pair of OAuth credentials to launch the VitalSource viewer. We'll need to instead figure out how to use credentials which enable the user to access appropriate materials depending on the user/institution etc.
