### PR TITLE
Add LMS fields to ApplicationInstance

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,3 +1,4 @@
+import logging
 import secrets
 from datetime import datetime
 from urllib.parse import urlparse
@@ -9,6 +10,8 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE
 from lms.models.application_settings import ApplicationSettings
+
+LOG = logging.getLogger(__name__)
 
 
 class ApplicationInstance(BASE):

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -34,6 +34,109 @@ Application instance {{instance.consumer_key}}
       </div>
     </div>
 
+    <div class="field is-horizontal">
+      <div class="field-label is-normal">
+        <label class="label">tool consumer instance guid</label>
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <p class="control is-expanded">
+            <input class="input" disabled type="text" value="{{instance.tool_consumer_instance_guid}}">
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label is-normal">
+        <label class="label">tool consumer info product family code</label>
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <p class="control is-expanded">
+            <input class="input" disabled type="text" value="{{instance.tool_consumer_info_product_family_code}}">
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label is-normal">
+        <label class="label">tool consumer instance description</label>
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <p class="control is-expanded">
+            <input class="input" disabled type="text" value="{{instance.tool_consumer_instance_description}}">
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label is-normal">
+        <label class="label">tool consumer instance url</label>
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <p class="control is-expanded">
+            <input class="input" disabled type="text" value="{{instance.tool_consumer_instance_url}}">
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label is-normal">
+        <label class="label">tool consumer instance name</label>
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <p class="control is-expanded">
+            <input class="input" disabled type="text" value="{{instance.tool_consumer_instance_name}}">
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label is-normal">
+        <label class="label">tool consumer instance contact email</label>
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <p class="control is-expanded">
+            <input class="input" disabled type="text" value="{{instance.tool_consumer_instance_contact_email}}">
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label is-normal">
+        <label class="label">tool consumer info version</label>
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <p class="control is-expanded">
+            <input class="input" disabled type="text" value="{{instance.tool_consumer_info_version}}">
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label is-normal">
+        <label class="label">custom canvas api domain</label>
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <p class="control is-expanded">
+            <input class="input" disabled type="text" value="{{instance.custom_canvas_api_domain}}">
+          </p>
+        </div>
+      </div>
+    </div>
 
     <div class="field is-horizontal">
       <div class="field-label">

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -42,6 +42,10 @@ class BasicLTILaunchViews:
         self.context.js_config.enable_lti_launch_mode()
         self.context.js_config.maybe_set_focused_user()
 
+        request.find_service(name="application_instance").get().update_lms_data(
+            self.request.params
+        )
+
     def basic_lti_launch(self, document_url=None, grading_supported=True):
         """Do a basic LTI launch with the given document_url."""
         self.sync_lti_data_to_h()

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -49,6 +49,10 @@ from lms.validation import ContentItemSelectionLTILaunchSchema
     schema=ContentItemSelectionLTILaunchSchema,
 )
 def content_item_selection(context, request):
+    request.find_service(name="application_instance").get().update_lms_data(
+        request.params
+    )
+
     request.find_service(name="course").get_or_create(
         context.h_group.authority_provided_id
     )

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -152,10 +152,42 @@ class TestApplicationInstance:
         assert application_instance.developer_secret
         assert application_instance.settings == {}
 
+    def test_update_lms_data(self, application_instance, lms_data):
+        lms_data["tool_consumer_instance_guid"] = "GUID"
+        application_instance.update_lms_data(lms_data)
+
+        for k, v in lms_data.items():
+            assert getattr(application_instance, k) == v
+
+    def test_update_lms_data_no_guid_doesnt_change_values(
+        self, application_instance, lms_data
+    ):
+        application_instance.update_lms_data(lms_data)
+
+        assert application_instance.tool_consumer_instance_guid is None
+        assert application_instance.tool_consumer_info_product_family_code is None
+
+    def test_update_lms_data_existing_guid(self, application_instance, lms_data):
+        application_instance.tool_consumer_instance_guid = "EXISTING_GUID"
+        lms_data["tool_consumer_instance_guid"] = "NEW GUID"
+
+        application_instance.update_lms_data(lms_data)
+
+        assert application_instance.tool_consumer_instance_guid == "EXISTING_GUID"
+
     @pytest.fixture
     def application_instance(self):
         """Return an ApplicationInstance with minimal required attributes."""
         return factories.ApplicationInstance()
+
+    @pytest.fixture
+    def lms_data(self):
+        return {
+            "tool_consumer_info_product_family_code": "FAMILY",
+            "tool_consumer_instance_description": "DESCRIPTION",
+            "tool_consumer_instance_url": "URL",
+            "tool_consumer_instance_name": "NAME",
+        }
 
 
 class TestApplicationSettings:

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -8,6 +8,7 @@ from lms.views.basic_lti_launch import BasicLTILaunchViews
 from tests import factories
 
 pytestmark = pytest.mark.usefixtures(
+    "application_instance_service",
     "assignment_service",
     "course_service",
     "h_api",

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -6,7 +6,9 @@ from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
 from lms.views.content_item_selection import content_item_selection
 
-pytestmark = pytest.mark.usefixtures("course_service", "lti_h_service")
+pytestmark = pytest.mark.usefixtures(
+    "application_instance_service", "course_service", "lti_h_service"
+)
 
 
 class TestContentItemSelection:


### PR DESCRIPTION
The standalone migration needs to be deployed first: https://github.com/hypothesis/lms/pull/2705

To test it

- Apply DB migration `hdev alembic upgrade head`
- Launch any assignment on canvas
- Check values no present on the new fields 

`select * from application_instances where tool_consumer_instance_guid is not null;`

- Manually change the GUID value to another 

`update application_instances set tool_consumer_instance_guid = 'UNIQUE GUID' where tool_consumer_instance_guid is not null;`

- Launch the assignment again, you should see an error logged on LMS' ouput



