### PR TITLE
Perform Canvas file matching to fix Canvas course copies

### DIFF
--- a/lms/models/module_item_configuration.py
+++ b/lms/models/module_item_configuration.py
@@ -1,8 +1,11 @@
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE
 
 __all__ = ["ModuleItemConfiguration"]
+
+from lms.models import ApplicationSettings
 
 
 class ModuleItemConfiguration(BASE):
@@ -41,3 +44,11 @@ class ModuleItemConfiguration(BASE):
 
     document_url = sa.Column(sa.String, nullable=False)
     """The URL of the document to be annotated for this assignment."""
+
+    extra = sa.Column(
+        "settings",
+        ApplicationSettings.as_mutable(JSONB),
+        server_default=sa.text("'{}'::jsonb"),
+        nullable=False,
+    )
+    """Tool consumer specific settings."""

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -32,7 +32,7 @@ class JSConfig:
         """
         return self._request.find_service(name="application_instance").get()
 
-    def add_canvas_file_id(self, course_id, canvas_file_id):
+    def add_canvas_file_id(self, course_id, canvas_file_id, resource_link_id):
         """
         Set the document to the Canvas file with the given canvas_file_id.
 
@@ -42,10 +42,14 @@ class JSConfig:
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
         """
+
         self._config["api"]["viaUrl"] = {
             "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
             "path": self._request.route_path(
-                "canvas_api.files.via_url", course_id=course_id, file_id=canvas_file_id
+                "canvas_api.files.via_url",
+                course_id=course_id,
+                file_id=canvas_file_id,
+                resource_link_id=resource_link_id,
             ),
         }
         self._add_canvas_speedgrader_settings(canvas_file_id=canvas_file_id)

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -62,7 +62,7 @@ def includeme(config):
     )
     config.add_route(
         "canvas_api.files.via_url",
-        "/api/canvas/courses/{course_id}/files/{file_id}/via_url",
+        "/api/canvas/courses/{course_id}/files/{file_id}/via_url/resource/{resource_link_id}",
     )
     config.add_route(
         "canvas_api.courses.group_sets.list",

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -1,4 +1,12 @@
-from lms.services.exceptions import CanvasFileNotFoundInCourse
+from functools import cached_property, lru_cache
+from logging import getLogger
+
+from sqlalchemy import and_
+
+from lms.models import File
+from lms.services.exceptions import CanvasAPIPermissionError, CanvasFileNotFoundInCourse
+
+LOG = getLogger(__name__)
 
 
 class CanvasService:
@@ -6,36 +14,185 @@ class CanvasService:
 
     api = None
 
-    def __init__(self, canvas_api):
+    def __init__(
+        self, canvas_api, application_instance_service, assignment_service, db_session
+    ):
         self.api = canvas_api
 
-    def public_url_for_file(self, file_id, course_id, check_in_course=False):
+        self._application_instance_service = application_instance_service
+        self._assignment_service = assignment_service
+        self._db_session = db_session
+
+    def public_url_for_file(
+        self, file_id, course_id, resource_link_id, check_in_course=False
+    ):
         """
         Get a public URL for a Canvas file.
 
-        This will also attempt to check if the file is in the course to detect
-        course copy situations and fix it if we can.
+        This will also attempt to use any file with the same size and name if
+        one can be found.
 
         :param file_id: The file to look up
         :param course_id: The course the file should be in
-        :param check_in_course: Raise CanvasFileNotFoundInCourse if file_id isn't in
-            course_id
+        :param resource_link_id: The id of the assignment
+        :param check_in_course: Attempt to map detect and map the file if it's
+            not in the course before attempting to retrieve it. This is more
+            thorough, but causes an extra API request
         :return: A URL suitable for public presentation of the file
