### PR TITLE
Reformat requirements files on make requirements

### DIFF
--- a/requirements/compile.sh
+++ b/requirements/compile.sh
@@ -23,3 +23,13 @@ tox -e functests --run-command "pip-compile requirements/functests.in"
 
 # Depends on requirements.txt and tests.txt and bddtests
 tox -e lint --run-command "pip-compile requirements/lint.in"
+
+# Reformat requirements files to match pip-tool>=5.0.5 format
+python requirements/reformat.py requirements/bddtests.txt
+python requirements/reformat.py requirements/dev.txt
+python requirements/reformat.py requirements/dockercompose.txt
+python requirements/reformat.py requirements/format.txt
+python requirements/reformat.py requirements/functests.txt
+python requirements/reformat.py requirements/lint.txt
+python requirements/reformat.py requirements/tests.txt
+python requirements/reformat.py requirements/requirements.txt

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -4,14 +4,25 @@
 #
 #    pip-compile requirements/format.in
 #
-appdirs==1.4.4            # via black
-black==20.8b1             # via -r requirements/format.in
-click==7.1.2              # via black
-dataclasses==0.7          # via black
-isort==5.7.0              # via -r requirements/format.in
-mypy-extensions==0.4.3    # via black
-pathspec==0.8.0           # via black
-regex==2020.7.14          # via black
-toml==0.10.1              # via black
-typed-ast==1.4.1          # via black
-typing-extensions==3.7.4.3  # via black
+appdirs==1.4.4
+    # via black
+black==20.8b1
+    # via -r requirements/format.in
+click==7.1.2
+    # via black
+dataclasses==0.7
+    # via black
+isort==5.7.0
+    # via -r requirements/format.in
+mypy-extensions==0.4.3
+    # via black
+pathspec==0.8.0
+    # via black
+regex==2020.7.14
+    # via black
+toml==0.10.1
+    # via black
+typed-ast==1.4.1
+    # via black
+typing-extensions==3.7.4.3
+    # via black

--- a/requirements/reformat.py
+++ b/requirements/reformat.py
@@ -1,0 +1,65 @@
+"""
+Quick script to reformat requirements.txt formatted by
+pip-tools<5.0.5 to the format used by newer versions.
+
+This is required as dependabot uses the newer version
+but our local enviroments can't upgrade
+due to venv-update being tied to older version of pip.
+
+Every dependency update involves a full file
+rewrite which is impossible to review without this script.
+
+tox 4.0 could potentially deprecate the need for venv-update
+
+Details about the issue in tox:
+    https://github.com/tox-dev/tox/issues/149
+
+and progress on the 4.0 release:
+    https://tox.readthedocs.io/en/rewrite/changelog.html
+"""
+import re
+import sys
+
+requirements_path = sys.argv[1]
+
+formatted_lines = []
+
+MULTI_DEP = re.compile(r".* # via .*,.*$")
+COMMENT = re.compile(r"^#")
+
+
+def _remove_trailing(string):
+    return re.sub(r"[ ]+$", "", string, flags=re.MULTILINE)
+
+
+with open(requirements_path, "r") as f:
+    for line in f:
+        # Comments in the original file
+        if COMMENT.match(line):
+            formatted_lines.append(line)
+            continue
+
+        if not MULTI_DEP.match(line):
+            # Requirements with only one entry in "via" are kept in the same line:
+            # package==XX # via other_package
+            #   becomes
+            # package==XX
+            #   # via other_package
+            formatted = line.replace("# via", "\n    # via")
+            formatted_lines.append(_remove_trailing(formatted))
+            continue
+
+        # For multiple entries in `# via` gets it's own line
+        # package==XX # via other_package, and_another
+        #   becomes
+        # package==XX
+        #   # via
+        #   #   other_package
+        #   #   and_another
+        formatted = line.replace("# via", "\n    # via \n    #  ")
+        formatted = formatted.replace(", ", "\n    #   ")
+        formatted_lines.append(_remove_trailing(formatted))
+
+
+with open(requirements_path, "w") as f:
+    f.write("".join(formatted_lines))


### PR DESCRIPTION
To test it just change any dependency, for example change:

`alembic`
to 
`alembic==1.5.2`

on `requirements/requirements.in`

and `make requirements`

the resulting diff should just be individual lines changing alembic's version (instead of that + reformatting)
