### PR TITLE
Add OAuth2Token test factory

### DIFF
--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -3,11 +3,21 @@ import sys
 from factory.alchemy import SQLAlchemyModelFactory
 
 from tests.factories.application_instance import ApplicationInstance
+from tests.factories.attributes import (
+    ACCESS_TOKEN,
+    H_DISPLAY_NAME,
+    H_USERNAME,
+    OAUTH_CONSUMER_KEY,
+    REFRESH_TOKEN,
+    SHARED_SECRET,
+    USER_ID,
+)
 from tests.factories.course import Course
 from tests.factories.grading_info import GradingInfo
 from tests.factories.h_group import HGroup
 from tests.factories.h_user import HUser
 from tests.factories.lti_user import LTIUser
+from tests.factories.oauth2_token import OAuth2Token
 
 
 def set_sqlalchemy_session(session, persistence=None):

--- a/tests/factories/application_instance.py
+++ b/tests/factories/application_instance.py
@@ -2,7 +2,7 @@ from factory import Faker, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
-from tests.factories._attributes import OAUTH_CONSUMER_KEY, SHARED_SECRET
+from tests.factories.attributes import OAUTH_CONSUMER_KEY, SHARED_SECRET
 
 ApplicationInstance = make_factory(  # pylint:disable=invalid-name
     models.ApplicationInstance,

--- a/tests/factories/attributes.py
+++ b/tests/factories/attributes.py
@@ -10,3 +10,5 @@ USER_ID = Faker("hexify", text="^" * 40)
 H_USERNAME = Faker("hexify", text="^" * 30)
 
 H_DISPLAY_NAME = Faker("name")
+
+ACCESS_TOKEN = REFRESH_TOKEN = Faker("hexify", text="^" * 32)

--- a/tests/factories/course.py
+++ b/tests/factories/course.py
@@ -2,7 +2,7 @@ import factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
-from tests.factories._attributes import OAUTH_CONSUMER_KEY
+from tests.factories.attributes import OAUTH_CONSUMER_KEY
 
 Course = factory.make_factory(  # pylint:disable=invalid-name
     models.Course,

--- a/tests/factories/grading_info.py
+++ b/tests/factories/grading_info.py
@@ -2,7 +2,7 @@ from factory import Faker, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
-from tests.factories._attributes import (
+from tests.factories.attributes import (
     H_DISPLAY_NAME,
     H_USERNAME,
     OAUTH_CONSUMER_KEY,

--- a/tests/factories/h_user.py
+++ b/tests/factories/h_user.py
@@ -1,7 +1,7 @@
 import factory
 
 from lms import models
-from tests.factories._attributes import H_DISPLAY_NAME, H_USERNAME
+from tests.factories.attributes import H_DISPLAY_NAME, H_USERNAME
 
 HUser = factory.make_factory(  # pylint:disable=invalid-name
     models.HUser,

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,7 +1,7 @@
 from factory import Faker, make_factory
 
 from lms import models
-from tests.factories._attributes import OAUTH_CONSUMER_KEY, USER_ID
+from tests.factories.attributes import OAUTH_CONSUMER_KEY, USER_ID
 
 LTIUser = make_factory(  # pylint:disable=invalid-name
     models.LTIUser,

--- a/tests/factories/oauth2_token.py
+++ b/tests/factories/oauth2_token.py
@@ -1,0 +1,15 @@
+from factory import SubFactory, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.application_instance import ApplicationInstance
+from tests.factories.attributes import ACCESS_TOKEN, REFRESH_TOKEN, USER_ID
+
+OAuth2Token = make_factory(  # pylint:disable=invalid-name
+    models.OAuth2Token,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    user_id=USER_ID,
+    application_instance=SubFactory(ApplicationInstance),
+    access_token=ACCESS_TOKEN,
+    refresh_token=REFRESH_TOKEN,
+)


### PR DESCRIPTION
Extracted from https://github.com/hypothesis/lms/pull/1923/ but with some changes:

* Added `FACTORY_CLASS=SQLAlchemyModelFactory` to the factory so that Factory Boy adds instances to the DB session automatically.

* Added `application_instance=SubFactory(ApplicationInstance)` to the factory so that, when you do `factories.OAuth2Token()`, Factory Boy will also generate an `ApplicationInstance` object (using `factories.ApplicationInstance`) and set it as the new `OAuth2Token`'s application instance.

  `OAuth2Token` has a non-nullable foreign key to `ApplicationInstance` so you can't save an `OAuth2Token` to the DB without first creating a matching `ApplicationInstance`, so it's convenient for the factory to do this for you. This simplifies a lot of tests that were having to create `ApplicationInstance`'s for this reason, now they don't.

  If you _don't_ want an `ApplicationInstance` to be generated for you, you can override it:

  ```python
  factories.OAuth2Token(application_instance=None)
  ```

  If you already have an `ApplicationInstance` and want that to be used, you can pass it in:

  ```python
  factories.OAuth2Token(application_instance=my_application_instance)
  ```

  If you do want an `ApplicationInstance` to be generated but you want to specify some of its fields, you can do that:

  ```python
  factories.OAuth2Token(application_instance__consumer_key=my_consumer_key)
  ```

  For more see the [`SubFactory` docs](https://factoryboy.readthedocs.io/en/latest/reference.html?highlight=exclude#subfactory)

* Removed `consumer_key` from the factory. Use `application_instance` instead

* I've updated all the existing tests to use the new factory