### PR TITLE
Truncate long URLs in "Assignment details" view

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -9,6 +9,7 @@ import {
 } from 'preact/hooks';
 
 import { Config } from '../config';
+import { truncateURL } from '../utils/format';
 
 import ContentSelector from './ContentSelector';
 import ErrorDialog from './ErrorDialog';
@@ -37,7 +38,7 @@ import GroupConfigSelector from './GroupConfigSelector';
 function contentDescription(content) {
   switch (content.type) {
     case 'url':
-      return content.url;
+      return truncateURL(content.url, 65 /* maxLength */);
     case 'file':
       return 'PDF file in Canvas';
     case 'vitalsource':
@@ -123,7 +124,7 @@ export default function FilePickerApp({ onSubmit }) {
         <div className="FilePickerApp__left-col">Assignment content</div>
         <div className="FilePickerApp__right-col">
           {content ? (
-            <i>{contentDescription(content)}</i>
+            <i data-testid="content-summary">{contentDescription(content)}</i>
           ) : (
             <Fragment>
               <p>

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -134,6 +134,31 @@ describe('FilePickerApp', () => {
       assert.notCalled(onSubmit);
     });
 
+    it('displays a summary of the assignment content', () => {
+      const wrapper = renderFilePicker();
+
+      selectContent(wrapper, 'https://example.com');
+
+      assert.equal(
+        wrapper.find('[data-testid="content-summary"]').text(),
+        'https://example.com'
+      );
+    });
+
+    it('truncates long URLs in assignment content summary', () => {
+      const wrapper = renderFilePicker();
+
+      selectContent(
+        wrapper,
+        'https://en.wikipedia.org/wiki/Cannonball_Baker_Sea-To-Shining-Sea_Memorial_Trophy_Dash'
+      );
+
+      assert.equal(
+        wrapper.find('[data-testid="content-summary"]').text(),
+        'en.wikipedia.org/…/Cannonball_Baker_Sea-To-Shining-Sea_Memorial_…'
+      );
+    });
+
     it('disables "Continue" button when group sets are enabled but no group set is selected', () => {
       const wrapper = renderFilePicker();
 

--- a/lms/static/scripts/frontend_apps/utils/format.js
+++ b/lms/static/scripts/frontend_apps/utils/format.js
@@ -11,18 +11,25 @@
  * @param {number} maxLength
  */
 export function truncateURL(url, maxLength) {
+  // The URL is progressively shortened in stages until its length becomes <=
+  // `maxLength` and then returned:
+  //
+  // 1. https://example.com/foobar/baz/quux?query#fragment
+  // 2. example.com/foobar/baz/quux?query#fragment (strip protocol)
+  // 3. example.com/foobar/baz/quux (strip query and fragment)
+  // 4. example.com/…/baz/quux (elide path segments incrementally)
+  // 5. example.com/…/quux
+  // 6. example.com/…/qu… (elide end of URL)
+
   if (url.length <= maxLength) {
     return url;
   }
 
-  // Strip the protocol and return if that is sufficient.
   const urlWithoutScheme = url.replace(/^[^:]+:\/\//, '');
   if (urlWithoutScheme.length <= maxLength) {
     return urlWithoutScheme;
   }
 
-  // Strip the query string and fragment, then continue removing path segments
-  // until the result is shorter than `maxLength`.
   let parsed;
   try {
     parsed = new URL(url);
@@ -41,7 +48,6 @@ export function truncateURL(url, maxLength) {
     pathSegments.shift();
   }
 
-  // If the final URL is still too long, just elide it.
   let result = getCandidate();
   if (result.length > maxLength) {
     result = result.slice(0, maxLength - 1) + '…';

--- a/lms/static/scripts/frontend_apps/utils/format.js
+++ b/lms/static/scripts/frontend_apps/utils/format.js
@@ -1,0 +1,51 @@
+/**
+ * Truncate a URL to be `maxLength` or fewer characters.
+ *
+ * If `url` needs to be shortened, `truncateURL` tries to preserve the most
+ * informative parts of the URL using some simple heuristics.
+ *
+ * If `url` is not a valid URL, it is just shortened to the first `maxLength - 1`
+ * characters.
+ *
+ * @param {string} url
+ * @param {number} maxLength
+ */
+export function truncateURL(url, maxLength) {
+  if (url.length <= maxLength) {
+    return url;
+  }
+
+  // Strip the protocol and return if that is sufficient.
+  const urlWithoutScheme = url.replace(/^[^:]+:\/\//, '');
+  if (urlWithoutScheme.length <= maxLength) {
+    return urlWithoutScheme;
+  }
+
+  // Strip the query string and fragment, then continue removing path segments
+  // until the result is shorter than `maxLength`.
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url.slice(0, maxLength - 1) + '…';
+  }
+
+  const hostname = parsed.hostname;
+  const pathSegments = parsed.pathname.split('/');
+  let pathTruncated = false;
+
+  const getCandidate = () =>
+    hostname + (pathTruncated ? '/…/' : '') + pathSegments.join('/');
+  while (pathSegments.length > 1 && getCandidate().length > maxLength) {
+    pathTruncated = true;
+    pathSegments.shift();
+  }
+
+  // If the final URL is still too long, just elide it.
+  let result = getCandidate();
+  if (result.length > maxLength) {
+    result = result.slice(0, maxLength - 1) + '…';
+  }
+
+  return result;
+}

--- a/lms/static/scripts/frontend_apps/utils/test/format-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/format-test.js
@@ -1,0 +1,38 @@
+import { truncateURL } from '../format';
+
+describe('truncateURL', () => {
+  [
+    // URLs less than the max length are unmodified.
+    ['https://example.com', 'https://example.com'],
+
+    // URLs just longer than the max length have their protocol removed.
+    ['https://example.com/foobar-bazquux', 'example.com/foobar-bazquux'],
+
+    // URLs that are shorter than the max length after removing the protocol,
+    // query string and fragment have those parts removed
+    [
+      'https://example.com/foobar-bazquux?a-long-query-string#some-fragment',
+      'example.com/foobar-bazquux',
+    ],
+
+    // URLs that are shorter than the max length after removing some path
+    // elements have the path truncated.
+    ['https://en.wikipedia.org/wiki/Australia', 'en.wikipedia.org/…/Australia'],
+
+    // URLs that are still too longer after removing all the path elements
+    // except the final one are just elided.
+    [
+      'https://en.wikipedia.org/wiki/Cannonball_Run_challenge',
+      'en.wikipedia.org/…/Cannonball…',
+    ],
+  ].forEach(([input, expected]) => {
+    it('truncates a long URL', () => {
+      assert.equal(truncateURL(input, 30), expected);
+    });
+  });
+
+  it('truncates an invalid URL', () => {
+    const invalidURL = 'foo$://foobar.com/wibble';
+    assert.equal(truncateURL(invalidURL, 10), invalidURL.slice(0, 9) + '…');
+  });
+});


### PR DESCRIPTION
When displaying a short description of the content for an assignment,
shorten long URLs so that the form does not overflow the viewport.

We could have gotten away with some very simple text truncation here,
but I've tried to do a little better and truncate the URL in a way that
preserves the most informative parts. I suspect we'll have use for this
logic in other places.

Fixes #2774

---

Example of group configuration screen with truncated URL:

<img width="828" alt="Truncated URL" src="https://user-images.githubusercontent.com/2458/120661439-2d4fe200-c480-11eb-8592-d60dbd4ac183.png">
