### PR TITLE
Do re-authorize after Canvas files errors

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -279,13 +279,6 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
     }
   }, [authToken, authUrl, fetchContentUrl, fetchGroups]);
 
-  const refetchContentUrl = useCallback(async () => {
-    const success = fetchContentUrl();
-    if (success) {
-      setErrorState(null);
-    }
-  }, [fetchContentUrl]);
-
   // Construct the <iframe> content
   let iFrameWrapper;
   const iFrame = (
@@ -324,16 +317,6 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
     </div>
   );
 
-  let retryLaunch;
-  switch (errorState) {
-    case 'error-authorizing':
-    case 'error-fetching':
-      retryLaunch = authorizeAndFetchUrl;
-      break;
-    default:
-      retryLaunch = refetchContentUrl;
-  }
-
   return (
     <div className="BasicLtiLaunchApp">
       {showSpinner && <Spinner className="BasicLtiLaunchApp__spinner" />}
@@ -342,7 +325,7 @@ export default function BasicLtiLaunchApp({ clientRpc }) {
           busy={fetchCount > 0}
           errorState={errorState}
           error={error}
-          onRetry={retryLaunch}
+          onRetry={authorizeAndFetchUrl}
         />
       )}
       {content}

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -275,7 +275,7 @@ describe('BasicLtiLaunchApp', () => {
         'LaunchErrorDialog[errorState="error-fetching-canvas-file"]'
       );
 
-      // Click the "Try again" button and verify that files are re-fetched after re-authorizing.
+      // Click the "Try again" button. This should re-authorize and then re-fetch files.
       fakeApiCall.resetHistory();
       act(() => {
         errorDialog.prop('onRetry')();
@@ -284,6 +284,7 @@ describe('BasicLtiLaunchApp', () => {
         authToken: 'dummyAuthToken',
         authUrl,
       });
+      await waitFor(() => fakeApiCall.called);
 
       // We didn't change the API response, so it will fail the same way and the same error dialog
       // should be shown.
@@ -323,6 +324,7 @@ describe('BasicLtiLaunchApp', () => {
         'LaunchErrorDialog[errorState="canvas-file-not-found-in-course"]'
       );
 
+      // Click the "Try again" button. This should re-authorize and then re-fetch files.
       act(() => {
         errorDialog.prop('onRetry')();
       });
@@ -330,6 +332,7 @@ describe('BasicLtiLaunchApp', () => {
         authToken: 'dummyAuthToken',
         authUrl,
       });
+      await waitFor(() => fakeApiCall.called);
 
       // We didn't change the API response, so it will fail the same way and the same error dialog
       // should be shown.

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -275,14 +275,15 @@ describe('BasicLtiLaunchApp', () => {
         'LaunchErrorDialog[errorState="error-fetching-canvas-file"]'
       );
 
-      // Click the "Try again" button and verify that files are re-fetched without re-authorizing.
+      // Click the "Try again" button and verify that files are re-fetched after re-authorizing.
       fakeApiCall.resetHistory();
       act(() => {
         errorDialog.prop('onRetry')();
       });
-      assert.notCalled(FakeAuthWindow);
-      assert.called(fakeApiCall);
-      await spinnerVisible(wrapper);
+      assert.calledWith(FakeAuthWindow, {
+        authToken: 'dummyAuthToken',
+        authUrl,
+      });
 
       // We didn't change the API response, so it will fail the same way and the same error dialog
       // should be shown.
@@ -322,14 +323,13 @@ describe('BasicLtiLaunchApp', () => {
         'LaunchErrorDialog[errorState="canvas-file-not-found-in-course"]'
       );
 
-      // Click the "Try again" button and verify that files are re-fetched without re-authorizing.
-      fakeApiCall.resetHistory();
       act(() => {
         errorDialog.prop('onRetry')();
       });
-      assert.notCalled(FakeAuthWindow);
-      assert.called(fakeApiCall);
-      await spinnerVisible(wrapper);
+      assert.calledWith(FakeAuthWindow, {
+        authToken: 'dummyAuthToken',
+        authUrl,
+      });
 
       // We didn't change the API response, so it will fail the same way and the same error dialog
       // should be shown.


### PR DESCRIPTION
_Do_ re-authorize with Canvas (requesting a new access token) when
clicking the <kbd>Try again</kbd> button after Canvas Files errors from
the proxy API.

Problem
-------

See https://github.com/hypothesis/support/issues/162

1. Hack the code to request access tokens without the sections scopes:

       diff --git a/lms/views/api/canvas/authorize.py b/lms/views/api/canvas/authorize.py
       index 39b310d9..1fa5f4e5 100644
       --- a/lms/views/api/canvas/authorize.py
       +++ b/lms/views/api/canvas/authorize.py
       @@ -25,9 +25,6 @@ FILES_SCOPES = (

       #: The Canvas API scopes that we need for our Sections feature.
       SECTIONS_SCOPES = (
       -    "url:GET|/api/v1/courses/:id",
       -    "url:GET|/api/v1/courses/:course_id/sections",
       -    "url:GET|/api/v1/courses/:course_id/users/:id",
       )

2. Delete all the OAuth 2 tokens from your DB to force it to get a new
   access token the next time you launch an assignment:

       $ tox -qe dockercompose -- exec postgres psql -U postgres -c 'DELETE FROM oauth2_token;'

3. Launch **localhost (make devdata) HTML Assignment** in the
   **Sections Enabled** course:
   https://hypothesis.instructure.com/courses/125/assignments/873

You should see:

1. When launching the assignment you should see the
   **Authorize Hypothesis** dialog, asking you to authorize a new access
   token

2. After authorizing you should see the
   **Couldn't get the file from Canvas** error dialog

3. After clicking <kbd>Try again</kbd> the assignment will launch but
   the client will be spinning forever

4. If you re-launch the assignment again the same thing will happen. The
   user is completely stuck

5. You can undo the hack above (that removed the sections scopes) and
   try to re-launch the assignment but it still won't work because it's
   always trying to use the access token that it already has in the DB
   (that lacks the necessary scopes) rather than getting a new access
   token

There are three problems here:

1. Somehow a user is launching an assignment in a course that has
   sections enabled, but the user's access token does not have the
   sections scopes. We've simulated this condition by hacking the code
   to not request the sections scopes. But
   https://github.com/hypothesis/support/issues/162 shows that it is
   (somehow) happening to production users as well.
   **This is not a bug**.  It's not possible for us to ensure that user
   in sections-enabled courses never have non-sections-enabled access
   tokens in our DB. Instead we need to request a new access token when
   we find out that the one we have isn't working.

2. We're showing the **Couldn't get the file from Canvas** error dialog
   even though the user is launching an HTML assignment. This is a bug,
   but its's a separate issue. I'll send a separate PR for this.

3. The <kbd>Try again</kbd> button is not working because it's trying to
   try-again without getting a new access token, resulting in broken
   assignment launches and the user being stuck forever.
   **This third problem is what this PR fixes.**

Solution
--------

In general whenever the frontend code receives an error response from
the proxy API it should show a <kbd>Try again</kbd> button and clicking on that
<kbd>Try again</kbd> button should re-try the entire end-to-end process
again, starting with getting a new access token.

This was a design decision that we made when we initially implemented
our Canvas API support, but recent changes have gone against this
decision and introduced some cases where the <kbd>Try again</kbd> button
_doesn't_ get a new access token.

The reasons for _always_ getting a new access token are:

* Re-trying the entire process maximizes the chance that the re-try will
  succeed. For example the problem could be to do with the access token
  itself (e.g. perhaps it lacks the necessary scopes, or has been
  deleted/invalidated in Canvas) in which case re-trying with the same
  access token will fail, but getting a new access token will succeed

* If we try to separate "errors that require a new access token" and
  "errors that don't require a new access token" this introduces the
  possibility of false-negatives where we don't think a new access token
  is required when actually it is. The result of a false negative like
  this will be that trying again doesn't work, and the user is stuck.

* The benefit of the <kbd>Try again</kbd> button *not* requesting a new access
  token when it doesn't need to is that it avoids making the user go
  through an unnecessary authorize. This is not a benefit that is worth
  the risk. Especially given that the <kbd>Try again</kbd> button is
  only shown when something has gone wrong.

* It keeps our code and tests simpler to always do the same thing

Testing
-------

1. Hack the code to request access tokens without the sections scopes:

       diff --git a/lms/views/api/canvas/authorize.py b/lms/views/api/canvas/authorize.py
       index 39b310d9..1fa5f4e5 100644
       --- a/lms/views/api/canvas/authorize.py
       +++ b/lms/views/api/canvas/authorize.py
       @@ -25,9 +25,6 @@ FILES_SCOPES = (

       #: The Canvas API scopes that we need for our Sections feature.
       SECTIONS_SCOPES = (
       -    "url:GET|/api/v1/courses/:id",
       -    "url:GET|/api/v1/courses/:course_id/sections",
       -    "url:GET|/api/v1/courses/:course_id/users/:id",
       )

2. Delete all the OAuth 2 tokens from your DB to force it to get a new
   access token the next time you launch an assignment:

       $ tox -qe dockercompose -- exec postgres psql -U postgres -c 'DELETE FROM oauth2_token;'

3. Launch **localhost (make devdata) HTML Assignment** in the
   **Sections Enabled** course:
   https://hypothesis.instructure.com/courses/125/assignments/873

4. When launching the assignment you should see the
   **Authorize Hypothesis** dialog, asking you to authorize a new access
   token

5. After authorizing you should see the
   **Couldn't get the file from Canvas** error dialog

6. Un-hack the `authorize.py` file, adding the sections scopes back

7. Click the <kbd>Try again</kbd> button

8. It should make you re-authorize and then the assignment should launch
   successfully