### PR TITLE
Make ApplicationSettings a SQLAlchemy type

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -5,7 +5,6 @@ import sqlalchemy as sa
 from Crypto import Random
 from Crypto.Cipher import AES
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.mutable import MutableDict
 
 from lms.db import BASE
 from lms.models.application_settings import ApplicationSettings
@@ -31,28 +30,13 @@ class ApplicationInstance(BASE):
         server_default=sa.sql.expression.true(),
         nullable=False,
     )
-    _settings = sa.Column(
+
+    settings = sa.Column(
         "settings",
-        MutableDict.as_mutable(JSONB),
+        ApplicationSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )
-
-    @property
-    def settings(self):
-        """
-        Get a settings object which can get and set grouped settings.
-
-        The object can be queried with `settings.get(group, key)` or
-        `settings.set(group, key, value)`.
-
-        :rtype: models.ApplicationSettings
-        """
-
-        if self._settings is None:
-            self._settings = {}
-
-        return ApplicationSettings(self._settings)
 
     #: A list of all the OAuth2Tokens for this application instance
     #: (each token belongs to a different user of this application
@@ -93,7 +77,7 @@ class ApplicationInstance(BASE):
             developer_secret=encrypted_secret,
             aes_cipher_iv=aes_iv,
             created=datetime.utcnow(),
-            _settings=settings,
+            settings=settings,
         )
 
 

--- a/lms/models/application_settings.py
+++ b/lms/models/application_settings.py
@@ -28,3 +28,9 @@ class ApplicationSettings(MutableDict):
 
     def clone(self):
         return ApplicationSettings(deepcopy(self))
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({super().__repr__()})"
+
+    def __str__(self):
+        return repr(self)

--- a/lms/models/application_settings.py
+++ b/lms/models/application_settings.py
@@ -1,11 +1,10 @@
 from copy import deepcopy
 
+from sqlalchemy.ext.mutable import MutableDict
 
-class ApplicationSettings:
+
+class ApplicationSettings(MutableDict):
     """Model for accessing and updating application settings."""
-
-    def __init__(self, data):
-        self.data = data
 
     def get(self, group, key):
         """
@@ -15,7 +14,7 @@ class ApplicationSettings:
         :param key: The key in that group
         :return: The value or None
         """
-        return self.data.get(group, {}).get(key)
+        return super().get(group, {}).get(key)
 
     def set(self, group, key, value):
         """
@@ -25,7 +24,7 @@ class ApplicationSettings:
         :param key: The key in that group
         :param value: The value to set
         """
-        self.data.setdefault(group, {})[key] = value
+        super().setdefault(group, {})[key] = value
 
     def clone(self):
-        return ApplicationSettings(deepcopy(self.data))
+        return ApplicationSettings(deepcopy(self))

