### PR TITLE
Onedrive poc share link

### DIFF
--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -82,6 +82,7 @@ class FilePickerConfig:
         return {
             "enabled": True,
             "clientId": request.registry.settings["onedrive_client_id"],
+            "redirectURI": request.route_url("onedrive.filepicker.authorize"),
         }
 
     @classmethod

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -46,6 +46,11 @@ def includeme(config):
     )
 
     config.add_route(
+        "onedrive.filepicker.authorize",
+        "/api/onedrive/filepicker/authorize",
+    )
+
+    config.add_route(
         "canvas_api.oauth.authorize",
         "/api/canvas/oauth/authorize",
         factory="lms.resources.OAuth2RedirectResource",

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -7,6 +7,9 @@ import {
   GooglePickerClient,
   PickerCanceledError,
 } from '../utils/google-picker-client';
+
+import { OneDrivePickerClient } from '../utils/onedrive-picker-client';
+
 import BookPicker from './BookPicker';
 import FullScreenSpinner from './FullScreenSpinner';
 import LMSFilePicker from './LMSFilePicker';
@@ -56,6 +59,11 @@ export default function ContentSelector({
         developerKey: googleDeveloperKey,
         origin: googleOrigin,
       },
+      onedrive: {
+        enabled: oneDriveFilesEnabled,
+        clientId: oneDriveClientId,
+        redirectURI: oneDriveRedirectURI,
+      },
       vitalSource: { enabled: vitalSourceEnabled },
     },
   } = useContext(Config);
@@ -94,6 +102,19 @@ export default function ContentSelector({
       origin: window === window.top ? window.location.href : googleOrigin,
     });
   }, [googleDeveloperKey, googleClientId, googleOrigin]);
