### PR TITLE
Use sa.Unicode over sa.String in DB models

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -20,12 +20,12 @@ class ApplicationInstance(BASE):
     __tablename__ = "application_instances"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
-    consumer_key = sa.Column(sa.String, unique=True, nullable=False)
-    shared_secret = sa.Column(sa.String, nullable=False)
-    lms_url = sa.Column(sa.String(2048), nullable=False)
-    requesters_email = sa.Column(sa.String(2048), nullable=False)
+    consumer_key = sa.Column(sa.Unicode, unique=True, nullable=False)
+    shared_secret = sa.Column(sa.Unicode, nullable=False)
+    lms_url = sa.Column(sa.Unicode(2048), nullable=False)
+    requesters_email = sa.Column(sa.Unicode(2048), nullable=False)
     created = sa.Column(sa.TIMESTAMP, default=datetime.utcnow(), nullable=False)
-    developer_key = sa.Column(sa.String)
+    developer_key = sa.Column(sa.Unicode)
     developer_secret = sa.Column(sa.LargeBinary)
     aes_cipher_iv = sa.Column(sa.LargeBinary)
     provisioning = sa.Column(

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -13,7 +13,7 @@ class LegacyCourse(BASE):
     #: The LTI consumer_key (oauth_consumer_key) of the application instance
     #: that these course settings belong to.
     consumer_key = sa.Column(
-        sa.String(),
+        sa.Unicode(),
         sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
         primary_key=True,
     )

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -35,7 +35,7 @@ class GroupInfo(BASE):
     #: The LTI consumer_key (oauth_consumer_key) of the application instance
     #: that this access token belongs to.
     consumer_key = sa.Column(
-        sa.String(),
+        sa.Unicode(),
         sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
         nullable=False,
     )

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -52,12 +52,12 @@ class Grouping(CreatedUpdatedMixin, BASE):
     #: have multiple sections or groups with the same id in different courses. In this
     #: case multiple Grouping's would have the same lms_id but they will have different
     #: parent_id's.
-    lms_id = sa.Column(sa.String(), nullable=False)
+    lms_id = sa.Column(sa.Unicode(), nullable=False)
 
     #: Full name given on the LMS (e.g. "A course name 101")
     lms_name = sa.Column(sa.UnicodeText(), nullable=False)
 
-    type = sa.Column(sa.String(), nullable=False)
+    type = sa.Column(sa.Unicode(), nullable=False)
 
     settings = sa.Column(
         "settings",

--- a/lms/models/lti_launches.py
+++ b/lms/models/lti_launches.py
@@ -12,8 +12,8 @@ class LtiLaunches(BASE):
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     created = sa.Column(sa.TIMESTAMP, default=datetime.utcnow)
-    context_id = sa.Column(sa.String)
-    lti_key = sa.Column(sa.String)
+    context_id = sa.Column(sa.Unicode)
+    lti_key = sa.Column(sa.Unicode)
 
     @classmethod
     def add(cls, db, context_id, oauth_consumer_key):

--- a/lms/models/module_item_configuration.py
+++ b/lms/models/module_item_configuration.py
@@ -28,10 +28,10 @@ class ModuleItemConfiguration(BASE):
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 
-    resource_link_id = sa.Column(sa.String, nullable=False)
+    resource_link_id = sa.Column(sa.Unicode, nullable=False)
     """The resource_link_id launch param of the module item or assignment."""
 
-    tool_consumer_instance_guid = sa.Column(sa.String, nullable=False)
+    tool_consumer_instance_guid = sa.Column(sa.Unicode, nullable=False)
     """
     The tool_consumer_instance_guid launch param of the LMS.
 
@@ -39,5 +39,5 @@ class ModuleItemConfiguration(BASE):
     across different LMS's.
     """
 
-    document_url = sa.Column(sa.String, nullable=False)
+    document_url = sa.Column(sa.Unicode, nullable=False)
     """The URL of the document to be annotated for this assignment."""

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -28,7 +28,7 @@ class OAuth2Token(BASE):
     #: The LTI consumer_key (oauth_consumer_key) of the application instance
     #: that this access token belongs to.
     consumer_key = sa.Column(
-        sa.String(),
+        sa.Unicode(),
         sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
         nullable=False,
     )


### PR DESCRIPTION
Something mentioned the other day, I think there's some value on being able to copy paste something as simple as "a column with a string" without having to remember String vs Unicode on every PR.

---

Main benefit it's consistency across models.
Behaviour wise main difference is requiring an explicit decoding while
using bytes.

https://docs.sqlalchemy.org/en/14/core/type_basics.html#sqlalchemy.types.Unicode