### PR TITLE
Add support for 500 errors

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -242,6 +242,16 @@ describe('BasicLtiLaunchApp', () => {
         );
       });
     });
+
+    it('shows an unrecoverable error dialog if the request returns a 500 error', async () => {
+      fakeApiCall.rejects(new ApiError(500, {}));
+      const wrapper = renderLtiLaunchApp();
+      await waitForElement(wrapper, 'FakeDialog');
+      assert.equal(
+        wrapper.find('ErrorDisplay').prop('message'),
+        'There was an unrecoverable problem with the server'
+      );
+    });
   });
 
   describe('speed grader config', () => {
@@ -270,7 +280,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('displays an error if reporting the submission fails', async () => {
-      const error = new ApiError(400, {});
+      const error = new ApiError(400, { error_message: 'Server error' });
       fakeApiCall.rejects(error);
 
       const wrapper = renderLtiLaunchApp();


### PR DESCRIPTION
- Add new category of error dialog for any 500 error from the server from any request. This provides a dialog informing the user to reload the page.

- Fix test that incorrectly did not contain an error_message but assumed a non-auth error would render. A submission error must contain an error_message otherwise it is assumed that it is a regular authorization error.


--------
fixes https://github.com/hypothesis/lms/issues/1741

I didn't try mundging the error dialogs together and instead whet for readability and just added a 4th dialog. I realize its very redundant but I think the consolidation step can happen later. I see an opportunity to create a component wrapper around the 4 error dialogs inside BasicLtiLaunchApp.js so that we can call just the 1 wrapper with different params, but I would want to keep that wrapper inside BasicLtiLaunchApp.js as its very specific to that file. 
