### PR TITLE
Fix blackboard content link

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -135,6 +135,7 @@ export default function ContentSelector({
           listFilesApi={listFilesApi}
           onCancel={cancelDialog}
           onSelectFile={selectCanvasFile}
+          missingFilesHelpLink="https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-upload-a-file-to-a-course/ta-p/618"
         />
       );
       break;
@@ -145,6 +146,9 @@ export default function ContentSelector({
           listFilesApi={blackboardListFilesApi}
           onCancel={cancelDialog}
           onSelectFile={selectBlackboardFile}
+          // An alias we maintain that provides multiple external documentation links for
+          // different versions of Blackboard (Classic vs. Ultra)
+          missingFilesHelpLink={'https://web.hypothes.is/help/bb-files'}
         />
       );
       break;

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -15,6 +15,31 @@ import FileList from './FileList';
  */
 
 /**
+ * @typedef NoFilesMessageProps
+ * @prop {string} href - Helpful documentation URL to link to
+ */
+
+/**
+ * Renders a helpful message with a link to documentation when there are no
+ * uploaded files.
+ *
+ * @param {NoFilesMessageProps} props
+ */
+function NoFilesMessage({ href }) {
+  return (
+    <div className="FileList__no-files-message">
+      <p>
+        There are no PDFs in this course.{' '}
+        <a href={href} target="_blank" rel="noreferrer">
+          Upload some files to the course
+        </a>{' '}
+        and try again.
+      </p>
+    </div>
+  );
+}
+
+/**
  * @typedef LMSFilePickerProps
  * @prop {string} authToken - Auth token for use in calls to the backend
  * @prop {APICallInfo} listFilesApi -
@@ -22,6 +47,9 @@ import FileList from './FileList';
  * @prop {() => any} onCancel - Callback invoked if the user cancels file selection
  * @prop {(f: File) => any} onSelectFile -
  *   Callback invoked with the metadata of the selected file if the user makes a selection
+ * @prop {string} missingFilesHelpLink - A helpful URL to documentation that explains
+ *   how to upload files to an LMS such as Canvas or Blackboard. This link is only shown
+ *   when the API call to returns available files returns an empty list.
  */
 
 /**
@@ -42,22 +70,6 @@ const INITIAL_DIALOG_STATE = {
   error: null,
 };
 
-const CanvasNoFiles = (
-  <div className="FileList__no-files-message">
-    <p>
-      There are no PDFs in this course.{' '}
-      <a
-        href="https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-upload-a-file-to-a-course/ta-p/618"
-        target="_blank"
-        rel="noreferrer"
-      >
-        Upload some files to the course
-      </a>{' '}
-      and try again.
-    </p>
-  </div>
-);
-
 /**
  * A file picker dialog that allows the user to choose files from their
  * LMS's file storage.
@@ -72,6 +84,7 @@ export default function LMSFilePicker({
   listFilesApi,
   onCancel,
   onSelectFile,
+  missingFilesHelpLink,
 }) {
   // The main state of the dialog and associated data.
   const [dialogState, setDialogState] = useState(INITIAL_DIALOG_STATE);
@@ -245,7 +258,7 @@ export default function LMSFilePicker({
           selectedFile={selectedFile}
           onUseFile={onSelectFile}
           onSelectFile={selectFile}
-          noFilesMessage={CanvasNoFiles} // Add Blackboard or other specific LMS warning messages here.
+          noFilesMessage={<NoFilesMessage href={missingFilesHelpLink} />}
         />
       )}
     </Dialog>

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -189,6 +189,8 @@ describe('ContentSelector', () => {
           type: 'file',
           file: { id: 123 },
         },
+        missingFilesHelpLink:
+          'https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-upload-a-file-to-a-course/ta-p/618',
       },
       {
         name: 'blackboard',
@@ -198,6 +200,7 @@ describe('ContentSelector', () => {
           type: 'url',
           url: 'blackboard://content-resource/123',
         },
+        missingFilesHelpLink: 'https://web.hypothes.is/help/bb-files',
       },
     ].forEach(test => {
       it(`supports selecting a file from the ${test.name} file dialog`, () => {
@@ -213,6 +216,16 @@ describe('ContentSelector', () => {
         });
 
         assert.calledWith(onSelectContent, test.result);
+      });
+
+      it('passes the appropriate `missingFilesHelpLink` value to `LMSFilePicker`', () => {
+        const wrapper = renderContentSelector({
+          defaultActiveDialog: test.dialogName,
+        });
+        assert.equal(
+          wrapper.find('LMSFilePicker').prop('missingFilesHelpLink'),
+          test.missingFilesHelpLink
+        );
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -3,10 +3,11 @@ import { Fragment, createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import { APIError } from '../../utils/api';
-
-import LMSFilePicker, { $imports } from '../LMSFilePicker';
 import ErrorDisplay from '../ErrorDisplay';
+import FileList from '../FileList';
+import LMSFilePicker, { $imports } from '../LMSFilePicker';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { waitForElement } from '../../../test-util/wait';
 
 describe('LMSFilePicker', () => {
   // eslint-disable-next-line react/prop-types
@@ -27,6 +28,7 @@ describe('LMSFilePicker', () => {
         onAuthorized={sinon.stub()}
         onSelectFile={sinon.stub()}
         onCancel={sinon.stub()}
+        missingFilesHelpLink={'https://fake_help_link'}
         {...props}
       />
     );
@@ -46,6 +48,9 @@ describe('LMSFilePicker', () => {
         apiCall: fakeApiCall,
       },
       './Dialog': FakeDialog,
+      // Don't mock <FileList> because <NoFiles> requires
+      // it to render for code coverage.
+      './FileList': FileList,
     });
   });
 
@@ -338,5 +343,20 @@ describe('LMSFilePicker', () => {
     await fakeApiCall;
     wrapper.update();
     assert.isFalse(wrapper.isEmptyRender());
+  });
+
+  describe('when no files are provided', () => {
+    beforeEach(() => {
+      fakeApiCall = sinon.stub().resolves([]); // no files returned
+    });
+
+    it('renders no file message with a help link', async () => {
+      const wrapper = renderFilePicker();
+      const fileList = await waitForElement(wrapper, 'FileList');
+      assert.equal(
+        fileList.prop('noFilesMessage').props.href,
+        'https://fake_help_link'
+      );
+    });
   });
 });


### PR DESCRIPTION
Make the no file message href dynamic 

Change the LMSFilePicker to render a different documentation help link when no files are returned for Blackboard vs Canvas.

------

Update

I have refactored this PR to no longer use a provider and instead take a `missingFilesHelpLink` prop from ContentSelector.
Secondly, we have decided the 0 way to link to Blackboard docs is to link to an internal alias we maintain that has external links for file upload documentation for both ultra and classic version so blackboard. Currently there is no way to differentiate between these versions from the perspective of the client or config.

Slack discussion here
https://hypothes-is.slack.com/archives/C2BLQDKHA/p1625075688421600

Fixes https://github.com/hypothesis/lms/issues/2860