### PR TITLE
Increase height of AuthWindow popup

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/AuthWindow.js
+++ b/lms/static/scripts/frontend_apps/utils/AuthWindow.js
@@ -40,7 +40,7 @@ export default class AuthWindow {
    */
   async authorize() {
     const width = 775;
-    const height = 475;
+    const height = 560;
     const left = Math.round(window.screen.width / 2 - width / 2);
     const top = Math.round(window.screen.height / 2 - height / 2);
     const settings = queryString


### PR DESCRIPTION
The fixed size auth window is a bit too small for Blackboard's content to fit. Increase the height to 560px which is just big enough to fit the content without a vertical scroll bar.

-----------

### Screen shots are from this branch

![Screen Shot 2021-06-29 at 9 25 11 AM](https://user-images.githubusercontent.com/3939074/123834262-12746000-d8bc-11eb-9063-5bef553aab98.png)
![Screen Shot 2021-06-29 at 9 25 22 AM](https://user-images.githubusercontent.com/3939074/123834270-13a58d00-d8bc-11eb-9df0-b164a0d08eae.png)


fixes https://github.com/hypothesis/lms/issues/2759
