### PR TITLE
Add ApplicationInstance.settings and Course.settings server_defaults

### DIFF
--- a/lms/migrations/versions/5086e8b137b9_add_settings_server_default_and_not_.py
+++ b/lms/migrations/versions/5086e8b137b9_add_settings_server_default_and_not_.py
@@ -1,0 +1,27 @@
+"""
+Add ApplicationInstance.settings and Course.settings server defaults and make them not-nullable.
+
+Revision ID: 5086e8b137b9
+Revises: 7f9824ded172
+Create Date: 2020-07-16 10:23:06.469812
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "5086e8b137b9"
+down_revision = "7f9824ded172"
+
+
+def upgrade():
+    op.alter_column("application_instances", "settings", nullable=False)
+    op.alter_column(
+        "application_instances", "settings", server_default=sa.text("'{}'::jsonb")
+    )
+    op.alter_column("course", "settings", server_default=sa.text("'{}'::jsonb"))
+
+
+def downgrade():
+    op.alter_column("application_instances", "settings", nullable=True)
+    op.alter_column("application_instances", "settings", server_default=None)
+    op.alter_column("course", "settings", server_default=None)

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -31,7 +31,12 @@ class ApplicationInstance(BASE):
         server_default=sa.sql.expression.true(),
         nullable=False,
     )
-    _settings = sa.Column("settings", MutableDict.as_mutable(JSONB))
+    _settings = sa.Column(
+        "settings",
+        MutableDict.as_mutable(JSONB),
+        server_default=sa.text("'{}'::jsonb"),
+        nullable=False,
+    )
 
     @property
     def settings(self):

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -23,7 +23,12 @@ class Course(BASE):
     #: settings belong to.
     authority_provided_id = sa.Column(sa.UnicodeText(), primary_key=True)
 
-    _settings = sa.Column("settings", MutableDict.as_mutable(JSONB), nullable=False)
+    _settings = sa.Column(
+        "settings",
+        MutableDict.as_mutable(JSONB),
+        server_default=sa.text("'{}'::jsonb"),
+        nullable=False,
+    )
 
     @property
     def settings(self):


### PR DESCRIPTION
...and also make `ApplicationSettings.settings` not-nullable like `Course.settings` already is.

Make `ApplicationInstance.settings` default to an empty dict rather than `NULL` at the Postgres level, and make it not nullable at the Postgres level.

In practice there are no NULLs in the QA or prod DBs. Let's enforce that at the DB level so that we don't need to worry about enforcing it (or potentially failing to enforce it) at the Python level (including both Python app code and future migration scripts).