### PR TITLE
Convert remaining UI component docs to JSDoc

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -21,7 +21,6 @@ import LMSGrader from './LMSGrader';
 import Spinner from './Spinner';
 
 /**
- * @typedef {import('./LMSGrader').User} User
  * @typedef {import('../services/client-rpc').ClientRpc} ClientRpc
  */
 
@@ -294,7 +293,7 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
         >
           <ErrorDisplay
             message="There was a problem fetching this Hypothesis assignment"
-            error={error}
+            error={/** @type {Error} */ (error)}
           />
         </Dialog>
       )}
@@ -306,7 +305,7 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
         >
           <ErrorDisplay
             message="There was a problem submitting this Hypothesis assignment"
-            error={error}
+            error={/** @type {Error} */ (error)}
           />
           <b>To fix this problem, try reloading the page.</b>
         </Dialog>

--- a/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
@@ -9,8 +9,15 @@ import ErrorDisplay from './ErrorDisplay';
 import Dialog from './Dialog';
 
 /**
+ * @typedef CanvasOAuth2RedirectErrorAppProps
+ * @prop {Location} [location] - Test seam
+ */
+
+/**
  * Error dialog displayed when authorization of Canvas API access via OAuth
  * fails.
+ *
+ * @param {CanvasOAuth2RedirectErrorAppProps} props
  */
 export default function CanvasOAuth2RedirectErrorApp({
   location = window.location,
@@ -85,6 +92,5 @@ export default function CanvasOAuth2RedirectErrorApp({
 }
 
 CanvasOAuth2RedirectErrorApp.propTypes = {
-  // Test seam for `window.location`.
   location: propTypes.object,
 };

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -5,8 +5,17 @@ import ErrorDisplay from './ErrorDisplay';
 import Dialog from './Dialog';
 
 /**
+ * @typedef ErrorDialogProps
+ * @prop {() => any} [onCancel]
+ * @prop {string} title
+ * @prop {import('./ErrorDisplay').ErrorLike} error
+ */
+
+/**
  * A dialog that informs the user about a problem that occurred and provides
  * them with links to get help or report the issue.
+ *
+ * @param {ErrorDialogProps} props
  */
 export default function ErrorDialog({ onCancel, title, error }) {
   return (

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -8,8 +8,27 @@ function emailLink({ address, subject = '', body = '' }) {
 }
 
 /**
+ * An `Error` or `Error`-like object.
+ *
+ * @typedef ErrorLike
+ * @prop {string} [message]
+ * @prop {Object} [details] - Optional JSON-serializable details of the error
+ */
+
+/**
+ * @typedef ErrorDisplayProps
+ * @prop {Object} [message] -
+ *   A short message to display explaining that a problem happened. This is
+ *   typically a general message like "There was a problem fetching this assignment".
+ * @prop {ErrorLike} error -
+ *   An `Error`-like object with specific details of the problem
+ */
+
+/**
  * Displays details of an error, such as a failed API call and provide the user
  * with information on how to get help with it.
+ *
+ * @param {ErrorDisplayProps} props
  */
 export default function ErrorDisplay({ message, error }) {
   let details = '';
@@ -95,16 +114,6 @@ export default function ErrorDisplay({ message, error }) {
 }
 
 ErrorDisplay.propTypes = {
-  /**
-   * A short message explaining that a problem happened.
-   */
   message: propTypes.oneOfType([propTypes.string, propTypes.element]),
-
-  /**
-   * An `Error`-like object with details of the problem.
-   *
-   * This is assumed to have a string `message` property and may have a
-   * JSON-serializable `details` property.
-   */
   error: propTypes.object.isRequired,
 };

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -15,6 +15,16 @@ import FileList from './FileList';
  */
 
 /**
+ * @typedef LMSFilePickerProps
+ * @prop {string} authToken - Auth token for use in calls to the backend
+ * @prop {string} authUrl - URL of the authorization endpoint
+ * @prop {string} courseId - ID of the course that the user is choosing a file for
+ * @prop {() => any} onCancel - Callback invoked if the user cancels file selection
+ * @prop {(f: File) => any} onSelectFile -
+ *   Callback invoked with the metadata of the selected file if the user makes a selection
+ */
+
+/**
  * @typedef DialogState
  * @prop {'fetching'|'fetched'|'authorizing'|'error'} state
  * @prop {File[]|null} files - List of fetched files
@@ -34,6 +44,8 @@ const INITIAL_DIALOG_STATE = {
  *
  * The picker will attempt to list files when mounted, and will show an
  * authorization popup if necessary.
+ *
+ * @param {LMSFilePickerProps} props
  */
 export default function LMSFilePicker({
   authToken,
@@ -115,7 +127,8 @@ export default function LMSFilePicker({
     onCancel();
   };
 
-  const useSelectedFile = () => onSelectFile(selectedFile);
+  const useSelectedFile = () =>
+    onSelectFile(/** @type {File} */ (selectedFile));
 
   const title =
     dialogState.state === 'authorizing' ? 'Allow file access' : 'Select a file';
@@ -150,7 +163,7 @@ export default function LMSFilePicker({
       {dialogState.state === 'error' && (
         <ErrorDisplay
           message="There was a problem fetching files"
-          error={dialogState.error}
+          error={/** @type {Error} */ (dialogState.error)}
         />
       )}
       {dialogState.state === 'authorizing' && authorizationAttempted && (
@@ -180,27 +193,9 @@ export default function LMSFilePicker({
 }
 
 LMSFilePicker.propTypes = {
-  /**
-   * Auth token for use in calls to the backend.
-   */
   authToken: propTypes.string,
-
-  /**
-   * URL of the authorization endpoint.
-   */
   authUrl: propTypes.string,
-
-  /**
-   * ID of the course that the user is choosing a file for.
-   */
   courseId: propTypes.string.isRequired,
-
-  /** Callback invoked if the user cancels file selection. */
   onCancel: propTypes.func.isRequired,
-
-  /**
-   * Callback invoked with the metadata of the selected file if the user makes
-   * a selection.
-   */
   onSelectFile: propTypes.func.isRequired,
 };

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -6,10 +6,7 @@ import StudentSelector from './StudentSelector';
 import SubmitGradeForm from './SubmitGradeForm';
 
 /**
- * @typedef User
- * @prop {string} displayName
- * @prop {string} userid
- *
+ * @typedef {import('../config').StudentInfo} StudentInfo
  * @typedef {import('../services/client-rpc').ClientRpc} ClientRpc
  */
 
@@ -19,7 +16,7 @@ import SubmitGradeForm from './SubmitGradeForm';
  * @prop {ClientRpc} clientRpc - Service for communicating with Hypothesis client
  * @prop {string} courseName
  * @prop {string} assignmentName
- * @prop {User[]} students - List of students to grade
+ * @prop {StudentInfo[]} students - List of students to grade
  */
 
 /**
@@ -61,7 +58,7 @@ export default function LMSGrader({
   /**
    * Makes an RPC call to the sidebar to change to the focused user.
    *
-   * @param {User|null} user - The user to focus on in the sidebar
+   * @param {StudentInfo|null} user - The user to focus on in the sidebar
    */
   const changeFocusedUser = useCallback(
     user => clientRpc.setFocusedUser(user),
@@ -103,7 +100,7 @@ export default function LMSGrader({
    * Return the current student, or an empty object if there is none
    */
   const getCurrentStudent = () => {
-    return students[currentStudentIndex] ? students[currentStudentIndex] : {};
+    return students[currentStudentIndex] ? students[currentStudentIndex] : null;
   };
 
   return (
@@ -125,10 +122,7 @@ export default function LMSGrader({
             />
           </li>
           <li className="LMSGrader__student-grade">
-            <SubmitGradeForm
-              student={getCurrentStudent()}
-              disabled={currentStudentIndex < 0}
-            />
+            <SubmitGradeForm student={getCurrentStudent()} />
           </li>
         </ul>
       </header>

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -66,7 +66,7 @@ export default function LMSGrader({
   );
 
   useEffect(() => {
-    if (students[currentStudentIndex]) {
+    if (currentStudentIndex >= 0) {
       changeFocusedUser(students[currentStudentIndex]);
     } else {
       changeFocusedUser(null);
@@ -100,7 +100,7 @@ export default function LMSGrader({
    * Return the current student, or an empty object if there is none
    */
   const getCurrentStudent = () => {
-    return students[currentStudentIndex] ? students[currentStudentIndex] : null;
+    return currentStudentIndex >= 0 ? students[currentStudentIndex] : null;
   };
 
   return (

--- a/lms/static/scripts/frontend_apps/components/Spinner.js
+++ b/lms/static/scripts/frontend_apps/components/Spinner.js
@@ -4,7 +4,14 @@ import propTypes from 'prop-types';
 import SvgIcon from './SvgIcon';
 
 /**
+ * @typedef SpinnerProps
+ * @prop {string} [className] - Additional classes to add to the spinner
+ */
+
+/**
  * A spinning loading indicator.
+ *
+ * @param {SpinnerProps} props
  */
 export default function Spinner({ className }) {
   return <SvgIcon className={className} name="spinner" inline={true} />;

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -12,7 +12,8 @@ import SvgIcon from './SvgIcon';
  * @typedef StudentSelectorProps
  * @prop {(index: number) => any} onSelectStudent -
  *   Callback invoked when the selected student changes
- * @prop {number} selectedStudentIndex - Index of selected student in `students`
+ * @prop {number} selectedStudentIndex -
+ *   Index of selected student in `students` or -1 if no student is selected
  * @prop {Student[]} students - Ordered list of students to display in the drop-down
  */
 

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -6,8 +6,17 @@ import Button from './Button';
 import Dialog from './Dialog';
 
 /**
+ * @typedef URLPickerProps
+ * @prop {() => any} onCancel
+ * @prop {(url: string) => any} onSelectURL -
+ *   Callback invoked with the entered URL when the user accepts the dialog
+ */
+
+/**
  * A dialog that allows the user to enter or paste the URL of a web page or
  * PDF file to use for an assignment.
+ *
+ * @param {URLPickerProps} props
  */
 export default function URLPicker({ onCancel, onSelectURL }) {
   const input = useRef(/** @type {HTMLInputElement|null} */ (null));
@@ -49,7 +58,5 @@ export default function URLPicker({ onCancel, onSelectURL }) {
 
 URLPicker.propTypes = {
   onCancel: propTypes.func,
-
-  /** Callback invoked when the entered URL when the user accepts the dialog. */
   onSelectURL: propTypes.func,
 };

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -4,10 +4,18 @@ import classNames from 'classnames';
 import propTypes from 'prop-types';
 
 /**
- * Shows a single validation error message that can be open or closed.
- * A user can also close the message by clicking on it.
+ * @typedef ValidationMessageProps
+ * @prop {string} message - Error message text
+ * @prop {boolean} [open] - Should this be open or closed
+ * @prop {() => any} [onClose] - Optional callback when the error message is closed
  */
 
+/**
+ * Shows a single validation error message that can be open or closed.
+ * A user can also close the message by clicking on it.
+ *
+ * @param {ValidationMessageProps} props
+ */
 export default function ValidationMessage({
   message,
   open = false,
@@ -45,10 +53,7 @@ export default function ValidationMessage({
 }
 
 ValidationMessage.propTypes = {
-  // Error message text
   message: propTypes.string.isRequired,
-  // Should this be open or closed
   open: propTypes.bool,
-  // Optional callback when the error message closes itself via onClick
   onClose: propTypes.func,
 };

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -76,8 +76,8 @@ describe('SubmitGradeForm', () => {
     );
   });
 
-  it('disables the submit button when the disable prop is true', () => {
-    const wrapper = renderForm({ disabled: true });
+  it('disables the submit button when the `student` prop is `null`', () => {
+    const wrapper = renderForm({ student: null });
     assert.isTrue(wrapper.find('button[type="submit"]').prop('disabled'));
   });
 

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -16,6 +16,8 @@ import { createContext } from 'preact';
  * @typedef StudentInfo
  * @prop {string} displayName
  * @prop {string} userid
+ * @prop {string} LISResultSourcedId - Unique outcome identifier
+ * @prop {string} LISOutcomeServiceUrl - API URL for posting outcome results
  */
 
 /**


### PR DESCRIPTION
This surfaced an issue where several properties were missing from the
`StudentInfo` type listed in `frontend_apps/config.js`. These properties are
needed when calling the API to submit a grade update.

It also surfaced an issue where the `SubmitGradeForm` component redundantly took
a nullable `student` prop as well as a `disabled` prop.  Whether to disable the
form can be inferred from whether `student` is null or not (and _should_ be to
avoid a possible inconsistency).
