### PR TITLE
Improve screen readers on dialog errors

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -258,14 +258,20 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
     </span>
   );
 
+  const focusedDialogButton = useRef(
+    /** @type {HTMLButtonElement | null} */ (null)
+  );
+
   const errorDialog = (
     <Fragment>
       {errorState === 'error-authorizing' && (
         <Dialog
+          initialFocus={focusedDialogButton}
           title="Authorize Hypothesis"
           role="alertdialog"
           buttons={[
             <Button
+              buttonRef={focusedDialogButton}
               onClick={authorizeAndFetchUrl}
               className="BasicLtiLaunchApp__button"
               label="Authorize"
@@ -278,11 +284,13 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
       )}
       {errorState === 'error-fetch' && (
         <Dialog
+          initialFocus={focusedDialogButton}
           title="Something went wrong"
           contentClass="BasicLtiLaunchApp__dialog"
           role="alertdialog"
           buttons={[
             <Button
+              buttonRef={focusedDialogButton}
               onClick={authorizeAndFetchUrl}
               className="BasicLtiLaunchApp__button"
               label="Try again"

--- a/lms/static/scripts/frontend_apps/components/Button.js
+++ b/lms/static/scripts/frontend_apps/components/Button.js
@@ -3,6 +3,7 @@ import { createElement } from 'preact';
 
 /**
  * @typedef ButtonProps
+ * @prop {Object} [buttonRef]
  * @prop {string} [className]
  * @prop {boolean} [disabled]
  * @prop {string} label
@@ -18,6 +19,7 @@ export default function Button({
   disabled = false,
   label,
   onClick,
+  buttonRef,
   type = 'button',
 }) {
   return (
@@ -26,6 +28,7 @@ export default function Button({
       disabled={disabled}
       onClick={onClick}
       type={type}
+      ref={buttonRef}
     >
       {label}
     </button>

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -53,8 +53,9 @@ export default function Dialog({
   title,
   buttons,
 }) {
-  const dialogTitleId = useUniqueId('dialog');
-  const rootEl = useRef(/** @type {HTMLDivElement|null} */ (null));
+  const dialogTitleId = useUniqueId('dialog-title');
+  const dialogDescriptionId = useUniqueId('dialog-description');
+  const rootEl = useRef(/** @type {HTMLDivElement | null} */ (null));
 
   useElementShouldClose(rootEl, true, () => {
     if (onCancel) {
@@ -77,19 +78,21 @@ export default function Dialog({
   }, []);
 
   return (
-    <div
-      role={role}
-      aria-labelledby={dialogTitleId}
-      aria-modal="true"
-      ref={rootEl}
-      tabIndex={-1}
-    >
+    <div>
       <div
         className="Dialog__background"
         style={{ zIndex: zIndexScale.dialogBackground }}
       />
       <div className="Dialog__container" style={{ zIndex: zIndexScale.dialog }}>
-        <div className={classNames('Dialog__content', contentClass)}>
+        <div
+          tabIndex={-1}
+          ref={rootEl}
+          role={role}
+          aria-labelledby={dialogTitleId}
+          aria-describedby={dialogDescriptionId}
+          aria-modal={true}
+          className={classNames('Dialog__content', contentClass)}
+        >
           <h1 className="Dialog__title" id={dialogTitleId}>
             {title}
             <span className="u-stretch" />
@@ -103,7 +106,7 @@ export default function Dialog({
               </button>
             )}
           </h1>
-          {children}
+          <div id={dialogDescriptionId}>{children}</div>
           <div className="u-stretch" />
           <div className="Dialog__actions">
             {onCancel && (

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -1,4 +1,4 @@
-import { createElement } from 'preact';
+import { createElement, Fragment } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import classNames from 'classnames';
 
@@ -78,7 +78,7 @@ export default function Dialog({
   }, []);
 
   return (
-    <div>
+    <Fragment>
       <div
         className="Dialog__background"
         style={{ zIndex: zIndexScale.dialogBackground }}
@@ -120,6 +120,6 @@ export default function Dialog({
           </div>
         </div>
       </div>
-    </div>
+    </Fragment>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -132,20 +132,14 @@ export default function LMSFilePicker({
   const title =
     dialogState.state === 'authorizing' ? 'Allow file access' : 'Select a file';
 
-  const focusedDialogButton = useRef(
-    /** @type {HTMLButtonElement | null} */ (null)
-  );
-
   return (
     <Dialog
-      initialFocus={focusedDialogButton}
       contentClass="LMSFilePicker__dialog"
       title={title}
       onCancel={cancel}
       buttons={[
         dialogState.state === 'authorizing' || dialogState.state === 'error' ? (
           <Button
-            buttonRef={focusedDialogButton}
             key="showAuthWindow"
             onClick={authorizeAndFetchFiles}
             label={
@@ -157,7 +151,6 @@ export default function LMSFilePicker({
           />
         ) : (
           <Button
-            buttonRef={focusedDialogButton}
             key="select"
             disabled={selectedFile === null}
             onClick={useSelectedFile}

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -132,14 +132,20 @@ export default function LMSFilePicker({
   const title =
     dialogState.state === 'authorizing' ? 'Allow file access' : 'Select a file';
 
+  const focusedDialogButton = useRef(
+    /** @type {HTMLButtonElement | null} */ (null)
+  );
+
   return (
     <Dialog
+      initialFocus={focusedDialogButton}
       contentClass="LMSFilePicker__dialog"
       title={title}
       onCancel={cancel}
       buttons={[
         dialogState.state === 'authorizing' || dialogState.state === 'error' ? (
           <Button
+            buttonRef={focusedDialogButton}
             key="showAuthWindow"
             onClick={authorizeAndFetchFiles}
             label={
@@ -151,6 +157,7 @@ export default function LMSFilePicker({
           />
         ) : (
           <Button
+            buttonRef={focusedDialogButton}
             key="select"
             disabled={selectedFile === null}
             onClick={useSelectedFile}


### PR DESCRIPTION
- Move the `aria-*` attributes down from the dialog root element to its content wrapper. This seems to prevent Voice Over from reading out “x items in group” after reading the header.

- Add `aria-describedby`. This facilitates reading of the actual content by the screen readers

- Pass a button ref as `initialFocus` for dialogs that have an authorize button in BasicLtiLaunchApp. This allows the screen reader to state the call to action after reading the content.

- These concepts are from https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/alertdialog.html

fixes https://github.com/hypothesis/lms/issues/1782