### PR TITLE
Support launching assignments using VitalSource books

### DIFF
--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -63,6 +63,9 @@ def configure(settings):
         # like this:
         #     python3 -c 'import secrets; print(secrets.token_hex())'
         "oauth2_state_secret": sg.get("OAUTH2_STATE_SECRET"),
+        # Default OAuth 1.0 key and secret for VitalSource LTI launches
+        "vitalsource_launch_key": sg.get("VITALSOURCE_LAUNCH_KEY"),
+        "vitalsource_launch_secret": sg.get("VITALSOURCE_LAUNCH_SECRET"),
     }
 
     env_settings["dev"] = asbool(env_settings["dev"])

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -64,8 +64,8 @@ def configure(settings):
         #     python3 -c 'import secrets; print(secrets.token_hex())'
         "oauth2_state_secret": sg.get("OAUTH2_STATE_SECRET"),
         # Default OAuth 1.0 key and secret for VitalSource LTI launches
-        "vitalsource_launch_key": sg.get("VITALSOURCE_LAUNCH_KEY"),
-        "vitalsource_launch_secret": sg.get("VITALSOURCE_LAUNCH_SECRET"),
+        "vitalsource_lti_launch_key": sg.get("VITALSOURCE_LTI_LAUNCH_KEY"),
+        "vitalsource_lti_launch_secret": sg.get("VITALSOURCE_LTI_LAUNCH_SECRET"),
     }
 
     env_settings["dev"] = asbool(env_settings["dev"])

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -75,6 +75,19 @@ class JSConfig:
             self._config["viaUrl"] = via_url(self._request, document_url)
             self._add_canvas_speedgrader_settings(document_url=document_url)
 
+    def add_vitalsource_launch_config(self, book_id, cfi=None):
+        vitalsource_svc = self._request.find_service(name="vitalsource")
+        launch_url, launch_params = vitalsource_svc.get_launch_params(
+            book_id, cfi, self._request.lti_user
+        )
+        self._config["vitalSource"] = {
+            "launchUrl": launch_url,
+            "launchParams": launch_params,
+        }
+        self._add_canvas_speedgrader_settings(
+            vitalsource_book_id=book_id, vitalsource_cfi=cfi
+        )
+
     def asdict(self):
         """
         Return the configuration for the app's JavaScript code.

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -48,3 +48,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.assignment.factory", name="assignment"
     )
+    config.register_service_factory(
+        "lms.services.vitalsource.VitalSourceService", name="vitalsource"
+    )

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -49,5 +49,5 @@ def includeme(config):
         "lms.services.assignment.factory", name="assignment"
     )
     config.register_service_factory(
-        "lms.services.vitalsource.VitalSourceService", name="vitalsource"
+        "lms.services.vitalsource.factory", name="vitalsource"
     )

--- a/lms/services/vitalsource.py
+++ b/lms/services/vitalsource.py
@@ -5,6 +5,8 @@ from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
 class VitalSourceService:
     def __init__(self, lti_launch_key, lti_launch_secret):
         """
+        Return a new VitalSourceService.
+
         :param lti_launch_key: OAuth consumer key
         :type lti_launch_key: str
         :param lti_launch_secret: OAuth consumer secret

--- a/lms/services/vitalsource.py
+++ b/lms/services/vitalsource.py
@@ -3,21 +3,36 @@ from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
 
 
 class VitalSourceService:
-    def __init__(self, oauth_key, oauth_secret):
-        self._oauth_key = oauth_key
-        self._oauth_secret = oauth_secret
+    def __init__(self, lti_launch_key, lti_launch_secret):
+        """
+        :param lti_launch_key: OAuth consumer key
+        :type lti_launch_key: str
+        :param lti_launch_secret: OAuth consumer secret
+        :type lti_launch_secret: str
+        """
+        self._lti_launch_key = lti_launch_key
+        self._lti_launch_secret = lti_launch_secret
 
     def get_launch_params(self, book_id, cfi, lti_user):
         """
-        Launch the VitalSource book viewer using an LTI launch.
+        Return the form params needed to launch the VitalSource book viewer.
+
+        The VitalSource book viewer is launched using an LTI launch. This involves
+        posting an HTML form containing the book ID and location along with metadata
+        about the current user and an OAuth 1.0 signature.
 
         See https://developer.vitalsource.com/hc/en-us/articles/215612237-POST-LTI-Create-a-Bookshelf-Launch
+
+        :param book_id: The VitalSource book ID ("vbid")
+        :param cfi: Book location, as a Canonical Fragment Identifier, for deep linking.
+        :param lti_user: Current LTI user information, from the LTI launch request
+        :type lti_user: LTIUser
         """
 
         launch_url = f"https://bc.vitalsource.com/books/{book_id}"
         book_location = "/cfi" + cfi
 
