### PR TITLE
Inject current ApplicationInstance into FileService

### DIFF
--- a/lms/services/file.py
+++ b/lms/services/file.py
@@ -2,19 +2,25 @@ from lms.models import File
 
 
 class FileService:
-    def __init__(self, db):
+    def __init__(self, application_instance, db):
+        self._application_instance = application_instance
         self._db = db
 
-    def get(self, application_instance, lms_id, type_):
-        """Return the file with application_instance, lms_id and type_ or None."""
+    def get(self, lms_id, type_):
+        """Return the file with the given lms_id and type_ or None."""
         return (
             self._db.query(File)
             .filter_by(
-                application_instance=application_instance, lms_id=lms_id, type=type_
+                application_instance=self._application_instance,
+                lms_id=lms_id,
+                type=type_,
             )
             .one_or_none()
         )
 
 
 def factory(_context, request):
-    return FileService(db=request.db)
+    return FileService(
+        application_instance=request.find_service(name="application_instance").get(),
+        db=request.db,
+    )

--- a/tests/unit/lms/services/file_test.py
+++ b/tests/unit/lms/services/file_test.py
@@ -12,19 +12,17 @@ class TestGet:
     ):
         file_ = factories.File(application_instance=application_instance)
 
-        assert svc.get(application_instance, file_.lms_id, file_.type) == file_
+        assert svc.get(file_.lms_id, file_.type) == file_
 
-    def test_it_returns_None_if_theres_no_matching_file(
-        self, application_instance, svc
-    ):
-        assert not svc.get(application_instance, "unknown_file_id", "canvas_file")
+    def test_it_returns_None_if_theres_no_matching_file(self, svc):
+        assert not svc.get("unknown_file_id", "canvas_file")
 
     def test_it_doesnt_return_matching_files_from_other_application_instances(
-        self, application_instance, svc
+        self, svc
     ):
         file_ = factories.File()
 
-        assert not svc.get(application_instance, file_.lms_id, file_.type)
+        assert not svc.get(file_.lms_id, file_.type)
 
 
 @pytest.mark.usefixtures("application_instance_service")
@@ -46,5 +44,5 @@ def noise(application_instance):
 
 
 @pytest.fixture
-def svc(db_session):
-    return FileService(db_session)
+def svc(application_instance, db_session):
+    return FileService(application_instance, db_session)


### PR DESCRIPTION
I'm not sure [what I was thinking](https://github.com/hypothesis/lms/pull/2892#discussion_r660528549) but the higher-level code that's going to call `FileService` ends up simpler if `FileService`'s factory injects the `ApplicationInstance`. Without this change `CanvasService.public_url_for_file()` ends up with too many arguments. See https://github.com/hypothesis/lms/pull/2899/files#r660780163