### PR TITLE
Add FileService

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -62,3 +62,4 @@ def includeme(config):
         "lms.services.application_instance.factory", name="application_instance"
     )
     config.register_service_factory("lms.services.grouping.factory", name="grouping")
+    config.register_service_factory("lms.services.file.factory", name="file")

--- a/lms/services/file.py
+++ b/lms/services/file.py
@@ -1,0 +1,20 @@
+from lms.models import File
+
+
+class FileService:
+    def __init__(self, db):
+        self._db = db
+
+    def get(self, application_instance, lms_id, type_):
+        """Return the file with application_instance, lms_id and type_ or None."""
+        return (
+            self._db.query(File)
+            .filter_by(
+                application_instance=application_instance, lms_id=lms_id, type=type_
+            )
+            .one_or_none()
+        )
+
+
+def factory(_context, request):
+    return FileService(db=request.db)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -16,6 +16,7 @@ from tests.factories.attributes import (
     USER_ID,
 )
 from tests.factories.course import Course, LegacyCourse
+from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo
 from tests.factories.grouping import Grouping
 from tests.factories.h_user import HUser

--- a/tests/factories/file.py
+++ b/tests/factories/file.py
@@ -1,0 +1,16 @@
+from factory import Faker, Sequence, SubFactory, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.application_instance import ApplicationInstance
+
+File = make_factory(
+    models.File,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    application_instance=SubFactory(ApplicationInstance),
+    type="canvas_file",
+    lms_id=Sequence(lambda n: f"{n}"),
+    course_id=Faker("random_int"),
+    name=Faker("word"),
+    size=Faker("random_int"),
+)

--- a/tests/unit/lms/services/file_test.py
+++ b/tests/unit/lms/services/file_test.py
@@ -1,0 +1,50 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.file import FileService, factory
+from tests import factories
+
+
+class TestGet:
+    def test_it_returns_the_matching_file_if_there_is_one(
+        self, application_instance, svc
+    ):
+        file_ = factories.File(application_instance=application_instance)
+
+        assert svc.get(application_instance, file_.lms_id, file_.type) == file_
+
+    def test_it_returns_None_if_theres_no_matching_file(
+        self, application_instance, svc
+    ):
+        assert not svc.get(application_instance, "unknown_file_id", "canvas_file")
+
+    def test_it_doesnt_return_matching_files_from_other_application_instances(
+        self, application_instance, svc
+    ):
+        file_ = factories.File()
+
+        assert not svc.get(application_instance, file_.lms_id, file_.type)
+
+
+@pytest.mark.usefixtures("application_instance_service")
+class TestFactory:
+    def test_it(self, pyramid_request):
+        file_service = factory(sentinel.context, pyramid_request)
+
+        assert isinstance(file_service, FileService)
+
+
+@pytest.fixture
+def application_instance():
+    return factories.ApplicationInstance()
+
+
+@pytest.fixture(autouse=True)
+def noise(application_instance):
+    factories.File(application_instance=application_instance)
+
+
+@pytest.fixture
+def svc(db_session):
+    return FileService(db_session)


### PR DESCRIPTION
This will be used by the Canvas service in future to look up matching files in the DB.

While `FileService` might look a little silly right now (it's just a single `get()` method) it actually does encapsulate a non-trivial amount of code and tests, keeping that complexity out of the higher-level business logic that's going to call this service in a future PR. It also provides a place for us to put other file-related methods in future if we ever need them (listing all the files in a course, searching for files by name and size, etc). It'd be the obvious place for code for bulk upserting files too.