### PR TITLE
Fix gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,10 +181,10 @@ gulp.task('watch', gulp.parallel(['watch-js', 'watch-css', 'watch-manifest']));
 function runKarma(done) {
   const karma = require('karma');
   new karma.Server(
-    {
-      configFile: path.resolve(__dirname, './lms/static/scripts/karma.config.js'),
-      ...karmaOptions,
-    },
+    karma.config.parseConfig(
+      path.resolve(__dirname, './lms/static/scripts/karma.config.js'),
+      karmaOptions
+    ),
     done
   ).start();
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -187,6 +187,15 @@ function runKarma(done) {
     ),
     done
   ).start();
+
+  process.on('SIGINT', () => {
+    // Give Karma a chance to handle SIGINT and cleanup, but forcibly
+    // exit if it takes too long.
+    setTimeout(() => {
+      done();
+      process.exit(1);
+    }, 5000);
+  });
 }
 
 // Unit and integration testing tasks.


### PR DESCRIPTION
Copied from the client...

### Commits

### Fix runKarma

Karam expects the config to be of type `Config`. This can be done by calling the karma.config.parseConfig method which creates a Config object that can be passed to karma.Server()

----------

### Kill gulp-karma process on Ctrl-C

The only way to kill `yarn test --watch` is sending a SIGINT via a
<kbd>Ctrl</kbd>+<kbd>C</kbd> keyboard shorcut. Killing karma process in
this way sometimes leaves the parent gulp process orphan. That's because
when karma is killed by SIGINT sometimes doesn't run the `done` in the
callback, hence leaving the gulp process waiting for the `done` signal.

On more rare occasions, I have seen orphan karma process too.

The solution presented here registers a listener for SIGINT and call the
`done` function. It doesn't unregister the event.