### PR TITLE
Timestamped model mixin

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,3 +1,4 @@
+from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
 from lms.models.course import Course

--- a/lms/models/_mixins.py
+++ b/lms/models/_mixins.py
@@ -1,0 +1,15 @@
+import sqlalchemy as sa
+
+
+class CreatedUpdatedMixin:
+    created = sa.Column(
+        sa.DateTime(),
+        server_default=sa.func.now(),
+        nullable=False,
+    )
+    updated = sa.Column(
+        sa.DateTime(),
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        nullable=False,
+    )

--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -1,13 +1,12 @@
-import datetime
-
 import sqlalchemy as sa
 
 from lms.db import BASE
+from lms.models import CreatedUpdatedMixin
 
 __all__ = ["GradingInfo"]
 
 
-class GradingInfo(BASE):
+class GradingInfo(CreatedUpdatedMixin, BASE):
     """
     A record of a student's launch of a Hypothesis-configured LMS assignment.
 
@@ -46,19 +45,6 @@ class GradingInfo(BASE):
     )
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
-    created = sa.Column(
-        sa.DateTime(),
-        default=datetime.datetime.utcnow,
-        server_default=sa.func.now(),
-        nullable=False,
-    )
-    updated = sa.Column(
-        sa.DateTime(),
-        server_default=sa.func.now(),
-        default=datetime.datetime.utcnow,
-        onupdate=datetime.datetime.utcnow,
-        nullable=False,
-    )
     lis_result_sourcedid = sa.Column(sa.UnicodeText(), nullable=False)
     lis_outcome_service_url = sa.Column(sa.UnicodeText(), nullable=False)
     oauth_consumer_key = sa.Column(sa.UnicodeText(), nullable=False)


### PR DESCRIPTION
Using the existing definitions of created and & updated

Running alembic revision --autogenerate results in an empty migration.

There's more models that have `created` but not updated, does it make sense to have CreatedMixin? 