### PR TITLE
Improve the CanvasFile model with a lookup table

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,6 +1,6 @@
 from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
-from lms.models.canvas_file import CanvasFile
+from lms.models.canvas_file import CanvasFile, CanvasFileLookup
 from lms.models.course import Course
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
 from lms.models.grading_info import GradingInfo

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -45,9 +45,13 @@ class ApplicationInstance(BASE):
         "OAuth2Token", back_populates="application_instance"
     )
 
-    #: A list of all the Canvas files for this application instance.
+    #: A list of all the CanvasFiles for this application instance.
     canvas_files = sa.orm.relationship(
         "CanvasFile", back_populates="application_instance"
+    )
+    #: A list of all the CanvasFileLookups for this application instance.
+    canvas_file_lookups = sa.orm.relationship(
+        "CanvasFileLookup", back_populates="application_instance"
     )
 
     #: A list of all the courses for this application instance.

--- a/lms/models/canvas_file.py
+++ b/lms/models/canvas_file.py
@@ -31,14 +31,40 @@ class CanvasFile(BASE):
     filename = sa.Column(sa.UnicodeText, nullable=False)
     size = sa.Column(sa.Integer, nullable=False)
 
-    # The file_id's of other Canvas files, in other courses, that we know this
-    # file was directly or indirectly copied from.
-    file_id_history = sa.Column(
-        MutableList.as_mutable(ARRAY(sa.Integer)),
-        server_default="{}",
+    application_instance = sa.orm.relationship(
+        "ApplicationInstance", back_populates="canvas_files"
+    )
+    lookups = sa.orm.relationship("CanvasFileLookup", back_populates="canvas_file")
+
+
+class CanvasFileLookup(BASE):
+    """A table for looking up rows in the canvas_file table above."""
+
+    __tablename__ = "canvas_file_lookup"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "consumer_key", "tool_consumer_instance_guid", "course_id", "file_id"
+        ),
+    )
+
+    id = sa.Column(sa.Integer, primary_key=True)
+
+    consumer_key = sa.Column(
+        sa.String,
+        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
+        nullable=False,
+    )
+    tool_consumer_instance_guid = sa.Column(sa.UnicodeText, nullable=False)
+    course_id = sa.Column(sa.Integer, nullable=False)
+    file_id = sa.Column(sa.Integer, nullable=False)
+
+    canvas_file_id = sa.Column(
+        sa.Integer,
+        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
         nullable=False,
     )
 
     application_instance = sa.orm.relationship(
         "ApplicationInstance", back_populates="canvas_files"
     )
+    canvas_file = sa.orm.relationship("CanvasFile", back_populates="lookups")


