### PR TITLE
Add custom validation message to URLPicker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -31,8 +31,38 @@ describe('URLPicker', () => {
     wrapper.find('input').getDOMNode().value = 'https://example.com/foo';
 
     wrapper.find(Button).props().onClick(new Event('click'));
+    wrapper.update();
 
+    assert.isFalse(wrapper.find('ValidationMessage').exists());
     assert.calledWith(onSelectURL, 'https://example.com/foo');
+  });
+
+  it('shows the validation message if a URL is not entered', () => {
+    const onSelectURL = sinon.stub();
+
+    const wrapper = renderUrlPicker({ onSelectURL });
+    wrapper.find(Button).props().onClick(new Event('click'));
+    wrapper.update();
+
+    assert.isTrue(wrapper.find('ValidationMessage').exists());
+    assert.equal(wrapper.find('ValidationMessage').prop('open'), true);
+    assert.equal(
+      wrapper.find('ValidationMessage').prop('message'),
+      'A valid URL is required'
+    );
+  });
+
+  it('dismisses the validation message on user input', () => {
+    const onSelectURL = sinon.stub();
+
+    const wrapper = renderUrlPicker({ onSelectURL });
+    wrapper.find(Button).props().onClick(new Event('click'));
+    wrapper.update();
+    assert.isTrue(wrapper.find('ValidationMessage').exists());
+    assert.equal(wrapper.find('ValidationMessage').prop('open'), true);
+
+    wrapper.find('input[name="path"]').simulate('input');
+    assert.equal(wrapper.find('ValidationMessage').prop('open'), false);
   });
 
   it(

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -66,8 +66,6 @@
 
   .Button {
     @include focus.outline-on-keyboard-focus;
-    &:not(:first-child) {
-      margin-left: 5px;
-    }
+    margin-left: 5px;
   }
 }

--- a/lms/static/styles/components/_URLPicker.scss
+++ b/lms/static/styles/components/_URLPicker.scss
@@ -1,0 +1,39 @@
+@keyframes validationErrorOpen--url {
+  from {
+    width: 0;
+    opacity: 0;
+  }
+  to {
+    width: 200px;
+    opacity: 0.9;
+  }
+}
+
+@keyframes validationErrorClose--url {
+  from {
+    width: 200px;
+    opacity: 1;
+  }
+  to {
+    width: 0px;
+    opacity: 0;
+  }
+}
+.URLPicker {
+  &__buttons {
+    position: relative;
+  }
+  .ValidationMessage {
+    line-height: inherit;
+    height: 100%;
+    right: 73px;
+  }
+
+  .ValidationMessage--open {
+    animation-name: validationErrorOpen--url;
+  }
+
+  .ValidationMessage--closed {
+    animation-name: validationErrorClose--url;
+  }
+}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -24,6 +24,7 @@
 @use 'components/Table';
 @use 'components/ValidationMessage';
 @use 'components/SvgIcon';
+@use 'components/URLPicker';
 
 // Element styles
 @use 'variables' as var;


### PR DESCRIPTION
This matches our validation UI for the grader and brings constancy to the app.

-------

This is mostly a cosmetic change that came about from this work:
https://github.com/hypothesis/lms/pull/2288

This just removes the use of the native form popup error and instead replaces it with our own branded validation popup that matches the grader. (somewhat still experimental) 

Current:
![old](https://user-images.githubusercontent.com/3939074/101706056-2d28d980-3a3d-11eb-9536-17a8d6fdbcd9.gif)

Changed: (also shows new CSS of buttons in prev. PR)
![new](https://user-images.githubusercontent.com/3939074/101706061-2ef29d00-3a3d-11eb-8d55-d25b5bad9675.gif)

