### PR TITLE
Fix Canvas course copy

### DIFF
--- a/lms/models/module_item_configuration.py
+++ b/lms/models/module_item_configuration.py
@@ -52,7 +52,7 @@ class ModuleItemConfiguration(BASE):
     )
 
     def get_canvas_mapped_file_id(self, file_id):
-        return self.extra.get("canvas_file_mappings", {}).get(file_id)
+        return self.extra.get("canvas_file_mappings", {}).get(file_id) or file_id
 
     def set_canvas_mapped_file_id(self, file_id, mapped_file_id):
         self.extra.setdefault("canvas_file_mappings", {})[file_id] = mapped_file_id

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -55,11 +55,13 @@ class CanvasService:
             if not found_file_id:
                 raise
 
+            # Try again to return a public URL, this time using found_file_id.
+            url = self.api.public_url(found_file_id)
+
             # Store a mapping so we don't have to re-search next time.
             module_item_configuration.set_canvas_mapped_file_id(file_id, found_file_id)
 
-            # Try again to return a public URL, this time using found_file_id.
-            return self.api.public_url(found_file_id)
+            return url
 
 
 class CanvasFileFinder:

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -45,6 +45,10 @@ class CanvasService:
             file_ = self._file_service.get(effective_file_id, type_="canvas_file")
 
             if not file_:
+                # We don't have a record of the assignment's file in our DB.
+                # This can happen, for example, if Hypothesis has not been
+                # launched in the original assignment's course since we
+                # deployed the code that started recording files in the DB.
                 raise
 
             # Look for a copy of the assignment's file that the current user
@@ -52,6 +56,10 @@ class CanvasService:
             found_file_id = self.find_matching_file_in_course(course_id, file_)
 
             if not found_file_id:
+                # We didn't find a matching file in the current course.
+                # This could mean that the file has been deleted, has been
+                # renamed, or the current user doesn't have permission to see
+                # the file.
                 raise
 
             # We found a matching copy of the assignment's file that the

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from lms import models
-from lms.services.exceptions import CanvasFileNotFoundInCourse
+from lms.services.exceptions import CanvasAPIPermissionError, CanvasFileNotFoundInCourse
 
 
 class CanvasService:
@@ -9,28 +9,63 @@ class CanvasService:
 
     api = None
 
-    def __init__(self, canvas_api):
+    def __init__(self, canvas_api, file_service):
         self.api = canvas_api
+        self._file_service = file_service
 
-    def public_url_for_file(self, file_id, course_id, check_in_course=False):
-        """
-        Get a public URL for a Canvas file.
+    def public_url_for_file(
+        self, module_item_configuration, file_id, course_id, check_in_course=False
+    ):
+        mapped_file_id = module_item_configuration.get_canvas_mapped_file_id(file_id)
 
-        This will also attempt to check if the file is in the course to detect
-        course copy situations and fix it if we can.
+        # If there's a previously stored mapping for file_id use that instead.
+        effective_file_id = mapped_file_id or file_id
 
-        :param file_id: The file to look up
-        :param course_id: The course the file should be in
-        :param check_in_course: Raise CanvasFileNotFoundInCourse if file_id isn't in
-            course_id
-        :return: A URL suitable for public presentation of the file
-        :raise  CanvasFileNotFoundInCourse: if check_in_course=True and file_id isn't in course_id
-            be in the course but isn't.
-        """
+        try:
+            return self._public_url(
+                effective_file_id,
+                course_id=course_id if check_in_course else None,
+            )
+        except (CanvasFileNotFoundInCourse, CanvasAPIPermissionError):
+            # Either the user can't see the file in the current course's list
+            # of files or the user got a permissions error from the Canvas API
+            # when trying to get a public URL for the file.
+            #
+            # This can happen because the course has been copied and the
+            # assignment's file_id is from the original course. Or it can
+            # happen because the assignment's file has been deleted from
+            # Canvas. Or it can happen because the user doesn't have permission
+            # to see the file ("unpublished" files in Canvas are visible to
+            # instructors but not to students).
+            #
+            # We'll try to find another copy of the same file that the current
+            # user *can* see in the current course and use that instead.
 
-        if check_in_course:
-            if not self.can_see_file_in_course(file_id, course_id):
-                raise CanvasFileNotFoundInCourse(file_id)
+            # Look for a previously saved record of the assignment's file in our DB.
+            file_ = self._file_service.get(effective_file_id, type_="canvas_file")
+
+            if not file_:
+                raise
+
+            # Look for a copy of the assignment's file that the current user
+            # *can* see in the current course.
+            found_file_id = self.find_matching_file_in_course(course_id, file_)
+
+            if not found_file_id:
+                raise
+
+            # We found a matching copy of the assignment's file that the
+            # current user *can* see in the current course. Store a mapping so
+            # that we don't have to re-do the search the next time the
+            # assignment is launched.
+            module_item_configuration.set_canvas_mapped_file_id(file_id, found_file_id)
+
+            # Try again using the found matching file.
+            return self._public_url(found_file_id)
+
+    def _public_url(self, file_id, course_id=None):
+        if course_id and not self.can_see_file_in_course(file_id, course_id):
+            raise CanvasFileNotFoundInCourse(file_id)
 
         return self.api.public_url(file_id)
 
@@ -82,4 +117,7 @@ class CanvasService:
 
 
 def factory(_context, request):
-    return CanvasService(canvas_api=request.find_service(name="canvas_api_client"))
+    return CanvasService(
+        canvas_api=request.find_service(name="canvas_api_client"),
+        file_service=request.find_service(name="file"),
+    )

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -86,7 +86,7 @@ class CanvasFileFinder:
         self, course_id: str, file_id: str
     ) -> Optional[str]:
         """
-        Return the ID of a file in course_id that matches `file`.
+        Return the ID of a file in course_id that matches the file with ID file_id.
 
         Search for a file that the current Canvas user can see in course_id and
         that matches the given `file` (same filename and size) and return the

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -57,9 +57,9 @@ class CanvasService:
             # user *can* see in the current course and use that instead.
 
             # Look for a previously saved record of the assignment's file in our DB.
-            file_ = self._file_service.get(effective_file_id, type_="canvas_file")
+            file = self._file_service.get(effective_file_id, type_="canvas_file")
 
-            if not file_:
+            if not file:
                 # We don't have a record of the assignment's file in our DB.
                 # This can happen, for example, if Hypothesis has not been
                 # launched in the original assignment's course since we
@@ -68,7 +68,7 @@ class CanvasService:
 
             # Look for a copy of the assignment's file that the current user
             # *can* see in the current course.
-            found_file_id = self.find_matching_file_in_course(course_id, file_)
+            found_file_id = self.find_matching_file_in_course(course_id, file)
 
             if not found_file_id:
                 # We didn't find a matching file in the current course.
@@ -98,23 +98,23 @@ class CanvasService:
         marked as "unpublished" in Canvas can only be seen by teachers, not
         students).
         """
-        for file_ in self.api.list_files(course_id):
+        for file in self.api.list_files(course_id):
             # The Canvas API returns file IDs as ints but the file_id param
             # that this method receives (from our proxy API) is a string.
             # Convert ints to strings so that we can compare them.
-            if str(file_["id"]) == file_id:
+            if str(file["id"]) == file_id:
                 return
 
         raise CanvasFileNotFoundInCourse(file_id)
 
     def find_matching_file_in_course(
-        self, course_id: str, file_: models.File
+        self, course_id: str, file: models.File
     ) -> Optional[str]:
         """
-        Return the ID of a file in course_id that matches file_.
+        Return the ID of a file in course_id that matches `file`.
 
         Search for a file that the current Canvas user can see in course_id and
-        that matches the given file_ (same filename and size) and return the
+        that matches the given `file` (same filename and size) and return the
         matching file's ID.
 
         Return None if no matching file is found.
@@ -125,7 +125,7 @@ class CanvasService:
             display_name = file_dict["display_name"]
             size = file_dict["size"]
 
-            if display_name == file_.name and size == file_.size:
+            if display_name == file.name and size == file.size:
                 return str(file_dict["id"])
 
         return None

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -16,6 +16,22 @@ class CanvasService:
     def public_url_for_file(
         self, module_item_configuration, file_id, course_id, check_in_course=False
     ):
+        """
+        Return a public URL for file_id.
+
+        :param module_item_configuration: the ModuleItemConfiguration for the
+            current assignment
+        :param file_id: the Canvas API ID of the file
+        :param course_id: the Canvas API ID of the course that the file is in
+        :param check_in_course: whether to check that file_id is in course_id
+
+        :raise CanvasFileNotFoundInCourse: if check_in_course was True and the
+            current user can't see file_id in course_id's list of files
+
+        :raise CanvasAPIPermissionError: if the user gets a permissions error
+            from the Canvas API when trying to get a public URL for file_id
+        """
+
         mapped_file_id = module_item_configuration.get_canvas_mapped_file_id(file_id)
 
         # If there's a previously stored mapping for file_id use that instead.

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -35,7 +35,7 @@ class CanvasService:
 
         try:
             if check_in_course:
-                self._finder.assert_file_in_course(effective_file_id, course_id)
+                self._finder.assert_file_in_course(course_id, effective_file_id)
             return self.api.public_url(effective_file_id)
         except (CanvasFileNotFoundInCourse, CanvasAPIPermissionError):
             # The user can't see the file in the course. This could be because:
@@ -71,7 +71,7 @@ class CanvasFileFinder:
         self._api = canvas_api
         self._file_service = file_service
 
-    def assert_file_in_course(self, file_id: str, course_id: str) -> bool:
+    def assert_file_in_course(self, course_id: str, file_id: str) -> bool:
         """Raise if the current user can't see file_id in course_id."""
         for file in self._api.list_files(course_id):
             # The Canvas API returns file IDs as ints but the file_id param

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -102,8 +102,9 @@ class CanvasFileFinder:
         for file_dict in file_dicts:
             display_name = file_dict["display_name"]
             size = file_dict["size"]
