### PR TITLE
Fix resource leaks that cause test failures in newer Python versions

### DIFF
--- a/lms/assets.py
+++ b/lms/assets.py
@@ -54,8 +54,9 @@ class _CachedFile:
 
         current_mtime = os.path.getmtime(self.path)
         if not self._mtime or self._mtime < current_mtime:  # pragma: no cover
-            self._cached = self.loader(open(self.path))
-            self._mtime = current_mtime
+            with open(self.path) as handle:
+                self._cached = self.loader(handle)
+                self._mtime = current_mtime
         return self._cached
 
 

--- a/tests/unit/lms/views/favicon_test.py
+++ b/tests/unit/lms/views/favicon_test.py
@@ -12,3 +12,6 @@ def test_favicon(pyramid_request):
         # See https://en.wikipedia.org/wiki/Favicon#Standardization
         "image/x-icon",
     )
+
+    # Avoid resource leak warning
+    response.app_iter.close()

--- a/tests/unit/lms/views/predicates/_helpers_test.py
+++ b/tests/unit/lms/views/predicates/_helpers_test.py
@@ -13,7 +13,7 @@ class TestBase:
 
         with pytest.raises(
             TypeError,
-            match="Can't instantiate abstract class CustomPredicateFactory with abstract methods name",
+            match="Can't instantiate abstract class CustomPredicateFactory with abstract methods? name",
         ):
             CustomPredicateFactory("test_value", "test_config")
 
@@ -23,7 +23,7 @@ class TestBase:
 
         with pytest.raises(
             TypeError,
-            match="Can't instantiate abstract class CustomPredicateFactory with abstract methods __call__",
+            match="Can't instantiate abstract class CustomPredicateFactory with abstract methods? __call__",
         ):
             CustomPredicateFactory("test_value", "test_config")
 


### PR DESCRIPTION
This PR fixes a couple of unclosed files that caused tests to fail with `ResourceWarning` errors in newer Python versions. It also accommodates a trivial change in the text of an error message between Python 3.6.x and Python 3.9.x.

Following this change all of the unit tests which do not depend on PyCrypto pass under Python 3.6.x and Python 3.9.x. The remaining cause of test failures with newer Python versions in the lms app is the unmaintained PyCrypto package which we'll need to replace. See https://github.com/hypothesis/lms/issues/2451.

See also https://github.com/hypothesis/h/pull/6508