### PR TITLE
Don't show error for "insufficient scopes"

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -153,6 +153,12 @@ class CanvasAPIError(ExternalRequestError):
         if error_description == "refresh_token not found":
             return CanvasAPIAccessTokenError
 
+        if (
+            status_code == 401
+            and {"message": "Insufficient scopes on access token."} in errors
+        ):
+            return CanvasAPIAccessTokenError
+
         if status_code == 401:
             return CanvasAPIPermissionError
 

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -86,6 +86,16 @@ class TestCanvasAPIError:
                 "401 Unauthorized",
                 CanvasAPIAccessTokenError,
             ),
+            # A 401 Unauthorized response from Canvas, because our access token had
+            # insufficient scopes;
+            (
+                401,
+                json.dumps(
+                    {"errors": [{"message": "Insufficient scopes on access token."}]}
+                ),
+                "401 Unauthorized",
+                CanvasAPIAccessTokenError,
+            ),
             # A 400 Bad Request response from Canvas, because our refresh token
             # was expired or deleted.
             (


### PR DESCRIPTION
If we get an `"Insufficient scopes on access token"` error from the Canvas API just show the user the non-error *Authorize* dialog so they can get us a new access token (we'll always request one with the needed scopes). Don't show the user an error dialog: this is an expected / unavoidable circumstance, and getting a new access token should always fix the problem.

Fixes https://github.com/hypothesis/lms/issues/2345

Unfortunately we have no choice but to use the English-language string `"Insufficient scopes on access token."` to identify this particular type of error. Canvas doesn't provide any kind of error codes meant for machines. The HTTP status can't be used because the same status is shared by different types of error that we need to respond differently to.

I've tested in three languages and `"Insufficient scopes on access token."` doesn't appear to get localized into the user's account's language as many of the strings in Canvas API responses do. As with other Canvas API response strings that we have no choice but to rely on, we have no way of knowing for sure that Instructure won't localize it in the future. If that happens, they'll break our app.

The string doesn't appear to be internationalized in Canvas's source code:

https://github.com/instructure/canvas-lms/blob/20f91713bc3b0524bf1a3bc580d9b6fa51d6053a/app/controllers/application_controller.rb#L1644-L1645

## Testing

1. Hack the code to request access tokens without the sections scopes:

       diff --git a/lms/views/api/canvas/authorize.py b/lms/views/api/canvas/authorize.py
       index 39b310d9..1fa5f4e5 100644
       --- a/lms/views/api/canvas/authorize.py
       +++ b/lms/views/api/canvas/authorize.py
       @@ -25,9 +25,6 @@ FILES_SCOPES = (

       #: The Canvas API scopes that we need for our Sections feature.
       SECTIONS_SCOPES = (
       -    "url:GET|/api/v1/courses/:id",
       -    "url:GET|/api/v1/courses/:course_id/sections",
       -    "url:GET|/api/v1/courses/:course_id/users/:id",
       )

2. Delete all the OAuth 2 tokens from your DB to force it to get a new access token the next time you launch an assignment:

       $ tox -qe dockercompose -- exec postgres psql -U postgres -c 'DELETE FROM oauth2_token;'

3. Launch **localhost HTML Assignment** in the **Sections Disabled** course so that you get an access token without the sections scopes in your DB. You should see the **Authorize** dialog and the assignment should launch successfully. https://hypothesis.instructure.com/courses/124/assignments/885

4. Un-hack the `authorize.py` file

5. Launch **localhost (make devdata) HTML Assignment** in the **Sections Enabled** course: https://hypothesis.instructure.com/courses/125/assignments/873

6. Your access token won't work (since it lacks the sections scopes). You'll see the **Authorize** dialog. After authorizing the assignment should work.

7. If you launch the [course-copied Canvas Files assignment](https://hypothesis.instructure.com/courses/253/assignments/1351) as either a teacher or as the `seanh+coursecopy` user (a student who isn't in the original course) you should see the Canvas Files-specific error dialog.