### PR TITLE
GroupInfo info defaults should be applied on read, not create

### DIFF
--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -84,6 +84,12 @@ class GroupInfo(BASE):
     #: A dict of info about this group.
     info = sa.Column(MutableDict.as_mutable(JSONB))
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("info", {})
+        kwargs["info"].setdefault("instructors", [])
+        kwargs["info"].setdefault("type", None)
+        super().__init__(*args, **kwargs)
+
     @property
     def _safe_info(self):
         if self.info is None:

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -84,27 +84,28 @@ class GroupInfo(BASE):
     #: A dict of info about this group.
     info = sa.Column(MutableDict.as_mutable(JSONB))
 
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("info", {})
-        kwargs["info"].setdefault("instructors", [])
-        kwargs["info"].setdefault("type", None)
-        super().__init__(*args, **kwargs)
+    @property
+    def _safe_info(self):
+        if self.info is None:
+            self.info = {}
+
+        return self.info
 
     @property
     def instructors(self):
-        return self.info["instructors"]
+        return self._safe_info.get("instructors", [])
 
     @instructors.setter
     def instructors(self, new_instructors):
-        self.info["instructors"] = new_instructors
+        self._safe_info["instructors"] = new_instructors
 
     @property
     def type(self):
-        return self.info["type"]
+        return self._safe_info.get("type", None)
 
     @type.setter
     def type(self, new_type):
-        self.info["type"] = new_type
+        self._safe_info["type"] = new_type
 
     def upsert_instructor(self, new_instructor):
         updated_instructors = []

--- a/tests/unit/lms/models/group_info_test.py
+++ b/tests/unit/lms/models/group_info_test.py
@@ -45,9 +45,6 @@ class TestGroupInfo:
         ):
             db_session.flush()
 
-    def test_instructors_defaults_to_an_empty_list(self):
-        assert GroupInfo().instructors == []
-
     def test_upsert_instructor_when_no_existing_instructors(self, group_info):
         instructor = factories.HUser()._asdict()
 
@@ -86,15 +83,21 @@ class TestGroupInfo:
 
         assert group_info.instructors == existing_instructors
 
-    def test_type_defaults_to_None(self):
-        assert GroupInfo().type is None
-
     def test_set_and_get_type(self):
         group_info = GroupInfo()
 
         group_info.type = "test_type"
 
         assert group_info.type == "test_type"
+
+    @pytest.mark.parametrize("blank_info", (True, False))
+    def test_info_defaults_ok(self, blank_info):
+        group_info = GroupInfo()
+        if blank_info:
+            group_info.info = None
+
+        assert group_info.type is None
+        assert group_info.instructors == []
 
     @pytest.fixture
     def existing_instructors(self, group_info):

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -30,18 +30,10 @@ class TestGroupInfoUpsert:
         assert group_info.type == "course_group"
 
     def test_it_updates_an_existing_GroupInfo_if_one_already_exists(
-        self, db_session, group_info_svc, params
+        self, db_session, group_info_svc, params, pre_existing_group
     ):
-        db_session.add(
-            GroupInfo(
-                **dict(
-                    params,
-                    id=None,
-                    authority_provided_id=self.AUTHORITY,
-                    consumer_key=self.CONSUMER_KEY,
-                )
-            )
-        )
+
+        db_session.add(pre_existing_group)
 
         group_info_svc.upsert(
             factories.HGroup(
@@ -133,6 +125,24 @@ class TestGroupInfoUpsert:
             for column in GroupInfo.columns()
             if column != "info"
         }
+
+    @pytest.fixture(
+        params=(True, False), ids=["GroupInfo w/o info", "GroupInfo w/info"]
+    )
+    def pre_existing_group(self, request, params):
+        pre_existing_group = GroupInfo(
+            **dict(
+                params,
+                id=None,
+                authority_provided_id=self.AUTHORITY,
+                consumer_key=self.CONSUMER_KEY,
+            )
+        )
+
+        if request.param:
+            pre_existing_group.info = None
+
+        return pre_existing_group
 
     @pytest.fixture
     def application_instance(self, pyramid_request):


### PR DESCRIPTION
Not sure how we got here, but groups infos in the wild don't have the defaults set. In general I think we must always assume this value is blank.

The result of this is reading a GroupInfo with "info = None" will cause a crash. ~This isn't an issue with using JSON fields, it's an issue of not using them correctly. We must never assume a key is present, or have a much better strategy for trying to setup the defaults.~ Seems we should have set this, although I still feel this is a risky way to go.

~I'm not sure if the DB migration was supposed to catch this. Working out how we got here can probably wait.~ It was, so how this has happened is a mystery. A real possibility is something we aren't thinking of is resulting in this getting blanked.