### PR TITLE
Fix some broken CanvasAPIClient tests

### DIFF
--- a/lms/services/canvas_api/_basic.py
+++ b/lms/services/canvas_api/_basic.py
@@ -29,15 +29,17 @@ class BasicClient:
     PAGINATION_MAXIMUM_REQUESTS = 25
     """The maximum number of calls to make before giving up."""
 
-    def __init__(self, canvas_host):
+    def __init__(self, canvas_host, session=None):
         """
         Create a new BasicClient for making calls to the Canvas API.
 
         :param canvas_host: Hostname of the Canvas instance
+        :param session: The requests Session to use
+        :type session: requests.Session
         """
 
         # This is a requests Session object, not a DB session etc.
-        self._session = Session()
+        self._session = session or Session()
         self._canvas_host = canvas_host
 
     def send(

--- a/tests/unit/lms/services/canvas_api/_authenticated_test.py
+++ b/tests/unit/lms/services/canvas_api/_authenticated_test.py
@@ -6,6 +6,7 @@ from h_matchers import Any
 from lms.services import CanvasAPIServerError, NoOAuth2Token, ProxyAPIAccessTokenError
 from lms.services.canvas_api._authenticated import TokenResponseSchema
 from lms.services.canvas_api._basic import BasicClient
+from tests import factories
 
 
 class TestAuthenticatedClient:
@@ -154,7 +155,9 @@ class TestAuthenticatedClientIntegrated:
     """Tests which include the real basic client and Schema."""
 
     def test_ok(self, token_method, http_session, token_response):
-        http_session.set_response(token_response)
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data=token_response
+        )
         token = token_method("code")
         assert token == token_response["access_token"]
 
@@ -162,7 +165,9 @@ class TestAuthenticatedClientIntegrated:
     def test_bad_expires_in(
         self, token_method, http_session, token_response, bad_value
     ):
-        http_session.set_response(dict(token_response, expires_in=bad_value))
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data=dict(token_response, expires_in=bad_value)
+        )
 
         with pytest.raises(CanvasAPIServerError):
             token_method("code")

--- a/tests/unit/lms/services/canvas_api/_basic_test.py
+++ b/tests/unit/lms/services/canvas_api/_basic_test.py
@@ -76,7 +76,7 @@ class TestBasicClient:
     def test_send_raises_CanvasAPIError_for_request_errors(
         self, basic_client, http_session, Schema
     ):
-        http_session.set_response(status_code=501)
+        http_session.send.return_value = factories.requests.Response(status_code=501)
 
         with pytest.raises(CanvasAPIError):
             basic_client.send("METHOD", "path/", schema=Schema)
@@ -126,7 +126,7 @@ class TestBasicClient:
 
     @pytest.fixture(autouse=True)
     def has_ok_response(self, http_session):
-        http_session.set_response()
+        http_session.send.return_value = factories.requests.Response(status_code=200)
 
     @pytest.fixture
     def Schema(self):

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -34,7 +34,9 @@ class TestCanvasAPIClientGetToken:
 class TestCanvasAPIClient:
     def test_authenticated_users_sections(self, canvas_api_client, http_session):
         sections = [{"id": 1, "name": "name_1"}, {"id": 2, "name": "name_2"}]
-        http_session.set_response({"sections": sections})
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data={"sections": sections}
+        )
 
         response = canvas_api_client.authenticated_users_sections("COURSE_ID")
 
@@ -52,10 +54,12 @@ class TestCanvasAPIClient:
     def test_authenticated_users_sections_deduplicates_sections(
         self, canvas_api_client, http_session
     ):
-        http_session.set_response(
-            {"sections": [{"id": 1, "name": "name"}, {"id": 1, "name": "name"}]}
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200,
+            json_data={
+                "sections": [{"id": 1, "name": "name"}, {"id": 1, "name": "name"}]
+            },
         )
-
         sections = canvas_api_client.authenticated_users_sections("course_id")
 
         assert sections == [{"id": 1, "name": "name"}]
@@ -63,8 +67,11 @@ class TestCanvasAPIClient:
     def test_authenticated_users_sections_raises_CanvasAPIError_with_conflicting_duplicates(
         self, canvas_api_client, http_session
     ):
