### PR TITLE
Change LMS to run Via 3 through NGINX to avoid CORS issues

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -23,7 +23,7 @@ feature_flags.section_groups = true
 oauth2_state_secret = "notasecret"
 
 # Set the default to Via 3 for dev (original via: 9080)
-via_url = http://localhost:9082
+via_url = http://localhost:9083
 legacy_via_url = http://localhost:9080
 
 h_authority = lms.hypothes.is


### PR DESCRIPTION
And also better represent what happens in production.

This is after changes were made in VIa 3 which made it both possible to run through NGINX and to drop special CORS support.