### PR TITLE
Fail test if an async error happens in-between tests

### DIFF
--- a/lms/static/scripts/bootstrap.js
+++ b/lms/static/scripts/bootstrap.js
@@ -12,3 +12,25 @@ configure({ adapter: new Adapter() });
 import { registerIcons } from './frontend_apps/components/SvgIcon';
 import iconSet from './frontend_apps/icons';
 registerIcons(iconSet);
+
+// Ensure that uncaught exceptions between tests result in the tests failing.
+// This works around an issue with mocha / karma-mocha, see
+// https://github.com/hypothesis/client/issues/2249.
+let pendingError = null;
+let pendingErrorNotice = null;
+
+window.addEventListener('error', event => {
+  pendingError = event.error;
+  pendingErrorNotice = 'An uncaught exception was thrown between tests';
+});
+window.addEventListener('unhandledrejection', event => {
+  pendingError = event.reason;
+  pendingErrorNotice = 'An uncaught promise rejection occurred between tests';
+});
+
+afterEach(() => {
+  if (pendingError) {
+    console.error(pendingErrorNotice);
+    throw pendingError;
+  }
+});

--- a/lms/static/scripts/bootstrap.js
+++ b/lms/static/scripts/bootstrap.js
@@ -19,16 +19,19 @@ registerIcons(iconSet);
 let pendingError = null;
 let pendingErrorNotice = null;
 
+/* istanbul ignore next */
 window.addEventListener('error', event => {
   pendingError = event.error;
   pendingErrorNotice = 'An uncaught exception was thrown between tests';
 });
