### PR TITLE
Tidy up GroupInfo.info

### DIFF
--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -93,6 +93,20 @@ class GroupInfo(BASE):
 
     @property
     def instructors(self):
+        """
+        Return the list of instructors associated with this course.
+
+        Warning: if you mutate this list your changes **will not be saved**.
+        For example this change won't be saved to the DB:
+
+            group_info.instructors.append(new_instructor)
+
+        Instead you should always assign to instructors rather than mutating it
+        in place:
+
+            group_info.instructors = new_list_of_instructors
+
+        """
         return self._safe_info.get("instructors", [])
 
     @instructors.setter

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -84,12 +84,6 @@ class GroupInfo(BASE):
     #: A dict of info about this group.
     _info = sa.Column("info", MutableDict.as_mutable(JSONB))
 
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("info", {})
-        kwargs["info"].setdefault("instructors", [])
-        kwargs["info"].setdefault("type", None)
-        super().__init__(*args, **kwargs)
-
     @property
     def _safe_info(self):
         if self._info is None:

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -82,7 +82,7 @@ class GroupInfo(BASE):
     custom_canvas_course_id = sa.Column(sa.UnicodeText())
 
     #: A dict of info about this group.
-    info = sa.Column(MutableDict.as_mutable(JSONB))
+    _info = sa.Column("info", MutableDict.as_mutable(JSONB))
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("info", {})
@@ -92,10 +92,10 @@ class GroupInfo(BASE):
 
     @property
     def _safe_info(self):
-        if self.info is None:
-            self.info = {}
+        if self._info is None:
+            self._info = {}
 
-        return self.info
+        return self._info
 
     @property
     def instructors(self):

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -123,7 +123,7 @@ class TestGroupInfoUpsert:
         return {
             column: f"TEST_{column.upper()}"
             for column in GroupInfo.columns()
-            if column != "info"
+            if column != "_info"
         }
 
     @pytest.fixture(


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/1839

`GroupInfo.info` is one of three JSON columns that we added to LMS before we realised that using JSON in Postgres is quite a pain due to lack of mutation tracking and lack of defaults and constraints.

The other two are `ApplicationInstance.settings` and `Course.settings`, which we've made safe (ish) and the model code nice enough by introducing a custom SQLAlchemy type `ApplicationSettings` with safe `get()` and `set()` methods and a docstring warning you not to bypass them: https://github.com/hypothesis/lms/pull/1909

`ApplicationSettings` doesn't apply to the `GroupInfo.info` column. `ApplicationSettings` is for maintaining a two-level dict in which each top-level item is a sub-dict and then the sub-dicts contain settings (and the settings themselves should be simple values like strings and booleans, not further dicts and lists, or you'll have to deal with mutation tracking issues). `GroupInfo.info` is different: it's used to store two keys: `"instructors"` is a list (defaults to `[]`) and `"type"` is a string (defaults to `"course_group"`).

I don't think it's worthwhile trying to devise a custom SQLAlchemy type for `GroupInfo.info`'s case at this time, so this PR just tidies a little bit of Python code mess that's been made while fixing unforeseen JSON-handling issues:

1. Rename `GroupInfo.info` (which is the raw dict which may be `None` or may be a dict with either of the `"instructors"` or `"type"` fields missing) to `GroupInfo._info` to discourage accessing it directly

2. Delete an unnecessary `__init__` method that was setting default values for `GroupInfo._info` and the `"instructors"` and `"type"` fields it contains. Setting defaults in `__init__` only works when creating new `GroupInfo`'s, it doesn't always work when reading them from the DB, and nothing prevents `info` from being `None` or being a dict with no `"instructors"` or `"type"` in the DB.

   The convenience `@property`'s `instructors` and `type` provide ways of accessing instructors and type with default values that work in both cases as long as you always go through those properties, so the `__init__` simply isn't needed.

3. Add a docstring warning that modifications won't be saved

`GroupInfo` now implements a fairly reasonable approach to "how to deal with JSON" in SQLAlchemy, as far as handling JSON's lack of constraints and defaults goes:

1. Name the JSON column itself with a leading `_` to warn people off it
2. Add a private `@property` for safely accessing the column (with defaulting to `{}`), like the `_safe_info` property below
3. Add getter and setter `@property`'s for each piece of public info that you're storing in your JSON column. These properties should be based on the private `_safe_foo` property, and then should provide their own defaults for the specific items that they get.

Note that this **does nothing to help with mutation tracking**. If you do `group_info.instructors.append(something)` that **will not be saved**. (Actually, sometimes it will be saved, and sometimes it won't, and a change elsewhere in the code can trip it from being saved to not being saved.) Instead you have to either do `group_info.instructors = group_info.instructors + [something]` or, if you do mutate it in place, you have to remember to call `group_info._info.changed()`. I've added a docstring warning about this.

It's disappointing how ugly this is and how much boilerplate Python code is needed. You've got the `_info` attribute itself and the `_safe_info` property, and then a getter and a setter property for each individual item in the dict. Even after adding `_info` and `_safe_info`, it's actually more additional lines of Python code and complexity per field than if each field had its own non-JSON column. I think this behaviour probably _can_ somehow be wrapped up in reusable code so that we don't need so much junk in every model class that has a JSON column. But that still wouldn't fix the mutation issue.

My honest opinion for the future: we should probably avoid JSON in future except when it's really needed, for something that actually wouldn't work or would be truly painful to do with non-JSON columns. For most cases, for example if we're just using JSON to try to avoid adding multiple Postgres columns / SQLAlchemy attributes to the model, JSON looks to be more trouble than it's worth, it will add considerably _more_ code noise to your model not less and it will make you deal mutation, defaults and constraints yourself instead of Postgres doing it. It also forces you to use Postgres's JSON querying syntax, which you probably aren't familiar with, rather than plain SQL if you're every trying to inspect the DB directly.

```python
class GroupInfo:

    _info = sa.Column("info", MutableDict.as_mutable(JSONB))

    @property
    def _safe_info(self):
        if self._info is None:
            self._info = {}

        return self._info

    @property
    def instructors(self):
        return self._safe_info.get("instructors", [])

    @instructors.setter
    def instructors(self, new_instructors):
        self._safe_info["instructors"] = new_instructors

    @property
    def type(self):
        return self._safe_info.get("type", None)

    @type.setter
    def type(self, new_type):
        self._safe_info["type"] = new_type
```