### PR TITLE
Fix Blackboard access token errors

### DIFF
--- a/lms/sentry.py
+++ b/lms/sentry.py
@@ -1,16 +1,16 @@
 """Sentry crash reporting integration."""
-from lms.services import ProxyAPIAccessTokenError
+from lms.services import OAuth2TokenError
 
 
-def filter_proxy_api_access_token_error(event):
-    """Filter out all ProxyAPIAccessTokenError's."""
-    return isinstance(event.exception, ProxyAPIAccessTokenError)
+def filter_oauth2_token_error(event):
+    """Filter out all OAuth2TokenError exceptions."""
+    return isinstance(event.exception, OAuth2TokenError)
 
 
 def includeme(config):
     config.add_settings(
         {
-            "h_pyramid_sentry.filters": [filter_proxy_api_access_token_error],
+            "h_pyramid_sentry.filters": [filter_oauth2_token_error],
             "h_pyramid_sentry.retry_support": True,
             "h_pyramid_sentry.sqlalchemy_support": True,
         }

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -13,8 +13,7 @@ from lms.services.exceptions import (
     LTILaunchVerificationError,
     LTIOAuthError,
     LTIOutcomesAPIError,
-    NoOAuth2Token,
-    ProxyAPIAccessTokenError,
+    OAuth2TokenError,
     ProxyAPIError,
     ServiceError,
 )

--- a/lms/services/blackboard_api/service.py
+++ b/lms/services/blackboard_api/service.py
@@ -59,12 +59,7 @@ class BlackboardAPIClient:
         )
 
     def list_files(self, course_id):
