### PR TITLE
Add `type` prop to shared buttons

### DIFF
--- a/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/CanvasOAuth2RedirectErrorApp.js
@@ -45,7 +45,12 @@ export default function CanvasOAuth2RedirectErrorApp({
   };
 
   const buttons = [
-    <LabeledButton key="close" onClick={() => window.close()} data-test="close">
+    <LabeledButton
+      type="button"
+      key="close"
+      onClick={() => window.close()}
+      data-test="close"
+    >
       Close
     </LabeledButton>,
   ];
@@ -53,6 +58,7 @@ export default function CanvasOAuth2RedirectErrorApp({
   if (authUrl) {
     buttons.push(
       <LabeledButton
+        type="button"
         key="try-again"
         onClick={retry}
         data-test="try-again"

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -122,7 +122,12 @@ export default function Dialog({
             <span className="u-stretch" />
             {onCancel && (
               <span className="Dialog__cancel">
-                <IconButton title="Close" icon="cancel" onClick={onCancel} />
+                <IconButton
+                  type="button"
+                  title="Close"
+                  icon="cancel"
+                  onClick={onCancel}
+                />
               </span>
             )}
           </h1>
@@ -130,7 +135,7 @@ export default function Dialog({
           <div className="u-stretch" />
           <div className="Dialog__actions">
             {onCancel && (
-              <LabeledButton title="Cancel" onClick={onCancel}>
+              <LabeledButton type="button" title="Cancel" onClick={onCancel}>
                 {cancelLabel}
               </LabeledButton>
             )}

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -184,6 +184,7 @@ export default function LMSFilePicker({
     case 'select':
       continueButton = (
         <LabeledButton
+          type="button"
           variant="primary"
           disabled={selectedFile === null}
           onClick={useSelectedFile}
@@ -197,6 +198,7 @@ export default function LMSFilePicker({
     case 'authorize':
       continueButton = (
         <LabeledButton
+          type="button"
           onClick={authorizeAndFetchFiles}
           variant="primary"
           data-test="authorize"
@@ -213,6 +215,7 @@ export default function LMSFilePicker({
     case 'authorize_retry':
       continueButton = (
         <LabeledButton
+          type="button"
           onClick={authorizeAndFetchFiles}
           variant="primary"
           data-test="authorize-again"
@@ -230,6 +233,7 @@ export default function LMSFilePicker({
     case 'retry':
       continueButton = (
         <LabeledButton
+          type="button"
           onClick={authorizeAndFetchFiles} // maybe it should use fetchFile function instead
           variant="primary"
           data-test="try-again"
@@ -247,6 +251,7 @@ export default function LMSFilePicker({
     case 'reload':
       continueButton = (
         <LabeledButton
+          type="button"
           disabled={dialogState.state === 'reloading'}
           onClick={fetchFiles}
           variant="primary"

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -46,6 +46,7 @@ function BaseDialog({
       buttons={
         onRetry && (
           <LabeledButton
+            type="button"
             buttonRef={focusedDialogButton}
             disabled={busy}
             onClick={onRetry}

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -37,7 +37,12 @@ export default function URLPicker({ onCancel, onSelectURL }) {
       title="Enter URL"
       onCancel={onCancel}
       buttons={[
-        <LabeledButton key="submit" onClick={submit} variant="primary">
+        <LabeledButton
+          type="button"
+          key="submit"
+          onClick={submit}
+          variant="primary"
+        >
           Submit
         </LabeledButton>,
       ]}


### PR DESCRIPTION
Add the required `type` prop to our shared buttons. In all cases, we can simply use type="button" as we don't have any forums.

depends on https://github.com/hypothesis/frontend-shared/pull/48
