### PR TITLE
Update casing of acronyms in identifiers in frontend code

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -45,7 +45,7 @@ import VitalSourceBookViewer from './VitalSourceBookViewer';
  * the content URL needs to be fetched from a remote source (eg. the LMS's
  * file storage) first, which may require authorization from the user.
  */
-export default function BasicLtiLaunchApp() {
+export default function BasicLTILaunchApp() {
   const {
     api: {
       authToken,
@@ -294,7 +294,7 @@ export default function BasicLtiLaunchApp() {
     />
   ) : (
     <iframe
-      className="BasicLtiLaunchApp__iframe"
+      className="BasicLTILaunchApp__iframe"
       src={contentUrl || ''}
       title="Course content with Hypothesis annotation viewer"
     />
@@ -320,7 +320,7 @@ export default function BasicLtiLaunchApp() {
   const content = (
     <div
       // Visually hide the iframe / grader if there is an error or no contentUrl.
-      className={classNames('BasicLtiLaunchApp__content', {
+      className={classNames('BasicLTILaunchApp__content', {
         'is-hidden': !showIframe,
       })}
     >
@@ -329,8 +329,8 @@ export default function BasicLtiLaunchApp() {
   );
 
   return (
-    <div className="BasicLtiLaunchApp">
-      {showSpinner && <Spinner className="BasicLtiLaunchApp__spinner" />}
+    <div className="BasicLTILaunchApp">
+      {showSpinner && <Spinner className="BasicLTILaunchApp__spinner" />}
       {errorState && (
         <LaunchErrorDialog
           busy={fetchCount > 0}

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -11,7 +11,7 @@ import {
 
 import { APIError, apiCall } from '../utils/api';
 import { Config } from '../config';
-import { ClientRpc, useService } from '../services';
+import { ClientRPC, useService } from '../services';
 
 import AuthWindow from '../utils/AuthWindow';
 import LMSGrader from './LMSGrader';
@@ -64,7 +64,7 @@ export default function BasicLtiLaunchApp() {
     vitalSource: vitalSourceConfig,
   } = useContext(Config);
 
-  const clientRpc = useService(ClientRpc);
+  const clientRPC = useService(ClientRPC);
 
   // Indicates what the application was doing when the error indicated by
   // `error` occurred.
@@ -165,7 +165,7 @@ export default function BasicLtiLaunchApp() {
           path: apiSync.path,
           data: apiSync.data,
         });
-        clientRpc.setGroups(groups);
+        clientRPC.setGroups(groups);
         success = true;
       } catch (e) {
         handleError(e, 'error-fetching', true /* retry */, apiSync.authUrl);
@@ -178,7 +178,7 @@ export default function BasicLtiLaunchApp() {
 
       return success;
     },
-    [apiSync, authToken, clientRpc]
+    [apiSync, authToken, clientRPC]
   );
 
   /**
@@ -304,7 +304,7 @@ export default function BasicLtiLaunchApp() {
     // Use the LMS Grader
     iFrameWrapper = (
       <LMSGrader
-        clientRpc={clientRpc}
+        clientRPC={clientRPC}
         students={grading.students}
         courseName={grading.courseName}
         assignmentName={grading.assignmentName}

--- a/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLtiLaunchApp.js
@@ -9,7 +9,7 @@ import {
   useState,
 } from 'preact/hooks';
 
-import { ApiError, apiCall } from '../utils/api';
+import { APIError, apiCall } from '../utils/api';
 import { Config } from '../config';
 import { ClientRpc, useService } from '../services';
 
@@ -120,7 +120,7 @@ export default function BasicLtiLaunchApp() {
     setAuthUrl(authUrl || null);
 
     if (
-      e instanceof ApiError &&
+      e instanceof APIError &&
       e.errorCode !== null &&
       [
         'canvas_api_permission_error',
@@ -132,7 +132,7 @@ export default function BasicLtiLaunchApp() {
     ) {
       setError(e);
       setErrorState(/** @type {ErrorState} */ (e.errorCode));
-    } else if (e instanceof ApiError && !e.errorMessage && retry) {
+    } else if (e instanceof APIError && !e.errorMessage && retry) {
       setErrorState('error-authorizing');
     } else {
       setError(e);

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -11,13 +11,13 @@ import FileList from './FileList';
 
 /**
  * @typedef {import("./FileList").File} File
- * @typedef {import("../config").ApiCallInfo} ApiCallInfo
+ * @typedef {import("../config").APICallInfo} APICallInfo
  */
 
 /**
  * @typedef LMSFilePickerProps
  * @prop {string} authToken - Auth token for use in calls to the backend
- * @prop {ApiCallInfo} listFilesApi -
+ * @prop {APICallInfo} listFilesApi -
  *   Config for the API call to list available files
  * @prop {() => any} onCancel - Callback invoked if the user cancels file selection
  * @prop {(f: File) => any} onSelectFile -

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -2,7 +2,7 @@ import { LabeledButton } from '@hypothesis/frontend-shared';
 import { createElement } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
-import { ApiError, apiCall } from '../utils/api';
+import { APIError, apiCall } from '../utils/api';
 
 import AuthButton from './AuthButton';
 import Dialog from './Dialog';
@@ -108,7 +108,7 @@ export default function LMSFilePicker({
         continueAction,
       });
     } catch (e) {
-      if (e instanceof ApiError && !e.errorMessage) {
+      if (e instanceof APIError && !e.errorMessage) {
         const continueAction = authorizationAttempted
           ? 'authorize_retry'
           : 'authorize';

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -6,13 +6,13 @@ import SubmitGradeForm from './SubmitGradeForm';
 
 /**
  * @typedef {import('../config').StudentInfo} StudentInfo
- * @typedef {import('../services/client-rpc').ClientRpc} ClientRpc
+ * @typedef {import('../services/client-rpc').ClientRPC} ClientRPC
  */
 
 /**
  * @typedef LMSGraderProps
  * @prop {Object} children - The <iframe> element displaying the assignment
- * @prop {ClientRpc} clientRpc - Service for communicating with Hypothesis client
+ * @prop {ClientRPC} clientRPC - Service for communicating with Hypothesis client
  * @prop {string} courseName
  * @prop {string} assignmentName
  * @prop {StudentInfo[]} students - List of students to grade
@@ -26,7 +26,7 @@ import SubmitGradeForm from './SubmitGradeForm';
  */
 export default function LMSGrader({
   children,
-  clientRpc,
+  clientRPC,
   assignmentName,
   courseName,
   students: unorderedStudents,
@@ -59,8 +59,8 @@ export default function LMSGrader({
    */
   const changeFocusedUser = useCallback(
     /** @param {StudentInfo|null} user - The user to focus on in the sidebar */
-    user => clientRpc.setFocusedUser(user),
-    [clientRpc]
+    user => clientRPC.setFocusedUser(user),
+    [clientRPC]
   );
 
   useEffect(() => {

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -7,7 +7,7 @@ import ErrorDisplay from './ErrorDisplay';
 
 /**
  * @typedef {import("preact").ComponentChildren} Children
- * @typedef {import('./BasicLtiLaunchApp').ErrorState} ErrorState
+ * @typedef {import('./BasicLTILaunchApp').ErrorState} ErrorState
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -4,7 +4,7 @@ import { act } from 'preact/test-utils';
 
 import { Config } from '../../config';
 import { ClientRpc, Services } from '../../services';
-import { ApiError } from '../../utils/api';
+import { APIError } from '../../utils/api';
 
 import BasicLtiLaunchApp, { $imports } from '../BasicLtiLaunchApp';
 import { checkAccessibility } from '../../../test-util/accessibility';
@@ -168,9 +168,9 @@ describe('BasicLtiLaunchApp', () => {
       );
     });
 
-    it('displays authorization prompt if content URL fetch fails with an `ApiError`', async () => {
-      // Make the initial URL fetch request reject with an unspecified `ApiError`.
-      fakeApiCall.rejects(new ApiError(400, {}));
+    it('displays authorization prompt if content URL fetch fails with an `APIError`', async () => {
+      // Make the initial URL fetch request reject with an unspecified `APIError`.
+      fakeApiCall.rejects(new APIError(400, {}));
 
       const wrapper = renderLtiLaunchApp();
       await spinnerVisible(wrapper);
@@ -201,8 +201,8 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('does not create a second auth window when Authorize button is clicked twice', async () => {
-      // Make the initial URL fetch request reject with an unspecified `ApiError`.
-      fakeApiCall.rejects(new ApiError(400, {}));
+      // Make the initial URL fetch request reject with an unspecified `APIError`.
+      fakeApiCall.rejects(new APIError(400, {}));
 
       const wrapper = renderLtiLaunchApp();
       const errorDialog = await waitForElement(
@@ -229,7 +229,7 @@ describe('BasicLtiLaunchApp', () => {
     [
       {
         description: 'a specific server error',
-        error: new ApiError(400, { message: 'Server error' }),
+        error: new APIError(400, { message: 'Server error' }),
       },
       {
         description: 'a network or other generic error',
@@ -267,7 +267,7 @@ describe('BasicLtiLaunchApp', () => {
     it('shows Canvas file permission error if content URL fetch fails with "canvas_api_permission_error" error', async () => {
       // Make the initial URL fetch request reject with a Canvas API permission error.
       fakeApiCall.rejects(
-        new ApiError(400, { error_code: 'canvas_api_permission_error' })
+        new APIError(400, { error_code: 'canvas_api_permission_error' })
       );
 
       const wrapper = renderLtiLaunchApp();
@@ -316,7 +316,7 @@ describe('BasicLtiLaunchApp', () => {
     it('shows Canvas file not found in course error if content URL fetch fails with "canvas_file_not_found_in_course" error', async () => {
       // Make the initial URL fetch request reject with a Canvas API permission error.
       fakeApiCall.rejects(
-        new ApiError(400, { error_code: 'canvas_file_not_found_in_course' })
+        new APIError(400, { error_code: 'canvas_file_not_found_in_course' })
       );
 
       const wrapper = renderLtiLaunchApp();
@@ -411,7 +411,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('displays an error if reporting the submission fails', async () => {
-      const error = new ApiError(400, {});
+      const error = new APIError(400, {});
       fakeApiCall.rejects(error);
 
       const wrapper = renderLtiLaunchApp();
@@ -556,7 +556,7 @@ describe('BasicLtiLaunchApp', () => {
     it('shows an error dialog if the first request fails and second succeeds', async () => {
       const wrapper = renderLtiLaunchApp();
       // Should show an error after the first request fails
-      contentUrlReject(new ApiError(400, {}));
+      contentUrlReject(new APIError(400, {}));
       await waitForElement(
         wrapper,
         'LaunchErrorDialog[errorState="error-authorizing"]'
@@ -580,7 +580,7 @@ describe('BasicLtiLaunchApp', () => {
       await contentVisible(wrapper);
 
       // Should show an error after failure
-      groupsCallReject(new ApiError(400, {}));
+      groupsCallReject(new APIError(400, {}));
       await waitForElement(
         wrapper,
         'LaunchErrorDialog[errorState="error-authorizing"]'
@@ -613,8 +613,8 @@ describe('BasicLtiLaunchApp', () => {
       it('shows an error dialog if the initial content/groups requests reject and second attempt also rejects', async () => {
         const wrapper = renderLtiLaunchApp();
         // Both requests reject first
-        contentUrlReject(new ApiError(400, {}));
-        groupsCallReject(new ApiError(400, {}));
+        contentUrlReject(new APIError(400, {}));
+        groupsCallReject(new APIError(400, {}));
 
         const errorDialog = await waitForElement(
           wrapper,
@@ -623,8 +623,8 @@ describe('BasicLtiLaunchApp', () => {
         resetApiCalls();
         await dialogShouldRemain(wrapper);
         // contentUrlReject rejects again
-        contentUrlReject(new ApiError(400, {}));
-        groupsCallReject(new ApiError(400, {}));
+        contentUrlReject(new APIError(400, {}));
+        groupsCallReject(new APIError(400, {}));
         // Click the "Authorize" button.
         act(() => {
           errorDialog.prop('onRetry')();
@@ -636,8 +636,8 @@ describe('BasicLtiLaunchApp', () => {
       it('shows an error dialog if contentUrl succeeds but groups rejects first', async () => {
         const wrapper = renderLtiLaunchApp();
         // Both requests reject first
-        contentUrlReject(new ApiError(400, {}));
-        groupsCallReject(new ApiError(400, {}));
+        contentUrlReject(new APIError(400, {}));
+        groupsCallReject(new APIError(400, {}));
 
         const errorDialog = await waitForElement(
           wrapper,
@@ -645,7 +645,7 @@ describe('BasicLtiLaunchApp', () => {
         );
         resetApiCalls();
         // groups still fails, but contentUrl does not.
-        groupsCallReject(new ApiError(400, {}));
+        groupsCallReject(new APIError(400, {}));
         // Click the "Authorize" button.
         act(() => {
           errorDialog.prop('onRetry')();
@@ -658,8 +658,8 @@ describe('BasicLtiLaunchApp', () => {
         const wrapper = renderLtiLaunchApp();
 
         // Make initial content URL and groups requests fail.
-        contentUrlReject(new ApiError(400, {}));
-        groupsCallReject(new ApiError(400, {}));
+        contentUrlReject(new APIError(400, {}));
+        groupsCallReject(new APIError(400, {}));
 
         resetApiCalls();
 

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -3,7 +3,7 @@ import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import { Config } from '../../config';
-import { ClientRpc, Services } from '../../services';
+import { ClientRPC, Services } from '../../services';
 import { APIError } from '../../utils/api';
 
 import BasicLtiLaunchApp, { $imports } from '../BasicLtiLaunchApp';
@@ -18,7 +18,7 @@ describe('BasicLtiLaunchApp', () => {
   let fakeRpcServer;
 
   const renderLtiLaunchApp = (props = {}) => {
-    const services = new Map([[ClientRpc, fakeRpcServer]]);
+    const services = new Map([[ClientRPC, fakeRpcServer]]);
     return mount(
       <Config.Provider value={fakeConfig}>
         <Services.Provider value={services}>

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -6,23 +6,23 @@ import { Config } from '../../config';
 import { ClientRPC, Services } from '../../services';
 import { APIError } from '../../utils/api';
 
-import BasicLtiLaunchApp, { $imports } from '../BasicLtiLaunchApp';
+import BasicLTILaunchApp, { $imports } from '../BasicLTILaunchApp';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { waitFor, waitForElement } from '../../../test-util/wait';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('BasicLtiLaunchApp', () => {
+describe('BasicLTILaunchApp', () => {
   let fakeApiCall;
   let FakeAuthWindow;
   let fakeConfig;
   let fakeRpcServer;
 
-  const renderLtiLaunchApp = (props = {}) => {
+  const renderLTILaunchApp = (props = {}) => {
     const services = new Map([[ClientRPC, fakeRpcServer]]);
     return mount(
       <Config.Provider value={fakeConfig}>
         <Services.Provider value={services}>
-          <BasicLtiLaunchApp {...props} />
+          <BasicLTILaunchApp {...props} />
         </Services.Provider>
       </Config.Provider>
     );
@@ -40,13 +40,13 @@ describe('BasicLtiLaunchApp', () => {
   }
 
   function contentHidden(wrapper) {
-    return waitForElement(wrapper, '.BasicLtiLaunchApp__content.is-hidden');
+    return waitForElement(wrapper, '.BasicLTILaunchApp__content.is-hidden');
   }
 
   function contentVisible(wrapper) {
     return waitForElement(
       wrapper,
-      '.BasicLtiLaunchApp__content:not(.is-hidden)'
+      '.BasicLTILaunchApp__content:not(.is-hidden)'
     );
   }
 
@@ -87,7 +87,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('displays the content URL in an iframe', () => {
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
 
       const iframe = wrapper.find('iframe');
       assert.isTrue(iframe.exists());
@@ -111,7 +111,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('attempts to fetch the groups when mounted', async () => {
-      renderLtiLaunchApp({ rpcServer: fakeRpcServer });
+      renderLTILaunchApp({ rpcServer: fakeRpcServer });
       await waitFor(() => fakeApiCall.called);
       assert.calledWith(fakeApiCall, {
         authToken: 'dummyAuthToken',
@@ -127,7 +127,7 @@ describe('BasicLtiLaunchApp', () => {
 
     it('passes the groups array from api call to rpcServer.setGroups', async () => {
       const groups = await fakeApiCall.resolves(['group1', 'group2']);
-      renderLtiLaunchApp();
+      renderLTILaunchApp();
       await groups;
       assert.calledWith(fakeRpcServer.setGroups, ['group1', 'group2']);
     });
@@ -144,7 +144,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('attempts to fetch the content URL when mounted', async () => {
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       await spinnerVisible(wrapper);
       await waitFor(() => fakeApiCall.called);
 
@@ -160,7 +160,7 @@ describe('BasicLtiLaunchApp', () => {
         via_url: 'https://via.hypothes.is/123',
       });
 
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       await contentVisible(wrapper);
       assert.equal(
         wrapper.find('iframe').prop('src'),
@@ -172,7 +172,7 @@ describe('BasicLtiLaunchApp', () => {
       // Make the initial URL fetch request reject with an unspecified `APIError`.
       fakeApiCall.rejects(new APIError(400, {}));
 
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       await spinnerVisible(wrapper);
       // Verify that an "Authorize" prompt is shown.
       const errorDialog = await waitForElement(
@@ -204,7 +204,7 @@ describe('BasicLtiLaunchApp', () => {
       // Make the initial URL fetch request reject with an unspecified `APIError`.
       fakeApiCall.rejects(new APIError(400, {}));
 
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       const errorDialog = await waitForElement(
         wrapper,
         'LaunchErrorDialog[errorState="error-authorizing"]'
@@ -240,7 +240,7 @@ describe('BasicLtiLaunchApp', () => {
         // Make the initial URL fetch request reject with the given error.
         fakeApiCall.rejects(error);
 
-        const wrapper = renderLtiLaunchApp();
+        const wrapper = renderLTILaunchApp();
         await spinnerVisible(wrapper);
 
         // Verify that an "Try again" prompt is shown.
@@ -270,7 +270,7 @@ describe('BasicLtiLaunchApp', () => {
         new APIError(400, { error_code: 'canvas_api_permission_error' })
       );
 
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       await spinnerVisible(wrapper);
 
       // Verify that the expected error dialog is shown.
@@ -319,7 +319,7 @@ describe('BasicLtiLaunchApp', () => {
         new APIError(400, { error_code: 'canvas_file_not_found_in_course' })
       );
 
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       await spinnerVisible(wrapper);
 
       // Verify that the expected error dialog is shown.
@@ -372,7 +372,7 @@ describe('BasicLtiLaunchApp', () => {
         },
       };
 
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
 
       const vsViewer = wrapper.find('VitalSourceBookViewer');
       assert.isTrue(vsViewer.exists());
@@ -396,7 +396,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('reports the submission when the content iframe starts loading', async () => {
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       await waitFor(() => fakeApiCall.called);
 
       assert.calledWith(fakeApiCall, {
@@ -414,7 +414,7 @@ describe('BasicLtiLaunchApp', () => {
       const error = new APIError(400, {});
       fakeApiCall.rejects(error);
 
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
 
       // Wait for the API call to fail and check that an error is displayed.
       // There should be no "Try again" button in this context, instead we just
@@ -431,7 +431,7 @@ describe('BasicLtiLaunchApp', () => {
       // `submissionParams` config provided by the backend.
       fakeConfig.canvas.speedGrader.submissionParams = undefined;
 
-      renderLtiLaunchApp();
+      renderLTILaunchApp();
       await new Promise(resolve => setTimeout(resolve, 0));
 
       assert.notCalled(fakeApiCall);
@@ -440,7 +440,7 @@ describe('BasicLtiLaunchApp', () => {
     it('does not report a submission if `speedGrader` object is omitted', async () => {
       fakeConfig.canvas.speedGrader = undefined;
 
-      renderLtiLaunchApp();
+      renderLTILaunchApp();
       await new Promise(resolve => setTimeout(resolve, 0));
 
       assert.notCalled(fakeApiCall);
@@ -449,7 +449,7 @@ describe('BasicLtiLaunchApp', () => {
     it('does not report the submission when there is no `contentUrl`', async () => {
       // When present, viaUrl becomes the contentUrl
       fakeConfig.viaUrl = null;
-      renderLtiLaunchApp();
+      renderLTILaunchApp();
       assert.isTrue(fakeApiCall.notCalled);
     });
   });
@@ -464,7 +464,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('renders the LMSGrader component', () => {
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       const LMSGrader = wrapper.find('LMSGrader');
       assert.isTrue(LMSGrader.exists());
     });
@@ -509,7 +509,7 @@ describe('BasicLtiLaunchApp', () => {
     };
 
     beforeEach(() => {
-      // When BasicLtiLaunchApp is rendered, it will attempt to fetch:
+      // When BasicLTILaunchApp is rendered, it will attempt to fetch:
       //  1. content url
       //  2. groups
       fakeConfig.api = {
@@ -532,7 +532,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('renders the spinner until contentUrl requests finish', async () => {
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       // Spinner should not go away if only the groups resolves
       groupsCallResolve(['group1', 'group2']);
       await spinnerVisible(wrapper);
@@ -546,7 +546,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('renders the iframe after contentUrl succeeds but groups remains pending', async () => {
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       contentUrlResolve({
         via_url: 'https://via.hypothes.is/123',
       });
@@ -554,7 +554,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('shows an error dialog if the first request fails and second succeeds', async () => {
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       // Should show an error after the first request fails
       contentUrlReject(new APIError(400, {}));
       await waitForElement(
@@ -572,7 +572,7 @@ describe('BasicLtiLaunchApp', () => {
     });
 
     it('shows an error dialog if the first request succeeds and second fails', async () => {
-      const wrapper = renderLtiLaunchApp();
+      const wrapper = renderLTILaunchApp();
       // Should not show an error yet
       contentUrlResolve({
         via_url: 'https://via.hypothes.is/123',
@@ -611,7 +611,7 @@ describe('BasicLtiLaunchApp', () => {
       }
 
       it('shows an error dialog if the initial content/groups requests reject and second attempt also rejects', async () => {
-        const wrapper = renderLtiLaunchApp();
+        const wrapper = renderLTILaunchApp();
         // Both requests reject first
         contentUrlReject(new APIError(400, {}));
         groupsCallReject(new APIError(400, {}));
@@ -634,7 +634,7 @@ describe('BasicLtiLaunchApp', () => {
       });
 
       it('shows an error dialog if contentUrl succeeds but groups rejects first', async () => {
-        const wrapper = renderLtiLaunchApp();
+        const wrapper = renderLTILaunchApp();
         // Both requests reject first
         contentUrlReject(new APIError(400, {}));
         groupsCallReject(new APIError(400, {}));
@@ -655,7 +655,7 @@ describe('BasicLtiLaunchApp', () => {
       });
 
       it('disables "Authorize" button while re-fetching content and groups', async () => {
-        const wrapper = renderLtiLaunchApp();
+        const wrapper = renderLTILaunchApp();
 
         // Make initial content URL and groups requests fail.
         contentUrlReject(new APIError(400, {}));
@@ -704,7 +704,7 @@ describe('BasicLtiLaunchApp', () => {
             ...fakeConfig,
             viaUrl: 'https://via.hypothes.is/123',
           };
-          return renderLtiLaunchApp();
+          return renderLTILaunchApp();
         },
       },
       {
@@ -724,7 +724,7 @@ describe('BasicLtiLaunchApp', () => {
               assignmentName: 'assignmentName',
             },
           };
-          return renderLtiLaunchApp();
+          return renderLTILaunchApp();
         },
       },
     ])

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { Fragment, createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
-import { ApiError } from '../../utils/api';
+import { APIError } from '../../utils/api';
 
 import LMSFilePicker, { $imports } from '../LMSFilePicker';
 import ErrorDisplay from '../ErrorDisplay';
@@ -65,9 +65,9 @@ describe('LMSFilePicker', () => {
     assert.deepEqual(fileList.prop('files'), expectedFiles);
   });
 
-  it('shows the authorization prompt if fetching files fails with an ApiError that has no `errorMessage`', async () => {
+  it('shows the authorization prompt if fetching files fails with an APIError that has no `errorMessage`', async () => {
     fakeApiCall.rejects(
-      new ApiError('Not authorized', {
+      new APIError('Not authorized', {
         /** without errorMessage */
       })
     );
@@ -105,7 +105,7 @@ describe('LMSFilePicker', () => {
 
   it('shows the "Authorize" and "Try again" buttons after 2 failed authorization requests', async () => {
     fakeApiCall.rejects(
-      new ApiError('Not authorized', {
+      new APIError('Not authorized', {
         /** without errorMessage */
       })
     );
@@ -160,7 +160,7 @@ describe('LMSFilePicker', () => {
   [
     {
       description: 'a server error with details',
-      error: new ApiError('Not authorized', {
+      error: new APIError('Not authorized', {
         message: 'Some error detail',
       }),
     },

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -9,7 +9,7 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 describe('LMSGrader', () => {
   let fakeStudents;
   let fakeOnChange;
-  let fakeClientRpc;
+  let fakeClientRPC;
 
   /**
    * Helper to return a list of displayNames of the students.
@@ -42,7 +42,7 @@ describe('LMSGrader', () => {
       },
     ];
     fakeOnChange = sinon.spy();
-    fakeClientRpc = {
+    fakeClientRPC = {
       setFocusedUser: sinon.stub(),
     };
 
@@ -60,7 +60,7 @@ describe('LMSGrader', () => {
         students={fakeStudents}
         courseName={'course name'}
         assignmentName={'course assignment'}
-        clientRpc={fakeClientRpc}
+        clientRPC={fakeClientRPC}
         {...props}
       >
         <div title="The assignment content iframe" />
@@ -189,7 +189,7 @@ describe('LMSGrader', () => {
 
   it('does not set a focus user by default', () => {
     renderGrader();
-    assert.calledWith(fakeClientRpc.setFocusedUser, null);
+    assert.calledWith(fakeClientRPC.setFocusedUser, null);
   });
 
   it('sets the focused user when a valid index is passed', () => {
@@ -199,7 +199,7 @@ describe('LMSGrader', () => {
       wrapper.find('StudentSelector').props().onSelectStudent(0); // note: initial index is -1
     });
 
-    assert.calledWith(fakeClientRpc.setFocusedUser, fakeStudents[0]);
+    assert.calledWith(fakeClientRPC.setFocusedUser, fakeStudents[0]);
   });
 
   it('does not set a focus user when the user index is invalid', () => {
@@ -208,7 +208,7 @@ describe('LMSGrader', () => {
       wrapper.find('StudentSelector').props().onSelectStudent(-1); // invalid choice
     });
 
-    assert.calledWith(fakeClientRpc.setFocusedUser, null);
+    assert.calledWith(fakeClientRPC.setFocusedUser, null);
   });
 
   it(

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -7,7 +7,7 @@ import { createContext } from 'preact';
  * decides _when_ to make the call and what to show while waiting for the
  * response.
  *
- * @typedef ApiCallInfo
+ * @typedef APICallInfo
  * @prop {string} path - The complete URL or path of the API call
  * @prop {string} [authUrl] -
  *   URL to display in a popup window if the call fails due to an authorization
@@ -61,13 +61,13 @@ import { createContext } from 'preact';
  * @prop {Object.<string,string>} formFields
  * @prop {Object} blackboard
  *   @prop {boolean} blackboard.enabled
- *   @prop {ApiCallInfo} blackboard.listFiles
+ *   @prop {APICallInfo} blackboard.listFiles
  * @prop {Object} canvas
  *   @prop {boolean} canvas.enabled
  *   @prop {boolean} canvas.groupsEnabled
  *   @prop {string} canvas.ltiLaunchUrl
- *   @prop {ApiCallInfo} canvas.listFiles
- *   @prop {ApiCallInfo} canvas.listGroupSets
+ *   @prop {APICallInfo} canvas.listFiles
+ *   @prop {APICallInfo} canvas.listGroupSets
  * @prop {Object} google
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey
@@ -99,8 +99,8 @@ import { createContext } from 'preact';
  * @prop {string} mode
  * @prop {Object} api
  *   @prop {string} api.authToken
- *   @prop {ApiCallInfo} api.sync
- *   @prop {ApiCallInfo} api.viaUrl
+ *   @prop {APICallInfo} api.sync
+ *   @prop {APICallInfo} api.viaUrl
  * @prop {Object} canvas
  *   @prop {SpeedGraderConfig} canvas.speedGrader
  * @prop {boolean} dev

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -2,7 +2,7 @@ import 'focus-visible';
 import { createElement, render } from 'preact';
 
 import { readConfig, Config } from './config';
-import BasicLtiLaunchApp from './components/BasicLtiLaunchApp';
+import BasicLTILaunchApp from './components/BasicLTILaunchApp';
 import CanvasOAuth2RedirectErrorApp from './components/CanvasOAuth2RedirectErrorApp';
 import FilePickerApp from './components/FilePickerApp';
 import {
@@ -48,7 +48,7 @@ switch (config.mode) {
       GradingService,
       new GradingService({ authToken: config.api.authToken })
     );
-    app = <BasicLtiLaunchApp />;
+    app = <BasicLTILaunchApp />;
     break;
   case 'content-item-selection':
     services.set(

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -6,7 +6,7 @@ import BasicLtiLaunchApp from './components/BasicLtiLaunchApp';
 import CanvasOAuth2RedirectErrorApp from './components/CanvasOAuth2RedirectErrorApp';
 import FilePickerApp from './components/FilePickerApp';
 import {
-  ClientRpc,
+  ClientRPC,
   GradingService,
   Services,
   VitalSourceService,
@@ -37,8 +37,8 @@ let app;
 switch (config.mode) {
   case 'basic-lti-launch':
     services.set(
-      ClientRpc,
-      new ClientRpc({
+      ClientRPC,
+      new ClientRPC({
         authToken: config.api.authToken,
         allowedOrigins: config.rpcServer.allowedOrigins,
         clientConfig: /** @type {ClientConfig} */ (config.hypothesisClient),

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -14,11 +14,11 @@ import { JWT } from '../utils/jwt';
  */
 
 /**
- * The subset of the Hypothesis client configuration that `ClientRpc` directly references.
+ * The subset of the Hypothesis client configuration that `ClientRPC` directly references.
  *
  * The backend will add other properties which are intentionally not included here,
  * even as an index signature. This other configuration is simply forwarded to
- * the client but not touched by `ClientRpc`.
+ * the client but not touched by `ClientRPC`.
  *
  * See https://h.readthedocs.io/projects/client/en/latest/publishers/config/.
  *
@@ -38,7 +38,7 @@ import { JWT } from '../utils/jwt';
  *  - Updating the Hypothesis client configuration in response to input
  *    in the LMS frontend, such as changing the focused user in grading mode.
  */
-export class ClientRpc {
+export class ClientRPC {
   /**
    * Setup the RPC server used to communicate with the Hypothesis client.
    *

--- a/lms/static/scripts/frontend_apps/services/index.js
+++ b/lms/static/scripts/frontend_apps/services/index.js
@@ -1,7 +1,7 @@
 import { createContext, createElement } from 'preact';
 import { useContext, useMemo } from 'preact/hooks';
 
-export { ClientRpc } from './client-rpc';
+export { ClientRPC } from './client-rpc';
 export { GradingService } from './grading';
 export { VitalSourceService } from './vitalsource';
 

--- a/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
@@ -1,6 +1,6 @@
-import { $imports, ClientRpc } from '../client-rpc';
+import { $imports, ClientRPC } from '../client-rpc';
 
-describe('ClientRpc', () => {
+describe('ClientRPC', () => {
   let authToken;
   let clientConfig;
   let fakeApiCall;
@@ -74,8 +74,8 @@ describe('ClientRpc', () => {
     $imports.$restore();
   });
 
-  function createClientRpc() {
-    return new ClientRpc({
+  function createClientRPC() {
+    return new ClientRPC({
       allowedOrigins: ['https://client.hypothes.is'],
       authToken,
       clientConfig,
@@ -83,18 +83,18 @@ describe('ClientRpc', () => {
   }
 
   it('initializes RPC server that accepts requests from specified origins', () => {
-    createClientRpc();
+    createClientRPC();
     assert.calledWith(FakeServer, ['https://client.hypothes.is']);
   });
 
   describe('"requestConfig" RPC handler', () => {
     it('is registered', () => {
-      createClientRpc();
+      createClientRPC();
       assert.calledWith(fakeServerInstance.register, 'requestConfig');
     });
 
     it('returns client config', async () => {
-      createClientRpc();
+      createClientRPC();
       const [, callback] = fakeServerInstance.register.args.find(
         ([method]) => method === 'requestConfig'
       );
@@ -102,7 +102,7 @@ describe('ClientRpc', () => {
     });
 
     it('returns initial grant token if still valid', async () => {
-      createClientRpc();
+      createClientRPC();
 
       const [, callback] = fakeServerInstance.register.args.find(
         ([method]) => method === 'requestConfig'
@@ -115,7 +115,7 @@ describe('ClientRpc', () => {
     });
 
     it('fetches and returns new grant token if it has expired', async () => {
-      createClientRpc();
+      createClientRPC();
       const [, callback] = fakeServerInstance.register.args.find(
         ([method]) => method === 'requestConfig'
       );
@@ -149,7 +149,7 @@ describe('ClientRpc', () => {
     });
 
     it('reports error to client if grant token fetch fails', async () => {
-      createClientRpc();
+      createClientRPC();
       const [, callback] = fakeServerInstance.register.args.find(
         ([method]) => method === 'requestConfig'
       );
@@ -169,14 +169,14 @@ describe('ClientRpc', () => {
   });
 
   it('registers "requestGroups" RPC handler', () => {
-    createClientRpc();
+    createClientRPC();
     assert.calledWith(fakeServerInstance.register, 'requestGroups');
   });
 
   describe('setGroups', () => {
     it('sets the groups returned by "requestGroups" RPC handler', async () => {
-      const clientRpc = createClientRpc();
-      clientRpc.setGroups(['groupA', 'groupB']);
+      const clientRPC = createClientRPC();
+      clientRPC.setGroups(['groupA', 'groupB']);
 
       const [, callback] = fakeServerInstance.register.args.find(
         ([method]) => method === 'requestGroups'
@@ -189,9 +189,9 @@ describe('ClientRpc', () => {
 
   describe('setFocusedUser', () => {
     it('sets focused user in client when user is passed', async () => {
-      const clientRpc = createClientRpc();
+      const clientRPC = createClientRPC();
 
-      await clientRpc.setFocusedUser({
+      await clientRPC.setFocusedUser({
         userid: 'acct:123@lms.hypothes.is',
         displayName: 'Student A',
       });
@@ -211,9 +211,9 @@ describe('ClientRpc', () => {
     });
 
     it('clears focused user in client when user is `null`', async () => {
-      const clientRpc = createClientRpc();
+      const clientRPC = createClientRPC();
 
-      await clientRpc.setFocusedUser(null);
+      await clientRPC.setFocusedUser(null);
 
       assert.calledWith(
         fakeRpcCall,

--- a/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
@@ -1,4 +1,4 @@
-import { ApiError } from '../../utils/api';
+import { APIError } from '../../utils/api';
 import { VitalSourceService } from '../vitalsource';
 
 describe('VitalSourceService', () => {
@@ -30,7 +30,7 @@ describe('VitalSourceService', () => {
       } catch (e) {
         err = e;
       }
-      assert.instanceOf(err, ApiError);
+      assert.instanceOf(err, APIError);
       assert.equal(err.message, 'Book not found');
     });
   });

--- a/lms/static/scripts/frontend_apps/services/vitalsource.js
+++ b/lms/static/scripts/frontend_apps/services/vitalsource.js
@@ -3,7 +3,7 @@
  * @typedef {import('../api-types').Chapter} Chapter
  */
 
-import { ApiError } from '../utils/api';
+import { APIError } from '../utils/api';
 import { bookList, chapterData } from '../utils/vitalsource-sample-data';
 
 /** @param {number} ms */
@@ -54,7 +54,7 @@ export class VitalSourceService {
   async fetchChapters(bookID, fetchDelay = 500) {
     await delay(fetchDelay);
     if (!chapterData[bookID]) {
-      throw new ApiError(404, { message: 'Book not found' });
+      throw new APIError(404, { message: 'Book not found' });
     }
     return chapterData[bookID];
   }

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -2,7 +2,7 @@
  * Error returned when an API call fails with a 4xx or 5xx response and
  * JSON body.
  */
-export class ApiError extends Error {
+export class APIError extends Error {
   /**
    * @param {number} status - HTTP status code
    * @param {any} data - Parsed JSON body from the API response
@@ -90,7 +90,7 @@ export async function apiCall({ path, authToken, data, params }) {
   const resultJson = await result.json();
 
   if (result.status >= 400 && result.status < 600) {
-    throw new ApiError(result.status, resultJson);
+    throw new APIError(result.status, resultJson);
   }
 
   return resultJson;

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -1,4 +1,4 @@
-import { ApiError, apiCall } from '../api';
+import { APIError, apiCall } from '../api';
 
 describe('api', () => {
   let fakeResponse;
@@ -91,7 +91,7 @@ describe('api', () => {
         expectedMessage: 'Unknown endpoint',
       },
     ].forEach(({ status, body, expectedMessage }) => {
-      it('throws an `ApiError` if the request fails', async () => {
+      it('throws an `APIError` if the request fails', async () => {
         fakeResponse.status = status;
         fakeResponse.json.resolves(body);
 
@@ -103,14 +103,14 @@ describe('api', () => {
           reason = err;
         }
 
-        assert.instanceOf(reason, ApiError);
+        assert.instanceOf(reason, APIError);
         assert.equal(reason.message, expectedMessage, '`Error.message`');
         assert.equal(
           reason.errorMessage,
           body.message,
-          '`ApiError.errorMessage`'
+          '`APIError.errorMessage`'
         );
-        assert.equal(reason.details, body.details, '`ApiError.details`');
+        assert.equal(reason.details, body.details, '`APIError.details`');
         assert.equal(reason.errorCode, null);
       });
     });

--- a/lms/static/styles/components/_BasicLTILaunchApp.scss
+++ b/lms/static/styles/components/_BasicLTILaunchApp.scss
@@ -3,15 +3,15 @@
 @use "../mixins";
 @use "../variables" as var;
 
-.BasicLtiLaunchApp {
+.BasicLTILaunchApp {
   height: 100%;
 }
 
-.BasicLtiLaunchApp__spinner {
+.BasicLTILaunchApp__spinner {
   @include mixins.spinner($size: var.$spinner-size);
 }
 
-.BasicLtiLaunchApp__content {
+.BasicLTILaunchApp__content {
   &.is-hidden {
     visibility: hidden;
   }
@@ -21,10 +21,10 @@
   height: 100%;
 }
 
-.BasicLtiLaunchApp__iframe {
+.BasicLTILaunchApp__iframe {
   width: 100%;
 
-  // nb. This element may be contained directly in the `BasicLtiLaunchApp__content` element or
+  // nb. This element may be contained directly in the `BasicLTILaunchApp__content` element or
   // within an `LMSGrader` wrapper. In both cases it should fill whatever space remains.
   flex-grow: 1;
 }

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -10,7 +10,7 @@
 @use 'components/label';
 
 // Preact components
-@use 'components/BasicLtiLaunchApp';
+@use 'components/BasicLTILaunchApp';
 @use 'components/BookList';
 @use 'components/ContentSelector';
 @use 'components/Dialog';
@@ -32,7 +32,7 @@
 @use '@hypothesis/frontend-shared/styles';
 
 // This ensures that root components which set `width: 100%; height: 100%`
-// (eg. the `BasicLtiLaunchApp`) will fill the viewport.
+// (eg. the `BasicLTILaunchApp`) will fill the viewport.
 html,
 body {
   height: 100%;


### PR DESCRIPTION
Update the names of several identifiers in frontend code to match the current [conventions for identifier naming](https://github.com/hypothesis/frontend-toolkit/blob/master/docs/js-guide.md#identifier-naming). See commit messages for details.

----

Note for future reference:

The shell command I used involved [fd](https://github.com/sharkdp/fd) and [sd](https://github.com/chmln/sd) (modern alternatives to `find` and `sed`):

```shellsession
$ fd . lms/static | xargs sd ApiCallInfo APICallInfo
```

For more targeted renaming of symbols I used TypeScript's rename refactoring via [`:ALERename`](https://github.com/dense-analysis/ale#2viii-refactoring-rename-actions) (in VS Code this is probably available in the context menu).