### PR TITLE
Replace Button in Dialog.js

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -1,9 +1,11 @@
-import { useElementShouldClose } from '@hypothesis/frontend-shared';
+import {
+  LabeledButton,
+  useElementShouldClose,
+} from '@hypothesis/frontend-shared';
 import { createElement, Fragment } from 'preact';
 import { useEffect, useLayoutEffect, useRef } from 'preact/hooks';
 import classNames from 'classnames';
 
-import Button from './Button';
 import { zIndexScale } from '../utils/style';
 import { useUniqueId } from '../utils/hooks';
 
@@ -131,11 +133,7 @@ export default function Dialog({
           <div className="u-stretch" />
           <div className="Dialog__actions">
             {onCancel && (
-              <Button
-                className="Button--cancel"
-                onClick={onCancel}
-                label={cancelLabel}
-              />
+              <LabeledButton onClick={onCancel}>{cancelLabel}</LabeledButton>
             )}
             {buttons}
           </div>

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -66,18 +66,16 @@ describe('Dialog', () => {
     assert.called(onCancel);
   });
 
-  it(`defaults cancel button's label to "Cancel"`, () => {
+  it(`defaults cancel button's text to "Cancel"`, () => {
     const wrapper = mount(<Dialog onCancel={sinon.stub()} />);
-    wrapper.find('.Dialog__cancel-btn');
-    assert.equal(wrapper.find('Button').prop('label'), 'Cancel');
+    assert.equal(wrapper.find('LabeledButton').text(), 'Cancel');
   });
 
-  it('adds a custom label to the cancel button', () => {
+  it('adds custom text to the cancel button', () => {
     const wrapper = mount(
       <Dialog onCancel={sinon.stub()} cancelLabel="hello" />
     );
-    wrapper.find('.Dialog__cancel-btn');
-    assert.equal(wrapper.find('Button').prop('label'), 'hello');
+    assert.equal(wrapper.find('LabeledButton').text(), 'hello');
   });
 
   describe('initial focus', () => {

--- a/lms/static/styles/components/_Button.scss
+++ b/lms/static/styles/components/_Button.scss
@@ -33,16 +33,6 @@
   display: none;
 }
 
-.Button--cancel {
-  color: var.$grey-6;
-  background-color: var.$grey-2;
-
-  &:hover {
-    background-color: var.$grey-3;
-    color: var.$brand;
-  }
-}
-
 .Button--danger {
   background-color: var.$brand;
 }

--- a/lms/static/styles/components/_Dialog.scss
+++ b/lms/static/styles/components/_Dialog.scss
@@ -1,3 +1,4 @@
+@use '@hypothesis/frontend-shared/styles/components/buttons';
 @use "@hypothesis/frontend-shared/styles/mixins/focus";
 
 @use "../mixins";
@@ -68,10 +69,8 @@
   justify-content: flex-end;
   margin-top: 10px;
 
-  .Button {
-    @include focus.outline-on-keyboard-focus;
-    &:not(:first-child) {
-      margin-left: 5px;
-    }
+  > *:not(:first-child) {
+    // Apply left margin to each action item of any DOM type except the first.
+    margin-left: 5px;
   }
 }

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -28,6 +28,9 @@
 // Element styles
 @use 'variables' as var;
 
+// Shared styles from frontend-shared package
+@use '@hypothesis/frontend-shared/styles';
+
 body {
   font-family: var.$sans-font-family;
   font-size: var.$normal-font-size;


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/2594

This is the first go at replacing Button with LabeledButton. This is more or less a straight conversion as simple as it gets.

### Commit

Replace Button in Dialog.js …

- Include @hypothesis/frontend-shared/styles in css main file
- Replace Button with LabeledButton

-----------

Only the cancel button has changed.

**Before**
![Screen Shot 2021-04-26 at 3 17 51 PM](https://user-images.githubusercontent.com/3939074/116157904-9c2c6500-a6a2-11eb-8a9f-d23566fa9856.png)

**After**
![Screen Shot 2021-04-26 at 3 14 39 PM](https://user-images.githubusercontent.com/3939074/116157719-52dc1580-a6a2-11eb-9d8c-3fe68c2e2083.png)

