### PR TITLE
Refresh grant token if necessary when Hypothesis client fetches configuration

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -25,6 +25,8 @@ def includeme(config):
         factory="lms.resources.LTILaunchResource",
     )
 
+    config.add_route("api.grant_token", "/api/grant_token", request_method="GET")
+
     config.add_route(
         "blackboard_api.oauth.authorize",
         "/api/blackboard/oauth/authorize",

--- a/lms/services/grant_token.py
+++ b/lms/services/grant_token.py
@@ -35,6 +35,7 @@ class GrantTokenService:
 
         claims = {
             "aud": urlparse(self._h_api_url_public).hostname,
+            "iat": now,
             "iss": self._h_jwt_client_id,
             "sub": h_user.userid(self._h_authority),
             "nbf": now,

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -10,6 +10,8 @@ import CanvasOAuth2RedirectErrorApp from './components/CanvasOAuth2RedirectError
 import FilePickerApp from './components/FilePickerApp';
 import { ClientRpc } from './services/client-rpc';
 
+/** @typedef {import('./services/client-rpc').ClientConfig} ClientConfig */
+
 const rootEl = document.querySelector('#app');
 if (!rootEl) {
   throw new Error('#app container for LMS frontend is missing');
@@ -28,8 +30,9 @@ switch (config.mode) {
       <BasicLtiLaunchApp
         clientRpc={
           new ClientRpc({
+            authToken: config.api.authToken,
             allowedOrigins: config.rpcServer.allowedOrigins,
-            clientConfig: config.hypothesisClient,
+            clientConfig: /** @type {ClientConfig} */ (config.hypothesisClient),
           })
         }
       />

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -14,15 +14,17 @@ import { JWT } from '../utils/jwt';
  */
 
 /**
- * The subset of the Hypothesis client configuration that `ClientRpc` references.
+ * The subset of the Hypothesis client configuration that `ClientRpc` directly references.
  *
- * The backend will set other configuration which is just forwarded to the client
- * and not touched by `ClientRpc`.
+ * The backend will add other properties which are intentionally not included here,
+ * even as an index signature. This other configuration is simply forwarded to
+ * the client but not touched by `ClientRpc`.
  *
  * See https://h.readthedocs.io/projects/client/en/latest/publishers/config/.
  *
  * @typedef ClientConfig
- * @prop {[ServiceConfig]} services
+ * @prop {[ServiceConfig]} services - Annotation configuration for the client.
+ *   In the LMS context this will always consist of exactly one entry.
  */
 
 /**
@@ -55,7 +57,7 @@ export class ClientRpc {
   constructor({ allowedOrigins, authToken, clientConfig }) {
     this._server = new Server(allowedOrigins);
 
-    // A convervative estimate of when the grant token was issued.
+    // A conservative estimate of when the grant token was issued.
     // When this is older than the true value, the frontend will just consider it
     // to "expire" earlier than it really does.
     const issuedAt = Date.now() - 30 * 1000;

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -65,11 +65,17 @@ export class ClientRpc {
     this._server.register('requestConfig', async () => {
       if (grantToken.hasExpired()) {
         const issuedAt = Date.now();
-        const response = await apiCall({
-          authToken,
-          path: '/api/grant_token',
-        });
-        grantToken = new JWT(response.grant_token, issuedAt);
+        try {
+          const response = await apiCall({
+            authToken,
+            path: '/api/grant_token',
+          });
+          grantToken = new JWT(response.grant_token, issuedAt);
+        } catch (err) {
+          throw new Error(
+            'Unable to fetch Hypothesis login. Please reload the assignment.'
+          );
+        }
       }
 
       clientConfig.services[0].grantToken = grantToken.value();

--- a/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
@@ -1,14 +1,28 @@
 import { $imports, ClientRpc } from '../client-rpc';
 
 describe('ClientRpc', () => {
+  let authToken;
   let clientConfig;
+  let fakeApiCall;
+
   let FakeServer;
-  let fakeSidebarWindow;
-  let fakeRpcCall;
   let fakeServerInstance;
 
+  let fakeSidebarWindow;
+  let fakeRpcCall;
+
+  let FakeJWT;
+  let fakeJwt;
+
   beforeEach(() => {
-    clientConfig = { showHighlights: true };
+    clientConfig = {
+      showHighlights: true,
+      services: [
+        {
+          grantToken: 'initial.grant.token',
+        },
+      ],
+    };
 
     fakeSidebarWindow = {
       frame: {},
@@ -24,7 +38,31 @@ describe('ClientRpc', () => {
 
     FakeServer = sinon.stub().returns(fakeServerInstance);
 
+    FakeJWT = sinon.spy(token => {
+      fakeJwt = {
+        hasExpired: sinon.stub().returns(false),
+        value: () => token,
+      };
+      return fakeJwt;
+    });
+
+    let grantTokenCounter = 0;
+    fakeApiCall = sinon.spy(async () => {
+      ++grantTokenCounter;
+      return {
+        grant_token: 'new.grant.token-' + grantTokenCounter,
+      };
+    });
+
+    authToken = 'dummy-auth-token';
+
     $imports.$mock({
+      '../utils/api': {
+        apiCall: fakeApiCall,
+      },
+      '../utils/jwt': {
+        JWT: FakeJWT,
+      },
       '../../postmessage_json_rpc': {
         Server: FakeServer,
         call: fakeRpcCall,
@@ -39,6 +77,7 @@ describe('ClientRpc', () => {
   function createClientRpc() {
     return new ClientRpc({
       allowedOrigins: ['https://client.hypothes.is'],
+      authToken,
       clientConfig,
     });
   }
@@ -48,13 +87,66 @@ describe('ClientRpc', () => {
     assert.calledWith(FakeServer, ['https://client.hypothes.is']);
   });
 
-  it('registers "requestConfig" RPC handler that returns client config', () => {
-    createClientRpc();
-    assert.calledWith(fakeServerInstance.register, 'requestConfig');
-    const [, callback] = fakeServerInstance.register.args.find(
-      ([method]) => method === 'requestConfig'
-    );
-    assert.equal(callback(), clientConfig);
+  describe('"requestConfig" RPC handler', () => {
+    it('is registered', () => {
+      createClientRpc();
+      assert.calledWith(fakeServerInstance.register, 'requestConfig');
+    });
+
+    it('returns client config', async () => {
+      createClientRpc();
+      const [, callback] = fakeServerInstance.register.args.find(
+        ([method]) => method === 'requestConfig'
+      );
+      assert.equal(await callback(), clientConfig);
+    });
+
+    it('returns initial grant token if still valid', async () => {
+      createClientRpc();
+
+      const [, callback] = fakeServerInstance.register.args.find(
+        ([method]) => method === 'requestConfig'
+      );
+      const config = await callback();
+
+      assert.notCalled(fakeApiCall);
+      assert.calledWith(FakeJWT, 'initial.grant.token', sinon.match.number);
+      assert.equal(config.services[0].grantToken, 'initial.grant.token');
+    });
+
+    it('fetches and returns new grant token if it has expired', async () => {
+      createClientRpc();
+      const [, callback] = fakeServerInstance.register.args.find(
+        ([method]) => method === 'requestConfig'
+      );
+
+      // Simulate initial grant token expiring. This should trigger fetching of
+      // a new token.
+      fakeJwt.hasExpired.returns(true);
+      let config = await callback();
+      assert.calledWith(fakeApiCall, {
+        authToken,
+        path: '/api/grant_token',
+      });
+      assert.equal(config.services[0].grantToken, 'new.grant.token-1');
+
+      // Re-fetch config before the new token expires.
+      fakeApiCall.resetHistory();
+      fakeJwt.hasExpired.returns(false);
+
+      config = await callback();
+
+      assert.notCalled(fakeApiCall);
+      assert.equal(config.services[0].grantToken, 'new.grant.token-1');
+
+      // Re-fetch config after the new token expires.
+      fakeJwt.hasExpired.returns(true);
+
+      config = await callback();
+
+      assert.calledWith(fakeApiCall, { authToken, path: '/api/grant_token' });
+      assert.equal(config.services[0].grantToken, 'new.grant.token-2');
+    });
   });
 
   it('registers "requestGroups" RPC handler', () => {

--- a/lms/static/scripts/frontend_apps/utils/jwt.js
+++ b/lms/static/scripts/frontend_apps/utils/jwt.js
@@ -1,0 +1,54 @@
+/**
+ * @typedef JWTPayload
+ * @prop {number} exp
+ * @prop {number} nbf
+ */
+
+/**
+ * Value class for working with JSON Web Tokens issued by the server.
+ */
+export class JWT {
+  /**
+   * Construct a JWT to wrap a recently issued JWT token.
+   *
+   * @param {string} token - Serialized JWT
+   * @param {number} issuedAt -
+   *   A _client_ timestamp in milliseconds estimating when the JWT was issued.
+   *   The estimate should bias towards being earlier than the true time, in
+   *   which case the JWT will "expire" earlier than the true expiry.
+   */
+  constructor(token, issuedAt) {
+    this._token = token;
+
+    const [, payloadBase64] = token.split('.');
+    this._payload = /** @type {JWTPayload} */ (JSON.parse(atob(payloadBase64)));
+
+    // Estimated offset of server's clock relative to client.
+    //
+    // +ve if the server's clock is ahead of the client or -ve if the server's
+    // clock is behind.
+    const skew = this._payload.nbf * 1000 - issuedAt;
+
+    this._validUntil = this._payload.exp * 1000 - skew;
+  }
+
+  /**
+   * Return true if the JWT token has expired.
+   *
+   * @param {number} [now] - Current timestamp in milliseconds
+   */
+  hasExpired(now = Date.now()) {
+    return now > this._validUntil;
+  }
+
+  value() {
+    if (this.hasExpired()) {
+      throw new Error('Tried to use an expired JWT token');
+    }
+    return this._token;
+  }
+
+  payload() {
+    return this._payload;
+  }
+}

--- a/lms/static/scripts/frontend_apps/utils/jwt.js
+++ b/lms/static/scripts/frontend_apps/utils/jwt.js
@@ -26,20 +26,32 @@ export class JWT {
   constructor(token, issuedAt) {
     this._token = token;
 
-    const [, payloadBase64] = token.split('.');
-    this._payload = /** @type {JWTPayload} */ (JSON.parse(atob(payloadBase64)));
+    try {
+      const [, payloadBase64] = token.split('.');
+      this._payload = /** @type {JWTPayload} */ (JSON.parse(
+        atob(payloadBase64)
+      ));
+    } catch (err) {
+      throw new Error('Failed to parse payload from JWT');
+    }
+
+    const iat = this._getField('iat', 'number');
+    const exp = this._getField('exp', 'number');
 
     // Estimated offset of server's clock relative to client.
     //
     // +ve if the server's clock is ahead of the client or -ve if the server's
     // clock is behind.
-    const skew = this._payload.iat * 1000 - issuedAt;
-
-    this._validUntil = this._payload.exp * 1000 - skew;
+    const skew = iat * 1000 - issuedAt;
+    this._validUntil = exp * 1000 - skew;
   }
 
   /**
    * Return true if the JWT token has expired.
+   *
+   * Note that validation for security purposes should be done by the server. Client-side
+   * checks of the expiry time are useful to check if a token is expired before
+   * it has been used, or if a JWT rejection may have been caused by an expired token.
    *
    * @param {number} [now] - Current timestamp in milliseconds
    */
@@ -56,5 +68,16 @@ export class JWT {
 
   payload() {
     return this._payload;
+  }
+
+  /**
+   * @param {keyof JWTPayload} field
+   * @param {string} type
+   */
+  _getField(field, type) {
+    if (!this._payload || typeof this._payload[field] !== type) {
+      throw new Error(`Missing or invalid "${field}" field in JWT payload`);
+    }
+    return this._payload[field];
   }
 }

--- a/lms/static/scripts/frontend_apps/utils/jwt.js
+++ b/lms/static/scripts/frontend_apps/utils/jwt.js
@@ -1,11 +1,17 @@
 /**
+ * Standard JWT payload fields referenced by `JWT`.
+ *
+ * See https://tools.ietf.org/html/rfc7519#page-9
+ *
  * @typedef JWTPayload
- * @prop {number} exp
- * @prop {number} nbf
+ * @prop {number} exp - Expiration time
+ * @prop {number} iat - Issued at
  */
 
 /**
- * Value class for working with JSON Web Tokens issued by the server.
+ * Value class for working with JSON Web Tokens [1] issued by the server.
+ *
+ * [1] https://tools.ietf.org/html/rfc7519
  */
 export class JWT {
   /**
@@ -27,7 +33,7 @@ export class JWT {
     //
     // +ve if the server's clock is ahead of the client or -ve if the server's
     // clock is behind.
-    const skew = this._payload.nbf * 1000 - issuedAt;
+    const skew = this._payload.iat * 1000 - issuedAt;
 
     this._validUntil = this._payload.exp * 1000 - skew;
   }

--- a/lms/static/scripts/frontend_apps/utils/test/jwt-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jwt-test.js
@@ -18,21 +18,21 @@ function timestamp() {
 }
 
 function expiredJwt() {
-  const nbf = timestamp() - 5;
-  const token = makeToken({ nbf, exp: nbf + 2 });
-  return new JWT(token, nbf * 1000);
+  const iat = timestamp() - 5;
+  const token = makeToken({ iat, exp: iat + 2 });
+  return new JWT(token, iat * 1000);
 }
 
 function validJwt() {
-  const nbf = timestamp();
-  const token = makeToken({ nbf, exp: nbf + 5 });
+  const iat = timestamp();
+  const token = makeToken({ iat, exp: iat + 5 });
   return new JWT(token, Date.now());
 }
 
 describe('JWT', () => {
   describe('#payload', () => {
     it('returns parsed payload', () => {
-      const payload = { nbf: 100, exp: 500 };
+      const payload = { iat: 100, exp: 500 };
       const token = makeToken(payload);
 
       const jwt = new JWT(token, 120);
@@ -44,34 +44,34 @@ describe('JWT', () => {
   describe('#hasExpired', () => {
     [
       {
-        // `issuedAt` and `nbf` are equal, so the server and client clocks are
+        // `issuedAt` and `iat` are equal, so the server and client clocks are
         // assumed to be in-sync.
         issuedAt: 0,
-        token: makeToken({ nbf: 0, exp: 5 }),
+        token: makeToken({ iat: 0, exp: 5 }),
         now: 2000,
         expired: false,
       },
       {
-        // `issuedAt` and `nbf` are equal, so the server and client clocks are
+        // `issuedAt` and `iat` are equal, so the server and client clocks are
         // assumed to be in-sync.
         issuedAt: 0,
-        token: makeToken({ nbf: 0, exp: 5 }),
+        token: makeToken({ iat: 0, exp: 5 }),
         now: 7000,
         expired: true,
       },
       {
-        // `issuedAt` is behind `nbf`, so the server's clock is assumed to be
+        // `issuedAt` is behind `iat`, so the server's clock is assumed to be
         // 1 sec ahead of the client.
         issuedAt: 0,
-        token: makeToken({ nbf: 1, exp: 5 }),
+        token: makeToken({ iat: 1, exp: 5 }),
         now: 4500,
         expired: true,
       },
       {
-        // `issuedAt` is ahead of `nbf`, so the server's clock is assumed to be
+        // `issuedAt` is ahead of `iat`, so the server's clock is assumed to be
         // 1 sec behind the client.
         issuedAt: 1000,
-        token: makeToken({ nbf: 0, exp: 5 }),
+        token: makeToken({ iat: 0, exp: 5 }),
         now: 5500,
         expired: false,
       },

--- a/lms/static/scripts/frontend_apps/utils/test/jwt-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jwt-test.js
@@ -1,0 +1,99 @@
+import { JWT } from '../jwt';
+
+function toBase64(value) {
+  return btoa(JSON.stringify(value));
+}
+
+function makeToken(payload) {
+  const header = {
+    alg: 'HS256',
+    typ: 'JWT',
+  };
+  const signature = 'dummysig';
+  return `${toBase64(header)}.${toBase64(payload)}.${signature}`;
+}
+
+function timestamp() {
+  return (Date.now() / 1000) | 0;
+}
+
+function expiredJwt() {
+  const nbf = timestamp() - 5;
+  const token = makeToken({ nbf, exp: nbf + 2 });
+  return new JWT(token, nbf * 1000);
+}
+
+function validJwt() {
+  const nbf = timestamp();
+  const token = makeToken({ nbf, exp: nbf + 5 });
+  return new JWT(token, Date.now());
+}
+
+describe('JWT', () => {
+  describe('#payload', () => {
+    it('returns parsed payload', () => {
+      const payload = { nbf: 100, exp: 500 };
+      const token = makeToken(payload);
+
+      const jwt = new JWT(token, 120);
+
+      assert.deepEqual(jwt.payload(), payload);
+    });
+  });
+
+  describe('#hasExpired', () => {
+    [
+      {
+        // `issuedAt` and `nbf` are equal, so the server and client clocks are
+        // assumed to be in-sync.
+        issuedAt: 0,
+        token: makeToken({ nbf: 0, exp: 5 }),
+        now: 2000,
+        expired: false,
+      },
+      {
+        // `issuedAt` and `nbf` are equal, so the server and client clocks are
+        // assumed to be in-sync.
+        issuedAt: 0,
+        token: makeToken({ nbf: 0, exp: 5 }),
+        now: 7000,
+        expired: true,
+      },
+      {
+        // `issuedAt` is behind `nbf`, so the server's clock is assumed to be
+        // 1 sec ahead of the client.
+        issuedAt: 0,
+        token: makeToken({ nbf: 1, exp: 5 }),
+        now: 4500,
+        expired: true,
+      },
+      {
+        // `issuedAt` is ahead of `nbf`, so the server's clock is assumed to be
+        // 1 sec behind the client.
+        issuedAt: 1000,
+        token: makeToken({ nbf: 0, exp: 5 }),
+        now: 5500,
+        expired: false,
+      },
+    ].forEach(({ issuedAt, token, now, expired }) => {
+      it('returns true if token has expired', () => {
+        const jwt = new JWT(token, issuedAt);
+        assert.equal(jwt.hasExpired(now), expired);
+      });
+    });
+  });
+
+  describe('#value', () => {
+    it('returns token as a string if valid', () => {
+      const jwt = validJwt();
+      assert.typeOf(jwt.value(), 'string');
+    });
+
+    it('throws an error if token has expired', () => {
+      const jwt = expiredJwt();
+      assert.throws(() => {
+        jwt.value();
+      }, 'Tried to use an expired JWT token');
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/test/jwt-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jwt-test.js
@@ -30,6 +30,40 @@ function validJwt() {
 }
 
 describe('JWT', () => {
+  describe('#constructor', () => {
+    [
+      // Wrong number of fields
+      'not-valid',
+      // Payload that is not valid base 64
+      'z.z.z',
+      // Invalid JSON
+      `a.${btoa('{')}.c`,
+    ].forEach(token => {
+      it('throws if extracting and parsing JWT payload fails', () => {
+        assert.throws(() => {
+          new JWT(token);
+        }, 'Failed to parse payload from JWT');
+      });
+    });
+
+    [
+      [{}, 'Missing or invalid "iat" field in JWT payload'],
+      [{ iat: 123 }, 'Missing or invalid "exp" field in JWT payload'],
+      [
+        { iat: 456, exp: 'foo' },
+        'Missing or invalid "exp" field in JWT payload',
+      ],
+    ].forEach(([payload, expectedError]) => {
+      it('throws if payload is missing required field', () => {
+        assert.throws(() => {
+          const encoded = btoa(JSON.stringify(payload));
+          const token = `abc.${encoded}.def`;
+          new JWT(token, 120);
+        }, expectedError);
+      });
+    });
+  });
+
   describe('#payload', () => {
     it('returns parsed payload', () => {
       const payload = { iat: 100, exp: 500 };

--- a/lms/views/api/grant_token.py
+++ b/lms/views/api/grant_token.py
@@ -1,0 +1,15 @@
+from pyramid.view import view_config
+
+
+@view_config(permission="api", renderer="json", route_name="api.grant_token")
+def grant_token(request):
+    """
+    Return a grant token that the Hypothesis client can use to log in to H.
+
+    See https://h.readthedocs.io/en/latest/publishers/authorization-grant-tokens/.
+    """
+
+    grant_token_svc = request.find_service(name="grant_token")
+    h_user = request.lti_user.h_user
+
+    return {"grant_token": grant_token_svc.generate_token(h_user)}

--- a/tests/unit/lms/services/grant_token_test.py
+++ b/tests/unit/lms/services/grant_token_test.py
@@ -22,6 +22,8 @@ class TestGrantTokenService:
 
         assert claims["iss"] == TEST_SETTINGS["h_jwt_client_id"]
         assert claims["sub"] == user.userid(TEST_SETTINGS["h_authority"])
+
+        assert claims["iat"] >= before
         assert claims["nbf"] >= before
         assert claims["exp"] >= before + datetime.timedelta(minutes=5).seconds
 

--- a/tests/unit/lms/views/api/grant_token_test.py
+++ b/tests/unit/lms/views/api/grant_token_test.py
@@ -1,0 +1,10 @@
+from lms.views.api.grant_token import grant_token
+
+
+class TestGrantToken:
+    def test_it_generates_token(self, pyramid_request, grant_token_service):
+        ctx = grant_token(pyramid_request)
+        grant_token_service.generate_token.assert_called_with(
+            pyramid_request.lti_user.h_user
+        )
+        assert ctx["grant_token"] == grant_token_service.generate_token.return_value


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/lms/pull/2500**~~

During an LTI launch the LMS backend generates a grant token for use by the Hypothesis client that is valid for 5 minutes.

If the Hypothesis client attempts to fetch its configuration after this time has elapsed then the client will fail to log in. With the sidebar application this rare because the sidebar launches as soon as Via loads. It could happen however if the LMS frontend did not load the assignment content immediately but instead paused for Canvas OAuth and the user took more than 5 minutes to respond. With the client's "Notebook" application this is expected to be much more common however, because the notebook isn't loaded until the user explicitly chooses the "Open notebook" menu option.

Fix the issue by modifying the LMS frontend to request a new grant token if the current one has expired when responding
to a `requestConfig` RPC request from the Hypothesis client.

 - Add a new `/api/grant_token` view in the backend (see `lms.views.api.grant_token`) that generates a fresh login token on demand. This is authenticated using the same JWT token as other LMS frontend API calls
 - Add a `JWT` JS class (`frontend_apps/utils/jwt`) that wraps a server-generated JWT and provides methods to check whether it is still valid.
 - Modify `ClientRpc` JS class to use the `JWT` helper to check if the JWT is still valid before returning config to the client, and fetch a new grant token otherwise.

Part of https://github.com/hypothesis/client/issues/2801

----

**Testing:**

1. Make a couple of local changes to shorten grant token lifetimes:

```diff
diff --git a/lms/services/grant_token.py b/lms/services/grant_token.py
index cbd054a9..45cd8dc0 100644
--- a/lms/services/grant_token.py
+++ b/lms/services/grant_token.py
@@ -38,7 +38,7 @@ class GrantTokenService:
             "iss": self._h_jwt_client_id,
             "sub": h_user.userid(self._h_authority),
             "nbf": now,
-            "exp": now + datetime.timedelta(minutes=5),
+            "exp": now + datetime.timedelta(seconds=10),
         }
 
         return jwt.encode(
diff --git a/lms/static/scripts/frontend_apps/services/client-rpc.js b/lms/static/scripts/frontend_apps/services/client-rpc.js
index 619f168e..a8133fb2 100644
--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -58,7 +58,7 @@ export class ClientRpc {
     // A convervative estimate of when the grant token was issued.
     // When this is older than the true value, the frontend will just consider it
     // to "expire" earlier than it really does.
-    const issuedAt = Date.now() - 30 * 1000;
+    const issuedAt = Date.now() - 1000;
     let grantToken = new JWT(clientConfig.services[0].grantToken, issuedAt);
 
     // Handle the requests for configuration from the Hypothesis client.
```

2. Launch an assignment with the browser devtools open at the Network tab and the "XHR" filter selected.
3. During the initial assignment launch there should be no `/api/grant_token` API call as the token rendered by the backend during the initial launch is still valid (nb. If you _do_ see this call unexpectedly, try restarting the lms dev server just in case it didn't rebuild when the branch was checked out)
4. Wait at least 10 seconds, then click on the user account menu icon in the client's sidebar and press the "n" key to launch the notebook. There should be an `/api/grant_token` API call followed by the Notebook app appearing.

