### PR TITLE
Make canvas_api._token_store a top-level service

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -39,3 +39,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.course.course_service_factory", name="course"
     )
+    config.register_service_factory(
+        "lms.services.token_store.token_store_service_factory", name="token_store"
+    )

--- a/lms/services/canvas_api/_authenticated.py
+++ b/lms/services/canvas_api/_authenticated.py
@@ -26,7 +26,7 @@ class AuthenticatedClient:
         Create an AuthenticatedClient object for making authenticated calls.
 
         :param basic_client: An instance of BasicClient
-        :param token_store: An instance of TokenStore
+        :param token_store: The token_store service
         :param client_id: The OAuth2 client id
         :param client_secret: The OAuth2 client secret
         :param redirect_uri: The OAuth 2 redirect URI

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -2,7 +2,6 @@ from urllib.parse import urlparse
 
 from lms.services.canvas_api._authenticated import AuthenticatedClient
 from lms.services.canvas_api._basic import BasicClient
-from lms.services.canvas_api._token_store import TokenStore
 from lms.services.canvas_api.client import CanvasAPIClient
 
 
@@ -19,15 +18,9 @@ def canvas_api_client_factory(_context, request):
     canvas_host = urlparse(ai_getter.lms_url()).netloc
     basic_client = BasicClient(canvas_host)
 
-    token_store = TokenStore(
-        consumer_key=request.lti_user.oauth_consumer_key,
-        user_id=request.lti_user.user_id,
-        db=request.db,
-    )
-
     authenticated_api = AuthenticatedClient(
         basic_client=basic_client,
-        token_store=token_store,
+        token_store=request.find_service(name="token_store"),
         client_id=ai_getter.developer_key(),
         client_secret=ai_getter.developer_secret(),
         redirect_uri=request.route_url("canvas_oauth_callback"),

--- a/lms/services/token_store.py
+++ b/lms/services/token_store.py
@@ -1,5 +1,3 @@
-"""Access to OAuth2Tokens in the DB."""
-
 import datetime
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -13,11 +11,11 @@ class TokenStore:
 
     def __init__(self, db, consumer_key, user_id):
         """
-        Construct a new TokenStore.
+        Return a new TokenStore.
 
-        :param db: An SQLAlchemy session
-        :param consumer_key: Consumer key to retrieve and save against
-        :param user_id: User id to retrieve and save against
+        :param db: the SQLAlchemy session
+        :param consumer_key: the LTI consumer key to use for tokens
+        :param user_id: the LTI user ID to user for tokens
         """
         self._db = db
         self._consumer_key = consumer_key
@@ -25,10 +23,10 @@ class TokenStore:
 
     def save(self, access_token, refresh_token, expires_in):
         """
-        Save an access token and refresh token to the DB.
+        Save an OAuth 2 token to the DB.
 
-        If there's already an `OAuth2Token` for the consumer key and user id
-        then overwrite its values. Otherwise create a new `OAuth2Token` and
+        If there's already an OAuth2Token for the user's consumer key and user
+        ID then overwrite its values. Otherwise create a new OAuth2Token and
         add it to the DB.
         """
         try:
@@ -46,7 +44,7 @@ class TokenStore:
 
     def get(self):
         """
-        Return the user's saved access and refresh tokens from the DB.
+        Return the user's saved OAuth 2 token from the DB.
 
         :raise CanvasAPIAccessTokenError: if we don't have an access token for the user
         """
@@ -61,3 +59,9 @@ class TokenStore:
                 explanation="We don't have a Canvas API access token for this user",
                 response=None,
             ) from err
+
+
+def token_store_service_factory(_context, request):
+    return TokenStore(
+        request.db, request.lti_user.oauth_consumer_key, request.lti_user.user_id
+    )

--- a/tests/unit/lms/services/canvas_api/_authenticated_test.py
+++ b/tests/unit/lms/services/canvas_api/_authenticated_test.py
@@ -72,7 +72,7 @@ class TestAuthenticatedClient:
             )
 
     def test_get_token(
-        self, authenticated_client, basic_client, token_store, token_response
+        self, authenticated_client, basic_client, token_store_service, token_response
     ):
         token = authenticated_client.get_token("authorization_code")
 
@@ -93,14 +93,14 @@ class TestAuthenticatedClient:
             url_stub="",
         )
 
-        token_store.save.assert_called_once_with(
+        token_store_service.save.assert_called_once_with(
             token_response["access_token"],
             token_response["refresh_token"],
             token_response["expires_in"],
         )
 
     def test_get_refreshed_token(
-        self, authenticated_client, basic_client, token_store, token_response
+        self, authenticated_client, basic_client, token_store_service, token_response
     ):
         token = authenticated_client.get_refreshed_token("refresh_token")
 
@@ -119,7 +119,7 @@ class TestAuthenticatedClient:
             url_stub="",
         )
 
