### PR TITLE
Use class for table styles

### DIFF
--- a/lms/extensions/feature_flags/_static/feature-flags.css
+++ b/lms/extensions/feature_flags/_static/feature-flags.css
@@ -7,18 +7,18 @@ li {
   margin-bottom: 20px;
 }
 
-table {
-    font-size: 1.2em;
-    border-collapse: collapse;
-}
-
 input[type=radio] {
-    transform: scale(1.5);
+  transform: scale(1.5);
 }
 
-table td, table th {
-    padding: 8px 16px;
-    text-align: center;
+.table {
+  font-size: 1.2em;
+  border-collapse: collapse;
+}
 
-    border:2px solid #ccc;
+.table td, .table th {
+  padding: 8px 16px;
+  text-align: center;
+
+  border:2px solid #ccc;
 }

--- a/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
+++ b/lms/extensions/feature_flags/_templates/cookie_form.html.jinja2
@@ -23,7 +23,7 @@
 
       <form class="feature_flags_form" action="{{ request.route_url('feature_flags_cookie_form') }}" method="post">
 
-        <table>
+        <table class="table">
           <tr>
             <th>Flag</th>
             <th><span title="The final state once all feature flag providers are applied">State</span></th>

--- a/lms/static/styles/lms.scss
+++ b/lms/static/styles/lms.scss
@@ -128,11 +128,13 @@ body {
   color: #444;
   background: #dedede;
 }
+
 .copy:focus {
   border-color: #52a7e7;
   outline: none;
   box-shadow: 0 0 5px #52a7e7;
 }
+
 .form-controls {
   max-width: 500px;
   display: flex;
@@ -162,33 +164,31 @@ body {
   background: #d00032;
 }
 
-/* A few table styles */
-
-table {
+.table {
   border-spacing: 0.5rem;
   border-collapse: collapse;
   max-width: 100%;
-}
 
-th {
-  border-bottom: 2px solid #dddddd;
-}
+  & th {
+    border-bottom: 2px solid #dddddd;
+  }
 
-th,
-td {
-  padding: 0.25em;
-  border: 1px solid #ddd;
-}
+  & tr:nth-child(odd) {
+    /* Zebra-stripe the rows */
+    background: #eee;
+  }
 
-table tr:nth-child(odd) {
-  /* Zebra-stripe the rows */
-  background: #eee;
-}
+  & th,
+  & td {
+    padding: 0.25em;
+    border: 1px solid #ddd;
+  }
 
-td.wrap {
-  /* wrap veryyyyyyyy long data */
-  white-space: normal;
-  word-break: break-all;
+  & td.wrap {
+    /* wrap veryyyyyyyy long data */
+    white-space: normal;
+    word-break: break-all;
+  }
 }
 
 /* Horizontally center an element's direct children. */

--- a/lms/static/styles/lms.scss
+++ b/lms/static/styles/lms.scss
@@ -12,9 +12,6 @@ body {
   color: var.$color-text;
 }
 
-.data {
-  font-family: 'Inconsolata', 'Hack', 'Courier New', 'Courier', monospace;
-}
 .content {
   display: flex;
   flex-direction: column;
@@ -153,15 +150,6 @@ body {
 .btn--gray {
   background: #f5f5f5;
   border: 0.1rem solid #dddddd;
-}
-
-.btn--red {
-  background: #5d5d5d;
-  color: #ffffff;
-}
-
-.btn--red:hover {
-  background: #d00032;
 }
 
 .table {

--- a/lms/static/styles/lms.scss
+++ b/lms/static/styles/lms.scss
@@ -135,11 +135,7 @@ body {
 .form-controls {
   max-width: 500px;
   display: flex;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   justify-content: flex-end;
-  -webkit-justify-content: flex-end;
 }
 
 .btn:hover {


### PR DESCRIPTION
This PR changes some table styles, currently used only by the `/flags` page, to use a class rather than element selector. This prevents these styles unexpectedly applying to other `<table>` elements. There should be no visual changes.

I also removed a few unused CSS classes and vendor prefixes. See commits for details.