+            id_ = str(file_dict["id"])
 
-            if display_name == file.name and size == file.size:
+            if display_name == file.name and size == file.size and id_ != file.lms_id:
                 return str(file_dict["id"])
 
         return None

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -30,12 +30,19 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
+        application_instance = self.request.find_service(
+            name="application_instance"
+        ).get()
+
+        module_item_configuration = self.request.find_service(name="assignment").get(
+            application_instance.tool_consumer_instance_guid,
+            self.request.matchdict["resource_link_id"],
+        )
+
         public_url = self.canvas.public_url_for_file(
-            file_id=self.request.matchdict["file_id"],
-            course_id=self.request.matchdict["course_id"],
-            # Teachers can have broad permissions and see files that aren't in
-            # the course. So do this slower check (extra API call) to warn the
-            # teacher that their students might not be able to see the file.
+            module_item_configuration,
+            self.request.matchdict["file_id"],
+            self.request.matchdict["course_id"],
             check_in_course=self.request.lti_user.is_instructor,
         )
 

--- a/tests/unit/lms/models/module_item_configuration_test.py
+++ b/tests/unit/lms/models/module_item_configuration_test.py
@@ -18,6 +18,11 @@ class TestModuleItemConfiguration:
 
         assert mic.get_canvas_mapped_file_id("original_file_id") == "new_mapped_file_id"
 
