### PR TITLE
Fix Canvas course copy (wip)

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -10,7 +10,10 @@ from lms.models.grouping import CanvasGroup, CanvasSection, Course, Grouping
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
 from lms.models.lti_user import LTIUser, display_name
-from lms.models.module_item_configuration import ModuleItemConfiguration
+from lms.models.module_item_configuration import (
+    CanvasModuleItemConfiguration,
+    ModuleItemConfiguration,
+)
 from lms.models.oauth2_token import OAuth2Token
 
 

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -86,6 +86,9 @@ class ApplicationInstance(BASE):
         "GroupInfo", back_populates="application_instance"
     )
 
+    #: A list of all the files for this application instance.
+    files = sa.orm.relationship("File", back_populates="application_instance")
+
     def decrypted_developer_secret(self, aes_secret):
         if self.developer_secret is None:
             return None

--- a/lms/models/file.py
+++ b/lms/models/file.py
@@ -33,6 +33,10 @@ class File(CreatedUpdatedMixin, BASE):
     )
     """Link to the application instance."""
 
+    application_instance = sa.orm.relationship(
+        "ApplicationInstance", back_populates="files"
+    )
+
     type = sa.Column(sa.UnicodeText(), nullable=False)
     """What type of file is this? e.g. 'canvas_file'."""
 

--- a/lms/models/module_item_configuration.py
+++ b/lms/models/module_item_configuration.py
@@ -1,4 +1,6 @@
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
 
 from lms.db import BASE
 
@@ -41,3 +43,18 @@ class ModuleItemConfiguration(BASE):
 
     document_url = sa.Column(sa.String, nullable=False)
     """The URL of the document to be annotated for this assignment."""
+
+    extra = sa.Column(
+        "extra",
+        MutableDict.as_mutable(JSONB),
+        server_default=sa.text("'{}'::jsonb"),
+        nullable=False,
+    )
+
+
+class CanvasModuleItemConfiguration(ModuleItemConfiguration):
+    def get_mapped_file_id(self, file_id):
+        return self.extra.get("canvas_file_mappings", {}).get(file_id)
+
+    def set_mapped_file_id(self, file_id, mapped_file_id):
+        self.extra.setdefault("canvas_file_mappings", {})[file_id] = mapped_file_id

--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -32,7 +32,7 @@ class JSConfig:
         """
         return self._request.find_service(name="application_instance").get()
 
-    def add_canvas_file_id(self, course_id, canvas_file_id):
+    def add_canvas_file_id(self, course_id, canvas_file_id, resource_link_id):
         """
         Set the document to the Canvas file with the given canvas_file_id.
 
@@ -45,7 +45,10 @@ class JSConfig:
         self._config["api"]["viaUrl"] = {
             "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
             "path": self._request.route_path(
-                "canvas_api.files.via_url", course_id=course_id, file_id=canvas_file_id
+                "canvas_api.files.via_url",
+                course_id=course_id,
+                file_id=canvas_file_id,
+                resource_link_id=resource_link_id,
             ),
         }
         self._add_canvas_speedgrader_settings(canvas_file_id=canvas_file_id)

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -62,7 +62,7 @@ def includeme(config):
     )
     config.add_route(
         "canvas_api.files.via_url",
-        "/api/canvas/courses/{course_id}/files/{file_id}/via_url",
+        "/api/canvas/courses/{course_id}/assignments/{resource_link_id}/files/{file_id}/via_url",
     )
     config.add_route(
         "canvas_api.courses.group_sets.list",

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -62,3 +62,4 @@ def includeme(config):
         "lms.services.application_instance.factory", name="application_instance"
     )
     config.register_service_factory("lms.services.grouping.factory", name="grouping")
+    config.register_service_factory("lms.services.file.factory", name="file")

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -1,4 +1,9 @@
-from lms.services.exceptions import CanvasFileNotFoundInCourse
+import logging
+
+from lms.services.exceptions import CanvasAPIPermissionError, CanvasFileNotFoundInCourse
+
+
+logger = logging.getLogger(__name__)
 
 
 class CanvasService:
@@ -6,36 +11,87 @@ class CanvasService:
 
     api = None
 
-    def __init__(self, canvas_api):
+    def __init__(self, canvas_api, file_service):
         self.api = canvas_api
+        self._file_service = file_service
 
