### PR TITLE
Don’t hardcode karma config port number

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/test/server-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/test/server-test.js
@@ -4,7 +4,7 @@ describe('Server', () => {
   // The window origin of the server.
   // postMessage messages must be sent to this origin in order for the server
   // to receive them.
-  const serversOrigin = 'http://localhost:9876';
+  let serversOrigin;
 
   let server;
   let registeredMethod;
@@ -13,7 +13,11 @@ describe('Server', () => {
   let receiveMessage;
 
   beforeEach('set up the test server', () => {
-    server = new Server(['http://localhost:9876']);
+    // The test server normally runs on http://localhost:9876, but may be
+    // on a higher port if multiple instances are running.
+    // Use window.location.origin to be safe.
+    serversOrigin = window.location.origin;
+    server = new Server([serversOrigin]);
     registeredMethod = sinon.stub().resolves('test_result');
     server.register('registeredMethodName', registeredMethod);
 


### PR DESCRIPTION
Don’t assume the port is 9876. If the client tests are running multiple instances, then the port number may not be 9876. This can happen if client tests are running at the same time lms tests are running. If lms starts second, then the port number may be 9877.

---------

I noticed these tests were failing for me and it was a bit hard to track down. I finally realized the port number was off by one, then it occured to me that I also had the client tests running in another instance of MS code. I did a grep in the client repo and it does not look like we are making this assumption there. I think this only was an issue with LMS.
