### PR TITLE
Add a feature flag for enabling Via internal `pywb` rewriter

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -16,7 +16,7 @@ session_cookie_secret = "notasecret"
 
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
-feature_flags_allowed_in_cookie = use_legacy_via
+feature_flags_allowed_in_cookie = use_legacy_via use_via_rewriter
 
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -32,7 +32,15 @@ class _ViaDoc:
 class _ViaClient:
     """A small wrapper to make calling Via easier."""
 
-    def __init__(self, service_url, legacy_service_url, host_url, legacy_mode=False):
+    def __init__(
+        # pylint: disable=too-many-arguments
+        self,
+        service_url,
+        legacy_service_url,
+        host_url,
+        legacy_mode=False,
+        via_rewriter_mode=False,
+    ):
         self.service_url = urlparse(service_url)
         self.legacy_service_url = legacy_service_url
 
@@ -43,14 +51,27 @@ class _ViaClient:
             "via.client.requestConfigFromFrame.ancestorLevel": "2",
             "via.external_link_mode": "new-tab",
         }
+
         self.legacy_mode = legacy_mode
+        self.via_rewriter_mode = via_rewriter_mode
 
     def url_for(self, doc):
-        if self.legacy_mode or doc.is_html:
+        if self.legacy_mode:
+            return self._legacy_via_url(doc.url)
+
+        if doc.is_html:
+            if self.via_rewriter_mode:
+                return self._pywb_style_url(
+                    self.service_url._replace(path="/html/v/").geturl(), doc.url
+                )
+
             return self._legacy_via_url(doc.url)
 
         if doc.is_pdf:
             return self._url_for("/pdf", doc.url)
+
+        if self.via_rewriter_mode:
+            self.options["via.rewrite"] = "1"
 
         return self._url_for("/route", doc.url)
 
@@ -61,6 +82,9 @@ class _ViaClient:
         return self.service_url._replace(path=path, query=urlencode(options)).geturl()
 
     def _legacy_via_url(self, doc_url):
+        return self._pywb_style_url(self.legacy_service_url, doc_url)
+
+    def _pywb_style_url(self, base_url, doc_url):
         parsed_url = urlparse(doc_url)
 
         params = [
@@ -68,10 +92,7 @@ class _ViaClient:
         ]
         params.extend(self.options.items())
 
-        return (
-            self.legacy_service_url
-            + parsed_url._replace(query=urlencode(params)).geturl()
-        )
+        return base_url + parsed_url._replace(query=urlencode(params)).geturl()
 
 
 def via_url(request, document_url, content_type=None):
@@ -96,4 +117,5 @@ def via_url(request, document_url, content_type=None):
         legacy_service_url=request.registry.settings["legacy_via_url"],
         host_url=request.host_url,
         legacy_mode=request.feature("use_legacy_via"),
+        via_rewriter_mode=request.feature("use_via_rewriter"),
     ).url_for(doc)

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -62,7 +62,7 @@ class TestViaURL:
 
     def test_it_routes_to_via_for_html(self, pyramid_request):
         final_url = via_url(
-            pyramid_request, f"http://doc.example.com/", content_type="html"
+            pyramid_request, "http://doc.example.com/", content_type="html"
         )
 
         assert final_url == Any.url.with_host("test_legacy_via_server.is")


### PR DESCRIPTION
This also includes the shortcut of going directly to the pywb end-point.

The flag is `use_via_rewriter` which can be enabled using cookies at: http://0.0.0.0:8001/flags

This should enable:

 * A short cut directly to the `pywb` end-point for known HTML documents
 * Adding the `via.rewrite` param for unknown types

This doesn't work right now, as the rewrite isn't implemented, but the routing should work

## Testing notes

Of course... you can't use the cookie flag due to the secure / not-secure cookie issue. So I think the only way to test is to set the environment variable: FEATURE_FLAG_USE_VIA_REWRITER

Then start everything and visit: https://hypothesis.instructure.com/courses/125/assignments/873

This should be broken, but when you inspect the location it should have `/html/v` in it.