### PR TITLE
Prevent error support text from having scroll bars

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -94,7 +94,7 @@ export default function ErrorDisplay({ message, error }) {
           )}
         </p>
       )}
-      <p>
+      <p className="ErrorDisplay__links">
         If the problem persists,{' '}
         <a href={supportLink} target="_blank" rel="noopener noreferrer">
           send us an email

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -9,6 +9,11 @@
   padding-right: 5px;
   margin-bottom: 10px;
 
+  &__links {
+    white-space: normal;
+    line-height: 1.25em;
+  }
+
   &__details {
     padding: 4px; // prevents focus ring from getting cut off
     &-summary {


### PR DESCRIPTION
Allow long text that details how to open a support ticket to wrap in small dialogs rather than displaying a horizontal scrollbar

![Screen Shot 2020-12-18 at 1 03 36 PM](https://user-images.githubusercontent.com/3939074/102661916-9a6df600-4132-11eb-95ab-8e392bff0bcc.png)