### PR TITLE
Add Docker Compose healthcheck config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,6 @@ services:
     image: postgres:11.5-alpine
     ports:
       - '127.0.0.1:5433:5432'
+    healthcheck:
+        test: ["CMD", "pg_isready", "-U", "postgres"]
+        interval: 1s


### PR DESCRIPTION
This enables health-checking of the Postgres service to see whether Postgres is up or not by using the `docker inspect` command. For example:

    docker inspect -f {{.State.Health.Status}} lms_postgres_1

Here's a Python script for checking whether a given service is running
and healthy:

    #!/usr/bin/env python
    """
    Exit with 0 if all the given services are healthy, 1 otherwise.

    Usage:

        bin/check-services lms_postgres_1 ...

    """
    from sys import argv, exit
    from subprocess import check_output, DEVNULL

    def check_service(service):
        try:
            status = (
                check_output(
                    [
                        "docker",
                        "inspect",
                        "-f",
                        "{{.State.Health.Status}}",
                        service,
                    ],
                    stderr=DEVNULL,
                )
                .decode()
                .strip()
            )
        except:
            pass
        else:
            if status == "healthy":
                return True

        return False

    if __name__ == "__main__":
        for service in argv[1:]:
            if not check_service(service):
                exit(1)