### PR TITLE
Add caching of some Canvas API responses

### DIFF
--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -1,6 +1,7 @@
 """High level access to Canvas API methods."""
 
 import logging
+from functools import lru_cache
 
 import marshmallow
 from marshmallow import EXCLUDE, Schema, fields, post_load, validate, validates_schema
@@ -207,6 +208,7 @@ class CanvasAPIClient:
                 for enrollment in data["enrollments"]
             ]
 
+    @lru_cache
     def list_files(self, course_id):
         """
         Return the list of files for the given `course_id`.
@@ -266,6 +268,7 @@ class CanvasAPIClient:
         updated_at = fields.String(required=True)
         size = fields.Integer(required=True)
 
+    @lru_cache
     def public_url(self, file_id):
         """
         Get a new temporary public download URL for the file with the given ID.


### PR DESCRIPTION
Because `CanvasAPIClient` is a `pyramid_services` service it is a per-request singleton:

`pyramid_services` instantiates services lazily. `FooService` doesn't get instantiated until something in the request does
`request.find_service(name="foo")`. Once `FooService` has been instantiated the instance is cached in a per-request registry so that any further calls to `find_service(name="foo")` made during the same request will return the same instance. But any calls made by other requests return another instance.

This is handy because it means that services can cache things on a per-request basis just by saving them on `self` or by using the standard library's `@cached_property` and `@lru_cache` decorators.

We likely want to make use of this service-layer caching for any methods that do expensive computation, DB queries or network requests.

Caching is a good pattern because it allows higher-level business logic to be simpler by just calling `FooService.foo()` repeatedly, safe in the knowledge that caching will mean that no network requests or anything will be sent twice. The higher level code doesn't need to hold on to `FooService`'s return values and pass them around, or use boolean local variables to track whether or not `FooService` was already called.

Caching also means that if two different components that don't know about each other and don't know each other's implementation details both call `FooService.foo()` it'll only actually be executed once.

I don't think there's any reason why a single request would ever want to make the same HTTP request to the Canvas API with the same arguments. If a single request ever calls any `CanvasAPIClient.foo()` repeatedly I think we'll always want that to be per-request cached.

In this commit I've restrained myself to just adding `@lru_cache` to `CanvasAPIClient.list_files()` and `CanvasAPIClient.public_url()`. Caching those two methods allows the logic in https://github.com/hypothesis/lms/pull/2899 to be simpler. But I see no reason why `@lru_cache` couldn't be added to the rest of this class's methods in a follow-up PR.