### PR TITLE
Ensure that Canvas files launches have a module item configuration

### DIFF
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -103,10 +103,25 @@ class BasicLTILaunchViews:
         Via. We have to re-do this file-ID-for-download-URL exchange on every
         single launch because Canvas's download URLs are temporary.
         """
-        self.context.js_config.add_canvas_file_id(
-            self.request.params["custom_canvas_course_id"],
-            self.request.params["file_id"],
+
+        course_id = self.request.params["custom_canvas_course_id"]
+        file_id = self.request.params["file_id"]
+
+        # Normally this would be done during `configure_module_item()` but
+        # Canvas skips that step. We are doing this to ensure that there is a
+        # module item configuration. As a result of this we can rely on this
+        # being around in future code.
+        self.assignment_service.set_document_url(
+            self.request.params["tool_consumer_instance_guid"],
+            self.request.params["resource_link_id"],
+            # This URL is mostly for show. We just want to ensure that a module
+            # configuration exists. If we're going to do that we might as well
+            # make sure this URL is meaningful.
+            document_url=f"canvas_file://course/{course_id}/file_id/{file_id}",
         )
+
+        self.context.js_config.add_canvas_file_id(course_id, file_id)
+
         return self.basic_lti_launch(grading_supported=False)
 
     @view_config(vitalsource_book=True)

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -117,7 +117,7 @@ class BasicLTILaunchViews:
             # This URL is mostly for show. We just want to ensure that a module
             # configuration exists. If we're going to do that we might as well
             # make sure this URL is meaningful.
-            document_url=f"canvas_file://course/{course_id}/file_id/{file_id}",
+            document_url=f"canvas://file/course/{course_id}/file_id/{file_id}",
         )
 
         self.context.js_config.add_canvas_file_id(course_id, file_id)

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -287,7 +287,7 @@ class TestCanvasFileBasicLTILaunch:
         assignment_service.set_document_url.assert_called_once_with(
             pyramid_request.params["tool_consumer_instance_guid"],
             pyramid_request.params["resource_link_id"],
-            document_url=f"canvas_file://course/{course_id}/file_id/{file_id}",
+            document_url=f"canvas://file/course/{course_id}/file_id/{file_id}",
         )
 
 

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -273,13 +273,21 @@ class TestCourseRecording:
 
 @pytest.mark.usefixtures("is_canvas")
 class TestCanvasFileBasicLTILaunch:
-    @pytest.mark.usefixtures("is_canvas")
-    def test_it_adds_the_canvas_file_id(self, context, pyramid_request):
+    def test_it(self, context, pyramid_request, assignment_service):
         canvas_file_basic_lti_launch_caller(context, pyramid_request)
 
         context.js_config.add_canvas_file_id.assert_called_once_with(
             pyramid_request.params["custom_canvas_course_id"],
             pyramid_request.params["file_id"],
+        )
+
+        course_id = pyramid_request.params["custom_canvas_course_id"]
+        file_id = pyramid_request.params["file_id"]
+
+        assignment_service.set_document_url.assert_called_once_with(
+            pyramid_request.params["tool_consumer_instance_guid"],
+            pyramid_request.params["resource_link_id"],
+            document_url=f"canvas_file://course/{course_id}/file_id/{file_id}",
         )
 
 


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/2769

We don't do anything with it, and the value we set isn't useful, but it ensures Canvas looks more like a normal launch for things down stream which might look up the details.