### PR TITLE
Remove `aria-describedby` wrapper around dialog children

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -54,7 +54,6 @@ export default function Dialog({
   buttons,
 }) {
   const dialogTitleId = useUniqueId('dialog-title');
-  const dialogDescriptionId = useUniqueId('dialog-description');
   const rootEl = useRef(/** @type {HTMLDivElement | null} */ (null));
 
   useElementShouldClose(rootEl, true, () => {
@@ -89,7 +88,6 @@ export default function Dialog({
           ref={rootEl}
           role={role}
           aria-labelledby={dialogTitleId}
-          aria-describedby={dialogDescriptionId}
           aria-modal={true}
           className={classNames('Dialog__content', contentClass)}
         >
@@ -106,7 +104,7 @@ export default function Dialog({
               </button>
             )}
           </h1>
-          <div id={dialogDescriptionId}>{children}</div>
+          {children}
           <div className="u-stretch" />
           <div className="Dialog__actions">
             {onCancel && (


### PR DESCRIPTION
b04e102270ddd01eeac2b25d826a143d0f03e7c1 added a div with an ID that
wrapped the contents of a dialog, that was then referenced by `aria-describedby`
in order to cause screen readers to announce the text of the dialog when opened.

Unfortunately wrapping the children broke the layout of the Canvas file picker
when there were many files in the table - see #2003. In addition,
labeling the entire contents of the dialog as the description is not
always appropriate. Typically only static text (eg. the first paragraph)
should be labeled this way.

This commit reverts the addition of `aria-describedby` to fix the
problem with the Canvas file picker while we look for a better solution.

For more background, the intended use of aria-describedby in the context of dialogs is described [here](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_roles_states_props). AIUI it is a nice-to-have a11y feature.