-        http_session.set_response(
-            {"sections": [{"id": 1, "name": "name"}, {"id": 1, "name": "DIFFERENT"}]}
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200,
+            json_data={
+                "sections": [{"id": 1, "name": "name"}, {"id": 1, "name": "DIFFERENT"}]
+            },
         )
 
         with pytest.raises(CanvasAPIError):
@@ -79,7 +86,9 @@ class TestCanvasAPIClient:
             dict(section, unexpected="ignored") for section in sections
         ]
 
-        http_session.set_response(sections_with_noise)
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data=sections_with_noise
+        )
 
         response = canvas_api_client.course_sections("COURSE_ID")
 
@@ -94,8 +103,9 @@ class TestCanvasAPIClient:
     def test_course_sections_deduplicates_sections(
         self, canvas_api_client, http_session
     ):
-        http_session.set_response(
-            [{"id": 1, "name": "name"}, {"id": 1, "name": "name"}]
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200,
+            json_data=[{"id": 1, "name": "name"}, {"id": 1, "name": "name"}],
         )
 
         sections = canvas_api_client.course_sections("course_id")
@@ -105,8 +115,9 @@ class TestCanvasAPIClient:
     def test_course_sections_raises_CanvasAPIError_with_conflicting_duplicates(
         self, canvas_api_client, http_session
     ):
-        http_session.set_response(
-            [{"id": 1, "name": "name"}, {"id": 1, "name": "DIFFERENT"}]
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200,
+            json_data=[{"id": 1, "name": "name"}, {"id": 1, "name": "DIFFERENT"}],
         )
 
         with pytest.raises(CanvasAPIError):
@@ -115,7 +126,9 @@ class TestCanvasAPIClient:
     def test_course_sections_raises_CanvasAPIError_with_too_few_returned(
         self, canvas_api_client, http_session
     ):
-        http_session.set_response([])
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data=[]
+        )
 
         with pytest.raises(CanvasAPIError):
             canvas_api_client.course_sections("dummy")
@@ -125,7 +138,9 @@ class TestCanvasAPIClient:
             {"id": 1, "name": "Group category 1"},
             {"id": 2, "name": "Group category 2"},
         ]
-        http_session.set_response(group_categories)
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data=group_categories
+        )
 
         response = canvas_api_client.course_group_categories("COURSE_ID")
 
@@ -142,13 +157,14 @@ class TestCanvasAPIClient:
         )
 
     def test_users_sections(self, canvas_api_client, http_session):
-        http_session.set_response(
-            {
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200,
+            json_data={
                 "enrollments": [
                     {"course_section_id": 101, "unexpected": "ignored"},
                     {"course_section_id": 102, "unexpected": "ignored"},
                 ]
-            }
+            },
         )
 
         response = canvas_api_client.users_sections("USER_ID", "COURSE_ID")
@@ -167,8 +183,11 @@ class TestCanvasAPIClient:
     def test_users_sections_deduplicates_sections(
         self, canvas_api_client, http_session
     ):
-        http_session.set_response(
-            {"enrollments": [{"course_section_id": 1}, {"course_section_id": 1}]}
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200,
+            json_data={
+                "enrollments": [{"course_section_id": 1}, {"course_section_id": 1}]
+            },
         )
 
         sections = canvas_api_client.users_sections("user_id", "course_id")
@@ -181,7 +200,9 @@ class TestCanvasAPIClient:
             {"display_name": "display_name_1", "id": 1, "updated_at": "updated_at_1"},
         ]
         files_with_noise = [dict(file, unexpected="ignored") for file in files]
-        http_session.set_response(files_with_noise)
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data=files_with_noise
+        )
 
         response = canvas_api_client.list_files("COURSE_ID")
 
@@ -223,7 +244,9 @@ class TestCanvasAPIClient:
             )
 
     def test_public_url(self, canvas_api_client, http_session):
-        http_session.set_response({"public_url": "public_url_value"})
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data={"public_url": "public_url_value"}
+        )
 
         response = canvas_api_client.public_url("FILE_ID")
 
@@ -268,7 +291,9 @@ class TestMetaBehavior:
     def test_methods_raise_CanvasAPIServerError_if_the_response_json_has_the_wrong_format(
         self, data_method, http_session
     ):
-        http_session.set_response({})
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data={}
+        )
 
         with pytest.raises(CanvasAPIServerError):
             data_method()
