### PR TITLE
Fix regression in LTI launch app height

### DIFF
--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -31,6 +31,13 @@
 // Shared styles from frontend-shared package
 @use '@hypothesis/frontend-shared/styles';
 
+// This ensures that root components which set `width: 100%; height: 100%`
+// (eg. the `BasicLtiLaunchApp`) will fill the viewport.
+html,
+body {
+  height: 100%;
+}
+
 body {
   font-family: var.$sans-font-family;
   font-size: var.$normal-font-size;


### PR DESCRIPTION
https://github.com/hypothesis/lms/pull/2793 removed a `height: 100%` rule for the `<body>` and `<html>` elements which caused the assignment content iframe to shrink to a small height because `BasicLtiLaunchApp`'s styles assumed that the parent element filled the page.