### PR TITLE
Deduplicate `requests` usage with a new service

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -6,6 +6,8 @@ from lms.services.exceptions import (
     ConsumerKeyError,
     ExternalRequestError,
     HAPIError,
+    HTTPError,
+    HTTPValidationError,
     LTILaunchVerificationError,
     LTIOAuthError,
     LTIOutcomesAPIError,
@@ -17,6 +19,7 @@ from lms.services.exceptions import (
 
 
 def includeme(config):
+    config.register_service_factory("lms.services.http.factory", name="http")
     config.register_service_factory(
         "lms.services.canvas_api.canvas_api_client_factory", name="canvas_api_client"
     )

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -218,3 +218,15 @@ class CanvasFileNotFoundInCourse(ServiceError):
     def __init__(self, file_id):
         self.details = {"file_id": file_id}
         super().__init__(self.details)
+
+
+class HTTPError(ServiceError):
+    """A problem with an HTTP request to an external service."""
+
+    def __init__(self, response=None):
+        super().__init__(response)
+        self.response = response
+
+
+class HTTPValidationError(HTTPError):
+    """An invalid HTTP response from an external service."""

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -84,7 +84,6 @@ class HAPI:
                 method=method,
                 url=self._base_url + path.lstrip("/"),
                 auth=self._http_auth,
-                timeout=10,
                 headers=headers,
                 **request_args,
             )

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -17,6 +17,21 @@ class HTTPService:
         # See https://docs.python-requests.org/en/latest/user/advanced/#session-objects
         self._session = _session or requests.Session()
 
+    def get(self, *args, **kwargs):
+        return self.request("GET", *args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        return self.request("PUT", *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self.request("POST", *args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        return self.request("PATCH", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self.request("DELETE", *args, **kwargs)
+
     def request(
         self,
         method,

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -1,0 +1,161 @@
+import requests
+from requests import RequestException
+
+from lms.services.exceptions import HTTPError, HTTPValidationError
+from lms.validation import ValidationError
+
+
+class HTTPService:
+    """Send HTTP requests with `requests` and receive the responses."""
+
+    def __init__(self, _session=None):
+        # A requests session is used so that cookies are persisted across
+        # requests and urllib3 connection pooling is used (which means that
+        # underlying TCP connections are re-used when making multiple requests
+        # to the same host, e.g. pagination).
+        #
+        # See https://docs.python-requests.org/en/latest/user/advanced/#session-objects
+        self._session = _session or requests.Session()
+
+    def request(
+        self,
+        method,
+        url,
+        params=None,
+        data=None,
+        json=None,
+        headers=None,
+        auth=None,
+        timeout=9,
+        schema=None,
+        **kwargs,
+    ):  # pylint:disable=too-many-arguments
+        """
+        Send a request with `requests` and return the requests.Response object.
+
+        Also supports validating the response with a `marshmallow` schema. If a
+        `schema` argument is given the response will be validated using the
+        schema and the schema output will be added to the returned response as
+        response.validated_data.
+
+        The schema must be a RequestsResponseSchema sub-class.
+
+        HTTPValidationError will be raised if schema validation fails.
+
+        :param method: The HTTP method to use, one of "GET", "PUT", "POST",
+            "PATCH", "DELETE", "OPTIONS" or "HEAD"
+
+        :param url: The URL to request
+
+        :param params: Query params to append to the URL.
+
+            This can be a dict or list of tuples and it'll be serialized into a
+            query string.
+
+            Or it can be a byte string and it'll be used directly as the query
+            string.
+
+        :param data: Form data to send in the body of the request.
+
+            This can be a dict or list of tuples and it'll be serialized into a
+            form body.
+
+            Or it can be bytes or a file-like object (e.g. a JSON byte string)
+            it'll be used directly as the request body.
+
+        :param json: Data to send in the body of the request as JSON.
+
+            Using this changes the request's content-type to application/json.
+
+            This can't be used at the same time as the `data` argument.
+
+        :type json: Any JSON-serializable object (e.g. a list or dict)
+
+        :param headers: Headers to send in the request.
+
+            Header values should be byte strings not unicode.
+
+        :type headers: dict
+
+        :param auth: Authorization to send in the request's Authorization header.
+
+            This can be a (user, pass) 2-tuple which will be serialized using
+            HTTP Basic Authentication.
+
+            Or it can be a callable in order to implement other authentication
+            schemes. `requests` itself and libraries like `requests_oauthlib`
+            provide auth callables that you can use or you can write your own.
+
+            See: https://docs.python-requests.org/en/master/user/authentication/
+
+        :param timeout: How long (in seconds) to wait before raising an error.
+
+            This can be a (connect_timeout, read_timeout) 2-tuple or it can be
+            a single float that will be used as both the connect and read
+            timeout.
+
+            Note that the read_timeout is *not* a time limit on the entire
+            response download. It's a time limit on how long to wait *between
+            bytes from the server*. The entire download can take much longer.
+
+        :param schema: A schema class to use to validate the response
+        :type schema: lms.validation.RequestsResponseSchema
+
+        :param kwargs: Any other keyword arguments will be passed directly to
+            requests.Session().request():
+            https://docs.python-requests.org/en/latest/api/#requests.Session.request
+
+        :raise HTTPError: If sending the request or receiving the response
+            fails (DNS failure, refused connection, timeout, too many
+            redirects, etc).
+
+            The original exception from requests will be available as
+            HTTPError.__cause__.
+
+            In this case HTTPError.response will be None.
+
+        :raise HTTPError: If an error response (4xx or 5xx) is received.
+
+            The original exception from requests will be available as
+            HTTPError.__cause__.
+
+            The error response will be available as HTTPError.response.
+
+        :raise HTTPValidationError: If a `schema` argument is given and the
+            response fails validation with the schema.
+
+            The original lms.validation.ValidationError will be available as
+            HTTPValidationError.__cause__.
+
+            The invalid response will be available as
+            HTTPValidationError.response.
+        """
+        response = None
+
+        try:
+            response = self._session.request(
+                method,
+                url,
+                params=params,
+                data=data,
+                json=json,
+                headers=headers,
+                auth=auth,
+                timeout=timeout,
+                **kwargs,
+            )
+            response.raise_for_status()
+        except RequestException as err:
+            raise HTTPError(response) from err
+
+        if schema:
+            try:
+                response.validated_data = schema(response).parse()
+            except ValidationError as err:
+                raise HTTPValidationError(response) from err
+
+        return response
+
+
+def factory(_context, _request):
+    return HTTPService()

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -41,7 +41,7 @@ class HTTPService:
         json=None,
         headers=None,
         auth=None,
-        timeout=9,
+        timeout=(10, 10),
         schema=None,
         **kwargs,
     ):  # pylint:disable=too-many-arguments
@@ -108,6 +108,10 @@ class HTTPService:
             This can be a (connect_timeout, read_timeout) 2-tuple or it can be
             a single float that will be used as both the connect and read
             timeout.
+
+            Good practice is to set this to slightly larger than a multiple of
+            3, which is the default TCP packet retransmission window. See:
+            https://docs.python-requests.org/en/master/user/advanced/#timeouts
 
             Note that the read_timeout is *not* a time limit on the entire
             response download. It's a time limit on how long to wait *between

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -102,9 +102,8 @@ class LTIOutcomesClient:
         response = None
 
         try:
-            response = self.http_service.request(
-                "POST",
-                self.service_url,
+            response = self.http_service.post(
+                url=self.service_url,
                 data=xml_body,
                 headers={"Content-Type": "application/xml"},
                 auth=self.oauth1_service.get_client(),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,6 +15,7 @@ from lms.services.grading_info import GradingInfoService
 from lms.services.grant_token import GrantTokenService
 from lms.services.group_info import GroupInfoService
 from lms.services.h_api import HAPI
+from lms.services.http import HTTPService
 from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
@@ -212,6 +213,14 @@ def course_service(pyramid_config):
     course_service = mock.create_autospec(CourseService, spec_set=True, instance=True)
     pyramid_config.register_service(course_service, name="course")
     return course_service
+
+
+@pytest.fixture
+def http_service(pyramid_config):
+    http_service = mock.create_autospec(HTTPService, instance=True, spec_set=True)
+    http_service.request.return_value = factories.requests.Response()
+    pyramid_config.register_service(http_service, name="http")
+    return http_service
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -71,7 +71,6 @@ class TestHAPI:
                 url="https://example.com/private/api/dummy-path",
                 # It adds the authentication headers.
                 auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
-                timeout=10,
                 headers={"Hypothesis-Application": "lms"},
                 data=sentinel.raw_body,
             )

--- a/tests/unit/lms/services/http_test.py
+++ b/tests/unit/lms/services/http_test.py
@@ -24,6 +24,16 @@ class TestHTTPService:
             {"url": url, "method": method}
         )
 
+    @pytest.mark.parametrize("method", ["GET", "PUT", "POST", "PATCH", "DELETE"])
+    def test_convenience_methods(self, svc, url, method):
+        httpretty.register_uri(method, url, body="test_response")
+
+        getattr(svc, method.lower())(url)
+
+        assert httpretty.last_request() == Any.object.with_attrs(
+            {"url": url, "method": method}
+        )
+
     def test_it_sends_request_params(self, svc, url):
         svc.request("GET", url, params={"test_param": "test_value"})
 
@@ -130,7 +140,7 @@ class TestHTTPService:
     @pytest.fixture(autouse=True)
     def test_response(self, url):
         httpretty.register_uri(
-            "GET", url, body='{"test_response_key": "TEST_RESPONSE_VALUE"}'
+            "GET", url, body='{"test_response_key": "test_response_value"}', priority=-1
         )
 
     @pytest.fixture

--- a/tests/unit/lms/services/http_test.py
+++ b/tests/unit/lms/services/http_test.py
@@ -1,0 +1,147 @@
+from unittest.mock import Mock, create_autospec, sentinel
+
+import httpretty
+import marshmallow
+import pytest
+import requests
+from h_matchers import Any
+
+from lms.services import HTTPError, HTTPValidationError
+from lms.services.http import HTTPService, factory
+from lms.validation import RequestsResponseSchema, ValidationError
+
+
+class TestHTTPService:
+    @pytest.mark.parametrize("method", ["GET", "PUT", "POST", "PATCH", "DELETE"])
+    def test_it_sends_the_request_and_returns_the_response(self, svc, method, url):
+        httpretty.register_uri(method, url, body="test_response")
+
+        response = svc.request(method, url)
+
+        assert response.status_code == 200
+        assert response.text == "test_response"
+        assert httpretty.last_request() == Any.object.with_attrs(
+            {"url": url, "method": method}
+        )
+
+    def test_it_sends_request_params(self, svc, url):
+        svc.request("GET", url, params={"test_param": "test_value"})
+
+        assert httpretty.last_request() == Any.object.with_attrs(
+            {"url": f"{url}?test_param=test_value"}
+        )
+
+    def test_it_sends_request_data(self, svc, url):
+        svc.request("GET", url, data={"test_key": "test_value"})
+
+        assert httpretty.last_request() == Any.object.with_attrs(
+            {"body": b"test_key=test_value"}
+        )
+
+    def test_it_sends_request_json(self, svc, url):
+        svc.request("GET", url, json={"test_key": "test_value"})
+
+        assert httpretty.last_request() == Any.object.with_attrs(
+            {"body": b'{"test_key": "test_value"}'}
+        )
+
+    def test_it_sends_request_headers(self, svc, url):
+        svc.request("GET", url, headers={"HEADER_KEY": "HEADER_VALUE"})
+
+        assert httpretty.last_request().headers["HEADER_KEY"] == "HEADER_VALUE"
+
+    def test_it_sends_request_auth(self, svc, url):
+        svc.request("GET", url, auth=("user", "pass"))
+
+        assert httpretty.last_request().headers["Authorization"] == "Basic dXNlcjpwYXNz"
+
+    def test_it_uses_custom_timeouts(self, session):
+        svc = HTTPService(session)
+
+        svc.request("GET", "https://example.com", timeout=3)
+
+        assert session.request.call_args[1]["timeout"] == 3
+
+    def test_it_passes_arbitrary_kwargs_to_requests(self, svc):
+        session = Mock()
+        svc = HTTPService(session)
+
+        svc.request("GET", "https://example.com", foo="bar")
+
+        assert session.request.call_args[1]["foo"] == "bar"
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            requests.ConnectionError(),
+            requests.HTTPError(),
+            requests.ReadTimeout(),
+            requests.TooManyRedirects(),
+        ],
+    )
+    def test_it_raises_if_sending_the_request_fails(self, exception, session):
+        session.request.side_effect = exception
+        svc = HTTPService(session)
+
+        with pytest.raises(HTTPError) as exc_info:
+            svc.request("GET", "https://example.com")
+
+        assert exc_info.value.response is None
+        assert exc_info.value.__cause__ == exception
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 500])
+    def test_it_raises_if_the_response_is_an_error(self, svc, url, status):
+        httpretty.register_uri("GET", url, status=status)
+
+        with pytest.raises(HTTPError) as exc_info:
+            svc.request("GET", url)
+
+        assert isinstance(exc_info.value.__cause__, requests.HTTPError)
+        assert exc_info.value.response == Any.instance_of(requests.Response).with_attrs(
+            {"status_code": status}
+        )
+
+    def test_if_a_schema_is_given_it_returns_the_validated_data(self, svc, url):
+        response = svc.request("GET", url, schema=self.Schema)
+
+        assert response.validated_data == {"test_response_key": "TEST_RESPONSE_VALUE"}
+
+    def test_if_a_schema_is_given_it_raises_if_the_response_is_invalid(self, svc, url):
+        httpretty.register_uri("GET", url, body="")
+
+        with pytest.raises(HTTPValidationError) as exc_info:
+            svc.request("GET", url, schema=self.Schema)
+
+        assert isinstance(exc_info.value.__cause__, ValidationError)
+
+    class Schema(RequestsResponseSchema):
+        test_response_key = marshmallow.fields.String(required=True)
+
+        @marshmallow.post_load
+        def post_load(self, data, **_kwargs):
+            data["test_response_key"] = data["test_response_key"].upper()
+            return data
+
+    @pytest.fixture
+    def url(self):
+        """Return the URL that we'll be sending test requests to."""
+        return "https://example.com/example"
+
+    @pytest.fixture(autouse=True)
+    def test_response(self, url):
+        httpretty.register_uri(
+            "GET", url, body='{"test_response_key": "TEST_RESPONSE_VALUE"}'
+        )
+
+    @pytest.fixture
+    def session(self):
+        return create_autospec(requests.Session, instance=True, spec_set=True)
+
+    @pytest.fixture
+    def svc(self):
+        return HTTPService()
+
+
+class TestFactory:
+    def test_it(self):
+        assert isinstance(factory(sentinel.context, sentinel.request), HTTPService)

--- a/tests/unit/lms/services/lti_outcomes_test.py
+++ b/tests/unit/lms/services/lti_outcomes_test.py
@@ -105,15 +105,14 @@ class TestLTIOutcomesClient:
             )
 
     def test_it_signs_request_with_oauth1(self, svc, http_service, oauth1_service):
