### PR TITLE
Use model defined onupdate on bulk_actions' upsert 

### DIFF
--- a/lms/db/_bulk_action.py
+++ b/lms/db/_bulk_action.py
@@ -52,7 +52,7 @@ class BulkAction:
         upsert_update_elements: List[str]
         """Columns to update when a match is found."""
 
-        upsert_trigger_onupdate: bool = True
+        upsert_use_onupdate: bool = True
         """Column to update with the current datetime"""
 
         def __set_name__(self, owner, name):
@@ -91,7 +91,7 @@ class BulkAction:
 
         upsert_update_elements = list(config.upsert_update_elements)
 
-        if config.upsert_trigger_onupdate:
+        if config.upsert_use_onupdate:
             onupdate_columns = self._get_columns_onupdate(model_class)
 
             for column_name, onupdate_value in onupdate_columns:

--- a/tests/unit/lms/db/_bulk_action_test.py
+++ b/tests/unit/lms/db/_bulk_action_test.py
@@ -13,7 +13,7 @@ class TestBulkAction:
         BULK_CONFIG = BulkAction.Config(
             upsert_index_elements=["id"],
             upsert_update_elements=["name"],
-            upsert_trigger_onupdate=False,
+            upsert_use_onupdate=False,
         )
 
         id = sa.Column(sa.Integer, primary_key=True)
@@ -58,7 +58,7 @@ class TestBulkAction:
         assert BulkAction(db_session).upsert(self.TableWithBulkUpsert, []) == []
 
     @pytest.mark.parametrize("column", ("scalar", "callable", "sql", "default"))
