### PR TITLE
Canvas groups backend

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -5,7 +5,7 @@ from lms.models.course import LegacyCourse
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
 from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
-from lms.models.grouping import CanvasSection, Course, Grouping
+from lms.models.grouping import CanvasGroup, CanvasSection, Course, Grouping
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
 from lms.models.lti_user import LTIUser, display_name

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -337,6 +337,7 @@ class JSConfig:
                 "lis_result_sourcedid": lis_result_sourcedid,
                 "lis_outcome_service_url": lis_outcome_service_url,
                 "learner_canvas_user_id": self._request.params["custom_canvas_user_id"],
+                "group_set": self._request.params.get("group_set"),
                 **kwargs,
             },
         }
@@ -531,6 +532,7 @@ class JSConfig:
         if "learner_canvas_user_id" in req.params:
             sync_api_config["data"]["learner"] = {
                 "canvas_user_id": req.params["learner_canvas_user_id"],
+                "group_set": req.params.get("group_set"),
             }
 
         return sync_api_config

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -210,10 +210,7 @@ class JSConfig:
             },
             "canvas": {
                 "enabled": self._canvas_files_available(),
-                "groupsEnabled": self._application_instance().settings.get(
-                    "canvas", "groups_enabled"
-                )
-                or False,
+                "groupsEnabled": self._context.canvas_groups_enabled,
                 # The "content item selection" that we submit to Canvas's
                 # content_item_return_url is actually an LTI launch URL with
                 # the selected document URL or file_id as a query parameter. To
@@ -518,6 +515,7 @@ class JSConfig:
                 "course": {
                     "context_id": req.params["context_id"],
                     "custom_canvas_course_id": req.params["custom_canvas_course_id"],
+                    "group_set": req.params.get("group_set"),
                 },
                 "group_info": {
                     key: value

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -498,7 +498,10 @@ class JSConfig:
         return [self._context.h_group.groupid(self._authority)]
 
     def _sync_api(self):
-        if not self._context.canvas_sections_enabled:
+        if (
+            not self._context.canvas_sections_enabled
+            and not self._context.canvas_groups_enabled
+        ):
             return None
 
         req = self._request

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -22,6 +22,9 @@ class LTILaunchResource:
         """Return the context resource for an LTI launch request."""
         self._request = request
         self._authority = self._request.registry.settings["h_authority"]
+        self._application_instance_service = self._request.find_service(
+            name="application_instance"
+        )
 
     def get_or_create_course(self):
         """Get the course this LTI launch based on the request's params."""
@@ -118,12 +121,8 @@ class LTILaunchResource:
             # Canvas course sections feature was released.
             return False
 
-        application_instance_service = self._request.find_service(
-            name="application_instance"
-        )
-
         try:
-            application_instance = application_instance_service.get()
+            application_instance = self._application_instance_service.get()
         except ConsumerKeyError:
             return False
 
@@ -143,16 +142,12 @@ class LTILaunchResource:
     @property
     def canvas_groups_enabled(self):
         """Return True if Canvas groups is enabled for this request."""
-        application_instance_service = self._request.find_service(
-            name="application_instance"
-        )
-
         try:
-            application_instance = application_instance_service.get()
+            application_instance = self._application_instance_service.get()
         except ConsumerKeyError:
             return False
 
-        return application_instance.settings.get("canvas", "groups_enabled") or False
+        return bool(application_instance.settings.get("canvas", "groups_enabled"))
 
     def _course_extra(self):
         """Extra information to store for courses."""

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -140,6 +140,20 @@ class LTILaunchResource:
 
         return legacy_course.settings.get("canvas", "sections_enabled")
 
+    @property
+    def canvas_groups_enabled(self):
+        """Return True if Canvas groups is enabled for this request."""
+        application_instance_service = self._request.find_service(
+            name="application_instance"
+        )
+
+        try:
+            application_instance = application_instance_service.get()
+        except ConsumerKeyError:
+            return False
+
+        return application_instance.settings.get("canvas", "groups_enabled") or False
+
     def _course_extra(self):
         """Extra information to store for courses."""
         extra = {}

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -276,15 +276,32 @@ class CanvasAPIClient:
             schema=self._ListGroups,
         )
 
-    def course_groups(self, course_id, only_own_groups=True):
+    def course_groups(self, course_id, only_own_groups=True, include_users=False):
+        params = {"only_own_groups": only_own_groups}
+        if include_users:
+            params["include[]"] = "users"
+
         return self._client.send(
             "GET",
             f"courses/{course_id}/groups",
-            params={"only_own_groups": only_own_groups},
+            params=params,
             schema=self._ListGroups,
         )
 
     class _ListGroups(RequestsResponseSchema):
+        class _Users(Schema):
+            """Schema for extracting a section ID from an enrollment dict."""
+
+            class Meta:
+                unknown = EXCLUDE
+
+            id = fields.Integer(required=True)
+
+        users = fields.List(
+            fields.Nested(_Users),
+            required=False,
+        )
+
         many = True
         id = fields.Integer(required=True)
         name = fields.Str(required=True)

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -295,6 +295,43 @@ class CanvasAPIClient:
             schema=self._ListGroups,
         )
 
+    def current_user_groups(self, course_id, group_category_id=None):
+        """
+        Get all groups the current user belongs in a course and optionally in a group_category.
+
+        :param course_id: Course canvas ID
+        :param group_category_id: Only return groups that belong to this group category
+        """
+        user_groups = self.course_groups(course_id, only_own_groups=True)
+
+        if group_category_id:
+            user_groups = [
+                g for g in user_groups if g["group_category_id"] == group_category_id
+            ]
+
+        return user_groups
+
+    def user_groups(self, course_id, user_id, group_category_id=None):
+        """
+        Get the groups a `user_id` belongs to in an specific `course_id`.
+
+        Optionally return only the groups that belong to a `group_category_id`
+        """
+        canvas_groups = self.course_groups(
+            course_id, only_own_groups=False, include_users=True
+        )
+        groups = []
+        # Look for the student we are grading in all the groups
+        for group in canvas_groups:
+            if group_category_id and group["group_category_id"] != group_category_id:
+                continue
+
+            for user in group["users"]:
+                if user["id"] == user_id:
+                    groups.append(group)
+
+        return groups
+
     class _ListGroups(RequestsResponseSchema):
         class _Users(Schema):
             """Schema for extracting a section ID from an enrollment dict."""

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -334,7 +334,7 @@ class CanvasAPIClient:
 
     class _ListGroups(RequestsResponseSchema):
         class _Users(Schema):
-            """Schema for extracting a section ID from an enrollment dict."""
+            """Users that belong to each group. Only present when using include[]=users."""
 
             class Meta:
                 unknown = EXCLUDE

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -277,6 +277,13 @@ class CanvasAPIClient:
         )
 
     def course_groups(self, course_id, only_own_groups=True, include_users=False):
+        """
+        Get all the groups of a course.
+
+        :param course_id: Course canvas ID
+        :param only_own_groups: Only return groups the current users belongs to
+        :param include_users: Optionally include all the users in each group
+        """
         params = {"only_own_groups": only_own_groups}
         if include_users:
             params["include[]"] = "users"

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -18,6 +18,7 @@ class GroupInfoService:
     GROUPING_TYPES = {
         "course": "course_group",
         "canvas_section": "section_group",
+        "canvas_group": "canvas_group_group",
     }
 
     def __init__(self, _context, request):

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -30,7 +30,7 @@ class GroupingService:
         self, tool_consumer_instance_guid, context_id, section_id, section_name
     ):
         """
-        Create an HGroup for a course section.
+        Upsert a Grouping for a course section.
 
         :param tool_consumer_instance_guid: Tool consumer GUID
         :param context_id: Course id the section is a part of
@@ -67,12 +67,12 @@ class GroupingService:
         group_set_id,
     ):
         """