-        token_store.save.assert_called_once_with(
+        token_store_service.save.assert_called_once_with(
             token_response["access_token"],
             token_response["refresh_token"],
             token_response["expires_in"],

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -185,8 +185,8 @@ class TestCanvasAPIClient:
 
 
 class TestMetaBehavior:
-    def test_methods_require_access_token(self, data_method, token_store):
-        token_store.get.side_effect = CanvasAPIAccessTokenError(
+    def test_methods_require_access_token(self, data_method, token_store_service):
+        token_store_service.get.side_effect = CanvasAPIAccessTokenError(
             "We don't have a Canvas API access token for this user"
         )
 

--- a/tests/unit/lms/services/canvas_api/conftest.py
+++ b/tests/unit/lms/services/canvas_api/conftest.py
@@ -1,18 +1,10 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
 from lms.services.canvas_api._authenticated import AuthenticatedClient
 from lms.services.canvas_api._basic import BasicClient
-from lms.services.canvas_api._token_store import TokenStore
 from tests import factories
-
-
-@pytest.fixture
-def token_store(oauth_token):
-    token_store = create_autospec(TokenStore, spec_set=True, instance=True)
-    token_store.get.return_value = oauth_token
-    return token_store
 
 
 @pytest.fixture
@@ -36,28 +28,11 @@ def http_session(patch):
 
 
 @pytest.fixture
-def authenticated_client(basic_client, token_store):
+def authenticated_client(basic_client, token_store_service):
     return AuthenticatedClient(
         basic_client=basic_client,
-        token_store=token_store,
+        token_store=token_store_service,
         client_id=sentinel.client_id,
         client_secret=sentinel.client_secret,
         redirect_uri=sentinel.redirect_uri,
-    )
-
-
-@pytest.fixture
-def lti_user():
-    return factories.LTIUser()
-
-
-@pytest.fixture
-def application_instance():
-    return factories.ApplicationInstance()
-
-
-@pytest.fixture
-def oauth_token(lti_user, application_instance):
-    return factories.OAuth2Token(
-        user_id=lti_user.user_id, application_instance=application_instance
     )

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -5,7 +5,6 @@ import pytest
 from lms.services.canvas_api.factory import canvas_api_client_factory
 
 
-@pytest.mark.usefixtures("ai_getter")
 class TestCanvasAPIClientFactory:
     def test_building_the_CanvasAPIClient(
         self, pyramid_request, CanvasAPIClient, AuthenticatedClient
@@ -22,23 +21,19 @@ class TestCanvasAPIClientFactory:
 
         BasicClient.assert_called_once_with("example.com")
 
-    def test_building_the_TokenStore(self, pyramid_request, TokenStore):
-        canvas_api_client_factory(sentinel.context, pyramid_request)
-
-        TokenStore.assert_called_once_with(
-            consumer_key=pyramid_request.lti_user.oauth_consumer_key,
-            user_id=pyramid_request.lti_user.user_id,
-            db=pyramid_request.db,
-        )
-
     def test_building_the_AuthenticatedClient(
-        self, pyramid_request, ai_getter, AuthenticatedClient, BasicClient, TokenStore
+        self,
+        pyramid_request,
+        ai_getter,
+        AuthenticatedClient,
+        BasicClient,
+        token_store_service,
     ):
         canvas_api_client_factory(sentinel.context, pyramid_request)
 
         AuthenticatedClient.assert_called_once_with(
             basic_client=BasicClient.return_value,
-            token_store=TokenStore.return_value,
+            token_store=token_store_service,
             client_id=ai_getter.developer_key(),
             client_secret=ai_getter.developer_secret(),
             redirect_uri=pyramid_request.route_url("canvas_oauth_callback"),
@@ -49,13 +44,12 @@ class TestCanvasAPIClientFactory:
         return patch("lms.services.canvas_api.factory.BasicClient")
 
     @pytest.fixture(autouse=True)
-    def TokenStore(self, patch):
-        return patch("lms.services.canvas_api.factory.TokenStore")
-
-    @pytest.fixture(autouse=True)
     def AuthenticatedClient(self, patch):
         return patch("lms.services.canvas_api.factory.AuthenticatedClient")
 
     @pytest.fixture(autouse=True)
     def CanvasAPIClient(self, patch):
         return patch("lms.services.canvas_api.factory.CanvasAPIClient")
+
+
+pytestmark = pytest.mark.usefixtures("ai_getter", "token_store_service")


### PR DESCRIPTION
Move `services.canvas_api._token_store.TokenStore` to a top-level service (`services.token_store.TokenStore`) and register it with pyramid_services as the `"token_store"` service.

This is because `TokenStore` isn't actually Canvas-specific: it's just a get-and-set service for `models.OAuth2Token`, which is a generic model for storing OAuth 2 tokens. `TokenStore` is used by `CanvasAPIClient` and will soon be used by the upcoming `BlackboardAPIClient` and possibly others in future.