### PR TITLE
Update the student selector buttons

### DIFF
--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -1,4 +1,4 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { SvgIcon, IconButton } from '@hypothesis/frontend-shared';
 import { createElement } from 'preact';
 
 /**
@@ -98,31 +98,25 @@ export default function StudentSelector({
 
   return (
     <div className="StudentSelector">
-      <button
-        className="StudentSelector__change-student"
-        aria-label="previous student"
-        disabled={!hasPrevView}
-        onClick={onPrevView}
-      >
-        <SvgIcon
-          className="StudentSelector__svg"
-          name="arrow-left"
-          inline={true}
+      <span className="StudentSelector__button">
+        <IconButton
+          className="InputButton--left"
+          icon="arrow-left"
+          disabled={!hasPrevView}
+          onClick={onPrevView}
+          title="Previous Student"
         />
-      </button>
+      </span>
       {buildStudentList()}
-      <button
-        className="StudentSelector__change-student"
-        aria-label="next student"
-        disabled={!hasNextView}
-        onClick={onNextView}
-      >
-        <SvgIcon
-          className="StudentSelector__svg"
-          name="arrow-right"
-          inline={true}
+      <span className="StudentSelector__button">
+        <IconButton
+          className="InputButton--right"
+          icon="arrow-right"
+          disabled={!hasNextView}
+          onClick={onNextView}
+          title="Next Student"
         />
-      </button>
+      </span>
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -58,7 +58,7 @@ describe('StudentSelector', () => {
   it('calls onChange (with the next student index) when the next button is clicked', () => {
     const onChange = sinon.spy();
     const wrapper = renderSelector({ onSelectStudent: onChange });
-    wrapper.find('button').last().simulate('click');
+    wrapper.find('IconButton button').last().simulate('click');
     assert.isTrue(onChange.calledWith(1));
   });
 
@@ -68,18 +68,18 @@ describe('StudentSelector', () => {
       onSelectStudent: onChange,
       selectedStudentIndex: 1,
     });
-    wrapper.find('button').first().simulate('click');
+    wrapper.find('IconButton button').first().simulate('click');
     assert.isTrue(onChange.calledWith(0));
   });
 
   it('should disable the previous button when there are no previous options in the list', () => {
     const wrapper = renderSelector({ selectedStudentIndex: -1 });
-    assert.isTrue(wrapper.find('button').first().prop('disabled'));
+    assert.isTrue(wrapper.find('IconButton').first().prop('disabled'));
   });
 
   it('should disable the next button when there are no next options in the list', () => {
     const wrapper = renderSelector({ selectedStudentIndex: 1 });
-    assert.isTrue(wrapper.find('button').last().prop('disabled'));
+    assert.isTrue(wrapper.find('IconButton').last().prop('disabled'));
   });
 
   it.skip(

--- a/lms/static/styles/_variables.scss
+++ b/lms/static/styles/_variables.scss
@@ -34,6 +34,16 @@ $subtitle-font-size: 15px;
 
 $input-font-size: 15px;
 
+// Layout spacing
+// -------------------------
+$layout-space: 1em;
+$layout-space--xxsmall: $layout-space * (1/4);
+$layout-space--xsmall: $layout-space * (1/2);
+$layout-space--small: $layout-space * (3/4);
+$layout-space--medium: $layout-space;
+$layout-space--large: $layout-space * 2;
+$layout-space--xlarge: $layout-space * 4;
+
 // Minimum font size for <input> fields on iOS. If the font size is smaller than
 // this, iOS will zoom into the field when focused.
 $touch-input-font-size: 16px;

--- a/lms/static/styles/buttons.scss
+++ b/lms/static/styles/buttons.scss
@@ -1,0 +1,40 @@
+@use "sass:map";
+
+// Button styling for LMS extending common button-component styles
+@use '@hypothesis/frontend-shared/styles/components/buttons';
+
+@use 'variables' as var;
+
+$input-button-colors: map.merge(
+  buttons.colors-for('IconButton'),
+  (
+    'background': var.$grey-2,
+    'hover-background': var.$grey-3,
+    'disabled-foreground': var.$grey-4,
+  )
+);
+
+// An icon-only button that sits next to a text input field.
+@mixin InputButtonBase {
+  $-options: (
+    'colormap': $input-button-colors,
+    'withVariants': false,
+  );
+  @include buttons.IconButton($-options) {
+    border: 1px solid var.$grey-3;
+    border-radius: 0; // Turn off border-radius to align with <input> edges
+    height: 100%;
+    padding: 0 var.$layout-space--xsmall;
+  }
+}
+
+.InputButton {
+  &--right {
+    @include InputButtonBase;
+    border-left: 0; // Avoid double border with the <input>
+  }
+  &--left {
+    @include InputButtonBase;
+    border-right: 0; // Avoid double border with the <input>
+  }
+}

--- a/lms/static/styles/components/_StudentSelector.scss
+++ b/lms/static/styles/components/_StudentSelector.scss
@@ -6,30 +6,12 @@
   display: flex;
 }
 
-.StudentSelector__svg {
-  color: var.$grey-5;
-  width: 1em;
-  height: 1em;
-}
-
-.StudentSelector__change-student {
-  @include focus.outline-on-keyboard-focus;
-  min-width: 60px;
-  height: 40px;
-  border: none;
-  background-color: var.$grey-2;
-  border: 1px solid var.$grey-3;
+.StudentSelector__button {
   font-size: 24px;
-  transition: background-color 0.2s, border-color 0.2s;
 
-  &:hover {
-    background-color: var.$grey-3;
-  }
-
-  &:disabled {
-    background-color: var.$grey-1;
-    cursor: default;
-    opacity: 0.5;
+  svg {
+    width: 1em;
+    height: 1em;
   }
 }
 
@@ -41,8 +23,6 @@
     @include focus.outline-on-keyboard-focus;
     appearance: none;
     border: 1px solid var.$grey-3;
-    border-left: none;
-    border-right: none;
     border-radius: 0;
     height: 40px;
     padding: 5px 35px 5px 20px;

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -4,6 +4,9 @@
 @use 'utils';
 @use 'typography';
 
+// Custom styling for buttons
+@use 'buttons';
+
 // HTML components
 @use 'components/browser-check-warning';
 @use 'components/heading';


### PR DESCRIPTION
- Replace the student selector buttons with customized IconButton
- Add buttons.scss module for global lms-only buttons' styles
- Copy over the layout-space vars from the client in preparation for use

-------------

This mostly leaves the styling unchanged and migrated over to the new buttons. I'm not advocating we actually keep the styling, I just don't have a proposed change at this point and the defaults seem a bit too light and get washed out. 

relates to the button audit
https://github.com/hypothesis/lms/issues/2587

**Before**
![Screen Shot 2021-05-06 at 5 28 02 PM](https://user-images.githubusercontent.com/3939074/117381229-710af800-ae90-11eb-8f4c-82c0322d54c4.png)

**After**
![Screen Shot 2021-05-06 at 5 27 58 PM](https://user-images.githubusercontent.com/3939074/117381227-70726180-ae90-11eb-9356-4056ee6dc75b.png)

_*The padding is slightly reduced_