-        :raise  CanvasFileNotFoundInCourse: if check_in_course=True and file_id isn't in course_id
-            be in the course but isn't.
+        :raise CanvasFileNotFoundInCourse: if the file is not accessible and
+            cannot be mapped to a file in the course
+        :raise CanvasAPIResourceNotFound: if the file is not valid at all, and
+            cannot be mapped to a file in the course
+        :raise CanvasAPIPermissionError: If we cannot retrieve the file for
+            any other reason
         """
+        # Check to see if we've mapped this file id to something else before
+        file_mapping = self._file_mapping(resource_link_id)
+        mapped_id = file_mapping.get(file_id, default=file_id)
 
-        if check_in_course:
-            if not self._file_in_course(file_id, course_id):
+        # If we are told to check up front, try and fix the file if it's not in
+        # the current course (as far as we can tell from this users point of
+        # view)
+        already_mapped = False
+        if check_in_course and not self._is_file_in_course(mapped_id, course_id):
+            mapped_id = self._match_file_in_course(file_id, course_id, file_mapping)
+            already_mapped = True
+
+            if not mapped_id:
                 raise CanvasFileNotFoundInCourse(file_id)
 
-        return self.api.public_url(file_id)
+        try:
+            return self.api.public_url(mapped_id)
 
-    def _file_in_course(self, file_id, course_id):
-        return any(
-            str(file_["id"]) == str(file_id) for file_ in self.api.list_files(course_id)
+        except CanvasAPIPermissionError:
+            # If we've already mapped this once, we aren't going to get a
+            # better answer now. So bail out
+            if already_mapped:
+                raise
+
+            if not (
+                mapped_id := self._match_file_in_course(
+                    file_id, course_id, file_mapping
+                )
+            ):
+                # We don't know why this failed, could be a course copy, could
+                # just be a permissions issue, all we know is we can't fix it
+                raise
+
+        return self.api.public_url(mapped_id)
+
+    @lru_cache
+    def _file_mapping(self, resource_link_id):
+        assignment = self._assignment_service.get(
+            tool_consumer_instance_guid=self._application_instance.tool_consumer_instance_guid,
+            resource_link_id=resource_link_id,
         )
+        return CanvasFileMapping(assignment.extra)
+
+    @cached_property
+    def _application_instance(self):
+        return self._application_instance_service.get()
+
+    @lru_cache
+    def _files_in_course(self, course_id):
+        return self.api.list_files(course_id)
+
+    def _is_file_in_course(self, file_id, course_id):
+        LOG.debug("Checking if Canvas file %s is in course %s", file_id, course_id)
+
+        return any(
+            str(file_["id"]) == str(file_id)
+            for file_ in self._files_in_course(course_id)
+        )
+
+    def _match_file_in_course(self, file_id, course_id, file_mapping):
+        """
+        Find matches in the current course for the specified files.
+
+        And update the mapping to match
+
+        :param file_id: The original file to match
+        :param course_id: The course to find a matching file in
+        :return: A mapped file, or None
+        """
+
+        file_ids_to_match = [file_id]
+
+        # We match not only the original id, but also the mapped id too. This
+        # allows us to code with some low probability scenarios where we have
+        # a mapping, the source and target of the mapping are inaccessible,
+        # and the source's name or size has changed. In this case we can use
+        # the information from the target to try and find a new matching file.
+        if target := file_mapping.get(file_id):
+            file_ids_to_match.append(target)
+
+        files_to_match = (
+            self._db_session.query(File)
+            .filter(
+                and_(
+                    File.application_instance_id == self._application_instance.id,
+                    File.lms_id.in_(file_ids_to_match),
+                    File.type == "canvas_file",
+                )
+            )
+            .all()
+        )
+
+        if files_to_match:
+            matching_keys = set((file.name, file.size) for file in files_to_match)
+            LOG.debug(
+                "Looking for matches in current course for Canvas files %s",
+                matching_keys,
+            )
+
+            for candidate in self._files_in_course(course_id):
+                if (candidate["display_name"], candidate["size"]) in matching_keys:
+                    # Update the mapping first!
+                    file_mapping[file_id] = candidate["id"]
+                    LOG.info(
+                        "Found match for inaccessible Canvas file %s -> %s",
+                        file_id,
+                        candidate["id"],
+                    )
+
+                    return candidate["id"]
+        else:
+            LOG.debug("No historical records of Canvas files found to perform match")
+
+        return None
+
+
+class CanvasFileMapping:
+    """
+    An abstraction the file mapping to appear dict like.
+
+    This is a little tricky because we need to deal with a sub-key of a JSON
+    field in the DB. This makes this look like a dict in some ways.
+    """
+
+    KEY = ("canvas", "file_mapping")
+
+    def __init__(self, settings):
+        self._settings = settings
+
+    def get(self, file_id, default=None):
+        return self._mapping.get(file_id, default)
+
+    def __setitem__(self, old_file_id, new_file_id):
+        mapping = self._mapping
+        mapping[old_file_id] = new_file_id
+
+        self._settings.set(*self.KEY, mapping)
+
+    @property
+    def _mapping(self):
+        return self._settings.get(*self.KEY) or {}
 
 
 def factory(_context, request):
-    return CanvasService(canvas_api=request.find_service(name="canvas_api_client"))
+    return CanvasService(
+        application_instance_service=request.find_service(name="application_instance"),
+        assignment_service=request.find_service(name="assignment"),
+        canvas_api=request.find_service(name="canvas_api_client"),
+        db_session=request.db,
+    )

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -41,8 +41,6 @@ class CanvasService:
         :return: A URL suitable for public presentation of the file
         :raise CanvasFileNotFoundInCourse: if the file is not accessible and
             cannot be mapped to a file in the course
-        :raise CanvasAPIResourceNotFound: if the file is not valid at all, and
-            cannot be mapped to a file in the course
         :raise CanvasAPIPermissionError: If we cannot retrieve the file for
             any other reason
         """

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -33,6 +33,7 @@ class FilesAPIViews:
         public_url = self.canvas.public_url_for_file(
             file_id=self.request.matchdict["file_id"],
             course_id=self.request.matchdict["course_id"],
+            resource_link_id=self.request.matchdict["resource_link_id"],
             # Teachers can have broad permissions and see files that aren't in
             # the course. So do this slower check (extra API call) to warn the
             # teacher that their students might not be able to see the file.

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -106,6 +106,7 @@ class BasicLTILaunchViews:
 
         course_id = self.request.params["custom_canvas_course_id"]
         file_id = self.request.params["file_id"]
+        resource_link_id = self.request.params["resource_link_id"]
 
         # Normally this would be done during `configure_module_item()` but
         # Canvas skips that step. We are doing this to ensure that there is a
@@ -113,14 +114,16 @@ class BasicLTILaunchViews:
         # being around in future code.
         self.assignment_service.set_document_url(
             self.request.params["tool_consumer_instance_guid"],
-            self.request.params["resource_link_id"],
+            resource_link_id,
             # This URL is mostly for show. We just want to ensure that a module
             # configuration exists. If we're going to do that we might as well
             # make sure this URL is meaningful.
             document_url=f"canvas://file/course/{course_id}/file_id/{file_id}",
         )
 
-        self.context.js_config.add_canvas_file_id(course_id, file_id)
+        self.context.js_config.add_canvas_file_id(
+            course_id, file_id, resource_link_id=resource_link_id
+        )
 
         return self.basic_lti_launch(grading_supported=False)
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -16,6 +16,7 @@ from tests.factories.attributes import (
     USER_ID,
 )
 from tests.factories.course import Course, LegacyCourse
+from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo
 from tests.factories.grouping import Grouping
 from tests.factories.h_user import HUser

--- a/tests/factories/file.py
+++ b/tests/factories/file.py
@@ -1,0 +1,14 @@
+from factory import Faker, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+File = make_factory(
+    models.File,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    type=Faker("random_element", elements=["canvas_file", "decoy_type"]),
+    lms_id=Faker("hexify", text="^" * 40),
+    course_id=Faker("hexify", text="^" * 40),
+    name=Faker("file_name", extension="pdf"),
+    size=Faker("numerify", text="#"),
+)

--- a/tests/factories/module_item_configuration.py
+++ b/tests/factories/module_item_configuration.py
@@ -1,4 +1,4 @@
-from factory import Faker, make_factory
+from factory import Dict, Faker, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
@@ -10,4 +10,5 @@ ModuleItemConfiguration = make_factory(
     resource_link_id=RESOURCE_LINK_ID,
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     document_url=Faker("uri"),
+    extra=Dict({}),
 )

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from h_matchers import Any
+from pytest import param
 
 from lms.models import GradingInfo, Grouping
 from lms.resources import LTILaunchResource, OAuth2RedirectResource
@@ -187,31 +188,24 @@ class TestEnableLTILaunchMode:
 class TestAddCanvasFileID:
     """Unit tests for JSConfig.add_canvas_file_id()."""
 
-    def test_it_adds_the_viaUrl_api_config(self, js_config):
-        js_config.add_canvas_file_id(
-            "example_canvas_course_id", "example_canvas_file_id"
-        )
+    def test_it(self, js_config, submission_params):
+        js_config.add_canvas_file_id("COURSE_ID", "FILE_ID", "RESOURCE_LINK_ID")
 
         assert js_config.asdict()["api"]["viaUrl"] == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
-            "path": "/api/canvas/courses/example_canvas_course_id/files/example_canvas_file_id/via_url",
+            "path": "/api/canvas/courses/COURSE_ID/files/FILE_ID/via_url/resource/RESOURCE_LINK_ID",
         }
 
