### PR TITLE
Fix Google API loader typecheck errors

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/google-api-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-api-client.js
@@ -12,8 +12,8 @@ async function loadGAPI() {
     gapiScript.onload = () => {
       resolve(window.gapi);
     };
-    gapiScript.onerror = ({ error }) => {
-      reject(error);
+    gapiScript.onerror = () => {
+      reject(new Error('Failed to load Google API client'));
     };
     document.body.appendChild(gapiScript);
   });

--- a/lms/static/scripts/frontend_apps/utils/test/google-api-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-api-client-test.js
@@ -45,7 +45,7 @@ describe('loadLibraries', () => {
     const libs = loadLibraries(['one', 'two']);
 
     // Simulate api.js failing to load.
-    dummyScript.onerror({ error: new Error('Script failed to load') });
+    dummyScript.onerror();
 
     let err;
     try {
@@ -53,7 +53,7 @@ describe('loadLibraries', () => {
     } catch (e) {
       err = e;
     }
-    assert.equal(err.message, 'Script failed to load');
+    assert.equal(err.message, 'Failed to load Google API client');
   });
 
   it('rejects if loading requested libraries fails', async () => {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/core": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.10.4",
+    "@types/gapi": "^0.0.39",
     "autoprefixer": "^9.8.5",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "babelify": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,6 +941,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/gapi@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/gapi/-/gapi-0.0.39.tgz#bc7fa8cd0cb175b36e3609790fb2ed73a33f6881"
+  integrity sha512-R1TZeZbvvbIC60DBJMhuOEivQHzOQtzl3uMDOOENTYQTSSDB6oEMpJo8HVPOTWivdUTbyEcB5qQOVr/JCKRlCQ==
+
 "@types/node@*":
   version "14.0.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.10.tgz#dbfaa170bd9eafccccb6d7060743a761b0844afd"


### PR DESCRIPTION
Add the `@types/gapi` package recommended in the Google API loader's
README [1]. This fixes the errors reported in this file when running `yarn typecheck`.

[1] https://github.com/google/google-api-javascript-client#features