### PR TITLE
Copy all CI checks to GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,66 @@
+name: Continuous integration
+on: [push]
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11.5-alpine
+        ports:
+        - 5433:5432
+    env:
+      TOX_PARALLEL_NO_SPINNER: 1
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6.9
+    - name: Update pip
+      run: python -m pip install --upgrade pip
+    - name: Install tox
+      run: python -m pip install tox
+    - name: Checkout git repo
+      uses: actions/checkout@v2
+    - name: Create test databases
+      run: |
+        psql -U postgres -h localhost -p 5433 -c 'CREATE DATABASE lms_test'
+        psql -U postgres -h localhost -p 5433 -c 'CREATE DATABASE lms_functests'
+        psql -U postgres -h localhost -p 5433 -c 'CREATE DATABASE lms_bddtests'
+    - name: Cache the .tox dir
+      uses: actions/cache@v2
+      with:
+        path: .tox
+        key: ${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements*') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}
+        restore-keys: |
+          .tox-
+    - name: Cache the node_modules dir
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
+    - name: yarn install
+      run: yarn install --frozen-lockfile
+    - name: yarn build
+      run: yarn build
+    - name: Run tox
+      run: tox --parallel auto -e checkformatting,lint,tests,functests,bddtests
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Cache the node_modules dir
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
+    - name: Install
+      run: yarn install --frozen-lockfile
+    - name: Format
+      run: yarn checkformatting
+    - name: Lint
+      run: yarn lint
+    - name: Typecheck
+      run: yarn typecheck
+    - name: Test
+      run: gulp test

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false
 
 [testenv]
+parallel_show_output = true
 skip_install = true
 passenv =
     HOME


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/1874

This gets all the CI checks that we run on Jenkins (or that `make sure` runs) working on GitHub Actions as well: backend and frontend formatting, linting and unit, functional and BDD tests.

See the checks running on GitHub Actions here: https://github.com/hypothesis/lms/actions?query=branch%3Agha

This runs two GitHub Actions jobs named backend and frontend in parallel. Within the backend job, after installing everything, the backend formatting, linting, and unit, functional and BDD tests all run in parallel:

* In parallel:
  * backend:
    * In serial:
      - Start Postgres Docker container
      - Install Python 3.6.9
      - Update pip
      - Install tox
      - Checkout the lms git repo
      - Create the test databases
      - Install the frontend dependencies
      - Build the frontend assets
      - In parallel:
        - Run the backend code formatting
        - Run the backend linting
        - Run the backend unit tests
        - Run the backend functional tests
        - Run the backend BDD tests
  * frontend:
    * In serial:
      - Checkout the lms git repo
      - Install the frontend dependencies
      - Run the frontend code formatting
      - Run the frontend linting
      - Run the frontend tests

Here's a list of everything that's preinstalled in the Ubuntu VM that GHA runs our jobs in: https://github.com/actions/virtual-environments/blob/ubuntu18/20200709.0/images/linux/Ubuntu1804-README.md