### PR TITLE
Scroll error details into view when `<details>` is opened

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -37,6 +37,14 @@ ${details}
     `,
   });
 
+  const onDetailsToggle = event => {
+    const details = event.target;
+    if (!details.open) {
+      return;
+    }
+    details.scrollIntoView({ behavior: 'smooth' });
+  };
+
   return (
     // nb. Wrapper `<div>` here exists to apply block layout to contents.
     <div className="ErrorDisplay">
@@ -67,7 +75,7 @@ ${details}
         .
       </p>
       {!!details && (
-        <details className="ErrorDisplay__details">
+        <details className="ErrorDisplay__details" onToggle={onDetailsToggle}>
           <summary className="ErrorDisplay__details-summary">
             Error Details
           </summary>

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -57,6 +57,22 @@ describe('ErrorDisplay', () => {
     assert.include(details.text(), 'Note from server');
   });
 
+  it('scrolls details into view when opened', () => {
+    const error = { message: '', details: 'Note from server' };
+
+    const wrapper = mount(
+      <ErrorDisplay message="Something went wrong" error={error} />
+    );
+
+    const details = wrapper.find('details');
+    const scrollIntoView = sinon.stub(details.getDOMNode(), 'scrollIntoView');
+
+    details.getDOMNode().open = true;
+    details.simulate('toggle');
+
+    assert.called(scrollIntoView);
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({


### PR DESCRIPTION
Resolve a possible confusion when expanding the "Error Details" section
of error dialogs in short viewports by scrolling the contents into view
after the `<details>` is toggled open.

On browsers that support it, the view will be scrolled smoothly, on others (eg. Safari) it will scroll instantly.

Fixes #1824

----

For example, given this error dialog:

<img width="839" alt="Screenshot 2020-06-10 14 55 48" src="https://user-images.githubusercontent.com/2458/84277212-1c011d80-ab2b-11ea-917a-d351d34e9648.png">

Clicking on the "Error details" text will expand the contents and scroll like so:

<img width="858" alt="Screenshot 2020-06-10 14 55 54" src="https://user-images.githubusercontent.com/2458/84277257-2b806680-ab2b-11ea-953b-af7f391e5868.png">
