### PR TITLE
Make error dialogs more consistent

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -21,7 +21,7 @@ export default function ErrorDialog({ onCancel, title, error, cancelLabel }) {
   return (
     <Dialog
       role="alertdialog"
-      title="Something went wrong :("
+      title="Something went wrong"
       onCancel={onCancel}
       cancelLabel={cancelLabel}
     >

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -219,7 +219,9 @@ export default function SubmitGradeForm({ student }) {
       </button>
       {!!submitGradeError && (
         <ErrorDialog
-          title="Submit Grade Error"
+          title={`There was a problem submitting ${
+            student ? student.displayName : ' the student'
+          }'s grade.`}
           error={{ message: submitGradeError }}
           onCancel={() => {
             setSubmitGradeError('');
@@ -229,7 +231,9 @@ export default function SubmitGradeForm({ student }) {
       )}
       {!!fetchGradeError && (
         <ErrorDialog
-          title="Fetch Grade Error"
+          title={`There was a problem fetching ${
+            student ? student.displayName : ' the student'
+          }'s grade.`}
           error={{ message: submitGradeError }}
           onCancel={() => {
             setFetchGradeError('');

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,3 +1,4 @@
+@use "../mixins";
 @use "../mixins/focus";
 @use "../variables" as var;
 
@@ -21,6 +22,7 @@
 }
 
 .Dialog__content {
+  @include mixins.font-normal;
   display: flex;
   flex-direction: column;
   max-height: 90vh;
@@ -48,7 +50,7 @@
   // enough to see easily and aligned with the right edge of the dialog.
   // Add negative margins so that the button does not force the dialog to
   // grow in height.
-  font-size: 20px;
+  font-size: var.$title-font-size;
   padding: 5px;
   margin: -10px 0px;
 

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -11,7 +11,6 @@
 
   &__links {
     white-space: normal;
-    line-height: 1.25em;
   }
 
   &__details {

--- a/lms/static/styles/components/_LMSGrader.scss
+++ b/lms/static/styles/components/_LMSGrader.scss
@@ -3,11 +3,10 @@
 .LMSGrader {
   display: flex;
   flex-direction: column;
-  font-size: 16px;
+  font-size: var.$input-font-size;
   height: 100%;
   width: 100%;
   position: fixed;
-  color: var.$grey-6;
 }
 
 .LMSGrader__grading-components {
@@ -39,12 +38,12 @@
 }
 
 .LMSGrader__assignment {
-  font-size: 18px;
+  font-size: var.$title-font-size;
   margin: 0 0 10px 0;
 }
 
 .LMSGrader__name {
-  font-size: 16px;
+  font-size: var.$subtitle-font-size;
   margin: 0;
 }
 

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -32,4 +32,5 @@ body {
   font-family: var.$sans-font-family;
   font-size: var.$normal-font-size;
   line-height: var.$normal-line-height;
+  color: var.$grey-7;
 }


### PR DESCRIPTION
Set font size for Dialog content
Do not override font color in LMSGrader
Add default font color to body (grey-7)
Use standard font sizes for LMSGrader
Fixup Dialog title text


-----------

fixes https://github.com/hypothesis/lms/issues/2320


dialogs now look a lot more similar. The main issue here was that the LMSGrader was overriding some of the default styling that dialogs were taking on when spawned from the app root (BasicLtiLauchApp)

A few things are done here. I moved the default color to the body, so now everything is dark grey. Previously, all the error dialogs seen from BasicLtiLauchApp were colored black which is not ideal. Now everything is off-black (better). Then I removed the color override from LMSGrader which was causing the major differences we were seeing. Additionally I forced the Dialog to set its own font size and then finally I removed some of the hard-coded px font sizes in the Grader. In some cases fonts few by 1px and in other they shrank, but this is  pretty insignificant. 

![Screen Shot 2020-12-22 at 12 16 01 PM](https://user-images.githubusercontent.com/3939074/102930047-96064d80-4450-11eb-999c-be331aab9c90.png)

![Screen Shot 2020-12-22 at 12 19 12 PM](https://user-images.githubusercontent.com/3939074/102930051-969ee400-4450-11eb-880f-1fc9f804f174.png)

