### PR TITLE
Add ApplicationInstance.lms_host()

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,5 +1,6 @@
 import secrets
 from datetime import datetime
+from urllib.parse import urlparse
 
 import sqlalchemy as sa
 from Cryptodome import Random
@@ -60,6 +61,27 @@ class ApplicationInstance(BASE):
         cipher = AES.new(aes_secret, AES.MODE_CFB, self.aes_cipher_iv)
 
         return cipher.decrypt(self.developer_secret)
+
+    def lms_host(self):
+        """
+        Return the hostname part of this ApplicationInstance's lms_url.
+
+        For example if application_instance.lms_url is
+        "https://example.com/lms/" then application_instance.lms_host() will
+        return "example.com".
+
+        :raise ValueError: if the ApplicationInstance's lms_url can't be parsed
+        """
+        # urlparse() or .netloc will raise ValueError for some invalid URLs.
+        lms_host = urlparse(self.lms_url).netloc
+
+        # For some URLs urlparse(url).netloc returns an empty string.
+        if not lms_host:
+            raise ValueError(
+                f"Couldn't parse self.lms_url ({self.lms_url}): urlparse() returned an empty netloc"
+            )
+
+        return lms_host
 
     @classmethod
     def get_by_consumer_key(cls, db, consumer_key):

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 from lms.services.canvas_api._authenticated import AuthenticatedClient
 from lms.services.canvas_api._basic import BasicClient
 from lms.services.canvas_api.client import CanvasAPIClient
@@ -14,12 +12,11 @@ def canvas_api_client_factory(_context, request):
     """
     application_instance = request.find_service(name="application_instance").get()
 
-    canvas_host = urlparse(application_instance.lms_url).netloc
     developer_secret = application_instance.decrypted_developer_secret(
         request.registry.settings["aes_secret"]
     )
 
-    basic_client = BasicClient(canvas_host)
+    basic_client = BasicClient(application_instance.lms_host())
 
     authenticated_api = AuthenticatedClient(
         basic_client=basic_client,

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -75,6 +75,18 @@ class TestApplicationInstance:
         with pytest.raises(IntegrityError, match="requesters_email"):
             db_session.flush()
 
+    def test_lms_host(self, application_instance):
+        application_instance.lms_url = "https://example.com/lms/"
+
+        assert application_instance.lms_host() == "example.com"
+
+    @pytest.mark.parametrize("lms_url", ["", "foo", "https://example[.com/foo"])
+    def test_lms_host_raises_ValueError(self, application_instance, lms_url):
+        application_instance.lms_url = lms_url
+
+        with pytest.raises(ValueError):
+            application_instance.lms_host()
+
     def test_get_returns_the_matching_ApplicationInstance(
         self, db_session, application_instance
     ):

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -21,13 +21,11 @@ class TestCanvasAPIClientFactory:
     def test_building_the_BasicClient(
         self, pyramid_request, BasicClient, application_instance_service
     ):
-        application_instance_service.get.return_value.lms_url = (
-            "https://example.com/path"
-        )
-
         canvas_api_client_factory(sentinel.context, pyramid_request)
 
-        BasicClient.assert_called_once_with("example.com")
+        BasicClient.assert_called_once_with(
+            application_instance_service.get.return_value.lms_host()
+        )
 
     def test_building_the_AuthenticatedClient(
         self,


### PR DESCRIPTION
The Canvas API client uses the netloc of `ApplicationInstance.lms_url`
as the base host to construct Canvas API URLs. The Blackboard API client
is going to have to do the same, so move the netloc parsing into the
model where both services can use it.