### PR TITLE
Admin routes default to trailing slash but will work without it

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -75,6 +75,6 @@ def includeme(config):
     config.add_route("lti_api.result.read", "/api/lti/result", request_method="GET")
     config.add_route("lti_api.result.record", "/api/lti/result", request_method="POST")
 
-    config.add_route("admin.index", "/admin")
-    config.add_route("admin.instances", "/admin/instances")
-    config.add_route("admin.instance", "/admin/instance/{consumer_key}")
+    config.add_route("admin.index", "/admin/")
+    config.add_route("admin.instances", "/admin/instances/")
+    config.add_route("admin.instance", "/admin/instance/{consumer_key}/")

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -1,5 +1,10 @@
 from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPNotFound
-from pyramid.view import forbidden_view_config, view_config, view_defaults
+from pyramid.view import (
+    forbidden_view_config,
+    notfound_view_config,
+    view_config,
+    view_defaults,
+)
 
 from lms.security import Permissions
 
@@ -7,6 +12,11 @@ from lms.security import Permissions
 @forbidden_view_config(path_info="/admin/*")
 def logged_out(request):
     return HTTPFound(location=request.route_url("pyramid_googleauth.login"))
+
+
+@notfound_view_config(path_info="/admin/*", append_slash=True)
+def notfound(_request):
+    return HTTPNotFound()
 
 
 @view_defaults(request_method="GET", permission=Permissions.ADMIN)

--- a/tests/unit/lms/views/admin_test.py
+++ b/tests/unit/lms/views/admin_test.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound
 
-from lms.views.admin import AdminViews, logged_out
+from lms.views.admin import AdminViews, logged_out, notfound
 from tests.matchers import temporary_redirect_to
 
 
@@ -85,3 +85,9 @@ def test_logged_out_redirects_to_login(pyramid_request):
     assert response == temporary_redirect_to(
         pyramid_request.route_url("pyramid_googleauth.login")
     )
+
+
+def test_not_found_view(pyramid_request):
+    response = notfound(pyramid_request)
+
+    assert response.status_code == 404


### PR DESCRIPTION
All of these should work:

/admin/ vs /admin
/admin/instances/ vs /admin/instances
/admin/instance/XXXX vs /admin/instance/XXXX/
