### PR TITLE
Add imsx_description to LTIOutcomesAPIError details

### DIFF
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -147,7 +147,19 @@ class LTIOutcomesClient:
             raise LTIOutcomesAPIError("Malformed LTI outcome response") from err
 
         if status != "success":
-            raise LTIOutcomesAPIError("LTI outcome request failed")
+            description = None
+            try:
+                # Look for an imsx_description to pass along to the client, but it is possible this field
+                # may not exist.
+                description = header["imsx_POXResponseHeaderInfo"]["imsx_statusInfo"][
+                    "imsx_description"
+                ]
+            except KeyError as err:
+                pass
+
+            raise LTIOutcomesAPIError(
+                explanation="LTI outcome request failed", details=description
+            )
 
         return body
 


### PR DESCRIPTION
When users see a grading error, its helpful to capture to error details at the same time so we can more quickly discover causes for these errors. Passing the response data to the LTIOutcomesAPIError will allow it to propagate to the client and render in the error dialog.