### PR TITLE
Fix `configured` predicate test not checking whether assignment is URL-configured

### DIFF
--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -236,6 +236,7 @@ class Configured(Base):
     def __init__(self, value, config):
         super().__init__(value, config)
         self.canvas_file = CanvasFile(True, config)
+        self.url_configured = URLConfigured(True, config)
         self.db_configured = DBConfigured(True, config)
         self.blackboard_copied = BlackboardCopied(True, config)
         self.brightspace_copied = BrightspaceCopied(True, config)
@@ -245,6 +246,7 @@ class Configured(Base):
         configured = any(
             [
                 self.canvas_file(context, request),
+                self.url_configured(context, request),
                 self.db_configured(context, request),
                 self.blackboard_copied(context, request),
                 self.brightspace_copied(context, request),

--- a/tests/unit/lms/views/predicates/_lti_launch_test.py
+++ b/tests/unit/lms/views/predicates/_lti_launch_test.py
@@ -163,7 +163,11 @@ class TestConfigured:
         assert predicate(mock.sentinel.context, pyramid_request) is expected
 
     @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
-    def test_when_assignment_is_db_configured(self, pyramid_request, value, expected):
+    def test_when_assignment_is_db_configured(
+        self, pyramid_request, assignment_service, value, expected
+    ):
+        assignment_service.get_document_url.return_value = "https://example.com"
+
         predicate = Configured(value, mock.sentinel.config)
 
         assert predicate(mock.sentinel.context, pyramid_request) is expected
@@ -185,6 +189,13 @@ class TestConfigured:
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
         }
         return pyramid_request
+
+    @pytest.fixture
+    def assignment_service(self, assignment_service):
+        # Make sure that the assignment is *not* DB-configured by default in
+        # these tests.
+        assignment_service.get_document_url.return_value = None
+        return assignment_service
 
 
 class TestAuthorizedToConfigureAssignments:

--- a/tests/unit/lms/views/predicates/_lti_launch_test.py
+++ b/tests/unit/lms/views/predicates/_lti_launch_test.py
@@ -166,7 +166,7 @@ class TestConfigured:
     def test_when_assignment_is_db_configured(
         self, pyramid_request, assignment_service, value, expected
     ):
-        assignment_service.get_document_url.return_value = "https://example.com"
+        assignment_service.get_document_url.return_value = mock.sentinel.document_url
 
         predicate = Configured(value, mock.sentinel.config)
 
@@ -199,7 +199,7 @@ class TestConfigured:
         }
         return pyramid_request
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def assignment_service(self, assignment_service):
         # Make sure that the assignment is *not* DB-configured by default in
         # these tests.

--- a/tests/unit/lms/views/predicates/_lti_launch_test.py
+++ b/tests/unit/lms/views/predicates/_lti_launch_test.py
@@ -172,6 +172,15 @@ class TestConfigured:
 
         assert predicate(mock.sentinel.context, pyramid_request) is expected
 
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_vitalsource_book(
+        self, pyramid_request, value, expected
+    ):
+        pyramid_request.params = {"vitalsource_book": True}
+        predicate = Configured(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
     @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
     def test_when_assignment_is_unconfigured(
         self, assignment_service, pyramid_request, value, expected


### PR DESCRIPTION
Fix a regression introduced in https://github.com/hypothesis/lms/pull/2416 where the check for an assignment being URL-configured in the `configured` predicate was accidentally removed. Also fix a flaw in the tests that caused this issue to go unnoticed. See commit message for details.

I also added a test for the assignment being configured via a VitalSource book. The functionality was implemented but not tested in https://github.com/hypothesis/lms/pull/2416.