-    @pytest.mark.usefixtures("with_upsert_trigger_onupdate")
+    @pytest.mark.usefixtures("with_upsert_use_onupdate")
     def test_upsert_with_onupdate_columns(self, db_session, column):
         db_session.add_all(
             [
@@ -108,7 +108,7 @@ class TestBulkAction:
         )
 
     @pytest.fixture
-    def with_upsert_trigger_onupdate(self):
-        self.TableWithBulkUpsert.BULK_CONFIG.upsert_trigger_onupdate = True
+    def with_upsert_use_onupdate(self):
+        self.TableWithBulkUpsert.BULK_CONFIG.upsert_use_onupdate = True
         yield
-        self.TableWithBulkUpsert.BULK_CONFIG.upsert_trigger_onupdate = False
+        self.TableWithBulkUpsert.BULK_CONFIG.upsert_use_onupdate = False

--- a/tests/unit/lms/db/_bulk_action_test.py
+++ b/tests/unit/lms/db/_bulk_action_test.py
@@ -19,19 +19,8 @@ class TestBulkAction:
         id = sa.Column(sa.Integer, primary_key=True)
         name = sa.Column(sa.String, nullable=False)
         other = sa.Column(sa.String)
-        onupdate_column = sa.Column(sa.String, onupdate=42)
 
-    class TableWithBulkUpsertOnUpdate(BASE):
-        __tablename__ = "test_table_with_bulk_upsert_onupdates"
-
-        BULK_CONFIG = BulkAction.Config(
-            upsert_index_elements=["id"],
-            upsert_update_elements=["name"],
-            upsert_trigger_onupdate=True,
-        )
-
-        id = sa.Column(sa.Integer, primary_key=True)
-        name = sa.Column(sa.String)
+        # Lots of auto update columns
         scalar = sa.Column(sa.Integer, onupdate=42)
         callable = sa.Column(sa.Integer, onupdate=lambda: 42)
         sql = sa.Column(sa.Integer, onupdate=sa.select([42]))
@@ -57,78 +46,37 @@ class TestBulkAction:
 
         assert isinstance(result, CursorResult)
 
-        rows = list(db_session.query(self.TableWithBulkUpsert))
-
-        assert (
-            rows
-            == Any.iterable.containing(
-                [
-                    Any.instance_of(self.TableWithBulkUpsert).with_attrs(expected)
-                    for expected in [
-                        {"id": 1, "name": "update_old", "other": "pre_1"},
-                        {"id": 2, "name": "pre_existing_2", "other": "pre_2"},
-                        {"id": 3, "name": "create_with_id", "other": "post_3"},
-                        {"id": 4, "name": "over_block_size", "other": "post_4"},
-                    ]
-                ]
-            ).only()
+        self.assert_has_rows(
+            db_session,
+            {"id": 1, "name": "update_old", "other": "pre_1"},
+            {"id": 2, "name": "pre_existing_2", "other": "pre_2"},
+            {"id": 3, "name": "create_with_id", "other": "post_3"},
+            {"id": 4, "name": "over_block_size", "other": "post_4"},
         )
 
     def test_upsert_does_nothing_if_given_an_empty_list_of_values(self, db_session):
         assert BulkAction(db_session).upsert(self.TableWithBulkUpsert, []) == []
 
-    def test_upsert_with_onupdate_columns(self, db_session):
+    @pytest.mark.parametrize("column", ("scalar", "callable", "sql", "default"))
+    @pytest.mark.usefixtures("with_upsert_trigger_onupdate")
+    def test_upsert_with_onupdate_columns(self, db_session, column):
         db_session.add_all(
             [
-                self.TableWithBulkUpsertOnUpdate(
-                    id=1, name="existing", scalar=0, callable=0, sql=0, default=0
-                ),
-                self.TableWithBulkUpsertOnUpdate(
-                    id=2, name="existing", scalar=1, callable=1, sql=1, default=1
-                ),
+                self.TableWithBulkUpsert(id=1, name="pre_existing_1", **{column: 0}),
+                self.TableWithBulkUpsert(id=2, name="pre_existing_2", **{column: 1}),
             ]
         )
         db_session.flush()
 
         BulkAction(db_session).upsert(
-            self.TableWithBulkUpsertOnUpdate,
-            [
-                {"id": 1, "name": "update_existing"},
-            ],
+            self.TableWithBulkUpsert, [{"id": 1, "name": "update_existing"}]
         )
 
-        rows = list(
-            db_session.query(self.TableWithBulkUpsertOnUpdate).order_by(
-                self.TableWithBulkUpsertOnUpdate.id.asc()
-            )
-        )
-        assert (
-            rows
-            == Any.iterable.containing(
-                [
-                    Any.instance_of(self.TableWithBulkUpsertOnUpdate).with_attrs(
-                        expected
-                    )
-                    for expected in [
-                        {
-                            "id": 1,
-                            "name": "update_existing",
-                            "scalar": 42,
-                            "callable": 42,
-                            "sql": 42,
-                            "default": 42,
-                        },
-                        {
-                            "id": 2,
-                            "name": "existing",
-                            "scalar": 1,
-                            "callable": 1,
-                            "sql": 1,
-                            "default": 1,
-                        },
-                    ]
-                ]
-            ).only()
+        self.assert_has_rows(
+            db_session,
+            # 42 is the onupdate default value
+            {"id": 1, "name": "update_existing", column: 42},
+            {"id": 2, "name": "pre_existing_2", column: 1},
         )
 
     def test_it_fails_with_missing_config(self, db_session):
@@ -145,3 +93,22 @@ class TestBulkAction:
                 NOT_THE_RIGHT_NAME = BulkAction.Config(
                     upsert_index_elements=["id"], upsert_update_elements=["name"]
                 )
+
+    def assert_has_rows(self, db_session, *attrs):
+        rows = list(db_session.query(self.TableWithBulkUpsert))
+
+        assert (
+            rows
+            == Any.iterable.containing(
+                [
+                    Any.instance_of(self.TableWithBulkUpsert).with_attrs(expected)
+                    for expected in attrs
+                ]
+            ).only()
+        )
+
+    @pytest.fixture
+    def with_upsert_trigger_onupdate(self):
+        self.TableWithBulkUpsert.BULK_CONFIG.upsert_trigger_onupdate = True
+        yield
+        self.TableWithBulkUpsert.BULK_CONFIG.upsert_trigger_onupdate = False

--- a/tests/unit/lms/events/subscriber_test.py
+++ b/tests/unit/lms/events/subscriber_test.py
@@ -58,7 +58,6 @@ class TestFilesDiscovered:
                 request=pyramid_request, values=[dict(new_attrs)]
             )
         )
-
         assert (
             db_session.query(File).all()
             == Any.list.containing(


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2909

This should work with all style of onupdate parameters except callables that expect a context parameter:

https://github.com/hypothesis/lms/pull/2844/files#diff-5743e15c634a3617289d65def23d8b87bf8cc430af559d08057d883e23467757R35