### PR TITLE
Refactor `contentItemFromXYZ` functions and add missing tests

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -2,21 +2,37 @@
  * @typedef {import('../api-types').File} File
  */
 
+import { stringify } from 'querystring';
+
 /**
  * Return a JSON-LD `ContentItem` representation of the LTI activity launch
  * URL for a given document URL.
+ *
+ * @param {string} ltiLaunchUrl
+ * @param {Object.<string,string>} params - Query parameters for the generated URL
  */
-export function contentItemForUrl(ltiLaunchUrl, documentUrl) {
+function contentItemWithParams(ltiLaunchUrl, params) {
   return {
     '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
     '@graph': [
       {
         '@type': 'LtiLinkItem',
         mediaType: 'application/vnd.ims.lti.v1.ltilink',
-        url: `${ltiLaunchUrl}?url=${encodeURIComponent(documentUrl)}`,
+        url: `${ltiLaunchUrl}?${stringify(params)}`,
       },
     ],
   };
+}
+
+/**
+ * Return a JSON-LD `ContentItem` representation of the LTI activity launch
+ * URL for a given document URL.
+ *
+ * @param {string} ltiLaunchUrl
+ * @param {string} documentUrl
+ */
+export function contentItemForUrl(ltiLaunchUrl, documentUrl) {
+  return contentItemWithParams(ltiLaunchUrl, { url: documentUrl });
 }
 
 /**
@@ -27,14 +43,8 @@ export function contentItemForUrl(ltiLaunchUrl, documentUrl) {
  * @param {File} file
  */
 export function contentItemForLmsFile(ltiLaunchUrl, file) {
-  return {
-    '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
-    '@graph': [
-      {
-        '@type': 'LtiLinkItem',
-        mediaType: 'application/vnd.ims.lti.v1.ltilink',
-        url: `${ltiLaunchUrl}?canvas_file=true&file_id=${file.id}`,
-      },
-    ],
-  };
+  return contentItemWithParams(ltiLaunchUrl, {
+    canvas_file: 'true',
+    file_id: file.id,
+  });
 }

--- a/lms/static/scripts/frontend_apps/utils/test/content-item-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/content-item-test.js
@@ -1,0 +1,43 @@
+import { contentItemForUrl, contentItemForLmsFile } from '../content-item';
+
+const ltiLaunchUrl = 'https://lms.hypothes.is/lti_launch';
+
+describe('content-item', () => {
+  describe('contentItemForUrl', () => {
+    it('returns expected JSON-LD representation', () => {
+      const documentUrl = 'https://example.com?param_a=1&param_b=2';
+
+      const contentItem = contentItemForUrl(ltiLaunchUrl, documentUrl);
+
+      assert.deepEqual(contentItem, {
+        '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
+        '@graph': [
+          {
+            '@type': 'LtiLinkItem',
+            mediaType: 'application/vnd.ims.lti.v1.ltilink',
+            url: ltiLaunchUrl + '?url=' + encodeURIComponent(documentUrl),
+          },
+        ],
+      });
+    });
+  });
+
+  describe('contentItemForLmsFile', () => {
+    it('returns expected JSON-LD representation', () => {
+      const file = { id: 'foobar' };
+
+      const contentItem = contentItemForLmsFile(ltiLaunchUrl, file);
+
+      assert.deepEqual(contentItem, {
+        '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
+        '@graph': [
+          {
+            '@type': 'LtiLinkItem',
+            mediaType: 'application/vnd.ims.lti.v1.ltilink',
+            url: ltiLaunchUrl + '?canvas_file=true&file_id=foobar',
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/1957**

Refactor the `contentItemFromUrl` and `contentItemFromFile` functions so
that it is easier to add new types of LMS assignment in future. Also add
missing tests for this module.