-        launch_params = _launch_params(
+        launch_params = self._launch_params(
             user_id=lti_user.user_id,
             roles=lti_user.roles,
             # Set a dummy `context_id`. This needs to be replaced with the real
@@ -31,8 +46,8 @@ class VitalSourceService:
 
     def _sign_form_params(self, url, params):
         client = oauthlib.oauth1.Client(
-            self._oauth_key,
-            self._oauth_secret,
+            self._lti_launch_key,
+            self._lti_launch_secret,
             signature_method=SIGNATURE_HMAC_SHA1,
             signature_type=SIGNATURE_TYPE_BODY,
         )
@@ -41,27 +56,27 @@ class VitalSourceService:
         params["oauth_signature"] = client.get_oauth_signature(oauth_request)
         return params
 
+    @staticmethod
+    def _launch_params(user_id, roles, context_id, location):
+        # See https://developer.vitalsource.com/hc/en-us/articles/206156238-General-LTI-Usage
+        params = {
+            # Standard LTI launch parameters
+            "lti_version": "LTI-1p0",
+            "lti_message_type": "basic-lti-launch-request",
+            # User data. These should be proxied from the LTI launch.
+            "user_id": user_id,
+            "roles": roles,
+            "context_id": context_id,
+            # Book presentation and location options
+            "launch_presentation_document_target": "window",
+            "custom_book_location": location,
+        }
 
-def _launch_params(user_id, roles, context_id, location):
-    # See https://developer.vitalsource.com/hc/en-us/articles/206156238-General-LTI-Usage
-    params = {
-        # Standard LTI launch parameters
-        "lti_version": "LTI-1p0",
-        "lti_message_type": "basic-lti-launch-request",
-        # User data. These should be proxied from the LTI launch.
-        "user_id": user_id,
-        "roles": roles,
-        "context_id": context_id,
-        # Book presentation and location options
-        "launch_presentation_document_target": "window",
-        "custom_book_location": location,
-    }
-
-    return params
+        return params
 
 
 def factory(_context, request):
     return VitalSourceService(
-        request.registry.settings["vitalsource_launch_key"],
-        request.registry.settings["vitalsource_launch_secret"],
+        request.registry.settings["vitalsource_lti_launch_key"],
+        request.registry.settings["vitalsource_lti_launch_secret"],
     )

--- a/lms/services/vitalsource.py
+++ b/lms/services/vitalsource.py
@@ -1,0 +1,60 @@
+import oauthlib
+from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
+
+
+class VitalSourceService:
+    def __init__(self, _context, request):
+        self._oauth_key = request.registry.settings["vitalsource_launch_key"]
+        self._oauth_secret = request.registry.settings["vitalsource_launch_secret"]
+
+    def get_launch_params(self, book_id, cfi, lti_user):
+        """
+        Launch the VitalSource book viewer using an LTI launch.
+
+        See https://developer.vitalsource.com/hc/en-us/articles/215612237-POST-LTI-Create-a-Bookshelf-Launch
+        """
+
+        launch_url = f"https://bc.vitalsource.com/books/{book_id}"
+        book_location = "/cfi" + cfi
+
+        launch_params = _launch_params(
+            user_id=lti_user.user_id,
+            roles=lti_user.roles,
+            # Set a dummy `context_id`. This needs to be replaced with the real
+            # course in future.
+            context_id="testcourse",
+            location=book_location,
+        )
+        self._sign_form_params(launch_url, launch_params)
+
+        return (launch_url, launch_params)
+
+    def _sign_form_params(self, url, params):
+        client = oauthlib.oauth1.Client(
+            self._oauth_key,
+            self._oauth_secret,
+            signature_method=SIGNATURE_HMAC_SHA1,
+            signature_type=SIGNATURE_TYPE_BODY,
+        )
+        params.update(client.get_oauth_params(oauthlib.common.Request(url, "POST")))
+        oauth_request = oauthlib.common.Request(url, "POST", body=params)
+        params["oauth_signature"] = client.get_oauth_signature(oauth_request)
+        return params
+
+
+def _launch_params(user_id, roles, context_id, location):
+    # See https://developer.vitalsource.com/hc/en-us/articles/206156238-General-LTI-Usage
+    params = {
+        # Standard LTI launch parameters
+        "lti_version": "LTI-1p0",
+        "lti_message_type": "basic-lti-launch-request",
+        # User data. These should be proxied from the LTI launch.
+        "user_id": user_id,
+        "roles": roles,
+        "context_id": context_id,
+        # Book presentation and location options
+        "launch_presentation_document_target": "window",
+        "custom_book_location": location,
+    }
+
+    return params

--- a/lms/services/vitalsource.py
+++ b/lms/services/vitalsource.py
@@ -11,7 +11,11 @@ class VitalSourceService:
         :type lti_launch_key: str
         :param lti_launch_secret: OAuth consumer secret
         :type lti_launch_secret: str
+        :raises ValueError: If credentials are invalid
         """
+        if not lti_launch_key or not lti_launch_secret:
+            raise ValueError("VitalSource LTI launch credentials are invalid")
+
         self._lti_launch_key = lti_launch_key
         self._lti_launch_secret = lti_launch_secret
 

--- a/lms/services/vitalsource.py
+++ b/lms/services/vitalsource.py
@@ -3,9 +3,9 @@ from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
 
 
 class VitalSourceService:
-    def __init__(self, _context, request):
-        self._oauth_key = request.registry.settings["vitalsource_launch_key"]
-        self._oauth_secret = request.registry.settings["vitalsource_launch_secret"]
+    def __init__(self, oauth_key, oauth_secret):
+        self._oauth_key = oauth_key
+        self._oauth_secret = oauth_secret
 
     def get_launch_params(self, book_id, cfi, lti_user):
         """
@@ -58,3 +58,10 @@ def _launch_params(user_id, roles, context_id, location):
     }
 
     return params
+
+
+def factory(_context, request):
+    return VitalSourceService(
+        request.registry.settings["vitalsource_launch_key"],
+        request.registry.settings["vitalsource_launch_secret"],
+    )

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -105,6 +105,26 @@ class BasicLTILaunchViews:
         )
         return self.basic_lti_launch(grading_supported=False)
 
