### PR TITLE
Add a central location for typedefs for API types

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -1,0 +1,16 @@
+/**
+ * Types for objects exchanged between the LMS frontend and backend via
+ * JSON HTTP requests.
+ */
+
+/**
+ * Object representing a file in the LMS's file storage.
+ *
+ * @typedef File
+ * @prop {string} id - Identifier for the file within the LMS's file storage
+ * @prop {string} display_name - Name of the file to present in the file picker
+ * @prop {string} updated_at - An ISO 8601 date string
+ */
+
+// Make TS treat this file as a module.
+export {};

--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -5,9 +5,7 @@ import Spinner from './Spinner';
 import Table from './Table';
 
 /**
- * @typedef File
- * @prop {string} display_name - The filename
- * @prop {string} updated_at - An ISO date or date + time string
+ * @typedef {import('../api-types').File} File
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -18,6 +18,8 @@ import Spinner from './Spinner';
 import URLPicker from './URLPicker';
 
 /**
+ * @typedef {import('../api-types').File} File
+ *
  * @typedef FilePickerAppProps
  * @prop {'lms'|'url'|null} [defaultActiveDialog] -
  *   The dialog that should be shown when the app is first opened.
@@ -52,7 +54,7 @@ export default function FilePickerApp({
 
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
   const [url, setUrl] = useState(/** @type {string|null} */ (null));
-  const [lmsFile, setLmsFile] = useState(null);
+  const [lmsFile, setLmsFile] = useState(/** @type {File|null} */ (null));
   const [isLoadingIndicatorVisible, setLoadingIndicatorVisible] = useState(
     false
   );

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('../api-types').File} File
+ */
+
+/**
  * Error returned when an API call fails with a 4xx or 5xx response and
  * JSON body.
  */
@@ -69,6 +73,13 @@ async function apiCall({ path, authToken, data }) {
   return resultJson;
 }
 
+/**
+ * List files in the LMS's file storage.
+ *
+ * @param {string} authToken
+ * @param {string} courseId
+ * @return {Promise<File[]>}
+ */
 async function listFiles(authToken, courseId) {
   return apiCall({
     authToken,

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('../api-types').File} File
+ */
+
+/**
  * Return a JSON-LD `ContentItem` representation of the LTI activity launch
  * URL for a given document URL.
  */
@@ -15,6 +19,13 @@ export function contentItemForUrl(ltiLaunchUrl, documentUrl) {
   };
 }
 
+/**
+ * Return a JSON-LD `ContentItem` representation of the LTI activity launch
+ * URL for a given LMS file
+ *
+ * @param {string} ltiLaunchUrl
+ * @param {File} file
+ */
 export function contentItemForLmsFile(ltiLaunchUrl, file) {
   return {
     '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',


### PR DESCRIPTION
Add an `api-types.js` file which describes the various objects sent to
or received from the LMS backend by the LMS frontend. Currently this
only has one type, `File` for an object in the LMS file picker.