-        Create an HGroup for a course section.
+        Upserst a Grouping for a canvas group.
 
         :param tool_consumer_instance_guid: Tool consumer GUID
-        :param context_id: Course id the section is a part of
-        :param group_id: A section id for a section group
-        :param group_name: The name of the section
+        :param context_id: Course id the group is a part of
+        :param group_id: Canvas group id
+        :param group_name: The name of the group
         :param group_set_id: Id of the canvas group set this group belongs to
         """
 

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -58,6 +58,44 @@ class GroupingService:
             )
         )
 
+    def canvas_group(  # pylint: disable=too-many-arguments
+        self,
+        tool_consumer_instance_guid,
+        context_id,
+        group_id,
+        group_name,
+        group_set_id,
+    ):
+        """
+        Create an HGroup for a course section.
+
+        :param section_name: The name of the section
+        :param tool_consumer_instance_guid: Tool consumer GUID
+        :param context_id: Course id the section is a part of
+        :param group_id: A section id for a section group
+        """
+
+        group_authority_provided_id = hashed_id(
+            tool_consumer_instance_guid, context_id, group_id
+        )
+
+        course_authority_provided_id = hashed_id(
+            tool_consumer_instance_guid, context_id
+        )
+
+        course = self._course_service.get(course_authority_provided_id)
+
+        return self.upsert(
+            CanvasSection(
+                application_instance=self._application_instance,
+                authority_provided_id=group_authority_provided_id,
+                lms_id=group_id,
+                lms_name=group_name,
+                parent=course,
+                extra={"group_set_id": group_set_id},
+            )
+        )
+
 
 def factory(_context, request):
     return GroupingService(

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -1,4 +1,4 @@
-from lms.models import CanvasSection, Grouping
+from lms.models import CanvasGroup, CanvasSection, Grouping
 from lms.models._hashed_id import hashed_id
 
 
@@ -69,14 +69,15 @@ class GroupingService:
         """
         Create an HGroup for a course section.
 
-        :param section_name: The name of the section
         :param tool_consumer_instance_guid: Tool consumer GUID
         :param context_id: Course id the section is a part of
         :param group_id: A section id for a section group
+        :param group_name: The name of the section
+        :param group_set_id: Id of the canvas group set this group belongs to
         """
 
         group_authority_provided_id = hashed_id(
-            tool_consumer_instance_guid, context_id, group_id
+            tool_consumer_instance_guid, context_id, "canvas_group", group_id
         )
 
         course_authority_provided_id = hashed_id(
@@ -86,12 +87,12 @@ class GroupingService:
         course = self._course_service.get(course_authority_provided_id)
 
         return self.upsert(
-            CanvasSection(
+            CanvasGroup(
                 application_instance=self._application_instance,
                 authority_provided_id=group_authority_provided_id,
                 lms_id=group_id,
                 lms_name=group_name,
-                parent=course,
+                parent_id=course.id,
                 extra={"group_set_id": group_set_id},
             )
         )

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -58,7 +58,7 @@ class GroupingService:
             )
         )
 
-    def canvas_group(  # pylint: disable=too-many-arguments
+    def upsert_canvas_group(  # pylint: disable=too-many-arguments
         self,
         tool_consumer_instance_guid,
         context_id,

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -33,6 +33,7 @@ class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
     """
 
     group_set = fields.Int(required=False)
