### PR TITLE
Fix dialog horizontal positioning

### DIFF
--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -5,6 +5,7 @@
 .Dialog__container {
   display: flex;
   position: fixed;
+  left: 0;
   top: 0;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Fix an issue where several dialogs were positioned too far over to the
right. The `Dialog__container` class was supposed to fill the viewport
but and center its contents but the `left` CSS property got removed in a
previous refactor.

Fixes https://github.com/hypothesis/lms/issues/1829.