### PR TITLE
Fix broken make commands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ passenv =
     dev: USERNAME
     dev: VIA_URL
 deps =
+    dev: -e .
     dev: -r requirements/dev.txt
     {format,checkformatting}: -r requirements/format.txt
     lint: -r requirements/lint.txt


### PR DESCRIPTION
A handful of make commands are currently broken:

    $ make db
    make: *** [Makefile:32: db] Error 1

(the underlying error, silenced by `tox -qq`, is: `ERROR: InvocationError for command could not find executable initdb`)

    $ make devdata
    ERROR: InvocationError for command could not find executable devdata

    $ make shell
    ModuleNotFoundError: No module named 'lms'

The problem seems to be that the lms module and its console scripts aren't available in the tox env `dev`.

This seems to have been caused by this previous PR https://github.com/hypothesis/lms/pull/2112 that removed `-e .` from `requirements/dev.*` in order to work around this issue in pip-compile: https://github.com/jazzband/pip-tools/issues/204

Note that the comments on the pip-compile issue suggest replacing `-e .` with `-e file:.#egg=lms` instead of just removing it, but we tried that (https://github.com/hypothesis/lms/pull/2111/) and found that it broke Dependabot.

But it turns out that removing `-e .` breaks some of our make commands.

This commit attempts a different fix: put the `-e .` back so that the make commands are fixed again, but put it in the `tox.ini` file rather than in the requirements file so that `pip-compile` and Dependabot aren't confused by it.