### PR TITLE
Implement CanvasFile polymorphic model

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -55,15 +55,6 @@ class BaseClass:
             if key in data:
                 setattr(self, key, data[key])
 
-    def __repr__(self):
-        return "{class_}({kwargs})".format(
-            class_=self.__class__.__name__,
-            kwargs=", ".join(
-                f"{kwarg}={repr(getattr(self, kwarg))}"
-                for kwarg in self.__table__.columns.keys()  # pylint:disable=no-member
-            ),
-        )
-
 
 BASE = declarative_base(
     # Create a default metadata object with naming conventions for indexes and

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,6 +1,7 @@
 from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
 from lms.models.canvas_file import CanvasFile
+from lms.models.canvas_file import CanvasFileOverride
 from lms.models.course import Course
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
 from lms.models.grading_info import GradingInfo

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -47,7 +47,7 @@ class ApplicationInstance(BASE):
 
     #: A list of all the Canvas files for this application instance.
     canvas_files = sa.orm.relationship(
-        "CanvasFile", back_populates="application_instance"
+        "CanvasFileBase", back_populates="application_instance"
     )
 
     #: A list of all the courses for this application instance.


### PR DESCRIPTION
TODO:

* Either make the `type` column an enum or get rid of it and use the
  `file_id_override` column (whether it's NULL or not) as the
  polymorphic_on switch

* Make file_id_override a foreign key to file_id (or to id, since
  file_id isn't a primary key or unique) with ondelete=cascade
  (this is known as an "adjacency list" pattern

Known issues:

* There's nothing at the model level to stop file_id_override from
  pointing to another CanvasFileOverride rather than to a CanvasFile or
  to prevent loops (circular references)