### PR TITLE
Fix timezone handling issue in JWT tests

### DIFF
--- a/tests/unit/lms/validation/authentication/_helpers/_jwt_test.py
+++ b/tests/unit/lms/validation/authentication/_helpers/_jwt_test.py
@@ -105,5 +105,5 @@ class TestEncodeJWT:
 
     @staticmethod
     def _jwt_lifetime(payload):
-        now = datetime.datetime.utcnow().timestamp()
+        now = datetime.datetime.now(datetime.timezone.utc).timestamp()
         return payload["exp"] - now


### PR DESCRIPTION
The tests were attempting to check the age of a Unix timestamp in a JWT
token by comparing the `exp` field in the payload against
`datetime.datetime.utcnow().timestamp()`. This expression however
returns the wrong value. `utcnow()` returns a "naive" datetime,
which has no TZ information, and `timestamp()` assumes, incorrectly, that "naive"
datetimes are using the local timezone.

The fix here is to use `datetime.now(timezone.utc)` to generate an
"aware" datetime, for which `timestamp()` returns the correct value.

See https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp

This fixes the tests failing during daylight savings in the UK.