### PR TITLE
Isolate TokenStore in unit tests

### DIFF
--- a/tests/unit/lms/services/canvas_api/_authenticated_test.py
+++ b/tests/unit/lms/services/canvas_api/_authenticated_test.py
@@ -6,8 +6,6 @@ from h_matchers import Any
 from lms.services import CanvasAPIAccessTokenError, CanvasAPIServerError
 from lms.services.canvas_api._authenticated import TokenResponseSchema
 from lms.services.canvas_api._basic import BasicClient
-from lms.services.canvas_api._token_store import TokenStore
-from tests import factories
 
 
 class TestAuthenticatedClient:
@@ -134,16 +132,6 @@ class TestAuthenticatedClient:
         basic_api.send.return_value = token_response
 
         return basic_api
-
-    @pytest.fixture
-    def token_store(self, oauth_token):
-        token_store = create_autospec(TokenStore, spec_set=True, instance=True)
-        token_store.get.return_value = oauth_token
-        return token_store
-
-    @pytest.fixture
-    def oauth_token(self):
-        return factories.OAuth2Token()
 
 
 @pytest.mark.usefixtures("http_session")

--- a/tests/unit/lms/services/canvas_api/_token_store_test.py
+++ b/tests/unit/lms/services/canvas_api/_token_store_test.py
@@ -70,3 +70,11 @@ class TestTokenStore:
             db_session.add(oauth_token)
 
         return oauth_token
+
+    @pytest.fixture
+    def token_store(self, db_session, application_instance, lti_user):
+        return TokenStore(
+            db_session,
+            consumer_key=application_instance.consumer_key,
+            user_id=lti_user.user_id,
+        )

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -185,7 +185,11 @@ class TestCanvasAPIClient:
 
 
 class TestMetaBehavior:
-    def test_methods_require_access_token(self, data_method):
+    def test_methods_require_access_token(self, data_method, token_store):
+        token_store.get.side_effect = CanvasAPIAccessTokenError(
+            "We don't have a Canvas API access token for this user"
+        )
+
         with pytest.raises(CanvasAPIAccessTokenError):
             data_method()
 

--- a/tests/unit/lms/services/canvas_api/conftest.py
+++ b/tests/unit/lms/services/canvas_api/conftest.py
@@ -1,4 +1,4 @@
-from unittest.mock import sentinel
+from unittest.mock import create_autospec, sentinel
 
 import pytest
 
@@ -9,12 +9,10 @@ from tests import factories
 
 
 @pytest.fixture
-def token_store(db_session, application_instance, lti_user):
-    return TokenStore(
-        db_session,
-        consumer_key=application_instance.consumer_key,
-        user_id=lti_user.user_id,
-    )
+def token_store(oauth_token):
+    token_store = create_autospec(TokenStore, spec_set=True, instance=True)
+    token_store.get.return_value = oauth_token
+    return token_store
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -44,18 +44,18 @@ class TestCanvasAPIClientFactory:
             redirect_uri=pyramid_request.route_url("canvas_oauth_callback"),
         )
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def BasicClient(self, patch):
         return patch("lms.services.canvas_api.factory.BasicClient")
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def TokenStore(self, patch):
         return patch("lms.services.canvas_api.factory.TokenStore")
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def AuthenticatedClient(self, patch):
         return patch("lms.services.canvas_api.factory.AuthenticatedClient")
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def CanvasAPIClient(self, patch):
         return patch("lms.services.canvas_api.factory.CanvasAPIClient")


### PR DESCRIPTION
Make it so that the only unit tests that instantiate a `TokenStore` object are the ones in `_token_store_test.py`. All others use a an autospecced mock `TokenStore`.

This is so that `TokenStore` can be moved from `lms.services.canvas_api._token_store.TokenStore` to a top-level service (`lms.services.token_store.TokenStore`) so that it can be shared by `CanvasAPIClient`, the upcoming `BlackboardAPIClient`, and possibly others in future.

When `TokenStore` is a top-level service it no longer makes sense for unit tests to consider it a close collaborator of `CanvasAPIClient` and not mock it.

`TokenStore` has a very simple API: it has only `save(access_token, refresh_token, expires_in)` and `get()` (no arguments) methods so it's very simple to mock and to assert that users like `CanvasAPIClient` and `BlackboardAPIClient` use it correctly.

The test isolation will also make the actual change to move `TokenStore` to a top-level service easier to make: the resulting test failures will be easier to understand and the tests will be easier to update.
