### PR TITLE
Enable `strict` option in tsconfig.json

### DIFF
--- a/lms/static/scripts/tsconfig.json
+++ b/lms/static/scripts/tsconfig.json
@@ -7,7 +7,8 @@
     "jsxFactory": "createElement",
     "module": "commonjs",
     "noEmit": true,
-    "strictNullChecks": true,
+    "strict": true,
+    "noImplicitAny": false,
     "target": "ES2020"
   },
   "include": [


### PR DESCRIPTION
This did not find any additional errors but could catch some in future.
`noImplicitAny` is left off because we still have un-annotated
parameters in the code that would need addressing first.