### PR TITLE
Add gap between rows in Assignment details form

### DIFF
--- a/lms/static/styles/components/_FilePickerApp.scss
+++ b/lms/static/styles/components/_FilePickerApp.scss
@@ -3,6 +3,7 @@
 .FilePickerApp__form {
   display: grid;
   grid-template-columns: auto 1fr;
+  row-gap: 1em;
 
   width: 500px; // Preferred width
   max-width: 80vw; // Constrain width to fit in viewport
@@ -14,7 +15,7 @@
 
 .FilePickerApp__heading {
   grid-column: 1 / 3;
-  margin-bottom: 1.5em;
+  margin-bottom: 1em;
 }
 
 .FilePickerApp__left-col {
@@ -23,7 +24,6 @@
 
   font-weight: bold;
   text-align: end;
-  margin-bottom: 1em;
 }
 
 .FilePickerApp__right-col {


### PR DESCRIPTION
Fix an issue where the "Assignment content" and "Group assignment" rows of the "Assignment details" form could touch visually if the assignment content row flowed onto multiple lines. The left column had a bottom margin set but the right column did not.

Fix the issue by replacing the left column's bottom margin with a `row-gap` which applies to the whole row. This gap is additive to any cell margins, so the bottom margin for the header row also had to be adjusted.

Strictly speaking `row-gap` requires browsers which are a little newer than our baseline (Safari 12, Chrome 66, Firefox 61), but only slightly. In older browsers the gap will simply be missing, which I think we can live with, as the numbers of such users is very small.

**Before:**

<img width="571" alt="Assignment URL truncation" src="https://user-images.githubusercontent.com/2458/121005990-4f02df00-c788-11eb-85a6-14c76fe75a63.png">

**After:**

<img width="571" alt="Assignment row gap" src="https://user-images.githubusercontent.com/2458/121006028-57f3b080-c788-11eb-8b6e-16800e9fbfd6.png">