+    @view_config(vitalsource_book=True)
+    def vitalsource_lti_launch(self):
+        """
+        Respond to a VitalSource book launch.
+
+        The book and chapter to show are configured by `book_id` and `cfi` request
+        parameters. VitalSource book launches involve a second LTI launch.
+        Hypothesis's LMS app generates the form parameters needed to load
+        VitalSource's book viewer using an LTI launch. The LMS frontend then
+        renders these parameters into a form and auto-submits the form to perform
+        an authenticated launch of the VS book viewer.
+        """
+        self.sync_lti_data_to_h()
+        self.store_lti_data()
+        self.context.js_config.maybe_enable_grading()
+        self.context.js_config.add_vitalsource_launch_config(
+            self.request.params["book_id"], self.request.params.get("cfi")
+        )
+        return {}
+
     @view_config(db_configured=True)
     def db_configured_basic_lti_launch(self):
         """

--- a/lms/views/predicates/__init__.py
+++ b/lms/views/predicates/__init__.py
@@ -13,6 +13,7 @@ from lms.views.predicates._lti_launch import (
     Configured,
     DBConfigured,
     URLConfigured,
+    VitalSourceBook,
 )
 
 
@@ -23,6 +24,7 @@ def includeme(config):
         BrightspaceCopied,
         CanvasFile,
         URLConfigured,
+        VitalSourceBook,
         Configured,
         AuthorizedToConfigureAssignments,
     ):

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -178,6 +178,13 @@ class CanvasFile(Base):
         return ("canvas_file" in request.params) == self.value
 
 
+class VitalSourceBook(Base):
+    name = "vitalsource_book"
+
+    def __call__(self, context, request):
+        return ("vitalsource_book" in request.params) == self.value
+
+
 class URLConfigured(Base):
     """
     Allow invoking an LTI launch view only for URL-configured assignments.
