### PR TITLE
Merge `contentItemFor*` functions

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -16,29 +16,13 @@ import URLPicker from './URLPicker';
 
 /**
  * @typedef {import('../api-types').File} File
+ * @typedef {import('../utils/content-item').Content} Content
  * @typedef {'lms'|'url'|null} DialogType
  *
  * @typedef FilePickerAppProps
  * @prop {DialogType} [defaultActiveDialog] -
  *   The dialog that should be shown when the app is first opened.
  * @prop {() => any} [onSubmit] - Callback invoked when the form is submitted.
- */
-
-/**
- * @typedef FileContent
- * @prop {'file'} type
- * @prop {File} file
- *
- * @typedef URLContent
- * @prop {'url'} type
- * @prop {string} url
- *
- * @typedef VitalSourceBookContent
- * @prop {'vitalsource'} type
- * @prop {string} bookID
- * @prop {string} cfi
- *
- * @typedef {FileContent|URLContent|VitalSourceBookContent} Content
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
@@ -1,41 +1,10 @@
 import { Fragment, createElement } from 'preact';
 
-import {
-  contentItemForUrl,
-  contentItemForLmsFile,
-  contentItemForVitalSourceBook,
-} from '../utils/content-item';
+import { contentItemForContent } from '../utils/content-item';
 
 /**
- * @typedef {import('./FilePickerApp').Content} Content
+ * @typedef {import('../utils/content-item').Content} Content
  */
-
-/**
- * Generate an LTI launch URL for a given piece of content.
- *
- * @param {string} ltiLaunchURL
- * @param {Content} content
- */
-function contentItemString(ltiLaunchURL, content) {
-  let contentItem = null;
-
-  switch (content.type) {
-    case 'url':
-      contentItem = contentItemForUrl(ltiLaunchURL, content.url);
-      break;
-    case 'file':
-      contentItem = contentItemForLmsFile(ltiLaunchURL, content.file);
-      break;
-    case 'vitalsource': {
-      contentItem = contentItemForVitalSourceBook(
-        ltiLaunchURL,
-        content.bookID,
-        content.cfi
-      );
-    }
-  }
-  return JSON.stringify(contentItem);
-}
 
 /**
  * @typedef FilePickerFormFieldsProps
@@ -65,16 +34,15 @@ export default function FilePickerFormFields({
   formFields,
   ltiLaunchURL,
 }) {
+  const contentItem = JSON.stringify(
+    contentItemForContent(ltiLaunchURL, content)
+  );
   return (
     <Fragment>
       {Object.entries(formFields).map(([field, value]) => (
         <input key={field} type="hidden" name={field} value={value} />
       ))}
-      <input
-        type="hidden"
-        name="content_items"
-        value={contentItemString(ltiLaunchURL, content)}
-      />
+      <input type="hidden" name="content_items" value={contentItem} />
       {content.type === 'url' && (
         // Set the `document_url` form field which is used by the `configure_module_item`
         // view. Used in LMSes where assignments are configured on first launch.

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -1,11 +1,7 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
 
-import {
-  contentItemForLmsFile,
-  contentItemForUrl,
-  contentItemForVitalSourceBook,
-} from '../../utils/content-item';
+import { contentItemForContent } from '../../utils/content-item';
 
 import FilePickerFormFields from '../FilePickerFormFields';
 
@@ -44,35 +40,13 @@ describe('FilePickerFormFields', () => {
   });
 
   describe('content_items field', () => {
-    it('renders content_items field for URL content', () => {
+    it('renders content_items field for content', () => {
+      const content = { type: 'url', url: 'https://example.com/' };
       const formFields = createComponent({
-        content: { type: 'url', url: 'https://example.com/' },
+        content,
       });
       const contentItems = getContentItem(formFields);
-      assert.deepEqual(
-        contentItems,
-        contentItemForUrl(launchURL, 'https://example.com/')
-      );
-    });
-
-    it('renders content_items field for LMS file content', () => {
-      const file = { id: 123 };
-      const formFields = createComponent({
-        content: { type: 'file', file },
-      });
-      const contentItems = getContentItem(formFields);
-      assert.deepEqual(contentItems, contentItemForLmsFile(launchURL, file));
-    });
-
-    it('renders content_items field for VitalSource book content', () => {
-      const formFields = createComponent({
-        content: { type: 'vitalsource', bookID: 'test-book', cfi: 'test-cfi' },
-      });
-      const contentItems = getContentItem(formFields);
-      assert.deepEqual(
-        contentItems,
-        contentItemForVitalSourceBook(launchURL, 'test-book', 'test-cfi')
-      );
+      assert.deepEqual(contentItems, contentItemForContent(launchURL, content));
     });
   });
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -24,9 +24,6 @@ describe('FilePickerFormFields', () => {
     );
   }
 
-  const getContentItem = wrapper =>
-    JSON.parse(wrapper.find('input[name="content_items"]').prop('value'));
-
   it('renders static form fields provided by backend', () => {
     const formFields = createComponent();
 
@@ -45,8 +42,14 @@ describe('FilePickerFormFields', () => {
       const formFields = createComponent({
         content,
       });
-      const contentItems = getContentItem(formFields);
-      assert.deepEqual(contentItems, contentItemForContent(launchURL, content));
+      const contentItems = formFields
+        .find('input[name="content_items"]')
+        .prop('value');
+
+      assert.deepEqual(
+        JSON.parse(contentItems),
+        contentItemForContent(launchURL, content)
+      );
     });
   });
 

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -1,65 +1,66 @@
+/** @typedef {import('../api-types').File} File */
+
 /**
- * @typedef {import('../api-types').File} File
+ * @typedef FileContent
+ * @prop {'file'} type
+ * @prop {File} file
+ *
+ * @typedef URLContent
+ * @prop {'url'} type
+ * @prop {string} url
+ *
+ * @typedef VitalSourceBookContent
+ * @prop {'vitalsource'} type
+ * @prop {string} bookID
+ * @prop {string} cfi
+ */
+
+/**
+ * Enumeration of the different types of content that may be used for an assignment.
+ *
+ * @typedef {FileContent|URLContent|VitalSourceBookContent} Content
  */
 
 import { stringify } from 'querystring';
 
 /**
- * @param {string} ltiLaunchUrl
- * @param {Object.<string,string>} params - Query parameters for the generated URL
+ * Return a JSON-LD `ContentItem` representation of the LTI activity launch
+ * URL for a given piece of content.
+ *
+ * This is used for the `content_items` field of the form submitted to the LMS
+ * to configure the LTI launch URL for a new assignment. See
+ * https://www.imsglobal.org/specs/lticiv1p0/specification.
+ *
+ * @param {string} ltiLaunchURL - Base URL for LTI assignment launches
+ * @param {Content} content - The assignment content
+ * @param {Record<string,string>} [extraParams] - Additional query params to add to the launch URL
  */
