### PR TITLE
Refresh client's grant token if it has expired

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -64,6 +64,8 @@ def includeme(config):
     )
     config.add_route("canvas_api.sync", "/api/canvas/sync", request_method="POST")
 
+    config.add_route("api.grant_token", "/api/grant_token", request_method="GET")
+
     config.add_route("lti_api.submissions.record", "/api/lti/submissions")
     config.add_route("lti_api.result.read", "/api/lti/result", request_method="GET")
     config.add_route("lti_api.result.record", "/api/lti/result", request_method="POST")

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -10,6 +10,8 @@ import CanvasOAuth2RedirectErrorApp from './components/CanvasOAuth2RedirectError
 import FilePickerApp from './components/FilePickerApp';
 import { ClientRpc } from './services/client-rpc';
 
+/** @typedef {import('./services/client-rpc').ClientConfig} ClientConfig */
+
 const rootEl = document.querySelector('#app');
 if (!rootEl) {
   throw new Error('#app container for LMS frontend is missing');
@@ -28,8 +30,9 @@ switch (config.mode) {
       <BasicLtiLaunchApp
         clientRpc={
           new ClientRpc({
+            authToken: config.api.authToken,
             allowedOrigins: config.rpcServer.allowedOrigins,
-            clientConfig: config.hypothesisClient,
+            clientConfig: /** @type {ClientConfig} */ (config.hypothesisClient),
           })
         }
       />

--- a/lms/views/api/grant_token.py
+++ b/lms/views/api/grant_token.py
@@ -1,0 +1,34 @@
+import datetime
+from urllib.parse import urlparse
+
+import jwt
+from pyramid.view import view_config
+
+
+@view_config(permission="api", renderer="json", route_name="api.grant_token")
+def grant_token(request):
+    """
+    Return a grant token that the Hypothesis client can use to log in to H.
+    """
+
+    # TODO - Avoid duplicating this code from `JSConfig._grant_token`.
+    api_url = request.registry.settings["h_api_url_public"]
+    authority = request.registry.settings["h_authority"]
+    h_user = request.lti_user.h_user
+    now = datetime.datetime.utcnow()
+
+    claims = {
+        "aud": urlparse(api_url).hostname,
+        "iss": request.registry.settings["h_jwt_client_id"],
+        "sub": h_user.userid(authority),
+        "nbf": now,
+        "exp": now + datetime.timedelta(minutes=5),
+    }
+
+    return {
+        "grant_token": jwt.encode(
+            claims,
+            request.registry.settings["h_jwt_client_secret"],
+            algorithm="HS256",
+        )
+    }


### PR DESCRIPTION
During an LTI launch the LMS backend generates a grant token for use by the
Hypothesis client that is valid for 5 minutes (see `JSConfig._grant_token`).

If the Hypothesis client attempts to fetch its configuration after this
time has elapsed then the client will fail to log in. With the sidebar
application this rare because the sidebar launches as soon as Via loads.
It could happen however if the LMS frontend did not load the assignment
content immediately but instead paused for Canvas OAuth and the user
took more than 5 minutes to respond. With the client's "Notebook"
application this is expected to be much more common however, because the
notebook isn't loaded until the user explicitly chooses the "Open
notebook" menu option. That might not happen for minutes or even hours.

Fix the issue by adding a new backend API view, `/api/grant_token` that returns
a new grant token and calling it from the LMS frontend if needed before
responding to a request from the Hypothesis client (which could be from
the sidebar or notebook) for configuration. This view returns a fresh grant token
which is used to update the one in the client config that was initially generated
during the LTI launch.

 - Add `/api/grant_token` route in `lms.views.api.grant_token`
 - Modify `ClientRpc` to check expiry time of grant token and refresh it
   if needed before responding to a `requestConfig` RPC call from the
   client

Part of https://github.com/hypothesis/client/issues/2801
Related [Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1615374523004200)

----

**TODO:**

- [ ] Get consensus on the general approach
- [ ] Agree on the route name/path for the backend API view (currently `/api/grant_token`)
- [ ] De-duplicate the logic between `JSConfig._grant_token` and `grant_token`?
- [ ] Write tests for backend and frontend changes