### PR TITLE
Remove duplicate authUrl setting

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -311,9 +311,6 @@ class JSConfig:
                 # authenticate itself to the API.
                 "authToken": self._auth_token()
             },
-            # The URL that the JavaScript code will open if it needs the user to
-            # authorize us to request a new Canvas access token.
-            "authUrl": self._request.route_url("canvas_api.authorize"),
             "canvas": {
                 # The URL that the JavaScript code will open if it needs the user to
                 # authorize us to request a new Canvas access token.


### PR DESCRIPTION
authUrl was in the settings twice (as authUrl and canvas.authUrl).