### PR TITLE
Use `pycryptodomex` instead of `pycryptodome`

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -2,8 +2,8 @@ import secrets
 from datetime import datetime
 
 import sqlalchemy as sa
-from Crypto import Random
-from Crypto.Cipher import AES
+from Cryptodome import Random
+from Cryptodome.Cipher import AES
 from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 from lms import models
 from lms.services import ConsumerKeyError

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -125,7 +125,7 @@ psycopg2==2.8.6
     # via -r requirements/requirements.txt
 py==1.10.0
     # via pytest
-pycryptodome==3.10.1
+pycryptodomex==3.10.1
     # via -r requirements/requirements.txt
 pyjwt==2.0.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -122,7 +122,7 @@ psycopg2==2.8.6
     # via -r requirements/requirements.txt
 ptyprocess==0.6.0
     # via pexpect
-pycryptodome==3.10.1
+pycryptodomex==3.10.1
     # via -r requirements/requirements.txt
 pygments==2.7.4
     # via ipython

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4
     # via black
-black==21.4b1
+black==21.4b2
     # via -r requirements/format.in
 click==7.1.2
     # via black

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -117,7 +117,7 @@ psycopg2==2.8.6
     # via -r requirements/requirements.txt
 py==1.10.0
     # via pytest
-pycryptodome==3.10.1
+pycryptodomex==3.10.1
     # via -r requirements/requirements.txt
 pyjwt==2.0.1
     # via

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -229,7 +229,7 @@ py==1.10.0
     #   pytest
 pycodestyle==2.7.0
     # via -r requirements/lint.in
-pycryptodome==3.10.1
+pycryptodomex==3.10.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -17,6 +17,6 @@ PyLTI
 PyJWT
 requests-oauthlib
 requests
-pycryptodome
+pycryptodomex
 webargs
 xmltodict

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -65,7 +65,7 @@ plaster==1.0
     #   pyramid
 psycopg2==2.8.6
     # via -r requirements/requirements.in
-pycryptodome==3.10.1
+pycryptodomex==3.10.1
     # via -r requirements/requirements.in
 pyjwt==2.0.1
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -117,7 +117,7 @@ psycopg2==2.8.6
     # via -r requirements/requirements.txt
 py==1.10.0
     # via pytest
-pycryptodome==3.10.1
+pycryptodomex==3.10.1
     # via -r requirements/requirements.txt
 pyjwt==2.0.1
     # via


### PR DESCRIPTION
Born of: https://github.com/hypothesis/lms/pull/2611 for: https://github.com/hypothesis/lms/issues/2590

The 'x' varient changes the name of the installed package so it's no longer a direct replacement for `pycrypto`. This means it can't conflict with it and both can be installed. It _also_ means that tools which inspect the virtual env can see it's not installed and don't get confused between the two.

I _think_ this fixes some bugs I've been having locally when switching branches where it says "AES" cannot be found. I think this is also affecting CI.