### PR TITLE
Dialog visual fixes

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -21,7 +21,7 @@ export default function ErrorDialog({ onCancel, title, error, cancelLabel }) {
   return (
     <Dialog
       role="alertdialog"
-      title="Something went wrong :("
+      title="Something went wrong"
       onCancel={onCancel}
       cancelLabel={cancelLabel}
     >

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -230,7 +230,7 @@ export default function SubmitGradeForm({ student }) {
       {!!fetchGradeError && (
         <ErrorDialog
           title="Fetch Grade Error"
-          error={{ message: submitGradeError }}
+          error={{ message: fetchGradeError }}
           onCancel={() => {
             setFetchGradeError('');
           }}

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,5 +1,6 @@
 @use "@hypothesis/frontend-shared/styles/mixins/focus";
 
+@use "../mixins";
 @use "../variables" as var;
 
 .Dialog__container {
@@ -22,6 +23,8 @@
 }
 
 .Dialog__content {
+  @include mixins.font-normal;
+  @include focus.outline-on-keyboard-focus;
   display: flex;
   flex-direction: column;
   max-height: 90vh;
@@ -49,7 +52,7 @@
   // enough to see easily and aligned with the right edge of the dialog.
   // Add negative margins so that the button does not force the dialog to
   // grow in height.
-  font-size: 20px;
+  font-size: var.$title-font-size;
   padding: 5px;
   margin: -10px 0px;
 

--- a/lms/static/styles/components/_ErrorDisplay.scss
+++ b/lms/static/styles/components/_ErrorDisplay.scss
@@ -12,7 +12,6 @@
 
   &__links {
     white-space: normal;
-    line-height: 1.25em;
   }
 
   &__details {

--- a/lms/static/styles/components/_LMSGrader.scss
+++ b/lms/static/styles/components/_LMSGrader.scss
@@ -3,7 +3,7 @@
 .LMSGrader {
   display: flex;
   flex-direction: column;
-  font-size: 16px;
+  font-size: var.$input-font-size;
   height: 100%;
   width: 100%;
   position: fixed;
@@ -39,12 +39,12 @@
 }
 
 .LMSGrader__assignment {
-  font-size: 18px;
+  font-size: var.$title-font-size;
   margin: 0 0 10px 0;
 }
 
 .LMSGrader__name {
-  font-size: 16px;
+  font-size: var.$subtitle-font-size;
   margin: 0;
 }
 


### PR DESCRIPTION
### Commits

Fix incorrect fetch grade message …

The fetch grade error was incorrectly showing the wrong message

------------

- Remove ":(" from ErrorDialog's title text for submit and fetch errors
- Set font size for Dialog content
- Remove focus outline when Dialog's content pane is in focus
- Do not override font color in LMSGrader
- ~Add default font color to body ($grey-7)~
- Use standard font sizes for LMSGrader

-----------

_Updates_

**Refactored this PR to only include CSS/text issues to dialogs. Pulled out the retry feature and will include that in another PR.
** removed body color, (will fix in follow up PR)

This PR builds off the orignal here
https://github.com/hypothesis/lms/pull/2329

fixes #2320

**Before**
![Screen Shot 2021-02-10 at 2 39 24 PM](https://user-images.githubusercontent.com/3939074/107582242-15d9aa00-6bae-11eb-9319-fcbfbebbd2e7.png)

**After**
![Screen Shot 2021-02-10 at 2 39 59 PM](https://user-images.githubusercontent.com/3939074/107582255-1a9e5e00-6bae-11eb-9484-ca646ca63997.png)




