### PR TITLE
Render error messages as sentences

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -7,6 +7,13 @@ function emailLink({ address, subject = '', body = '' }) {
 }
 
 /**
+ * @param {string} str
+ */
+function toSentence(str) {
+  return str.match(/[.!?]$/) ? str : str + '.';
+}
+
+/**
  * An `Error` or `Error`-like object.
  *
  * @typedef ErrorLike
@@ -16,7 +23,7 @@ function emailLink({ address, subject = '', body = '' }) {
 
 /**
  * @typedef ErrorDisplayProps
- * @prop {Object} [message] -
+ * @prop {string|null} [message] -
  *   A short message to display explaining that a problem happened. This is
  *   typically a general message like "There was a problem fetching this assignment".
  * @prop {ErrorLike} error -
@@ -69,10 +76,10 @@ export default function ErrorDisplay({ message, error }) {
     <div className="ErrorDisplay">
       {message && (
         <p>
-          {message}
+          {!error.message && toSentence(message)}
           {error.message && (
             <Fragment>
-              : <i>{error.message}</i>
+              {message}: <i>{toSentence(error.message)}</i>
             </Fragment>
           )}
         </p>

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -1,4 +1,4 @@
-import { Fragment, createElement } from 'preact';
+import { createElement } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import { ApiError, listFiles } from '../utils/api';
@@ -167,7 +167,7 @@ export default function LMSFilePicker({
       )}
       {dialogState.state === 'authorizing' && authorizationAttempted && (
         <ErrorDisplay
-          message={<Fragment>{`Failed to authorize with Canvas`}</Fragment>}
+          message={'Failed to authorize with Canvas'}
           error={new Error('')}
         />
       )}

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -117,6 +117,34 @@ describe('ErrorDisplay', () => {
     assert.called(scrollIntoView);
   });
 
+  [
+    {
+      message: 'Not a sentence',
+      output: 'Not a sentence.',
+    },
+    {
+      message: 'A sentence',
+      output: 'A sentence.',
+    },
+    {
+      message: 'Oh no',
+      error: 'Tech details',
+      output: 'Oh no: Tech details.',
+    },
+    {
+      message: 'Oh no',
+      error: 'Tech details.',
+      output: 'Oh no: Tech details.',
+    },
+  ].forEach(({ message, error, output }, index) => {
+    it(`formats errors as sentences (${index})`, () => {
+      const wrapper = mount(
+        <ErrorDisplay message={message} error={{ message: error }} />
+      );
+      assert.equal(wrapper.find('p').first().text(), output);
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -6,6 +6,7 @@ import { ApiError } from '../../utils/api';
 
 import LMSFilePicker, { $imports } from '../LMSFilePicker';
 import ErrorDisplay from '../ErrorDisplay';
+import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('LMSFilePicker', () => {
   const FakeButton = () => null;
@@ -44,6 +45,7 @@ describe('LMSFilePicker', () => {
 
     fakeListFiles = sinon.stub().resolves([]);
 
+    $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../utils/AuthWindow': FakeAuthWindow,
       '../utils/api': {
@@ -112,11 +114,12 @@ describe('LMSFilePicker', () => {
 
     assert.isTrue(wrapper.exists('FakeButton[label="Try again"]'));
 
-    const errorDetails = wrapper.find(ErrorDisplay);
-    assert.isTrue(
-      errorDetails.text().includes('Failed to authorize with Canvas')
+    const errorDetails = wrapper.find('ErrorDisplay');
+    assert.equal(
+      errorDetails.prop('message'),
+      'Failed to authorize with Canvas'
     );
-    assert.equal(errorDetails.props().error.message, '');
+    assert.equal(errorDetails.prop('error').message, '');
   });
 
   [


### PR DESCRIPTION
Add trailing periods to error messages if they do not already end with
punctuation.

The error messages to come from a variety of sources so it is difficult to
ensure that they are always consistent about whether or not they end
with punctuation. Therefore we treat this as a formatting concern and
add it if necessary when rendering the error.

Fixes #1891