### PR TITLE
Replace `PyLTI` with `oauthlib`

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -10,7 +10,6 @@ from lms.services.exceptions import (
     LTILaunchVerificationError,
     LTIOAuthError,
     LTIOutcomesAPIError,
-    NoConsumerKey,
     NoOAuth2Token,
     ServiceError,
 )

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -12,10 +12,6 @@ class LTILaunchVerificationError(ServiceError):
     """
 
 
-class NoConsumerKey(LTILaunchVerificationError):
-    """Raised when a launch request has no ``oauth_consumer_key`` parameter."""
-
-
 class ConsumerKeyError(LTILaunchVerificationError):
     """Raised when a given ``consumer_key`` doesn't exist in the DB."""
 

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -42,11 +42,6 @@ h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
 h-vialib==1.0.15
     # via -r requirements/requirements.txt
-httplib2==0.19.0
-    # via
-    #   -r requirements/requirements.txt
-    #   oauth2
-    #   pylti
 httpretty==1.0.5
     # via -r requirements/bddtests.in
 hupper==1.10.2
@@ -90,10 +85,6 @@ marshmallow==3.8.0
     #   webargs
 newrelic==6.2.0.156
     # via -r requirements/requirements.txt
-oauth2==1.9.0.post1
-    # via
-    #   -r requirements/requirements.txt
-    #   pylti
 oauthlib==3.1.0
     # via
     #   -r requirements/requirements.txt
@@ -131,13 +122,8 @@ pyjwt==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
-pylti==0.7.0
-    # via -r requirements/requirements.txt
 pyparsing==2.4.7
-    # via
-    #   -r requirements/requirements.txt
-    #   httplib2
-    #   packaging
+    # via packaging
 pyramid-exclog==1.0
     # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
@@ -189,7 +175,6 @@ six==1.15.0
     #   jsonschema
     #   packaging
     #   parse-type
-    #   pylti
     #   python-dateutil
     #   webtest
 soupsieve==2.0.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -41,11 +41,6 @@ h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
 h-vialib==1.0.15
     # via -r requirements/requirements.txt
-httplib2==0.19.0
-    # via
-    #   -r requirements/requirements.txt
-    #   oauth2
-    #   pylti
 hupper==1.10.2
     # via
     #   -r requirements/requirements.txt
@@ -89,10 +84,6 @@ marshmallow==3.8.0
     #   webargs
 newrelic==6.2.0.156
     # via -r requirements/requirements.txt
-oauth2==1.9.0.post1
-    # via
-    #   -r requirements/requirements.txt
-    #   pylti
 oauthlib==3.1.0
     # via
     #   -r requirements/requirements.txt
@@ -130,12 +121,6 @@ pyjwt==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
-pylti==0.7.0
-    # via -r requirements/requirements.txt
-pyparsing==2.4.7
-    # via
-    #   -r requirements/requirements.txt
-    #   httplib2
 pyramid-exclog==1.0
     # via -r requirements/requirements.txt
 pyramid-ipython==0.2
@@ -185,7 +170,6 @@ six==1.15.0
     # via
     #   -r requirements/requirements.txt
     #   jsonschema
-    #   pylti
     #   python-dateutil
     #   traitlets
 sqlalchemy==1.4.11

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -40,11 +40,6 @@ h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
 h-vialib==1.0.15
     # via -r requirements/requirements.txt
-httplib2==0.19.0
-    # via
-    #   -r requirements/requirements.txt
-    #   oauth2
-    #   pylti
 httpretty==1.0.5
     # via -r requirements/functests.in
 hupper==1.10.2
@@ -88,10 +83,6 @@ marshmallow==3.8.0
     #   webargs
 newrelic==6.2.0.156
     # via -r requirements/requirements.txt
-oauth2==1.9.0.post1
-    # via
-    #   -r requirements/requirements.txt
-    #   pylti
 oauthlib==3.1.0
     # via
     #   -r requirements/requirements.txt
@@ -123,13 +114,8 @@ pyjwt==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
-pylti==0.7.0
-    # via -r requirements/requirements.txt
 pyparsing==2.4.7
-    # via
-    #   -r requirements/requirements.txt
-    #   httplib2
-    #   packaging
+    # via packaging
 pyramid-exclog==1.0
     # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
@@ -179,7 +165,6 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   jsonschema
     #   packaging
-    #   pylti
     #   python-dateutil
     #   webtest
 soupsieve==2.0.1

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -82,13 +82,6 @@ h-vialib==1.0.15
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-httplib2==0.19.0
-    # via
-    #   -r requirements/bddtests.txt
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   oauth2
-    #   pylti
 httpretty==1.0.5
     # via
     #   -r requirements/bddtests.txt
