### PR TITLE
Split the non Canvas API responsibilities into a new service

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,3 +1,4 @@
+from lms.services.canvas import CanvasService
 from lms.services.exceptions import (
     CanvasAPIError,
     CanvasAPIPermissionError,
@@ -26,6 +27,8 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.canvas_api.canvas_api_client_factory", name="canvas_api_client"
     )
+    config.register_service_factory("lms.services.canvas.factory", iface=CanvasService)
+
     config.register_service_factory("lms.services.h_api.HAPI", name="h_api")
     config.register_service_factory(
         "lms.services.launch_verifier.LaunchVerifier", name="launch_verifier"

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -18,16 +18,15 @@ class CanvasService:
 
         :param file_id: The file to look up
         :param course_id: The course the file should be in
-        :param check_in_course: Enable pre-emptive checking for the file in the
-            course regardless of whether the user has permission to see it
+        :param check_in_course: Raise CanvasFileNotFoundInCourse if file_id isn't in
+            course_id
         :return: A URL suitable for public presentation of the file
-        :raises  CanvasFileNotFoundInCourse: If we determine the file should
+        :raise  CanvasFileNotFoundInCourse: if check_in_course=True and file_id isn't in course_id
             be in the course but isn't.
         """
 
         if check_in_course:
             if not self._file_in_course(file_id, course_id):
-                # Looks like a course copy
                 raise CanvasFileNotFoundInCourse(file_id)
 
         return self.api.public_url(file_id)

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -1,0 +1,42 @@
+from lms.services.exceptions import CanvasFileNotFoundInCourse
+
+
+class CanvasService:
+    """A high level Canvas service."""
+
+    api = None
+
+    def __init__(self, canvas_api):
+        self.api = canvas_api
+
+    def public_url_for_file(self, file_id, course_id, check_in_course=False):
+        """
+        Get a public URL for a Canvas file.
+
+        This will also attempt to check if the file is in the course to detect
+        course copy situations and fix it if we can.
+
+        :param file_id: The file to look up
+        :param course_id: The course the file should be in
+        :param check_in_course: Enable pre-emptive checking for the file in the
+            course regardless of whether the user has permission to see it
+        :return: A URL suitable for public presentation of the file
+        :raises  CanvasFileNotFoundInCourse: If we determine the file should
+            be in the course but isn't.
+        """
+
+        if check_in_course:
+            if not self._file_in_course(file_id, course_id):
+                # Looks like a course copy
+                raise CanvasFileNotFoundInCourse(file_id)
+
+        return self.api.public_url(file_id)
+
+    def _file_in_course(self, file_id, course_id):
+        return any(
+            str(file_["id"]) == str(file_id) for file_ in self.api.list_files(course_id)
+        )
+
+
+def factory(_context, request):
+    return CanvasService(canvas_api=request.find_service(name="canvas_api_client"))

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -3,7 +3,7 @@
 import marshmallow
 from marshmallow import EXCLUDE, Schema, fields, post_load, validate, validates_schema
 
-from lms.services import CanvasAPIError, CanvasFileNotFoundInCourse
+from lms.services import CanvasAPIError
 from lms.validation import RequestsResponseSchema
 
 
@@ -225,17 +225,6 @@ class CanvasAPIClient:
         display_name = fields.Str(required=True)
         id = fields.Integer(required=True)
         updated_at = fields.String(required=True)
-
-    def check_file_in_course(self, file_id, course_id):
-        """
-        Raise if the file with ID file_id isn't in the course with ID course_id.
-
-        :raise CanvasFileNotFoundInCourse: If the file isn't in the course
-        """
-        if not any(
-            str(file_["id"]) == str(file_id) for file_ in self.list_files(course_id)
-        ):
-            raise CanvasFileNotFoundInCourse(file_id)
 
     def public_url(self, file_id):
         """

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -33,9 +33,9 @@ class FilesAPIViews:
         public_url = self.canvas.public_url_for_file(
             file_id=self.request.matchdict["file_id"],
             course_id=self.request.matchdict["course_id"],
-            # For teachers we can do a pre-emptive check to see if the file is
-            # in the course or not, to catch course copy scenarios even though
-            # the teacher has permission to see the file
+            # Teachers can have broad permissions and see files that aren't in
+            # the course. So do this slower check (extra API call) to warn the
+            # teacher that their students might not be able to see the file.
             check_in_course=self.request.lti_user.is_instructor,
         )
 

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -2,6 +2,7 @@
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
+from lms.services.canvas import CanvasService
 from lms.views import helpers
 
 
@@ -9,7 +10,7 @@ from lms.views import helpers
 class FilesAPIViews:
     def __init__(self, request):
         self.request = request
-        self.canvas_api_client = request.find_service(name="canvas_api_client")
+        self.canvas = request.find_service(CanvasService)
 
     @view_config(request_method="GET", route_name="canvas_api.courses.files.list")
     def list_files(self):
@@ -19,7 +20,7 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
-        return self.canvas_api_client.list_files(self.request.matchdict["course_id"])
+        return self.canvas.api.list_files(self.request.matchdict["course_id"])
 
     @view_config(request_method="GET", route_name="canvas_api.files.via_url")
     def via_url(self):
@@ -29,14 +30,13 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
-        file_id = self.request.matchdict["file_id"]
-        course_id = self.request.matchdict["course_id"]
-
-        if self.request.lti_user.is_instructor:
-            self.canvas_api_client.check_file_in_course(file_id, course_id)
-
-        public_url = self.canvas_api_client.public_url(
-            self.request.matchdict["file_id"]
+        public_url = self.canvas.public_url_for_file(
+            file_id=self.request.matchdict["file_id"],
+            course_id=self.request.matchdict["course_id"],
+            # For teachers we can do a pre-emptive check to see if the file is
+            # in the course or not, to catch course copy scenarios even though
+            # the teacher has permission to see the file
+            check_in_course=self.request.lti_user.is_instructor,
         )
 
         # Currently we only let users pick PDF files, so we can save a little

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -3,12 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from lms.services import (
-    CanvasAPIError,
-    CanvasAPIServerError,
-    CanvasFileNotFoundInCourse,
-    ProxyAPIAccessTokenError,
-)
+from lms.services import CanvasAPIError, CanvasAPIServerError, ProxyAPIAccessTokenError
 from lms.services.canvas_api.client import CanvasAPIClient
 from tests import factories
 
@@ -287,31 +282,6 @@ class TestCanvasAPIClient:
             timeout=Any(),
         )
 
-    @pytest.mark.usefixtures("list_files_response")
-    @pytest.mark.parametrize("file_id", [1, "1"])
-    def test_check_file_in_course_checks_that_the_file_is_in_the_course(
-        self, canvas_api_client, file_id, http_session
-    ):
-        canvas_api_client.check_file_in_course(
-            file_id=file_id, course_id="test_course_id"
-        )
-
-        http_session.send.assert_called_once_with(
-            Any.request(
-                url=Any.url.with_path("api/v1/courses/test_course_id/files"),
-            ),
-            timeout=Any(),
-        )
-
-    @pytest.mark.usefixtures("list_files_response")
-    def test_check_file_in_course_raises_if_the_file_isnt_in_the_course(
-        self, canvas_api_client
-    ):
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_api_client.check_file_in_course(
-                file_id="not_in_course", course_id="test_course_id"
-            )
-
     def test_public_url(self, canvas_api_client, http_session):
         http_session.send.return_value = factories.requests.Response(
             status_code=200, json_data={"public_url": "public_url_value"}
@@ -325,25 +295,6 @@ class TestCanvasAPIClient:
                 "GET", url=Any.url.with_path("api/v1/files/FILE_ID/public_url")
             ),
             timeout=Any(),
-        )
-
-    @pytest.fixture
-    def list_files_response(self, http_session):
-        """Make the network send a valid Canvas API list files response."""
-        http_session.send.return_value = factories.requests.Response(
-            json_data=[
-                {
-                    "display_name": "display_name_1",
-                    "id": 1,
-                    "updated_at": "updated_at_1",
-                },
-                {
-                    "display_name": "display_name_2",
-                    "id": 2,
-                    "updated_at": "updated_at_2",
-                },
-            ],
-            status_code=200,
         )
 
 

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,0 +1,45 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services import CanvasFileNotFoundInCourse, CanvasService
+from lms.services.canvas import factory
+
+
+class TestCanvasService:
+    @pytest.mark.parametrize("check_in_course", (True, False))
+    def test_public_url_for_file(self, canvas_service, check_in_course):
+        canvas_service.api.list_files.return_value = [{"id": sentinel.file_id}]
+
+        result = canvas_service.public_url_for_file(
+            file_id=sentinel.file_id, check_in_course=check_in_course, course_id="*any*"
+        )
+
+        assert result == canvas_service.api.public_url.return_value
+        canvas_service.api.public_url.assert_called_once_with(sentinel.file_id)
+
+    def test_public_url_for_file_with_unsuccessful_file_check(self, canvas_service):
+        canvas_service.api.list_files.return_value = []
+
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            canvas_service.public_url_for_file(
+                file_id=sentinel.file_id,
+                course_id=sentinel.course_id,
+                check_in_course=True,
+            )
+
+    @pytest.fixture
+    def canvas_service(self, canvas_api_client):
+        return CanvasService(canvas_api=canvas_api_client)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, CanvasService, canvas_api_client):
+        result = factory("*any*", request=pyramid_request)
+
+        assert result == CanvasService.return_value
+        CanvasService.assert_called_once_with(canvas_api=canvas_api_client)
+
+    @pytest.fixture
+    def CanvasService(self, patch):
+        return patch("lms.services.canvas.CanvasService")

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -1,113 +1,40 @@
 import pytest
 
