### PR TITLE
Remove prototype matcher for h-matchers version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     {tests,bddtests,functests,lint}: httpretty
     {tests,bddtests,functests,lint}: pytest
     {tests,functests,lint,bddtests}: factory-boy
-    {tests,bddtests,functests,lint}: h-matchers>=1.2.5
+    {tests,bddtests,functests,lint}: h-matchers>=1.2.8
     {bddtests,functests,lint}: webtest
     {bddtests,lint}: behave
     lint: pylint<2.5


### PR DESCRIPTION
This PR takes a matcher which was written here and sub-sequently moved out to `h-matchers` and replaces it with the new version now in `h-matchers`. 

## Review notes

* The tests haven't been changed at all, the request matcher is just gone
* There was some tomfoolery with the imports I fixed as well