### PR TITLE
Fix a couple of typecheck errors in the LMS entry point

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -19,8 +19,17 @@ import Spinner from './Spinner';
 import URLPicker from './URLPicker';
 
 /**
+ * @typedef FilePickerAppProps
+ * @prop {'lms'|'url'|null} [defaultActiveDialog] -
+ *   The dialog that should be shown when the app is first opened.
+ * @prop {() => any} [onSubmit] - Callback invoked when the form is submitted.
+ */
+
+/**
  * An application that allows the user to choose the web page or PDF for an
  * assignment.
+ *
+ * @param {FilePickerAppProps} props
  */
 export default function FilePickerApp({
   defaultActiveDialog = null,
@@ -220,11 +229,6 @@ export default function FilePickerApp({
 }
 
 FilePickerApp.propTypes = {
-  /**
-   * The dialog that should be shown when the app is first opened.
-   */
   defaultActiveDialog: propTypes.oneOf(['url', 'lms']),
-
-  /** Callback invoked when the form is submitted. */
   onSubmit: propTypes.func,
 };

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -11,6 +11,9 @@ import FilePickerApp from './components/FilePickerApp';
 import { startRpcServer } from '../postmessage_json_rpc/server';
 
 const rootEl = document.querySelector('#app');
+if (!rootEl) {
+  throw new Error('#app container for LMS frontend is missing');
+}
 
 const config = readConfig();
 


### PR DESCRIPTION
 - Report a useful error in the console if the `#app` container for the
   LMS frontend is missing. This would indicate an error in the template
   rendered by the backend. Without this TS reports, correctly, that
   the root element passed to `render` might be `null`.

 - Convert FilePickerApp props to JSDoc and indicate that props provided
   for use in tests are optional