-from lms.services import CanvasAPIError, CanvasFileNotFoundInCourse
 from lms.views.api.canvas.files import FilesAPIViews
 
-pytestmark = pytest.mark.usefixtures("canvas_api_client")
 
-
-class TestListFiles:
-    def test_it_gets_the_list_of_files_from_canvas(
-        self, canvas_api_client, pyramid_request
-    ):
-        FilesAPIViews(pyramid_request).list_files()
-
-        canvas_api_client.list_files.assert_called_once_with("test_course_id")
-
-    def test_it_returns_the_list_of_files(self, canvas_api_client, pyramid_request):
-        assert (
-            FilesAPIViews(pyramid_request).list_files()
-            == canvas_api_client.list_files.return_value
-        )
-
-    # CanvasAPIError's are caught and handled by an exception view, so the
-    # normal view just lets them raise.
-    def test_it_doesnt_catch_CanvasAPIErrors_from_list_files(
-        self, canvas_api_client, pyramid_request
-    ):
-        canvas_api_client.list_files.side_effect = CanvasAPIError("Oops")
-
-        with pytest.raises(CanvasAPIError, match="Oops"):
-            FilesAPIViews(pyramid_request).list_files()
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
+@pytest.mark.usefixtures("canvas_service")
+class TestFilesAPIViews:
+    def test_list_files(self, canvas_service, pyramid_request):
         pyramid_request.matchdict = {"course_id": "test_course_id"}
