### PR TITLE
Remove flag icon from annotation cards for LMS users

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -484,6 +484,7 @@ class JSConfig:
             # https://h.readthedocs.io/projects/client/en/latest/publishers/config/#configuring-the-client-using-json
             "services": [
                 {
+                    "allowFlagging": False,
                     "allowLeavingGroups": False,
                     "apiUrl": api_url,
                     "authority": self._authority,

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -161,6 +161,7 @@ class TestEnableLTILaunchMode:
             "hypothesisClient": {
                 "services": [
                     {
+                        "allowFlagging": False,
                         "allowLeavingGroups": False,
                         "apiUrl": "https://example.com/api/",
                         "authority": "TEST_AUTHORITY",


### PR DESCRIPTION
Turn off the `allowFlagging` option to remove the flag icon from
annotation cards in the LMS context.

Relates to https://github.com/hypothesis/client/pull/3424
