### PR TITLE
Use the real session maker so we get an identical session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,8 @@ from unittest import mock
 import factory.random
 import pytest
 import sqlalchemy
-from sqlalchemy.orm import sessionmaker
 
 from lms import db
-
-SESSION = sessionmaker()
 
 
 def get_test_database_url(default):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,8 +6,9 @@ from webtest import TestApp
 
 from lms import db
 from lms.app import create_app
+from lms.db import SESSION
 from tests import factories
-from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
+from tests.conftest import TEST_SETTINGS, get_test_database_url
 
 TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(
     default="postgresql://postgres@localhost:5433/lms_functests"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,8 +6,9 @@ import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 
+from lms.db import SESSION
 from tests import factories
-from tests.conftest import SESSION, TEST_SETTINGS, get_test_database_url
+from tests.conftest import TEST_SETTINGS, get_test_database_url
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 TEST_SETTINGS["sqlalchemy.url"] = get_test_database_url(


### PR DESCRIPTION
For some reason we use a different session maker in the tests vs. the app. This means the `db_session` fixture doesn't really well represent the real session object.