### PR TITLE
Make the authUrl setting per-endpoint

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -40,9 +40,12 @@ class JSConfig:
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
         """
-        self._config["api"]["viaCallbackUrl"] = self._request.route_url(
-            "canvas_api.files.via_url", file_id=canvas_file_id
-        )
+        self._config["api"]["viaUrl"] = {
+            "authUrl": self._request.route_url("canvas_api.authorize"),
+            "path": self._request.route_path(
+                "canvas_api.files.via_url", file_id=canvas_file_id
+            ),
+        }
         self._add_canvas_speedgrader_settings(canvas_file_id=canvas_file_id)
 
     def add_document_url(self, document_url):
@@ -151,7 +154,13 @@ class JSConfig:
                 # construct these launch URLs our JavaScript code needs the
                 # base URL of our LTI launch endpoint.
                 "ltiLaunchUrl": self._request.route_url("lti_launches"),
-                "courseId": self._request.params.get("custom_canvas_course_id"),
+                "listFiles": {
+                    "authUrl": self._request.route_url("canvas_api.authorize"),
+                    "path": self._request.route_path(
+                        "canvas_api.courses.files.list",
+                        course_id=self._request.params.get("custom_canvas_course_id"),
+                    ),
+                },
             },
             "google": {
                 "clientId": self._request.registry.settings["google_client_id"],
@@ -311,14 +320,7 @@ class JSConfig:
                 # authenticate itself to the API.
                 "authToken": self._auth_token()
             },
-            # The URL that the JavaScript code will open if it needs the user to
-            # authorize us to request a new Canvas access token.
-            "authUrl": self._request.route_url("canvas_api.authorize"),
-            "canvas": {
-                # The URL that the JavaScript code will open if it needs the user to
-                # authorize us to request a new Canvas access token.
-                "authUrl": self._request.route_url("canvas_api.authorize"),
-            },
+            "canvas": {},
             # Some debug information, currently used in the Gherkin tests.
             "debug": {"tags": []},
             # Tell the JavaScript code whether we're in "dev" mode.
@@ -432,6 +434,7 @@ class JSConfig:
         req = self._request
 
         sync_api_config = {
+            "authUrl": req.route_url("canvas_api.authorize"),
             "path": req.route_path("canvas_api.sync"),
             "data": {
                 "lms": {

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -37,6 +37,9 @@ class JSConfig:
         """
         Set the document to the Canvas file with the given canvas_file_id.
 
+        This configures the frontend to make an API call to get the URL to use
+        as the src for the Via iframe.
+
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
         """
@@ -51,6 +54,10 @@ class JSConfig:
     def add_document_url(self, document_url):
         """
         Set the document to the document at the given document_url.
+
+        This configures the frontend to inject the Via iframe with this URL as
+        its src immediately, without making any further API requests to get the
+        Via URL.
 
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing

