### PR TITLE
Fix isort (make format and make checkformatting)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,9 +83,9 @@ commands =
     lint: pydocstyle lms tests
     lint: pycodestyle lms tests
     format: black lms tests
-    format: isort --recursive --quiet --atomic lms tests
+    format: isort --quiet --atomic lms tests
     checkformatting: black --check lms tests
-    checkformatting: isort --recursive --quiet --check-only lms tests
+    checkformatting: isort --quiet --check-only lms tests
     docker-compose: docker-compose {posargs}
     clean: coverage erase
     pip-compile: pip-compile {posargs}


### PR DESCRIPTION
isort 5.0 removed the `--recursive` option, it's now just always recursive:

https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#500-penny---july-4-2020