### PR TITLE
Adjust `FilePickerApp` (assignment-configuration) form layout

### DIFF
--- a/lms/static/styles/components/_FilePickerApp.scss
+++ b/lms/static/styles/components/_FilePickerApp.scss
@@ -3,7 +3,8 @@
 .FilePickerApp__form {
   display: grid;
   grid-template-columns: auto 1fr;
-  row-gap: 1em;
+  row-gap: 1rem;
+  column-gap: 1rem;
 
   width: 500px; // Preferred width
   max-width: 80vw; // Constrain width to fit in viewport
@@ -14,15 +15,12 @@
 }
 
 .FilePickerApp__heading {
-  grid-column: 1 / 3;
-  margin-bottom: 1em;
+  grid-column: 1 / span 2;
 }
 
 .FilePickerApp__left-col {
   grid-column: 1;
-  padding-right: 20px;
-
-  font-weight: bold;
+  font-weight: 800;
   text-align: end;
 }
 
@@ -34,14 +32,18 @@
   & > p:first-child {
     margin-top: 0;
   }
+
+  // Vertical spacing for child elements
+  & > :not(:first-child) {
+    margin-top: 0.5rem;
+  }
 }
 
 // Footer with actions to navigate between steps in the assignment configuration
 // flow.
 .FilePickerApp__footer {
-  grid-column: 1 / 3;
-
-  margin-top: 1em;
+  grid-column: 1 / span 2;
+  padding: 0.5rem 0;
   display: flex;
   flex-direction: row;
   justify-content: flex-end;

--- a/lms/static/styles/components/_GroupConfigSelector.scss
+++ b/lms/static/styles/components/_GroupConfigSelector.scss
@@ -1,7 +1,0 @@
-// Control below checkbox for choosing group set or authorizing with the LMS
-// if needed.
-.GroupConfigSelector__select {
-  // This margin matches that of `<p>` elements and ensures that the "Group set"
-  // select label has the same vertical alignment as the authorization prompt text.
-  margin-top: 1em;
-}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -17,7 +17,6 @@
 @use 'components/FileList';
 @use 'components/FilePickerApp';
 @use 'components/FullScreenSpinner';
-@use 'components/GroupConfigSelector';
 @use 'components/LMSGrader';
 @use 'components/StudentSelector';
 @use 'components/SubmitGradeForm';


### PR DESCRIPTION
This PR makes a few adjustments to the CSS layout of the `FilePickerApp` form, and obviates the need for a SASS module for the `GroupConfigSelector` (at least for now).

User-visible changes: spacing between grid sections and elements is very subtly more consistent.

* Imitate the vertical-spacing implementation and units used in the `frontend-shared` package for consistency (and eventual replacement with utility classes or mixins)
* Use `column-gap` instead of padding/margin for simplicity

### After

These next few screenshots show the in-progress new `Checkbox` component styling:

<img width="802" alt="Screen Shot 2021-06-11 at 8 45 20 AM" src="https://user-images.githubusercontent.com/439947/121690540-f8e9b080-ca93-11eb-87e2-fc784b29a0fd.png">

<img width="802" alt="Screen Shot 2021-06-11 at 8 46 30 AM" src="https://user-images.githubusercontent.com/439947/121690546-fc7d3780-ca93-11eb-90bd-dcb6f2998bc3.png">

<img width="801" alt="Screen Shot 2021-06-11 at 8 44 32 AM" src="https://user-images.githubusercontent.com/439947/121690663-20407d80-ca94-11eb-930f-a3b33b0ed097.png">

This is what the changes look like with the current, unstyled checkbox:

<img width="808" alt="Screen Shot 2021-06-11 at 8 59 55 AM" src="https://user-images.githubusercontent.com/439947/121690692-26365e80-ca94-11eb-9160-9879054738a2.png">

