### PR TITLE
Add some convenience variables to `make shell`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ source =
     tests/unit
 omit =
     lms/scripts/*
+    lms/pshell.py
 
     # Don't bother covering these files as they just contain feature flags test
     # views, not really user-facing code.

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -32,6 +32,9 @@ h_api_url_private = http://localhost:5000/api/
 rpc_allowed_origins = http://localhost:5000
 sentry_environment = dev
 
+[pshell]
+setup = lms.pshell.setup
+
 ###
 # logging configuration
 # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html

--- a/lms/pshell.py
+++ b/lms/pshell.py
@@ -1,0 +1,26 @@
+from contextlib import suppress
+
+from transaction.interfaces import NoTransaction
+
+from lms import models
+
+
+def setup(env):
+    request = env["request"]
+
+    request.tm.begin()
+
+    env["tm"] = request.tm
+    env["tm"].__doc__ = "Active transaction manager (a transaction is already begun)."
+
+    env["db"] = env["session"] = request.db
+    env["db"].__doc__ = "Active DB session."
+
+    env["m"] = env["models"] = models
+    env["m"].__doc__ = "The lms.models package."
+
+    try:
+        yield
+    finally:
+        with suppress(NoTransaction):
+            request.tm.abort()


### PR DESCRIPTION
See: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/commandline.html#extending-the-shell

Add some custom convenience variables to `make shell`. This means that
when you run `make shell` you'll see this:

    $ make shell
    Python 3.6.9 (default, May 26 2020, 13:51:02)
    Type 'copyright', 'credits' or 'license' for more information
    IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

    Environment:
    app          The WSGI application.
    db           Active DB session.
    m            The lms.models package.
    models       The lms.models package.
    registry     Active Pyramid registry.
    request      Active request object.
    root         Root of the default resource tree.
    root_factory Default root factory used to create `root`.
    session      Active DB session.
    tm           Active transaction manager (a transaction is already begun).

    In [1]:

Differences:

* There's a new local variable `tm` that's just an alias for
  `request.tm`

* There are new local variables `db` and `session` that're just aliases
  for `request.db`

* `request.tm.begin()` has already been called.

  You have to call this before you can use the DB, so you almost always
  end up having to call it after running `make shell`. This is now done
  automatically for you.

* There are new local variables `m` and `models` that're just aliases
  for `lms.models`.

  This means that you don't have to do `from lms import models` anymore.

These new convenience variables are similar to ones that h's
`make shell` already has (it already has `m`, `models` and `session`).