### PR TITLE
Add ApplicationInstance test factory

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -45,6 +45,9 @@ class ApplicationInstance(BASE):
         "OAuth2Token", back_populates="application_instance"
     )
 
+    #: A list of all the courses for this application instance.
+    courses = sa.orm.relationship("Course", back_populates="application_instance")
+
     #: A list of all the GroupInfo's for this application instance.
     group_infos = sa.orm.relationship(
         "GroupInfo", back_populates="application_instance"

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -18,6 +18,11 @@ class Course(BASE):
         primary_key=True,
     )
 
+    #: The ApplicationInstance that this access token belongs to.
+    application_instance = sa.orm.relationship(
+        "ApplicationInstance", back_populates="courses"
+    )
+
     #: The authority_provided_id that uniquely identifies the course that these
     #: settings belong to.
     authority_provided_id = sa.Column(sa.UnicodeText(), primary_key=True)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -2,6 +2,7 @@ import sys
 
 from factory.alchemy import SQLAlchemyModelFactory
 
+from tests.factories.application_instance import ApplicationInstance
 from tests.factories.course import Course
 from tests.factories.grading_info import GradingInfo
 from tests.factories.h_group import HGroup
@@ -9,7 +10,7 @@ from tests.factories.h_user import HUser
 from tests.factories.lti_user import LTIUser
 
 
-def set_sqlalchemy_session(session):
+def set_sqlalchemy_session(session, persistence=None):
     # Set the Meta.sqlalchemy_session option on all our SQLAlchemy test factory
     # classes. We can't do it in the normal Factory Boy way:
     #
@@ -26,6 +27,9 @@ def set_sqlalchemy_session(session):
     for factory_class in _sqlalchemy_factory_classes():
         # pylint:disable=protected-access
         factory_class._meta.sqlalchemy_session = session
+
+        if persistence:
+            factory_class._meta.sqlalchemy_session_persistence = persistence
 
 
 def clear_sqlalchemy_session():

--- a/tests/factories/_attributes.py
+++ b/tests/factories/_attributes.py
@@ -3,6 +3,7 @@
 from factory import Faker
 
 OAUTH_CONSUMER_KEY = Faker("hexify", text="Hypothesis" + "^" * 32)
+SHARED_SECRET = Faker("hexify", text="^" * 64)
 
 USER_ID = Faker("hexify", text="^" * 40)
 

--- a/tests/factories/application_instance.py
+++ b/tests/factories/application_instance.py
@@ -1,0 +1,14 @@
+from factory import Faker, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories._attributes import OAUTH_CONSUMER_KEY, SHARED_SECRET
+
+ApplicationInstance = make_factory(  # pylint:disable=invalid-name
+    models.ApplicationInstance,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    consumer_key=OAUTH_CONSUMER_KEY,
+    shared_secret=SHARED_SECRET,
+    lms_url=Faker("uri"),
+    requesters_email=Faker("email"),
+)

--- a/tests/functional/api/basic_lti_launch_test.py
+++ b/tests/functional/api/basic_lti_launch_test.py
@@ -12,7 +12,6 @@ from tests import factories
 
 
 class TestBasicLTILaunch:
