### PR TITLE
Improve lti outcome error detail

### DIFF
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -146,7 +146,7 @@ class LTIOutcomesClient:
         except KeyError as err:
             raise LTIOutcomesAPIError("Malformed LTI outcome response") from err
 
-        if status == "success":
+        if status != "success":
             raise LTIOutcomesAPIError(explanation="LTI outcome request failed", response=data, details=data)
 
         return body

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -146,8 +146,8 @@ class LTIOutcomesClient:
         except KeyError as err:
             raise LTIOutcomesAPIError("Malformed LTI outcome response") from err
 
-        if status != "success":
-            raise LTIOutcomesAPIError("LTI outcome request failed")
+        if status == "success":
+            raise LTIOutcomesAPIError(explanation="LTI outcome request failed", response=data, details=data)
 
         return body
 

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -24,6 +24,7 @@ const GRADE_MULTIPLIER = 10;
 
 /**
  * @typedef {import('../config').StudentInfo} StudentInfo
+ * @typedef {import('./ErrorDisplay').ErrorLike} ErrorLike
  */
 
 /**
@@ -32,7 +33,7 @@ const GRADE_MULTIPLIER = 10;
  * and error status of that fetch request.
  *
  * @param {StudentInfo|null} student
- * @param {(value: string) => void} setFetchGradeError
+ * @param {(value: ErrorLike) => void} setFetchGradeError
  */
 const useFetchGrade = (student, setFetchGradeError) => {
   const {
@@ -57,7 +58,7 @@ const useFetchGrade = (student, setFetchGradeError) => {
             setGrade(scaleGrade(currentScore, GRADE_MULTIPLIER));
           }
         } catch (e) {
-          setFetchGradeError(e.errorMessage ? e.errorMessage : 'Unknown error');
+          setFetchGradeError(e);
         } finally {
           setGradeLoading(false);
         }
@@ -89,13 +90,13 @@ const useFetchGrade = (student, setFetchGradeError) => {
  */
 export default function SubmitGradeForm({ student }) {
   // State for loading the grade
-  const [fetchGradeError, setFetchGradeError] = useState('');
+  const [fetchGradeError, setFetchGradeError] = useState(/** @type {ErrorLike|null} */ (null));
   const { grade, gradeLoading } = useFetchGrade(student, setFetchGradeError);
 
   // The following is state for saving the grade
   //
   // If there is an error when submitting a grade?
-  const [submitGradeError, setSubmitGradeError] = useState('');
+  const [submitGradeError, setSubmitGradeError] = useState(/** @type {ErrorLike|null} */ (null));
   // Is set to true when the grade is being currently posted to the service
   const [gradeSaving, setGradeSaving] = useState(false);
   // Changes the input field's background to green for a short duration when true
@@ -151,7 +152,7 @@ export default function SubmitGradeForm({ student }) {
         });
         setGradeSaved(true);
       } catch (e) {
-        setSubmitGradeError(e.errorMessage ? e.errorMessage : 'Unknown error');
+        setSubmitGradeError(e);
       }
       setGradeSaving(false);
     }
@@ -220,9 +221,9 @@ export default function SubmitGradeForm({ student }) {
       {!!submitGradeError && (
         <ErrorDialog
           title="Submit Grade Error"
-          error={{ message: submitGradeError }}
+          error={ submitGradeError }
           onCancel={() => {
-            setSubmitGradeError('');
+            setSubmitGradeError(null);
           }}
           cancelLabel="Close"
         />
@@ -230,9 +231,9 @@ export default function SubmitGradeForm({ student }) {
       {!!fetchGradeError && (
         <ErrorDialog
           title="Fetch Grade Error"
-          error={{ message: fetchGradeError }}
+          error={ fetchGradeError }
           onCancel={() => {
-            setFetchGradeError('');
+            setFetchGradeError(null);
           }}
           cancelLabel="Close"
         />


### PR DESCRIPTION
In trying to track down the grading issue we have seen in moodle with several customers, I had a difficult time finding details about the request errors beecause paper trail cuts off after so many days -- and I can't see logs in newrelic. I think It probably would be useful to capture to the details with the error so they can be preserved in a screen shot with a hubspot ticket. I'd like to hand this off as a start point to gaining more error information so we can track down moodle issues with grading. 

This will still not relay the school or LMS service and it may be nice to also do that, but that will probably be easy to figure out from the ticket in any case.  If there is anything else that may be useful to relay to the error, let's add that too.

Relates to https://github.com/hypothesis/support/issues/169


TODO:
- [ ] - fix client tests
- [ ] - should we relay additional details to the client?


![Screen Shot 2021-03-31 at 4 37 17 PM](https://user-images.githubusercontent.com/3939074/113224125-8e202b80-923f-11eb-97f0-1722bf9642c7.png)


