### PR TITLE
Fix an admin pages crash

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -43,7 +43,7 @@ Application instance {{instance.consumer_key}}
         <div class="field is-narrow">
           <div class="control">
             <label class="checkbox">
-              <input {% if instance.settings.canvas.sections_enabled %}checked {% endif%} type="checkbox" name="sections_enabled">
+              <input {% if instance.settings.get("canvas", "sections_enabled") %}checked {% endif%} type="checkbox" name="sections_enabled">
             </label>
           </div>
         </div>
@@ -58,7 +58,7 @@ Application instance {{instance.consumer_key}}
         <div class="field is-narrow">
           <div class="control">
             <label class="checkbox">
-              <input {% if instance.settings.canvas.groups_enabled %}checked {% endif%} type="checkbox" name="groups_enabled">
+              <input {% if instance.settings.get("canvas", "groups_enabled") %}checked {% endif%} type="checkbox" name="groups_enabled">
             </label>
           </div>
         </div>


### PR DESCRIPTION
`/admin/instance/<consumer_key>/` is crashing with:

    jinja2.exceptions.UndefinedError: 'lms.models.application_settings.ApplicationSettings object' has no attribute 'canvas'

Not sure what happened here. How was this every working?