### PR TITLE
[WIP] DB Modeling test

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,13 +1,15 @@
+from lms.models._lms import LMS
 from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
-from lms.models.course import Course
+from lms.models.course import Course, _Course
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
 from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
+from lms.models.grouping import CanvasGroup, CanvasSection, Grouping
 from lms.models.h_group import HGroup
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
-from lms.models.lti_user import LTIUser, display_name
+from lms.models.lti_user import LTIUser, _LTIUser, display_name
 from lms.models.module_item_configuration import ModuleItemConfiguration
 from lms.models.oauth2_token import OAuth2Token
 

--- a/lms/models/_lms.py
+++ b/lms/models/_lms.py
@@ -1,0 +1,21 @@
+import sqlalchemy as sa
+
+from lms.db import BASE
+
+
+class LMS(BASE):
+    __tablename__ = "lms"
+    __table_args__ = (
+        sa.UniqueConstraint("application_instance_id", "tool_consumer_instance_guid"),
+    )
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+
+    application_instance_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("application_instances.id", ondelete="cascade"),
+    )
+
+    tool_consumer_instance_guid = sa.Column(sa.String, nullable=False)
+
+    tool_consumer_info_product_family_code = sa.Column(sa.UnicodeText(), nullable=True)

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -3,6 +3,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE
 from lms.models.application_settings import ApplicationSettings
+from lms.models.grouping import Grouping
 
 
 class Course(BASE):
@@ -26,6 +27,20 @@ class Course(BASE):
     #: The authority_provided_id that uniquely identifies the course that these
     #: settings belong to.
     authority_provided_id = sa.Column(sa.UnicodeText(), primary_key=True)
+
+    settings = sa.Column(
+        "settings",
+        ApplicationSettings.as_mutable(JSONB),
+        server_default=sa.text("'{}'::jsonb"),
+        nullable=False,
+    )
+
+
+class _Course(Grouping):
+    __tablename__ = "course_grouping"
+    __mapper_args__ = {"polymorphic_identity": "course"}
+
+    id = sa.Column(sa.Integer, sa.ForeignKey("grouping.id"), primary_key=True)
 
     settings = sa.Column(
         "settings",

--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -69,3 +69,11 @@ class GradingInfo(BASE):
     tool_consumer_info_product_family_code = sa.Column(sa.UnicodeText(), nullable=True)
     h_username = sa.Column(sa.UnicodeText(), nullable=False)
     h_display_name = sa.Column(sa.UnicodeText(), nullable=False)
+
+    lms_id = sa.Column(
+        sa.Integer, sa.ForeignKey("lms.id", ondelete="cascade"), nullable=True
+    )
+
+    lti_user_id = sa.Column(
+        sa.Integer, sa.ForeignKey("lti_user.id", ondelete="cascade"), nullable=True
+    )

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,0 +1,30 @@
+import sqlalchemy as sa
+
+from lms.db import BASE
+
+
+class Grouping(BASE):
+    __tablename__ = "grouping"
+    __mapper_args__ = {"polymorphic_identity": "grouping", "polymorphic_on": "type"}
+    __table_args__ = (
+        sa.UniqueConstraint("application_instance_id", "authority_provided_id"),
+    )
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+
+    application_instance_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("application_instances.id", ondelete="cascade"),
+    )
+    authority_provided_id = sa.Column(sa.UnicodeText())
+    type = sa.Column(sa.String())
+
+    name = sa.Column(sa.UnicodeText(), nullable=False)
+
+
+class CanvasSection(Grouping):
+    __mapper_args__ = {"polymorphic_identity": "canvas_section"}
+
+
+class CanvasGroup(Grouping):
+    __mapper_args__ = {"polymorphic_identity": "canvas_group"}

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -1,6 +1,25 @@
 from typing import NamedTuple
 
+import sqlalchemy as sa
+
+from lms.db import BASE
 from lms.models import HUser
+
+
+class _LTIUser(BASE):
+    __tablename__ = "lti_user"
+    __table_args__ = (sa.UniqueConstraint("lms_id", "provider_unique_id"),)
+
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    lms_id = sa.Column(
+        sa.Integer, sa.ForeignKey("lms.id", ondelete="cascade"), nullable=True
+    )
+
+    # provider = sa.Column(sa.UnicodeText(), nullable=False)  this is the lms.tool_consumer_instance_guid
+    provider_unique_id = sa.Column(sa.UnicodeText(), nullable=False)
+
+    name = sa.Column(sa.UnicodeText(), nullable=False)
 
 
 class LTIUser(NamedTuple):

--- a/lms/models/module_item_configuration.py
+++ b/lms/models/module_item_configuration.py
@@ -41,3 +41,7 @@ class ModuleItemConfiguration(BASE):
 
     document_url = sa.Column(sa.String, nullable=False)
     """The URL of the document to be annotated for this assignment."""
+
+    lms_id = sa.Column(
+        sa.Integer, sa.ForeignKey("lms.id", ondelete="cascade"), nullable=True
+    )


### PR DESCRIPTION
Describes a potential new modeling for some LMS entities, there's no renaming or removal of tables yet

# New tables

## LMS

One particular LMS install identified by it's `application_instance_id` (FK) and the `tool_consumer_instance_guid`

## HGroup

A relationship between `application_instance_id` and unique (together) `authority_provided_id` representing groups in H

`CanvasGroup` and `CanvasSection` are both `hgroups` with a different value in the type column. They both don't add new columns

## _Course (replaces Course)

Also an hgroup but adding new columns (and stored in a new different, joined, table) https://docs.sqlalchemy.org/en/14/orm/inheritance.html#joined-table-inheritance

Data could be migrated from existing "course" to the new "_course", probably easier in a a multi step process with the two tables created on the DB.

## _LTIUser 

Existing LTIUser namedtuple as a DB model,  relates to lms. Would replace `LTIUser`

# New relationships

## ModuleItemConfiguration relates to lms 

I don't think this could be backfilled with just the information on this table so it's nullable atm. Maybe as LMS fills with data tool_consumer_instance_guid might be enough but I'd say the application_instance_id would be a best effort guess?

## GradingInfo (`lis_result_sourcedid`) relates to lms

Again not sure if possible to back fill easily, here we have the consumer_key but not the `tool_consumer_instance_guid`


## GradingInfo (`lis_result_sourcedid`) relates to _LTIUser

Same problem as for the lms relationship, here we have h_user and user_id but I think they could tecnically be duplicated (belonging to different instances).

# Other

No changes to `group_info` as it seems to be used mostly for analytics atm


![mymodel](https://user-images.githubusercontent.com/1433832/117936551-47752500-b305-11eb-94e9-a9b0a174b227.png)

