### PR TITLE
Verify cache buster in static asset requests

### DIFF
--- a/lms/assets.py
+++ b/lms/assets.py
@@ -119,23 +119,6 @@ class Environment:
         return "{}/{}".format(self.assets_base_url, manifest[path])
 
 
-def _add_cors_header(wrapped):
-    def wrapper(context, request):  # pragma: no cover
-        # Add a CORS header to the response because static assets from
-        # the sidebar are loaded into pages served by a different origin:
-        # The domain hosting the page into which the sidebar has been injected
-        # or embedded.
-        #
-        # Some browsers enforce cross-origin restrictions on certain types of
-        # resources, eg. Firefox enforces same-domain policy for @font-face
-        # unless a CORS header is provided.
-        response = wrapped(context, request)
-        response.headers.extend({"Access-Control-Allow-Origin": "*"})
-        return response
-
-    return wrapper
-
-
 def _load_bundles(file_):  # pragma: no cover
     """Read an asset bundle config from a file object."""
     parser = configparser.ConfigParser()
@@ -144,9 +127,7 @@ def _load_bundles(file_):  # pragma: no cover
 
 
 # Site assets
-ASSETS_VIEW = _add_cors_header(
-    static_view("lms:../build", cache_max_age=None, use_subpath=True)
-)
+ASSETS_VIEW = static_view("lms:../build", cache_max_age=None, use_subpath=True)
 
 
 def includeme(config):  # pragma: no cover


### PR DESCRIPTION
Static asset URLs have a cache busting query string at the end (eg. `/assets/scripts/frontend_apps.bundle.js?1234`). The query string will depend on the version of the application. This query string is used when generating asset URLs for inclusion in HTML responses, but not checked when serving requests. As a result, if a client received an HTML response from version X of the application and then requested the asset which was handled by version Y of the application, they could end up receiving version Y of the asset but cache it under the URL for version X.

This PR improves the situation by checking the cache busting query param in asset requests and returning a 404 response if it is wrong. The first commit removes an unnecessary CORS-related decorator which was copied over from h but is not relevant for the lms app. The second commit adds a decorator to static asset requests that checks the cache-buster.

There are various ways that we can reduce the likelihood of an HTML / asset mismatch when deploying the app, but this PR at least makes it so that a request with the wrong asset version is less likely to be cached downstream. For example Cloudflare uses a [3 minute](https://support.cloudflare.com/hc/en-us/articles/200172516-Understanding-Cloudflare-s-CDN#h_51422705-42d0-450d-8eb1-5321dcadb5bc) rather than 120 minute cache expiry for 404 responses. This change will also surface any scenarios where an HTML page is served with outdated asset URLs or asset URLs that do not include the cache-buster for any reason.

Part of https://github.com/hypothesis/lms/issues/2799.

----

TODO: Add/update tests