### PR TITLE
Centralize frontend configuration parsing and documentation

### DIFF
--- a/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
@@ -35,7 +35,7 @@ export default function CanvasOAuth2RedirectErrorApp({
   const error = { details: errorDetails };
 
   const retry = () => {
-    location.href = authorizeUrl;
+    location.href = /** @type {string} */ (authorizeUrl);
   };
 
   const buttons = [

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -1,7 +1,7 @@
 import { createContext } from 'preact';
 
 /**
- * Parameters for an "canned" API call that the frontend can make to the server.
+ * Parameters for a "canned" API call that the frontend can make to the server.
  *
  * The parameters of the call are decided by the backend, but the frontend
  * decides _when_ to make the call and what to show while waiting for the
@@ -116,6 +116,10 @@ export function readConfig() {
     throw new Error(`No config object found for selector "${selector}"`);
   }
 
-  const config = JSON.parse(/** @type {string} */ (configEl.textContent));
-  return config;
+  try {
+    const config = JSON.parse(/** @type {string} */ (configEl.textContent));
+    return config;
+  } catch (err) {
+    throw new Error('Failed to parse frontend configuration');
+  }
 }

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -1,7 +1,121 @@
 import { createContext } from 'preact';
 
 /**
+ * Parameters for an "canned" API call that the frontend can make to the server.
+ *
+ * The parameters of the call are decided by the backend, but the frontend
+ * decides _when_ to make the call and what to show while waiting for the
+ * response.
+ *
+ * @typedef ApiCallInfo
+ * @prop {string} path
+ * @prop {Object} data
+ */
+
+/**
+ * @typedef StudentInfo
+ * @prop {string} displayName
+ * @prop {string} userid
+ */
+
+/**
+ * Data needed to render the grading bar shown when an instructor views an assignment.
+ *
+ * @typedef GradingConfig
+ * @prop {string} assignmentName
+ * @prop {string} courseName
+ * @prop {boolean} enabled
+ * @prop {StudentInfo[]} students
+ */
+
+/**
+ * Data needed to record an assignment submission.
+ *
+ * @typedef SpeedGraderConfig
+ * @prop {Object} submissionParams
+ */
+
+/**
+ * Configuration for the content/file picker app shown while configuring an
+ * assignment.
+ *
+ * @typedef FilePickerConfig
+ * @prop {string} formAction
+ * @prop {Object.<string,string>} formFields
+ * @prop {Object} canvas
+ *   @prop {boolean} canvas.enabled
+ *   @prop {string} canvas.ltiLaunchUrl
+ *   @prop {string} canvas.courseId
+ * @prop {Object} google
+ *   @prop {string} clientId
+ *   @prop {string} developerKey
+ *   @prop {string} origin
+ */
+
+/**
+ * Configuration for the error dialog shown if authorizing access to the
+ * Canvas API fails.
+ *
+ * @typedef CanvasAuthErrorConfig
+ * @prop {string|null} authorizeUrl
+ * @prop {boolean} invalidScope
+ * @prop {string} errorDetails
+ * @prop {string[]} scopes
+ */
+
+/**
+ * Data/configuration needed for frontend applications in the LMS app.
+ * The `mode` property specifies which frontend application should load and
+ * the available configuration/data depends on the mode and LTI user role.
+ *
+ * The documentation for these properties lives in the `JSConfig` class in
+ * the backend code.
+ *
+ * @typedef ConfigObject
+ * @prop {string} mode
+ * @prop {Object} api
+ *   @prop {string} api.authToken
+ *   @prop {ApiCallInfo} api.sync
+ *   @prop {string} api.viaCallbackUrl
+ * @prop {string} authUrl
+ * @prop {Object} canvas
+ *   @prop {string} canvas.authUrl
+ *   @prop {SpeedGraderConfig} canvas.speedGrader
+ * @prop {boolean} dev
+ * @prop {FilePickerConfig} filePicker
+ * @prop {GradingConfig} grading
+ * @prop {Object} hypothesisClient
+ * @prop {Object} rpcServer
+ *   @prop {string[]} rpcServer.allowedOrigins
+ * @prop {string} viaUrl
+ * @prop {CanvasAuthErrorConfig} canvasOAuth2RedirectError
+ */
+
+/**
  * Configuration object for the file picker application, read from a JSON
  * script tag injected into the page by the backend.
  */
-export const Config = createContext({ api: {} });
+
+const defaultConfig = /** @type {any} */ ({ api: {} });
+
+export const Config = createContext(
+  /** @type {ConfigObject} */ (defaultConfig)
+);
+
+/**
+ * Read frontend app configuration from a JSON `<script>` tag in the page
+ * matching the selector ".js-config".
+ *
+ * @return {ConfigObject}
+ */
+export function readConfig() {
+  const selector = '.js-config';
+  const configEl = document.querySelector(selector);
+
+  if (!configEl) {
+    throw new Error(`No config object found for selector "${selector}"`);
+  }
+
+  const config = JSON.parse(/** @type {string} */ (configEl.textContent));
+  return config;
+}

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -4,19 +4,23 @@ import 'focus-visible';
 // Setup app.
 import { createElement, render } from 'preact';
 
-import { Config } from './config';
+import { readConfig, Config } from './config';
 import BasicLtiLaunchApp from './components/BasicLtiLaunchApp';
 import CanvasOAuth2RedirectErrorApp from './components/CanvasOAuth2RedirectErrorApp';
 import FilePickerApp from './components/FilePickerApp';
 import { startRpcServer } from '../postmessage_json_rpc/server';
 
 const rootEl = document.querySelector('#app');
-const config = JSON.parse(document.querySelector('.js-config').textContent);
+
+const config = readConfig();
 
 let rpcServer;
 if (config.mode === 'basic-lti-launch') {
   // Create an RPC Server and start listening to postMessage calls.
-  rpcServer = startRpcServer();
+  rpcServer = startRpcServer({
+    allowedOrigins: config.rpcServer.allowedOrigins,
+    clientConfig: config.hypothesisClient,
+  });
 }
 
 render(

--- a/lms/static/scripts/frontend_apps/test/config-test.js
+++ b/lms/static/scripts/frontend_apps/test/config-test.js
@@ -1,0 +1,33 @@
+import { readConfig } from '../config';
+
+describe('readConfig', () => {
+  let expectedConfig;
+  let configEl;
+
+  beforeEach(() => {
+    expectedConfig = {
+      allowedOrigins: ['https://hypothes.is'],
+    };
+    configEl = document.createElement('script');
+    configEl.className = 'js-config';
+    configEl.type = 'application/json';
+    configEl.textContent = JSON.stringify(expectedConfig);
+    document.body.appendChild(configEl);
+  });
+
+  afterEach(() => {
+    configEl.remove();
+  });
+
+  it('should throw an error if the .js-config object is missing', () => {
+    configEl.remove();
+    assert.throws(() => {
+      readConfig();
+    }, 'No config object found for selector ".js-config"');
+  });
+
+  it('should return the parsed configuration', () => {
+    const config = readConfig();
+    assert.deepEqual(config, expectedConfig);
+  });
+});

--- a/lms/static/scripts/frontend_apps/test/config-test.js
+++ b/lms/static/scripts/frontend_apps/test/config-test.js
@@ -19,11 +19,18 @@ describe('readConfig', () => {
     configEl.remove();
   });
 
-  it('should throw an error if the .js-config object is missing', () => {
+  it('should throw if the .js-config object is missing', () => {
     configEl.remove();
     assert.throws(() => {
       readConfig();
     }, 'No config object found for selector ".js-config"');
+  });
+
+  it('should throw if the config cannot be parsed', () => {
+    configEl.textContent = 'not valid JSON';
+    assert.throws(() => {
+      readConfig();
+    }, 'Failed to parse frontend configuration');
   });
 
   it('should return the parsed configuration', () => {

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -8,7 +8,11 @@ let server = {}; // Singleton RPC server reference
  * @param {Object} options
  *   @param {string[]} options.allowedOrigins -
  *     Origins that are allowed to request client configuration
- *   @param {Object} options.clientConfig - Configuration for the Hypothesis client
+ *   @param {Object} options.clientConfig -
+ *     Configuration for the Hypothesis client. Whatever is provided here is
+ *     passed directly to the client via `window.postMessage` when it requests
+ *     configuration. It should be a subset of the config options specified at
+ *     https://h.readthedocs.io/projects/client/en/latest/publishers/config/.
  * @return {Server} - Instance of the server.
  */
 function startRpcServer({ allowedOrigins, clientConfig }) {

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -5,14 +5,14 @@ let server = {}; // Singleton RPC server reference
 /**
  * Create a new RPC server and register any methods it will support.
  *
- * @param {Object} config
- *   @param {string[]} config.allowedOrigins -
+ * @param {Object} options
+ *   @param {string[]} options.allowedOrigins -
  *     Origins that are allowed to request client configuration
- *   @param {Object} config.clientConfig - Configuration for the Hypothesis client
+ *   @param {Object} options.clientConfig - Configuration for the Hypothesis client
  * @return {Server} - Instance of the server.
  */
-function startRpcServer(config) {
-  server = new Server(config.allowedOrigins);
+function startRpcServer({ allowedOrigins, clientConfig }) {
+  server = new Server(allowedOrigins);
 
   /**
    * Methods that are remotely callable by JSON-RPC over postMessage.
@@ -25,7 +25,7 @@ function startRpcServer(config) {
   /**
    * Config request RPC handler.
    */
-  server.register('requestConfig', () => config.clientConfig);
+  server.register('requestConfig', () => clientConfig);
 
   /**
    * Section groups RPC handler.

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -5,10 +5,14 @@ let server = {}; // Singleton RPC server reference
 /**
  * Create a new RPC server and register any methods it will support.
  *
+ * @param {Object} config
+ *   @param {string[]} config.allowedOrigins -
+ *     Origins that are allowed to request client configuration
+ *   @param {Object} config.clientConfig - Configuration for the Hypothesis client
  * @return {Server} - Instance of the server.
  */
-function startRpcServer() {
-  server = new Server();
+function startRpcServer(config) {
+  server = new Server(config.allowedOrigins);
 
   /**
    * Methods that are remotely callable by JSON-RPC over postMessage.
@@ -20,14 +24,8 @@ function startRpcServer() {
 
   /**
    * Config request RPC handler.
-   *
-   * @returns {Object} - A Hypothesis client config object for the current LTI request.
    */
-  server.register('requestConfig', () => {
-    const configEl = document.querySelector('.js-config');
-    const clientConfigObj = JSON.parse(configEl.textContent).hypothesisClient;
-    return clientConfigObj;
-  });
+  server.register('requestConfig', () => config.clientConfig);
 
   /**
    * Section groups RPC handler.

--- a/lms/static/scripts/postmessage_json_rpc/server/test/server-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/test/server-test.js
@@ -1,36 +1,19 @@
 import Server from '../server';
 
-describe('postmessage_json_rpc/server#Server', () => {
+describe('Server', () => {
   // The window origin of the server.
   // postMessage messages must be sent to this origin in order for the server
   // to receive them.
   const serversOrigin = 'http://localhost:9876';
 
-  let configEl;
   let server;
   let registeredMethod;
   let registeredMethodError;
   let listener;
   let receiveMessage;
 
-  beforeEach('inject the server config into the document', () => {
-    configEl = document.createElement('script');
-    configEl.setAttribute('type', 'application/json');
-    configEl.classList.add('js-config');
-    configEl.textContent = JSON.stringify({
-      rpcServer: {
-        allowedOrigins: ['http://localhost:9876'],
-      },
-    });
-    document.body.appendChild(configEl);
-  });
-
-  afterEach('remove the server config from the document', () => {
-    configEl.remove();
-  });
-
   beforeEach('set up the test server', () => {
-    server = new Server();
+    server = new Server(['http://localhost:9876']);
     registeredMethod = sinon.stub().resolves('test_result');
     server.register('registeredMethodName', registeredMethod);
 


### PR DESCRIPTION
Originally the LMS frontend and postmessage RPC server were entirely
separate and read configuration from different sources. For various
reasons the frontend app and RPC server were unified into a single
application that read the same configuration object, however the
configuration parsing was duplicated multiple times in the frontend.

This commit centralizes the knowledge of how to parse frontend
configuration from the page in a `readConfig` function in `config.js`.
Rather than having this function be called in multiple places, the
frontend's `index.js` calls this function once and then passes the
necessary configuration through to `startRpcServer` and the `Server`
constructor.

As part of this cleanup, JSDoc definitions of the structure of the
config object expected by the frontend have been added to `config.js`.
This provides a central reference that can be compared with the
corresponding `JSConfig` class on the backend.

 - Centralize frontend config parsing in `readConfig` function

 - Add JSDoc definitions of frontend config structure to `config.js`

 - Improve JSDoc types for `Server` class