### PR TITLE
Remove references to Via 3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,14 +8,13 @@
 
 ### You will need
 
-* The LMS app integrates h, the Hypothesis client, Via 3, and Via, so you will need to
+* The LMS app integrates h, the Hypothesis client and Via, so you will need to
   set up development environments for each of those before you can develop the
   LMS app:
 
   * https://h.readthedocs.io/en/latest/developing/install/
   * https://h.readthedocs.io/projects/client/en/latest/developers/developing/
-  * https://github.com/hypothesis/via3 (Serves PDF content)
-  * https://github.com/hypothesis/viahtml (Serves HTTP content)
+  * https://github.com/hypothesis/via (Serves PDF content)
 
 * [Git](https://git-scm.com/)
 

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -21,7 +21,7 @@ feature_flags_allowed_in_cookie = vitalsource
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"
 
-# Set the default to Via 3 for dev (original via: 9080)
+# Set the default to Via for dev.
 via_url = http://localhost:9083
 
 h_authority = lms.hypothes.is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def get_test_database_url(default):
 
 TEST_SETTINGS = {
     "dev": False,
-    "via_url": "http://TEST_VIA3_SERVER.is/",
+    "via_url": "http://TEST_VIA_SERVER.is/",
     "jwt_secret": "test_secret",
     "google_client_id": "fake_client_id",
     "google_developer_key": "fake_developer_key",

--- a/tests/unit/lms/config/__init___test.py
+++ b/tests/unit/lms/config/__init___test.py
@@ -158,14 +158,14 @@ class TestConfigure:
             envvar_name, *args, **kwargs
         ):  # pylint: disable=unused-argument
             if envvar_name == "VIA_URL":
-                return "https://via3.hypothes.is"
+                return "https://via.hypothes.is"
             return mock.DEFAULT
 
         setting_getter.get.side_effect = side_effect
 
         configurator = configure({})
 
-        assert configurator.registry.settings["via_url"] == "https://via3.hypothes.is/"
+        assert configurator.registry.settings["via_url"] == "https://via.hypothes.is/"
 
     def test_trailing_slashes_are_appended_to_h_api_url_public(self, setting_getter):
         def side_effect(

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -23,7 +23,7 @@ class TestViaURL:
         url_params["via.sec"] = Any.string()
         url_params["via.blocked_for"] = "lms"
         assert final_url == Any.url.matching(
-            "http://test_via3_server.is/route"
+            "http://test_via_server.is/route"
         ).with_query(url_params)
 
     pywb_test_params = pytest.mark.parametrize(
@@ -46,21 +46,21 @@ class TestViaURL:
         ),
     )
 
-    def test_it_redirects_to_via3_view_pdf_directly_for_google_drive(
+    def test_it_redirects_to_via_view_pdf_directly_for_google_drive(
         self, pyramid_request
     ):
         google_drive_url = "https://drive.google.com/uc?id=<SOME-ID>&export=download"
         final_url = via_url(pyramid_request, google_drive_url)
 
         assert final_url == Any.url.matching(
-            "http://test_via3_server.is/pdf"
+            "http://test_via_server.is/pdf"
         ).containing_query({"url": google_drive_url})
 
-    def test_it_redirects_to_via3_view_pdf_directly_if_content_type_is_pdf(
+    def test_it_redirects_to_via_view_pdf_directly_if_content_type_is_pdf(
         self, pyramid_request
     ):
         final_url = via_url(pyramid_request, "any url", content_type="pdf")
 
         assert (
-            final_url == Any.url.matching("http://test_via3_server.is/pdf").with_query()
+            final_url == Any.url.matching("http://test_via_server.is/pdf").with_query()
         )


### PR DESCRIPTION
It's just called "Via" now.

Also removed documentation of Via HTML as a dependency in README.markdown. Via HTML is a dependency of Via, let Via's README document it.