+
+  // Initialize the OneDrive client if credentials have been provided.
+  // We do this eagerly to make the picker load faster if the user does click
+  // on the "Select from One Drive" button.
+  const oneDrivePicker = useMemo(() => {
+    if (!oneDriveClientId || !oneDriveRedirectURI) {
+      return null;
+    }
+    return new OneDrivePickerClient({
+      clientId: oneDriveClientId,
+      redirectURI: oneDriveRedirectURI,
+    });
+  }, [oneDriveClientId, oneDriveRedirectURI]);
 
   /** @param {string} url */
   const selectURL = url => {
@@ -183,6 +204,36 @@ export default function ContentSelector({
     }
   };
 
+  const showOneDrivePicker = async () => {
+    setLoadingIndicatorVisible(true);
+    const picker = /** @type {OneDrivePickerClient} */ (oneDrivePicker);
+    await picker.showPicker(
+      function (result) {
+        // TODO handle no selection
+        // TODO handle more permissions?
+        const sharedLink = result.value[0].permissions[0].link.webUrl;
+        // https://docs.microsoft.com/en-us/graph/api/shares-get?view=graph-rest-1.0&tabs=http#encoding-sharing-urls
+        // First, use base64 encode the URL.
+        // Convert the base64 encoded result to unpadded base64url format by removing = characters from the end of the value, replacing / with _ and + with -.)
+        const b64SharedLink = btoa(sharedLink)
+          .replace(/\//g, '_')
+          .replace(/\+/g, '-')
+          .replace(/=/g, '');
+        // Append u! to be beginning of the string.
+        const url = `https://api.onedrive.com/v1.0/shares/u!${b64SharedLink}/root/content`;
+
+        onSelectContent({ type: 'url', url });
+      },
+      function (error) {
+        console.error(error);
+        onError({
+          title: 'There was a problem choosing a file from One Drive',
+          error,
+        });
+      }
+    );
+  };
+
   return (
     <Fragment>
       {isLoadingIndicatorVisible && <FullScreenSpinner />}
@@ -223,6 +274,16 @@ export default function ContentSelector({
               Select PDF from Google Drive
             </LabeledButton>
           )}
+          {oneDriveFilesEnabled && (
+            <LabeledButton
+              onClick={showOneDrivePicker}
+              variant="primary"
+              data-testid="one-drive-button"
+            >
+              Select PDF from One Drive
+            </LabeledButton>
+          )}
+
           {vitalSourceEnabled && (
             <LabeledButton
               onClick={() => selectDialog('vitalSourceBook')}

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -59,7 +59,7 @@ export default function ContentSelector({
         developerKey: googleDeveloperKey,
         origin: googleOrigin,
       },
-      onedrive: {
+      microsoftOneDrive: {
         enabled: oneDriveFilesEnabled,
         clientId: oneDriveClientId,
         redirectURI: oneDriveRedirectURI,

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -72,6 +72,10 @@ import { createContext } from 'preact';
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey
  *   @prop {string} google.origin
+ * @prop {Object} onedrive
+ *   @prop {boolean} onedrive.enabled
+ *   @prop {string} onedrive.clientId
+ *   @prop {string} onedrive.redirectURI
  * @prop {Object} vitalSource
  *   @prop {boolean} vitalSource.enabled
  */

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -72,7 +72,7 @@ import { createContext } from 'preact';
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey
  *   @prop {string} google.origin
- * @prop {Object} onedrive
+ * @prop {Object} microsoftOneDrive
  *   @prop {boolean} onedrive.enabled
  *   @prop {string} onedrive.clientId
  *   @prop {string} onedrive.redirectURI

--- a/lms/static/scripts/frontend_apps/utils/onedrive-api-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-api-client.js
@@ -1,0 +1,21 @@
+async function loadOneDriveAPI() {
+  if (window.odapi) {
+    return window.odapi;
+  }
+
+  return new Promise((resolve, reject) => {
+    const oneDriveScript = document.createElement('script');
+    oneDriveScript.src = 'https://js.live.net/v7.2/OneDrive.js';
+    oneDriveScript.onload = () => {
+      resolve(window.odapi);
+    };
+    oneDriveScript.onerror = () => {
+      reject(new Error('Failed to load One Drive API client'));
+    };
+    document.body.appendChild(oneDriveScript);
+  });
+}
+
+// Separate function declaration from export to work around
+// https://github.com/robertknight/babel-plugin-mockable-imports/issues/9.
+export { loadOneDriveAPI };

--- a/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
@@ -1,0 +1,24 @@
+import { loadOneDriveAPI } from './onedrive-api-client';
+
+export class OneDrivePickerClient {
+  constructor({ clientId, redirectURI }) {
+    loadOneDriveAPI();
+
+    this._filePickerOptions = {
+      clientId: clientId,
+      action: 'share',
+      multiSelect: false,
+      viewType: 'files', //  	The type of item that can be selected.
+      advanced: {
+        redirectUri: redirectURI,
+        filter: '.pdf',
+        createLinkParameters: { type: 'view', scope: 'anonymous' },
+      },
+    };
+  }
+
+  async showPicker(success) {
+    const callbacks = { success: success };
+    window.OneDrive.open({ ...this._filePickerOptions, ...callbacks });
+  }
+}

--- a/lms/templates/onedrive.html.jinja2
+++ b/lms/templates/onedrive.html.jinja2
@@ -1,0 +1,15 @@
+{% extends "lms:templates/base.html.jinja2" %}
+
+{% block content %}
+  <div id="app"></div>
+{% endblock %}
+
+{% block styles %}
+  {% for url in  asset_urls("frontend_apps_css") %}
+    <link rel="stylesheet" href="{{ url }}">
+  {% endfor %}
+{% endblock %}
+
+{% block scripts %}
+  <script type="text/javascript" src="https://js.live.net/v7.2/OneDrive.js"></script>
+{% endblock %}

--- a/lms/templates/onedrive.html.jinja2
+++ b/lms/templates/onedrive.html.jinja2
@@ -1,13 +1,9 @@
 {% extends "lms:templates/base.html.jinja2" %}
 
 {% block content %}
-  <div id="app"></div>
 {% endblock %}
 
 {% block styles %}
-  {% for url in  asset_urls("frontend_apps_css") %}
-    <link rel="stylesheet" href="{{ url }}">
-  {% endfor %}
 {% endblock %}
 
 {% block scripts %}

--- a/lms/views/api/onedrive.py
+++ b/lms/views/api/onedrive.py
@@ -1,0 +1,10 @@
+from pyramid.view import view_config
+
+
+@view_config(
+    request_method="GET",
+    route_name="onedrive.filepicker.authorize",
+    renderer="lms:templates/onedrive.html.jinja2",
+)
+def authorize(request):
+    return {}


### PR DESCRIPTION
Different approach than #2881 

- Here we don't need to authorize the students 
- It will work for any file selected by the teacher 

The process is:
- File picker in "share" mode will automatically create a shared link with our app
- From the shared link (which will render a HTML frame around the document with all onedrive's UI) we generate a download URL
- We store that URL on the assignment 
- Launches use the stored URL verbatim 


As for permissions, "share" implies write (to create the link) so the authorization prompt looks very similar to the one in the other approach but it's only seen once by the teacher (while configuring the assignment) and never while launching it.