-    def public_url_for_file(self, file_id, course_id, check_in_course=False):
-        """
-        Get a public URL for a Canvas file.
+    def public_url_for_file(
+        self, file_id, course_id, module_item_configuration, check_in_course=False
+    ):
+        mapped_file_id = module_item_configuration.get_mapped_file_id(file_id)
 
-        This will also attempt to check if the file is in the course to detect
-        course copy situations and fix it if we can.
+        if mapped_file_id:
+            # If there's a previously stored mapping for file_id use that instead.
+            logger.info("Found a previously mapped_file_id: %s", mapped_file_id)
+            effective_file_id = mapped_file_id
+        else:
+            logger.info("No previously mapped_file_id")
+            effective_file_id = file_id
 
-        :param file_id: The file to look up
-        :param course_id: The course the file should be in
-        :param check_in_course: Raise CanvasFileNotFoundInCourse if file_id isn't in
-            course_id
-        :return: A URL suitable for public presentation of the file
-        :raise  CanvasFileNotFoundInCourse: if check_in_course=True and file_id isn't in course_id
-            be in the course but isn't.
-        """
+        try:
+            return self._public_url(
+                effective_file_id,
+                course_id=course_id if check_in_course else None,
+            )
+        except (CanvasFileNotFoundInCourse, CanvasAPIPermissionError) as err:
+            if isinstance(err, CanvasFileNotFoundInCourse):
+                logger.info("File not found in course")
+            else:
+                logger.info("Got a permissions error from Canvas")
 
-        if check_in_course:
-            if not self._file_in_course(file_id, course_id):
-                raise CanvasFileNotFoundInCourse(file_id)
+            # Look up the file's metadata in our DB.
+            file_ = self._file_service.get(effective_file_id, type_="canvas_file")
+
+            if not file_:
+                logger.info("File was not found in DB")
+                raise
+
+            # Find a matching file in the current course.
+            found_file_id = self.find(course_id, file_)
+
+            if not found_file_id:
+                logger.info("No matching file was found in course")
+                raise
+
+            logger.info("A matching file was found in the course")
+            logger.info("Updating the mapping and trying again")
+
+            # Update the mapping.
+            module_item_configuration.set_mapped_file_id(file_id, found_file_id)
+
+            # Try again with the new file_id.
+            return self._public_url(found_file_id)
+
+    def _public_url(self, file_id, course_id=None):
+        if course_id and not self.is_file_in_course(file_id, course_id):
+            raise CanvasFileNotFoundInCourse(file_id)
 
         return self.api.public_url(file_id)
 
-    def _file_in_course(self, file_id, course_id):
-        return any(
-            str(file_["id"]) == str(file_id) for file_ in self.api.list_files(course_id)
-        )
+    def find(self, course_id, file_):
+        file_dicts = self.api.list_files(course_id)
+
+        for file_dict in file_dicts:
+            display_name = file_dict["display_name"]
+            size = file_dict["size"]
+
+            if display_name == file_.name and size == file_.size:
+                return str(file_dict["id"])
+
+        return None
+
+    def is_file_in_course(self, file_id, course_id):
+        files_in_course = self.api.list_files(course_id)
+
+        for file_ in files_in_course:
+            if str(file_["id"]) == file_id:
+                return True
+
+        return False
 
 
 def factory(_context, request):
-    return CanvasService(canvas_api=request.find_service(name="canvas_api_client"))
+    return CanvasService(
+        canvas_api=request.find_service(name="canvas_api_client"),
+        file_service=request.find_service(name="file"),
+    )

--- a/lms/services/file.py
+++ b/lms/services/file.py
@@ -1,0 +1,23 @@
+from lms.models import File
+
+
+class FileService:
+    def __init__(self, application_instance, db):
+        self._application_instance = application_instance
+        self._db = db
+
+    def get(self, lms_id, type_):
+        return self._query.filter_by(lms_id=lms_id, type=type_).one_or_none()
+
+    @property
+    def _query(self):
+        return self._db.query(File).filter_by(
+            application_instance=self._application_instance
+        )
+
+
+def factory(_context, request):
+    return FileService(
+        application_instance=request.find_service(name="application_instance").get(),
+        db=request.db,
+    )

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -1,6 +1,7 @@
 """Proxy API views for files-related Canvas API endpoints."""
 from pyramid.view import view_config, view_defaults
 
+from lms.models import CanvasModuleItemConfiguration
 from lms.security import Permissions
 from lms.services.canvas import CanvasService
 from lms.views import helpers
