### PR TITLE
Enable canvas groups assignments on new installs

### DIFF
--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -30,7 +30,12 @@ def create_application_instance(request):
         developer_key,
         developer_secret,
         request.registry.settings["aes_secret"],
-        settings={"canvas": {"sections_enabled": bool(developer_key)}},
+        settings={
+            "canvas": {
+                "sections_enabled": bool(developer_key),
+                "groups_enabled": bool(developer_key),
+            }
+        },
     )
     request.db.add(instance)
 

--- a/tests/unit/lms/views/test_application_instance.py
+++ b/tests/unit/lms/views/test_application_instance.py
@@ -68,6 +68,24 @@ class TestCreateApplicationInstance:
             == canvas_sections_enabled
         )
 
+    @pytest.mark.parametrize(
+        "developer_key,canvas_groups_enabled",
+        [("test_developer_key", True), ("", False)],
+    )
+    def test_it_sets_canvas_groups_enabled(
+        self, pyramid_request, developer_key, canvas_groups_enabled
+    ):
+        pyramid_request.params["developer_key"] = developer_key
+        pyramid_request.params["developer_secret"] = "test_developer_secret"
+
+        create_application_instance(pyramid_request)
+
+        application_instance = pyramid_request.db.query(ApplicationInstance).one()
+        assert (
+            bool(application_instance.settings.get("canvas", "groups_enabled"))
+            == canvas_groups_enabled
+        )
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.method = "POST"


### PR DESCRIPTION
Both sections and groups enabled by default for now.