### PR TITLE
Show instructors an error when Canvas file ID not found

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -33,7 +33,7 @@ class JSConfig:
     def _ai_getter(self):
         return self._request.find_service(name="ai_getter")
 
-    def add_canvas_file_id(self, canvas_file_id):
+    def add_canvas_file_id(self, course_id, canvas_file_id):
         """
         Set the document to the Canvas file with the given canvas_file_id.
 
@@ -46,7 +46,7 @@ class JSConfig:
         self._config["api"]["viaUrl"] = {
             "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
             "path": self._request.route_path(
-                "canvas_api.files.via_url", file_id=canvas_file_id
+                "canvas_api.files.via_url", course_id=course_id, file_id=canvas_file_id
             ),
         }
         self._add_canvas_speedgrader_settings(canvas_file_id=canvas_file_id)

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -58,7 +58,10 @@ def includeme(config):
     config.add_route(
         "canvas_api.courses.files.list", "/api/canvas/courses/{course_id}/files"
     )
-    config.add_route("canvas_api.files.via_url", "/api/canvas/files/{file_id}/via_url")
+    config.add_route(
+        "canvas_api.files.via_url",
+        "/api/canvas/courses/{course_id}/files/{file_id}/via_url",
+    )
     config.add_route("canvas_api.sync", "/api/canvas/sync", request_method="POST")
 
     config.add_route("lti_api.submissions.record", "/api/lti/submissions")

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -3,6 +3,7 @@ from lms.services.exceptions import (
     CanvasAPIError,
     CanvasAPIPermissionError,
     CanvasAPIServerError,
+    CanvasFileNotFoundInCourse,
     ConsumerKeyError,
     ExternalRequestError,
     HAPIError,

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -201,3 +201,13 @@ class LTIOutcomesAPIError(ExternalRequestError):
     Raised whenever an LTI outcomes API request times out or when an
     unsuccessful, invalid or unexpected response is received from the API.
     """
+
+
+class CanvasFileNotFoundInCourse(ServiceError):
+    """A Canvas file ID wasn't found in the current course."""
+
+    error_code = "canvas_file_not_found_in_course"
+
+    def __init__(self, file_id):
+        self.details = {"file_id": file_id}
+        super().__init__(self.details)

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -29,7 +29,7 @@ import Spinner from './Spinner';
  * These affect the message that is shown to users and the actions
  * offered to remedy the problem.
  *
- * @typedef {'error-fetching'|'error-authorizing'|'error-reporting-submission'|'error-fetching-canvas-file'} ErrorState
+ * @typedef {'error-fetching'|'error-authorizing'|'error-reporting-submission'|'error-fetching-canvas-file'|'canvas-file-not-found-in-course'} ErrorState
  */
 
 /**
@@ -122,6 +122,12 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
     ) {
       setError(e);
       setErrorState('error-fetching-canvas-file');
+    } else if (
+      e instanceof ApiError &&
+      e.errorCode === 'canvas_file_not_found_in_course'
+    ) {
+      setError(e);
+      setErrorState('canvas-file-not-found-in-course');
     } else if (e instanceof ApiError && !e.errorMessage && retry) {
       setErrorState('error-authorizing');
     } else {
@@ -378,6 +384,44 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
               edit this assignment and re-select the file.
             </li>
           </ul>
+          <ErrorDisplay error={/** @type {Error} */ (error)} />
+        </Dialog>
+      )}
+      {errorState === 'canvas-file-not-found-in-course' && (
+        <Dialog
+          initialFocus={focusedDialogButton}
+          title="Hypothesis couldn't find the file in the course"
+          role="alertdialog"
+          buttons={[
+            <Button
+              buttonRef={focusedDialogButton}
+              className="BasicLtiLaunchApp__button"
+              disabled={fetchCount > 0}
+              key="retry"
+              label="Try again"
+              onClick={refetchContentUrl}
+            />,
+          ]}
+        >
+          <p>This might have happened because:</p>
+
+          <ul>
+            <li>The file has been deleted from Canvas</li>
+            <li>The course was copied from another course</li>
+          </ul>
+
+          <p>
+            To fix the issue,{' '}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://web.hypothes.is/help/fixing-a-broken-canvas-file-link/"
+            >
+              edit the assignment and re-select the file
+            </a>
+            .
+          </p>
+
           <ErrorDisplay error={/** @type {Error} */ (error)} />
         </Dialog>
       )}

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -85,7 +85,7 @@ export default function ErrorDisplay({ message, error }) {
         </p>
       )}
       <p>
