### PR TITLE
Remove `-e .` from requirements

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,4 @@
 factory-boy
 pyramid_ipython
 supervisor
--e .
 -r requirements.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile requirements/dev.in
 #
--e .                      # via -r requirements/dev.in
 alembic==1.4.3            # via -r requirements/requirements.txt
 attrs==20.2.0             # via -r requirements/requirements.txt, jsonschema
 backcall==0.2.0           # via ipython


### PR DESCRIPTION
This seems to be unnecessary and causes problems.

See:

https://github.com/hypothesis/lms/pull/2111
https://github.com/hypothesis/via3/pull/262