### PR TITLE
Rename AuthenticatedClient._token_store to oauth2_token_service

### DIFF
--- a/lms/services/canvas_api/_authenticated.py
+++ b/lms/services/canvas_api/_authenticated.py
@@ -20,19 +20,19 @@ class AuthenticatedClient:
     """
 
     def __init__(  # pylint: disable=too-many-arguments
-        self, basic_client, token_store, client_id, client_secret, redirect_uri
+        self, basic_client, oauth2_token_service, client_id, client_secret, redirect_uri
     ):
         """
         Create an AuthenticatedClient object for making authenticated calls.
 
         :param basic_client: An instance of BasicClient
-        :param token_store: The token_store service
+        :param oauth2_token_service: The "oauth2_token" service
         :param client_id: The OAuth2 client id
         :param client_secret: The OAuth2 client secret
         :param redirect_uri: The OAuth 2 redirect URI
         """
         self._client = basic_client
-        self._token_store = token_store
+        self._oauth2_token_service = oauth2_token_service
 
         # For making token requests
         self._client_id = client_id
@@ -57,11 +57,11 @@ class AuthenticatedClient:
         call_args = (method, path, schema, params)
 
         try:
-            auth_header = f"Bearer {self._token_store.get().access_token}"
+            auth_header = f"Bearer {self._oauth2_token_service.get().access_token}"
             return self._client.send(*call_args, headers={"Authorization": auth_header})
 
         except CanvasAPIAccessTokenError:
-            refresh_token = self._token_store.get().refresh_token
+            refresh_token = self._oauth2_token_service.get().refresh_token
             if not refresh_token:
                 raise
 
@@ -116,7 +116,7 @@ class AuthenticatedClient:
             schema=TokenResponseSchema,
         )
 
-        self._token_store.save(
+        self._oauth2_token_service.save(
             parsed_params["access_token"],
             parsed_params.get("refresh_token", refresh_token),
             parsed_params.get("expires_in"),

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -20,7 +20,7 @@ def canvas_api_client_factory(_context, request):
 
     authenticated_api = AuthenticatedClient(
         basic_client=basic_client,
-        token_store=request.find_service(name="oauth2_token"),
+        oauth2_token_service=request.find_service(name="oauth2_token"),
         client_id=ai_getter.developer_key(),
         client_secret=ai_getter.developer_secret(),
         redirect_uri=request.route_url("canvas_oauth_callback"),

--- a/tests/unit/lms/services/canvas_api/conftest.py
+++ b/tests/unit/lms/services/canvas_api/conftest.py
@@ -31,7 +31,7 @@ def http_session(patch):
 def authenticated_client(basic_client, oauth2_token_service):
     return AuthenticatedClient(
         basic_client=basic_client,
-        token_store=oauth2_token_service,
+        oauth2_token_service=oauth2_token_service,
         client_id=sentinel.client_id,
         client_secret=sentinel.client_secret,
         redirect_uri=sentinel.redirect_uri,

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -33,7 +33,7 @@ class TestCanvasAPIClientFactory:
 
         AuthenticatedClient.assert_called_once_with(
             basic_client=BasicClient.return_value,
-            token_store=oauth2_token_service,
+            oauth2_token_service=oauth2_token_service,
             client_id=ai_getter.developer_key(),
             client_secret=ai_getter.developer_secret(),
             redirect_uri=pyramid_request.route_url("canvas_oauth_callback"),


### PR DESCRIPTION
I think it's a little weird for the name of the `"oauth2_token"` service to change to something completely different (`token_store`) when it gets passed to `AuthenticatedClient`. Makes the code hard to follow / makes it hard to know what `token_store` actually is. So rename `token_store` to `oauth2_token_service`. This is consistent with how references to other services are named, elsewhere in the code (`*_svc` is sometimes used but `*_service` is more common).