### PR TITLE
Separate VitalSource launch factory

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -49,5 +49,5 @@ def includeme(config):
         "lms.services.assignment.factory", name="assignment"
     )
     config.register_service_factory(
-        "lms.services.vitalsource.VitalSourceService", name="vitalsource"
+        "lms.services.vitalsource.factory", name="vitalsource"
     )

--- a/lms/services/vitalsource.py
+++ b/lms/services/vitalsource.py
@@ -3,9 +3,9 @@ from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
 
 
 class VitalSourceService:
-    def __init__(self, _context, request):
-        self._oauth_key = request.registry.settings["vitalsource_launch_key"]
-        self._oauth_secret = request.registry.settings["vitalsource_launch_secret"]
+    def __init__(self, oauth_key, oauth_secret):
+        self._oauth_key = oauth_key
+        self._oauth_secret = oauth_secret
 
     def get_launch_params(self, book_id, cfi, lti_user):
         """
@@ -58,3 +58,10 @@ def _launch_params(user_id, roles, context_id, location):
     }
 
     return params
+
+
+def factory(_context, request):
+    return VitalSourceService(
+        request.registry.settings["vitalsource_launch_key"],
+        request.registry.settings["vitalsource_launch_secret"],
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,6 @@ TEST_SETTINGS = {
     "oauth2_state_secret": "test_oauth2_state_secret",
     "session_cookie_secret": "notasecret",
     "via_secret": "not_a_secret",
-    "vitalsource_launch_key": "test_vs_launch_key",
-    "vitalsource_launch_secret": "test_vs_launch_secret",
 }
 
 

--- a/tests/unit/lms/services/__init___test.py
+++ b/tests/unit/lms/services/__init___test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lms.services import includeme
+from lms.services import includeme, vitalsource
 from lms.services.application_instance_getter import (
     application_instance_getter_service_factory,
 )
@@ -12,7 +12,6 @@ from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.services.oauth1 import OAuth1Service
-from lms.services.vitalsource import VitalSourceService
 
 
 class TestIncludeme:
@@ -28,7 +27,7 @@ class TestIncludeme:
             ("group_info", GroupInfoService),
             ("lti_h", LTIHService),
             ("oauth1", OAuth1Service),
-            ("vitalsource", VitalSourceService),
+            ("vitalsource", vitalsource.factory),
         ),
     )
     def test_it_has_the_expected_service(self, name, service_class, pyramid_config):


### PR DESCRIPTION
This tweaks the Vital Source factory and tests to use our latest approach to services:

Add a separate `factory()` function for `VitalSourceService` so that the `VitalSourceService` class itself is more "pure" and doesn't depend on the Pyramid context and request.