### PR TITLE
Store course as a grouping

### DIFF
--- a/lms/migrations/versions/bb11b5b06274_grouping_table.py
+++ b/lms/migrations/versions/bb11b5b06274_grouping_table.py
@@ -1,0 +1,68 @@
+"""
+Adds new grouping table.
+
+Revision ID: bb11b5b06274
+Revises: 5f80062abcf4
+Create Date: 2021-05-19 11:11:39.560969
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "bb11b5b06274"
+down_revision = "5f80062abcf4"
+
+
+def upgrade():
+    op.create_table(
+        "grouping",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("application_instance_id", sa.Integer(), nullable=False),
+        sa.Column("authority_provided_id", sa.UnicodeText(), nullable=False),
+        sa.Column("parent_id", sa.Integer(), nullable=True),
+        sa.Column("lms_id", sa.String(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column("lms_name", sa.UnicodeText(), nullable=False),
+        sa.Column(
+            "settings",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "extra",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["application_instance_id"],
+            ["application_instances.id"],
+            name=op.f("fk__grouping__application_instance_id__application_instances"),
+            ondelete="cascade",
+        ),
+        sa.ForeignKeyConstraint(
+            ["parent_id"],
+            ["grouping.id"],
+            name=op.f("fk__grouping__parent_id__grouping"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__grouping")),
+        sa.UniqueConstraint(
+            "application_instance_id",
+            "authority_provided_id",
+            name=op.f("uq__grouping__application_instance_id"),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("grouping")

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,10 +1,11 @@
 from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
-from lms.models.course import Course
+from lms.models.course import _Course
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
 from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
+from lms.models.grouping import Course, Grouping
 from lms.models.h_group import HGroup
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -79,7 +79,7 @@ class ApplicationInstance(BASE):
     )
 
     #: A list of all the courses for this application instance.
-    courses = sa.orm.relationship("Course", back_populates="application_instance")
+    courses = sa.orm.relationship("_Course", back_populates="application_instance")
 
     #: A list of all the GroupInfo's for this application instance.
     group_infos = sa.orm.relationship(

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -5,7 +5,7 @@ from lms.db import BASE
 from lms.models.application_settings import ApplicationSettings
 
 
-class Course(BASE):
+class _Course(BASE):
     """An LTI course."""
 
     __tablename__ = "course"

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,0 +1,80 @@
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from lms.db import BASE
+from lms.models import CreatedUpdatedMixin
+from lms.models.application_settings import ApplicationSettings
+
+MAX_GROUP_NAME_LENGTH = 25
+
+
+class Grouping(CreatedUpdatedMixin, BASE):
+    __tablename__ = "grouping"
+    __mapper_args__ = {"polymorphic_identity": "grouping", "polymorphic_on": "type"}
+    __table_args__ = (
+        sa.UniqueConstraint("application_instance_id", "authority_provided_id"),
+    )
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+
+    application_instance_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("application_instances.id", ondelete="cascade"),
+        nullable=False,
+    )
+    application_instance = sa.orm.relationship("ApplicationInstance")
+
+    authority_provided_id = sa.Column(sa.UnicodeText(), nullable=False)
+
+    parent_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("grouping.id", ondelete="cascade"),
+        nullable=True,
+    )
+
+    #: ID on the LMS, not unique across LMS or even in the same LMS instance
+    lms_id = sa.Column(sa.String(), nullable=False)
+
+    #: Full name given on the LMS (e.g. "A course name 101")
+    lms_name = sa.Column(sa.UnicodeText(), nullable=False)
+
+    type = sa.Column(sa.String(), nullable=False)
+
+    settings = sa.Column(
+        "settings",
+        ApplicationSettings.as_mutable(JSONB),
+        server_default=sa.text("'{}'::jsonb"),
+        nullable=False,
+    )
+
+    extra = sa.Column(
+        "extra",
+        ApplicationSettings.as_mutable(JSONB),
+        server_default=sa.text("'{}'::jsonb"),
+        nullable=False,
+    )
+
+    @property
+    def name(self):
+        """Return an h-compatible group name."""
+        name = self.lms_name.strip()
+
+        if len(name) > MAX_GROUP_NAME_LENGTH:
+            return name[: MAX_GROUP_NAME_LENGTH - 1].rstrip() + "…"
+
+        return name
+
+    def groupid(self, authority):
+        return f"group:{self.authority_provided_id}@{authority}"
+
+
+class CanvasSection(Grouping):
+    __mapper_args__ = {"polymorphic_identity": "canvas_section"}
+
+
+class CanvasGroup(Grouping):
+    __mapper_args__ = {"polymorphic_identity": "canvas_group"}
+
+
+class Course(Grouping):
+    __mapper_args__ = {"polymorphic_identity": "course"}

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -24,15 +24,29 @@ class Grouping(CreatedUpdatedMixin, BASE):
     )
     application_instance = sa.orm.relationship("ApplicationInstance")
 
+    #: The authority_provided_id of the Group that was created for this Grouping in h's DB.
     authority_provided_id = sa.Column(sa.UnicodeText(), nullable=False)
 
-    parent_id = sa.Column(
+        #: The id of the parent grouping that this grouping belongs to.
+        #:
+        #: For example if the grouping represents a Canvas section or group then parent_id
+        #: will reference the grouping for the course that the section or group belongs to.
+        parent_id = sa.Column(
         sa.Integer(),
         sa.ForeignKey("grouping.id", ondelete="cascade"),
         nullable=True,
     )
 
-    #: ID on the LMS, not unique across LMS or even in the same LMS instance
+    #: The LMS's ID for the grouping.
+    #:
+    #: For example for a course this is the value of the context_id launch param.
+    #: For a Canvas section or group this is the value of the section or group's id
+    #: from the Canvas API.
+    #:
+    #: lms_id may not be unique without `parent_id`. For example a Canvas instance may
+    #: have multiple sections or groups with the same id in different courses. In this
+    #: case multiple Grouping's would have the same lms_id but they will have different
+    #: parent_id's.
     lms_id = sa.Column(sa.String(), nullable=False)
 
     #: Full name given on the LMS (e.g. "A course name 101")

--- a/lms/models/h_group.py
+++ b/lms/models/h_group.py
@@ -14,21 +14,6 @@ class HGroup(NamedTuple):
         return f"group:{self.authority_provided_id}@{authority}"
 
     @classmethod
-    def course_group(cls, course_name, tool_consumer_instance_guid, context_id):
-        """
-        Create an HGroup for a course.
-
-        :param course_name: The name of the course
-        :param tool_consumer_instance_guid: Tool consumer GUID
-        :param context_id: Course id
-        """
-        return HGroup(
-            cls._name(course_name),
-            hashed_id(tool_consumer_instance_guid, context_id),
-            type="course_group",
-        )
-
-    @classmethod
     def section_group(
         cls, section_name, tool_consumer_instance_guid, context_id, section_id
     ):

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -69,7 +69,24 @@ class LTILaunchResource:
         return grouping_service.course_grouping(
             tool_consumer_instance_guid=params["tool_consumer_instance_guid"],
             context_id=params["context_id"],
+            extra=self.course_extra,
         )
+
+    @property
+    def course_extra(self):
+        """Extra information to store for courses."""
+        extra = {}
+
+        if self.is_canvas:
+            extra = {
+                "canvas": {
+                    "custom_canvas_course_id": self._request.parsed_params.get(
+                        "custom_canvas_course_id"
+                    )
+                }
+            }
+
+        return extra
 
     @property
     def is_canvas(self):

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -1,7 +1,6 @@
 """Traversal resources for LTI launch views."""
 import functools
 
-from lms.models import HGroup
 from lms.resources._js_config import JSConfig
 from lms.services import ConsumerKeyError
 
@@ -70,6 +69,7 @@ class LTILaunchResource:
             tool_consumer_instance_guid=params["tool_consumer_instance_guid"],
             context_id=params["context_id"],
             extra=self.course_extra,
+            course_name=params["context_title"],
         )
 
     @property
@@ -149,6 +149,4 @@ class LTILaunchResource:
         if not self.canvas_sections_supported():
             return False
 
-        course_id = self.h_group.authority_provided_id
-        course = self._request.find_service(name="course").get_or_create(course_id)
-        return course.settings.get("canvas", "sections_enabled")
+        return self.get_or_create_course().settings.get("canvas", "sections_enabled")

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -23,6 +23,17 @@ class LTILaunchResource:
         self._request = request
         self._authority = self._request.registry.settings["h_authority"]
 
+    def get_or_create_course(self):
+        params = self._request.parsed_params
+        course = self._request.find_service(name="course").get_or_create(
+            self.h_group.authority_provided_id,
+            params["context_id"],
+            params["context_title"],
+            extra=self.course_extra,
+        )
+
+        return course
+
     @property
     def h_group(self):
         """
