### PR TITLE
Fix most remaining typecheck errors

### DIFF
--- a/lms/static/scripts/frontend_apps/common/dom.js
+++ b/lms/static/scripts/frontend_apps/common/dom.js
@@ -3,7 +3,7 @@
  * function that removes the listeners.
  *
  * @param {Element} element
- * @param {string[]} events
+ * @param {string|string[]} events
  * @param {(e: Event) => any} listener
  * @param {Object} options
  *   @param {boolean} [options.useCapture]
@@ -17,7 +17,7 @@ export function listen(element, events, listener, { useCapture = false } = {}) {
     element.addEventListener(event, listener, useCapture)
   );
   return () => {
-    events.forEach(event =>
+    /** @type {string[]} */ (events).forEach(event =>
       element.removeEventListener(event, listener, useCapture)
     );
   };

--- a/lms/static/scripts/frontend_apps/common/use-element-should-close.js
+++ b/lms/static/scripts/frontend_apps/common/use-element-should-close.js
@@ -67,7 +67,7 @@ export default function useElementShouldClose(
 
     // Close element when user presses Escape key, regardless of focus.
     const removeKeypressListener = listen(document.body, ['keydown'], event => {
-      if (event.key === 'Escape') {
+      if (/** @type {KeyboardEvent} */ (event).key === 'Escape') {
         handleClose();
       }
     });
@@ -79,7 +79,7 @@ export default function useElementShouldClose(
       'focus',
       event => {
         const current = getCurrentNode(closeableEl);
-        if (!current.contains(event.target)) {
+        if (!current.contains(/** @type {Node} */ (event.target))) {
           handleClose();
         }
       },
@@ -93,7 +93,7 @@ export default function useElementShouldClose(
       ['mousedown', 'click'],
       event => {
         const current = getCurrentNode(closeableEl);
-        if (!current.contains(event.target)) {
+        if (!current.contains(/** @type {Node} */ (event.target))) {
           handleClose();
         }
       },

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -100,7 +100,7 @@ export default function SubmitGradeForm({ disabled = false, student }) {
   } = useContext(Config);
 
   // Used to handle keyboard input changes for the grade input field.
-  const inputRef = useRef(null);
+  const inputRef = useRef(/** @type {HTMLInputElement|null} */ (null));
 
   // Clear the previous grade saved status when the user changes.
   useEffect(() => {
@@ -172,6 +172,7 @@ export default function SubmitGradeForm({ disabled = false, student }) {
           ref={inputRef}
           onInput={handleKeyDown}
           type="input"
+          // @ts-expect-error - `defaultValue` is missing from `<input>` prop types.
           defaultValue={grade}
           key={student.LISResultSourcedId}
         />

--- a/lms/static/scripts/postmessage_json_rpc/client/client.js
+++ b/lms/static/scripts/postmessage_json_rpc/client/client.js
@@ -83,6 +83,7 @@ async function call(
   try {
     return await Promise.race([response, timeoutExpired]);
   } finally {
+    // @ts-ignore - TS can't infer that listener will be initialized here.
     window_.removeEventListener('message', listener);
   }
 }

--- a/lms/static/scripts/postmessage_json_rpc/server/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/server/index.js
@@ -1,6 +1,12 @@
 import Server from './server';
 
-let server = {}; // Singleton RPC server reference
+// Singleton RPC server reference.
+//
+// The fact that this is a singleton is a hangover from an earlier iteration of
+// the code where the RPC server and LMS frontend were separate JS applications.
+// We could now call `startRpcServer` at startup and pass the resulting `Server`
+// down to clients that need it.
+let server;
 
 /**
  * Create a new RPC server and register any methods it will support.
@@ -66,6 +72,9 @@ function startRpcServer({ allowedOrigins, clientConfig }) {
  * @returns {Promise<SidebarFrame>} - The `SidebarFrame`
  */
 function getSidebarWindow() {
+  if (!server) {
+    throw new Error('RPC server is not active');
+  }
   return server.sidebarWindow;
 }
 


### PR DESCRIPTION
This PR fixes the remaining errors when running `yarn typecheck`, except
for several (4) related to a mixup of numbers and strings when formatting
grades that will be addressed separately.

One of the errors in `postmessage_json_rpc/server/index.js` indicates a
design issue that stems from an earlier version of the code where the
RPC server and LMS frontend were separate JS applications. As this PR is
focused on fixing typecheck errors I have just made a note of the issue and
added a check in case `getSidebarWindow` is called when the server has not
been started.