### PR TITLE
Add "VitalSource Book" option to file picker behind feature flag

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -16,7 +16,7 @@ session_cookie_secret = "notasecret"
 
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
-feature_flags_allowed_in_cookie = 
+feature_flags_allowed_in_cookie = vitalsource
 
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -196,6 +196,9 @@ class JSConfig:
                 "developerKey": self._request.registry.settings["google_developer_key"],
                 "origin": google_picker_origin(),
             },
+            "vitalSource": {
+                "enabled": self._request.feature("vitalsource"),
+            },
         }
 
     def maybe_enable_grading(self):

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -5,6 +5,7 @@ import { Config } from '../config';
 import {
   contentItemForUrl,
   contentItemForLmsFile,
+  contentItemForVitalSourceBook,
 } from '../utils/content-item';
 import {
   GooglePickerClient,
@@ -19,7 +20,6 @@ import URLPicker from './URLPicker';
 
 /**
  * @typedef {import('../api-types').File} File
- *
  * @typedef {'lms'|'url'|null} DialogType
  *
  * @typedef FilePickerAppProps
@@ -50,12 +50,14 @@ export default function FilePickerApp({
         developerKey: googleDeveloperKey,
         origin: googleOrigin,
       },
+      vitalSource: { enabled: vitalSourceEnabled },
     },
   } = useContext(Config);
 
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
   const [url, setUrl] = useState(/** @type {string|null} */ (null));
   const [lmsFile, setLmsFile] = useState(/** @type {File|null} */ (null));
+  const [vitalSourceBook, setVitalSourceBook] = useState(false);
   const [isLoadingIndicatorVisible, setLoadingIndicatorVisible] = useState(
     false
   );
@@ -140,6 +142,11 @@ export default function FilePickerApp({
     }
   };
 
