### PR TITLE
Centralise model object creation and refactor Canvas sync tests

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -4,7 +4,7 @@ from lms.models.course import Course
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
 from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
-from lms.models.h_group import HGroup, h_group_name
+from lms.models.h_group import HGroup
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
 from lms.models.lti_user import LTIUser, display_name

--- a/lms/models/_hashed_id.py
+++ b/lms/models/_hashed_id.py
@@ -1,0 +1,18 @@
+import hashlib
+
+
+def hashed_id(*parts):
+    """
+    Create a hashed id from multiple stringifying parts.
+
+    It is crucial that if any one of the parts changes meaningfully that it's
+    stringification changes too.
+
+    :param parts: An objects which can be converted to strings
+    :return: A string which can be used as an id.
+    """
+    hash_object = hashlib.sha1()
+    for part in parts:
+        hash_object.update(str(part).encode())
+
+    return hash_object.hexdigest()

--- a/lms/models/_hashed_id.py
+++ b/lms/models/_hashed_id.py
@@ -8,8 +8,8 @@ def hashed_id(*parts):
     It is crucial that if any one of the parts changes meaningfully that it's
     stringification changes too.
 
-    :param parts: An objects which can be converted to strings
-    :return: A string which can be used as an id.
+    :param parts: An iterable of objects which can be converted to strings
+    :return: A string which can be used as an id
     """
     hash_object = hashlib.sha1()
     for part in parts:

--- a/lms/models/h_group.py
+++ b/lms/models/h_group.py
@@ -1,5 +1,7 @@
 from typing import NamedTuple
 
+from lms.models._hashed_id import hashed_id
+
 
 class HGroup(NamedTuple):
     name: str
@@ -9,15 +11,54 @@ class HGroup(NamedTuple):
     def groupid(self, authority):
         return f"group:{self.authority_provided_id}@{authority}"
 
+    @classmethod
+    def from_lti_parts(
+        # pylint: disable=too-many-arguments
+        cls,
+        name,
+        tool_consumer_instance_guid,
+        context_id,
+        section_id=None,
+        type_=type,
+    ):
+        """
+        Create an HGroup from LMS specific parts.
 
