### PR TITLE
Search by both original and mapped file ID

### DIFF
--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -100,14 +100,10 @@ class CanvasFileFinder:
                 continue
 
             for file_dict in self._api.list_files(course_id):
-                display_name = file_dict["display_name"]
-                size = file_dict["size"]
-                id_ = str(file_dict["id"])
-
                 if (
-                    display_name == file.name
-                    and size == file.size
-                    and id_ != file.lms_id
+                    file_dict["display_name"] == file.name
+                    and file_dict["size"] == file.size
+                    and str(file_dict["id"]) != file.lms_id
                 ):
                     return str(file_dict["id"])
 


### PR DESCRIPTION
When launching a Canvas Files assignment and the `CanvasService.public_url_for_file()` method is called:

If there is a `mapped_file_id` in the DB but we nonetheless don't see the `mapped_file_id` in the current course or we get a permissions error when trying to get a public URL for the `mapped_file_id`, use both the `mapped_file_id` and the assignment's original `file_id` to try to find a matching file in the course.

I think this might fix an obscure Canvas course copy edge case involving renaming files in Canvas and possibly requiring chains of multiple course copies. I'm not sure exactly what the edge case that this covers is, yet. But it shouldn't do any harm.