### PR TITLE
Tidy up the requests.Response test factory

### DIFF
--- a/tests/factories/requests_.py
+++ b/tests/factories/requests_.py
@@ -2,49 +2,49 @@ import json
 from io import BytesIO
 
 import requests
-from factory import Factory, Faker
+from factory import Factory, Faker, post_generation
+
+# pylint:disable=no-self-argument,method-hidden
 
 
 class Response(Factory):
     class Meta:
         model = requests.Response
 
-    raw = None
-    json_data = None
     encoding = "utf-8"
     status_code = Faker(
         "random_element", elements=[200, 201, 301, 304, 401, 404, 500, 501],
     )
-    headers = None
 
-    @classmethod
-    def _adjust_kwargs(cls, **kwargs):
-        headers = kwargs["headers"] or {}
-        encoding = kwargs["encoding"]
-        raw = kwargs["raw"]
-        json_data = kwargs["json_data"]
+    @post_generation
+    def headers(response, _create, headers, **_kwargs):
+        """Lower-case all header names. Requests requires this."""
+        if headers:
+            response.headers = {key.lower(): value for key, value in headers.items()}
 
-        if raw is None and json_data is not None:
-            raw = json.dumps(json_data)
+    @post_generation
+    def json_data(response, _create, json_data, **_kwargs):
+        """Set raw and content-type if json_data is given."""
+        if json_data is not None:
+            response.headers.setdefault(
+                "content-type", f"application/json; charset={response.encoding}"
+            )
 
-            if not headers:
-                headers["Content-Type"] = f"application/json; charset={encoding}"
+            response.raw = json.dumps(json_data)
 
-        kwargs["raw"] = BytesIO(raw.encode(encoding)) if isinstance(raw, str) else raw
+    @post_generation
+    def raw(response, _create, raw, **_kwargs):
+        """Encode raw body strings to bytes."""
+        raw = response.raw or raw
 
-        # Requests seems to store these lower case and expects them that way
-        kwargs["headers"] = {key.lower(): value for key, value in headers.items()}
-
-        return kwargs
+        if isinstance(raw, str):
+            response.raw = BytesIO(raw.encode(response.encoding))
 
     @classmethod
     def _create(cls, model_class, *_args, **kwargs):
         response = model_class()
+
         for field, value in kwargs.items():
             setattr(response, field, value)
 
         return response
-
-
-class OKResponse(Response):
-    status_code = 200

--- a/tests/unit/lms/services/canvas_api/conftest.py
+++ b/tests/unit/lms/services/canvas_api/conftest.py
@@ -26,7 +26,7 @@ def http_session(patch):
     session = session()
 
     def set_response(json_data=None, raw=None, status_code=200):
