### PR TITLE
Simplify _canvas_files_available()

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -1,7 +1,7 @@
 import functools
 
 from lms.models import GroupInfo, HUser
-from lms.services import ConsumerKeyError, HAPIError
+from lms.services import HAPIError
 from lms.validation.authentication import BearerTokenSchema
 from lms.views.helpers import via_url
 
@@ -351,14 +351,9 @@ class JSConfig:
         if not self._context.is_canvas:
             return False
 
-        try:
-            developer_key = self._application_instance().developer_key
-        except ConsumerKeyError:
-            return False
-
         return (
             "custom_canvas_course_id" in self._request.params
-            and developer_key is not None
+            and self._application_instance().developer_key is not None
         )
 
     @property

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -87,17 +87,6 @@ class TestEnableContentItemSelectionMode:
 
         self.assert_canvas_file_picker_not_enabled(js_config)
 
-    def test_it_doesnt_enable_the_canvas_file_picker_if_the_consumer_key_isnt_found_in_the_db(
-        self, application_instance_service, js_config
-    ):
-        application_instance_service.get.side_effect = ConsumerKeyError()
-
-        js_config.enable_content_item_selection_mode(
-            mock.sentinel.form_action, mock.sentinel.form_fields
-        )
-
-        self.assert_canvas_file_picker_not_enabled(js_config)
-
     def test_it_doesnt_enable_the_canvas_file_picker_if_we_dont_have_a_developer_key(
         self, application_instance_service, js_config
     ):


### PR DESCRIPTION
This helper method is documented as raising `ConsumerKeyError` but I
don't think it actually does raise it: it catches it and returns
`False`.

There's no point in catching `ConsumerKeyError` here though because
`_canvas_files_available()` is only called by one method
(`enable_content_item_selection_mode()`) and that method already calls a
bunch of other things that can raise `ConsumerKeyError`.