+    def test_get_canvas_mapped_file_id_returns_the_given_file_id_if_no_mapping_exists(
+        self, mic
+    ):
+        assert mic.get_canvas_mapped_file_id("file_id") == "file_id"
+
     @pytest.fixture
     def mic(self, db_session):
         mic = ModuleItemConfiguration(

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,3 +1,4 @@
+from functools import partial
 from unittest.mock import DEFAULT, call, sentinel
 
 import pytest
@@ -12,210 +13,165 @@ from tests import factories
 
 
 class TestPublicURLForFile:
-    def test_without_check_in_course(
-        self,
-        canvas_service,
-        canvas_api_client,
-        module_item_configuration,
-        file_id_from_current_course,
+    def test_without_check_in_course_and_without_a_mapped_file_id(
+        self, canvas_service, file_from_current_course, public_url_for_file
     ):
-        # This is what happens during a normal student assignment launch.
-        url = canvas_service.public_url_for_file(
-            module_item_configuration, file_id_from_current_course, sentinel.course_id
-        )
+        # This is what happens during a normal student assignment launch:
+        # check_in_course is False and there's no mapped_file_id in the DB.
+
+        url = public_url_for_file(file_id=str(file_from_current_course["id"]))
 
         # check_in_course was False, so it didn't call list_files() to check
         # whether the file_id was in the course.
-        canvas_api_client.list_files.assert_not_called()
+        canvas_service.api.list_files.assert_not_called()
 
         # It calls the Canvas API with the file_id and returns the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
+        canvas_service.api.public_url.assert_called_once_with(
+            str(file_from_current_course["id"])
         )
-        assert url == canvas_api_client.public_url.return_value
+        assert url == canvas_service.api.public_url.return_value
 
-    def test_with_check_in_course(
-        self,
-        canvas_service,
-        canvas_api_client,
-        module_item_configuration,
-        file_id_from_current_course,
+    def test_if_check_in_course_is_True_it_checks_that_the_file_is_in_the_course(
+        self, canvas_service, file_from_current_course, public_url_for_file
     ):
-        # This is what happens during a normal instructor launch.
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_current_course,
-            sentinel.course_id,
-            check_in_course=True,
+        # This is what happens during a normal instructor launch;
+        # check_in_course is True and there's no mapped_file_id in the DB.
+
+        url = public_url_for_file(
+            file_id=str(file_from_current_course["id"]), check_in_course=True
         )
 
         # check_in_course was True so it called list_files() to check whether
         # file_id was in the course.
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
 
         # It calls the Canvas API with the file_id and returns the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
+        canvas_service.api.public_url.assert_called_once_with(
+            str(file_from_current_course["id"])
         )
-        assert url == canvas_api_client.public_url.return_value
+        assert url == canvas_service.api.public_url.return_value
 
-    def test_with_mapped_file_id_and_without_check_in_course(
+    def test_if_theres_a_mapped_file_id_it_uses_it(
         self,
         canvas_service,
-        canvas_api_client,
         module_item_configuration,
-        file_id_from_current_course,
-        file_id_from_a_different_course,
+        file_from_current_course,
+        file_from_a_different_course,
+        public_url_for_file,
     ):
-        # This is what happens when a student launches a course-copied
-        # assignment that has already been fixed (we've already stored a
+        # If there's a mapped_file_id in the DB it gets used instead of the
+        # given file_id.
+        #
+        # This is what happens when a user launches a course-copied assignment
+        # that has previously been fixed (we've previously stored a
         # mapped_file_id in the DB).
 
         # Store a mapped_file_id in the DB. This would have been done by a
         # previous request.
         module_item_configuration.set_canvas_mapped_file_id(
-            file_id_from_a_different_course, file_id_from_current_course
+            str(file_from_a_different_course["id"]), str(file_from_current_course["id"])
         )
 
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_a_different_course,
-            sentinel.course_id,
+        url = public_url_for_file(
+            file_id=str(file_from_a_different_course["id"]), check_in_course=True
         )
 
-        # check_in_course was False, so it didn't call list_files() to check
-        # whether the file_id was in the course.
-        canvas_api_client.list_files.assert_not_called()
+        # It checks that the mapped_file_id is in the course (not the original file_id).
+        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
 
         # It called public_url() with the mapped_file_id rather than with the
         # original file_id, and returned the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
+        canvas_service.api.public_url.assert_called_once_with(
+            str(file_from_current_course["id"])
         )
-        assert url == canvas_api_client.public_url.return_value
-
-    def test_with_mapped_file_id_and_check_in_course(
-        self,
-        canvas_service,
-        canvas_api_client,
-        module_item_configuration,
-        file_id_from_current_course,
-        file_id_from_a_different_course,
-    ):
-        # This is what happens when an instructor launches a course-copied
-        # assignment that has already been fixed (we've already stored a
-        # mapped_file_id in the DB).
-
-        # Store a mapped_file_id in the DB. This would have been done by a
-        # previous request.
-        module_item_configuration.set_canvas_mapped_file_id(
-            file_id_from_a_different_course, file_id_from_current_course
-        )
-
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_a_different_course,
-            sentinel.course_id,
-            check_in_course=True,
-        )
-
-        # check_in_course was True so it called list_files() to check whether
-        # mapped_file_id was in the course.
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
-
-        # It called public_url() with the mapped_file_id rather than with the
-        # original file_id, and returned the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
-        )
-        assert url == canvas_api_client.public_url.return_value
+        assert url == canvas_service.api.public_url.return_value
 
     def test_file_not_found_in_course_and_matching_file_found(
         self,
         canvas_service,
-        canvas_api_client,
-        module_item_configuration,
         file_service,
+        module_item_configuration,
         file_from_current_course,
-        file_id_from_current_course,
-        file_id_from_a_different_course,
+        file_from_a_different_course,
+        public_url_for_file,
     ):
         # This is what happens when an instructor launches an assignment whose
         # file_id is *not* in the current course.
-
-        # We *do* have a models.File object for the file_id in the DB, and its
-        # name and size *do* match one of the files in the current course in Canvas.
         file_service.get.return_value = factories.File(
             name=file_from_current_course["display_name"],
             size=file_from_current_course["size"],
         )
 
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_a_different_course,
-            sentinel.course_id,
-            check_in_course=True,
+        url = public_url_for_file(
+            file_id=str(file_from_a_different_course["id"]), check_in_course=True
         )
 
-        # check_in_course was True so it called list_files() to check whether
-        # file_id was in the course.
-        #
-        # There's also a second call to list_files() because it calls it again
-        # to look for a matching file in the current course. This does not make
-        # two network requests because CanvasAPIClient.list_files() has
-        # caching.
-        assert canvas_api_client.list_files.call_args_list == [
-            call(sentinel.course_id),
-            call(sentinel.course_id),
-        ]
-        # It looks up the given file_id in the DB.
+        # It looked up the given file_id in the DB.
         file_service.get.assert_called_once_with(
-            file_id_from_a_different_course, type_="canvas_file"
+            str(file_from_a_different_course["id"]), type_="canvas_file"
         )
-        # It stores a file mapping from the given file_id to the matching
-        # found_file_id so that it doesn't have to re-do the search the next
-        # time the assignment is launched.
-        assert (
-            module_item_configuration.get_canvas_mapped_file_id(
-                file_id_from_a_different_course
-            )
-            == file_id_from_current_course
+        # It stored a mapping from the given file_id to found_file_id.
+        assert module_item_configuration.get_canvas_mapped_file_id(
+            str(file_from_a_different_course["id"])
+        ) == str(file_from_current_course["id"])
+        # It got the found_file_id's public URL and returned it.
+        canvas_service.api.public_url.assert_called_once_with(
+            str(file_from_current_course["id"])
         )
-        # It calls public_url() with the found_file_id and returns the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
-        )
-        assert url == canvas_api_client.public_url.return_value
+        assert url == canvas_service.api.public_url.return_value
 
-    def test_file_not_found_in_course_but_no_file_info(
+    def test_permissions_error_and_matching_file_found(
         self,
         canvas_service,
-        module_item_configuration,
         file_service,
-        file_id_from_a_different_course,
+        module_item_configuration,
+        file_from_current_course,
+        file_from_a_different_course,
+        public_url_for_file,
+    ):
+        # This is what happens when a student launches an assignment whose
+        # file_id is *not* in the current course.
+        canvas_service.api.public_url.side_effect = [CanvasAPIPermissionError, DEFAULT]
+        file_service.get.return_value = factories.File(
+            name=file_from_current_course["display_name"],
+            size=file_from_current_course["size"],
+        )
+
+        url = public_url_for_file(file_id=str(file_from_a_different_course["id"]))
+
+        # It looked up the given file_id in the DB.
+        file_service.get.assert_called_once_with(
+            str(file_from_a_different_course["id"]), type_="canvas_file"
+        )
+        # It stored a mapping from the given file_id to found_file_id.
+        assert module_item_configuration.get_canvas_mapped_file_id(
+            str(file_from_a_different_course["id"])
+        ) == str(file_from_current_course["id"])
+        # It got found_file_id's public URL and returned it.
+        assert canvas_service.api.public_url.call_args_list == [
+            call(str(file_from_a_different_course["id"])),
+            call(str(file_from_current_course["id"])),
+        ]
+        assert url == canvas_service.api.public_url.return_value
+
+    def test_file_not_found_in_course_but_no_file_info(
+        self, file_service, file_from_a_different_course, public_url_for_file
     ):
         # This is what happens when a teacher launches an assignment whose
         # file_id is *not* in the current course and we don't have a record of
-        # the file_id in our DB.  Without a record we can't search for a
+        # the file_id in our DB. Without a record we can't search for a
         # matching file so we raise an error.
 
         # There's no record of the file_id in the DB.
         file_service.get.return_value = None
 
         with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_service.public_url_for_file(
-                module_item_configuration,
-                file_id_from_a_different_course,
-                sentinel.course_id,
-                check_in_course=True,
+            public_url_for_file(
+                str(file_from_a_different_course["id"]), check_in_course=True
             )
 
     def test_file_not_found_in_course_but_no_matching_file(
-        self,
-        canvas_service,
-        module_item_configuration,
-        file_service,
-        file_id_from_a_different_course,
+        self, file_service, file_from_a_different_course, public_url_for_file
     ):
         # This is what happens when a teacher launches an assignment whose
         # file_id is *not* in the current course and even though we do have a
@@ -228,116 +184,47 @@ class TestPublicURLForFile:
         file_service.get.return_value = factories.File(name="foo")
 
         with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_service.public_url_for_file(
-                module_item_configuration,
-                file_id_from_a_different_course,
-                sentinel.course_id,
-                check_in_course=True,
+            public_url_for_file(
+                file_id=str(file_from_a_different_course["id"]), check_in_course=True
             )
-
-    def test_permissions_error_and_matching_file_found(
-        self,
-        canvas_service,
-        canvas_api_client,
-        module_item_configuration,
-        file_service,
-        file_from_current_course,
-        file_id_from_current_course,
-        file_id_from_a_different_course,
-    ):
-        # This is what happens when a student launches an assignment whose
-        # file_id is *not* in the current course.
-
-        # The code is going to call public_url() twice. The first call is with
-        # the original file_id and public_url() raises a permissions error. The
-        # second call is with the matching found_file_id and public_url()
-        # successfully returns a URL.
-        canvas_api_client.public_url.side_effect = [CanvasAPIPermissionError, DEFAULT]
-
-        # We *do* have a models.File object for the file_id in the DB, and its
-        # name and size *do* match one of the files in the current course in Canvas.
-        file_service.get.return_value = factories.File(
-            name=file_from_current_course["display_name"],
-            size=file_from_current_course["size"],
-        )
-
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_a_different_course,
-            sentinel.course_id,
-        )
-
-        # It looks up the given file_id in the DB.
-        file_service.get.assert_called_once_with(
-            file_id_from_a_different_course, type_="canvas_file"
-        )
-        # It calls list_files() to look for a matching file in the current course.
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
-        # It stores a file mapping from the given file_id to the matching
-        # found_file_id so that it doesn't have to re-do the search the next
-        # time the assignment is launched.
-        assert (
-            module_item_configuration.get_canvas_mapped_file_id(
-                file_id_from_a_different_course
-            )
-            == file_id_from_current_course
-        )
-        # It calls public_url() twice: one with the original file_id and once
-        # with the matching found_file_id.
-        assert canvas_api_client.public_url.call_args_list == [
-            call(file_id_from_a_different_course),
-            call(file_id_from_current_course),
-        ]
-        # It returns the public URL of the file in the current course.
-        assert url == canvas_api_client.public_url.return_value
 
     def test_permissions_error_but_no_file_info(
         self,
         canvas_service,
-        canvas_api_client,
-        module_item_configuration,
         file_service,
-        file_id_from_a_different_course,
+        file_from_a_different_course,
+        public_url_for_file,
     ):
         # This is what happens when a student launches an assignment whose
         # file_id is *not* in the current course and we don't have a record of
         # the file_id in our DB. Without a record we can't search for a
         # matching file so we raise an error.
-        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
         file_service.get.return_value = None
 
         with pytest.raises(CanvasAPIPermissionError):
-            canvas_service.public_url_for_file(
-                module_item_configuration,
-                file_id_from_a_different_course,
-                sentinel.course_id,
-            )
+            public_url_for_file(file_id=str(file_from_a_different_course["id"]))
 
     def test_permissions_error_but_no_matching_file(
         self,
         canvas_service,
-        canvas_api_client,
-        module_item_configuration,
         file_service,
-        file_id_from_a_different_course,
+        file_from_a_different_course,
+        public_url_for_file,
     ):
         # This is what happens when a student launches an assignment whose
         # file_id is *not* in the current course and even though we do have a
         # record of this file_id in our DB we don't find a matching file in the
         # current course. Since we can't find a matching file we can't fix the
         # assignment so we raise an error.
-        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
 
         # The file record that we find in our DB. Its name doesn't match any
         # file in the current course.
         file_service.get.return_value = factories.File(name="foo")
 
         with pytest.raises(CanvasAPIPermissionError):
-            canvas_service.public_url_for_file(
-                module_item_configuration,
-                file_id_from_a_different_course,
-                sentinel.course_id,
-            )
+            public_url_for_file(file_id=str(file_from_a_different_course["id"]))
 
     @pytest.fixture
     def module_item_configuration(self, db_session):
@@ -346,24 +233,22 @@ class TestPublicURLForFile:
         return module_item_configuration
 
     @pytest.fixture
-    def file_from_current_course(self, canvas_api_client):
-        """Return the Canvas API file dict for a file that *is* in the current course."""
-        return canvas_api_client.list_files.return_value[1]
+    def public_url_for_file(self, canvas_service, module_item_configuration):
+        return partial(
+            canvas_service.public_url_for_file,
+            module_item_configuration,
+            course_id=sentinel.course_id,
+        )
 
     @pytest.fixture
-    def file_id_from_current_course(self, file_from_current_course):
-        """Return the ID of a file from the current course, as a string."""
-        return str(file_from_current_course["id"])
+    def file_from_current_course(self, canvas_service):
+        """Return the Canvas API file dict for a file that *is* in the current course."""
+        return canvas_service.api.list_files.return_value[1]
 
     @pytest.fixture
     def file_from_a_different_course(self):
         """Return the Canvas API file dict for a file from a *different* course."""
         return {"id": 4, "display_name": "File 4", "size": 4096}
-
-    @pytest.fixture
-    def file_id_from_a_different_course(self, file_from_a_different_course):
-        """Return the ID of a file from a *different* course, as a string."""
-        return str(file_from_a_different_course["id"])
 
 
 class TestAssertFileInCourse:
@@ -377,10 +262,10 @@ class TestAssertFileInCourse:
 
 class TestFindMatchingFileInCourse:
     def test_it_returns_the_id_if_theres_a_matching_file_in_the_course(
-        self, canvas_service, canvas_api_client
+        self, canvas_service
     ):
         # The file dict from the Canvas API that we expect the search to match.
-        matching_file_dict = canvas_api_client.list_files.return_value[1]
+        matching_file_dict = canvas_service.api.list_files.return_value[1]
 
         file_ = factories.File(
             name=matching_file_dict["display_name"],
@@ -391,7 +276,7 @@ class TestFindMatchingFileInCourse:
             sentinel.course_id, file_
         )
 
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
         assert matching_file_id == str(matching_file_dict["id"])
 
     def test_it_returns_None_if_theres_no_matching_file_in_the_course(
@@ -418,12 +303,8 @@ class TestFactory:
 
 @pytest.fixture
 def canvas_service(canvas_api_client, file_service):
-    return CanvasService(canvas_api_client, file_service)
-
-
-@pytest.fixture
-def canvas_api_client(canvas_api_client):
-    canvas_api_client.list_files.return_value = [
+    canvas_service = CanvasService(canvas_api_client, file_service)
+    canvas_service.api.list_files.return_value = [
         {"id": 1, "display_name": "File 1", "size": 1024},
         {
             "id": 2,
@@ -436,4 +317,4 @@ def canvas_api_client(canvas_api_client):
             "size": 3072,
         },
     ]
-    return canvas_api_client
+    return canvas_service

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,29 +1,369 @@
-from unittest.mock import sentinel
+from unittest.mock import DEFAULT, call, sentinel
 
 import pytest
 
-from lms.services import CanvasFileNotFoundInCourse, CanvasService
+from lms.services import (
+    CanvasAPIPermissionError,
+    CanvasFileNotFoundInCourse,
+    CanvasService,
+)
 from lms.services.canvas import factory
 from tests import factories
 
 
 class TestPublicURLForFile:
-    @pytest.mark.parametrize("check_in_course", (True, False))
-    def test_public_url_for_file(self, canvas_service, check_in_course):
-        result = canvas_service.public_url_for_file(
-            file_id="2", check_in_course=check_in_course, course_id="*any*"
+    def test_without_check_in_course(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_id_from_current_course,
+    ):
+        # This is what happens during a normal student assignment launch.
+        url = canvas_service.public_url_for_file(
+            module_item_configuration, file_id_from_current_course, sentinel.course_id
         )
 
-        assert result == canvas_service.api.public_url.return_value
-        canvas_service.api.public_url.assert_called_once_with("2")
+        # check_in_course was False, so it didn't call list_files() to check
+        # whether the file_id was in the course.
+        canvas_api_client.list_files.assert_not_called()
 
-    def test_public_url_for_file_with_unsuccessful_file_check(self, canvas_service):
-        canvas_service.api.list_files.return_value = []
+        # It calls the Canvas API with the file_id and returns the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_with_check_in_course(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_id_from_current_course,
+    ):
+        # This is what happens during a normal instructor launch.
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_current_course,
+            sentinel.course_id,
+            check_in_course=True,
+        )
+
+        # check_in_course was True so it called list_files() to check whether
+        # file_id was in the course.
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+
+        # It calls the Canvas API with the file_id and returns the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_with_mapped_file_id_and_without_check_in_course(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_id_from_current_course,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a student launches a course-copied
+        # assignment that has already been fixed (we've already stored a
+        # mapped_file_id in the DB).
+
+        # Store a mapped_file_id in the DB. This would have been done by a
+        # previous request.
+        module_item_configuration.set_canvas_mapped_file_id(
+            file_id_from_a_different_course, file_id_from_current_course
+        )
+
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_a_different_course,
+            sentinel.course_id,
+        )
+
+        # check_in_course was False, so it didn't call list_files() to check
+        # whether the file_id was in the course.
+        canvas_api_client.list_files.assert_not_called()
+
+        # It called public_url() with the mapped_file_id rather than with the
+        # original file_id, and returned the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_with_mapped_file_id_and_check_in_course(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_id_from_current_course,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when an instructor launches a course-copied
+        # assignment that has already been fixed (we've already stored a
+        # mapped_file_id in the DB).
+
+        # Store a mapped_file_id in the DB. This would have been done by a
+        # previous request.
+        module_item_configuration.set_canvas_mapped_file_id(
+            file_id_from_a_different_course, file_id_from_current_course
+        )
+
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_a_different_course,
+            sentinel.course_id,
+            check_in_course=True,
+        )
+
+        # check_in_course was True so it called list_files() to check whether
+        # mapped_file_id was in the course.
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+
+        # It called public_url() with the mapped_file_id rather than with the
+        # original file_id, and returned the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_file_not_found_in_course_and_matching_file_found(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_service,
+        file_from_current_course,
+        file_id_from_current_course,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when an instructor launches an assignment whose
+        # file_id is *not* in the current course.
+
+        # We *do* have a models.File object for the file_id in the DB, and its
+        # name and size *do* match one of the files in the current course in Canvas.
+        file_service.get.return_value = factories.File(
+            name=file_from_current_course["display_name"],
+            size=file_from_current_course["size"],
+        )
+
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_a_different_course,
+            sentinel.course_id,
+            check_in_course=True,
+        )
+
+        # check_in_course was True so it called list_files() to check whether
+        # file_id was in the course.
+        #
+        # There's also a second call to list_files() because it calls it again
+        # to look for a matching file in the current course. This does not make
+        # two network requests because CanvasAPIClient.list_files() has
+        # caching.
+        assert canvas_api_client.list_files.call_args_list == [
+            call(sentinel.course_id),
+            call(sentinel.course_id),
+        ]
+        # It looks up the given file_id in the DB.
+        file_service.get.assert_called_once_with(
+            file_id_from_a_different_course, type_="canvas_file"
+        )
+        # It stores a file mapping from the given file_id to the matching
+        # found_file_id so that it doesn't have to re-do the search the next
+        # time the assignment is launched.
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(
+                file_id_from_a_different_course
+            )
+            == file_id_from_current_course
+        )
+        # It calls public_url() with the found_file_id and returns the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_file_not_found_in_course_but_no_file_info(
+        self,
+        canvas_service,
+        module_item_configuration,
+        file_service,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a teacher launches an assignment whose
+        # file_id is *not* in the current course and we don't have a record of
+        # the file_id in our DB.  Without a record we can't search for a
+        # matching file so we raise an error.
+
+        # There's no record of the file_id in the DB.
+        file_service.get.return_value = None
 
         with pytest.raises(CanvasFileNotFoundInCourse):
             canvas_service.public_url_for_file(
-                file_id="2", course_id=sentinel.course_id, check_in_course=True
+                module_item_configuration,
+                file_id_from_a_different_course,
+                sentinel.course_id,
+                check_in_course=True,
             )
+
+    def test_file_not_found_in_course_but_no_matching_file(
+        self,
+        canvas_service,
+        module_item_configuration,
+        file_service,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a teacher launches an assignment whose
+        # file_id is *not* in the current course and even though we do have a
+        # record of this file_id in our DB we don't find a matching file in the
+        # current course. Since we can't find a matching file we can't fix the
+        # assignment so we raise an error.
+
+        # The file record that we find in our DB. Its name doesn't match any
+        # file in the current course.
+        file_service.get.return_value = factories.File(name="foo")
+
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            canvas_service.public_url_for_file(
+                module_item_configuration,
+                file_id_from_a_different_course,
+                sentinel.course_id,
+                check_in_course=True,
+            )
+
+    def test_permissions_error_and_matching_file_found(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_service,
+        file_from_current_course,
+        file_id_from_current_course,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a student launches an assignment whose
+        # file_id is *not* in the current course.
+
+        # The code is going to call public_url() twice. The first call is with
+        # the original file_id and public_url() raises a permissions error. The
+        # second call is with the matching found_file_id and public_url()
+        # successfully returns a URL.
+        canvas_api_client.public_url.side_effect = [CanvasAPIPermissionError, DEFAULT]
+
+        # We *do* have a models.File object for the file_id in the DB, and its
+        # name and size *do* match one of the files in the current course in Canvas.
+        file_service.get.return_value = factories.File(
+            name=file_from_current_course["display_name"],
+            size=file_from_current_course["size"],
+        )
+
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_a_different_course,
+            sentinel.course_id,
+        )
+
+        # It looks up the given file_id in the DB.
+        file_service.get.assert_called_once_with(
+            file_id_from_a_different_course, type_="canvas_file"
+        )
+        # It calls list_files() to look for a matching file in the current course.
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+        # It stores a file mapping from the given file_id to the matching
+        # found_file_id so that it doesn't have to re-do the search the next
+        # time the assignment is launched.
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(
+                file_id_from_a_different_course
+            )
+            == file_id_from_current_course
+        )
+        # It calls public_url() twice: one with the original file_id and once
+        # with the matching found_file_id.
+        assert canvas_api_client.public_url.call_args_list == [
+            call(file_id_from_a_different_course),
+            call(file_id_from_current_course),
+        ]
+        # It returns the public URL of the file in the current course.
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_permissions_error_but_no_file_info(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_service,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a student launches an assignment whose
+        # file_id is *not* in the current course and we don't have a record of
+        # the file_id in our DB. Without a record we can't search for a
+        # matching file so we raise an error.
+        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        file_service.get.return_value = None
+
+        with pytest.raises(CanvasAPIPermissionError):
+            canvas_service.public_url_for_file(
+                module_item_configuration,
+                file_id_from_a_different_course,
+                sentinel.course_id,
+            )
+
+    def test_permissions_error_but_no_matching_file(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_service,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a student launches an assignment whose
+        # file_id is *not* in the current course and even though we do have a
+        # record of this file_id in our DB we don't find a matching file in the
+        # current course. Since we can't find a matching file we can't fix the
+        # assignment so we raise an error.
+        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+
+        # The file record that we find in our DB. Its name doesn't match any
+        # file in the current course.
+        file_service.get.return_value = factories.File(name="foo")
+
+        with pytest.raises(CanvasAPIPermissionError):
+            canvas_service.public_url_for_file(
+                module_item_configuration,
+                file_id_from_a_different_course,
+                sentinel.course_id,
+            )
+
+    @pytest.fixture
+    def module_item_configuration(self, db_session):
+        module_item_configuration = factories.ModuleItemConfiguration()
+        db_session.flush()
+        return module_item_configuration
+
+    @pytest.fixture
+    def file_from_current_course(self, canvas_api_client):
+        """Return the Canvas API file dict for a file that *is* in the current course."""
+        return canvas_api_client.list_files.return_value[1]
+
+    @pytest.fixture
+    def file_id_from_current_course(self, file_from_current_course):
+        """Return the ID of a file from the current course, as a string."""
+        return str(file_from_current_course["id"])
+
+    @pytest.fixture
+    def file_from_a_different_course(self):
+        """Return the Canvas API file dict for a file from a *different* course."""
+        return {"id": 4, "display_name": "File 4", "size": 4096}
+
+    @pytest.fixture
+    def file_id_from_a_different_course(self, file_from_a_different_course):
+        """Return the ID of a file from a *different* course, as a string."""
+        return str(file_from_a_different_course["id"])
 
 
 class TestCanSeeFileInCourse:
@@ -63,11 +403,13 @@ class TestFindMatchingFileInCourse:
 
 
 class TestFactory:
-    def test_it(self, pyramid_request, CanvasService, canvas_api_client):
+    def test_it(self, pyramid_request, CanvasService, canvas_api_client, file_service):
         result = factory("*any*", request=pyramid_request)
 
         assert result == CanvasService.return_value
-        CanvasService.assert_called_once_with(canvas_api=canvas_api_client)
+        CanvasService.assert_called_once_with(
+            canvas_api=canvas_api_client, file_service=file_service
+        )
 
     @pytest.fixture
     def CanvasService(self, patch):
@@ -75,15 +417,23 @@ class TestFactory:
 
 
 @pytest.fixture
-def canvas_service(canvas_api_client):
-    return CanvasService(canvas_api=canvas_api_client)
+def canvas_service(canvas_api_client, file_service):
+    return CanvasService(canvas_api_client, file_service)
 
 
 @pytest.fixture
 def canvas_api_client(canvas_api_client):
     canvas_api_client.list_files.return_value = [
         {"id": 1, "display_name": "File 1", "size": 1024},
-        {"id": 2, "display_name": "File 2", "size": 2048},
-        {"id": 3, "display_name": "File 3", "size": 3072},
+        {
+            "id": 2,
+            "display_name": "File 2",
+            "size": 2048,
+        },
+        {
+            "id": 3,
+            "display_name": "File 3",
+            "size": 3072,
+        },
     ]
     return canvas_api_client

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -366,13 +366,13 @@ class TestPublicURLForFile:
         return str(file_from_a_different_course["id"])
 
 
-class TestCanSeeFileInCourse:
-    @pytest.mark.parametrize("file_id,expected_result", [("2", True), ("4", False)])
-    def test_it(self, canvas_service, canvas_api_client, file_id, expected_result):
-        result = canvas_service.can_see_file_in_course(file_id, sentinel.course_id)
+class TestAssertFileInCourse:
+    def test_it_does_not_raise_if_the_file_is_in_the_course(self, canvas_service):
+        canvas_service.assert_file_in_course("2", sentinel.course_id)
 
-        assert result == expected_result
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+    def test_it_raises_if_the_file_isnt_in_the_course(self, canvas_service):
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            canvas_service.assert_file_in_course("4", sentinel.course_id)
 
 
 class TestFindMatchingFileInCourse:

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -127,6 +127,26 @@ class TestPublicURLForFile:
         with pytest.raises(CanvasAPIPermissionError):
             public_url_for_file(sentinel.file_id)
 
+    def test_it_doesnt_save_a_mapped_file_id_if_getting_that_files_public_url_fails(
+        self,
+        canvas_api_client,
+        canvas_file_finder,
+        module_item_configuration,
+        public_url_for_file,
+    ):
+        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        canvas_file_finder.find_matching_file_in_course.return_value = (
+            sentinel.found_file_id
+        )
+
+        with pytest.raises(CanvasAPIPermissionError):
+            public_url_for_file(sentinel.file_id)
+
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(sentinel.file_id)
+            == sentinel.file_id
+        )
+
     @pytest.fixture
     def module_item_configuration(self, db_session):
         module_item_configuration = factories.ModuleItemConfiguration()

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -202,6 +202,24 @@ class TestCanvasFileFinder:
             sentinel.course_id, sentinel.file_id
         )
 
+    def test_find_matching_file_in_course_doesnt_return_the_same_file(
+        self, finder, canvas_api_client, file_service
+    ):
+        # If the response from the Canvas API contains a "matching" file dict
+        # that happens to be the *same* file as the one we're searching for (it
+        # has the same id) find_matching_file_in_course() should not return
+        # the same file_id as it was asked to search for a match for.
+        matching_file_dict = canvas_api_client.list_files.return_value[1]
+        file_service.get.return_value = factories.File(
+            lms_id=str(matching_file_dict["id"]),
+            name=matching_file_dict["display_name"],
+            size=matching_file_dict["size"],
+        )
+
+        assert not finder.find_matching_file_in_course(
+            sentinel.course_id, sentinel.file_id
+        )
+
     @pytest.fixture
     def finder(self, canvas_api_client, file_service):
         return CanvasFileFinder(canvas_api_client, file_service)

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -28,7 +28,7 @@ class TestPublicURLForFile:
         CanvasFileFinder.assert_called_once_with(canvas_api_client, file_service)
         if check_in_course:
             canvas_file_finder.assert_file_in_course.assert_called_once_with(
-                sentinel.file_id, sentinel.course_id
+                sentinel.course_id, sentinel.file_id
             )
         else:
             canvas_file_finder.assert_file_in_course.assert_not_called()
@@ -42,7 +42,7 @@ class TestPublicURLForFile:
         url = public_url_for_file(sentinel.file_id, check_in_course=True)
 
         canvas_file_finder.assert_file_in_course.assert_called_once_with(
-            sentinel.mapped_file_id, sentinel.course_id
+            sentinel.course_id, sentinel.mapped_file_id
         )
         canvas_api_client.public_url.assert_called_once_with(sentinel.mapped_file_id)
         assert url == canvas_api_client.public_url.return_value
@@ -180,11 +180,11 @@ class TestCanvasFileFinder:
     def test_assert_file_in_course_doesnt_raise_if_the_file_is_in_the_course(
         self, finder
     ):
-        finder.assert_file_in_course("2", sentinel.course_id)
+        finder.assert_file_in_course(sentinel.course_id, "2")
 
     def test_assert_file_in_course_raises_if_the_file_isnt_in_the_course(self, finder):
         with pytest.raises(CanvasFileNotFoundInCourse):
-            finder.assert_file_in_course("4", sentinel.course_id)
+            finder.assert_file_in_course(sentinel.course_id, "4")
 
     def test_find_matching_file_in_course_returns_the_matching_file_id(
         self, finder, canvas_api_client, file_service

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,5 +1,5 @@
 from functools import partial
-from unittest.mock import DEFAULT, call, sentinel
+from unittest.mock import call, sentinel
 
 import pytest
 
@@ -8,229 +8,136 @@ from lms.services import (
     CanvasFileNotFoundInCourse,
     CanvasService,
 )
-from lms.services.canvas import factory
+from lms.services.canvas import CanvasFileFinder, factory
 from tests import factories
 
 
 class TestPublicURLForFile:
-    def test_without_check_in_course_and_without_a_mapped_file_id(
-        self, canvas_service, file_from_current_course, public_url_for_file
+    @pytest.mark.parametrize("check_in_course", [True, False])
+    def test_the_happy_path(
+        self,
+        canvas_api_client,
+        canvas_file_finder,
+        check_in_course,
+        file_service,
+        public_url_for_file,
+        CanvasFileFinder,
     ):
-        # This is what happens during a normal student assignment launch:
-        # check_in_course is False and there's no mapped_file_id in the DB.
+        url = public_url_for_file(sentinel.file_id, check_in_course=check_in_course)
 
-        url = public_url_for_file(file_id=str(file_from_current_course["id"]))
+        CanvasFileFinder.assert_called_once_with(canvas_api_client, file_service)
+        if check_in_course:
+            canvas_file_finder.assert_file_in_course.assert_called_once_with(
+                sentinel.file_id, sentinel.course_id
+            )
+        else:
+            canvas_file_finder.assert_file_in_course.assert_not_called()
+        canvas_api_client.public_url.assert_called_once_with(sentinel.file_id)
+        assert url == canvas_api_client.public_url.return_value
 
-        # check_in_course was False, so it didn't call list_files() to check
-        # whether the file_id was in the course.
-        canvas_service.api.list_files.assert_not_called()
-
-        # It calls the Canvas API with the file_id and returns the public URL.
-        canvas_service.api.public_url.assert_called_once_with(
-            str(file_from_current_course["id"])
-        )
-        assert url == canvas_service.api.public_url.return_value
-
-    def test_if_check_in_course_is_True_it_checks_that_the_file_is_in_the_course(
-        self, canvas_service, file_from_current_course, public_url_for_file
-    ):
-        # This is what happens during a normal instructor launch;
-        # check_in_course is True and there's no mapped_file_id in the DB.
-
-        url = public_url_for_file(
-            file_id=str(file_from_current_course["id"]), check_in_course=True
-        )
-
-        # check_in_course was True so it called list_files() to check whether
-        # file_id was in the course.
-        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
-
-        # It calls the Canvas API with the file_id and returns the public URL.
-        canvas_service.api.public_url.assert_called_once_with(
-            str(file_from_current_course["id"])
-        )
-        assert url == canvas_service.api.public_url.return_value
-
+    @pytest.mark.usefixtures("with_mapped_file_id")
     def test_if_theres_a_mapped_file_id_it_uses_it(
+        self, canvas_api_client, canvas_file_finder, public_url_for_file
+    ):
+        url = public_url_for_file(sentinel.file_id, check_in_course=True)
+
+        canvas_file_finder.assert_file_in_course.assert_called_once_with(
+            sentinel.mapped_file_id, sentinel.course_id
+        )
+        canvas_api_client.public_url.assert_called_once_with(sentinel.mapped_file_id)
+        assert url == canvas_api_client.public_url.return_value
+
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_the_file_isnt_in_the_course_it_finds_a_matching_file_instead(
         self,
-        canvas_service,
+        canvas_api_client,
+        canvas_file_finder,
         module_item_configuration,
-        file_from_current_course,
-        file_from_a_different_course,
         public_url_for_file,
     ):
-        # If there's a mapped_file_id in the DB it gets used instead of the
-        # given file_id.
-        #
-        # This is what happens when a user launches a course-copied assignment
-        # that has previously been fixed (we've previously stored a
-        # mapped_file_id in the DB).
-
-        # Store a mapped_file_id in the DB. This would have been done by a
-        # previous request.
-        module_item_configuration.set_canvas_mapped_file_id(
-            str(file_from_a_different_course["id"]), str(file_from_current_course["id"])
+        canvas_file_finder.assert_file_in_course.side_effect = (
+            CanvasFileNotFoundInCourse(sentinel.file_id)
+        )
+        canvas_file_finder.find_matching_file_in_course.return_value = (
+            sentinel.found_file_id
         )
 
-        url = public_url_for_file(
-            file_id=str(file_from_a_different_course["id"]), check_in_course=True
+        url = public_url_for_file(sentinel.file_id, check_in_course=True)
+
+        canvas_file_finder.find_matching_file_in_course.assert_called_once_with(
+            sentinel.course_id, sentinel.mapped_file_id
         )
-
-        # It checks that the mapped_file_id is in the course (not the original file_id).
-        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
-
-        # It called public_url() with the mapped_file_id rather than with the
-        # original file_id, and returned the public URL.
-        canvas_service.api.public_url.assert_called_once_with(
-            str(file_from_current_course["id"])
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(sentinel.file_id)
+            == sentinel.found_file_id
         )
-        assert url == canvas_service.api.public_url.return_value
+        canvas_api_client.public_url.assert_called_once_with(sentinel.found_file_id)
+        assert url == canvas_api_client.public_url.return_value
 
-    def test_file_not_found_in_course_and_matching_file_found(
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_the_file_isnt_in_the_course_and_theres_no_matching_file_it_raises(
+        self, canvas_file_finder, public_url_for_file
+    ):
+        canvas_file_finder.assert_file_in_course.side_effect = (
+            CanvasFileNotFoundInCourse(sentinel.file_id)
+        )
+        canvas_file_finder.find_matching_file_in_course.return_value = None
+
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            public_url_for_file(sentinel.file_id, check_in_course=True)
+
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_theres_a_permissions_error_it_finds_a_matching_file_instead(
         self,
-        canvas_service,
-        file_service,
+        canvas_api_client,
+        canvas_file_finder,
         module_item_configuration,
-        file_from_current_course,
-        file_from_a_different_course,
         public_url_for_file,
     ):
-        # This is what happens when an instructor launches an assignment whose
-        # file_id is *not* in the current course.
-        file_service.get.return_value = factories.File(
-            name=file_from_current_course["display_name"],
-            size=file_from_current_course["size"],
-        )
-
-        url = public_url_for_file(
-            file_id=str(file_from_a_different_course["id"]), check_in_course=True
-        )
-
-        # It looked up the given file_id in the DB.
-        file_service.get.assert_called_once_with(
-            str(file_from_a_different_course["id"]), type_="canvas_file"
-        )
-        # It stored a mapping from the given file_id to found_file_id.
-        assert module_item_configuration.get_canvas_mapped_file_id(
-            str(file_from_a_different_course["id"])
-        ) == str(file_from_current_course["id"])
-        # It got the found_file_id's public URL and returned it.
-        canvas_service.api.public_url.assert_called_once_with(
-            str(file_from_current_course["id"])
-        )
-        assert url == canvas_service.api.public_url.return_value
-
-    def test_permissions_error_and_matching_file_found(
-        self,
-        canvas_service,
-        file_service,
-        module_item_configuration,
-        file_from_current_course,
-        file_from_a_different_course,
-        public_url_for_file,
-    ):
-        # This is what happens when a student launches an assignment whose
-        # file_id is *not* in the current course.
-        canvas_service.api.public_url.side_effect = [CanvasAPIPermissionError, DEFAULT]
-        file_service.get.return_value = factories.File(
-            name=file_from_current_course["display_name"],
-            size=file_from_current_course["size"],
-        )
-
-        url = public_url_for_file(file_id=str(file_from_a_different_course["id"]))
-
-        # It looked up the given file_id in the DB.
-        file_service.get.assert_called_once_with(
-            str(file_from_a_different_course["id"]), type_="canvas_file"
-        )
-        # It stored a mapping from the given file_id to found_file_id.
-        assert module_item_configuration.get_canvas_mapped_file_id(
-            str(file_from_a_different_course["id"])
-        ) == str(file_from_current_course["id"])
-        # It got found_file_id's public URL and returned it.
-        assert canvas_service.api.public_url.call_args_list == [
-            call(str(file_from_a_different_course["id"])),
-            call(str(file_from_current_course["id"])),
+        canvas_api_client.public_url.side_effect = [
+            CanvasAPIPermissionError,
+            sentinel.url,
         ]
-        assert url == canvas_service.api.public_url.return_value
+        canvas_file_finder.find_matching_file_in_course.return_value = (
+            sentinel.found_file_id
+        )
 
-    def test_file_not_found_in_course_but_no_file_info(
-        self, file_service, file_from_a_different_course, public_url_for_file
+        url = public_url_for_file(sentinel.file_id)
+
+        canvas_file_finder.find_matching_file_in_course.assert_called_once_with(
+            sentinel.course_id, sentinel.mapped_file_id
+        )
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(sentinel.file_id)
+            == sentinel.found_file_id
+        )
+        assert canvas_api_client.public_url.call_args_list == [
+            call(sentinel.mapped_file_id),
+            call(sentinel.found_file_id),
+        ]
+        assert url == sentinel.url
+
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_theres_a_permissions_error_and_theres_no_matching_file_it_raises(
+        self, canvas_api_client, canvas_file_finder, public_url_for_file
     ):
-        # This is what happens when a teacher launches an assignment whose
-        # file_id is *not* in the current course and we don't have a record of
-        # the file_id in our DB. Without a record we can't search for a
-        # matching file so we raise an error.
-
-        # There's no record of the file_id in the DB.
-        file_service.get.return_value = None
-
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            public_url_for_file(
-                str(file_from_a_different_course["id"]), check_in_course=True
-            )
-
-    def test_file_not_found_in_course_but_no_matching_file(
-        self, file_service, file_from_a_different_course, public_url_for_file
-    ):
-        # This is what happens when a teacher launches an assignment whose
-        # file_id is *not* in the current course and even though we do have a
-        # record of this file_id in our DB we don't find a matching file in the
-        # current course. Since we can't find a matching file we can't fix the
-        # assignment so we raise an error.
-
-        # The file record that we find in our DB. Its name doesn't match any
-        # file in the current course.
-        file_service.get.return_value = factories.File(name="foo")
-
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            public_url_for_file(
-                file_id=str(file_from_a_different_course["id"]), check_in_course=True
-            )
-
-    def test_permissions_error_but_no_file_info(
-        self,
-        canvas_service,
-        file_service,
-        file_from_a_different_course,
-        public_url_for_file,
-    ):
-        # This is what happens when a student launches an assignment whose
-        # file_id is *not* in the current course and we don't have a record of
-        # the file_id in our DB. Without a record we can't search for a
-        # matching file so we raise an error.
-        canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
-        file_service.get.return_value = None
+        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        canvas_file_finder.find_matching_file_in_course.return_value = None
 
         with pytest.raises(CanvasAPIPermissionError):
-            public_url_for_file(file_id=str(file_from_a_different_course["id"]))
-
-    def test_permissions_error_but_no_matching_file(
-        self,
-        canvas_service,
-        file_service,
-        file_from_a_different_course,
-        public_url_for_file,
-    ):
-        # This is what happens when a student launches an assignment whose
-        # file_id is *not* in the current course and even though we do have a
-        # record of this file_id in our DB we don't find a matching file in the
-        # current course. Since we can't find a matching file we can't fix the
-        # assignment so we raise an error.
-        canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
-
-        # The file record that we find in our DB. Its name doesn't match any
-        # file in the current course.
-        file_service.get.return_value = factories.File(name="foo")
-
-        with pytest.raises(CanvasAPIPermissionError):
-            public_url_for_file(file_id=str(file_from_a_different_course["id"]))
+            public_url_for_file(sentinel.file_id)
 
     @pytest.fixture
     def module_item_configuration(self, db_session):
         module_item_configuration = factories.ModuleItemConfiguration()
         db_session.flush()
         return module_item_configuration
+
+    @pytest.fixture
+    def with_mapped_file_id(self, module_item_configuration):
+        module_item_configuration.set_canvas_mapped_file_id(
+            sentinel.file_id, sentinel.mapped_file_id
+        )
 
     @pytest.fixture
     def public_url_for_file(self, canvas_service, module_item_configuration):
@@ -240,51 +147,64 @@ class TestPublicURLForFile:
             course_id=sentinel.course_id,
         )
 
-    @pytest.fixture
-    def file_from_current_course(self, canvas_service):
-        """Return the Canvas API file dict for a file that *is* in the current course."""
-        return canvas_service.api.list_files.return_value[1]
+    @pytest.fixture(autouse=True)
+    def CanvasFileFinder(self, patch):
+        return patch("lms.services.canvas.CanvasFileFinder")
 
     @pytest.fixture
-    def file_from_a_different_course(self):
-        """Return the Canvas API file dict for a file from a *different* course."""
-        return {"id": 4, "display_name": "File 4", "size": 4096}
+    def canvas_file_finder(self, CanvasFileFinder):
+        return CanvasFileFinder.return_value
 
 
-class TestAssertFileInCourse:
-    def test_it_does_not_raise_if_the_file_is_in_the_course(self, canvas_service):
-        canvas_service.assert_file_in_course("2", sentinel.course_id)
+class TestCanvasFileFinder:
+    def test_assert_file_in_course_doesnt_raise_if_the_file_is_in_the_course(
+        self, finder
+    ):
+        finder.assert_file_in_course("2", sentinel.course_id)
 
-    def test_it_raises_if_the_file_isnt_in_the_course(self, canvas_service):
+    def test_assert_file_in_course_raises_if_the_file_isnt_in_the_course(self, finder):
         with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_service.assert_file_in_course("4", sentinel.course_id)
+            finder.assert_file_in_course("4", sentinel.course_id)
 
-
-class TestFindMatchingFileInCourse:
-    def test_it_returns_the_id_if_theres_a_matching_file_in_the_course(
-        self, canvas_service
+    def test_find_matching_file_in_course_returns_the_matching_file_id(
+        self, finder, canvas_api_client, file_service
     ):
         # The file dict from the Canvas API that we expect the search to match.
-        matching_file_dict = canvas_service.api.list_files.return_value[1]
-
-        file_ = factories.File(
+        matching_file_dict = canvas_api_client.list_files.return_value[1]
+        file_service.get.return_value = factories.File(
             name=matching_file_dict["display_name"],
             size=matching_file_dict["size"],
         )
 
-        matching_file_id = canvas_service.find_matching_file_in_course(
-            sentinel.course_id, file_
+        matching_file_id = finder.find_matching_file_in_course(
+            sentinel.course_id, sentinel.file_id
         )
 
-        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
+        file_service.get.assert_called_once_with(sentinel.file_id, type_="canvas_file")
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
         assert matching_file_id == str(matching_file_dict["id"])
 
-    def test_it_returns_None_if_theres_no_matching_file_in_the_course(
-        self, canvas_service
+    def test_find_matching_file_in_course_returns_None_if_theres_file_in_the_db(
+        self, finder, file_service
     ):
-        assert not canvas_service.find_matching_file_in_course(
-            sentinel.course_id, factories.File()
+        file_service.get.return_value = None
+
+        assert not finder.find_matching_file_in_course(
+            sentinel.course_id, sentinel.file_id
         )
+
+    def test_find_matching_file_in_course_returns_None_if_theres_no_match(
+        self, finder, file_service
+    ):
+        file_service.get.return_value = factories.File(name="foo")
+
+        assert not finder.find_matching_file_in_course(
+            sentinel.course_id, sentinel.file_id
+        )
+
+    @pytest.fixture
+    def finder(self, canvas_api_client, file_service):
+        return CanvasFileFinder(canvas_api_client, file_service)
 
 
 class TestFactory:
@@ -302,9 +222,8 @@ class TestFactory:
 
 
 @pytest.fixture
-def canvas_service(canvas_api_client, file_service):
-    canvas_service = CanvasService(canvas_api_client, file_service)
-    canvas_service.api.list_files.return_value = [
+def canvas_api_client(canvas_api_client):
+    canvas_api_client.list_files.return_value = [
         {"id": 1, "display_name": "File 1", "size": 1024},
         {
             "id": 2,
@@ -317,4 +236,9 @@ def canvas_service(canvas_api_client, file_service):
             "size": 3072,
         },
     ]
-    return canvas_service
+    return canvas_api_client
+
+
+@pytest.fixture
+def canvas_service(canvas_api_client, file_service):
+    return CanvasService(canvas_api_client, file_service)

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -3,7 +3,9 @@ import pytest
 from lms.views.api.canvas.files import FilesAPIViews
 
 
-@pytest.mark.usefixtures("canvas_service")
+@pytest.mark.usefixtures(
+    "application_instance_service", "assignment_service", "canvas_service"
+)
 class TestFilesAPIViews:
     def test_list_files(self, canvas_service, pyramid_request):
         pyramid_request.matchdict = {"course_id": "test_course_id"}
@@ -14,27 +16,40 @@ class TestFilesAPIViews:
         canvas_service.api.list_files.assert_called_once_with("test_course_id")
 
     @pytest.mark.usefixtures("with_teacher_or_student")
-    def test_via_url(self, pyramid_request, canvas_service, helpers):
+    def test_via_url(
+        self,
+        pyramid_request,
+        application_instance_service,
+        assignment_service,
+        canvas_service,
+        helpers,
+    ):
+        application_instance = application_instance_service.get.return_value
+        module_item_configuration = assignment_service.get.return_value
         pyramid_request.matchdict = {
             "course_id": "test_course_id",
             "file_id": "test_file_id",
+            "resource_link_id": "test_resource_link_id",
         }
 
         result = FilesAPIViews(pyramid_request).via_url()
 
-        assert result["via_url"] == helpers.via_url.return_value
-
+        assignment_service.get.assert_called_once_with(
+            application_instance.tool_consumer_instance_guid,
+            "test_resource_link_id",
+        )
         canvas_service.public_url_for_file.assert_called_once_with(
-            file_id="test_file_id",
-            course_id="test_course_id",
+            module_item_configuration,
+            "test_file_id",
+            "test_course_id",
             check_in_course=pyramid_request.lti_user.is_instructor,
         )
-
         helpers.via_url.assert_called_once_with(
             pyramid_request,
             canvas_service.public_url_for_file.return_value,
             content_type="pdf",
         )
+        assert result == {"via_url": helpers.via_url.return_value}
 
     @pytest.fixture(params=("instructor", "learner"))
     def with_teacher_or_student(self, request, pyramid_request):

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -9,6 +9,7 @@ from lms.services.assignment import AssignmentService
 from lms.services.blackboard_api import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
+from lms.services.file import FileService
 from lms.services.grading_info import GradingInfoService
 from lms.services.grant_token import GrantTokenService
 from lms.services.group_info import GroupInfoService
@@ -45,6 +46,7 @@ __all__ = (
     "oauth2_token_service",
     "h_api",
     "vitalsource_service",
+    "file_service",
 )
 
 
@@ -189,3 +191,8 @@ def oauth2_token_service(mock_service, oauth_token):
 @pytest.fixture
 def vitalsource_service(mock_service):
     return mock_service(VitalSourceService, service_name="vitalsource")
+
+
+@pytest.fixture
+def file_service(mock_service):
+    return mock_service(FileService, service_name="file")


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2764.

Depends on https://github.com/hypothesis/lms/pull/2907

Testing
=====

All the test cases should work with our [Canvas test site](https://hypothesis.instructure.com/).

You need to run `make devdata` in the LMS project to make sure you have the latest development data.

To get to an SQL shell (to run the various example SQL commands in the test cases below) run `make sql`.

Test data:

* [Developer Test Course with Sections Enabled][] is the original (non-copied) test course
  * [localhost (make devdata) Canvas Files Assignment] is a Canvas Files assignment in this course
  * File **798** (`Françoise_Hardy.pdf`) is a PDF file in this course that the assignment uses
  * `eng+canvasteacher@hypothes.is` is a teacher in this course (all user passwords are in 1Password)
  * `eng+canvasstudent@hypothes.is` is a student in this course

* [Copy of Developer Test Course with Sections Enabled][] is a copied course
  * [localhost (make devdata) Canvas Files Assignment (copy)][] is a copied Canvas Files assignment in this course
  * `eng+canvasteacher@hypothes.is` is a teacher who is in both the copied course and the original course
  * `eng+canvasstudent@hypothes.is` is a student who is in both the copied course and the original course
  * `eng+coursecopyteacher` is a teacher who is in the copied course but *not* the original course
  * `eng+coursecopystudent` is a student who is in the copied course but *not* the original course

Launching a non-course-copied assignment
----------------------------------------

Launch [localhost (make devdata) Canvas Files Assignment][] from [Developer Test Course with Sections Enabled][] as both a teacher and a student.

The assignment should launch successfully.

You should not have any mappings in your DB:

```sql
postgres=# select * from module_item_configurations where extra != '{}';
 id | resource_link_id | tool_consumer_instance_guid | document_url | extra
----+------------------+-----------------------------+--------------+-------
(0 rows)
```

Launching a course-copied assignment: teacher also belongs to original course
-----------------------------------------------------------------------------

Launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+canvasteacher@hypothes.is`.

The assignment should launch successfully.

Even though the teacher could access the original file (since they belong to the original course) we detect that the file isn't in the current course and map it to the matching file in the current course. The mapping means that other users who *aren't* in the original course will be able to launch the assignment. You should find that a mapping has been created in the DB:

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

Launching a course-copied assignment: student also belongs to original course
-----------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+canvasstudent@hypothes.is`.

The assignment should launch successfully.

You should not have any mappings in your DB:

```sql
postgres=# select * from module_item_configurations where extra != '{}';
 id | resource_link_id | tool_consumer_instance_guid | document_url | extra
----+------------------+-----------------------------+--------------+-------
(0 rows)
```

Since the student belongs to the original course they're able to access the original file. When students launch assignments we **don't** check to make sure that the file is in the current course because that check requires extra network requests, so no mapping gets created.

If you first launch the assignment as `eng+canvasteacher@hypothes.is` (thus creating a mapping) and _then_ launch the assignment as `eng+canvasstudent@hypothes.is` then it should find and use the existing mapping.

Launching a course-copied assignment: teacher does not belong to original course
--------------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+coursecopyteacher@hypothes.is`.

The assignment should launch successfully.

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

Launching a course-copied assignment: student does not belong to original course
--------------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+coursecopystudent@hypothes.is`.

The assignment should launch successfully.

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

When we don't have a record of the original course's files
----------------------------------------------------------

The creation of "mappings" in order to fix course copied assignments depends on us having information about the assignment's original file in our DB (the file used by the original assignment in the original course, this is the file whose ID comes to us in the `file_id` parameter whenever the original or a copied assignment is launched.

If you have created or launched any assignment in the original course as a teacher then we will have downloaded the info about all of the original course's files (as they were at the time of your launch).

Launching assignments as a student does not download info about the course's files.

It is possible that a user could be launching a course-copied assignment and we don't have info about the assignment's original file in our DB. For example this could happen if the course was copied before we had deployed the file info tracking feature.

First, delete all the file info from your DB:

```sql
postgres=# delete from file;
DELETE 12
```

Also delete any previously created mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][].

If you launch the assignment as a teacher (member of the original course or not) you'll run into a **Hypothesis couldn't find the file in the course** error message.

If you launch the assignment as a student who isn't a member of the original course you'll get a **Couldn't get the file from Canvas** error.

If you launch the assignment as a student who is also a member of the original course it will launch successfully.

Deleted files
-------------

If you launch [localhost (make devdata) Canvas Files Assignment Whose File Has Been Deleted](https://hypothesis.instructure.com/courses/125/assignments/1370) in [Developer Test Course with Sections Enabled][] as a teacher you'll get the **Hypothesis couldn't find the file in the course** error.

We notice that the file isn't in the course which triggers us to think that the assignment might have been course copied and to look for a matching file that _is_ in the course. We won't find a matching file in the course (since Canvas omits deleted files from its list-files API responses) to the look up fails and we just fall back to the error dialog.

If you launch this assignment as a student it will launch successfully. (This is because Canvas doesn't seem to actually delete files when you delete them. Ever. Students can still download them.)

Deleting and re-uploading a file
--------------------------------

What if you delete an assignment's file from Canvas and then re-upload the same file again? This will create a new file in Canvas with a new file ID. But the new file will have the same filenamena and size as the deleted one.

If you now launch the assignment whose file was deleted as a student it will just launch successfully downloading the original (deleted) file since students can still download deleted files from Canvas.

But if you launch the assignment as a teacher we'll notice that the assignment's file ID isn't in the course and will find the new file in the course with the same name and size and will create a mapping and "fix" the assignment :)

Unpublished files
-----------------

Files can be marked as "unpublished" in Canvas which means that teachers can see them but students can't.

[localhost (make devdata) Canvas Files Assignment Whose File Is Unpublished](https://hypothesis.instructure.com/courses/125/assignments/1371) is an assignment for an unpublished file.

The assignment will launch successfully for teachers but students get a **Couldn't get the file from Canvas** error.

**But** if the course has another file with the same name and size then when a student launched the assignment we would create a mapping to that file and the launch would succeed :)

Editing assignments
-------------------

What if we store a mapping in our DB and then a user edits the assignment and changes its file?

Since the mappings map one file ID to another if the user changes the `file_id` in Canvas the previous mapping will no longer apply. (So editing works as expected.)

Renaming files
----------------------

TODO

[localhost (make devdata) Canvas Files Assignment]: https://hypothesis.instructure.com/courses/125/assignments/875/
[Developer Test Course with Sections Enabled]: https://hypothesis.instructure.com/courses/125
[Copy of Developer Test Course with Sections Enabled]: https://hypothesis.instructure.com/courses/252
[localhost (make devdata) Canvas Files Assignment (copy)]: https://hypothesis.instructure.com/courses/252/assignments/1321