### PR TITLE
Move {get,set}_canvas_file_mapping() onto model

### DIFF
--- a/lms/models/module_item_configuration.py
+++ b/lms/models/module_item_configuration.py
@@ -50,3 +50,9 @@ class ModuleItemConfiguration(BASE):
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )
+
+    def get_canvas_mapped_file_id(self, file_id):
+        return self.extra.get("canvas_file_mappings", {}).get(file_id)
+
+    def set_canvas_mapped_file_id(self, file_id, mapped_file_id):
+        self.extra.setdefault("canvas_file_mappings", {})[file_id] = mapped_file_id

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -59,26 +59,6 @@ class AssignmentService:
         # just one key from the cache, you have to clear the entire cache.)
         self.get.cache_clear()
 
-    def get_canvas_mapped_file_id(
-        self, tool_consumer_instance_guid, resource_link_id, file_id
-    ):
-        mic = self.get(tool_consumer_instance_guid, resource_link_id)
-
-        if not mic:
-            return None
-
-        return mic.extra.get("canvas_file_mappings", {}).get(file_id)
-
-    def set_canvas_mapped_file_id(
-        self, tool_consumer_instance_guid, resource_link_id, file_id, mapped_file_id
-    ):
-        mic = self.get(tool_consumer_instance_guid, resource_link_id)
-
-        if not mic:
-            raise ValueError("ModuleItemConfiguration not found")
-
-        mic.extra.setdefault("canvas_file_mappings", {})[file_id] = mapped_file_id
-
 
 def factory(_context, request):
     return AssignmentService(db=request.db)

--- a/tests/unit/lms/models/module_item_configuration_test.py
+++ b/tests/unit/lms/models/module_item_configuration_test.py
@@ -1,0 +1,30 @@
+import pytest
+
+from lms.models import ModuleItemConfiguration
+
+
+class TestModuleItemConfiguration:
+    def test_set_canvas_mapped_file_id_creates_a_new_mapping_if_none_exists(self, mic):
+        mic.set_canvas_mapped_file_id("original_file_id", "mapped_file_id")
+
+        assert mic.get_canvas_mapped_file_id("original_file_id") == "mapped_file_id"
+
+    def test_set_canvas_mapped_file_id_overwrites_an_existing_mapping_if_one_exists(
+        self, mic
+    ):
+        mic.set_canvas_mapped_file_id("original_file_id", "mapped_file_id")
+
+        mic.set_canvas_mapped_file_id("original_file_id", "new_mapped_file_id")
+
+        assert mic.get_canvas_mapped_file_id("original_file_id") == "new_mapped_file_id"
+
+    @pytest.fixture
+    def mic(self, db_session):
+        mic = ModuleItemConfiguration(
+            resource_link_id="resource_link_id",
+            tool_consumer_instance_guid="tool_consumer_instance_guid",
+            document_url="document_url",
+        )
+        db_session.add(mic)
+        db_session.flush()
+        return mic

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -60,69 +60,6 @@ class TestAssignmentService:
 
         assert assignment.document_url == "NEW_DOCUMENT_URL"
 
-    def test_get_canvas_mapped_file_id_returns_None_if_the_assignment_doesnt_exist(
-        self, svc
-    ):
-        assert not svc.get_canvas_mapped_file_id(
-            "unknown_resource_link_id", "unknown_resource_link_id", "file_id"
-        )
-
-    def test_set_canvas_mapped_file_id_creates_a_new_mapping_if_none_exists(
-        self, assignment, svc
-    ):
-        svc.set_canvas_mapped_file_id(
-            assignment.tool_consumer_instance_guid,
-            assignment.resource_link_id,
-            "original_file_id",
-            "mapped_file_id",
-        )
-
-        assert (
-            svc.get_canvas_mapped_file_id(
-                assignment.tool_consumer_instance_guid,
-                assignment.resource_link_id,
-                "original_file_id",
-            )
-            == "mapped_file_id"
-        )
-
-    def test_set_canvas_mapped_file_id_overwrites_an_existing_mapping_if_one_exists(
-        self, assignment, svc
-    ):
-        svc.set_canvas_mapped_file_id(
-            assignment.tool_consumer_instance_guid,
-            assignment.resource_link_id,
-            "original_file_id",
-            "mapped_file_id",
-        )
-
-        svc.set_canvas_mapped_file_id(
-            assignment.tool_consumer_instance_guid,
-            assignment.resource_link_id,
-            "original_file_id",
-            "new_mapped_file_id",
-        )
-
-        assert (
-            svc.get_canvas_mapped_file_id(
-                assignment.tool_consumer_instance_guid,
-                assignment.resource_link_id,
-                "original_file_id",
-            )
-            == "new_mapped_file_id"
-        )
-
-    def test_set_canvas_mapped_file_id_raises_ValueError_if_the_assignment_doesnt_exist(
-        self, svc
-    ):
-        with pytest.raises(ValueError):
-            svc.set_canvas_mapped_file_id(
-                "unknown_tool_consumer_instance_guid",
-                "unknown_resource_link_id",
-                "original_file_id",
-                "new_mapped_file_id",
-            )
-
     @pytest.fixture
     def assignment(self):
         return factories.ModuleItemConfiguration()


### PR DESCRIPTION
I'm not sure [what I was thinking](https://github.com/hypothesis/lms/pull/2878#issuecomment-870505721) but this code is much simpler in the model than in the service and the higher-level code that calls it ends up simpler as well (see https://github.com/hypothesis/lms/pull/2899/files#r660780163)