### PR TITLE
Remove unneeded unicode_literals imports

### DIFF
--- a/tests/unit/lms/config/__init___test.py
+++ b/tests/unit/lms/config/__init___test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from unittest import mock
 
 import pyramid.config


### PR DESCRIPTION
These are from Python 2.