### PR TITLE
Extend frontend API token lifetime from 1 to 24 hours

### DIFF
--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -1,4 +1,6 @@
 """Schema for our bearer token-based LTI authentication."""
+from datetime import timedelta
+
 import marshmallow
 
 from lms.models import LTIUser
@@ -137,9 +139,10 @@ class BearerTokenSchema(PyramidRequestSchema):
 
         https://marshmallow.readthedocs.io/en/2.x-line/extending.html#example-enveloping
         """
-        return {
-            "authorization": f"Bearer {_jwt.encode_jwt(data, self.context['secret'])}"
-        }
+        token = _jwt.encode_jwt(
+            data, self.context["secret"], lifetime=timedelta(hours=24)
+        )
+        return {"authorization": f"Bearer {token}"}
 
     @marshmallow.pre_load
     def _decode_jwt(self, data, **_kwargs):

--- a/lms/validation/authentication/_helpers/_jwt.py
+++ b/lms/validation/authentication/_helpers/_jwt.py
@@ -39,7 +39,10 @@ def decode_jwt(jwt_str, secret):
     return payload
 
 
-def encode_jwt(payload, secret):
+ONE_HOUR = datetime.timedelta(hours=1)
+
+
+def encode_jwt(payload, secret, lifetime=ONE_HOUR):
     """
     Return ``payload`` as a JWT encoded with ``secret``.
 
@@ -50,12 +53,14 @@ def encode_jwt(payload, secret):
     :type payload: dict
     :arg secret: the secret to sign the JWT with
     :type secret: str
+    :arg lifetime: how long the token should be valid for
+    :type lifetime: timedelta
 
     :return: the JWT string
     :rtype: str
     """
     payload = copy.deepcopy(payload)
-    payload["exp"] = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+    payload["exp"] = datetime.datetime.utcnow() + lifetime
 
     jwt_str = jwt.encode(payload, secret, algorithm="HS256")
 

--- a/tests/unit/lms/validation/authentication/_bearer_token_test.py
+++ b/tests/unit/lms/validation/authentication/_bearer_token_test.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from pyramid.testing import DummyRequest
 from webargs.pyramidparser import parser
@@ -18,7 +20,9 @@ class TestBearerTokenSchema:
     def test_it_serializes_lti_users_into_bearer_tokens(self, lti_user, schema, _jwt):
         authorization_param_value = schema.authorization_param(lti_user)
 
-        _jwt.encode_jwt.assert_called_once_with(lti_user._asdict(), "test_secret")
+        _jwt.encode_jwt.assert_called_once_with(
+            lti_user._asdict(), "test_secret", lifetime=datetime.timedelta(hours=24)
+        )
         assert authorization_param_value == f"Bearer {_jwt.encode_jwt.return_value}"
 
     def test_it_deserializes_lti_users_from_authorization_headers(

--- a/tests/unit/lms/validation/authentication/_helpers/_jwt_test.py
+++ b/tests/unit/lms/validation/authentication/_helpers/_jwt_test.py
@@ -86,3 +86,24 @@ class TestEncodeJWT:
         jwt_str = _jwt.encode_jwt({"TEST_KEY": "TEST_VALUE"}, "test_secret")
 
         assert isinstance(jwt_str, str)
+
+    def test_it_uses_one_hour_lifetime_by_default(self):
+        jwt_str = _jwt.encode_jwt({}, "test_secret")
+        decoded_payload = jwt.decode(jwt_str, "test_secret", algorithms=["HS256"])
+        lifetime_minutes = self._jwt_lifetime(decoded_payload) / 60
+
+        assert round(lifetime_minutes) == 60
+
+    def test_it_uses_custom_lifetime(self):
+        jwt_str = _jwt.encode_jwt(
+            {}, "test_secret", lifetime=datetime.timedelta(hours=24)
+        )
+        decoded_payload = jwt.decode(jwt_str, "test_secret", algorithms=["HS256"])
+        lifetime_hours = self._jwt_lifetime(decoded_payload) / (60 * 60)
+
+        assert round(lifetime_hours) == 24
+
+    @staticmethod
+    def _jwt_lifetime(payload):
+        now = datetime.datetime.utcnow().timestamp()
+        return payload["exp"] - now


### PR DESCRIPTION
Following up on [this Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1615897553001500?thread_ts=1615543250.068600&cid=C4K6M7P5E), this PR extends the lifetime of the JWT used by the LMS frontend in API calls to the backend from one to 24 hours. This makes it much less likely that it will expire in the middle of a user session.

The other uses of JWT (eg. for the state param in OAuth 2 flows) continue to use tokens with a one hour expiry.

- Add `lifetime` parameter to `encode_jwt` helper. The default remains at one hour. This allows different consumers to set different lifetimes
- Set a custom 24-hour lifetime on the JWT generated by the backend for the LMS frontend to use in API calls