### PR TITLE
Store courses on the new Course(Grouping) table

### DIFF
--- a/lms/models/h_group.py
+++ b/lms/models/h_group.py
@@ -14,21 +14,6 @@ class HGroup(NamedTuple):
         return f"group:{self.authority_provided_id}@{authority}"
 
     @classmethod
-    def course_group(cls, course_name, tool_consumer_instance_guid, context_id):
-        """
-        Create an HGroup for a course.
-
-        :param course_name: The name of the course
-        :param tool_consumer_instance_guid: Tool consumer GUID
-        :param context_id: Course id
-        """
-        return HGroup(
-            cls._name(course_name),
-            hashed_id(tool_consumer_instance_guid, context_id),
-            type="course_group",
-        )
-
-    @classmethod
     def section_group(
         cls, section_name, tool_consumer_instance_guid, context_id, section_id
     ):

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -37,7 +37,6 @@ class BasicLTILaunchViews:
         self.context = context
         self.request = request
         self.assignment_service = request.find_service(name="assignment")
-        self.course_service = request.find_service(name="course")
 
         self.context.js_config.enable_lti_launch_mode()
         self.context.js_config.maybe_set_focused_user()
@@ -50,7 +49,7 @@ class BasicLTILaunchViews:
         """Do a basic LTI launch with the given document_url."""
         self.sync_lti_data_to_h()
         self.store_lti_data()
-        self.course_service.get_or_create(self.context.h_group.authority_provided_id)
+        self.context.get_or_create_course()
 
         if grading_supported:
             self.context.js_config.maybe_enable_grading()
@@ -236,7 +235,7 @@ class BasicLTILaunchViews:
         we'll save it in our DB. Subsequent launches of the same assignment
         will then be DB-configured launches rather than unconfigured.
         """
-        self.course_service.get_or_create(self.context.h_group.authority_provided_id)
+        self.context.get_or_create_course()
 
         form_fields = {
             param: value

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -53,9 +53,7 @@ def content_item_selection(context, request):
         request.params
     )
 
-    request.find_service(name="course").get_or_create(
-        context.h_group.authority_provided_id
-    )
+    context.get_or_create_course()
 
     request.find_service(name="lti_h").sync([context.h_group], request.params)
 

--- a/tests/unit/lms/models/h_group_test.py
+++ b/tests/unit/lms/models/h_group_test.py
@@ -5,11 +5,6 @@ from tests import factories
 
 GROUP_CONSTRUCTORS = (
     (
-        HGroup.course_group,
-        ("tool_consumer_instance_guid", "context_id"),
-        "course_group",
-    ),
-    (
         HGroup.section_group,
         ("tool_consumer_instance_guid", "context_id", "section_id"),
         "sections_group",
@@ -24,13 +19,6 @@ class TestHGroup:
         groupid = group.groupid("lms.hypothes.is")
 
         assert groupid == "group:test_authority_provided_id@lms.hypothes.is"
-
-    def test_course_group(self, hashed_id):
-        group = HGroup.course_group("irrelevant", "tool_guid", "context_id")
-
-        hashed_id.assert_called_once_with("tool_guid", "context_id")
-        assert group.authority_provided_id == hashed_id.return_value
-        assert group.type == "course_group"
 
     def test_sections_group(self, hashed_id):
         group = HGroup.section_group(

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -243,13 +243,11 @@ class TestCommon:
 
 class TestCourseRecording:
     def test_it_records_the_course_in_the_DB(
-        self, context, pyramid_request, view_caller, course_service
+        self, context, pyramid_request, view_caller
     ):
         view_caller(context, pyramid_request)
 
-        course_service.get_or_create.assert_called_once_with(
-            context.h_group.authority_provided_id
-        )
+        context.get_or_create_course.assert_called_once_with()
 
     @pytest.fixture(
         params=[

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -23,14 +23,10 @@ class TestContentItemSelection:
             },
         )
 
-    def test_it_records_the_course_in_the_DB(
-        self, context, pyramid_request, course_service
-    ):
+    def test_it_records_the_course_in_the_DB(self, context, pyramid_request):
         content_item_selection(context, pyramid_request)
 
-        course_service.get_or_create.assert_called_once_with(
-            context.h_group.authority_provided_id
-        )
+        context.get_or_create_course.assert_called_once_with()
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION


#### Testing notes
- Truncate all existing courses on your local DB `truncate course;`

- Create a course on your local DB an assignment https://hypothesis.instructure.com/courses/125/

- Check course rows in both tables
```
postgres=# select * from course;
-[ RECORD 1 ]---------+-------------------------------------------
consumer_key          | Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
authority_provided_id | 653e9620a656a954c684942f6443fa3e3410c03a
settings              | {"canvas": {"sections_enabled": true}}

postgres=# select * from grouping;
-[ RECORD 1 ]-----------+-----------------------------------------------
created                 | 2021-05-28 13:26:58.086679
updated                 | 2021-05-28 13:26:58.086679
id                      | 1
application_instance_id | 8
authority_provided_id   | 653e9620a656a954c684942f6443fa3e3410c03a
parent_id               | 
lms_id                  | f3cd019017839c4630358662a05540f2f6ec5f93
lms_name                | Developer Test Course with Sections Enabled
type                    | course
settings                | {"canvas": {"sections_enabled": true}}
extra                   | {"canvas": {"custom_canvas_course_id": "125"}}
```

