### PR TITLE
We rely on marshmallow directly, not just as a dependency of webargs

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,6 +4,7 @@ h-api
 h-pyramid-sentry
 h-vialib
 importlib_resources
+marshmallow
 newrelic
 oauthlib
 psycopg2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -50,7 +50,9 @@ markupsafe==1.1.1
     #   mako
     #   pyramid-jinja2
 marshmallow==3.8.0
-    # via webargs
+    # via
+    #   -r requirements/requirements.in
+    #   webargs
 newrelic==6.2.0.156
     # via -r requirements/requirements.in
 oauthlib==3.1.0


### PR DESCRIPTION
Installing webargs gets us marshmallow, but we could remove webargs
one day and continue using marshmallow. This means we list it as an independant
requirement, and that it therefore shows up in our dependency analysis.