### PR TITLE
Simpler clearer Canvas Sync API

### DIFF
--- a/lms/models/h_group.py
+++ b/lms/models/h_group.py
@@ -51,7 +51,7 @@ class HGroup(NamedTuple):
         """Return an h-compatible group name from the given string."""
 
         if name is None:
-            return None
+            raise ValueError("Name is mandatory to create a group")
 
         name = name.strip()
 

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -41,7 +41,7 @@ class Sync:
         if not self._is_speedgrader:
             return sections
 
-        # Speedgrader requests are made by the teacher, but we want the
+        # SpeedGrader requests are made by the teacher, but we want the
         # learners sections. The canvas API won't give us names for those so
         # we will just use them to filter the course sections
         user_id = self._request.json["learner"]["canvas_user_id"]

--- a/tests/unit/lms/models/h_group_test.py
+++ b/tests/unit/lms/models/h_group_test.py
@@ -1,5 +1,4 @@
 import pytest
-from pytest import param
 
 from lms.models import HGroup
 from tests import factories
@@ -45,7 +44,6 @@ class TestHGroup:
     @pytest.mark.parametrize(
         "name,expected_result",
         (
-            (None, None),
             ("Test Course", "Test Course"),
             (" Test Course ", "Test Course"),
             ("Test   Course", "Test   Course"),
@@ -53,23 +51,24 @@ class TestHGroup:
             ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
         ),
     )
-    @pytest.mark.parametrize(
-        "constructor",
-        (
-            param(
-                lambda name: HGroup.course_group(name, "blah", "blah"),
-                id="course_group",
-            ),
-            param(
-                lambda name: HGroup.section_group(name, "blah", "blah", "blah"),
-                id="section_group",
-            ),
-        ),
-    )
-    def test_contructors_truncate_the_name(self, constructor, name, expected_result):
-        group = constructor(name)
+    def test_constructors_truncate_the_name(
+        self, name_only_constructor, name, expected_result
+    ):
+        group = name_only_constructor(name)
 
         assert group.name == expected_result
+
+    def test_constructors_name_is_mandatory(self, name_only_constructor):
+        with pytest.raises(ValueError):
+            name_only_constructor(None)
+
+    @pytest.fixture(
+        params=GROUP_CONSTRUCTORS, ids=[group[2] for group in GROUP_CONSTRUCTORS]
+    )
+    def name_only_constructor(self, request):
+        constructor, args, _group_type = request.param
+
+        return lambda name: constructor(name, *args)
 
     @pytest.fixture
     def hashed_id(self, patch):


### PR DESCRIPTION
By unifying the flow of speedgrader with the other ways of syncing we can now:

 * Split each section up into discrete parts
 * Remove an inner function (as it's only used once)
 * Remove the path which allowed `HGroups` to be created without a name

As a result the main sync function is now:

```python
def sync(self):
    groups = self._to_groups(self._get_sections())

    self._sync_to_h(groups)

    authority = self._request.registry.settings["h_authority"]
    return [group.groupid(authority) for group in groups]
```

This is for: https://github.com/hypothesis/lms/issues/1753