### PR TITLE
Add CanvasFile model

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,5 +1,6 @@
 from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
+from lms.models.canvas_file import CanvasFile
 from lms.models.course import Course
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
 from lms.models.grading_info import GradingInfo

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -45,6 +45,11 @@ class ApplicationInstance(BASE):
         "OAuth2Token", back_populates="application_instance"
     )
 
+    #: A list of all the Canvas files for this application instance.
+    canvas_files = sa.orm.relationship(
+        "CanvasFile", back_populates="application_instance"
+    )
+
     #: A list of all the courses for this application instance.
     courses = sa.orm.relationship("Course", back_populates="application_instance")
 

--- a/lms/models/canvas_file.py
+++ b/lms/models/canvas_file.py
@@ -1,0 +1,44 @@
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.ext.mutable import MutableList
+
+from lms.db import BASE
+
+
+class CanvasFile(BASE):
+    """
+    A file that we've seen in a response from the Canvas Files API.
+
+    https://canvas.instructure.com/doc/api/files.html
+    """
+
+    __tablename__ = "canvas_file"
+    __table_args__ = (
+        sa.UniqueConstraint("consumer_key", "tool_consumer_instance_guid", "file_id"),
+    )
+
+    id = sa.Column(sa.Integer, primary_key=True)
+
+    consumer_key = sa.Column(
+        sa.String,
+        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
+        nullable=False,
+    )
+    tool_consumer_instance_guid = sa.Column(sa.UnicodeText, nullable=False)
+    file_id = sa.Column(sa.Integer, nullable=False)
+
+    course_id = sa.Column(sa.Integer, nullable=False)
+    filename = sa.Column(sa.UnicodeText, nullable=False)
+    size = sa.Column(sa.Integer, nullable=False)
+
+    # The file_id's of other Canvas files, in other courses, that we know this
+    # file was directly or indirectly copied from.
+    file_id_history = sa.Column(
+        MutableList.as_mutable(ARRAY(sa.Integer)),
+        server_default="{}",
+        nullable=False,
+    )
+
+    application_instance = sa.orm.relationship(
+        "ApplicationInstance", back_populates="canvas_files"
+    )


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/2322

### Generic vs Canvas-specific

It's likely that different types of file (Canvas files, Blackboard files, ...) have some fields in common or similar. But I think we should just add a `models.CanvasFile` (`canvas_file` DB table) rather than trying to implement something generic:

* We don't actually have support for any other file storage backends yet (e.g. Blackboard, Moodle), other than Google Drive. 
* Even if/when we add Blackboard files support, the proof-of-concept for that did not require storing records of those files in the DB (we need to store records of Canvas files in the DB for very Canvas-specific reasons to do with fixing course-copied Canvas files assignments).
* The Blackboard API is absurdly difficult to get started with. Our Blackboard test site has had its DB wiped since I did my Blackboard files proof of concept and I can't get the API access working in order to see what Blackboard files look like and how they compare to Canvas ones. Let's not let Blackboard get in the way of this Canvas work.
* We can save time now by not trying to design a generic model
* There's not much reason to think that spending the time to design a generic model now will save us time in future: we don't know if we'll ever want a generic model in the future, and we don't know what we'll want to store in it if it does turn out that we want one. A generic model that we designed now would most likely turn out to be wrong when it comes to storing a new type of file in it
* When it comes to storing another type of file in the DB, we don't know that we'll want a generic table. We may prefer separate `canvas_file` and `blackboard_file` tables
* If we _do_ later want a generic table, we can migrate the `canvas_file` table at that time. Add the new generic table and a DB migration to copy the `canvas_file` table into it and then delete the `canvas_file` table, etc. This is a bunch of work, but it's better to do the work then, when we know what we actually want to store in the table, rather than trying to do it now and getting it wrong. Also we might never need to do it
* I'm keen to avoid SQL schema design anti-patterns such as storing multiple values in a single column or [unnecessary JSON](https://www.2ndquadrant.com/en/blog/postgresql-anti-patterns-unnecessary-jsonhstore-dynamic-columns/) etc