### PR TITLE
Set default color in body

### DIFF
--- a/lms/static/styles/_variables.scss
+++ b/lms/static/styles/_variables.scss
@@ -9,6 +9,9 @@ $grey-5: #7a7a7a;
 $grey-6: #3f3f3f;
 $grey-7: #202020;
 
+// Text colors
+$color-text: $grey-7;
+
 $brand: #d00032;
 
 $color-success: #00a36d;

--- a/lms/static/styles/components/_Button.scss
+++ b/lms/static/styles/components/_Button.scss
@@ -10,7 +10,6 @@
   border: none;
   border-radius: 2px;
   color: var.$white;
-  cursor: pointer;
   font-weight: bold;
   padding-left: 15px;
   padding-right: 15px;

--- a/lms/static/styles/components/_LMSGrader.scss
+++ b/lms/static/styles/components/_LMSGrader.scss
@@ -7,7 +7,6 @@
   height: 100%;
   width: 100%;
   position: fixed;
-  color: var.$grey-6;
 }
 
 .LMSGrader__grading-components {

--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -23,7 +23,6 @@
   transition: background-color 0.2s, border-color 0.2s;
 
   &:hover {
-    cursor: pointer;
     background-color: var.$grey-3;
   }
 

--- a/lms/static/styles/components/_SubmitGradeForm.scss
+++ b/lms/static/styles/components/_SubmitGradeForm.scss
@@ -43,7 +43,6 @@
     transition: background-color 0.2s;
 
     &:hover {
-      cursor: pointer;
       background-color: var.$grey-3;
     }
 

--- a/lms/static/styles/components/_ValidationMessage.scss
+++ b/lms/static/styles/components/_ValidationMessage.scss
@@ -38,13 +38,12 @@
   border: none;
   animation-duration: 0.3s;
   animation-fill-mode: forwards;
-  &:hover {
-    cursor: pointer;
-  }
 }
+
 .ValidationMessage--open {
   animation-name: validationErrorOpen;
 }
+
 .ValidationMessage--closed {
   animation-name: validationErrorClose;
 }

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -37,3 +37,10 @@ body {
   line-height: var.$normal-line-height;
   color: var.$color-text;
 }
+
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
+  cursor: pointer;
+}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -35,4 +35,5 @@ body {
   font-family: var.$sans-font-family;
   font-size: var.$normal-font-size;
   line-height: var.$normal-line-height;
+  color: var.$color-text;
 }


### PR DESCRIPTION
A few basic sass changes across the app.
- Fix the default color of the app to match the client with grey7.  This means the dialog text (previously black) is very slightly lighter and the grading bar text (prevently grey6) is very slightly darker. 

- Bake in a default cursor pointer effect for all buttons and button-like elements. This also matches the client's behavoir. Note that some of these sass changes will be wiped out when we convert the buttons over. Currently, the new buttons don't have a pointer styling so there is a lack of affordance for users when hovering over buttons--this fixes that.