### PR TITLE
Disable invalid-name warnings in tests

### DIFF
--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -68,6 +68,7 @@ argument-naming-style=any
 class-naming-style=any
 function-naming-style=any
 method-naming-style=any
+variable-naming-style=any
 
 good-names=
     # PyLint's default good names.

--- a/tests/unit/lms/extensions/feature_flags/_helpers_test.py
+++ b/tests/unit/lms/extensions/feature_flags/_helpers_test.py
@@ -78,7 +78,6 @@ class TestFeatureFlagsCookieHelper:
 
     @pytest.fixture(autouse=True)
     def jwt_cookie_helper(self, patch):
-        # pylint: disable=invalid-name
         JWTCookieHelper = patch("lms.extensions.feature_flags._helpers.JWTCookieHelper")
 
         JWTCookieHelper.return_value.get.return_value = {

--- a/tests/unit/lms/services/canvas_api/_basic_test.py
+++ b/tests/unit/lms/services/canvas_api/_basic_test.py
@@ -130,7 +130,6 @@ class TestBasicClient:
 
     @pytest.fixture
     def Schema(self):
-        # pylint: disable=invalid-name
         Schema = create_autospec(RequestsResponseSchema)
         Schema.many = False
 


### PR DESCRIPTION
As we've already done for argument, function, method and class names. This PyLint rule doesn't fit with our usual naming style in tests