### PR TITLE
Render more details with LTI outcome errors

### DIFF
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -24,6 +24,7 @@ const GRADE_MULTIPLIER = 10;
 
 /**
  * @typedef {import('../config').StudentInfo} StudentInfo
+ * @typedef {import('./ErrorDisplay').ErrorLike} ErrorLike
  */
 
 /**
@@ -32,7 +33,7 @@ const GRADE_MULTIPLIER = 10;
  * and error status of that fetch request.
  *
  * @param {StudentInfo|null} student
- * @param {(value: string) => void} setFetchGradeError
+ * @param {(value: ErrorLike) => void} setFetchGradeError
  */
 const useFetchGrade = (student, setFetchGradeError) => {
   const {
@@ -57,7 +58,7 @@ const useFetchGrade = (student, setFetchGradeError) => {
             setGrade(scaleGrade(currentScore, GRADE_MULTIPLIER));
           }
         } catch (e) {
-          setFetchGradeError(e.errorMessage ? e.errorMessage : 'Unknown error');
+          setFetchGradeError(e);
         } finally {
           setGradeLoading(false);
         }
@@ -89,13 +90,17 @@ const useFetchGrade = (student, setFetchGradeError) => {
  */
 export default function SubmitGradeForm({ student }) {
   // State for loading the grade
-  const [fetchGradeError, setFetchGradeError] = useState('');
+  const [fetchGradeError, setFetchGradeError] = useState(
+    /** @type {ErrorLike|null} */ (null)
+  );
   const { grade, gradeLoading } = useFetchGrade(student, setFetchGradeError);
 
   // The following is state for saving the grade
   //
   // If there is an error when submitting a grade?
-  const [submitGradeError, setSubmitGradeError] = useState('');
+  const [submitGradeError, setSubmitGradeError] = useState(
+    /** @type {ErrorLike|null} */ (null)
+  );
   // Is set to true when the grade is being currently posted to the service
   const [gradeSaving, setGradeSaving] = useState(false);
   // Changes the input field's background to green for a short duration when true
@@ -151,7 +156,7 @@ export default function SubmitGradeForm({ student }) {
         });
         setGradeSaved(true);
       } catch (e) {
-        setSubmitGradeError(e.errorMessage ? e.errorMessage : 'Unknown error');
+        setSubmitGradeError(e);
       }
       setGradeSaving(false);
     }
@@ -219,20 +224,20 @@ export default function SubmitGradeForm({ student }) {
       </button>
       {!!submitGradeError && (
         <ErrorDialog
-          title="Submit Grade Error"
-          error={{ message: submitGradeError }}
+          title="Unable to submit grade"
+          error={submitGradeError}
           onCancel={() => {
-            setSubmitGradeError('');
+            setSubmitGradeError(null);
           }}
           cancelLabel="Close"
         />
       )}
       {!!fetchGradeError && (
         <ErrorDialog
-          title="Fetch Grade Error"
-          error={{ message: fetchGradeError }}
+          title="Unable to fetch grade"
+          error={fetchGradeError}
           onCancel={() => {
-            setFetchGradeError('');
+            setFetchGradeError(null);
           }}
           cancelLabel="Close"
         />

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -164,9 +164,15 @@ describe('SubmitGradeForm', () => {
 
     it('shows the error dialog when the grade request throws an error', () => {
       const wrapper = renderForm();
-      fakeSubmitGrade.throws({ errorMessage: '' });
+      const error = {
+        errorMessage: 'message',
+        details: 'details',
+      };
+      fakeSubmitGrade.throws(error);
       wrapper.find('button[type="submit"]').simulate('click');
       assert.isTrue(wrapper.find('ErrorDialog').exists());
+      // Ensure the error object passed to ErrorDialog is the same as the one thrown
+      assert.equal(wrapper.find('ErrorDialog').prop('error'), error);
     });
 
     it('sets the `is-saved` class when the grade has posted', async () => {
@@ -228,10 +234,17 @@ describe('SubmitGradeForm', () => {
     });
 
     it('shows the error dialog when the grade request throws an error', () => {
-      fakeFetchGrade.throws({ errorMessage: '' });
+      const error = {
+        errorMessage: 'message',
+        details: 'details',
+      };
+      fakeFetchGrade.throws(error);
       const wrapper = renderForm();
       wrapper.find('button[type="submit"]').simulate('click');
+
       assert.isTrue(wrapper.find('ErrorDialog').exists());
+      // Ensure the error object passed to ErrorDialog is the same as the one thrown
+      assert.equal(wrapper.find('ErrorDialog').prop('error'), error);
     });
 
     it("sets the input defaultValue prop to the student's grade", async () => {


### PR DESCRIPTION
In order to help pinpoint moodle grading errors, it will help to relay more information to the client so that it may be captured in a screen shot at the time the error occurs. This helps prevent losing metadata when the logs expire in paper trail after too much time.

--------

This is just the client change in this PR
https://github.com/hypothesis/lms/pull/2536


![Screen Shot 2021-03-31 at 4 37 17 PM](https://user-images.githubusercontent.com/3939074/113366513-43b9b000-930e-11eb-9924-4ad92f982704.png)
