### PR TITLE
Rename CanvasOAuthCallbackSchema to OAuthCallbackSchema

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -10,8 +10,8 @@ from pyramid_googleauth import GoogleSecurityPolicy
 from lms.validation import ValidationError
 from lms.validation.authentication import (
     BearerTokenSchema,
-    CanvasOAuthCallbackSchema,
     LaunchParamsAuthSchema,
+    OAuthCallbackSchema,
 )
 
 
@@ -175,7 +175,7 @@ def _get_lti_user(request):
         partial(bearer_token_schema.lti_user, location="headers"),
         partial(bearer_token_schema.lti_user, location="querystring"),
         partial(bearer_token_schema.lti_user, location="form"),
-        CanvasOAuthCallbackSchema(request).lti_user,
+        OAuthCallbackSchema(request).lti_user,
     ]
 
     for schema in schemas:

--- a/lms/validation/authentication/__init__.py
+++ b/lms/validation/authentication/__init__.py
@@ -11,4 +11,4 @@ from lms.validation.authentication._exceptions import (
     MissingStateParamError,
 )
 from lms.validation.authentication._launch_params import LaunchParamsAuthSchema
-from lms.validation.authentication._oauth import CanvasOAuthCallbackSchema
+from lms.validation.authentication._oauth import OAuthCallbackSchema

--- a/lms/validation/authentication/_oauth.py
+++ b/lms/validation/authentication/_oauth.py
@@ -1,4 +1,3 @@
-"""Validation for OAuth views."""
 import secrets
 
 import marshmallow
