### PR TITLE
Rename CanvasOAuth2RedirectResource to OAuth2RedirectResource

### DIFF
--- a/lms/resources/__init__.py
+++ b/lms/resources/__init__.py
@@ -8,6 +8,6 @@ See the traversal-related sections in the Pyramid docs:
 * https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/traversal.html
 * https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html
 """
-from lms.resources.canvas_oauth2_redirect import CanvasOAuth2RedirectResource
 from lms.resources.default import DefaultResource
 from lms.resources.lti_launch import LTILaunchResource
+from lms.resources.oauth2_redirect import OAuth2RedirectResource

--- a/lms/resources/oauth2_redirect.py
+++ b/lms/resources/oauth2_redirect.py
@@ -3,8 +3,8 @@ from pyramid.security import Allow
 from lms.resources._js_config import JSConfig
 
 
-class CanvasOAuth2RedirectResource:
-    """Resource for the Canvas OAuth 2 redirect popup."""
+class OAuth2RedirectResource:
+    """Resource for the OAuth 2 redirect popup."""
 
     __acl__ = [(Allow, "lti_user", "canvas_api")]
 

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -27,12 +27,12 @@ def includeme(config):
     config.add_route(
         "canvas_oauth_callback",
         "/canvas_oauth_callback",
-        factory="lms.resources.CanvasOAuth2RedirectResource",
+        factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route(
         "canvas_api.authorize",
         "/api/canvas/authorize",
-        factory="lms.resources.CanvasOAuth2RedirectResource",
+        factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route(
         "canvas_api.courses.files.list", "/api/canvas/courses/{course_id}/files"

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -5,7 +5,7 @@ import jwt
 import pytest
 
 from lms.models import GradingInfo, HGroup
-from lms.resources import CanvasOAuth2RedirectResource, LTILaunchResource
+from lms.resources import LTILaunchResource, OAuth2RedirectResource
 from lms.resources._js_config import JSConfig
 from lms.services import ConsumerKeyError, HAPIError
 
@@ -507,7 +507,7 @@ class TestEnableCanvasOauth2RedirectErrorMode:
     @pytest.fixture
     def context(self):
         return mock.create_autospec(
-            CanvasOAuth2RedirectResource, spec_set=True, instance=True
+            OAuth2RedirectResource, spec_set=True, instance=True
         )
 
 

--- a/tests/unit/lms/resources/oauth2_redirect_test.py
+++ b/tests/unit/lms/resources/oauth2_redirect_test.py
@@ -1,15 +1,15 @@
 import pytest
 
-from lms.resources import CanvasOAuth2RedirectResource
+from lms.resources import OAuth2RedirectResource
 
 
-class TestCanvasOAuth2RedirectResource:
+class TestOAuth2RedirectResource:
     def test_sets_jsconfig(self, pyramid_request, JSConfig):
-        resource = CanvasOAuth2RedirectResource(pyramid_request)
+        resource = OAuth2RedirectResource(pyramid_request)
         JSConfig.assert_called_once_with(resource, pyramid_request)
         assert resource.js_config == JSConfig.return_value
 
 
 @pytest.fixture
 def JSConfig(patch):
-    return patch("lms.resources.canvas_oauth2_redirect.JSConfig")
+    return patch("lms.resources.oauth2_redirect.JSConfig")

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -185,15 +185,15 @@ class TestOAuth2RedirectError:
         assert kwargs["authorize_url"] == expected_auth_url
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request, CanvasOAuth2RedirectResource):
-        context = CanvasOAuth2RedirectResource(pyramid_request)
+    def pyramid_request(self, pyramid_request, OAuth2RedirectResource):
+        context = OAuth2RedirectResource(pyramid_request)
         context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
         pyramid_request.context = context
         return pyramid_request
 
     @pytest.fixture(autouse=True)
-    def CanvasOAuth2RedirectResource(self, patch):
-        return patch("lms.resources.CanvasOAuth2RedirectResource")
+    def OAuth2RedirectResource(self, patch):
+        return patch("lms.resources.OAuth2RedirectResource")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
There's nothing Canvas-specific about this. It only has the Canvas-specific name because it's only used in Canvas currently, but I'm pretty sure we're gonna end up using this for Blackboard OAuth 2 redirects as well.

The only reason this view exists is because the `"canvas_oauth_callback"` and `"canvas_api.authorize"` routes that use it (the two routes for the authorization popup window) need `context.js_config` to be set (because they use the Preact app for the error dialog that's shown if we receive a bad redirect from Canvas). They can't use the default resource because it doesn't have `context.js_config`. And `context.js_config` can't be added to the default resource because that resource is used by a bunch of views that don't and can't have `context.js_config`.