### PR TITLE
Extract TokenResponseSchema into OAuthTokenResponseSchema

### DIFF
--- a/lms/services/canvas_api/_authenticated.py
+++ b/lms/services/canvas_api/_authenticated.py
@@ -1,10 +1,7 @@
 """Access to the authenticated parts of the Canvas API."""
 
-import marshmallow
-from marshmallow import fields
-
 from lms.services import NoOAuth2Token, ProxyAPIAccessTokenError
-from lms.validation import RequestsResponseSchema
+from lms.validation.authentication import OAuthTokenResponseSchema
 
 
 class AuthenticatedClient:
@@ -128,7 +125,7 @@ class AuthenticatedClient:
             "login/oauth2/token",
             url_stub="",
             params=params,
-            schema=TokenResponseSchema,
+            schema=OAuthTokenResponseSchema,
         )
 
         self._oauth2_token_service.save(
@@ -138,16 +135,3 @@ class AuthenticatedClient:
         )
 
         return parsed_params["access_token"]
-
-
-class TokenResponseSchema(RequestsResponseSchema):
-    """Schema for validating OAuth 2 token responses from Canvas."""
-
-    access_token = fields.Str(required=True)
-    refresh_token = fields.Str()
-    expires_in = fields.Integer()
-
-    @marshmallow.validates("expires_in")
-    def validate_quantity(self, expires_in):  # pylint:disable=no-self-use
-        if expires_in <= 0:
-            raise marshmallow.ValidationError("expires_in must be greater than 0")

--- a/lms/validation/authentication/__init__.py
+++ b/lms/validation/authentication/__init__.py
@@ -11,4 +11,7 @@ from lms.validation.authentication._exceptions import (
     MissingStateParamError,
 )
 from lms.validation.authentication._launch_params import LaunchParamsAuthSchema
-from lms.validation.authentication._oauth import OAuthCallbackSchema
+from lms.validation.authentication._oauth import (
+    OAuthCallbackSchema,
+    OAuthTokenResponseSchema,
+)

--- a/lms/validation/authentication/_oauth.py
+++ b/lms/validation/authentication/_oauth.py
@@ -4,7 +4,7 @@ import marshmallow
 from webargs import fields
 
 from lms.models import LTIUser
