### PR TITLE
Fix a migration script

### DIFF
--- a/lms/migrations/versions/5086e8b137b9_add_settings_server_default_and_not_.py
+++ b/lms/migrations/versions/5086e8b137b9_add_settings_server_default_and_not_.py
@@ -8,12 +8,33 @@ Create Date: 2020-07-16 10:23:06.469812
 """
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import sessionmaker
 
 revision = "5086e8b137b9"
 down_revision = "7f9824ded172"
 
 
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class ApplicationInstance(Base):
+    __tablename__ = "application_instances"
+    id = sa.Column(sa.Integer, primary_key=True)
+    settings = sa.Column(MutableDict.as_mutable(JSONB))
+
+
 def upgrade():
+    session = Session(bind=op.get_bind())
+
+    for ai in session.query(ApplicationInstance).filter_by(settings=None):
+        ai.settings = {}
+
+    session.commit()
+
     op.alter_column("application_instances", "settings", nullable=False)
     op.alter_column(
         "application_instances", "settings", server_default=sa.text("'{}'::jsonb")


### PR DESCRIPTION
There are ApplicationInstances on QA and prod with NULL settings. Need to backfill those before making the column not-NULLable.