### PR TITLE
Merge the different API permissions into one

### DIFF
--- a/lms/resources/default.py
+++ b/lms/resources/default.py
@@ -7,9 +7,7 @@ class DefaultResource:
 
     __acl__ = [
         (Allow, "report_viewers", "view"),
-        (Allow, "lti_user", "canvas_api"),
-        (Allow, "lti_user", "lti_outcomes"),
-        (Allow, "lti_user", "sync_api"),
+        (Allow, "lti_user", "api"),
     ]
 
     def __init__(self, request):

--- a/lms/resources/oauth2_redirect.py
+++ b/lms/resources/oauth2_redirect.py
@@ -6,7 +6,7 @@ from lms.resources._js_config import JSConfig
 class OAuth2RedirectResource:
     """Resource for the OAuth 2 redirect popup."""
 
-    __acl__ = [(Allow, "lti_user", "canvas_api")]
+    __acl__ = [(Allow, "lti_user", "api")]
 
     def __init__(self, request):
         # The frontend config is only used by the exception view, but it is OK

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -31,9 +31,7 @@ SECTIONS_SCOPES = (
 )
 
 
-@view_config(
-    request_method="GET", route_name="canvas_api.authorize", permission="canvas_api"
-)
+@view_config(request_method="GET", route_name="canvas_api.authorize", permission="api")
 def authorize(request):
     ai_getter = request.find_service(name="ai_getter")
     course_service = request.find_service(name="course")
@@ -73,7 +71,7 @@ def authorize(request):
 @view_config(
     request_method="GET",
     route_name="canvas_oauth_callback",
-    permission="canvas_api",
+    permission="api",
     renderer="lms:templates/api/oauth2/redirect.html.jinja2",
     schema=CanvasOAuthCallbackSchema,
 )

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -4,7 +4,7 @@ from pyramid.view import view_config, view_defaults
 from lms.views import helpers
 
 
-@view_defaults(permission="canvas_api", renderer="json")
+@view_defaults(permission="api", renderer="json")
 class FilesAPIViews:
     def __init__(self, request):
         self.request = request

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -11,7 +11,7 @@ class Sync:
         route_name="canvas_api.sync",
         request_method="POST",
         renderer="json",
-        permission="sync_api",
+        permission="api",
     )
     def sync(self):
         groups = self._to_groups(self._get_sections())

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -10,7 +10,7 @@ from lms.validation import (
 )
 
 
-@view_defaults(request_method="POST", renderer="json", permission="lti_outcomes")
+@view_defaults(request_method="POST", renderer="json", permission="api")
 class LTIOutcomesViews:
     """Views for proxy APIs interacting with LTI Outcome Management APIs."""
 

--- a/tests/unit/lms/resources/default_test.py
+++ b/tests/unit/lms/resources/default_test.py
@@ -1,4 +1,3 @@
-import pytest
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from lms.resources import DefaultResource
@@ -25,17 +24,15 @@ class TestDefaultResource:
 
         assert not pyramid_request.has_permission("view", resource)
 
-    def test_it_allows_lti_users_to_use_the_canvas_api(
-        self, pyramid_config, pyramid_request
-    ):
+    def test_it_allows_lti_users_to_use_the_api(self, pyramid_config, pyramid_request):
         pyramid_config.testing_securitypolicy("some_lti_user", groupids=["lti_user"])
         pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
 
         resource = DefaultResource(pyramid_request)
 
-        assert pyramid_request.has_permission("canvas_api", resource)
+        assert pyramid_request.has_permission("api", resource)
 
-    def test_it_doesnt_allow_others_to_use_the_canvas_api(
+    def test_it_doesnt_allow_others_to_use_the_api(
         self, pyramid_config, pyramid_request
     ):
         pyramid_config.testing_securitypolicy("someone_else", groupids=["others"])
@@ -43,17 +40,4 @@ class TestDefaultResource:
 
         resource = DefaultResource(pyramid_request)
 
-        assert not pyramid_request.has_permission("canvas_api", resource)
-
-    @pytest.mark.parametrize(
-        "groupid,permission", [("lti_user", True), ("others", False)]
-    )
-    def test_sync_api_permission(
-        self, pyramid_config, pyramid_request, groupid, permission
-    ):
-        pyramid_config.testing_securitypolicy("some_lti_user", groupids=[groupid])
-        pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
-
-        resource = DefaultResource(pyramid_request)
-
-        assert pyramid_request.has_permission("sync_api", resource) == permission
+        assert not pyramid_request.has_permission("api", resource)


### PR DESCRIPTION
Merge the separate `"canvas_api"`, `"lti_outcomes"`, and `"sync_api"` permissions into a single `"api"` permission.

These permissions are all given to LTI users anyway so it doesn't make any difference, and there's really no need to give certain users access to only certain APIs: just giving LTI users access to the whole API is fine.

We're soon going to be adding Blackboard API endpoints that will need to be protected by permissions and we don't want to have to add another separare `"blackboard_api"` permission. Instead it'll just reuse this new `"api"` permission.