@@ -277,7 +302,9 @@ class TestMetaBehavior:
     def test_methods_raise_CanvasAPIServerError_if_the_response_is_invalid_json(
         self, data_method, http_session
     ):
-        http_session.set_response(raw="[broken json")
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, raw="[broken json"
+        )
 
         with pytest.raises(CanvasAPIServerError):
             data_method()

--- a/tests/unit/lms/services/canvas_api/conftest.py
+++ b/tests/unit/lms/services/canvas_api/conftest.py
@@ -1,30 +1,20 @@
-from unittest.mock import sentinel
+from unittest.mock import create_autospec, sentinel
 
 import pytest
+import requests
 
 from lms.services.canvas_api._authenticated import AuthenticatedClient
 from lms.services.canvas_api._basic import BasicClient
-from tests import factories
 
 
 @pytest.fixture
-def basic_client():
-    return BasicClient("canvas_host")
+def basic_client(http_session):
+    return BasicClient("canvas_host", session=http_session)
 
 
 @pytest.fixture
-def http_session(patch):
-    session = patch("lms.services.canvas_api._basic.Session")
-    session = session()
-
-    def set_response(json_data=None, raw=None, status_code=200):
-        session.send.return_value = factories.requests.Response(
-            json_data=json_data, raw=raw, status_code=status_code
-        )
-
-    session.set_response = set_response
-
-    return session
+def http_session():
+    return create_autospec(requests.Session, spec_set=True, instance=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
Problem
-------

A bunch of tests in `tests/unit/lms/services/canvas_api/` aren't
actually testing what they think they're testing. If you break the
`tests/unit/lms/services/canvas_api_client/conftest.py::http_session()`
fixture:

```diff
diff --git a/tests/unit/lms/services/canvas_api/conftest.py b/tests/unit/lms/services/canvas_api/conftest.py
index 984f8113..9cf46dc6 100644
--- a/tests/unit/lms/services/canvas_api/conftest.py
+++ b/tests/unit/lms/services/canvas_api/conftest.py
@@ -18,9 +18,7 @@ def http_session(patch):
     session = session()

     def set_response(json_data=None, raw=None, status_code=200):
-        session.send.return_value = factories.requests.Response(
-            json_data=json_data, raw=raw, status_code=status_code
-        )
+        session.send.side_effect = RuntimeError()

     session.set_response = set_response
```

Then these tests still pass even though they use the `http_session`
fixture which we've now hacked to cause all HTTP requests to crash:

    # This still passes.
    $ tox -q tests/unit/lms/services/canvas_api/client_test.py::TestMetaBehavior

What's going wrong, in detail
-----------------------------

The Canvas API client tests deviate from our usual test style in ways
that're creating problems:

1. The amount of code being executed under a single unit test is too
   large. Tests for `CanvasAPIClient` use the real `AuthenticatedClient`
   and `BasicClient`. This makes whats-actually-happening when a given
   unit test much more difficult to trace, and much more likely to
   contain subtle problems, because there's just so much more going on.

   Our usual approach is to unit test one module at a time. The unit
   tests for `foo.py` will mock out any other modules from our own code
   that `foo.py` imports. This means that you can open `foo.py` and
   `foo_test.py` side-by-side in an editor and you have all the code
   that those tests are executing in view (more or less: modulo shared
   fixtures and the like).

   The Canvas API client tests execute the entire `canvas_api_client/`
   directory at once.

2. As a sort of side-effect of (1) when they do need to mock something
   the Canvas API client tests take a different-from-usual approach to
   patching.

   Our normal approach is **patch names within the module being
   tested**. So `foo_test.py` will patch names within `foo.py`. For
   example if `foo.py` did `from lms import bar` then `foo_test.py`
   would patch `"lms.foo.bar"`. `foo_test.py` would _not_ patch
   `"lms.bar.gar"`. This is called "patching at source" and there's a
   very good reason why we don't do it. See this old GitHub comment for
   a detailed explanation:
   https://github.com/hypothesis/via/pull/222#discussion_r469865055
   The Canvas API client tests have essentially the same problem.

**We really want to avoid patching at source**. Patching at source very
easily leads to tests that aren't really testing what they think they're
testing. For example the test will try to set up some method to return a
broken response, but fail to actually set this up correctly. The test
will then assert that the method-under-test handles the broken response
without failing. The method-under-test will succeed, because the broken
response was never actually set up. The test will pass. In fact the
method-under-test could be broken and failing under the intended test
conditions, but the test could be passing anyway since the conditions
aren't actually set up. That is what was happening with the Canvas API
client tests (see below for detailed explanation) and with other
instances of source-patching that we've had.

**These issues are hard to detect and fix**. Source-patching makes it
easy for these kinds of test bugs to creep in, and once in they're
difficult to detect and to fix. Get a whole bunch of these in your test
suite and you have an infestation that can only be fixed by a large
investment of time by a developer who really understands pytest and
mock.

Let's look at one particular unit test in detail to explain what's
happening. We'll look at
`tests/unit/lms/services/canvas_api/client_test.py::TestMetaBehavior::test_methods_raise_CanvasAPIServerError_if_the_response_json_has_the_wrong_format`.
What happens:

1. The test depends on the `data_method` fixture, so pytest executes
   this fixture first:

https://github.com/hypothesis/lms/blob/136d816e74340008b0173a7f2d56663ac54c63e2/tests/unit/lms/services/canvas_api/client_test.py#L267-L270
   The `data_method` fixture is defined further down in the same test
   class:

   https://github.com/hypothesis/lms/blob/c51e43d41f2ac0201ff2515de266f16da8d5d0f7/tests/unit/lms/services/canvas_api/client_test.py#L294-L298

2. The `data_method` fixture depends on the `canvas_api_client` fixture:

 
 
 https://github.com/hypothesis/lms/blob/136d816e74340008b0173a7f2d56663ac54c63e2/tests/unit/lms/services/canvas_api/client_test.py#L294-L295

   The `canvas_api_client` fixture is defined further down in the same
   test class:

   https://github.com/hypothesis/lms/blob/c51e43d41f2ac0201ff2515de266f16da8d5d0f7/tests/unit/lms/services/canvas_api/client_test.py#L301-L303

3. The `canvas_api_client` fixture depends on the `authenticated_client` fixture:

   https://github.com/hypothesis/lms/blob/136d816e74340008b0173a7f2d56663ac54c63e2/tests/unit/lms/services/canvas_api/client_test.py#L301-L302

   **Unlike our usual test style** the Canvas API client tests have
   their own `conftest.py` file containing shared fixtures. The
   `authenticated_client` fixture is defined in
   `tests/unit/lms/services/canvas_api/conftest.py`. Also **unlike our
   usual test style** the `authenticated_client` fixture returns a real
   `AuthenticatedClient` object rather than a mock, even though this is
   a unit test for `CanvasAPIClient` not `AuthenticatedClient`:

   https://github.com/hypothesis/lms/blob/c51e43d41f2ac0201ff2515de266f16da8d5d0f7/tests/unit/lms/services/canvas_api/conftest.py#L30-L38

4. The `authenticated_client` fixture depends on the `basic_client`
   fixture:

   https://github.com/hypothesis/lms/blob/136d816e74340008b0173a7f2d56663ac54c63e2/tests/unit/lms/services/canvas_api/conftest.py#L30-L31

   The `basic_client` fixture is also defined in `conftest.py`. Again,
   **unlike our usual test style** the `basic_client` fixture returns a
   real `BasicClient` object rather than a mock, even though this is a
   unit test for `CanvasAPIClient` not `BasicClient`:

   https://github.com/hypothesis/lms/blob/c51e43d41f2ac0201ff2515de266f16da8d5d0f7/tests/unit/lms/services/canvas_api/conftest.py#L10-L12

5. So at this point, during pytest's execution of the `data_method`
   fixtures (and the other fixtures that `data_method` depends on
   directly or indirectly), **the `BasicClient` instance has been
   constructed**. `BasicClient.__init__()` constructs a
   `requests.Session` object:

   https://github.com/hypothesis/lms/blob/c51e43d41f2ac0201ff2515de266f16da8d5d0f7/lms/services/canvas_api/_basic.py#L32-L41

   So at this point `lms.services.canvas_api._basic.Session` has already
   been called, and a real `requests.Session` object has already been
   constructed.

6. Going all the way back up to the actual unit test that's being
   executed (`test_methods_raise_CanvasAPIServerError_if_the_response_json_has_the_wrong_format`),
   the test also depends on the `http_session` fixture:

   https://github.com/hypothesis/lms/blob/136d816e74340008b0173a7f2d56663ac54c63e2/tests/unit/lms/services/canvas_api/client_test.py#L267-L270

   `http_session` is defined in `conftest.py`. **Unlike our usual test
   style** the unit tests for `CanvasAPIClient` now patch a name within
   a different module: the `http_session` fixture patches
   `"lms.services.canvas_api._basic.Session"` and sets up a mock HTTP
   response. This is the dreaded patch-at-source:

   https://github.com/hypothesis/lms/blob/c51e43d41f2ac0201ff2515de266f16da8d5d0f7/tests/unit/lms/services/canvas_api/conftest.py#L15-L27

7. And that's the problem: at this point in the execution of fixtures
   patching `"_basic.Session"` has no effect. As we've already seen in
   step 5 above, `BasicClient()` has already been instantiated and it
   has already called `Session()` and created a real `requests.Session`
   object.  Replacing `Session()` with a mock after `Session()` has
   already been called (and is not going to be called again) does
   nothing. The unit test (and several others like it) is effectively
   not using the `http_session` fixture. When these tests call
   `http_session.set_response({})` or
   `http_session.set_response(raw="[broken json")` these calls **have no
   effect**. The tests are not actually setting up the scenarios that
   they think they are setting up.

Solution
--------

Add the requests session as an optional argument to
`BasicClient.__init__()` and have the `basic_client` fixture depend on
the `http_session` fixture and pass the `http_session` fixture in to
`BasicClient`:

```python
class BasicClient:
    def __init__(self, canvas_host, session=None):
        self._session = session or Session()
        ...

    ...

...

@pytest.fixture
def basic_client(http_session):
    return BasicClient(..., session=http_session)
```

The call to `patch()` can now be removed from the `http_session`
fixture: it no longer needs to patch anything.

This means that whenever any test uses `basic_client` pytest will
execute `http_session` _first_ and the requests session that
`http_session` returns will be passed to `BasicClient`.

This has a couple of consequences:

1. It's no longer possible to get a `BasicClient` with a real requests
   session from the `basic_client` fixture. In practice all the tests
   still pass so it doesn't look like any tests need this.

2. The `http_session.set_response()` method is no longer possible.

   The `http_session` fixture used to add a `set_response()` method
   to the mock `requests.Session`:

   ```python
   @pytest.fixture
   def http_session():
       session = patch("lms.services.canvas_api._basic.Session")
       session = session()

       def set_response(json_data=None, raw=None, status_code=200):
           session.send.return_value = factories.requests.Response(
               json_data=json_data, raw=raw, status_code=status_code
           )

       session.set_response = set_response

       return session
    ```

    Using `create_autospec(..., spec_set=True)` means you can't _set_
    any attribute on the mock that doesn't exist on the real
    `requests.Session` class, so `session.set_response()` can no longer
    be added.

    We could just remove the `spec_set=True` but using it is a mock best
    practice for a reason: generally you want tests to fail if code
    either reads or writes an attribute that doesn't exist

    I decided to just get rid of `set_response()` and replace calls like
    `http_session.set_response(...)` with
    `http_session.send.return_value = factories.requests.Response(...)`.
    This is longer but it's also arguably more readable: I can see
    exactly what the test is doing, rather than having to look up a
    shared fixture in a `conftest.py` file to understand it. This is
    similar to other recent decisions we made about fixtures: in some
    cases it can actually be better for test readability to make the
    tests do more work.

    I decided not to but for completeness sake it would actually be
    possible to re-implement `set_response()` as a standalone fixture:

    ```python
    @pytest.fixture
    def set_response(http_session):

        def set_response(json_data=None, raw=None, status_code=200):
            http_session.send.return_value = factories.requests.Response(
               json_data=json_data, raw=raw, status_code=status_code
           )

        return set_response
    ```

Longer-term: if the Canvas API client tests used our usual approach to
unit testing and patching they wouldn't have this problem. The amount of
code-under-test per test method would also be much smaller making the
tests easier to understand, the tests for different modules would be
more decoupled making refactoring easier, and coverage reporting would
be more useful.