-    @pytest.mark.usefixtures("http_intercept")
     def test_a_good_request_loads_fine(self, app, lti_params):
         response = app.post(
             "/lti_launches",
@@ -100,7 +99,7 @@ class TestBasicLTILaunch:
 
         return params
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def http_intercept(self, _http_intercept):
         """
         Monkey-patch Python's socket core module to mock all HTTP responses.

--- a/tests/functional/api/basic_lti_launch_test.py
+++ b/tests/functional/api/basic_lti_launch_test.py
@@ -7,7 +7,8 @@ import pytest
 from h_matchers import Any
 from httpretty import httpretty
 
-from lms.models import ApplicationInstance, ModuleItemConfiguration
+from lms.models import ModuleItemConfiguration
+from tests import factories
 
 
 class TestBasicLTILaunch:
@@ -27,20 +28,8 @@ class TestBasicLTILaunch:
         assert response.html
 
     @pytest.fixture(autouse=True)
-    def application_instance(self, db_session):
-        # Load app so we create the instance after the DB has been truncated
-
-        application_instance = ApplicationInstance(
-            consumer_key="Hypothesis1b40eafba184a131307049e01e9c147d",
-            shared_secret="TEST_SECRET",
-            lms_url="test_lms_url",
-            requesters_email="test_requesters_email",
-        )
-
-        db_session.add(application_instance)
-        db_session.commit()
-
-        return application_instance
+    def application_instance(self):
+        return factories.ApplicationInstance()
 
     @pytest.fixture(autouse=True, params=["configured", "unconfigured"])
     def module_item_configuration(self, request, db_session):

--- a/tests/functional/api/basic_lti_launch_test.py
+++ b/tests/functional/api/basic_lti_launch_test.py
@@ -27,7 +27,7 @@ class TestBasicLTILaunch:
         assert response.html
 
     @pytest.fixture(autouse=True)
-    def application_instance(self):
+    def application_instance(self, db_session):  # pylint:disable=unused-argument
         return factories.ApplicationInstance()
 
     @pytest.fixture(autouse=True, params=["configured", "unconfigured"])

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -36,7 +36,7 @@ def app(pyramid_app, db_engine):
     return TestApp(pyramid_app)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def db_session(db_engine):
     """Get a standalone database session for preparing database state."""
 

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -2,34 +2,32 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from lms.models import ApplicationInstance, ApplicationSettings
+from tests import factories
 
 # pylint: disable=protected-access
 
 
 class TestApplicationInstance:
-    def test_it_persists_application_instance(self, db_session, application_instance):
+    def test_it_persists_application_instance(self, db_session):
         initial_count = db_session.query(ApplicationInstance).count()
-        db_session.add(application_instance)
+
+        factories.ApplicationInstance()
+
         new_count = db_session.query(ApplicationInstance).count()
         assert new_count == initial_count + 1
 
-    def test_provisioning_defaults_to_True(self, db_session, application_instance):
-        db_session.add(application_instance)
-
+    def test_provisioning_defaults_to_True(self, application_instance, db_session):
         db_session.flush()
 
         assert application_instance.provisioning is True
 
-    def test_provisioning_can_be_disabled(self, db_session, application_instance):
+    def test_provisioning_can_be_disabled(self, application_instance):
         application_instance.provisioning = False
-        db_session.add(application_instance)
-        db_session.flush()
 
         assert not application_instance.provisioning
 
     def test_provisioning_is_not_nullable(self, db_session, application_instance):
         application_instance.provisioning = None
-        db_session.add(application_instance)
 
         db_session.flush()
 
@@ -54,28 +52,24 @@ class TestApplicationInstance:
 
     def test_consumer_key_cant_be_null(self, db_session, application_instance):
         application_instance.consumer_key = None
-        db_session.add(application_instance)
 
         with pytest.raises(IntegrityError, match="consumer_key"):
             db_session.flush()
 
     def test_shared_secret_cant_be_null(self, db_session, application_instance):
         application_instance.shared_secret = None
-        db_session.add(application_instance)
 
         with pytest.raises(IntegrityError, match="shared_secret"):
             db_session.flush()
 
     def test_lms_url_cant_be_null(self, db_session, application_instance):
         application_instance.lms_url = None
-        db_session.add(application_instance)
 
         with pytest.raises(IntegrityError, match="lms_url"):
             db_session.flush()
 
     def test_requesters_email_cant_be_null(self, db_session, application_instance):
         application_instance.requesters_email = None
-        db_session.add(application_instance)
 
         with pytest.raises(IntegrityError, match="requesters_email"):
             db_session.flush()
@@ -83,8 +77,6 @@ class TestApplicationInstance:
     def test_get_returns_the_matching_ApplicationInstance(
         self, db_session, application_instance
     ):
-        db_session.add(application_instance)
-
         assert (
             ApplicationInstance.get_by_consumer_key(
                 db_session, application_instance.consumer_key
@@ -104,12 +96,7 @@ class TestApplicationInstance:
     @pytest.fixture
     def application_instance(self):
         """Return an ApplicationInstance with minimal required attributes."""
-        return ApplicationInstance(
-            consumer_key="TEST_CONSUMER_KEY",
-            shared_secret="TEST_SHARED_SECRET",
-            lms_url="TEST_LMS_URL",
-            requesters_email="TEST_EMAIL",
-        )
+        return factories.ApplicationInstance()
 
 
 class TestApplicationSettings:

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -21,8 +21,9 @@ class TestApplicationInstance:
 
         assert application_instance.provisioning is True
 
-    def test_provisioning_can_be_disabled(self, application_instance):
+    def test_provisioning_can_be_disabled(self, application_instance, db_session):
         application_instance.provisioning = False
+        db_session.flush()
 
         assert not application_instance.provisioning
 

--- a/tests/unit/lms/models/grading_info_test.py
+++ b/tests/unit/lms/models/grading_info_test.py
@@ -1,7 +1,8 @@
 import pytest
 import sqlalchemy.exc
 
-from lms.models import ApplicationInstance, GradingInfo
+from lms.models import GradingInfo
+from tests import factories
 
 
 class TestGradingInfo:
@@ -58,16 +59,9 @@ class TestGradingInfo:
             db_session.flush()
 
     @pytest.fixture
-    def application_instance(self, db_session):
+    def application_instance(self):
         """Return the ApplicationInstance that the GradingInfos belong to."""
-        application_instance = ApplicationInstance(
-            consumer_key="test_consumer_key",
-            shared_secret="test_shared_secret",
-            lms_url="test_lms_url",
-            requesters_email="test_requesters_email",
-        )
-        db_session.add(application_instance)
-        return application_instance
+        return factories.ApplicationInstance()
 
     @pytest.fixture
     def grading_info(self, grading_info_params):

--- a/tests/unit/lms/models/group_info_test.py
+++ b/tests/unit/lms/models/group_info_test.py
@@ -2,12 +2,12 @@ import factory
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from lms.models import ApplicationInstance, GroupInfo
+from lms.models import GroupInfo
 from tests import factories
 
 
 class TestGroupInfo:
-    def test_persist_and_retrieve(self, db_session, group_info):
+    def test_persist_and_retrieve(self, application_instance, db_session, group_info):
         db_session.add(group_info)
 
         retrieved_group_info = db_session.query(GroupInfo).one()
@@ -16,7 +16,7 @@ class TestGroupInfo:
         assert (
             retrieved_group_info.authority_provided_id == "test_authority_provided_id"
         )
-        assert retrieved_group_info.consumer_key == "test_consumer_key"
+        assert retrieved_group_info.consumer_key == application_instance.consumer_key
 
     def test_application_instance_relation(
         self, application_instance, db_session, group_info
@@ -109,12 +109,7 @@ class TestGroupInfo:
     @pytest.fixture(autouse=True)
     def application_instance(self):
         """Return the ApplicationInstance that the test GroupInfo belongs to."""
-        return ApplicationInstance(
-            consumer_key="test_consumer_key",
-            shared_secret="test_shared_secret",
-            lms_url="test_lms_url",
-            requesters_email="test_requesters_email",
-        )
+        return factories.ApplicationInstance()
 
     @pytest.fixture
     def group_info(self, application_instance):

--- a/tests/unit/lms/models/oauth2_token_test.py
+++ b/tests/unit/lms/models/oauth2_token_test.py
@@ -3,7 +3,8 @@ import datetime
 import pytest
 import sqlalchemy.exc
 
-from lms.models import ApplicationInstance, OAuth2Token
+from lms.models import OAuth2Token
+from tests import factories
 
 
 class TestOAuth2Token:
@@ -23,7 +24,7 @@ class TestOAuth2Token:
 
         token = db_session.query(OAuth2Token).one()
         assert token.user_id == "test_user_id"
-        assert token.consumer_key == "test_consumer_key"
+        assert token.consumer_key == application_instance.consumer_key
         assert token.consumer_key == application_instance.consumer_key
         assert token.application_instance == application_instance
         assert token.access_token == "test_access_token"
@@ -106,16 +107,9 @@ class TestOAuth2Token:
         assert isinstance(token.received_at, datetime.datetime)
 
     @pytest.fixture(autouse=True)
-    def application_instance(self, db_session):
+    def application_instance(self):
         """Return the ApplicationInstance that the test OAuth2Token's belong to."""
-        application_instance = ApplicationInstance(
-            consumer_key="test_consumer_key",
-            shared_secret="test_shared_secret",
-            lms_url="test_lms_url",
-            requesters_email="test_requesters_email",
-        )
-        db_session.add(application_instance)
-        return application_instance
+        return factories.ApplicationInstance()
 
     @pytest.fixture
     def init_kwargs(self, application_instance):

--- a/tests/unit/lms/models/oauth2_token_test.py
+++ b/tests/unit/lms/models/oauth2_token_test.py
@@ -25,7 +25,6 @@ class TestOAuth2Token:
         token = db_session.query(OAuth2Token).one()
         assert token.user_id == "test_user_id"
         assert token.consumer_key == application_instance.consumer_key
-        assert token.consumer_key == application_instance.consumer_key
         assert token.application_instance == application_instance
         assert token.access_token == "test_access_token"
         assert token.refresh_token == "test_refresh_token"

--- a/tests/unit/lms/services/canvas_api_test.py
+++ b/tests/unit/lms/services/canvas_api_test.py
@@ -8,10 +8,11 @@ from h_matchers import Any
 from pytest import param
 from requests import Request, RequestException, Response
 
-from lms.models import ApplicationInstance, OAuth2Token
+from lms.models import OAuth2Token
 from lms.services import CanvasAPIAccessTokenError, CanvasAPIError, CanvasAPIServerError
 from lms.services.canvas_api import CanvasAPIClient, _CanvasAPIAuthenticatedClient
 from lms.validation import RequestsResponseSchema, ValidationError
+from tests import factories
 
 # pylint: disable=protected-access
 
@@ -592,16 +593,11 @@ def http_session(patch):
 
 
 @pytest.fixture(autouse=True)
-def application_instance(db_session, pyramid_request):
+def application_instance(pyramid_request):
     """Return the ApplicationInstance that the test OAuth2Token's belong to."""
-    application_instance = ApplicationInstance(
+    return factories.ApplicationInstance(
         consumer_key=pyramid_request.lti_user.oauth_consumer_key,
-        shared_secret="test_shared_secret",
-        lms_url="test_lms_url",
-        requesters_email="test_requesters_email",
     )
-    db_session.add(application_instance)
-    return application_instance
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -112,7 +112,7 @@ class TestCourseService:
 
     @pytest.fixture
     def other_application_instance(self):
-        return factories.ApplicationInstance()
+        return factories.ApplicationInstance(consumer_key="other_consumer_key")
 
 
 pytestmark = pytest.mark.usefixtures("ai_getter")


### PR DESCRIPTION
Extracted from https://github.com/hypothesis/lms/pull/1923/ but with some changes:

* Added `FACTORY_CLASS=SQLAlchemyModelFactory` to the factory so that Factory Boy adds instances to the DB session automatically.

* I've updated all the existing tests to use the new factory

* Also used the `ApplicationInstance` as a sub-factory in the `OAuth2Token` factory, separate PR: https://github.com/hypothesis/lms/pull/1942

* Also used the `ApplicationInstance` as a sub-factory in the `Course` factory, separate PR: https://github.com/hypothesis/lms/pull/1944