### PR TITLE
Convert `Dialog` props from prop-types to JSDoc and fix ref usage in `URLPicker`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -13,7 +13,8 @@ import { useUniqueId } from '../utils/hooks';
  *
  * @typedef DialogProps
  * @prop {Object} children - The content of the dialog.
- * @prop {Object} [initialFocus] - A ref associated with the child element to focus when the dialog is rendered.
+ * @prop {import("preact/hooks").Ref<HTMLElement>} [initialFocus] -
+ *   Child element to focus when the dialog is rendered.
  * @prop {JSXElement[]} [buttons] -
  *   Additional `Button` elements to display at the bottom of the dialog.
  *   A "Cancel" button is added automatically if the `onCancel` prop is set.

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -58,7 +58,7 @@ export default function Dialog({
   const rootEl = useRef(/** @type {HTMLDivElement|null} */ (null));
 
   useElementShouldClose(rootEl, true, () => {
-    if (typeof onCancel === 'function') {
+    if (onCancel) {
       onCancel();
     }
   });

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -9,6 +9,23 @@ import { zIndexScale } from '../utils/style';
 import { useUniqueId } from '../utils/hooks';
 
 /**
+ * @typedef {import("preact").JSX.Element} JSXElement
+ *
+ * @typedef DialogProps
+ * @prop {Object} children - The content of the dialog.
+ * @prop {Object} [initialFocus] - A ref associated with the child element to focus when the dialog is rendered.
+ * @prop {JSXElement[]} [buttons] -
+ *   Additional `Button` elements to display at the bottom of the dialog.
+ *   A "Cancel" button is added automatically if the `onCancel` prop is set.
+ * @prop {string} [contentClass] - e.g. <button>
+ * @prop {'dialog'|'alertdialog'} [role] - The aria role for the dialog (defaults to" dialog")
+ * @prop {string} title - The title of the dialog.
+ * @prop {() => any} [onCancel] -
+ *   A callback to invoke when the user cancels the dialog. If provided, a
+ *   "Cancel" button will be displayed.
+ */
+
+/**
  * A modal dialog wrapper with a title. The wrapper sets initial focus to itself
  * unless an element inside of it is specified with the `initialFocus` ref.
  * Optional action buttons may be passed in with the `buttons` prop but the
@@ -24,6 +41,8 @@ import { useUniqueId } from '../utils/hooks';
  *
  * - A description which is reliably read out when the dialog is opened, in
  *   addition to the title.
+ *
+ * @param {DialogProps} props
  */
 export default function Dialog({
   children,
@@ -35,7 +54,7 @@ export default function Dialog({
   buttons,
 }) {
   const dialogTitleId = useUniqueId('dialog');
-  const rootEl = useRef();
+  const rootEl = useRef(/** @type {HTMLDivElement|null} */ (null));
 
   useElementShouldClose(rootEl, true, () => {
     if (typeof onCancel === 'function') {
@@ -103,42 +122,13 @@ export default function Dialog({
 }
 
 Dialog.propTypes = {
-  /** The content of the dialog. */
   children: propTypes.any,
-
-  /**
-   * A ref associated with the child element to focus when the dialog is
-   * rendered.
-   */
   initialFocus: propTypes.object,
-
-  /**
-   * Additional buttons to display at the bottom of the dialog.
-   *
-   * The "Cancel" button is added automatically if the `onCancel` prop is set.
-   */
   buttons: propTypes.arrayOf(
     propTypes.oneOfType([propTypes.instanceOf(Button), propTypes.element])
   ), // e.g. <button>
-
-  /**
-   * Class applied to the content of the dialog.
-   *
-   * The primary role of this class is to set the size of the dialog.
-   */
   contentClass: propTypes.string,
-
-  /**
-   * The aria role for the dialog (defaults to" dialog")
-   */
   role: propTypes.oneOf(['alertdialog', 'dialog']),
-
-  /** The title of the dialog. */
   title: propTypes.string,
-
-  /**
-   * A callback to invoke when the user cancels the dialog. If provided,
-   * a "Cancel" button will be displayed.
-   */
   onCancel: propTypes.func,
 };

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -1,4 +1,5 @@
-import { createRef, createElement } from 'preact';
+import { createElement } from 'preact';
+import { useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import Button from './Button';
@@ -9,8 +10,8 @@ import Dialog from './Dialog';
  * PDF file to use for an assignment.
  */
 export default function URLPicker({ onCancel, onSelectURL }) {
-  const input = createRef();
-  const form = createRef();
+  const input = useRef(/** @type {HTMLInputElement|null} */ (null));
+  const form = useRef(/** @type {HTMLFormElement|null} */ (null));
   const submit = event => {
     event.preventDefault();
     if (form.current.checkValidity()) {


### PR DESCRIPTION
This PR converts the prop documentation for `Dialog` from prop-types to JSDoc and makes some improvements to it in the process. In doing this I uncovered a mistake in `URLPicker` where the wrong function was used to create refs (`createRef` instead of `useRef`). This mistake went unnoticed because of the way the refs were used, but in general is not safe because `createRef` creates a new object every time that it is called, whereas `useRef` returns the same object on each render.