### PR TITLE
Reduce layout shift after selecting PDF files

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Button.js
+++ b/lms/static/scripts/frontend_apps/components/Button.js
@@ -3,7 +3,7 @@ import { createElement } from 'preact';
 
 /**
  * @typedef ButtonProps
- * @prop {any} [buttonRef]
+ * @prop {import('preact').Ref<HTMLButtonElement>} [buttonRef]
  * @prop {string} [className]
  * @prop {boolean} [disabled]
  * @prop {string} label

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -20,8 +20,10 @@ import URLPicker from './URLPicker';
 /**
  * @typedef {import('../api-types').File} File
  *
+ * @typedef {'lms'|'url'|null} DialogType
+ *
  * @typedef FilePickerAppProps
- * @prop {'lms'|'url'|null} [defaultActiveDialog] -
+ * @prop {DialogType} [defaultActiveDialog] -
  *   The dialog that should be shown when the app is first opened.
  * @prop {() => any} [onSubmit] - Callback invoked when the form is submitted.
  */
@@ -93,18 +95,27 @@ export default function FilePickerApp({
    */
   const [shouldSubmit, submit] = useState(false);
 
-  const cancelDialog = () => setActiveDialog(null);
+  const cancelDialog = () => {
+    setLoadingIndicatorVisible(false);
+    setActiveDialog(null);
+  };
+
+  /** @param {DialogType} type */
+  const selectDialog = type => {
+    setLoadingIndicatorVisible(true);
+    setActiveDialog(type);
+  };
 
   /** @param {File} file */
   const selectLMSFile = file => {
-    setActiveDialog(null);
+    cancelDialog();
     setLmsFile(file);
     submit(true);
   };
 
   /** @param {string} url */
   const selectURL = url => {
-    setActiveDialog(null);
+    cancelDialog();
     setUrl(url);
     submit(true);
   };
@@ -194,13 +205,13 @@ export default function FilePickerApp({
           <Button
             className="FilePickerApp__source-button"
             label="Enter URL of web page or PDF"
-            onClick={() => setActiveDialog('url')}
+            onClick={() => selectDialog('url')}
           />
           {canvasEnabled && (
             <Button
               className="FilePickerApp__source-button"
               label={`Select PDF from Canvas`}
-              onClick={() => setActiveDialog('lms')}
+              onClick={() => selectDialog('lms')}
             />
           )}
           {googlePicker && (

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -122,12 +122,21 @@ describe('FilePickerApp', () => {
   it('shows URL selection dialog when "Enter URL" button is clicked', () => {
     const wrapper = renderFilePicker();
 
+    assert.isFalse(wrapper.find('.FilePickerApp__loading-backdrop').exists());
+
     const btn = wrapper.find('Button[label="Enter URL of web page or PDF"]');
     interact(wrapper, () => {
       btn.props().onClick();
     });
 
-    assert.isTrue(wrapper.exists('URLPicker'));
+    const urlPicker = wrapper.find('URLPicker');
+    assert.isTrue(urlPicker.exists());
+    assert.isTrue(wrapper.find('.FilePickerApp__loading-backdrop').exists());
+
+    interact(wrapper, () => {
+      urlPicker.props().onCancel();
+    });
+    assert.isFalse(wrapper.find('.FilePickerApp__loading-backdrop').exists());
   });
 
   it('submits a URL when a URL is selected', () => {
@@ -152,10 +161,14 @@ describe('FilePickerApp', () => {
   it('shows LMS file dialog when "Select PDF from Canvas" is clicked', () => {
     const wrapper = renderFilePicker();
 
+    assert.isFalse(wrapper.find('.FilePickerApp__loading-backdrop').exists());
+
     const btn = wrapper.find('Button[label="Select PDF from Canvas"]');
     interact(wrapper, () => {
       btn.props().onClick();
     });
+
+    assert.isTrue(wrapper.find('.FilePickerApp__loading-backdrop').exists());
 
     const filePicker = wrapper.find('LMSFilePicker');
     assert.isTrue(filePicker.exists());
@@ -164,6 +177,11 @@ describe('FilePickerApp', () => {
       filePicker.prop('listFilesApi'),
       fakeConfig.filePicker.canvas.listFiles
     );
+
+    interact(wrapper, () => {
+      filePicker.props().onCancel();
+    });
+    assert.isFalse(wrapper.find('.FilePickerApp__loading-backdrop').exists());
   });
 
   it('submits an LMS file when an LMS file is selected', () => {


### PR DESCRIPTION
After clicking on `Select PDF` button a number of different interfaces could render:
* full filepicker: files are fetched and displayed without problem
* empty filepicker: no associated files in the LMS for that curse
* authorization error
* other error

Previously, we optimistically displayed the filepicker, but if an error raised the layout was shifted quickly.

Based on [this conversation](https://app.slack.com/client/T03QZM0HN/C07NXBDNW/thread/C07NXBDNW-1605712544.110500), it was decided that :
* FilePickerApp will show the loading spinner when a button is clicked, and
* LMSFilePicker won't render while trying to fetch files.

This will prevent the LMSFilePicker component to re-render from one state from another.

This is an example screenshoot  of going through two consecutive authorization errors:

 ![Nov-27-2020 15-04-41](https://user-images.githubusercontent.com/8555781/100457292-0aec9e80-30c2-11eb-8ee0-6e3f04b46c7e.gif)


To test this PR, `files.py` can be patched to loop to display two error states, two empty file results and one non-empty result:

```diff
diff --git a/lms/views/api/canvas/files.py b/lms/views/api/canvas/files.py
index 2eb9c068..0efec11f 100644
--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -6,6 +6,9 @@ from lms.views import helpers
 
 @view_defaults(permission="api", renderer="json")
 class FilesAPIViews:
+
+    foo = 0
+
     def __init__(self, request):
         self.request = request
         self.canvas_api_client = request.find_service(name="canvas_api_client")
@@ -18,6 +21,18 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
+        import time
+
+        time.sleep(3)
+
+        if FilesAPIViews.foo < 2:
+            FilesAPIViews.foo += 1
+            return 0 / 0
+        elif FilesAPIViews.foo < 4:
+            FilesAPIViews.foo += 1
+            return []
+
+        FilesAPIViews.foo = 0
         return self.canvas_api_client.list_files(self.request.matchdict["course_id"])
 
     @view_config(request_method="GET", route_name="canvas_api.files.via_url")
``` 


Closes #2232 