### PR TITLE
Add a file table and update it when we retrieve a list of Canvas files (2)

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -98,6 +98,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.services")
     config.include("lms.validation")
     config.include("lms.tweens")
+    config.scan("lms.events")
     config.add_static_view(name="export", path="lms:static/export")
     config.add_static_view(name="static", path="lms:static")
 

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cached_property
 
 import alembic.command
 import alembic.config
@@ -6,10 +7,12 @@ import sqlalchemy
 import zope.sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.orm.properties import ColumnProperty
 
-__all__ = ("BASE", "init")
+from lms.db._bulk_action import BulkAction
+
+__all__ = ("BASE", "init", "BulkAction")
 
 
 LOG = logging.getLogger(__name__)
@@ -85,9 +88,6 @@ BASE = declarative_base(
 )
 
 
-SESSION = sessionmaker()
-
-
 def init(engine, drop=False):
     """
     Create all the database tables if they don't already exist.
@@ -121,6 +121,17 @@ def _stamp_db(engine):  # pragma: nocover
 def make_engine(settings):
     """Construct a sqlalchemy engine from the passed ``settings``."""
     return sqlalchemy.create_engine(settings["sqlalchemy.url"])
+
+
+class CustomSession(Session):
+    @cached_property
+    def bulk(self):
+        """Get an object for performing bulk actions."""
+
+        return BulkAction(self)
+
+
+SESSION = sessionmaker(class_=CustomSession)
 
 
 def _session(request):  # pragma: no cover

--- a/lms/db/_bulk_action.py
+++ b/lms/db/_bulk_action.py
@@ -1,0 +1,88 @@
+"""
+Adds a set of low level DB operations for bulk operations.
+
+Why is this here, rather than services?
+
+ * The functionality is very low level and generic (we wish the basic Session
+ object had it)
+ * You shouldn't mock this in your code in general
+ * There's nothing LMS specific about it
+
+For more see: https://stackoverflow.com/c/hypothesis/questions/477
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+from sqlalchemy.dialects.postgresql import insert
+from zope.sqlalchemy import mark_changed
+
+
+class BulkAction:
+    """
+    An extension to the DB session which adds bulk actions.
+
+    These can be accessed via request.db.bulk.<method_name>().
+
+    To enable for a particular model add config to the model like this:
+
+        class MyModel(BASE):
+            # Enable bulk actions
+            BULK_CONFIG = BulkAction.Config(
+                upsert_index_elements=[...],
+                upsert_update_elements=[...],
+            )
+    """
+
+    def __init__(self, session):
+        """
+        Initialize object.
+
+        :session: SQLAlchemy session object
+        """
+        self._session = session
+
+    @dataclass
+    class Config:
+        upsert_index_elements: List[str]
+        """Columns to match when upserting. This must match an index."""
+
+        upsert_update_elements: List[str]
+        """Columns to update when a match is found."""
+
+        def __set_name__(self, owner, name):
+            if name != "BULK_CONFIG":
+                raise ValueError(
+                    "The configuration must be attached to the model with "
+                    "the name 'BULK_CONFIG'"
+                )
+
+    def upsert(self, model_class, values):
+        """
+        Create or update the specified values in the table.
+
+        :param model_class: The model type to upsert
+        :param values: Dicts of values to upsert
+        """
+
+        config = model_class.BULK_CONFIG
+
+        stmt = insert(model_class).values(values)
+        stmt = stmt.on_conflict_do_update(
+            # The columns to use to find matching rows.
+            index_elements=config.upsert_index_elements,
+            # The columns to update.
+            set_={
+                element: getattr(stmt.excluded, element)
+                for element in config.upsert_update_elements
+            },
+        )
+
+        result = self._session.execute(stmt)
+
+        # Let SQLAlchemy know that something has changed, otherwise it will
+        # never commit the transaction we are working on and it will get rolled
+        # back
+        mark_changed(self._session)
+
+        return result

--- a/lms/events/__init__.py
+++ b/lms/events/__init__.py
@@ -1,0 +1,1 @@
+from lms.events.subscriber import FilesDiscoveredEvent

