### PR TITLE
Include value for blocked_for for via/checkmate

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -22,4 +22,4 @@ def via_url(request, document_url, content_type=None):
         service_url=request.registry.settings["via_url"],
         host_url=request.host_url,
         secret=request.registry.settings["via_secret"],
-    ).url_for(document_url, content_type)
+    ).url_for(document_url, content_type, blocked_for="lms")

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -36,7 +36,7 @@ h-matchers==1.2.10
     # via -r requirements/bddtests.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-h-vialib==1.0.10
+h-vialib==1.0.12
     # via -r requirements/requirements.txt
 httplib2==0.19.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,7 @@ h-api==1.0.0
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-h-vialib==1.0.10
+h-vialib==1.0.12
     # via -r requirements/requirements.txt
 httplib2==0.19.0
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -34,7 +34,7 @@ h-matchers==1.2.10
     # via -r requirements/functests.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-h-vialib==1.0.10
+h-vialib==1.0.12
     # via -r requirements/requirements.txt
 httplib2==0.19.0
     # via

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -71,7 +71,7 @@ h-pyramid-sentry==1.2.1
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-h-vialib==1.0.10
+h-vialib==1.0.12
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,7 +20,7 @@ h-api==1.0.0
     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.in
-h-vialib==1.0.10
+h-vialib==1.0.12
     # via -r requirements/requirements.in
 httplib2==0.19.0
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -34,7 +34,7 @@ h-matchers==1.2.10
     # via -r requirements/tests.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-h-vialib==1.0.10
+h-vialib==1.0.12
     # via -r requirements/requirements.txt
 httplib2==0.19.0
     # via

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -21,6 +21,7 @@ class TestViaURL:
         url_params = dict(self.DEFAULT_OPTIONS)
         url_params["url"] = url
         url_params["via.sec"] = Any.string()
+        url_params["via.blocked_for"] = "lms"
         assert final_url == Any.url.matching(
             "http://test_via3_server.is/route"
         ).with_query(url_params)


### PR DESCRIPTION
Checkout versions of:

https://github.com/hypothesis/lms/pull/2457 (this PR)
https://github.com/hypothesis/checkmatelib/pull/8
https://github.com/hypothesis/h-vialib/pull/20
https://github.com/hypothesis/via3/pull/392
https://github.com/hypothesis/viahtml/pull/90
https://github.com/hypothesis/checkmate/pull/206

use your local copy of the libraries:

checkmate on via3 and viahtml
```
commands=
dev: pip install -e /home/marcos/hypo/checkmatelib
```

and h-vialib on lms

```
commands=
dev: pip install -e /home/marcos/hypo/h-vialib
```

- Start all the services and check and assigment that result in a block with your local checkmate (this one does at the moment: https://hypothesis.instructure.com/courses/125/assignments/1069)

   You should see the short version of the blocked page.

   "lms" has gone from lms -> via3 -> viahtml -> checkmate

- Repeat the same but start via3 with `CHECKMATE_ENABLED=1 make dev`
  Again you should see the sort version of the block page but this time "lms" went lms -> via3 -> checkmate (should work with viahtml stopped)

- Repeat again but with `master` branch on LMS. You should see the long version of the block page.







