### PR TITLE
Don't create_all when alembic is present on make db

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ source =
     tests/unit
 omit =
     lms/pshell.py
+    lms/migrations/*
 
     # Don't bother covering these files as they just contain feature flags test
     # views, not really user-facing code.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def db_engine():
     # the current models. Doing this at the beginning of each test run ensures
     # that any schema changes made to the models since the last test run will
     # be applied to the test DB schema before running the tests again.
-    db.init(engine, drop=True)
+    db.init(engine, drop=True, stamp=False)
 
     return engine
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -42,7 +42,7 @@ def pyramid_app(environment):  # pylint: disable=unused-argument
 
 @pytest.fixture
 def app(pyramid_app, db_engine):
-    db.init(db_engine)
+    db.init(db_engine, stamp=False)
 
     return TestApp(pyramid_app)
 


### PR DESCRIPTION
If starting from a empty DB we should create_all and stamp the DB with
the correct alembic version so migrate head does the right thing.

If using `make db` on a non empty DB we should rely on alembic to get us
to the right state, ie don't `create_all` or stamp the DB if alembic is
present.

# Testing

- Drop your DB tables
- Checkout to some commit before a table is added, eg `a2fe3341`
- `make db`. It should create the tables an stamp the DB (but not run alembic!)

```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.                                                                
INFO  [alembic.runtime.migration] Will assume transactional DDL.                                                              
INFO  [alembic.runtime.migration] Running stamp_revision  -> 5f80062abcf4                                                     
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.                                                                
INFO  [alembic.runtime.migration] Will assume transactional DDL.             
```
- Checkout master and `make db` again. It should run the migrations from the stamped version

```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.                                                               
INFO  [alembic.runtime.migration] Running upgrade 5f80062abcf4 -> bb11b5b06274, Adds new grouping table.  
```