--- a/lms/events/subscriber.py
+++ b/lms/events/subscriber.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from typing import List
+
+from pyramid.events import subscriber
+from pyramid.request import Request
+
+from lms.models.file import File
+
+
+@dataclass
+class FilesDiscoveredEvent:
+    """Notify that a file has been found in an LMS."""
+
+    request: Request
+    values: List[dict]
+
+
+@subscriber(FilesDiscoveredEvent)
+def files_discovered(event):
+    """Record discovered files in the DB."""
+
+    application_instance = event.request.find_service(name="application_instance").get()
+
+    for value in event.values:
+        value["application_instance_id"] = application_instance.id
+
+    event.request.db.bulk.upsert(File, values=event.values)

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -3,6 +3,7 @@ from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
 from lms.models.course import LegacyCourse
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
+from lms.models.file import File
 from lms.models.grading_info import GradingInfo
 from lms.models.group_info import GroupInfo
 from lms.models.grouping import CanvasGroup, CanvasSection, Course, Grouping

--- a/lms/models/file.py
+++ b/lms/models/file.py
@@ -1,0 +1,49 @@
+import sqlalchemy as sa
+
+from lms.db import BASE, BulkAction
+from lms.models._mixins import CreatedUpdatedMixin
+
+
+class File(CreatedUpdatedMixin, BASE):
+    """A record of files we've seen in LMS's."""
+
+    __tablename__ = "file"
+    __table_args__ = (
+        sa.UniqueConstraint("application_instance_id", "lms_id", "type", "course_id"),
+    )
+
+    # Enable bulk actions
+    BULK_CONFIG = BulkAction.Config(
+        upsert_index_elements=[
+            "application_instance_id",
+            "lms_id",
+            "type",
+            "course_id",
+        ],
+        upsert_update_elements=["name", "size"],
+    )
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+    """Primary key"""
+
+    application_instance_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("application_instances.id", ondelete="cascade"),
+        nullable=False,
+    )
+    """Link to the application instance."""
+
+    type = sa.Column(sa.String(), nullable=False)
+    """What type of file is this? e.g. 'canvas_file'."""
+
+    lms_id = sa.Column(sa.String(), nullable=False)
+    """The natural id of the file in the LMS."""
+
+    course_id = sa.Column(sa.String())
+    """If the file is associated with a specific course set it here."""
+
+    name = sa.Column(sa.String())
+    """The user facing file name."""
+
+    size = sa.Column(sa.Integer())
+    """The size of the file in bytes."""

--- a/lms/models/file.py
+++ b/lms/models/file.py
@@ -33,16 +33,16 @@ class File(CreatedUpdatedMixin, BASE):
     )
     """Link to the application instance."""
 
-    type = sa.Column(sa.String(), nullable=False)
+    type = sa.Column(sa.UnicodeText(), nullable=False)
     """What type of file is this? e.g. 'canvas_file'."""
 
-    lms_id = sa.Column(sa.String(), nullable=False)
+    lms_id = sa.Column(sa.UnicodeText(), nullable=False)
     """The natural id of the file in the LMS."""
 
-    course_id = sa.Column(sa.String())
+    course_id = sa.Column(sa.UnicodeText())
     """If the file is associated with a specific course set it here."""
 
-    name = sa.Column(sa.String())
+    name = sa.Column(sa.UnicodeText())
     """The user facing file name."""
 
     size = sa.Column(sa.Integer())

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -26,4 +26,4 @@ def canvas_api_client_factory(_context, request):
         redirect_uri=request.route_url("canvas_api.oauth.callback"),
     )
 
-    return CanvasAPIClient(authenticated_api)
+    return CanvasAPIClient(authenticated_api, request=request)

--- a/tests/unit/lms/db/__init___test.py
+++ b/tests/unit/lms/db/__init___test.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from lms.db import BASE
+from lms.db._bulk_action import BulkAction
 
 
 class Child(BASE):
@@ -67,3 +68,8 @@ class TestBase:
     @pytest.fixture
     def model(self):
         return ModelClass(id=1234, column="original_value")
+
+
+class TestCustomSession:
+    def test_it_adds_bulk_object(self, db_session):
+        assert isinstance(db_session.bulk, BulkAction)

