### PR TITLE
Add group set selection to assignment configuration form

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -210,6 +210,10 @@ class JSConfig:
             },
             "canvas": {
                 "enabled": self._canvas_files_available(),
+                "groupsEnabled": self._ai_getter.settings().get(
+                    "canvas", "groups_enabled"
+                )
+                or False,
                 # The "content item selection" that we submit to Canvas's
                 # content_item_return_url is actually an LTI launch URL with
                 # the selected document URL or file_id as a query parameter. To
@@ -220,6 +224,13 @@ class JSConfig:
                     "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
                     "path": self._request.route_path(
                         "canvas_api.courses.files.list",
+                        course_id=self._request.params.get("custom_canvas_course_id"),
+                    ),
+                },
+                "listGroupCategories": {
+                    "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
+                    "path": self._request.route_path(
+                        "canvas_api.courses.group_categories.list",
                         course_id=self._request.params.get("custom_canvas_course_id"),
                     ),
                 },

--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -12,5 +12,17 @@
  * @prop {string} updated_at - An ISO 8601 date string
  */
 
+/**
+ * Object representing a set of groups in the LMS.
+ *
+ * Many LMSes have some entity that is a named set of groups into which
+ * students can be divided for an assignment. The terminology depends on the
+ * LMS. In Canvas and Blackboard this is called a "Group Set".
+ *
+ * @typedef GroupSet
+ * @prop {string} id
+ * @prop {string} name
+ */
+
 // Make TS treat this file as a module.
 export {};

