### PR TITLE
Fix mixup of strings and numbers when formatting grades

### DIFF
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -128,7 +128,8 @@ export default function SubmitGradeForm({ disabled = false, student }) {
       try {
         await submitGrade({
           student,
-          grade: value / GRADE_MULTIPLIER,
+          // nb. `value` will be a number if there was no validation error.
+          grade: /** @type {number} */ (value) / GRADE_MULTIPLIER,
           authToken,
         });
         setGradeSaved(true);

--- a/lms/static/scripts/frontend_apps/utils/test/validation-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/validation-test.js
@@ -2,58 +2,61 @@ import { formatToNumber, scaleGrade, validateGrade } from '../validation';
 
 describe('#validation', () => {
   describe('formatToNumber', () => {
-    it('translates the string to a number', async () => {
+    it('translates the string to a number', () => {
       assert.isTrue(formatToNumber('1') === 1);
     });
 
-    it('does not translate the empty string to a number', async () => {
+    it('does not translate the empty string to a number', () => {
       assert.isTrue(typeof formatToNumber(' ') === 'string');
     });
 
-    it('does not translate a non numerical string to a number', async () => {
+    it('does not translate a non numerical string to a number', () => {
       assert.isTrue(typeof formatToNumber('a') === 'string');
     });
 
-    it('translates the string to a number with leading and trailing spaces', async () => {
+    it('translates the string to a number with leading and trailing spaces', () => {
       assert.isTrue(formatToNumber(' 1 ') === 1);
     });
   });
 
   describe('#validateGrade', () => {
-    it('fails validation if the value is not a number', async () => {
+    it('fails validation if the value is not a number', () => {
       assert.equal(validateGrade('1'), 'Grade must be a valid number');
     });
 
-    it('fails validation if the value is less than 0', async () => {
+    it('fails validation if the value is less than 0', () => {
       assert.equal(validateGrade(-1), 'Grade must be between 0 and 10');
     });
 
-    it('fails validation if the value is greater than 10', async () => {
+    it('fails validation if the value is greater than 10', () => {
       assert.equal(validateGrade(11), 'Grade must be between 0 and 10');
     });
 
-    it('passes validation if its a valid number between 0 and 10', async () => {
+    it('passes validation if its a valid number between 0 and 10', () => {
       assert.equal(validateGrade(1), undefined);
     });
   });
 
   describe('#scaleGrade', () => {
     const GRADE_MULTIPLIER = 10;
-    it('scales the grade by 10', async () => {
-      assert.equal(scaleGrade(0.5, GRADE_MULTIPLIER), 5);
+    it('scales the grade by 10', () => {
+      assert.strictEqual(scaleGrade(0.5, GRADE_MULTIPLIER), '5');
     });
-    it('does not lose precision', async () => {
+    it('does not lose precision', () => {
       // note: 0.33 * 10 = 3.3000000000000003
-      assert.equal(scaleGrade(0.33, GRADE_MULTIPLIER), 3.3);
+      assert.strictEqual(scaleGrade(0.33, GRADE_MULTIPLIER), '3.3');
     });
-    it('rounds to same number of significate figures', async () => {
-      assert.equal(scaleGrade(0.9999, GRADE_MULTIPLIER), 9.999);
+    it('rounds to same number of significant figures', () => {
+      assert.strictEqual(scaleGrade(0.9999, GRADE_MULTIPLIER), '9.999');
     });
-    it('does not scale 0', async () => {
-      assert.equal(scaleGrade(0, GRADE_MULTIPLIER), 0);
+    it('returns a string when input is 0', () => {
+      assert.strictEqual(scaleGrade(0, GRADE_MULTIPLIER), '0');
     });
-    it('does not care about trailing zeros', async () => {
-      assert.equal(scaleGrade(0.9, GRADE_MULTIPLIER), 9);
+    it('returns a string when input is 1', () => {
+      assert.strictEqual(scaleGrade(1, GRADE_MULTIPLIER), '10');
+    });
+    it('does not care about trailing zeros', () => {
+      assert.strictEqual(scaleGrade(0.9, GRADE_MULTIPLIER), '9');
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/validation.js
+++ b/lms/static/scripts/frontend_apps/utils/validation.js
@@ -26,7 +26,7 @@ function formatToNumber(originalValue) {
  * - a numeric type
  * - between or equal to the the range of [0 - 10]
  * -
- * @param {number} value - Value to test
+ * @param {number|string} value - Value to test
  * @return {string|undefined} - Returns an error message or undefined if valid.
  */
 function validateGrade(value) {
@@ -49,13 +49,13 @@ function validateGrade(value) {
  *
  * @param {number} grade
  * @param {number} multiplier
- * @return {number}
+ * @return {string}
  */
 function scaleGrade(grade, multiplier) {
   const sGrade = grade.toString();
   if (sGrade.indexOf('.') < 0) {
     // no decimal value, just returns the scaled value
-    return grade * multiplier;
+    return (grade * multiplier).toString();
   } else {
     const decimalDigitsLength = sGrade.split('.')[1].length;
     // scale and round to one less the number of decimal digits the grade had


### PR DESCRIPTION
This is the final PR to make `yarn typecheck` run without producing any errors. Once it lands, we can make that command part of the CI process.

 - The `scaleGrade` function in `validation.js` was documented to return
   a number but could actually return a number or a string. Since it
   formats a number for display, change it to always return a string.

   I think there is room to simplify these functions but for now I just
   fixed the inconsistency in the return values and updated the tests.

 - Remove unnecessary `async`-ness in tests

Note that there are some unrelated typecheck errors in `SubmitGradeForm.js` which are fixed in https://github.com/hypothesis/lms/pull/1920.