### PR TITLE
Set a timeout on requests to LTI Outcomes Service

### DIFF
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -104,6 +104,7 @@ class LTIOutcomesClient:
                 data=xml_body,
                 headers={"Content-Type": "application/xml"},
                 auth=self.oauth1_service.get_client(),
+                timeout=9,
             )
 
             # Raise an exception if the status is bad

--- a/tests/unit/lms/services/lti_outcomes_test.py
+++ b/tests/unit/lms/services/lti_outcomes_test.py
@@ -101,6 +101,7 @@ class TestLTIOutcomesClient:
             data=Any(),
             headers=Any(),
             auth=oauth1_service.get_client.return_value,
+            timeout=Any(),
         )
 
     def test_requests_fail_if_http_status_is_error(self, svc, respond_with):


### PR DESCRIPTION
Requests to an LMS's LTI Outcomes Service endpoint had no timeout
set, so if the LMS instance was unresponsive this could cause the
gunicorn worker to hang for an extended period of time and be
unavailable to process other requests.

This commit applies the same 9-second timeout to LTI Outcomes requests
that are applied to Canvas API requests. See `lms.services.canvas_api._basic`.

Slack discussion of related incident: https://hypothes-is.slack.com/archives/C074BUPEG/p1602494853011300