### PR DESCRIPTION
Improves the `CanvasFile` model (https://github.com/hypothesis/lms/pull/2323) by adding a separate `CanvasFileLookup` table.

## Problem

The `CanvasFile` model proposed in https://github.com/hypothesis/lms/pull/2323 has both `file_id` and `file_id_override` columns on a single DB table.

When we receive a file from the Canvas API, we might insert a row like this into the DB:

| tool_consumer_instance_guid  | consumer_key | file_id | course_id | filename | size | file_id_override |
| - | - | - | - | - | - | - |
| "tcig" | "ck" | 1 | A | "foo.pdf" | 1024 | NULL |

Let's say we receive an assignment launch with file ID `1` and course ID `B`. File `1` isn't in course `B`, it's in course `A`. But let's say we find another file -- file `3` -- that **is** in course `B` and that has the same filename and size as file `1`. Then we'd insert another row like this:

| tool_consumer_instance_guid  | consumer_key | file_id | course_id | filename | size | file_id_override |
| - | - | - | - | - | - | - |
| "tcig" | "ck" | 1 | B | NULL | NULL | 3 |

This row tells the application that if it receives an assignment launch with file ID `1` and course ID `B` then it should use file ID `3` instead.

This approach has some benefits:

1. It's simple. Which is why it might ultimately be preferable over the alternative approach proposed in _this_ PR, if we're willing to ignore its problems

2. Because there can be a unique constraint on `(tool_consumer_instance_guid, consumer_key, file_id, course_id)`, **the same file ID can never appear twice in the same course**. This is important because when we receive an assignment launch we can look up the `CanvasFile` with the given `tool_consumer_instance_guid`, `consumer_key`, `file_id` and `course_id` from the launch params and we know we'll find either a single `CanvasFile` or `None`. (And if we do find a `CanvasFile` it will either be an override row, in which case we might have to look up the original row if we need any of the info from it, or it will already be the original row.)

While this approach does work, it has some problems:

* We're storing two types of object in a single DB table:

  1. Canvas files: these have a `filename` and `size` but never a `file_id_override`
  2. Overrides: these have a `file_id_override` but nothing in the `filename` or `size` columns

  This isn't necessarily a problem. I think we can use Postgres check constraints to enforce that if `file_id_override` is `NULL` then `filename` and `size` must not be `NULL` and if `file_id_override` is not `NULL` then `filename` and `size` must be `NULL`. 

  And we can also use SQLAlchemy's "single-table inheritance" / polymorphism feature to have separate model classes `CanvasFile` (with `filename` and `size` attrs but no `file_id_override`) and `CanvasFileOverride` (with a `file_id_override` attr but no `filename` or `size`) that share the same underlying DB table. See https://github.com/hypothesis/lms/pull/2332 for a very rough implementation of this polymorphism.

* A `file_id_override` can point to a row with a different `tool_consumer_instance_guid` and/or `consumer_key`, which makes no sense.

  I think this can be fixed by replacing the `file_id_override` column with four columns `tool_consumer_instance_guid_override`, `consumer_key_override`, `file_id_override` and `course_id_override` that form a composite foreign key to another row in the same table.

* A `file_id_override` can refer to another override row.

  We can make `file_id_override` be a foreign key to another row in the same table, so that a `file_id_override` must always point to a `file_id` that actually does exist elsewhere in the table. And we can use `ON DELETE CASCADE`. But how can we prevent a `file_id_override` from pointing to another override row, which makes no sense? And how can we prevent self-referential cycles?

  I think this might be fixable with some changes to the model, but by the time you've made the necessary changes the table has gotten pretty wild, and the solution has lost the simplicity that is its main benefit:

  * Replace the single `file_id_override` column with four columns `tool_consumer_instance_guid_override`, `consumer_key_override`, `file_id_override` and `course_id_override`
  * Add check constraints that if any one of the `*_override` columns is `NULL` then all four must be and vice-versa
  * Add check constrains that if the `*_override` columns are not `NULL` then the `tool_consumer_instance_guid`, `consumer_key`, `file_id` and `course_id` columns must be `NULL` and vice-versa
  * When querying the table we'd now need to use self-joins

## Solution

This PR proposes an alternative model that avoids the downsides.

### Inserting files into the DB

When we receive a file from the Canvas API we'll insert two rows into two different tables:

1. We'll insert a row like this into the `canvas_file` table:

   | consumer_key | tool_consumer_instance_guid | file_id | filename | size |
   | - | - | - | - | - |
   | "ck" | "tcig" | 1 | "foo.pdf" | 1024 |

2. Notice that the `canvas_file` row does not record which course the file belongs to: there's no `course_id` column. For that we'll insert a second row into the `canvas_file_lookup_table`:

   | consumer_key | tool_consumer_instance_guid | file_id | course_id | use_file_id |
   | - | - | - | - | - |
   | "ck" | "tcig" | 1 | A | 1 |

   The `consumer_key`, `tool_consumer_instance_guid` and `file_id` columns form a composite foreign key to the `canvas_file` table, establishing a many->one relationship `canvas_file_lookup` -> `canvas_file`.

The Python code for inserting these two rows would be something like this:

```python
db.add(CanvasFile(
    consumer_key=consumer_key,
    tool_consumer_instance_guid=tool_consumer_instance_guid,
    file_id=file_id,
    filename=filename,
    size=size,
    lookups=[CanvasFileLookup(course_id=course_id, use_file_id=file_id)]
))
```

### Inserting copies of files into the DB

Let's say we receive an assignment launch with file ID `1` and course ID `B`. File `1` isn't in course `B`, it's in course `A`. But let's say we find another file -- file `3` -- that **is** in course `B` and that has the same filename and size as file `1`. We wouldn't add anything to the `canvas_file` table. We'd insert a second row into the `canvas_file_lookup` table, pointing to file `3`'s existing row in the `canvas_file` table:

| consumer_key | tool_consumer_instance_guid | file_id | course_id | use_file_id |
| - | - | - | - | - |
| "ck" | "tcig" | 1 | B | 3 |

This tells the application: if you receive a launch with file ID `1` and course ID `B` then use file ID `3` instead

### Launching assignments

When we receive an assignment launch we'll look up the `consumer_key`, `tool_consumer_instance_guid`, `file_id` and `course_id` from the launch params in the `CanvasFileLookup` table. We know that we'll get either one result or `None`. If we get a result then get its `file_id`.

```python
try:
    file_id_to_use = db.query(CanvasFileLookup).filter_by(
        tool_consumer_instance_guid=tool_consumer_instance_guid,
        consumer_key=consumer_key,
        file_id=file_id,
        course_id=course_id,
    ).one().use_file_id
except NoResultFound:
    # Look for file_id in any other course.
    # If found look for a matching file (same filename and size) in *this* course (will require a JOIN query).
    # If found add a CanvasFileLookup for it. 
```

### Benefits

* The `CanvasFile` table is clean. It only contains info about files we've received from the Canvas API, one row per file received. There are no overrides or lookups polluting the `CanvasFile` table

* A `CanvasFileLookup` can only point to a `CanvasFIle`, never to another `CanvasFileLookup`. No circular references are possible

* The same `file_id` can only appear once in the same course because there can be a `(consumer_key, tool_consumer_instance_guid, file_id, course_id)` unique constraint on `CanvasFileLookup`.

* A `CanvasFileLookup` **cannot** point to a `CanvasFile` that has a different `consumer_key` or `tool_consumer_instance_guid`

### Downsides

* Shouldn't the `CanvasFileLookup` table really be a many-to-many relationship between `CanvasFile` and [the `Course` model that we already have](https://github.com/hypothesis/lms/blob/f852887cd69f48a4c5fd278242e4dc3db5c846f7/lms/models/course.py#L8-L35)? Probably yes, but for a bunch of complicated reasons it's hard to add a many-to-many between `CanvasFile` and `Course`. We'd have to do a bunch of refactoring first

* Always having to insert two rows: whenever you add a `CanvasFile` to the DB (or a potentially large list of them at once) you also have to add one `CanvasFileLookup` for each `CanvasFile`

* When there's a `CanvasFileLookup` with course ID `B` and `use_file_id` `3`, there's nothing to ensure that file `3` is actually in course `B`. It feels like something's not quite right with the model here

* Can't tell original files from copies.

  There's no way to tell the difference between a `CanvasFileLookup` that was created because its `CanvasFile` was actually seen in that course in a Canvas API response, and a `CanvasFileLookup` that was created because we matched on `filename` and `size` and decided that a file in one course is a copy of another file in another course.

  The code doesn't actually _need_ to distinguish these two.

  We could just add an `inferred` (boolean) column to `CanvasFileLookup` for this purpose.

* We can't delete orphaned `CanvasFile`'s from the DB

  When a `CanvasFile` is deleted we can make Postgres automatically delete all its `CanvasFileLookup`'s with an `ON DELETE CASCADE`.

  But I don't think we can do the other way round: if all the `CanvasFileLookup`'s pointing to a given `CanvasFile` are deleted, I don't think there's any way to get the database to automatically delete the `CanvasFile`.

  This isn't a big problem: orphaned `CanvasFile`'s wouldn't actually present an issue. And also we have no plans to ever delete either `CanvasFile`'s or `CanvasFileLookup`'s.

## Alternative Solutions

* Stick with the existing model from https://github.com/hypothesis/lms/pull/2323 where there's just a single `CanvasFile` table with both `file_id` and `file_id_override` columns, but fix the problems with it:

  Make `file_id_override` a foreign key to another row of the same table, with `ON DELETE CASCADE`.

  Add check constraints to enforce that if `file_id_override` is `NULL` then `filename` and `size` must not be `NULL` and if `file_id_override` is not `NULL` then `filename` and `size` must be `NULL`. 

  Use SQLAlchemy's "single-table inheritance" / polymorphism feature to have separate model classes `CanvasFile` (with `filename` and `size` attrs but no `file_id_override`) and `CanvasFileOverride` (with a `file_id_override` attr but no `filename` or `size`) that share the same underlying DB table.

  See https://github.com/hypothesis/lms/pull/2332 for a very rough implementation of this polymorphism.

  By tweaking the model and using self-joins when querying for rows we might be able to make it impossible for overrides to point to other override rows

  But by the time you've implemented all these fixes the solution has lost the simplicity that is its main benefit.

* Do a solution similar to the one in this PR but instead of a `CanvasFileLookup` table create a many-many relationship table between `CanvasFile` and `Course`. Would require lots of refactoring and DB migrations to fix problems with the existing `models.Course` and related code.