--- a/lms/models/application_settings.py
+++ b/lms/models/application_settings.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from sqlalchemy.ext.mutable import MutableDict
 
 
@@ -25,9 +23,6 @@ class ApplicationSettings(MutableDict):
         :param value: The value to set
         """
         super().setdefault(group, {})[key] = value
-
-    def clone(self):
-        return ApplicationSettings(deepcopy(self))
 
     def __repr__(self):
         return f"{self.__class__.__name__}({super().__repr__()})"

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -1,6 +1,5 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.mutable import MutableDict
 
 from lms.db import BASE
 from lms.models.application_settings import ApplicationSettings
@@ -23,18 +22,9 @@ class Course(BASE):
     #: settings belong to.
     authority_provided_id = sa.Column(sa.UnicodeText(), primary_key=True)
 
-    _settings = sa.Column(
+    settings = sa.Column(
         "settings",
-        MutableDict.as_mutable(JSONB),
+        ApplicationSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )
-
-    @property
-    def settings(self):
-        """
-        Return this course's settings.
-
-        :rtype: models.ApplicationSettings
-        """
-        return ApplicationSettings(self._settings)

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -28,8 +28,7 @@ class CourseService:
         return bool(
             self._db.query(Course)
             .filter(Course.consumer_key == self._consumer_key)
-            # pylint: disable=protected-access
-            .filter(Course._settings[group][key] == json.dumps(value))
+            .filter(Course.settings[group][key] == json.dumps(value))
             .limit(1)
             .count()
         )
@@ -52,7 +51,7 @@ class CourseService:
         course = Course(
             consumer_key=self._consumer_key,
             authority_provided_id=authority_provided_id,
-            _settings=course_settings.data,
+            settings=course_settings,
         )
 
         self._db.add(course)

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 
 from lms.models import Course, CourseGroupsExportedFromH
 
@@ -39,7 +40,7 @@ class CourseService:
     def _create(self, authority_provided_id):
         # By default we'll make our course setting have the same settings
         # as the application instance
-        course_settings = self._ai_getter.settings().clone()
+        course_settings = deepcopy(self._ai_getter.settings())
 
         # Unless! The group was pre-sections, and we've just seen it for the
         # first time in which case turn sections off

--- a/tests/factories/course.py
+++ b/tests/factories/course.py
@@ -7,5 +7,5 @@ Course = factory.make_factory(  # pylint:disable=invalid-name
     models.Course,
     consumer_key=OAUTH_CONSUMER_KEY,
     authority_provided_id=factory.Faker("hexify", text="^" * 40),
-    _settings=factory.lazy_attribute(lambda o: {}),
+    settings=factory.lazy_attribute(lambda o: {}),
 )

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -35,11 +35,10 @@ class TestApplicationInstance:
 
         assert application_instance.provisioning is not None
 
-    def test_settings_defaults_to_an_empty_dict(self, application_instance):
+    def test_settings_defaults_to_None(self, application_instance):
         settings = application_instance.settings
 
-        assert isinstance(settings, ApplicationSettings)
-        assert settings == {}
+        assert settings is None
 
     def test_settings_can_be_retrieved(self, application_instance):
         application_instance.settings = {"group": {"key": "value"}}

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -39,19 +39,19 @@ class TestApplicationInstance:
         settings = application_instance.settings
 
         assert isinstance(settings, ApplicationSettings)
-        assert settings.data == {}
+        assert settings == {}
 
     def test_settings_can_be_retrieved(self, application_instance):
-        application_instance._settings = {"group": {"key": "value"}}
+        application_instance.settings = {"group": {"key": "value"}}
 
         assert application_instance.settings.get("group", "key") == "value"
 
     def test_can_update_settings(self, application_instance):
-        application_instance._settings = {"group": {"key": "value"}}
+        application_instance.settings = {"group": {"key": "value"}}
 
         application_instance.settings.set("group", "key", "new_value")
 
-        assert application_instance._settings["group"]["key"] == "new_value"
+        assert application_instance.settings["group"]["key"] == "new_value"
 
     def test_consumer_key_cant_be_null(self, db_session, application_instance):
         application_instance.consumer_key = None

--- a/tests/unit/lms/models/application_settings_test.py
+++ b/tests/unit/lms/models/application_settings_test.py
@@ -5,7 +5,7 @@ from lms.models import ApplicationSettings
 
 class TestApplicationSettings:
     def test_data(self, application_settings):
-        assert application_settings.data == {"test_group": {"test_key": "test_value"}}
+        assert application_settings == {"test_group": {"test_key": "test_value"}}
 
     @pytest.mark.parametrize(
         "group,key,expected_value",
@@ -35,7 +35,7 @@ class TestApplicationSettings:
     def test_set(self, application_settings, group, key, value, expected_value):
         application_settings.set(group, key, value)
 
-        assert application_settings.data[group][key] == expected_value
+        assert application_settings[group][key] == expected_value
 
     def test_clone(self, application_settings):
         cloned_settings = application_settings.clone()

--- a/tests/unit/lms/models/application_settings_test.py
+++ b/tests/unit/lms/models/application_settings_test.py
@@ -46,6 +46,18 @@ class TestApplicationSettings:
         assert application_settings.get("test_group", "test_key") == "test_value"
         assert cloned_settings.get("test_group", "test_key") == "new_value"
 
+    def test__repr__(self, application_settings):
+        assert (
+            repr(application_settings)
+            == "ApplicationSettings({'test_group': {'test_key': 'test_value'}})"
+        )
+
+    def test__str__(self, application_settings):
+        assert (
+            str(application_settings)
+            == "ApplicationSettings({'test_group': {'test_key': 'test_value'}})"
+        )
+
     @pytest.fixture
     def application_settings(self):
         return ApplicationSettings({"test_group": {"test_key": "test_value"}})

--- a/tests/unit/lms/models/application_settings_test.py
+++ b/tests/unit/lms/models/application_settings_test.py
@@ -37,15 +37,6 @@ class TestApplicationSettings:
 
         assert application_settings[group][key] == expected_value
 
-    def test_clone(self, application_settings):
-        cloned_settings = application_settings.clone()
-
-        assert cloned_settings.get("test_group", "test_key") == "test_value"
-
-        cloned_settings.set("test_group", "test_key", "new_value")
-        assert application_settings.get("test_group", "test_key") == "test_value"
-        assert cloned_settings.get("test_group", "test_key") == "new_value"
-
     def test__repr__(self, application_settings):
         assert (
             repr(application_settings)

--- a/tests/unit/lms/models/course_test.py
+++ b/tests/unit/lms/models/course_test.py
@@ -3,7 +3,7 @@ from lms.models import Course
 
 class TestCourse:
     def test_settings(self):
-        course = Course(_settings={"group": {"key": "value"}})
+        course = Course(settings={"group": {"key": "value"}})
 
         settings = course.settings
 

--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -103,7 +103,7 @@ class TestApplicationInstanceGetter:
         assert not ai_getter.canvas_sections_supported()
 
     def test_settings(self, ai_getter, test_application_instance):
-        assert ai_getter.settings().data == test_application_instance.settings.data
+        assert ai_getter.settings() == test_application_instance.settings
 
     def test_shared_secret_returns_the_shared_secret(self, ai_getter):
         assert ai_getter.shared_secret() == "TEST_SHARED_SECRET"

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -98,7 +98,7 @@ class TestCourseService:
 
             for settings in settings_set:
                 db_session.add(
-                    factories.Course(consumer_key=consumer_key, _settings=settings,)
+                    factories.Course(consumer_key=consumer_key, settings=settings)
                 )
 
         return add_courses_with_settings


### PR DESCRIPTION
**Depends on** https://github.com/hypothesis/lms/pull/1907 for the tests to pass.

This means that instead of doing this:

https://github.com/hypothesis/lms/blob/2e7133a6714a06347d1fbc3d080d602e755ec44e/lms/models/application_instance.py#L34-L50

which is repeated in both [`ApplicationInstance`](https://github.com/hypothesis/lms/blob/2e7133a6714a06347d1fbc3d080d602e755ec44e/lms/models/application_instance.py#L34-L50) and [`Course`](https://github.com/hypothesis/lms/blob/2e7133a6714a06347d1fbc3d080d602e755ec44e/lms/models/course.py#L26-L35), both places (and any future ones) can now just do this one-liner:

https://github.com/hypothesis/lms/blob/90d8df42328c7a594a981964dd55f34832684154/lms/models/application_instance.py#L34

# Benefits

* The boilerplate code that's required in each model class to use `ApplicationSettings` is much shorter
* `ApplicationSettings` attributes on models behave like you would expect them to: the same as any other SQLAlchemy attribute. This differs from before in a bunch of ways
* Models no longer have separate `_settings`, `settings` and `settings.data` attributes. There's now just one `settings` attr which is an `ApplicationSettings` object

# Demo

## New "transient" models get `settings=None` by default

When you create a new `ApplicationInstance` (for example) that isn't in the DB yet, `settings` is initially `None` and so trying to use it can crash:

```python
>>> ai = models.ApplicationInstance()                                                                                                                                                               
>>> ai.settings is None                                                                                                                                                                             
True

>>> ai.settings.get("canvas", "sections_enabled")                                                                                                                                                   
AttributeError: 'NoneType' object has no attribute 'get'
```

This could be fixed by adding an `__init__()` that sets a default value. Something like:

```python
class ApplicationInstance(Base):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.settings = self.settings or ApplicationSettings()
```

But I don't think we should do this. Defaulting to `None` is okay because this is how SQLAlchemy model attributes normally work. For example the `consumer_key` attribute (a string) is the same:

```python
>>> ai = models.ApplicationInstance()                                                                                                                                                               
>>> ai.consumer_key is None                                                                                                                                                                         
True

>>> ai.consumer_key.upper()                                                                                                                                                                         
AttributeError: 'NoneType' object has no attribute 'upper'
```

## Passing a dict to `settings` turns it into an `ApplicationSettings`

I'm not actually sure how / why this works :) But if you initialize an `ApplicationInstance` passing a plain dict as `settings` it gets turned into an `ApplicationSettings`:

```python
>>> ai = models.ApplicationInstance(settings={"canvas": {"sections_enabled": True}})                                                                                                                
>>> ai.settings                                                                                                                                                                                    
ApplicationSettings({'canvas': {'sections_enabled': True}})

>>> ai.settings.get("foo", "bar") is None                                                                                                                                                          
True
```

Assigning to `settings` also does the same:

```python
>>> ai = models.ApplicationInstance()                                                                                                                                                              
>>> ai.settings = {"canvas": {"sections_enabled": True}}                                                                                                                                           
>>> ai.settings                                                                                                                                                                                    
ApplicationSettings({'canvas': {'sections_enabled': True}})
```

## Persistent objects with `NULL` in the `settings` column get `settings=None`

The `application_instances.settings` column is currently nullable in the DB. If you retrieve a row that has `NULL` in the column it gets `settings=None`:

```python
>>> ai = db.query(models.ApplicationInstance).filter_by(consumer_key='Hypothesis84a316e31206259c3c58cbf7e8b0cbc8').one()                                                                           
>>> ai.settings is None                                                                                                                                                                            
True
```

This is annoying because it means that any code that wants to use `settings` has to account for the fact that it might be `None`. This is fixable though: we can make `settings` not nullable and default to an empty dict at the Postgres level: https://github.com/hypothesis/lms/pull/1907. This seems like the right way to handle this, as this is how you would normally make any other type of column required and have a default. It's also quite nice and explicit: it gives the default value and `nullable=False` right on the model attribute in the class (which is where you'd normally expect to find defaults and `nullable=False` for any other type of SQLAlchemy attribute. The `ApplicationSettings` and `ApplicationInstance` classes (and the Python code generally) don't need to deal with null values or defaults except for specifying them in the attribute declaration:

```python
class ApplicationInstance:
    settings = Column(ApplicationSettings.as_mutable(JSONB), server_default=text("'{}'::jsonb"), nullable=False)
```

## Persistent objects with non-NULL in the `settings` column get `ApplicationSettings` objects

No surprise here:

```python
>>> ai = db.query(models.ApplicationInstance).filter_by(consumer_key='Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b').one()                                                                           
>>> ai.settings                                                                                                                                                                                    
ApplicationSettings({'canvas': {'sections_enabled': True}})
```

## You can mutate the dict directly and then call `changed()`

If you use `ApplicationSettings`'s `set()` method then changes will automatically be persisted.

`ApplicationSettings` is also a `dict` subclass so you can mutate it with normal `dict` methods. Normally any top-level mutations will be persisted (since `ApplicationSettings` subclasses SQLAlchemy's `MutableDict` which supports top-level mutations) but any nested mutations will not be persisted unless you call `changed()`:

```python
>>> ai = db.query(models.ApplicationInstance).filter_by(consumer_key='Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b').one()                                                                           
>>> ai.settings["canvas"]["sections_enabled"] = False                                                                                                                                              
>>> ai.settings.changed()
>>> tm.commit()
```

Direct mutation also enables you to make the dict invalid, but I think that's fixable. Covered further down below.

## All of the normal `dict` methods are accessible

`ApplicationSettings` no longer composes a dict (it was previously accessible as `ai.data`), it now subclasses `MutableDict` (which subclasses `dict`). This means that all of the normal methods for reading and writing dicts, comparisons, etc are available.

We _could_ override all of the standard `dict` methods in `ApplicationSettings` and disable them, forcing use of the safe `get()` and `set()` methods. But I don't think we should bother. I think the more Pythonic thing to do is just document "good behaviour" in the `ApplicationSettings` docstring and leave it up to the user.

It's a little weird that `ApplicationSettings` behaves in every way like a normal `dict` _except_ that its `get()` method has a different signature and behaviour from `dict.get()`.

## Python's normal copy protocol works

Since `ApplicationSettings` is a dict subclass you can copy (clone) it in the same way you'd clone a normal dict or other standard Python object: by using the `copy` module. The custom `clone()` method that `ApplicationSettings` used to have is no longer needed. There's probably all sorts of other standard Python stuff that now works too:

```python
>>> import copy                                                                                                                                                                                    
>>> ai.settings                                                                                                                                                                                    
ApplicationSettings({'foo': 'bar', 'canvas': {'sections_enabled': False}})

>>> settings_copy = copy.deepcopy(ai.settings)                                                                                                                                                     
>>> settings_copy                                                                                                                                                                                  
ApplicationSettings({'foo': 'bar', 'canvas': {'sections_enabled': False}})

>>> settings_copy.set("canvas", "sections_enabled", True)                                                                                                                                          
>>> settings_copy                                                                                                                                                                                  
ApplicationSettings({'foo': 'bar', 'canvas': {'sections_enabled': True}})

>>> ai.settings                                                                                                                                                                                    
ApplicationSettings({'foo': 'bar', 'canvas': {'sections_enabled': False}})
```

## The `Course` test factory

The `Course` test factory creates an empty `ApplicationSettings` by default but lets you specify it using a dict:

```python
>>> course = factories.Course()                                                                                                                                                                     
>>> course.settings                                                                                                                                                                                 
ApplicationSettings({})

>>> course = factories.Course(settings={"foo": "bar"})                                                                                                                                              
>>> course.settings                                                                                                                                                                                 
ApplicationSettings({'foo': 'bar'})
```
## You can set `settings` to a malformed dict

Because you can directly assign `settings` using a dict and can also mutate it using `dict` methods directly, it's possible to break things. I think this is probably another case of "you should go through the `get()` and `set()` methods and if you don't it's your responsibility":

```python
>>> ai = models.ApplicationInstance(settings={"foo": 23})                                                                                                                                           
>>> ai.settings.get("foo", "bar")                                                                                                                                                                   
AttributeError: 'int' object has no attribute 'get'
```

We _could_ prevent this by adding validation to the `ApplicationSettings` class. `ApplicationSettings` would have to override `__init__()` and all `dict` mutator methods and validate the value (e.g. raise if a top-level key is being set to a non-dict value). I don't think there's a SQLAlchemy way of doing this--I think we'd have to do it in a Python way, by overriding all the dict mutator methods in `ApplicationSettings`.

I'm not sure whether this is worthwhile?

I'd like to do it in a separate PR or not at all.