### PR TITLE
Add Blackboard file picker dialog and button

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -18,7 +18,7 @@ import URLPicker from './URLPicker';
  * @prop {string} title
  * @prop {Error} error
  *
- * @typedef {'lmsFile'|'url'|null} DialogType
+ * @typedef {'blackboardFile'|'canvasFile'|'url'|null} DialogType
  *
  * @typedef {import('../utils/content-item').Content} Content
  */
@@ -43,7 +43,11 @@ export default function ContentSelector({
   const {
     api: { authToken },
     filePicker: {
-      canvas: { enabled: canvasEnabled, listFiles: listFilesApi },
+      blackboard: {
+        enabled: blackboardFilesEnabled,
+        listFiles: blackboardListFilesApi,
+      },
+      canvas: { enabled: canvasFilesEnabled, listFiles: listFilesApi },
       google: {
         clientId: googleClientId,
         developerKey: googleDeveloperKey,
@@ -95,9 +99,16 @@ export default function ContentSelector({
   };
 
   /** @param {File} file */
-  const selectLMSFile = file => {
+  const selectCanvasFile = file => {
     cancelDialog();
     onSelectContent({ type: 'file', file });
+  };
+
+  /** @param {File} file */
+  const selectBlackboardFile = file => {
+    cancelDialog();
+    // file.id shall be a url of the form blackboard://content-resource/{file_id}
+    onSelectContent({ type: 'url', url: file.id });
   };
 
   let dialog;
@@ -105,13 +116,23 @@ export default function ContentSelector({
     case 'url':
       dialog = <URLPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
       break;
-    case 'lmsFile':
+    case 'canvasFile':
       dialog = (
         <LMSFilePicker
           authToken={authToken}
           listFilesApi={listFilesApi}
           onCancel={cancelDialog}
-          onSelectFile={selectLMSFile}
+          onSelectFile={selectCanvasFile}
+        />
+      );
+      break;
+    case 'blackboardFile':
+      dialog = (
+        <LMSFilePicker
+          authToken={authToken}
+          listFilesApi={blackboardListFilesApi}
+          onCancel={cancelDialog}
+          onSelectFile={selectBlackboardFile}
         />
       );
       break;
@@ -161,13 +182,22 @@ export default function ContentSelector({
           >
             Enter URL of web page or PDF
           </LabeledButton>
-          {canvasEnabled && (
+          {canvasFilesEnabled && (
             <LabeledButton
-              onClick={() => selectDialog('lmsFile')}
+              onClick={() => selectDialog('canvasFile')}
               variant="primary"
-              data-testid="lms-file-button"
+              data-testid="canvas-file-button"
             >
               Select PDF from Canvas
+            </LabeledButton>
+          )}
+          {blackboardFilesEnabled && (
+            <LabeledButton
+              onClick={() => selectDialog('blackboardFile')}
+              variant="primary"
+              data-testid="blackboard-file-button"
+            >
+              Select PDF from Blackboard
             </LabeledButton>
           )}
           {googlePicker && (

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -59,6 +59,9 @@ import { createContext } from 'preact';
  * @typedef FilePickerConfig
  * @prop {string} formAction
  * @prop {Object.<string,string>} formFields
+ * @prop {Object} blackboard
+ *   @prop {boolean} blackboard.enabled
+ *   @prop {ApiCallInfo} blackboard.listFiles
  * @prop {Object} canvas
  *   @prop {boolean} canvas.enabled
  *   @prop {boolean} canvas.groupsEnabled


### PR DESCRIPTION
Add Blackboard file picker dialog and button 

Add a Blackboard file picker similar to the Canvas PDF file picker. The Blackboard file picker enabled flag is passed in from config.blackboard.enabled. The file list is passed from config.blackboard.listFile.

The selected file is sent by passing a hidden field called document_url in the POST request and is set by passing a URLContent object to FilePickerFormField's `content` prop. Note that this is slightly different than the Canvas picker which uses a FileContent object instead and gets passed via content_items hidden field.

--------------

_Based from https://github.com/hypothesis/lms/pull/2636_

Test with `blackboardteacher`

Test content link:
https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_39_1&course_id=_19_1

![Screen Shot 2021-06-02 at 5 49 06 PM](https://user-images.githubusercontent.com/3939074/120569495-dcca7d00-c3ca-11eb-92cc-92b9de17992f.png)

![Screen Shot 2021-06-02 at 5 49 10 PM](https://user-images.githubusercontent.com/3939074/120569498-dd631380-c3ca-11eb-8dd7-e89de57a3cbb.png) 

POST body
```

{
  ...
  content_items: {"@context":"http://purl.imsglobal.org/ctx/lti/v1/ContentItem","@graph":[{"@type":"LtiLinkItem","mediaType":"application/vnd.ims.lti.v1.ltilink","url":"http://localhost:8001/lti_launches?url=blackboard%3A%2F%2Fcontent-resource%2F123"}]}
  document_url: blackboard://content-resource/123
}

```
I am still unsure about this line of code which adds the `content` prop as a param to the http://localhost:8001/lti_launches url for the `content_items` key passed in the POST request.
 https://github.com/hypothesis/lms/blob/6360fb6b6161e9c5c54c02e08e3eaecd61b28703/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js#L43

I think that the server does not need `url=` param attached here and only cares about `document_url` field in the blackboard case. As it stands now, it appears to be begin to pass it along, and it might further complicate this bit of code to have yet another exception to ignore the `url` param for this case.  I'm inclined to just leave this as it until we finalize the mechanism between the server and client for blackboard. I could use some direction on this.



fixes https://github.com/hypothesis/lms/issues/2029