### PR TITLE
Add `make coverage` back as a separate command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ deps =
     {format,checkformatting}: -r requirements/format.txt
     lint: -r requirements/lint.txt
     tests: -r requirements/tests.txt
+    coverage: -r requirements/tests.txt
     functests: -r requirements/functests.txt
     bddtests: -r requirements/bddtests.txt
     dockercompose: -r requirements/dockercompose.txt
@@ -77,8 +78,8 @@ commands =
     functests: sh bin/create-db lms_functests
     bddtests: sh bin/create-db lms_bddtests
     tests: coverage run -m pytest -v {posargs:tests/unit/}
-    tests: -coverage combine
-    tests: coverage report
+    coverage: -coverage combine
+    coverage: coverage report
     functests: pytest {posargs:tests/functional/}
     bddtests: behave {posargs:tests/bdd/}
     lint: pylint lms


### PR DESCRIPTION
This allows you to see the coverage report again without having to re-run the entire test suite.