--- a/lms/static/scripts/frontend_apps/components/AuthButton.js
+++ b/lms/static/scripts/frontend_apps/components/AuthButton.js
@@ -1,0 +1,64 @@
+import { LabeledButton } from '@hypothesis/frontend-shared';
+
+import { createElement } from 'preact';
+import { useCallback, useEffect, useRef } from 'preact/hooks';
+
+import AuthWindow from '../utils/AuthWindow';
+
+/**
+ * @typedef AuthButtonProps
+ * @prop {string} authURL - Initial URL for the authorization popup. See `AuthWindow`.
+ * @prop {string} authToken - Auth token between the LMS frontend and backend. See `AuthWindow`.
+ * @prop {string} [label]
+ * @prop {() => void} onAuthComplete - Callback invoked when authorization completes
+ */
+
+/**
+ * Button that prompts the user to authorize the Hypothesis LMS app to access
+ * their data in the LMS (or another service).
+ *
+ * This component is typically shown to the user when an attempt to fetch data
+ * from the LMS via an LMS-specific API fails, requiring the user to complete
+ * an OAuth or OAuth-like authentication flow before the attempt can proceed.
+ *
+ * @param {AuthButtonProps} props
+ */
+export default function AuthButton({
+  authURL,
+  authToken,
+  label = 'Authorize',
+  onAuthComplete,
+}) {
+  /** @type {{ current: AuthWindow|null }} */
+  const authWindow = useRef(null);
+
+  const authorize = useCallback(async () => {
+    if (authWindow.current) {
+      authWindow.current.focus();
+      return;
+    }
+
+    authWindow.current = new AuthWindow({ authToken, authUrl: authURL });
+
+    try {
+      await authWindow.current.authorize();
+      onAuthComplete();
+    } finally {
+      authWindow.current.close();
+      authWindow.current = null;
+    }
+  }, [authToken, authURL, onAuthComplete]);
+
+  // Close auth window if component is unmounted.
+  useEffect(() => {
+    return () => {
+      authWindow.current?.close();
+    };
+  }, []);
+
+  return (
+    <LabeledButton onClick={authorize} variant="primary">
+      {label}
+    </LabeledButton>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -1,0 +1,196 @@
+import { Fragment, createElement } from 'preact';
+import { useContext, useMemo, useState } from 'preact/hooks';
+
+import { LabeledButton } from '@hypothesis/frontend-shared';
+
+import { Config } from '../config';
+import {
+  GooglePickerClient,
+  PickerCanceledError,
+} from '../utils/google-picker-client';
+import LMSFilePicker from './LMSFilePicker';
+import URLPicker from './URLPicker';
+import Spinner from './Spinner';
+
+/**
+ * @typedef {import('../api-types').File} File
+ *
+ * @typedef ErrorInfo
+ * @prop {string} title
+ * @prop {Error} error
+ *
+ * @typedef {'lms'|'url'|null} DialogType
+ *
+ * @typedef FileContent
+ * @prop {'file'} type
+ * @prop {File} file
+ *
+ * @typedef URLContent
+ * @prop {'url'} type
+ * @prop {string} url
+ *
+ * @typedef VitalSourceBookContent
+ * @prop {'vitalsource'} type
+ *
+ * @typedef {FileContent|URLContent|VitalSourceBookContent} Content
+ */
+
+/**
+ * @typedef ContentSelectorProps
+ * @prop {(ei: ErrorInfo) => void} setErrorInfo
+ * @prop {(c: Content) => void} onSelectContent
+ */
+
+/**
+ * Component that allows the user to choose the content for an assignment.
+ *
+ * @param {ContentSelectorProps} props
+ */
+export default function ContentSelector({ setErrorInfo, onSelectContent }) {
+  const {
+    api: { authToken },
+    filePicker: {
+      canvas: { enabled: canvasEnabled, listFiles: listFilesApi },
+      google: {
+        clientId: googleClientId,
+        developerKey: googleDeveloperKey,
+        origin: googleOrigin,
+      },
+      vitalSource: { enabled: vitalSourceEnabled },
+    },
+  } = useContext(Config);
+
+  const [isLoadingIndicatorVisible, setLoadingIndicatorVisible] = useState(
+    false
+  );
+  const [activeDialog, setActiveDialog] = useState(
+    /** @type {DialogType} */ (null)
+  );
+
+  const cancelDialog = () => {
+    setLoadingIndicatorVisible(false);
+    setActiveDialog(null);
+  };
+
+  /** @param {DialogType} type */
+  const selectDialog = type => {
+    setLoadingIndicatorVisible(true);
+    setActiveDialog(type);
+  };
+  // Initialize the Google Picker client if credentials have been provided.
+  // We do this eagerly to make the picker load faster if the user does click
+  // on the "Select from Google Drive" button.
+  const googlePicker = useMemo(() => {
+    if (!googleClientId || !googleDeveloperKey || !googleOrigin) {
+      return null;
+    }
+    return new GooglePickerClient({
+      developerKey: googleDeveloperKey,
+      clientId: googleClientId,
+
+      // If the form is being displayed inside an iframe, then the backend
+      // must provide the URL of the top-level frame to us so we can pass it
+      // to the Google Picker API. Otherwise we can use the URL of the current
+      // tab.
+      origin: window === window.top ? window.location.href : googleOrigin,
+    });
+  }, [googleDeveloperKey, googleClientId, googleOrigin]);
+
+  /** @param {string} url */
+  const selectURL = url => {
+    cancelDialog();
+    onSelectContent({ type: 'url', url });
+  };
+
+  /** @param {File} file */
+  const selectLMSFile = file => {
+    cancelDialog();
+    onSelectContent({ type: 'file', file });
+  };
+
+  let dialog;
+  switch (activeDialog) {
+    case 'url':
+      dialog = <URLPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
+      break;
+    case 'lms':
+      dialog = (
+        <LMSFilePicker
+          authToken={authToken}
+          listFilesApi={listFilesApi}
+          onCancel={cancelDialog}
+          onSelectFile={selectLMSFile}
+        />
+      );
+      break;
+    default:
+      dialog = null;
+  }
+
+  const showGooglePicker = async () => {
+    try {
+      setLoadingIndicatorVisible(true);
+      const picker = /** @type {GooglePickerClient} */ (googlePicker);
+      const { id, url } = await picker.showPicker();
+      await picker.enablePublicViewing(id);
+      onSelectContent({ type: 'url', url });
+    } catch (error) {
+      setLoadingIndicatorVisible(false);
+      if (!(error instanceof PickerCanceledError)) {
+        console.error(error);
+        setErrorInfo({
+          title: 'There was a problem choosing a file from Google Drive',
+          error,
+        });
+      }
+    }
+  };
+
+  const selectVitalSourceBook = () => {
+    onSelectContent({ type: 'vitalsource' });
+  };
+
+  return (
+    <Fragment>
+      {isLoadingIndicatorVisible && (
+        <div className="FilePickerApp__loading-backdrop">
+          <Spinner className="FilePickerApp__loading-spinner" />
+        </div>
+      )}
+      <div className="FilePickerApp__document-source-buttons">
+        <LabeledButton
+          onClick={() => selectDialog('url')}
+          type="button"
+          variant="primary"
+        >
+          Enter URL of web page or PDF
+        </LabeledButton>
+        {canvasEnabled && (
+          <LabeledButton
+            onClick={() => selectDialog('lms')}
+            variant="primary"
+          >
+            Select PDF from Canvas
+          </LabeledButton>
+        )}
+        {googlePicker && (
+          <LabeledButton
+            onClick={showGooglePicker}
+            variant="primary"
+          >
+            Select PDF from Google Drive
+          </LabeledButton>
+        )}
+        {vitalSourceEnabled && (
+          <LabeledButton
+            onClick={selectVitalSourceBook}
+            variant="primary"
+          >
+            Select book from VitalSource
+          </LabeledButton>
+        )}
+      </div>
+      {dialog}
+    </Fragment>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -1,30 +1,20 @@
-import { createElement } from 'preact';
-import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { LabeledButton } from '@hypothesis/frontend-shared';
+import { Fragment, createElement } from 'preact';
+import { useContext, useEffect, useRef, useState } from 'preact/hooks';
 
 import { Config } from '../config';
-import {
-  contentItemForUrl,
-  contentItemForLmsFile,
-  contentItemForVitalSourceBook,
-} from '../utils/content-item';
-import {
-  GooglePickerClient,
-  PickerCanceledError,
-} from '../utils/google-picker-client';
 
-import Button from './Button';
+import ContentSelector from './ContentSelector';
 import ErrorDialog from './ErrorDialog';
-import LMSFilePicker from './LMSFilePicker';
-import Spinner from './Spinner';
-import URLPicker from './URLPicker';
+import GroupConfigSelector from './GroupConfigSelector';
+import LTIContentItemFormFields from './LTIContentItemFormFields';
 
 /**
  * @typedef {import('../api-types').File} File
- * @typedef {'lms'|'url'|null} DialogType
+ * @typedef {import('./ContentSelector').Content} Content
+ * @typedef {import('./GroupConfigSelector').GroupConfig} GroupConfig
  *
  * @typedef FilePickerAppProps
- * @prop {DialogType} [defaultActiveDialog] -
- *   The dialog that should be shown when the app is first opened.
  * @prop {() => any} [onSubmit] - Callback invoked when the form is submitted.
  */
 
@@ -34,37 +24,20 @@ import URLPicker from './URLPicker';
  *
  * @param {FilePickerAppProps} props
  */
-export default function FilePickerApp({
-  defaultActiveDialog = null,
-  onSubmit,
-}) {
+export default function FilePickerApp({ onSubmit }) {
   const submitButton = useRef(/** @type {HTMLInputElement|null} */ (null));
   const {
-    api: { authToken },
     filePicker: {
       formAction,
       formFields,
-      canvas: { enabled: canvasEnabled, listFiles: listFilesApi, ltiLaunchUrl },
-      google: {
-        clientId: googleClientId,
-        developerKey: googleDeveloperKey,
-        origin: googleOrigin,
-      },
-      vitalSource: { enabled: vitalSourceEnabled },
+      canvas: { groupsEnabled, ltiLaunchUrl },
     },
   } = useContext(Config);
 
-  const [activeDialog, setActiveDialog] = useState(defaultActiveDialog);
-  const [url, setUrl] = useState(/** @type {string|null} */ (null));
-  const [lmsFile, setLmsFile] = useState(/** @type {File|null} */ (null));
-
-  // Whether the user chose a book from VitalSource. This is currently a
-  // boolean because there is no choice about which book is used. In future this
-  // will contain the selected book and chapter.
-  const [vitalSourceBook, setVitalSourceBook] = useState(false);
-
-  const [isLoadingIndicatorVisible, setLoadingIndicatorVisible] =
-    useState(false);
+  const [content, setContent] = useState(/** @type {Content|null} */ (null));
+  const [groupConfig, setGroupConfig] = useState(
+    /** @type {GroupConfig} */ ({ useGroups: false, groupSet: null })
+  );
 
   /**
    * @typedef ErrorInfo
@@ -76,80 +49,12 @@ export default function FilePickerApp({
     /** @type {ErrorInfo|null} */ (null)
   );
 
-  // Initialize the Google Picker client if credentials have been provided.
-  // We do this eagerly to make the picker load faster if the user does click
-  // on the "Select from Google Drive" button.
-  const googlePicker = useMemo(() => {
-    if (!googleClientId || !googleDeveloperKey || !googleOrigin) {
-      return null;
-    }
-    return new GooglePickerClient({
-      developerKey: googleDeveloperKey,
-      clientId: googleClientId,
-
-      // If the form is being displayed inside an iframe, then the backend
-      // must provide the URL of the top-level frame to us so we can pass it
-      // to the Google Picker API. Otherwise we can use the URL of the current
-      // tab.
-      origin: window === window.top ? window.location.href : googleOrigin,
-    });
-  }, [googleDeveloperKey, googleClientId, googleOrigin]);
-
   /**
    * Flag indicating whether the form should be auto-submitted on the next
    * render.
    */
-  const [shouldSubmit, submit] = useState(false);
-
-  const cancelDialog = () => {
-    setLoadingIndicatorVisible(false);
-    setActiveDialog(null);
-  };
-
-  /** @param {DialogType} type */
-  const selectDialog = type => {
-    setLoadingIndicatorVisible(true);
-    setActiveDialog(type);
-  };
-
-  /** @param {File} file */
-  const selectLMSFile = file => {
-    cancelDialog();
-    setLmsFile(file);
-    submit(true);
-  };
-
-  /** @param {string} url */
-  const selectURL = url => {
-    cancelDialog();
-    setUrl(url);
-    submit(true);
-  };
-
-  const showGooglePicker = async () => {
-    try {
-      setLoadingIndicatorVisible(true);
-      const picker = /** @type {GooglePickerClient} */ (googlePicker);
-      const { id, url } = await picker.showPicker();
-      await picker.enablePublicViewing(id);
-      setUrl(url);
-      submit(true);
-    } catch (error) {
-      setLoadingIndicatorVisible(false);
-      if (!(error instanceof PickerCanceledError)) {
-        console.error(error);
-        setErrorInfo({
-          title: 'There was a problem choosing a file from Google Drive',
-          error,
-        });
-      }
-    }
-  };
-
-  const selectVitalSourceBook = () => {
-    setVitalSourceBook(true);
-    submit(true);
-  };
+  const [shouldSubmit, setShouldSubmit] = useState(false);
+  const submit = () => setShouldSubmit(true);
 
   // Submit the form after a selection is made via one of the available
   // methods.
@@ -162,40 +67,6 @@ export default function FilePickerApp({
     }
   }, [shouldSubmit]);
 
-  let dialog;
-  switch (activeDialog) {
-    case 'url':
-      dialog = <URLPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
-      break;
-    case 'lms':
-      dialog = (
-        <LMSFilePicker
-          authToken={authToken}
-          listFilesApi={listFilesApi}
-          onCancel={cancelDialog}
-          onSelectFile={selectLMSFile}
-        />
-      );
-      break;
-    default:
-      dialog = null;
-  }
-
-  let contentItem = null;
-  if (url) {
-    contentItem = contentItemForUrl(ltiLaunchUrl, url);
-  } else if (lmsFile) {
-    contentItem = contentItemForLmsFile(ltiLaunchUrl, lmsFile);
-  } else if (vitalSourceBook) {
-    // Chosen from `https://api.vitalsource.com/v4/products` response.
-    const bookId = 'BOOKSHELF-TUTORIAL';
-    // CFI chosen from `https://api.vitalsource.com/v4/products/BOOKSHELF-TUTORIAL/toc`
-    // response.
-    const cfi = '/6/8[;vnd.vst.idref=vst-70a6f9d3-0932-45ba-a583-6060eab3e536]';
-    contentItem = contentItemForVitalSourceBook(ltiLaunchUrl, bookId, cfi);
-  }
-  contentItem = JSON.stringify(contentItem);
-
   return (
     <main>
       <form
@@ -204,57 +75,49 @@ export default function FilePickerApp({
         method="POST"
         onSubmit={onSubmit}
       >
-        <input type="hidden" name="content_items" value={contentItem} />
-        {Object.keys(formFields).map(field => (
-          <input
-            key={field}
-            type="hidden"
-            name={field}
-            value={formFields[field]}
+        {!content && (
+          <Fragment>
+            <h1 className="heading-1">Select web page or PDF</h1>
+            <p>
+              You can select content for your assignment from one of the
+              following sources:
+            </p>
+            <ContentSelector
+              setErrorInfo={setErrorInfo}
+              onSelectContent={content => {
+                setContent(content);
+                if (!groupsEnabled) {
+                  submit();
+                }
+              }}
+            />
+          </Fragment>
+        )}
+        {content && groupsEnabled && (
+          <Fragment>
+            <GroupConfigSelector
+              groupConfig={groupConfig}
+              onChangeGroupConfig={setGroupConfig}
+            />
+            <LabeledButton
+              disabled={groupConfig.useGroups && !groupConfig.groupSet}
+              onClick={() => submit()}
+              variant="primary"
+            >
+              Continue
+            </LabeledButton>
+          </Fragment>
+        )}
+        {content && (
+          <LTIContentItemFormFields
+            content={content}
+            formFields={formFields}
+            grouping={groupConfig}
+            ltiLaunchURL={ltiLaunchUrl}
           />
-        ))}
-        <h1 className="heading-1">Select web page or PDF</h1>
-        <p>
-          You can select content for your assignment from one of the following
-          sources:
-        </p>
-        <input name="document_url" type="hidden" value={url || ''} />
-        <div className="FilePickerApp__document-source-buttons">
-          <Button
-            className="FilePickerApp__source-button"
-            label="Enter URL of web page or PDF"
-            onClick={() => selectDialog('url')}
-          />
-          {canvasEnabled && (
-            <Button
-              className="FilePickerApp__source-button"
-              label={`Select PDF from Canvas`}
-              onClick={() => selectDialog('lms')}
-            />
-          )}
-          {googlePicker && (
-            <Button
-              className="FilePickerApp__source-button"
-              label="Select PDF from Google Drive"
-              onClick={showGooglePicker}
-            />
-          )}
-          {vitalSourceEnabled && (
-            <Button
-              className="FilePickerApp__source-button"
-              label="Select book from VitalSource"
-              onClick={selectVitalSourceBook}
-            />
-          )}
-        </div>
+        )}
         <input style={{ display: 'none' }} ref={submitButton} type="submit" />
       </form>
-      {isLoadingIndicatorVisible && (
-        <div className="FilePickerApp__loading-backdrop">
-          <Spinner className="FilePickerApp__loading-spinner" />
-        </div>
-      )}
-      {dialog}
       {errorInfo && (
         <ErrorDialog
           title={errorInfo.title}

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -1,0 +1,156 @@
+import { LabeledCheckbox } from '@hypothesis/frontend-shared';
+
+import { Fragment, createElement } from 'preact';
+import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+
+import { Config } from '../config';
+import { apiCall } from '../utils/api';
+import { useUniqueId } from '../utils/hooks';
+
+import AuthButton from './AuthButton';
+
+/**
+ * @typedef {import('../api-types').GroupSet} GroupSet
+ */
+
+/**
+ * Configuration relating to how students are divided into groups for an
+ * assignment.
+ *
+ * @typedef GroupConfig
+ * @prop {boolean} useGroups - Whether students are divided into groups
+ * @prop {string|null} groupSet - The ID of the grouping to use. This should
+ *   be the `id` of a `GroupSet` returned by the LMS backend.
+ */
+
+/**
+ * @typedef GroupSetSelectorProps
+ * @prop {GroupConfig} groupConfig
+ * @prop {(g: GroupConfig) => void} onChangeGroupConfig
+ */
+
+/**
+ * Component that allows instructors to configure how students are divided into
+ * groups for an assignment.
+ *
+ * @param {GroupSetSelectorProps} props
+ */
+export default function GroupConfigSelector({
+  groupConfig,
+  onChangeGroupConfig,
+}) {
+  const [groupSets, setGroupSets] = useState(
+    /** @type {GroupSet[]|null} */ (null)
+  );
+
+  // Track whether authorization is needed.
+  // TODO: We need to track:
+  //  - Whether we need to authorize
+  //  - Whether an authorization attempt failed, in which case a suitable error
+  //    needs to be shown
+  const [authNeeded, setAuthNeeded] = useState(false);
+
+  const {
+    api: { authToken },
+    filePicker: {
+      canvas: { listGroupCategories: listGroupSetsAPI },
+    },
+  } = useContext(Config);
+
+  const fetchGroupSets = useCallback(async () => {
+    setAuthNeeded(false);
+
+    try {
+      const groupSets = /** @type {GroupSet[]} */ (
+        await apiCall({
+          authToken,
+          path: listGroupSetsAPI.path,
+        })
+      );
+      setGroupSets(groupSets);
+    } catch (e) {
+      // Test for different kinds of error and handle accordingly.
+      setAuthNeeded(true);
+    }
+  }, [authToken, listGroupSetsAPI]);
+
+  const useGroups = groupConfig.useGroups;
+  const haveFetchedGroups = groupSets !== null;
+
+  useEffect(() => {
+    if (useGroups && !haveFetchedGroups) {
+      fetchGroupSets();
+    }
+  }, [fetchGroupSets, useGroups, haveFetchedGroups]);
+
+  const checkboxID = useUniqueId('GroupSetSelector__enabled');
+  const selectID = useUniqueId('GroupSetSelector__select');
+
+  const groupSet = groupConfig.useGroups ? groupConfig.groupSet : null;
+  const fetchingGroupSets = !groupSets && !authNeeded && useGroups;
+
+  return (
+    <Fragment>
+      <div>
+        <LabeledCheckbox
+          checked={useGroups}
+          id={checkboxID}
+          name="groupsEnabled"
+          onInput={e =>
+            onChangeGroupConfig({
+              useGroups: /** @type {HTMLInputElement} */ (e.target).checked,
+              groupSet: groupSet ?? null,
+            })
+          }
+        >
+          Use groups for this assignment
+        </LabeledCheckbox>
+      </div>
+      {authNeeded && (
+        <Fragment>
+          <p>Canvas needs your permission to fetch group sets</p>
+          <AuthButton
+            authURL={/** @type {string} */ (listGroupSetsAPI.authUrl)}
+            authToken={authToken}
+            onAuthComplete={fetchGroupSets}
+          />
+        </Fragment>
+      )}
+      {!authNeeded && useGroups && (
+        <div>
+          <label htmlFor={selectID}>Group set:</label>
+          <select
+            disabled={!useGroups || fetchingGroupSets}
+            id={selectID}
+            onInput={e =>
+              onChangeGroupConfig({
+                useGroups,
+                groupSet:
+                  /** @type {HTMLInputElement} */ (e.target).value || null,
+              })
+            }
+          >
+            {fetchingGroupSets && <option>Fetching group sets…</option>}
+            {groupSets && (
+              <Fragment>
+                <option disabled selected={groupSet === null}>
+                  Select group set
+                </option>
+                <hr />
+                {groupSets.map(gs => (
+                  <option
+                    key={gs.id}
+                    value={gs.id}
+                    selected={gs.id === groupSet}
+                  >
+                    {gs.name}
+                  </option>
+                ))}
+              </Fragment>
+            )}
+          </select>
+        </div>
+      )}
+    </Fragment>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -1,10 +1,10 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
 import { createElement } from 'preact';
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import { ApiError, apiCall } from '../utils/api';
 
-import AuthWindow from '../utils/AuthWindow';
+import AuthButton from './AuthButton';
 import Dialog from './Dialog';
 import ErrorDisplay from './ErrorDisplay';
 import FileList from './FileList';
@@ -82,11 +82,6 @@ export default function LMSFilePicker({
   // The file within `files` which is currently selected.
   const [selectedFile, selectFile] = useState(/** @type {File|null} */ (null));
 
-  // `AuthWindow` instance, set only when waiting for the user to approve
-  // the app's access to the user's files in the LMS.
-  /** @type {import('preact').Ref<AuthWindow>} */
-  const authWindow = useRef(null);
-
   // Fetches files or shows a prompt to authorize access.
   const fetchFiles = useCallback(async () => {
     try {
@@ -140,42 +135,12 @@ export default function LMSFilePicker({
     }
   }, [authToken, listFilesApi, authorizationAttempted]);
 
-  // Execute the authorization flow in a popup window and then attempt to
-  // fetch files.
-  const authorizeAndFetchFiles = useCallback(async () => {
-    if (authWindow.current) {
-      authWindow.current.focus();
-      return;
-    }
-
-    // We assume here that the API call to list files will always require
-    // authentication. This is true for the LMSes (Canvas, Blackboard) that
-    // we currently support.
-    const authUrl = /** @type {string} */ (listFilesApi.authUrl);
-    authWindow.current = new AuthWindow({ authToken, authUrl });
-
-    try {
-      await authWindow.current.authorize();
-      await fetchFiles();
-    } finally {
-      authWindow.current.close();
-      authWindow.current = null;
-    }
-  }, [fetchFiles, authToken, listFilesApi]);
-
   // On the initial load, fetch files or prompt to authorize if we know that
   // authorization will be required.
   useEffect(() => {
     fetchFiles();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const cancel = () => {
-    if (authWindow.current) {
-      authWindow.current.close();
-    }
-    onCancel();
-  };
 
   const useSelectedFile = () =>
     onSelectFile(/** @type {File} */ (selectedFile));
@@ -196,13 +161,12 @@ export default function LMSFilePicker({
     },
     authorize: {
       continueButton: (
-        <LabeledButton
-          onClick={authorizeAndFetchFiles}
-          variant="primary"
-          data-testid="authorize"
-        >
-          Authorize
-        </LabeledButton>
+        <AuthButton
+          authURL={/** @type {string} */ (listFilesApi.authUrl)}
+          authToken={authToken}
+          onAuthComplete={fetchFiles}
+          data-testid="try-again"
+        />
       ),
       warningOrError: (
         <p data-testid="authorization warning">
@@ -212,13 +176,13 @@ export default function LMSFilePicker({
     },
     authorize_retry: {
       continueButton: (
-        <LabeledButton
-          onClick={authorizeAndFetchFiles}
-          variant="primary"
+        <AuthButton
+          authURL={/** @type {string} */ (listFilesApi.authUrl)}
+          authToken={authToken}
+          label="Try again"
+          onAuthComplete={fetchFiles}
           data-testid="try-again"
-        >
-          Try again
-        </LabeledButton>
+        />
       ),
       warningOrError: (
         <ErrorDisplay
@@ -229,13 +193,13 @@ export default function LMSFilePicker({
     },
     retry: {
       continueButton: (
-        <LabeledButton
-          onClick={authorizeAndFetchFiles} // maybe it should use fetchFile function instead
-          variant="primary"
+        <AuthButton
+          authURL={/** @type {string} */ (listFilesApi.authUrl)}
+          authToken={authToken}
+          label="Try again"
+          onAuthComplete={fetchFiles}
           data-testid="try-again"
-        >
-          Try again
-        </LabeledButton>
+        />
       ),
       warningOrError: (
         <ErrorDisplay
@@ -270,7 +234,7 @@ export default function LMSFilePicker({
     <Dialog
       contentClass="LMSFilePicker__dialog"
       title={dialogState.title}
-      onCancel={cancel}
+      onCancel={onCancel}
       buttons={continueButton}
     >
       {warningOrError}

--- a/lms/static/scripts/frontend_apps/components/LTIContentItemFormFields.js
+++ b/lms/static/scripts/frontend_apps/components/LTIContentItemFormFields.js
@@ -1,0 +1,93 @@
+import { Fragment, createElement } from 'preact';
+
+import {
+  contentItemForUrl,
+  contentItemForLmsFile,
+  contentItemForVitalSourceBook,
+} from '../utils/content-item';
+
+/**
+ * @typedef {import('./ContentSelector').Content} Content
+ * @typedef {import('./GroupSetSelector').GroupConfig} Grouping
+ */
+
+/**
+ * @typedef LTIContentItemFormFieldsProps
+ * @prop {string} ltiLaunchURL
+ * @prop {Content} content
+ * @prop {Record<string,string>} formFields
+ * @prop {Grouping} grouping
+ */
+
+/**
+ * Generate an LTI launch URL for a given.
+ *
+ * @param {string} ltiLaunchURL
+ * @param {Content|null} content
+ * @param {Grouping} grouping
+ */
+function contentItemString(ltiLaunchURL, content, grouping) {
+  let contentItem = null;
+  const options = {};
+  if (grouping.useGroups && grouping.groupSet) {
+    options.groupSet = grouping.groupSet;
+  }
+
+  switch (content?.type) {
+    case 'url':
+      contentItem = contentItemForUrl(ltiLaunchURL, content.url, options);
+      break;
+    case 'file':
+      contentItem = contentItemForLmsFile(ltiLaunchURL, content.file, options);
+      break;
+    case 'vitalsource': {
+      // Chosen from `https://api.vitalsource.com/v4/products` response.
+      const bookId = 'BOOKSHELF-TUTORIAL';
+      // CFI chosen from `https://api.vitalsource.com/v4/products/BOOKSHELF-TUTORIAL/toc`
+      // response.
+      const cfi =
+        '/6/8[;vnd.vst.idref=vst-70a6f9d3-0932-45ba-a583-6060eab3e536]';
+      contentItem = contentItemForVitalSourceBook(
+        ltiLaunchURL,
+        bookId,
+        cfi,
+        options
+      );
+    }
+  }
+  return JSON.stringify(contentItem);
+}
+
+/**
+ * Render the hidden form fields containing information about the selected
+ * content and other assignments.
+ *
+ * @param {LTIContentItemFormFieldsProps} props
+ */
+export default function LTIContentItemFormFields({
+  ltiLaunchURL,
+  content,
+  formFields,
+  grouping,
+}) {
+  return (
+    <Fragment>
+      <input
+        type="hidden"
+        name="content_items"
+        value={contentItemString(ltiLaunchURL, content, grouping)}
+      />
+      {Object.keys(formFields).map(field => (
+        <input
+          key={field}
+          type="hidden"
+          name={field}
+          value={formFields[field]}
+        />
+      ))}
+      {content?.type === 'url' && (
+        <input name="document_url" type="hidden" value={content.url} />
+      )}
+    </Fragment>
+  );
+}

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -61,8 +61,10 @@ import { createContext } from 'preact';
  * @prop {Object.<string,string>} formFields
  * @prop {Object} canvas
  *   @prop {boolean} canvas.enabled
+ *   @prop {boolean} canvas.groupsEnabled
  *   @prop {string} canvas.ltiLaunchUrl
  *   @prop {ApiCallInfo} canvas.listFiles
+ *   @prop {ApiCallInfo} canvas.listGroupCategories
  * @prop {Object} google
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -1,5 +1,8 @@
 /**
  * @typedef {import('../api-types').File} File
+ *
+ * @typedef Options
+ * @prop {string} [groupSet]
  */
 
 import { stringify } from 'querystring';
@@ -7,8 +10,13 @@ import { stringify } from 'querystring';
 /**
  * @param {string} ltiLaunchUrl
  * @param {Object.<string,string>} params - Query parameters for the generated URL
+ * @param {Options} options
  */
-function contentItemWithParams(ltiLaunchUrl, params) {
+function contentItemWithParams(ltiLaunchUrl, params, options) {
+  if (options.groupSet) {
+    params.group_set = options.groupSet;
+  }
+
   return {
     '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
     '@graph': [
@@ -27,9 +35,10 @@ function contentItemWithParams(ltiLaunchUrl, params) {
  *
  * @param {string} ltiLaunchUrl
  * @param {string} documentUrl
+ * @param {Options} [options]
  */
-export function contentItemForUrl(ltiLaunchUrl, documentUrl) {
-  return contentItemWithParams(ltiLaunchUrl, { url: documentUrl });
+export function contentItemForUrl(ltiLaunchUrl, documentUrl, options = {}) {
+  return contentItemWithParams(ltiLaunchUrl, { url: documentUrl }, options);
 }
 
 /**
@@ -38,12 +47,17 @@ export function contentItemForUrl(ltiLaunchUrl, documentUrl) {
  *
  * @param {string} ltiLaunchUrl
  * @param {File} file
+ * @param {Options} options
  */
-export function contentItemForLmsFile(ltiLaunchUrl, file) {
-  return contentItemWithParams(ltiLaunchUrl, {
-    canvas_file: 'true',
-    file_id: file.id,
-  });
+export function contentItemForLmsFile(ltiLaunchUrl, file, options = {}) {
+  return contentItemWithParams(
+    ltiLaunchUrl,
+    {
+      canvas_file: 'true',
+      file_id: file.id,
+    },
+    options
+  );
 }
 
 /**
@@ -55,11 +69,21 @@ export function contentItemForLmsFile(ltiLaunchUrl, file) {
  * @param {string} cfi -
  *   Location in the book. This is an EPUB CFI path without the surrounding
  *   `epubcfi(...)` fragment. See http://idpf.org/epub/linking/cfi/epub-cfi.html.
+ * @param {Options} options
  */
-export function contentItemForVitalSourceBook(ltiLaunchUrl, bookId, cfi) {
-  return contentItemWithParams(ltiLaunchUrl, {
-    vitalsource_book: 'true',
-    book_id: bookId,
-    cfi,
-  });
+export function contentItemForVitalSourceBook(
+  ltiLaunchUrl,
+  bookId,
+  cfi,
+  options = {}
+) {
+  return contentItemWithParams(
+    ltiLaunchUrl,
+    {
+      vitalsource_book: 'true',
+      book_id: bookId,
+      cfi,
+    },
+    options
+  );
 }

--- a/lms/static/styles/components/_FilePickerApp.scss
+++ b/lms/static/styles/components/_FilePickerApp.scss
@@ -36,4 +36,8 @@
   display: inline-flex;
   flex-direction: column;
   margin-top: 30px;
+
+  & > :not(:first-child) {
+    margin-top: 10px;
+  }
 }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -174,6 +174,9 @@ def application_instance_service(pyramid_config):
     application_instance_service.get.return_value.settings.set(
         "canvas", "sections_enabled", True
     )
+    application_instance_service.get.return_value.settings.set(
+        "canvas", "groups_enabled", False
+    )
 
     pyramid_config.register_service(
         application_instance_service, name="application_instance"

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -42,10 +42,15 @@ class TestEnableContentItemSelectionMode:
             },
             "canvas": {
                 "enabled": True,
+                "groupsEnabled": False,
                 "ltiLaunchUrl": "http://example.com/lti_launches",
                 "listFiles": {
                     "authUrl": "http://example.com/api/canvas/oauth/authorize",
                     "path": "/api/canvas/courses/test_course_id/files",
+                },
+                "listGroupCategories": {
+                    "authUrl": "http://example.com/api/canvas/oauth/authorize",
+                    "path": "/api/canvas/courses/test_course_id/group_categories",
                 },
             },
             "vitalSource": {


### PR DESCRIPTION
This branch implements group set selection in the assignment configuration form. The UI should eventually look like [these mocks](https://github.com/hypothesis/lms/issues/2523#issuecomment-821160185). The current state is that the overall flow is functional but the layout is not fully implemented.

When assignment configuration is complete, the the LTI launch URL that is submitted to Canvas and displayed in the Canvas assignment configuration will be the same as before if groups are disabled. If groups are enabled however there will be an additional `group_set` query parameter in the URL whose value is the ID of the Group Set in Canvas.

----

**Assignment configuration flow:**

The initial content screen looks the same as before:

<img width="521" alt="group-set-select-1" src="https://user-images.githubusercontent.com/2458/118473143-90f8b200-b701-11eb-8b54-a82fccc6f0e0.png">

<img width="517" alt="group-set-select-2" src="https://user-images.githubusercontent.com/2458/118473154-948c3900-b701-11eb-8dbc-c34540745c45.png">

Once content has been selected, the form submits as before if groups are disabled for an installation of the LMS app. If groups are enabled however, a new screen is shown to allow the user to choose the group configuration:

<img width="540" alt="group-set-select-3" src="https://user-images.githubusercontent.com/2458/118473177-9950ed00-b701-11eb-9cf5-059fe7b70830.png">

When the user checks the "Use groups" option, the list of Group Sets is fetched from the backend. If this fails, the user is prompted to authorize:

<img width="366" alt="group-set-select-4" src="https://user-images.githubusercontent.com/2458/118473192-9c4bdd80-b701-11eb-88a2-a69a00208ec0.png">

Once authorization succeeds, the list of groups is shown in a `<select>` and the "Continue" button is disabled until the user makes a choice:

<img width="247" alt="group-set-select-5" src="https://user-images.githubusercontent.com/2458/118473202-9fdf6480-b701-11eb-9deb-e79808e93ab1.png">

<img width="260" alt="group-set-select-6" src="https://user-images.githubusercontent.com/2458/118473213-a2da5500-b701-11eb-96ec-1df650cb6aec.png">

<img width="274" alt="group-set-select-7" src="https://user-images.githubusercontent.com/2458/118473235-a7067280-b701-11eb-8ab5-dc86e6b45a1d.png">

