### PR TITLE
Remove an unnecessary `settings` attribute

### DIFF
--- a/tests/factories/course.py
+++ b/tests/factories/course.py
@@ -9,5 +9,4 @@ Course = factory.make_factory(  # pylint:disable=invalid-name
     FACTORY_CLASS=SQLAlchemyModelFactory,
     consumer_key=OAUTH_CONSUMER_KEY,
     authority_provided_id=factory.Faker("hexify", text="^" * 40),
-    settings=factory.lazy_attribute(lambda o: {}),
 )

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -30,6 +30,7 @@ class TestCourseService:
         existing_course = factories.Course(
             consumer_key=pyramid_request.lti_user.oauth_consumer_key,
             authority_provided_id="test_authority_provided_id",
+            settings={},
         )
         existing_course.settings.set("canvas", "sections_enabled", False)
         ai_getter.settings.return_value.set("canvas", "sections_enabled", True)


### PR DESCRIPTION
This does mean that if a test creates a new `Course` and then it wants to call `course.settings.set()` or `get()` before having added it to the DB, the test has to first set `settings={}` itself because the `server_default` only takes effect on saving to the DB. This is the same as how `models.Course.settings` works for production code, though, so I think it might be best for the factory _not_ to hide that fact.

I think maybe a good guide for how clever a factory should be / how many of the model's attributes a factory should autogenerate might be: it should generate the minimum set of attrs necessary to save the object to the DB. And `settings` isn't necessary for that. It's a balance between making factories convenient for tests to use (reducing how much work a test must do itself) versus factories potentially hiding bugs because they're generating a lot of properties that wouldn't exist on a new object in production code.

At least I think that guide should apply for default factories like `factories.Course()`. I think it would be fine to add specialized factories that do generate more fields. For example a `factories.CourseWithCanvasSectionsEnabled()` would be fine.