### PR TITLE
Convert prop documentation from prop-types to JSDoc for `Table` and `FileList`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -13,13 +13,13 @@ import Table from './Table';
 
 /**
  * @typedef FileListProps
- * @prop {File[]} files - List of file objects returned by a `listFiles` call.
- * @prop {boolean} [isLoading] - Whether to show a loading indicator.
- * @prop {File|null} selectedFile - The file within `files` which is currently selected.
+ * @prop {File[]} files - List of file objects returned by a `listFiles` call
+ * @prop {boolean} [isLoading] - Whether to show a loading indicator
+ * @prop {File|null} selectedFile - The file within `files` which is currently selected
  * @prop {(f: File) => any} [onSelectFile] -
  *   Callback invoked when the user clicks on a file
  * @prop {(f: File) => any} [onUseFile] -
- *   Callback invoked when the user double-clicks a file to indicate that they want to use it.
+ *   Callback invoked when the user double-clicks a file to indicate that they want to use it
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -6,7 +6,26 @@ import Spinner from './Spinner';
 import Table from './Table';
 
 /**
+ * @typedef File
+ * @prop {string} display_name - The filename
+ * @prop {string} updated_at - An ISO date or date + time string
+ */
+
+/**
+ * @typedef FileListProps
+ * @prop {File[]} files - List of file objects returned by a `listFiles` call.
+ * @prop {boolean} [isLoading] - Whether to show a loading indicator.
+ * @prop {File|null} selectedFile - The file within `files` which is currently selected.
+ * @prop {(f: File) => any} [onSelectFile] -
+ *   Callback invoked when the user clicks on a file
+ * @prop {(f: File) => any} [onUseFile] -
+ *   Callback invoked when the user double-clicks a file to indicate that they want to use it.
+ */
+
+/**
  * List of the files within a single directory.
+ *
+ * @param {FileListProps} props
  */
 export default function FileList({
   files,
@@ -61,24 +80,9 @@ export default function FileList({
 }
 
 FileList.propTypes = {
-  /** List of file objects returned by a `listFiles` call. */
   files: propTypes.arrayOf(propTypes.object),
-
-  /** Whether to show a loading indicator. */
   isLoading: propTypes.bool,
-
-  /** The file within `files` which is currently selected. */
   selectedFile: propTypes.object,
-
-  /**
-   * Callback passed the selected file when the user clicks on a file in
-   * order to select it before performing further actions on it.
-   */
   onSelectFile: propTypes.func,
-
-  /**
-   * Callback passed when the user double-clicks a file to indicate that they
-   * want to use it.
-   */
   onUseFile: propTypes.func,
 };

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -10,15 +10,21 @@ import Dialog from './Dialog';
 import ErrorDisplay from './ErrorDisplay';
 import FileList from './FileList';
 
+/**
+ * @typedef {import("./FileList").File} File
+ */
+
+/**
+ * @typedef DialogState
+ * @prop {'fetching'|'fetched'|'authorizing'|'error'} state
+ * @prop {File[]|null} files - List of fetched files
+ * @prop {Error|null} error - Details of current error, if `state` is 'error'
+ */
+
+/** @type {DialogState} */
 const INITIAL_DIALOG_STATE = {
-  // The current state of the dialog, one of:
-  // "fetching", "fetched", "authorizing" or "error".
   state: 'fetching',
-
-  // List of fetched files. Set when state is "fetched".
   files: null,
-
-  // Fetch error details. Set when state is "error".
   error: null,
 };
 
@@ -43,11 +49,11 @@ export default function LMSFilePicker({
   const [authorizationAttempted, setAuthorizationAttempted] = useState(false);
 
   // The file within `files` which is currently selected.
-  const [selectedFile, selectFile] = useState(null);
+  const [selectedFile, selectFile] = useState(/** @type {File|null} */ (null));
 
   // `AuthWindow` instance, set only when waiting for the user to approve
   // the app's access to the user's files in the LMS.
-  const authWindow = useRef(null);
+  const authWindow = useRef(/** @type {AuthWindow|null} */ (null));
 
   // Fetches files or shows a prompt to authorize access.
   const fetchFiles = useCallback(async () => {
@@ -86,6 +92,7 @@ export default function LMSFilePicker({
       setAuthorizationAttempted(true);
       authWindow.current.close();
       // eslint-disable-next-line require-atomic-updates
+      // @ts-ignore - `authWindow` is marked as non-nullable.
       authWindow.current = null;
     }
   }, [fetchFiles, authToken, authUrl]);

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -6,6 +6,11 @@ import propTypes from 'prop-types';
 /**
  * Return the next item to select when advancing the selection by `step` items
  * forwards (if positive) or backwards (if negative).
+ *
+ * @template Item
+ * @param {Item[]} items
+ * @param {Item} currentItem
+ * @param {number} step
  */
 function nextItem(items, currentItem, step) {
   const index = items.indexOf(currentItem);
@@ -25,7 +30,33 @@ function nextItem(items, currentItem, step) {
 }
 
 /**
+ * @typedef TableColumn
+ * @prop {string} label - Header label for the column
+ * @prop {string} className - Additional classes for the column's `<th>` element
+ */
+
+/**
+ * @template Item
+ * @typedef TableProps
+ * @prop {string} accessibleLabel - An accessible label for the table.
+ * @prop {TableColumn[]} columns - The columns to display in this table.
+ * @prop {Item[]} items - The items to display in this table.
+ * @prop {(it: Item, selected: boolean) => any} renderItem -
+ *   A function called to render each item.
+ *   The result should be a list of `<td>` elements (one per column) wrapped inside a Fragment.
+ * @prop {Item|null} selectedItem - The currently selected item from `items`
+ * @prop {(it: Item) => any} onSelectItem -
+ *   Callback invoked when the user changes the selected item.
+ * @prop {(it: Item) => any} onUseItem -
+ *   Callback invoked when a user chooses to use an item by double-clicking it
+ *   or pressing Enter while it is selected.
+ */
+
+/**
  * An interactive table of items with a sticky header.
+ *
+ * @template Item
+ * @param {TableProps<Item>} props
  */
 export default function Table({
   accessibleLabel,
@@ -36,7 +67,7 @@ export default function Table({
   renderItem,
   selectedItem,
 }) {
-  const rowRefs = useRef([]);
+  const rowRefs = useRef(/** @type {(HTMLElement|null)[]} */ ([]));
 
   const focusAndSelectItem = item => {
     const itemIndex = items.indexOf(item);
@@ -51,7 +82,9 @@ export default function Table({
     let handled = false;
     if (event.key === 'Enter') {
       handled = true;
-      onUseItem(selectedItem);
+      if (selectedItem) {
+        onUseItem(selectedItem);
+      }
     } else if (event.key === 'ArrowUp') {
       handled = true;
       focusAndSelectItem(nextItem(items, selectedItem, -1));
@@ -91,7 +124,7 @@ export default function Table({
           {items.map((item, index) => (
             <tr
               aria-selected={selectedItem === item}
-              key={item.name}
+              key={index}
               className={classnames({
                 Table__row: true,
                 'is-selected': selectedItem === item,
@@ -112,49 +145,16 @@ export default function Table({
 }
 
 Table.propTypes = {
-  /**
-   * An accessible label for the table.
-   */
   accessibleLabel: propTypes.string.isRequired,
-
-  /**
-   * The columns to display in this table.
-   */
   columns: propTypes.arrayOf(
     propTypes.shape({
       label: propTypes.string,
       className: propTypes.string,
     })
   ).isRequired,
-
-  /**
-   * The items to display in this table.
-   */
   items: propTypes.arrayOf(propTypes.any).isRequired,
-
-  /**
-   * A function called to render each item. The result should be a list of
-   * `<td>` elements (one per column) wrapped inside a Fragment.
-   *
-   * The function takes two arguments: The item to render and a boolean
-   * indicating whether the item is currently selected.
-   */
   renderItem: propTypes.func.isRequired,
-
-  /**
-   * The currently selected item from `items` or `null` if no item is
-   * selected.
-   */
   selectedItem: propTypes.any,
-
-  /**
-   * Callback invoked when the user changes the selected item.
-   */
   onSelectItem: propTypes.func,
-
-  /**
-   * Callback invoked when a user chooses to use an item by double-clicking it
-   * or pressing Enter while it is selected.
-   */
   onUseItem: propTypes.func,
 };

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -38,8 +38,8 @@ function nextItem(items, currentItem, step) {
 /**
  * @template Item
  * @typedef TableProps
- * @prop {string} accessibleLabel - An accessible label for the table.
- * @prop {TableColumn[]} columns - The columns to display in this table.
+ * @prop {string} accessibleLabel - An accessible label for the table
+ * @prop {TableColumn[]} columns - The columns to display in this table
  * @prop {Item[]} items -
  *   The items to display in this table, one per row. `renderItem` defines how
  *   information from each item is represented as a series of table cells.
@@ -48,10 +48,10 @@ function nextItem(items, currentItem, step) {
  *   The result should be a list of `<td>` elements (one per column) wrapped inside a Fragment.
  * @prop {Item|null} selectedItem - The currently selected item from `items`
  * @prop {(it: Item) => any} onSelectItem -
- *   Callback invoked when the user changes the selected item.
+ *   Callback invoked when the user changes the selected item
  * @prop {(it: Item) => any} onUseItem -
  *   Callback invoked when a user chooses to use an item by double-clicking it
- *   or pressing Enter while it is selected.
+ *   or pressing Enter while it is selected
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -40,9 +40,11 @@ function nextItem(items, currentItem, step) {
  * @typedef TableProps
  * @prop {string} accessibleLabel - An accessible label for the table.
  * @prop {TableColumn[]} columns - The columns to display in this table.
- * @prop {Item[]} items - The items to display in this table.
+ * @prop {Item[]} items -
+ *   The items to display in this table, one per row. `renderItem` defines how
+ *   information from each item is represented as a series of table cells.
  * @prop {(it: Item, selected: boolean) => any} renderItem -
- *   A function called to render each item.
+ *   A function called to render each item as the contents of a table row.
  *   The result should be a list of `<td>` elements (one per column) wrapped inside a Fragment.
  * @prop {Item|null} selectedItem - The currently selected item from `items`
  * @prop {(it: Item) => any} onSelectItem -


### PR DESCRIPTION
Migrate the documentation for `Table` and `FileList` from prop-types to
JSDoc and add more specific types.

In the process two minor issues were found:

 - `Table` assumed that items had a `name` property but `FileList` passed in
   items with no such property. Due to the way `name` was used (as a `key`
   value) this fortunately did not cause any visible problems.

 - If the user pressed 'Enter' when the table was focused but no items
   were selected, that could cause an error in the calling component due
   to a callback (`onUseItem`) being called with `null`