### PR TITLE
Don't show error dialogs when refresh tokens expire

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -106,10 +106,18 @@ class CanvasAPIError(ExternalRequestError):
         response = getattr(cause, "response", None)
         status_code = getattr(response, "status_code", None)
 
+        exception_class = CanvasAPIServerError
+
         if status_code == 401:
             exception_class = CanvasAPIAccessTokenError
-        else:
-            exception_class = CanvasAPIServerError
+        elif response is not None:
+            try:
+                json = response.json()
+            except ValueError:
+                pass
+            else:
+                if json.get("error_description") == "refresh_token not found":
+                    exception_class = CanvasAPIAccessTokenError
 
         details = {
             "validation_errors": getattr(cause, "messages", None),

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -101,6 +101,16 @@ class TestCanvasAPIError:
             "response": {"status": expected_status, "body": '{"foo": "bar"}'},
         }
 
+    def test_it_raises_CanvasAccessTokenError_for_refresh_token_not_found_responses(
+        self,
+    ):
+        cause = self._requests_exception(
+            status=400,
+            body=json.dumps({"error_description": "refresh_token not found",}),
+        )
+
+        self.assert_raises(cause, CanvasAPIAccessTokenError)
+
     @pytest.mark.parametrize(
         "cause",
         [
@@ -189,7 +199,7 @@ class TestCanvasAPIError:
             httpretty.GET,
             "https://example.com",
             priority=1,
-            body=json.dumps({"foo": "bar"}),
+            body=kwargs.pop("body", json.dumps({"foo": "bar"})),
             **kwargs
         )
 


### PR DESCRIPTION
When a Canvas API refresh token expires (or the access token gets deleted from Canvas) Canvas sends us a "refresh_token not found" error response. When this happens just ask the user to re-authorize, don't show them an error dialog that makes it look like something went wrong.