### PR TITLE
Fix ErrorDisplay so it shows error.message

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -1,4 +1,4 @@
-import { Fragment, createElement } from 'preact';
+import { createElement } from 'preact';
 
 /**
  * Generate a `mailto:` URL that prompts to send an email with pre-filled fields.
@@ -15,6 +15,8 @@ function emailLink({ address, subject = '', body = '' }) {
 }
 
 /**
+ * Adds punctuation to a string if missing.
+ *
  * @param {string} str
  */
 function toSentence(str) {
@@ -34,8 +36,13 @@ function toSentence(str) {
  * @prop {string|null} [message] -
  *   A short message to display explaining that a problem happened. This is
  *   typically a general message like "There was a problem fetching this assignment".
+ *   In cases where the the error originates from the server, this message may not
+ *   be necessary, but in other cases where the `error.message` is generic and perhaps
+ *   originates from an exception in the client, then this prop can be used to
+ *   provide additional specifics.
  * @prop {ErrorLike} error -
- *   An `Error`-like object with specific details of the problem
+ *   An `Error`-like object with specific details of the problem. If `error` contains
+ *   a `message` property, then that string will be rendered.
  */
 
 /**
@@ -84,15 +91,22 @@ export default function ErrorDisplay({ message, error }) {
   return (
     // nb. Wrapper `<div>` here exists to apply block layout to contents.
     <div className="ErrorDisplay">
-      {message && (
-        <p>
-          {!error.message && toSentence(message)}
-          {error.message && (
-            <Fragment>
-              {message}: <i>{toSentence(error.message)}</i>
-            </Fragment>
-          )}
+      {message && error.message && (
+        // Display both error messages if they are both provided
+        <p data-testid="message">
+          {message}: <i>{toSentence(error.message)}</i>
         </p>
+      )}
+      {message && !error.message && (
+        // Only the component's message prop is provided
+        <p data-testid="message">{toSentence(message)}</p>
+      )}
+      {!message && error.message && (
+        // Only the error's message property is provided
+        <p data-testid="message">{toSentence(error.message)}</p>
+      )}
+      {!message && !error.message && (
+        <p data-testid="message">An unknown error occurred.</p>
       )}
       <p className="ErrorDisplay__links">
         If the problem persists,{' '}

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -151,6 +151,33 @@ describe('ErrorDisplay', () => {
     });
   });
 
+  [
+    {
+      message: 'Provided by client',
+      error: 'Provided by server',
+      output: 'Provided by client: Provided by server.',
+    },
+    {
+      message: 'Provided by client',
+      output: 'Provided by client.',
+    },
+    {
+      error: 'Provided by server',
+      output: 'Provided by server.',
+    },
+    {
+      // Should not show any messages
+      output: 'An unknown error occurred.',
+    },
+  ].forEach(({ message, error, output }, index) => {
+    it(`shows the appropriate error message if provided (${index})`, () => {
+      const wrapper = mount(
+        <ErrorDisplay message={message} error={{ message: error }} />
+      );
+      assert.equal(wrapper.find('p[data-testid="message"]').text(), output);
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -61,7 +61,7 @@ describe('LaunchErrorDialog', () => {
     {
       errorState: 'canvas_group_set_not_found',
       expectedText:
-        "Assignment's group set no longer exists in CanvasHypothesis couldn't load this assignment because the assignment's group set no longer exists in Canvas.To fix this problem, an instructor needs to edit the assignment settings and select a new group set.If the problem persists, send us an email or open a support ticket. You can also visit our help documents.",
+        "Assignment's group set no longer exists in CanvasHypothesis couldn't load this assignment because the assignment's group set no longer exists in Canvas.To fix this problem, an instructor needs to edit the assignment settings and select a new group set.Detailed error info.If the problem persists, send us an email or open a support ticket. You can also visit our help documents.",
       retryAction: null,
     },
     {
@@ -72,7 +72,7 @@ describe('LaunchErrorDialog', () => {
     {
       errorState: 'canvas_student_not_in_group',
       expectedText:
-        "You're not in any of this assignment's groupsHypothesis couldn't launch this assignment because you aren't in any of the groups in the assignment's group set.To fix the problem, an instructor needs to add your Canvas user account to one of this assignment's groups.If the problem persists, send us an email or open a support ticket. You can also visit our help documents.",
+        "You're not in any of this assignment's groupsHypothesis couldn't launch this assignment because you aren't in any of the groups in the assignment's group set.To fix the problem, an instructor needs to add your Canvas user account to one of this assignment's groups.Detailed error info.If the problem persists, send us an email or open a support ticket. You can also visit our help documents.",
       retryAction: null,
     },
   ].forEach(


### PR DESCRIPTION
Fix ErrorDisplay to show the provided message in the rare cases where error.message is not empty AND the message prop is missing.

nb. In most cases error.message's text originated from the server.

--------

There are 4 possible states for the messages that ErrorDisplay renders

1. message && error.message = "message: _error.message_"
2. message && !error.message = "message"
3. !message && error.message = "error.message"
4. !message && !error.message = ""

Prior to this fix, case 3 was not working and so the error.message was not showing in the DOM.

run `make devdata`
Load up this assignment https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_80_1&course_id=_19_1

...you can now see the error message in the dialog

_"A problem occurred while handling this request. Hypothesis has been notified."_

![Screen Shot 2021-06-23 at 3 06 33 PM](https://user-images.githubusercontent.com/3939074/123175640-f6de0500-d436-11eb-81bb-fec688dee243.png)

Fixes https://github.com/hypothesis/lms/issues/2859