@@ -229,19 +236,19 @@ class Configured(Base):
     def __init__(self, value, config):
         super().__init__(value, config)
         self.canvas_file = CanvasFile(True, config)
-        self.url_configured = URLConfigured(True, config)
         self.db_configured = DBConfigured(True, config)
         self.blackboard_copied = BlackboardCopied(True, config)
         self.brightspace_copied = BrightspaceCopied(True, config)
+        self.vitalsource_book = VitalSourceBook(True, config)
 
     def __call__(self, context, request):
         configured = any(
             [
                 self.canvas_file(context, request),
-                self.url_configured(context, request),
                 self.db_configured(context, request),
                 self.blackboard_copied(context, request),
                 self.brightspace_copied(context, request),
+                self.vitalsource_book(context, request),
             ]
         )
         return configured == self.value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,6 @@ TEST_SETTINGS = {
     "oauth2_state_secret": "test_oauth2_state_secret",
     "session_cookie_secret": "notasecret",
     "via_secret": "not_a_secret",
-    "vitalsource_launch_key": "test_vs_launch_key",
-    "vitalsource_launch_secret": "test_vs_launch_secret",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,8 @@ TEST_SETTINGS = {
     "oauth2_state_secret": "test_oauth2_state_secret",
     "session_cookie_secret": "notasecret",
     "via_secret": "not_a_secret",
+    "vitalsource_launch_key": "test_vs_launch_key",
+    "vitalsource_launch_secret": "test_vs_launch_secret",
 }
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,6 +20,7 @@ from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.services.oauth1 import OAuth1Service
 from lms.services.oauth2_token import OAuth2TokenService
+from lms.services.vitalsource import VitalSourceService
 from tests import factories
 from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
 
@@ -264,6 +265,15 @@ def oauth2_token_service(oauth_token, pyramid_config):
     oauth2_token_service.get.return_value = oauth_token
     pyramid_config.register_service(oauth2_token_service, name="oauth2_token")
     return oauth2_token_service
+
+
+@pytest.fixture
+def vitalsource_service(pyramid_config):
+    vitalsource_service = mock.create_autospec(
+        VitalSourceService, instance=True, spec_set=True
+    )
+    pyramid_config.register_service(vitalsource_service, name="vitalsource")
+    return vitalsource_service
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/services/__init___test.py
+++ b/tests/unit/lms/services/__init___test.py
@@ -12,6 +12,7 @@ from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.services.oauth1 import OAuth1Service
+from lms.services.vitalsource import VitalSourceService
 
 
 class TestIncludeme:
@@ -27,6 +28,7 @@ class TestIncludeme:
             ("group_info", GroupInfoService),
             ("lti_h", LTIHService),
             ("oauth1", OAuth1Service),
+            ("vitalsource", VitalSourceService),
         ),
     )
     def test_it_has_the_expected_service(self, name, service_class, pyramid_config):

--- a/tests/unit/lms/services/__init___test.py
+++ b/tests/unit/lms/services/__init___test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lms.services import includeme
+from lms.services import includeme, vitalsource
 from lms.services.application_instance_getter import (
     application_instance_getter_service_factory,
 )
@@ -12,7 +12,6 @@ from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.services.oauth1 import OAuth1Service
-from lms.services.vitalsource import VitalSourceService
 
 
 class TestIncludeme:
@@ -28,7 +27,7 @@ class TestIncludeme:
             ("group_info", GroupInfoService),
             ("lti_h", LTIHService),
             ("oauth1", OAuth1Service),
-            ("vitalsource", VitalSourceService),
+            ("vitalsource", vitalsource.factory),
         ),
     )
     def test_it_has_the_expected_service(self, name, service_class, pyramid_config):

--- a/tests/unit/lms/services/vitalsource_test.py
+++ b/tests/unit/lms/services/vitalsource_test.py
@@ -32,8 +32,8 @@ class TestVitalSourceService:
         svc.get_launch_params("book-id", "/cfi", lti_user)
 
         OAuth1Client.assert_called_with(
-            "oauth_key",
-            "oauth_secret",
+            "lti_launch_key",
+            "lti_launch_secret",
             signature_method=SIGNATURE_HMAC_SHA1,
             signature_type=SIGNATURE_TYPE_BODY,
         )
