### PR TITLE
Add the blackboard.files_enabled setting

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -1,7 +1,7 @@
 import functools
 
 from lms.models import GroupInfo, HUser
-from lms.services import ConsumerKeyError, HAPIError
+from lms.services import HAPIError
 from lms.validation.authentication import BearerTokenSchema
 from lms.views.helpers import via_url
 
@@ -197,7 +197,7 @@ class JSConfig:
             "formAction": form_action,
             "formFields": form_fields,
             "blackboard": {
-                "enabled": self._blackboard_files_available(),
+                "enabled": self._blackboard_files_enabled(),
                 "listFiles": {
                     "authUrl": self._request.route_url(
                         "blackboard_api.oauth.authorize"
@@ -337,9 +337,13 @@ class JSConfig:
         """Return the authToken setting."""
         return BearerTokenSchema(self._request).authorization_param(self._lti_user)
 
-    def _blackboard_files_available(self):
-        """Return True if the Blackboard Files API is available to this request."""
-        return self._request.feature("blackboard_files")
+    def _blackboard_files_enabled(self):
+        """
+        Return True if the Blackboard Files API is enabled for this request.
+
+        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
+        """
+        return self._application_instance().settings.get("blackboard", "files_enabled")
 
     def _canvas_files_available(self):
         """

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -351,14 +351,9 @@ class JSConfig:
         if not self._context.is_canvas:
             return False
 
-        try:
-            developer_key = self._application_instance().developer_key
-        except ConsumerKeyError:
-            return False
-
         return (
             "custom_canvas_course_id" in self._request.params
-            and developer_key is not None
+            and self._application_instance().developer_key is not None
         )
 
     @property

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -67,6 +67,21 @@ Application instance {{instance.consumer_key}}
 
     <div class="field is-horizontal">
       <div class="field-label">
+        <label class="label">Blackboard files enabled
+      </div>
+      <div class="field-body">
+        <div class="field is-narrow">
+          <div class="control">
+            <label class="checkbox">
+              <input {% if instance.settings.get("blackboard", "files_enabled") %}checked {% endif%} type="checkbox" name="blackboard_files_enabled">
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label">
         <!-- Left empty for spacing -->
       </div>
       <div class="field-body">

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -93,6 +93,12 @@ class AdminViews:
             self.request.params.get("groups_enabled") == "on",
         )
 
+        ai.settings.set(
+            "blackboard",
+            "files_enabled",
+            self.request.params.get("blackboard_files_enabled") == "on",
+        )
+
         self.request.session.flash(
             f"Updated application instance {ai.consumer_key}", "messages"
         )

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -136,8 +136,9 @@ class TestEnableContentItemSelectionMode:
         assert "courseId" not in js_config.asdict()
 
     @pytest.fixture
-    def blackboard_files_enabled(self, pyramid_request):
-        pyramid_request.feature = lambda feature: feature == "blackboard_files"
+    def blackboard_files_enabled(self, application_instance_service):
+        application_instance = application_instance_service.get.return_value
+        application_instance.settings.set("blackboard", "files_enabled", True)
 
 
 class TestEnableLTILaunchMode:

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -87,17 +87,6 @@ class TestEnableContentItemSelectionMode:
 
         self.assert_canvas_file_picker_not_enabled(js_config)
 
-    def test_it_doesnt_enable_the_canvas_file_picker_if_the_consumer_key_isnt_found_in_the_db(
-        self, application_instance_service, js_config
-    ):
-        application_instance_service.get.side_effect = ConsumerKeyError()
-
-        js_config.enable_content_item_selection_mode(
-            mock.sentinel.form_action, mock.sentinel.form_fields
-        )
-
-        self.assert_canvas_file_picker_not_enabled(js_config)
-
     def test_it_doesnt_enable_the_canvas_file_picker_if_we_dont_have_a_developer_key(
         self, application_instance_service, js_config
     ):


### PR DESCRIPTION
Replace the `"blackboard_files"` feature flag with a `blackboard.files_enabled` application instance setting. This allows us to enable Blackboard files for our test assignments in our test Blackboard instance, without enabling them for the public. Also once Blackboard files has been released to the public I think it might be opt-in at least at first, in which case we'll just keep using this setting.

One day we might want to enable Blackboard files by default at which point we'd need to detect whether the LMS is Blackboard (so as not to show the Blackboard files button in non-Blackboard LMS's) and then, when talking to the Blackboard API totally fails, detect that and show an error message explaining how the user needs to get their admin to set up an OAuth client in Blackboard.