@@ -16,27 +15,27 @@ from lms.validation.authentication._exceptions import (
 from lms.validation.authentication._helpers import _jwt
 
 
-class CanvasOAuthCallbackSchema(PyramidRequestSchema):
+class OAuthCallbackSchema(PyramidRequestSchema):
     """
-    Schema for validating OAuth 2 redirect_uri requests from Canvas.
+    Schema for validating OAuth 2 redirect_uri requests.
 
     This schema provides two convenience methods:
 
-    First, :meth:`CanvasOAuthCallbackSchema.state_param` returns a string
+    First, :meth:`OAuthCallbackSchema.state_param` returns a string
     suitable for passing to an authorization server's authorization endpoint as
     the ``state`` query parameter::
 
-       >>> schema = CanvasOAuthCallbackSchema()
+       >>> schema = OAuthCallbackSchema()
        >>> schema.context['request'] = request
        >>> schema.state_param(request.lti_user)
        'xyz...123'
 
-    Calling :meth:`CanvasOAuthCallbackSchema.state_param` also has the side
+    Calling :meth:`OAuthCallbackSchema.state_param` also has the side
     effect of inserting a CSRF token into the session that will be checked
     against the ``state`` parameter when the authorization server returns the
     ``state`` parameter to us in a later ``redirect_uri`` request.
 
-    Second, :meth:`CanvasOAuthCallbackSchema.lti_user` returns the
+    Second, :meth:`OAuthCallbackSchema.lti_user` returns the
     models.LTIUser authenticated by the ``state`` param in the
     current request. This will raise if the request doesn't contain a ``state``
     query parameter or if the ``state`` is expired or invalid::
@@ -44,10 +43,10 @@ class CanvasOAuthCallbackSchema(PyramidRequestSchema):
        >>> schema.lti_user()
        LTIUser(user_id='...', oauth_consumer_key='...')
 
-    Finally, :class:`CanvasOAuthCallbackSchema` can also be used as a schema to
+    Finally, :class:`OAuthCallbackSchema` can also be used as a schema to
     guard a ``redirect_uri`` view, for example::
 
-        @view_config(..., schema=CanvasOAuthCallbackSchema)
+        @view_config(..., schema=OAuthCallbackSchema)
         def redirect_uri_view(request):
             # The authorization code and state sent by the authorization server
             # are available in request.parsed_params.

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -3,7 +3,7 @@ from pyramid.view import view_config
 
 from lms.security import Permissions
 from lms.services import NoOAuth2Token
-from lms.validation.authentication import CanvasOAuthCallbackSchema
+from lms.validation.authentication import OAuthCallbackSchema
 
 
 @view_config(
@@ -15,7 +15,7 @@ def authorize(request):
     return HTTPFound(
         location=request.route_url(
             "blackboard_api.oauth.callback",
-            _query={"state": CanvasOAuthCallbackSchema(request).state_param()},
+            _query={"state": OAuthCallbackSchema(request).state_param()},
         )
     )
 

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -16,7 +16,7 @@ from pyramid.view import exception_view_config, view_config
 
 from lms.security import Permissions
 from lms.services import CanvasAPIServerError
-from lms.validation.authentication import BearerTokenSchema, CanvasOAuthCallbackSchema
+from lms.validation.authentication import BearerTokenSchema, OAuthCallbackSchema
 
 #: The Canvas API scopes that we need for our Canvas Files feature.
 FILES_SCOPES = (
@@ -67,7 +67,7 @@ def authorize(request):
                     "client_id": application_instance.developer_key,
                     "response_type": "code",
                     "redirect_uri": request.route_url("canvas_api.oauth.callback"),
-                    "state": CanvasOAuthCallbackSchema(request).state_param(),
+                    "state": OAuthCallbackSchema(request).state_param(),
                     "scope": " ".join(scopes),
                 }
             ),
@@ -83,7 +83,7 @@ def authorize(request):
     route_name="canvas_api.oauth.callback",
     permission=Permissions.API,
     renderer="lms:templates/api/oauth2/redirect.html.jinja2",
-    schema=CanvasOAuthCallbackSchema,
+    schema=OAuthCallbackSchema,
 )
 def oauth2_redirect(request):
     authorization_code = request.parsed_params["code"]

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -511,7 +511,7 @@ class TestGetLTIUser:
         self,
         launch_params_auth_schema,
         bearer_token_schema,
-        CanvasOAuthCallbackSchema,
+        OAuthCallbackSchema,
         canvas_oauth_callback_schema,
         pyramid_request,
     ):
@@ -524,7 +524,7 @@ class TestGetLTIUser:
 
         lti_user = _get_lti_user(pyramid_request)
 
-        CanvasOAuthCallbackSchema.assert_called_once_with(pyramid_request)
+        OAuthCallbackSchema.assert_called_once_with(pyramid_request)
         canvas_oauth_callback_schema.lti_user.assert_called_once_with()
         assert lti_user == canvas_oauth_callback_schema.lti_user.return_value
 
@@ -564,12 +564,12 @@ class TestGetLTIUser:
         return BearerTokenSchema.return_value
 
     @pytest.fixture(autouse=True)
-    def CanvasOAuthCallbackSchema(self, patch):
-        return patch("lms.security.CanvasOAuthCallbackSchema")
+    def OAuthCallbackSchema(self, patch):
+        return patch("lms.security.OAuthCallbackSchema")
 
     @pytest.fixture
-    def canvas_oauth_callback_schema(self, CanvasOAuthCallbackSchema):
-        return CanvasOAuthCallbackSchema.return_value
+    def canvas_oauth_callback_schema(self, OAuthCallbackSchema):
+        return OAuthCallbackSchema.return_value
 
     @pytest.fixture(autouse=True)
     def LaunchParamsAuthSchema(self, patch):

--- a/tests/unit/lms/validation/authentication/_oauth_test.py
+++ b/tests/unit/lms/validation/authentication/_oauth_test.py
@@ -9,11 +9,11 @@ from lms.validation.authentication import (
     InvalidStateParamError,
     MissingStateParamError,
 )
-from lms.validation.authentication._oauth import CanvasOAuthCallbackSchema
+from lms.validation.authentication._oauth import OAuthCallbackSchema
 from tests import factories
 
 
-class TestCanvasOauthCallbackSchema:
+class TestOauthCallbackSchema:
     def test_state_param_encodes_lti_user_and_csrf_token_into_state_jwt(
         self, schema, secrets, _jwt, lti_user
     ):
@@ -142,7 +142,7 @@ class TestCanvasOauthCallbackSchema:
 
     @pytest.fixture
     def schema(self, pyramid_request):
-        return CanvasOAuthCallbackSchema(pyramid_request)
+        return OAuthCallbackSchema(pyramid_request)
 
     @pytest.fixture
     def pyramid_request(self, lti_user):

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -18,11 +18,11 @@ class TestAuthorize:
         )
 
     def test_it_authenticates_the_redirect_with_an_OAuth2_state_param(
-        self, pyramid_request, CanvasOAuthCallbackSchema
+        self, pyramid_request, OAuthCallbackSchema
     ):
         response = authorize(pyramid_request)
 
-        CanvasOAuthCallbackSchema.assert_called_once_with(pyramid_request)
+        OAuthCallbackSchema.assert_called_once_with(pyramid_request)
         state = parse_qs(urlparse(response.location).query).get("state")
         assert state == ["test_state"]
 
@@ -51,9 +51,9 @@ class TestOAuth2Redirect:
 
 
 @pytest.fixture(autouse=True)
-def CanvasOAuthCallbackSchema(patch):
-    CanvasOAuthCallbackSchema = patch(
-        "lms.views.api.blackboard.authorize.CanvasOAuthCallbackSchema"
+def OAuthCallbackSchema(patch):
+    OAuthCallbackSchema = patch(
+        "lms.views.api.blackboard.authorize.OAuthCallbackSchema"
     )
-    CanvasOAuthCallbackSchema.return_value.state_param.return_value = "test_state"
-    return CanvasOAuthCallbackSchema
+    OAuthCallbackSchema.return_value.state_param.return_value = "test_state"
+    return OAuthCallbackSchema

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -81,13 +81,13 @@ class TestAuthorize:
         self.assert_file_scopes_only(authorize.authorize(pyramid_request))
 
     def test_it_includes_the_state_in_a_query_param(
-        self, pyramid_request, CanvasOAuthCallbackSchema, canvas_oauth_callback_schema
+        self, pyramid_request, OAuthCallbackSchema, canvas_oauth_callback_schema
     ):
         response = authorize.authorize(pyramid_request)
 
         query_params = parse_qs(urlparse(response.location).query)
 
-        CanvasOAuthCallbackSchema.assert_called_once_with(pyramid_request)
+        OAuthCallbackSchema.assert_called_once_with(pyramid_request)
         canvas_oauth_callback_schema.state_param.assert_called_once_with()
         assert query_params["state"] == [
             canvas_oauth_callback_schema.state_param.return_value
@@ -225,12 +225,12 @@ def BearerTokenSchema(patch):
 
 
 @pytest.fixture(autouse=True)
-def CanvasOAuthCallbackSchema(patch):
-    return patch("lms.views.api.canvas.authorize.CanvasOAuthCallbackSchema")
+def OAuthCallbackSchema(patch):
+    return patch("lms.views.api.canvas.authorize.OAuthCallbackSchema")
 
 
 @pytest.fixture
-def canvas_oauth_callback_schema(CanvasOAuthCallbackSchema):
-    schema = CanvasOAuthCallbackSchema.return_value
+def canvas_oauth_callback_schema(OAuthCallbackSchema):
+    schema = OAuthCallbackSchema.return_value
     schema.state_param.return_value = "test_state"
     return schema


### PR DESCRIPTION
There's nothing Canvas-specific about this schema and it's actually now used by the blackboard authorize() view as well.