### PR TITLE
Fix the Course test factory

### DIFF
--- a/tests/factories/course.py
+++ b/tests/factories/course.py
@@ -1,10 +1,12 @@
 import factory
+from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
 from tests.factories._attributes import OAUTH_CONSUMER_KEY
 
 Course = factory.make_factory(  # pylint:disable=invalid-name
     models.Course,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
     consumer_key=OAUTH_CONSUMER_KEY,
     authority_provided_id=factory.Faker("hexify", text="^" * 40),
     _settings=factory.lazy_attribute(lambda o: {}),


### PR DESCRIPTION
Test factories for SQLAlchemy models should have
`FACTORY_CLASS=SQLAlchemyModelFactory`. This lets Factory Boy know that
it's a SQLAlchemy factory and means that it automatically adds it to the
test DB session when you do `factories.course()`,
`factories.course.create()` or `factories.course.create_batch()`.

If you want to make one _without_ adding it to the DB session (or
without even needing to have a DB session) use `build()` or
`build_batch()`.

See `factories.GradingInfo` for an existing example of this.