### PR TITLE
Update canvas oauth buttons

### DIFF
--- a/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
@@ -1,9 +1,9 @@
+import { LabeledButton } from '@hypothesis/frontend-shared';
 import { Fragment, createElement } from 'preact';
 import { useContext } from 'preact/hooks';
 
 import { Config } from '../config';
 
-import Button from './Button';
 import ErrorDisplay from './ErrorDisplay';
 import Dialog from './Dialog';
 
@@ -45,16 +45,22 @@ export default function CanvasOAuth2RedirectErrorApp({
   };
 
   const buttons = [
-    <Button
-      className="Button--cancel"
-      key="close"
-      label="Close"
-      onClick={() => window.close()}
-    />,
+    <LabeledButton key="close" onClick={() => window.close()} data-test="close">
+      Close
+    </LabeledButton>,
   ];
 
   if (authUrl) {
-    buttons.push(<Button key="try-again" label="Try again" onClick={retry} />);
+    buttons.push(
+      <LabeledButton
+        key="try-again"
+        onClick={retry}
+        data-test="try-again"
+        variant="primary"
+      >
+        Try again
+      </LabeledButton>
+    );
   }
 
   return (

--- a/lms/static/scripts/frontend_apps/components/test/CanvasOAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/CanvasOAuth2RedirectErrorApp-test.js
@@ -72,7 +72,7 @@ describe('CanvasOAuth2RedirectErrorApp', () => {
 
   it(`closes the window when the dialog's "Close" button is clicked`, () => {
     const wrapper = renderApp();
-    wrapper.find('Button[label="Close"]').props().onClick();
+    wrapper.find('LabeledButton[data-test="close"]').props().onClick();
     assert.called(window.close);
   });
 
@@ -81,7 +81,7 @@ describe('CanvasOAuth2RedirectErrorApp', () => {
     fakeConfig.authUrl = 'https://lms.hypothes.is/auth/url';
 
     const wrapper = renderApp();
-    const tryAgainButton = wrapper.find('Button[label="Try again"]');
+    const tryAgainButton = wrapper.find('LabeledButton[data-test="try-again"]');
     assert.isTrue(tryAgainButton.exists());
     assert.equal(fakeLocation.href, initialLocation);
 
@@ -92,6 +92,6 @@ describe('CanvasOAuth2RedirectErrorApp', () => {
 
   it('does not show "Try again" button if no retry URL is provided', () => {
     const wrapper = renderApp();
-    assert.isFalse(wrapper.exists('Button[label="Try again"]'));
+    assert.isFalse(wrapper.exists('LabeledButton[data-test="try-again"]'));
   });
 });


### PR DESCRIPTION
~_Depends on https://github.com/hypothesis/lms/pull/2604_~


Test URL for auth

http://localhost:8001/canvas_oauth_callback?authUrl=blah

Test assignment for missing keys
https://hypothesis.instructure.com/courses/121/assignments/850

**Before**

![Screen Shot 2021-04-27 at 2 40 39 PM](https://user-images.githubusercontent.com/3939074/116320048-6358c280-a76c-11eb-9237-4e2faeb70193.png)

![Screen Shot 2021-04-27 at 2 51 39 PM](https://user-images.githubusercontent.com/3939074/116320060-681d7680-a76c-11eb-8069-b4f60499d077.png)


**After**

![Screen Shot 2021-04-27 at 3 27 40 PM](https://user-images.githubusercontent.com/3939074/116320489-2d680e00-a76d-11eb-99c7-89756bd5ebbf.png)

![Screen Shot 2021-04-27 at 3 23 45 PM](https://user-images.githubusercontent.com/3939074/116320180-9d29c900-a76c-11eb-9da8-93a5d9d526ed.png)