--- a/tests/unit/lms/db/_bulk_action_test.py
+++ b/tests/unit/lms/db/_bulk_action_test.py
@@ -1,0 +1,69 @@
+import pytest
+import sqlalchemy as sa
+from h_matchers import Any
+from sqlalchemy.engine import CursorResult
+
+from lms.db import BASE, BulkAction
+
+
+class TestBulkUpsertMixin:
+    class TableWithBulkUpsert(BASE):
+        __tablename__ = "test_table_with_bulk_upsert"
+
+        BULK_CONFIG = BulkAction.Config(
+            upsert_index_elements=["id"], upsert_update_elements=["name"]
+        )
+
+        id = sa.Column(sa.Integer, primary_key=True)
+        name = sa.Column(sa.String)
+        other = sa.Column(sa.String)
+
+    def test_upsert(self, db_session):
+        db_session.add_all(
+            [
+                self.TableWithBulkUpsert(id=1, name="pre_existing_1", other="pre_1"),
+                self.TableWithBulkUpsert(id=2, name="pre_existing_2", other="pre_2"),
+            ]
+        )
+        db_session.flush()
+
+        result = BulkAction(db_session).upsert(
+            self.TableWithBulkUpsert,
+            [
+                {"id": 1, "name": "update_old", "other": "post_1"},
+                {"id": 3, "name": "create_with_id", "other": "post_3"},
+                {"id": 4, "name": "over_block_size", "other": "post_4"},
+            ],
+        )
+
+        assert isinstance(result, CursorResult)
+
+        rows = list(db_session.query(self.TableWithBulkUpsert))
+
+        assert (
+            rows
+            == Any.iterable.containing(
+                [
+                    Any.instance_of(self.TableWithBulkUpsert).with_attrs(expected)
+                    for expected in [
+                        {"id": 1, "name": "update_old", "other": "pre_1"},
+                        {"id": 2, "name": "pre_existing_2", "other": "pre_2"},
+                        {"id": 3, "name": "create_with_id", "other": "post_3"},
+                        {"id": 4, "name": "over_block_size", "other": "post_4"},
+                    ]
+                ]
+            ).only()
+        )
+
+    def test_it_fails_with_missing_config(self, db_session):
+        with pytest.raises(AttributeError):
+            BulkAction(db_session).upsert("object_without_config", [])
+
+    def test_you_cannot_add_config_with_the_wrong_name(self):
+        # Not sure why this isn't ValueError... must be a descriptor thing
+        with pytest.raises(RuntimeError):
+
+            class MisconfiguredModel:  # pylint: disable=unused-variable
+                NOT_THE_RIGHT_NAME = BulkAction.Config(
+                    upsert_index_elements=["id"], upsert_update_elements=["name"]
+                )

