### PR TITLE
Functional tests for /reports and extra case for no auth on /lti_launch

### DIFF
--- a/tests/functional/api/basic_lti_launch_test.py
+++ b/tests/functional/api/basic_lti_launch_test.py
@@ -26,6 +26,22 @@ class TestBasicLTILaunch:
         assert response.headers["Content-Type"] == Any.string.matching("^text/html")
         assert response.html
 
+    def test_no_auth_blocks(self, app, lti_params):
+        unauthenticated_lti_params = dict(lti_params)
+        del unauthenticated_lti_params["oauth_signature"]
+        response = app.post(
+            "/lti_launches",
+            params=unauthenticated_lti_params,
+            headers={
+                "Accept": "text/html",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            status=403,
+        )
+
+        assert response.headers["Content-Type"] == Any.string.matching("^text/html")
+        assert response.html
+
     @pytest.fixture(autouse=True)
     def application_instance(self, db_session):  # pylint:disable=unused-argument
         return factories.ApplicationInstance()

--- a/tests/functional/views/reports_test.py
+++ b/tests/functional/views/reports_test.py
@@ -4,7 +4,7 @@ from pyramid.authentication import AuthTicket
 class TestReports:
     def test_it_allows_whitelisted_user(self, app):
         cookie_token = AuthTicket(
-            "TEST_LMS_SECRET", "jeremy", "0.0.0.0", hashalg="sha512"
+            "TEST_LMS_SECRET", "report_viewer", "0.0.0.0", hashalg="sha512"
         ).cookie_value()
 
         app.set_cookie("auth_tkt", cookie_token)

--- a/tests/functional/views/reports_test.py
+++ b/tests/functional/views/reports_test.py
@@ -1,0 +1,31 @@
+from pyramid.authentication import AuthTicket
+
+
+class TestReports:
+    def test_it_allows_whitelisted_user(self, app):
+        cookie_token = AuthTicket(
+            "TEST_LMS_SECRET", "jeremy", "0.0.0.0", hashalg="sha512"
+        ).cookie_value()
+
+        app.set_cookie("auth_tkt", cookie_token)
+
+        response = app.get(
+            "/reports",
+            status=200,
+        )
+
+        assert "Application Instances" in response.text
+
+    def test_it_doesnt_allow_any_user(self, app):
+        cookie_token = AuthTicket(
+            "TEST_LMS_SECRET", "some-user", "0.0.0.0", hashalg="sha512"
+        ).cookie_value()
+
+        app.set_cookie("auth_tkt", cookie_token)
+
+        response = app.get(
+            "/reports",
+            status=200,
+        )
+        for field in ["came_from", "username", "password"]:
+            assert field in response.forms[0].fields


### PR DESCRIPTION
Split from the pyramid 2.0 PR

Wanted to confirm what's the behavior of the /report endpoint before update/changes.

