### PR TITLE
Get real Blackboard access tokens

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -21,6 +21,9 @@ from lms.services.exceptions import (
 def includeme(config):
     config.register_service_factory("lms.services.http.factory", name="http")
     config.register_service_factory(
+        "lms.services.blackboard_api.factory", name="blackboard_api_client"
+    )
+    config.register_service_factory(
         "lms.services.canvas_api.canvas_api_client_factory", name="canvas_api_client"
     )
     config.register_service_factory("lms.services.h_api.HAPI", name="h_api")

--- a/lms/services/blackboard_api.py
+++ b/lms/services/blackboard_api.py
@@ -1,0 +1,60 @@
+from lms.validation.authentication import OAuthTokenResponseSchema
+
+
+class BlackboardAPIClient:
+    def __init__(
+        self,
+        blackboard_host,
+        client_id,
+        client_secret,
+        redirect_uri,
+        http_service,
+        oauth2_token_service,
+    ):  # pylint:disable=too-many-arguments
+        self.blackboard_host = blackboard_host
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+
+        self._http_service = http_service
+        self._oauth2_token_service = oauth2_token_service
+
+    def get_token(self, authorization_code):
+        """
+        Get an access token from Blackboard and save it in the DB.
+
+        :raise services.HTTPError: if something goes wrong with the access
+            token request to Blackboard
+        """
+        # Send a request to Blackboard to get an access token.
+        response = self._http_service.post(
+            f"https://{self.blackboard_host}/learn/api/public/v1/oauth2/token",
+            data={
+                "grant_type": "authorization_code",
+                "redirect_uri": self.redirect_uri,
+                "code": authorization_code,
+            },
+            auth=(self.client_id, self.client_secret),
+            schema=OAuthTokenResponseSchema,
+        )
+
+        # Save the access token to the DB.
+        self._oauth2_token_service.save(
+            response.validated_data["access_token"],
+            response.validated_data.get("refresh_token"),
+            response.validated_data.get("expires_in"),
+        )
+
+
+def factory(_context, request):
+    application_instance = request.find_service(name="application_instance").get()
+    settings = request.registry.settings
+
+    return BlackboardAPIClient(
+        blackboard_host=application_instance.lms_host(),
+        client_id=settings["blackboard_api_client_id"],
+        client_secret=settings["blackboard_api_client_secret"],
+        redirect_uri=request.route_url("blackboard_api.oauth.callback"),
+        http_service=request.find_service(name="http"),
+        oauth2_token_service=request.find_service(name="oauth2_token"),
+    )

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -4,7 +4,6 @@ from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
 from lms.security import Permissions
-from lms.services import NoOAuth2Token
 from lms.validation.authentication import OAuthCallbackSchema
 
 
@@ -47,13 +46,8 @@ def authorize(request):
     route_name="blackboard_api.oauth.callback",
     permission=Permissions.API,
     renderer="lms:templates/api/oauth2/redirect.html.jinja2",
+    schema=OAuthCallbackSchema,
 )
 def oauth2_redirect(request):
-    oauth2_token_service = request.find_service(name="oauth2_token")
-
-    try:
-        oauth2_token_service.get()
-    except NoOAuth2Token:
-        oauth2_token_service.save("fake_access_token", "fake_refresh_token", 9999)
-
+    request.find_service(name="blackboard_api_client").get_token(request.params["code"])
     return {}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,6 +9,7 @@ from pyramid.request import apply_request_extensions
 from lms.models import ApplicationSettings
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
+from lms.services.blackboard_api import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
 from lms.services.grading_info import GradingInfoService
@@ -192,6 +193,15 @@ def assignment_service(pyramid_config):
     )
     pyramid_config.register_service(assignment_service, name="assignment")
     return assignment_service
