### PR TITLE
Add environment fixture for functional tests

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,6 +1,7 @@
 import contextlib
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 from webtest import TestApp
 
 from lms import db
@@ -25,6 +26,16 @@ def clean_database(db_engine):
 
 
 @pytest.fixture(scope="session")
+def monkeysession():
+    # It's planned to include this on pytest directly
+    # https://github.com/pytest-dev/pytest/issues/363
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+
+
+@pytest.fixture(scope="session")
+@pytest.mark.usefixtures("environment")
 def pyramid_app():
     return create_app(None, **TEST_SETTINGS)
 
@@ -34,6 +45,11 @@ def app(pyramid_app, db_engine):
     db.init(db_engine)
 
     return TestApp(pyramid_app)
+
+
+@pytest.fixture(scope="session")
+def environment(monkeysession):
+    monkeysession.setenv("LMS_SECRET", TEST_SETTINGS["lms_secret"])
 
 
 @pytest.fixture


### PR DESCRIPTION
Explicitly assign some environment values on a functional tests fixture.

https://hypothes-is.slack.com/archives/C1MA4E9B9/p1618398308442900