### PR TITLE
Display a warning banner in old + unsupported browsers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,11 +70,15 @@ var bundleBaseConfig = {
 var bundles = [
   {
     name: 'frontend_apps',
-    entry: './lms/static/scripts/frontend_apps/index',
+    entry: './lms/static/scripts/frontend_apps/index.js',
   },
   {
     name: 'new_application_instance',
     entry: './lms/static/scripts/new-application-instance.js',
+  },
+  {
+    name: 'browser_check',
+    entry: './lms/static/scripts/browser_check/index.js',
   },
 ];
 

--- a/lms/assets.ini
+++ b/lms/assets.ini
@@ -1,6 +1,7 @@
 [bundles]
 
 frontend_apps_js =
+  scripts/browser_check.bundle.js
   scripts/frontend_apps.bundle.js
 
 new_application_instance_js =

--- a/lms/static/scripts/browser_check/.babelrc
+++ b/lms/static/scripts/browser_check/.babelrc
@@ -1,0 +1,14 @@
+// Custom compilation settings for the `browser_check` bundle. This is intended
+// to work in old browsers that are not supported by the main LMS frontend.
+{
+  "presets": [
+    ["@babel/preset-env", {
+       "targets": {
+         "chrome": "40",
+         "firefox": "38",
+         "safari": "9",
+         "ie": "11"
+      }
+    }]
+  ]
+}

--- a/lms/static/scripts/browser_check/browser-check.js
+++ b/lms/static/scripts/browser_check/browser-check.js
@@ -1,0 +1,25 @@
+/**
+ * Run a series of feature tests to see if the browser is new enough to support Hypothesis.
+ *
+ * We use feature tests to try to avoid false negatives.
+ *
+ * @return {boolean}
+ */
+export function isBrowserSupported() {
+  const checks = [
+    // ES APIs.
+    () => Promise.resolve(),
+    () => new Map(),
+
+    // DOM API checks for APIs used by the LMS frontend and Hypothesis client.
+    () => new URL(document.location.href), // URL constructor.
+    () => new Request('https://hypothes.is'), // Part of the `fetch` API.
+  ];
+
+  try {
+    checks.forEach(check => check());
+    return true;
+  } catch (err) {
+    return false;
+  }
+}

--- a/lms/static/scripts/browser_check/index.js
+++ b/lms/static/scripts/browser_check/index.js
@@ -8,6 +8,7 @@ if (!isBrowserSupported()) {
     <b>You may need to upgrade your browser to use Hypothesis.</b>
     See <a href="https://web.hypothes.is/help/which-browsers-are-supported-by-hypothesis/" target="_blank">this support article</a> for more information.
   </div>
+  <div class="u-stretch"></div>
   <button class="Button">Dismiss</button>
 `;
 

--- a/lms/static/scripts/browser_check/index.js
+++ b/lms/static/scripts/browser_check/index.js
@@ -1,0 +1,20 @@
+import { isBrowserSupported } from './browser-check';
+
+if (!isBrowserSupported()) {
+  const browserWarning = document.createElement('div');
+  browserWarning.className = 'browser-check-warning';
+  browserWarning.innerHTML = `
+  <div>
+    <b>You may need to upgrade your browser to use Hypothesis.</b>
+    See <a href="https://web.hypothes.is/help/which-browsers-are-supported-by-hypothesis/" target="_blank">this support article</a> for more information.
+  </div>
+  <button class="Button">Dismiss</button>
+`;
+
+  const dismissButton = browserWarning.querySelector('button');
+  dismissButton.onclick = () => {
+    browserWarning.style.display = 'none';
+  };
+
+  document.body.appendChild(browserWarning);
+}

--- a/lms/static/scripts/browser_check/test/browser-check-test.js
+++ b/lms/static/scripts/browser_check/test/browser-check-test.js
@@ -1,0 +1,17 @@
+import { isBrowserSupported } from '../browser-check';
+
+describe('isBrowserSupported', () => {
+  it('returns true in a modern browser', () => {
+    assert.isTrue(isBrowserSupported());
+  });
+
+  it('returns false if a check fails', () => {
+    const stub = sinon
+      .stub(Promise, 'resolve')
+      .throws(new Error('Not supported'));
+
+    assert.isFalse(isBrowserSupported());
+
+    stub.restore();
+  });
+});

--- a/lms/static/styles/_variables.scss
+++ b/lms/static/styles/_variables.scss
@@ -11,6 +11,10 @@ $grey-7: #202020;
 
 $brand: #d00032;
 
+$color-success: #00a36d;
+$color-notice: #fbc168;
+$color-error: #d93c3f;
+
 // Typography.
 $sans-font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande',
   sans-serif !default;

--- a/lms/static/styles/components/_browser-check-warning.scss
+++ b/lms/static/styles/components/_browser-check-warning.scss
@@ -1,0 +1,22 @@
+@use '../variables' as var;
+
+// A warning banner shown at the top of the view in unsupported browsers.
+// This is styled to match warning toasts and banners in the Hypothesis client.
+.browser-check-warning {
+  position: fixed;
+  left: 5px;
+  top: 5px;
+  right: 5px;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  background-color: white;
+  border: 2px solid var.$color-notice;
+  padding: 0.75em;
+
+  // In case the frontend app does load (partially or fully),
+  // raise the banner above any content that it renders.
+  z-index: 10000;
+}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -5,6 +5,7 @@
 @use 'typography';
 
 // HTML components
+@use 'components/browser-check-warning';
 @use 'components/heading';
 @use 'components/label';
 

--- a/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
@@ -13,6 +13,6 @@
 {% block scripts %}
   {{ super() }}
   {% for url in asset_urls("frontend_apps_js") %}
-    <script async defer src="{{ url }}"></script>
+    <script defer src="{{ url }}"></script>
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
This PR adds a client-side check for the current browser's compatibility with the LMS app and shows
a warning banner if it is not supported.

The check and banner are included in a new `browser_check` JS bundle which is loaded before the main
frontend app bundle and is compiled to work in older browsers. It performs feature tests to decide
whether to show the banner, similar to the client's boot script. If the checks fail, an advisory banner
with a support link is shown:

<img width="709" alt="lms-warning-banner" src="https://user-images.githubusercontent.com/2458/97455987-53ccfe00-1930-11eb-9610-4c33ca1bf0da.png">

When the banner is shown this does not stop the frontend app from
attempting to load. That way we can accept rare false positives in these
checks and still let users attempt to use the LMS application.

Fixes https://github.com/hypothesis/product-backlog/issues/1141 [1]

[1] This fixes the issue *as-stated* but I strongly suspect that some of the support tickets classed under "unsupported browser" may be other issues. I'll follow up with support after this is merged.

----

**Testing:**

The banner is not easy to see in Canvas because Canvas itself doesn't work in many of the older browsers where this warning would be shown. However you can trigger it in Moodle using IE 11 for example:

<img width="872" alt="lms-frontend-old-moodle-browser" src="https://user-images.githubusercontent.com/2458/97453760-f33cc180-192d-11eb-94aa-2cee149c4e40.png">

Another, easier, way to test locally is to modify the `isBrowserSupported` function to always return `false`.
