### PR TITLE
Bump Chrome version to 57

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Button.js
+++ b/lms/static/scripts/frontend_apps/components/Button.js
@@ -3,7 +3,7 @@ import { createElement } from 'preact';
 
 /**
  * @typedef ButtonProps
- * @prop {Object} [buttonRef]
+ * @prop {any} [buttonRef]
  * @prop {string} [className]
  * @prop {boolean} [disabled]
  * @prop {string} label

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "sinon": "^9.2.1",
     "typescript": "^4.0.5"
   },
-  "browserslist": "chrome 55, edge 17, firefox 53, safari 10.1",
+  "browserslist": "chrome 57, edge 17, firefox 53, safari 10.1",
   "browserify": {
     "transform": [
       "babelify",


### PR DESCRIPTION
This is to match the bumped Chrome version in the client.

This set of changes also includes an unrelated fix to a type in the `Button` component to soothe CI grouchiness.