### PR TITLE
Update `SvgIcon` component to latest version from client

### DIFF
--- a/lms/static/scripts/bootstrap.js
+++ b/lms/static/scripts/bootstrap.js
@@ -10,3 +10,8 @@ patchPropTypes(propTypes);
 import { configure } from 'enzyme';
 import { Adapter } from 'enzyme-adapter-preact-pure';
 configure({ adapter: new Adapter() });
+
+// Register the same set of icons that is available in the app.
+import { registerIcons } from './frontend_apps/components/SvgIcon';
+import iconSet from './frontend_apps/icons';
+registerIcons(iconSet);

--- a/lms/static/scripts/frontend_apps/components/Spinner.js
+++ b/lms/static/scripts/frontend_apps/components/Spinner.js
@@ -2,19 +2,12 @@ import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import SvgIcon from './SvgIcon';
-import { trustMarkup } from '../utils/trusted';
 
 /**
  * A spinning loading indicator.
  */
 export default function Spinner({ className }) {
-  return (
-    <SvgIcon
-      className={className}
-      src={trustMarkup(require('../../../images/spinner.svg'))}
-      inline={true}
-    />
-  );
+  return <SvgIcon className={className} name="spinner" inline={true} />;
 }
 
 Spinner.propTypes = {

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -2,7 +2,6 @@ import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import SvgIcon from './SvgIcon';
-import { trustMarkup } from '../utils/trusted';
 
 /**
  * A student navigation tool which shows a student selection list and a previous and next button.
@@ -75,7 +74,7 @@ export default function StudentSelector({
         </select>
         <SvgIcon
           className="StudentsSelector__students-icon"
-          src={trustMarkup(require('../../../images/caret-down.svg'))}
+          name="caret-down"
           inline={true}
         />{' '}
       </span>
@@ -92,7 +91,7 @@ export default function StudentSelector({
       >
         <SvgIcon
           className="StudentSelector-change-student-svg"
-          src={trustMarkup(require('../../../images/arrow-left.svg'))}
+          name="arrow-left"
           inline={true}
         />
       </button>
@@ -105,7 +104,7 @@ export default function StudentSelector({
       >
         <SvgIcon
           className="StudentSelector-change-student-svg"
-          src={trustMarkup(require('../../../images/arrow-right.svg'))}
+          name="arrow-right"
           inline={true}
         />
       </button>

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -15,7 +15,6 @@ import Spinner from './Spinner';
 import SvgIcon from './SvgIcon';
 import { fetchGrade, submitGrade } from '../utils/grader-service';
 import { useUniqueId } from '../utils/hooks';
-import { trustMarkup } from '../utils/trusted';
 import { formatToNumber, scaleGrade, validateGrade } from '../utils/validation';
 import ValidationMessage from './ValidationMessage';
 
@@ -191,7 +190,7 @@ export default function SubmitGradeForm({ disabled = false, student }) {
       >
         <SvgIcon
           className="SubmitGradeForm__check-icon"
-          src={trustMarkup(require('../../../images/check.svg'))}
+          name="check"
           inline={true}
         />{' '}
         Submit Grade

--- a/lms/static/scripts/frontend_apps/components/SvgIcon.js
+++ b/lms/static/scripts/frontend_apps/components/SvgIcon.js
@@ -1,7 +1,35 @@
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { createElement } from 'preact';
 import { useLayoutEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
+
+/**
+ * Object mapping icon names to SVG markup.
+ *
+ * @typedef {Object.<string,string>} IconMap
+ */
+
+/**
+ * @template T
+ * @typedef {import("preact/hooks").Ref<T>} Ref
+ */
+
+/**
+ * Map of icon name to SVG data.
+ *
+ * @type {IconMap}
+ */
+let iconRegistry = {};
+
+/**
+ * @typedef SvgIconProps
+ * @prop {string} name - The name of the icon to display.
+ *   The name must match a name that has already been registered using the
+ *   `registerIcons` function.
+ * @prop {string} [className] - A CSS class to apply to the `<svg>` element.
+ * @prop {boolean} [inline] - Apply a style allowing for inline display of icon wrapper.
+ * @prop {string} [title] - Optional title attribute to apply to the SVG's containing `span`.
+ */
 
 /**
  * Component that renders icons using inline `<svg>` elements.
@@ -9,24 +37,29 @@ import propTypes from 'prop-types';
  *
  * This matches the way we do icons on the website, see
  * https://github.com/hypothesis/h/pull/3675
+ *
+ * @param {SvgIconProps} props
  */
-
-export default function SvgIcon({ className = '', inline = false, src }) {
-  if (!src) {
-    throw new Error(`Unknown svg supplied to src prop`);
+export default function SvgIcon({
+  name,
+  className = '',
+  inline = false,
+  title = '',
+}) {
+  if (!iconRegistry[name]) {
+    throw new Error(`Icon name "${name}" is not registered`);
   }
-  if (!src.trustedHTML) {
-    throw new Error(
-      'Un-trusted resource passed to SvgIcon. If this is a valid svg, use the `trustMarkup` wrapper.'
-    );
-  }
+  const markup = { __html: iconRegistry[name] };
 
-  const markup = { __html: src.trustedHTML };
-  const element = useRef();
-
+  const element = /** @type {Ref<HTMLElement>} */ (useRef());
   useLayoutEffect(() => {
     const svg = element.current.querySelector('svg');
-    svg.setAttribute('class', className);
+
+    // The icon should always contain an `<svg>` element, but check here as we
+    // don't validate the markup when it is registered.
+    if (svg) {
+      svg.setAttribute('class', className);
+    }
   }, [
     className,
     // `markup` is a dependency of this effect because the SVG is replaced if
@@ -34,24 +67,50 @@ export default function SvgIcon({ className = '', inline = false, src }) {
     markup,
   ]);
 
+  const spanProps = {};
+  if (title) {
+    spanProps.title = title;
+  }
+
   return (
     <span
-      className={classNames('svg-icon', { 'svg-icon--inline': inline })}
+      className={classnames('svg-icon', { 'svg-icon--inline': inline })}
       dangerouslySetInnerHTML={markup}
       ref={element}
+      {...spanProps}
     />
   );
 }
 
 SvgIcon.propTypes = {
-  /** A CSS class to apply to the `<svg>` element. */
+  name: propTypes.string.isRequired,
   className: propTypes.string,
-
-  /** Apply a style allowing for inline display of icon wrapper */
   inline: propTypes.bool,
-
-  /** Imported SVG resource with a trusted wrapper. */
-  src: propTypes.shape({
-    trustedHTML: propTypes.string,
-  }),
+  title: propTypes.string,
 };
+
+/**
+ * Register icons for use with the `SvgIcon` component.
+ *
+ * @param {IconMap} icons
+ * @param {Object} options
+ *  @param {boolean} [options.reset] - If `true`, remove existing registered icons.
+ */
+export function registerIcons(icons, { reset = false } = {}) {
+  if (reset) {
+    iconRegistry = {};
+  }
+  Object.assign(iconRegistry, icons);
+}
+
+/**
+ * Return the currently available icons.
+ *
+ * To register icons, don't mutate this directly but call `registerIcons`
+ * instead.
+ *
+ * @return {IconMap}
+ */
+export function availableIcons() {
+  return iconRegistry;
+}

--- a/lms/static/scripts/frontend_apps/icons.js
+++ b/lms/static/scripts/frontend_apps/icons.js
@@ -1,0 +1,13 @@
+// @ts-nocheck - TS doesn't understand `require('.../icon.svg')`
+
+/**
+ * Set of icons used by the LMS frontend via the `SvgIcon`
+ * component.
+ */
+export default {
+  'arrow-left': require('../../images/arrow-left.svg'),
+  'arrow-right': require('../../images/arrow-right.svg'),
+  'caret-down': require('../../images/caret-down.svg'),
+  check: require('../../images/check.svg'),
+  spinner: require('../../images/spinner.svg'),
+};

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -14,6 +14,10 @@ const rootEl = document.querySelector('#app');
 
 const config = readConfig();
 
+import { registerIcons } from './components/SvgIcon';
+import iconSet from './icons';
+registerIcons(iconSet);
+
 let rpcServer;
 if (config.mode === 'basic-lti-launch') {
   // Create an RPC Server and start listening to postMessage calls.

--- a/lms/static/styles/components/_SvgIcon.scss
+++ b/lms/static/styles/components/_SvgIcon.scss
@@ -3,7 +3,6 @@
   display: flex;
 
   &--inline {
-    
     display: inline;
   }
 }


### PR DESCRIPTION
Update the `SvgIcon` component to match the latest version from
`src/shared/components` in the `client` repository, with the casing of
file names and class names adapted to the LMS frontend's conventions [2].

The main change is to the way that icons are registered [1]. Icons are
now registered in `frontend_apps/index.js` by a call to `registerIcons`
and then referenced via a `name` prop in components.

In future we should look to publish components like this as a package and then consume
it on our various repos. This PR will make that easier by making the APIs consistent.

[1] The lms and client repositories evolved different means of enabling
    icons to be used by `SvgIcon` without hardcoding the list of icons
    within the component itself. The client's method has several advantages:

    - It makes places where `SvgIcon` is used easier to read
    - It avoids the need to suppress a TypeScript error about the use of
      `require('/path/to/icon.svg')`

   There are downsides too, such as needing to manually remove icons from
   the registered set when they are no longer used.

[2] A subject that the frontend devs need to discuss separately

----

For testing these changes, I found it convenient to temporarily patch the backend code to make the grading view show up inside Canvas. See [Slack thread](https://hypothes-is.slack.com/archives/C1MA4E9B9/p1594722772397300). Alternatively you can test in another LMS that does use our custom grading view.