-    def test_it_sets_the_canvas_file_id(self, js_config, submission_params):
-        js_config.add_canvas_file_id(
-            "example_canvas_course_id", "example_canvas_file_id"
-        )
-
-        assert submission_params()["canvas_file_id"] == "example_canvas_file_id"
+        assert submission_params()["canvas_file_id"] == "FILE_ID"
 
 
 class TestAddDocumentURL:
     """Unit tests for JSConfig.add_document_url()."""
 
     def test_it_adds_the_via_url(self, js_config, pyramid_request, via_url):
-        js_config.add_document_url("example_document_url")
+        js_config.add_document_url("DOCUMENT_URL")
 
-        via_url.assert_called_once_with(pyramid_request, "example_document_url")
+        via_url.assert_called_once_with(pyramid_request, "DOCUMENT_URL")
         assert js_config.asdict()["viaUrl"] == via_url.return_value
 
     def test_it_adds_the_viaUrl_api_config_for_Blackboard_documents(self, js_config):
@@ -223,9 +217,9 @@ class TestAddDocumentURL:
         }
 
     def test_it_sets_the_document_url(self, js_config, submission_params):
-        js_config.add_document_url("example_document_url")
+        js_config.add_document_url("DOCUMENT_URL")
 
-        assert submission_params()["document_url"] == "example_document_url"
+        assert submission_params()["document_url"] == "DOCUMENT_URL"
 
 
 class TestAddVitalsourceLaunchConfig:
@@ -314,11 +308,17 @@ class TestAddCanvasFileIDAddDocumentURLCommon:
 
     @pytest.fixture(
         params=[
-            {
-                "method": "add_canvas_file_id",
-                "args": ["example_canvas_course_id", "example_canvas_file_id"],
-            },
-            {"method": "add_document_url", "args": ["example_document_url"]},
+            param(
+                {
+                    "method": "add_canvas_file_id",
+                    "args": ["COURSE_ID", "FILE_ID", "RESOURCE_LINK_ID"],
+                },
+                id="add_canvas_file_id",
+            ),
+            param(
+                {"method": "add_document_url", "args": ["DOCUMENT_URL"]},
+                id="add_document_url",
+            ),
         ]
     )
     def method_caller(self, js_config, request):

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,44 +1,209 @@
-from unittest.mock import sentinel
+import functools
+from unittest.mock import call, sentinel
 
 import pytest
 
-from lms.services import CanvasFileNotFoundInCourse, CanvasService
+from lms.services import (
+    CanvasAPIPermissionError,
+    CanvasFileNotFoundInCourse,
+    CanvasService,
+)
 from lms.services.canvas import factory
+from tests import factories
 
 
-class TestCanvasService:
-    @pytest.mark.parametrize("check_in_course", (True, False))
-    def test_public_url_for_file(self, canvas_service, check_in_course):
-        canvas_service.api.list_files.return_value = [{"id": sentinel.file_id}]
-
+class TestCanvasServicePublicURLForFile:
+    def test_it(self, canvas_service, assignment):
+        # We'll demonstrate the full call here, other tests use a caller pattern
+        # to make the tests more compact
         result = canvas_service.public_url_for_file(
-            file_id=sentinel.file_id, check_in_course=check_in_course, course_id="*any*"
+            file_id="FILE_ID",
+            course_id="COURSE_ID",
+            resource_link_id=assignment.resource_link_id,
+            check_in_course=False,
         )
 
         assert result == canvas_service.api.public_url.return_value
