### PR TITLE
Add UI to select books from VitalSource

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -21,5 +21,25 @@
  * @prop {string} name
  */
 
+/**
+ * Metadata for an ebook that is available to annotate.
+ *
+ * @typedef Book
+ * @prop {string} id
+ * @prop {string} title
+ * @prop {string} cover_image - URL of a cover image for the book
+ */
+
+/**
+ * Metadata for a chapter within an ebook.
+ *
+ * @typedef Chapter
+ * @prop {string} cfi -
+ *   An EPUB CFI indicating the location of the chapter within the book.
+ *   See http://idpf.org/epub/linking/cfi/.
+ * @prop {string} page
+ * @prop {string} title
+ */
+
 // Make TS treat this file as a module.
 export {};

--- a/lms/static/scripts/frontend_apps/components/BookList.js
+++ b/lms/static/scripts/frontend_apps/components/BookList.js
@@ -1,0 +1,58 @@
+import { createElement } from 'preact';
+
+import Table from './Table';
+
+/**
+ * @typedef {import('../api-types').Book} Book
+ */
+
+/**
+ * @typedef BookListProps
+ * @prop {Book[]} books
+ * @prop {boolean} isLoading
+ * @prop {Book|null} selectedBook
+ * @prop {(b: Book) => any} onSelectBook
+ * @prop {(b: Book) => any} onUseBook
+ */
+
+/**
+ * @param {BookListProps} props
+ */
+export default function BookList({
+  books,
+  isLoading = false,
+  selectedBook,
+  onSelectBook,
+  onUseBook,
+}) {
+  const columns = [
+    {
+      label: 'Title',
+    },
+  ];
+
+  return (
+    <div className="BookList">
+      <Table
+        accessibleLabel="Book list"
+        columns={columns}
+        items={books}
+        isLoading={isLoading}
+        onSelectItem={onSelectBook}
+        onUseItem={onUseBook}
+        renderItem={book => <td>{book.title}</td>}
+        selectedItem={selectedBook}
+      />
+      {selectedBook && (
+        <div className="BookList__cover-container">
+          <img
+            className="BookList__cover"
+            alt="Book cover"
+            src={selectedBook.cover_image}
+            data-testid="cover-image"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/BookList.js
+++ b/lms/static/scripts/frontend_apps/components/BookList.js
@@ -48,16 +48,16 @@ export default function BookList({
         renderItem={book => <td>{book.title}</td>}
         selectedItem={selectedBook}
       />
-      {selectedBook && (
-        <div className="BookList__cover-container">
+      <div className="BookList__cover-container">
+        {selectedBook && (
           <img
             className="BookList__cover"
             alt="Book cover"
             src={selectedBook.cover_image}
             data-testid="cover-image"
           />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/BookList.js
+++ b/lms/static/scripts/frontend_apps/components/BookList.js
@@ -8,14 +8,19 @@ import Table from './Table';
 
 /**
  * @typedef BookListProps
- * @prop {Book[]} books
- * @prop {boolean} isLoading
- * @prop {Book|null} selectedBook
- * @prop {(b: Book) => any} onSelectBook
- * @prop {(b: Book) => any} onUseBook
+ * @prop {Book[]} books - List of available books
+ * @prop {boolean} isLoading - Whether to show a loading indicator
+ * @prop {Book|null} selectedBook - Book within `books` which is currently selected
+ * @prop {(b: Book) => void} onSelectBook - Callback invoked when user selects a book
+ * @prop {(b: Book) => void} onUseBook -
+ *   Callback invoked when user confirms they want to use the selected book for
+ *   an assignment.
  */
 
 /**
+ * Component that presents the user with a list of books from a source (eg. VitalSource)
+ * and allows them to choose one for an assignment.
+ *
  * @param {BookListProps} props
  */
 export default function BookList({

--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -68,7 +68,7 @@ export default function BookPicker({ authToken, onCancel, onSelectBook }) {
   return (
     <Dialog
       onCancel={onCancel}
-      title="Select book from VitalSource"
+      title={step === 'select-book' ? 'Select book' : 'Select chapter'}
       buttons={[
         <LabeledButton
           key="submit"

--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -1,0 +1,120 @@
+import { LabeledButton } from '@hypothesis/frontend-shared';
+import { createElement } from 'preact';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+
+import { fetchBooks, fetchChapters } from '../utils/api';
+
+import BookList from './BookList';
+import ChapterList from './ChapterList';
+import Dialog from './Dialog';
+import ErrorDisplay from './ErrorDisplay';
+
+/**
+ * @typedef {import('../api-types').Chapter} Chapter
+ * @typedef {import('../api-types').Book} Book
+ *
+ * @typedef BookPickerProps
+ * @prop {string} authToken
+ * @prop {() => any} onCancel
+ * @prop {(b: Book, c: Chapter) => any} onSelectBook
+ */
+
+/**
+ * A dialog that allows the user to select a book from VitalSource
+ *
+ * @param {BookPickerProps} props
+ */
+export default function BookPicker({ authToken, onCancel, onSelectBook }) {
+  const [bookList, setBookList] = useState(/** @type {Book[]|null} */ (null));
+  const [chapterList, setChapterList] = useState(
+    /** @type {Chapter[]|null} */ (null)
+  );
+  const [book, setBook] = useState(/** @type {Book|null} */ (null));
+  const [chapter, setChapter] = useState(/** @type {Chapter|null} */ (null));
+  const [step, setStep] = useState(
+    /** @type {'select-book'|'select-chapter'} */ ('select-book')
+  );
+  const [error, setError] = useState(/** @type {Error|null} */ (null));
+
+  /** @type {(b: Book) => void} */
+  const confirmBook = useCallback(book => {
+    setBook(book);
+    setChapterList(null);
+    setStep('select-chapter');
+  }, []);
+
+  /** @type {(c: Chapter) => void} */
+  const confirmChapter = useCallback(
+    chapter => {
+      onSelectBook(/** @type {Book} */ (book), chapter);
+    },
+    [book, onSelectBook]
+  );
+
+  useEffect(() => {
+    if (step === 'select-book' && !bookList) {
+      fetchBooks(authToken).then(setBookList).catch(setError);
+    } else if (step === 'select-chapter' && !chapterList) {
+      const currentBook = /** @type {Book} */ (book);
+      fetchChapters(authToken, currentBook.id)
+        .then(setChapterList)
+        .catch(setError);
+    }
+  }, [authToken, book, bookList, step, chapterList]);
+
+  const canSubmit =
+    (step === 'select-book' && book) || (step === 'select-chapter' && chapter);
+
+  return (
+    <Dialog
+      onCancel={onCancel}
+      title="Select book from VitalSource"
+      buttons={[
+        <LabeledButton
+          key="submit"
+          data-testid="select-button"
+          disabled={!canSubmit}
+          onClick={() => {
+            if (step === 'select-book' && book) {
+              confirmBook(book);
+            } else if (step === 'select-chapter' && chapter) {
+              confirmChapter(chapter);
+            }
+          }}
+          variant="primary"
+        >
+          {step === 'select-book' ? 'Select book' : 'Select chapter'}
+        </LabeledButton>,
+      ]}
+    >
+      {step === 'select-book' && !error && (
+        <BookList
+          books={bookList || []}
+          isLoading={!bookList}
+          selectedBook={book}
+          onSelectBook={setBook}
+          onUseBook={confirmBook}
+        />
+      )}
+      {step === 'select-chapter' && !error && (
+        <ChapterList
+          chapters={chapterList || []}
+          isLoading={!chapterList}
+          selectedChapter={chapter}
+          onSelectChapter={setChapter}
+          onUseChapter={confirmChapter}
+        />
+      )}
+      {error && (
+        <ErrorDisplay
+          message={
+            step === 'select-book'
+              ? 'Unable to fetch books'
+              : 'Unable to fetch chapters'
+          }
+          error={error}
+        />
+      )}
+    </Dialog>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -16,7 +16,8 @@ import ErrorDisplay from './ErrorDisplay';
  * @typedef BookPickerProps
  * @prop {string} authToken
  * @prop {() => void} onCancel
- * @prop {(b: Book, c: Chapter) => void} onSelectBook
+ * @prop {(b: Book, c: Chapter) => void} onSelectBook - Callback invoked when
+ *   a book and chapter have been selected
  */
 
 /**
@@ -24,6 +25,10 @@ import ErrorDisplay from './ErrorDisplay';
  *
  * The list of available books is fetched from VitalSource, but this component
  * could be adapted to work with other book sources in future.
+ *
+ * The dialog has two steps: The user first chooses a book to use and then chooses
+ * which chapter to use from that book. Once both are chosen the `onSelectBook`
+ * callback is called.
  *
  * @param {BookPickerProps} props
  */
@@ -78,6 +83,9 @@ export default function BookPicker({ authToken, onCancel, onSelectBook }) {
           data-testid="select-button"
           disabled={!canSubmit}
           onClick={() => {
+            // nb. The `book` and `chapter` checks should be redundant, as the button
+            // should not be clickable if no book/chapter is selected, but they
+            // keep TS happy.
             if (step === 'select-book' && book) {
               confirmBook(book);
             } else if (step === 'select-chapter' && chapter) {

--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -15,12 +15,15 @@ import ErrorDisplay from './ErrorDisplay';
  *
  * @typedef BookPickerProps
  * @prop {string} authToken
- * @prop {() => any} onCancel
- * @prop {(b: Book, c: Chapter) => any} onSelectBook
+ * @prop {() => void} onCancel
+ * @prop {(b: Book, c: Chapter) => void} onSelectBook
  */
 
 /**
- * A dialog that allows the user to select a book from VitalSource
+ * A dialog that allows the user to select a book and chapter to use in an assignment.
+ *
+ * The list of available books is fetched from VitalSource, but this component
+ * could be adapted to work with other book sources in future.
  *
  * @param {BookPickerProps} props
  */

--- a/lms/static/scripts/frontend_apps/components/ChapterList.js
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.js
@@ -11,13 +11,16 @@ import Table from './Table';
  * @prop {Chapter[]} chapters - List of available chapters
  * @prop {boolean} [isLoading] - Whether to show a loading indicator
  * @prop {Chapter|null} selectedChapter - The chapter within `chapters` which is currently selected
- * @prop {(c: Chapter) => void} onSelectChapter -
- *   Callback invoked when the user clicks on a chapter
+ * @prop {(c: Chapter) => void} onSelectChapter - Callback invoked when the user selects a chapter
  * @prop {(c: Chapter) => void} onUseChapter -
- *   Callback invoked when the user double-clicks a chapter
+ *   Callback invoked when user confirms they want to use the selected chapter for
+ *   an assignment.
  */
 
 /**
+ * Component that presents a list of chapters from a book and allows the user
+ * to choose one for an assignment.
+ *
  * @param {ChapterListProps} props
  */
 export default function ChapterList({

--- a/lms/static/scripts/frontend_apps/components/ChapterList.js
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.js
@@ -1,0 +1,56 @@
+import { Fragment, createElement } from 'preact';
+
+import Table from './Table';
+
+/**
+ * @typedef {import('../api-types').Chapter} Chapter
+ */
+
+/**
+ * @typedef ChapterListProps
+ * @prop {Chapter[]} chapters - List of available chapters
+ * @prop {boolean} [isLoading] - Whether to show a loading indicator
+ * @prop {Chapter|null} selectedChapter - The chapter within `chapters` which is currently selected
+ * @prop {(c: Chapter) => void} onSelectChapter -
+ *   Callback invoked when the user clicks on a chapter
+ * @prop {(c: Chapter) => void} onUseChapter -
+ *   Callback invoked when the user double-clicks a chapter
+ */
+
+/**
+ * @param {ChapterListProps} props
+ */
+export default function ChapterList({
+  chapters,
+  isLoading = false,
+  selectedChapter,
+  onSelectChapter,
+  onUseChapter,
+}) {
+  const columns = [
+    {
+      label: 'Title',
+    },
+    {
+      label: 'Page',
+    },
+  ];
+
+  return (
+    <Table
+      accessibleLabel="Table of Contents"
+      columns={columns}
+      isLoading={isLoading}
+      items={chapters}
+      onSelectItem={onSelectChapter}
+      onUseItem={onUseChapter}
+      selectedItem={selectedChapter}
+      renderItem={chapter => (
+        <Fragment>
+          <td aria-label={chapter.title}>{chapter.title}</td>
+          <td>{chapter.page}</td>
+        </Fragment>
+      )}
+    />
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -7,18 +7,21 @@ import {
   GooglePickerClient,
   PickerCanceledError,
 } from '../utils/google-picker-client';
+import BookPicker from './BookPicker';
 import FullScreenSpinner from './FullScreenSpinner';
 import LMSFilePicker from './LMSFilePicker';
 import URLPicker from './URLPicker';
 
 /**
+ * @typedef {import('../api-types').Book} Book
  * @typedef {import('../api-types').File} File
+ * @typedef {import('../api-types').Chapter} Chapter
  *
  * @typedef ErrorInfo
  * @prop {string} title
  * @prop {Error} error
  *
- * @typedef {'blackboardFile'|'canvasFile'|'url'|null} DialogType
+ * @typedef {'blackboardFile'|'canvasFile'|'url'|'vitalSourceBook'|null} DialogType
  *
  * @typedef {import('../utils/content-item').Content} Content
  */
@@ -111,6 +114,15 @@ export default function ContentSelector({
     onSelectContent({ type: 'url', url: file.id });
   };
 
+  /**
+   * @param {Book} book
+   * @param {Chapter} chapter
+   */
+  const selectVitalSourceBook = (book, chapter) => {
+    cancelDialog();
+    onSelectContent({ type: 'vitalsource', bookID: book.id, cfi: chapter.cfi });
+  };
+
   let dialog;
   switch (activeDialog) {
     case 'url':
@@ -136,6 +148,15 @@ export default function ContentSelector({
         />
       );
       break;
+    case 'vitalSourceBook':
+      dialog = (
+        <BookPicker
+          authToken={authToken}
+          onCancel={cancelDialog}
+          onSelectBook={selectVitalSourceBook}
+        />
+      );
+      break;
     default:
       dialog = null;
   }
@@ -157,16 +178,6 @@ export default function ContentSelector({
         });
       }
     }
-  };
-
-  const selectVitalSourceBook = () => {
-    // Chosen from `https://api.vitalsource.com/v4/products` response.
-    const bookID = 'BOOKSHELF-TUTORIAL';
-    // CFI chosen from `https://api.vitalsource.com/v4/products/BOOKSHELF-TUTORIAL/toc`
-    // response.
-    const cfi = '/6/8[;vnd.vst.idref=vst-70a6f9d3-0932-45ba-a583-6060eab3e536]';
-
-    onSelectContent({ type: 'vitalsource', bookID, cfi });
   };
 
   return (
@@ -211,7 +222,7 @@ export default function ContentSelector({
           )}
           {vitalSourceEnabled && (
             <LabeledButton
-              onClick={selectVitalSourceBook}
+              onClick={() => selectDialog('vitalSourceBook')}
               variant="primary"
               data-testid="vitalsource-button"
             >

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -2,6 +2,8 @@ import classnames from 'classnames';
 import { createElement } from 'preact';
 import { useRef } from 'preact/hooks';
 
+import Spinner from './Spinner';
+
 /**
  * Return the next item to select when advancing the selection by `step` items
  * forwards (if positive) or backwards (if negative).
@@ -39,6 +41,8 @@ function nextItem(items, currentItem, step) {
  * @typedef TableProps
  * @prop {string} accessibleLabel - An accessible label for the table
  * @prop {TableColumn[]} columns - The columns to display in this table
+ * @prop {boolean} [isLoading] - Show an indicator that data for the table is
+ *   currently being fetched
  * @prop {Item[]} items -
  *   The items to display in this table, one per row. `renderItem` defines how
  *   information from each item is represented as a series of table cells.
@@ -62,6 +66,7 @@ function nextItem(items, currentItem, step) {
 export default function Table({
   accessibleLabel,
   columns,
+  isLoading = false,
   items,
   onSelectItem,
   onUseItem,
@@ -148,6 +153,11 @@ export default function Table({
           ))}
         </tbody>
       </table>
+      {isLoading && (
+        <div className="Table__spinner">
+          <Spinner />
+        </div>
+      )}
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -50,9 +50,9 @@ function nextItem(items, currentItem, step) {
  *   A function called to render each item as the contents of a table row.
  *   The result should be a list of `<td>` elements (one per column) wrapped inside a Fragment.
  * @prop {Item|null} selectedItem - The currently selected item from `items`
- * @prop {(it: Item) => any} onSelectItem -
+ * @prop {(it: Item) => void} onSelectItem -
  *   Callback invoked when the user changes the selected item
- * @prop {(it: Item) => any} onUseItem -
+ * @prop {(it: Item) => void} onUseItem -
  *   Callback invoked when a user chooses to use an item by double-clicking it
  *   or pressing Enter while it is selected
  */

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -33,7 +33,7 @@ function nextItem(items, currentItem, step) {
 /**
  * @typedef TableColumn
  * @prop {string} label - Header label for the column
- * @prop {string} className - Additional classes for the column's `<th>` element
+ * @prop {string} [className] - Additional classes for the column's `<th>` element
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/test/BookList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookList-test.js
@@ -31,7 +31,7 @@ describe('BookList', () => {
   });
 
   [true, false].forEach(isLoading => {
-    it('shows loading indicator if books are being fetched', () => {
+    it('shows loading indicator in table if books are being fetched', () => {
       const bookList = renderBookList({ isLoading });
       assert.equal(bookList.find('Table').prop('isLoading'), isLoading);
     });

--- a/lms/static/scripts/frontend_apps/components/test/BookList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookList-test.js
@@ -1,0 +1,68 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import BookList from '../BookList';
+
+describe('BookList', () => {
+  const bookData = [
+    {
+      id: 'test-book',
+      title: 'Test book',
+      cover_image: 'https://example.com/test.jpg',
+    },
+  ];
+
+  const noop = () => {};
+  const renderBookList = (props = {}) =>
+    mount(
+      <BookList
+        books={bookData}
+        selectedBook={null}
+        onSelectBook={noop}
+        onUseBook={noop}
+        {...props}
+      />
+    );
+
+  it('renders book titles', () => {
+    const bookList = renderBookList();
+    assert.equal(bookList.find('tbody > tr').length, bookData.length);
+    assert.include(bookList.html(), '<td>Test book</td>');
+  });
+
+  [true, false].forEach(isLoading => {
+    it('shows loading indicator if books are being fetched', () => {
+      const bookList = renderBookList({ isLoading });
+      assert.equal(bookList.find('Table').prop('isLoading'), isLoading);
+    });
+  });
+
+  it('calls `onSelectBook` callback when a book is selected', () => {
+    const onSelectBook = sinon.stub();
+    const bookList = renderBookList({ onSelectBook });
+
+    bookList.find('Table').prop('onSelectItem')(bookData[0]);
+
+    assert.calledWith(onSelectBook, bookData[0]);
+  });
+
+  it('calls `onUseBook` callback when a book is double-clicked', () => {
+    const onUseBook = sinon.stub();
+    const bookList = renderBookList({ onUseBook });
+
+    bookList.find('Table').prop('onUseItem')(bookData[0]);
+
+    assert.calledWith(onUseBook, bookData[0]);
+  });
+
+  it('does not show a cover image if no book is selected', () => {
+    const bookList = renderBookList();
+    assert.isFalse(bookList.exists('img[data-testid="cover-image"]'));
+  });
+
+  it('shows cover of selected book', () => {
+    const bookList = renderBookList({ selectedBook: bookData[0] });
+    const coverImage = bookList.find('img[data-testid="cover-image"]');
+    assert.equal(coverImage.prop('src'), bookData[0].cover_image);
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -34,9 +34,9 @@ describe('BookPicker', () => {
     $imports.$restore();
   });
 
-  const selectBook = wrapper => {
+  const selectBook = (wrapper, index = 0) => {
     const bookList = wrapper.find('BookList');
-    const book = bookList.prop('books')[0];
+    const book = bookList.prop('books')[index];
     act(() => {
       bookList.prop('onSelectBook')(book);
     });
@@ -44,9 +44,9 @@ describe('BookPicker', () => {
     return book;
   };
 
-  const selectChapter = wrapper => {
+  const selectChapter = (wrapper, index = 0) => {
     const chapterList = wrapper.find('ChapterList');
-    const chapter = chapterList.prop('chapters')[0];
+    const chapter = chapterList.prop('chapters')[index];
     act(() => {
       chapterList.prop('onSelectChapter')(chapter);
     });
@@ -66,6 +66,7 @@ describe('BookPicker', () => {
   it('fetches and displays book list when picker is opened', async () => {
     const picker = renderBookPicker();
 
+    // The book list should initially be empty and in a loading state.
     let bookList = picker.find('BookList');
     assert.deepEqual(bookList.prop('books'), []);
     assert.isTrue(bookList.prop('isLoading'));
@@ -73,17 +74,20 @@ describe('BookPicker', () => {
 
     await waitForElement(picker, 'BookList[isLoading=false]');
 
+    // The book list should display details of books once fetched.
     bookList = picker.find('BookList');
     assert.deepEqual(bookList.prop('books'), bookData.bookList);
   });
 
   it('fetches and displays chapter list when a book is chosen', async () => {
+    // Wait for books to load and then pick the first one.
     const picker = renderBookPicker();
     await waitForElement(picker, 'BookList[isLoading=false]');
 
     const book = selectBook(picker);
     clickSelectButton(picker);
 
+    // After a book is chosen, the chapter list should appear in a loading state.
     assert.isFalse(picker.exists('BookList'));
     let chapterList = picker.find('ChapterList');
     assert.isTrue(chapterList.exists());
@@ -92,6 +96,7 @@ describe('BookPicker', () => {
 
     await waitForElement(picker, 'ChapterList[isLoading=false]');
 
+    // The list of chapters for the selected book should be presented once fetched.
     chapterList = picker.find('ChapterList');
     assert.equal(chapterList.prop('chapters'), bookData.chapterData[book.id]);
   });

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -1,0 +1,142 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { waitForElement } from '../../../test-util/wait';
+import * as bookData from '../../utils/vitalsource-sample-data';
+import BookPicker, { $imports } from '../BookPicker';
+
+describe('BookPicker', () => {
+  let fakeAPI;
+
+  const renderBookPicker = (props = {}) =>
+    mount(<BookPicker authToken="dummy-auth-token" {...props} />);
+
+  beforeEach(() => {
+    fakeAPI = {
+      fetchBooks: sinon.stub().resolves(bookData.bookList),
+      fetchChapters: sinon
+        .stub()
+        .callsFake(async (authToken, bookID) => bookData.chapterData[bookID]),
+    };
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$restore({
+      './Dialog': true,
+    });
+    $imports.$mock({
+      '../utils/api': fakeAPI,
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  const selectBook = wrapper => {
+    const bookList = wrapper.find('BookList');
+    const book = bookList.prop('books')[0];
+    act(() => {
+      bookList.prop('onSelectBook')(book);
+    });
+    wrapper.update();
+    return book;
+  };
+
+  const selectChapter = wrapper => {
+    const chapterList = wrapper.find('ChapterList');
+    const chapter = chapterList.prop('chapters')[0];
+    act(() => {
+      chapterList.prop('onSelectChapter')(chapter);
+    });
+    wrapper.update();
+    return chapter;
+  };
+
+  const clickSelectButton = wrapper => {
+    act(() => {
+      wrapper
+        .find('LabeledButton[data-testid="select-button"]')
+        .prop('onClick')();
+    });
+    wrapper.update();
+  };
+
+  it('fetches and displays book list when picker is opened', async () => {
+    const picker = renderBookPicker();
+
+    let bookList = picker.find('BookList');
+    assert.deepEqual(bookList.prop('books'), []);
+    assert.isTrue(bookList.prop('isLoading'));
+    assert.calledWith(fakeAPI.fetchBooks, 'dummy-auth-token');
+
+    await waitForElement(picker, 'BookList[isLoading=false]');
+
+    bookList = picker.find('BookList');
+    assert.deepEqual(bookList.prop('books'), bookData.bookList);
+  });
+
+  it('fetches and displays chapter list when a book is chosen', async () => {
+    const picker = renderBookPicker();
+    await waitForElement(picker, 'BookList[isLoading=false]');
+
+    const book = selectBook(picker);
+    clickSelectButton(picker);
+
+    assert.isFalse(picker.exists('BookList'));
+    let chapterList = picker.find('ChapterList');
+    assert.isTrue(chapterList.exists());
+    assert.equal(chapterList.prop('isLoading'), true);
+    assert.calledWith(fakeAPI.fetchChapters, 'dummy-auth-token');
+
+    await waitForElement(picker, 'ChapterList[isLoading=false]');
+
+    chapterList = picker.find('ChapterList');
+    assert.equal(chapterList.prop('chapters'), bookData.chapterData[book.id]);
+  });
+
+  it('invokes `onSelectBook` callback after a book and chapter are chosen', async () => {
+    const onSelectBook = sinon.stub();
+    const picker = renderBookPicker({ onSelectBook });
+    await waitForElement(picker, 'BookList[isLoading=false]');
+
+    const book = selectBook(picker);
+    clickSelectButton(picker);
+
+    await waitForElement(picker, 'ChapterList[isLoading=false]');
+    const chapter = selectChapter(picker);
+    clickSelectButton(picker);
+
+    assert.calledWith(onSelectBook, book, chapter);
+  });
+
+  it('shows error that occurs while fetching books', async () => {
+    const error = new Error('Something went wrong');
+    fakeAPI.fetchBooks.rejects(error);
+
+    const picker = renderBookPicker();
+    const errorDisplay = await waitForElement(picker, 'ErrorDisplay');
+
+    assert.equal(errorDisplay.prop('message'), 'Unable to fetch books');
+    assert.equal(errorDisplay.prop('error'), error);
+    assert.isFalse(picker.exists('BookList'));
+  });
+
+  it('shows error that occurs while fetching chapters', async () => {
+    const error = new Error('Something went wrong');
+    fakeAPI.fetchChapters.rejects(error);
+
+    const picker = renderBookPicker();
+    await waitForElement(picker, 'BookList[isLoading=false]');
+
+    selectBook(picker);
+    clickSelectButton(picker);
+
+    const errorDisplay = await waitForElement(picker, 'ErrorDisplay');
+
+    assert.equal(errorDisplay.prop('message'), 'Unable to fetch chapters');
+    assert.equal(errorDisplay.prop('error'), error);
+    assert.isFalse(picker.exists('ChapterList'));
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
@@ -1,0 +1,61 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import ChapterList from '../ChapterList';
+
+describe('ChapterList', () => {
+  const chapterData = [
+    {
+      title: 'Chapter One',
+      page: '10',
+    },
+    {
+      title: 'Chapter Two',
+      page: '20',
+    },
+  ];
+  const noop = () => {};
+  const renderChapterList = (props = {}) =>
+    mount(
+      <ChapterList
+        chapters={chapterData}
+        selectedChapter={null}
+        onSelectChapter={noop}
+        onUseChapter={noop}
+        {...props}
+      />
+    );
+
+  it('renders chapter titles', () => {
+    const chapterList = renderChapterList();
+    const rows = chapterList.find('tbody > tr');
+    assert.equal(rows.length, chapterData.length);
+    assert.equal(rows.at(0).find('td').at(0).text(), chapterData[0].title);
+    assert.equal(rows.at(0).find('td').at(1).text(), chapterData[0].page);
+  });
+
+  [true, false].forEach(isLoading => {
+    it('shows loading indicator if chapters are being fetched', () => {
+      const chapterList = renderChapterList({ isLoading });
+      assert.equal(chapterList.find('Table').prop('isLoading'), isLoading);
+    });
+  });
+
+  it('calls `onSelectChapter` callback when a chapter is selected', () => {
+    const onSelectChapter = sinon.stub();
+    const chapterList = renderChapterList({ onSelectChapter });
+
+    chapterList.find('Table').prop('onSelectItem')(chapterData[0]);
+
+    assert.calledWith(onSelectChapter, chapterData[0]);
+  });
+
+  it('calls `onUseChapter` callback when a chapter is double-clicked', () => {
+    const onUseChapter = sinon.stub();
+    const chapterList = renderChapterList({ onUseChapter });
+
+    chapterList.find('Table').prop('onUseItem')(chapterData[0]);
+
+    assert.calledWith(onUseChapter, chapterData[0]);
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
@@ -35,7 +35,7 @@ describe('ChapterList', () => {
   });
 
   [true, false].forEach(isLoading => {
-    it('shows loading indicator if chapters are being fetched', () => {
+    it('shows loading indicator in table if chapters are being fetched', () => {
       const chapterList = renderChapterList({ isLoading });
       assert.equal(chapterList.find('Table').prop('isLoading'), isLoading);
     });

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -370,7 +370,7 @@ describe('ContentSelector', () => {
     assert.isTrue(wrapper.exists('BookPicker'));
   });
 
-  it('submits selecting a book from VitalSource', () => {
+  it('submits VitalSource book ID and chapter CFI', () => {
     const onSelectContent = sinon.stub();
     const wrapper = renderContentSelector({
       defaultActiveDialog: 'vitalSourceBook',

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -353,7 +353,7 @@ describe('ContentSelector', () => {
     );
   });
 
-  it('submits hard-coded book and chapter when VitalSource button is selected', () => {
+  it('shows VitalSource book picker when VitalSource button is clicked', () => {
     fakeConfig.filePicker.vitalSource.enabled = true;
     const onSelectContent = sinon.stub();
     const wrapper = renderContentSelector({ onSelectContent });
@@ -365,10 +365,27 @@ describe('ContentSelector', () => {
       button.props().onClick();
     });
 
+    const bookPicker = wrapper.find('BookPicker');
+    assert.equal(bookPicker.prop('authToken'), fakeConfig.api.authToken);
+    assert.isTrue(wrapper.exists('BookPicker'));
+  });
+
+  it('submits selecting a book from VitalSource', () => {
+    const onSelectContent = sinon.stub();
+    const wrapper = renderContentSelector({
+      defaultActiveDialog: 'vitalSourceBook',
+      onSelectContent,
+    });
+
+    const picker = wrapper.find('BookPicker');
+    interact(wrapper, () => {
+      picker.props().onSelectBook({ id: 'test-book' }, { cfi: '/1/2' });
+    });
+
     assert.calledWith(onSelectContent, {
       type: 'vitalsource',
-      bookID: 'BOOKSHELF-TUTORIAL',
-      cfi: '/6/8[;vnd.vst.idref=vst-70a6f9d3-0932-45ba-a583-6060eab3e536]',
+      bookID: 'test-book',
+      cfi: '/1/2',
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/Table-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Table-test.js
@@ -116,6 +116,16 @@ describe('Table', () => {
     assert.notCalled(onSelectItem);
   });
 
+  it('hides spinner if data is fetched', () => {
+    const wrapper = renderTable({ isLoading: false });
+    assert.isFalse(wrapper.exists('Spinner'));
+  });
+
+  it('shows spinner if data is loading', () => {
+    const wrapper = renderTable({ isLoading: true });
+    assert.isTrue(wrapper.exists('Spinner'));
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -102,6 +102,9 @@ function delay(ms) {
 /**
  * Fetch a list of available ebooks to use in assignments.
  *
+ * This is currently a fake that waits for a fixed time before returning
+ * hard-coded data.
+ *
  * @param {string} authToken
  * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
  * @return {Promise<Book[]>}
@@ -114,6 +117,9 @@ export async function fetchBooks(authToken, fetchDelay = 500) {
 /**
  * Fetch a list of chapters that can be used as the target location for an
  * ebook assignment.
+ *
+ * This is currently a fake that waits for a fixed time before returning
+ * hard-coded data.
  *
  * @param {string} authToken
  * @param {string} bookId

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -1,6 +1,10 @@
 /**
+ * @typedef {import('../api-types').Book} Book
+ * @typedef {import('../api-types').Chapter} Chapter
  * @typedef {import('../api-types').File} File
  */
+
+import { bookList, chapterData } from './vitalsource-sample-data';
 
 /**
  * Error returned when an API call fails with a 4xx or 5xx response and
@@ -63,7 +67,7 @@ export class ApiError extends Error {
  *   @param {string} options.authToken
  *   @param {Object} [options.data] - JSON-serializable body of the request
  */
-async function apiCall({ path, authToken, data }) {
+export async function apiCall({ path, authToken, data }) {
   let body;
 
   /** @type {Record<string,string>} */
@@ -90,6 +94,36 @@ async function apiCall({ path, authToken, data }) {
   return resultJson;
 }
 
-// Separate export from declaration to work around
-// https://github.com/robertknight/babel-plugin-mockable-imports/issues/9
-export { apiCall };
+/** @param {number} ms */
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch a list of available ebooks to use in assignments.
+ *
+ * @param {string} authToken
+ * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
+ * @return {Promise<Book[]>}
+ */
+export async function fetchBooks(authToken, fetchDelay = 500) {
+  await delay(fetchDelay);
+  return bookList;
+}
+
+/**
+ * Fetch a list of chapters that can be used as the target location for an
+ * ebook assignment.
+ *
+ * @param {string} authToken
+ * @param {string} bookId
+ * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
+ * @return {Promise<Chapter[]>}
+ */
+export async function fetchChapters(authToken, bookId, fetchDelay = 500) {
+  await delay(fetchDelay);
+  if (!chapterData[bookId]) {
+    throw new ApiError(404, { message: 'Book not found' });
+  }
+  return chapterData[bookId];
+}

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -1,4 +1,4 @@
-import { ApiError, apiCall } from '../api';
+import { ApiError, apiCall, fetchBooks, fetchChapters } from '../api';
 
 describe('api', () => {
   let fakeResponse;
@@ -124,5 +124,36 @@ describe('api', () => {
 
     assert.instanceOf(reason, TypeError);
     assert.equal(reason.message, 'Parse failed');
+  });
+
+  describe('fetchBooks', () => {
+    it('returns book data', async () => {
+      const data = await fetchBooks('auth-token', 1 /* delay */);
+      assert.isTrue(Array.isArray(data));
+      assert.equal(data.length, 2);
+    });
+  });
+
+  describe('fetchChapters', () => {
+    it('returns chapter list', async () => {
+      const data = await fetchChapters(
+        'auth-token',
+        'BOOKSHELF-TUTORIAL',
+        1 /* delay */
+      );
+      assert.isTrue(Array.isArray(data));
+      assert.equal(data.length, 45);
+    });
+
+    it('throws if book ID is unknown', async () => {
+      let err;
+      try {
+        await fetchChapters('auth-token', 'unknown-book-id', 1 /* delay */);
+      } catch (e) {
+        err = e;
+      }
+      assert.instanceOf(err, ApiError);
+      assert.equal(err.message, 'Book not found');
+    });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/vitalsource-sample-data.js
+++ b/lms/static/scripts/frontend_apps/utils/vitalsource-sample-data.js
@@ -1,0 +1,345 @@
+/**
+ * @typedef {import('../api-types').Chapter} Chapter
+ */
+
+// Dummy book and chapter data for testing the book selection UI. This is
+// extracted from the VitalSource Products API.
+//
+// See https://developer.vitalsource.com/hc/en-us/articles/360010967153-GET-v4-products-vbid-Title-TOC-Metadata.
+//
+// The book metadata comes from the `https://api/vitalsource.com/v4/products/{BOOK_ID}`
+// response.
+//
+// The chapter metadata comes from the `https://api/vitalsource.com/v4/products/{BOOK_ID}/toc`
+// response.
+
+export const bookList = [
+  {
+    // Chosen from `https://api.vitalsource.com/v4/products` response.
+    id: 'BOOKSHELF-TUTORIAL',
+    title: 'Bookshelf Tutorial',
+    cover_image:
+      'https://covers.vitalbook.com/vbid/BOOKSHELF-TUTORIAL/width/480',
+  },
+  {
+    // See https://github.com/hypothesis/product-backlog/issues/1200
+    id: '9781400847402',
+    title: '"T. rex" and the Crater of Doom',
+    cover_image: 'https://covers.vitalbook.com/vbid/9781400847402/width/480',
+  },
+];
+
+/** @type {Record<string, Chapter[]>} */
+export const chapterData = {
+  'BOOKSHELF-TUTORIAL': [
+    {
+      title: 'Cover',
+      cfi: '/6/2[;vnd.vst.idref=vst-4b4cfacf-80a2-440c-acaf-70ed8fb158f1]',
+      page: '1',
+    },
+    {
+      title: 'Welcome!',
+      cfi: '/6/4[;vnd.vst.idref=vst-ae169b91-f520-449d-b99c-655767e4d0a1]',
+      page: '2',
+    },
+    {
+      title: 'Welcome!',
+      cfi: '/6/4[;vnd.vst.idref=vst-ae169b91-f520-449d-b99c-655767e4d0a1]',
+      page: '2',
+    },
+    {
+      title: 'Getting Started',
+      cfi: '/6/6[;vnd.vst.idref=vst-1bc048d4-7e99-404a-bce8-5dda6038a042]',
+      page: '3',
+    },
+    {
+      title: 'Part 1: How Do I Access My Digital Content?',
+      cfi: '/6/8[;vnd.vst.idref=vst-70a6f9d3-0932-45ba-a583-6060eab3e536]',
+      page: '4',
+    },
+    {
+      title: 'Part 1: How Do I Access My Digital Content?',
+      cfi: '/6/8[;vnd.vst.idref=vst-70a6f9d3-0932-45ba-a583-6060eab3e536]',
+      page: '4',
+    },
+    {
+      title: 'Find an eBook in Your Learning Management System',
+      cfi: '/6/10[;vnd.vst.idref=vst-353dae26-fc2c-4666-9f42-8780bbd7b96c]',
+      page: '5',
+    },
+    {
+      title: 'Redeem a Code for an eBook in Bookshelf',
+      cfi: '/6/12[;vnd.vst.idref=vst-45af6392-b176-46e3-9f0c-0a083fc6103e]',
+      page: '6',
+    },
+    {
+      title: 'Video Demonstration: Redeeming a Code in Bookshelf Online',
+      cfi: '/6/14[;vnd.vst.idref=vst-070d7be2-6463-4c3f-acf2-13dc00e25c3c]',
+      page: '7',
+    },
+    {
+      title: 'Access Content Through Bridge',
+      cfi: '/6/16[;vnd.vst.idref=vst-4cf3e83d-8eba-4ebc-a35f-c999dc093d4c]',
+      page: '8',
+    },
+    {
+      title: 'Part 2: Create and Manage Your Bookshelf Account',
+      cfi: '/6/18[;vnd.vst.idref=vst-510c9334-1807-4b2c-bb32-c45da93065ba]',
+      page: '9',
+    },
+    {
+      title: 'Part 2: Create and Manage Your Bookshelf Account',
+      cfi: '/6/18[;vnd.vst.idref=vst-510c9334-1807-4b2c-bb32-c45da93065ba]',
+      page: '9',
+    },
+    {
+      title: 'Video Demonstration: Create Your Bookshelf Account',
+      cfi: '/6/20[;vnd.vst.idref=vst-2e5f44ef-7fae-42fd-b326-a3e9989da503]',
+      page: '10',
+    },
+    {
+      title: 'Manage Your Bookshelf Account',
+      cfi: '/6/22[;vnd.vst.idref=vst-75af51a6-e0c3-480a-8c09-54bf7680703d]',
+      page: '11',
+    },
+    {
+      title: 'Learning Check: Create and Manage Your Bookshelf Account',
+      cfi: '/6/24[;vnd.vst.idref=vst-bb1fc8ec-16f4-43f8-931b-b384aea75dbc]',
+      page: '12',
+    },
+    {
+      title: 'Part 3: Download the Bookshelf Desktop and Mobile Apps',
+      cfi: '/6/26[;vnd.vst.idref=vst-fbd8d78c-9094-4307-ad8c-4548ecb12672]',
+      page: '13',
+    },
+    {
+      title: 'Part 3: Download the Bookshelf Desktop and Mobile Apps',
+      cfi: '/6/26[;vnd.vst.idref=vst-fbd8d78c-9094-4307-ad8c-4548ecb12672]',
+      page: '13',
+    },
+    {
+      title:
+        'Video Demonstration: Downloading the Bookshelf Desktop Application',
+      cfi: '/6/28[;vnd.vst.idref=vst-50dc1ebe-4bff-40b0-b343-8ffeac0ee79a]',
+      page: '14',
+    },
+    {
+      title: 'Part 4: Enhance Learning Experience with Bookshelf',
+      cfi: '/6/30[;vnd.vst.idref=vst-4d80c0ec-c94b-4ade-956c-c7beba2cbf41]',
+      page: '15',
+    },
+    {
+      title: 'Part 4: Enhance Learning with Bookshelf',
+      cfi: '/6/30[;vnd.vst.idref=vst-4d80c0ec-c94b-4ade-956c-c7beba2cbf41]',
+      page: '15',
+    },
+    {
+      title: 'Navigate an eBook in Bookshelf Online',
+      cfi: '/6/32[;vnd.vst.idref=vst-9982048e-f662-4957-9b3f-e3f3c5b4dcbd]',
+      page: '16',
+    },
+    {
+      title: 'Video Demonstration: Tools for Navigating an eBook',
+      cfi: '/6/34[;vnd.vst.idref=vst-34b9bf9d-b2b6-4577-b870-fb3900db224d]',
+      page: '17',
+    },
+    {
+      title: 'Learning Check: Navigating an eBook',
+      cfi: '/6/36[;vnd.vst.idref=vst-e246fd61-edbb-4d5a-a432-bef2f8e17d40]',
+      page: '18',
+    },
+    {
+      title: 'Search for Key Words',
+      cfi: '/6/38[;vnd.vst.idref=vst-9e8556a2-dae1-41bf-99ed-0b9cfe69180b]',
+      page: '19',
+    },
+    {
+      title: 'Search for an Exact Phrase',
+      cfi: '/6/40[;vnd.vst.idref=vst-e9babc51-7aad-4a10-9e08-3f8f95b5d34a]',
+      page: '20',
+    },
+    {
+      title: 'Search Across Your Library',
+      cfi: '/6/42[;vnd.vst.idref=vst-996a8bd0-0743-4876-9c0b-243b098f34da]',
+      page: '21',
+    },
+    {
+      title: 'Learning Check: Searching for Content',
+      cfi: '/6/44[;vnd.vst.idref=vst-8cfc6d45-cdd8-4145-a70d-eee280a5fedf]',
+      page: '22',
+    },
+    {
+      title: 'Highlight Text and Add Notes',
+      cfi: '/6/46[;vnd.vst.idref=vst-830e2f21-8f48-48c9-be3e-ae7d27bfa68c]',
+      page: '23',
+    },
+    {
+      title: 'Video Demonstration: Making Highlights and Notes',
+      cfi: '/6/48[;vnd.vst.idref=vst-f1fc6ed5-ca4c-4d01-a08d-518513964317]',
+      page: '24',
+    },
+    {
+      title: 'Manage Highlighters',
+      cfi: '/6/50[;vnd.vst.idref=vst-48506c57-a291-414c-aa8e-7ed7cd8ed89d]',
+      page: '25',
+    },
+    {
+      title: 'Video Demonstration: Managing Highlighters',
+      cfi: '/6/52[;vnd.vst.idref=vst-a6c7b7bf-7e6b-4aab-829f-ab61fbd7d367]',
+      page: '26',
+    },
+    {
+      title: 'Learning Check: Creating Highlights and Managing Highlighters',
+      cfi: '/6/54[;vnd.vst.idref=vst-47f9ee6e-042a-46fc-8eee-daeb5f9b4fd8]',
+      page: '27',
+    },
+    {
+      title: 'Subscribe to Other Bookshelf Users',
+      cfi: '/6/56[;vnd.vst.idref=vst-571fdb7c-2547-4bed-8bc6-59821e36092b]',
+      page: '28',
+    },
+    {
+      title: 'Share Highlights and Notes',
+      cfi: '/6/58[;vnd.vst.idref=vst-eaf11d17-7b35-4189-82d9-299a35aeab78]',
+      page: '29',
+    },
+    {
+      title: 'Video Demonstration: Sharing and Subscribing',
+      cfi: '/6/60[;vnd.vst.idref=vst-e46a628b-ab7c-42f9-8e7a-5aafd1503001]',
+      page: '30',
+    },
+    {
+      title: 'Manage Your Notebook',
+      cfi: '/6/62[;vnd.vst.idref=vst-6d6266f0-4b68-4b7d-a0e0-1322c62e6389]',
+      page: '31',
+    },
+    {
+      title: 'Study with Review Mode',
+      cfi: '/6/64[;vnd.vst.idref=vst-af780b01-1961-42a7-8aa5-8c0da20aaa04]',
+      page: '32',
+    },
+    {
+      title: 'Video Demonstration: Notebook and Review Mode',
+      cfi: '/6/66[;vnd.vst.idref=vst-aca7b9db-ba85-4393-87a2-fb7ad6b4c3c4]',
+      page: '33',
+    },
+    {
+      title: 'Learning Check: Notebook and Review Mode',
+      cfi: '/6/68[;vnd.vst.idref=vst-76d16952-eb1b-400e-92b6-7d18b656afa1]',
+      page: '34',
+    },
+    {
+      title: 'Study with Flash Cards',
+      cfi: '/6/70[;vnd.vst.idref=vst-2b3481e1-596a-49ac-a50b-76ea73658c18]',
+      page: '35',
+    },
+    {
+      title: 'Video Demonstration: Creating Flashcards',
+      cfi: '/6/72[;vnd.vst.idref=vst-b19a9bba-1155-4944-82ef-73d1e71891ea]',
+      page: '36',
+    },
+    {
+      title: 'Learn with Text-to-Speech',
+      cfi: '/6/74[;vnd.vst.idref=vst-65cd738c-65d4-486e-9eee-726de86c85db]',
+      page: '37',
+    },
+    {
+      title: 'Part 5: Recap and Action Items',
+      cfi: '/6/76[;vnd.vst.idref=vst-2ee70751-8a10-432a-8918-1c49810add84]',
+      page: '38',
+    },
+    {
+      title: 'Steps to Make Bookshelf a Part of Your Routine',
+      cfi: '/6/76[;vnd.vst.idref=vst-2ee70751-8a10-432a-8918-1c49810add84]',
+      page: '38',
+    },
+    {
+      title: 'VitalSource Support Channels',
+      cfi: '/6/78[;vnd.vst.idref=vst-b924e0ab-57dd-4aaa-b9d6-3012add8f2d8]',
+      page: '39',
+    },
+  ],
+
+  9781400847402: [
+    {
+      title: 'Cover Page',
+      cfi: '/6/2[;vnd.vst.idref=cover]',
+      page: 'i',
+    },
+    {
+      title: 'Title Page',
+      cfi: '/6/6[;vnd.vst.idref=title]',
+      page: 'iii',
+    },
+    {
+      title: 'Copyright Page',
+      cfi: '/6/8[;vnd.vst.idref=copy]',
+      page: 'iv',
+    },
+    {
+      title: 'Dedication Page',
+      cfi: '/6/10[;vnd.vst.idref=ded]',
+      page: 'v',
+    },
+    {
+      title: 'Contents',
+      cfi: '/6/12[;vnd.vst.idref=toc]',
+      page: 'vii',
+    },
+    {
+      title: 'Forward',
+      cfi: '/6/14[;vnd.vst.idref=forward]',
+      page: 'ix',
+    },
+    {
+      title: 'Preface',
+      cfi: '/6/16[;vnd.vst.idref=preface]',
+      page: 'xix',
+    },
+    {
+      title: 'Chapter 1: Armageddon',
+      cfi: '/6/20[;vnd.vst.idref=ch1]',
+      page: '3',
+    },
+    {
+      title: 'Chapter 2: Ex Libro Lapidum Historia Mundi',
+      cfi: '/6/22[;vnd.vst.idref=ch2]',
+      page: '19',
+    },
+    {
+      title: 'Chapter 3: Gradualist versus Catastrophist',
+      cfi: '/6/24[;vnd.vst.idref=ch3]',
+      page: '43',
+    },
+    {
+      title: 'Chapter 4: Iridium',
+      cfi: '/6/26[;vnd.vst.idref=ch4]',
+      page: '59',
+    },
+    {
+      title: 'Chapter 5: The Search for the Impact Site',
+      cfi: '/6/28[;vnd.vst.idref=ch5]',
+      page: '82',
+    },
+    {
+      title: 'Chapter 6: The Crater of Doom',
+      cfi: '/6/30[;vnd.vst.idref=ch6]',
+      page: '106',
+    },
+    {
+      title: 'Chapter 7: The World after Chicxulub',
+      cfi: '/6/32[;vnd.vst.idref=ch7]',
+      page: '130',
+    },
+    {
+      title: 'Notes',
+      cfi: '/6/34[;vnd.vst.idref=ch8]',
+      page: '147',
+    },
+    {
+      title: 'Index',
+      cfi: '/6/36[;vnd.vst.idref=ch9]',
+      page: '171',
+    },
+  ],
+};

--- a/lms/static/styles/components/_BookList.scss
+++ b/lms/static/styles/components/_BookList.scss
@@ -1,0 +1,22 @@
+.BookList {
+  display: flex;
+  flex-direction: row;
+}
+
+.BookList__cover {
+  width: 160px;
+  height: auto;
+}
+
+.BookList__cover-container {
+  margin-left: 5px;
+
+  // Align top of cover image with top edge of table.
+  margin-top: 10px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  background-color: #eee;
+}

--- a/lms/static/styles/components/_BookList.scss
+++ b/lms/static/styles/components/_BookList.scss
@@ -1,11 +1,14 @@
+// Height of cover images, chosen to work when the file picker app is shown
+// inside the shortest expected window (~340px in Canvas).
+$-cover-image-height: 180px;
+
 .BookList {
   display: flex;
   flex-direction: row;
 }
 
 .BookList__cover {
-  width: 160px;
-  height: auto;
+  height: $-cover-image-height;
 }
 
 .BookList__cover-container {
@@ -14,9 +17,15 @@
   // Align top of cover image with top edge of table.
   margin-top: 10px;
 
+  // Set a min width that is large enough to keep the cover container's width
+  // constant as the user navigates between books, as long as the cover image's
+  // aspect ratio is not greater than 1:1.
+  min-width: $-cover-image-height;
+
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
 
   background-color: #eee;
 }

--- a/lms/static/styles/components/_Table.scss
+++ b/lms/static/styles/components/_Table.scss
@@ -21,6 +21,15 @@ $table-item-height: 40px;
   }
 }
 
+.Table__spinner {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
 .Table__table {
   @include focus.outline-on-keyboard-focus;
 

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -11,6 +11,7 @@
 
 // Preact components
 @use 'components/BasicLtiLaunchApp';
+@use 'components/BookList';
 @use 'components/ContentSelector';
 @use 'components/Dialog';
 @use 'components/ErrorDisplay';


### PR DESCRIPTION
Modify the "Select book from VitalSource" option in the file picker app to show a book and chapter selection UI instead of submitting a hardcoded book. The data shown in the book and chapter selection UI is
currently hardcoded data, derived from the VitalSource Products API [1],
for the two books which we know are available.

 - Add a loading state (`isLoading`) to the `Table` component to indicate that data is currently being fetched. This is used by the `BookList` and `ChapterList` components added in this PR.
 - Add `BookPicker`, `BookList` and `ChapterList` components to support selecting a book from VitalSource and then a chapter within that book
 - Modify `ContentSelector` component to show the `BookPicker` when the "Select book from VitalSource" option is selected, instead of submitting a hardcoded book ID and chapter.
 - Add dummy book and chapter data from the VitalSource API in `vitalsource-sample-data.js`. This will in future be replaced by calls from the frontend to the backend which will in turn make a request to the VitalSource Products API.

[1] https://developer.vitalsource.com/hc/en-us/articles/360010967153-GET-v4-products-vbid-Title-TOC-Metadata

Part of https://github.com/hypothesis/product-backlog/issues/1200.

---

nb. In order to test these flows, you will need to go to http://localhost:8001/flags and turn on the "VitalSource" option locally.

When clicking the "Select book from VitalSource" button in the file picker, instead of selecting a hard-coded book, a list of "relevant" books is now fetched and shown. This list is currently hard-coded JSON data. In future this will be fetched from the backend. We may also introduce alternate flows where the user enters a search query or enters a book identifier or link:

<img width="728" alt="Book picker 1" src="https://user-images.githubusercontent.com/2458/121709799-d629bd00-cad0-11eb-9643-9ee63062c9f2.png">

When a book is selected, the cover image is shown:

<img width="740" alt="Book picker 2" src="https://user-images.githubusercontent.com/2458/121709811-d9bd4400-cad0-11eb-895c-db3971c448f8.png">

When a book has been selected, the chapter list for that book is displayed. The chapter list data is also hard-coded JSON. In future this will be fetched from the backend.

<img width="736" alt="Chapter picker" src="https://user-images.githubusercontent.com/2458/121709825-dd50cb00-cad0-11eb-8d69-0ebc96244693.png">

After the user has chosen a book and chapter to use, they are shown group set configuration. This screen is unchanged:

<img width="568" alt="Book chosen" src="https://user-images.githubusercontent.com/2458/121709841-e04bbb80-cad0-11eb-80ad-0b87cf35c5d1.png">

After the user clicks "Continue" in this screen, the `book_id` and `cfi` query params in the LTI launch URL will reflect the chosen book:

<img width="342" alt="book_id query param" src="https://user-images.githubusercontent.com/2458/121709856-e477d900-cad0-11eb-871c-d8d542ddbd41.png">
<img width="296" alt="cfi query param" src="https://user-images.githubusercontent.com/2458/121709871-e772c980-cad0-11eb-882a-13ae104bb42c.png">



**TODO:**

- [x] Add screenshots to the PR description
- [x] Finish adding tests for new components
- [x] Fix issue where cover image can overflow container in the `BookList` component
- [x] Make the loading state look nicer when the `BookList` and `ChapterList` data is being loaded