### PR TITLE
Add a file table and update it when we retrieve a list of Canvas files

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -98,6 +98,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.services")
     config.include("lms.validation")
     config.include("lms.tweens")
+    config.scan("lms.events")
     config.add_static_view(name="export", path="lms:static/export")
     config.add_static_view(name="static", path="lms:static")
 

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -6,10 +6,12 @@ import sqlalchemy
 import zope.sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.orm.properties import ColumnProperty
 
-__all__ = ("BASE", "init")
+from lms.db._bulk_action import BulkAction
+
+__all__ = ("BASE", "init", "BulkAction")
 
 
 LOG = logging.getLogger(__name__)
@@ -85,9 +87,6 @@ BASE = declarative_base(
 )
 
 
-SESSION = sessionmaker()
-
-
 def init(engine, drop=False):
     """
     Create all the database tables if they don't already exist.
@@ -121,6 +120,13 @@ def _stamp_db(engine):  # pragma: nocover
 def make_engine(settings):
     """Construct a sqlalchemy engine from the passed ``settings``."""
     return sqlalchemy.create_engine(settings["sqlalchemy.url"])
+
+
+class CustomSession(Session):
+    bulk = BulkAction()
+
+
+SESSION = sessionmaker(class_=CustomSession)
 
 
 def _session(request):  # pragma: no cover

--- a/lms/db/_bulk_action.py
+++ b/lms/db/_bulk_action.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+from typing import List
+
+from sqlalchemy.dialects.postgresql import insert
+from zope.sqlalchemy import mark_changed
+
+from lms.db._session_extension import SessionExtension
+
+
+class BulkAction(SessionExtension):
+    """
+    An extension to the DB session which adds bulk actions.
+
+    These can be accessed via `session.bulk.<method_name>()`.
+
+    To enable for a particular model add config to the model like this:
+
+        class MyModel(BASE):
+            # Enable bulk actions
+            BULK_CONFIG = BulkAction.Config(
+                upsert_index_elements=[...],
+                upsert_update_elements=[...],
+            )
+    """
+
+    @dataclass
+    class Config:
+        upsert_index_elements: List[str]
+        """Columns to match when upserting. This must match an index."""
+
+        upsert_update_elements: List[str]
+        """Columns to update when a match is found."""
+
+        def __set_name__(self, owner, name):
+            # Ensure we have the right name when attached to objects
+            if name != "BULK_CONFIG":
+                raise ValueError(
+                    "The configuration must be attached to the model with "
+                    "the name 'BULK_CONFIG'"
+                )
+
+    def upsert(self, model_class, values):
+        """
+        Create or update the specified values in the table.
+
+        :param model_class: The model type to upsert
+        :param values: Dicts of values to upsert
+        """
+
+        config = self._get_config(model_class)
+
+        stmt = insert(model_class).values(values)
+        stmt = stmt.on_conflict_do_update(
+            # Match when the rules are the same
+            index_elements=config.upsert_index_elements,
+            # Then set these elements
+            set_={
+                element: getattr(stmt.excluded, element)
+                for element in config.upsert_update_elements
+            },
+        )
+
+        # This session attribute is here because we are a session extension
+        result = self.session.execute(stmt)
+
+        # Let SQLAlchemy know that something has changed, otherwise it will
+        # never commit the transaction we are working on and it will get rolled
+        # back
+        mark_changed(self.session)
+
+        return result
+
+    @classmethod
+    def _get_config(cls, model_class):
+        """
+        Get the bulk config in this model or raise.
+
+        :param model_class: Class to get config from
+        :rtype: Config
+        :raises NotImplementedError: If the config is missing
+        """
+        try:
+            return model_class.BULK_CONFIG
+        except AttributeError as err:
+            raise NotImplementedError(
+                f"Model class '{model_class}' does not have the expected config "
+                "attribute: 'BULK_CONFIG'"
+            ) from err

--- a/lms/db/_session_extension.py
+++ b/lms/db/_session_extension.py
@@ -1,0 +1,29 @@
+class SessionExtension:
+    """
+    A self returning descriptor to adding functionality to a session.
+
+    To use this, sub-class it and then add your object to the session:
+
+    class CustomSession(Session):
+        my_extension = MyExtension()
+
+    The `name` and `session` attributes will be available to your instance.
+    """
+
+    session = None
+    name = None
+
+    def __set_name__(self, owner, name):
+        # Store the name for more informative errors
+        self.name = name
+
+    def __get__(self, instance, owner):
+        if not instance:
+            raise TypeError(
+                f"You can only call '{self.name}' on instances not the bare "
+                f"class: '{owner.__name__}'"
+            )
+
+        # Store the session and return ourselves
+        self.session = instance
+        return self

--- a/lms/events/__init__.py
+++ b/lms/events/__init__.py
@@ -1,0 +1,1 @@
+from lms.events.subscriber import FilesDiscoveredEvent

--- a/lms/events/subscriber.py
+++ b/lms/events/subscriber.py
@@ -1,0 +1,29 @@
+from pyramid.events import subscriber
+
+from lms.models.file import File
+
+
+class FilesDiscoveredEvent:
+    """Notify that a file has been found in an LMS."""
+
+    def __init__(self, request, values):
+        """
+        Initialize the event.
+
+        :param request: Pyramid request object
+        :param values: List of dicts of file information
+        """
+        self.request = request
+        self.values = values
+
+
+@subscriber(FilesDiscoveredEvent)
+def files_discovered(event):
+    """Record discovered files in the DB."""
+
+    application_instance = event.request.find_service(name="application_instance").get()
+
+    for value in event.values:
+        value["application_instance_id"] = application_instance.id
+
+    event.request.db.bulk.upsert(File, values=event.values)

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -3,6 +3,7 @@ from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
 from lms.models.course import LegacyCourse
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
+from lms.models.file import File
 from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
 from lms.models.grouping import CanvasSection, Course, Grouping

--- a/lms/models/file.py
+++ b/lms/models/file.py
@@ -1,0 +1,49 @@
+import sqlalchemy as sa
+
+from lms.db import BASE, BulkAction
+from lms.models._mixins import CreatedUpdatedMixin
+
+
+class File(CreatedUpdatedMixin, BASE):
+    """A record of files we've seen in LMS's."""
+
+    __tablename__ = "file"
+    __table_args__ = (
+        sa.UniqueConstraint("application_instance_id", "lms_id", "type", "course_id"),
+    )
+
+    # Enable bulk actions
+    BULK_CONFIG = BulkAction.Config(
+        upsert_index_elements=[
+            "application_instance_id",
+            "lms_id",
+            "type",
+            "course_id",
+        ],
+        upsert_update_elements=["name", "size"],
+    )
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+    """Primary key"""
+
+    application_instance_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("application_instances.id", ondelete="cascade"),
+        nullable=False,
+    )
+    """Link to the application instance."""
+
+    type = sa.Column(sa.String(), nullable=False)
+    """What type of file is this? e.g. 'canvas_file'."""
+
+    lms_id = sa.Column(sa.String(), nullable=False)
+    """The natural id of the file in the LMS."""
+
+    course_id = sa.Column(sa.String())
+    """If the file is associated with a specific course set it here."""
+
+    name = sa.Column(sa.String())
+    """The user facing file name."""
+
+    size = sa.Column(sa.Integer())
+    """The size of the file in bytes."""

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,3 +1,4 @@
+from lms.services.canvas import CanvasService
 from lms.services.exceptions import (
     CanvasAPIError,
     CanvasAPIPermissionError,
@@ -26,6 +27,8 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.canvas_api.canvas_api_client_factory", name="canvas_api_client"
     )
+    config.register_service_factory("lms.services.canvas.factory", iface=CanvasService)
+
     config.register_service_factory("lms.services.h_api.HAPI", name="h_api")
     config.register_service_factory(
         "lms.services.launch_verifier.LaunchVerifier", name="launch_verifier"

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -1,0 +1,42 @@
+from lms.services.exceptions import CanvasFileNotFoundInCourse
+
+
+class CanvasService:
+    """A high level Canvas service."""
+
+    api = None
+
+    def __init__(self, canvas_api):
+        self.api = canvas_api
+
+    def public_url_for_file(self, file_id, course_id, check_in_course=False):
+        """
+        Get a public URL for a Canvas file.
+
+        This will also attempt to check if the file is in the course to detect
+        course copy situations and fix it if we can.
+
+        :param file_id: The file to look up
+        :param course_id: The course the file should be in
+        :param check_in_course: Enable pre-emptive checking for the file in the
+            course regardless of whether the user has permission to see it
+        :return: A URL suitable for public presentation of the file
+        :raises  CanvasFileNotFoundInCourse: If we determine the file should
+            be in the course but isn't.
+        """
+
+        if check_in_course:
+            if not self._file_in_course(file_id, course_id):
+                # Looks like a course copy
+                raise CanvasFileNotFoundInCourse(file_id)
+
+        return self.api.public_url(file_id)
+
+    def _file_in_course(self, file_id, course_id):
+        return any(
+            str(file_["id"]) == str(file_id) for file_ in self.api.list_files(course_id)
+        )
+
+
+def factory(_context, request):
+    return CanvasService(canvas_api=request.find_service(name="canvas_api_client"))

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -3,7 +3,7 @@
 import marshmallow
 from marshmallow import EXCLUDE, Schema, fields, post_load, validate, validates_schema
 
-from lms.services import CanvasAPIError, CanvasFileNotFoundInCourse
+from lms.services import CanvasAPIError
 from lms.validation import RequestsResponseSchema
 
 
@@ -225,17 +225,6 @@ class CanvasAPIClient:
         display_name = fields.Str(required=True)
         id = fields.Integer(required=True)
         updated_at = fields.String(required=True)
-
-    def check_file_in_course(self, file_id, course_id):
-        """
-        Raise if the file with ID file_id isn't in the course with ID course_id.
-
-        :raise CanvasFileNotFoundInCourse: If the file isn't in the course
-        """
-        if not any(
-            str(file_["id"]) == str(file_id) for file_ in self.list_files(course_id)
-        ):
-            raise CanvasFileNotFoundInCourse(file_id)
 
     def public_url(self, file_id):
         """

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -26,4 +26,4 @@ def canvas_api_client_factory(_context, request):
         redirect_uri=request.route_url("canvas_api.oauth.callback"),
     )
 
