### PR TITLE
Re-add `document_url` form field to `FilePickerApp`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -238,6 +238,11 @@ export default function FilePickerApp({
           You can select content for your assignment from one of the following
           sources:
         </p>
+        {content?.type === 'url' && (
+          // Set the `document_url` form field which is used by the `configure_module_item`
+          // view. Used in LMSes where assignments are configured on first launch.
+          <input name="document_url" type="hidden" value={content.url} />
+        )}
         <div className="FilePickerApp__document-source-buttons">
           <Button
             className="FilePickerApp__source-button"

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -162,6 +162,20 @@ describe('FilePickerApp', () => {
     );
   });
 
+  it('sets `document_url` form field when a URL is selected', () => {
+    const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+    const wrapper = renderFilePicker({ defaultActiveDialog: 'url', onSubmit });
+
+    const picker = wrapper.find('URLPicker');
+    interact(wrapper, () => {
+      picker.props().onSelectURL('https://example.com');
+    });
+
+    assert.called(onSubmit);
+    const documentURLField = wrapper.find('input[name="document_url"]');
+    assert.equal(documentURLField.prop('value'), 'https://example.com');
+  });
+
   it('shows LMS file dialog when "Select PDF from Canvas" is clicked', () => {
     const wrapper = renderFilePicker();
 


### PR DESCRIPTION
This field was removed in 8c4cb991cda7c2aac1d7cd28b293d1eb32c870c2 under
the mistaken assumption that it is not used. However this field is in
fact used in non-Canvas LMSes where the URL for an assignment is
configured on the first launch.

**Testing:**

Steps to reproduce:

1. In Moodle create a new External Tool assignment and select Hypothesis as the external tool
2. Click "Save and display" at the bottom of the assignment configuration form
3. When the assignment launches, you should see the content selection app. Choose a URL for the assignment
4. After submitting the URL, the assignment should load

Slack thread: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1621364059016100