### PR TITLE
Add test factories to `make shell`

### DIFF
--- a/lms/pshell.py
+++ b/lms/pshell.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import suppress
 
 from transaction.interfaces import NoTransaction
@@ -6,6 +7,12 @@ from lms import models
 
 
 def setup(env):
+    sys.path = ["."] + sys.path
+
+    from tests import factories  # pylint:disable=import-outside-toplevel
+
+    sys.path = sys.path[1:]
+
     request = env["request"]
 
     request.tm.begin()
@@ -18,6 +25,10 @@ def setup(env):
 
     env["m"] = env["models"] = models
     env["m"].__doc__ = "The lms.models package."
+
+    env["f"] = env["factories"] = factories
+    env["f"].__doc__ = "The test factories for quickly creating objects."
+    factories.set_sqlalchemy_session(request.db)
 
     try:
         yield

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,6 @@
 -r requirements.txt
 -e .
 
+factory-boy
 pyramid_ipython
 honcho

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,5 +1,47 @@
+import sys
+
+from factory.alchemy import SQLAlchemyModelFactory
+
 from tests.factories.course import Course
 from tests.factories.grading_info import GradingInfo
 from tests.factories.h_group import HGroup
 from tests.factories.h_user import HUser
 from tests.factories.lti_user import LTIUser
+
+
+def set_sqlalchemy_session(session):
+    # Set the Meta.sqlalchemy_session option on all our SQLAlchemy test factory
+    # classes. We can't do it in the normal Factory Boy way:
+    #
+    #     class MyFactory:
+    #         class Meta:
+    #             sqlalchemy_session = session
+    #
+    # Because we don't have `session` available to us at import time.
+    # So we have to do it this way instead.
+    #
+    # See:
+    # https://factoryboy.readthedocs.io/en/latest/orms.html#sqlalchemy
+    # https://factoryboy.readthedocs.io/en/latest/reference.html#factory.Factory._meta
+    for factory_class in _sqlalchemy_factory_classes():
+        # pylint:disable=protected-access
+        factory_class._meta.sqlalchemy_session = session
+
+
+def clear_sqlalchemy_session():
+    # Delete the sqlalchemy session from all our test factories.
+    # Just in case, so we don't have references to the session hanging about.
+    for factory_class in _sqlalchemy_factory_classes():
+        factory_class._meta.sqlalchemy_session = None  # pylint:disable=protected-access
+
+
+def _sqlalchemy_factory_classes():
+    # Return all the SQLAlchemy factory classes from tests.factories.
+    for factory_class in sys.modules[__name__].__dict__.values():
+        try:
+            is_sqla_factory = issubclass(factory_class, SQLAlchemyModelFactory)
+        except TypeError:
+            is_sqla_factory = False
+
+        if is_sqla_factory:
+            yield factory_class


### PR DESCRIPTION
Make the test factories available in `make shell`'s environment so you do things like this:

```python
$ make shell
Python 3.6.9 (default, May 26 2020, 13:51:02)

...

In [1]: f.LTIUser()                                                                                                                                                                                     
Out[1]: LTIUser(user_id='8955e3587d3831542127e503dbdcafac8125e98d', oauth_consumer_key='Hypothesise8ef1f48811f42990fadfa0147696bbe', roles='Learner', tool_consumer_instance_guid='f34f2010df2144cc496bf8ff87ecdd5d6a8f5e25', display_name='Karen Paul', email='')
```