### PR TITLE
Tidy up some routes

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -44,7 +44,7 @@ class JSConfig:
             is missing
         """
         self._config["api"]["viaUrl"] = {
-            "authUrl": self._request.route_url("canvas_api.authorize"),
+            "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
             "path": self._request.route_path(
                 "canvas_api.files.via_url", file_id=canvas_file_id
             ),
@@ -162,7 +162,7 @@ class JSConfig:
                 # base URL of our LTI launch endpoint.
                 "ltiLaunchUrl": self._request.route_url("lti_launches"),
                 "listFiles": {
-                    "authUrl": self._request.route_url("canvas_api.authorize"),
+                    "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
                     "path": self._request.route_path(
                         "canvas_api.courses.files.list",
                         course_id=self._request.params.get("custom_canvas_course_id"),
@@ -441,7 +441,7 @@ class JSConfig:
         req = self._request
 
         sync_api_config = {
-            "authUrl": req.route_url("canvas_api.authorize"),
+            "authUrl": req.route_url("canvas_api.oauth.authorize"),
             "path": req.route_path("canvas_api.sync"),
             "data": {
                 "lms": {

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -24,14 +24,15 @@ def includeme(config):
         "/content_item_selection",
         factory="lms.resources.LTILaunchResource",
     )
-    config.add_route(
-        "canvas_api.oauth.callback",
-        "/canvas_oauth_callback",
-        factory="lms.resources.OAuth2RedirectResource",
-    )
+
     config.add_route(
         "canvas_api.oauth.authorize",
         "/api/canvas/oauth/authorize",
+        factory="lms.resources.OAuth2RedirectResource",
+    )
+    config.add_route(
+        "canvas_api.oauth.callback",
+        "/canvas_oauth_callback",
         factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route(

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -31,7 +31,7 @@ def includeme(config):
         factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route(
-        # Unfortunately we can't easily fix this URL to match the others as its  
+        # Unfortunately we can't easily fix this URL to match the others as its
         # been given out to Canvas instances
         "canvas_api.oauth.callback",
         "/canvas_oauth_callback",

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -31,6 +31,8 @@ def includeme(config):
         factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route(
+        # Unfortunately we can't easily fix this URL to match the others as its  
+        # been given out to Canvas instances
         "canvas_api.oauth.callback",
         "/canvas_oauth_callback",
         factory="lms.resources.OAuth2RedirectResource",

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -25,13 +25,13 @@ def includeme(config):
         factory="lms.resources.LTILaunchResource",
     )
     config.add_route(
-        "canvas_oauth_callback",
+        "canvas_api.oauth.callback",
         "/canvas_oauth_callback",
         factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route(
-        "canvas_api.authorize",
-        "/api/canvas/authorize",
+        "canvas_api.oauth.authorize",
+        "/api/canvas/oauth/authorize",
         factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route(

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -23,7 +23,7 @@ def canvas_api_client_factory(_context, request):
         oauth2_token_service=request.find_service(name="oauth2_token"),
         client_id=ai_getter.developer_key(),
         client_secret=ai_getter.developer_secret(),
-        redirect_uri=request.route_url("canvas_oauth_callback"),
+        redirect_uri=request.route_url("canvas_api.oauth.callback"),
     )
 
     return CanvasAPIClient(authenticated_api)

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -31,7 +31,9 @@ SECTIONS_SCOPES = (
 )
 
 
-@view_config(request_method="GET", route_name="canvas_api.authorize", permission="api")
+@view_config(
+    request_method="GET", route_name="canvas_api.oauth.authorize", permission="api"
+)
 def authorize(request):
     ai_getter = request.find_service(name="ai_getter")
     course_service = request.find_service(name="course")
@@ -56,7 +58,7 @@ def authorize(request):
                 {
                     "client_id": ai_getter.developer_key(),
                     "response_type": "code",
-                    "redirect_uri": request.route_url("canvas_oauth_callback"),
+                    "redirect_uri": request.route_url("canvas_api.oauth.callback"),
                     "state": CanvasOAuthCallbackSchema(request).state_param(),
                     "scope": " ".join(scopes),
                 }
@@ -70,7 +72,7 @@ def authorize(request):
 
 @view_config(
     request_method="GET",
-    route_name="canvas_oauth_callback",
+    route_name="canvas_api.oauth.callback",
     permission="api",
     renderer="lms:templates/api/oauth2/redirect.html.jinja2",
     schema=CanvasOAuthCallbackSchema,
@@ -89,12 +91,12 @@ def oauth2_redirect(request):
 
 @exception_view_config(
     request_method="GET",
-    route_name="canvas_oauth_callback",
+    route_name="canvas_api.oauth.callback",
     renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
 )
 @exception_view_config(
     request_method="GET",
-    route_name="canvas_api.authorize",
+    route_name="canvas_api.oauth.authorize",
     renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
 )
 def oauth2_redirect_error(request):
@@ -104,7 +106,8 @@ def oauth2_redirect_error(request):
             request.lti_user
         )
         authorize_url = request.route_url(
-            "canvas_api.authorize", _query=[("authorization", authorization_param)]
+            "canvas_api.oauth.authorize",
+            _query=[("authorization", authorization_param)],
         )
 
     request.context.js_config.enable_canvas_oauth2_redirect_error_mode(

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -25,11 +25,11 @@ class ExceptionViews:
 
        If "message" is present the frontend will show an error dialog that
        indicates that something went wrong and has a [Try again] button that
-       opens the "canvas_api.authorize" route.
+       opens the "canvas_api.oauth.authorize" route.
 
        If no "message" is present the frontend will show a standard
        authorization dialog (not an error dialog) and the button that opens
-       "canvas_api.authorize" route will be labelled [Authorize].
+       "canvas_api.oauth.authorize" route will be labelled [Authorize].
 
     2. "details": Optional further error details to show to the user after
        "message", for debugging and support.

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -29,7 +29,7 @@ class TestEnableContentItemSelectionMode:
                 "enabled": True,
                 "ltiLaunchUrl": "http://example.com/lti_launches",
                 "listFiles": {
-                    "authUrl": "http://example.com/api/canvas/authorize",
+                    "authUrl": "http://example.com/api/canvas/oauth/authorize",
                     "path": "/api/canvas/courses/test_course_id/files",
                 },
             },
@@ -106,7 +106,7 @@ class TestAddCanvasFileID:
         js_config.add_canvas_file_id("example_canvas_file_id")
 
         assert js_config.asdict()["api"]["viaUrl"] == {
-            "authUrl": "http://example.com/api/canvas/authorize",
+            "authUrl": "http://example.com/api/canvas/oauth/authorize",
             "path": "/api/canvas/files/example_canvas_file_id/via_url",
         }
 
@@ -327,7 +327,7 @@ class TestJSConfigAPISync:
     @pytest.mark.usefixtures("section_groups_on")
     def test_it(self, sync, pyramid_request, GroupInfo):
         assert sync == {
-            "authUrl": "http://example.com/api/canvas/authorize",
+            "authUrl": "http://example.com/api/canvas/oauth/authorize",
             "path": "/api/canvas/sync",
             "data": {
                 "course": {

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -36,7 +36,7 @@ class TestCanvasAPIClientFactory:
             oauth2_token_service=oauth2_token_service,
             client_id=ai_getter.developer_key(),
             client_secret=ai_getter.developer_secret(),
-            redirect_uri=pyramid_request.route_url("canvas_oauth_callback"),
+            redirect_uri=pyramid_request.route_url("canvas_api.oauth.callback"),
         )
 
     @pytest.fixture(autouse=True)

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -177,7 +177,7 @@ class TestOAuth2RedirectError:
         schema.authorization_param.assert_called_once_with(pyramid_request.lti_user)
 
         expected_auth_url = pyramid_request.route_url(
-            "canvas_api.authorize", _query=[("authorization", "auth-param")]
+            "canvas_api.oauth.authorize", _query=[("authorization", "auth-param")]
         )
         js_config = pyramid_request.context.js_config
         js_config.enable_canvas_oauth2_redirect_error_mode.assert_called_once()


### PR DESCRIPTION
This is to make way for the Blackboard API routes to be added:

* Consistenly use `"canvas_api.*"` for Canvas API route names
* Consistently use `"canvas_api.oauth.*"` for Canvas API authorization route names
* Put the `"authorize"` route before the `"callback"` route because that's the order they get called in