@@ -45,7 +45,7 @@ class TestVitalSourceService:
         params = {k: v for (k, v) in params.items() if k.startswith("oauth_")}
 
         assert params == {
-            "oauth_consumer_key": "oauth_key",
+            "oauth_consumer_key": "lti_launch_key",
             "oauth_nonce": Any.string.matching("[0-9]+"),
             "oauth_signature": Any.string.matching("[0-9a-zA-Z+=]+"),
             "oauth_signature_method": "HMAC-SHA1",
@@ -55,7 +55,7 @@ class TestVitalSourceService:
 
     @pytest.fixture
     def svc(self):
-        return VitalSourceService("oauth_key", "oauth_secret")
+        return VitalSourceService("lti_launch_key", "lti_launch_secret")
 
     @pytest.fixture
     def lti_user(self):
@@ -71,13 +71,13 @@ class TestFactory:
         svc = factory(sentinel.context, pyramid_request)
 
         VitalSourceService.assert_called_once_with(
-            sentinel.oauth_key, sentinel.oauth_secret
+            sentinel.vs_lti_launch_key, sentinel.vs_lti_launch_secret
         )
         assert svc == VitalSourceService.return_value
 
     @pytest.mark.parametrize(
         "name_of_missing_envvar",
-        ["vitalsource_launch_key", "vitalsource_launch_secret"],
+        ["vitalsource_lti_launch_key", "vitalsource_lti_launch_secret"],
     )
     def test_it_raises_if_an_envvar_is_missing(
         self, pyramid_request, name_of_missing_envvar
@@ -89,10 +89,12 @@ class TestFactory:
 
     @pytest.fixture
     def pyramid_config(self, pyramid_config):
-        pyramid_config.registry.settings["vitalsource_launch_key"] = sentinel.oauth_key
         pyramid_config.registry.settings[
-            "vitalsource_launch_secret"
-        ] = sentinel.oauth_secret
+            "vitalsource_lti_launch_key"
+        ] = sentinel.vs_lti_launch_key
+        pyramid_config.registry.settings[
+            "vitalsource_lti_launch_secret"
+        ] = sentinel.vs_lti_launch_secret
         return pyramid_config
 
     @pytest.fixture(autouse=True)

--- a/tests/unit/lms/services/vitalsource_test.py
+++ b/tests/unit/lms/services/vitalsource_test.py
@@ -1,0 +1,78 @@
+import pytest
+from h_matchers import Any
+from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
+
+from lms.services.vitalsource import VitalSourceService
+from tests import factories
+
+
+class TestVitalSourceService:
+    def test_it_generates_lti_launch_form_params(self, pyramid_request, lti_user):
+        svc = VitalSourceService({}, pyramid_request)
+
+        launch_url, params = svc.get_launch_params("book-id", "/abc", lti_user)
+
+        # Ignore OAuth signature params in this test.
+        params = {k: v for (k, v) in params.items() if not k.startswith("oauth_")}
+
+        assert launch_url == "https://bc.vitalsource.com/books/book-id"
+        assert params == {
+            "user_id": "teststudent",
+            "roles": "Learner",
+            "context_id": "testcourse",
+            "launch_presentation_document_target": "window",
+            "lti_version": "LTI-1p0",
+            "lti_message_type": "basic-lti-launch-request",
+            "custom_book_location": "/cfi/abc",
+        }
+
+    def test_it_uses_correct_launch_key_and_secret_to_sign_params(
+        self, pyramid_request, lti_user, OAuth1Client
+    ):
+        svc = VitalSourceService({}, pyramid_request)
+
+        svc.get_launch_params("book-id", "/cfi", lti_user)
+
+        OAuth1Client.assert_called_with(
+            pyramid_request.registry.settings["vitalsource_launch_key"],
+            pyramid_request.registry.settings["vitalsource_launch_secret"],
+            signature_method=SIGNATURE_HMAC_SHA1,
+            signature_type=SIGNATURE_TYPE_BODY,
+        )
+
+    def test_it_signs_lti_launch_form_params(self, pyramid_request, lti_user):
+        svc = VitalSourceService({}, pyramid_request)
+
+        _, params = svc.get_launch_params("book-id", "/cfi", lti_user)
+
+        # Ignore non-OAuth signature params in this test.
+        params = {k: v for (k, v) in params.items() if k.startswith("oauth_")}
+
+        assert params == {
+            "oauth_consumer_key": "test_vs_launch_key",
+            "oauth_nonce": Any.string.matching("[0-9]+"),
+            "oauth_signature": Any.string.matching("[0-9a-zA-Z+=]+"),
+            "oauth_signature_method": "HMAC-SHA1",
+            "oauth_timestamp": Any.string.matching("[0-9]+"),
+            "oauth_version": "1.0",
+        }
+
+    def test_it_raises_if_launch_key_not_set(self, pyramid_request):
+        del pyramid_request.registry.settings["vitalsource_launch_key"]
+
+        with pytest.raises(KeyError):
+            VitalSourceService({}, pyramid_request)
+
+    def test_it_raises_if_launch_secret_not_set(self, pyramid_request):
+        del pyramid_request.registry.settings["vitalsource_launch_secret"]
+
+        with pytest.raises(KeyError):
+            VitalSourceService({}, pyramid_request)
+
+    @pytest.fixture
+    def lti_user(self):
+        return factories.LTIUser(user_id="teststudent", roles="Learner")
+
+    @pytest.fixture
+    def OAuth1Client(self, patch):
+        return patch("lms.services.vitalsource.oauthlib.oauth1.Client")

--- a/tests/unit/lms/services/vitalsource_test.py
+++ b/tests/unit/lms/services/vitalsource_test.py
@@ -9,6 +9,20 @@ from tests import factories
 
 
 class TestVitalSourceService:
+    @pytest.mark.parametrize(
+        "key,secret",
+        [
+            (None, "launch-secret"),
+            ("launch-key", None),
+            ("", ""),
+        ],
+    )
+    def test_init_raises_if_launch_credentials_invalid(self, key, secret):
+        with pytest.raises(
+            ValueError, match="VitalSource LTI launch credentials are invalid"
+        ):
+            VitalSourceService(key, secret)
+
     def test_it_generates_lti_launch_form_params(self, svc, lti_user):
         launch_url, params = svc.get_launch_params("book-id", "/abc", lti_user)
 

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -130,6 +130,25 @@ def configure_module_item_caller(context, pyramid_request):
     return views.configure_module_item()
 
 
+def vitalsource_lti_launch_caller(context, pyramid_request):
+    """
+    Call BasicLTILaunchViews.vitalsource_lti_launch().
+
+    Set up the appropriate conditions and then call
+    BasicLTILaunchViews.vitalsource_lti_launch(), and return whatever
+    BasicLTILaunchViews.vitalsource_lti_launch() returns.
+    """
+
+    # The book_id and cfi params are assumed present when vitalsource_lti_launch()
+    # is called.
+    pyramid_request.params["book_id"] = "book-id"
+    pyramid_request.params["cfi"] = "/abc"
+
+    views = BasicLTILaunchViews(context, pyramid_request)
+
+    return views.vitalsource_lti_launch()
+
+
 class TestBasicLTILaunchViewsInit:
     """Unit tests for BasicLTILaunchViews.__init__()."""
 
@@ -207,6 +226,7 @@ class TestCommon:
             brightspace_copied_basic_lti_launch_caller,
             url_configured_basic_lti_launch_caller,
             configure_module_item_caller,
+            vitalsource_lti_launch_caller,
         ]
     )
     def view_caller(self, request):
