### PR TITLE
Add resource_link_id param to via_url API

### DIFF
--- a/lms/resources/_js_config.py
+++ b/lms/resources/_js_config.py
@@ -32,7 +32,7 @@ class JSConfig:
         """
         return self._request.find_service(name="application_instance").get()
 
-    def add_canvas_file_id(self, course_id, canvas_file_id):
+    def add_canvas_file_id(self, course_id, resource_link_id, canvas_file_id):
         """
         Set the document to the Canvas file with the given canvas_file_id.
 
@@ -45,7 +45,10 @@ class JSConfig:
         self._config["api"]["viaUrl"] = {
             "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
             "path": self._request.route_path(
-                "canvas_api.files.via_url", course_id=course_id, file_id=canvas_file_id
+                "canvas_api.files.via_url",
+                course_id=course_id,
+                resource_link_id=resource_link_id,
+                file_id=canvas_file_id,
             ),
         }
         self._add_canvas_speedgrader_settings(canvas_file_id=canvas_file_id)

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -62,7 +62,7 @@ def includeme(config):
     )
     config.add_route(
         "canvas_api.files.via_url",
-        "/api/canvas/courses/{course_id}/files/{file_id}/via_url",
+        "/api/canvas/courses/{course_id}/assignments/{resource_link_id}/files/{file_id}/via_url",
     )
     config.add_route(
         "canvas_api.courses.group_sets.list",

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -106,6 +106,7 @@ class BasicLTILaunchViews:
 
         course_id = self.request.params["custom_canvas_course_id"]
         file_id = self.request.params["file_id"]
+        resource_link_id = self.request.params["resource_link_id"]
 
         # Normally this would be done during `configure_module_item()` but
         # Canvas skips that step. We are doing this to ensure that there is a
@@ -113,14 +114,14 @@ class BasicLTILaunchViews:
         # being around in future code.
         self.assignment_service.set_document_url(
             self.request.params["tool_consumer_instance_guid"],
-            self.request.params["resource_link_id"],
+            resource_link_id,
             # This URL is mostly for show. We just want to ensure that a module
             # configuration exists. If we're going to do that we might as well
             # make sure this URL is meaningful.
             document_url=f"canvas://file/course/{course_id}/file_id/{file_id}",
         )
 
-        self.context.js_config.add_canvas_file_id(course_id, file_id)
+        self.context.js_config.add_canvas_file_id(course_id, resource_link_id, file_id)
 
         return self.basic_lti_launch(grading_supported=False)
 

--- a/tests/unit/lms/resources/_js_config_test.py
+++ b/tests/unit/lms/resources/_js_config_test.py
@@ -189,17 +189,21 @@ class TestAddCanvasFileID:
 
     def test_it_adds_the_viaUrl_api_config(self, js_config):
         js_config.add_canvas_file_id(
-            "example_canvas_course_id", "example_canvas_file_id"
+            "example_canvas_course_id",
+            "example_resource_link_id",
+            "example_canvas_file_id",
         )
 
         assert js_config.asdict()["api"]["viaUrl"] == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
-            "path": "/api/canvas/courses/example_canvas_course_id/files/example_canvas_file_id/via_url",
+            "path": "/api/canvas/courses/example_canvas_course_id/assignments/example_resource_link_id/files/example_canvas_file_id/via_url",
         }
 
     def test_it_sets_the_canvas_file_id(self, js_config, submission_params):
         js_config.add_canvas_file_id(
-            "example_canvas_course_id", "example_canvas_file_id"
+            "example_canvas_course_id",
+            "example_resource_link_id",
+            "example_canvas_file_id",
         )
 
         assert submission_params()["canvas_file_id"] == "example_canvas_file_id"
@@ -316,7 +320,11 @@ class TestAddCanvasFileIDAddDocumentURLCommon:
         params=[
             {
                 "method": "add_canvas_file_id",
-                "args": ["example_canvas_course_id", "example_canvas_file_id"],
+                "args": [
+                    "example_canvas_course_id",
+                    "example_resource_link_id",
+                    "example_canvas_file_id",
+                ],
             },
             {"method": "add_document_url", "args": ["example_document_url"]},
         ]

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -278,6 +278,7 @@ class TestCanvasFileBasicLTILaunch:
 
         context.js_config.add_canvas_file_id.assert_called_once_with(
             pyramid_request.params["custom_canvas_course_id"],
+            pyramid_request.params["resource_link_id"],
             pyramid_request.params["file_id"],
         )
 


### PR DESCRIPTION
Pass the assignments `resource_link_id` (assignment ID) to the Canvas Files `/via_url` API.

In future PRs the `/via_url` API is going to need the `resource_link_id` to fix course-copied Canvas files assignments. It's needed to look up the assignment's `ModulteItemConfiguration` (assignment configuration) in the DB in order to get and set "Canvas file mappings" in the `ModulteItemConfiguration.extra` column.