### PR TITLE
Move browser support list to `browserslist` key in package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,14 +3,10 @@
     ["@babel/preset-react", {
       "pragma": "createElement"
     }],
+
+    // Compile JS for browser targets set by `browserslist` key in package.json.
     ["@babel/preset-env", {
-       "bugfixes": true,
-       "targets": {
-         "chrome": "55",
-         "edge": "17",
-         "firefox": "53",
-         "safari": "10.1",
-      }
+       "bugfixes": true
     }]
   ],
   "env": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "sinon": "^9.2.1",
     "typescript": "^4.0.5"
   },
+  "browserslist": "chrome 55, edge 17, firefox 53, safari 10.1",
   "browserify": {
     "transform": [
       "babelify",


### PR DESCRIPTION
Move the browser support list from `.babelrc` to package.json, where it
will be seen by both CSS and JS processing tools. This results in
slightly smaller CSS bundles due to avoiding unnecessary vendor
prefixing.

See https://github.com/hypothesis/client/pull/2698