-def h_group_name(name):
-    """Return an h-compatible group name from the given string."""
-    name = name.strip()
+        :param name: The name of the course
+        :param tool_consumer_instance_guid: Tool consumer GUID
+        :param context_id: Course id
+        :param section_id: A section id for a section group
+        :param type_: Group type (defaults to "course_group")
+        """
+        return HGroup(
+            name=cls._name(name) if name is not None else None,
+            authority_provided_id=cls._authority_provided_id(
+                tool_consumer_instance_guid, context_id, section_id
+            ),
+            type=type_,
+        )
 
-    # The maximum length of an h group name.
-    group_name_max_length = 25
+    @classmethod
+    def _name(cls, name):
+        """Return an h-compatible group name from the given string."""
 
-    if len(name) > group_name_max_length:
-        name = name[: group_name_max_length - 1].rstrip() + "…"
+        name = name.strip()
 
-    return name
+        # The maximum length of an h group name.
+        group_name_max_length = 25
+
+        if len(name) > group_name_max_length:
+            name = name[: group_name_max_length - 1].rstrip() + "…"
+
+        return name
+
+    @classmethod
+    def _authority_provided_id(
+        cls, tool_consumer_instance_guid, context_id, section_id=None
+    ):
+        """Return an h-compatible authority_provided_id from the LTI parts."""
+
+        if section_id is None:
+            return hashed_id(tool_consumer_instance_guid, context_id)
+
+        return hashed_id(tool_consumer_instance_guid, context_id, section_id)

--- a/lms/models/h_user.py
+++ b/lms/models/h_user.py
@@ -1,5 +1,6 @@
-import hashlib
 from typing import NamedTuple
+
+from lms.models._hashed_id import hashed_id
 
 
 class HUser(NamedTuple):
@@ -35,15 +36,8 @@ class HUser(NamedTuple):
         provider = lti_user.tool_consumer_instance_guid
         provider_unique_id = lti_user.user_id
 
-        def username():
-            """Return the h username for the current request."""
-            username_hash_object = hashlib.sha1()
-            username_hash_object.update(provider.encode())
-            username_hash_object.update(provider_unique_id.encode())
-            return username_hash_object.hexdigest()[:30]
-
         return cls(
-            username=username(),
+            username=hashed_id(provider, provider_unique_id)[:30],
             display_name=lti_user.display_name,
             provider=provider,
             provider_unique_id=provider_unique_id,

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -56,8 +56,8 @@ class LTILaunchResource:
 
         params = self._request.parsed_params
 
-        return HGroup.from_lti_parts(
-            name=params["context_title"],
+        return HGroup.course_group(
+            course_name=params["context_title"],
             tool_consumer_instance_guid=params["tool_consumer_instance_guid"],
             context_id=params["context_id"],
         )

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -1,10 +1,9 @@
 """Traversal resources for LTI launch views."""
 import functools
-import hashlib
 
 from pyramid.security import Allow
 
-from lms.models import HGroup, h_group_name
+from lms.models import HGroup
 from lms.resources._js_config import JSConfig
 
 
@@ -54,16 +53,13 @@ class LTILaunchResource:
         # tool_consumer_instance_guid uniquely identifies an instance of an LMS,
         # and context_id uniquely identifies a course within an LMS. Together they
         # globally uniquely identify a course.
-        hash_object = hashlib.sha1()
-        hash_object.update(
-            self._request.parsed_params["tool_consumer_instance_guid"].encode()
-        )
-        hash_object.update(self._request.parsed_params["context_id"].encode())
-        authority_provided_id = hash_object.hexdigest()
 
-        return HGroup(
-            name=h_group_name(self._request.parsed_params["context_title"]),
-            authority_provided_id=authority_provided_id,
+        params = self._request.parsed_params
+
+        return HGroup.from_lti_parts(
+            name=params["context_title"],
+            tool_consumer_instance_guid=params["tool_consumer_instance_guid"],
+            context_id=params["context_id"],
         )
 
     @property

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -1,8 +1,6 @@
-import hashlib
-
 from pyramid.view import view_config
 
-from lms.models import HGroup, h_group_name
+from lms.models import HGroup
 
 
 @view_config(
@@ -16,10 +14,8 @@ def sync(request):
     canvas_api_svc = request.find_service(name="canvas_api_client")
     lti_h_svc = request.find_service(name="lti_h")
 
-    context_id = request.json["course"]["context_id"]
     course_id = request.json["course"]["custom_canvas_course_id"]
     group_info = request.json["group_info"]
-    tool_consumer_instance_guid = request.json["lms"]["tool_consumer_instance_guid"]
 
     if request.lti_user.is_learner:
         # For learners we only want the client to show the sections that the
@@ -30,20 +26,19 @@ def sync(request):
         # client to show all of the course's sections.
         sections = canvas_api_svc.course_sections(course_id)
 
+    tool_consumer_instance_guid = request.json["lms"]["tool_consumer_instance_guid"]
+    context_id = request.json["course"]["context_id"]
+
     def group(section):
         """Return an HGroup from the given Canvas section dict."""
-        hash_object = hashlib.sha1()
-        hash_object.update(tool_consumer_instance_guid.encode())
-        hash_object.update(context_id.encode())
-        hash_object.update(str(section["id"]).encode())
-        authority_provided_id = hash_object.hexdigest()
 
-        if "name" in section:
-            name = h_group_name(section["name"])
-        else:
-            name = None
-
-        return HGroup(name, authority_provided_id, type="section_group")
+        return HGroup.from_lti_parts(
+            name=section.get("name"),
+            tool_consumer_instance_guid=tool_consumer_instance_guid,
+            context_id=context_id,
+            section_id=section["id"],
+            type_="section_group",
+        )
 
     groups = [group(section) for section in sections]
     lti_h_svc.sync(groups, group_info)

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -32,12 +32,11 @@ def sync(request):
     def group(section):
         """Return an HGroup from the given Canvas section dict."""
 
-        return HGroup.from_lti_parts(
-            name=section.get("name"),
+        return HGroup.section_group(
+            section_name=section.get("name"),
             tool_consumer_instance_guid=tool_consumer_instance_guid,
             context_id=context_id,
             section_id=section["id"],
-            type_="section_group",
         )
 
     groups = [group(section) for section in sections]

--- a/tests/factories/h_group.py
+++ b/tests/factories/h_group.py
@@ -6,4 +6,5 @@ HGroup = make_factory(  # pylint:disable=invalid-name
     models.HGroup,
     name=Sequence(lambda n: f"Test Group {n}"),
     authority_provided_id=Faker("hexify", text="^" * 40),
+    type=Faker("random_element", elements=["course_group", "section_group"]),
 )

--- a/tests/unit/lms/models/_hashed_id_test.py
+++ b/tests/unit/lms/models/_hashed_id_test.py
@@ -1,0 +1,21 @@
+import pytest
+
+from lms.models._hashed_id import hashed_id
+
+
+class TestHashedId:
+    @pytest.mark.parametrize(
+        "parts,resulting_id",
+        (
+            (["a", 1, None], "f975d6bab6cf2c8046233dacc9332b2b0b2b2810"),
+            (["b", 1, None], "977b5d9c262d94c91a784635e72e63583e6d0024"),
+            (
+                [ValueError(), 1.2234, "thing"],
+                "697ea95083b8e46a97eb3d30bf0320e7a7485929",
+            ),
+        ),
+    )
+    def test_golden_master(self, parts, resulting_id):
+        # Some canned responses that prove the algorithm hasn't changed and
+        # that it doesn't fall over
+        assert hashed_id(*parts) == resulting_id

--- a/tests/unit/lms/models/h_group_test.py
+++ b/tests/unit/lms/models/h_group_test.py
@@ -2,26 +2,47 @@ from unittest import mock
 
 import pytest
 
-from lms.models import HGroup, h_group_name
+from lms.models import HGroup
 
 
-def test_groupid():
-    group = HGroup(mock.sentinel.name, "test_authority_provided_id")
+class TestHGroup:
+    def test_groupid(self):
+        group = HGroup(mock.sentinel.name, "test_authority_provided_id")
 
-    groupid = group.groupid("lms.hypothes.is")
+        groupid = group.groupid("lms.hypothes.is")
 
-    assert groupid == "group:test_authority_provided_id@lms.hypothes.is"
+        assert groupid == "group:test_authority_provided_id@lms.hypothes.is"
 
+    @pytest.mark.parametrize(
+        "context_parts",
+        (
+            ["tool_consumer_instance_guid", "context_id"],
+            ["tool_consumer_instance_guid", "context_id", "section_id"],
+        ),
+    )
+    def test_from_lti_parts(self, context_parts, hashed_id):
+        group = HGroup.from_lti_parts("irrelevant", *context_parts, type_="type_string")
 
-@pytest.mark.parametrize(
-    "name,expected_result",
-    (
-        ("Test Course", "Test Course"),
-        (" Test Course ", "Test Course"),
-        ("Test   Course", "Test   Course"),
-        ("Object Oriented Polymorphism 101", "Object Oriented Polymorp…"),
-        ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
-    ),
-)
-def test_h_group_name(name, expected_result):
-    assert h_group_name(name) == expected_result
+        hashed_id.assert_called_once_with(*context_parts)
+        assert group.authority_provided_id == hashed_id.return_value
+        assert group.type == "type_string"
+
+    @pytest.mark.parametrize(
+        "name,expected_result",
+        (
+            (None, None),
+            ("Test Course", "Test Course"),
+            (" Test Course ", "Test Course"),
+            ("Test   Course", "Test   Course"),
+            ("Object Oriented Polymorphism 101", "Object Oriented Polymorp…"),
+            ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
+        ),
+    )
+    def test_from_lti_parts_truncates_the_name(self, name, expected_result):
+        group = HGroup.from_lti_parts(name, "irrelevant", "irrelevant")
+
+        assert group.name == expected_result
+
+    @pytest.fixture
+    def hashed_id(self, patch):
+        return patch("lms.models.h_group.hashed_id")

--- a/tests/unit/lms/models/h_group_test.py
+++ b/tests/unit/lms/models/h_group_test.py
@@ -1,31 +1,46 @@
-from unittest import mock
-
 import pytest
+from pytest import param
 
 from lms.models import HGroup
+from tests import factories
+
+GROUP_CONSTRUCTORS = (
+    (
+        HGroup.course_group,
+        ("tool_consumer_instance_guid", "context_id"),
+        "course_group",
+    ),
+    (
+        HGroup.section_group,
+        ("tool_consumer_instance_guid", "context_id", "section_id"),
+        "sections_group",
+    ),
+)
 
 
 class TestHGroup:
     def test_groupid(self):
-        group = HGroup(mock.sentinel.name, "test_authority_provided_id")
+        group = factories.HGroup(authority_provided_id="test_authority_provided_id")
 
         groupid = group.groupid("lms.hypothes.is")
 
         assert groupid == "group:test_authority_provided_id@lms.hypothes.is"
 
-    @pytest.mark.parametrize(
-        "context_parts",
-        (
-            ["tool_consumer_instance_guid", "context_id"],
-            ["tool_consumer_instance_guid", "context_id", "section_id"],
-        ),
-    )
-    def test_from_lti_parts(self, context_parts, hashed_id):
-        group = HGroup.from_lti_parts("irrelevant", *context_parts, type_="type_string")
+    def test_course_group(self, hashed_id):
+        group = HGroup.course_group("irrelevant", "tool_guid", "context_id")
 
-        hashed_id.assert_called_once_with(*context_parts)
+        hashed_id.assert_called_once_with("tool_guid", "context_id")
         assert group.authority_provided_id == hashed_id.return_value
-        assert group.type == "type_string"
+        assert group.type == "course_group"
+
+    def test_sections_group(self, hashed_id):
+        group = HGroup.section_group(
+            "irrelevant", "tool_guid", "context_id", "section_id"
+        )
+
+        hashed_id.assert_called_once_with("tool_guid", "context_id", "section_id")
+        assert group.authority_provided_id == hashed_id.return_value
+        assert group.type == "section_group"
 
     @pytest.mark.parametrize(
         "name,expected_result",
@@ -38,8 +53,21 @@ class TestHGroup:
             ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
         ),
     )
-    def test_from_lti_parts_truncates_the_name(self, name, expected_result):
-        group = HGroup.from_lti_parts(name, "irrelevant", "irrelevant")
+    @pytest.mark.parametrize(
+        "constructor",
+        (
+            param(
+                lambda name: HGroup.course_group(name, "blah", "blah"),
+                id="course_group",
+            ),
+            param(
+                lambda name: HGroup.section_group(name, "blah", "blah", "blah"),
+                id="section_group",
+            ),
+        ),
+    )
+    def test_contructors_truncate_the_name(self, constructor, name, expected_result):
+        group = constructor(name)
 
         assert group.name == expected_result
 

--- a/tests/unit/lms/models/h_user_test.py
+++ b/tests/unit/lms/models/h_user_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lms.models import HUser
 from tests import factories
 
@@ -8,15 +10,26 @@ class TestHUser:
 
         assert h_user.userid("test_authority") == "acct:test_username@test_authority"
 
-    def test_from_lti_user(self):
+    def test_from_lti_user(self, hashed_id):
         lti_user = factories.LTIUser(
             tool_consumer_instance_guid="test_tool_consumer_instance_guid",
             user_id="test_user_id",
         )
 
-        assert HUser.from_lti_user(lti_user) == HUser(
-            username="16aa3b3e92cdfa53e5996d138a7013",
+        h_user = HUser.from_lti_user(lti_user)
+
+        hashed_id.assert_called_once_with(h_user.provider, h_user.provider_unique_id)
+
+        assert h_user == HUser(
+            username=hashed_id.return_value[:30],
             display_name=lti_user.display_name,
             provider=lti_user.tool_consumer_instance_guid,
             provider_unique_id=lti_user.user_id,
         )
+
+    @pytest.fixture
+    def hashed_id(self, patch):
+        hashed_id = patch("lms.models.h_user.hashed_id")
+        hashed_id.return_value = "x" * 30 + "1234567890"
+
+        return hashed_id

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -29,12 +29,15 @@ class TestACL:
 
 class TestHGroup:
     @pytest.mark.usefixtures("has_course")
-    def test_it(self, lti_launch, HGroup, h_group_name):
-        assert lti_launch.h_group == HGroup.return_value
-        h_group_name.assert_called_once_with("test_context_title")
-        HGroup.assert_called_once_with(
-            name=h_group_name.return_value,
-            authority_provided_id="d55a3c86dd79d390ec8dc6a8096d0943044ea268",
+    def test_it(self, lti_launch, HGroup, pyramid_request):
+        assert lti_launch.h_group == HGroup.from_lti_parts.return_value
+
+        HGroup.from_lti_parts.assert_called_once_with(
+            name="test_context_title",
+            tool_consumer_instance_guid=pyramid_request.parsed_params[
+                "tool_consumer_instance_guid"
+            ],
+            context_id=pyramid_request.parsed_params["context_id"],
         )
 
 
@@ -192,11 +195,6 @@ pytestmark = pytest.mark.usefixtures("ai_getter", "course_service")
 @pytest.fixture
 def lti_launch(pyramid_request):
     return LTILaunchResource(pyramid_request)
-
-
-@pytest.fixture(autouse=True)
-def h_group_name(patch):
-    return patch("lms.resources.lti_launch.h_group_name")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -30,10 +30,10 @@ class TestACL:
 class TestHGroup:
     @pytest.mark.usefixtures("has_course")
     def test_it(self, lti_launch, HGroup, pyramid_request):
-        assert lti_launch.h_group == HGroup.from_lti_parts.return_value
+        assert lti_launch.h_group == HGroup.course_group.return_value
 
-        HGroup.from_lti_parts.assert_called_once_with(
-            name="test_context_title",
+        HGroup.course_group.assert_called_once_with(
+            course_name="test_context_title",
             tool_consumer_instance_guid=pyramid_request.parsed_params[
                 "tool_consumer_instance_guid"
             ],

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -62,12 +62,11 @@ def assert_sync_and_return(lti_h_service, request_json):
 
     def _groups_for(sections):
         return [
-            HGroup.from_lti_parts(
-                name=section.get("name", f"Section {section['id']}"),
+            HGroup.section_group(
+                section_name=section.get("name", f"Section {section['id']}"),
                 tool_consumer_instance_guid=tool_guid,
                 context_id=context_id,
                 section_id=section["id"],
-                type_="section_group",
             )
             for section in sections
         ]


### PR DESCRIPTION
Partially achieves: https://github.com/hypothesis/lms/issues/1753

 * We now have a re-usable "hashed_id" function which the models use to create ids
 * This replaces all the places which performed hashed based ids before
 * All construction logic has been centralised into the models
 * Services are responsible for getting the right values, and the model is responsible for combining them
 * This simplifies test and removes lots of "magic" hex values which opaquely line up with input strings
 * Went to town as a result of this on the Canvas sync tests to try and make them easier to understand

## Review notes

 * The changes have been broken up into four commits
 * The commits do not work individually, but hopefully help when reading it
 * The biggest changes are to the sync tests (which was the motivator for this)