@@ -164,12 +157,6 @@ newrelic==6.2.0.156
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-oauth2==1.9.0.post1
-    # via
-    #   -r requirements/bddtests.txt
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   pylti
 oauthlib==3.1.0
     # via
     #   -r requirements/bddtests.txt
@@ -244,17 +231,11 @@ pyjwt==2.0.1
     #   h-vialib
 pylint==2.8.2
     # via -r requirements/lint.in
-pylti==0.7.0
-    # via
-    #   -r requirements/bddtests.txt
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
 pyparsing==2.4.7
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-    #   httplib2
     #   packaging
 pyramid-exclog==1.0
     # via
@@ -342,7 +323,6 @@ six==1.15.0
     #   jsonschema
     #   packaging
     #   parse-type
-    #   pylti
     #   python-dateutil
     #   webtest
 snowballstemmer==2.0.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -10,10 +10,10 @@ pyramid-jinja2
 pyramid-retry
 pyramid-services
 gunicorn
+oauthlib
 sqlalchemy
 psycopg2
 zope.sqlalchemy
-PyLTI
 PyJWT
 requests-oauthlib
 requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,10 +24,6 @@ h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.in
 h-vialib==1.0.15
     # via -r requirements/requirements.in
-httplib2==0.19.0
-    # via
-    #   oauth2
-    #   pylti
 hupper==1.10.2
     # via pyramid
 idna==2.10
@@ -51,10 +47,10 @@ marshmallow==3.8.0
     # via webargs
 newrelic==6.2.0.156
     # via -r requirements/requirements.in
-oauth2==1.9.0.post1
-    # via pylti
 oauthlib==3.1.0
-    # via requests-oauthlib
+    # via
+    #   -r requirements/requirements.in
+    #   requests-oauthlib
 pastedeploy==2.1.0
     # via plaster-pastedeploy
 plaster-pastedeploy==0.7
@@ -71,10 +67,6 @@ pyjwt==2.0.1
     # via
     #   -r requirements/requirements.in
     #   h-vialib
-pylti==0.7.0
-    # via -r requirements/requirements.in
-pyparsing==2.4.7
-    # via httplib2
 pyramid-exclog==1.0
     # via -r requirements/requirements.in
 pyramid-jinja2==2.8
@@ -111,7 +103,6 @@ sentry-sdk==0.17.6
 six==1.15.0
     # via
     #   jsonschema
-    #   pylti
     #   python-dateutil
 sqlalchemy==1.4.11
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -40,11 +40,6 @@ h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
 h-vialib==1.0.15
     # via -r requirements/requirements.txt
-httplib2==0.19.0
-    # via
-    #   -r requirements/requirements.txt
-    #   oauth2
-    #   pylti
 httpretty==1.0.5
     # via -r requirements/tests.in
 hupper==1.10.2
@@ -88,10 +83,6 @@ marshmallow==3.8.0
     #   webargs
 newrelic==6.2.0.156
     # via -r requirements/requirements.txt
-oauth2==1.9.0.post1
-    # via
-    #   -r requirements/requirements.txt
-    #   pylti
 oauthlib==3.1.0
     # via
     #   -r requirements/requirements.txt
@@ -123,13 +114,8 @@ pyjwt==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
-pylti==0.7.0
-    # via -r requirements/requirements.txt
 pyparsing==2.4.7
-    # via
-    #   -r requirements/requirements.txt
-    #   httplib2
-    #   packaging
+    # via packaging
 pyramid-exclog==1.0
     # via -r requirements/requirements.txt
 pyramid-jinja2==2.8
@@ -179,7 +165,6 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   jsonschema
     #   packaging
-    #   pylti
     #   python-dateutil
 sqlalchemy==1.4.11
     # via


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/2590

PyLTI is kind of unmaintained and the tests are very broken. This replaces it with `oauthlib` which we already use.

## Review notes

* The way `oauthlib` works is you have to sub-class objects and fill in loads of methods
* The major difficulty in this was previously our code and tests were pretty confused about whether this was a POST or a GET. It's always a POST. This mostly just confused me.
* There's also some weirdness where the URL we get isn't necessarily the one that was signed against. We have to strip any GET params prior to checking the signature
* Due to the important thing being the request body, and the tests previously written around the `params` exclusively the tests were quite heavily rewritten

## Testing notes

Nothing really to do but try it against a number of LTI tool consumers. I've tried Canvas and Moodle.