-        If the problem persists{' '}
+        If the problem persists,{' '}
         <a href={supportLink} target="_blank" rel="noopener noreferrer">
           send us an email
         </a>{' '}

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -28,6 +28,12 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
+        file_id = self.request.matchdict["file_id"]
+        course_id = self.request.matchdict["course_id"]
+
+        if self.request.lti_user.is_instructor:
+            self.canvas_api_client.check_file_in_course(file_id, course_id)
+
         public_url = self.canvas_api_client.public_url(
             self.request.matchdict["file_id"]
         )

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -11,6 +11,7 @@ from lms.services import (
     CanvasAPIAccessTokenError,
     CanvasAPIError,
     CanvasAPIPermissionError,
+    CanvasFileNotFoundInCourse,
     LTIOutcomesAPIError,
     NoOAuth2Token,
 )
@@ -105,6 +106,7 @@ class ExceptionViews:
         return self.error_response()
 
     @exception_view_config(context=CanvasAPIPermissionError)
+    @exception_view_config(context=CanvasFileNotFoundInCourse)
     def canvas_api_permission_error(self):
         return self.error_response(
             error_code=self.context.error_code, details=self.context.details

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -86,7 +86,10 @@ class BasicLTILaunchViews:
         self.sync_lti_data_to_h()
         self.store_lti_data()
         self.course_service.get_or_create(self.context.h_group.authority_provided_id)
-        self.context.js_config.add_canvas_file_id(self.request.params["file_id"])
+        self.context.js_config.add_canvas_file_id(
+            self.request.params["custom_canvas_course_id"],
+            self.request.params["file_id"],
+        )
         return {}
 
     @view_config(db_configured=True)

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -126,15 +126,19 @@ class TestAddCanvasFileID:
     """Unit tests for JSConfig.add_canvas_file_id()."""
 
     def test_it_adds_the_viaUrl_api_config(self, js_config):
-        js_config.add_canvas_file_id("example_canvas_file_id")
+        js_config.add_canvas_file_id(
+            "example_canvas_course_id", "example_canvas_file_id"
+        )
 
         assert js_config.asdict()["api"]["viaUrl"] == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
-            "path": "/api/canvas/files/example_canvas_file_id/via_url",
+            "path": "/api/canvas/courses/example_canvas_course_id/files/example_canvas_file_id/via_url",
         }
 
     def test_it_sets_the_canvas_file_id(self, js_config, submission_params):
-        js_config.add_canvas_file_id("example_canvas_file_id")
+        js_config.add_canvas_file_id(
+            "example_canvas_course_id", "example_canvas_file_id"
+        )
 
         assert submission_params()["canvas_file_id"] == "example_canvas_file_id"
 
@@ -213,7 +217,10 @@ class TestAddCanvasFileIDAddDocumentURLCommon:
 
     @pytest.fixture(
         params=[
-            {"method": "add_canvas_file_id", "args": ["example_canvas_file_id"]},
+            {
+                "method": "add_canvas_file_id",
+                "args": ["example_canvas_course_id", "example_canvas_file_id"],
+            },
             {"method": "add_document_url", "args": ["example_document_url"]},
         ]
     )
@@ -221,9 +228,7 @@ class TestAddCanvasFileIDAddDocumentURLCommon:
         """Return a function that calls the method-under-test with default args."""
 
         def method_caller():
