### PR TITLE
Add UI playground

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,6 +94,10 @@ var bundles = [
     name: 'browser_check',
     entry: './lms/static/scripts/browser_check/index.js',
   },
+  {
+    name: 'ui-playground',
+    entry: './lms/static/scripts/ui-playground/index.js',
+  },
 ];
 
 var bundleConfigs = bundles.map(function(config) {
@@ -124,6 +128,7 @@ var cssBundles = [
   './lms/static/styles/lms.css',
   './lms/static/styles/reports.css',
   './lms/static/styles/frontend_apps.scss',
+  './lms/static/styles/ui-playground/ui-playground.scss',
 ];
 
 gulp.task('build-css', () => {

--- a/lms/assets.ini
+++ b/lms/assets.ini
@@ -15,3 +15,9 @@ lms_css =
 
 reports_css =
   styles/reports.css
+
+ui_playground_css =
+  styles/ui-playground.css
+
+ui_playground_js =
+  scripts/ui-playground.bundle.js

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -5,6 +5,7 @@ def includeme(config):
     config.add_route("assets", "/assets/*subpath")
     config.add_route("status", "/_status")
     config.add_route("favicon", "/favicon.ico")
+    config.add_route("ui-playground", "/ui-playground/*remainder")
 
     config.add_route("login", "/login")
     config.add_route("logout", "/logout")

--- a/lms/static/scripts/ui-playground/index.js
+++ b/lms/static/scripts/ui-playground/index.js
@@ -1,0 +1,8 @@
+// Entry point for local webserver pattern-library bundle
+import { startApp } from '@hypothesis/frontend-shared/lib/pattern-library';
+
+import lmsIcons from '../frontend_apps/icons.js';
+
+startApp({
+  icons: lmsIcons,
+});

--- a/lms/static/styles/ui-playground/ui-playground.scss
+++ b/lms/static/styles/ui-playground/ui-playground.scss
@@ -1,0 +1,2 @@
+// Shared pattern-library styles
+@use '@hypothesis/frontend-shared/styles/pattern-library';

--- a/lms/templates/ui-playground.html.jinja2
+++ b/lms/templates/ui-playground.html.jinja2
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>UI component pattern library</title>
+  {% for url in asset_urls("ui_playground_css") %}
+    <link rel="stylesheet" href="{{ url }}"/>
+  {% endfor %}
+</head>
+<body>
+  <div id="app"></div>
+  {% for url in asset_urls("ui_playground_js") %}
+    <script src="{{ url }}"></script>
+  {% endfor %}
+</body>
+</html>

--- a/lms/views/ui_playground.py
+++ b/lms/views/ui_playground.py
@@ -1,0 +1,14 @@
+from pyramid.httpexceptions import HTTPNotFound
+from pyramid.view import notfound_view_config, view_config
+
+
+@view_config(
+    route_name="ui-playground", renderer="lms:templates/ui-playground.html.jinja2"
+)
+def ui_playground(_request):
+    return {}
+
+
+@notfound_view_config(path_info="/ui-playground", append_slash=True)
+def notfound(_request):
+    return HTTPNotFound()

--- a/scripts/gulp/create-style-bundle.js
+++ b/scripts/gulp/create-style-bundle.js
@@ -8,9 +8,16 @@ const postcss = require('postcss');
 const sass = require('sass');
 
 /**
+ * @typedef Options
+ * @prop {string} input - Input file path
+ * @prop {boolean} minify - Whether to minify the generated bundle
+ * @prop {string} output - Output file path
+ */
+
+/**
  * Compile a SASS file and postprocess the result.
  *
- * @param {options} options - Object specifying the input and output paths and
+ * @param {Options} options - Object specifying the input and output paths and
  *                  whether to minify the result.
  * @return {Promise} Promise for completion of the build.
  */

--- a/tests/unit/lms/views/test_ui_playground.py
+++ b/tests/unit/lms/views/test_ui_playground.py
@@ -1,0 +1,11 @@
+from lms.views import ui_playground
+
+
+def test_ui_playground(pyramid_request):
+    response = ui_playground.ui_playground(pyramid_request)
+    assert response == {}
+
+
+def test_not_found_view(pyramid_request):
+    response = ui_playground.notfound(pyramid_request)
+    assert response.status_code == 404


### PR DESCRIPTION
### Commits

Add ui-playground …

- Add /ui-playground route and view
- Add static routes for js and css bundle files that ui-playground needs from the /build folder
- Add basic ui-playground html template
- Add js and css bundles for ui-playground app from frontend-shared
- Add eslint file to ignore arrow functions --otherwise causing errors in IDE

----------

http://localhost:8001/ui-playground

This is a prototype for adding the basic ui-playground to LMS and leveraging pyramid instead of using express.  This adds a new route called /ui-playground and also allows several static resources to be served from the temporary build/ dir that our frontend code uses to drop bundled resources.

This only sets up the ui playground but does not add any custom LMS pages or components. I could imagine we may have dialogs or pages that are specific to LMS eventually. 

I'd like to seek some help from the backend folks to see if I have done this in a reasonable way.

related to https://github.com/hypothesis/lms/issues/2675

TODO:

- [x] Add py test coverage for new view
