### PR TITLE
Fix course copy in Blackboard

### DIFF
--- a/lms/views/predicates/__init__.py
+++ b/lms/views/predicates/__init__.py
@@ -7,24 +7,18 @@ https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#view-a
 """
 from lms.views.predicates._lti_launch import (
     AuthorizedToConfigureAssignments,
+    BlackboardCopied,
     CanvasFile,
     Configured,
     DBConfigured,
     URLConfigured,
 )
 
-__all__ = [
-    "DBConfigured",
-    "CanvasFile",
-    "URLConfigured",
-    "Configured",
-    "AuthorizedToConfigureAssignments",
-]
-
 
 def includeme(config):
     for view_predicate_factory in (
         DBConfigured,
+        BlackboardCopied,
         CanvasFile,
         URLConfigured,
         Configured,

--- a/tests/unit/lms/views/predicates/__init___test.py
+++ b/tests/unit/lms/views/predicates/__init___test.py
@@ -3,6 +3,7 @@ from unittest import mock
 from lms.views.predicates import includeme
 from lms.views.predicates._lti_launch import (
     AuthorizedToConfigureAssignments,
+    BlackboardCopied,
     CanvasFile,
     Configured,
     DBConfigured,
@@ -17,6 +18,7 @@ def test_includeme_adds_the_view_predicates():
 
     assert config.add_view_predicate.call_args_list == [
         mock.call("db_configured", DBConfigured),
+        mock.call("blackboard_copied", BlackboardCopied),
         mock.call("canvas_file", CanvasFile),
         mock.call("url_configured", URLConfigured),
         mock.call("configured", Configured),


### PR DESCRIPTION
Fixes [course copy in Blackboard](https://github.com/hypothesis/lms/issues/2261).

## Problem

When you copy a course in Blackboard, Blackboard copies all of the course's Hypothesis assignments but the new copies of the assignments all get new `resource_link_id`'s. Since the `resource_link_id` launch param is what we use to look up the assignment's settings (`ModuleItemConfiguration`) we fail to find the settings for the new copy of the assignment: to us it just looks like a brand new assignment, a new `resource_link_id` that we've never seen before. So we show the dialog asking to choose the document for the assignment.

## Solution

It turns out that Blackboard also includes an undocumented and non-standard launch param `resource_link_id_history`, which is the `resource_link_id` of the original assignment that this assignment was copied from. Look up the `resource_link_id_history`'s `ModuleItemConfiguration` in the DB and make a new copy of it with the new `resource_link_id`.

Note that the presence of a `resource_link_id_history` launch param doesn't guarantee that we will have a `ModuleItemConfiguration` for that `resource_link_id_history` in the DB. For example if you copy a course, and then don't launch the copied course's assignments, and then make a copy of the copy of the course, and launch that second copy's assignments, then we'll receive a launch request with both a `resource_link_id` and a `resource_link_id_history` that are both missing from our DB.

I didn't make any of the code in this PR Blackboard-specific: if it happens that any other LMS also sends the `resource_link_id_history` param then we may as well use it. (I don't think any other LMS's do support it though.)