### PR TITLE
Center and standardise the size of a few spinners

### DIFF
--- a/lms/static/styles/_variables.scss
+++ b/lms/static/styles/_variables.scss
@@ -37,3 +37,5 @@ $touch-input-font-size: 16px;
 
 // Accessibility.
 $touch-target-size: 44px;
+
+$spinner-size: 100px;

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,15 +1,15 @@
+@use "../variables" as var;
+
 .BasicLtiLaunchApp {
   height: 100%;
 }
 
 .BasicLtiLaunchApp__spinner {
-  $spinner-size: 50px;
-
   position: absolute;
-  width: $spinner-size;
-  height: $spinner-size;
-  left: calc(50% - #{$spinner-size / 2});
-  top: 100px;
+  width: var.$spinner-size;
+  height: var.$spinner-size;
+  left: calc(50% - #{var.$spinner-size / 2});
+  top: calc(50% - #{var.$spinner-size / 2});
 }
 
 .BasicLtiLaunchApp__content {

--- a/lms/static/styles/components/_FilePickerApp.scss
+++ b/lms/static/styles/components/_FilePickerApp.scss
@@ -1,3 +1,5 @@
+@use "../variables" as var;
+
 .FilePickerApp__form {
   max-width: 600px;
   margin-left: auto;
@@ -22,13 +24,11 @@
 }
 
 .FilePickerApp__loading-spinner {
-  $spinner-size: 100px;
-
   position: absolute;
-  width: $spinner-size;
-  height: $spinner-size;
-  left: calc(50% - #{$spinner-size});
-  top: calc(50% - #{$spinner-size});
+  width: var.$spinner-size;
+  height: var.$spinner-size;
+  left: calc(50% - #{var.$spinner-size / 2});
+  top: calc(50% - #{var.$spinner-size / 2});
 }
 
 .FilePickerApp__document-source-buttons {

--- a/lms/static/styles/components/_SubmitGradeForm.scss
+++ b/lms/static/styles/components/_SubmitGradeForm.scss
@@ -99,7 +99,7 @@
 }
 
 .SubmitGradeForm__submit-spinner {
-  @include mixins.spinner(100px);
+  @include mixins.spinner(var.$spinner-size);
 }
 
 .SubmitGradeForm__fetch-spinner {


### PR DESCRIPTION
Make 100px the size of the standard spinner.

One of them was not centered vertically.

Before:

![spinner-small](https://user-images.githubusercontent.com/8555781/100249256-a7853400-2f3c-11eb-93e7-121da011e4f6.gif)

After:
![spinner-big](https://user-images.githubusercontent.com/8555781/100249376-c5529900-2f3c-11eb-98eb-4a96e2b89be0.gif)