@@ -53,8 +64,9 @@ class LTILaunchResource:
 
         params = self._request.parsed_params
 
-        return HGroup.course_group(
-            course_name=params["context_title"],
+        grouping_service = self._request.find_service(name="grouping")
+
+        return grouping_service.course_grouping(
             tool_consumer_instance_guid=params["tool_consumer_instance_guid"],
             context_id=params["context_id"],
         )

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -56,3 +56,4 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.application_instance.factory", name="application_instance"
     )
+    config.register_service_factory("lms.services.grouping.factory", name="grouping")

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -12,7 +12,7 @@ class CourseService:
         self._db = db
 
     def get_or_create(self, authority_provided_id, context_id, name, extra=None):
-        """Add the current course to the `course` table if it's not there already."""
+        """Add the current course to the `grouping` table if it's not there already."""
         return self._get(
             authority_provided_id, context_id, name, extra
         ) or self._create(authority_provided_id, context_id, name, extra)
@@ -54,7 +54,7 @@ class CourseService:
         course = (
             self._db.query(Course)
             .filter_by(
-                application_instance_id=self._application_instance.id,
+                application_instance=self._application_instance,
                 authority_provided_id=authority_provided_id,
             )
             .one_or_none()

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -2,23 +2,22 @@ import json
 from copy import deepcopy
 
 from lms.models import Course, CourseGroupsExportedFromH
+from lms.models import _Course as LegacyCourse
 
 
 class CourseService:
     def __init__(self, application_instance_service, consumer_key, db):
-        self._application_instance_service = application_instance_service
+        self._application_instance = application_instance_service.get()
         self._consumer_key = consumer_key
         self._db = db
 
-    def get_or_create(self, authority_provided_id):
-        """
-        Add the current course to the `course` table if it's not there already.
+    def get_or_create(self, authority_provided_id, context_id, name, extra=None):
+        """Add the current course to the `course` table if it's not there already."""
+        return self._get(
+            authority_provided_id, context_id, name, extra
+        ) or self._create(authority_provided_id, context_id, name, extra)
 
-        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
-        """
-        return self._get(authority_provided_id) or self._create(authority_provided_id)
-
-    def any_with_setting(self, group, key, value=True):
+    def any_with_setting(self, group, key, value=True) -> bool:
         """
         Return whether any course has the specified setting.
 
@@ -29,22 +28,59 @@ class CourseService:
         :param key: Setting key
         :param value: Expected value
         """
-
         return bool(
             self._db.query(Course)
-            .filter(Course.consumer_key == self._consumer_key)
+            .filter(Course.application_instance_id == self._application_instance.id)
             .filter(Course.settings[group][key] == json.dumps(value))
+            .limit(1)
+            .count()
+        ) or bool(
+            self._db.query(LegacyCourse)
+            .filter(LegacyCourse.consumer_key == self._consumer_key)
+            .filter(LegacyCourse.settings[group][key] == json.dumps(value))
             .limit(1)
             .count()
         )
 
-    def _get(self, authority_provided_id):
-        return self._db.query(Course).get((self._consumer_key, authority_provided_id))
+    def _get(self, authority_provided_id, context_id, name, extra):
+        """
+        Get a Course from Course and fallback to rows on LegacyCourse.
 
-    def _create(self, authority_provided_id):
+        We are moving rows from LegacyCourse to Course so this method could potentially
+        create a new row in Course and delete the existing one on LegacyCourse,
+        that the reason it needs all the information of the course (context_id, name...) despite being called `_get`.
+        """
+        # Let's try first on the new table
+        course = (
+            self._db.query(Course)
+            .filter_by(
+                application_instance_id=self._application_instance.id,
+                authority_provided_id=authority_provided_id,
+            )
+            .one_or_none()
+        )
+        if course:
+            return course
+
+        # Fall-back to the old table
+        legacy_course = self._db.query(LegacyCourse).get(
+            (self._consumer_key, authority_provided_id)
+        )
+        if legacy_course:
+            # We have a record on the old, table, create one in the new one
+            course = self._create(authority_provided_id, context_id, name, extra)
+            # And delete the old one
+            self._db.delete(legacy_course)
+
+            return course
+
+        # First time we've seen this course, create it on the new table directly
+        return self._create(authority_provided_id, context_id, name, extra)
+
+    def _create(self, authority_provided_id, context_id, name, extra):
         # By default we'll make our course setting have the same settings
         # as the application instance
-        course_settings = deepcopy(self._application_instance_service.get().settings)
+        course_settings = deepcopy(self._application_instance.settings)
 
         # Unless! The group was pre-sections, and we've just seen it for the
         # first time in which case turn sections off
@@ -54,9 +90,12 @@ class CourseService:
             course_settings.set("canvas", "sections_enabled", False)
 
         course = Course(
-            consumer_key=self._consumer_key,
+            application_instance_id=self._application_instance.id,
             authority_provided_id=authority_provided_id,
+            lms_id=context_id,
+            lms_name=name,
             settings=course_settings,
+            extra=extra,
         )
 
         self._db.add(course)

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -1,0 +1,41 @@
+from lms.models._hashed_id import hashed_id
+
+
+class GroupingService:
+    def __init__(self, db, course_service):
+        self._db = db
+        self._course_service = course_service
+
+    def course_grouping(
+        self,
+        tool_consumer_instance_guid,
+        course_name,
+        context_id,
+        extra=None,
+    ):
+        """
+        Get / update / create a Grouping for a course.
+
+        :param tool_consumer_instance_guid: Tool consumer GUID
+        :param course_name: The name of the course
+        :param context_id: Course id on the LMS
+        :param extra: Any other extra information of the course
+        """
+        authority_provided_id = hashed_id(tool_consumer_instance_guid, context_id)
+
+        # As courses are found in both Grouping and the old `course` table
+        # we don't handle the upsert logic here, course_service will get or crate a row in the new table
+        course = self._course_service.get_or_create(
+            authority_provided_id, context_id, course_name, extra
+        )
+        # Update some fields that might have changed
+        course.lms_name = course_name
+
+        return course
+
+
+def factory(_context, request):
+    return GroupingService(
+        request.db,
+        request.find_service(name="course"),
+    )

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -8,6 +8,8 @@ class Sync:
     def __init__(self, request):
         self._request = request
 
+        self._grouping_service = self._request.find_service(name="grouping")
+
     @view_config(
         route_name="canvas_api.sync",
         request_method="POST",

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -50,7 +50,7 @@ class BasicLTILaunchViews:
         """Do a basic LTI launch with the given document_url."""
         self.sync_lti_data_to_h()
         self.store_lti_data()
-        self.course_service.get_or_create(self.context.h_group.authority_provided_id)
+        self.context.get_or_create_course()
 
         if grading_supported:
             self.context.js_config.maybe_enable_grading()
@@ -236,7 +236,7 @@ class BasicLTILaunchViews:
         we'll save it in our DB. Subsequent launches of the same assignment
         will then be DB-configured launches rather than unconfigured.
         """
-        self.course_service.get_or_create(self.context.h_group.authority_provided_id)
+        self.context.get_or_create_course()
 
         form_fields = {
             param: value

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -52,10 +52,7 @@ def content_item_selection(context, request):
     request.find_service(name="application_instance").get().update_lms_data(
         request.params
     )
-
-    request.find_service(name="course").get_or_create(
-        context.h_group.authority_provided_id
-    )
+    context.get_or_create_course()
 
     request.find_service(name="lti_h").sync([context.h_group], request.params)
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -15,8 +15,9 @@ from tests.factories.attributes import (
     TOOL_CONSUMER_INSTANCE_GUID,
     USER_ID,
 )
-from tests.factories.course import Course
+from tests.factories.course import Course, LegacyCourse
 from tests.factories.grading_info import GradingInfo
+from tests.factories.grouping import Grouping
 from tests.factories.h_group import HGroup
 from tests.factories.h_user import HUser
 from tests.factories.lti_user import LTIUser

--- a/tests/factories/course.py
+++ b/tests/factories/course.py
@@ -1,11 +1,21 @@
 import factory
 from factory.alchemy import SQLAlchemyModelFactory
 
-from lms import models
+from lms.models import Course
+from lms.models import _Course as LegacyCourse
 from tests.factories import ApplicationInstance
 
 Course = factory.make_factory(
-    models.Course,
+    Course,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    application_instance=factory.SubFactory(ApplicationInstance),
+    authority_provided_id=factory.Faker("hexify", text="^" * 40),
+    lms_id=factory.Faker("hexify", text="^" * 40),
+    lms_name=factory.Sequence(lambda n: f"Test Group {n}"),
+)
+
+LegacyCourse = factory.make_factory(
+    LegacyCourse,
     FACTORY_CLASS=SQLAlchemyModelFactory,
     application_instance=factory.SubFactory(ApplicationInstance),
     authority_provided_id=factory.Faker("hexify", text="^" * 40),

--- a/tests/factories/grouping.py
+++ b/tests/factories/grouping.py
@@ -1,0 +1,14 @@
+import factory
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories import ApplicationInstance
+
+Grouping = make_factory(
+    models.Grouping,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    application_instance=factory.SubFactory(ApplicationInstance),
+    authority_provided_id=factory.Faker("hexify", text="^" * 40),
+    lms_id=factory.Faker("hexify", text="^" * 40),
+)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,6 +14,7 @@ from lms.services.course import CourseService
 from lms.services.grading_info import GradingInfoService
 from lms.services.grant_token import GrantTokenService
 from lms.services.group_info import GroupInfoService
+from lms.services.grouping import GroupingService
 from lms.services.h_api import HAPI
 from lms.services.http import HTTPService
 from lms.services.launch_verifier import LaunchVerifier
@@ -221,6 +222,15 @@ def http_service(pyramid_config):
     http_service.request.return_value = factories.requests.Response()
     pyramid_config.register_service(http_service, name="http")
     return http_service
+
+
+@pytest.fixture
+def grouping_service(pyramid_config):
+    grouping_service = mock.create_autospec(
+        GroupingService, spec_set=True, instance=True
+    )
+    pyramid_config.register_service(grouping_service, name="grouping")
+    return grouping_service
 
 
 @pytest.fixture

--- a/tests/unit/lms/models/grouping_test.py
+++ b/tests/unit/lms/models/grouping_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from lms.models import Grouping
+from tests import factories
+
+
+class TestGrouping:
+    def test_groupid(self):
+        group = factories.Grouping(authority_provided_id="test_authority_provided_id")
+
+        groupid = group.groupid("lms.hypothes.is")
+
+        assert groupid == "group:test_authority_provided_id@lms.hypothes.is"
+
+    @pytest.mark.parametrize(
+        "name,expected_result",
+        (
+            ("Test Course", "Test Course"),
+            (" Test Course ", "Test Course"),
+            ("Test   Course", "Test   Course"),
+            ("Object Oriented Polymorphism 101", "Object Oriented Polymorp…"),
+            ("  Object Oriented Polymorphism 101  ", "Object Oriented Polymorp…"),
+        ),
+    )
+    def test_name(self, name, expected_result):
+        group = Grouping(lms_name=name)
+
+        assert group.name == expected_result

--- a/tests/unit/lms/models/h_group_test.py
+++ b/tests/unit/lms/models/h_group_test.py
@@ -5,11 +5,6 @@ from tests import factories
 
 GROUP_CONSTRUCTORS = (
     (
-        HGroup.course_group,
-        ("tool_consumer_instance_guid", "context_id"),
-        "course_group",
-    ),
-    (
         HGroup.section_group,
         ("tool_consumer_instance_guid", "context_id", "section_id"),
         "sections_group",
@@ -24,13 +19,6 @@ class TestHGroup:
         groupid = group.groupid("lms.hypothes.is")
 
         assert groupid == "group:test_authority_provided_id@lms.hypothes.is"
-
-    def test_course_group(self, hashed_id):
-        group = HGroup.course_group("irrelevant", "tool_guid", "context_id")
-
-        hashed_id.assert_called_once_with("tool_guid", "context_id")
-        assert group.authority_provided_id == hashed_id.return_value
-        assert group.type == "course_group"
 
     def test_sections_group(self, hashed_id):
         group = HGroup.section_group(

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -12,15 +12,21 @@ pytestmark = pytest.mark.usefixtures("application_instance_service", "course_ser
 
 class TestHGroup:
     @pytest.mark.usefixtures("has_course")
-    def test_it(self, lti_launch, HGroup, pyramid_request):
-        assert lti_launch.h_group == HGroup.course_group.return_value
+    def test_it(
+        self,
+        lti_launch,
+        grouping_service,
+        pyramid_request,
+    ):
+        assert lti_launch.h_group == grouping_service.course_grouping.return_value
 
-        HGroup.course_group.assert_called_once_with(
-            course_name="test_context_title",
+        grouping_service.course_grouping.assert_called_once_with(
             tool_consumer_instance_guid=pyramid_request.parsed_params[
                 "tool_consumer_instance_guid"
             ],
             context_id=pyramid_request.parsed_params["context_id"],
+            extra={},
+            course_name="test_context_title",
         )
 
 
@@ -135,13 +141,16 @@ class TestCanvasSectionsSupported:
         ] = "canvas"
 
 
-@pytest.mark.usefixtures("has_course")
+@pytest.mark.usefixtures("has_course", "grouping_service")
 class TestCanvasSectionsEnabled:
     def test_its_enabled_when_everything_is_right(self, lti_launch, course_service):
         assert lti_launch.canvas_sections_enabled
 
         course_service.get_or_create.assert_called_once_with(
-            lti_launch.h_group.authority_provided_id
+            lti_launch.h_group.authority_provided_id,
+            "test_context_id",
+            "test_context_title",
+            extra={},
         )
 
     def test_its_disabled_if_sections_are_not_supported(
@@ -173,14 +182,28 @@ class TestCanvasSectionsEnabled:
             yield canvas_sections_supported
 
 
+class TestCourseExtra:
+    def test_empty_in_non_canvas(self, pyramid_request):
+        parsed_params = {}
+        pyramid_request.parsed_params = parsed_params
+
+        assert LTILaunchResource(pyramid_request).course_extra == {}
+
+    def test_includes_course_coure_id(self, pyramid_request):
+        parsed_params = {
+            "tool_consumer_info_product_family_code": "canvas",
+            "custom_canvas_course_id": "ID",
+        }
+        pyramid_request.parsed_params = parsed_params
+
+        assert LTILaunchResource(pyramid_request).course_extra == {
+            "canvas": {"custom_canvas_course_id": "ID"}
+        }
+
+
 @pytest.fixture
 def lti_launch(pyramid_request):
     return LTILaunchResource(pyramid_request)
-
-
-@pytest.fixture(autouse=True)
-def HGroup(patch):
-    return patch("lms.resources.lti_launch.HGroup")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -4,7 +4,7 @@ from unittest.mock import sentinel
 import pytest
 
 from lms.models import Course, CourseGroupsExportedFromH
-from lms.services import ConsumerKeyError
+from lms.models import _Course as LegacyCourse
 from lms.services.course import course_service_factory
 from tests import factories
 
@@ -20,7 +20,7 @@ class TestCourseService:
             "canvas", "sections_enabled", canvas_sections_enabled
         )
 
-        svc.get_or_create("test_authority_provided_id")
+        svc.get_or_create("test_authority_provided_id", "context_id", "course name")
 
         course = db_session.query(Course).one()
         assert (
@@ -35,13 +35,15 @@ class TestCourseService:
             authority_provided_id="test_authority_provided_id",
             settings={},
         )
+        # Immediately  the the newly crated course so all objects have the right IDs
+        existing_course = pyramid_request.db.query(Course).one()
+
         existing_course.settings.set("canvas", "sections_enabled", False)
         application_instance_service.get.return_value.settings.set(
             "canvas", "sections_enabled", True
         )
 
-        svc.get_or_create("test_authority_provided_id")
-
+        svc.get_or_create("test_authority_provided_id", "context_id", "course name")
         existing_course = pyramid_request.db.query(Course).one()
         assert not existing_course.settings.get("canvas", "sections_enabled")
 
@@ -59,18 +61,10 @@ class TestCourseService:
             "canvas", "sections_enabled", canvas_sections_enabled
         )
 
-        svc.get_or_create("test_authority_provided_id")
+        svc.get_or_create("test_authority_provided_id", "context_id", "course name")
 
         course = db_session.query(Course).one()
         assert not course.settings.get("canvas", "sections_enabled")
-
-    def test_get_or_create_raises_if_theres_no_ApplicationInstance(
-        self, application_instance_service, svc
-    ):
-        application_instance_service.get.side_effect = ConsumerKeyError
-
-        with pytest.raises(ConsumerKeyError):
-            svc.get_or_create("test_authority_provided_id")
 
     @pytest.mark.parametrize(
         "settings_set,value,expected",
@@ -94,8 +88,31 @@ class TestCourseService:
             [{"group": {"key": value}}],
             application_instance=factories.ApplicationInstance(),
         )
+        # Factory created models won't have IDs until we flush them
+        svc._db.flush()  # pylint: disable=protected-access
 
         assert svc.any_with_setting("group", "key", value) is expected
+
+    def test_get_deletes_old_course_record(self, application_instance, db_session, svc):
+        legacy_course = factories.LegacyCourse(
+            application_instance=application_instance
+        )
+
+        # There's now a course on the `courses` table
+        assert db_session.query(LegacyCourse).count() == 1
+
+        course = svc._get(  # pylint: disable=protected-access
+            legacy_course.authority_provided_id,
+            "context_id",
+            "name",
+            {},
+        )
+
+        # Row on `courses` has been removed
+        assert not db_session.query(LegacyCourse).count()
+        # and added to the grouping one
+        assert db_session.query(Course).count() == 1
+        assert course.lms_name == "name"
 
     @pytest.fixture
     def add_courses_with_settings(self, application_instance):
@@ -110,11 +127,12 @@ class TestCourseService:
         return add_courses_with_settings
 
     @pytest.fixture
-    def svc(self, pyramid_request):
+    def svc(self, pyramid_request, application_instance_service, application_instance):
+        application_instance_service.get.return_value = application_instance
         return course_service_factory(sentinel.context, pyramid_request)
 
     @pytest.fixture(autouse=True)
     def application_instance(self, pyramid_request):
         return factories.ApplicationInstance(
-            consumer_key=pyramid_request.lti_user.oauth_consumer_key
+            consumer_key=pyramid_request.lti_user.oauth_consumer_key, settings={}
         )

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -1,0 +1,28 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.grouping import GroupingService, factory
+from tests import factories
+
+pytestmark = pytest.mark.usefixtures("course_service")
+
+
+class TestGroupingService:
+    def test_course_grouping_updates_name(self, svc, course_service):
+        course_service.get_or_create.return_value = factories.Course()
+
+        course = svc.course_grouping("guid", "new name", "context_id")
+
+        assert course.name == "new name"
+
+    @pytest.fixture
+    def svc(self, db_session, course_service):
+        return GroupingService(db_session, course_service)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request):
+        grouping_service = factory(sentinel.context, pyramid_request)
+
+        assert isinstance(grouping_service, GroupingService)

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -4,7 +4,9 @@ from lms.models import HGroup
 from lms.views.api.canvas.sync import Sync
 from tests.conftest import TEST_SETTINGS
 
-pytestmark = pytest.mark.usefixtures("canvas_api_client", "lti_h_service")
+pytestmark = pytest.mark.usefixtures(
+    "canvas_api_client", "lti_h_service", "grouping_service"
+)
 
 
 @pytest.mark.usefixtures("user_is_learner")

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -243,13 +243,11 @@ class TestCommon:
 
 class TestCourseRecording:
     def test_it_records_the_course_in_the_DB(
-        self, context, pyramid_request, view_caller, course_service
+        self, context, pyramid_request, view_caller
     ):
         view_caller(context, pyramid_request)
 
-        course_service.get_or_create.assert_called_once_with(
-            context.h_group.authority_provided_id
-        )
+        context.get_or_create_course.assert_called_once_with()
 
     @pytest.fixture(
         params=[

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -24,19 +24,20 @@ class TestContentItemSelection:
         )
 
     def test_it_records_the_course_in_the_DB(
-        self, context, pyramid_request, course_service
+        self,
+        context,
+        pyramid_request,
     ):
         content_item_selection(context, pyramid_request)
 
-        course_service.get_or_create.assert_called_once_with(
-            context.h_group.authority_provided_id
-        )
+        context.get_or_create_course.assert_called_once_with()
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.params = {
             "content_item_return_url": "TEST_CONTENT_ITEM_RETURN_URL",
             "lti_version": "TEST_LTI_VERSION",
+            "context_title": "CONTEXT_TITLE",
         }
         return pyramid_request
 


### PR DESCRIPTION
## Testing notes

- Create a course on your local DB using the old schema (from `master` or from this branch but without running the migration) opening an assignment https://hypothesis.instructure.com/courses/125/

- Check the course on the `course` table

```
postgres=# select * from course;
                consumer_key                |          authority_provided_id           |                settings                
--------------------------------------------+------------------------------------------+----------------------------------------
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a | 653e9620a656a954c684942f6443fa3e3410c03a | {"canvas": {"sections_enabled": true}}
(1 row)
```

- Apply migration to create the grouping table `hdev alembic upgrade head`
- Check the new table 

```
postgres=# select * from grouping;
 created | updated | id | application_instance_id | authority_provided_id | parent_id | lms_id | type | lms_name | settings | extra 
---------+---------+----+-------------------------+-----------------------+-----------+--------+------+----------+----------+-------
(0 rows)
```

- Lunch any assignment again on the same course  https://hypothesis.instructure.com/courses/125/
- Check DB rows, existing `course` should have been removed and "moved" to the new grouping table

```
postgres=# select * from course;
 consumer_key | authority_provided_id | settings 
--------------+-----------------------+----------
(0 rows)

postgres=# select * from grouping;
-[ RECORD 1 ]-----------+-----------------------------------------------
created                 | 2021-05-24 13:10:06.738377
updated                 | 2021-05-24 13:10:06.738377
id                      | 2
application_instance_id | 8
authority_provided_id   | 653e9620a656a954c684942f6443fa3e3410c03a
parent_id               | 
lms_id                  | f3cd019017839c4630358662a05540f2f6ec5f93
type                    | course
lms_name                | Developer Test Course with Sections Enabled
settings                | {"canvas": {"sections_enabled": true}}
extra                   | {"canvas": {"custom_canvas_course_id": "125"}}
```

- Lunch an assigment from a course that didn't exist on `course` beforehand, https://hypothesis.instructure.com/courses/124
- A new row should appear on `grouping`

```
created                 | 2021-05-24 13:12:49.796875
updated                 | 2021-05-24 13:12:49.796875
id                      | 3
application_instance_id | 7
authority_provided_id   | cc5b6de979f437ed8c62105efd4fafb3b635e893
parent_id               | 
lms_id                  | 31e8b270384ca8176925a8d35a48f63a4a30ca5f
type                    | course
lms_name                | Developer Test Course with Sections Disabled
settings                | {"canvas": {"sections_enabled": false}}
extra                   | {"canvas": {"custom_canvas_course_id": "124"}}
```
