-        canvas_service.api.public_url.assert_called_once_with(sentinel.file_id)
+        canvas_service.api.public_url.assert_called_once_with("FILE_ID")
 
-    def test_public_url_for_file_with_unsuccessful_file_check(self, canvas_service):
-        canvas_service.api.list_files.return_value = []
+    def test_total_failure(self, canvas_service, public_url_for_file, db_session, file):
+        # Ensure there's no file to match against
+        db_session.delete(file)
+        # Ensure the API fails consistently
+        canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
 
+        with pytest.raises(CanvasAPIPermissionError):
+            public_url_for_file()
+
+    def test_it_with_pre_mapped_file(
+        self, canvas_service, public_url_for_file, assignment
+    ):
+        assignment.extra.set("canvas", "file_mapping", {"OLD_ID": "NEW_ID"})
+
+        public_url_for_file(file_id="OLD_ID")
+
+        canvas_service.api.public_url.assert_called_once_with("NEW_ID")
+
+    def test_it_with_check_in_course_and_file_in_course(
+        self, canvas_service, public_url_for_file, file
+    ):
+        canvas_service.api.list_files.return_value = [{"id": file.lms_id}]
+
+        public_url_for_file(file_id=file.lms_id, check_in_course=True)
+
+        canvas_service.api.list_files.assert_called_once_with("COURSE_ID")
+
+    def test_it_with_check_in_course_and_file_not_in_course(self, public_url_for_file):
         with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_service.public_url_for_file(
-                file_id=sentinel.file_id,
-                course_id=sentinel.course_id,
-                check_in_course=True,
-            )
+            public_url_for_file(check_in_course=True)
+
+    @pytest.mark.usefixtures("with_matching_mapping")
+    def test_it_can_map_a_file_from_file_id(
+        self, canvas_service, public_url_for_file, assignment, file
+    ):
+        # We do the detailed testing of the matching here, although the same
+        # can happen in a different location with `check_in_course` True.
+        canvas_service.api.public_url.side_effect = (
+            CanvasAPIPermissionError,
+            sentinel.happy_response,
+        )
+
+        response = public_url_for_file(file_id=file.lms_id, check_in_course=False)
+
+        assert response == sentinel.happy_response
+        assert canvas_service.api.public_url.call_args_list == [
+            # We looked for `file.lms_id` here because it was file_id requested
+            call(file.lms_id),
+            # Then we looked up the result of mapping when it failed
+            call("perfect_match"),
+        ]
+        assert assignment.extra.get("canvas", "file_mapping") == {
+            file.lms_id: "perfect_match"
+        }
+
+    @pytest.mark.usefixtures("with_matching_mapping")
+    def test_it_can_map_a_file_from_mapping_target(
+        self, canvas_service, public_url_for_file, assignment, file
+    ):
+        # We do the detailed testing of the matching here, although the same
+        # can happen in a different location with `check_in_course` True.
+        canvas_service.api.public_url.side_effect = (
+            CanvasAPIPermissionError,
+            sentinel.happy_response,
+        )
+
+        assignment.extra.set("canvas", "file_mapping", {"OLD_ID": file.lms_id})
+
+        response = public_url_for_file(file_id="OLD_ID", check_in_course=False)
+
+        assert response == sentinel.happy_response
+        assert canvas_service.api.public_url.call_args_list == [
+            # We looked for `file.lms_id` here because it was the map target
+            call(file.lms_id),
+            # Then we looked up the result of mapping when it failed
+            call("perfect_match"),
+        ]
+        assert assignment.extra.get("canvas", "file_mapping") == {
+            "OLD_ID": "perfect_match"
+        }
+
+    @pytest.mark.usefixtures("with_matching_mapping")
+    def test_it_only_maps_once_with_check_in_course(
+        self, canvas_service, public_url_for_file
+    ):
+        canvas_service.api.public_url.side_effect = (
+            CanvasAPIPermissionError,
+            sentinel.happy_response,
+        )
+
+        with pytest.raises(CanvasAPIPermissionError):
+            public_url_for_file(check_in_course=True)
+
+        # We can tell we bailed out the first time by checking how many times
+        # we called public_url
+        canvas_service.api.public_url.assert_called_once_with("perfect_match")
 
     @pytest.fixture
