### PR TITLE
Remove some unnecessary comments

### DIFF
--- a/tests/functional/api/basic_lti_launch_test.py
+++ b/tests/functional/api/basic_lti_launch_test.py
@@ -22,16 +22,10 @@ class TestBasicLTILaunch:
 
         self.assert_response_is_html(result)
 
-    # ---------------------------------------------------------------------- #
-    # Assertions
-
     @classmethod
     def assert_response_is_html(cls, response):
         assert response.headers["Content-Type"] == Any.string.matching("^text/html")
         assert response.html
-
-    # ---------------------------------------------------------------------- #
-    # Helper methods
 
     @classmethod
     def lti_launch(cls, app, params, status=200):
@@ -63,8 +57,6 @@ class TestBasicLTILaunch:
         )
 
         return params
-
-    # Fixtures ------------------------------------------------------------- #
 
     @pytest.fixture(autouse=True)
     def application_instance(self, db_session):


### PR DESCRIPTION
"Separator comments" aren't really part of our code style.

You can tell when something's a fixture because it has an
`@pytest.fixture` decorator on it. You can tell when something is a
helper method because it neither has the `@pytest.fixture` decorator nor
has a name beginning with `test_`. You can tell when something is an
assertion method (a special kind of test helper method) because it has a
name beginning with `assert_`.

It's a good idea to group these different kind of methods together but
we don't need separator comments for them, and we never use these kind
of comments anywhere else in our code.

The comments are liable to become misleading when people modify things or
add new things in the wrong places.