### PR TITLE
Store files migration

### DIFF
--- a/lms/migrations/versions/47d738f87eb5_add_file_table.py
+++ b/lms/migrations/versions/47d738f87eb5_add_file_table.py
@@ -1,0 +1,51 @@
+"""
+Add file table.
+
+Revision ID: 47d738f87eb5
+Revises: bb11b5b06274
+Create Date: 2021-06-15 13:44:45.368126
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "47d738f87eb5"
+down_revision = "bb11b5b06274"
+
+
+def upgrade():
+    op.create_table(
+        "file",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("application_instance_id", sa.Integer(), nullable=False),
+        sa.Column("type", sa.UnicodeText(), nullable=False),
+        sa.Column("lms_id", sa.UnicodeText(), nullable=False),
+        sa.Column("course_id", sa.UnicodeText(), nullable=True),
+        sa.Column("name", sa.UnicodeText(), nullable=True),
+        sa.Column("size", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["application_instance_id"],
+            ["application_instances.id"],
+            name=op.f("fk__file__application_instance_id__application_instances"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__file")),
+        sa.UniqueConstraint(
+            "application_instance_id",
+            "lms_id",
+            "type",
+            "course_id",
+            name=op.f("uq__file__application_instance_id"),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("file")


### PR DESCRIPTION
Adds the file table for: https://github.com/hypothesis/lms/pull/2811

## Testing notes

```
docker stop lms_postgres_1; docker rm lms_postgres_1; make services
hdev alembic upgrade head
make sql
\d+ files;
```
You should see the file table with:

```
         Column          |            Type             | Collation | Nullable |             Default              
-------------------------+-----------------------------+-----------+----------+----------------------------------
 created                 | timestamp without time zone |           | not null | now()
 updated                 | timestamp without time zone |           | not null | now()
 id                      | integer                     |           | not null | nextval('file_id_seq'::regclass)
 application_instance_id | integer                     |           | not null | 
 type                    | character varying           |           | not null | 
 lms_id                  | character varying           |           | not null | 
 course_id               | character varying           |           |          | 
 name                    | character varying           |           |          | 
 size                    | integer                     |           |          | 
Indexes:
    "pk__file" PRIMARY KEY, btree (id)
    "uq__file__application_instance_id" UNIQUE CONSTRAINT, btree (application_instance_id, lms_id, type, course_id)
Foreign-key constraints:
    "fk__file__application_instance_id__application_instances" FOREIGN KEY (application_instance_id) REFERENCES application_instances(id) ON DELETE CASCADE
```

Then downgrade and update:

* `hdev alembic downgrade -1`
* `make sql; \d+ files` - The table should be gone
* `hdev alembic upgrade +1`
* `make sql; \d+ files` - The table should be back