### PR TITLE
Fix content iframe size in grader in Firefox

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -266,9 +266,7 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
   let iFrameWrapper;
   const iFrame = (
     <iframe
-      width="100%"
-      height="100%"
-      className="js-via-iframe"
+      className="BasicLtiLaunchApp__iframe"
       src={contentUrl || ''}
       title="Course content with Hypothesis annotation viewer"
     />
@@ -292,14 +290,14 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
   }
 
   const content = (
-    <span
+    <div
       // Visually hide the iframe / grader if there is an error or no contentUrl.
       className={classNames('BasicLtiLaunchApp__content', {
         'is-hidden': !showIframe,
       })}
     >
       {iFrameWrapper}
-    </span>
+    </div>
   );
 
   const focusedDialogButton = useRef(
@@ -367,10 +365,10 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
   );
 
   return (
-    <span className="BasicLtiLaunchApp">
+    <div className="BasicLtiLaunchApp">
       {showSpinner && <Spinner className="BasicLtiLaunchApp__spinner" />}
       {errorDialog}
       {content}
-    </span>
+    </div>
   );
 }

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,3 +1,7 @@
+.BasicLtiLaunchApp {
+  height: 100%;
+}
+
 .BasicLtiLaunchApp__spinner {
   $spinner-size: 50px;
 
@@ -12,4 +16,16 @@
   &.is-hidden {
     visibility: hidden;
   }
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.BasicLtiLaunchApp__iframe {
+  width: 100%;
+
+  // nb. This element may be contained directly in the `BasicLtiLaunchApp__content` element or
+  // within an `LMSGrader` wrapper. In both cases it should fill whatever space remains.
+  flex-grow: 1;
 }


### PR DESCRIPTION
The content `<iframe>`'s size was set using a `height="100%` attribute.

In situations when the grader bar is shown, this caused the iframe to be
the wrong height in Firefox (but not Chrome). Instead of being the
height of the viewport minus the height of the grader, it ended up being
the same height as the viewport. I don't know exactly why Firefox and Chrome
produce different results here or which is right, but sizing the iframe the correct
way fixes the problem.

This PR fixes the issue by using `flex-grow: 1` to make the iframe fill
the remaining space in the `LMSGrader` parent after the grader is
allocated space. This produces the same results in all browsers.

To make this sizing method work in contexts where the `LMSGrader`
is not used, the `BasicLtiLaunchApp__content` container was made to have
the same `display: flex; flex-direction: column` layout as `LMSGrader`.
This required also specifying the height of the
`BasicLtiLaunchApp`'s root `<div>`.

This commit also removes an unused `js-via-iframe` CSS class.

Fixes https://github.com/hypothesis/support/issues/149