### PR TITLE
Synchronize Babel configuration with the client

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,12 +4,23 @@
       "pragma": "createElement"
     }],
     ["@babel/preset-env", {
+       "bugfixes": true,
        "targets": {
-         "browsers": ["> 0.3%"]
+         "chrome": "55",
+         "edge": "17",
+         "firefox": "53",
+         "safari": "10.1",
       }
     }]
   ],
-  "plugins": [
-    "transform-async-to-promises"
-  ]
+  "env": {
+    "development": {
+      "presets": [
+        ["@babel/preset-react", {
+          "development": true,
+          "pragma": "createElement"
+        }]
+      ]
+    }
+  }
 }

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -51,9 +51,13 @@ function createGoogleLibFakes() {
       PICKED: 'picked',
       CANCEL: 'cancel',
     },
-    DocsUploadView: () => {},
-    PickerBuilder: () => pickerBuilder,
-    View: () => pickerView,
+    DocsUploadView: function () {},
+    PickerBuilder: function () {
+      return pickerBuilder;
+    },
+    View: function () {
+      return pickerView;
+    },
     ViewId: {
       DOCS: 'docs',
     },


### PR DESCRIPTION
We recently established a new minimum set of supported browsers for the
Hypothesis client [1] and updated the JS compilation settings accordingly.
This commit brings the LMS frontend's minimum supported browsers in line
with the client.

The related PR https://github.com/hypothesis/lms/pull/2203 adds a warning banner which will be displayed in browsers that don't support the modern JS syntax to which the LMS frontend is now compiled.

[1] https://github.com/hypothesis/client/pull/2659
