### PR TITLE
Show custom error dialog for Canvas file permission errors

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -20,6 +20,15 @@ export class ApiError extends Error {
     this.status = status;
 
     /**
+     * Identifier for the specific error that happened.
+     *
+     * This can be used to show custom error dialogs for specific issues.
+     *
+     * @type {string|null}
+     */
+    this.errorCode = data.error_code || null;
+
+    /**
      * Server-provided error message.
      *
      * May be `null` if the server did not provide any details about what the

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -88,7 +88,26 @@ describe('api', () => {
           '`ApiError.errorMessage`'
         );
         assert.equal(reason.details, body.details, '`ApiError.details`');
+        assert.equal(reason.errorCode, null);
       });
+    });
+
+    it('sets `errorCode` property if server provides an `error_code`', async () => {
+      fakeResponse.status = 400;
+      fakeResponse.json.resolves({
+        error_code: 'canvas_api_permission_error',
+        details: {},
+      });
+
+      const response = apiCall({ path: '/api/test', authToken: 'auth' });
+      let reason;
+      try {
+        await response;
+      } catch (err) {
+        reason = err;
+      }
+
+      assert.equal(reason.errorCode, 'canvas_api_permission_error');
     });
   });
 


### PR DESCRIPTION
This PR adds a more specific and helpful error message in LTI launches that fail due to the Canvas file used in the assignment not being accessible, following the proposal in https://github.com/hypothesis/lms/issues/2217#issuecomment-722281453.

When the backend reports that fetching the content URL for an assignment
launch fails due to a Canvas file permission error, indicated by
`"error_code": "canvas_api_permission_error"` in the API response, show
a specific dialog for that error. This dialog explains common causes of
the problem and how to rectify them. It also differs from the generic
error dialog in that clicking "Try again" does not retry authorization,
since we know that is not necessary.

Summary of changes in this PR:

- Add an `errorCode` property to the `ApiError` error class and populate it from the `error_code` field in the API response
- Add a new `error-fetching-canvas-file` error state to the `BasicLtiLaunchApp` component, set this state if the `error_code` is `canvas_api_permission_error` and then render a specific error message in this error state. Unlike other error states, the "Try again" button does not attempt re-authorization in this state
- Slightly modify the name of existing error states for consistency (`error-fetch` => `error-fetching` etc.)

Something I didn't address in this PR is that there is some repetition of markup across the dialogs shown for the various error states. I left that refactoring as a follow-up task.