-    def canvas_service(self, canvas_api_client):
-        return CanvasService(canvas_api=canvas_api_client)
+    def with_matching_mapping(self, canvas_service, file):
+        # Add some matching and non-matching examples
+        canvas_service.api.list_files.return_value = [
+            {"id": "wrong_name", "display_name": "wrong", "size": file.size},
+            {"id": "wrong_size", "display_name": file.name, "size": "99999"},
+            {"id": "perfect_match", "display_name": file.name, "size": file.size},
+        ]
+
+    @pytest.fixture
+    def application_instance(self, application_instance_service):
+        application_instance = application_instance_service.get.return_value
+        application_instance.id = "12345678"
+
+        return application_instance
+
+    @pytest.fixture
+    def assignment(self):
+        return factories.ModuleItemConfiguration()
+
+    @pytest.fixture
+    def assignment_service(self, assignment_service, assignment):
+        assignment_service.get.return_value = assignment
+        return assignment_service
+
+    @pytest.fixture
+    def file(self, application_instance, db_session):
+        file = factories.File(
+            application_instance_id=application_instance.id, type="canvas_file"
+        )
+        db_session.flush()
+        return file
+
+    @pytest.fixture
+    def public_url_for_file(self, canvas_service, assignment, file):
+        return functools.partial(
+            canvas_service.public_url_for_file,
+            file_id=file.lms_id,
+            course_id="COURSE_ID",
+            resource_link_id=assignment.resource_link_id,
+            check_in_course=False,
+        )
+
+    @pytest.fixture
+    def canvas_service(
+        self,
+        db_session,
+        canvas_api_client,
+        application_instance_service,
+        assignment_service,
+    ):
+        canvas_service = CanvasService(
+            application_instance_service=application_instance_service,
+            assignment_service=assignment_service,
+            canvas_api=canvas_api_client,
+            db_session=db_session,
+        )
+
+        canvas_service.api.list_files.return_value = []
+
+        return canvas_service
 
 
 class TestFactory:
