### PR TITLE
Fix absolute path in requirements/dev.txt

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,5 @@
 factory-boy
 pyramid_ipython
 supervisor
--e .
+-e file:.#egg=lms
 -r requirements.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements/dev.in
 #
--e .                      # via -r requirements/dev.in
+-e file:.#egg=lms         # via -r requirements/dev.in
 alembic==1.4.2            # via -r requirements/requirements.txt
 attrs==20.2.0             # via -r requirements/requirements.txt, jsonschema
 backcall==0.2.0           # via ipython


### PR DESCRIPTION
If you compile the dev requirements:

    tox -e dev --run-command 'pip-compile requirements/dev.in'

you'll see that it actually modifies `dev.txt` and adds an absolute path:

```diff
diff --git a/requirements/dev.txt b/requirements/dev.txt
index 772739b0..2732dc83 100644
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements/dev.in
 #
--e .                      # via -r requirements/dev.in
+-e file:///home/seanh/Projects/lms  # via -r requirements/dev.in
 alembic==1.4.2            # via -r requirements/requirements.txt
 attrs==20.2.0             # via -r requirements/requirements.txt, jsonschema
 backcall==0.2.0           # via ipython
```

This seems to be an issue with pip-compile, fix it using this workaround: https://github.com/jazzband/pip-tools/issues/204