### PR TITLE
Fix error payload to use `message` rather than `error_message`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -207,7 +207,7 @@ describe('BasicLtiLaunchApp', () => {
     [
       {
         description: 'a specific server error',
-        error: new ApiError(400, { error_message: 'Server error' }),
+        error: new ApiError(400, { message: 'Server error' }),
       },
       {
         description: 'a network or other generic error',

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -123,7 +123,7 @@ describe('LMSFilePicker', () => {
     {
       description: 'a server error with details',
       error: new ApiError('Not authorized', {
-        error_message: 'Some error detail',
+        message: 'Some error detail',
       }),
     },
     {

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -8,7 +8,8 @@
  */
 export class ApiError extends Error {
   constructor(status, data) {
-    const message = data.error_message || data.message || 'API call failed';
+    // If message is omitted, pass a default error message.
+    const message = data.message || 'API call failed';
     super(message);
 
     /**
@@ -26,7 +27,7 @@ export class ApiError extends Error {
      *
      * @type {string|null}
      */
-    this.errorMessage = data.error_message || null;
+    this.errorMessage = data.message || null;
 
     /**
      * Server-provided details of the error.

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -69,12 +69,12 @@ describe('api', () => {
     [
       {
         status: 403,
-        body: { error_message: null, details: {} },
+        body: { message: null, details: {} },
         expectedMessage: 'API call failed',
       },
       {
         status: 400,
-        body: { error_message: 'Something went wrong', details: {} },
+        body: { message: 'Something went wrong', details: {} },
         expectedMessage: 'Something went wrong',
       },
       {
@@ -96,9 +96,13 @@ describe('api', () => {
         }
 
         assert.instanceOf(reason, ApiError);
-        assert.equal(reason.message, expectedMessage);
-        assert.equal(reason.errorMessage, body.error_message);
-        assert.equal(reason.details, body.details);
+        assert.equal(reason.message, expectedMessage, '`Error.message`');
+        assert.equal(
+          reason.errorMessage,
+          body.message,
+          '`ApiError.errorMessage`'
+        );
+        assert.equal(reason.details, body.details, '`ApiError.details`');
       });
     });
   });

--- a/lms/views/api/error.py
+++ b/lms/views/api/error.py
@@ -17,7 +17,7 @@ def validation_error(context, request):
     request.response.status_int = 422
     # For frontend requests to proxy API endpoints, handle schema
     # validation errors.
-    return {"error_message": context.explanation, "details": context.messages}
+    return {"message": context.explanation, "details": context.messages}
 
 
 @exception_view_config(context=CanvasAPIAccessTokenError, renderer="json")
@@ -28,7 +28,7 @@ def canvas_api_access_token_error(request):
     # error message to the user in this case. Just the 400 status so the
     # frontend knows that the request failed, and that it should show the user
     # an [Authorize] button so they can get a (new) access token and try again.
-    return {"error_message": None, "details": None}
+    return {"message": None, "details": None}
 
 
 @exception_view_config(context=CanvasAPIError, renderer="json")
@@ -37,7 +37,7 @@ def proxy_api_error(context, request):
     request.response.status_int = 400
     # Send the frontend an error message and details to show to the user for
     # debugging.
-    return {"error_message": context.explanation, "details": context.details}
+    return {"message": context.explanation, "details": context.details}
 
 
 @forbidden_view_config(path_info="/api/*", renderer="json")

--- a/tests/unit/lms/views/api/error_test.py
+++ b/tests/unit/lms/views/api/error_test.py
@@ -10,7 +10,7 @@ class TestSchemaValidationError:
         )
         assert pyramid_request.response.status_code == 422
         assert json_data == {
-            "error_message": "Unable to process the contained instructions",
+            "message": "Unable to process the contained instructions",
             "details": "foobar",
         }
 
@@ -20,7 +20,7 @@ class TestCanvasAPIAccessTokenError:
         json_data = error.canvas_api_access_token_error(pyramid_request)
 
         assert pyramid_request.response.status_code == 400
-        assert json_data == {"error_message": None, "details": None}
+        assert json_data == {"message": None, "details": None}
 
 
 class TestCanvasAPIError:
@@ -32,7 +32,7 @@ class TestCanvasAPIError:
 
         assert pyramid_request.response.status_code == 400
         assert json_data == {
-            "error_message": "test_explanation",
+            "message": "test_explanation",
             "details": {"foo": "bar"},
         }
 
@@ -46,7 +46,7 @@ class TestLTIOutcomesAPIError:
 
         assert pyramid_request.response.status_code == 400
         assert json_data == {
-            "error_message": "test_explanation",
+            "message": "test_explanation",
             "details": {"foo": "bar"},
         }
 


### PR DESCRIPTION
Some of the error responses use `error_message` rather than just `message`. This inconsistency created an issue where in some cases, error details were passed but ignored on the client because ApiError was only setting its `errorMessage` param to `error_message` rather than `message`.

fixes https://github.com/hypothesis/lms/issues/1741

This PR is related to closing https://github.com/hypothesis/lms/pull/1857