### PR TITLE
Don't raise CanvasAPIAccessTokenError from OAuth2TokenService

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -9,6 +9,7 @@ from lms.services.exceptions import (
     LTIOAuthError,
     LTIOutcomesAPIError,
     NoConsumerKey,
+    NoOAuth2Token,
     ServiceError,
 )
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -24,6 +24,10 @@ class LTIOAuthError(LTILaunchVerificationError):
     """Raised when OAuth signature verification of a launch request fails."""
 
 
+class NoOAuth2Token(ServiceError):
+    """A requested OAuth 2 token wasn't found in the DB."""
+
+
 class ExternalRequestError(ServiceError):
     """
     A problem with a network request to an external service.

--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -3,7 +3,7 @@ import datetime
 from sqlalchemy.orm.exc import NoResultFound
 
 from lms.models import OAuth2Token
-from lms.services import CanvasAPIAccessTokenError
+from lms.services import NoOAuth2Token
 
 
 class OAuth2TokenService:
@@ -31,7 +31,7 @@ class OAuth2TokenService:
         """
         try:
             oauth2_token = self.get()
-        except CanvasAPIAccessTokenError:
+        except NoOAuth2Token:
             oauth2_token = OAuth2Token(
                 consumer_key=self._consumer_key, user_id=self._user_id
             )
@@ -46,7 +46,7 @@ class OAuth2TokenService:
         """
         Return the user's saved OAuth 2 token from the DB.
 
-        :raise CanvasAPIAccessTokenError: if we don't have an access token for the user
+        :raise NoOAuth2Token: if we don't have an OAuth 2 token for the user
         """
         try:
             return (
@@ -55,10 +55,7 @@ class OAuth2TokenService:
                 .one()
             )
         except NoResultFound as err:
-            raise CanvasAPIAccessTokenError(
-                explanation="We don't have a Canvas API access token for this user",
-                response=None,
-            ) from err
+            raise NoOAuth2Token("We don't have an OAuth 2 token for this user") from err
 
 
 def oauth2_token_service_factory(_context, request):

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -6,7 +6,7 @@ from h_matchers import Any
 from pytest import param
 
 from lms.models import OAuth2Token
-from lms.services import CanvasAPIAccessTokenError
+from lms.services import NoOAuth2Token
 from lms.services.oauth2_token import OAuth2TokenService, oauth2_token_service_factory
 from tests import factories
 
@@ -49,7 +49,7 @@ class TestOAuth2TokenService:
             }
         )
 
-        with pytest.raises(CanvasAPIAccessTokenError):
+        with pytest.raises(NoOAuth2Token):
             store.get()
 
     @pytest.fixture(


### PR DESCRIPTION
It doesn't make sense to raise a Canvas-specific error from this generic OAuth 2 service. Add a new `NoOAuth2Token` exception and raise that instead.

Catch `NoOAuth2Token` in the (Canvas-specific) `AuthenticatedClient` that calls `OAuth2TokenService` and wrap it in `CanvasAPIAccessTokenError`, so the rest of the Canvas API services and views are unaffected