### PR TITLE
Enable `noImplicitAny` option in TypeScript config

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Button.js
+++ b/lms/static/scripts/frontend_apps/components/Button.js
@@ -7,7 +7,7 @@ import { createElement } from 'preact';
  * @prop {string} [className]
  * @prop {boolean} [disabled]
  * @prop {string} label
- * @prop {() => any} onClick
+ * @prop {(e: Event) => any} onClick
  * @prop {string} [type]
  */
 

--- a/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
@@ -23,10 +23,10 @@ export default function CanvasOAuth2RedirectErrorApp({
 }) {
   const {
     canvasOAuth2RedirectError: {
-      authUrl = null,
+      authUrl = /** @type {string|null} */ (null),
       invalidScope = false,
       errorDetails = '',
-      scopes = [],
+      scopes = /** @type {string[]} */ ([]),
     },
   } = useContext(Config);
 

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -1,5 +1,13 @@
 import { Fragment, createElement } from 'preact';
 
+/**
+ * Generate a `mailto:` URL that prompts to send an email with pre-filled fields.
+ *
+ * @param {Object} args
+ * @param {string} args.address - Email address to sent to
+ * @param {string} [args.subject] - Pre-filled subject line
+ * @param {string} [args.body] - Pre-filled body
+ */
 function emailLink({ address, subject = '', body = '' }) {
   return `mailto:${address}?subject=${encodeURIComponent(
     subject
@@ -37,6 +45,7 @@ function toSentence(str) {
  * @param {ErrorDisplayProps} props
  */
 export default function ErrorDisplay({ message, error }) {
+  /** @type {string|undefined} */
   let details = '';
 
   if (typeof error.details === 'object' && error.details !== null) {
@@ -63,8 +72,9 @@ export default function ErrorDisplay({ message, error }) {
     body: supportEmailBody,
   });
 
+  /** @param {Event} event */
   const onDetailsToggle = event => {
-    const details = event.target;
+    const details = /** @type {HTMLDetailsElement} */ (event.target);
     if (!details.open) {
       return;
     }

--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -34,6 +34,7 @@ export default function FileList({
   onUseFile,
   noFilesMessage,
 }) {
+  /** @param {string} isoString */
   const formatDate = isoString => new Date(isoString).toLocaleDateString();
   const columns = [
     {

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -94,12 +94,15 @@ export default function FilePickerApp({
   const [shouldSubmit, submit] = useState(false);
 
   const cancelDialog = () => setActiveDialog(null);
+
+  /** @param {File} file */
   const selectLMSFile = file => {
     setActiveDialog(null);
     setLmsFile(file);
     submit(true);
   };
 
+  /** @param {string} url */
   const selectURL = url => {
     setActiveDialog(null);
     setUrl(url);

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -56,10 +56,9 @@ export default function LMSGrader({
 
   /**
    * Makes an RPC call to the sidebar to change to the focused user.
-   *
-   * @param {StudentInfo|null} user - The user to focus on in the sidebar
    */
   const changeFocusedUser = useCallback(
+    /** @param {StudentInfo|null} user - The user to focus on in the sidebar */
     user => clientRpc.setFocusedUser(user),
     [clientRpc]
   );
@@ -90,6 +89,8 @@ export default function LMSGrader({
 
   /**
    * Callback to set the current selected student.
+   *
+   * @param {number} studentIndex
    */
   const onSelectStudent = studentIndex => {
     setCurrentStudentIndex(studentIndex);

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -41,6 +41,7 @@ const useFetchGrade = student => {
   const [gradeLoading, setGradeLoading] = useState(false);
 
   useEffect(() => {
+    /** @type {boolean} */
     let didCancel;
     if (student) {
       // Fetch the grade from the service api
@@ -124,6 +125,8 @@ export default function SubmitGradeForm({ student }) {
 
   /**
    * Validate the grade and if it passes, then submit the grade to to `onSubmitGrade`
+   *
+   * @param {Event} event
    */
   const onSubmitGrade = async event => {
     event.preventDefault();

--- a/lms/static/scripts/frontend_apps/components/SvgIcon.js
+++ b/lms/static/scripts/frontend_apps/components/SvgIcon.js
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import { createElement } from 'preact';
 import { useLayoutEffect, useRef } from 'preact/hooks';
-import propTypes from 'prop-types';
+import * as propTypes from 'prop-types';
 
 /**
  * Object mapping icon names to SVG markup.

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -8,11 +8,11 @@ import { useRef } from 'preact/hooks';
  *
  * @template Item
  * @param {Item[]} items
- * @param {Item} currentItem
+ * @param {Item|null} currentItem
  * @param {number} step
  */
 function nextItem(items, currentItem, step) {
-  const index = items.indexOf(currentItem);
+  const index = currentItem ? items.indexOf(currentItem) : -1;
   if (index < 0) {
     return items[0];
   }
@@ -70,6 +70,7 @@ export default function Table({
 }) {
   const rowRefs = useRef(/** @type {(HTMLElement|null)[]} */ ([]));
 
+  /** @param {Item} item */
   const focusAndSelectItem = item => {
     const itemIndex = items.indexOf(item);
     const rowEl = rowRefs.current[itemIndex];
@@ -79,6 +80,7 @@ export default function Table({
     onSelectItem(item);
   };
 
+  /** @param {KeyboardEvent} event */
   const onKeyDown = event => {
     let handled = false;
     if (event.key === 'Enter') {

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -20,6 +20,8 @@ import Dialog from './Dialog';
 export default function URLPicker({ onCancel, onSelectURL }) {
   const input = useRef(/** @type {HTMLInputElement|null} */ (null));
   const form = useRef(/** @type {HTMLFormElement|null} */ (null));
+
+  /** @param {Event} event */
   const submit = event => {
     event.preventDefault();
     if (form.current.checkValidity()) {

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -28,9 +28,11 @@ export default function ValidationMessage({
 
   /**
    * Closes the validation error message and notifies parent
+   *
+   * @param {Event} event
    */
-  const closeValidationError = e => {
-    e.preventDefault();
+  const closeValidationError = event => {
+    event.preventDefault();
     setShowError(false);
     onClose();
   };

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -53,9 +53,9 @@ import { createContext } from 'preact';
  *   @prop {string} canvas.ltiLaunchUrl
  *   @prop {ApiCallInfo} canvas.listFiles
  * @prop {Object} google
- *   @prop {string} clientId
- *   @prop {string} developerKey
- *   @prop {string} origin
+ *   @prop {string} google.clientId
+ *   @prop {string} google.developerKey
+ *   @prop {string} google.origin
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/AuthWindow.js
+++ b/lms/static/scripts/frontend_apps/utils/AuthWindow.js
@@ -1,3 +1,4 @@
+// @ts-ignore - Types are missing for query-string
 import queryString from 'query-string';
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -7,6 +7,10 @@
  * JSON body.
  */
 export class ApiError extends Error {
+  /**
+   * @param {number} status - HTTP status code
+   * @param {any} data - Parsed JSON body from the API response
+   */
   constructor(status, data) {
     // If message is omitted, pass a default error message.
     const message = data.message || 'API call failed';
@@ -61,9 +65,12 @@ export class ApiError extends Error {
  */
 async function apiCall({ path, authToken, data }) {
   let body;
+
+  /** @type {Record<string,string>} */
   const headers = {
     Authorization: authToken,
   };
+
   if (data !== undefined) {
     body = JSON.stringify(data);
     headers['Content-Type'] = 'application/json; charset=UTF-8';

--- a/lms/static/scripts/frontend_apps/utils/google-api-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-api-client.js
@@ -25,7 +25,7 @@ async function loadGAPI() {
  * See https://developers.google.com/api-client-library/javascript/reference/referencedocs
  *
  * @param {string[]} names
- * @return {Promise<Object>}
+ * @return {Promise<Record<string, any>>}
  *   The `gapi` object with properties corresponding to each of the named
  *   libraries' entry points.
  */
@@ -37,6 +37,8 @@ async function loadLibraries(names) {
       callback: () => {
         resolve(gapi);
       },
+
+      /** @param {any} err */
       onerror: err => {
         reject(err);
       },

--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.js
@@ -2,6 +2,7 @@ import { loadLibraries } from './google-api-client';
 
 export const GOOGLE_DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive';
 
+/** @param {string} origin */
 function addHttps(origin) {
   if (origin.indexOf('://') !== -1) {
     return origin;
@@ -17,6 +18,16 @@ export class PickerCanceledError extends Error {
     super('Dialog was canceled');
   }
 }
+
+/**
+ * Subset of the `Document` type returned by the Google Picker.
+ *
+ * See https://developers.google.com/picker/docs/reference#document
+ *
+ * @typedef PickerDocument
+ * @prop {string} id
+ * @prop {string} url
+ */
 
 /**
  * A wrapper around the Google Picker API client libraries.
@@ -90,9 +101,17 @@ export class GooglePickerClient {
       }
     }
 
+    /** @type {(doc: PickerDocument) => void} */
     let resolve;
+
+    /** @type {(e: Error) => void} */
     let reject;
 
+    /**
+     * @param {Object} args
+     * @param {any} args.action
+     * @param {PickerDocument[]} args.docs
+     */
     function pickerCallback({ action, docs }) {
       if (action === pickerLib.Action.PICKED) {
         const doc = docs[0];
@@ -127,6 +146,8 @@ export class GooglePickerClient {
   /**
    * Change the sharing settings on a document in Google Drive to make it
    * publicly viewable to anyone with the link.
+   *
+   * @param {string} docId
    */
   async enablePublicViewing(docId) {
     const gapiClient = await this._gapiClient;

--- a/lms/static/scripts/postmessage_json_rpc/client.js
+++ b/lms/static/scripts/postmessage_json_rpc/client.js
@@ -7,6 +7,9 @@ function generateId() {
 
 /**
  * Return a Promise that rejects with an error after `delay` ms.
+ *
+ * @param {number} delay
+ * @param {string} message
  */
 function createTimeout(delay, message) {
   return new Promise((_, reject) => {
@@ -47,6 +50,7 @@ async function call(
   // Await response or timeout.
   let listener;
   const response = new Promise((resolve, reject) => {
+    /** @param {MessageEvent} event */
     listener = event => {
       if (event.origin !== origin) {
         // Not from the frame that we sent the request to.

--- a/lms/static/scripts/postmessage_json_rpc/random.js
+++ b/lms/static/scripts/postmessage_json_rpc/random.js
@@ -1,3 +1,4 @@
+/** @param {number} val */
 function byteToHex(val) {
   const str = val.toString(16);
   return str.length === 1 ? '0' + str : str;

--- a/lms/static/scripts/postmessage_json_rpc/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server.js
@@ -28,6 +28,10 @@
  */
 
 /**
+ * @typedef {(...args: any[]) => any|Promise<any>} RpcMethod
+ */
+
+/**
  * A JSON-RPC-over-postMessage server.
  *
  * After constructing a server you have to call its register() method to
@@ -52,7 +56,10 @@ export class Server {
     this._boundReceiveMessage = this._receiveMessage.bind(this);
     window.addEventListener('message', this._boundReceiveMessage);
 
-    // The methods that can be called remotely via this server.
+    /**
+     * The methods that can be called remotely via this server.
+     * @type {Record<string,RpcMethod>}
+     */
     this._registeredMethods = {};
 
     this.sidebarWindow = new Promise(resolve => {
@@ -64,7 +71,7 @@ export class Server {
    * Register a remotely callable method with this server.
    *
    * @param {string} name
-   * @param {(...args: any[]) => any|Promise<any>} method
+   * @param {RpcMethod} method
    */
   register(name, method) {
     this._registeredMethods[name] = method;

--- a/lms/static/scripts/tsconfig.json
+++ b/lms/static/scripts/tsconfig.json
@@ -8,7 +8,6 @@
     "module": "commonjs",
     "noEmit": true,
     "strict": true,
-    "noImplicitAny": false,
     "target": "ES2020"
   },
   "include": [

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "watchify": "^3.11.1"
   },
   "devDependencies": {
+    "@types/classnames": "^2.2.11",
+    "@types/prop-types": "^15.7.3",
     "axe-core": "^4.0.2",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-mockable-imports": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,6 +993,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@types/classnames@^2.2.11":
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
+  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1007,6 +1012,11 @@
   version "14.0.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.10.tgz#dbfaa170bd9eafccccb6d7060743a761b0844afd"
   integrity sha512-Bz23oN/5bi0rniKT24ExLf4cK0JdvN3dH/3k0whYkdN4eI4vS2ZW/2ENNn2uxHCzWcbdHIa/GRuWQytfzCjRYw==
+
+"@types/prop-types@^15.7.3":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Fix the remaining issues that prevented the lms frontend from being
compiled with `noImplicitAny` enabled and remove the override in
`tsconfig.json`. Note that this setting is implicitly enabled by default when
`strict` is `true`.

The result is that the types of all identifiers must be either specified
or inferred, improving documentation for the reader and helping to catch
some minor bugs.