### PR TITLE
Re-introduce accessible descriptions for dialogs

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -1,5 +1,5 @@
 import { createElement, Fragment } from 'preact';
-import { useEffect, useRef } from 'preact/hooks';
+import { useEffect, useLayoutEffect, useRef } from 'preact/hooks';
 import classNames from 'classnames';
 
 import Button from './Button';
@@ -37,10 +37,9 @@ import { useUniqueId } from '../utils/hooks';
  * https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html
  * https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/alertdialog.html
  *
- * Things that are not implemented here yet:
- *
- * - A description which is reliably read out when the dialog is opened, in
- *   addition to the title.
+ * If the dialog's content, specified by the `children` prop, contains a paragraph
+ * (`<p>`) element, that element will be identified as the dialog's accessible
+ * description.
  *
  * @param {DialogProps} props
  */
@@ -54,6 +53,8 @@ export default function Dialog({
   buttons,
 }) {
   const dialogTitleId = useUniqueId('dialog-title');
+  const dialogDescriptionId = useUniqueId('dialog-description');
+
   const rootEl = useRef(/** @type {HTMLDivElement | null} */ (null));
 
   useElementShouldClose(rootEl, true, () => {
@@ -75,6 +76,19 @@ export default function Dialog({
     //
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // If the content of the dialog contains a paragraph of text, mark it as the
+  // dialog's accessible description.
+  //
+  // A limitation of this approach is that it doesn't update if the dialog's
+  // content changes after the initial render.
+  useLayoutEffect(() => {
+    const description = rootEl.current.querySelector('p');
+    if (description) {
+      description.id = dialogDescriptionId;
+      rootEl.current.setAttribute('aria-describedby', dialogDescriptionId);
+    }
+  }, [dialogDescriptionId]);
 
   return (
     <Fragment>

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -101,6 +101,29 @@ describe('Dialog', () => {
     container.remove();
   });
 
+  it("marks the first `<p>` in the dialog's content as the accessible description", () => {
+    const wrapper = mount(
+      <Dialog>
+        <p>Enter a URL</p>
+      </Dialog>
+    );
+    const content = wrapper.find('[role="dialog"]').getDOMNode();
+    const paragraphEl = wrapper.find('p').getDOMNode();
+
+    assert.ok(content.getAttribute('aria-describedby'));
+    assert.equal(content.getAttribute('aria-describedby'), paragraphEl.id);
+  });
+
+  it("does not set an accessible description if the dialog's content does not have a `<p>`", () => {
+    const wrapper = mount(
+      <Dialog>
+        <button>Click me</button>
+      </Dialog>
+    );
+    const content = wrapper.find('[role="dialog"]').getDOMNode();
+    assert.isNull(content.getAttribute('aria-describedby'));
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({


### PR DESCRIPTION
This is a follow-up to https://github.com/hypothesis/lms/pull/2018 which
re-introduces accessible descriptions for dialogs using a different
approach. Instead of wrapping all of the dialog contents in an element
which is marked as the description, a layout effect instead picks out
the first `<p>` element, if any, and marks it as the description.

Compared to the previous approach this has some benefits:

 - It only identifies static text as a description, not non-descriptive
   elements like tables or images

 - It doesn't wrap the children, which avoids the issue that was fixed
   in #2018

There is also a downside in that it won't update if the dialog's content
changes after it is initially displayed. I believe this is an acceptible
limitation.

There are other approaches we could consider such as requiring `Dialog`
consumers to explicitly specify a separate `description` prop. That
would be more React-y, although it may duplicate the content. The
approach taken here has the benefit of just-working with existing
dialogs.

----

**Testing:**

The easiest way to see the effect of this is to trigger a few dialogs in the LMS app, select the `Dialog__content` element in the dev tools "Elements" view and look at the element's computed accessibility properties in the "Accessibility" tab. The "Description" value should match the first `<p>` element in the dialog, if there is one. For example:

<img width="700" alt="Dialog description" src="https://user-images.githubusercontent.com/2458/90629934-12c1ba80-e218-11ea-83ef-140317eb7b78.png">
