### PR TITLE
Add missing frontend tests and enforce code coverage

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -45,7 +45,8 @@ function contentDescription(content) {
     case 'vitalsource':
       return 'Book from VitalSource';
     default:
-      return 'Other content';
+      /* istanbul ignore next */
+      throw new Error('Unknown content type');
   }
 }
 

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -111,10 +111,16 @@ describe('ErrorDisplay', () => {
     const details = wrapper.find('details');
     const scrollIntoView = sinon.stub(details.getDOMNode(), 'scrollIntoView');
 
+    // Details should be scrolled into view if details is opened.
     details.getDOMNode().open = true;
     details.simulate('toggle');
-
     assert.called(scrollIntoView);
+
+    // Details should not be scrolled into view if details is closed.
+    scrollIntoView.resetHistory();
+    details.getDOMNode().open = false;
+    details.simulate('toggle');
+    assert.notCalled(scrollIntoView);
   });
 
   [

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -78,13 +78,17 @@ describe('FilePickerApp', () => {
     assert.isTrue(wrapper.exists('ContentSelector'));
   });
 
-  function selectContent(wrapper, url) {
+  function selectContent(wrapper, content) {
     const picker = wrapper.find('ContentSelector');
     interact(wrapper, () => {
-      picker.props().onSelectContent({
-        type: 'url',
-        url,
-      });
+      picker.props().onSelectContent(
+        typeof content === 'string'
+          ? {
+              type: 'url',
+              url: content,
+            }
+          : content
+      );
     });
   }
 
@@ -143,15 +147,30 @@ describe('FilePickerApp', () => {
       assert.notCalled(onSubmit);
     });
 
-    it('displays a summary of the assignment content', () => {
-      const wrapper = renderFilePicker();
+    [
+      {
+        content: 'https://example.com',
+        summary: 'https://example.com',
+      },
+      {
+        content: { type: 'file', id: 'abcd' },
+        summary: 'PDF file in Canvas',
+      },
+      {
+        content: { type: 'vitalsource', bookID: 'abc', cfi: '/1/2' },
+        summary: 'Book from VitalSource',
+      },
+    ].forEach(({ content, summary }) => {
+      it('displays a summary of the assignment content', () => {
+        const wrapper = renderFilePicker();
 
-      selectContent(wrapper, 'https://example.com');
+        selectContent(wrapper, content);
 
-      assert.equal(
-        wrapper.find('[data-testid="content-summary"]').text(),
-        'https://example.com'
-      );
+        assert.equal(
+          wrapper.find('[data-testid="content-summary"]').text(),
+          summary
+        );
+      });
     });
 
     it('truncates long URLs in assignment content summary', () => {

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -123,21 +123,28 @@ describe('SubmitGradeForm', () => {
   });
 
   context('validation messages', () => {
+    beforeEach(() => {
+      $imports.$mock({
+        '../utils/validation': {
+          validateGrade: sinon.stub().returns('err'),
+        },
+      });
+    });
+
     it('does not render the validation message by default', () => {
       const wrapper = renderForm();
       assert.isFalse(wrapper.find('ValidationMessage').exists());
     });
 
     it('shows the validation message when the validator returns an error', () => {
-      $imports.$mock({
-        '../utils/validation': {
-          validateGrade: sinon.stub().returns('err'),
-        },
-      });
       const wrapper = renderForm();
       wrapper.find('button[type="submit"]').simulate('click');
       assert.isTrue(wrapper.find('ValidationMessage').prop('open'));
       assert.equal(wrapper.find('ValidationMessage').prop('message'), 'err');
+
+      // Clicking the error message should dismiss it.
+      wrapper.find('ValidationMessage').invoke('onClose')();
+      assert.isFalse(wrapper.find('ValidationMessage').prop('open'));
     });
 
     it('hides the validation message after it was opened when input is detected', () => {
@@ -173,6 +180,10 @@ describe('SubmitGradeForm', () => {
       assert.isTrue(wrapper.find('ErrorDialog').exists());
       // Ensure the error object passed to ErrorDialog is the same as the one thrown
       assert.equal(wrapper.find('ErrorDialog').prop('error'), error);
+
+      // Error message should be hidden when its close action is triggered.
+      wrapper.find('ErrorDialog').invoke('onCancel')();
+      assert.isFalse(wrapper.exists('ErrorDialog'));
     });
 
     it('sets the `is-saved` class when the grade has posted', async () => {
@@ -245,6 +256,10 @@ describe('SubmitGradeForm', () => {
       assert.isTrue(wrapper.find('ErrorDialog').exists());
       // Ensure the error object passed to ErrorDialog is the same as the one thrown
       assert.equal(wrapper.find('ErrorDialog').prop('error'), error);
+
+      // Error message should be hidden when its close action is triggered.
+      wrapper.find('ErrorDialog').invoke('onCancel')();
+      assert.isFalse(wrapper.exists('ErrorDialog'));
     });
 
     it("sets the input defaultValue prop to the student's grade", async () => {

--- a/lms/static/scripts/frontend_apps/components/test/Table-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Table-test.js
@@ -105,6 +105,11 @@ describe('Table', () => {
     wrapper.setProps({ selectedItem: items[items.length - 1] });
     assertKeySelectsItem('ArrowDown', items.length - 1);
 
+    // Up or down arrow should select the first item if no item is selected.
+    wrapper.setProps({ selectedItem: null });
+    assertKeySelectsItem('ArrowUp', 0);
+    assertKeySelectsItem('ArrowDown', 0);
+
     // Other keys should do nothing.
     onSelectItem.reset();
     wrapper.find('table').simulate('keydown', { key: 'Tab' });

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -34,6 +34,22 @@ describe('URLPicker', () => {
     assert.calledWith(onSelectURL, 'https://example.com/foo');
   });
 
+  it('does not invoke `onSelectURL` if URL is not valid', () => {
+    const onSelectURL = sinon.stub();
+
+    const wrapper = renderUrlPicker({ onSelectURL });
+    wrapper.find('input').getDOMNode().value = 'not-a-url';
+
+    const reportValidity = sinon.stub(
+      wrapper.find('form').getDOMNode(),
+      'reportValidity'
+    );
+    wrapper.find('LabeledButton').props().onClick(new Event('click'));
+
+    assert.notCalled(onSelectURL);
+    assert.calledOnce(reportValidity);
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.js
@@ -2,7 +2,16 @@ import { loadLibraries } from './google-api-client';
 
 export const GOOGLE_DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive';
 
-/** @param {string} origin */
+/**
+ * Convert a domain (example.com) into a valid web origin (https://example.com).
+ *
+ * This is needed because the origin value may ultimately come from the
+ * `custom_canvas_api_domain` LTI launch parameter on the backend, in which
+ * case it may be a domain rather than a URL. If so, this should really be handled
+ * on the backend.
+ *
+ * @param {string} origin
+ */
 function addHttps(origin) {
   if (origin.indexOf('://') !== -1) {
     return origin;
@@ -50,7 +59,7 @@ export class GooglePickerClient {
   constructor({ developerKey, clientId, origin }) {
     this._clientId = clientId;
     this._developerKey = developerKey;
-    this._origin = origin;
+    this._origin = addHttps(origin);
 
     const libs = loadLibraries(['auth2', 'client', 'picker']);
 
@@ -133,7 +142,7 @@ export class GooglePickerClient {
       .setDeveloperKey(this._developerKey)
       .setMaxItems(1)
       .setOAuthToken(accessToken)
-      .setOrigin(addHttps(this._origin))
+      .setOrigin(this._origin)
       .build();
     picker.setVisible(true);
 

--- a/lms/static/scripts/karma.config.js
+++ b/lms/static/scripts/karma.config.js
@@ -76,7 +76,7 @@ module.exports = function (config) {
               [
                 'babel-plugin-istanbul',
                 {
-                  exclude: ['**/test/**/*.js'],
+                  exclude: ['**/test/**/*.js', '**/test-util/**/*.js'],
                 },
               ],
             ],
@@ -90,6 +90,11 @@ module.exports = function (config) {
       reports: ['json', 'html'],
       'report-config': {
         json: { subdir: './' },
+      },
+      thresholds: {
+        global: {
+          statements: 100,
+        },
       },
     },
 

--- a/lms/static/scripts/postmessage_json_rpc/client.js
+++ b/lms/static/scripts/postmessage_json_rpc/client.js
@@ -1,10 +1,5 @@
 import { generateHexString } from './random';
 
-/** Generate a random ID to associate RPC requests and responses. */
-function generateId() {
-  return generateHexString(10);
-}
-
 /**
  * Return a Promise that rejects with an error after `delay` ms.
  *
@@ -36,7 +31,7 @@ async function call(
   params = [],
   timeout = 2000,
   window_ = window,
-  id = generateId()
+  id = generateHexString(10)
 ) {
   // Send RPC request.
   const request = {


### PR DESCRIPTION
This PR adds test cases to cover the remaining statements that were not previously covered in the frontend code, bringing coverage up to 100%. With all statements fully covered, enforcing code coverage going forwards becomes straightforward and does not require a service like Codecov. All statements must be either covered or explicitly ignored (with `/* istanbul ignore next */`). If there is code without coverage then `gulp test` will fail, but still output the same information as if the check was not enabled. This means that during development you can just ignore the error.

- Add missing test cases for various modules under the `frontend_apps` directory
- Exclude files in the `test-util` directory from code coverage. These are helpers used only within tests.
- Add `thresholds` property to `coverageIstanbulReporter` in `karma.config.js` to requirement complete statement coverage