-        return pyramid_request
 
+        result = FilesAPIViews(pyramid_request).list_files()
 
-class TestViaURL:
-    @pytest.mark.usefixtures("user_is_instructor")
-    def test_it_checks_whether_the_file_is_in_the_course(
-        self, canvas_api_client, pyramid_request
-    ):
-        FilesAPIViews(pyramid_request).via_url()
+        assert result == canvas_service.api.list_files.return_value
+        canvas_service.api.list_files.assert_called_once_with("test_course_id")
 
-        canvas_api_client.check_file_in_course.assert_called_once_with(
-            "test_file_id", "test_course_id"
-        )
-
-    @pytest.mark.usefixtures("user_is_instructor")
-    def test_it_raises_if_the_file_isnt_in_the_course(
-        self, canvas_api_client, pyramid_request
-    ):
-        canvas_api_client.check_file_in_course.side_effect = CanvasFileNotFoundInCourse(
-            1
-        )
-
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            FilesAPIViews(pyramid_request).via_url()
-
-    @pytest.mark.usefixtures("user_is_learner")
-    def test_it_doesnt_check_whether_the_file_is_in_the_course(
-        self, canvas_api_client, pyramid_request
-    ):
-        FilesAPIViews(pyramid_request).via_url()
-
-        canvas_api_client.check_file_in_course.assert_not_called()
-
-    def test_it_gets_the_public_url_from_canvas(
-        self, canvas_api_client, pyramid_request
-    ):
-        FilesAPIViews(pyramid_request).via_url()
-
-        canvas_api_client.public_url.assert_called_once_with("test_file_id")
-
-    def test_it_gets_the_via_url_for_the_public_url(
-        self, canvas_api_client, pyramid_request, helpers
-    ):
-        FilesAPIViews(pyramid_request).via_url()
-
-        helpers.via_url.assert_called_once_with(
-            pyramid_request,
-            canvas_api_client.public_url.return_value,
-            content_type="pdf",
-        )
-
-    # CanvasAPIError's are caught and handled by an exception view, so the
-    # normal view just lets them raise.
-    def test_doesnt_catch_CanvasAPIErrors_from_public_url(
-        self, canvas_api_client, pyramid_request
-    ):
-        canvas_api_client.public_url.side_effect = CanvasAPIError("Oops")
-
-        with pytest.raises(CanvasAPIError, match="Oops"):
-            FilesAPIViews(pyramid_request).via_url()
-
-    def test_it_returns_the_via_url(self, pyramid_request, helpers):
-        data = FilesAPIViews(pyramid_request).via_url()
-
-        assert data["via_url"] == helpers.via_url.return_value
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
+    def test_via_url(self, pyramid_request, canvas_service, helpers):
         pyramid_request.matchdict = {
             "course_id": "test_course_id",
             "file_id": "test_file_id",
         }
