### PR TITLE
Try and prevent error details from escaping from the box

### DIFF
--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -10,8 +10,8 @@
   padding-right: 5px;
   margin-bottom: 10px;
   max-width: 100%;
-  
-  &__details {  
+
+  &__details {
     padding: 4px; // prevents focus ring from getting cut off
     &-summary {
       @include focus.outline-on-keyboard-focus;
@@ -25,6 +25,8 @@
     background-color: var.$grey-1;
     border: 1px solid var.$grey-3;
     white-space: pre-wrap;
+    /* Prevent very long single words from breaking out of the box */
+    overflow-wrap: break-word;
     max-width: 100%;
     padding: 10px;
     margin-bottom: 0;


### PR DESCRIPTION
Very long single words / tokens can break out of the details area and cause
horizontal scrolling and hidden content.

## To test

This is kind of tricky. You need one of the exceptions that has a massive stack trace in it to see the difference. You could also get any old error and bodge the text to see it.

If I find an easy way I'll add it.

## Results

Before:
![image](https://user-images.githubusercontent.com/7131143/86818536-67e9a880-c07e-11ea-91f7-c0d65beea754.png)

After:
![image](https://user-images.githubusercontent.com/7131143/86818482-5a342300-c07e-11ea-9ff2-2d1f79368a69.png)
