### PR TITLE
Ignore `initialFocus` if element is `null` or disabled

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -64,8 +64,10 @@ export default function Dialog({
   });
 
   useEffect(() => {
-    if (initialFocus) {
-      initialFocus.current.focus();
+    /** @type {HTMLElement & { disabled?: boolean }} */
+    const focusEl = initialFocus?.current;
+    if (focusEl && !focusEl.disabled) {
+      focusEl.focus();
     } else {
       // Modern accessibility guidance is to focus the dialog itself rather than
       // trying to be smart about focusing a particular control within the

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -66,39 +66,74 @@ describe('Dialog', () => {
     assert.called(onCancel);
   });
 
-  it('focuses the `initialFocus` ref if set', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+  describe('initial focus', () => {
+    let container;
 
-    const inputRef = createRef();
-    mount(
-      <Dialog initialFocus={inputRef}>
-        <input ref={inputRef} />
-      </Dialog>,
-      { attachTo: container }
-    );
-    assert.equal(document.activeElement, inputRef.current);
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
 
-    container.remove();
-  });
+    afterEach(() => {
+      container.remove();
+    });
 
-  it('focuses the root element of the dialog if no `initialFocus` is set', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+    it('focuses the `initialFocus` element', () => {
+      const inputRef = createRef();
 
-    const wrapper = mount(
-      <Dialog>
-        <div>Test</div>
-      </Dialog>,
-      { attachTo: container }
-    );
+      mount(
+        <Dialog initialFocus={inputRef}>
+          <input ref={inputRef} />
+        </Dialog>,
+        { attachTo: container }
+      );
 
-    assert.equal(
-      document.activeElement,
-      wrapper.find('[role="dialog"]').getDOMNode()
-    );
+      assert.equal(document.activeElement, inputRef.current);
+    });
 
-    container.remove();
+    it('focuses the dialog if `initialFocus` prop is missing', () => {
+      const wrapper = mount(
+        <Dialog>
+          <div>Test</div>
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+
+    it('focuses the dialog if `initialFocus` ref is `null`', () => {
+      const wrapper = mount(
+        <Dialog initialFocus={{ current: null }}>
+          <div>Test</div>
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+
+    it('focuses the dialog if `initialFocus` element is disabled', () => {
+      const inputRef = createRef();
+
+      const wrapper = mount(
+        <Dialog initialFocus={inputRef}>
+          <button ref={inputRef} disabled={true} />
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
   });
 
   it(


### PR DESCRIPTION
Ignore the `initialFocus` prop passed to `Dialog` and focus the root
element of the dialog if the `initialFocus` element is not rendered or
disabled at the point when the focusing logic runs.

Such a scenario may indicate a logic error in the parent of `Dialog` but
if that happens it is better to focus the dialog than cause an error, which
will most likely leave focus on whatever element launched the dialog.

This change is a follow-up to https://github.com/hypothesis/lms/pull/1951.