### PR TITLE
Add course group set endpoint to canvas API

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -64,6 +64,11 @@ def includeme(config):
         "canvas_api.files.via_url",
         "/api/canvas/courses/{course_id}/files/{file_id}/via_url",
     )
+    config.add_route(
+        "canvas_api.courses.group_categories.list",
+        "/api/canvas/courses/{course_id}/group_categories",
+    )
+
     config.add_route("canvas_api.sync", "/api/canvas/sync", request_method="POST")
 
     config.add_route("lti_api.submissions.record", "/api/lti/submissions")

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -255,6 +255,19 @@ class CanvasAPIClient:
 
         public_url = fields.Str(required=True)
 
+    def course_group_categories(self, course_id):
+        return self._client.send(
+            "GET",
+            f"courses/{course_id}/group_categories",
+            schema=self._ListGroupCategories,
+        )
+
+    class _ListGroupCategories(RequestsResponseSchema):
+        many = True
+
+        id = fields.Integer(required=True)
+        name = fields.Str(required=True)
+
     @classmethod
     def _ensure_sections_unique(cls, sections):
         """

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -31,6 +31,8 @@ SECTIONS_SCOPES = (
     "url:GET|/api/v1/courses/:course_id/users/:id",
 )
 
+GROUPS_SCOPES = ("url:GET|/api/v1/courses/:course_id/group_categories",)
+
 
 @view_config(
     request_method="GET",
@@ -50,6 +52,9 @@ def authorize(request):
         or course_service.any_with_setting("canvas", "sections_enabled", True)
     ):
         scopes += SECTIONS_SCOPES
+
+    if ai_getter.settings().get("canvas", "groups_enabled"):
+        scopes += GROUPS_SCOPES
 
     auth_url = urlunparse(
         (

--- a/lms/views/api/canvas/groups.py
+++ b/lms/views/api/canvas/groups.py
@@ -1,0 +1,25 @@
+"""Proxy API views for group-related Canvas API endpoints."""
+from pyramid.view import view_config, view_defaults
+
+from lms.security import Permissions
+
+
+@view_defaults(permission=Permissions.API, renderer="json")
+class GroupsAPIViews:
+    def __init__(self, request):
+        self.request = request
+        self.canvas_api_client = request.find_service(name="canvas_api_client")
+
+    @view_config(
+        request_method="GET", route_name="canvas_api.courses.group_categories.list"
+    )
+    def course_group_categories(self):
+        """
+        Return the list of group categories in the given course.
+
+        :raise lms.services.CanvasAPIError: if the Canvas API request fails.
+            This exception is caught and handled by an exception view.
+        """
+        return self.canvas_api_client.course_group_categories(
+            self.request.matchdict["course_id"]
+        )

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -120,6 +120,27 @@ class TestCanvasAPIClient:
         with pytest.raises(CanvasAPIError):
             canvas_api_client.course_sections("dummy")
 
+    def test_group_categories_list(self, canvas_api_client, http_session):
+        group_categories = [
+            {"id": 1, "name": "Group category 1"},
+            {"id": 2, "name": "Group category 2"},
+        ]
+        http_session.set_response(group_categories)
+
+        response = canvas_api_client.course_group_categories("COURSE_ID")
+
+        assert response == group_categories
+
+        http_session.send.assert_called_once_with(
+            Any.request(
+                "GET",
+                url=Any.url.with_path(
+                    "api/v1/courses/COURSE_ID/group_categories"
+                ).with_query({"per_page": Any.string()}),
+            ),
+            timeout=Any(),
+        )
+
     def test_users_sections(self, canvas_api_client, http_session):
         http_session.set_response(
             {
@@ -264,6 +285,7 @@ class TestMetaBehavior:
     methods = {
         "authenticated_users_sections": ["course_id"],
         "course_sections": ["course_id"],
+        "course_group_categories": ["course_id"],
         "users_sections": ["user_id", "course_id"],
         "list_files": ["course_id"],
         "public_url": ["file_id"],

--- a/tests/unit/lms/views/api/canvas/groups_test.py
+++ b/tests/unit/lms/views/api/canvas/groups_test.py
@@ -1,0 +1,40 @@
+import pytest
+
+from lms.services import CanvasAPIError
+from lms.views.api.canvas.groups import GroupsAPIViews
+
+pytestmark = pytest.mark.usefixtures("canvas_api_client")
+
+
+class TestListGroupCategories:
+    def test_it_gets_group_categories_from_canvas(
+        self, canvas_api_client, pyramid_request
+    ):
+        GroupsAPIViews(pyramid_request).course_group_categories()
+
+        canvas_api_client.course_group_categories.assert_called_once_with(
+            "test_course_id"
+        )
+
+    def test_it_returns_the_list_of_group_categories(
+        self, canvas_api_client, pyramid_request
+    ):
+        assert (
+            GroupsAPIViews(pyramid_request).course_group_categories()
+            == canvas_api_client.course_group_categories.return_value
+        )
+
+    # CanvasAPIError's are caught and handled by an exception view, so the
+    # normal view just lets them raise.
+    def test_it_doesnt_catch_CanvasAPIErrors_from_list_group_categories(
+        self, canvas_api_client, pyramid_request
+    ):
+        canvas_api_client.course_group_categories.side_effect = CanvasAPIError("Oops")
+
+        with pytest.raises(CanvasAPIError, match="Oops"):
+            GroupsAPIViews(pyramid_request).course_group_categories()
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.matchdict = {"course_id": "test_course_id"}
+        return pyramid_request


### PR DESCRIPTION
 # Testing

(there's probably a more straightforward method to test this)

### Enable groups on the application_instances

```make sql```

An run something simlar to this, use a `where id = X` or similar if you rather not enable it in all instances locally.

```update application_instances set settings = jsonb_set(settings, '{canvas,groups_enabled}', 'true');```

### Remove existing oauth tokens

```make sql``` (or same shell as before)

Delete all oauth tokens locally, again, use `delete where ...` if you rather target an specific one.
```truncate  oauth2_token;``` 


### Re-authorize you user

head to `https://hypothesis.instructure.com/courses/125/assignments/1575` open any assigment and click "authorize"

### Copy the authorization key

I found the easiest to copy it from any other API call on the browerer, for example after opening the assigment, open the network tab on the brower and copy the Authorization header from the call to `http://localhost:8001/api/canvas/sync`

### Call the new endpoint

Using the auth key, use a curl command or similar to call the new endpoint

```
curl 'http://localhost:8001/api/canvas/courses/125/group_categories' \
  -H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImVuZytjYW52YXN0ZWFjaGVyQGh5cG90aGVzLmlzIiwib2F1dGhfY29uc3VtZXJfa2V5IjoiSHlwb3RoZXNpc2IzYmUwYjMzZDBiNWU0YjFjZjNhYWYwNGUwZTE4MTlhIiwidXNlcl9pZCI6Ijk2OWZjMjk0ZWUyNmUzZjFkMGM5NzE0YWYzMzUxZGM0ZWFjZmQ2ZGYiLCJ0b29sX2NvbnN1bWVyX2luc3RhbmNlX2d1aWQiOiJWQ1N5OERBS0NGSVFZYUl0cFNHeVhoT1hJbGs1QTZOV2R1VlZHMXUzOmNhbnZhcy1sbXMiLCJkaXNwbGF5X25hbWUiOiJIeXBvdGhlc2lzIDEwMSBUZWFjaGVyIiwicm9sZXMiOiJJbnN0cnVjdG9yIiwiZXhwIjoxNjE5MjU4MjU0fQ.JJ2Q8xQT70MDCjDTRPQOIOZQgl-yl4NYJQ97f-5K3Y0' \
  -H 'Content-Type: application/json; charset=UTF-8' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  --compressed
```

results in:

```[{"id": 121, "name": "Test group set"}, {"id": 122, "name": "Empty group set"}, {"id": 125, "name": "PoC"}]```







