### PR TITLE
Add AssignmentService.{get,set}_canvas_mapped_file_id()

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -59,6 +59,26 @@ class AssignmentService:
         # just one key from the cache, you have to clear the entire cache.)
         self.get.cache_clear()
 
+    def get_canvas_mapped_file_id(
+        self, tool_consumer_instance_guid, resource_link_id, file_id
+    ):
+        mic = self.get(tool_consumer_instance_guid, resource_link_id)
+
+        if not mic:
+            return None
+
+        return mic.extra.get("canvas_file_mappings", {}).get(file_id)
+
+    def set_canvas_mapped_file_id(
+        self, tool_consumer_instance_guid, resource_link_id, file_id, mapped_file_id
+    ):
+        mic = self.get(tool_consumer_instance_guid, resource_link_id)
+
+        if not mic:
+            raise ValueError("ModuleItemConfiguration not found")
+
+        mic.extra.setdefault("canvas_file_mappings", {})[file_id] = mapped_file_id
+
 
 def factory(_context, request):
     return AssignmentService(db=request.db)

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -60,6 +60,69 @@ class TestAssignmentService:
 
         assert assignment.document_url == "NEW_DOCUMENT_URL"
 
+    def test_get_canvas_mapped_file_id_returns_None_if_the_assignment_doesnt_exist(
+        self, svc
+    ):
+        assert not svc.get_canvas_mapped_file_id(
+            "unknown_resource_link_id", "unknown_resource_link_id", "file_id"
+        )
+
+    def test_set_canvas_mapped_file_id_creates_a_new_mapping_if_none_exists(
+        self, assignment, svc
+    ):
+        svc.set_canvas_mapped_file_id(
+            assignment.tool_consumer_instance_guid,
+            assignment.resource_link_id,
+            "original_file_id",
+            "mapped_file_id",
+        )
+
+        assert (
+            svc.get_canvas_mapped_file_id(
+                assignment.tool_consumer_instance_guid,
+                assignment.resource_link_id,
+                "original_file_id",
+            )
+            == "mapped_file_id"
+        )
+
+    def test_set_canvas_mapped_file_id_overwrites_an_existing_mapping_if_one_exists(
+        self, assignment, svc
+    ):
+        svc.set_canvas_mapped_file_id(
+            assignment.tool_consumer_instance_guid,
+            assignment.resource_link_id,
+            "original_file_id",
+            "mapped_file_id",
+        )
+
+        svc.set_canvas_mapped_file_id(
+            assignment.tool_consumer_instance_guid,
+            assignment.resource_link_id,
+            "original_file_id",
+            "new_mapped_file_id",
+        )
+
+        assert (
+            svc.get_canvas_mapped_file_id(
+                assignment.tool_consumer_instance_guid,
+                assignment.resource_link_id,
+                "original_file_id",
+            )
+            == "new_mapped_file_id"
+        )
+
+    def test_set_canvas_mapped_file_id_raises_ValueError_if_the_assignment_doesnt_exist(
+        self, svc
+    ):
+        with pytest.raises(ValueError):
+            svc.set_canvas_mapped_file_id(
+                "unknown_tool_consumer_instance_guid",
+                "unknown_resource_link_id",
+                "original_file_id",
+                "new_mapped_file_id",
+            )
+
     @pytest.fixture
     def assignment(self):
         return factories.ModuleItemConfiguration()


### PR DESCRIPTION
This was already approved in a previous PR (https://github.com/hypothesis/lms/pull/2878) but then got lost in some rebase confusion (that PR got merged into _another_ PR and then got rebased out of that other PR before the other PR was merged into master).