### PR TITLE
Add `yarn typecheck` command, but don't run it during CI yet, and fix basic JSDoc errors

### DIFF
--- a/lms/static/scripts/frontend_apps/common/dom.js
+++ b/lms/static/scripts/frontend_apps/common/dom.js
@@ -4,10 +4,10 @@
  *
  * @param {Element} element
  * @param {string[]} events
- * @param {(event: Event) => any} listener
+ * @param {(e: Event) => any} listener
  * @param {Object} options
- * @param {boolean} [options.useCapture]
- * @return {function} Function which removes the event listeners.
+ *   @param {boolean} [options.useCapture]
+ * @return {() => void} Function which removes the event listeners.
  */
 export function listen(element, events, listener, { useCapture = false } = {}) {
   if (!Array.isArray(events)) {

--- a/lms/static/scripts/frontend_apps/common/dom.js
+++ b/lms/static/scripts/frontend_apps/common/dom.js
@@ -2,9 +2,10 @@
  * Attach listeners for one or multiple events to an element and return a
  * function that removes the listeners.
  *
- * @param {Element}
+ * @param {Element} element
  * @param {string[]} events
  * @param {(event: Event) => any} listener
+ * @param {Object} options
  * @param {boolean} [options.useCapture]
  * @return {function} Function which removes the event listeners.
  */

--- a/lms/static/scripts/frontend_apps/common/use-element-should-close.js
+++ b/lms/static/scripts/frontend_apps/common/use-element-should-close.js
@@ -31,7 +31,7 @@ import { listen } from './dom';
  *                                Reference to a DOM element or preat component
  *                                that should be closed when DOM elements external
  *                                to it are interacted with or `Esc` is pressed
- * @param {bool} isOpen - Whether the element is currently open. This hook does
+ * @param {boolean} isOpen - Whether the element is currently open. This hook does
  *                        not attach event listeners/do anything if it's not.
  * @param {() => void} handleClose - A function that will do the actual closing
  *                                   of `closeableEl`
@@ -45,7 +45,7 @@ export default function useElementShouldClose(
    *  Helper to return the underlying node object whether
    *  `closeableEl` is attached to an HTMLNode or Preact component.
    *
-   *  @param {Preact ref} closeableEl
+   *  @param {any} closeableEl
    *  @returns {Node}
    */
 

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -63,7 +63,7 @@ export default function Dialog({
       aria-labelledby={dialogTitleId}
       aria-modal="true"
       ref={rootEl}
-      tabIndex="-1"
+      tabIndex={-1}
     >
       <div
         className="Dialog__background"

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -9,6 +9,12 @@ import StudentSelector from './StudentSelector';
 import SubmitGradeForm from './SubmitGradeForm';
 
 /**
+ * @typedef User
+ * @prop {string} displayName
+ * @prop {string} userid
+ */
+
+/**
  * The LMSGrader component is fixed at the top of the page. This toolbar shows which assignment is currently
  * active as well as a list of students to both view and submit grades for.
  */

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -70,7 +70,7 @@ export default function Table({
       <table
         aria-label={accessibleLabel}
         className="Table__table"
-        tabIndex="0"
+        tabIndex={0}
         role="grid"
         onKeyDown={onKeyDown}
       >
@@ -100,7 +100,7 @@ export default function Table({
               onClick={() => onSelectItem(item)}
               onDblClick={() => onUseItem(item)}
               ref={node => (rowRefs.current[index] = node)}
-              tabIndex="-1"
+              tabIndex={-1}
             >
               {renderItem(item, selectedItem === item)}
             </tr>

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -39,7 +39,7 @@ export default function ValidationMessage({
       onClick={closeValidationError}
       className={errorClass}
       value={message}
-      tabIndex={showError ? '0' : '-1'}
+      tabIndex={showError ? 0 : -1}
     />
   );
 }

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -40,7 +40,7 @@ export class ApiError extends Error {
 /**
  * Make an API call to the LMS app backend.
  *
- * @param options
+ * @param {Object} options
  * @param {string} options.path - The `/api/...` path of the endpoint to call
  * @param {string} options.authToken
  * @param {Object} [options.data] - JSON-serializable body of the request

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -41,9 +41,9 @@ export class ApiError extends Error {
  * Make an API call to the LMS app backend.
  *
  * @param {Object} options
- * @param {string} options.path - The `/api/...` path of the endpoint to call
- * @param {string} options.authToken
- * @param {Object} [options.data] - JSON-serializable body of the request
+ *   @param {string} options.path - The `/api/...` path of the endpoint to call
+ *   @param {string} options.authToken
+ *   @param {Object} [options.data] - JSON-serializable body of the request
  */
 async function apiCall({ path, authToken, data }) {
   let body;

--- a/lms/static/scripts/frontend_apps/utils/grader-service.js
+++ b/lms/static/scripts/frontend_apps/utils/grader-service.js
@@ -16,11 +16,10 @@ import { apiCall } from './api';
 /**
  * Submits a student's grade to the LTI endpoint.
  *
- * @param {Student} student - Student object
- * @param {number} grade - A number between 0 and 1
- * @param {string} authToken - The auth token from the config
- * @return {Object} - An empty object
- *
+ * @param {Object} options
+ * @param {Student} options.student - Student object
+ * @param {number} options.grade - A number between 0 and 1
+ * @param {string} options.authToken - The auth token from the config
  */
 function submitGrade({ student, grade, authToken }) {
   return apiCall({
@@ -37,10 +36,10 @@ function submitGrade({ student, grade, authToken }) {
 /**
  * Fetches a student's grade from the LTI endpoint
  *
- * @param {Student} student - Student object
- * @param {string} authToken - The auth token from the config
- * @return {FetchGradeResult}
- *
+ * @param {Object} options
+ * @param {Student} options.student - Student object
+ * @param {string} options.authToken - The auth token from the config
+ * @return {Promise<FetchGradeResult>}
  */
 function fetchGrade({ student, authToken }) {
   return apiCall({

--- a/lms/static/scripts/frontend_apps/utils/grader-service.js
+++ b/lms/static/scripts/frontend_apps/utils/grader-service.js
@@ -17,9 +17,9 @@ import { apiCall } from './api';
  * Submits a student's grade to the LTI endpoint.
  *
  * @param {Object} options
- * @param {Student} options.student - Student object
- * @param {number} options.grade - A number between 0 and 1
- * @param {string} options.authToken - The auth token from the config
+ *   @param {Student} options.student - Student object
+ *   @param {number} options.grade - A number between 0 and 1
+ *   @param {string} options.authToken - The auth token from the config
  */
 function submitGrade({ student, grade, authToken }) {
   return apiCall({
@@ -37,8 +37,8 @@ function submitGrade({ student, grade, authToken }) {
  * Fetches a student's grade from the LTI endpoint
  *
  * @param {Object} options
- * @param {Student} options.student - Student object
- * @param {string} options.authToken - The auth token from the config
+ *   @param {Student} options.student - Student object
+ *   @param {string} options.authToken - The auth token from the config
  * @return {Promise<FetchGradeResult>}
  */
 function fetchGrade({ student, authToken }) {

--- a/lms/static/scripts/frontend_apps/utils/validation.js
+++ b/lms/static/scripts/frontend_apps/utils/validation.js
@@ -2,7 +2,7 @@
  * Coerce a string value from an input field to an numeric value.
  * If the value can't be properly cast, then it will remain a string.
  *
- * @param {string} value - The value to attempt to translate
+ * @param {string} originalValue - The value to attempt to translate
  * @return {number|string} - Translated value or original if not translated
  */
 function formatToNumber(originalValue) {

--- a/lms/static/scripts/postmessage_json_rpc/client/client.js
+++ b/lms/static/scripts/postmessage_json_rpc/client/client.js
@@ -21,9 +21,9 @@ function createTimeout(delay, message) {
  * @param {string} origin - Origin filter for `window.postMessage` call
  * @param {string} method - Name of the JSON-RPC method
  * @param {any[]} params - Parameters of the JSON-RPC method
- * @param [number] timeout - Maximum time to wait in ms
- * @param [Window] window_ - Test seam.
- * @param [id] id - Test seam.
+ * @param {number} [timeout] - Maximum time to wait in ms
+ * @param {Window} [window_] - Test seam.
+ * @param {string} [id] - Test seam.
  * @return {Promise<any>} - A Promise for the response to the call
  */
 async function call(

--- a/lms/static/scripts/postmessage_json_rpc/client/random.js
+++ b/lms/static/scripts/postmessage_json_rpc/client/random.js
@@ -10,9 +10,8 @@ function byteToHex(val) {
  * @return {string}
  */
 function generateHexString(len) {
-  const crypto = window.crypto || window.msCrypto; /* IE 11 */
   const bytes = new Uint8Array(len / 2);
-  crypto.getRandomValues(bytes);
+  window.crypto.getRandomValues(bytes);
   return Array.from(bytes).map(byteToHex).join('');
 }
 

--- a/lms/static/scripts/postmessage_json_rpc/client/random.js
+++ b/lms/static/scripts/postmessage_json_rpc/client/random.js
@@ -6,7 +6,7 @@ function byteToHex(val) {
 /**
  * Generate a random hex string of `len` chars.
  *
- * @param {number} - An even-numbered length string to generate.
+ * @param {number} len - An even-numbered length string to generate.
  * @return {string}
  */
 function generateHexString(len) {

--- a/lms/static/scripts/tsconfig.json
+++ b/lms/static/scripts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "lib": ["es2018", "dom"],
+    "jsx": "react",
+    "jsxFactory": "createElement",
+    "module": "commonjs",
+    "noEmit": true,
+    "strictNullChecks": true,
+    "target": "ES2020"
+  },
+  "include": [
+    "frontend_apps/**/*.js"
+  ],
+  "exclude": [
+    "frontend_apps/**/test/*.js"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "checkformatting": "prettier --check lms/**/*.js scripts/**/*.js",
     "format": "prettier --list-different --write lms/**/*.js scripts/**/*.js",
     "lint": "eslint lms/static/scripts",
-    "test": "gulp test"
+    "test": "gulp test",
+    "typecheck": "tsc --build lms/static/scripts/tsconfig.json"
   },
   "repository": {
     "type": "git",
@@ -76,7 +77,8 @@
     "karma-sinon": "^1.0.5",
     "mocha": "^8.0.1",
     "prettier": "2.0.5",
-    "sinon": "^9.0.2"
+    "sinon": "^9.0.2",
+    "typescript": "^3.9.6"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "normalize.css": "^8.0.1",
     "postcss": "^7.0.31",
     "preact": "10.4.5",
+    "prop-types": "^15.7.2",
     "query-string": "^5.0.0",
     "sass": "^1.26.9",
     "stringify": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "watchify": "^3.11.1"
   },
   "devDependencies": {
-    "@types/enzyme": "^3.10.5",
     "axe-core": "^3.5.5",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-mockable-imports": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6667,6 +6667,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+
 ua-parser-js@0.7.21:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"

--- a/yarn.lock
+++ b/yarn.lock
@@ -936,43 +936,15 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@types/cheerio@*":
-  version "0.22.18"
-  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.18.tgz#19018dceae691509901e339d63edf1e935978fe6"
-  integrity sha512-Fq7R3fINAPSdUEhOyjG4iVxgHrOnqDJbY0/BUuiN0pvD/rfmZWekVZnv+vcs8TtpA2XF50uv50LaE4EnpEL/Hw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/enzyme@^3.10.5":
-  version "3.10.5"
-  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.5.tgz#fe7eeba3550369eed20e7fb565bfb74eec44f1f0"
-  integrity sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==
-  dependencies:
-    "@types/cheerio" "*"
-    "@types/react" "*"
-
 "@types/node@*":
   version "14.0.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.10.tgz#dbfaa170bd9eafccccb6d7060743a761b0844afd"
   integrity sha512-Bz23oN/5bi0rniKT24ExLf4cK0JdvN3dH/3k0whYkdN4eI4vS2ZW/2ENNn2uxHCzWcbdHIa/GRuWQytfzCjRYw==
-
-"@types/prop-types@*":
-  version "15.7.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
-"@types/react@*":
-  version "16.9.35"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.35.tgz#a0830d172e8aadd9bd41709ba2281a3124bbd368"
-  integrity sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
 
 JSONStream@^1.0.3:
   version "1.3.5"
@@ -2220,11 +2192,6 @@ css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
-
-csstype@^2.2.0:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
-  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 custom-event@~1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Similar to what we did in the client recently, this adds a `yarn typecheck` command which uses the TypeScript compiler to check for JSDoc errors and semantic errors in JavaScript code. About half of the errors that were reported were basic JSDoc mistakes, and I have also fixed those here in separate individual commits.

There are still many (~70) errors left to resolve, so for the moment this command is not run during CI and instead developers must run it manually. The idea is that we will gradually work our way through those in separate PRs.