### PR TITLE
Refine group set configuration UI

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -29,9 +29,9 @@ import GroupConfigSelector from './GroupConfigSelector';
  */
 
 /**
- * Return a human-readable description of the selected content for an assignment.
+ * Return a human-readable description of assignment content.
  *
- * @param {Content} content
+ * @param {Content} content - Type and details of assignment content
  * @return {string}
  */
 function contentDescription(content) {

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -29,6 +29,25 @@ import GroupConfigSelector from './GroupConfigSelector';
  */
 
 /**
+ * Return a human-readable description of the selected content for an assignment.
+ *
+ * @param {Content} content
+ * @return {string}
+ */
+function contentDescription(content) {
+  switch (content.type) {
+    case 'url':
+      return content.url;
+    case 'file':
+      return 'PDF file in Canvas';
+    case 'vitalsource':
+      return 'Book from VitalSource';
+    default:
+      return 'Other content';
+  }
+}
+
+/**
  * An application that allows the user to choose the web page or PDF for an
  * assignment.
  *
@@ -100,33 +119,42 @@ export default function FilePickerApp({ onSubmit }) {
         method="POST"
         onSubmit={onSubmit}
       >
-        {!content && (
-          <Fragment>
-            <h1 className="heading-1">Select web page or PDF</h1>
-            <p>
-              You can select content for your assignment from one of the
-              following sources:
-            </p>
-            <ContentSelector
-              onSelectContent={selectContent}
-              onError={setErrorInfo}
-            />
-          </Fragment>
-        )}
+        <h1 className="FilePickerApp__heading">Assignment details</h1>
+        <div className="FilePickerApp__left-col">Assignment content</div>
+        <div className="FilePickerApp__right-col">
+          {content ? (
+            <i>{contentDescription(content)}</i>
+          ) : (
+            <Fragment>
+              <p>
+                You can select content for your assignment from one of the
+                following sources:
+              </p>
+              <ContentSelector
+                onSelectContent={selectContent}
+                onError={setErrorInfo}
+              />
+            </Fragment>
+          )}
+        </div>
         {content && enableGroupConfig && (
           <Fragment>
-            <h1 className="heading-1">Group settings</h1>
-            <GroupConfigSelector
-              groupConfig={groupConfig}
-              onChangeGroupConfig={setGroupConfig}
-            />
-            <LabeledButton
-              disabled={groupConfig.useGroupSet && !groupConfig.groupSet}
-              variant="primary"
-              onClick={submit}
-            >
-              Continue
-            </LabeledButton>
+            <div className="FilePickerApp__left-col">Group assignment</div>
+            <div className="FilePickerApp__right-col">
+              <GroupConfigSelector
+                groupConfig={groupConfig}
+                onChangeGroupConfig={setGroupConfig}
+              />
+            </div>
+            <div className="FilePickerApp__footer">
+              <LabeledButton
+                disabled={groupConfig.useGroupSet && !groupConfig.groupSet}
+                variant="primary"
+                onClick={submit}
+              >
+                Continue
+              </LabeledButton>
+            </div>
           </Fragment>
         )}
         {content && (

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -115,7 +115,7 @@ export default function GroupConfigSelector({
             })
           }
         >
-          Use groups for this assignment
+          This is a group assignment
         </LabeledCheckbox>
       </div>
       {fetchError && (

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -118,7 +118,7 @@ export default function GroupConfigSelector({
           This is a group assignment
         </LabeledCheckbox>
       </div>
-      {fetchError && (
+      {fetchError && useGroupSet && (
         // Currently all fetch errors are handled by attempting to re-authorize
         // and then re-fetch group sets.
         <Fragment>

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -60,9 +60,10 @@ describe('GroupConfigSelector', () => {
     $imports.$restore();
   });
 
-  function createComponent(props = {}) {
+  // Helper that simulates GroupConfigSelector's containing component.
+  function Container(props) {
     const noop = () => {};
-    return mount(
+    return (
       <Config.Provider value={fakeConfig}>
         <GroupConfigSelector
           groupConfig={{ useGroupSet: false, groupSet: null }}
@@ -71,6 +72,10 @@ describe('GroupConfigSelector', () => {
         />
       </Config.Provider>
     );
+  }
+
+  function createComponent(props = {}) {
+    return mount(<Container {...props} />);
   }
 
   function toggleCheckbox(wrapper) {
@@ -187,5 +192,23 @@ describe('GroupConfigSelector', () => {
       'option[data-testid="groupset-option"]'
     );
     assert.equal(options.length, fakeGroupSets.length);
+  });
+
+  it('hides authorization prompt if checkbox is de-selected', async () => {
+    fakeAPICall
+      .withArgs(groupSetsAPIRequest)
+      .rejects(new Error('Authorization failed'));
+    const wrapper = createComponent({
+      groupConfig: { useGroupSet: true, groupSet: null },
+    });
+
+    await waitForElement(wrapper, 'AuthButton');
+
+    // De-activate group sets. In the actual app this would be done by the user
+    // toggling the checkbox. The checkbox state lives in the parent component
+    // though.
+    wrapper.setProps({ groupConfig: { useGroupSet: false, groupSet: null } });
+
+    assert.isFalse(wrapper.exists('AuthButton'));
   });
 });

--- a/lms/static/styles/components/_FilePickerApp.scss
+++ b/lms/static/styles/components/_FilePickerApp.scss
@@ -1,8 +1,48 @@
 @use "../variables" as var;
 
 .FilePickerApp__form {
-  max-width: 600px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+
+  width: 500px; // Preferred width
+  max-width: 80vw; // Constrain width to fit in viewport
+
   margin-left: auto;
   margin-right: auto;
-  margin-top: 20vh;
+  margin-top: 10vh;
+}
+
+.FilePickerApp__heading {
+  grid-column: 1 / 3;
+  margin-bottom: 1.5em;
+}
+
+.FilePickerApp__left-col {
+  grid-column: 1;
+  padding-right: 20px;
+
+  font-weight: bold;
+  text-align: end;
+  margin-bottom: 1em;
+}
+
+.FilePickerApp__right-col {
+  grid-column: 2;
+
+  // Make sure that the text at the top of the right column is aligned with
+  // the label in the left column, whether that text is part of a `<p>` or not.
+  & > p:first-child {
+    margin-top: 0;
+  }
+}
+
+// Footer with actions to navigate between steps in the assignment configuration
+// flow.
+.FilePickerApp__footer {
+  grid-column: 1 / 3;
+
+  margin-top: 1em;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
 }


### PR DESCRIPTION
This PR is the next step towards aligning the group set configuration UI with the mocks in https://github.com/hypothesis/lms/issues/2523#issuecomment-821160185.

- The first commit updates the layout and text in the main `FilePickerApp` component
- The second commit updates a checkbox label in the group set configuration step of the form
- The last commit fixes a bug where an authorization prompt in the group configuration step remained visible after de-selecting the checkbox

After these changes land there is some further work to be done on the group configuration UI elements (the checkbox, select widget and associated labels).

Part of https://github.com/hypothesis/lms/issues/2524.

----

Initial content selection screen:

(_nb. There is a VitalSource option here because I have a feature flag for that enabled locally. Users won't see it in production._)

<img width="820" alt="assignment-details-1" src="https://user-images.githubusercontent.com/2458/119981880-0a23bf00-bfb6-11eb-9cd9-6d01130b154e.png">

The dialogs that appear during content selection are the same as before:

<img width="787" alt="assignment-details-2" src="https://user-images.githubusercontent.com/2458/119981888-0db74600-bfb6-11eb-9db5-e6da76b54673.png">

Group configuration screen:

<img width="792" alt="assignment-details-3" src="https://user-images.githubusercontent.com/2458/119981899-11e36380-bfb6-11eb-896f-68b9287e24e9.png">

This is the screen with UI elements that need additional work, to come in later PRs.