-    def test_it(self, pyramid_request, CanvasService, canvas_api_client):
-        result = factory("*any*", request=pyramid_request)
+    def test_it(
+        self,
+        pyramid_request,
+        CanvasService,
+        canvas_api_client,
+        application_instance_service,
+        assignment_service,
+    ):
+        result = factory(sentinel.context, request=pyramid_request)
 
         assert result == CanvasService.return_value
-        CanvasService.assert_called_once_with(canvas_api=canvas_api_client)
+        CanvasService.assert_called_once_with(
+            canvas_api=canvas_api_client,
+            application_instance_service=application_instance_service,
+            assignment_service=assignment_service,
+            db_session=pyramid_request.db,
+        )
 
     @pytest.fixture
     def CanvasService(self, patch):

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import sentinel
+
 import pytest
 
 from lms.views.api.canvas.files import FilesAPIViews
@@ -6,18 +8,19 @@ from lms.views.api.canvas.files import FilesAPIViews
 @pytest.mark.usefixtures("canvas_service")
 class TestFilesAPIViews:
     def test_list_files(self, canvas_service, pyramid_request):
-        pyramid_request.matchdict = {"course_id": "test_course_id"}
+        pyramid_request.matchdict = {"course_id": sentinel.course_id}
 
         result = FilesAPIViews(pyramid_request).list_files()
 
         assert result == canvas_service.api.list_files.return_value
-        canvas_service.api.list_files.assert_called_once_with("test_course_id")
+        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
 
     @pytest.mark.usefixtures("with_teacher_or_student")
     def test_via_url(self, pyramid_request, canvas_service, helpers):
         pyramid_request.matchdict = {
-            "course_id": "test_course_id",
-            "file_id": "test_file_id",
+            "course_id": sentinel.course_id,
+            "file_id": sentinel.file_id,
+            "resource_link_id": sentinel.resource_link_id,
         }
 
         result = FilesAPIViews(pyramid_request).via_url()
@@ -25,8 +28,9 @@ class TestFilesAPIViews:
         assert result["via_url"] == helpers.via_url.return_value
 
         canvas_service.public_url_for_file.assert_called_once_with(
-            file_id="test_file_id",
-            course_id="test_course_id",
+            file_id=sentinel.file_id,
+            course_id=sentinel.course_id,
+            resource_link_id=sentinel.resource_link_id,
             check_in_course=pyramid_request.lti_user.is_instructor,
         )
 

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -279,6 +279,7 @@ class TestCanvasFileBasicLTILaunch:
         context.js_config.add_canvas_file_id.assert_called_once_with(
             pyramid_request.params["custom_canvas_course_id"],
             pyramid_request.params["file_id"],
+            resource_link_id=pyramid_request.params["resource_link_id"],
         )
 
         course_id = pyramid_request.params["custom_canvas_course_id"]


### PR DESCRIPTION
This expands the `CanvasService` to use the data we _may_ have stored about files in the event we can't look them up for one reason or another.

The `public_url` will now attempt to match files if:

 * You request pre-emptive checking with `check_in_course` and the file isn't in the course
 * You get a  `CanvasAPIPermissionError` _and_ you haven't already tried to map (as we'd just get the same result)

If a match is found, then the mapping from the old id to the new is stored. Both of these Ids can be used for future matches to cover obscure situations where something odd happens to the original file.

## Review notes

I'm breaking this PR up into some smaller chunks:

 * [x] https://github.com/hypothesis/lms/pull/2842 - Make the assignment service get() method public

## Matching overview

* The matching is always performed on the **original file id**
* Matching is performed on a **mapped file id** if the assignment has a mapping from the original file id
* We use the file ids to retrieve **our records of when we last saw the files**, to get their names and sizes
* We retrieve the **list of files the current user can see in the current course**
* If any of them **match the names _and_ sizes** of the files we found in our records we have a match
* We will update the **assignment map from the original file id -> the new match** 
* We will proceed with the newly mapped file id
