### PR TITLE
Replace `pycrypto` with `pycryptodome`

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -101,5 +101,8 @@ def _build_unique_key():
 
 def _encrypt_oauth_secret(oauth_secret, key, init_v):
     """Encrypt an oauth secrety via AES encryption."""
-    cipher = AES.new(key, AES.MODE_CFB, init_v)
-    return cipher.encrypt(oauth_secret)
+
+    if isinstance(oauth_secret, str):
+        oauth_secret = oauth_secret.encode("utf-8")
+
+    return AES.new(key, AES.MODE_CFB, init_v).encrypt(oauth_secret)

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -125,7 +125,7 @@ psycopg2==2.8.6
     # via -r requirements/requirements.txt
 py==1.10.0
     # via pytest
-pycrypto==2.6.1
+pycryptodome==3.10.1
     # via -r requirements/requirements.txt
 pyjwt==2.0.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -122,7 +122,7 @@ psycopg2==2.8.6
     # via -r requirements/requirements.txt
 ptyprocess==0.6.0
     # via pexpect
-pycrypto==2.6.1
+pycryptodome==3.10.1
     # via -r requirements/requirements.txt
 pygments==2.7.4
     # via ipython

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4
     # via black
-black==21.4b0
+black==21.4b1
     # via -r requirements/format.in
 click==7.1.2
     # via black
@@ -16,7 +16,7 @@ isort==5.8.0
     # via -r requirements/format.in
 mypy-extensions==0.4.3
     # via black
-pathspec==0.8.0
+pathspec==0.8.1
     # via black
 regex==2020.7.14
     # via black

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -117,7 +117,7 @@ psycopg2==2.8.6
     # via -r requirements/requirements.txt
 py==1.10.0
     # via pytest
-pycrypto==2.6.1
+pycryptodome==3.10.1
     # via -r requirements/requirements.txt
 pyjwt==2.0.1
     # via

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -229,7 +229,7 @@ py==1.10.0
     #   pytest
 pycodestyle==2.7.0
     # via -r requirements/lint.in
-pycrypto==2.6.1
+pycryptodome==3.10.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -17,6 +17,6 @@ PyLTI
 PyJWT
 requests-oauthlib
 requests
-pycrypto==2.6.1
+pycryptodome
 webargs
 xmltodict

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -65,7 +65,7 @@ plaster==1.0
     #   pyramid
 psycopg2==2.8.6
     # via -r requirements/requirements.in
-pycrypto==2.6.1
+pycryptodome==3.10.1
     # via -r requirements/requirements.in
 pyjwt==2.0.1
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -117,7 +117,7 @@ psycopg2==2.8.6
     # via -r requirements/requirements.txt
 py==1.10.0
     # via pytest
-pycrypto==2.6.1
+pycryptodome==3.10.1
     # via -r requirements/requirements.txt
 pyjwt==2.0.1
     # via


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/2590

`pycrypto` is unsuppored and `pycryptodome` is nearly a drop in replacement for it