### PR TITLE
Update zope.interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ wired==0.2.2              # via pyramid-services
 xmltodict==0.12.0         # via -r requirements.in
 zipp==3.1.0               # via importlib-metadata
 zope.deprecation==4.3.0   # via pyramid, pyramid-jinja2
-zope.interface==4.4.3     # via pyramid, pyramid-retry, pyramid-services, transaction, wired, zope.sqlalchemy
+zope.interface==5.1.0     # via pyramid, pyramid-retry, pyramid-services, transaction, wired, zope.sqlalchemy
 zope.sqlalchemy==0.7.7    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This fixes an incompatibility with current versions of setuptools [1].
The same fix was previously made in h [2] by running:

```
make upgrade-package name='zope.interface'
```

[1] https://github.com/zopefoundation/zope.interface/issues/30.
[2] https://github.com/hypothesis/h/commit/beb140c1bf65d3132cb76b2720000b4e96f14b23