### PR TITLE
Remove an obsolete ESLint config setting

### DIFF
--- a/lms/static/scripts/.eslintrc
+++ b/lms/static/scripts/.eslintrc
@@ -1,6 +1,5 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2018,
     "sourceType": "module"
   }
 }


### PR DESCRIPTION
Remove the `ecmaVersion` setting which overrode settings from the
`eslint-config-hypothesis` package and caused an error if trying to use
ES language features from ES 2019+