### PR TITLE
Extract `LaunchErrorDialog` component

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -1,0 +1,176 @@
+import { createElement } from 'preact';
+import { useRef } from 'preact/hooks';
+
+import Button from './Button';
+import Dialog from './Dialog';
+import ErrorDisplay from './ErrorDisplay';
+
+/**
+ * @typedef {import("preact").ComponentChildren} Children
+ * @typedef {import('./BasicLtiLaunchApp').ErrorState} ErrorState
+ */
+
+/**
+ * Common structure for LTI launch error dialogs.
+ *
+ * This is a "full-screen", non-cancelable dialog consisting of:
+ *
+ *  - An explanation of what went wrong and how to resolve it
+ *  - An optional "Try again" button
+ *  - An optional detailed error message for use when contacting support
+ *
+ * @param {Object} props
+ * @param {boolean} props.busy
+ * @param {Children} props.children
+ * @param {Error|null} [props.error]
+ * @param {() => void} [props.onRetry]
+ * @param {string} [props.retryLabel]
+ * @param {string} [props.title]
+ */
+function BaseDialog({
+  busy,
+  children,
+  error = null,
+  onRetry,
+  retryLabel = 'Try again',
+  title = 'Something went wrong',
+}) {
+  const focusedDialogButton = useRef(
+    /** @type {HTMLButtonElement | null} */ (null)
+  );
+  return (
+    <Dialog
+      initialFocus={focusedDialogButton}
+      title={title}
+      role="alertdialog"
+      buttons={
+        onRetry && (
+          <Button
+            buttonRef={focusedDialogButton}
+            disabled={busy}
+            label={retryLabel}
+            onClick={onRetry}
+          />
+        )
+      }
+    >
+      {children}
+      {error && <ErrorDisplay error={error} />}
+    </Dialog>
+  );
+}
+
+/**
+ * @typedef LaunchErrorDialogProps
+ * @prop {boolean} busy -
+ *   Flag indicating that the app is busy and should not allow the user to
+ *   click the "Try again" button
+ * @prop {ErrorState} errorState - What kind of error occurred?
+ * @prop {Error|null} error - Detailed information about the error
+ * @prop {() => void} onRetry -
+ *   Callback invoked when user clicks the "Try again" button
+ */
+
+/**
+ * Dialog that is displayed if an LTI launch failed.
+ *
+ * The dialog provides an explanation of what went wrong and steps to fix the
+ * problem.
+ *
+ * @param {LaunchErrorDialogProps} props
+ */
+export default function LaunchErrorDialog({
+  busy,
+  error,
+  errorState,
+  onRetry,
+}) {
+  switch (errorState) {
+    case 'error-authorizing':
+      // nb. There are no error details shown here, since failing to authorize
+      // is a "normal" event which will happen if the user has not authorized before
+      // or the authorization has expired or been revoked.
+      return (
+        <BaseDialog
+          busy={busy}
+          onRetry={onRetry}
+          retryLabel="Authorize"
+          title="Authorize Hypothesis"
+        >
+          <p>Hypothesis needs your authorization to launch this assignment.</p>
+        </BaseDialog>
+      );
+    case 'error-fetching-canvas-file':
+      return (
+        <BaseDialog
+          busy={busy}
+          error={error}
+          onRetry={onRetry}
+          title="Couldn't get the file from Canvas"
+        >
+          <p>
+            Hypothesis couldn&apos;t get the assignment&apos;s file from Canvas.
+          </p>
+          <p>
+            You might not have permission to read the file in Canvas. This could
+            be because:
+          </p>
+          <ul>
+            <li>
+              The file is marked as <i>Unpublished</i> in Canvas: an instructor
+              needs to publish the file.
+            </li>
+            <li>
+              This course was copied from another course: an instructor needs to
+              edit this assignment and re-select the file.
+            </li>
+          </ul>
+        </BaseDialog>
+      );
+    case 'canvas-file-not-found-in-course':
+      return (
+        <BaseDialog
+          busy={busy}
+          error={error}
+          onRetry={onRetry}
+          title="Hypothesis couldn't find the file in the course"
+        >
+          <p>This might have happened because:</p>
+
+          <ul>
+            <li>The file has been deleted from Canvas</li>
+            <li>The course was copied from another course</li>
+          </ul>
+
+          <p>
+            To fix the issue,{' '}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://web.hypothes.is/help/fixing-a-broken-canvas-file-link/"
+            >
+              edit the assignment and re-select the file
+            </a>
+            .
+          </p>
+        </BaseDialog>
+      );
+    case 'error-fetching':
+      return (
+        <BaseDialog busy={busy} error={error} onRetry={onRetry}>
+          <p>There was a problem fetching this Hypothesis assignment.</p>
+        </BaseDialog>
+      );
+    case 'error-reporting-submission':
+      // nb. There is no retry action here as we just suggest reloading the entire
+      // page.
+      return (
+        <BaseDialog busy={busy} error={error}>
+          <p>
+            There was a problem submitting this Hypothesis assignment.{' '}
+            <b>To fix this problem, try reloading the page.</b>
+          </p>
+        </BaseDialog>
+      );
+  }
+}

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -1,0 +1,111 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+import LaunchErrorDialog, { $imports } from '../LaunchErrorDialog';
+
+describe('LaunchErrorDialog', () => {
+  let retryStub;
+
+  function renderDialog(props) {
+    return mount(
+      <LaunchErrorDialog
+        errorState="error-authorizing"
+        busy={false}
+        onRetry={retryStub}
+        {...props}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    retryStub = sinon.stub();
+
+    $imports.$mock(mockImportedComponents());
+
+    // Un-mock `Dialog` so we can get a reference to the "Try again" button.
+    $imports.$restore({
+      './Dialog': true,
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  [
+    {
+      errorState: 'error-authorizing',
+      expectedText: 'Hypothesis needs your authorization',
+      hasDetailedError: false,
+      retryAction: 'Authorize',
+    },
+    {
+      errorState: 'error-fetching-canvas-file',
+      expectedText: "Hypothesis couldn't get the assignment's file from Canvas",
+    },
+    {
+      errorState: 'canvas-file-not-found-in-course',
+      expectedText: 'edit the assignment and re-select the file',
+    },
+    {
+      errorState: 'error-fetching',
+      expectedText: 'There was a problem fetching this Hypothesis assignment',
+    },
+    {
+      errorState: 'error-reporting-submission',
+      expectedText: 'There was a problem submitting this Hypothesis assignment',
+      retryAction: null,
+    },
+  ].forEach(
+    ({
+      errorState,
+      expectedText,
+      hasDetailedError = true,
+      retryAction = 'Try again',
+    }) => {
+      it(`displays expected error for "${errorState}" error state`, () => {
+        const error = new Error('Detailed error info');
+
+        const wrapper = renderDialog({ error, errorState });
+
+        assert.include(wrapper.text(), expectedText);
+        assert.equal(wrapper.exists('Button'), retryAction !== null);
+        if (retryAction) {
+          assert.equal(wrapper.find('Button').prop('label'), retryAction);
+        }
+        assert.equal(wrapper.exists('ErrorDisplay'), hasDetailedError);
+      });
+    }
+  );
+
+  it('initiates retry when "Try again" button is clicked', () => {
+    const wrapper = renderDialog();
+
+    act(() => {
+      wrapper.find('Button').prop('onClick')();
+    });
+
+    assert.called(retryStub);
+  });
+
+  it('enables "Try again" button if `busy` is false', () => {
+    const wrapper = renderDialog({ busy: false });
+    assert.isFalse(wrapper.find('Button').prop('disabled'));
+  });
+
+  it('disables "Try again" button if `busy` is true', () => {
+    const wrapper = renderDialog({ busy: true });
+    assert.isTrue(wrapper.find('Button').prop('disabled'));
+  });
+
+  it('shows error details', () => {
+    const error = new Error('Oh no');
+    const wrapper = renderDialog({
+      errorState: 'error-fetching-canvas-file',
+      error,
+    });
+    assert.equal(wrapper.find('ErrorDisplay').prop('error'), error);
+  });
+});


### PR DESCRIPTION
Extract the various error dialogs that can be shown by the `BasicLtiLaunchApp` component into a separate `LaunchErrorDialog` component. This will help keep `BasicLtiLaunchApp` readable as new error cases are added. It also makes testing easier as the `BasicLtiLaunchApp` tests can focus on checking _which_ error dialog is shown and the `LaunchErrorDialog` component tests check _what_ is shown in a particular error dialog.

There should be no visual changes to the dialogs, except for a minor change in the layout of the text for the case when creating the speedgrader submission fails in Canvas due to fixing an inconsistency wrt. the other dialogs.