### PR TITLE
Add a convenient `make db` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,15 @@ services: python
 db: args?=upgrade head
 db: python
 	@tox -qqe dev --run-command 'initdb conf/development.ini'
-	@tox -qe dev --run-command 'alembic -c conf/alembic.ini $(args)'
+	@tox -qe dev  --run-command 'alembic -c conf/alembic.ini $(args)'
 
 .PHONY: dev
 dev: build/manifest.json python
-	@tox -qe dev -- honcho start ${processes}
+	@tox -qe dev --run-command 'honcho start ${processes}'
 
 .PHONY: devdata
 devdata: python
-	@tox -qe dev -- devdata conf/development.ini
+	@tox -qe dev --run-command 'devdata conf/development.ini'
 
 .PHONY: web
 web: python
@@ -58,7 +58,7 @@ assets:
 
 .PHONY: shell
 shell: python
-	@tox -qe dev -- pshell conf/development.ini
+	@tox -qe dev --run-command 'pshell conf/development.ini'
 
 .PHONY: sql
 sql: python

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ services: python
 .PHONY: db
 db: args?=upgrade head
 db: python
-	@tox -qqe dev --run-command 'initdb conf/development.ini'
+	@tox -qqe dev --run-command 'initdb conf/development.ini'  # See setup.py for what initdb is.
 	@tox -qe dev  --run-command 'alembic -c conf/alembic.ini $(args)'
 
 .PHONY: dev
@@ -44,7 +44,7 @@ dev: build/manifest.json python
 
 .PHONY: devdata
 devdata: python
-	@tox -qe dev --run-command 'devdata conf/development.ini'
+	@tox -qe dev --run-command 'devdata conf/development.ini'  # See setup.py for what devdata is.
 
 .PHONY: web
 web: python

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ help:
 	@echo "make help              Show this help message"
 	@echo 'make services          Run the services that `make dev` requires'
 	@echo "                       (Postgres) in Docker"
+	@echo 'make db                Upgrade the DB schema to the latest version'
 	@echo "make dev               Run the entire app (web server and other processes)"
 	@echo "make web               Run the web server on its own (useful for debugging the "
 	@echo "                       Python code with pdb)"
@@ -30,6 +31,12 @@ help:
 services: args?=up -d
 services: python
 	@tox -qe docker-compose -- $(args)
+
+.PHONY: db
+db: args?=upgrade head
+db: python
+	@tox -qqe dev --run-command 'initdb conf/development.ini'
+	@tox -qe dev --run-command 'alembic -c conf/alembic.ini $(args)'
 
 .PHONY: dev
 dev: build/manifest.json python

--- a/lms/scripts/__init__.py
+++ b/lms/scripts/__init__.py
@@ -1,3 +1,2 @@
 from lms.scripts.devdata import devdata
-
-__all__ = ["devdata"]
+from lms.scripts.initdb import initdb

--- a/lms/scripts/initdb.py
+++ b/lms/scripts/initdb.py
@@ -1,0 +1,16 @@
+"""
+A CLI command to initialize the database if it isn't already initialized.
+
+Usage:
+
+    initdb conf/development.ini
+"""
+import sys
+
+from pyramid.paster import bootstrap
+
+
+def initdb():
+    # Initialise the pyramid environment, which is enough to trigger the
+    # initialisation code in `lms.db.__init__.py` to setup the DB for us.
+    bootstrap(sys.argv[1])

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
     entry_points="""\
     [console_scripts]
     devdata = lms.scripts:devdata
+    initdb = lms.scripts:initdb
     """,
 )


### PR DESCRIPTION
Depends on #1853 in order to work properly.

Fixes #1708

# 1. Add a script for initializing the DB

To test it:

1. Delete your DB:

       $ make services args='down'
       $ make services

2. Verify that your DB hasn't been initialized:

       $ docker exec -it lms_postgres_1 psql -U postgres -c "\d"
       Did not find any relations.

3. Run the script:

       $ tox -qqe dev --run-command 'initdb conf/development.ini'

4. Verify that now your DB has been initialized:

       $ docker exec -it lms_postgres_1 psql -U postgres -c "\d"
                               List of relations
        Schema |               Name                |   Type   |  Owner
       --------+-----------------------------------+----------+----------
        public | application_instances             | table    | postgres
        public | application_instances_id_seq      | sequence | postgres
        public | course                            | table    | postgres
        ...

# 2. Add a convenient `make db` command

This is just so that:

1. You don't have to remember
   `tox -qe dev --run-command 'alembic -c conf/alembic.ini upgrade head'`,
   it's now just `make db`

2. You also don't have to remember that the long tox command for
   upgrading your DB is different in h than in lms. I'll send a similar
   PR to h that also adds `make db` to h

To test this:

1. Delete your DB:

       $ make services args='down'
       $ make services

2. Run `make db`, this will both initialize your DB and upgrade it to the latest version:

       $ make db

3. Run `make db` again. Since your DB it already initialized and at the latest version this won't do anything, but it's safe to run:

       $ make db