+  const selectVitalSourceBook = () => {
+    setVitalSourceBook(true);
+    submit(true);
+  };
+
   // Submit the form after a selection is made via one of the available
   // methods.
   useEffect(() => {
@@ -175,6 +182,13 @@ export default function FilePickerApp({
     contentItem = contentItemForUrl(ltiLaunchUrl, url);
   } else if (lmsFile) {
     contentItem = contentItemForLmsFile(ltiLaunchUrl, lmsFile);
+  } else if (vitalSourceBook) {
+    // Chosen from `https://api.vitalsource.com/v4/products` response.
+    const bookId = 'BOOKSHELF-TUTORIAL';
+    // CFI chosen from `https://api.vitalsource.com/v4/products/BOOKSHELF-TUTORIAL/toc`
+    // response.
+    const cfi = '/6/8[;vnd.vst.idref=vst-70a6f9d3-0932-45ba-a583-6060eab3e536]';
+    contentItem = contentItemForVitalSourceBook(ltiLaunchUrl, bookId, cfi);
   }
   contentItem = JSON.stringify(contentItem);
 
@@ -219,6 +233,13 @@ export default function FilePickerApp({
               className="FilePickerApp__source-button"
               label="Select PDF from Google Drive"
               onClick={showGooglePicker}
+            />
+          )}
+          {vitalSourceEnabled && (
+            <Button
+              className="FilePickerApp__source-button"
+              label="Select book from VitalSource"
+              onClick={selectVitalSourceBook}
             />
           )}
         </div>

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -57,7 +57,12 @@ export default function FilePickerApp({
   const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
   const [url, setUrl] = useState(/** @type {string|null} */ (null));
   const [lmsFile, setLmsFile] = useState(/** @type {File|null} */ (null));
+
+  // Whether the user chose a book from VitalSource. This is currently a
+  // boolean because there is no choice about which book is used. In future this
+  // will contain the selected book and chapter.
   const [vitalSourceBook, setVitalSourceBook] = useState(false);
+
   const [isLoadingIndicatorVisible, setLoadingIndicatorVisible] = useState(
     false
   );

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -8,6 +8,7 @@ import { Config } from '../../config';
 import {
   contentItemForLmsFile,
   contentItemForUrl,
+  contentItemForVitalSourceBook,
 } from '../../utils/content-item';
 import { PickerCanceledError } from '../../utils/google-picker-client';
 import FilePickerApp, { $imports } from '../FilePickerApp';
@@ -54,6 +55,9 @@ describe('FilePickerApp', () => {
           },
         },
         google: {},
+        vitalSource: {
+          enabled: false,
+        },
       },
     };
 
@@ -350,6 +354,39 @@ describe('FilePickerApp', () => {
 
       wrapper.setProps({}); // Force re-render.
       assert.isFalse(wrapper.exists('Spinner'));
+    });
+  });
+
+  describe('VitalSource Book selector', () => {
+    it('renders VitalSource picker button if enabled', () => {
+      fakeConfig.filePicker.vitalSource.enabled = true;
+      const wrapper = renderFilePicker();
+      assert.isTrue(
+        wrapper.exists('Button[label="Select book from VitalSource"]')
+      );
+    });
+
+    it('submits hard-coded book and chapter when VitalSource picker button is selected', () => {
+      fakeConfig.filePicker.vitalSource.enabled = true;
+      const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+      const wrapper = renderFilePicker({ onSubmit });
+
+      const button = wrapper.find(
+        'Button[label="Select book from VitalSource"]'
+      );
+      interact(wrapper, () => {
+        button.props().onClick();
+      });
+
+      assert.called(onSubmit);
+      assert.deepEqual(
+        getContentItem(wrapper),
+        contentItemForVitalSourceBook(
+          fakeConfig.filePicker.canvas.ltiLaunchUrl,
+          'BOOKSHELF-TUTORIAL',
+          '/6/8[;vnd.vst.idref=vst-70a6f9d3-0932-45ba-a583-6060eab3e536]'
+        )
+      );
     });
   });
 

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -56,6 +56,8 @@ import { createContext } from 'preact';
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey
  *   @prop {string} google.origin
+ * @prop {Object} vitalSource
+ *   @prop {boolean} vitalSource.enabled
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -5,9 +5,6 @@
 import { stringify } from 'querystring';
 
 /**
- * Return a JSON-LD `ContentItem` representation of the LTI activity launch
- * URL for a given document URL.
- *
  * @param {string} ltiLaunchUrl
  * @param {Object.<string,string>} params - Query parameters for the generated URL
  */
@@ -46,5 +43,23 @@ export function contentItemForLmsFile(ltiLaunchUrl, file) {
   return contentItemWithParams(ltiLaunchUrl, {
     canvas_file: 'true',
     file_id: file.id,
+  });
+}
+
+/**
+ * Return a JSON-LD `ContentItem` representation of the LTI activity launch URL
+ * for a VitalSource ebook.
+ *
+ * @param {string} ltiLaunchUrl
+ * @param {string} bookId - VitalSource book ID (aka. `vbid`)
+ * @param {string} cfi -
+ *   Location in the book. This is an EPUB CFI path without the surrounding
+ *   `epubcfi(...)` fragment. See http://idpf.org/epub/linking/cfi/epub-cfi.html.
+ */
+export function contentItemForVitalSourceBook(ltiLaunchUrl, bookId, cfi) {
+  return contentItemWithParams(ltiLaunchUrl, {
+    vitalsource_book: 'true',
+    book_id: bookId,
+    cfi,
   });
 }

--- a/lms/static/scripts/frontend_apps/utils/test/content-item-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/content-item-test.js
@@ -1,4 +1,8 @@
-import { contentItemForUrl, contentItemForLmsFile } from '../content-item';
+import {
+  contentItemForUrl,
+  contentItemForLmsFile,
+  contentItemForVitalSourceBook,
+} from '../content-item';
 
 const ltiLaunchUrl = 'https://lms.hypothes.is/lti_launch';
 
@@ -35,6 +39,32 @@ describe('content-item', () => {
             '@type': 'LtiLinkItem',
             mediaType: 'application/vnd.ims.lti.v1.ltilink',
             url: ltiLaunchUrl + '?canvas_file=true&file_id=foobar',
+          },
+        ],
+      });
+    });
+  });
+
+  describe('contentItemForVitalSourceBook', () => {
+    it('returns expected JSON-LD data', () => {
+      const bookId = 'TEST-BOOK';
+      const chapterCfi = '/4/5';
+
+      const contentItem = contentItemForVitalSourceBook(
+        ltiLaunchUrl,
+        bookId,
+        chapterCfi
+      );
+
+      assert.deepEqual(contentItem, {
+        '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
+        '@graph': [
+          {
+            '@type': 'LtiLinkItem',
+            mediaType: 'application/vnd.ims.lti.v1.ltilink',
+            url:
+              ltiLaunchUrl +
+              '?vitalsource_book=true&book_id=TEST-BOOK&cfi=%2F4%2F5',
           },
         ],
       });

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -43,6 +43,9 @@ class TestEnableContentItemSelectionMode:
                     "path": "/api/canvas/courses/test_course_id/files",
                 },
             },
+            "vitalSource": {
+                "enabled": False,
+            },
         }
 
     def test_google_picker_origin_falls_back_to_lms_url_if_theres_no_custom_canvas_api_domain(
@@ -112,6 +115,17 @@ class TestEnableContentItemSelectionMode:
         )
 
         self.assert_canvas_file_picker_not_enabled(js_config)
+
+    def test_it_enables_vitalsource_picker_if_feature_enabled(
+        self, pyramid_request, js_config
+    ):
+        pyramid_request.feature = lambda feature: feature == "vitalsource"
+
+        js_config.enable_content_item_selection_mode(
+            mock.sentinel.form_action, mock.sentinel.form_fields
+        )
+
+        assert js_config.asdict()["filePicker"]["vitalSource"]["enabled"]
 
     def assert_canvas_file_picker_not_enabled(self, js_config):
         assert not js_config.asdict()["filePicker"]["canvas"]["enabled"]


### PR DESCRIPTION
This commit adds a option to the file picker app which configures an
assignment that will use a hard-coded VitalSource book and chapter. This
assignment configuration is currently not handled by the LTI launch
code. This will follow in subsequent PRs.

This option is currently behind a `vitalsource` feature flag which is enabled via cookies, to enable the VitalSource developers to turn it on for themselves.

In future our LMS app will query the VitalSource API for a list of available books and allow the user to make a selection.

**Decision points:**

This is a note about some decisions that I need to discuss with the LMS owners:

- What should the format of the query params be for different types of LMS assignment? In this PR I've just copied the example of the way Canvas files assignments are configured, but I think that approach will become suboptimal as we add new assignment types in future (Blackboard files, Moodle files, etc.)

**Testing:**

1. Check out this branch and restart the dev server
2. Go to http://localhost:8001/flags and confirm vitalsource flag is _off_
3. Launch the assignment picker and check that it presents the same options as on master
4. Go to http://localhost:8001/flags and turn the vitalsource flag _on_
5. Re-launch the assignment picker and verify that there is a new "Select book from VitalSource" option
6. Click the option and check that the assignment URL is set to exactly `http://localhost:8001/lti_launches?vitalsource_book=true&book_id=BOOKSHELF-TUTORIAL&cfi=%2F6%2F8%5B%3Bvnd.vst.idref%3Dvst-70a6f9d3-0932-45ba-a583-6060eab3e536%5D`. The URL format here follows the example of the Canvas file picker, which has a `canvas_file=true` query param followed by arguments for that type of assignment

<img width="814" alt="vitalsource-picker" src="https://user-images.githubusercontent.com/2458/106868649-f1219600-66c6-11eb-84b7-577a2ebf506e.png">
