### PR TITLE
Add Brightspace course copy support

### DIFF
--- a/lms/views/predicates/__init__.py
+++ b/lms/views/predicates/__init__.py
@@ -8,6 +8,7 @@ https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#view-a
 from lms.views.predicates._lti_launch import (
     AuthorizedToConfigureAssignments,
     BlackboardCopied,
+    BrightspaceCopied,
     CanvasFile,
     Configured,
     DBConfigured,
@@ -19,6 +20,7 @@ def includeme(config):
     for view_predicate_factory in (
         DBConfigured,
         BlackboardCopied,
+        BrightspaceCopied,
         CanvasFile,
         URLConfigured,
         Configured,

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -1,4 +1,6 @@
 """Predicates for use with LTI launch views."""
+from abc import ABC
+
 from lms.views.predicates._helpers import Base
 
 
@@ -42,39 +44,55 @@ class DBConfigured(Base):
         return has_document_url == self.value
 
 
-class BlackboardCopied(Base):
+class _CourseCopied(Base, ABC):
     """
-    Allow invoking an LTI launch view for newly course-copied Blackboard assignments.
+    Allow invoking an LTI launch view for newly course-copied assignments.
 
-    When a user uses Blackboard's Course Copy feature to copy a course that
-    contains Hypothesis assignments, Blackboard copies the Hypothesis
-    assignments into the new course. Blackboard gives new
-    resource_link_id's to the new copies of the assignments and includes
-    the original resource_link_id in a resource_link_id_history launch
-    param.
+    When a user uses an LMS's Course Copy feature to copy a course that
+    contains Hypothesis assignments, most (all?) LMS's copy the Hypothesis
+    assignments into the new course and give the new copies of the assignments
+    new resource_link_id's.
 
-    Pass blackboard_copied=True to a view's configuration to allow invoking the
-    view only for newly course-copied Blackboard assignments where we don't yet
-    have a document_url for the new resource_link_id but we do have a
-    document_url for the resource_link_id_history.
+    Some LMS's then give us the resource_link_id of the original assignment as
+    well, so that we can find the assignment settings (ModuleItemConfiguration)
+    in our DB when the new assignment is launched.
 
-    For example:
-
-        @view_config(..., blackboard_copied=True)
-        def blackboard_course_copied_assignment_launch_view(context, request):
-            ...
-
-    resource_link_id_history is a non-standard and undocumented param
-    that's only used by Blackboard as far as we know, but nothing in this
-    code actually prevents us from using resource_link_id_history if
-    another LMS sends it to us.
+    Subclasses of this predicate allow invoking views only for newly
+    course-copied assignments where we don't yet have a document_url for the
+    new resource_link_id but we do have a document_url for the original
+    assignment resource_link_id.
     """
-
-    name = "blackboard_copied"
 
     def __init__(self, value, config):
         super().__init__(value, config)
         self.db_configured = DBConfigured(True, config)
+
+    @property
+    def param_name(self):
+        """
+        Return the name of the launch param for the original resource_link_id.
+
+        The name of the launch param that contains the resource_link_id of the
+        original assignment that this assignment was copied from. The default
+        implementation of get_original_resource_link_id() below uses this.
+        """
+        raise NotImplementedError()  # pragma: nocover
+
+    @classmethod
+    def get_original_resource_link_id(cls, request):
+        """
+        Return the original resource_link_id.
+
+        Return the resource_link_id of the original assignment that this
+        assignment was copied from.
+
+        The default implementation uses the self.param_name property (which
+        must be provided by subclasses) to retrieve a launch param.
+        If the original resource_link_id can't simply be read from a launch
+        param then subclasses should override get_original_resource_link_id()
+        instead of overriding param_name().
+        """
+        return request.params.get(cls.param_name)
 
     def __call__(self, context, request):
         if self.db_configured(context, request):
@@ -82,23 +100,63 @@ class BlackboardCopied(Base):
             # so it's not a newly copied assignment.
             is_newly_copied = False
         else:
-            resource_link_id_history = request.params.get("resource_link_id_history")
+            original_resource_link_id = self.get_original_resource_link_id(request)
             tool_consumer_instance_guid = request.params.get(
                 "tool_consumer_instance_guid"
             )
 
-            if not resource_link_id_history or not tool_consumer_instance_guid:
+            if not original_resource_link_id or not tool_consumer_instance_guid:
                 is_newly_copied = False
             else:
                 # Look for the document URL of the previous assignment that
                 # this one was copied from.
                 assignment_service = request.find_service(name="assignment")
                 previous_document_url = assignment_service.get_document_url(
-                    tool_consumer_instance_guid, resource_link_id_history
+                    tool_consumer_instance_guid, original_resource_link_id
                 )
                 is_newly_copied = bool(previous_document_url)
 
         return is_newly_copied == self.value
+
+
+class BlackboardCopied(_CourseCopied):
+    """
+    Allow invoking an LTI launch view for newly course-copied Blackboard assignments.
+
+    For example:
+
+        @view_config(..., blackboard_copied=True)
+        def blackboard_course_copied_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "blackboard_copied"
+
+    # resource_link_id_history is a non-standard and undocument that's only
+    # used by Blackboard as far as we know, but nothing in our code actually
+    # prevents us from using resource_link_id_history if another LMS sends it
+    # to us.
+    param_name = "resource_link_id_history"
+
+
+class BrightspaceCopied(_CourseCopied):
+    """
+    Allow invoking an LTI launch view for newly course-copied Brightspace assignments.
+
+    For example:
+
+        @view_config(..., brightspace_copied=True)
+        def brightspace_course_copied_assignment_launch_view(context, request):
+            ...
+    """
+
+    name = "brightspace_copied"
+
+    # ext_d2l_resource_link_id_history is a non-standard and undocumented param
+    # that's only used by Brightspace, but nothing in this code actually
+    # prevents us from using ext_d2l_resource_link_id_history if another LMS
+    # sends it to us.
+    param_name = "ext_d2l_resource_link_id_history"
 
 
 class CanvasFile(Base):
@@ -174,6 +232,7 @@ class Configured(Base):
         self.url_configured = URLConfigured(True, config)
         self.db_configured = DBConfigured(True, config)
         self.blackboard_copied = BlackboardCopied(True, config)
+        self.brightspace_copied = BrightspaceCopied(True, config)
 
     def __call__(self, context, request):
         configured = any(
@@ -182,6 +241,7 @@ class Configured(Base):
                 self.url_configured(context, request),
                 self.db_configured(context, request),
                 self.blackboard_copied(context, request),
+                self.brightspace_copied(context, request),
             ]
         )
         return configured == self.value

--- a/tests/unit/lms/views/predicates/__init___test.py
+++ b/tests/unit/lms/views/predicates/__init___test.py
@@ -4,6 +4,7 @@ from lms.views.predicates import includeme
 from lms.views.predicates._lti_launch import (
     AuthorizedToConfigureAssignments,
     BlackboardCopied,
+    BrightspaceCopied,
     CanvasFile,
     Configured,
     DBConfigured,
@@ -19,6 +20,7 @@ def test_includeme_adds_the_view_predicates():
     assert config.add_view_predicate.call_args_list == [
         mock.call("db_configured", DBConfigured),
         mock.call("blackboard_copied", BlackboardCopied),
+        mock.call("brightspace_copied", BrightspaceCopied),
         mock.call("canvas_file", CanvasFile),
         mock.call("url_configured", URLConfigured),
         mock.call("configured", Configured),


### PR DESCRIPTION
Add Brightspace course copy support. Fixes https://github.com/hypothesis/lms/issues/2282

Course copy works exactly the same in Brightspace as it does in Blackboard: the copied assignments get a new `resource_link_id` so we can't find their settings in our DB, but the original `resource_link_id` is supplied in an additional launch param. In Blackboard this additional launch param is called `resource_link_id_history`, in Brightspace it's `ext_d2l_resource_link_id_history`.

There's some work in this PR to make previously Blackboard-specific code generic. The actual amount of new code we'd have to add if we came across a third LMS that worked in a new way (but with a third param name) is pretty minimal / the amount of Blackboard or Brightspace-specific code is pretty minimal. It's roughly this:

```python
# views/basic_lti_launch.py:

@view_config(blackboard_copied=True)
def blackboard_copied_basic_lti_launch(self):
    return self.course_copied_basic_lti_launch(BlackboardCopied.get_original_resource_link_id(self.request))

@view_config(brightspace_copied=True)
def brightspace_copied_basic_lti_launch(self):
    return self.course_copied_basic_lti_launch(BrightspaceCopied.get_original_resource_link_id(self.request))

# predicates/_lti_launch.py:

class BlackboardCopied(_CourseCopied):
    name = "blackboard_copied"
    param_name = "resource_link_id_history"

class BrightspaceCopied(_CourseCopied):
    name = "brightspace_copied"
    param_name = "ext_d2l_resource_link_id_history"
```

So far the original `resource_link_id` can always be found by just reading another launch param, and only the name of the param changes. But the above code design should extend to other LMS's that need to look up the original launch param in another way. For example:

```python
# views/basic_lti_launch.py:

@view_config(moodle_copied=True)
def moodle_copied_basic_lti_launch(self):
    # Since we have a separate *_copied_basic_lti_launch() view for each LMS we
    # _could_ do other Moodle-specific stuff here if it were necessary.

    return self.course_copied_basic_lti_launch(MoodleCopied.get_original_resource_link_id(self.request))

# predicates/_lti_launch.py:

class MoodleCopied(_CourseCopied):
    name = "moodle_copied"

    @staticmethod
    def get_original_resource_link_id(request):
        moodle_api_svc = request.find_service(name="moodle_api")
        return moodle_api_svc.get_original_resource_link_id(request)
```

### Longer-term code design

Each view and corresponding view predicate are closely related. I think a code reorganization that gets them into the same files might be an improvement. This'd be a lot more work and raise all sorts of questions so I haven't tackled it yet.

```
lms/
  views/
    basic_lti_launch/
      _base.py:
        class BasicLTILaunchViewBaseClass:
            ...

      blackboard.py:
        class BlackboardCopiedViewPredicate:
            ...

        class BlackboardBasicLTILaunchView(BasicLTILaunchViewBaseClass):
            @view_config(blackboard_copied=True)
            def blackboard_copied_basic_lti_launch(self):
                ...

      brightspace.py:
        class BrightspaceCopiedViewPredicate:
            ...

        class BrightspaceBasicLTILaunchView(BasicLTILaunchViewBaseClass):
            @view_config(brightspace_copied=True)
            def brightspace_copied_basic_lti_launch(self):
                ...
```