### PR TITLE
Extract client login token generation into a service

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -51,3 +51,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.vitalsource.factory", name="vitalsource"
     )
+    config.register_service_factory(
+        "lms.services.grant_token.factory", name="grant_token"
+    )

--- a/lms/services/grant_token.py
+++ b/lms/services/grant_token.py
@@ -1,0 +1,59 @@
+import datetime
+from urllib.parse import urlparse
+
+import jwt
+
+
+class GrantTokenService:
+    """
+    Service that generates "grant tokens" used to login to the Hypothesis client.
+
+    These tokens are generated in the LMS backend and forwarded to the Hypothesis
+    client in assignments via the LMS frontend. The Hypothesis client exchanges
+    these tokens for an H API access token which is then used for subsequent API
+    requests.
+
+    See https://h.readthedocs.io/en/latest/publishers/authorization-grant-tokens/
+    """
+
+    def __init__(
+        self, h_api_url_public, h_authority, h_jwt_client_id, h_jwt_client_secret
+    ):
+        self._h_api_url_public = h_api_url_public
+        self._h_authority = h_authority
+        self._h_jwt_client_id = h_jwt_client_id
+        self._h_jwt_client_secret = h_jwt_client_secret
+
+    def generate_token(self, h_user):
+        """
+        Generate a short-lived login token for a given H user.
+
+        :type h_user: models.HUser
+        """
+
+        now = datetime.datetime.utcnow()
+
+        claims = {
+            "aud": urlparse(self._h_api_url_public).hostname,
+            "iss": self._h_jwt_client_id,
+            "sub": h_user.userid(self._h_authority),
+            "nbf": now,
+            "exp": now + datetime.timedelta(minutes=5),
+        }
+
+        return jwt.encode(
+            claims,
+            self._h_jwt_client_secret,
+            algorithm="HS256",
+        )
+
+
+def factory(_context, request):
+    settings = request.registry.settings
+
+    return GrantTokenService(
+        h_api_url_public=settings["h_api_url_public"],
+        h_authority=settings["h_authority"],
+        h_jwt_client_id=settings["h_jwt_client_id"],
+        h_jwt_client_secret=settings["h_jwt_client_secret"],
+    )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,7 @@ from lms.services.assignment import AssignmentService
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
 from lms.services.grading_info import GradingInfoService
+from lms.services.grant_token import GrantTokenService
 from lms.services.group_info import GroupInfoService
 from lms.services.h_api import HAPI
 from lms.services.launch_verifier import LaunchVerifier
@@ -215,6 +216,15 @@ def grading_info_service(pyramid_config):
     grading_info_service.get_by_assignment.return_value = []
     pyramid_config.register_service(grading_info_service, name="grading_info")
     return grading_info_service
+
+
+@pytest.fixture
+def grant_token_service(pyramid_config):
+    grant_token_service = mock.create_autospec(
+        GrantTokenService, instance=True, spec_set=True
+    )
+    pyramid_config.register_service(grant_token_service, name="grant_token")
+    return grant_token_service
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/grant_token_test.py
+++ b/tests/unit/lms/services/grant_token_test.py
@@ -1,0 +1,30 @@
+import datetime
+from unittest.mock import sentinel
+
+import jwt
+import pytest
+
+from lms.models import HUser
+from lms.services.grant_token import factory
+from tests.conftest import TEST_SETTINGS
+
+
+class TestGrantTokenService:
+    def test_it_generates_valid_jwt_token(self, svc):
+        before = int(datetime.datetime.now().timestamp())
+        user = HUser(username="abcdef123")
+
+        grant_token = svc.generate_token(user)
+        secret = TEST_SETTINGS["h_jwt_client_secret"]
+        claims = jwt.decode(
+            grant_token, secret, audience="example.com", algorithms=["HS256"]
+        )
+
+        assert claims["iss"] == TEST_SETTINGS["h_jwt_client_id"]
+        assert claims["sub"] == user.userid(TEST_SETTINGS["h_authority"])
+        assert claims["nbf"] >= before
+        assert claims["exp"] >= before + datetime.timedelta(minutes=5).seconds
+
+    @pytest.fixture
+    def svc(self, pyramid_request):
+        return factory(sentinel.context, pyramid_request)


### PR DESCRIPTION
_This is a follow-up to https://github.com/hypothesis/lms/pull/2487._

Extract the logic that generates login ("grant") tokens for the Hypothesis client
into a `grant_token` service so that it can be re-used for an API view
that will allow the LMS frontend to regenerate the grant token when
needed.

I retained the existing "grant token" terminology in this PR, although the purpose of that is not immediately obvious from the name. Perhaps we should rename it to `client_login_token` in future?