### PR TITLE
Use shared `Modal` in `BookPicker` component

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -1,4 +1,4 @@
-import { LabeledButton } from '@hypothesis/frontend-shared';
+import { LabeledButton, Modal } from '@hypothesis/frontend-shared';
 import { createElement } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
@@ -6,7 +6,6 @@ import { useService, VitalSourceService } from '../services';
 
 import BookList from './BookList';
 import ChapterList from './ChapterList';
-import Dialog from './Dialog';
 import ErrorDisplay from './ErrorDisplay';
 
 /**
@@ -76,7 +75,7 @@ export default function BookPicker({ onCancel, onSelectBook }) {
     (step === 'select-book' && book) || (step === 'select-chapter' && chapter);
 
   return (
-    <Dialog
+    <Modal
       onCancel={onCancel}
       title={step === 'select-book' ? 'Select book' : 'Select chapter'}
       buttons={[
@@ -128,6 +127,6 @@ export default function BookPicker({ onCancel, onSelectBook }) {
           error={error}
         />
       )}
-    </Dialog>
+    </Modal>
   );
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.5",
     "@babel/preset-react": "^7.14.5",
-    "@hypothesis/frontend-shared": "3.2.0",
+    "@hypothesis/frontend-shared": "3.3.0",
     "@types/gapi": "^0.0.39",
     "autoprefixer": "^10.2.6",
     "babel-plugin-transform-async-to-promises": "^0.8.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,10 +971,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@hypothesis/frontend-shared@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.2.0.tgz#f045a046871e1fcc4f8f7e5f5ab7a4b76f1d454c"
-  integrity sha512-uV4xRGJMESN1v43Wl076aVgdSxJ/Q3YBqLBK0W1HT7TKvKbEWF4TP/ifk2D9W7NJ8ljx59pXKQQoR0mfNzBYxQ==
+"@hypothesis/frontend-shared@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.3.0.tgz#50186386e4a81e921df6d56dd10fcd452175d920"
+  integrity sha512-SRYpmjwfMbL4QB5M/a2ca8+BNiEa2z5XLdHJetJLGNpBE4xZW6brpAvZPsZJbdbqt6WJO4+wgQPnM46C8HHQdw==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
This PR bumps the `frontend-shared` package version and uses in the provided `Modal` component  in the `BookPicker` component (VitalSource). This was a very simple substitution as the component API is the same as the local LMS `Dialog`, and the tests mock imported components.

These changes only replace the Modal “shell.” The content in the book- and chapter-picking steps remains unchanged. What you should expect to see: 

* The Modal "shell" looks and behaves like our standardized Panel/Dialog/Modal patterns. This is more about standardization than beautification.
* Overflowing content scrolls correctly based on viewport constraints.

A couple of notes:

* The width of the book-picking modals in Canvas, while wide enough to accommodate the content, “looks” a little narrow. This isn’t the case in Moodle, where the modal widths feel more “correct.” This is a result of the responsive sizing of the `Modal`: the viewport size in Canvas is small enough to trigger the narrow-screen layout, while Moodle gives quite a bit more space, and gets the wider-screen layout. **Looking into this is my immediate next UI step.**
* In Canvas (smaller viewport), there isn’t enough padding around the buttons in the book-selection step when a book is selected (second of the three screenshots for Canvas:after). Because we are imminently replacing this step with a paste-a-url variant, I’m not going to track this down. The final step, chapter selection, _will_ remain, and looks fine (excepting possibly too narrow, see above) in Canvas.

I've tested this change in Canvas and Moodle, in Chrome. I can't test in Safari because of secure content restrictions. It would be superb to get this tested in more browsers and LMSes as we can...

Fixes https://github.com/hypothesis/lms/issues/2870

### Canvas: Before

<img width="818" alt="Screen Shot 2021-06-28 at 12 05 36 PM" src="https://user-images.githubusercontent.com/439947/123671705-92db8800-d80c-11eb-82b7-0fdec8dcbbd4.png">

<img width="824" alt="Screen Shot 2021-06-28 at 12 05 52 PM" src="https://user-images.githubusercontent.com/439947/123671747-9ec74a00-d80c-11eb-9ff4-4cd5d29869a4.png">

<img width="824" alt="Screen Shot 2021-06-28 at 12 05 45 PM" src="https://user-images.githubusercontent.com/439947/123671723-9838d280-d80c-11eb-87a2-37fbe582bf31.png">

### Canvas: After

<img width="817" alt="Screen Shot 2021-06-28 at 12 10 34 PM" src="https://user-images.githubusercontent.com/439947/123671814-aedf2980-d80c-11eb-9ad4-e546861c4ba1.png">

<img width="819" alt="Screen Shot 2021-06-28 at 12 10 40 PM" src="https://user-images.githubusercontent.com/439947/123671826-b0a8ed00-d80c-11eb-98a0-882acebddff4.png">

<img width="819" alt="Screen Shot 2021-06-28 at 12 10 52 PM" src="https://user-images.githubusercontent.com/439947/123671864-ba325500-d80c-11eb-8c0a-8278ec4197aa.png">


### Moodle: Before

<img width="1374" alt="Screen Shot 2021-06-28 at 12 19 59 PM" src="https://user-images.githubusercontent.com/439947/123672401-45134f80-d80d-11eb-9c7b-da0bb84f5510.png">

<img width="1373" alt="Screen Shot 2021-06-28 at 12 20 05 PM" src="https://user-images.githubusercontent.com/439947/123672414-480e4000-d80d-11eb-980d-adf070487cc6.png">

<img width="1372" alt="Screen Shot 2021-06-28 at 12 20 14 PM" src="https://user-images.githubusercontent.com/439947/123672427-4b093080-d80d-11eb-9424-36f33d87c4fc.png">

### Moodle: After

<img width="1371" alt="Screen Shot 2021-06-28 at 12 17 02 PM" src="https://user-images.githubusercontent.com/439947/123672466-552b2f00-d80d-11eb-87f7-5a322511aef3.png">

<img width="1370" alt="Screen Shot 2021-06-28 at 12 17 08 PM" src="https://user-images.githubusercontent.com/439947/123672474-58beb600-d80d-11eb-85d4-cf78f4b72a6e.png">

<img width="1368" alt="Screen Shot 2021-06-28 at 12 17 17 PM" src="https://user-images.githubusercontent.com/439947/123672481-5b211000-d80d-11eb-9ff1-2d59b63653c5.png">