--- a/tests/unit/lms/events/subscriber_test.py
+++ b/tests/unit/lms/events/subscriber_test.py
@@ -1,0 +1,96 @@
+import pytest
+from h_matchers import Any
+
+from lms.events import FilesDiscoveredEvent
+from lms.events.subscriber import files_discovered
+from lms.models import File
+from tests import factories
+
+
+class TestFilesDiscovered:
+    @pytest.mark.parametrize("extras", ({}, {"name": "new"}, {"course_id": "cid_1"}))
+    def test_it_can_add_new_values(
+        self, pyramid_request, db_session, application_instance, extras
+    ):
+        attrs = dict(type="new", lms_id="id_1", **extras)
+
+        files_discovered(
+            # Use a dict call here again to prevent SQLAlchemy from messing
+            # with our dict in place
+            event=FilesDiscoveredEvent(request=pyramid_request, values=[dict(attrs)])
+        )
+
+        assert db_session.query(File).all() == [
+            Any.instance_of(File).with_attrs(
+                dict(application_instance_id=application_instance.id, **attrs)
+            )
+        ]
+
+    @pytest.mark.usefixtures("existing_file")
+    def test_it_can_update_old_values(
+        self, pyramid_request, db_session, existing_attrs
+    ):
+        new_attrs = dict(existing_attrs, name="new")
+
+        files_discovered(
+            # Use a dict call here again to prevent SQLAlchemy from messing
+            # with our dict in place
+            event=FilesDiscoveredEvent(request=pyramid_request, values=[new_attrs])
+        )
+
+        assert db_session.query(File).all() == [
+            Any.instance_of(File).with_attrs(new_attrs)
+        ]
+
+    # We don't cover the application instance id here 'cos it's annoying
+    @pytest.mark.parametrize("field", ("type", "lms_id", "course_id"))
+    @pytest.mark.usefixtures("existing_file")
+    def test_old_values_are_only_updated_for_exact_matches(
+        self, db_session, field, pyramid_request, existing_attrs
+    ):
+        new_attrs = dict(existing_attrs)
+        new_attrs[field] = "different"
+
+        files_discovered(
+            # Use a dict call here again to prevent SQLAlchemy from messing
+            # with our dict in place
+            event=FilesDiscoveredEvent(
+                request=pyramid_request, values=[dict(new_attrs)]
+            )
+        )
+
+        assert (
+            db_session.query(File).all()
+            == Any.list.containing(
+                [
+                    Any.instance_of(File).with_attrs(existing_attrs),
+                    Any.instance_of(File).with_attrs(new_attrs),
+                ]
+            ).only()
+        )
+
+    @pytest.fixture
+    def existing_attrs(self, application_instance):
+        return {
+            "application_instance_id": application_instance.id,
+            "type": "existing_type",
+            "lms_id": "existing_lms_id",
+            "course_id": "existing_course_id",
+        }
+
+    @pytest.fixture
+    def existing_file(self, db_session, existing_attrs):
+        file = File(**existing_attrs)
+        db_session.add(file)
+        db_session.flush()
+
+        return file
+
+    @pytest.fixture(autouse=True)
+    def application_instance(self, db_session, application_instance_service):
+        application_instance = factories.ApplicationInstance(id=1234)
+        db_session.add(application_instance)
+        db_session.flush()
+        application_instance_service.get.return_value = application_instance
+
+        return application_instance

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -324,8 +324,18 @@ class TestCanvasAPIClient:
 
     def test_list_files(self, canvas_api_client, http_session):
         files = [
-            {"display_name": "display_name_1", "id": 1, "updated_at": "updated_at_1"},
-            {"display_name": "display_name_1", "id": 1, "updated_at": "updated_at_1"},
+            {
+                "display_name": "display_name_1",
+                "id": 1,
+                "updated_at": "updated_at_1",
+                "size": 12345,
+            },
+            {
+                "display_name": "display_name_1",
+                "id": 1,
+                "updated_at": "updated_at_1",
+                "size": 12345,
+            },
         ]
         files_with_noise = [dict(file, unexpected="ignored") for file in files]
         http_session.send.return_value = factories.requests.Response(
@@ -452,5 +462,5 @@ class TestMetaBehavior:
 
 
 @pytest.fixture
-def canvas_api_client(authenticated_client):
-    return CanvasAPIClient(authenticated_client)
+def canvas_api_client(authenticated_client, pyramid_request):
+    return CanvasAPIClient(authenticated_client, pyramid_request)

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -15,7 +15,9 @@ class TestCanvasAPIClientFactory:
     ):
         canvas_api = canvas_api_client_factory(sentinel.context, pyramid_request)
 
-        CanvasAPIClient.assert_called_once_with(AuthenticatedClient.return_value)
+        CanvasAPIClient.assert_called_once_with(
+            AuthenticatedClient.return_value, pyramid_request
+        )
         assert canvas_api == CanvasAPIClient.return_value
 
     def test_building_the_BasicClient(


### PR DESCRIPTION
This is following on from: https://github.com/hypothesis/lms/pull/2777 where the conversation has gotten a bit too dense to follow.

This is based on https://github.com/hypothesis/lms/pull/2810 and also has https://github.com/hypothesis/lms/pull/2808 merged in. When https://github.com/hypothesis/lms/pull/2808 is merged this can be rebased to skip the first commit.

This can't be merged before: https://github.com/hypothesis/lms/pull/2824

Testing notes:

 * Run `make sql`
 * Run `select * from file` - You shouldn't see anything
 * Open a canvas course as a teacher
 * Run `select * from file` - You should see lots of records
 * Open a canvas course as a teacher
 * It shouldn't crash
