### PR TITLE
Remove NoOAuth2Token from exception views

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -13,7 +13,6 @@ from lms.services import (
     CanvasAPIPermissionError,
     CanvasFileNotFoundInCourse,
     LTIOutcomesAPIError,
-    NoOAuth2Token,
 )
 from lms.validation import ValidationError
 
@@ -100,7 +99,6 @@ class ExceptionViews:
             422, message=self.context.explanation, details=self.context.messages
         )
 
-    @exception_view_config(context=NoOAuth2Token)
     @exception_view_config(context=CanvasAPIAccessTokenError)
     def canvas_api_access_token_error(self):
         return self.error_response()


### PR DESCRIPTION
`NoOAuth2Token` is never raised by any view, so it never gets caught by
the exception view.

`NoOAuth2Token` is only ever raised by `OAuth2TokenService.get()`

https://github.com/hypothesis/lms/blob/486f56a6324cd100735737f90787a9c8b8641b70/lms/services/oauth2_token.py#L58

`OAuth2TokenService` is only ever used by `CanvasAPIClient`:

https://github.com/hypothesis/lms/blob/486f56a6324cd100735737f90787a9c8b8641b70/lms/services/canvas_api/factory.py#L22

`CanvasAPIClient` (or more accurately its private helper class
`AuthenticatedClient`) catches `NoOAuth2Token` and turns it into
`CanvasAPIAccessTokenError`:

https://github.com/hypothesis/lms/blob/486f56a6324cd100735737f90787a9c8b8641b70/lms/services/canvas_api/_authenticated.py#L61-L65