### PR TITLE
Raise a distinct error for missing Canvas files

### DIFF
--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -12,6 +12,7 @@ from lms.services import (
     ExternalRequestError,
     OAuth2TokenError,
 )
+from lms.services.exceptions import CanvasAPIResourceNotFound
 from lms.validation import ValidationError
 
 
@@ -123,6 +124,13 @@ class TestCanvasAPIError:
                 ),
                 "401 Unauthorized",
                 CanvasAPIPermissionError,
+            ),
+            # A missing resource response from Canvas
+            (
+                404,
+                json.dumps({"test": "body"}),
+                "404 Not Found",
+                CanvasAPIResourceNotFound,
             ),
             # A 400 Bad Request response from Canvas, because we sent an invalid
             # parameter or something.


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/pull/2783

We can tell the difference between a request to get a specific Canvas file because it's not there verses a general failure. 

Previously asking for a missing file would result in the more generic `CanvasAPIServerError`. In the case of course copy the distinction is important.

 * If the file access results in a permissions error - we should try and map it
 * If the file access results in a 404 - we should try and map it
 * If the file access results in another error we won't try

Previously the last two cases were the same case