### PR TITLE
Add Course.application_instance sub-factory

### DIFF
--- a/tests/factories/course.py
+++ b/tests/factories/course.py
@@ -2,11 +2,11 @@ import factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
-from tests.factories.attributes import OAUTH_CONSUMER_KEY
+from tests.factories import ApplicationInstance
 
 Course = factory.make_factory(  # pylint:disable=invalid-name
     models.Course,
     FACTORY_CLASS=SQLAlchemyModelFactory,
-    consumer_key=OAUTH_CONSUMER_KEY,
+    application_instance=factory.SubFactory(ApplicationInstance),
     authority_provided_id=factory.Faker("hexify", text="^" * 40),
 )


### PR DESCRIPTION
* Add `application_instance=SubFactory(ApplicationInstance)` to the `Course` factory so that, when you do `factories.Course()`, Factory Boy will also generate an `ApplicationInstance` object (using `factories.ApplicationInstance`) and set it as the new `Course`'s application instance.

  `Course` has a non-nullable foreign key to `ApplicationInstance` so you can't save a `Course` to the DB without first creating a matching `ApplicationInstance`, so it's convenient for the factory to do this for you.
  
  If you _don't_ want an `ApplicationInstance` to be generated for you, you can override it:

  ```python
  factories.Course(application_instance=None)
  ```

  If you already have an `ApplicationInstance` and want that to be used, you can pass it in:

  ```python
  factories.Course(application_instance=my_application_instance)
  ```

  If you do want an `ApplicationInstance` to be generated but you want to specify some of its fields, you can do that:

  ```python
  factories.Course(application_instance__consumer_key=my_consumer_key)
  ```

  For more see the [`SubFactory` docs](https://factoryboy.readthedocs.io/en/latest/reference.html?highlight=exclude#subfactory)

* Removed `consumer_key` from the factory. Use `application_instance` instead

* Updated the existing tests