### PR TITLE
Make browser support test work better in Edge Legacy

### DIFF
--- a/lms/static/scripts/browser_check/browser-check.js
+++ b/lms/static/scripts/browser_check/browser-check.js
@@ -1,7 +1,8 @@
 /**
  * Run a series of feature tests to see if the browser is new enough to support Hypothesis.
  *
- * We use feature tests to try to avoid false negatives.
+ * We use feature tests to try to avoid false negatives. These are only representative,
+ * not exhaustive, checks of required APIs.
  *
  * @return {boolean}
  */
@@ -14,6 +15,7 @@ export function isBrowserSupported() {
     // DOM API checks for APIs used by the LMS frontend and Hypothesis client.
     () => new URL(document.location.href), // URL constructor.
     () => new Request('https://hypothes.is'), // Part of the `fetch` API.
+    () => document.body.prepend.name, // Element.prepend() method.
   ];
 
   try {


### PR DESCRIPTION
Add a browser feature test for [`Element.prepend()` method](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend). This fixes a
failure of the "unsupported browser" banner to show in older,
unsupported versions of Edge (<= 16). This test is also a good match for
our minimum Chrome version (available in v54, our minimum is Chrome
v55).

Part of https://github.com/hypothesis/product-backlog/issues/1141.