### PR TITLE
Add size prop to Dialog and ErrorDialog

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -236,6 +236,11 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
     iFrameWrapper = iFrame;
   }
 
+  const dialogSize = {
+    width: 500,
+    height: 200,
+  };
+
   const content = (
     <span
       // Visually hide the iframe / grader if there is an error or no contentUrl.
@@ -253,6 +258,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
         <Dialog
           title="Authorize Hypothesis"
           role="alertdialog"
+          size={dialogSize}
           buttons={[
             <Button
               onClick={authorizeAndFetchUrl}
@@ -270,6 +276,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
           title="Something went wrong"
           contentClass="BasicLtiLaunchApp__dialog"
           role="alertdialog"
+          size={dialogSize}
           buttons={[
             <Button
               onClick={authorizeAndFetchUrl}
@@ -290,6 +297,7 @@ export default function BasicLtiLaunchApp({ rpcServer }) {
           title="Something went wrong"
           contentClass="BasicLtiLaunchApp__dialog"
           role="alertdialog"
+          size={dialogSize}
         >
           <ErrorDisplay
             message="There was a problem submitting this Hypothesis assignment"

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -33,6 +33,10 @@ export default function Dialog({
   role = 'dialog',
   title,
   buttons,
+  size = {
+    width: null,
+    height: null,
+  },
 }) {
   const dialogTitleId = useUniqueId('dialog');
   const rootEl = useRef();
@@ -57,6 +61,15 @@ export default function Dialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const containerStyle = {};
+
+  if (size.width) {
+    containerStyle.width = size.width;
+  }
+  if (size.height) {
+    containerStyle.height = size.height;
+  }
+
   return (
     <div
       role={role}
@@ -70,7 +83,10 @@ export default function Dialog({
         style={{ zIndex: zIndexScale.dialogBackground }}
       />
       <div className="Dialog__container" style={{ zIndex: zIndexScale.dialog }}>
-        <div className={classNames('Dialog__content', contentClass)}>
+        <div
+          style={containerStyle}
+          className={classNames('Dialog__content', contentClass)}
+        >
           <h1 className="Dialog__title" id={dialogTitleId}>
             {title}
             <span className="u-stretch" />
@@ -141,4 +157,14 @@ Dialog.propTypes = {
    * a "Cancel" button will be displayed.
    */
   onCancel: propTypes.func,
+
+  /**
+   * Force a width or a height or both on the dialog's content.
+   * This can be used to keep dialogs a consistent size relative
+   * to one another.
+   */
+  size: propTypes.shape({
+    height: propTypes.oneOfType([propTypes.string, propTypes.number]),
+    width: propTypes.oneOfType([propTypes.string, propTypes.number]),
+  }),
 };

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -8,12 +8,13 @@ import Dialog from './Dialog';
  * A dialog that informs the user about a problem that occurred and provides
  * them with links to get help or report the issue.
  */
-export default function ErrorDialog({ onCancel, title, error }) {
+export default function ErrorDialog({ onCancel, title, error, size = {} }) {
   return (
     <Dialog
       role="alertdialog"
       title="Something went wrong :("
       onCancel={onCancel}
+      size={size}
     >
       <ErrorDisplay message={title} error={error} />
     </Dialog>
@@ -25,5 +26,12 @@ ErrorDialog.propTypes = {
   title: propTypes.string.isRequired,
   error: propTypes.shape({
     message: propTypes.string.isRequired,
+  }),
+  /**
+   * Pass a width and/or height value to the child Dialog
+   */
+  size: propTypes.shape({
+    height: propTypes.oneOfType([propTypes.string, propTypes.number]),
+    width: propTypes.oneOfType([propTypes.string, propTypes.number]),
   }),
 };

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -204,6 +204,10 @@ export default function FilePickerApp({
           title={errorInfo.title}
           error={errorInfo.error}
           onCancel={() => setErrorInfo(null)}
+          size={{
+            width: 700,
+            heigh: 300,
+          }}
         />
       )}
     </main>

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -116,6 +116,10 @@ export default function LMSFilePicker({
   return (
     <Dialog
       contentClass="LMSFilePicker__dialog"
+      size={{
+        width: 700,
+        height: 300,
+      }}
       title={title}
       onCancel={cancel}
       buttons={[

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -27,6 +27,10 @@ export default function URLPicker({ onCancel, onSelectURL }) {
       onCancel={onCancel}
       buttons={[<Button key="submit" label="Submit" onClick={submit} />]}
       initialFocus={input}
+      size={{
+        width: 700,
+        height: 300,
+      }}
     >
       <p>Enter the URL of any publicly available web page or PDF.</p>
       <form ref={form} className="u-flex-row" onSubmit={submit}>

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -101,6 +101,32 @@ describe('Dialog', () => {
     container.remove();
   });
 
+  context('with `size` prop', () => {
+    it('sets a width on the dialog content', () => {
+      const wrapper = mount(<Dialog size={{ width: 100 }} />);
+      assert.equal(
+        wrapper.find('.Dialog__content').getDOMNode().style.width,
+        '100px'
+      );
+      assert.equal(
+        wrapper.find('.Dialog__content').getDOMNode().style.height,
+        ''
+      );
+    });
+
+    it('sets a height on the dialog content', () => {
+      const wrapper = mount(<Dialog size={{ height: 100 }} />);
+      assert.equal(
+        wrapper.find('.Dialog__content').getDOMNode().style.height,
+        '100px'
+      );
+      assert.equal(
+        wrapper.find('.Dialog__content').getDOMNode().style.width,
+        ''
+      );
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
@@ -22,4 +22,13 @@ describe('ErrorDialog', () => {
       error: err,
     });
   });
+
+  it('passes the `size` prop to the Dialog', () => {
+    const err = new Error('Something went wrong');
+    const sizes = { width: 100, height: 100 };
+    const wrapper = mount(
+      <ErrorDialog title="Oh no!" error={err} size={sizes} />
+    );
+    assert.equal(wrapper.find('Dialog').prop('size'), sizes);
+  });
 });

--- a/lms/static/styles/components/_SubmitGradeForm.scss
+++ b/lms/static/styles/components/_SubmitGradeForm.scss
@@ -26,7 +26,6 @@
 .SubmitGradeForm {
   display: flex;
   position: relative;
-  white-space: nowrap;
 
   &__check-icon {
     color: var.$grey-5;


### PR DESCRIPTION
- Fixes inconsistently sized dialogs by forcing a width and or height. If the width or height is larger than the window, it will still shrink accordingly.

- Sets the width/height of the file picker and adjacent dialogs to 700x300. This prevents awkward resizing when a quick error appears. 700px width is necessary because the file picker’s table’s width is 100% and filles up to the max-width of 700px. Currently, all dialogs obey that max-width value.

- Sets the width/height of BasicLtiLaunchApp error dialogs to 500x200. While these values are subjective, they are somewhat reasonable based of the content of the these error dialogs.

- Fix a white space issue on the SubmitGradeForm error dialog. While this dialog is not bound to any size (it is somewhat of an isolated case) there was an issue where the content was not word wrapping and was forcing the width larger than it needed to be. The `white-space` rule was likely an older rule for the grader itself that needed to be removed. The rule was unintentionally cascading to the dialog.


fixes https://github.com/hypothesis/lms/issues/1832