-        session.send.return_value = factories.requests.OKResponse(
+        session.send.return_value = factories.requests.Response(
             json_data=json_data, raw=raw, status_code=status_code
         )
 


### PR DESCRIPTION
This tidies up the `Response` factory a little, separating things out into separate methods and making the code/logic "flatter".

The behaviour of the factory hasn't changed.

Demo
----

Non-JSON responses:

```python
>>> response = factories.requests.Response()
>>> response.encoding
'utf-8'

>>> response.status_code
500

>>> response.headers
{}

>>> response.raw is None
True

>>> response.json()
JSONDecodeError
```

Lower-casing headers:

```python
>>> factories.requests.Response(headers={"FOO": "BAR"}).headers
{"foo": "BAR"}
```

Encoding raw bodies:

```python
>>> factories.requests.Response(raw="hi").raw.read()
b'hi'
```

JSON:

```python
>>> factories.requests.Response(json_data={"foo": "bar"}).json()
{'foo': 'bar'}

>>> factories.requests.Response(json_data={"foo": "bar"}).raw.read()
b'{"foo": "bar"}'

>>> factories.requests.Response(json_data={"foo": "bar"}).headers
{'content-type': 'application/json; charset=utf-8'}

>>> factories.requests.Response(json_data={"foo": "bar"}).json_data
AttributeError
```

If both `json_data` and `raw` are given `json_data` wins. Otherwise calling `json()` would fail with `JSONDecodeError` if the given `raw` wasn't valid JSON. An alternative here would be to raise an error if both `json_data` and `raw` are given:

```python
>>> factories.requests.Response(raw="hi", json_data={"foo": "bar"}).json()
{'foo': 'bar'}

>>> factories.requests.Response(raw="hi", json_data={"foo": "bar"}).raw.read()
b'{"foo": "bar"}'
```

Generating args vs adjusting them in post
-----------------------------------

Normally the way that Factory Boy works is you write code to generate the positional and keyword arguments that will be passed to the model class:

```python
class SomeFactory(Factory):
    arg = "default_value"
    arg_2 = Faker("random_element", elements=[...])
    arg_3 = LazyFunction(dict)

    @lazy_attribute
    def arg_4(self):
        ...
````

... and so on.

These are all ways of defining how to generate _default_ arguments, but if the user passes in a custom argument it overrides them. For example if you do `SomeFactory(arg_4="foo")` then the `arg_4()` method does not get called, the value `"foo"` is just used directly.

The `Response` factory in this PR is pretty unusual in that it has a few attributes that are different from the above behaviour. Rather than generating default values for when the user doesn't provide any, this factory wants to _change_ the values that the user does provide:

1. It wants to convert all header names to lower-case. If the user does `factories.Response(headers={"FOO": "bar"})` then the user-given value `"FOO"` gets lower-cased

2. It wants to set the `"content-type"` header to `"application/json"` by default but this has to happen _after_ the header name lower-casing. A user supplied `headers={"content-type": "..."}` _or_ `headers={"Content-Type": "..."}` will both override the default `"application/json"` value

3. It wants to encode a user-given `raw` string to bytes. If the user does `factories.Response(raw="foo")` then `"foo"` will get encoded to bytes

These are all examples of "post-processing" or "adjusting" the arguments after they've been generated, whether generated by the factory or supplied by the user.

Factory Boy provides two different ways to do post-processing rather than pre-generating:

1. Overriding the [`_adjust_kwargs()`](https://factoryboy.readthedocs.io/en/latest/reference.html#factory.Factory._adjust_kwargs) method lets you adjust kwargs before they get sent to the model's `__init__()` (or to our custom `_create()`, in the case of this `Response` factory). Unfortunately there's only one `_adjust_kwargs()` method so you have to do all your kwargs adjusting in one long method, unless you break it up into separate methods and call them yourself. Your method also has to deal with the `kwargs` dict, which can be awkward. If you needed to modify the kwargs _before_ they get sent to the model class, rather than modifying the model object after it has been constructed, you would have to use `_adjust_kwargs()`. Fortunately that's not the case for our `Response` factory

2. [Post-generation hooks](https://factoryboy.readthedocs.io/en/latest/reference.html#post-generation-hooks) provide a way to modify the model object after it has been constructed. This is what I've gone for in this PR because it allows you to register multiple hooks and easily separate post-generation code for different attributes into different methods, and it avoids having to work with the awkward `kwargs` dict.

Unnecessary class attrs
-----------------------

It's unnecessary to put these attributes at the top of the class:

```python
class Response(Factory):
    raw = None
    json_data = None
    headers = None
```

The way Factory Boy works is that you can pass **any** arguments to a factory, even if the factory class doesn't know about them, and they will be passed through to the model's `__init__()` method as keyword arguments (or to our custom `_create()` method in the case of this factory). So if you're not going to actually generate a default value for an attribute (other than `None`) you just don't need to mention it in your factory class at all.

Use `@post_generation` instead of `_adjust_kwargs()`
---------------------------------------------------

Overriding `_adjust_kwargs()` sucks because there's only one `_adjust_kwargs()` method so you have to do all your kwargs adjusting in one long method. You could split it up into multiple methods and call them yourself, but that's not ideal either.

The `@post_generation` decorator is better because you can use it multiple times, registering a different `@post_generation` method for each different argument. This just makes it easier to split things up into separate little methods.

`@post_generation` methods are also nicer because the constructed `Response` object is passed to them, rather than a kwargs dict.

Explanation:

Here's an example `@post_generation` method:

```python
@post_generation
def headers(response, _create, headers, **_kwargs):
    """Lower-case all header names. Requests requires this."""
    if headers:
        response.headers = {key.lower(): value for key, value in headers.items()}
```

This method:

* Is always called whenever the factory is called
* Is called *after* the `_create()` method has been called and the `requests.Response` object has been created
* Is passed these arguments:
  - `response`: the created `requests.Response` object
  - `create`: whether or not Factory Boy's "create" strategy was used. This is basically whether or not the object should be added to the DB session if it's a SQLAlchemy model. We don't care about this for our factory
  - `headers`: any `headers` argument that was passed to `factories.requests.Response(headers={...})`. This is `None` if no `headers` were passed
  - `**kwargs`: you can pass custom arguments to specific post-generation methods. For example you can do `factories.requests.Response(headers={}, headers__foo="foo", headers__bar="bar")` and `kwargs` will be `{'bar': 'bar', 'foo': 'foo'}`. We're not making use of this
* Removes its argument from kwargs. The presence of a `@post_generation` method named `headers` means that, even if the user passes a `headers` argument to `factories.requests.Response(headers={...})`, `headers` will not be passed to the model's `__init__()` method (or our custom `_create()` method in the case of our `Response` class) in the `kwargs` dict. Registering a `@post_generation` method for an attribute says "remove this attribute from `kwargs`, don't use it in initially creating the object, pass it to this method _after_ creating the object instead." This is useful for custom arguments like `json_data` that are just arguments to our factory and are not actually part of the underlying `requests.Response` object

See: https://factoryboy.readthedocs.io/en/latest/reference.html#post-generation-hooks

`OKResponse`
------------

I deleted `OKResponse` as it's not needed. You can just do `factories.requests.Response(status_code=200)`. The one place where `OKResponse` was called was actually already passing in `status_code` so this class wasn't doing anything.

`json_data`
---------------

Because it's now a `@post_generation` method `json_data` is no longer being set as an attribute on the `Response` object :)

(If `@post_generation` were not being used `json_data` could have been added to `Params` instead: https://factoryboy.readthedocs.io/en/latest/reference.html#parameters)