-function contentItemWithParams(ltiLaunchUrl, params) {
+export function contentItemForContent(ltiLaunchURL, content, extraParams) {
+  const params = { ...extraParams };
+
+  switch (content.type) {
+    case 'file':
+      params.canvas_file = 'true';
+      params.file_id = content.file.id;
+      break;
+    case 'url':
+      params.url = content.url;
+      break;
+    case 'vitalsource':
+      params.vitalsource_book = 'true';
+      params.book_id = content.bookID;
+      params.cfi = content.cfi;
+      break;
+  }
+
   return {
     '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
     '@graph': [
       {
         '@type': 'LtiLinkItem',
         mediaType: 'application/vnd.ims.lti.v1.ltilink',
-        url: `${ltiLaunchUrl}?${stringify(params)}`,
+        url: `${ltiLaunchURL}?${stringify(params)}`,
       },
     ],
   };
-}
-
-/**
- * Return a JSON-LD `ContentItem` representation of the LTI activity launch
- * URL for a given document URL.
- *
- * @param {string} ltiLaunchUrl
- * @param {string} documentUrl
- */
-export function contentItemForUrl(ltiLaunchUrl, documentUrl) {
-  return contentItemWithParams(ltiLaunchUrl, { url: documentUrl });
-}
-
-/**
- * Return a JSON-LD `ContentItem` representation of the LTI activity launch
- * URL for a given LMS file
- *
- * @param {string} ltiLaunchUrl
- * @param {File} file
- */
-export function contentItemForLmsFile(ltiLaunchUrl, file) {
-  return contentItemWithParams(ltiLaunchUrl, {
-    canvas_file: 'true',
-    file_id: file.id,
-  });
-}
-
-/**
- * Return a JSON-LD `ContentItem` representation of the LTI activity launch URL
- * for a VitalSource ebook.
- *
- * @param {string} ltiLaunchUrl
- * @param {string} bookId - VitalSource book ID (aka. `vbid`)
- * @param {string} cfi -
- *   Location in the book. This is an EPUB CFI path without the surrounding
- *   `epubcfi(...)` fragment. See http://idpf.org/epub/linking/cfi/epub-cfi.html.
- */
-export function contentItemForVitalSourceBook(ltiLaunchUrl, bookId, cfi) {
-  return contentItemWithParams(ltiLaunchUrl, {
-    vitalsource_book: 'true',
-    book_id: bookId,
-    cfi,
-  });
 }

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -1,3 +1,5 @@
+import { stringify } from 'querystring';
+
 /** @typedef {import('../api-types').File} File */
 
 /**
@@ -20,8 +22,6 @@
  *
  * @typedef {FileContent|URLContent|VitalSourceBookContent} Content
  */
-
-import { stringify } from 'querystring';
 
 /**
  * Return a JSON-LD `ContentItem` representation of the LTI activity launch

--- a/lms/static/scripts/frontend_apps/utils/test/content-item-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/content-item-test.js
@@ -1,73 +1,47 @@
-import {
-  contentItemForUrl,
-  contentItemForLmsFile,
-  contentItemForVitalSourceBook,
-} from '../content-item';
+import { contentItemForContent } from '../content-item';
 
-const ltiLaunchUrl = 'https://lms.hypothes.is/lti_launch';
+const ltiLaunchURL = 'https://lms.hypothes.is/lti_launch';
 
-describe('content-item', () => {
-  describe('contentItemForUrl', () => {
-    it('returns expected JSON-LD representation', () => {
-      const documentUrl = 'https://example.com?param_a=1&param_b=2';
+describe('contentItemForContent', () => {
+  [
+    {
+      content: { type: 'url', url: 'https://example.com?param_a=1&param_b=2' },
+      expectedURL: `${ltiLaunchURL}?url=${encodeURIComponent(
+        'https://example.com?param_a=1&param_b=2'
+      )}`,
+    },
+    {
+      content: { type: 'file', file: { id: 'foobar' } },
+      expectedURL: `${ltiLaunchURL}?canvas_file=true&file_id=foobar`,
+    },
+    {
+      content: { type: 'vitalsource', bookID: 'TEST-BOOK', cfi: '/4/5' },
+      expectedURL: `${ltiLaunchURL}?vitalsource_book=true&book_id=TEST-BOOK&cfi=%2F4%2F5`,
+    },
+  ].forEach(({ content, expectedURL }) => {
+    it('returns JSON-LD representation for content', () => {
+      const item = contentItemForContent(ltiLaunchURL, content);
 
-      const contentItem = contentItemForUrl(ltiLaunchUrl, documentUrl);
-
-      assert.deepEqual(contentItem, {
+      assert.deepEqual(item, {
         '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
         '@graph': [
           {
             '@type': 'LtiLinkItem',
             mediaType: 'application/vnd.ims.lti.v1.ltilink',
-            url: ltiLaunchUrl + '?url=' + encodeURIComponent(documentUrl),
+            url: expectedURL,
           },
         ],
       });
     });
   });
 
-  describe('contentItemForLmsFile', () => {
-    it('returns expected JSON-LD representation', () => {
-      const file = { id: 'foobar' };
-
-      const contentItem = contentItemForLmsFile(ltiLaunchUrl, file);
-
-      assert.deepEqual(contentItem, {
-        '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
-        '@graph': [
-          {
-            '@type': 'LtiLinkItem',
-            mediaType: 'application/vnd.ims.lti.v1.ltilink',
-            url: ltiLaunchUrl + '?canvas_file=true&file_id=foobar',
-          },
-        ],
-      });
-    });
-  });
-
-  describe('contentItemForVitalSourceBook', () => {
-    it('returns expected JSON-LD data', () => {
-      const bookId = 'TEST-BOOK';
-      const chapterCfi = '/4/5';
-
-      const contentItem = contentItemForVitalSourceBook(
-        ltiLaunchUrl,
-        bookId,
-        chapterCfi
-      );
-
-      assert.deepEqual(contentItem, {
-        '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
-        '@graph': [
-          {
-            '@type': 'LtiLinkItem',
-            mediaType: 'application/vnd.ims.lti.v1.ltilink',
-            url:
-              ltiLaunchUrl +
-              '?vitalsource_book=true&book_id=TEST-BOOK&cfi=%2F4%2F5',
-          },
-        ],
-      });
-    });
+  it('adds extra query params to launch URL', () => {
+    const item = contentItemForContent(
+      ltiLaunchURL,
+      { type: 'url', url: 'https://example.com' },
+      { group_set: 'group1' }
+    );
+    const url = new URL(item['@graph'][0].url);
+    assert.equal(url.searchParams.get('group_set'), 'group1');
   });
 });


### PR DESCRIPTION
Combine the `contentItemFor<ContentType>` functions into a single
`contentItemForContent` function which accepts a `Content` object as an
argument, as well as additional query params to add to the launch URL.

Combining these functions removes the need to switch on the content type in other
places in the code.

The support for adding additional query params will be used to add the
`group_set` query param in assignments that are configured to use
groups.