-    return CanvasAPIClient(authenticated_api)
+    return CanvasAPIClient(authenticated_api, request=request)

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -2,6 +2,7 @@
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
+from lms.services.canvas import CanvasService
 from lms.views import helpers
 
 
@@ -9,7 +10,7 @@ from lms.views import helpers
 class FilesAPIViews:
     def __init__(self, request):
         self.request = request
-        self.canvas_api_client = request.find_service(name="canvas_api_client")
+        self.canvas = request.find_service(CanvasService)
 
     @view_config(request_method="GET", route_name="canvas_api.courses.files.list")
     def list_files(self):
@@ -19,7 +20,7 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
-        return self.canvas_api_client.list_files(self.request.matchdict["course_id"])
+        return self.canvas.api.list_files(self.request.matchdict["course_id"])
 
     @view_config(request_method="GET", route_name="canvas_api.files.via_url")
     def via_url(self):
@@ -29,14 +30,13 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
-        file_id = self.request.matchdict["file_id"]
-        course_id = self.request.matchdict["course_id"]
-
-        if self.request.lti_user.is_instructor:
-            self.canvas_api_client.check_file_in_course(file_id, course_id)
-
-        public_url = self.canvas_api_client.public_url(
-            self.request.matchdict["file_id"]
+        public_url = self.canvas.public_url_for_file(
+            file_id=self.request.matchdict["file_id"],
+            course_id=self.request.matchdict["course_id"],
+            # For teachers we can do a pre-emptive check to see if the file is
+            # in the course or not, to catch course copy scenarios even though
+            # the teacher has permission to see the file
+            check_in_course=self.request.lti_user.is_instructor,
         )
 
         # Currently we only let users pick PDF files, so we can save a little

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,8 @@ from unittest import mock
 import factory.random
 import pytest
 import sqlalchemy
-from sqlalchemy.orm import sessionmaker
 
 from lms import db
-
-SESSION = sessionmaker()
 
 
 def get_test_database_url(default):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,8 +6,9 @@ from webtest import TestApp
 
 from lms import db
 from lms.app import create_app
+from lms.db import SESSION
 from tests import factories
-from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
+from tests.conftest import TEST_SETTINGS, get_test_database_url
 
 TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(
     default="postgresql://postgres@localhost:5433/lms_functests"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,8 +6,9 @@ import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 
+from lms.db import SESSION
 from tests import factories
-from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
+from tests.conftest import TEST_SETTINGS, get_test_database_url
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(

--- a/tests/unit/lms/db/_bulk_action_test.py
+++ b/tests/unit/lms/db/_bulk_action_test.py
@@ -1,0 +1,75 @@
+import pytest
+import sqlalchemy as sa
+from h_matchers import Any
+from sqlalchemy.engine import CursorResult
+
+from lms.db import BASE, BulkAction
+
+
+class TestBulkUpsertMixin:
+    class TableWithBulkUpsert(BASE):
+        __tablename__ = "test_table_with_bulk_upsert"
+
+        BULK_CONFIG = BulkAction.Config(
+            upsert_index_elements=["id"], upsert_update_elements=["name"]
+        )
+
+        id = sa.Column(sa.Integer, primary_key=True)
+        name = sa.Column(sa.String)
+        other = sa.Column(sa.String)
+
+    def test_upsert(self, db_session):
+        db_session.add_all(
+            [
+                self.TableWithBulkUpsert(id=1, name="pre_existing_1", other="pre_1"),
+                self.TableWithBulkUpsert(id=2, name="pre_existing_2", other="pre_2"),
+            ]
+        )
+        db_session.flush()
+
+        result = db_session.bulk.upsert(
+            self.TableWithBulkUpsert,
+            [
+                {"id": 1, "name": "update_old", "other": "post_1"},
+                {"id": 3, "name": "create_with_id", "other": "post_3"},
+                {"id": 4, "name": "over_block_size", "other": "post_4"},
+            ],
+        )
+
+        assert isinstance(result, CursorResult)
+
+        rows = list(db_session.query(self.TableWithBulkUpsert))
+
+        assert (
+            rows
+            == Any.iterable.containing(
+                [
+                    Any.instance_of(self.TableWithBulkUpsert).with_attrs(expected)
+                    for expected in [
+                        {"id": 1, "name": "update_old", "other": "pre_1"},
+                        {"id": 2, "name": "pre_existing_2", "other": "pre_2"},
+                        {"id": 3, "name": "create_with_id", "other": "post_3"},
+                        {"id": 4, "name": "over_block_size", "other": "post_4"},
+                    ]
+                ]
+            ).only()
+        )
+
+    def test_it_fails_with_missing_config(self, db_session):
+        with pytest.raises(NotImplementedError):
+            db_session.bulk.upsert("object_without_config", [])
+
+    def test_you_cannot_add_config_with_the_wrong_name(self):
+        # Not sure why this isn't ValueError... must be a descriptor thing
+        with pytest.raises(RuntimeError):
+
+            class MisconfiguredModel:  # pylint: disable=unused-variable
+                NOT_THE_RIGHT_NAME = BulkAction.Config(
+                    upsert_index_elements=["id"], upsert_update_elements=["name"]
+                )
+
+    @pytest.fixture
+    def db_session(self, db_session):
+        db_session.bulk = BulkAction()
+        db_session.bulk.session = db_session
+        return db_session

--- a/tests/unit/lms/db/_session_extension_test.py
+++ b/tests/unit/lms/db/_session_extension_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from lms.db._session_extension import SessionExtension
+
+
+class TestSessionExtension:
+    def test_it(self, session):
+        result = session.extension
+
+        assert isinstance(result, SessionExtension)
+        assert result.session == session
+
+    def test_it_stores_the_name(self, session):
+        assert session.extension.name == "extension"
+
+    def test_you_cannot_call_it_on_the_class(self):
+        class Session:
+            extension = SessionExtension()
+
+        with pytest.raises(TypeError):
+            assert Session.extension
+
+    @pytest.fixture
+    def session(self):
+        class Session:
+            extension = SessionExtension()
+
+        return Session()

--- a/tests/unit/lms/events/subscriber_test.py
+++ b/tests/unit/lms/events/subscriber_test.py
@@ -1,0 +1,99 @@
+import pytest
+from h_matchers import Any
+
+from lms.events import FilesDiscoveredEvent
+from lms.events.subscriber import files_discovered
+from lms.models import File
+from tests import factories
+
+
+class TestFilesDiscovered:
+    @pytest.mark.parametrize("extras", ({}, {"name": "new"}, {"course_id": "cid_1"}))
+    def test_it_can_add_new_values(
+        self, pyramid_request, db_session, application_instance, extras
+    ):
+        attrs = dict(type="new", lms_id="id_1", **extras)
+
+        files_discovered(
+            # Use a dict call here again to prevent SQLAlchemy from messing
+            # with our dict in place
+            event=FilesDiscoveredEvent(request=pyramid_request, values=[dict(attrs)])
+        )
+
+        assert db_session.query(File).all() == [
+            Any.instance_of(File).with_attrs(
+                dict(application_instance_id=application_instance.id, **attrs)
+            )
+        ]
+
+    @pytest.mark.usefixtures("existing_file")
+    def test_it_can_update_old_values(
+        self,
+        pyramid_request,
+        db_session,
+        existing_attrs,
+    ):
+        new_attrs = dict(existing_attrs, name="new")
+
+        files_discovered(
+            # Use a dict call here again to prevent SQLAlchemy from messing
+            # with our dict in place
+            event=FilesDiscoveredEvent(request=pyramid_request, values=[new_attrs])
+        )
+
+        assert db_session.query(File).all() == [
+            Any.instance_of(File).with_attrs(new_attrs)
+        ]
+
+    # We don't cover the application instance id here 'cos it's annoying
+    @pytest.mark.parametrize("field", ("type", "lms_id", "course_id"))
+    @pytest.mark.usefixtures("existing_file")
+    def test_old_values_are_only_updated_for_exact_matches(
+        self, db_session, field, pyramid_request, existing_attrs
+    ):
+        new_attrs = dict(existing_attrs)
+        new_attrs[field] = "different"
+
+        files_discovered(
+            # Use a dict call here again to prevent SQLAlchemy from messing
+            # with our dict in place
+            event=FilesDiscoveredEvent(
+                request=pyramid_request, values=[dict(new_attrs)]
+            )
+        )
+
+        assert (
+            db_session.query(File).all()
+            == Any.list.containing(
+                [
+                    Any.instance_of(File).with_attrs(existing_attrs),
+                    Any.instance_of(File).with_attrs(new_attrs),
+                ]
+            ).only()
+        )
+
+    @pytest.fixture
+    def existing_attrs(self, application_instance):
+        return {
+            "application_instance_id": application_instance.id,
+            "type": "existing_type",
+            "lms_id": "existing_lms_id",
+            "course_id": "existing_course_id",
+        }
+
+    @pytest.fixture
+    def existing_file(self, db_session, existing_attrs):
+        file = File(**existing_attrs)
+        db_session.add(file)
+        db_session.flush()
+
+        return file
+
+    @pytest.fixture(autouse=True)
+    def application_instance(self, db_session, application_instance_service):
+        application_instance = factories.ApplicationInstance(id=1234)
+        db_session.add(application_instance)
+        db_session.flush()
+        application_instance_service.get.return_value = application_instance
+
+        return application_instance

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -3,12 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from lms.services import (
-    CanvasAPIError,
-    CanvasAPIServerError,
-    CanvasFileNotFoundInCourse,
-    ProxyAPIAccessTokenError,
-)
+from lms.services import CanvasAPIError, CanvasAPIServerError, ProxyAPIAccessTokenError
 from lms.services.canvas_api.client import CanvasAPIClient
 from tests import factories
 
@@ -287,31 +282,6 @@ class TestCanvasAPIClient:
             timeout=Any(),
         )
 
-    @pytest.mark.usefixtures("list_files_response")
-    @pytest.mark.parametrize("file_id", [1, "1"])
-    def test_check_file_in_course_checks_that_the_file_is_in_the_course(
-        self, canvas_api_client, file_id, http_session
-    ):
-        canvas_api_client.check_file_in_course(
-            file_id=file_id, course_id="test_course_id"
-        )
-
-        http_session.send.assert_called_once_with(
-            Any.request(
-                url=Any.url.with_path("api/v1/courses/test_course_id/files"),
-            ),
-            timeout=Any(),
-        )
-
-    @pytest.mark.usefixtures("list_files_response")
-    def test_check_file_in_course_raises_if_the_file_isnt_in_the_course(
-        self, canvas_api_client
-    ):
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_api_client.check_file_in_course(
-                file_id="not_in_course", course_id="test_course_id"
-            )
-
     def test_public_url(self, canvas_api_client, http_session):
         http_session.send.return_value = factories.requests.Response(
             status_code=200, json_data={"public_url": "public_url_value"}
@@ -325,25 +295,6 @@ class TestCanvasAPIClient:
                 "GET", url=Any.url.with_path("api/v1/files/FILE_ID/public_url")
             ),
             timeout=Any(),
-        )
-
-    @pytest.fixture
-    def list_files_response(self, http_session):
-        """Make the network send a valid Canvas API list files response."""
-        http_session.send.return_value = factories.requests.Response(
-            json_data=[
-                {
-                    "display_name": "display_name_1",
-                    "id": 1,
-                    "updated_at": "updated_at_1",
-                },
-                {
-                    "display_name": "display_name_2",
-                    "id": 2,
-                    "updated_at": "updated_at_2",
-                },
-            ],
-            status_code=200,
         )
 
 

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -260,8 +260,18 @@ class TestCanvasAPIClient:
 
     def test_list_files(self, canvas_api_client, http_session):
         files = [
-            {"display_name": "display_name_1", "id": 1, "updated_at": "updated_at_1"},
-            {"display_name": "display_name_1", "id": 1, "updated_at": "updated_at_1"},
+            {
+                "display_name": "display_name_1",
+                "id": 1,
+                "updated_at": "updated_at_1",
+                "size": 12345,
+            },
+            {
+                "display_name": "display_name_1",
+                "id": 1,
+                "updated_at": "updated_at_1",
+                "size": 12345,
+            },
         ]
         files_with_noise = [dict(file, unexpected="ignored") for file in files]
         http_session.send.return_value = factories.requests.Response(
@@ -346,5 +356,5 @@ class TestMetaBehavior:
 
 
 @pytest.fixture
-def canvas_api_client(authenticated_client):
-    return CanvasAPIClient(authenticated_client)
+def canvas_api_client(authenticated_client, pyramid_request):
+    return CanvasAPIClient(authenticated_client, pyramid_request)

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -15,7 +15,9 @@ class TestCanvasAPIClientFactory:
     ):
         canvas_api = canvas_api_client_factory(sentinel.context, pyramid_request)
 
-        CanvasAPIClient.assert_called_once_with(AuthenticatedClient.return_value)
+        CanvasAPIClient.assert_called_once_with(
+            AuthenticatedClient.return_value, pyramid_request
+        )
         assert canvas_api == CanvasAPIClient.return_value
 
     def test_building_the_BasicClient(

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,0 +1,45 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services import CanvasFileNotFoundInCourse, CanvasService
+from lms.services.canvas import factory
+
+
+class TestCanvasService:
+    @pytest.mark.parametrize("check_in_course", (True, False))
+    def test_public_url_for_file(self, canvas_service, check_in_course):
+        canvas_service.api.list_files.return_value = [{"id": sentinel.file_id}]
+
+        result = canvas_service.public_url_for_file(
+            file_id=sentinel.file_id, check_in_course=check_in_course, course_id="*any*"
+        )
+
+        assert result == canvas_service.api.public_url.return_value
+        canvas_service.api.public_url.assert_called_once_with(sentinel.file_id)
+
+    def test_public_url_for_file_with_unsuccessful_file_check(self, canvas_service):
+        canvas_service.api.list_files.return_value = []
+
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            canvas_service.public_url_for_file(
+                file_id=sentinel.file_id,
+                course_id=sentinel.course_id,
+                check_in_course=True,
+            )
+
+    @pytest.fixture
+    def canvas_service(self, canvas_api_client):
+        return CanvasService(canvas_api=canvas_api_client)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, CanvasService, canvas_api_client):
+        result = factory("*any*", request=pyramid_request)
+
+        assert result == CanvasService.return_value
+        CanvasService.assert_called_once_with(canvas_api=canvas_api_client)
+
+    @pytest.fixture
+    def CanvasService(self, patch):
+        return patch("lms.services.canvas.CanvasService")

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -1,113 +1,40 @@
 import pytest
 
-from lms.services import CanvasAPIError, CanvasFileNotFoundInCourse
 from lms.views.api.canvas.files import FilesAPIViews
 
-pytestmark = pytest.mark.usefixtures("canvas_api_client")
 
-
-class TestListFiles:
-    def test_it_gets_the_list_of_files_from_canvas(
-        self, canvas_api_client, pyramid_request
-    ):
-        FilesAPIViews(pyramid_request).list_files()
-
-        canvas_api_client.list_files.assert_called_once_with("test_course_id")
-
-    def test_it_returns_the_list_of_files(self, canvas_api_client, pyramid_request):
-        assert (
-            FilesAPIViews(pyramid_request).list_files()
-            == canvas_api_client.list_files.return_value
-        )
-
-    # CanvasAPIError's are caught and handled by an exception view, so the
-    # normal view just lets them raise.
-    def test_it_doesnt_catch_CanvasAPIErrors_from_list_files(
-        self, canvas_api_client, pyramid_request
-    ):
-        canvas_api_client.list_files.side_effect = CanvasAPIError("Oops")
-
-        with pytest.raises(CanvasAPIError, match="Oops"):
-            FilesAPIViews(pyramid_request).list_files()
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
+@pytest.mark.usefixtures("canvas_service")
+class TestFilesAPIViews:
+    def test_list_files(self, canvas_service, pyramid_request):
         pyramid_request.matchdict = {"course_id": "test_course_id"}
-        return pyramid_request
 
+        result = FilesAPIViews(pyramid_request).list_files()
 
-class TestViaURL:
-    @pytest.mark.usefixtures("user_is_instructor")
-    def test_it_checks_whether_the_file_is_in_the_course(
-        self, canvas_api_client, pyramid_request
-    ):
-        FilesAPIViews(pyramid_request).via_url()
+        assert result == canvas_service.api.list_files.return_value
+        canvas_service.api.list_files.assert_called_once_with("test_course_id")
 
-        canvas_api_client.check_file_in_course.assert_called_once_with(
-            "test_file_id", "test_course_id"
-        )
-
-    @pytest.mark.usefixtures("user_is_instructor")
-    def test_it_raises_if_the_file_isnt_in_the_course(
-        self, canvas_api_client, pyramid_request
-    ):
-        canvas_api_client.check_file_in_course.side_effect = CanvasFileNotFoundInCourse(
-            1
-        )
-
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            FilesAPIViews(pyramid_request).via_url()
-
-    @pytest.mark.usefixtures("user_is_learner")
-    def test_it_doesnt_check_whether_the_file_is_in_the_course(
-        self, canvas_api_client, pyramid_request
-    ):
-        FilesAPIViews(pyramid_request).via_url()
-
-        canvas_api_client.check_file_in_course.assert_not_called()
-
-    def test_it_gets_the_public_url_from_canvas(
-        self, canvas_api_client, pyramid_request
-    ):
-        FilesAPIViews(pyramid_request).via_url()
-
-        canvas_api_client.public_url.assert_called_once_with("test_file_id")
-
-    def test_it_gets_the_via_url_for_the_public_url(
-        self, canvas_api_client, pyramid_request, helpers
-    ):
-        FilesAPIViews(pyramid_request).via_url()
-
-        helpers.via_url.assert_called_once_with(
-            pyramid_request,
-            canvas_api_client.public_url.return_value,
-            content_type="pdf",
-        )
-
-    # CanvasAPIError's are caught and handled by an exception view, so the
-    # normal view just lets them raise.
-    def test_doesnt_catch_CanvasAPIErrors_from_public_url(
-        self, canvas_api_client, pyramid_request
-    ):
-        canvas_api_client.public_url.side_effect = CanvasAPIError("Oops")
-
-        with pytest.raises(CanvasAPIError, match="Oops"):
-            FilesAPIViews(pyramid_request).via_url()
-
-    def test_it_returns_the_via_url(self, pyramid_request, helpers):
-        data = FilesAPIViews(pyramid_request).via_url()
-
-        assert data["via_url"] == helpers.via_url.return_value
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
+    def test_via_url(self, pyramid_request, canvas_service, helpers):
         pyramid_request.matchdict = {
             "course_id": "test_course_id",
             "file_id": "test_file_id",
         }
-        return pyramid_request
 
+        result = FilesAPIViews(pyramid_request).via_url()
 
-@pytest.fixture(autouse=True)
-def helpers(patch):
-    return patch("lms.views.api.canvas.files.helpers")
+        assert result["via_url"] == helpers.via_url.return_value
+
+        canvas_service.public_url_for_file.assert_called_once_with(
+            file_id="test_file_id",
+            course_id="test_course_id",
+            check_in_course=pyramid_request.lti_user.is_instructor,
+        )
+
+        helpers.via_url.assert_called_once_with(
+            pyramid_request,
+            canvas_service.public_url_for_file.return_value,
+            content_type="pdf",
+        )
+
+    @pytest.fixture
+    def helpers(self, patch):
+        return patch("lms.views.api.canvas.files.helpers")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from lms.models import ApplicationSettings
+from lms.services import CanvasService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
 from lms.services.blackboard_api.service import BlackboardAPIClient
@@ -30,6 +31,7 @@ __all__ = (
     "assignment_service",
     "blackboard_api_client",
     "canvas_api_client",
+    "canvas_service",
     "course_service",
     "grading_info_service",
     "grant_token_service",
@@ -50,9 +52,10 @@ __all__ = (
 def mock_service(pyramid_config):
     def mock_service(service_class, service_name=None):
         mock_service = mock.create_autospec(service_class, spec_set=True, instance=True)
+
         if service_name:
             pyramid_config.register_service(mock_service, name=service_name)
-        else:  # pragma: no cover
+        else:
             pyramid_config.register_service(mock_service, iface=service_class)
 
         return mock_service
@@ -104,6 +107,14 @@ def canvas_api_client(mock_service):
         3600,
     )
     return canvas_api_client
+
+
+@pytest.fixture
+def canvas_service(mock_service, canvas_api_client):
+    canvas_service = mock_service(CanvasService)
+    canvas_service.api = canvas_api_client
+
+    return canvas_service
 
 
 @pytest.fixture


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/2768

Use a custom event and subscriber to store the data to try and keep view-ish looking stuff out of the API class. Not sure how I feel about that yet.

This adds a `File` table which is keyed to the application instance. We could probably get away with making this a shared table, but I feel like that's going against the grain of what we're doing nowadays.

### Some things I learned along the way

* We can't easily store information when getting single files as we don't have that information (bummer)
* For single files we ask for a public URL but there are no other details
* We could make another call, but this might be a new end-point (and so new permission?) or trigger the full file pull down
* Recently in `h` we removed `db.init()` in favour of using alembic exclusively, that might not really be very good for development, as you can't change the DB code and have it be present in the DB without constantly updating a migration for it? That's not really how we tend to work (write the model class first, migration when it's done).

### The approach taken in this PR

 * I've intercepted the call to list_files so there are no ways of accessing this data that don't cause the data to be stored in the DB
 * This is a little icky, because the API could be doing double duty here (getting and persisting)
 * To get around this I've made the API register a custom `FilesDiscoveredEvent` instead which technically decouples it
 * It's not that clean, as we need the request to get our work done, so we have to pass that down
 * We could have the API call the DB code directly, or have it look up a service etc, but it all feels a bit icky and view-ish to be doing in the bowels of the API. We could make the call in the view itself, but some views call methods which result in a call to list_files but don't actually have access to the underlying data at any point.
 
The code could be much nicer if we could use `get_current_request()` inside the subscriber so the caller is really decoupled from the request object and can raise a more plain event, but:

 * You can't really do that as you have to call request.registry.notify to send the event anyway
 * The docs heavily imply you really shouldn't use that function

This feels like it's a nice-ish pattern, as we could potentially notify that we've found all sorts of things in our API's and code, and selectively chose which to persist etc. It's also relatively clear how you'd slot this in other places (not that anything else is particularly hard).

Even though it's not technically different from calling the code directly or a service (it's all synchronous) I think this has the right semantics. The API raises the event, but doesn't care if anyone is listening. We could conceivably have the event handled out of band (with celery), discard it, or ignore it's failure and the calling code should be none the wiser.

### Testing notes

 * To trigger this you need to be a teacher, and access an assignment with a Canvas file
 * Once done try: `make sql`
 * `select * from files;`
 * You should also be able to re-load the assigment (causing an update) without anything going wrong