### PR TITLE
Allow group_set with a None value for non group assignments

### DIFF
--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -32,7 +32,7 @@ class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
     typically encodes the assignment context and LMS user.
     """
 
-    group_set = fields.Int(required=False)
+    group_set = fields.Int(required=False, allow_none=True)
     """Canvas group_set ID for assignments that use the small groups feature."""
 
 

--- a/tests/unit/lms/validation/_api_test.py
+++ b/tests/unit/lms/validation/_api_test.py
@@ -45,6 +45,13 @@ class TestAPIRecordSpeedgraderSchema:
 
         APIRecordSpeedgraderSchema(request).parse()
 
+    def test_it_doesnt_raise_null_group_set(self, json_request, all_fields):
+        all_fields["group_set"] = None  # Present, but set to None
+
+        request = json_request(all_fields)
+
+        APIRecordSpeedgraderSchema(request).parse()
+
     @pytest.fixture
     def all_fields(self):
         return {
@@ -54,6 +61,7 @@ class TestAPIRecordSpeedgraderSchema:
             "learner_canvas_user_id": "canvas_user_123",
             "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
             "lis_result_sourcedid": "modelstudent-assignment1",
+            "group_set": 1,
         }
 
 


### PR DESCRIPTION
Before this fix "group_set" was always present but set to None for non
groups assignments causing a validation error.

Test for failing validation for non groups assignments