### PR TITLE
Add the blackboard.files_enabled setting

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -197,7 +197,7 @@ class JSConfig:
             "formAction": form_action,
             "formFields": form_fields,
             "blackboard": {
-                "enabled": self._blackboard_files_available(),
+                "enabled": self._blackboard_files_enabled(),
                 "listFiles": {
                     "authUrl": self._request.route_url(
                         "blackboard_api.oauth.authorize"
@@ -337,9 +337,13 @@ class JSConfig:
         """Return the authToken setting."""
         return BearerTokenSchema(self._request).authorization_param(self._lti_user)
 
-    def _blackboard_files_available(self):
-        """Return True if the Blackboard Files API is available to this request."""
-        return self._request.feature("blackboard_files")
+    def _blackboard_files_enabled(self):
+        """
+        Return True if the Blackboard Files API is enabled for this request.
+
+        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
+        """
+        return self._application_instance().settings.get("blackboard", "files_enabled")
 
     def _canvas_files_available(self):
         """

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -67,6 +67,21 @@ Application instance {{instance.consumer_key}}
 
     <div class="field is-horizontal">
       <div class="field-label">
+        <label class="label">Blackboard files enabled
+      </div>
+      <div class="field-body">
+        <div class="field is-narrow">
+          <div class="control">
+            <label class="checkbox">
+              <input {% if instance.settings.get("blackboard", "files_enabled") %}checked {% endif%} type="checkbox" name="blackboard_files_enabled">
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="field is-horizontal">
+      <div class="field-label">
         <!-- Left empty for spacing -->
       </div>
       <div class="field-body">

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -93,6 +93,12 @@ class AdminViews:
             self.request.params.get("groups_enabled") == "on",
         )
 
+        ai.settings.set(
+            "blackboard",
+            "files_enabled",
+            self.request.params.get("blackboard_files_enabled") == "on",
+        )
+
         self.request.session.flash(
             f"Updated application instance {ai.consumer_key}", "messages"
         )

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -136,8 +136,9 @@ class TestEnableContentItemSelectionMode:
         assert "courseId" not in js_config.asdict()
 
     @pytest.fixture
-    def blackboard_files_enabled(self, pyramid_request):
-        pyramid_request.feature = lambda feature: feature == "blackboard_files"
+    def blackboard_files_enabled(self, application_instance_service):
+        application_instance = application_instance_service.get.return_value
+        application_instance.settings.set("blackboard", "files_enabled", True)
 
 
 class TestEnableLTILaunchMode:


### PR DESCRIPTION
Replace the blackboard_files feature flag with a blackboard.files_enabled application instance setting.

This was already reviewed but the commit got lost in a rebase: https://github.com/hypothesis/lms/pull/2692/commits/116e817c30f870ccc05508d2154c21abee1d7a78