-        http_service.request.side_effect = OSError()
+        http_service.post.side_effect = OSError()
 
         # We don't care if this actually does anything afterwards, so just
         # fail here so we can see how we were called
         with pytest.raises(OSError):
             svc.record_result(self.GRADING_ID)
 
-        http_service.request.assert_called_once_with(
-            "POST",
+        http_service.post.assert_called_once_with(
             url=Any(),
             data=Any(),
             headers=Any(),
@@ -121,13 +120,13 @@ class TestLTIOutcomesClient:
         )
 
     def test_requests_fail_if_the_third_party_request_fails(self, svc, http_service):
-        http_service.request.side_effect = HTTPError
+        http_service.post.side_effect = HTTPError
 
         with pytest.raises(LTIOutcomesAPIError):
             svc.read_result(self.GRADING_ID)
 
     def test_requests_fail_if_body_not_xml(self, svc, http_service):
-        http_service.request.return_value = factories.requests.Response(
+        http_service.post.return_value = factories.requests.Response(
             status_code=200,
             body='{"not":"xml"}',
             content_type="application/json",
@@ -168,7 +167,7 @@ class TestLTIOutcomesClient:
 
     @classmethod
     def sent_body(cls, http_service):
-        return xmltodict.parse(http_service.request.call_args[1]["data"])
+        return xmltodict.parse(http_service.post.call_args[1]["data"])
 
     @classmethod
     def sent_pox_body(cls, http_service):
@@ -261,7 +260,7 @@ class TestLTIOutcomesClient:
                     include_description,
                 )
 
-            http_service.request.return_value = factories.requests.Response(
+            http_service.post.return_value = factories.requests.Response(
                 status_code=status,
                 raw=response_body,
                 content_type="application/xml",


### PR DESCRIPTION
Problem
-------

There's a bit of logic that's repeated in a few places about using
`requests` to send a request, receive the response, and validate the
response using a `marshmallow` schema, with associated error handling
and tests, re-using a TCP session, making sure appropriate timeouts are
always used, etc. This is a basic version of the logic that's repeated:

```python
session = requests.Session()

try:
    response = session.request(method, url, timeout=9, ...)
    response.raise_for_status()
except requests.RequestException as err:
    raise CustomHTTPErrorClass(response) from err

validated_data = None

if schema:
    try:
        validated_data = schema(response).parse()
    except lms.validation.ValidationError as err:
        raise CustomHTTPValidationErrorClass(response) from err

return (response, validated_data)
```

This logic (or very similar) is repeated in `HAPIClient`,
`LTIOutcomesService` and `CanvasAPIClient` (in the `BasicClient` helper
class):

* https://github.com/hypothesis/lms/blob/b995d470acf28f70c342b03d0d4acd45b4c508c1/lms/services/h_api.py#L83-L99
* https://github.com/hypothesis/lms/blob/b995d470acf28f70c342b03d0d4acd45b4c508c1/lms/services/lti_outcomes.py#L101-L119
* https://github.com/hypothesis/lms/blob/b995d470acf28f70c342b03d0d4acd45b4c508c1/lms/services/canvas_api/_basic.py#L85-L95

The upcoming `BlackboardAPIClient` also needs to send HTTP requests
using `requests` and validate the responses using `marshmallow` in
exactly the same way, but that would mean duplicating this similar code
and tests for a fourth time.

Solution
--------

Add a new `HTTPService` to do the send-request-and-validate-response
bit. This will be implemented once, correctly, in `HTTPService` and
thoroughly unit tested there. Other services will just need to use a
very simple interface that `HTTPService` will provide, and their unit
tests will just need to work with a mock of that very simple interface.
A large amount of code and tests will be simplified and duplication
removed. Our code's behaviour (e.g. robustness) will be improved because
send-request-and-validate-response will be implemented and tested once
carefully and correctly, instead of several times with varying degrees
of correctness (e.g. timeouts missing in some places etc).

This PR adds the `HTTPService` and refactors `LTIOutcomesClient` and
`HAPI` and their tests to use `HTTPService`.

The new `BlackboardAPIClient` that'll use `HTTPService` will come in a
later PR.

Refactoring `CanvasAPIClient` to use `HTTPService` will also come
separately: that ones a bit more work.