-        """
-        Return the list of files in the given course.
-
-        :raise ProxyAPIAccessTokenError: if we don't have a Blackboard API
-            access token for the current user
-        """
+        """Return the list of files in the given course."""
         return self._http_service.get(
             self._api_url(f"courses/uuid:{course_id}/resources"),
             oauth=True,

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -30,8 +30,8 @@ class CanvasAPIClient:
 
     All methods may raise:
 
-    :raise ProxyAPIAccessTokenError: if we can't get the list of sections
-        because we don't have a working Canvas API access token for the user
+    :raise OAuth2TokenError: if we can't get the list of sections because we
+        don't have a working Canvas API access token for the user
     :raise CanvasAPIServerError: if we do have an access token but the
         Canvas API request fails for any other reason
     """

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -103,7 +103,7 @@ class HTTPService:
             The invalid response will be available as
             HTTPValidationError.response.
 
-        :raise NoOAuth2Token: If oauth=True was given but we don't have an
+        :raise OAuth2TokenError: If oauth=True was given but we don't have an
             access token for the current user in our DB
         """
         response = None

--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -3,7 +3,7 @@ import datetime
 from sqlalchemy.orm.exc import NoResultFound
 
 from lms.models import OAuth2Token
-from lms.services import NoOAuth2Token
+from lms.services import OAuth2TokenError
 
 
 class OAuth2TokenService:
@@ -31,7 +31,7 @@ class OAuth2TokenService:
         """
         try:
             oauth2_token = self.get()
-        except NoOAuth2Token:
+        except OAuth2TokenError:
             oauth2_token = OAuth2Token(
                 consumer_key=self._consumer_key, user_id=self._user_id
             )
@@ -46,7 +46,7 @@ class OAuth2TokenService:
         """
         Return the user's saved OAuth 2 token from the DB.
 
-        :raise NoOAuth2Token: if we don't have an OAuth 2 token for the user
+        :raise OAuth2TokenError: if we don't have an OAuth 2 token for the user
         """
         try:
             return (
@@ -55,7 +55,9 @@ class OAuth2TokenService:
                 .one()
             )
         except NoResultFound as err:
-            raise NoOAuth2Token("We don't have an OAuth 2 token for this user") from err
+            raise OAuth2TokenError(
+                "We don't have an OAuth 2 token for this user"
+            ) from err
 
 
 def oauth2_token_service_factory(_context, request):

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -11,7 +11,7 @@ from lms.services import (
     BlackboardFileNotFoundInCourse,
     CanvasAPIPermissionError,
     CanvasFileNotFoundInCourse,
-    ProxyAPIAccessTokenError,
+    OAuth2TokenError,
     ProxyAPIError,
 )
 from lms.validation import ValidationError
@@ -107,7 +107,7 @@ class ExceptionViews:
             message=self.context.explanation, details=self.context.details
         )
 
-    @exception_view_config(context=ProxyAPIAccessTokenError)
+    @exception_view_config(context=OAuth2TokenError)
     def proxy_api_access_token_error(self):
         return self.error_response()
 

--- a/tests/unit/lms/sentry_test.py
+++ b/tests/unit/lms/sentry_test.py
@@ -3,21 +3,19 @@ from unittest import mock
 import pytest
 from h_pyramid_sentry.event import Event
 
-from lms.sentry import filter_proxy_api_access_token_error
-from lms.services import ProxyAPIAccessTokenError
+from lms.sentry import filter_oauth2_token_error
+from lms.services import OAuth2TokenError
 
 
-class TestFilterProxyAPIAccessTokenError:
+class TestFilterOAuth2TokenError:
     def test_it_filters_proxy_api_access_token_error(self):
         event = exception_event(
-            ProxyAPIAccessTokenError(
-                "We don't have a Canvas API access token for this user"
-            )
+            OAuth2TokenError("We don't have a Canvas API access token for this user")
         )
-        assert filter_proxy_api_access_token_error(event)
+        assert filter_oauth2_token_error(event)
 
     def test_it_doesnt_filter_other_exception_events(self, unexpected_exception_event):
-        assert not filter_proxy_api_access_token_error(unexpected_exception_event)
+        assert not filter_oauth2_token_error(unexpected_exception_event)
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from lms.services import CanvasAPIError, CanvasAPIServerError, ProxyAPIAccessTokenError
+from lms.services import CanvasAPIError, CanvasAPIServerError, OAuth2TokenError
 from lms.services.canvas_api.client import CanvasAPIClient
 from tests import factories
 
@@ -416,11 +416,11 @@ class TestCanvasAPIClient:
 
 class TestMetaBehavior:
     def test_methods_require_access_token(self, data_method, oauth2_token_service):
-        oauth2_token_service.get.side_effect = ProxyAPIAccessTokenError(
+        oauth2_token_service.get.side_effect = OAuth2TokenError(
             "We don't have a Canvas API access token for this user"
         )
 
-        with pytest.raises(ProxyAPIAccessTokenError):
+        with pytest.raises(OAuth2TokenError):
             data_method()
 
     @pytest.mark.usefixtures("oauth_token")

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -10,7 +10,7 @@ from lms.services import (
     CanvasAPIPermissionError,
     CanvasAPIServerError,
     ExternalRequestError,
-    ProxyAPIAccessTokenError,
+    OAuth2TokenError,
 )
 from lms.validation import ValidationError
 
@@ -84,7 +84,7 @@ class TestCanvasAPIError:
                 401,
                 json.dumps({"errors": [{"message": "Invalid access token."}]}),
                 "401 Unauthorized",
-                ProxyAPIAccessTokenError,
+                OAuth2TokenError,
             ),
             # A 401 Unauthorized response from Canvas, because our access token had
             # insufficient scopes;
@@ -94,7 +94,7 @@ class TestCanvasAPIError:
                     {"errors": [{"message": "Insufficient scopes on access token."}]}
                 ),
                 "401 Unauthorized",
-                ProxyAPIAccessTokenError,
+                OAuth2TokenError,
             ),
             # A 400 Bad Request response from Canvas, because our refresh token
             # was expired or deleted.
@@ -107,7 +107,7 @@ class TestCanvasAPIError:
                     }
                 ),
                 "400 Bad Request",
-                ProxyAPIAccessTokenError,
+                OAuth2TokenError,
             ),
             # A permissions error from Canvas, because the Canvas user doesn't
             # have permission to make the API call.

--- a/tests/unit/lms/services/http_test.py
+++ b/tests/unit/lms/services/http_test.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 from h_matchers import Any
 
-from lms.services.exceptions import HTTPError, HTTPValidationError, NoOAuth2Token
+from lms.services.exceptions import HTTPError, HTTPValidationError, OAuth2TokenError
 from lms.services.http import HTTPService, factory
 from lms.validation import RequestsResponseSchema, ValidationError
 
@@ -156,9 +156,9 @@ class TestHTTPService:
     def test_oauth_raises_if_theres_no_access_token_for_the_user(
         self, svc, url, oauth2_token_service
     ):
-        oauth2_token_service.get.side_effect = NoOAuth2Token
+        oauth2_token_service.get.side_effect = OAuth2TokenError
 
-        with pytest.raises(NoOAuth2Token):
+        with pytest.raises(OAuth2TokenError):
             svc.request("GET", url, oauth=True)
 
     class Schema(RequestsResponseSchema):

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -6,7 +6,7 @@ from h_matchers import Any
 from pytest import param
 
 from lms.models import OAuth2Token
-from lms.services import NoOAuth2Token
+from lms.services import OAuth2TokenError
 from lms.services.oauth2_token import OAuth2TokenService, oauth2_token_service_factory
 from tests import factories
 
@@ -37,7 +37,7 @@ class TestOAuth2TokenService:
         assert result == oauth_token
 
     @pytest.mark.parametrize("wrong_param", ("consumer_key", "user_id"))
-    def test_get_raises_NoOAuth2Token_with_no_token(
+    def test_get_raises_OAuth2TokenError_with_no_token(
         self, db_session, wrong_param, application_instance, lti_user
     ):
         store = OAuth2TokenService(
@@ -49,7 +49,7 @@ class TestOAuth2TokenService:
             }
         )
 
-        with pytest.raises(NoOAuth2Token):
+        with pytest.raises(OAuth2TokenError):
             store.get()
 
     @pytest.fixture(


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/2834 (but doesn't entirely fix it yet).

How this works for Canvas on master
-----------------------------------

`AuthenticatedClient` calls `OAuth2TokenService` to get an access token
for the user. If we don't have an access token for the user
`OAuth2TokenService` will raise `NoOAuth2Token`. `AuthenticatedClient`
catches `NoOAuth2Token` and raises `ProxyAPIAccessTokenError`:

https://github.com/hypothesis/lms/blob/be46e8c356c0da97d86c53cedab28d4b31570cc4/lms/services/canvas_api/_authenticated.py#L56-L62

An exception view catches `ProxyAPIAccessTokenError` and turns it into a
specific error response. This error response causes the frontend to show
the **Authorize Hypothesis** dialog (which does not look like an error
dialog since this is an expected situation, nothing has gone wrong):

https://github.com/hypothesis/lms/blob/5f958d7d4f8645a9d81c1afb23edb101d9c1fcb9/lms/views/api/exceptions.py#L110-L112

What's going wrong for Blackboard on master
-------------------------------------------

`BlackboardAPIClient` calls `HTTPService` in a couple of places. For
example when launching a Blackboard files assignment:

https://github.com/hypothesis/lms/blob/5f958d7d4f8645a9d81c1afb23edb101d9c1fcb9/lms/services/blackboard_api/service.py#L67-L72

`HTTPService` calls `OAuth2TokenService` to get an access token. This
will raise `NoOAuth2Token` if we don't have an access token for the
user, just as it does when `CanvasAPIClient`'s `AuthenticatedClient`
calls `OAuth2TokenService`:

https://github.com/hypothesis/lms/blob/5f958d7d4f8645a9d81c1afb23edb101d9c1fcb9/lms/services/http.py#L111-L115

Neither `HTTPService` nor `BlackboardAPIClient` nor the view catches the
`NoOAuth2Token` exception so it gets raised back up to Pyramid. There is
no exception view for `NoOAuth2Token` so Pyramid returns a 500 Server
Error which the frontend turns into a **Something went wrong** error
dialog.

Solution
--------

`BlackboardAPIClient` could catch `NoOAuth2Token` and raise
`ProxyAPIAccessTokenError` like `CanvasAPIClient`'s
`AuthenticatedClient` does.

But instead I went for something simpler:

Why use two exception classes when you can use one?

Make the exception view catch `NoOAuth2Token` instead of
`ProxyAPIAccessTokenError`. Delete `ProxyAPIAccessTokenError`.
`CanvasAPIClient` and `BlackboardAPIClient` can just call
`OAuth2TokenService` (directly or indirectly) and lets the
`NoOAuth2Token` error fly up to Pyramid which will direct it to the
`NoOAuth2Token` error exception view.

`NoOAuth2Token` renamed to `OAuth2TokenError`
---------------------------------------------

`ProxyAPIAccessTokenError` was actually used for two purposes:

1. When we don't have an access token for the user.

   This is when `OAuth2TokenService` raises `NoOAuth2Token` and
   `AuthenticatedClient` catches it and raises
   `ProxyAPIAccessTokenError`.

2. When we do have an access token but it doesn't work (e.g. because its
   expired or been revoked).

   `CanvasAPIError.raise_from()` detects access token-related error
   responses from Canvas (`"Invalid access token"`,
   `"refresh_token not found"` or `"Insufficient scopes on access token"`)
   and raises `ProxyAPIAccessTokenError`:

   https://github.com/hypothesis/lms/blob/5f958d7d4f8645a9d81c1afb23edb101d9c1fcb9/lms/services/exceptions.py#L164-L174

`NoOAuth2Token` is now used in both of those cases instead so I've
renamed it to the more general `OAuth2TokenError`.

This works because our behaviour when our OAuth 2 token has expired or
been revoked is the same as our behaviour when we don't have a token: we
tell the frontend to ask the user for a new token.

Testing
-------

Delete all the access tokens from your DB:

    tox -qe dockercompose -- exec postgres psql -U postgres -c 'DELETE FROM oauth2_token;'

Now launch a Canvas assignment and launch a Blackboard files assignment.
In both cases you should get an **Authorize Hypothesis** dialog and then
the assignment should launch.

Break all the access tokens in your DB:

    tox -qe dockercompose -- exec postgres psql -U postgres -c "UPDATE oauth2_token SET access_token = 'foo';"

Now launch a Canvas assignment and it should just work: it'll use the
refresh token to get a new access token without user interaction.

**Known issue:** In Blackboard this will show an error because we don't
yet have code for detecting access token-related error responses from
the Blackboard API or for using refresh tokens with Blackboard. But the
**Try again** button on the error dialog will work: it'll ask the user
for a new access token and then launch the assignment successfully.

Break all the access tokens and refresh tokens in your DB:

    tox -qe dockercompose -- exec postgres psql -U postgres -c "UPDATE oauth2_token SET access_token = 'foo', refresh_token = 'bar';"

Now launch a Canvas assignment and you should get the
**Authorize Hypothesis** dialog (no error) and the assignment should
launch successfully.

**Known issue:** In Blackboard this will show an error dialog again, but
again the **Try again** button will work.