+
+
+@pytest.fixture
+def blackboard_api_client(pyramid_config):
+    blackboard_api_client = mock.create_autospec(
+        BlackboardAPIClient, spec_set=True, instance=True
+    )
+    pyramid_config.register_service(blackboard_api_client, name="blackboard_api_client")
+    return blackboard_api_client
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/blackboard_api_test.py
+++ b/tests/unit/lms/services/blackboard_api_test.py
@@ -1,0 +1,101 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services import HTTPError, HTTPValidationError
+from lms.services.blackboard_api import BlackboardAPIClient, factory
+from lms.validation.authentication import OAuthTokenResponseSchema
+
+
+class TestBlackboardAPIClient:
+    def test_it(self, svc, http_service, oauth2_token_service):
+        http_service.post.return_value.validated_data = {
+            "access_token": sentinel.access_token,
+            "refresh_token": sentinel.refresh_token,
+            "expires_in": sentinel.expires_in,
+        }
+
+        svc.get_token(sentinel.authorization_code)
+
+        # It calls the Blackboard API to get the access token.
+        http_service.post.assert_called_once_with(
+            "https://blackboard.example.com/learn/api/public/v1/oauth2/token",
+            data={
+                "grant_type": "authorization_code",
+                "redirect_uri": sentinel.redirect_uri,
+                "code": sentinel.authorization_code,
+            },
+            auth=(sentinel.client_id, sentinel.client_secret),
+            schema=OAuthTokenResponseSchema,
+        )
+
+        # It saves the access token in the DB.
+        oauth2_token_service.save.assert_called_once_with(
+            sentinel.access_token, sentinel.refresh_token, sentinel.expires_in
+        )
+
+    @pytest.mark.parametrize("exception_class", [HTTPError, HTTPValidationError])
+    def test_it_raises_if_http_service_raises(self, svc, http_service, exception_class):
+        http_service.post.side_effect = exception_class
+
+        with pytest.raises(exception_class):
+            svc.get_token(sentinel.authorization_code)
+
+    def test_if_theres_no_refresh_token_or_expires_in(
+        self, svc, http_service, oauth2_token_service
+    ):
+        # refresh_token and expires_in are optional fields in
+        # OAuthTokenResponseSchema so get_token() has to still work if they're
+        # missing from the validated data.
+        http_service.post.return_value.validated_data = {
+            "access_token": sentinel.access_token
+        }
+
+        svc.get_token(sentinel.authorization_code)
+
+        oauth2_token_service.save.assert_called_once_with(
+            sentinel.access_token, None, None
+        )
+
+    @pytest.fixture
+    def svc(self, http_service, oauth2_token_service):
+        return BlackboardAPIClient(
+            blackboard_host="blackboard.example.com",
+            client_id=sentinel.client_id,
+            client_secret=sentinel.client_secret,
+            redirect_uri=sentinel.redirect_uri,
+            http_service=http_service,
+            oauth2_token_service=oauth2_token_service,
+        )
+
+
+@pytest.mark.usefixtures(
+    "application_instance_service", "http_service", "oauth2_token_service"
+)
+class TestFactory:
+    def test_it(
+        self,
+        application_instance_service,
+        http_service,
+        oauth2_token_service,
+        pyramid_request,
+        BlackboardAPIClient,
+    ):
+        application_instance = application_instance_service.get.return_value
+        settings = pyramid_request.registry.settings
+
+        service = factory(sentinel.context, pyramid_request)
+
+        BlackboardAPIClient.assert_called_once_with(
+            blackboard_host=application_instance.lms_host(),
+            client_id=settings["blackboard_api_client_id"],
+            client_secret=settings["blackboard_api_client_secret"],
+            redirect_uri=pyramid_request.route_url("blackboard_api.oauth.callback"),
+            http_service=http_service,
+            oauth2_token_service=oauth2_token_service,
+        )
+        assert service == BlackboardAPIClient.return_value
+
+    @pytest.fixture(autouse=True)
+    def BlackboardAPIClient(self, patch):
+        return patch("lms.services.blackboard_api.BlackboardAPIClient")


### PR DESCRIPTION
Actually call the Blackboard API to get a real access token and save it to the DB, instead of saving a fake one.

## Testing

1. To see the <kbd>Choose PDF from Blackboard</kbd> you need to cherry-pick https://github.com/hypothesis/lms/pull/2636 onto this branch: `git cherry-pick frontend-changes-for-blackboard-files-poc`

