### PR TITLE
Improve the behavior or grade fetch errors

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -23,6 +23,7 @@ import { useUniqueId } from '../utils/hooks';
  * @prop {() => any} [onCancel] -
  *   A callback to invoke when the user cancels the dialog. If provided, a
  *   "Cancel" button will be displayed.
+ * @prop {string} [cancelLabel] - Label for the cancel button
  */
 
 /**
@@ -54,6 +55,7 @@ export default function Dialog({
   contentClass,
   initialFocus,
   onCancel,
+  cancelLabel = 'Cancel',
   role = 'dialog',
   title,
   buttons,
@@ -132,7 +134,7 @@ export default function Dialog({
               <Button
                 className="Button--cancel"
                 onClick={onCancel}
-                label="Cancel"
+                label={cancelLabel}
               />
             )}
             {buttons}

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -8,6 +8,7 @@ import Dialog from './Dialog';
  * @prop {() => any} [onCancel]
  * @prop {string} title
  * @prop {import('./ErrorDisplay').ErrorLike} error
+ * @prop {string} [cancelLabel]
  */
 
 /**
@@ -16,12 +17,13 @@ import Dialog from './Dialog';
  *
  * @param {ErrorDialogProps} props
  */
-export default function ErrorDialog({ onCancel, title, error }) {
+export default function ErrorDialog({ onCancel, title, error, cancelLabel }) {
   return (
     <Dialog
       role="alertdialog"
       title="Something went wrong :("
       onCancel={onCancel}
+      cancelLabel={cancelLabel}
     >
       <ErrorDisplay message={title} error={error} />
     </Dialog>

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -66,6 +66,20 @@ describe('Dialog', () => {
     assert.called(onCancel);
   });
 
+  it(`defaults cancel button's label to "Cancel"`, () => {
+    const wrapper = mount(<Dialog onCancel={sinon.stub()} />);
+    wrapper.find('.Dialog__cancel-btn');
+    assert.equal(wrapper.find('Button').prop('label'), 'Cancel');
+  });
+
+  it('adds a custom label to the cancel button', () => {
+    const wrapper = mount(
+      <Dialog onCancel={sinon.stub()} cancelLabel="hello" />
+    );
+    wrapper.find('.Dialog__cancel-btn');
+    assert.equal(wrapper.find('Button').prop('label'), 'hello');
+  });
+
   describe('initial focus', () => {
     let container;
 

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -227,6 +227,13 @@ describe('SubmitGradeForm', () => {
       );
     });
 
+    it('shows the error dialog when the grade request throws an error', () => {
+      fakeFetchGrade.throws({ errorMessage: '' });
+      const wrapper = renderForm();
+      wrapper.find('button[type="submit"]').simulate('click');
+      assert.isTrue(wrapper.find('ErrorDialog').exists());
+    });
+
     it("sets the input defaultValue prop to the student's grade", async () => {
       const wrapper = renderForm();
       await waitFor(() => !isFetchingGrade(wrapper));


### PR DESCRIPTION
- Add a dialog that the alerts the user that an error has occurred when fetching a students grade.
- Kill off the grade loading spinner in the grade input field after an error.
- Add cancelLabel to ErrorDialog  / Dialog to override the button's label for more appropriate action naming.

-----

This is part of an effort to make the erros a bit more understandable from the customer's point of view to help our own triage efforts. We are seeing that GET requests to `api/lti/result?lis_result_sourcedid` failing in some customer environments. It's unclear why, but it was initially unclear what the problem was because failed GET requests were not handled in a reasonable way on the UI. It was previously assuming that such things were unlikely to fail. Since that is not the case, this simply adds the familiar error dialog when a GET request fails and kills off the loading spinner so the UI does not look like its still stuck.

To fake an error from a GET request, you can add

`if(data === undefined) {
     throw new ApiError(result.status, resultJson);
  }`

inside of `apiCall` in api.js

![error](https://user-images.githubusercontent.com/3939074/101553518-a48d3900-3969-11eb-8d84-b298cb4efc8d.gif)

https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=110

relates to https://github.com/hypothesis/support/issues/124