### PR TITLE
Redirect to the real Blackboard authorization page

### DIFF
--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -68,6 +68,8 @@ def configure(settings):
         "vitalsource_lti_launch_secret": sg.get("VITALSOURCE_LTI_LAUNCH_SECRET"),
         "admin_auth_google_client_id": sg.get("ADMIN_AUTH_GOOGLE_CLIENT_ID"),
         "admin_auth_google_client_secret": sg.get("ADMIN_AUTH_GOOGLE_CLIENT_SECRET"),
+        "blackboard_api_client_id": sg.get("BLACKBOARD_API_CLIENT_ID"),
+        "blackboard_api_client_secret": sg.get("BLACKBOARD_API_CLIENT_SECRET"),
     }
 
     env_settings["dev"] = asbool(env_settings["dev"])

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode, urlunparse
+
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
@@ -12,10 +14,30 @@ from lms.validation.authentication import OAuthCallbackSchema
     permission=Permissions.API,
 )
 def authorize(request):
+    application_instance = request.find_service(name="application_instance").get()
+    client_id = request.registry.settings["blackboard_api_client_id"]
+    state = OAuthCallbackSchema(request).state_param()
+
     return HTTPFound(
-        location=request.route_url(
-            "blackboard_api.oauth.callback",
-            _query={"state": OAuthCallbackSchema(request).state_param()},
+        location=urlunparse(
+            (
+                "https",
+                application_instance.lms_host(),
+                "learn/api/public/v1/oauth2/authorizationcode",
+                "",
+                urlencode(
+                    {
+                        "client_id": client_id,
+                        "response_type": "code",
+                        "redirect_uri": request.route_url(
+                            "blackboard_api.oauth.callback"
+                        ),
+                        "state": state,
+                        "scope": "read offline",
+                    }
+                ),
+                "",
+            )
         )
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,8 @@ TEST_SETTINGS = {
     "oauth2_state_secret": "test_oauth2_state_secret",
     "session_cookie_secret": "notasecret",
     "via_secret": "not_a_secret",
+    "blackboard_api_client_id": "test_blackboard_api_client_id",
+    "blackboard_api_client_secret": "test_blackboard_api_client_secret",
 }
 
 

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -1,30 +1,46 @@
-from urllib.parse import parse_qs, urlparse
-
 import pytest
+from h_matchers import Any
 
 from lms.services import NoOAuth2Token
 from lms.views.api.blackboard.authorize import authorize, oauth2_redirect
+from tests.matchers import temporary_redirect_to
 
-pytestmark = pytest.mark.usefixtures("oauth2_token_service")
+pytestmark = pytest.mark.usefixtures(
+    "application_instance_service", "oauth2_token_service"
+)
 
 
 class TestAuthorize:
-    def test_it_just_redirects_to_the_oauth2_redirect_view(self, pyramid_request):
-        response = authorize(pyramid_request)
-
-        assert response.status_int == 302
-        assert response.location.startswith(
-            pyramid_request.route_url("blackboard_api.oauth.callback")
-        )
-
-    def test_it_authenticates_the_redirect_with_an_OAuth2_state_param(
-        self, pyramid_request, OAuthCallbackSchema
+    def test_it_redirects_to_the_Blackboard_authorization_page(
+        self,
+        application_instance_service,
+        OAuthCallbackSchema,
+        oauth_callback_schema,
+        pyramid_request,
     ):
+        application_instance = application_instance_service.get.return_value
+
         response = authorize(pyramid_request)
 
         OAuthCallbackSchema.assert_called_once_with(pyramid_request)
-        state = parse_qs(urlparse(response.location).query).get("state")
-        assert state == ["test_state"]
+        assert response == temporary_redirect_to(
+            Any.url(
+                scheme="https",
+                host=application_instance.lms_host(),
+                path="learn/api/public/v1/oauth2/authorizationcode",
+                query={
+                    "client_id": pyramid_request.registry.settings[
+                        "blackboard_api_client_id"
+                    ],
+                    "response_type": "code",
+                    "redirect_uri": pyramid_request.route_url(
+                        "blackboard_api.oauth.callback"
+                    ),
+                    "state": str(oauth_callback_schema.state_param.return_value),
+                    "scope": "read offline",
+                },
+            )
+        )
 
 
 class TestOAuth2Redirect:
@@ -55,5 +71,9 @@ def OAuthCallbackSchema(patch):
     OAuthCallbackSchema = patch(
         "lms.views.api.blackboard.authorize.OAuthCallbackSchema"
     )
-    OAuthCallbackSchema.return_value.state_param.return_value = "test_state"
     return OAuthCallbackSchema
+
+
+@pytest.fixture
+def oauth_callback_schema(OAuthCallbackSchema):
+    return OAuthCallbackSchema.return_value

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,8 @@ passenv =
     dev: VIA_URL
     dev: VITALSOURCE_LTI_LAUNCH_KEY
     dev: VITALSOURCE_LTI_LAUNCH_SECRET
+    dev: BLACKBOARD_API_CLIENT_ID
+    dev: BLACKBOARD_API_CLIENT_SECRET
 deps =
     dev: -r requirements/dev.txt
     {format,checkformatting}: -r requirements/format.txt


### PR DESCRIPTION
When the user clicks the <kbd>Choose PDF from Blackboard</kbd> button, if we don't already have a Blackboard API access token for that user, the frontend opens a popup window to Blackboard's OAuth authorization page in order to start the process of getting an access token and saving it in our DB.

The view that the popup window opens to is `views/api/blackboard/authorize.py::authorize()` and our current implementation of that view is a fake: it just redirects directly to our OAuth redirect view instead of to Blackboard:

https://github.com/hypothesis/lms/blob/c4b4614aa7544ce3840150ca48da61d6cb1d2781/lms/views/api/blackboard/authorize.py#L9-L20

What's supposed to happen is that we redirect to Blackboard's authorization page, the user clicks <kbd>Allow</kbd>, and then _Blackboard_ redirects to our OAuth redirect view.

This PR changes the `authorize()` view so that it actually redirects to the real Blackboard authorization page instead of skipping it.

Note that the OAuth redirect view that gets called when the user clicks <kbd>Allow</kbd> is still a fake, so we still don't actually talk to Blackboard to get a real access token, we still just store a fake token in the DB. That's coming in a later PR.

## Testing

1. To see the <kbd>Choose PDF from Blackboard</kbd> you need to cherry-pick https://github.com/hypothesis/lms/pull/2636 onto this branch: `git cherry-pick b8a99c878c50a517c8ebdb76e4e54127e88b0500`

2. You need the latest dev data: run `make devdata`

3. The authorization only triggers if you don't already have a Blackboard API access token (real or fake) for the user in your DB. You can make sure of this by deleting them: `tox -qe dockercompose -- exec postgres psql --pset expanded=auto -U postgres -c 'DELETE FROM oauth2_token;'`

4. Also, the assignment configuration UI only triggers if you don't already have a `ModuleItemConfiguration` for the test assignment in your DB. Make sure of that too: `tox -qe dockercompose -- exec postgres psql --pset expanded=auto -U postgres -c "DELETE FROM module_item_configurations WHERE tool_consumer_instance_guid = '041c05b262b54282a0d9b61c42413ec0' and resource_link_id = '_39_1';"`

5. Go to our test Blackboard site: https://aunltd-test.blackboard.com/

6. Log in using the `blackboardteacher` account in 1Password

5. Revoke our LMS app's access to the `blackboardteacher` account.

   When you allow our app access to the Blackboard API, Blackboard remembers this decision and doesn't ask you again. Blackboard's authorization URL immediately redirects to our OAuth URL without showing the user anything. This has the effect of the authorization popup window popping up and then immediately closing again (authorization having been successful). Which sort of prevents you from actually testing it. And since we use shared user accounts _someone else_ might have already allowed the app access to the account. So you need to revoke any previously given access:

   Go to https://aunltd-test.blackboard.com/ultra/tools, click on **Application Authorization**, and revoke Hypothesis Dev.

7. Go to **Developer Test Course with Original Course View**: https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline

8. Launch **localhost (make devdata) Blackboard Files Test Assignment**, it'll open in a new tab

9. You should see this:

   ![Screenshot from 2021-05-26 18-54-08](https://user-images.githubusercontent.com/22498/119708056-c749d600-be53-11eb-8762-28b4588c7ddf.png)

10. Click <kbd>Select PDF from Blackboard</kbd>

11. You should see this:

    ![Screenshot from 2021-05-26 18-55-00](https://user-images.githubusercontent.com/22498/119708276-e8aac200-be53-11eb-837d-f2eb3b829055.png)

12. Click <kbd>Authorize</kbd>

13. You should see this:

    ![Screenshot from 2021-05-26 19-00-59](https://user-images.githubusercontent.com/22498/119709101-bfd6fc80-be54-11eb-9c09-0ff61ad8f080.png)

    **TODO:** The popup window is too short. You have to scroll down to see the <kbd>Allow</kbd> button.

14. Click <kbd>Allow</kbd>

15. You should see this:

    ![Screenshot from 2021-05-26 19-02-03](https://user-images.githubusercontent.com/22498/119709240-e4cb6f80-be54-11eb-89a9-e1bf7feb9a91.png)

That's it. The code doesn't actually do anything with the authorization that you allowed (it doesn't actually get a real access token from Blackboard and save it in the DB) and the list of files is fake. That's all coming in later PRs. For now there's no need to complete the assignment creation.

If you click <kbd>Deny</kbd> instead of <kbd>Allow</kbd> it'll still act as if you clicked <kbd>Allow</kbd>. That's because the view that deals with your allow or deny is still a fake view at this point.

If you want to test it again you'll need to revoke the authorization in Blackboard again and delete the fake access token from `oauth2_token` table again. If you selected a file and completed the assignment configuration you'll need to delete the `module_item_configurations` row again too.