2. You need the latest dev data: run `make devdata`

3. The authorization only triggers if you don't already have a `ModuleItemConfiguration` for the test assignment or Blackboard API access token (real or fake) for the user in your DB. You can make sure of this by deleting them: `tox -qe dockercompose -- exec postgres psql -U postgres -c "'DELETE FROM oauth2_token; DELETE FROM module_item_configurations WHERE tool_consumer_instance_guid = \'041c05b262b54282a0d9b61c42413ec0\' and resource_link_id = \'_39_1\';'"`

5. Go to our test Blackboard site: https://aunltd-test.blackboard.com/

6. Log in using the `blackboardteacher` account in 1Password

5. Revoke our LMS app's access to the `blackboardteacher` account.

   When you allow our app access to the Blackboard API, Blackboard remembers this decision and doesn't ask you again. Blackboard's authorization URL immediately redirects to our OAuth URL without showing the user anything. This has the effect of the authorization popup window popping up and then immediately closing again (authorization having been successful). Which sort of prevents you from actually testing it. And since we use shared user accounts _someone else_ might have already allowed the app access to the account. So you need to revoke any previously given access:

   Go to https://aunltd-test.blackboard.com/ultra/tools, click on **Application Authorization**, and revoke Hypothesis Dev.

7. Go to **Developer Test Course with Original Course View**: https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline

8. Launch **localhost (make devdata) Blackboard Files Test Assignment**, it'll open in a new tab

9. You should see this:

   ![Screenshot from 2021-05-26 18-54-08](https://user-images.githubusercontent.com/22498/119708056-c749d600-be53-11eb-8762-28b4588c7ddf.png)

10. Click <kbd>Select PDF from Blackboard</kbd>

11. You should see this:

    ![Screenshot from 2021-05-26 18-55-00](https://user-images.githubusercontent.com/22498/119708276-e8aac200-be53-11eb-837d-f2eb3b829055.png)

12. Click <kbd>Authorize</kbd>

13. You should see this:

    ![Screenshot from 2021-05-26 19-00-59](https://user-images.githubusercontent.com/22498/119709101-bfd6fc80-be54-11eb-9c09-0ff61ad8f080.png)

    **Known issue:** The popup window is too short. You have to scroll down to see the <kbd>Allow</kbd> button.

14. Click <kbd>Allow</kbd>

15. You should see this:

    ![Screenshot from 2021-05-26 19-02-03](https://user-images.githubusercontent.com/22498/119709240-e4cb6f80-be54-11eb-89a9-e1bf7feb9a91.png)

16. If you now look in your DB you should find that a real Blackboard access token has been saved: `tox -qe dockercompose -- exec postgres psql -U postgres -c "SELECT * FROM oauth2_token;"`

17. Assuming you didn't actually select a file and complete the assignment configuration you should be able to launch the assignment again and this time you'll get to the files list without being asked to authorize again because you already have an access token in your DB.

### Known issues

Error handling isn't done. If something goes wrong with the request to Blackboard and `HTTPService` raises an `HTTPError` or `HTTPValidationError` you'll end up with a JSON error message from our proxy API rendered directly to the user in the popup window. The same thing will happen if you click <kbd>Deny</kbd> instead of <kbd>Allow</kbd> on Blackboard's authorization page.

The desired behavior is our usual nice error dialog with <kbd>Try again</kbd> button.

The Canvas API code handles this with an exception view:

https://github.com/hypothesis/lms/blob/be46e8c356c0da97d86c53cedab28d4b31570cc4/lms/views/api/canvas/authorize.py#L100-L128

But there's a bunch of Canvas-specific stuff in that: the `"canvas_api.oauth.authorize"` route name is passed to `route_url()`, `js_config.enable_canvas_oauth2_redirect_error_mode()` is called, Canvas API scopes are passed to it.

We either need to write something very similar looking (but not exactly the same) for Blackboard or we need to do some refactoring to be able to share code. I'll create a separate issue for this.