### PR TITLE
Add missing query parameter encoding when fetching grades

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -65,9 +65,10 @@ export class ApiError extends Error {
  * @param {Object} options
  *   @param {string} options.path - The `/api/...` path of the endpoint to call
  *   @param {string} options.authToken
+ *   @param {Record<string, string>} [options.params] - Query parameters
  *   @param {Object} [options.data] - JSON-serializable body of the request
  */
-export async function apiCall({ path, authToken, data }) {
+export async function apiCall({ path, authToken, data, params }) {
   let body;
 
   /** @type {Record<string,string>} */
@@ -80,7 +81,16 @@ export async function apiCall({ path, authToken, data }) {
     headers['Content-Type'] = 'application/json; charset=UTF-8';
   }
 
-  const result = await fetch(path, {
+  let query = '';
+  if (params) {
+    const urlParams = new URLSearchParams();
+    Object.entries(params).forEach(([name, value]) =>
+      urlParams.append(name, value)
+    );
+    query = `?${urlParams}`;
+  }
+
+  const result = await fetch(path + query, {
     method: data === undefined ? 'GET' : 'POST',
     body,
     headers,

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -65,8 +65,8 @@ export class ApiError extends Error {
  * @param {Object} options
  *   @param {string} options.path - The `/api/...` path of the endpoint to call
  *   @param {string} options.authToken
- *   @param {Record<string, string>} [options.params] - Query parameters
  *   @param {Object} [options.data] - JSON-serializable body of the request
+ *   @param {Record<string, string>} [options.params] - Query parameters
  */
 export async function apiCall({ path, authToken, data, params }) {
   let body;
@@ -87,7 +87,7 @@ export async function apiCall({ path, authToken, data, params }) {
     Object.entries(params).forEach(([name, value]) =>
       urlParams.append(name, value)
     );
-    query = `?${urlParams}`;
+    query = '?' + urlParams.toString();
   }
 
   const result = await fetch(path + query, {

--- a/lms/static/scripts/frontend_apps/utils/grader-service.js
+++ b/lms/static/scripts/frontend_apps/utils/grader-service.js
@@ -44,7 +44,11 @@ function submitGrade({ student, grade, authToken }) {
 function fetchGrade({ student, authToken }) {
   return apiCall({
     authToken,
-    path: `/api/lti/result?lis_result_sourcedid=${student.LISResultSourcedId}&lis_outcome_service_url=${student.LISOutcomeServiceUrl}`,
+    path: '/api/lti/result',
+    params: {
+      lis_result_sourcedid: student.LISResultSourcedId,
+      lis_outcome_service_url: student.LISOutcomeServiceUrl,
+    },
   });
 }
 export { fetchGrade, submitGrade };

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -30,6 +30,29 @@ describe('api', () => {
       });
     });
 
+    it('sets query params if `params` is passed', async () => {
+      const params = {
+        a_key: 'some value',
+        encode_me: 'https://example.com',
+      };
+
+      await apiCall({ path: '/api/test', authToken: 'auth', params });
+
+      assert.calledWith(
+        window.fetch,
+        `/api/test?a_key=some+value&encode_me=${encodeURIComponent(
+          params.encode_me
+        )}`,
+        {
+          method: 'GET',
+          body: undefined,
+          headers: {
+            Authorization: 'auth',
+          },
+        }
+      );
+    });
+
     it('makes a POST request if a body is provided', async () => {
       const data = { param: 'value' };
       await apiCall({ path: '/api/test', authToken: 'auth', data });

--- a/lms/static/scripts/frontend_apps/utils/test/grader-service-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/grader-service-test.js
@@ -15,7 +15,7 @@ describe('grader-services', () => {
     $imports.$restore();
   });
 
-  context('submitGrade', () => {
+  describe('submitGrade', () => {
     it('returns a promise', async () => {
       const result = submitGrade({
         student: {
@@ -51,36 +51,29 @@ describe('grader-services', () => {
     });
   });
 
-  context('fetchGrade', () => {
-    it('returns a promise', async () => {
-      const result = fetchGrade({
-        student: {
-          LISResultSourcedId: 0,
-          LISOutcomeServiceUrl: 'url',
-        },
-        authToken: 'auth',
-      });
-      assert.isTrue(result instanceof Promise);
-    });
-
+  describe('fetchGrade', () => {
     it('calls fetchGrade with the provided parameters', async () => {
-      await submitGrade({
+      fakeApiCall.resolves({ currentScore: 9.0 });
+
+      const result = await fetchGrade({
         student: {
-          LISResultSourcedId: 0,
+          LISResultSourcedId: 'abcd',
           LISOutcomeServiceUrl: 'url',
         },
         authToken: 'auth',
       });
+
       assert.isTrue(
         fakeApiCall.calledWithMatch({
           authToken: 'auth',
           path: '/api/lti/result',
-          data: {
-            lis_result_sourcedid: 0,
+          params: {
+            lis_result_sourcedid: 'abcd',
             lis_outcome_service_url: 'url',
           },
         })
       );
+      assert.equal(result.currentScore, 9.0);
     });
   });
 });


### PR DESCRIPTION
Query parameters were not encoded when constructing the `/api/lti/result` URL that is used by the LMS frontend to fetch grades. This could potentially have caused problems if the `lis_*` parameters, which ultimately come from the external LMS, contained characters that require URL-encoding.

 - Add optional `params` argument to `apiCall` function which specifies
   an object of query params
 - Use the `params` argument in `fetchGrade` rather than constructing
   the query string manually
 - Fix tests for `fetchGrade`. The main test called `submitGrade` rather
   than `fetchGrade`.
   
**Manual testing:**

Log in to our Moodle instance using the `moodleteacher` account and check that grades are fetched and submitted correctly in one of the "localhost (make devdata)" assignments in https://hypothesisuniversity.moodlecloud.com/course/view.php?id=11.