### PR TITLE
Automate `make services`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 .PHONY: help
 help:
 	@echo "make help              Show this help message"
-	@echo 'make services          Run the services that `make dev` requires'
-	@echo "                       (Postgres) in Docker"
 	@echo "make dev               Run the entire app (web server and other processes)"
 	@echo "make web               Run the web server on its own (useful for debugging the "
 	@echo "                       Python code with pdb)"

--- a/README.markdown
+++ b/README.markdown
@@ -56,12 +56,6 @@ installation process:
 
     cd lms
 
-### Run the services with Docker Compose
-
-Start the services that the LMS app requires using Docker Compose:
-
-    make services
-
 ### Create the development data and settings
 
 Create the database contents and environment variable settings needed to get lms

--- a/bin/check-services
+++ b/bin/check-services
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""
+Exit with 0 if all the given services are healthy, 1 otherwise.
+
+Usage:
+
+    bin/check-services lms_postgres_1 ...
+
+"""
+from sys import argv, exit
+from subprocess import check_output, DEVNULL
+
+
+def check_service(service):
+    try:
+        status = (
+            check_output(
+                [
+                    "docker",
+                    "inspect",
+                    "-f",
+                    "{{.State.Health.Status}}",
+                    service,
+                ],
+                stderr=DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+    except:
+        pass
+    else:
+        if status == "healthy":
+            return True
+
+    return False
+
+
+if __name__ == "__main__":
+    for service in argv[1:]:
+        if not check_service(service):
+            exit(1)

--- a/bin/start-and-wait-for-services
+++ b/bin/start-and-wait-for-services
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+"""
+Start the given services and wait for them to become healthy.
+
+Usage:
+
+    bin/start-and-wait-for-services lms_postgres_1 ...
+
+"""
+from os import environ
+from sys import argv, exit
+from subprocess import run
+
+if "JENKINS_URL" in environ:
+    exit()
+
+for command in ("start-services", "wait-for-services"):
+    run([f"bin/{command}"] + argv[1:])

--- a/bin/start-services
+++ b/bin/start-services
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""
+Start the given services if they aren't already running.
+
+Usage:
+
+    bin/start-services lms_postgres_1 ...
+
+"""
+from sys import argv
+from subprocess import run
+
+
+if run(["bin/check-services"] + argv[1:]).returncode:
+    run(["make", "services"])

--- a/bin/wait-for-services
+++ b/bin/wait-for-services
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""
+Wait for the given services to start and become healthy.
+
+Exit with status 0 once all the services are healthy.
+
+Exit with status 1 if any of the services are unhealthy or if they aren't all
+healthy after about 10 seconds.
+
+Usage:
+
+    bin/wait-for-services lms_postgres_1 ...
+"""
+from sys import argv, exit
+from subprocess import run
+from time import sleep
+
+for _ in range(100):
+    if run(["bin/check-services"] + argv[1:]).returncode == 0:
+        exit()
+    sleep(0.1)
+
+exit(1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       - '127.0.0.1:5433:5432'
     healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
-        interval: 0.1s
+        interval: 1s
         timeout: 1s
-        retries: 10
+        retries: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,3 @@ services:
     healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
         interval: 1s
-        timeout: 1s
-        retries: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,8 @@ services:
     image: postgres:11.5-alpine
     ports:
       - '127.0.0.1:5433:5432'
+    healthcheck:
+        test: ["CMD", "pg_isready", "-U", "postgres"]
+        interval: 0.1s
+        timeout: 1s
+        retries: 10

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ tox_pyenv_fallback = false
 skip_install = true
 passenv =
     HOME
+    JENKINS_URL
     {tests,functests,bddtests}: TEST_DATABASE_URL
     {tests,functests}: PYTEST_ADDOPTS
     dev: SESSION_COOKIE_SECRET
@@ -68,11 +69,13 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 whitelist_externals =
     tests,functests,bddtests: sh
-commands =
-    dev: {posargs:gunicorn --paste conf/development.ini}
+commands_pre:
+    {dev,tests,functests,bddtests}: {toxinidir}/bin/start-and-wait-for-services lms_postgres_1
     tests: sh bin/create-db lms_test
     functests: sh bin/create-db lms_functests
     bddtests: sh bin/create-db lms_bddtests
+commands =
+    dev: {posargs:gunicorn --paste conf/development.ini}
     tests: coverage run -m pytest -v -Werror {posargs:tests/unit/}
     tests: -coverage combine
     tests: coverage report


### PR DESCRIPTION
Make `make` and `tox` commands that require the services (Postgres) to be running automatically start the services if they aren't already running, wait for the services, and then continue.

This eliminates the need to manually type `make services`.