### PR TITLE
Handle access token-related errors from Blackboard

### DIFF
--- a/lms/validation/_base.py
+++ b/lms/validation/_base.py
@@ -149,7 +149,7 @@ class RequestsResponseSchema(PlainSchema):
     def _pre_load(self, response, **_kwargs):  # pylint: disable=no-self-use
         try:
             return response.json()
-        except ValueError as err:
+        except (AttributeError, ValueError) as err:
             raise marshmallow.ValidationError(
                 "response doesn't have a valid JSON body"
             ) from err


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/2854

Fixes https://github.com/hypothesis/lms/issues/2834

Handle access token-related errors from Blackboard correctly.

It's common for Blackboard API requests to come back with an error
response that means our access token was invalid. For example this
happens when the access token has been expired or has been revoked. When
these happen we need to catch them and raise `OAuth2TokenError` so that
the frontend displays an **Authorize Hypothesis** dialog rather than
displaying a **Something went wrong** error dialog.

Testing
-------

Break all the access tokens in your DB:

    tox -qe dockercompose -- exec postgres psql -U postgres -c "UPDATE oauth2_token SET access_token = 'foo';"

This will generate the same response from Blackboard as if the access
tokens had expired. Alternatively you can wait for one hour to let them
actually expire.

Now launch the Blackboard Files test assignment. You should see the
**Authorize Hypothesis** dialog and then the assignment should launch
successfully.