### PR TITLE
Check presence of `ignoreOtherConfiguration` in `hypothesisConfig`

### DIFF
--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -52,7 +52,7 @@ h-matchers==1.2.11
     # via -r requirements/bddtests.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
-h-vialib==1.0.15
+h-vialib==1.0.16
     # via -r requirements/requirements.txt
 httpretty==1.1.3
     # via -r requirements/bddtests.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,8 @@
 #
 alembic==1.6.4
     # via -r requirements/requirements.txt
+appnope==0.1.2
+    # via ipython
 attrs==20.2.0
     # via
     #   -r requirements/requirements.txt
@@ -49,7 +51,7 @@ h-api==1.0.1
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
-h-vialib==1.0.15
+h-vialib==1.0.16
     # via -r requirements/requirements.txt
 hupper==1.10.2
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -50,7 +50,7 @@ h-matchers==1.2.11
     # via -r requirements/functests.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
-h-vialib==1.0.15
+h-vialib==1.0.16
     # via -r requirements/requirements.txt
 httpretty==1.1.3
     # via -r requirements/functests.in

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -95,7 +95,7 @@ h-pyramid-sentry==1.2.3
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-h-vialib==1.0.15
+h-vialib==1.0.16
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -28,7 +28,7 @@ h-api==1.0.1
     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.in
-h-vialib==1.0.15
+h-vialib==1.0.16
     # via -r requirements/requirements.in
 hupper==1.10.2
     # via pyramid

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -50,7 +50,7 @@ h-matchers==1.2.11
     # via -r requirements/tests.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
-h-vialib==1.0.15
+h-vialib==1.0.16
     # via -r requirements/requirements.txt
 httpretty==1.1.3
     # via -r requirements/tests.in

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -6,11 +6,13 @@ from lms.views.helpers import via_url
 
 class TestViaURL:
     DEFAULT_OPTIONS = {
+        # Default options set by h_vialib
+        "via.client.ignoreOtherConfiguration": "1",
         "via.client.openSidebar": "1",
+        "via.external_link_mode": "new-tab",
         # This is the `request.host_url`
         "via.client.requestConfigFromFrame.origin": "http://example.com",
         "via.client.requestConfigFromFrame.ancestorLevel": "2",
-        "via.external_link_mode": "new-tab",
     }
 
     def test_if_creates_the_correct_via_url(self, pyramid_request):


### PR DESCRIPTION
Part of https://github.com/hypothesis/viahtml/pull/192

First commit:
h_vialib was modified to include the above option to disregard other
configurations that could be present in the host page.

Although the `ignoreOtherConfiguration` is not set by the code in LMS,
given its importance we test it here too.

Second commit:
Upgrade `h-vialib` using `hdev requirements --package h-vialib` command.