### PR TITLE
Add ProxyAPIError and ProxyAPIAccessTokenError

### DIFF
--- a/lms/sentry.py
+++ b/lms/sentry.py
@@ -1,16 +1,16 @@
 """Sentry crash reporting integration."""
-from lms.services import CanvasAPIAccessTokenError
+from lms.services import ProxyAPIAccessTokenError
 
 
-def filter_canvas_api_access_token_error(event):
-    """Filter out all CanvasAPIAccessTokenError's."""
-    return isinstance(event.exception, CanvasAPIAccessTokenError)
+def filter_proxy_api_access_token_error(event):
+    """Filter out all ProxyAPIAccessTokenError's."""
+    return isinstance(event.exception, ProxyAPIAccessTokenError)
 
 
 def includeme(config):
     config.add_settings(
         {
-            "h_pyramid_sentry.filters": [filter_canvas_api_access_token_error],
+            "h_pyramid_sentry.filters": [filter_proxy_api_access_token_error],
             "h_pyramid_sentry.retry_support": True,
             "h_pyramid_sentry.sqlalchemy_support": True,
         }

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,5 +1,4 @@
 from lms.services.exceptions import (
-    CanvasAPIAccessTokenError,
     CanvasAPIError,
     CanvasAPIPermissionError,
     CanvasAPIServerError,
@@ -11,6 +10,8 @@ from lms.services.exceptions import (
     LTIOAuthError,
     LTIOutcomesAPIError,
     NoOAuth2Token,
+    ProxyAPIAccessTokenError,
+    ProxyAPIError,
     ServiceError,
 )
 

--- a/lms/services/canvas_api/_authenticated.py
+++ b/lms/services/canvas_api/_authenticated.py
@@ -3,7 +3,7 @@
 import marshmallow
 from marshmallow import fields
 
-from lms.services import CanvasAPIAccessTokenError, NoOAuth2Token
+from lms.services import NoOAuth2Token, ProxyAPIAccessTokenError
 from lms.validation import RequestsResponseSchema
 
 
@@ -13,7 +13,7 @@ class AuthenticatedClient:
 
     All methods in the authenticated client may raise:
 
-    :raise CanvasAPIAccessTokenError: if the request fails because our
+    :raise ProxyAPIAccessTokenError: if the request fails because our
          Canvas API access token for the user is missing, expired, or has
          been deleted
     :raise CanvasAPIServerError: if the request fails for any other reason
@@ -47,11 +47,11 @@ class AuthenticatedClient:
         :param path: The path in the API to make a request to
         :param schema: Schema to apply to the return values
         :param params: Any query parameters to add to the request
-        :raise CanvasAPIAccessTokenError: if the request fails because our
+        :raise ProxyAPIAccessTokenError: if the request fails because our
             Canvas API access token for the user is missing, expired, or has
             been deleted
         :return: JSON deserialised object
-        :raise CanvasAPIAccessTokenError: If a token is required and cannot be
+        :raise ProxyAPIAccessTokenError: If a token is required and cannot be
             found / refreshed
         """
         call_args = (method, path, schema, params)
@@ -59,7 +59,7 @@ class AuthenticatedClient:
         try:
             oauth2_token = self._oauth2_token_service.get()
         except NoOAuth2Token as err:
-            raise CanvasAPIAccessTokenError(
+            raise ProxyAPIAccessTokenError(
                 explanation="We don't have a Canvas API access token for this user",
                 response=None,
             ) from err
@@ -72,7 +72,7 @@ class AuthenticatedClient:
                 *call_args,
                 headers={"Authorization": f"Bearer {access_token}"},
             )
-        except CanvasAPIAccessTokenError:
+        except ProxyAPIAccessTokenError:
             if not refresh_token:
                 raise
 

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -29,7 +29,7 @@ class CanvasAPIClient:
 
     All methods may raise:
 
-    :raise CanvasAPIAccessTokenError: if we can't get the list of sections
+    :raise ProxyAPIAccessTokenError: if we can't get the list of sections
         because we don't have a working Canvas API access token for the user
     :raise CanvasAPIServerError: if we do have an access token but the
         Canvas API request fails for any other reason

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -8,11 +8,10 @@ from pyramid.view import (
 )
 
 from lms.services import (
-    CanvasAPIAccessTokenError,
-    CanvasAPIError,
     CanvasAPIPermissionError,
     CanvasFileNotFoundInCourse,
-    LTIOutcomesAPIError,
+    ProxyAPIAccessTokenError,
+    ProxyAPIError,
 )
 from lms.validation import ValidationError
 
@@ -99,8 +98,14 @@ class ExceptionViews:
             422, message=self.context.explanation, details=self.context.messages
         )
 
-    @exception_view_config(context=CanvasAPIAccessTokenError)
-    def canvas_api_access_token_error(self):
+    @exception_view_config(context=ProxyAPIError)
+    def proxy_api_error(self):
+        return self.error_response(
+            message=self.context.explanation, details=self.context.details
+        )
+
+    @exception_view_config(context=ProxyAPIAccessTokenError)
+    def proxy_api_access_token_error(self):
         return self.error_response()
 
     @exception_view_config(context=CanvasAPIPermissionError)
@@ -108,13 +113,6 @@ class ExceptionViews:
     def canvas_api_permission_error(self):
         return self.error_response(
             error_code=self.context.error_code, details=self.context.details
-        )
-
-    @exception_view_config(context=CanvasAPIError)
-    @exception_view_config(context=LTIOutcomesAPIError)
-    def proxy_api_error(self):
-        return self.error_response(
-            message=self.context.explanation, details=self.context.details
         )
 
     @exception_view_config(path_info="/api/*", context=Exception)

--- a/tests/unit/lms/sentry_test.py
+++ b/tests/unit/lms/sentry_test.py
@@ -3,21 +3,21 @@ from unittest import mock
 import pytest
 from h_pyramid_sentry.event import Event
 
-from lms.sentry import filter_canvas_api_access_token_error
-from lms.services import CanvasAPIAccessTokenError
+from lms.sentry import filter_proxy_api_access_token_error
+from lms.services import ProxyAPIAccessTokenError
 
 
-class TestFilterCanvasAPIAccessTokenError:
-    def test_it_filters_canvas_api_access_token_error(self):
+class TestFilterProxyAPIAccessTokenError:
+    def test_it_filters_proxy_api_access_token_error(self):
         event = exception_event(
-            CanvasAPIAccessTokenError(
+            ProxyAPIAccessTokenError(
                 "We don't have a Canvas API access token for this user"
             )
         )
-        assert filter_canvas_api_access_token_error(event)
+        assert filter_proxy_api_access_token_error(event)
 
     def test_it_doesnt_filter_other_exception_events(self, unexpected_exception_event):
-        assert not filter_canvas_api_access_token_error(unexpected_exception_event)
+        assert not filter_proxy_api_access_token_error(unexpected_exception_event)
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -4,10 +4,10 @@ import pytest
 from h_matchers import Any
 
 from lms.services import (
-    CanvasAPIAccessTokenError,
     CanvasAPIError,
     CanvasAPIServerError,
     CanvasFileNotFoundInCourse,
+    ProxyAPIAccessTokenError,
 )
 from lms.services.canvas_api.client import CanvasAPIClient
 from tests import factories
@@ -257,11 +257,11 @@ class TestCanvasAPIClient:
 
 class TestMetaBehavior:
     def test_methods_require_access_token(self, data_method, oauth2_token_service):
-        oauth2_token_service.get.side_effect = CanvasAPIAccessTokenError(
+        oauth2_token_service.get.side_effect = ProxyAPIAccessTokenError(
             "We don't have a Canvas API access token for this user"
         )
 
-        with pytest.raises(CanvasAPIAccessTokenError):
+        with pytest.raises(ProxyAPIAccessTokenError):
             data_method()
 
     @pytest.mark.usefixtures("oauth_token")

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -6,11 +6,11 @@ import pytest
 import requests
 
 from lms.services import (
-    CanvasAPIAccessTokenError,
     CanvasAPIError,
     CanvasAPIPermissionError,
     CanvasAPIServerError,
     ExternalRequestError,
+    ProxyAPIAccessTokenError,
 )
 from lms.validation import ValidationError
 
@@ -84,7 +84,7 @@ class TestCanvasAPIError:
                 401,
                 json.dumps({"errors": [{"message": "Invalid access token."}]}),
                 "401 Unauthorized",
-                CanvasAPIAccessTokenError,
+                ProxyAPIAccessTokenError,
             ),
             # A 401 Unauthorized response from Canvas, because our access token had
             # insufficient scopes;
@@ -94,7 +94,7 @@ class TestCanvasAPIError:
                     {"errors": [{"message": "Insufficient scopes on access token."}]}
                 ),
                 "401 Unauthorized",
-                CanvasAPIAccessTokenError,
+                ProxyAPIAccessTokenError,
             ),
             # A 400 Bad Request response from Canvas, because our refresh token
             # was expired or deleted.
@@ -107,7 +107,7 @@ class TestCanvasAPIError:
                     }
                 ),
                 "400 Bad Request",
-                CanvasAPIAccessTokenError,
+                ProxyAPIAccessTokenError,
             ),
             # A permissions error from Canvas, because the Canvas user doesn't
             # have permission to make the API call.

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -37,7 +37,7 @@ class TestOAuth2TokenService:
         assert result == oauth_token
 
     @pytest.mark.parametrize("wrong_param", ("consumer_key", "user_id"))
-    def test_get_raises_CanvasAPIAccessTokenError_with_no_token(
+    def test_get_raises_NoOAuth2Token_with_no_token(
         self, db_session, wrong_param, application_instance, lti_user
     ):
         store = OAuth2TokenService(

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -20,9 +20,9 @@ class TestSchemaValidationError:
         return ValidationError(messages="foobar")
 
 
-class TestCanvasAPIAccessTokenError:
+class TestProxyAPIAccessTokenError:
     def test_it(self, pyramid_request, views):
-        json_data = views.canvas_api_access_token_error()
+        json_data = views.proxy_api_access_token_error()
 
         assert pyramid_request.response.status_code == 400
         assert json_data == {}


### PR DESCRIPTION
This is some ground work before adding in Blackboard API support.

A new `ProxyAPIError` base class is added which both `CanvasAPIError`
and `LTIOutcomesAPIError` inherit from. In future a new
`BlackboardAPIError` will also inherit from this. The
`proxy_api_error()` exception view that was previously associated with
`CanvasAPIError` and `LTIOutcomesAPIError` is now associated with
`ProxyAPIError` so if future Blackboard code uses `ProxyAPIError` it'll
get the exception view behavior for free.

`CanvasAPIAccessTokenError` is renamed to `ProxyAPIError` so that it can
be reused by the Blackboard API code. For example
`CanvasAPIAccessTokenError`'s are filtered out from Sentry. Since that's
now been changed to a `ProxyAPIAccessTokenError` that the Blackboard
code can also use, the Blackboard code will get the Sentry filtering for
free. There was nothing actually Canvas-specific about
`CanvasAPIAccessTokenError`.