### PR TITLE
Minor dialog css fixes

### DIFF
--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -6,7 +6,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
+  overflow-y: auto;
   padding-right: 5px;
   margin-bottom: 10px;
   max-width: 100%;

--- a/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
+++ b/lms/templates/api/canvas/oauth2_redirect_error.html.jinja2
@@ -2,67 +2,67 @@
 
 {% block content %}
   <div class="Dialog__background" style="z-index: 1;"></div>
-  <div class="Dialog__container" style="z-index: 2;">
-    <div class="Dialog__content LMSFilePicker__dialog">
-      {% if invalid_scope %}
-        <h1 class="Dialog__title">Developer Key Scopes Missing</h1>
-        <div class="ErrorDisplay">
-          <p>
-            A Canvas admin needs to edit Hypothesis's developer key and add these
-            scopes:
-          </p>
+    <div class="Dialog__container" style="z-index: 2;">
+      <div class="Dialog__content">
+        {% if invalid_scope %}
+          <h1 class="Dialog__title">Developer Key Scopes Missing</h1>
+          <div class="ErrorDisplay">
+            <p>
+              A Canvas admin needs to edit Hypothesis's developer key and add these
+              scopes:
+            </p>
 
-          <ol>
-            {% for scope in scopes %}
-              <li><code>{{ scope }}</code></li>
-            {% endfor %}
-          </ol>
+            <ol>
+              {% for scope in scopes %}
+                <li><code>{{ scope }}</code></li>
+              {% endfor %}
+            </ol>
 
-          <p>For more information see:
-          <a target="_blank"
-             rel="noopener noreferrer"
-             href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
-          >Canvas API Endpoints Used by the Hypothesis LMS App</a>.
-          </p>
-        {% else %}
-          <h1 class="Dialog__title">Authorization Failed</h1>
+            <p>For more information see:
+            <a target="_blank"
+              rel="noopener noreferrer"
+              href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
+            >Canvas API Endpoints Used by the Hypothesis LMS App</a>.
+            </p>
+          {% else %}
+            <h1 class="Dialog__title">Authorization Failed</h1>
 
-          <p>Something went wrong when authorizing Hypothesis.</p>
-        {% endif %}
+            <p>Something went wrong when authorizing Hypothesis.</p>
+          {% endif %}
 
-        <p>To get help from Hypothesis
-        <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support" target="_blank" rel="noopener noreferrer">send us an email</a>
-        or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener noreferrer">open a support ticket</a>.
-        You can also visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer"> help documents</a>.</p>
+          <p>To get help from Hypothesis
+          <a href="mailto:support@hypothes.is?subject=Hypothesis%20LMS%20Support" target="_blank" rel="noopener noreferrer">send us an email</a>
+          or <a href="https://web.hypothes.is/get-help/" target="_blank" rel="noopener noreferrer">open a support ticket</a>.
+          You can also visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer"> help documents</a>.</p>
 
-        {% if details %}
-          <details class="ErrorDisplay__details">
-            <summary class="ErrorDisplay__details-summary">Error Details</summary>
-            <p>The error message from Canvas was:</p>
-            <pre class="ErrorDisplay__details-content">{{ details }}</pre>
-          </details>
-        {% endif %}
-      </div>
+          {% if details %}
+            <details class="ErrorDisplay__details">
+              <summary class="ErrorDisplay__details-summary">Error Details</summary>
+              <p>The error message from Canvas was:</p>
+              <pre class="ErrorDisplay__details-content">{{ details }}</pre>
+            </details>
+          {% endif %}
 
-      <div class="u-stretch"></div>
-      <div class="Dialog__actions">
-        {% if authorize_url %}
-          <button class="Button Button--cancel" type="button"
-                  onclick="window.close()">
-            Cancel
-          </button>
-          <button class="Button"
-                  type="button"
-                  onclick="window.location.href = '{{ authorize_url }}'">
-            Try again
-          </button>
-        {% else %}
-          <button class="Button"
-                  type="button"
-                  onclick="window.close()">
-            Close
-          </button>
-        {% endif %}
+        <div class="u-stretch"></div>
+        <div class="Dialog__actions">
+          {% if authorize_url %}
+            <button class="Button Button--cancel" type="button"
+                    onclick="window.close()">
+              Cancel
+            </button>
+            <button class="Button"
+                    type="button"
+                    onclick="window.location.href = '{{ authorize_url }}'">
+              Try again
+            </button>
+          {% else %}
+            <button class="Button"
+                    type="button"
+                    onclick="window.close()">
+              Close
+            </button>
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Fix closing div tag on template. It was in the wrong location and broke the DOM when rendering a basic auth error
- Hide scroll bars when they are not needed on ErrorDisplay

------

github's differ is not the best, but the only changes on the template file are moving a div tag to the bottom of that template and removing an erroneous class.
![Screen Shot 2020-06-09 at 9 43 53 AM](https://user-images.githubusercontent.com/3939074/84176084-c3038d80-aa35-11ea-9307-8a10e543796b.png)

beyond compare is much better...

![Screen Shot 2020-06-09 at 9 43 47 AM](https://user-images.githubusercontent.com/3939074/84176079-c0a13380-aa35-11ea-83b6-1650f8e60129.png)
