### PR TITLE
Allow "/" char when checking Base64 string in a test

### DIFF
--- a/tests/unit/lms/services/vitalsource_test.py
+++ b/tests/unit/lms/services/vitalsource_test.py
@@ -58,10 +58,11 @@ class TestVitalSourceService:
         # Ignore non-OAuth signature params in this test.
         params = {k: v for (k, v) in params.items() if k.startswith("oauth_")}
 
+        base64_char = "[0-9a-zA-Z+=/]"
         assert params == {
             "oauth_consumer_key": "lti_launch_key",
             "oauth_nonce": Any.string.matching("[0-9]+"),
-            "oauth_signature": Any.string.matching("[0-9a-zA-Z+=]+"),
+            "oauth_signature": Any.string.matching(f"{base64_char}+"),
             "oauth_signature_method": "HMAC-SHA1",
             "oauth_timestamp": Any.string.matching("[0-9]+"),
             "oauth_version": "1.0",


### PR DESCRIPTION
Add missing "/" character to allowed chars list in a test checking for a
Base64 string. This caused [occassional failures](https://github.com/hypothesis/lms/pull/2686/checks?check_run_id=2599723103) in this test.

[1] https://en.wikipedia.org/wiki/Base64#Base64_table