-        return pyramid_request
 
+        result = FilesAPIViews(pyramid_request).via_url()
 
-@pytest.fixture(autouse=True)
-def helpers(patch):
-    return patch("lms.views.api.canvas.files.helpers")
+        assert result["via_url"] == helpers.via_url.return_value
+
+        canvas_service.public_url_for_file.assert_called_once_with(
+            file_id="test_file_id",
+            course_id="test_course_id",
+            check_in_course=pyramid_request.lti_user.is_instructor,
+        )
+
+        helpers.via_url.assert_called_once_with(
+            pyramid_request,
+            canvas_service.public_url_for_file.return_value,
+            content_type="pdf",
+        )
+
+    @pytest.fixture
+    def helpers(self, patch):
+        return patch("lms.views.api.canvas.files.helpers")

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -13,6 +13,7 @@ class TestFilesAPIViews:
         assert result == canvas_service.api.list_files.return_value
         canvas_service.api.list_files.assert_called_once_with("test_course_id")
 
+    @pytest.mark.usefixtures("with_teacher_or_student")
     def test_via_url(self, pyramid_request, canvas_service, helpers):
         pyramid_request.matchdict = {
             "course_id": "test_course_id",
@@ -34,6 +35,10 @@ class TestFilesAPIViews:
             canvas_service.public_url_for_file.return_value,
             content_type="pdf",
         )
+
+    @pytest.fixture(params=("instructor", "learner"))
+    def with_teacher_or_student(self, request, pyramid_request):
+        pyramid_request.lti_user._replace(roles=request.param)
 
     @pytest.fixture
     def helpers(self, patch):

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from lms.models import ApplicationSettings
+from lms.services import CanvasService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
 from lms.services.blackboard_api.service import BlackboardAPIClient
@@ -30,6 +31,7 @@ __all__ = (
     "assignment_service",
     "blackboard_api_client",
     "canvas_api_client",
+    "canvas_service",
     "course_service",
     "grading_info_service",
     "grant_token_service",
@@ -50,9 +52,10 @@ __all__ = (
 def mock_service(pyramid_config):
     def mock_service(service_class, service_name=None):
         mock_service = mock.create_autospec(service_class, spec_set=True, instance=True)
+
         if service_name:
             pyramid_config.register_service(mock_service, name=service_name)
-        else:  # pragma: no cover
+        else:
             pyramid_config.register_service(mock_service, iface=service_class)
 
         return mock_service
@@ -104,6 +107,14 @@ def canvas_api_client(mock_service):
         3600,
     )
     return canvas_api_client
+
+
+@pytest.fixture
+def canvas_service(mock_service, canvas_api_client):
+    canvas_service = mock_service(CanvasService)
+    canvas_service.api = canvas_api_client
+
+    return canvas_service
 
 
 @pytest.fixture


### PR DESCRIPTION
This makes the Canvas API service a pure API interface, and means it does not also have other canvas service responsibilities. This also extracts logic from the view and puts it into the service, thinning the view.

This is being done because:

 * It's probably the correct thing to do
 * The amount of logic in here is about to grow a lot