### PR TITLE
Fix a bad patch fixture

### DIFF
--- a/tests/unit/lms/services/canvas_api/_authenticated_test.py
+++ b/tests/unit/lms/services/canvas_api/_authenticated_test.py
@@ -6,6 +6,7 @@ from h_matchers import Any
 from lms.services import CanvasAPIAccessTokenError, CanvasAPIServerError
 from lms.services.canvas_api._authenticated import TokenResponseSchema
 from lms.services.canvas_api._basic import BasicClient
+from lms.services.canvas_api._token_store import TokenStore
 from tests import factories
 
 
@@ -135,11 +136,9 @@ class TestAuthenticatedClient:
         return basic_api
 
     @pytest.fixture
-    def token_store(self, patch, oauth_token):
-        token_store = patch("lms.services.canvas_api._token_store.TokenStore")
-
+    def token_store(self, oauth_token):
+        token_store = create_autospec(TokenStore, spec_set=True, instance=True)
         token_store.get.return_value = oauth_token
-
         return token_store
 
     @pytest.fixture


### PR DESCRIPTION
This `lms/services/canvas_api/_authenticated.py` unit test fixture just wants to create a mock `TokenStore` object so that it can be passed as an argument to `AuthenticatedClient.__init__()` (this is a little difficult to track down: the mock `token_store` is passed to `AuthenticatedClient.__init__()` in the [`authenticated_client` fixture `tests/unit/lms/services/canvas_api/conftest.py`](https://github.com/hypothesis/lms/blob/fe108203ffe0359645a7ef84387a49893e4a1411/tests/unit/lms/services/canvas_api/conftest.py#L44)).

The test **does not** want to replace the name `"lms.services.canvas_api._token_store.TokenStore"` (in `_token_store.py`'s namespace) with a mock. The use of `patch()`, which replaces names in namespaces, is incorrect and misleading: `create_autospec()` is the right tool to use here.

* `create_autospec()` just does what we want: gives us a mock. It doesn't also replace a name in `_token_store.py`'s namespace, which we don't want. Using `patch()` is misleading because it looks like we're trying to replace the name in `_token_store.py`'s namespace but in fact the test doesn't care about that.

* `patch()` returns a mock _of the `TokenStore` class_, not a mock of an object instance of the class. A mock object instance is what's actually wanted here. There are all sorts of differences between mocks-of-classes and mocks-of-instances, for example mocks-of-classes are callable (and return a mock instance of the class!). The tests were getting away with this because they happened not to trip on any of the differences but it was incorrect and could have led to problems (either test failures, or tests passing that should fail). The `instance=True` argument to `create_autospec()` makes it return a mock instance not a class.

* Although this test wasn't actually relying on the patching of the name in `_token_store.py`'s namespace, it's worth noting that the patching also wasn't working. The unit tests for a `foo.py` module should only ever patch names within that `foo.py` module's namespace. If `foo.py`'s unit tests patch a name within `bar.py` (which `foo.py` imports) the patch won't actually apply in time, `foo.py`'s code will end up using the real object not the mock because `foo.py` will have imported the name from `bar.py` before the patch gets executed. These tests aren't running into this problem because they're not actually relying on the patch, they're passing the mock `token_store` to `AuthenticatedClient.__init__()` as an argument.

See this GitHub comment for another example and detailed explanation of the issue with misusing `patch()` in this way:

https://github.com/hypothesis/via3/pull/222#discussion_r469865055
