### PR TITLE
Suppress error formatting for log lines containing certain strings

### DIFF
--- a/bin/logger
+++ b/bin/logger
@@ -116,17 +116,17 @@ colors = Colors()
 
 def main():
     while True:
-        _write('READY\n')
+        _write("READY\n")
         header = _parse_header(sys.stdin.readline())
-        payload = sys.stdin.read(int(header['len']))
+        payload = sys.stdin.read(int(header["len"]))
 
         # Only handle PROCESS_LOG_* events and just ACK anything else.
-        if header['eventname'] == 'PROCESS_LOG_STDOUT':
+        if header["eventname"] == "PROCESS_LOG_STDOUT":
             _log_payload(payload)
-        elif header['eventname'] == 'PROCESS_LOG_STDERR':
+        elif header["eventname"] == "PROCESS_LOG_STDERR":
             _log_payload(payload, err=True)
 
-        _write('RESULT 2\nOK')
+        _write("RESULT 2\nOK")
 
 
 def _write(s):
@@ -135,25 +135,36 @@ def _write(s):
 
 
 def _parse_header(data):
-    return dict([x.split(':') for x in data.split()])
+    return dict([x.split(":") for x in data.split()])
+
+
+# Patterns in log lines that identify them as not being errors, even if the
+# log line was written to stderr.
+NON_ERROR_MARKERS = ["[INFO]"]
 
 
 def _log_payload(payload, err=False):
-    headerdata, data = payload.split('\n', 1)
+    headerdata, data = payload.split("\n", 1)
     header = _parse_header(headerdata)
-    name = header['processname']
+    name = header["processname"]
     if err:
-        name += ' (stderr)'
-    prefix = '{name:{width}} | '.format(name=name, width=WIDTH)
-    for line in data.splitlines():
-        output_line = prefix + line + '\n'
+        name += " (stderr)"
+    prefix = "{name:{width}} | ".format(name=name, width=WIDTH)
 
-        if '--dev' in sys.argv:
-            output_line = colors.color(name, output_line, error=err)
+    for line in data.splitlines():
+        format_as_error = err and all(
+            [marker not in line for marker in NON_ERROR_MARKERS]
+        )
+
+        output_line = prefix + line + "\n"
+
+        if "--dev" in sys.argv:
+            output_line = colors.color(name, output_line, error=format_as_error)
 
         sys.stderr.write(output_line)
+
     sys.stderr.flush()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Avoid formatting lines containing certain strings as errors if even they
come from stderr. This avoids `make dev` printing a whole bunch of
non-error output with bold red error styling.

Copy the `bin/logger` script from https://github.com/hypothesis/h/pull/6125 with
a minor change to the `NON_ERROR_MARKERS` variable to account for the
slightly different formatting of `INFO` lines from gunicorn. The
"Starting monitor" string was also removed from `NON_ERROR_MARKERS`
because that line isn't output when starting `make dev`.