### PR TITLE
Add custom error response for Canvas API permissions errors

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,6 +1,7 @@
 from lms.services.exceptions import (
     CanvasAPIAccessTokenError,
     CanvasAPIError,
+    CanvasAPIPermissionError,
     CanvasAPIServerError,
     ConsumerKeyError,
     ExternalRequestError,

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -20,6 +20,15 @@ export class ApiError extends Error {
     this.status = status;
 
     /**
+     * Identifier for the specific error that happened.
+     *
+     * This can be used to show custom error dialogs for specific issues.
+     *
+     * @type {string|null}
+     */
+    this.errorCode = data.error_code || null;
+
+    /**
      * Server-provided error message.
      *
      * May be `null` if the server did not provide any details about what the

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -88,7 +88,26 @@ describe('api', () => {
           '`ApiError.errorMessage`'
         );
         assert.equal(reason.details, body.details, '`ApiError.details`');
+        assert.equal(reason.errorCode, null);
       });
+    });
+
+    it('sets `errorCode` property if server provides an `error_code`', async () => {
+      fakeResponse.status = 400;
+      fakeResponse.json.resolves({
+        error_code: 'canvas_api_permission_error',
+        details: {},
+      });
+
+      const response = apiCall({ path: '/api/test', authToken: 'auth' });
+      let reason;
+      try {
+        await response;
+      } catch (err) {
+        reason = err;
+      }
+
+      assert.equal(reason.errorCode, 'canvas_api_permission_error');
     });
   });
 

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lms.services import CanvasAPIError, LTIOutcomesAPIError
+from lms.services import CanvasAPIError, CanvasAPIPermissionError, LTIOutcomesAPIError
 from lms.validation import ValidationError
 from lms.views.api.exceptions import ExceptionViews
 
@@ -26,6 +26,21 @@ class TestCanvasAPIAccessTokenError:
 
         assert pyramid_request.response.status_code == 400
         assert json_data == {}
+
+
+class TestCanvasAPIPermissionError:
+    def test_it(self, context, pyramid_request, views):
+        json_data = views.canvas_api_permission_error()
+
+        assert pyramid_request.response.status_code == 400
+        assert json_data == {
+            "error_code": context.error_code,
+            "details": context.details,
+        }
+
+    @pytest.fixture
+    def context(self):
+        return CanvasAPIPermissionError(details={"foo": "bar"})
 
 
 class TestCanvasAPIError:


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/2217

Depends on https://github.com/hypothesis/lms/pull/2222

Add a custom error response from our Canvas proxy API for Canvas API permissions errors. This error response is used:

* When a learner launches a Canvas Files assignment and the assignment's file is marked as _Unpublished_ in Canvas
* When a user launches a Canvas Files assignment in a course that was created from another course using Canvas's course copy feature, and the user isn't a member of the original course (so they don't have permission to read the original course's copy of the file)
* There might also be other ways to get a permissions error from the Canvas API?

Of course, adding a custom error response doesn't help any users until the frontend code has been updated to handle the new type of response by showing a new error dialog. This backend-only PR can still be merged now though:

1. It doesn't break the current UX for any other types of error

2. It doesn't change the current UX for Canvas Files permissions errors. The current behaviour (on master) when trying to launch a Canvas Files assignment whose file the user doesn't have permission to read is that we keep on asking the user to re-authorize us with Canvas forever and give no explanation as to why. This is obviously broken behaviour but it's no more broken on this branch than on master. This branch adds the new proxy API response that a future PR could use to fix this behaviour