@@ -407,6 +427,19 @@ class TestUnconfiguredBasicLTILaunchNotAuthorized:
         ).unconfigured_basic_lti_launch_not_authorized()
 
         assert data == {}
+
+
+class TestVitalsourceLTILaunch:
+    def test_it_adds_vitalsource_launch_config(self, context, pyramid_request):
+        pyramid_request.params.update(
+            {"vitalsource_book": "true", "book_id": "book-id", "cfi": "/abc"}
+        )
+
+        BasicLTILaunchViews(context, pyramid_request).vitalsource_lti_launch()
+
+        context.js_config.add_vitalsource_launch_config.assert_called_once_with(
+            "book-id", "/abc"
+        )
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/predicates/__init___test.py
+++ b/tests/unit/lms/views/predicates/__init___test.py
@@ -9,6 +9,7 @@ from lms.views.predicates._lti_launch import (
     Configured,
     DBConfigured,
     URLConfigured,
+    VitalSourceBook,
 )
 
 
@@ -23,6 +24,7 @@ def test_includeme_adds_the_view_predicates():
         mock.call("brightspace_copied", BrightspaceCopied),
         mock.call("canvas_file", CanvasFile),
         mock.call("url_configured", URLConfigured),
+        mock.call("vitalsource_book", VitalSourceBook),
         mock.call("configured", Configured),
         mock.call(
             "authorized_to_configure_assignments", AuthorizedToConfigureAssignments

--- a/tests/unit/lms/views/predicates/_lti_launch_test.py
+++ b/tests/unit/lms/views/predicates/_lti_launch_test.py
@@ -11,6 +11,7 @@ from lms.views.predicates import (
     Configured,
     DBConfigured,
     URLConfigured,
+    VitalSourceBook,
 )
 from tests import factories
 
@@ -112,6 +113,21 @@ class TestCanvasFile:
     @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
     def test_when_assignment_is_not_canvas_file(self, value, expected):
         predicate = CanvasFile(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, DummyRequest()) is expected
+
+
+class TestVitalSourceBook:
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_vitalsource_book(self, value, expected):
+        request = DummyRequest(params={"vitalsource_book": "true"})
+        predicate = VitalSourceBook(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_assignment_is_not_vitalsource_book(self, value, expected):
+        predicate = VitalSourceBook(value, mock.sentinel.config)
 
         assert predicate(mock.sentinel.context, DummyRequest()) is expected
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,8 @@ passenv =
     dev: SENTRY_ENVIRONMENT
     dev: USERNAME
     dev: VIA_URL
+    dev: VITALSOURCE_LAUNCH_KEY
+    dev: VITALSOURCE_LAUNCH_SECRET
 deps =
     dev: -e .
     dev: -r requirements/dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,8 @@ passenv =
     dev: SENTRY_ENVIRONMENT
     dev: USERNAME
     dev: VIA_URL
-    dev: VITALSOURCE_LAUNCH_KEY
-    dev: VITALSOURCE_LAUNCH_SECRET
+    dev: VITALSOURCE_LTI_LAUNCH_KEY
+    dev: VITALSOURCE_LTI_LAUNCH_SECRET
 deps =
     dev: -e .
     dev: -r requirements/dev.txt


### PR DESCRIPTION
_This PR contains the backend changes extracted from https://github.com/hypothesis/lms/pull/2390 and rebase on master. See that PR for manual testing steps._

----

This commit adds support for loading the VitalSource book viewer in an
LTI launch if the assignment URL contains `vitalsource_enabled=true` in
the query params, similar to how Canvas files assignments are
configured.

The VitalSource book viewer is loaded via the LTI 1.1 launch process.
When an assignment is configured to use VitalSource, the backend
generates form parameters for an LTI launch and signs them using a
key and secret specified by two new env vars: `VITALSOURCE_LTI_LAUNCH_KEY`
and `VITALSOURCE_LTI_LAUNCH_SECRET`. These form parameters are rendered into
the configuration for the LMS frontend.

Existing logic in the LMS frontend then responds to this configuration
by rendering the form using the parameters supplied by the backend and
submitting it to load the VitalSource book viewer app.

There is currently an issue that the VS app always tries to load the
production Hypothesis client, which won't work with the development LMS
app.

 - Whitelist the `VITALSOURCE_LTI_LAUNCH_KEY` and `VITALSOURCE_LTI_LAUNCH_SECRET` env vars in tox.ini.
 - Add a backend service in `lms/services/vitalsource.py` to handle VitalSource
   LTI launches
 - Add logic to the LTI launch views to handle launching an assignment
   configured to show a VS book
   
Update 2021-02-23: Renamed env vars from `VITALSOURCE_LAUNCH_*` => `VITALSOURCE_LTI_LAUNCH_*`