+/* istanbul ignore next */
 window.addEventListener('unhandledrejection', event => {
   pendingError = event.reason;
   pendingErrorNotice = 'An uncaught promise rejection occurred between tests';
 });
 
 afterEach(() => {
+  /* istanbul ignore if */
   if (pendingError) {
     console.error(pendingErrorNotice);
     throw pendingError;

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import { Fragment, createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
 import { Config } from '../../config';
 import { ApiError } from '../../utils/api';
@@ -67,6 +68,7 @@ describe('BasicLtiLaunchApp', () => {
     fakeApiCall = sinon.stub();
     FakeAuthWindow = sinon.stub().returns({
       authorize: sinon.stub().resolves(null),
+      focus: sinon.stub(),
     });
     fakeRpcServer = {
       setGroups: sinon.stub(),
@@ -216,11 +218,16 @@ describe('BasicLtiLaunchApp', () => {
       // Click the "Authorize" button
       fakeApiCall.reset();
       fakeApiCall.resolves({ via_url: 'https://via.hypothes.is/123' });
-      authButton.prop('onClick')();
+
+      act(() => {
+        authButton.prop('onClick')();
+      });
       assert.calledOnce(FakeAuthWindow);
 
       // Click the "Authorize" button again
-      authButton.prop('onClick')();
+      act(() => {
+        authButton.prop('onClick')();
+      });
       assert.calledOnce(FakeAuthWindow);
     });
 

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -1,19 +1,15 @@
 import { act } from 'preact/test-utils';
-import { Fragment, createElement } from 'preact';
+import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import LMSGrader, { $imports } from '../LMSGrader';
 import { checkAccessibility } from '../../../test-util/accessibility';
+import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('LMSGrader', () => {
   let fakeStudents;
   let fakeOnChange;
   let fakeClientRpc;
-
-  // eslint-disable-next-line react/prop-types
-  const FakeStudentSelector = ({ children }) => {
-    return <Fragment>{children}</Fragment>;
-  };
 
   /**
    * Helper to return a list of displayNames of the students.
@@ -23,7 +19,7 @@ describe('LMSGrader', () => {
    */
   function getDisplayNames(wrapper) {
     return wrapper
-      .find('FakeStudentSelector')
+      .find('StudentSelector')
       .prop('students')
       .map(s => {
         return s.displayName;
@@ -50,9 +46,7 @@ describe('LMSGrader', () => {
       setFocusedUser: sinon.stub(),
     };
 
-    $imports.$mock({
-      './StudentSelector': FakeStudentSelector,
-    });
+    $imports.$mock(mockImportedComponents());
   });
 
   afterEach(() => {
@@ -174,7 +168,7 @@ describe('LMSGrader', () => {
     ];
     const wrapper = renderGrader();
     const orderedStudentNames = wrapper
-      .find('FakeStudentSelector')
+      .find('StudentSelector')
       .prop('students')
       .map(s => {
         return s.displayName;
@@ -185,7 +179,7 @@ describe('LMSGrader', () => {
   it('set the selected student count to "Student 2 of 2" when the index changers to 1', () => {
     const wrapper = renderGrader();
     act(() => {
-      wrapper.find(FakeStudentSelector).props().onSelectStudent(1); // second student
+      wrapper.find('StudentSelector').props().onSelectStudent(1); // second student
     });
     assert.equal(
       wrapper.find('.LMSGrader__student-count').text(),
@@ -202,7 +196,7 @@ describe('LMSGrader', () => {
     const wrapper = renderGrader();
 
     act(() => {
-      wrapper.find(FakeStudentSelector).props().onSelectStudent(0); // note: initial index is -1
+      wrapper.find('StudentSelector').props().onSelectStudent(0); // note: initial index is -1
     });
 
     assert.calledWith(fakeClientRpc.setFocusedUser, fakeStudents[0]);
@@ -211,7 +205,7 @@ describe('LMSGrader', () => {
   it('does not set a focus user when the user index is invalid', () => {
     const wrapper = renderGrader();
     act(() => {
-      wrapper.find(FakeStudentSelector).props().onSelectStudent(-1); // invalid choice
+      wrapper.find('StudentSelector').props().onSelectStudent(-1); // invalid choice
     });
 
     assert.calledWith(fakeClientRpc.setFocusedUser, null);

--- a/lms/static/scripts/postmessage_json_rpc/test/client-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/test/client-test.js
@@ -31,13 +31,26 @@ describe('postmessage_json_rpc/client', () => {
       );
     }
 
+    function emitReply(result = null) {
+      fakeWindow.emitter.emit('message', {
+        origin,
+        data: {
+          jsonrpc: '2.0',
+          id: messageId,
+          result,
+        },
+      });
+    }
+
     beforeEach(() => {
       frame = { postMessage: sinon.stub() };
       fakeWindow = new FakeWindow();
     });
 
-    it('sends a message to the target frame', () => {
-      doCall();
+    it('sends a message to the target frame', async () => {
+      const result = doCall();
+      emitReply();
+      await result;
 
       assert.calledWith(frame.postMessage, {
         jsonrpc: '2.0',
@@ -137,14 +150,7 @@ describe('postmessage_json_rpc/client', () => {
     it('resolves with the result if the `result` field is set in the response', async () => {
       const call = doCall();
       const expectedResult = { foo: 'bar' };
-      fakeWindow.emitter.emit('message', {
-        origin,
-        data: {
-          jsonrpc: '2.0',
-          id: messageId,
-          result: expectedResult,
-        },
-      });
+      emitReply(expectedResult);
 
       assert.deepEqual(await call, expectedResult);
     });


### PR DESCRIPTION
If an uncaught exception is thrown or promise rejected in-between tests,
ensure the test suite fails. This applies a workaround for an issue in
karma-mocha which was earlier applied for the client in
https://github.com/hypothesis/client/pull/2421.

This caught several problems in the existing tests which are also fixed
in this commit:

 - `LSMGrader` did not mock the complex `SubmitGradeForm` component as
   we would normally do, and also did not do all the setup required for
   testing `SubmitGradeForm`. As a result, the tests ended up attempting
   real API calls which triggered warnings and produced exceptions which
   went uncaught. Resolve the issue by using `mockImportedComponents` to
   mock all imported components

 - One of the tests for `postmessage_json_rpc/client` did not mock a response
   from the Hypothesis client, resulting in a timeout exception

 - A mock in the `BasicLtiLaunchApp` tests was missing a required
   `focus` method. Also fix an issue where an invocation of a callback
   prop was not wrapped in `act`, as is best practice.
