### PR TITLE
Add CanvasService.find_matching_file_in_course()

### DIFF
--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+from lms import models
 from lms.services.exceptions import CanvasFileNotFoundInCourse
 
 
@@ -53,6 +56,29 @@ class CanvasService:
                 return True
 
         return False
+
+    def find_matching_file_in_course(
+        self, course_id: str, file_: models.File
+    ) -> Optional[str]:
+        """
+        Return the ID of a file in course_id that matches file_.
+
+        Search for a file that the current Canvas user can see in course_id and
+        that matches the given file_ (same filename and size) and return the
+        matching file's ID.
+
+        Return None if no matching file is found.
+        """
+        file_dicts = self.api.list_files(course_id)
+
+        for file_dict in file_dicts:
+            display_name = file_dict["display_name"]
+            size = file_dict["size"]
+
+            if display_name == file_.name and size == file_.size:
+                return str(file_dict["id"])
+
+        return None
 
 
 def factory(_context, request):


### PR DESCRIPTION
A future PR is going to add business logic to `CanvasService.public_url_for_file()` that will call this `CanvasService.find_matching_file_in_course()`.

I've made `find_matching_file_in_course()` a separate public method because it's a logically separate unit that *could* be used by other code outside of `CanvasService` even though it isn't going to be right now, and because having it be a separate public method encourages a good method name, good docstring, and its own separate unit tests. Small separate units instead of one big unit where a top-level public method calls lots of private methods.

When searching for a matching file in a course we do this by calling the Canvas API to get a list of all the files in the course, rather than looking in our `models.File` table in the DB, because:

* It always gets the most up to date list of files from the course, doesn't return false positives or false negatives
* It only returns the files that the current user can see, which is what we want. For example students can't see "unpublished" files but teachers can. Our `models.File` table doesn't know about this