### PR TITLE
Prevent dialog size from changing when error details opened

### DIFF
--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -9,7 +9,6 @@
   overflow-y: auto;
   padding-right: 5px;
   margin-bottom: 10px;
-  max-width: 100%;
 
   &__details {
     padding: 4px; // prevents focus ring from getting cut off
@@ -27,8 +26,17 @@
     white-space: pre-wrap;
     /* Prevent very long single words from breaking out of the box */
     overflow-wrap: break-word;
-    max-width: 100%;
     padding: 10px;
     margin-bottom: 0;
+
+    // When the `ErrorDisplay` is embedded in a container (eg. a dialog) whose
+    // size depends on the preferred width of its children, we want to avoid the
+    // container changing size when the `ErrorDisplay` is opened or closed.
+    //
+    // Therefore we override the instrinsic width of the content with a small
+    // value using `width` and set `min-width` to make the `ErrorDisplay` still
+    // fill the final width of the container.
+    width: 200px;
+    min-width: 100%;
   }
 }


### PR DESCRIPTION
By default the `Dialog` component's width is set based on the preferred
width of the dialog content, up to a default maximum of min(700px,
90vw). In dialogs that have an "Error details" section rendered by an
`ErrorDisplay`, this can cause the dialog's width to change when the
error details are expanded and collapsed. When the `ErrorDisplay` is
collapsed the preferred width depends only on the `<summary>`. When
open, it also depends upon the content, which by default is the laid-out
width of the error message before any line breaking happens.

This commit resolves the issue by setting `width` to override the
intrinsic width of the error message which is used when calculating the
width of the dialog but then also `min-width` to make the error message
fill the final width allocated to the `ErrorDisplay`. Hat tip to [1].

Several `max-width` properties were removed as they are no longer
required.

Fixes https://github.com/hypothesis/lms/issues/1890

[1] https://stackoverflow.com/questions/24632208/