### PR TITLE
Allow score 0 to be saved

### DIFF
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -65,7 +65,7 @@ class LTIOutcomesClient:
 
         request = {"resultRecord": {"sourcedGUID": {"sourcedId": lis_result_sourcedid}}}
 
-        if score:
+        if score is not None:
             request["resultRecord"]["result"] = {
                 "resultScore": {"language": "en", "textString": score}
             }

--- a/tests/unit/lms/services/lti_outcomes_test.py
+++ b/tests/unit/lms/services/lti_outcomes_test.py
@@ -62,13 +62,20 @@ class TestLTIOutcomesClient:
         assert sourced_id == self.GRADING_ID
 
     @pytest.mark.usefixtures("response")
-    def test_record_result_sends_score(self, svc):
-        svc.record_result(self.GRADING_ID, score=0.5)
+    @pytest.mark.parametrize(
+        "score_provided,score_in_record",
+        [
+            (0.5, "0.5"),
+            (0, "0"),  # test the zero value
+        ],
+    )
+    def test_record_result_sends_score(self, svc, score_provided, score_in_record):
+        svc.record_result(self.GRADING_ID, score=score_provided)
 
         result_record = self.sent_pox_body()["replaceResultRequest"]["resultRecord"]
         score = result_record["result"]["resultScore"]["textString"]
 
-        assert score == "0.5"
+        assert score == score_in_record
 
     @pytest.mark.usefixtures("response")
     def test_record_result_calls_hook(self, svc):


### PR DESCRIPTION
`record_result` was rejecting scores of zero because it was treating them as if they were None. This fixes the response so it won’t ignore a 0 value but will still ignore a None value.

fixes #1345 

-----------

I confirmed that at least with moodle and blackboard, if you enter the grader UI, you can indeed set a value of zero for a student. This lead me to believe on our LMS backend was not handling the score right. I tracked this down to an exception being throw in `_get_body` due to malformed xml because the <resultRecord> was missing.
