### PR TITLE
Add ApplicationInstance.lms_host()

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,5 +1,6 @@
 import secrets
 from datetime import datetime
+from urllib.parse import urlparse
 
 import sqlalchemy as sa
 from Cryptodome import Random
@@ -52,6 +53,25 @@ class ApplicationInstance(BASE):
     group_infos = sa.orm.relationship(
         "GroupInfo", back_populates="application_instance"
     )
+
+    def lms_host(self):
+        """
+        Return the hostname part of this ApplicationInstance's lms_url.
+
+        For example if application_instance.lms_url is
+        "https://example.com/lms/" then application_instance.lms_host() will
+        return "example.com".
+
+        :raise ValueError: if the ApplicationInstance's lms_url can't be parsed
+        """
+        # urlparse() or .netloc will raise ValueError for some invalid URLs.
+        lms_host = urlparse(self.lms_url).netloc
+
+        # For some URLs urlparse(url).netloc returns an empty string.
+        if not lms_host:
+            raise ValueError()
+
+        return lms_host
 
     @classmethod
     def get_by_consumer_key(cls, db, consumer_key):

--- a/lms/services/application_instance_getter.py
+++ b/lms/services/application_instance_getter.py
@@ -57,6 +57,18 @@ class ApplicationInstanceGetter:
         """
         return self._get_by_consumer_key().lms_url
 
+    def lms_host(self):
+        """
+        Return the hostname part of the current request's LMS URL.
+
+        :raise ConsumerKeyError: if the request's consumer key isn't in the DB
+        :raise ValueError: if the request's LMS URL can't be parsed
+
+        :return: the matching LMS host
+        :rtype: str
+        """
+        return self._get_by_consumer_key().lms_host()
+
     def provisioning_enabled(self):
         """
         Return ``True`` if provisioning is enabled for the current request.

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 from lms.services.canvas_api._authenticated import AuthenticatedClient
 from lms.services.canvas_api._basic import BasicClient
 from lms.services.canvas_api.client import CanvasAPIClient
@@ -14,8 +12,7 @@ def canvas_api_client_factory(_context, request):
     """
     ai_getter = request.find_service(name="ai_getter")
 
-    canvas_host = urlparse(ai_getter.lms_url()).netloc
-    basic_client = BasicClient(canvas_host)
+    basic_client = BasicClient(ai_getter.lms_host())
 
     authenticated_api = AuthenticatedClient(
         basic_client=basic_client,

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -73,6 +73,18 @@ class TestApplicationInstance:
         with pytest.raises(IntegrityError, match="requesters_email"):
             db_session.flush()
 
+    def test_lms_host(self, application_instance):
+        application_instance.lms_url = "https://example.com/lms/"
+
+        assert application_instance.lms_host() == "example.com"
+
+    @pytest.mark.parametrize("lms_url", ["", "foo", "https://example[.com/foo"])
+    def test_lms_host_raises_ValueError(self, application_instance, lms_url):
+        application_instance.lms_url = lms_url
+
+        with pytest.raises(ValueError):
+            application_instance.lms_host()
+
     def test_get_returns_the_matching_ApplicationInstance(
         self, db_session, application_instance
     ):

--- a/tests/unit/lms/services/application_instance_getter_test.py
+++ b/tests/unit/lms/services/application_instance_getter_test.py
@@ -58,6 +58,20 @@ class TestApplicationInstanceGetter:
         with pytest.raises(ConsumerKeyError):
             ai_getter.lms_url()
 
+    def test_lms_host_returns_the_lms_host(self, ai_getter, test_application_instance):
+        assert ai_getter.lms_host() == test_application_instance.lms_host()
+
+    def test_lms_host_raises_ValueError(self, ai_getter, test_application_instance):
+        test_application_instance.lms_url = ""  # Not a valid URL.
+
+        with pytest.raises(ValueError):
+            assert ai_getter.lms_host()
+
+    @pytest.mark.usefixtures("unknown_consumer_key")
+    def test_lms_host_raises_if_consumer_key_unknown(self, ai_getter):
+        with pytest.raises(ConsumerKeyError):
+            ai_getter.lms_url()
+
     @pytest.mark.parametrize("flag", [True, False])
     def test_provisioning_returns_the_provisioning_flag(
         self, ai_getter, flag, test_application_instance

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -17,11 +17,9 @@ class TestCanvasAPIClientFactory:
         assert canvas_api == CanvasAPIClient.return_value
 
     def test_building_the_BasicClient(self, pyramid_request, BasicClient, ai_getter):
-        ai_getter.lms_url.return_value = "https://example.com/path"
-
         canvas_api_client_factory(sentinel.context, pyramid_request)
 
-        BasicClient.assert_called_once_with("example.com")
+        BasicClient.assert_called_once_with(ai_getter.lms_host.return_value)
 
     def test_building_the_AuthenticatedClient(
         self,


### PR DESCRIPTION
The Canvas API client uses the netloc of `ApplicationInstance.lms_url` as the base host to construct Canvas API URLs. The Blackboard API client is going to have to do the same, so move the netloc parsing into the model where both services can use it.