### PR TITLE
Bump `frontend-shared` package to v3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "^7.14.5",
     "@babel/preset-env": "^7.14.5",
     "@babel/preset-react": "^7.14.5",
-    "@hypothesis/frontend-shared": "^3.0.0",
+    "@hypothesis/frontend-shared": "3.1.1",
     "@types/gapi": "^0.0.39",
     "autoprefixer": "^10.2.6",
     "babel-plugin-transform-async-to-promises": "^0.8.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,10 +971,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@hypothesis/frontend-shared@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.0.0.tgz#95e0a10e2d347e74ba6d3149320372954029de9e"
-  integrity sha512-l0B7Ch+Jcp0b89lFm3ePpyudFCCwam0LwLlldFlrvMkH+PC6NbShUG3YB+VVSwbsu/YF0d/RSzzeyhqp9+Zljg==
+"@hypothesis/frontend-shared@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.1.1.tgz#e84c26e6266abde203d86fabb72c4d425ce0d92a"
+  integrity sha512-DHShN4RtaP0hFRGDugZECy80N+ODz2IHn3R8T4lMa+XqBg+rwaXqfn+2x2p0UrK060jHSyQeo/rFl3uLPqpe7Q==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
Bump the package version to avail upon the new `Checkbox` element styling.

Small-groups assignment configuration flow, before:

<img width="808" alt="Screen Shot 2021-06-11 at 8 59 55 AM" src="https://user-images.githubusercontent.com/439947/121926109-9dc1f300-cd0b-11eb-91f6-b501941fa18d.png">

and after:

<img width="800" alt="Screen Shot 2021-06-14 at 12 23 24 PM" src="https://user-images.githubusercontent.com/439947/121926119-a1557a00-cd0b-11eb-920b-07436f897f42.png">

No other user-facing changes in this package version.
