### PR TITLE
UI improvements for dialog, spinner and error state of LMS app

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import Button from './Button';
 import useElementShouldClose from '../common/use-element-should-close';
 import { zIndexScale } from '../utils/style';
+import Spinner from './Spinner';
 import { useUniqueId } from '../utils/hooks';
 
 /**
@@ -33,6 +34,7 @@ export default function Dialog({
   role = 'dialog',
   title,
   buttons,
+  isLoading = false,
 }) {
   const dialogTitleId = useUniqueId('dialog');
   const rootEl = useRef();
@@ -87,6 +89,7 @@ export default function Dialog({
           {children}
           <div className="u-stretch" />
           <div className="Dialog__actions">
+            <Spinner visible={isLoading} className="Dialog__spinner" />
             {onCancel && (
               <Button
                 className="Button--cancel"
@@ -141,4 +144,8 @@ Dialog.propTypes = {
    * a "Cancel" button will be displayed.
    */
   onCancel: propTypes.func,
+  /**
+   * Renders a spinner when true next to the buttons (defaults to false)
+   */
+  isLoading: propTypes.bool,
 };

--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -55,7 +55,7 @@ export default function FileList({
           </Fragment>
         )}
       />
-      {isLoading && <Spinner className="FileList__spinner" />}
+      <Spinner visible={isLoading} className="FileList__spinner" />
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -195,7 +195,7 @@ export default function FilePickerApp({
       </form>
       {isLoadingIndicatorVisible && (
         <div className="FilePickerApp__loading-backdrop">
-          <Spinner className="FilePickerApp__loading-spinner" />
+          <Spinner visible={true} className="FilePickerApp__loading-spinner" />
         </div>
       )}
       {dialog}

--- a/lms/static/scripts/frontend_apps/components/Spinner.js
+++ b/lms/static/scripts/frontend_apps/components/Spinner.js
@@ -1,4 +1,5 @@
 import { createElement } from 'preact';
+import classnames from 'classnames';
 import propTypes from 'prop-types';
 
 import SvgIcon from './SvgIcon';
@@ -7,16 +8,30 @@ import { trustMarkup } from '../utils/trusted';
 /**
  * A spinning loading indicator.
  */
-export default function Spinner({ className }) {
+export default function Spinner({ className, visible = false }) {
   return (
-    <SvgIcon
-      className={className}
-      src={trustMarkup(require('../../../images/spinner.svg'))}
-      inline={true}
-    />
+    <span
+      className={classnames('Spinner', className, {
+        'Spinner--fade-in': visible,
+      })}
+    >
+      <SvgIcon
+        className={'Spinner__svg'}
+        src={trustMarkup(require('../../../images/spinner.svg'))}
+      />
+    </span>
   );
 }
 
 Spinner.propTypes = {
+  /**
+   * A CSS class to apply to wrapper element. this can be used for
+   * positioning, and optionally color and size.
+   */
   className: propTypes.string,
+  /**
+   * Shows the spinner when true and hides it otherwise.
+   * Applies a css fade animate when this variable is toggle.
+   */
+  visible: propTypes.bool,
 };

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -177,10 +177,8 @@ export default function SubmitGradeForm({ disabled = false, student }) {
           key={student.LISResultSourcedId}
         />
         <Spinner
-          className={classNames('SubmitGradeForm__fetch-spinner', {
-            'is-active': gradeLoading,
-            'is-fade-away': !gradeLoading && student.LISResultSourcedId,
-          })}
+          visible={gradeLoading}
+          className="SubmitGradeForm__fetch-spinner"
         />
       </span>
       <button
@@ -207,7 +205,7 @@ export default function SubmitGradeForm({ disabled = false, student }) {
       )}
       {gradeSaving && (
         <div className="SubmitGradeForm__loading-backdrop">
-          <Spinner className="SubmitGradeForm__submit-spinner" />
+          <Spinner visible={true} className="SubmitGradeForm__submit-spinner" />
         </div>
       )}
     </form>

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -101,6 +101,16 @@ describe('Dialog', () => {
     container.remove();
   });
 
+  it('does not render the spinner when `isLoading` is falsely', () => {
+    const wrapper = mount(<Dialog title="Test dialog" />);
+    assert.isFalse(wrapper.find('Spinner').prop('visible'));
+  });
+
+  it('renders the spinner when `isLoading` is true', () => {
+    const wrapper = mount(<Dialog title="Test dialog" isLoading={true} />);
+    assert.isTrue(wrapper.find('Spinner').prop('visible'));
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/components/test/FileList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FileList-test.js
@@ -57,7 +57,7 @@ describe('FileList', () => {
 
   it('does not show a loading indicator if `isLoading` is false', () => {
     const wrapper = renderFileList({ isLoading: false });
-    assert.isFalse(wrapper.exists('.FileList__spinner'));
+    assert.isFalse(wrapper.find('Spinner').prop('visible'));
   });
 
   it(

--- a/lms/static/scripts/frontend_apps/components/test/Spinner-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Spinner-test.js
@@ -5,7 +5,18 @@ import Spinner from '../Spinner';
 
 describe('Spinner', () => {
   it('renders a spinner', () => {
-    const wrapper = mount(<Spinner className="loading-thingie" />);
-    assert.isTrue(wrapper.exists('SvgIcon.loading-thingie'));
+    const wrapper = mount(
+      <Spinner className="loading-thingie" visible={true} />
+    );
+    assert.isTrue(wrapper.exists('SvgIcon.Spinner__svg')); // apply default styling to svg
+    assert.isTrue(wrapper.exists('.loading-thingie')); // custom supplied class
+    assert.isTrue(wrapper.exists('.Spinner--fade-in')); // visible is true
+  });
+
+  it('renders a spinner hidden', () => {
+    const wrapper = mount(
+      <Spinner className="loading-thingie" visible={false} />
+    );
+    assert.isFalse(wrapper.exists('.Spinner--fade-in'));
   });
 });

--- a/lms/static/styles/_mixins.scss
+++ b/lms/static/styles/_mixins.scss
@@ -33,11 +33,8 @@
   }
 }
 
-// Creates a spinner style with a provided $size and $color. The spinner
-// will be positioned in the center of its parent as long as that element is
-// `position: relative`
+// Creates a spinner style with a provided $size and $color.
 @mixin spinner($size, $color: var.$grey-5) {
-  position: absolute;
   width: $size;
   height: $size;
   left: calc(50% - #{$size / 2});

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,10 +1,8 @@
+@use "../mixins";
+  
 .BasicLtiLaunchApp__spinner {
-  $spinner-size: 50px;
-
+  @include mixins.spinner(100px);
   position: absolute;
-  width: $spinner-size;
-  height: $spinner-size;
-  left: calc(50% - #{$spinner-size / 2});
   top: 100px;
 }
 
@@ -13,3 +11,4 @@
     visibility: hidden;
   }
 }
+

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,3 +1,4 @@
+@use "../mixins";
 @use "../mixins/focus";
 @use "../variables" as var;
 
@@ -72,3 +73,7 @@
     }
   }
 }
+.Dialog__spinner {
+  @include mixins.spinner(28px);
+  margin: auto 0 auto auto;
+}  

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -1,3 +1,6 @@
+@use "../mixins";
+
+
 $file-list-icon-size: 24px;
 
 .FileList {
@@ -12,10 +15,9 @@ $file-list-icon-size: 24px;
 }
 
 .FileList__spinner {
+  @include mixins.spinner($file-list-icon-size);
   position: absolute;
   margin: 15px;
-  left: calc(50% - #{$file-list-icon-size / 2});
-  top: calc(50% - #{$file-list-icon-size / 2});
 }
 
 .FileList__name-header {

--- a/lms/static/styles/components/_FilePickerApp.scss
+++ b/lms/static/styles/components/_FilePickerApp.scss
@@ -1,3 +1,6 @@
+@use "../mixins";
+
+
 .FilePickerApp__form {
   max-width: 600px;
   margin-left: auto;
@@ -22,13 +25,7 @@
 }
 
 .FilePickerApp__loading-spinner {
-  $spinner-size: 100px;
-
-  position: absolute;
-  width: $spinner-size;
-  height: $spinner-size;
-  left: calc(50% - #{$spinner-size});
-  top: calc(50% - #{$spinner-size});
+  @include mixins.spinner(100px);
 }
 
 .FilePickerApp__document-source-buttons {

--- a/lms/static/styles/components/_Spinner.scss
+++ b/lms/static/styles/components/_Spinner.scss
@@ -1,0 +1,16 @@
+.Spinner {
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0s linear 1000ms, opacity 1000ms;
+}
+
+.Spinner--fade-in {
+  visibility: visible;
+  opacity: 1;
+  transition: visibility 0s linear 0s, opacity 50ms;
+}
+
+.Spinner__svg {
+  width: 100%;
+  height: 100%;
+}

--- a/lms/static/styles/components/_SubmitGradeForm.scss
+++ b/lms/static/styles/components/_SubmitGradeForm.scss
@@ -2,17 +2,6 @@
 @use "../mixins/focus";
 @use "../variables" as var;
 
-@keyframes SubmitGradeForm__fadeAway {
-  from {
-    opacity: 1;
-    visibility: inherit;
-  }
-  to {
-    opacity: 0;
-    visibility: hidden;
-  }
-}
-
 @keyframes SubmitGradeForm__gradeSaved {
   from {
     background-color: #58bf4b;
@@ -101,17 +90,10 @@
 
 .SubmitGradeForm__submit-spinner {
   @include mixins.spinner(100px);
+  position: absolute;
 }
 
 .SubmitGradeForm__fetch-spinner {
   @include mixins.spinner(28px);
-  animation-duration: 0.5s;
-  visibility: hidden;
-  animation-fill-mode: forwards;
-  &.is-fade-away {
-    animation-name: SubmitGradeForm__fadeAway;
-  }
-  &.is-active {
-    visibility: inherit;
-  }
+  position: absolute;
 }

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -30,6 +30,7 @@
 @use 'components/StudentSelector';
 @use 'components/SubmitGradeForm';
 @use 'components/ValidationMessage';
+@use 'components/Spinner';
 @use 'components/SvgIcon';
 
 


### PR DESCRIPTION
The motivation for the extent of these changes comes from fixing a flickering issue when the error state jumps no error to an error between waiting for authorization of the popup window and receiving a second error from the api.

The BasicLtiLaunchApp is reworked to not reset error state on outgoing requests and instead resets error state value only after subsequent requests come back and we know there are no new errors.

The groups and contentUrl fetchers were previously fully atomic and took care of resetting the error state. They now return an error code which we can use to prevent flicker because the caller (authorizeAndFetchUrl) can now clear the error state rather than these two de-coupled requests.

Additionally some improvements were made to the spinner. These are mostly superficial but improve the UI. There is now an additional <Spinner> in the error dialog in addition to the full page spinner in BasicLtiLaunchApp. This has the advantage of showing the pending
requests while a previous error (if triggered) is still being displayed without rendering a huge spinner over the dialog.

One minor blind spot is if the initial requests fail and invoke an error. We don't keep track of which requests the loading states were triggered by. So for example, if the groups
errors first, then later the contentUrl resolves or errors, there will be a very short time the small spinner is rendered on the error dialog. This is unintended and cant not be solved unless we have a way of structuring the loading state with the errors that triggered them. This could be done either by a transaction or some queue or list. This would only add complexity and could be fixed later.

Additional fixes:

  - Spinner no longer operates by being removed from DOM. Now has `visible` prop. This gives it the advantage of having css animations. In some cases where we render a full background the spinner, it still gets removed from the DOM --that can be improved later to facilitate animations.
  - Allow styling to be set on the spinner's wrapper to adjust position from the caller component's css.
  - Refactor all instances of the spinner's css to use mixins.spinner()
  - Minor refactors on several tests that needed changes

----------

Test with these two

   https://hypothesis.instructure.com/courses/125/assignments/875
   https://hypothesis.instructure.com/courses/121/assignments/851

fixes https://github.com/hypothesis/lms/issues/1826

You can see when slowing down the network request, we don't see the double loader when I refresh the whole page. But when it's faster (no throttling), it can be seen. Thats just that "blind spot" I was talking about. 

![canvas_851](https://user-images.githubusercontent.com/3939074/84546810-fc96fb80-acb6-11ea-91fa-88341ed9245b.gif)
