### PR TITLE
Rename TokenStore to OAuth2TokenService

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -40,5 +40,5 @@ def includeme(config):
         "lms.services.course.course_service_factory", name="course"
     )
     config.register_service_factory(
-        "lms.services.token_store.token_store_service_factory", name="token_store"
+        "lms.services.oauth2_token.oauth2_token_service_factory", name="oauth2_token"
     )

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -20,7 +20,7 @@ def canvas_api_client_factory(_context, request):
 
     authenticated_api = AuthenticatedClient(
         basic_client=basic_client,
-        token_store=request.find_service(name="token_store"),
+        token_store=request.find_service(name="oauth2_token"),
         client_id=ai_getter.developer_key(),
         client_secret=ai_getter.developer_secret(),
         redirect_uri=request.route_url("canvas_oauth_callback"),

--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -6,7 +6,7 @@ from lms.models import OAuth2Token
 from lms.services import CanvasAPIAccessTokenError
 
 
-class TokenStore:
+class OAuth2TokenService:
     """Save and retrieve OAuth2Tokens from the DB."""
 
     def __init__(self, db, consumer_key, user_id):
@@ -61,7 +61,7 @@ class TokenStore:
             ) from err
 
 
-def token_store_service_factory(_context, request):
-    return TokenStore(
+def oauth2_token_service_factory(_context, request):
+    return OAuth2TokenService(
         request.db, request.lti_user.oauth_consumer_key, request.lti_user.user_id
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,7 +18,7 @@ from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.services.oauth1 import OAuth1Service
-from lms.services.token_store import TokenStore
+from lms.services.oauth2_token import OAuth2TokenService
 from tests import factories
 from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
 
@@ -247,11 +247,13 @@ def oauth1_service(pyramid_config):
 
 
 @pytest.fixture
-def token_store_service(oauth_token, pyramid_config):
-    token_store_service = mock.create_autospec(TokenStore, instance=True, spec_set=True)
-    token_store_service.get.return_value = oauth_token
-    pyramid_config.register_service(token_store_service, name="token_store")
-    return token_store_service
+def oauth2_token_service(oauth_token, pyramid_config):
+    oauth2_token_service = mock.create_autospec(
+        OAuth2TokenService, instance=True, spec_set=True
+    )
+    oauth2_token_service.get.return_value = oauth_token
+    pyramid_config.register_service(oauth2_token_service, name="oauth2_token")
+    return oauth2_token_service
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/services/canvas_api/_authenticated_test.py
+++ b/tests/unit/lms/services/canvas_api/_authenticated_test.py
@@ -72,7 +72,7 @@ class TestAuthenticatedClient:
             )
 
     def test_get_token(
-        self, authenticated_client, basic_client, token_store_service, token_response
+        self, authenticated_client, basic_client, oauth2_token_service, token_response
     ):
         token = authenticated_client.get_token("authorization_code")
 
@@ -93,14 +93,14 @@ class TestAuthenticatedClient:
             url_stub="",
         )
 
-        token_store_service.save.assert_called_once_with(
+        oauth2_token_service.save.assert_called_once_with(
             token_response["access_token"],
             token_response["refresh_token"],
             token_response["expires_in"],
         )
 
     def test_get_refreshed_token(
-        self, authenticated_client, basic_client, token_store_service, token_response
+        self, authenticated_client, basic_client, oauth2_token_service, token_response
     ):
         token = authenticated_client.get_refreshed_token("refresh_token")
 
@@ -119,7 +119,7 @@ class TestAuthenticatedClient:
             url_stub="",
         )
 
-        token_store_service.save.assert_called_once_with(
+        oauth2_token_service.save.assert_called_once_with(
             token_response["access_token"],
             token_response["refresh_token"],
             token_response["expires_in"],

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -185,8 +185,8 @@ class TestCanvasAPIClient:
 
 
 class TestMetaBehavior:
-    def test_methods_require_access_token(self, data_method, token_store_service):
-        token_store_service.get.side_effect = CanvasAPIAccessTokenError(
+    def test_methods_require_access_token(self, data_method, oauth2_token_service):
+        oauth2_token_service.get.side_effect = CanvasAPIAccessTokenError(
             "We don't have a Canvas API access token for this user"
         )
 

--- a/tests/unit/lms/services/canvas_api/conftest.py
+++ b/tests/unit/lms/services/canvas_api/conftest.py
@@ -28,10 +28,10 @@ def http_session(patch):
 
 
 @pytest.fixture
-def authenticated_client(basic_client, token_store_service):
+def authenticated_client(basic_client, oauth2_token_service):
     return AuthenticatedClient(
         basic_client=basic_client,
-        token_store=token_store_service,
+        token_store=oauth2_token_service,
         client_id=sentinel.client_id,
         client_secret=sentinel.client_secret,
         redirect_uri=sentinel.redirect_uri,

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -27,13 +27,13 @@ class TestCanvasAPIClientFactory:
         ai_getter,
         AuthenticatedClient,
         BasicClient,
-        token_store_service,
+        oauth2_token_service,
     ):
         canvas_api_client_factory(sentinel.context, pyramid_request)
 
         AuthenticatedClient.assert_called_once_with(
             basic_client=BasicClient.return_value,
-            token_store=token_store_service,
+            token_store=oauth2_token_service,
             client_id=ai_getter.developer_key(),
             client_secret=ai_getter.developer_secret(),
             redirect_uri=pyramid_request.route_url("canvas_oauth_callback"),
@@ -52,4 +52,4 @@ class TestCanvasAPIClientFactory:
         return patch("lms.services.canvas_api.factory.CanvasAPIClient")
 
 
-pytestmark = pytest.mark.usefixtures("ai_getter", "token_store_service")
+pytestmark = pytest.mark.usefixtures("ai_getter", "oauth2_token_service")


### PR DESCRIPTION
Just to make it clearer what it actually is: it's a service wrapper for `models.OAuth2Token`. Getting "OAuth 2" in there is particularly important