### PR TITLE
Add `yarn typecheck` to `make frontend-lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ backend-lint: python
 frontend-lint: node_modules/.uptodate
 	@yarn checkformatting
 	@yarn lint
+	@yarn typecheck
 
 # Backend and frontend tests are split into separate targets because on Jenkins
 # we need to run them with different Docker images, but `make test` runs both.


### PR DESCRIPTION
Now that all the errors have been fixed, make `yarn typecheck` part of
the checks that `make frontend-lint` runs which in turn makes it part of the CI checks.