### PR TITLE
Align CSS used by static form and frontend apps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,7 @@ gulp.task(
 );
 
 var cssBundles = [
-  './lms/static/styles/lms.css',
+  './lms/static/styles/lms.scss',
   './lms/static/styles/reports.css',
   './lms/static/styles/frontend_apps.scss',
   './lms/static/styles/ui-playground/ui-playground.scss',

--- a/lms/static/styles/lms.scss
+++ b/lms/static/styles/lms.scss
@@ -1,24 +1,17 @@
+@use 'normalize.css/normalize';
+
+@use 'variables' as var;
+
 * {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
-  vertical-align: top;
 }
-html,
-html a {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.004);
-}
-html {
-  height: 100%;
-  font-family: 'Roboto', sans-serif;
-  font-size: 14px;
-}
+
 body {
-  height: 100%;
-  margin: 0;
+  font-family: var.$sans-font-family;
+  font-size: var.$normal-font-size;
+  color: var.$color-text;
 }
+
 .data {
   font-family: 'Inconsolata', 'Hack', 'Courier New', 'Courier', monospace;
 }
@@ -33,11 +26,10 @@ body {
   padding: 80px 30px;
 }
 .modal-text {
-  margin: 0 0 20px;
-  font-size: 18px;
   color: #333;
-  font-weight: 500;
   max-width: 550px;
+  font-size: 18px;
+  line-height: 1.4em;
 }
 .modal-subtext {
   margin: -10px 0 20px;

--- a/lms/templates/base.html.jinja2
+++ b/lms/templates/base.html.jinja2
@@ -10,8 +10,6 @@
     <link rel="stylesheet"
           type="text/css"
           href="{{ url }}">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
-          rel="stylesheet">
     {% endfor %}
     {% endblock %}
     {% block styles %}{% endblock %}


### PR DESCRIPTION
This PR incrementally aligns the CSS used by static forms (eg. https://lms.hypothes.is/welcome, https://lms.hypothes.is/flags) with the CSS used by the frontend mini-apps (file picker, assignment launch etc.) by:

- Converting the entry point for the static form's CSS bundle (`lms.css`) to a SASS file so it can use the same mixins, variables, base styles etc. as other bundles
- Using the same CSS reset in lms.scss as frontend_apps.scss
- Changing the font stack and default text color in the static forms to match that used by the frontend apps
- Removing several universal / generic selectors in lms.css

The initial motivation for this was that I uncovered that the frontend apps were loading both the `lms.css` and `frontend_apps.css` bundles and some universal selectors in `lms.css` were causing unexpected effects in the frontend apps (`vertical-align: top`). Aligning the base element styles, typography and CSS reset means that we can combine these bundles in the same page without unexpected problems. For most frontend apps we shouldn't be loading the `lms.css` bundle at all, but I think it makes sense to do this alignment even if we make that change for consistency across the app.

While I was looking at this I notice that we load the Material Icons font on almost every page but don't use these icons anywhere (grep for references to `material-icons` classes). Hence I removed the icons from `base.html.jinja2`.

----

nb. These screenshots are on macOS. The font change will look a little different on other systems.

**Before:**

<img width="582" alt="lms-welcome-before-2" src="https://user-images.githubusercontent.com/2458/121199680-08d27c00-c86b-11eb-962b-10b525d18df9.png">

**After:**

<img width="575" alt="lms-welcome-after-2" src="https://user-images.githubusercontent.com/2458/121199725-10922080-c86b-11eb-9b18-79b1c3ca953d.png">
