### PR TITLE
Show activity indicator when file picker form is submitted

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -7,8 +7,8 @@ import {
   GooglePickerClient,
   PickerCanceledError,
 } from '../utils/google-picker-client';
+import FullScreenSpinner from './FullScreenSpinner';
 import LMSFilePicker from './LMSFilePicker';
-import Spinner from './Spinner';
 import URLPicker from './URLPicker';
 
 /**
@@ -150,11 +150,7 @@ export default function ContentSelector({
 
   return (
     <Fragment>
-      {isLoadingIndicatorVisible && (
-        <div className="ContentSelector__loading-backdrop">
-          <Spinner className="ContentSelector__loading-spinner" />
-        </div>
-      )}
+      {isLoadingIndicatorVisible && <FullScreenSpinner />}
       <div className="ContentSelector__actions">
         <div className="ContentSelector__actions-buttons">
           <LabeledButton

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -13,6 +13,7 @@ import { Config } from '../config';
 import ContentSelector from './ContentSelector';
 import ErrorDialog from './ErrorDialog';
 import FilePickerFormFields from './FilePickerFormFields';
+import FullScreenSpinner from './FullScreenSpinner';
 import GroupConfigSelector from './GroupConfigSelector';
 
 /**
@@ -167,6 +168,7 @@ export default function FilePickerApp({ onSubmit }) {
         )}
         <input style={{ display: 'none' }} ref={submitButton} type="submit" />
       </form>
+      {shouldSubmit && <FullScreenSpinner />}
       {errorInfo && (
         <ErrorDialog
           title={errorInfo.title}

--- a/lms/static/scripts/frontend_apps/components/FullScreenSpinner.js
+++ b/lms/static/scripts/frontend_apps/components/FullScreenSpinner.js
@@ -1,0 +1,17 @@
+import { createElement } from 'preact';
+
+import Spinner from './Spinner';
+
+/**
+ * A full-screen loading indicator.
+ *
+ * This consists of a spinner centered in the viewport above a transparent
+ * backdrop which dims the content behind it.
+ */
+export default function FullScreenSpinner() {
+  return (
+    <div className="FullScreenSpinner__backdrop">
+      <Spinner className="FullScreenSpinner__spinner" />
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -65,6 +65,9 @@ describe('ContentSelector', () => {
     );
   };
 
+  const isLoadingIndicatorVisible = wrapper =>
+    wrapper.exists('FullScreenSpinner');
+
   it('renders Canvas file picker button if Canvas file picker enabled', () => {
     fakeConfig.filePicker.canvas.enabled = true;
     const wrapper = renderContentSelector();
@@ -92,7 +95,7 @@ describe('ContentSelector', () => {
   it('shows URL selection dialog when "Enter URL" button is clicked', () => {
     const wrapper = renderContentSelector();
 
-    assert.isFalse(wrapper.find('.ContentSelector__loading-backdrop').exists());
+    assert.isFalse(isLoadingIndicatorVisible(wrapper));
 
     const btn = wrapper.find('LabeledButton[data-testid="url-button"]');
     interact(wrapper, () => {
@@ -101,12 +104,12 @@ describe('ContentSelector', () => {
 
     const urlPicker = wrapper.find('URLPicker');
     assert.isTrue(urlPicker.exists());
-    assert.isTrue(wrapper.find('.ContentSelector__loading-backdrop').exists());
+    assert.isTrue(isLoadingIndicatorVisible(wrapper));
 
     interact(wrapper, () => {
       urlPicker.props().onCancel();
     });
-    assert.isFalse(wrapper.find('.ContentSelector__loading-backdrop').exists());
+    assert.isFalse(isLoadingIndicatorVisible(wrapper));
   });
 
   it('supports selecting a URL', () => {
@@ -130,14 +133,14 @@ describe('ContentSelector', () => {
   it('shows LMS file dialog when "Select PDF from Canvas" is clicked', () => {
     const wrapper = renderContentSelector();
 
-    assert.isFalse(wrapper.find('.ContentSelector__loading-backdrop').exists());
+    assert.isFalse(isLoadingIndicatorVisible(wrapper));
 
     const btn = wrapper.find('LabeledButton[data-testid="lms-file-button"]');
     interact(wrapper, () => {
       btn.props().onClick();
     });
 
-    assert.isTrue(wrapper.find('.ContentSelector__loading-backdrop').exists());
+    assert.isTrue(isLoadingIndicatorVisible(wrapper));
 
     const filePicker = wrapper.find('LMSFilePicker');
     assert.isTrue(filePicker.exists());
@@ -150,7 +153,7 @@ describe('ContentSelector', () => {
     interact(wrapper, () => {
       filePicker.props().onCancel();
     });
-    assert.isFalse(wrapper.find('.ContentSelector__loading-backdrop').exists());
+    assert.isFalse(isLoadingIndicatorVisible(wrapper));
   });
 
   it('supports selecting an LMS file', () => {
@@ -245,9 +248,9 @@ describe('ContentSelector', () => {
 
     it('shows loading indicator while waiting for user to pick file', () => {
       const wrapper = renderContentSelector();
-      assert.isFalse(wrapper.exists('Spinner'));
+      assert.isFalse(isLoadingIndicatorVisible(wrapper));
       clickGoogleDriveButton(wrapper);
-      assert.isTrue(wrapper.exists('Spinner'));
+      assert.isTrue(isLoadingIndicatorVisible(wrapper));
     });
 
     it('shows error message if Google Picker fails to load', async () => {
@@ -296,7 +299,7 @@ describe('ContentSelector', () => {
       }
 
       wrapper.setProps({}); // Force re-render.
-      assert.isFalse(wrapper.exists('Spinner'));
+      assert.isFalse(isLoadingIndicatorVisible(wrapper));
     });
   });
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -117,6 +117,7 @@ describe('FilePickerApp', () => {
         },
         null /* groupSet */
       );
+      assert.isTrue(wrapper.exists('FullScreenSpinner'));
     });
   });
 
@@ -167,6 +168,7 @@ describe('FilePickerApp', () => {
           },
           useGroupSet ? 'groupSet1' : null
         );
+        assert.isTrue(wrapper.exists('FullScreenSpinner'));
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -117,6 +117,14 @@ describe('FilePickerApp', () => {
         },
         null /* groupSet */
       );
+    });
+
+    it('shows activity indicator when form is submitted', () => {
+      const wrapper = renderFilePicker();
+      assert.isFalse(wrapper.exists('FullScreenSpinner'));
+
+      selectContent(wrapper, 'https://example.com');
+
       assert.isTrue(wrapper.exists('FullScreenSpinner'));
     });
   });
@@ -168,8 +176,20 @@ describe('FilePickerApp', () => {
           },
           useGroupSet ? 'groupSet1' : null
         );
-        assert.isTrue(wrapper.exists('FullScreenSpinner'));
       });
+    });
+
+    it('shows activity indicator when form is submitted', () => {
+      const wrapper = renderFilePicker();
+      assert.isFalse(wrapper.exists('FullScreenSpinner'));
+
+      selectContent(wrapper, 'https://example.com');
+      selectGroupConfig(wrapper, { useGroupSet: true, groupSet: 'groupSet1' });
+      interact(wrapper, () => {
+        wrapper.find('LabeledButton[children="Continue"]').props().onClick();
+      });
+
+      assert.isTrue(wrapper.exists('FullScreenSpinner'));
     });
   });
 

--- a/lms/static/scripts/frontend_apps/components/test/FullScreenSpinner-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FullScreenSpinner-test.js
@@ -1,0 +1,12 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import FullScreenSpinner from '../FullScreenSpinner';
+
+describe('FullScreenSpinner', () => {
+  // There is no logic in this component, so this is just a basic "make sure it
+  // doesn't crash" test.
+  it('renders', () => {
+    mount(<FullScreenSpinner />);
+  });
+});

--- a/lms/static/styles/components/_BasicLtiLaunchApp.scss
+++ b/lms/static/styles/components/_BasicLtiLaunchApp.scss
@@ -1,5 +1,6 @@
 @use "sass:math";
 
+@use "../mixins";
 @use "../variables" as var;
 
 .BasicLtiLaunchApp {
@@ -7,11 +8,7 @@
 }
 
 .BasicLtiLaunchApp__spinner {
-  position: absolute;
-  width: var.$spinner-size;
-  height: var.$spinner-size;
-  left: calc(50% - #{math.div(var.$spinner-size, 2)});
-  top: calc(50% - #{math.div(var.$spinner-size, 2)});
+  @include mixins.spinner($size: var.$spinner-size);
 }
 
 .BasicLtiLaunchApp__content {

--- a/lms/static/styles/components/_ContentSelector.scss
+++ b/lms/static/styles/components/_ContentSelector.scss
@@ -1,25 +1,3 @@
-@use "sass:math";
-
-@use "../variables" as var;
-
-.ContentSelector__loading-backdrop {
-  background-color: white;
-  bottom: 0;
-  left: 0;
-  opacity: 0.5;
-  position: fixed;
-  right: 0;
-  top: 0;
-}
-
-.ContentSelector__loading-spinner {
-  position: absolute;
-  width: var.$spinner-size;
-  height: var.$spinner-size;
-  left: calc(50% - #{math.div(var.$spinner-size, 2)});
-  top: calc(50% - #{math.div(var.$spinner-size, 2)});
-}
-
 .ContentSelector__actions {
   // A flex container (row) with two children: a column of buttons and a
   // "spacer" to take up the rest of the row space not needed by the buttons.

--- a/lms/static/styles/components/_FullScreenSpinner.scss
+++ b/lms/static/styles/components/_FullScreenSpinner.scss
@@ -4,13 +4,13 @@
 @use "../variables" as var;
 
 .FullScreenSpinner__backdrop {
-  background-color: white;
+  position: fixed;
   bottom: 0;
   left: 0;
-  opacity: 0.5;
-  position: fixed;
   right: 0;
   top: 0;
+  background-color: white;
+  opacity: 0.5;
 }
 
 .FullScreenSpinner__spinner {

--- a/lms/static/styles/components/_FullScreenSpinner.scss
+++ b/lms/static/styles/components/_FullScreenSpinner.scss
@@ -1,0 +1,18 @@
+@use "sass:math";
+
+@use "../mixins";
+@use "../variables" as var;
+
+.FullScreenSpinner__backdrop {
+  background-color: white;
+  bottom: 0;
+  left: 0;
+  opacity: 0.5;
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+
+.FullScreenSpinner__spinner {
+  @include mixins.spinner($size: var.$spinner-size);
+}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -16,6 +16,7 @@
 @use 'components/ErrorDisplay';
 @use 'components/FileList';
 @use 'components/FilePickerApp';
+@use 'components/FullScreenSpinner';
 @use 'components/LMSGrader';
 @use 'components/StudentSelector';
 @use 'components/SubmitGradeForm';


### PR DESCRIPTION
Since the assignment creation form is shown in an iframe, there is no indicator in the browser when the form is being submitted and the browser is waiting for the server's response. This is not a major problem because this typically happens quickly, but in case it is slow show a spinner to indicate that something is happening.

For this purpose I have extracted and re-used the spinner + backdrop that are used when the Canvas/Blackboard file picker dialog is loading. Here it is with an artificially delayed form submission:

https://user-images.githubusercontent.com/2458/120670456-56747080-c488-11eb-91e7-154e9a13eb1c.mov

