### PR TITLE
Extract logic to show auth popup into `AuthButton` component

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AuthButton.js
+++ b/lms/static/scripts/frontend_apps/components/AuthButton.js
@@ -1,0 +1,66 @@
+import { LabeledButton } from '@hypothesis/frontend-shared';
+import { createElement } from 'preact';
+import { useCallback, useEffect, useRef } from 'preact/hooks';
+
+import AuthWindow from '../utils/AuthWindow';
+
+/**
+ * @typedef AuthButtonProps
+ * @prop {string} authURL - Initial URL for the authorization popup. See `AuthWindow`.
+ * @prop {string} authToken - Auth token between the LMS frontend and backend. See `AuthWindow`.
+ * @prop {string} [label] - Custom label for the "Authorize" button
+ * @prop {() => void} onAuthComplete - Callback invoked when the authorization flow completes.
+ *   This does not guarantee that authorization was successful. Instead
+ *   the caller should retry whatever operation triggered the authorization
+ *   prompt and check whether it succeeds.
+ */
+
+/**
+ * Button that prompts the user to authorize the Hypothesis LMS app to access
+ * their data in the LMS (or another service).
+ *
+ * This component is typically shown to the user when an attempt to fetch data
+ * from the LMS via an LMS-specific API fails, requiring the user to complete
+ * an OAuth or OAuth-like authentication flow before the attempt can proceed.
+ *
+ * @param {AuthButtonProps} props
+ */
+export default function AuthButton({
+  authURL,
+  authToken,
+  label = 'Authorize',
+  onAuthComplete,
+}) {
+  /** @type {{ current: AuthWindow|null }} */
+  const authWindow = useRef(null);
+
+  const authorize = useCallback(async () => {
+    if (authWindow.current) {
+      authWindow.current.focus();
+      return;
+    }
+
+    authWindow.current = new AuthWindow({ authToken, authUrl: authURL });
+
+    try {
+      await authWindow.current.authorize();
+      onAuthComplete();
+    } finally {
+      authWindow.current.close();
+      authWindow.current = null;
+    }
+  }, [authToken, authURL, onAuthComplete]);
+
+  // Close auth window if component is unmounted.
+  useEffect(() => {
+    return () => {
+      authWindow.current?.close();
+    };
+  }, []);
+
+  return (
+    <LabeledButton onClick={authorize} variant="primary">
+      {label}
+    </LabeledButton>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/test/AuthButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AuthButton-test.js
@@ -1,0 +1,102 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+
+import AuthButton, { $imports } from '../AuthButton';
+
+describe('AuthButton', () => {
+  const authToken = 'dummy-token';
+  const authURL = 'https://example.com/authorize';
+
+  let FakeAuthWindow;
+  let fakeAuthWindow;
+
+  beforeEach(() => {
+    fakeAuthWindow = {
+      authorize: sinon.stub().resolves(),
+      close: sinon.stub(),
+      focus: sinon.stub(),
+    };
+    FakeAuthWindow = sinon.stub().returns(fakeAuthWindow);
+
+    $imports.$mock({
+      '../utils/AuthWindow': FakeAuthWindow,
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  function createComponent(props = {}) {
+    const noop = () => {};
+
+    return mount(
+      <AuthButton
+        authToken={authToken}
+        authURL={authURL}
+        onAuthComplete={noop}
+        {...props}
+      />
+    );
+  }
+
+  it('shows authorization popup when button is clicked', () => {
+    const authButton = createComponent();
+
+    act(() => {
+      authButton.find('LabeledButton').props().onClick();
+    });
+
+    assert.calledWith(FakeAuthWindow, { authToken, authUrl: authURL });
+    assert.called(fakeAuthWindow.authorize);
+  });
+
+  it('focuses the existing popup if open when button is clicked', () => {
+    const authButton = createComponent();
+
+    act(() => {
+      authButton.find('LabeledButton').props().onClick();
+    });
+    assert.notCalled(fakeAuthWindow.focus);
+
+    act(() => {
+      authButton.find('LabeledButton').props().onClick();
+    });
+    assert.called(fakeAuthWindow.focus);
+
+    // Popup window should not be created a second time.
+    assert.calledOnce(FakeAuthWindow);
+    assert.calledOnce(fakeAuthWindow.authorize);
+  });
+
+  it('invokes `onAuthComplete` callback when authorization completes', () => {
+    let onAuthComplete;
+    const authCompleteCalled = new Promise(
+      resolve => (onAuthComplete = resolve)
+    );
+    const authButton = createComponent({ onAuthComplete });
+
+    act(() => {
+      authButton.find('LabeledButton').props().onClick();
+    });
+
+    return authCompleteCalled;
+  });
+
+  it('shows custom label', () => {
+    const authButton = createComponent({ label: 'Try again' });
+    assert.equal(authButton.find('LabeledButton').text(), 'Try again');
+  });
+
+  it('closes the authorization popup when unmounted', () => {
+    const authButton = createComponent();
+
+    act(() => {
+      authButton.find('LabeledButton').props().onClick();
+    });
+    authButton.unmount();
+
+    assert.calledOnce(fakeAuthWindow.close);
+  });
+});


### PR DESCRIPTION
Extract the logic for showing an authorization prompt, when fetching
files from the LMS fails, into a separate `AuthButton` component.

This simplifies the `LMSFilePicker` component and tests and will enable the
"Authorize" button logic to be reused in other places.

Part of https://github.com/hypothesis/lms/issues/2524.

----

**Manual testing:**

1. Delete your existing access token for the "localhost (make devdata)" installation of Hypothesis at https://hypothesis.instructure.com/profile/settings
2. Create an assignment and select the "Select PDF from Canvas" option
3. Click "Authorize" and verify that the auth popup appears
4. Check that clicking "Authorize" while the auth popup is open brings focus to the already-open window
5. Check that files are shown after the authorization flow in the popup completes
6. Repeat step (1) and (2). This time check that dismissing the auth popup without authorizing results in a dialog with a "Try again" button, and that clicking "Try again" shows the auth prompt again. Authorizing here should then result in the file list being shown