### PR TITLE
WIP: Add interface for pasting a URL to a VitalSource book

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -76,7 +76,7 @@ export default function BookPicker({ onCancel, onSelectBook }) {
       onCancel={onCancel}
       title={
         step === 'select-book'
-          ? 'Paste URL to VitalSource book'
+          ? 'Paste link to VitalSource book'
           : 'Select chapter'
       }
       buttons={[

--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import { useService, VitalSourceService } from '../services';
 
-import BookList from './BookList';
+import BookSelector from './BookSelector';
 import ChapterList from './ChapterList';
 import ErrorDisplay from './ErrorDisplay';
 
@@ -33,7 +33,6 @@ import ErrorDisplay from './ErrorDisplay';
 export default function BookPicker({ onCancel, onSelectBook }) {
   const vsService = useService(VitalSourceService);
 
-  const [bookList, setBookList] = useState(/** @type {Book[]|null} */ (null));
   const [chapterList, setChapterList] = useState(
     /** @type {Chapter[]|null} */ (null)
   );
@@ -60,16 +59,14 @@ export default function BookPicker({ onCancel, onSelectBook }) {
   );
 
   useEffect(() => {
-    if (step === 'select-book' && !bookList) {
-      vsService.fetchBooks().then(setBookList).catch(setError);
-    } else if (step === 'select-chapter' && !chapterList) {
+    if (step === 'select-chapter' && !chapterList) {
       const currentBook = /** @type {Book} */ (book);
       vsService
         .fetchChapters(currentBook.id)
         .then(setChapterList)
         .catch(setError);
     }
-  }, [book, bookList, step, chapterList, vsService]);
+  }, [book, step, chapterList, vsService]);
 
   const canSubmit =
     (step === 'select-book' && book) || (step === 'select-chapter' && chapter);
@@ -77,7 +74,11 @@ export default function BookPicker({ onCancel, onSelectBook }) {
   return (
     <Modal
       onCancel={onCancel}
-      title={step === 'select-book' ? 'Select book' : 'Select chapter'}
+      title={
+        step === 'select-book'
+          ? 'Paste URL to VitalSource book'
+          : 'Select chapter'
+      }
       buttons={[
         <LabeledButton
           key="submit"
@@ -100,13 +101,7 @@ export default function BookPicker({ onCancel, onSelectBook }) {
       ]}
     >
       {step === 'select-book' && !error && (
-        <BookList
-          books={bookList || []}
-          isLoading={!bookList}
-          selectedBook={book}
-          onSelectBook={setBook}
-          onUseBook={confirmBook}
-        />
+        <BookSelector selectedBook={book} onSelectBook={setBook} />
       )}
       {step === 'select-chapter' && !error && (
         <ChapterList

--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -1,0 +1,156 @@
+import {
+  IconButton,
+  SvgIcon,
+  TextInput,
+  TextInputWithButton,
+  Thumbnail,
+} from '@hypothesis/frontend-shared';
+import { createElement } from 'preact';
+import { useRef, useState } from 'preact/hooks';
+
+import { useService, VitalSourceService } from '../services';
+
+/**
+ * @typedef {import('../api-types').Book} Book
+ */
+
+/**
+ * @typedef BookSelectorProps
+ * @prop {Book|null} selectedBook
+ * @prop {(b: Book|null) => void} onSelectBook - Callback invoked when user selects a book
+ */
+
+/**
+ * Component that prompts a user to enter/paste a URL to a VitalSource book.
+ *
+ * @param {BookSelectorProps} props
+ */
+export default function BookSelector({ selectedBook, onSelectBook }) {
+  const vsService = useService(VitalSourceService);
+
+  const inputRef = useRef(/** @type {HTMLInputElement|null} */ (null));
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [error, setError] = useState(/** @type {string|null} */ (null));
+  const previousURL = useRef(/** @type {string|null} */ (null));
+
+  /**
+   * A naive regex matcher for a VBID in a URL-like string
+   *
+   * @param {string} url
+   * @returns {string|false}
+   */
+  const bookIDFromURL = url => {
+    const bookIdPattern = /book\/([0-9A-Z-]+)\/?/;
+    const matches = url.match(bookIdPattern);
+    return !!matches && matches[1];
+  };
+
+  /**
+   * Attempt to retrieve a book by bookID (vbid) via service
+   *
+   * @param {string} bookID
+   */
+  const fetchBook = bookID => {
+    setIsLoading(true);
+    vsService
+      .fetchBook(bookID)
+      .then(onSelectBook)
+      .catch(err => setError(err.message))
+      .finally(() => setIsLoading(false));
+  };
+
+  // Respond to changes in the input field
+  const onChangeURL = () => {
+    const url = inputRef.current.value;
+    if (url && url === previousURL.current) {
+      // Do nothing if there is no real change. This situation can arise if the
+      // user "submits" a URL by typing "Enter" and then interacts elsewhere in
+      // the UI (a spurious change event can be triggered).
+      // This prevents reloading the same book.
+      return;
+    }
+    previousURL.current = url;
+
+    // Reset selected book, if any
+    onSelectBook(null);
+    setError(null);
+
+    if (url) {
+      // Don't try to fetch, or set any errors, if the input field is empty
+      const bookID = bookIDFromURL(url);
+      if (!bookID) {
+        setError("That doesn't look like a VitalSource book URL");
+        return;
+      }
+      fetchBook(bookID);
+    }
+  };
+
+  // Capture "Enter" and make sure it does not submit the whole shebang
+  /** @param {KeyboardEvent} event */
+  const onKeyDown = event => {
+    let handled = false;
+    if (event.key === 'Enter') {
+      handled = true;
+      onChangeURL();
+    }
+    if (handled) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  return (
+    <div className="hyp-u-layout-row hyp-u-horizontal-spacing BookSelector">
+      <div className="BookSelector__thumbnail">
+        <Thumbnail isLoading={isLoading}>
+          {selectedBook && (
+            <img
+              alt={`Book cover for ${selectedBook.title}`}
+              src={selectedBook.cover_image}
+              data-testid="cover-image"
+            />
+          )}
+        </Thumbnail>
+      </div>
+      <div className="hyp-u-stretch hyp-u-vertical-spacing--3">
+        <div>Paste a link to the VitalSource book you&apos;d like to use:</div>
+
+        <TextInputWithButton>
+          <TextInput
+            error={!!error}
+            inputRef={inputRef}
+            onChange={onChangeURL}
+            onKeyDown={onKeyDown}
+            placeholder="e.g. https://bookshelf.vitalsource.com/#/book/012345678..."
+          />
+          <IconButton
+            icon="arrow-right"
+            variant="dark"
+            onClick={onChangeURL}
+            title="Find book"
+          />
+        </TextInputWithButton>
+
+        {selectedBook && (
+          <div className="hyp-u-layout-row--center hyp-u-horizontal-spacing">
+            <SvgIcon name="check" className="hyp-u-color--success" />
+            <div className="hyp-u-stretch">
+              <strong>
+                <em>{selectedBook.title}</em>
+              </strong>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="hyp-u-layout-row--center hyp-u-horizontal-spacing hyp-u-color--error">
+            <SvgIcon name="cancel" />
+            <div className="hyp-u-stretch">{error}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/icons.js
+++ b/lms/static/scripts/frontend_apps/icons.js
@@ -13,4 +13,5 @@ export default {
   // Shared icons
   'arrow-left': require('@hypothesis/frontend-shared/images/icons/arrow-left.svg'),
   'arrow-right': require('@hypothesis/frontend-shared/images/icons/arrow-right.svg'),
+  cancel: require('@hypothesis/frontend-shared/images/icons/cancel.svg'),
 };

--- a/lms/static/scripts/frontend_apps/services/vitalsource.js
+++ b/lms/static/scripts/frontend_apps/services/vitalsource.js
@@ -34,7 +34,7 @@ export class VitalSourceService {
    *
    * @param {string} bookID
    * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
-   * @return {Promise<Book|null>}
+   * @return {Promise<Book>}
    */
   async fetchBook(bookID, fetchDelay = 500) {
     await delay(fetchDelay);

--- a/lms/static/scripts/frontend_apps/services/vitalsource.js
+++ b/lms/static/scripts/frontend_apps/services/vitalsource.js
@@ -27,6 +27,25 @@ export class VitalSourceService {
   }
 
   /**
+   * Fetch a book by bookID ("vbid")
+   *
+   * This is currently a fake that waits for a fixed time before returning
+   * hard-coded data.
+   *
+   * @param {string} bookID
+   * @param {number} [fetchDelay] - Dummy delay to simulate slow third-party
+   * @return {Promise<Book|null>}
+   */
+  async fetchBook(bookID, fetchDelay = 500) {
+    await delay(fetchDelay);
+    const book = bookList.find(b => b.id === bookID);
+    if (!book) {
+      throw new APIError(404, { message: 'Book not found' });
+    }
+    return book;
+  }
+
+  /**
    * Fetch a list of available ebooks to use in assignments.
    *
    * This is currently a fake that waits for a fixed time before returning

--- a/lms/static/styles/components/_BookSelector.scss
+++ b/lms/static/styles/components/_BookSelector.scss
@@ -1,0 +1,11 @@
+.BookSelector {
+  @media screen and (min-width: 42rem) {
+    // Where space allows, make the book selection UI comfortably wide
+    min-width: 36rem;
+  }
+
+  &__thumbnail {
+    width: 110px;
+    height: 150px;
+  }
+}

--- a/lms/static/styles/components/_BookSelector.scss
+++ b/lms/static/styles/components/_BookSelector.scss
@@ -1,6 +1,10 @@
 .BookSelector {
+  // The containing `Modal` component will take up 90vw on narrow screens.
+  // For viewports that are wider, `Modal` sets a min-width, but it's a little
+  // narrow for this particular interface. The book-selector feels about right
+  // at 36em where space allows. 42em minimum here allows for at least 3em
+  // of horizontal breathing room on each side of the modal's contents.
   @media screen and (min-width: 42rem) {
-    // Where space allows, make the book selection UI comfortably wide
     min-width: 36rem;
   }
 

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -31,6 +31,12 @@
 // Shared styles from frontend-shared package
 @use '@hypothesis/frontend-shared/styles';
 
+// Make the shared package utility styles available for
+// initial prototyping purposes.
+// NB: These styles have not been made explicitly public by this package
+// yet, so this inclusion may be temporary.
+@use '@hypothesis/frontend-shared/styles/util' as hyp-u;
+
 // This ensures that root components which set `width: 100%; height: 100%`
 // (eg. the `BasicLTILaunchApp`) will fill the viewport.
 html,

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -12,6 +12,7 @@
 // Preact components
 @use 'components/BasicLTILaunchApp';
 @use 'components/BookList';
+@use 'components/BookSelector';
 @use 'components/ContentSelector';
 @use 'components/Dialog';
 @use 'components/ErrorDisplay';


### PR DESCRIPTION
This draft PR demonstrates a UI that allows an instructor to select a VitalSource book for an assignment reading by pasting in a valid VitalSource book URL.

## To Play With This

1. Check out this branch
2. run your local `lms` environment
3. visit http://localhost:8001/flags and ensure the `vitalsource` flag is `on`
4. Create or edit a `localhost` assignment. (I’m glossing over this, but ping me or other team members if you need assistance). You should see a VitalSource option in the content-picker for assignment configuration. Click this.

You should see this initially:

![D5F983F5-DD61-409A-A797-4C771216795B](https://user-images.githubusercontent.com/439947/124177745-9f671700-da7e-11eb-92e9-788618ab3f28.png)

Now, try entering either of these URLS into the input field:

* https://bookshelf.vitalsource.com/#/book/9781400847402
* https://bookshelf.vitalsource.com/#/book/BOOKSHELF-TUTORIAL

and either tabbing, typing `Enter`, clicking the little button or otherwise blurring the input field.

If you modify the URL such that the book ID changes, you should see a basic validation error. If you modify the URL such that it doesn’t match the pattern `/\/book/[0-9A-Z-]+\/`, you should see a field-validation error.

These interactions are captured in the following video:

![paste-valid-url](https://user-images.githubusercontent.com/439947/124177773-aaba4280-da7e-11eb-8fb3-dc6cc1869d4f.gif)

## What’s done and what’s not done

It’s early days yet. This is in prototype form right now, which means:

* The API interactions are faked and are based on limited, hard-coded local data.
* User-facing wording is placeholder only.
* There is a basic “parse a bookID from a URL-like string” function in the new `BookSelector` component itself, but it’s naive and in prototype state. Needs attention at some point.
* I haven’t cleaned up after the now-unused `BookList` in this branch
* There are no tests yet

### UI TODOs

* There is a subtle height issue with the input field in its error state. It has to do with a one-pixel border being removed and re-added. It should be a simple enough fix. Symptom: tiny layout wiggle when the field goes into error state.
* The input field should focus when the modal is opened. I overlooked this today and don’t have time to chase it down now (it may involve sharing a `ref` between `BookPicker` and `BookSelector`).

## Some notes on implementation details
I attempted to create a component that could be (at least very nearly) a drop-in replacement for `BookList` such that I wouldn’t need to disturb `BookPicker` much.

`BookSelector` does make its own API call to (attempt to) retrieve a book by entered `bookID`.  Curious as to whether this is OK, as it keeps `BookPicker` from bloating too much, or if it’s bad in that all API interactions should be centralized in `BookPicker`?

I found out the hard way we need to handle `enter` keypresses, but there was prior art to help me out there.

I’m catching API Errors much like other components, but I’m using a local error pattern here instead of `ErrorDisplay` at the moment. This can be debated and discussed!

Part of https://github.com/hypothesis/lms/issues/2863

