### PR TITLE
Support configuring group set for assignment in file picker UI

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -12,5 +12,14 @@
  * @prop {string} updated_at - An ISO 8601 date string
  */
 
+/**
+ * Object representing a set of groups that students can be divided into for
+ * an assignment.
+ *
+ * @typedef GroupSet
+ * @prop {string} id
+ * @prop {string} name
+ */
+
 // Make TS treat this file as a module.
 export {};

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -40,7 +40,7 @@ export default function FilePickerApp({ onSubmit }) {
     filePicker: {
       formAction,
       formFields,
-      canvas: { groupsEnabled, ltiLaunchUrl },
+      canvas: { groupsEnabled: enableGroupConfig, ltiLaunchUrl },
     },
   } = useContext(Config);
 
@@ -48,7 +48,7 @@ export default function FilePickerApp({ onSubmit }) {
 
   const [groupConfig, setGroupConfig] = useState(
     /** @type {GroupConfig} */ ({
-      useGroups: false,
+      useGroupSet: false,
       groupSet: null,
     })
   );
@@ -85,11 +85,11 @@ export default function FilePickerApp({ onSubmit }) {
   const selectContent = useCallback(
     content => {
       setContent(content);
-      if (!groupsEnabled) {
+      if (!enableGroupConfig) {
         submit();
       }
     },
-    [groupsEnabled, submit]
+    [enableGroupConfig, submit]
   );
 
   return (
@@ -113,7 +113,7 @@ export default function FilePickerApp({ onSubmit }) {
             />
           </Fragment>
         )}
-        {content && groupsEnabled && (
+        {content && enableGroupConfig && (
           <Fragment>
             <h1 className="heading-1">Group settings</h1>
             <GroupConfigSelector
@@ -121,7 +121,7 @@ export default function FilePickerApp({ onSubmit }) {
               onChangeGroupConfig={setGroupConfig}
             />
             <LabeledButton
-              disabled={groupConfig.useGroups && !groupConfig.groupSet}
+              disabled={groupConfig.useGroupSet && !groupConfig.groupSet}
               variant="primary"
               onClick={submit}
             >
@@ -134,7 +134,7 @@ export default function FilePickerApp({ onSubmit }) {
             ltiLaunchURL={ltiLaunchUrl}
             content={content}
             formFields={formFields}
-            groupSet={groupConfig.useGroups ? groupConfig.groupSet : null}
+            groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
           />
         )}
         <input style={{ display: 'none' }} ref={submitButton} type="submit" />

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
@@ -4,6 +4,7 @@ import { contentItemForContent } from '../utils/content-item';
 
 /**
  * @typedef {import('../utils/content-item').Content} Content
+ * @typedef {import('./GroupConfigSelector').GroupConfig} GroupConfig
  */
 
 /**
@@ -13,6 +14,7 @@ import { contentItemForContent } from '../utils/content-item';
  * @prop {Content} content - Content for the assignment
  * @prop {Record<string,string>} formFields - Form fields provided by the backend
  *   that should be included in the response without any changes
+ * @prop {string|null} groupSet
  */
 
 /**
@@ -32,10 +34,13 @@ import { contentItemForContent } from '../utils/content-item';
 export default function FilePickerFormFields({
   content,
   formFields,
+  groupSet,
   ltiLaunchURL,
 }) {
+  /** @type {Record<string,string>} */
+  const extraParams = groupSet ? { group_set: groupSet } : {};
   const contentItem = JSON.stringify(
-    contentItemForContent(ltiLaunchURL, content)
+    contentItemForContent(ltiLaunchURL, content, extraParams)
   );
   return (
     <Fragment>

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -41,8 +41,8 @@ import AuthButton from './AuthButton';
  *  3. Divide students into multiple groups based on a Canvas Group Set
  *
  * The choice between (1) and (2) is currently part of the configuration of an
- * installation of the Hypothesis LMS app. The choice between 1/2 and 3 is done
- * per assignment by the instructor.
+ * installation of the Hypothesis LMS app. The choice between (1 or 2) and (3)
+ * is done per assignment by the instructor.
  *
  * Other LMSes have similar concepts to a Group Set, although the terminology
  * varies (eg. Moodle has "Groupings").

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -17,13 +17,13 @@ import AuthButton from './AuthButton';
  * assignment.
  *
  * @typedef GroupConfig
- * @prop {boolean} useGroups - Whether students are divided into groups
+ * @prop {boolean} useGroupSet - Whether students are divided into groups
  * @prop {string|null} groupSet - The ID of the grouping to use. This should
  *   be the `id` of a `GroupSet` returned by the LMS backend.
  */
 
 /**
- * @typedef GroupSetSelectorProps
+ * @typedef GroupConfigSelectorProps
  * @prop {GroupConfig} groupConfig
  * @prop {(g: GroupConfig) => void} onChangeGroupConfig
  */
@@ -32,7 +32,7 @@ import AuthButton from './AuthButton';
  * Component that allows instructors to configure how students are divided into
  * groups for an assignment.
  *
- * @param {GroupSetSelectorProps} props
+ * @param {GroupConfigSelectorProps} props
  */
 export default function GroupConfigSelector({
   groupConfig,
@@ -69,31 +69,31 @@ export default function GroupConfigSelector({
     }
   }, [authToken, listGroupSetsAPI]);
 
-  const useGroups = groupConfig.useGroups;
+  const useGroupSet = groupConfig.useGroupSet;
   const haveFetchedGroups = groupSets !== null;
 
   useEffect(() => {
-    if (useGroups && !haveFetchedGroups) {
+    if (useGroupSet && !haveFetchedGroups) {
       fetchGroupSets();
     }
-  }, [fetchGroupSets, useGroups, haveFetchedGroups]);
+  }, [fetchGroupSets, useGroupSet, haveFetchedGroups]);
 
   const checkboxID = useUniqueId('GroupSetSelector__enabled');
   const selectID = useUniqueId('GroupSetSelector__select');
 
-  const groupSet = groupConfig.useGroups ? groupConfig.groupSet : null;
-  const fetchingGroupSets = !groupSets && !fetchError && useGroups;
+  const groupSet = groupConfig.useGroupSet ? groupConfig.groupSet : null;
+  const fetchingGroupSets = !groupSets && !fetchError && useGroupSet;
 
   return (
     <Fragment>
       <div>
         <LabeledCheckbox
-          checked={useGroups}
+          checked={useGroupSet}
           id={checkboxID}
           name="groupsEnabled"
           onInput={e =>
             onChangeGroupConfig({
-              useGroups: /** @type {HTMLInputElement} */ (e.target).checked,
+              useGroupSet: /** @type {HTMLInputElement} */ (e.target).checked,
               groupSet: groupSet ?? null,
             })
           }
@@ -113,7 +113,7 @@ export default function GroupConfigSelector({
           />
         </Fragment>
       )}
-      {!fetchError && useGroups && (
+      {!fetchError && useGroupSet && (
         <div>
           <label htmlFor={selectID}>Group set:</label>
           <select
@@ -121,7 +121,7 @@ export default function GroupConfigSelector({
             id={selectID}
             onInput={e =>
               onChangeGroupConfig({
-                useGroups,
+                useGroupSet,
                 groupSet:
                   /** @type {HTMLInputElement} */ (e.target).value || null,
               })

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -17,7 +17,9 @@ import AuthButton from './AuthButton';
  * assignment.
  *
  * @typedef GroupConfig
- * @prop {boolean} useGroupSet - Whether students are divided into groups
+ * @prop {boolean} useGroupSet - Whether students are divided into groups based
+ *   on a grouping/group set defined in the LMS (the terminology varies depending
+ *   on the LMS).
  * @prop {string|null} groupSet - The ID of the grouping to use. This should
  *   be the `id` of a `GroupSet` returned by the LMS backend.
  */
@@ -31,6 +33,19 @@ import AuthButton from './AuthButton';
 /**
  * Component that allows instructors to configure how students are divided into
  * groups for an assignment.
+ *
+ * In Canvas, there are three possibilities:
+ *
+ *  1. Use one group for the whole course
+ *  2. Use one group per Canvas Section
+ *  3. Divide students into multiple groups based on a Canvas Group Set
+ *
+ * The choice between (1) and (2) is currently part of the configuration of an
+ * installation of the Hypothesis LMS app. The choice between 1/2 and 3 is done
+ * per assignment by the instructor.
+ *
+ * Other LMSes have similar concepts to a Group Set, although the terminology
+ * varies (eg. Moodle has "Groupings").
  *
  * @param {GroupConfigSelectorProps} props
  */
@@ -90,7 +105,9 @@ export default function GroupConfigSelector({
         <LabeledCheckbox
           checked={useGroupSet}
           id={checkboxID}
-          name="groupsEnabled"
+          // The `name` prop is required by LabeledCheckbox but is unimportant
+          // as this field is not actually part of the submitted form.
+          name="use_group_set"
           onInput={e =>
             onChangeGroupConfig({
               useGroupSet: /** @type {HTMLInputElement} */ (e.target).checked,

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -1,0 +1,154 @@
+import { LabeledCheckbox } from '@hypothesis/frontend-shared';
+import { Fragment, createElement } from 'preact';
+import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+
+import { Config } from '../config';
+import { apiCall } from '../utils/api';
+import { useUniqueId } from '../utils/hooks';
+
+import AuthButton from './AuthButton';
+
+/**
+ * @typedef {import('../api-types').GroupSet} GroupSet
+ */
+
+/**
+ * Configuration relating to how students are divided into groups for an
+ * assignment.
+ *
+ * @typedef GroupConfig
+ * @prop {boolean} useGroups - Whether students are divided into groups
+ * @prop {string|null} groupSet - The ID of the grouping to use. This should
+ *   be the `id` of a `GroupSet` returned by the LMS backend.
+ */
+
+/**
+ * @typedef GroupSetSelectorProps
+ * @prop {GroupConfig} groupConfig
+ * @prop {(g: GroupConfig) => void} onChangeGroupConfig
+ */
+
+/**
+ * Component that allows instructors to configure how students are divided into
+ * groups for an assignment.
+ *
+ * @param {GroupSetSelectorProps} props
+ */
+export default function GroupConfigSelector({
+  groupConfig,
+  onChangeGroupConfig,
+}) {
+  const [groupSets, setGroupSets] = useState(
+    /** @type {GroupSet[]|null} */ (null)
+  );
+
+  const [fetchError, setFetchError] = useState(
+    /** @type {Error|null} */ (null)
+  );
+
+  const {
+    api: { authToken },
+    filePicker: {
+      canvas: { listGroupSets: listGroupSetsAPI },
+    },
+  } = useContext(Config);
+
+  const fetchGroupSets = useCallback(async () => {
+    setFetchError(null);
+
+    try {
+      const groupSets = /** @type {GroupSet[]} */ (
+        await apiCall({
+          authToken,
+          path: listGroupSetsAPI.path,
+        })
+      );
+      setGroupSets(groupSets);
+    } catch (err) {
+      setFetchError(err);
+    }
+  }, [authToken, listGroupSetsAPI]);
+
+  const useGroups = groupConfig.useGroups;
+  const haveFetchedGroups = groupSets !== null;
+
+  useEffect(() => {
+    if (useGroups && !haveFetchedGroups) {
+      fetchGroupSets();
+    }
+  }, [fetchGroupSets, useGroups, haveFetchedGroups]);
+
+  const checkboxID = useUniqueId('GroupSetSelector__enabled');
+  const selectID = useUniqueId('GroupSetSelector__select');
+
+  const groupSet = groupConfig.useGroups ? groupConfig.groupSet : null;
+  const fetchingGroupSets = !groupSets && !fetchError && useGroups;
+
+  return (
+    <Fragment>
+      <div>
+        <LabeledCheckbox
+          checked={useGroups}
+          id={checkboxID}
+          name="groupsEnabled"
+          onInput={e =>
+            onChangeGroupConfig({
+              useGroups: /** @type {HTMLInputElement} */ (e.target).checked,
+              groupSet: groupSet ?? null,
+            })
+          }
+        >
+          Use groups for this assignment
+        </LabeledCheckbox>
+      </div>
+      {fetchError && (
+        // Currently all fetch errors are handled by attempting to re-authorize
+        // and then re-fetch group sets.
+        <Fragment>
+          <p>Canvas needs your permission to fetch group sets</p>
+          <AuthButton
+            authURL={/** @type {string} */ (listGroupSetsAPI.authUrl)}
+            authToken={authToken}
+            onAuthComplete={fetchGroupSets}
+          />
+        </Fragment>
+      )}
+      {!fetchError && useGroups && (
+        <div>
+          <label htmlFor={selectID}>Group set:</label>
+          <select
+            disabled={fetchingGroupSets}
+            id={selectID}
+            onInput={e =>
+              onChangeGroupConfig({
+                useGroups,
+                groupSet:
+                  /** @type {HTMLInputElement} */ (e.target).value || null,
+              })
+            }
+          >
+            {fetchingGroupSets && <option>Fetching group sets…</option>}
+            {groupSets && (
+              <Fragment>
+                <option disabled selected={groupSet === null}>
+                  Select group set
+                </option>
+                <hr />
+                {groupSets.map(gs => (
+                  <option
+                    key={gs.id}
+                    value={gs.id}
+                    selected={gs.id === groupSet}
+                    data-testid="groupset-option"
+                  >
+                    {gs.name}
+                  </option>
+                ))}
+              </Fragment>
+            )}
+          </select>
+        </div>
+      )}
+    </Fragment>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -88,11 +88,11 @@ describe('FilePickerApp', () => {
     });
   }
 
-  function selectGroupConfig(wrapper, useGroups, groupSet = null) {
+  function selectGroupConfig(wrapper, useGroupSet, groupSet = null) {
     const groupSelector = wrapper.find('GroupConfigSelector');
     interact(wrapper, () => {
       groupSelector.props().onChangeGroupConfig({
-        useGroups,
+        useGroupSet,
         groupSet,
       });
     });
@@ -142,13 +142,13 @@ describe('FilePickerApp', () => {
       );
     });
 
-    [true, false].forEach(useGroups => {
+    [true, false].forEach(useGroupSet => {
       it('submits form when "Continue" button is clicked', () => {
         const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
         const wrapper = renderFilePicker({ onSubmit });
 
         selectContent(wrapper, 'https://example.com');
-        selectGroupConfig(wrapper, useGroups, 'groupSet1');
+        selectGroupConfig(wrapper, useGroupSet, 'groupSet1');
 
         assert.notCalled(onSubmit);
         interact(wrapper, () => {
@@ -162,7 +162,7 @@ describe('FilePickerApp', () => {
             type: 'url',
             url: 'https://example.com',
           },
-          useGroups ? 'groupSet1' : null
+          useGroupSet ? 'groupSet1' : null
         );
       });
     });

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -88,7 +88,10 @@ describe('FilePickerApp', () => {
     });
   }
 
-  function selectGroupConfig(wrapper, useGroupSet, groupSet = null) {
+  function selectGroupConfig(
+    wrapper,
+    { useGroupSet = false, groupSet = null }
+  ) {
     const groupSelector = wrapper.find('GroupConfigSelector');
     interact(wrapper, () => {
       groupSelector.props().onChangeGroupConfig({
@@ -117,7 +120,7 @@ describe('FilePickerApp', () => {
     });
   });
 
-  context('when groups are enabled', () => {
+  context('when group configuration is enabled', () => {
     beforeEach(() => {
       fakeConfig.filePicker.canvas.groupsEnabled = true;
     });
@@ -131,11 +134,11 @@ describe('FilePickerApp', () => {
       assert.notCalled(onSubmit);
     });
 
-    it('disables "Continue" button when groups are enabled but no group set is selected', () => {
+    it('disables "Continue" button when group sets are enabled but no group set is selected', () => {
       const wrapper = renderFilePicker();
 
       selectContent(wrapper, 'https://example.com');
-      selectGroupConfig(wrapper, true, null);
+      selectGroupConfig(wrapper, { useGroupSet: true, groupSet: null });
 
       assert.isTrue(
         wrapper.find('LabeledButton[children="Continue"]').prop('disabled')
@@ -148,7 +151,7 @@ describe('FilePickerApp', () => {
         const wrapper = renderFilePicker({ onSubmit });
 
         selectContent(wrapper, 'https://example.com');
-        selectGroupConfig(wrapper, useGroupSet, 'groupSet1');
+        selectGroupConfig(wrapper, { useGroupSet, groupSet: 'groupSet1' });
 
         assert.notCalled(onSubmit);
         interact(wrapper, () => {

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -18,6 +18,7 @@ describe('FilePickerFormFields', () => {
       <FilePickerFormFields
         content={{ type: 'url', url: 'https://testsite.example/' }}
         formFields={staticFormFields}
+        groupSet={null}
         ltiLaunchURL={launchURL}
         {...props}
       />
@@ -36,21 +37,32 @@ describe('FilePickerFormFields', () => {
     });
   });
 
-  describe('content_items field', () => {
-    it('renders content_items field for content', () => {
-      const content = { type: 'url', url: 'https://example.com/' };
-      const formFields = createComponent({
-        content,
-      });
-      const contentItems = formFields
-        .find('input[name="content_items"]')
-        .prop('value');
-
-      assert.deepEqual(
-        JSON.parse(contentItems),
-        contentItemForContent(launchURL, content)
-      );
+  it('renders `content_items` field for content', () => {
+    const content = { type: 'url', url: 'https://example.com/' };
+    const formFields = createComponent({
+      content,
     });
+    const contentItems = JSON.parse(
+      formFields.find('input[name="content_items"]').prop('value')
+    );
+    assert.deepEqual(contentItems, contentItemForContent(launchURL, content));
+  });
+
+  it('adds `group_set` query param to LTI launch URL if `groupSet` prop is specified', () => {
+    const content = { type: 'url', url: 'https://example.com/' };
+    const formFields = createComponent({
+      content,
+      groupSet: 'groupSet1',
+    });
+    const contentItems = JSON.parse(
+      formFields.find('input[name="content_items"]').prop('value')
+    );
+    assert.deepEqual(
+      contentItems,
+      contentItemForContent(launchURL, content, {
+        group_set: 'groupSet1',
+      })
+    );
   });
 
   it('renders `document_url` field for URL content', () => {

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -1,0 +1,191 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { waitForElement } from '../../../test-util/wait';
+import { Config } from '../../config';
+import GroupConfigSelector, { $imports } from '../GroupConfigSelector';
+
+describe('GroupConfigSelector', () => {
+  const authURL = 'https://testlms.hypothes.is/authorize';
+  const groupSetsAPIRequest = {
+    authToken: 'valid-token',
+    path: '/api/group-sets',
+  };
+
+  let fakeAPICall;
+  let fakeConfig;
+  let fakeGroupSets;
+
+  beforeEach(() => {
+    fakeGroupSets = [
+      {
+        id: 'groupSet1',
+        name: 'Group Set 1',
+      },
+      {
+        id: 'groupSet2',
+        name: 'Group Set 2',
+      },
+    ];
+
+    fakeAPICall = sinon.stub();
+    fakeAPICall.withArgs(groupSetsAPIRequest).resolves(fakeGroupSets);
+    fakeConfig = {
+      api: { authToken: groupSetsAPIRequest.authToken },
+      filePicker: {
+        canvas: {
+          listGroupSets: {
+            authUrl: authURL,
+            path: groupSetsAPIRequest.path,
+          },
+        },
+      },
+    };
+
+    $imports.$mock(mockImportedComponents());
+
+    // Avoid mocking shared components so we can treat them just like native
+    // form controls. We might want to do this for other tests in future.
+    $imports.$restore({
+      '@hypothesis/frontend-shared': true,
+    });
+
+    $imports.$mock({
+      '../utils/api': { apiCall: fakeAPICall },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  function createComponent(props = {}) {
+    const noop = () => {};
+    return mount(
+      <Config.Provider value={fakeConfig}>
+        <GroupConfigSelector
+          groupConfig={{ useGroups: false, groupSet: null }}
+          onChangeGroupConfig={noop}
+          {...props}
+        />
+      </Config.Provider>
+    );
+  }
+
+  function toggleCheckbox(wrapper) {
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    checkbox.getDOMNode().click();
+    checkbox.simulate('input');
+  }
+
+  [
+    [{ useGroups: false, groupSet: null }, false],
+    [{ useGroups: true, groupSet: null }, true],
+  ].forEach(([groupConfig, shouldBeChecked], index) => {
+    it(`sets checkbox state to reflect \`useGroups\` state (${index})`, () => {
+      const wrapper = createComponent({ groupConfig });
+      assert.equal(
+        wrapper.find('LabeledCheckbox').prop('checked'),
+        shouldBeChecked
+      );
+    });
+  });
+
+  it('invokes `onChangeGroupConfig` callback when checkbox is checked', () => {
+    const onChangeGroupConfig = sinon.stub();
+    const wrapper = createComponent({ onChangeGroupConfig });
+
+    toggleCheckbox(wrapper);
+    assert.calledWith(onChangeGroupConfig, {
+      useGroups: true,
+      groupSet: null,
+    });
+
+    onChangeGroupConfig.resetHistory();
+    toggleCheckbox(wrapper);
+    assert.calledWith(onChangeGroupConfig, {
+      useGroups: false,
+      groupSet: null,
+    });
+  });
+
+  it('fetches available group sets when checkbox is checked', async () => {
+    const wrapper = createComponent({
+      groupConfig: { useGroups: true, groupConfig: null },
+    });
+
+    // While groups are being fetched, the `<select>` should be visible but disabled
+    // and display a fetching status.
+    const groupSetSelect = wrapper.find('select');
+    assert.isTrue(groupSetSelect.exists());
+    assert.isTrue(groupSetSelect.prop('disabled'));
+    assert.equal(groupSetSelect.find('option').length, 1);
+    assert.equal(groupSetSelect.find('option').text(), 'Fetching group sets…');
+
+    // Once group sets are fetched, they should be rendered as `<option>`s.
+    const options = await waitForElement(
+      wrapper,
+      'option[data-testid="groupset-option"]'
+    );
+    assert.equal(options.length, fakeGroupSets.length);
+
+    fakeGroupSets.forEach((gs, i) => {
+      assert.equal(options.at(i).text(), gs.name);
+      assert.equal(options.at(i).prop('value'), gs.id);
+    });
+  });
+
+  it('invokes `onChangeGroupConfig` callback when a group set is selected', async () => {
+    const onChangeGroupConfig = sinon.stub();
+    const wrapper = createComponent({
+      groupConfig: { useGroups: true, groupConfig: null },
+      onChangeGroupConfig,
+    });
+
+    const options = await waitForElement(
+      wrapper,
+      'option[data-testid="groupset-option"]'
+    );
+    assert.equal(options.length, fakeGroupSets.length);
+    assert.notCalled(onChangeGroupConfig);
+
+    const select = wrapper.find('select').getDOMNode();
+
+    options.forEach((option, i) => {
+      onChangeGroupConfig.resetHistory();
+
+      select.value = option.prop('value');
+      select.dispatchEvent(new Event('input'));
+
+      assert.calledWith(onChangeGroupConfig, {
+        useGroups: true,
+        groupSet: fakeGroupSets[i].id,
+      });
+    });
+  });
+
+  it('prompts for authorization if needed', async () => {
+    fakeAPICall
+      .withArgs(groupSetsAPIRequest)
+      .rejects(new Error('Authorization failed'));
+    const wrapper = createComponent({
+      groupConfig: { useGroups: true, groupSet: null },
+    });
+
+    // Check that authorization prompt is shown if initial group set fetch fails.
+    const authButton = await waitForElement(wrapper, 'AuthButton');
+    assert.equal(authButton.prop('authURL'), authURL);
+    assert.equal(authButton.prop('authToken'), 'valid-token');
+
+    // Check that group sets are fetched and rendered after authorization completes.
+    fakeAPICall.withArgs(groupSetsAPIRequest).resolves(fakeGroupSets);
+    authButton.prop('onAuthComplete')();
+
+    const options = await waitForElement(
+      wrapper,
+      'option[data-testid="groupset-option"]'
+    );
+    assert.equal(options.length, fakeGroupSets.length);
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -65,7 +65,7 @@ describe('GroupConfigSelector', () => {
     return mount(
       <Config.Provider value={fakeConfig}>
         <GroupConfigSelector
-          groupConfig={{ useGroups: false, groupSet: null }}
+          groupConfig={{ useGroupSet: false, groupSet: null }}
           onChangeGroupConfig={noop}
           {...props}
         />
@@ -80,10 +80,10 @@ describe('GroupConfigSelector', () => {
   }
 
   [
-    [{ useGroups: false, groupSet: null }, false],
-    [{ useGroups: true, groupSet: null }, true],
+    [{ useGroupSet: false, groupSet: null }, false],
+    [{ useGroupSet: true, groupSet: null }, true],
   ].forEach(([groupConfig, shouldBeChecked], index) => {
-    it(`sets checkbox state to reflect \`useGroups\` state (${index})`, () => {
+    it(`sets checkbox state to reflect \`useGroupSet\` state (${index})`, () => {
       const wrapper = createComponent({ groupConfig });
       assert.equal(
         wrapper.find('LabeledCheckbox').prop('checked'),
@@ -98,21 +98,21 @@ describe('GroupConfigSelector', () => {
 
     toggleCheckbox(wrapper);
     assert.calledWith(onChangeGroupConfig, {
-      useGroups: true,
+      useGroupSet: true,
       groupSet: null,
     });
 
     onChangeGroupConfig.resetHistory();
     toggleCheckbox(wrapper);
     assert.calledWith(onChangeGroupConfig, {
-      useGroups: false,
+      useGroupSet: false,
       groupSet: null,
     });
   });
 
   it('fetches available group sets when checkbox is checked', async () => {
     const wrapper = createComponent({
-      groupConfig: { useGroups: true, groupConfig: null },
+      groupConfig: { useGroupSet: true, groupConfig: null },
     });
 
     // While groups are being fetched, the `<select>` should be visible but disabled
@@ -139,7 +139,7 @@ describe('GroupConfigSelector', () => {
   it('invokes `onChangeGroupConfig` callback when a group set is selected', async () => {
     const onChangeGroupConfig = sinon.stub();
     const wrapper = createComponent({
-      groupConfig: { useGroups: true, groupConfig: null },
+      groupConfig: { useGroupSet: true, groupSet: null },
       onChangeGroupConfig,
     });
 
@@ -159,7 +159,7 @@ describe('GroupConfigSelector', () => {
       select.dispatchEvent(new Event('input'));
 
       assert.calledWith(onChangeGroupConfig, {
-        useGroups: true,
+        useGroupSet: true,
         groupSet: fakeGroupSets[i].id,
       });
     });
@@ -170,7 +170,7 @@ describe('GroupConfigSelector', () => {
       .withArgs(groupSetsAPIRequest)
       .rejects(new Error('Authorization failed'));
     const wrapper = createComponent({
-      groupConfig: { useGroups: true, groupSet: null },
+      groupConfig: { useGroupSet: true, groupSet: null },
     });
 
     // Check that authorization prompt is shown if initial group set fetch fails.


### PR DESCRIPTION
**Depends on ~~https://github.com/hypothesis/lms/pull/2700~~, ~~https://github.com/hypothesis/lms/pull/2706~~, ~~https://github.com/hypothesis/lms/pull/2717~~, ~~https://github.com/hypothesis/lms/pull/2707~~**

Add support in the `FilePickerApp` frontend app for configuring whether an assignment uses groups and which group set it uses. The current UI is not polished but it supports the workflow end-to-end. Polishing the UI to match the mocks will happen in subsequent PRs.

 - Check for `groupsEnabled` config property in app config. When this
   flag is set, selecting the content no longer auto-submits the form
   but instead presents a checkbox to select whether groups are enabled
   and a list of available group sets.
 - Add a `GroupConfigSelector` component which presents the checkbox to
   choose whether groups are enabled, fetches the list of groups when it
   is checked and allows the user to select the groups.
 - Change the hidden form field generation logic to add a `group_set`
   query param to the LTI launch URL if groups are enabled for an
   assignment

----

**Testing:**

In order to see the changes here you will need to test using an installation of the LMS app in Canvas that has groups enabled. To enable groups for your local LMS app installed in our test Canvas site at https://hypothesis.instructure.com: 

1. Run `make devdata` in the lms repo and restart the lms dev server to make sure all your env vars etc are up to date
2. Go to http://localhost:8001/admin/instances/ and enter the consumer key for an LMS app installation
3. Check the "Groups enabled" checkbox and click "Save"

[1] To find the consumer keys for installations of the LMS app in https://hypothesis.instructure.com, see `lms/devdata.json` in the devdata repo. The one I usually test with is "localhost (make devdata) with sections enabled" which has the consumer key `Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a`.

**Current UI changes: (nb: This is completely unpolished! See https://github.com/hypothesis/lms/issues/2523#issuecomment-821160185 for target UI)**

When groups are enabled for an LMS app install, selecting content for an assignment shows a new "Group settings" screen:

<img width="272" alt="group-settings-groups-disabled" src="https://user-images.githubusercontent.com/2458/119094604-2c8f6880-ba09-11eb-842d-2be0970ab159.png">

Enabling groups will fetch the list of group sets. When groups are enabled, the user is required to choose a group set before clicking "Continue":

<img width="260" alt="group-settings-groups-enabled" src="https://user-images.githubusercontent.com/2458/119094591-28fbe180-ba09-11eb-95b3-0452699b164d.png">

If the backend does not have a valid access token for the Canvas API for the current user, they will see a prompt to authorize after clicking the checkbox:

<img width="337" alt="group-settings-authorize-prompt" src="https://user-images.githubusercontent.com/2458/119095463-36659b80-ba0a-11eb-83bd-9356b63d51cf.png">

The authorization prompt is not displayed until the checkbox is checked and group sets need to be fetched. This minimizes friction in the case where groups are not enabled for an assignment.

After clicking "Continue", a new `group_set` query param is added to the LTI launch URL if groups were enabled:

<img width="400" alt="group-set-query-param" src="https://user-images.githubusercontent.com/2458/119094639-34e7a380-ba09-11eb-9abe-3b220bc8fdb8.png">
