### PR TITLE
Add migration to delete stale objects when runing all alembic migrations

### DIFF
--- a/lms/migrations/versions/a930adadac74_add_group_info_table.py
+++ b/lms/migrations/versions/a930adadac74_add_group_info_table.py
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a930adadac74"
-down_revision = "edab0e4610e0"
+down_revision = "d54c5430ea36"
 
 
 def upgrade():

--- a/lms/migrations/versions/d54c5430ea36_delete_stale_objects.py
+++ b/lms/migrations/versions/d54c5430ea36_delete_stale_objects.py
@@ -1,0 +1,47 @@
+"""
+Delete stale DB objects that were removed from the DB not using alembic.
+
+This migration was added retroactively in alambic's history as it only affects
+local setups and we don't want to run it in production.
+
+Revision ID: d54c5430ea36
+Revises: edab0e4610e0
+Create Date: 2021-06-16 10:14:09.764318
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d54c5430ea36"
+down_revision = "edab0e4610e0"
+
+
+def upgrade():
+    op.drop_table("oauth2_unvalidated_credentials")
+    op.drop_constraint(
+        "fk__lis_result_sourcedid__oauth_consumer_key__applicati_7fc0",
+        "lis_result_sourcedid",
+        type_="foreignkey",
+    )
+
+
+def downgrade():
+    op.create_foreign_key(
+        "fk__lis_result_sourcedid__oauth_consumer_key__applicati_7fc0",
+        "lis_result_sourcedid",
+        "application_instances",
+        ["oauth_consumer_key"],
+        ["consumer_key"],
+    )
+    op.create_table(
+        "oauth2_unvalidated_credentials",
+        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column("client_id", sa.TEXT(), autoincrement=False, nullable=True),
+        sa.Column("client_secret", sa.TEXT(), autoincrement=False, nullable=True),
+        sa.Column(
+            "authorization_server", sa.TEXT(), autoincrement=False, nullable=True
+        ),
+        sa.Column("email_address", sa.TEXT(), autoincrement=False, nullable=True),
+        sa.PrimaryKeyConstraint("id", name="pk__oauth2_unvalidated_credentials"),
+    )


### PR DESCRIPTION
A table and a FK were never deleted using the migrations and alembic is
not aware of that so it tries to delete them with every `--autogenerate`
usage.


## Test

- Switch to  `master`
- Nuke the DB `docker stop lms_postgres_1; docker rm lms_postgres_1; make services`
- Get your DB from scratch using alembic `hdev alembic upgrade head`
- Autogenerate a new migration `hdev alembic revision --autogenerate`
- Autogeneraed migration contains:

```
op.drop_table('oauth2_unvalidated_credentials')                             
op.drop_constraint('fk__lis_result_sourcedid__oauth_consumer_key__applicati_7fc0', 'lis_result_sourcedid', type_='foreignkey')
```



Repeat the process on the branch (delete auto generated migration from previous steps)

- Auto generated migration it's empty
- `hdev alembic history`  containts `edab0e4610e0 -> d54c5430ea36, Delete stale DB objects that were removed from the DB not using alembic
`


