### PR TITLE
Add temporary logging to help debug XML error

### DIFF
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -122,7 +122,11 @@ class LTIOutcomesClient:
                 "Unable to parse XML response from LTI Outcomes service", response
             ) from err
 
-        return self._get_body(data)
+        try:
+            return self._get_body(data)
+        except LTIOutcomesAPIError as err:
+            err.response = response
+            raise
 
     @classmethod
     def _get_body(cls, data):


### PR DESCRIPTION
Add logging to help see the XML response from customer's LMS that may be potentially causing the issue related to "Malformed LTI outcome response"

-------

The goal here is to see the XML response (as a dict) of the customer's LMS when requesting a grade. 
relates to https://github.com/hypothesis/support/issues/124
