### PR TITLE
Raise ProxyAPIAccessTokenError not NoOAuth2Token

### DIFF
--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -1,18 +1,18 @@
 import pytest
 
-from lms.services import NoOAuth2Token
+from lms.services import NoOAuth2Token, ProxyAPIAccessTokenError
 from lms.views.api.blackboard.files import BlackboardFilesAPIViews
 
 pytestmark = pytest.mark.usefixtures("oauth2_token_service")
 
 
 class CommonTests:
-    def test_it_raises_NoOAuth2Token_if_theres_no_access_token_for_the_user(
+    def test_it_raises_ProxyAPIAccessTokenError_if_theres_no_access_token_for_the_user(
         self, oauth2_token_service, view
     ):
         oauth2_token_service.get.side_effect = NoOAuth2Token()
 
-        with pytest.raises(NoOAuth2Token):
+        with pytest.raises(ProxyAPIAccessTokenError):
             view()
 
 


### PR DESCRIPTION
You would need the frontend changes from
https://github.com/hypothesis/lms/pull/2636 to actually test this, but:

`ProxyAPIAccessTokenError` is the one that has an exception view:

https://github.com/hypothesis/lms/blob/e174b161e90918c94402b8e662e150b063b67b42/lms/views/api/exceptions.py#L107-L109

The exception view returns a response that triggers the frontend to show
a "You need to authorize" dialog.

If the view raises `NoOAuth2Token` instead that gets caught by the
catch-all exception view that triggers a "Something went wrong" dialog.