-            method_name = request.param["method"]
-            args = request.param["args"]
-            return getattr(js_config, method_name)(*args)
+            return getattr(js_config, request.param["method"])(*request.param["args"])
 
         return method_caller
 

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -3,8 +3,14 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from lms.services import CanvasAPIAccessTokenError, CanvasAPIError, CanvasAPIServerError
+from lms.services import (
+    CanvasAPIAccessTokenError,
+    CanvasAPIError,
+    CanvasAPIServerError,
+    CanvasFileNotFoundInCourse,
+)
 from lms.services.canvas_api.client import CanvasAPIClient
+from tests import factories
 
 
 class TestCanvasAPIClientGetToken:
@@ -170,6 +176,31 @@ class TestCanvasAPIClient:
             timeout=Any(),
         )
 
+    @pytest.mark.usefixtures("list_files_response")
+    @pytest.mark.parametrize("file_id", [1, "1"])
+    def test_check_file_in_course_checks_that_the_file_is_in_the_course(
+        self, canvas_api_client, file_id, http_session
+    ):
+        canvas_api_client.check_file_in_course(
+            file_id=file_id, course_id="test_course_id"
+        )
+
+        http_session.send.assert_called_once_with(
+            Any.request(
+                url=Any.url.with_path("api/v1/courses/test_course_id/files"),
+            ),
+            timeout=Any(),
+        )
+
+    @pytest.mark.usefixtures("list_files_response")
+    def test_check_file_in_course_raises_if_the_file_isnt_in_the_course(
+        self, canvas_api_client
+    ):
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            canvas_api_client.check_file_in_course(
+                file_id="not_in_course", course_id="test_course_id"
+            )
+
     def test_public_url(self, canvas_api_client, http_session):
         http_session.set_response({"public_url": "public_url_value"})
 
@@ -181,6 +212,25 @@ class TestCanvasAPIClient:
                 "GET", url=Any.url.with_path("api/v1/files/FILE_ID/public_url")
             ),
             timeout=Any(),
+        )
+
+    @pytest.fixture
+    def list_files_response(self, http_session):
+        """Make the network send a valid Canvas API list files response."""
+        http_session.send.return_value = factories.requests.Response(
+            json_data=[
+                {
+                    "display_name": "display_name_1",
+                    "id": 1,
+                    "updated_at": "updated_at_1",
+                },
+                {
+                    "display_name": "display_name_2",
+                    "id": 2,
+                    "updated_at": "updated_at_2",
+                },
+            ],
+            status_code=200,
         )
 
 

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -20,6 +20,10 @@ def canvas_file_basic_lti_launch_caller(context, pyramid_request):
     BasicLTILaunchViews.canvas_file_basic_lti_launch(), and return whatever
     BasicLTILaunchViews.canvas_file_basic_lti_launch() returns.
     """
+    # The custom_canvas_course_id param is always present when
+    # canvas_file_basic_lti_launch() is called: Canvas always includes this
+    # param because we request it in our config.xml.
+    pyramid_request.params["custom_canvas_course_id"] = "TEST_COURSE_ID"
     # The file_id param is always present when canvas_file_basic_lti_launch()
     # is called. The canvas_file=True view predicate ensures this.
     pyramid_request.params["file_id"] = "TEST_FILE_ID"
@@ -219,7 +223,8 @@ class TestCanvasFileBasicLTILaunch:
         canvas_file_basic_lti_launch_caller(context, pyramid_request)
 
         context.js_config.add_canvas_file_id.assert_called_once_with(
-            pyramid_request.params["file_id"]
+            pyramid_request.params["custom_canvas_course_id"],
+            pyramid_request.params["file_id"],
         )
 
 


### PR DESCRIPTION
Show instructors an error message when they're launching a Canvas files assignment and the assignment's file ID isn't found in the course:

![Screenshot from 2020-11-11 15-11-30](https://user-images.githubusercontent.com/22498/98828630-3586f800-2430-11eb-986a-c22f1e515083.png)

This happens when:

* The assignment was copied from another course using Canvas's course-copy feature: the new copies of the assignment's still have the file ID from the original course's copy of the file
* The assignment's file has been deleted from Canvas