### PR TITLE
Add space between checkbox and group set select

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -118,52 +118,56 @@ export default function GroupConfigSelector({
           This is a group assignment
         </LabeledCheckbox>
       </div>
-      {fetchError && useGroupSet && (
-        // Currently all fetch errors are handled by attempting to re-authorize
-        // and then re-fetch group sets.
-        <Fragment>
-          <p>Canvas needs your permission to fetch group sets</p>
-          <AuthButton
-            authURL={/** @type {string} */ (listGroupSetsAPI.authUrl)}
-            authToken={authToken}
-            onAuthComplete={fetchGroupSets}
-          />
-        </Fragment>
-      )}
-      {!fetchError && useGroupSet && (
-        <div>
-          <label htmlFor={selectID}>Group set:</label>
-          <select
-            disabled={fetchingGroupSets}
-            id={selectID}
-            onInput={e =>
-              onChangeGroupConfig({
-                useGroupSet,
-                groupSet:
-                  /** @type {HTMLInputElement} */ (e.target).value || null,
-              })
-            }
-          >
-            {fetchingGroupSets && <option>Fetching group sets…</option>}
-            {groupSets && (
-              <Fragment>
-                <option disabled selected={groupSet === null}>
-                  Select group set
-                </option>
-                <hr />
-                {groupSets.map(gs => (
-                  <option
-                    key={gs.id}
-                    value={gs.id}
-                    selected={gs.id === groupSet}
-                    data-testid="groupset-option"
-                  >
-                    {gs.name}
-                  </option>
-                ))}
-              </Fragment>
-            )}
-          </select>
+      {useGroupSet && (
+        <div className="GroupConfigSelector__select">
+          {fetchError && (
+            // Currently all fetch errors are handled by attempting to re-authorize
+            // and then re-fetch group sets.
+            <Fragment>
+              <p>Canvas needs your permission to fetch group sets</p>
+              <AuthButton
+                authURL={/** @type {string} */ (listGroupSetsAPI.authUrl)}
+                authToken={authToken}
+                onAuthComplete={fetchGroupSets}
+              />
+            </Fragment>
+          )}
+          {!fetchError && (
+            <Fragment>
+              <label htmlFor={selectID}>Group set: </label>
+              <select
+                disabled={fetchingGroupSets}
+                id={selectID}
+                onInput={e =>
+                  onChangeGroupConfig({
+                    useGroupSet,
+                    groupSet:
+                      /** @type {HTMLInputElement} */ (e.target).value || null,
+                  })
+                }
+              >
+                {fetchingGroupSets && <option>Fetching group sets…</option>}
+                {groupSets && (
+                  <Fragment>
+                    <option disabled selected={groupSet === null}>
+                      Select group set
+                    </option>
+                    <hr />
+                    {groupSets.map(gs => (
+                      <option
+                        key={gs.id}
+                        value={gs.id}
+                        selected={gs.id === groupSet}
+                        data-testid="groupset-option"
+                      >
+                        {gs.name}
+                      </option>
+                    ))}
+                  </Fragment>
+                )}
+              </select>
+            </Fragment>
+          )}
         </div>
       )}
     </Fragment>

--- a/lms/static/styles/components/_GroupConfigSelector.scss
+++ b/lms/static/styles/components/_GroupConfigSelector.scss
@@ -1,0 +1,7 @@
+// Control below checkbox for choosing group set or authorizing with the LMS
+// if needed.
+.GroupConfigSelector__select {
+  // This margin matches that of `<p>` elements and ensures that the "Group set"
+  // select label has the same vertical alignment as the authorization prompt text.
+  margin-top: 1em;
+}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -17,6 +17,7 @@
 @use 'components/FileList';
 @use 'components/FilePickerApp';
 @use 'components/FullScreenSpinner';
+@use 'components/GroupConfigSelector';
 @use 'components/LMSGrader';
 @use 'components/StudentSelector';
 @use 'components/SubmitGradeForm';


### PR DESCRIPTION
Wrap the contents of the space below the "This is a group assignment" checkbox in a `GroupConfigSelector__select` div with a top margin. The top margin is the same as that of a `<p>` element so the visual margin is the same whether this area is displaying the authorization prompt (which begins with a paragraph) or the group set `<select>` control and its `<label>`.

**Before:**

<img width="540" alt="Group set select no space" src="https://user-images.githubusercontent.com/2458/121043028-2bea2680-c7ac-11eb-8739-6b7aeca55e3e.png">

**After:**

<img width="579" alt="Group set auth" src="https://user-images.githubusercontent.com/2458/121042896-0826e080-c7ac-11eb-9093-71936f40a9e0.png">

<img width="550" alt="Group set select" src="https://user-images.githubusercontent.com/2458/121042908-0bba6780-c7ac-11eb-8973-9a7546cdd0a5.png">
