### PR TITLE
Explicitly sort by `position` when getting files

### DIFF
--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -353,6 +353,7 @@ class TestCanvasAPIClient:
                     {
                         "content_types[]": "application/pdf",
                         "per_page": Any.string(),
+                        "sort": "position",
                     }
                 ),
             ),


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2879

Sorting by name (the default) leads to, depending on number of files/ pagination, weird behavior.

For example, to reproduce the orignal bug, you can rename this file to `AAAA.pdf` (which already exists on the root folder)

https://hypothesis.instructure.com/courses/125/files/folder/Duplicated%20name%20file?

(remember to rename it back to something else to avoid leaving the course in a broken state)

change your pagination setting locally to something smaller in `lms/services/canvas_api/_basic.py` change `PAGINATION_PER_PAGE` to `2`

you'll get an exception if you try to launch the assignment. Notice that is not just a duplicated row, of the two AAAA.pdf files only one is returned but twice so information is lost.

To fix this we do both:

- Remove duplicates and notify in sentry. We don't want to pass the duplicates along in the system but we want to have some track record of that happening.
- We change the ordering on canvas api using the `sort` parameter to avoid the duplicates in the first place

According to the docs https://canvas.instructure.com/doc/api/files.html#method.files.api_index the allowed values for sort are 
**name, size, created_at, updated_at, content_type, user**. All of them allow for duplicates, maybe "created_at" being the less likely to produce them (it uses postgres' datetime so it has a lot of resolution) but could potentially also be problematic. 

There's another, undocumented, option "position", https://github.com/instructure/canvas-lms/blob/master/app/controllers/files_controller.rb#L305 which uses two columns which should be better. 