@@ -30,9 +31,23 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
+        application_instance = self.request.find_service(
+            name="application_instance"
+        ).get()
+
+        module_item_configuration = (
+            self.request.db.query(CanvasModuleItemConfiguration)
+            .filter_by(
+                resource_link_id=self.request.matchdict["resource_link_id"],
+                tool_consumer_instance_guid=application_instance.tool_consumer_instance_guid,
+            )
+            .one()
+        )
+
         public_url = self.canvas.public_url_for_file(
             file_id=self.request.matchdict["file_id"],
             course_id=self.request.matchdict["course_id"],
+            module_item_configuration=module_item_configuration,
             # Teachers can have broad permissions and see files that aren't in
             # the course. So do this slower check (extra API call) to warn the
             # teacher that their students might not be able to see the file.

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -106,6 +106,7 @@ class BasicLTILaunchViews:
 
         course_id = self.request.params["custom_canvas_course_id"]
         file_id = self.request.params["file_id"]
+        resource_link_id = self.request.params["resource_link_id"]
 
         # Normally this would be done during `configure_module_item()` but
         # Canvas skips that step. We are doing this to ensure that there is a
@@ -113,14 +114,14 @@ class BasicLTILaunchViews:
         # being around in future code.
         self.assignment_service.set_document_url(
             self.request.params["tool_consumer_instance_guid"],
-            self.request.params["resource_link_id"],
+            resource_link_id,
             # This URL is mostly for show. We just want to ensure that a module
             # configuration exists. If we're going to do that we might as well
             # make sure this URL is meaningful.
             document_url=f"canvas://file/course/{course_id}/file_id/{file_id}",
         )
 
-        self.context.js_config.add_canvas_file_id(course_id, file_id)
+        self.context.js_config.add_canvas_file_id(course_id, file_id, resource_link_id)
 
         return self.basic_lti_launch(grading_supported=False)
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -16,6 +16,7 @@ from tests.factories.attributes import (
     USER_ID,
 )
 from tests.factories.course import Course, LegacyCourse
+from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo
 from tests.factories.grouping import Grouping
 from tests.factories.h_user import HUser

--- a/tests/factories/file.py
+++ b/tests/factories/file.py
@@ -1,0 +1,16 @@
+from factory import Faker, Sequence, SubFactory, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.application_instance import ApplicationInstance
+
+File = make_factory(
+    models.File,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    application_instance=SubFactory(ApplicationInstance),
+    type="canvas_file",
+    lms_id=Sequence(lambda n: f"{n}"),
+    course_id=Faker("random_int"),
+    name=Faker("word"),
+    size=Faker("random_int"),
+)


### PR DESCRIPTION
Canvas Course Copy Test Cases
=============================

All the test cases should work with our [Canvas test site](https://hypothesis.instructure.com/).

You need to run `make devdata` in the LMS project to make sure you have the latest development data.

To get to an SQL shell (to run the various example SQL commands in the test cases below) run `make sql`.

Test data:

* [Developer Test Course with Sections Enabled][] is the original (non-copied) test course
  * [localhost (make devdata) Canvas Files Assignment] is a Canvas Files assignment in this course
  * File **798** (`Françoise_Hardy.pdf`) is a PDF file in this course that the assignment uses
  * `eng+canvasteacher@hypothes.is` is a teacher in this course (all user passwords are in 1Password)
  * `eng+canvasstudent@hypothes.is` is a student in this course

* [Copy of Developer Test Course with Sections Enabled][] is a copied course
  * [localhost (make devdata) Canvas Files Assignment (copy)][] is a copied Canvas Files assignment in this course
  * `eng+canvasteacher@hypothes.is` is a teacher who is in both the copied course and the original course
  * `eng+canvasstudent@hypothes.is` is a student who is in both the copied course and the original course
  * `eng+coursecopyteacher` is a teacher who is in the copied course but *not* the original course
  * `eng+coursecopystudent` is a student who is in the copied course but *not* the original course

Launching a non-course-copied assignment
----------------------------------------

Launch [localhost (make devdata) Canvas Files Assignment][] from [Developer Test Course with Sections Enabled][] as both a teacher and a student.

The assignment should launch successfully.

You should not have any mappings in your DB:

```sql
postgres=# select * from module_item_configurations where extra != '{}';
 id | resource_link_id | tool_consumer_instance_guid | document_url | extra
----+------------------+-----------------------------+--------------+-------
(0 rows)
```

Launching a course-copied assignment: teacher also belongs to original course
-----------------------------------------------------------------------------

Launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+canvasteacher@hypothes.is`.

The assignment should launch successfully.

Even though the teacher could access the original file (since they belong to the original course) we detect that the file isn't in the current course and map it to the matching file in the current course. The mapping means that other users who *aren't* in the original course will be able to launch the assignment. You should find that a mapping has been created in the DB:

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

Launching a course-copied assignment: student also belongs to original course
-----------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+canvasstudent@hypothes.is`.

The assignment should launch successfully.

You should not have any mappings in your DB:

```sql
postgres=# select * from module_item_configurations where extra != '{}';
 id | resource_link_id | tool_consumer_instance_guid | document_url | extra
----+------------------+-----------------------------+--------------+-------
(0 rows)
```

Since the student belongs to the original course they're able to access the original file. When students launch assignments we **don't** check to make sure that the file is in the current course because that check requires extra network requests, so no mapping gets created.

If you first launch the assignment as `eng+canvasteacher@hypothes.is` (thus creating a mapping) and _then_ launch the assignment as `eng+canvasstudent@hypothes.is` then it should find and use the existing mapping.

Launching a course-copied assignment: teacher does not belong to original course
--------------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+coursecopyteacher@hypothes.is`.

The assignment should launch successfully.

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

Launching a course-copied assignment: student does not belong to original course
--------------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+coursecopystudent@hypothes.is`.

The assignment should launch successfully.

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

When we don't have a record of the original course's files
----------------------------------------------------------

The creation of "mappings" in order to fix course copied assignments depends on us having information about the assignment's original file in our DB (the file used by the original assignment in the original course, this is the file whose ID comes to us in the `file_id` parameter whenever the original or a copied assignment is launched.

If you have created or launched any assignment in the original course as a teacher then we will have downloaded the info about all of the original course's files (as they were at the time of your launch).

Launching assignments as a student does not download info about the course's files.

It is possible that a user could be launching a course-copied assignment and we don't have info about the assignment's original file in our DB. For example this could happen if the course was copied before we had deployed the file info tracking feature.

First, delete all the file info from your DB:

```sql
postgres=# delete from file;
DELETE 12
```

Also delete any previously created mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][].

If you launch the assignment as a teacher (member of the original course or not) you'll run into a **Hypothesis couldn't find the file in the course** error message.

If you launch the assignment as a student who isn't a member of the original course you'll get a **Couldn't get the file from Canvas** error.

If you launch the assignment as a student who is also a member of the original course it will launch successfully.

Deleted files
-------------

If you launch [localhost (make devdata) Canvas Files Assignment Whose File Has Been Deleted](https://hypothesis.instructure.com/courses/125/assignments/1370) in [Developer Test Course with Sections Enabled][] as a teacher you'll get the **Hypothesis couldn't find the file in the course** error.

We notice that the file isn't in the course which triggers us to think that the assignment might have been course copied and to look for a matching file that _is_ in the course. We won't find a matching file in the course (since Canvas omits deleted files from its list-files API responses) to the look up fails and we just fall back to the error dialog.

If you launch this assignment as a student it will launch successfully. (This is because Canvas doesn't seem to actually delete files when you delete them. Ever. Students can still download them.)

Deleting and re-uploading a file
--------------------------------

What if you delete an assignment's file from Canvas and then re-upload the same file again? This will create a new file in Canvas with a new file ID. But the new file will have the same filenamena and size as the deleted one.

If you now launch the assignment whose file was deleted as a student it will just launch successfully downloading the original (deleted) file since students can still download deleted files from Canvas.

But if you launch the assignment as a teacher we'll notice that the assignment's file ID isn't in the course and will find the new file in the course with the same name and size and will create a mapping and "fix" the assignment :)

Unpublished files
-----------------

Files can be marked as "unpublished" in Canvas which means that teachers can see them but students can't.

[localhost (make devdata) Canvas Files Assignment Whose File Is Unpublished](https://hypothesis.instructure.com/courses/125/assignments/1371) is an assignment for an unpublished file.

The assignment will launch successfully for teachers but students get a **Couldn't get the file from Canvas** error.

**But** if the course has another file with the same name and size then when a student launched the assignment we would create a mapping to that file and the launch would succeed :)

Editing assignments
-------------------

What if we store a mapping in our DB and then a user edits the assignment and changes its file?

Since the mappings map one file ID to another if the user changes the `file_id` in Canvas the previous mapping will no longer apply. (So editing works as expected.)




[localhost (make devdata) Canvas Files Assignment]: https://hypothesis.instructure.com/courses/125/assignments/875/
[Developer Test Course with Sections Enabled]: https://hypothesis.instructure.com/courses/125
[Copy of Developer Test Course with Sections Enabled]: https://hypothesis.instructure.com/courses/252
[localhost (make devdata) Canvas Files Assignment (copy)]: https://hypothesis.instructure.com/courses/252/assignments/1321