-from lms.validation._base import PyramidRequestSchema
+from lms.validation._base import PyramidRequestSchema, RequestsResponseSchema
 from lms.validation.authentication._exceptions import (
     ExpiredJWTError,
     ExpiredStateParamError,
@@ -131,3 +131,16 @@ class OAuthCallbackSchema(PyramidRequestSchema):
             raise ExpiredStateParamError() from err
         except InvalidJWTError as err:
             raise InvalidStateParamError() from err
+
+
+class OAuthTokenResponseSchema(RequestsResponseSchema):
+    """Schema for token responses from OAuth 2 authentication servers."""
+
+    access_token = fields.Str(required=True)
+    refresh_token = fields.Str()
+    expires_in = fields.Integer()
+
+    @marshmallow.validates("expires_in")
+    def validate_quantity(self, expires_in):  # pylint:disable=no-self-use
+        if expires_in <= 0:
+            raise marshmallow.ValidationError("expires_in must be greater than 0")


### PR DESCRIPTION
Extract `services.canvas_api._authenticated.TokenResponseSchema` out into `lms.validation.authentication.OAuthTokenResponseSchema`.

This is a generic OAuth 2 schema, it doesn't have anything in particular to do with Canvas and it now needs to be re-used by Blackboard (in a future PR).

This PR extracts the schema out into a reusable location in `lms.validation` and adds unit tests for the schema.

While some parts of the schema's behavior are currently covered by the integrated tests under `tests/unit/lms/services/canvas_api/` the coverage isn't very good. Currently on master you can break the schema in various ways and the tests will still pass. For example:

* You can remove the `required=True`, making the `access_token` field optional
* You can make the optional `refresh_token` and `expires_in` fields required
* You can delete the `refresh_token` field

The new unit tests cover all this.

## Code design notes

I think it's worth some notes on the LMS app's code design with validation schemas, since these are going to come up a few more times in implementing Blackboard files:

Validation schemas are treated as separate (and separately unit tested) re-usable components that can be used in multiple places, passed around as arguments, etc. Schemas make sense as separate logical units: validating an object (such as a request or response) and either returning the validated data or raising a correctly-formatted exception seems like a standalone unit of logic. And Marshmallow (like pretty much any validation library) hands this to us on a plate: Marshmallow schemas are standalone classes. These reusable schemas handle validation so that other parts of the code can just use them and assume that the data will be valid or an appropriate exception will have been raised.

Similarly [`HTTPService`](https://github.com/hypothesis/lms/blob/06895480fa412947f04bddc61b77077f2d31dbc9/lms/services/http.py#L8-L176) is a separate (and separately unit tested) component that sends an HTTP request and returns the response, dealing with calling `requests` properly and handling its errors. And `HTTPService` also supports validating the response with a given schema.

Combining `HTTPService` with a schema the upcoming `BlackboardAPIClient` can just do:

```python
response = http_service.post(
    oauth_token_url, data={...}, auth=(...), schema=OAuthTokenResponseSchema,
)
```

Similarly `CanvasAPIClient` can do:

```python
response = http_service.post(
    canvas_oauth_token_url, data={...}, auth=(...), schema=OAuthTokenResponseSchema,
)
```

`HTTPService` and its tests (calling `requests` and `marshmallow` correctly and dealing with their errors) only needs to be written once. The tests for `BlackboardAPIClient`, `CanvasAPIClient` and others don't need to worry about these details.

Similarly the code for `OAuthTokenResponseSchema` and its tests only needed to be written once, and the tests for the clients that use it don't need to worry about the details.

To give another example: [`OAuthCallbackSchema`](https://github.com/hypothesis/lms/blob/06895480fa412947f04bddc61b77077f2d31dbc9/lms/validation/authentication/_oauth.py#L18-L133) is another standalone reusable schema class. It validates OAuth callback _requests_ (as opposed to responses). It's used by the Canvas API code to generate OAuth 2 `state` params and to protect the Canvas OAuth 2 redirect view:

https://github.com/hypothesis/lms/blob/d952bf408960374d71f5d72c08cfa25ba10f2350/lms/views/api/canvas/authorize.py#L70

https://github.com/hypothesis/lms/blob/d952bf408960374d71f5d72c08cfa25ba10f2350/lms/views/api/canvas/authorize.py#L81-L88

The Blackboard API code also uses `OAuthCallbackSchema` to generate `state` params (and will soon use it to protect its redirect view as well):

https://github.com/hypothesis/lms/blob/8a510e3ea97f72d5e572f7a6fef2bc5a5f1fa259/lms/views/api/blackboard/authorize.py#L19

`OAuthCallbackSchema` is also used in `security.py` to create an `LTIUser` from an OAuth 2 `state` param in a request:

https://github.com/hypothesis/lms/blob/dbbc4777db5224b22606411b3b042cf1bb2eeb8b/lms/security.py#L178

### Reasons for this approach

An important advantage of this is that it breaks things down into *small* reusable components. You can open the `OAuthTokenResponseSchema` code and its tests side-by-side, both are small, they're easy to fit in your head at once, it's easy to make sure that everything is really covered by the tests. The tests just call `OAuthTokenResponseSchema` directly, there is no other code-under-test involved.

Similarly the `BlackboardAPIClient.get_token()` method that will use `HTTPService` and `OAuthTokenResponseSchema` is small. You can open its tests side-by-side, keep it all in your head at once, and ensure that everything is really covered by the tests. The tests for `BlackboardAPIClient` don't need to worry about sending HTTP requests or about different possibilities for valid and invalid OAuth token responses. Again: the amount of code-under-test at once is small. `HTTPService` is mocked out.

It's easy to *find* the unit tests for `OAuthTokenResponseSchema`: the schema is defined in `lms/validation/authentication/_oauth.py` so of course its tests are found in `tests/unit/lms/validation/authentication/_oauth_test.py` in `TestOAuthTokenResponseSchema`.

Having a schema be a separately unit tested component also makes refactoring code that uses the schema easier. For example if we change the location of the schema class itself, or if we change what part of the code is responsible for actually calling the schema, the unit tests for the schema just move around with the schema class itself. We don't have to schema being unit tested indirectly by tests that call `BlackboardAPIClient.get_token()`. If we change what part of the code is responsible for actually calling the schema, we don't have to now find all those `BlackboardAPIClient.get_token()` tests that were actually testing the schema and rewrite them as `HTTPService.post()` tests or something else.

Lastly, Marshmallow schemas are composable. Schemas can inherit from each other or from shared base classes. They can re-use each other via composition. Shared fields and helper methods can be defined that can be shared between schemas. Etc. Having all the schemas together in `lms/validation/` makes this code sharing easier to do. It also makes it easy to see how to write a schema, because you have lots of examples to hand. This applies to the schema's unit tests as well, where lots of examples of how we test schemas can easily be found in `tests/unit/lms/validation/` and there could also be shared pytest fixtures, helpers, factories, etc. It's similar to how all our test factories are defined together in [`lms/tests/factories`](https://github.com/hypothesis/lms/tree/master/tests/factories) so our best practices for writing test factories can easily be seen and [shared attributes](https://github.com/hypothesis/lms/blob/master/tests/factories/attributes.py) can be re-used by different factories.

Putting all the schemas in `lms/validation/` does have the disadvantage that a particular schema's definition can be distant from where it's used. This is particularly true of schemas that're only used in one place. For example if `BlackboardFilesResponseSchema` was defined in `lms/validation/` but only used in a method of `lms/services/blackboard_api.py`. For this reason we might want to define schemas in `blackboard_api.py` if they're only used by the code in that file but still have those schemas use things from `lms/validation/` (like the `RequestsResponseSchema` base class). This has the advantage of keeping the schema and the method that uses the schema close together. But it has the disadvantage of spreading schemas and their tests around, which can make it harder to follow code re-use and best practices among schemas and schema tests.