--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -10,7 +10,7 @@ import Table from './Table';
 
 /**
  * @typedef FileListProps
- * @prop {File[]} files - List of file objects returned by a `listFiles` call
+ * @prop {File[]} files - List of file objects returned by the API
  * @prop {boolean} [isLoading] - Whether to show a loading indicator
  * @prop {File|null} selectedFile - The file within `files` which is currently selected
  * @prop {(f: File) => any} onSelectFile -

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -42,14 +42,13 @@ export default function FilePickerApp({
     filePicker: {
       formAction,
       formFields,
-      canvas: { enabled: canvasEnabled, ltiLaunchUrl, courseId },
+      canvas: { enabled: canvasEnabled, listFiles: listFilesApi, ltiLaunchUrl },
       google: {
         clientId: googleClientId,
         developerKey: googleDeveloperKey,
         origin: googleOrigin,
       },
     },
-    canvas,
   } = useContext(Config);
 
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
@@ -147,8 +146,7 @@ export default function FilePickerApp({
       dialog = (
         <LMSFilePicker
           authToken={authToken}
-          authUrl={canvas.authUrl}
-          courseId={courseId}
+          listFilesApi={listFilesApi}
           onCancel={cancelDialog}
           onSelectFile={selectLMSFile}
         />

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -41,17 +41,20 @@ describe('FilePickerApp', () => {
 
   beforeEach(() => {
     fakeConfig = {
-      api: {},
+      api: { authToken: 'dummy-auth-token' },
       filePicker: {
         formAction: 'https://www.shinylms.com/',
         formFields: { hidden_field: 'hidden_value' },
         canvas: {
           enabled: true,
           ltiLaunchUrl: 'https://lms.anno.co/lti_launch',
+          listFiles: {
+            authUrl: 'https://lms.anno.co/authorize',
+            path: 'https://lms.anno.co/api/files',
+          },
         },
         google: {},
       },
-      canvas: {},
     };
 
     container = document.createElement('div');
@@ -154,7 +157,13 @@ describe('FilePickerApp', () => {
       btn.props().onClick();
     });
 
-    assert.isTrue(wrapper.exists('LMSFilePicker'));
+    const filePicker = wrapper.find('LMSFilePicker');
+    assert.isTrue(filePicker.exists());
+    assert.equal(filePicker.prop('authToken'), fakeConfig.api.authToken);
+    assert.equal(
+      filePicker.prop('listFilesApi'),
+      fakeConfig.filePicker.canvas.listFiles
+    );
   });
 
   it('submits an LMS file when an LMS file is selected', () => {

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -1,15 +1,19 @@
 import { createContext } from 'preact';
 
 /**
- * Parameters for a "canned" API call that the frontend can make to the server.
+ * Parameters for an API call that the frontend can make to the server.
  *
  * The parameters of the call are decided by the backend, but the frontend
  * decides _when_ to make the call and what to show while waiting for the
  * response.
  *
  * @typedef ApiCallInfo
- * @prop {string} path
- * @prop {Object} data
+ * @prop {string} path - The complete URL or path of the API call
+ * @prop {string} [authUrl] -
+ *   URL to display in a popup window if the call fails due to an authorization
+ *   error. This is used when the API call requires an OAuth 2 authorization
+ *   flow to be completed with eg. an external LMS's API
+ * @prop {Object} [data]
  */
 
 /**
@@ -47,7 +51,7 @@ import { createContext } from 'preact';
  * @prop {Object} canvas
  *   @prop {boolean} canvas.enabled
  *   @prop {string} canvas.ltiLaunchUrl
- *   @prop {string} canvas.courseId
+ *   @prop {ApiCallInfo} canvas.listFiles
  * @prop {Object} google
  *   @prop {string} clientId
  *   @prop {string} developerKey
@@ -78,10 +82,8 @@ import { createContext } from 'preact';
  * @prop {Object} api
  *   @prop {string} api.authToken
  *   @prop {ApiCallInfo} api.sync
- *   @prop {string} api.viaCallbackUrl
- * @prop {string} authUrl
+ *   @prop {ApiCallInfo} api.viaUrl
  * @prop {Object} canvas
- *   @prop {string} canvas.authUrl
  *   @prop {SpeedGraderConfig} canvas.speedGrader
  * @prop {boolean} dev
  * @prop {FilePickerConfig} filePicker

--- a/lms/static/scripts/frontend_apps/utils/AuthWindow.js
+++ b/lms/static/scripts/frontend_apps/utils/AuthWindow.js
@@ -4,6 +4,13 @@ import queryString from 'query-string';
  * Manages an LMS authentication popup window.
  */
 export default class AuthWindow {
+  /**
+   * @param {Object} options
+   * @param {string} options.authToken -
+   *   Authorization token used for API requests between frontend and backend
+   * @param {string} options.authUrl -
+   *   The initial URL to open in the authorization popup
+   */
   constructor({ authToken, authUrl }) {
     this._authToken = authToken;
     this._authUrl = authUrl;

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -74,20 +74,6 @@ async function apiCall({ path, authToken, data }) {
   return resultJson;
 }
 
-/**
- * List files in the LMS's file storage.
- *
- * @param {string} authToken
- * @param {string} courseId
- * @return {Promise<File[]>}
- */
-async function listFiles(authToken, courseId) {
-  return apiCall({
-    authToken,
-    path: `/api/canvas/courses/${courseId}/files`,
-  });
-}
-
 // Separate export from declaration to work around
 // https://github.com/robertknight/babel-plugin-mockable-imports/issues/9
-export { apiCall, listFiles };
+export { apiCall };

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -1,4 +1,4 @@
-import { ApiError, apiCall, listFiles } from '../api';
+import { ApiError, apiCall } from '../api';
 
 describe('api', () => {
   let fakeResponse;
@@ -50,21 +50,6 @@ describe('api', () => {
     });
   });
 
-  describe('listFiles', () => {
-    it('fetches file data from the backend', async () => {
-      const response = listFiles('auth-token', 'course-id');
-      assert.calledWith(window.fetch, '/api/canvas/courses/course-id/files', {
-        method: 'GET',
-        body: undefined,
-        headers: {
-          Authorization: 'auth-token',
-        },
-      });
-      const data = await response;
-      assert.deepEqual(data, await fakeResponse.json());
-    });
-  });
-
   context('when an API call fails', () => {
     [
       {
@@ -87,7 +72,7 @@ describe('api', () => {
         fakeResponse.status = status;
         fakeResponse.json.resolves(body);
 
-        const response = listFiles('auth-token', 'course-id');
+        const response = apiCall({ path: '/api/test', authToken: 'auth' });
         let reason;
         try {
           await response;
@@ -110,7 +95,7 @@ describe('api', () => {
   it('throws original error if `fetch` or parsing JSON fails', async () => {
     fakeResponse.json.rejects(new TypeError('Parse failed'));
 
-    const response = listFiles('auth-token', 'course-id');
+    const response = apiCall({ path: '/api/test', authToken: 'auth' });
     let reason;
     try {
       await response;

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -10,13 +10,6 @@ from lms.resources._js_config import JSConfig
 from lms.services import ConsumerKeyError, HAPIError
 
 
-class TestJSConfig:
-    """General unit tests for JSConfig."""
-
-    def test_auth_url(self, config):
-        assert config["canvas"]["authUrl"] == "http://example.com/api/canvas/authorize"
-
-
 class TestEnableContentItemSelectionMode:
     def test_it(self, context, js_config):
         js_config.enable_content_item_selection_mode(
@@ -35,7 +28,10 @@ class TestEnableContentItemSelectionMode:
             "canvas": {
                 "enabled": True,
                 "ltiLaunchUrl": "http://example.com/lti_launches",
-                "courseId": "test_course_id",
+                "listFiles": {
+                    "authUrl": "http://example.com/api/canvas/authorize",
+                    "path": "/api/canvas/courses/test_course_id/files",
+                },
             },
         }
 
@@ -106,13 +102,13 @@ class TestEnableContentItemSelectionMode:
 class TestAddCanvasFileID:
     """Unit tests for JSConfig.add_canvas_file_id()."""
 
-    def test_it_adds_the_viaCallbackUrl(self, js_config):
+    def test_it_adds_the_viaUrl_api_config(self, js_config):
         js_config.add_canvas_file_id("example_canvas_file_id")
 
-        assert (
-            js_config.asdict()["api"]["viaCallbackUrl"]
-            == "http://example.com/api/canvas/files/example_canvas_file_id/via_url"
-        )
+        assert js_config.asdict()["api"]["viaUrl"] == {
+            "authUrl": "http://example.com/api/canvas/authorize",
+            "path": "/api/canvas/files/example_canvas_file_id/via_url",
+        }
 
     def test_it_sets_the_canvas_file_id(self, js_config, submission_params):
         js_config.add_canvas_file_id("example_canvas_file_id")
@@ -331,6 +327,7 @@ class TestJSConfigAPISync:
     @pytest.mark.usefixtures("section_groups_on")
     def test_it(self, sync, pyramid_request, GroupInfo):
         assert sync == {
+            "authUrl": "http://example.com/api/canvas/authorize",
             "path": "/api/canvas/sync",
             "data": {
                 "course": {


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2061

Instead of a single `authUrl` setting in the JavaScript config, change it to three `authUrl` settings: one for each OAuth 2.0 API endpoint used. Currently this is three endpoints:

1. The sync API
2. The Canvas files list API
3. The Canvas files Via URL API

This config tidy up is intended to make way for adding Blackboard API support in future.

This will break the frontend: it needs to be updated to work with these config changes.

Specific changes:

* Remove the `config.canvas.authUrl` setting from the JavaScript config.

  This has now been replaced by multiple per-endpoint `authUrl` settings, in the different API endpoint configs distributed throughout the config object.

* Also remove the `config.authUrl` setting.

  This was a duplicate of `config.canvas.authUrl` and was unused.

* Replace the `config.api.viaUrlCallback` string with a `config.api.viaUrl` object with `path` and `authUrl` strings.

* Replace the `config.filePicker.canvas.courseId` string with a `config.filePicker.canvas.listFiles` object with `path` and `authUrl` parts. The `courseId` string is now embedded in the `path` string.

* Add an `authUrl` string to the `config.api.sync` object.