### PR TITLE
Extract FilePickerApp hidden form field rendering into separate component

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -3,17 +3,13 @@ import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import { Config } from '../config';
 import {
-  contentItemForUrl,
-  contentItemForLmsFile,
-  contentItemForVitalSourceBook,
-} from '../utils/content-item';
-import {
   GooglePickerClient,
   PickerCanceledError,
 } from '../utils/google-picker-client';
 
 import Button from './Button';
 import ErrorDialog from './ErrorDialog';
+import FilePickerFormFields from './FilePickerFormFields';
 import LMSFilePicker from './LMSFilePicker';
 import Spinner from './Spinner';
 import URLPicker from './URLPicker';
@@ -198,24 +194,6 @@ export default function FilePickerApp({
       dialog = null;
   }
 
-  let contentItem = null;
-  switch (content?.type) {
-    case 'url':
-      contentItem = contentItemForUrl(ltiLaunchUrl, content.url);
-      break;
-    case 'file':
-      contentItem = contentItemForLmsFile(ltiLaunchUrl, content.file);
-      break;
-    case 'vitalsource':
-      contentItem = contentItemForVitalSourceBook(
-        ltiLaunchUrl,
-        content.bookID,
-        content.cfi
-      );
-      break;
-  }
-  contentItem = JSON.stringify(contentItem);
-
   return (
     <main>
       <form
@@ -224,25 +202,11 @@ export default function FilePickerApp({
         method="POST"
         onSubmit={onSubmit}
       >
-        <input type="hidden" name="content_items" value={contentItem} />
-        {Object.keys(formFields).map(field => (
-          <input
-            key={field}
-            type="hidden"
-            name={field}
-            value={formFields[field]}
-          />
-        ))}
         <h1 className="heading-1">Select web page or PDF</h1>
         <p>
           You can select content for your assignment from one of the following
           sources:
         </p>
-        {content?.type === 'url' && (
-          // Set the `document_url` form field which is used by the `configure_module_item`
-          // view. Used in LMSes where assignments are configured on first launch.
-          <input name="document_url" type="hidden" value={content.url} />
-        )}
         <div className="FilePickerApp__document-source-buttons">
           <Button
             className="FilePickerApp__source-button"
@@ -271,6 +235,13 @@ export default function FilePickerApp({
             />
           )}
         </div>
+        {content && (
+          <FilePickerFormFields
+            ltiLaunchURL={ltiLaunchUrl}
+            content={content}
+            formFields={formFields}
+          />
+        )}
         <input style={{ display: 'none' }} ref={submitButton} type="submit" />
       </form>
       {isLoadingIndicatorVisible && (

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
@@ -1,0 +1,85 @@
+import { Fragment, createElement } from 'preact';
+
+import {
+  contentItemForUrl,
+  contentItemForLmsFile,
+  contentItemForVitalSourceBook,
+} from '../utils/content-item';
+
+/**
+ * @typedef {import('./FilePickerApp').Content} Content
+ */
+
+/**
+ * @typedef FilePickerFormFieldsProps
+ * @prop {string} ltiLaunchURL - URL that the LMS should use to launch the
+ *   assignment.
+ * @prop {Content} content - Content for the assignment
+ * @prop {Record<string,string>} formFields - Form fields provided by the backend
+ *   that should be included in the response without any changes
+ */
+
+/**
+ * Generate an LTI launch URL for a given piece of content.
+ *
+ * @param {string} ltiLaunchURL
+ * @param {Content} content
+ */
+function contentItemString(ltiLaunchURL, content) {
+  let contentItem = null;
+
+  switch (content.type) {
+    case 'url':
+      contentItem = contentItemForUrl(ltiLaunchURL, content.url);
+      break;
+    case 'file':
+      contentItem = contentItemForLmsFile(ltiLaunchURL, content.file);
+      break;
+    case 'vitalsource': {
+      contentItem = contentItemForVitalSourceBook(
+        ltiLaunchURL,
+        content.bookID,
+        content.cfi
+      );
+    }
+  }
+  return JSON.stringify(contentItem);
+}
+
+/**
+ * Render the hidden form fields in the file picker form containing information
+ * about the selected assignment.
+ *
+ * This form may be used in two different scenarios:
+ *
+ *  - A "Content Item Selection" form when configuring an assignment. In this
+ *    case the form will look like "Section 3.2, Example Response" in
+ *    https://www.imsglobal.org/specs/lticiv1p0/specification
+ *  - When an assignment without any content configuration is launched.
+ *    See the `configure_module_item` view.
+ *
+ * @param {FilePickerFormFieldsProps} props
+ */
+export default function FilePickerFormFields({
+  content,
+  formFields,
+  ltiLaunchURL,
+}) {
+  return (
+    <Fragment>
+      {Object.entries(formFields).map(([field, value]) => (
+        <input key={field} type="hidden" name={field} value={value} />
+      ))}
+      <input
+        type="hidden"
+        name="content_items"
+        value={contentItemString(ltiLaunchURL, content)}
+      />
+      {content.type === 'url' && (
+        // Set the `document_url` form field which is used by the `configure_module_item`
+        // view. Used in LMSes where assignments are configured on first launch.
+        <input name="document_url" type="hidden" value={content.url} />
+      )}
+    </Fragment>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
@@ -11,15 +11,6 @@ import {
  */
 
 /**
- * @typedef FilePickerFormFieldsProps
- * @prop {string} ltiLaunchURL - URL that the LMS should use to launch the
- *   assignment.
- * @prop {Content} content - Content for the assignment
- * @prop {Record<string,string>} formFields - Form fields provided by the backend
- *   that should be included in the response without any changes
- */
-
-/**
  * Generate an LTI launch URL for a given piece of content.
  *
  * @param {string} ltiLaunchURL
@@ -45,6 +36,15 @@ function contentItemString(ltiLaunchURL, content) {
   }
   return JSON.stringify(contentItem);
 }
+
+/**
+ * @typedef FilePickerFormFieldsProps
+ * @prop {string} ltiLaunchURL - URL that the LMS should use to launch the
+ *   assignment.
+ * @prop {Content} content - Content for the assignment
+ * @prop {Record<string,string>} formFields - Form fields provided by the backend
+ *   that should be included in the response without any changes
+ */
 
 /**
  * Render the hidden form fields in the file picker form containing information

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -1,0 +1,87 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import {
+  contentItemForLmsFile,
+  contentItemForUrl,
+  contentItemForVitalSourceBook,
+} from '../../utils/content-item';
+
+import FilePickerFormFields from '../FilePickerFormFields';
+
+describe('FilePickerFormFields', () => {
+  const launchURL = 'https://testlms.hypothes.is/lti_launch';
+  const staticFormFields = {
+    lti_message_type: 'ContentItemSelection',
+    lti_version: 'LTI-1p0',
+    oauth_stuff: 'foobar',
+  };
+
+  function createComponent(props = {}) {
+    return mount(
+      <FilePickerFormFields
+        content={{ type: 'url', url: 'https://testsite.example/' }}
+        formFields={staticFormFields}
+        ltiLaunchURL={launchURL}
+        {...props}
+      />
+    );
+  }
+
+  const getContentItem = wrapper =>
+    JSON.parse(wrapper.find('input[name="content_items"]').prop('value'));
+
+  it('renders static form fields provided by backend', () => {
+    const formFields = createComponent();
+
+    Object.entries(staticFormFields).forEach(([name, value]) => {
+      const field = formFields
+        .find('input[type="hidden"]')
+        .filter(`[name="${name}"]`);
+      assert.isTrue(field.exists());
+      assert.equal(field.prop('value'), value);
+    });
+  });
+
+  describe('content_items field', () => {
+    it('renders content_items field for URL content', () => {
+      const formFields = createComponent({
+        content: { type: 'url', url: 'https://example.com/' },
+      });
+      const contentItems = getContentItem(formFields);
+      assert.deepEqual(
+        contentItems,
+        contentItemForUrl(launchURL, 'https://example.com/')
+      );
+    });
+
+    it('renders content_items field for LMS file content', () => {
+      const file = { id: 123 };
+      const formFields = createComponent({
+        content: { type: 'file', file },
+      });
+      const contentItems = getContentItem(formFields);
+      assert.deepEqual(contentItems, contentItemForLmsFile(launchURL, file));
+    });
+
+    it('renders content_items field for VitalSource book content', () => {
+      const formFields = createComponent({
+        content: { type: 'vitalsource', bookID: 'test-book', cfi: 'test-cfi' },
+      });
+      const contentItems = getContentItem(formFields);
+      assert.deepEqual(
+        contentItems,
+        contentItemForVitalSourceBook(launchURL, 'test-book', 'test-cfi')
+      );
+    });
+  });
+
+  it('renders `document_url` field for URL content', () => {
+    const formFields = createComponent({
+      content: { type: 'url', url: 'https://example.com/' },
+    });
+    const documentURLField = formFields.find('input[name="document_url"]');
+    assert.isTrue(documentURLField.exists());
+    assert.equal(documentURLField.prop('value'), 'https://example.com/');
+  });
+});


### PR DESCRIPTION
Extract the rendering of hidden form fields in `FilePickerApp` into a separate `FilePickerFormFields` component. This will keep `FilePickerApp` more manageable as additional steps are added to the assignment configuration flow.

There are no functional changes in this PR.

Part of https://github.com/hypothesis/lms/issues/2524.

---

**Testing:**

- Try configuring LMS assignments in Canvas using the various available options (Enter URL, select file from Canvas, select file from Google). The "External tool URL" that appears in Canvas should be the same as before.