### PR TITLE
Update to LabeldButton in LauchErrorDialog

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -1,7 +1,7 @@
+import { LabeledButton } from '@hypothesis/frontend-shared';
 import { createElement } from 'preact';
 import { useRef } from 'preact/hooks';
 
-import Button from './Button';
 import Dialog from './Dialog';
 import ErrorDisplay from './ErrorDisplay';
 
@@ -45,12 +45,14 @@ function BaseDialog({
       role="alertdialog"
       buttons={
         onRetry && (
-          <Button
+          <LabeledButton
             buttonRef={focusedDialogButton}
             disabled={busy}
-            label={retryLabel}
             onClick={onRetry}
-          />
+            variant="primary"
+          >
+            {retryLabel}
+          </LabeledButton>
         )
       }
     >

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -71,9 +71,9 @@ describe('LaunchErrorDialog', () => {
         const wrapper = renderDialog({ error, errorState });
 
         assert.include(wrapper.text(), expectedText);
-        assert.equal(wrapper.exists('Button'), retryAction !== null);
+        assert.equal(wrapper.exists('LabeledButton'), retryAction !== null);
         if (retryAction) {
-          assert.equal(wrapper.find('Button').prop('label'), retryAction);
+          assert.equal(wrapper.find('LabeledButton').text(), retryAction);
         }
         assert.equal(wrapper.exists('ErrorDisplay'), hasDetailedError);
       });
@@ -84,7 +84,7 @@ describe('LaunchErrorDialog', () => {
     const wrapper = renderDialog();
 
     act(() => {
-      wrapper.find('Button').prop('onClick')();
+      wrapper.find('LabeledButton').prop('onClick')();
     });
 
     assert.called(retryStub);
@@ -92,12 +92,12 @@ describe('LaunchErrorDialog', () => {
 
   it('enables "Try again" button if `busy` is false', () => {
     const wrapper = renderDialog({ busy: false });
-    assert.isFalse(wrapper.find('Button').prop('disabled'));
+    assert.isFalse(wrapper.find('LabeledButton').prop('disabled'));
   });
 
   it('disables "Try again" button if `busy` is true', () => {
     const wrapper = renderDialog({ busy: true });
-    assert.isTrue(wrapper.find('Button').prop('disabled'));
+    assert.isTrue(wrapper.find('LabeledButton').prop('disabled'));
   });
 
   it('shows error details', () => {


### PR DESCRIPTION
Straightforward conversion to LabledButton

**Before**
![Screen Shot 2021-05-03 at 8 49 09 AM](https://user-images.githubusercontent.com/3939074/116899511-79db9f80-abec-11eb-9f2d-01c7de865c8a.png)

**After**
![Screen Shot 2021-05-03 at 8 35 01 AM](https://user-images.githubusercontent.com/3939074/116899525-7cd69000-abec-11eb-8199-aee48f7a9805.png)
