### PR TITLE
Don't crash when a Canvas course has no files

### DIFF
--- a/lms/db/_bulk_action.py
+++ b/lms/db/_bulk_action.py
@@ -64,6 +64,23 @@ class BulkAction:
         :param model_class: The model type to upsert
         :param values: Dicts of values to upsert
         """
+        if not values:
+            # Don't attempt to upsert an empty list of values into the DB.
+            #
+            # This would be worse than pointless: it would actually crash in
+            # some cases. This SQLAlchemy code:
+            #
+            #     insert(MyModel).values([])
+            #
+            # produces this SQL:
+            #
+            #     INSERT INTO my_table DEFAULT VALUES RETURNING my_table.id
+            #
+            # which tells the DB to insert one row into my_table using the
+            # default values for all of the columns. If my_table has a column
+            # with a NOT NULLABLE constraint and no default value this will
+            # cause a "null value violates not-null constraint" crash.
+            return []
 
         config = model_class.BULK_CONFIG
 

--- a/tests/unit/lms/db/_bulk_action_test.py
+++ b/tests/unit/lms/db/_bulk_action_test.py
@@ -6,7 +6,7 @@ from sqlalchemy.engine import CursorResult
 from lms.db import BASE, BulkAction
 
 
-class TestBulkUpsertMixin:
+class TestBulkAction:
     class TableWithBulkUpsert(BASE):
         __tablename__ = "test_table_with_bulk_upsert"
 
@@ -15,7 +15,7 @@ class TestBulkUpsertMixin:
         )
 
         id = sa.Column(sa.Integer, primary_key=True)
-        name = sa.Column(sa.String)
+        name = sa.Column(sa.String, nullable=False)
         other = sa.Column(sa.String)
 
     def test_upsert(self, db_session):
@@ -55,9 +55,14 @@ class TestBulkUpsertMixin:
             ).only()
         )
 
+    def test_upsert_does_nothing_if_given_an_empty_list_of_values(self, db_session):
+        assert BulkAction(db_session).upsert(self.TableWithBulkUpsert, []) == []
+
     def test_it_fails_with_missing_config(self, db_session):
         with pytest.raises(AttributeError):
-            BulkAction(db_session).upsert("object_without_config", [])
+            BulkAction(db_session).upsert(
+                "object_without_config", [{"id": 1, "name": "name", "other": "other"}]
+            )
 
     def test_you_cannot_add_config_with_the_wrong_name(self):
         # Not sure why this isn't ValueError... must be a descriptor thing


### PR DESCRIPTION
Test course with no Canvas files but with pre-installed localhost, QA and prod application instances so you can reproduce the crash: https://hypothesis.instructure.com/courses/270 (you'll need to re-run `make devdata`)

Fixes https://github.com/hypothesis/lms/issues/2865

Slack discussion: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1624372670308400

When getting the list of files for a Canvas course that has no files the
bulk upsert code that's trying to upsert the empty list of files into
the DB crashes. The reason is that this:

```python
stmt = insert(MyModel).values([])
```

produces this SQL (you can see the SQL by doing `print(stmt)` in
Python):

```sql
INSERT INTO my_table DEFAULT VALUES RETURNING my_table.id
```

The SQL tells SQLAlchemy to insert rows into the table using the DB
schema's default values for all the rows, which means using `NULL` for
any rows that don't have another default specified in the schema. If any
of these rows have `NOT NULLABLE` constraints this will produce a `null
value in column "foo" violates not-null constraint` error.