### PR TITLE
Record Canvas files in the DB

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -48,3 +48,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.assignment.factory", name="assignment"
     )
+    config.register_service_factory(
+        "lms.services.canvas_files.factory", name="canvas_files"
+    )

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -26,4 +26,6 @@ def canvas_api_client_factory(_context, request):
         redirect_uri=request.route_url("canvas_api.oauth.callback"),
     )
 
-    return CanvasAPIClient(authenticated_api)
+    return CanvasAPIClient(
+        authenticated_api, request.find_service(name="canvas_files"), request.lti_user
+    )

--- a/lms/services/canvas_files.py
+++ b/lms/services/canvas_files.py
@@ -1,0 +1,30 @@
+from lms.models import CanvasFile
+
+
+class CanvasFilesService:
+    """Methods for working with the models.CanvasFile DB model."""
+
+    def __init__(self, db):
+        self._db = db
+
+    def upsert(self, canvas_file):
+        existing_file = (
+            self._db.query(CanvasFile)
+            .filter_by(
+                consumer_key=canvas_file.consumer_key,
+                tool_consumer_instance_guid=canvas_file.tool_consumer_instance_guid,
+                course_id=canvas_file.course_id,
+                file_id=canvas_file.file_id,
+            )
+            .one_or_none()
+        )
+
+        if existing_file:
+            existing_file.filename = canvas_file.filename
+            existing_file.size = canvas_file.size
+        else:
+            self._db.add(canvas_file)
+
+
+def factory(_context, request):
+    return CanvasFilesService(request.db)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -15,6 +15,7 @@ from tests.factories.attributes import (
     TOOL_CONSUMER_INSTANCE_GUID,
     USER_ID,
 )
+from tests.factories.canvas_file import CanvasFile
 from tests.factories.course import Course
 from tests.factories.grading_info import GradingInfo
 from tests.factories.h_group import HGroup

--- a/tests/factories/canvas_file.py
+++ b/tests/factories/canvas_file.py
@@ -1,0 +1,17 @@
+from factory import Faker, SubFactory, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories import ApplicationInstance
+from tests.factories.attributes import TOOL_CONSUMER_INSTANCE_GUID
+
+CanvasFile = make_factory(
+    models.CanvasFile,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    application_instance=SubFactory(ApplicationInstance),
+    tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
+    file_id=Faker("random_int"),
+    course_id=Faker("random_int"),
+    filename=Faker("file_name", extension="pdf"),
+    size=Faker("random_int"),
+)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,6 +11,7 @@ from lms.models import ApplicationSettings
 from lms.services.application_instance_getter import ApplicationInstanceGetter
 from lms.services.assignment import AssignmentService
 from lms.services.canvas_api import CanvasAPIClient
+from lms.services.canvas_files import CanvasFilesService
 from lms.services.course import CourseService
 from lms.services.grading_info import GradingInfoService
 from lms.services.group_info import GroupInfoService
@@ -190,6 +191,15 @@ def canvas_api_client(pyramid_config):
     )
     pyramid_config.register_service(canvas_api_client, name="canvas_api_client")
     return canvas_api_client
+
+
+@pytest.fixture
+def canvas_files_service(pyramid_config):
+    canvas_files_service = mock.create_autospec(
+        CanvasFilesService, spec_set=True, instance=True
+    )
+    pyramid_config.register_service(canvas_files_service, name="canvas_files")
+    return canvas_files_service
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -4,16 +4,26 @@ import pytest
 
 from lms.services.canvas_api.factory import canvas_api_client_factory
 
-pytestmark = pytest.mark.usefixtures("ai_getter", "oauth2_token_service")
+pytestmark = pytest.mark.usefixtures(
+    "ai_getter", "oauth2_token_service", "canvas_files_service"
+)
 
 
 class TestCanvasAPIClientFactory:
     def test_building_the_CanvasAPIClient(
-        self, pyramid_request, CanvasAPIClient, AuthenticatedClient
+        self,
+        canvas_files_service,
+        pyramid_request,
+        CanvasAPIClient,
+        AuthenticatedClient,
     ):
         canvas_api = canvas_api_client_factory(sentinel.context, pyramid_request)
 
-        CanvasAPIClient.assert_called_once_with(AuthenticatedClient.return_value)
+        CanvasAPIClient.assert_called_once_with(
+            AuthenticatedClient.return_value,
+            canvas_files_service,
+            pyramid_request.lti_user,
+        )
         assert canvas_api == CanvasAPIClient.return_value
 
     def test_building_the_BasicClient(self, pyramid_request, BasicClient, ai_getter):

--- a/tests/unit/lms/services/canvas_files_test.py
+++ b/tests/unit/lms/services/canvas_files_test.py
@@ -1,0 +1,57 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.models import CanvasFile
+from lms.services.canvas_files import factory
+from tests import factories
+
+
+class TestUpsert:
+    def test_if_theres_no_record_in_the_db_it_adds_one(self, db_session, svc):
+        canvas_file = factories.CanvasFile.build()
+
+        svc.upsert(canvas_file)
+
+        assert (
+            db_session.query(CanvasFile)
+            .filter_by(
+                consumer_key=canvas_file.application_instance.consumer_key,
+                tool_consumer_instance_guid=canvas_file.tool_consumer_instance_guid,
+                course_id=canvas_file.course_id,
+                file_id=canvas_file.file_id,
+                filename=canvas_file.filename,
+                size=canvas_file.size,
+            )
+            .one_or_none()
+        )
+
+    def test_if_theres_a_record_in_the_db_it_updates_it(self, db_session, svc):
+        existing_file = factories.CanvasFile()
+        new_file = factories.CanvasFile.build(
+            consumer_key=existing_file.application_instance.consumer_key,
+            tool_consumer_instance_guid=existing_file.tool_consumer_instance_guid,
+            course_id=existing_file.course_id,
+            file_id=existing_file.file_id,
+            filename="NEW" + existing_file.filename,
+        )
+
+        svc.upsert(new_file)
+
+        assert (
+            db_session.query(CanvasFile)
+            .filter_by(
+                consumer_key=new_file.consumer_key,
+                tool_consumer_instance_guid=new_file.tool_consumer_instance_guid,
+                course_id=new_file.course_id,
+                file_id=new_file.file_id,
+                filename=new_file.filename,
+                size=new_file.size,
+            )
+            .one_or_none()
+        )
+
+
+@pytest.fixture
+def svc(pyramid_request):
+    return factory(sentinel.context, pyramid_request)


### PR DESCRIPTION
Depends on: https://github.com/hypothesis/lms/pull/2323, https://github.com/hypothesis/lms/pull/2327

Save records of the Canvas files that we've seen in our DB, whenever we receive data about files from the Canvas API