### PR TITLE
Refactor internal state of the Canvas file picker dialog

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -184,10 +184,9 @@ describe('LMSFilePicker', () => {
 
       // The details of the error should be displayed, along with a "Try again"
       // button.
-      const tryAgainButton = wrapper.find(
-        'AuthButton[data-testid="try-again"]'
-      );
+      const tryAgainButton = wrapper.find('AuthButton');
       assert.isTrue(tryAgainButton.exists());
+      assert.equal(tryAgainButton.prop('label'), 'Try again');
 
       const errorDetails = wrapper.find(ErrorDisplay);
       assert.include(errorDetails.props(), {
@@ -220,7 +219,6 @@ describe('LMSFilePicker', () => {
     assert.called(fakeApiCall);
 
     const reloadButton = wrapper.find('LabeledButton[data-testid="reload"]');
-    assert.isFalse(reloadButton.prop('disabled'));
 
     const waitMs = 3000;
     fakeApiCall
@@ -230,17 +228,20 @@ describe('LMSFilePicker', () => {
     reloadButton.prop('onClick')();
     wrapper.update();
 
-    assert.isTrue(
-      wrapper.find('LabeledButton[data-testid="reload"]').prop('disabled')
-    );
+    // While re-fetching files the "Reload" button will be replaced by the
+    // select button, but the label will change to "Reload" until a non-empty
+    // file list is returned to avoid a "Reload => Select => Reload" transition
+    // if the file list still comes back empty.
+    const selectButton = wrapper.find('LabeledButton[data-testid="select"]');
+    assert.equal(selectButton.text(), 'Reload');
+    assert.isTrue(selectButton.prop('disabled'));
 
     clock.tick(waitMs);
     await fakeApiCall;
     wrapper.update();
 
-    assert.isFalse(
-      wrapper.find('LabeledButton[data-testid="reload"]').prop('disabled')
-    );
+    // The file list is empty, so the reload button should be shown again.
+    assert.isTrue(wrapper.exists('LabeledButton[data-testid="reload"]'));
 
     clock.restore();
   });


### PR DESCRIPTION
While trying to make some changes to the way the "fetching" state is
rendered in order to be consistent with upcoming UI for the VitalSource
book picker I found it confusing to understand the possible states of
the dialog and the rendered output in each.

This commit refactors the internal states of the `LMSFilePicker` component to
try and simplify the situation.

 - The single `DialogState` type has been converted into a union that
   specifies the 4 main states: Prompting for authorization,
   fetching files, showing a file list, displaying an error.

 - A union has been introduced to describe the 3 possible actions that
   the dialog may offer as the main affirmative action for the dialog:
   Authorize, Reload, Select a file

 - Rendering of messages associated with the "authorizing" and "error"
   states has been inlined into the main UI rendering at the end of
   `LMSFilePicker`

 - Switching on union discriminator fields has been converted to use
   `switch` statements for clarity, per [1]

[1] https://hypothes-is.slack.com/archives/C1M8NH76X/p1621942239121100

----

**TODO:**

- Adjust the tests as necessary and re-check the output in all of the various states 