+    """Canvas group_set ID for assignments that use the small groups feature."""
 
 
 class APIReadResultSchema(PyramidRequestSchema):

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -32,6 +32,8 @@ class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
     typically encodes the assignment context and LMS user.
     """
 
+    group_set = fields.Int(required=False)
+
 
 class APIReadResultSchema(PyramidRequestSchema):
     """Schema for validating proxy requests to LTI Outcomes API for reading grades."""

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -39,6 +39,12 @@ class Sync:
 
     @property
     def _is_group_launch(self):
+        application_instance = self._request.find_service(
+            name="application_instance"
+        ).get()
+        if not application_instance.settings.get("canvas", "groups_enabled"):
+            return False
+
         try:
             self.group_set
         except (KeyError, ValueError, TypeError):
@@ -153,3 +159,5 @@ class Sync:
             for user in group["users"]:
                 if user["id"] == grading_user_id:
                     return group
+
+        return None

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -7,6 +7,7 @@ class Sync:
     def __init__(self, request):
         self._request = request
         self._grouping_service = self._request.find_service(name="grouping")
+        self._canvas_api = self._request.find_service(name="canvas_api_client")
 
     @view_config(
         route_name="canvas_api.sync",
@@ -15,7 +16,10 @@ class Sync:
         permission=Permissions.API,
     )
     def sync(self):
-        groups = self._to_groupings(self._get_sections())
+        if self.is_group_launch:
+            groups = self._to_groups_groupings(self._get_canvas_groups())
+        else:
+            groups = self._to_section_groupings(self._get_sections())
 
         self._sync_to_h(groups)
 
@@ -26,19 +30,31 @@ class Sync:
     def _is_speedgrader(self):
         return "learner" in self._request.json
 
+    @property
+    def is_group_launch(self):
+        return self._request.json["course"].get("group_set") is not None
+
+    def _get_canvas_groups(self):
+        lti_user = self._request.lti_user
+        if lti_user.is_learner:
+            groups = [self._canvas_learner_group()]
+        else:
+            groups = self._canvas_course_groups()
+
+        return groups
+
     def _get_sections(self):
-        canvas_api = self._request.find_service(name="canvas_api_client")
         course_id = self._request.json["course"]["custom_canvas_course_id"]
         lti_user = self._request.lti_user
 
         if lti_user.is_learner:
             # For learners we only want the client to show the sections that
             # the student belongs to, so fetch only the user's sections.
-            return canvas_api.authenticated_users_sections(course_id)
+            return self._canvas_api.authenticated_users_sections(course_id)
 
         # For non-learners (e.g. instructors, teaching assistants) we want the
         # client to show all of the course's sections.
-        sections = canvas_api.course_sections(course_id)
+        sections = self._canvas_api.course_sections(course_id)
         if not self._is_speedgrader:
             return sections
 
@@ -47,12 +63,27 @@ class Sync:
         # we will just use them to filter the course sections
         user_id = self._request.json["learner"]["canvas_user_id"]
         learner_section_ids = {
-            sec["id"] for sec in canvas_api.users_sections(user_id, course_id)
+            sec["id"] for sec in self._canvas_api.users_sections(user_id, course_id)
         }
 
         return [sec for sec in sections if sec["id"] in learner_section_ids]
 
-    def _to_groupings(self, sections):
+    def _to_groups_groupings(self, groups):
+        tool_guid = self._request.json["lms"]["tool_consumer_instance_guid"]
+        context_id = self._request.json["course"]["context_id"]
+
+        return [
+            self._grouping_service.canvas_group(
+                tool_consumer_instance_guid=tool_guid,
+                context_id=context_id,
+                group_name=group["name"],
+                group_id=group["id"],
+                group_set_id=group["group_category_id"],
+            )
+            for group in groups
+        ]
+
+    def _to_section_groupings(self, sections):
         tool_guid = self._request.json["lms"]["tool_consumer_instance_guid"]
         context_id = self._request.json["course"]["context_id"]
 
@@ -70,3 +101,26 @@ class Sync:
         lti_h_svc = self._request.find_service(name="lti_h")
         group_info = self._request.json["group_info"]
         lti_h_svc.sync(groups, group_info)
+
+    def _canvas_learner_group(self):
+        lti_user = self._request.lti_user
+        if not lti_user.is_learner:
+            return None
+
+        group_set_id = int(self._request.json["course"]["group_set"])
+        course_id = self._request.json["course"]["custom_canvas_course_id"]
+
+        student_groups = self._canvas_api.course_groups(course_id, only_own_groups=True)
+
+        course_group = [
+            g for g in student_groups if g["group_category_id"] == group_set_id
+        ]
+        if not course_group:
+            return None
+
+        return course_group[0]
+
+    def _canvas_course_groups(self):
+        group_set_id = int(self._request.json["course"]["group_set"])
+
+        return self._canvas_api.group_category_groups(group_set_id)

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -16,7 +16,7 @@ class Sync:
         permission=Permissions.API,
     )
     def sync(self):
-        if self.is_group_launch:
+        if self._is_group_launch:
             groups = self._to_groups_groupings(self._get_canvas_groups())
         else:
             groups = self._to_section_groupings(self._get_sections())
@@ -31,17 +31,32 @@ class Sync:
         return "learner" in self._request.json
 
     @property
-    def is_group_launch(self):
-        return self._request.json["course"].get("group_set") is not None
+    def group_set(self):
+        if self._is_speedgrader:
+            return int(self._request.json["learner"].get("group_set"))
+
+        return int(self._request.json["course"].get("group_set"))
+
+    @property
+    def _is_group_launch(self):
+        try:
+            self.group_set
+        except (KeyError, ValueError, TypeError):
+            return False
+        else:
+            return True
 
     def _get_canvas_groups(self):
         lti_user = self._request.lti_user
         if lti_user.is_learner:
-            groups = [self._canvas_learner_group()]
-        else:
-            groups = self._canvas_course_groups()
+            # For learners only one group, the one the student belongs to.
+            return [self._canvas_learner_group()]
 
-        return groups
+        if self._is_speedgrader:
+            return [self._canvas_speedgrader_group()]
+
+        # If not grading return all the groups in the course so the teacher can toggle between them.
+        return self._canvas_course_groups()
 
     def _get_sections(self):
         course_id = self._request.json["course"]["custom_canvas_course_id"]
@@ -73,7 +88,7 @@ class Sync:
         context_id = self._request.json["course"]["context_id"]
 
         return [
-            self._grouping_service.canvas_group(
+            self._grouping_service.upsert_canvas_group(
                 tool_consumer_instance_guid=tool_guid,
                 context_id=context_id,
                 group_name=group["name"],
@@ -103,11 +118,7 @@ class Sync:
         lti_h_svc.sync(groups, group_info)
 
     def _canvas_learner_group(self):
-        lti_user = self._request.lti_user
-        if not lti_user.is_learner:
-            return None
-
-        group_set_id = int(self._request.json["course"]["group_set"])
+        group_set_id = self.group_set
         course_id = self._request.json["course"]["custom_canvas_course_id"]
 
         student_groups = self._canvas_api.course_groups(course_id, only_own_groups=True)
@@ -124,3 +135,21 @@ class Sync:
         group_set_id = int(self._request.json["course"]["group_set"])
 
         return self._canvas_api.group_category_groups(group_set_id)
+
+    def _canvas_speedgrader_group(self):
+        # SpeedGrader requests are made by the teacher, get the student we are grading
+        grading_user_id = int(self._request.json["learner"]["canvas_user_id"])
+        group_category_id = self.group_set
+
+        course_id = self._request.json["course"]["custom_canvas_course_id"]
+        canvas_groups = self._canvas_api.course_groups(
+            course_id, only_own_groups=False, include_users=True
+        )
+        # Look for the student we are grading in all the groups
+        for group in canvas_groups:
+            if group["group_category_id"] != group_category_id:
+                continue
+
+            for user in group["users"]:
+                if user["id"] == grading_user_id:
+                    return group

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -30,7 +30,6 @@ class Sync:
     def _is_speedgrader(self):
         return "learner" in self._request.json
 
-    @property
     def group_set(self):
         if self._is_speedgrader:
             return int(self._request.json["learner"].get("group_set"))
@@ -46,7 +45,7 @@ class Sync:
             return False
 
         try:
-            self.group_set
+            self.group_set()
         except (KeyError, ValueError, TypeError):
             return False
         else:
@@ -55,14 +54,22 @@ class Sync:
     def _get_canvas_groups(self):
         lti_user = self._request.lti_user
         if lti_user.is_learner:
-            # For learners only one group, the one the student belongs to.
-            return [self._canvas_learner_group()]
+            # For learners, the groups they belong within the course
+            return self._canvas_api.current_user_groups(
+                self._request.json["course"]["custom_canvas_course_id"],
+                self.group_set(),
+            )
 
         if self._is_speedgrader:
-            return [self._canvas_speedgrader_group()]
+            # SpeedGrader requests are made by the teacher, get the student we are grading
+            return self._canvas_api.user_groups(
+                self._request.json["course"]["custom_canvas_course_id"],
+                int(self._request.json["learner"]["canvas_user_id"]),
+                self.group_set(),
+            )
 
         # If not grading return all the groups in the course so the teacher can toggle between them.
-        return self._canvas_course_groups()
+        return self._canvas_api.group_category_groups(self.group_set())
 
     def _get_sections(self):
         course_id = self._request.json["course"]["custom_canvas_course_id"]
@@ -122,42 +129,3 @@ class Sync:
         lti_h_svc = self._request.find_service(name="lti_h")
         group_info = self._request.json["group_info"]
         lti_h_svc.sync(groups, group_info)
-
-    def _canvas_learner_group(self):
-        group_set_id = self.group_set
-        course_id = self._request.json["course"]["custom_canvas_course_id"]
-
-        student_groups = self._canvas_api.course_groups(course_id, only_own_groups=True)
-
-        course_group = [
-            g for g in student_groups if g["group_category_id"] == group_set_id
-        ]
-        if not course_group:
-            return None
-
-        return course_group[0]
-
-    def _canvas_course_groups(self):
-        group_set_id = int(self._request.json["course"]["group_set"])
-
-        return self._canvas_api.group_category_groups(group_set_id)
-
-    def _canvas_speedgrader_group(self):
-        # SpeedGrader requests are made by the teacher, get the student we are grading
-        grading_user_id = int(self._request.json["learner"]["canvas_user_id"])
-        group_category_id = self.group_set
-
-        course_id = self._request.json["course"]["custom_canvas_course_id"]
-        canvas_groups = self._canvas_api.course_groups(
-            course_id, only_own_groups=False, include_users=True
-        )
-        # Look for the student we are grading in all the groups
-        for group in canvas_groups:
-            if group["group_category_id"] != group_category_id:
-                continue
-
-            for user in group["users"]:
-                if user["id"] == grading_user_id:
-                    return group
-
-        return None

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -114,6 +114,7 @@ class CanvasPreRecordHook:
         params = {
             "focused_user": parsed_params["h_username"],
             "learner_canvas_user_id": parsed_params["learner_canvas_user_id"],
+            "group_set": parsed_params.get("group_set"),
         }
 
         if parsed_params.get("document_url"):

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -510,6 +510,7 @@ class TestJSConfigAPISync:
     def test_it_adds_learner_canvas_user_id_for_SpeedGrader_launches(self, sync):
         assert sync["data"]["learner"] == {
             "canvas_user_id": "test_learner_canvas_user_id",
+            "group_set": None,
         }
 
     def test_its_None_if_section_and_groups_arent_enabled(self, sync):
@@ -712,11 +713,6 @@ def context():
 @pytest.fixture
 def section_groups_on(context):
     context.canvas_sections_enabled = True
-
-
-@pytest.fixture
-def canvas_groups_on(context):
-    context.canvas_groups_enabled = True
 
 
 @pytest.fixture

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -493,6 +493,7 @@ class TestJSConfigAPISync:
                 "course": {
                     "context_id": "test_context_id",
                     "custom_canvas_course_id": "test_custom_canvas_course_id",
+                    "group_set": None,
                 },
                 "lms": {
                     "tool_consumer_instance_guid": "test_tool_consumer_instance_guid"
@@ -511,7 +512,7 @@ class TestJSConfigAPISync:
             "canvas_user_id": "test_learner_canvas_user_id",
         }
 
-    def test_its_None_if_section_groups_isnt_enabled(self, sync):
+    def test_its_None_if_section_and_groups_arent_enabled(self, sync):
         assert sync is None
 
     @pytest.fixture
@@ -704,12 +705,18 @@ def context():
         h_group=mock.create_autospec(Grouping, instance=True, spec_set=True),
         is_canvas=True,
         canvas_sections_enabled=False,
+        canvas_groups_enabled=False,
     )
 
 
 @pytest.fixture
 def section_groups_on(context):
     context.canvas_sections_enabled = True
+
+
+@pytest.fixture
+def canvas_groups_on(context):
+    context.canvas_groups_enabled = True
 
 
 @pytest.fixture

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -195,6 +195,25 @@ class TestCourseExtra:
         }
 
 
+@pytest.mark.usefixtures("has_course")
+class TestCanvasGroupsEnabled:
+    def test_false_when_no_application_instance(
+        self, application_instance_service, lti_launch
+    ):
+        application_instance_service.get.side_effect = ConsumerKeyError
+
+        assert not lti_launch.canvas_groups_enabled
+
+    @pytest.mark.parametrize("settings_value", [True, False])
+    def test_returns_settings_value(
+        self, settings_value, application_instance_service, lti_launch
+    ):
+        settings = ApplicationSettings({"canvas": {"groups_enabled": settings_value}})
+        application_instance_service.get.return_value.settings = settings
+
+        assert lti_launch.canvas_groups_enabled == settings_value
+
+
 @pytest.fixture
 def lti_launch(pyramid_request):
     return LTILaunchResource(pyramid_request)

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -156,8 +156,12 @@ class TestCanvasAPIClient:
             timeout=Any(),
         )
 
-    @pytest.mark.parametrize("only_own_groups", [True, False])
-    def test_course_groups(self, only_own_groups, canvas_api_client, http_session):
+    @pytest.mark.parametrize(
+        "only_own_groups,include_users", [(True, False), (False, True)]
+    )
+    def test_course_groups(
+        self, only_own_groups, include_users, canvas_api_client, http_session
+    ):
         groups = [
             {
                 "id": 1,
@@ -177,16 +181,23 @@ class TestCanvasAPIClient:
         )
 
         response = canvas_api_client.course_groups(
-            "COURSE_ID", only_own_groups=only_own_groups
+            "COURSE_ID", only_own_groups=only_own_groups, include_users=include_users
         )
 
         assert response == groups
+
+        expected_params = {
+            "per_page": Any.string(),
+            "only_own_groups": str(only_own_groups),
+        }
+        if include_users:
+            expected_params["include[]"] = "users"
 
         http_session.send.assert_called_once_with(
             Any.request(
                 "GET",
                 url=Any.url.with_path("api/v1/courses/COURSE_ID/groups").with_query(
-                    {"per_page": Any.string(), "only_own_groups": str(only_own_groups)}
+                    expected_params
                 ),
             ),
             timeout=Any(),

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -203,29 +203,82 @@ class TestCanvasAPIClient:
             timeout=Any(),
         )
 
-    def test_group_category_groups(self, canvas_api_client, http_session):
-        groups = [
-            {
-                "id": 1,
-                "name": "Group 1",
-                "description": "Group 1",
-                "group_category_id": 1,
-            },
-            {
-                "id": 2,
-                "name": "Group 2",
-                "description": "Group 2",
-                "group_category_id": 1,
-            },
-        ]
-        http_session.send.return_value = factories.requests.Response(
-            status_code=200, json_data=groups
+    @pytest.mark.usefixtures("list_groups_response")
+    def test_current_user_groups(self, canvas_api_client):
+        course_id = 1
+        group_category_id = 1
+
+        response = canvas_api_client.current_user_groups(course_id, group_category_id)
+
+        assert len(response) == 1
+        assert response[0]["group_category_id"] == group_category_id
+
+    @pytest.mark.usefixtures("list_groups_response")
+    def test_current_user_groups_no_group_category(self, canvas_api_client):
+        course_id = 1
+
+        response = canvas_api_client.current_user_groups(
+            course_id, group_category_id=None
         )
 
+        assert len(response) == 2
+
+    @pytest.mark.usefixtures("list_groups_response")
+    def test_current_user_groups_empty(self, canvas_api_client):
+        course_id = 1
+        group_category_id = 10000
+
+        response = canvas_api_client.current_user_groups(course_id, group_category_id)
+
+        assert not response
+
+    @pytest.mark.usefixtures("list_groups_with_users_response")
+    def test_user_groups_none_match_group_category_id(self, canvas_api_client):
+        course_id = 1
+        user_id = 10000
+        group_category_id = 10000
+
+        response = canvas_api_client.user_groups(course_id, user_id, group_category_id)
+
+        assert not response
+
+    @pytest.mark.usefixtures("list_groups_with_users_response")
+    def test_user_groups_none_match_user_id(self, canvas_api_client):
+        course_id = 1
+        user_id = 10000
+        group_category_id = 2
+
+        response = canvas_api_client.user_groups(course_id, user_id, group_category_id)
+
+        assert not response
+
+    @pytest.mark.usefixtures("list_groups_with_users_response")
+    def test_user_groups_no_group_category(self, canvas_api_client):
+        course_id = 1
+        user_id = 1
+
+        response = canvas_api_client.user_groups(course_id, user_id)
+
+        assert len(response) == 1
+        assert user_id in [u["id"] for u in response[0]["users"]]
+
+    @pytest.mark.usefixtures("list_groups_with_users_response")
+    def test_user_groups(self, canvas_api_client):
+        course_id = 1
+        user_id = 1
+        group_category_id = 2
+
+        response = canvas_api_client.user_groups(course_id, user_id, group_category_id)
+
+        assert len(response) == 1
+        assert user_id in [u["id"] for u in response[0]["users"]]
+        assert response[0]["group_category_id"] == group_category_id
+
+    @pytest.mark.usefixtures("list_groups_response")
+    def test_group_category_groups(self, canvas_api_client, http_session):
         response = canvas_api_client.group_category_groups("GROUP_CATEGORY")
 
-        assert response == groups
-
+        assert len(response) == 2
         http_session.send.assert_called_once_with(
             Any.request(
                 "GET",
@@ -336,6 +389,48 @@ class TestCanvasAPIClient:
                 "GET", url=Any.url.with_path("api/v1/files/FILE_ID/public_url")
             ),
             timeout=Any(),
+        )
+
+    @pytest.fixture
+    def list_groups_response(self, http_session):
+        http_session.send.return_value = factories.requests.Response(
+            json_data=[
+                {
+                    "id": 1,
+                    "name": "Group 1",
+                    "description": "Group 1",
+                    "group_category_id": 1,
+                },
+                {
+                    "id": 2,
+                    "name": "Group 2",
+                    "description": "Group 2",
+                    "group_category_id": 2,
+                },
+            ],
+            status_code=200,
+        )
+
+    @pytest.fixture
+    def list_groups_with_users_response(self, http_session):
+        http_session.send.return_value = factories.requests.Response(
+            json_data=[
+                {
+                    "id": 1,
+                    "name": "Group 1",
+                    "description": "Group 1",
+                    "group_category_id": 1,
+                    "users": [],
+                },
+                {
+                    "id": 2,
+                    "name": "Group 2",
+                    "description": "Group 2",
+                    "group_category_id": 2,
+                    "users": [{"id": 1}],
+                },
+            ],
+            status_code=200,
         )
 
     @pytest.fixture

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -79,6 +79,31 @@ class TestGroupingService:
         )
         assert grouping.parent_id == course_service.get.return_value.id
 
+    def test_canvas_group_and_sections_dont_conflict(
+        self, svc, course_service, db_session
+    ):
+        course_service.get.return_value = factories.Course()
+        db_session.flush()
+
+        group = svc.upsert_canvas_group(
+            self.TOOL_CONSUMER_INSTANCE_GUID,
+            self.CONTEXT_ID,
+            "same_id",
+            "group_name",
+            "group_set_id",
+        )
+        section = svc.upsert_canvas_section(
+            self.TOOL_CONSUMER_INSTANCE_GUID,
+            self.CONTEXT_ID,
+            "same_id",
+            "section_name",
+        )
+
+        assert group.authority_provided_id != section.authority_provided_id
+        assert (
+            group.parent_id == section.parent_id == course_service.get.return_value.id
+        )
+
     @pytest.fixture
     def svc(self, db_session, course_service, application_instance_service):
         return GroupingService(db_session, application_instance_service, course_service)

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -62,6 +62,23 @@ class TestGroupingService:
         )
         assert grouping.parent_id == course_service.get.return_value.id
 
+    def test_canvas_group_finds_course(self, svc, course_service, db_session):
+        course_service.get.return_value = factories.Course()
+        db_session.flush()
+
+        grouping = svc.upsert_canvas_group(
+            self.TOOL_CONSUMER_INSTANCE_GUID,
+            self.CONTEXT_ID,
+            "group_id",
+            "group_name",
+            "group_set_id",
+        )
+
+        course_service.get.assert_called_once_with(
+            hashed_id(self.TOOL_CONSUMER_INSTANCE_GUID, self.CONTEXT_ID),
+        )
+        assert grouping.parent_id == course_service.get.return_value.id
+
     @pytest.fixture
     def svc(self, db_session, course_service, application_instance_service):
         return GroupingService(db_session, application_instance_service, course_service)

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -66,6 +66,7 @@ def test_sections_sync_when_the_user_is_an_instructor(
 
 @pytest.mark.usefixtures("user_is_learner", "is_group_launch")
 def test_get_canvas_groups_learner(pyramid_request):
+    # pylint: disable=protected-access
     with mock.patch.object(
         Sync, "_canvas_learner_group", autospec=True
     ) as _canvas_learner_group:
@@ -77,6 +78,7 @@ def test_get_canvas_groups_learner(pyramid_request):
 
 @pytest.mark.usefixtures("is_group_and_speedgrader", "user_is_instructor")
 def test_get_canvas_groups_speedgrader(pyramid_request):
+    # pylint: disable=protected-access
     with mock.patch.object(
         Sync, "_canvas_speedgrader_group", autospec=True
     ) as _canvas_speedgrader_group:
@@ -90,6 +92,7 @@ def test_get_canvas_groups_speedgrader(pyramid_request):
 
 @pytest.mark.usefixtures("user_is_instructor")
 def test_get_canvas_groups_instructor(pyramid_request):
+    # pylint: disable=protected-access
     with mock.patch.object(
         Sync, "_canvas_course_groups", autospec=True
     ) as _canvas_course_groups:
@@ -100,35 +103,62 @@ def test_get_canvas_groups_instructor(pyramid_request):
 
 
 @pytest.mark.parametrize(
-    "group_set_value,expected_value",
-    [(None, False), ("a", False), ("1", True), (1, True)],
+    "groups_enabled,group_set_value,expected_value",
+    [
+        (True, None, False),
+        (True, "a", False),
+        (True, "1", True),
+        (True, 1, True),
+        (False, "1", False),
+    ],
 )
 def test_is_group_launch(
-    group_set_value, expected_value, pyramid_request, request_json
+    groups_enabled,
+    group_set_value,
+    expected_value,
+    pyramid_request,
+    request_json,
+    application_instance_service,
 ):
+    application_instance_service.get.return_value.settings = {
+        "canvas": {"groups_enabled": groups_enabled}
+    }
+    # pylint: disable=protected-access
     request_json["course"] = {"group_set": group_set_value}
 
-    assert (  # pylint: disable=protected-access
-        Sync(pyramid_request)._is_group_launch == expected_value
-    )
+    assert Sync(pyramid_request)._is_group_launch == expected_value
 
 
 @pytest.mark.parametrize(
-    "group_set_value,expected_value",
-    [(None, False), ("a", False), ("1", True), (1, True)],
+    "groups_enabled,group_set_value,expected_value",
+    [
+        (True, None, False),
+        (True, "a", False),
+        (True, "1", True),
+        (True, 1, True),
+        (False, 1, False),
+    ],
 )
 def test_is_group_launch_in_speed_grader(
-    group_set_value, expected_value, pyramid_request, request_json
+    groups_enabled,
+    group_set_value,
+    expected_value,
+    pyramid_request,
+    request_json,
+    application_instance_service,
 ):
+    application_instance_service.get.return_value.settings = {
+        "canvas": {"groups_enabled": groups_enabled}
+    }
+    # pylint: disable=protected-access
     request_json["course"] = {"group_set": group_set_value}
 
-    assert (  # pylint: disable=protected-access
-        Sync(pyramid_request)._is_group_launch == expected_value
-    )
+    assert Sync(pyramid_request)._is_group_launch == expected_value
 
 
 @pytest.mark.usefixtures("is_group_and_speedgrader")
 def test_canvas_speedgrader_group(pyramid_request, request_json, canvas_api_client):
+    # pylint: disable=protected-access
     course_id = request_json["course"]["custom_canvas_course_id"]
     user_id = request_json["learner"]["canvas_user_id"]
     group_category_id = request_json["learner"]["group_set"]
@@ -151,6 +181,7 @@ def test_canvas_speedgrader_group(pyramid_request, request_json, canvas_api_clie
 def test_canvas_speedgrader_group_missing(
     pyramid_request, request_json, canvas_api_client
 ):
+    # pylint: disable=protected-access
     course_id = request_json["course"]["custom_canvas_course_id"]
     canvas_api_client.course_groups.return_value = []
 
@@ -164,6 +195,7 @@ def test_canvas_speedgrader_group_missing(
 
 @pytest.mark.usefixtures("is_group_launch")
 def test_canvas_course_groups(pyramid_request, request_json, canvas_api_client):
+    # pylint: disable=protected-access
     group_category_id = request_json["course"]["group_set"]
 
     groups = Sync(pyramid_request)._canvas_course_groups()
@@ -174,6 +206,7 @@ def test_canvas_course_groups(pyramid_request, request_json, canvas_api_client):
 
 @pytest.mark.usefixtures("is_group_launch", "user_is_learner")
 def test_canvas_learner_group(pyramid_request, request_json, canvas_api_client):
+    # pylint: disable=protected-access
     canvas_api_client.course_groups.return_value = [
         {"group_category_id": 0},
         {"group_category_id": 1},
@@ -191,6 +224,7 @@ def test_canvas_learner_group(pyramid_request, request_json, canvas_api_client):
 
 @pytest.mark.usefixtures("is_group_launch", "user_is_learner")
 def test_canvas_learner_group_empty(pyramid_request, request_json, canvas_api_client):
+    # pylint: disable=protected-access
     canvas_api_client.course_groups.return_value = []
 
     course_id = request_json["course"]["custom_canvas_course_id"]
@@ -328,8 +362,11 @@ def is_speedgrader(request_json):
 
 
 @pytest.fixture
-def is_group_launch(request_json):
+def is_group_launch(application_instance_service, request_json):
     request_json["course"]["group_set"] = 1
+    application_instance_service.get.return_value.settings = {
+        "canvas": {"groups_enabled": True}
+    }
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -65,41 +65,38 @@ def test_sections_sync_when_the_user_is_an_instructor(
 
 
 @pytest.mark.usefixtures("user_is_learner", "is_group_launch")
-def test_get_canvas_groups_learner(pyramid_request):
+def test_get_canvas_groups_learner(pyramid_request, canvas_api_client):
     # pylint: disable=protected-access
-    with mock.patch.object(
-        Sync, "_canvas_learner_group", autospec=True
-    ) as _canvas_learner_group:
-        groups = Sync(pyramid_request)._get_canvas_groups()
+    group_set = 1
+    course_id = "test_custom_canvas_course_id"
 
-        _canvas_learner_group.assert_called_once()
-        assert groups == [_canvas_learner_group.return_value]
+    Sync(pyramid_request)._get_canvas_groups()
+
+    canvas_api_client.current_user_groups.assert_called_once_with(course_id, group_set)
 
 
 @pytest.mark.usefixtures("is_group_and_speedgrader", "user_is_instructor")
-def test_get_canvas_groups_speedgrader(pyramid_request):
+def test_get_canvas_groups_speedgrader(pyramid_request, canvas_api_client):
     # pylint: disable=protected-access
-    with mock.patch.object(
-        Sync, "_canvas_speedgrader_group", autospec=True
-    ) as _canvas_speedgrader_group:
-        groups = Sync(pyramid_request)._get_canvas_groups()
+    group_set = 1
+    course_id = "test_custom_canvas_course_id"
+    learner_id = 111
 
-        print(pyramid_request.json)
+    Sync(pyramid_request)._get_canvas_groups()
 
-        _canvas_speedgrader_group.assert_called_once()
-        assert groups == [_canvas_speedgrader_group.return_value]
+    canvas_api_client.user_groups.assert_called_once_with(
+        course_id, learner_id, group_set
+    )
 
 
-@pytest.mark.usefixtures("user_is_instructor")
-def test_get_canvas_groups_instructor(pyramid_request):
+@pytest.mark.usefixtures("user_is_instructor", "is_group_launch")
+def test_get_canvas_groups_instructor(pyramid_request, canvas_api_client):
     # pylint: disable=protected-access
-    with mock.patch.object(
-        Sync, "_canvas_course_groups", autospec=True
-    ) as _canvas_course_groups:
-        groups = Sync(pyramid_request)._get_canvas_groups()
+    group_set = 1
 
-        _canvas_course_groups.assert_called_once()
-        assert groups == _canvas_course_groups.return_value
+    Sync(pyramid_request)._get_canvas_groups()
+
+    canvas_api_client.group_category_groups.assert_called_once_with(group_set)
 
 
 @pytest.mark.parametrize(
@@ -154,87 +151,6 @@ def test_is_group_launch_in_speed_grader(
     request_json["course"] = {"group_set": group_set_value}
 
     assert Sync(pyramid_request)._is_group_launch == expected_value
-
-
-@pytest.mark.usefixtures("is_group_and_speedgrader")
-def test_canvas_speedgrader_group(pyramid_request, request_json, canvas_api_client):
-    # pylint: disable=protected-access
-    course_id = request_json["course"]["custom_canvas_course_id"]
-    user_id = request_json["learner"]["canvas_user_id"]
-    group_category_id = request_json["learner"]["group_set"]
-
-    canvas_api_client.course_groups.return_value = [
-        {"group_category_id": 1, "users": []},
-        {"group_category_id": 0, "users": [{"id": user_id}]},
-        {"group_category_id": 1, "users": [{"id": 0}, {"id": user_id}]},
-    ]
-
-    group = Sync(pyramid_request)._canvas_speedgrader_group()
-
-    canvas_api_client.course_groups.assert_called_once_with(
-        course_id, only_own_groups=False, include_users=True
-    )
-    assert group["group_category_id"] == group_category_id
-
-
-@pytest.mark.usefixtures("is_group_and_speedgrader")
-def test_canvas_speedgrader_group_missing(
-    pyramid_request, request_json, canvas_api_client
-):
-    # pylint: disable=protected-access
-    course_id = request_json["course"]["custom_canvas_course_id"]
-    canvas_api_client.course_groups.return_value = []
-
-    group = Sync(pyramid_request)._canvas_speedgrader_group()
-
-    canvas_api_client.course_groups.assert_called_once_with(
-        course_id, only_own_groups=False, include_users=True
-    )
-    assert group is None
-
-
-@pytest.mark.usefixtures("is_group_launch")
-def test_canvas_course_groups(pyramid_request, request_json, canvas_api_client):
-    # pylint: disable=protected-access
-    group_category_id = request_json["course"]["group_set"]
-
-    groups = Sync(pyramid_request)._canvas_course_groups()
-
-    canvas_api_client.group_category_groups.assert_called_once_with(group_category_id)
-    assert groups == canvas_api_client.group_category_groups.return_value
-
-
-@pytest.mark.usefixtures("is_group_launch", "user_is_learner")
-def test_canvas_learner_group(pyramid_request, request_json, canvas_api_client):
-    # pylint: disable=protected-access
-    canvas_api_client.course_groups.return_value = [
-        {"group_category_id": 0},
-        {"group_category_id": 1},
-    ]
-
-    course_id = request_json["course"]["custom_canvas_course_id"]
-
-    groups = Sync(pyramid_request)._canvas_learner_group()
-
-    canvas_api_client.course_groups.assert_called_once_with(
-        course_id, only_own_groups=True
-    )
-    assert groups["group_category_id"] == 1
-
-
-@pytest.mark.usefixtures("is_group_launch", "user_is_learner")
-def test_canvas_learner_group_empty(pyramid_request, request_json, canvas_api_client):
-    # pylint: disable=protected-access
-    canvas_api_client.course_groups.return_value = []
-
-    course_id = request_json["course"]["custom_canvas_course_id"]
-
-    groups = Sync(pyramid_request)._canvas_learner_group()
-
-    canvas_api_client.course_groups.assert_called_once_with(
-        course_id, only_own_groups=True
-    )
-    assert groups is None
 
 
 @pytest.mark.usefixtures("user_is_instructor")

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -1,41 +1,216 @@
+from unittest import mock
+
 import pytest
 
 from lms.views.api.canvas.sync import Sync
 from tests.conftest import TEST_SETTINGS
 
 pytestmark = pytest.mark.usefixtures(
-    "canvas_api_client", "lti_h_service", "grouping_service"
+    "canvas_api_client",
+    "lti_h_service",
+    "grouping_service",
+    "application_instance_service",
 )
 
 
 @pytest.mark.usefixtures("user_is_learner")
-def test_sync_when_the_user_is_a_learner(
-    pyramid_request, canvas_api_client, sections, assert_sync_and_return, request_json
+def test_sections_sync_when_the_user_is_a_learner(
+    pyramid_request,
+    canvas_api_client,
+    sections,
+    assert_sync_and_return_sections,
+    request_json,
 ):
     groupids = Sync(pyramid_request).sync()
 
     course_id = request_json["course"]["custom_canvas_course_id"]
     canvas_api_client.authenticated_users_sections.assert_called_once_with(course_id)
 
-    assert_sync_and_return(groupids, sections=sections.authenticated_user)
+    assert_sync_and_return_sections(groupids, sections=sections.authenticated_user)
+
+
+@pytest.mark.usefixtures("is_group_launch")
+def test_groups_sync(
+    pyramid_request,
+    assert_sync_and_return_groups,
+):
+
+    groups = [{"name": "group", "id": 1, "group_category_id": 2}]
+
+    with mock.patch.object(
+        Sync, "_get_canvas_groups", autospec=True
+    ) as _get_canvas_groups:
+
+        _get_canvas_groups.return_value = groups
+
+        groupids = Sync(pyramid_request).sync()
+
+    assert_sync_and_return_groups(groupids, groups=groups)
 
 
 @pytest.mark.usefixtures("user_is_instructor")
-def test_sync_when_the_user_is_an_instructor(
-    pyramid_request, canvas_api_client, sections, assert_sync_and_return, request_json
+def test_sections_sync_when_the_user_is_an_instructor(
+    pyramid_request,
+    canvas_api_client,
+    sections,
+    assert_sync_and_return_sections,
+    request_json,
 ):
     groupids = Sync(pyramid_request).sync()
 
     course_id = request_json["course"]["custom_canvas_course_id"]
     canvas_api_client.course_sections.assert_called_once_with(course_id)
 
-    assert_sync_and_return(groupids, sections=sections.course)
+    assert_sync_and_return_sections(groupids, sections=sections.course)
+
+
+@pytest.mark.usefixtures("user_is_learner", "is_group_launch")
+def test_get_canvas_groups_learner(pyramid_request):
+    with mock.patch.object(
+        Sync, "_canvas_learner_group", autospec=True
+    ) as _canvas_learner_group:
+        groups = Sync(pyramid_request)._get_canvas_groups()
+
+        _canvas_learner_group.assert_called_once()
+        assert groups == [_canvas_learner_group.return_value]
+
+
+@pytest.mark.usefixtures("is_group_and_speedgrader", "user_is_instructor")
+def test_get_canvas_groups_speedgrader(pyramid_request):
+    with mock.patch.object(
+        Sync, "_canvas_speedgrader_group", autospec=True
+    ) as _canvas_speedgrader_group:
+        groups = Sync(pyramid_request)._get_canvas_groups()
+
+        print(pyramid_request.json)
+
+        _canvas_speedgrader_group.assert_called_once()
+        assert groups == [_canvas_speedgrader_group.return_value]
+
+
+@pytest.mark.usefixtures("user_is_instructor")
+def test_get_canvas_groups_instructor(pyramid_request):
+    with mock.patch.object(
+        Sync, "_canvas_course_groups", autospec=True
+    ) as _canvas_course_groups:
+        groups = Sync(pyramid_request)._get_canvas_groups()
+
+        _canvas_course_groups.assert_called_once()
+        assert groups == _canvas_course_groups.return_value
+
+
+@pytest.mark.parametrize(
+    "group_set_value,expected_value",
+    [(None, False), ("a", False), ("1", True), (1, True)],
+)
+def test_is_group_launch(
+    group_set_value, expected_value, pyramid_request, request_json
+):
+    request_json["course"] = {"group_set": group_set_value}
+
+    assert (  # pylint: disable=protected-access
+        Sync(pyramid_request)._is_group_launch == expected_value
+    )
+
+
+@pytest.mark.parametrize(
+    "group_set_value,expected_value",
+    [(None, False), ("a", False), ("1", True), (1, True)],
+)
+def test_is_group_launch_in_speed_grader(
+    group_set_value, expected_value, pyramid_request, request_json
+):
+    request_json["course"] = {"group_set": group_set_value}
+
+    assert (  # pylint: disable=protected-access
+        Sync(pyramid_request)._is_group_launch == expected_value
+    )
+
+
+@pytest.mark.usefixtures("is_group_and_speedgrader")
+def test_canvas_speedgrader_group(pyramid_request, request_json, canvas_api_client):
+    course_id = request_json["course"]["custom_canvas_course_id"]
+    user_id = request_json["learner"]["canvas_user_id"]
+    group_category_id = request_json["learner"]["group_set"]
+
+    canvas_api_client.course_groups.return_value = [
+        {"group_category_id": 1, "users": []},
+        {"group_category_id": 0, "users": [{"id": user_id}]},
+        {"group_category_id": 1, "users": [{"id": 0}, {"id": user_id}]},
+    ]
+
+    group = Sync(pyramid_request)._canvas_speedgrader_group()
+
+    canvas_api_client.course_groups.assert_called_once_with(
+        course_id, only_own_groups=False, include_users=True
+    )
+    assert group["group_category_id"] == group_category_id
+
+
+@pytest.mark.usefixtures("is_group_and_speedgrader")
+def test_canvas_speedgrader_group_missing(
+    pyramid_request, request_json, canvas_api_client
+):
+    course_id = request_json["course"]["custom_canvas_course_id"]
+    canvas_api_client.course_groups.return_value = []
+
+    group = Sync(pyramid_request)._canvas_speedgrader_group()
+
+    canvas_api_client.course_groups.assert_called_once_with(
+        course_id, only_own_groups=False, include_users=True
+    )
+    assert group is None
+
+
+@pytest.mark.usefixtures("is_group_launch")
+def test_canvas_course_groups(pyramid_request, request_json, canvas_api_client):
+    group_category_id = request_json["course"]["group_set"]
+
+    groups = Sync(pyramid_request)._canvas_course_groups()
+
+    canvas_api_client.group_category_groups.assert_called_once_with(group_category_id)
+    assert groups == canvas_api_client.group_category_groups.return_value
+
+
+@pytest.mark.usefixtures("is_group_launch", "user_is_learner")
+def test_canvas_learner_group(pyramid_request, request_json, canvas_api_client):
+    canvas_api_client.course_groups.return_value = [
+        {"group_category_id": 0},
+        {"group_category_id": 1},
+    ]
+
+    course_id = request_json["course"]["custom_canvas_course_id"]
+
+    groups = Sync(pyramid_request)._canvas_learner_group()
+
+    canvas_api_client.course_groups.assert_called_once_with(
+        course_id, only_own_groups=True
+    )
+    assert groups["group_category_id"] == 1
+
+
+@pytest.mark.usefixtures("is_group_launch", "user_is_learner")
+def test_canvas_learner_group_empty(pyramid_request, request_json, canvas_api_client):
+    canvas_api_client.course_groups.return_value = []
+
+    course_id = request_json["course"]["custom_canvas_course_id"]
+
+    groups = Sync(pyramid_request)._canvas_learner_group()
+
+    canvas_api_client.course_groups.assert_called_once_with(
+        course_id, only_own_groups=True
+    )
+    assert groups is None
 
 
 @pytest.mark.usefixtures("user_is_instructor")
 @pytest.mark.usefixtures("is_speedgrader")
-def test_sync_when_in_SpeedGrader(
-    pyramid_request, canvas_api_client, sections, assert_sync_and_return, request_json
+def test_sections_sync_when_in_SpeedGrader(
+    pyramid_request,
+    canvas_api_client,
+    sections,
+    assert_sync_and_return_sections,
+    request_json,
 ):
     groupids = Sync(pyramid_request).sync()
 
@@ -44,11 +219,11 @@ def test_sync_when_in_SpeedGrader(
     canvas_api_client.course_sections.assert_called_once_with(course_id)
     canvas_api_client.users_sections.assert_called_once_with(user_id, course_id)
 
-    assert_sync_and_return(groupids, sections=sections.user)
+    assert_sync_and_return_sections(groupids, sections=sections.user)
 
 
 @pytest.fixture
-def assert_sync_and_return(lti_h_service, request_json, grouping_service):
+def assert_sync_and_return_sections(lti_h_service, request_json, grouping_service):
     tool_guid = request_json["lms"]["tool_consumer_instance_guid"]
     context_id = request_json["course"]["context_id"]
 
@@ -75,8 +250,31 @@ def assert_sync_and_return(lti_h_service, request_json, grouping_service):
 
 
 @pytest.fixture
-def is_speedgrader(request_json):
-    request_json["learner"] = {"canvas_user_id": "user_id"}
+def assert_sync_and_return_groups(lti_h_service, request_json, grouping_service):
+    tool_guid = request_json["lms"]["tool_consumer_instance_guid"]
+    context_id = request_json["course"]["context_id"]
+
+    def assert_return_values(groupids, groups):
+        expected_groups = [
+            grouping_service.upsert_canvas_group(
+                tool_consumer_instance_guid=tool_guid,
+                context_id=context_id,
+                group_id=group["id"],
+                group_name=group.get("name", f"Group {group['id']}"),
+                group_set_id=group["group_category_id"],
+            )
+            for group in groups
+        ]
+
+        lti_h_service.sync.assert_called_once_with(
+            expected_groups, request_json["group_info"]
+        )
+
+        assert groupids == [
+            group.groupid(TEST_SETTINGS["h_authority"]) for group in expected_groups
+        ]
+
+    return assert_return_values
 
 
 @pytest.fixture
@@ -122,3 +320,18 @@ def request_json():
         "lms": {"tool_consumer_instance_guid": "test_tool_consumer_instance_guid"},
         "group_info": {"foo": "bar"},
     }
+
+
+@pytest.fixture
+def is_speedgrader(request_json):
+    request_json["learner"] = {"canvas_user_id": 111}
+
+
+@pytest.fixture
+def is_group_launch(request_json):
+    request_json["course"]["group_set"] = 1
+
+
+@pytest.fixture
+def is_group_and_speedgrader(request_json):
+    request_json["learner"] = {"canvas_user_id": 111, "group_set": 1}


### PR DESCRIPTION
# Testing notes

- Truncate your courses and grouping tables to test the insertion of a new course & groups
```truncate grouping, course;```

- Enable groups on the application instance

http://localhost:8001/admin/instance/Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a/

- Open an assignment with groups https://hypothesis.instructure.com/courses/125/assignments/873

- Check the grouping table, it should contain one row for the course and for each group (if opened as a teacher). Pay attention to the parent_id relationship, sections should point to the course.

```
-[ RECORD 1 ]-----------+-------------------------------------------------------------------------------------------------------
created                 | 2021-06-07 12:47:11.497763
updated                 | 2021-06-07 12:47:11.497763
id                      | 130
application_instance_id | 8
authority_provided_id   | 653e9620a656a954c684942f6443fa3e3410c03a
parent_id               | 
lms_id                  | f3cd019017839c4630358662a05540f2f6ec5f93
type                    | course
lms_name                | Developer Test Course with Sections Enabled
settings                | {"canvas": {"groups_enabled": true, "sections_enabled": true}, "blackboard": {"files_enabled": false}}
extra                   | {"canvas": {"custom_canvas_course_id": "125"}}
-[ RECORD 2 ]-----------+-------------------------------------------------------------------------------------------------------
created                 | 2021-06-07 12:47:11.619672
updated                 | 2021-06-07 12:47:11.619672
id                      | 131
application_instance_id | 8
authority_provided_id   | 381c455de84ae2f6d2fc84142f4e898b29d748f3
parent_id               | 130
lms_id                  | 132
type                    | canvas_group
lms_name                | another group
settings                | {}
extra                   | {"group_set_id": 121}
-[ RECORD 3 ]-----------+-------------------------------------------------------------------------------------------------------
created                 | 2021-06-07 12:47:11.619672
updated                 | 2021-06-07 12:47:11.619672
id                      | 132
application_instance_id | 8
authority_provided_id   | 102a25279bc609179f58cb4bf5c50d7dfc6f0929
parent_id               | 130
lms_id                  | 130
type                    | canvas_group
lms_name                | others
settings                | {}
extra                   | {"group_set_id": 121}
-[ RECORD 4 ]-----------+-------------------------------------------------------------------------------------------------------
created                 | 2021-06-07 12:47:11.619672
updated                 | 2021-06-07 12:47:11.619672
id                      | 133
application_instance_id | 8
authority_provided_id   | 802107eead62d51dcdef0f317f0eb0b9868eaa7c
parent_id               | 130
lms_id                  | 129
type                    | canvas_group
lms_name                | Seans
settings                | {}
extra                   | {"group_set_id": 121}
-[ RECORD 5 ]-----------+-------------------------------------------------------------------------------------------------------
created                 | 2021-06-07 12:47:11.619672
updated                 | 2021-06-07 12:47:11.619672
id                      | 134
application_instance_id | 8
authority_provided_id   | e8c66a347a5f547ae87928d4e92e5045908f8d54
parent_id               | 130
lms_id                  | 131
type                    | canvas_group
lms_name                | test
settings                | {}
extra                   | {"group_set_id": 121}
```

- The client should show all the groups in the top left menu.

- Open speed grader,  it should open the client for students that launched the assignment.

- Open the same assignment as a student. The menu should show only one group (no selection possible).




