### PR TITLE
Move VitalSource API wrappers to a service

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -2,7 +2,7 @@ import { LabeledButton } from '@hypothesis/frontend-shared';
 import { createElement } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
-import { fetchBooks, fetchChapters } from '../utils/api';
+import { useService, VitalSourceService } from '../services';
 
 import BookList from './BookList';
 import ChapterList from './ChapterList';
@@ -14,7 +14,6 @@ import ErrorDisplay from './ErrorDisplay';
  * @typedef {import('../api-types').Book} Book
  *
  * @typedef BookPickerProps
- * @prop {string} authToken
  * @prop {() => void} onCancel
  * @prop {(b: Book, c: Chapter) => void} onSelectBook - Callback invoked when
  *   a book and chapter have been selected
@@ -32,7 +31,9 @@ import ErrorDisplay from './ErrorDisplay';
  *
  * @param {BookPickerProps} props
  */
-export default function BookPicker({ authToken, onCancel, onSelectBook }) {
+export default function BookPicker({ onCancel, onSelectBook }) {
+  const vsService = useService(VitalSourceService);
+
   const [bookList, setBookList] = useState(/** @type {Book[]|null} */ (null));
   const [chapterList, setChapterList] = useState(
     /** @type {Chapter[]|null} */ (null)
@@ -61,14 +62,15 @@ export default function BookPicker({ authToken, onCancel, onSelectBook }) {
 
   useEffect(() => {
     if (step === 'select-book' && !bookList) {
-      fetchBooks(authToken).then(setBookList).catch(setError);
+      vsService.fetchBooks().then(setBookList).catch(setError);
     } else if (step === 'select-chapter' && !chapterList) {
       const currentBook = /** @type {Book} */ (book);
-      fetchChapters(authToken, currentBook.id)
+      vsService
+        .fetchChapters(currentBook.id)
         .then(setChapterList)
         .catch(setError);
     }
-  }, [authToken, book, bookList, step, chapterList]);
+  }, [book, bookList, step, chapterList, vsService]);
 
   const canSubmit =
     (step === 'select-book' && book) || (step === 'select-chapter' && chapter);

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -151,7 +151,6 @@ export default function ContentSelector({
     case 'vitalSourceBook':
       dialog = (
         <BookPicker
-          authToken={authToken}
           onCancel={cancelDialog}
           onSelectBook={selectVitalSourceBook}
         />

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -365,8 +365,6 @@ describe('ContentSelector', () => {
       button.props().onClick();
     });
 
-    const bookPicker = wrapper.find('BookPicker');
-    assert.equal(bookPicker.prop('authToken'), fakeConfig.api.authToken);
     assert.isTrue(wrapper.exists('BookPicker'));
   });
 

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -5,7 +5,12 @@ import { readConfig, Config } from './config';
 import BasicLtiLaunchApp from './components/BasicLtiLaunchApp';
 import CanvasOAuth2RedirectErrorApp from './components/CanvasOAuth2RedirectErrorApp';
 import FilePickerApp from './components/FilePickerApp';
-import { ClientRpc, GradingService, Services } from './services';
+import {
+  ClientRpc,
+  GradingService,
+  Services,
+  VitalSourceService,
+} from './services';
 
 /** @typedef {import('./services/client-rpc').ClientConfig} ClientConfig */
 
@@ -46,6 +51,10 @@ switch (config.mode) {
     app = <BasicLtiLaunchApp />;
     break;
   case 'content-item-selection':
+    services.set(
+      VitalSourceService,
+      new VitalSourceService({ authToken: config.api.authToken })
+    );
     app = <FilePickerApp />;
     break;
   case 'canvas-oauth2-redirect-error':

--- a/lms/static/scripts/frontend_apps/services/index.js
+++ b/lms/static/scripts/frontend_apps/services/index.js
@@ -3,6 +3,7 @@ import { useContext, useMemo } from 'preact/hooks';
 
 export { ClientRpc } from './client-rpc';
 export { GradingService } from './grading';
+export { VitalSourceService } from './vitalsource';
 
 /**
  * Directory of available services.

--- a/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
@@ -1,0 +1,37 @@
+import { ApiError } from '../../utils/api';
+import { VitalSourceService } from '../vitalsource';
+
+describe('VitalSourceService', () => {
+  describe('#fetchBooks', () => {
+    it('returns book data', async () => {
+      const service = new VitalSourceService({ authToken: 'dummy-token' });
+      const data = await service.fetchBooks(1 /* delay */);
+      assert.isTrue(Array.isArray(data));
+      assert.equal(data.length, 2);
+    });
+  });
+
+  describe('#fetchChapters', () => {
+    it('returns chapter list', async () => {
+      const service = new VitalSourceService({ authToken: 'dummy-token' });
+      const data = await service.fetchChapters(
+        'BOOKSHELF-TUTORIAL',
+        1 /* delay */
+      );
+      assert.isTrue(Array.isArray(data));
+      assert.equal(data.length, 45);
+    });
+
+    it('throws if book ID is unknown', async () => {
+      const service = new VitalSourceService({ authToken: 'dummy-token' });
+      let err;
+      try {
+        await service.fetchChapters('unknown-book-id', 1 /* delay */);
+      } catch (e) {
+        err = e;
+      }
+      assert.instanceOf(err, ApiError);
+      assert.equal(err.message, 'Book not found');
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/services/vitalsource.js
+++ b/lms/static/scripts/frontend_apps/services/vitalsource.js
@@ -1,0 +1,61 @@
+/**
+ * @typedef {import('../api-types').Book} Book
+ * @typedef {import('../api-types').Chapter} Chapter
+ */
+
+import { ApiError } from '../utils/api';
+import { bookList, chapterData } from '../utils/vitalsource-sample-data';
+
+/** @param {number} ms */
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Service for fetching information about available VitalSoure books and the
+ * list of chapters in a book.
+ */
+export class VitalSourceService {
+  /**
+   * @param {object} options
+   *   @param {string} options.authToken
+   */
+  constructor({ authToken }) {
+    // This field is not currently used. It will be in future to fetch book
+    // and chapter info from the backend.
+    this._authToken = authToken;
+  }
+
+  /**
+   * Fetch a list of available ebooks to use in assignments.
+   *
+   * This is currently a fake that waits for a fixed time before returning
+   * hard-coded data.
+   *
+   * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
+   * @return {Promise<Book[]>}
+   */
+  async fetchBooks(fetchDelay = 500) {
+    await delay(fetchDelay);
+    return bookList;
+  }
+
+  /**
+   * Fetch a list of chapters that can be used as the target location for an
+   * ebook assignment.
+   *
+   * This is currently a fake that waits for a fixed time before returning
+   * hard-coded data.
+   *
+   * @param {string} bookID - VitalSource book ID ("vbid")
+   * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
+   * @return {Promise<Chapter[]>}
+   */
+  async fetchChapters(bookID, fetchDelay = 500) {
+    await delay(fetchDelay);
+    if (!chapterData[bookID]) {
+      throw new ApiError(404, { message: 'Book not found' });
+    }
+    return chapterData[bookID];
+  }
+}

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -1,12 +1,4 @@
 /**
- * @typedef {import('../api-types').Book} Book
- * @typedef {import('../api-types').Chapter} Chapter
- * @typedef {import('../api-types').File} File
- */
-
-import { bookList, chapterData } from './vitalsource-sample-data';
-
-/**
  * Error returned when an API call fails with a 4xx or 5xx response and
  * JSON body.
  */
@@ -102,44 +94,4 @@ export async function apiCall({ path, authToken, data, params }) {
   }
 
   return resultJson;
-}
-
-/** @param {number} ms */
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-/**
- * Fetch a list of available ebooks to use in assignments.
- *
- * This is currently a fake that waits for a fixed time before returning
- * hard-coded data.
- *
- * @param {string} authToken
- * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
- * @return {Promise<Book[]>}
- */
-export async function fetchBooks(authToken, fetchDelay = 500) {
-  await delay(fetchDelay);
-  return bookList;
-}
-
-/**
- * Fetch a list of chapters that can be used as the target location for an
- * ebook assignment.
- *
- * This is currently a fake that waits for a fixed time before returning
- * hard-coded data.
- *
- * @param {string} authToken
- * @param {string} bookId
- * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
- * @return {Promise<Chapter[]>}
- */
-export async function fetchChapters(authToken, bookId, fetchDelay = 500) {
-  await delay(fetchDelay);
-  if (!chapterData[bookId]) {
-    throw new ApiError(404, { message: 'Book not found' });
-  }
-  return chapterData[bookId];
 }

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -1,4 +1,4 @@
-import { ApiError, apiCall, fetchBooks, fetchChapters } from '../api';
+import { ApiError, apiCall } from '../api';
 
 describe('api', () => {
   let fakeResponse;
@@ -147,36 +147,5 @@ describe('api', () => {
 
     assert.instanceOf(reason, TypeError);
     assert.equal(reason.message, 'Parse failed');
-  });
-
-  describe('fetchBooks', () => {
-    it('returns book data', async () => {
-      const data = await fetchBooks('auth-token', 1 /* delay */);
-      assert.isTrue(Array.isArray(data));
-      assert.equal(data.length, 2);
-    });
-  });
-
-  describe('fetchChapters', () => {
-    it('returns chapter list', async () => {
-      const data = await fetchChapters(
-        'auth-token',
-        'BOOKSHELF-TUTORIAL',
-        1 /* delay */
-      );
-      assert.isTrue(Array.isArray(data));
-      assert.equal(data.length, 45);
-    });
-
-    it('throws if book ID is unknown', async () => {
-      let err;
-      try {
-        await fetchChapters('auth-token', 'unknown-book-id', 1 /* delay */);
-      } catch (e) {
-        err = e;
-      }
-      assert.instanceOf(err, ApiError);
-      assert.equal(err.message, 'Book not found');
-    });
   });
 });


### PR DESCRIPTION
Extract the VitalSource-specific API wrappers out of `utils/api.js` and put them in a VS-specific service. This change follows the example of `GradingService`.