### PR TITLE
A POC to demonstrate the effect of a helper object on course copy tests

### DIFF
--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -45,6 +45,10 @@ class CanvasService:
             file_ = self._file_service.get(effective_file_id, type_="canvas_file")
 
             if not file_:
+                # We don't have a record of the assignment's file in our DB.
+                # This can happen, for example, if Hypothesis has not been
+                # launched in the original assignment's course since we
+                # deployed the code that started recording files in the DB.
                 raise
 
             # Look for a copy of the assignment's file that the current user
@@ -52,6 +56,10 @@ class CanvasService:
             found_file_id = self.find_matching_file_in_course(course_id, file_)
 
             if not found_file_id:
+                # We didn't find a matching file in the current course.
+                # This could mean that the file has been deleted, has been
+                # renamed, or the current user doesn't have permission to see
+                # the file.
                 raise
 
             # We found a matching copy of the assignment's file that the

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from lms import models
-from lms.services.exceptions import CanvasFileNotFoundInCourse
+from lms.services.exceptions import CanvasAPIPermissionError, CanvasFileNotFoundInCourse
 
 
 class CanvasService:
@@ -9,28 +9,63 @@ class CanvasService:
 
     api = None
 
-    def __init__(self, canvas_api):
+    def __init__(self, canvas_api, file_service):
         self.api = canvas_api
+        self._file_service = file_service
 
-    def public_url_for_file(self, file_id, course_id, check_in_course=False):
-        """
-        Get a public URL for a Canvas file.
+    def public_url_for_file(
+        self, module_item_configuration, file_id, course_id, check_in_course=False
+    ):
+        mapped_file_id = module_item_configuration.get_canvas_mapped_file_id(file_id)
 
-        This will also attempt to check if the file is in the course to detect
-        course copy situations and fix it if we can.
+        # If there's a previously stored mapping for file_id use that instead.
+        effective_file_id = mapped_file_id or file_id
 
-        :param file_id: The file to look up
-        :param course_id: The course the file should be in
-        :param check_in_course: Raise CanvasFileNotFoundInCourse if file_id isn't in
-            course_id
-        :return: A URL suitable for public presentation of the file
-        :raise  CanvasFileNotFoundInCourse: if check_in_course=True and file_id isn't in course_id
-            be in the course but isn't.
-        """
+        try:
+            return self._public_url(
+                effective_file_id,
+                course_id=course_id if check_in_course else None,
+            )
+        except (CanvasFileNotFoundInCourse, CanvasAPIPermissionError):
+            # Either the user can't see the file in the current course's list
+            # of files or the user got a permissions error from the Canvas API
+            # when trying to get a public URL for the file.
+            #
+            # This can happen because the course has been copied and the
+            # assignment's file_id is from the original course. Or it can
+            # happen because the assignment's file has been deleted from
+            # Canvas. Or it can happen because the user doesn't have permission
+            # to see the file ("unpublished" files in Canvas are visible to
+            # instructors but not to students).
+            #
+            # We'll try to find another copy of the same file that the current
+            # user *can* see in the current course and use that instead.
 
-        if check_in_course:
-            if not self.can_see_file_in_course(file_id, course_id):
-                raise CanvasFileNotFoundInCourse(file_id)
+            # Look for a previously saved record of the assignment's file in our DB.
+            file_ = self._file_service.get(effective_file_id, type_="canvas_file")
+
+            if not file_:
+                raise
+
+            # Look for a copy of the assignment's file that the current user
+            # *can* see in the current course.
+            found_file_id = self.find_matching_file_in_course(course_id, file_)
+
+            if not found_file_id:
+                raise
+
+            # We found a matching copy of the assignment's file that the
+            # current user *can* see in the current course. Store a mapping so
+            # that we don't have to re-do the search the next time the
+            # assignment is launched.
+            module_item_configuration.set_canvas_mapped_file_id(file_id, found_file_id)
+
+            # Try again using the found matching file.
+            return self._public_url(found_file_id)
+
+    def _public_url(self, file_id, course_id=None):
+        if course_id and not self.can_see_file_in_course(file_id, course_id):
+            raise CanvasFileNotFoundInCourse(file_id)
 
         return self.api.public_url(file_id)
 
@@ -82,4 +117,7 @@ class CanvasService:
 
 
 def factory(_context, request):
-    return CanvasService(canvas_api=request.find_service(name="canvas_api_client"))
+    return CanvasService(
+        canvas_api=request.find_service(name="canvas_api_client"),
+        file_service=request.find_service(name="file"),
+    )

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -57,9 +57,9 @@ class CanvasService:
             # user *can* see in the current course and use that instead.
 
             # Look for a previously saved record of the assignment's file in our DB.
-            file_ = self._file_service.get(effective_file_id, type_="canvas_file")
+            file = self._file_service.get(effective_file_id, type_="canvas_file")
 
-            if not file_:
+            if not file:
                 # We don't have a record of the assignment's file in our DB.
                 # This can happen, for example, if Hypothesis has not been
                 # launched in the original assignment's course since we
@@ -68,7 +68,7 @@ class CanvasService:
 
             # Look for a copy of the assignment's file that the current user
             # *can* see in the current course.
-            found_file_id = self.find_matching_file_in_course(course_id, file_)
+            found_file_id = self.find_matching_file_in_course(course_id, file)
 
             if not found_file_id:
                 # We didn't find a matching file in the current course.
@@ -98,23 +98,23 @@ class CanvasService:
         marked as "unpublished" in Canvas can only be seen by teachers, not
         students).
         """
-        for file_ in self.api.list_files(course_id):
+        for file in self.api.list_files(course_id):
             # The Canvas API returns file IDs as ints but the file_id param
             # that this method receives (from our proxy API) is a string.
             # Convert ints to strings so that we can compare them.
-            if str(file_["id"]) == file_id:
+            if str(file["id"]) == file_id:
                 return
 
         raise CanvasFileNotFoundInCourse(file_id)
 
     def find_matching_file_in_course(
-        self, course_id: str, file_: models.File
+        self, course_id: str, file: models.File
     ) -> Optional[str]:
         """
-        Return the ID of a file in course_id that matches file_.
+        Return the ID of a file in course_id that matches `file`.
 
         Search for a file that the current Canvas user can see in course_id and
-        that matches the given file_ (same filename and size) and return the
+        that matches the given `file` (same filename and size) and return the
         matching file's ID.
 
         Return None if no matching file is found.
@@ -125,7 +125,7 @@ class CanvasService:
             display_name = file_dict["display_name"]
             size = file_dict["size"]
 
-            if display_name == file_.name and size == file_.size:
+            if display_name == file.name and size == file.size:
                 return str(file_dict["id"])
 
         return None

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -16,6 +16,22 @@ class CanvasService:
     def public_url_for_file(
         self, module_item_configuration, file_id, course_id, check_in_course=False
     ):
+        """
+        Return a public URL for file_id.
+
+        :param module_item_configuration: the ModuleItemConfiguration for the
+            current assignment
+        :param file_id: the Canvas API ID of the file
+        :param course_id: the Canvas API ID of the course that the file is in
+        :param check_in_course: whether to check that file_id is in course_id
+
+        :raise CanvasFileNotFoundInCourse: if check_in_course was True and the
+            current user can't see file_id in course_id's list of files
+
+        :raise CanvasAPIPermissionError: if the user gets a permissions error
+            from the Canvas API when trying to get a public URL for file_id
+        """
+
         mapped_file_id = module_item_configuration.get_canvas_mapped_file_id(file_id)
 
         # If there's a previously stored mapping for file_id use that instead.

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -30,12 +30,19 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
+        application_instance = self.request.find_service(
+            name="application_instance"
+        ).get()
+
+        module_item_configuration = self.request.find_service(name="assignment").get(
+            application_instance.tool_consumer_instance_guid,
+            self.request.matchdict["resource_link_id"],
+        )
+
         public_url = self.canvas.public_url_for_file(
-            file_id=self.request.matchdict["file_id"],
-            course_id=self.request.matchdict["course_id"],
-            # Teachers can have broad permissions and see files that aren't in
-            # the course. So do this slower check (extra API call) to warn the
-            # teacher that their students might not be able to see the file.
+            module_item_configuration,
+            self.request.matchdict["file_id"],
+            self.request.matchdict["course_id"],
             check_in_course=self.request.lti_user.is_instructor,
         )
 

--- a/tests/factories/module_item_configuration.py
+++ b/tests/factories/module_item_configuration.py
@@ -10,4 +10,5 @@ ModuleItemConfiguration = make_factory(
     resource_link_id=RESOURCE_LINK_ID,
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     document_url=Faker("uri"),
+    extra={},
 )

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,3 +1,4 @@
+from functools import partial
 from unittest.mock import DEFAULT, call, sentinel
 
 import pytest
@@ -12,210 +13,165 @@ from tests import factories
 
 
 class TestPublicURLForFile:
-    def test_without_check_in_course(
-        self,
-        canvas_service,
-        canvas_api_client,
-        module_item_configuration,
-        file_id_from_current_course,
+    def test_without_check_in_course_and_without_a_mapped_file_id(
+        self, canvas_service, file_from_current_course, public_url_for_file
     ):
-        # This is what happens during a normal student assignment launch.
-        url = canvas_service.public_url_for_file(
-            module_item_configuration, file_id_from_current_course, sentinel.course_id
-        )
+        # This is what happens during a normal student assignment launch:
+        # check_in_course is False and there's no mapped_file_id in the DB.
+
+        url = public_url_for_file(file_id=str(file_from_current_course["id"]))
 
         # check_in_course was False, so it didn't call list_files() to check
         # whether the file_id was in the course.
-        canvas_api_client.list_files.assert_not_called()
+        canvas_service.api.list_files.assert_not_called()
 
         # It calls the Canvas API with the file_id and returns the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
+        canvas_service.api.public_url.assert_called_once_with(
+            str(file_from_current_course["id"])
         )
-        assert url == canvas_api_client.public_url.return_value
+        assert url == canvas_service.api.public_url.return_value
 
-    def test_with_check_in_course(
-        self,
-        canvas_service,
-        canvas_api_client,
-        module_item_configuration,
-        file_id_from_current_course,
+    def test_if_check_in_course_is_True_it_checks_that_the_file_is_in_the_course(
+        self, canvas_service, file_from_current_course, public_url_for_file
     ):
-        # This is what happens during a normal instructor launch.
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_current_course,
-            sentinel.course_id,
-            check_in_course=True,
+        # This is what happens during a normal instructor launch;
+        # check_in_course is True and there's no mapped_file_id in the DB.
+
+        url = public_url_for_file(
+            file_id=str(file_from_current_course["id"]), check_in_course=True
         )
 
         # check_in_course was True so it called list_files() to check whether
         # file_id was in the course.
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
 
         # It calls the Canvas API with the file_id and returns the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
+        canvas_service.api.public_url.assert_called_once_with(
+            str(file_from_current_course["id"])
         )
-        assert url == canvas_api_client.public_url.return_value
+        assert url == canvas_service.api.public_url.return_value
 
-    def test_with_mapped_file_id_and_without_check_in_course(
+    def test_if_theres_a_mapped_file_id_it_uses_it(
         self,
         canvas_service,
-        canvas_api_client,
         module_item_configuration,
-        file_id_from_current_course,
-        file_id_from_a_different_course,
+        file_from_current_course,
+        file_from_a_different_course,
+        public_url_for_file,
     ):
-        # This is what happens when a student launches a course-copied
-        # assignment that has already been fixed (we've already stored a
+        # If there's a mapped_file_id in the DB it gets used instead of the
+        # given file_id.
+        #
+        # This is what happens when a user launches a course-copied assignment
+        # that has previously been fixed (we've previously stored a
         # mapped_file_id in the DB).
 
         # Store a mapped_file_id in the DB. This would have been done by a
         # previous request.
         module_item_configuration.set_canvas_mapped_file_id(
-            file_id_from_a_different_course, file_id_from_current_course
+            str(file_from_a_different_course["id"]), str(file_from_current_course["id"])
         )
 
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_a_different_course,
-            sentinel.course_id,
+        url = public_url_for_file(
+            file_id=str(file_from_a_different_course["id"]), check_in_course=True
         )
 
-        # check_in_course was False, so it didn't call list_files() to check
-        # whether the file_id was in the course.
-        canvas_api_client.list_files.assert_not_called()
+        # It checks that the mapped_file_id is in the course (not the original file_id).
+        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
 
         # It called public_url() with the mapped_file_id rather than with the
         # original file_id, and returned the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
+        canvas_service.api.public_url.assert_called_once_with(
+            str(file_from_current_course["id"])
         )
-        assert url == canvas_api_client.public_url.return_value
-
-    def test_with_mapped_file_id_and_check_in_course(
-        self,
-        canvas_service,
-        canvas_api_client,
-        module_item_configuration,
-        file_id_from_current_course,
-        file_id_from_a_different_course,
-    ):
-        # This is what happens when an instructor launches a course-copied
-        # assignment that has already been fixed (we've already stored a
-        # mapped_file_id in the DB).
-
-        # Store a mapped_file_id in the DB. This would have been done by a
-        # previous request.
-        module_item_configuration.set_canvas_mapped_file_id(
-            file_id_from_a_different_course, file_id_from_current_course
-        )
-
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_a_different_course,
-            sentinel.course_id,
-            check_in_course=True,
-        )
-
-        # check_in_course was True so it called list_files() to check whether
-        # mapped_file_id was in the course.
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
-
-        # It called public_url() with the mapped_file_id rather than with the
-        # original file_id, and returned the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
-        )
-        assert url == canvas_api_client.public_url.return_value
+        assert url == canvas_service.api.public_url.return_value
 
     def test_file_not_found_in_course_and_matching_file_found(
         self,
         canvas_service,
-        canvas_api_client,
-        module_item_configuration,
         file_service,
+        module_item_configuration,
         file_from_current_course,
-        file_id_from_current_course,
-        file_id_from_a_different_course,
+        file_from_a_different_course,
+        public_url_for_file,
     ):
         # This is what happens when an instructor launches an assignment whose
         # file_id is *not* in the current course.
-
-        # We *do* have a models.File object for the file_id in the DB, and its
-        # name and size *do* match one of the files in the current course in Canvas.
         file_service.get.return_value = factories.File(
             name=file_from_current_course["display_name"],
             size=file_from_current_course["size"],
         )
 
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_a_different_course,
-            sentinel.course_id,
-            check_in_course=True,
+        url = public_url_for_file(
+            file_id=str(file_from_a_different_course["id"]), check_in_course=True
         )
 
-        # check_in_course was True so it called list_files() to check whether
-        # file_id was in the course.
-        #
-        # There's also a second call to list_files() because it calls it again
-        # to look for a matching file in the current course. This does not make
-        # two network requests because CanvasAPIClient.list_files() has
-        # caching.
-        assert canvas_api_client.list_files.call_args_list == [
-            call(sentinel.course_id),
-            call(sentinel.course_id),
-        ]
-        # It looks up the given file_id in the DB.
+        # It looked up the given file_id in the DB.
         file_service.get.assert_called_once_with(
-            file_id_from_a_different_course, type_="canvas_file"
+            str(file_from_a_different_course["id"]), type_="canvas_file"
         )
-        # It stores a file mapping from the given file_id to the matching
-        # found_file_id so that it doesn't have to re-do the search the next
-        # time the assignment is launched.
-        assert (
-            module_item_configuration.get_canvas_mapped_file_id(
-                file_id_from_a_different_course
-            )
-            == file_id_from_current_course
+        # It stored a mapping from the given file_id to found_file_id.
+        assert module_item_configuration.get_canvas_mapped_file_id(
+            str(file_from_a_different_course["id"])
+        ) == str(file_from_current_course["id"])
+        # It got the found_file_id's public URL and returned it.
+        canvas_service.api.public_url.assert_called_once_with(
+            str(file_from_current_course["id"])
         )
-        # It calls public_url() with the found_file_id and returns the public URL.
-        canvas_api_client.public_url.assert_called_once_with(
-            file_id_from_current_course
-        )
-        assert url == canvas_api_client.public_url.return_value
+        assert url == canvas_service.api.public_url.return_value
 
-    def test_file_not_found_in_course_but_no_file_info(
+    def test_permissions_error_and_matching_file_found(
         self,
         canvas_service,
-        module_item_configuration,
         file_service,
-        file_id_from_a_different_course,
+        module_item_configuration,
+        file_from_current_course,
+        file_from_a_different_course,
+        public_url_for_file,
+    ):
+        # This is what happens when a student launches an assignment whose
+        # file_id is *not* in the current course.
+        canvas_service.api.public_url.side_effect = [CanvasAPIPermissionError, DEFAULT]
+        file_service.get.return_value = factories.File(
+            name=file_from_current_course["display_name"],
+            size=file_from_current_course["size"],
+        )
+
+        url = public_url_for_file(file_id=str(file_from_a_different_course["id"]))
+
+        # It looked up the given file_id in the DB.
+        file_service.get.assert_called_once_with(
+            str(file_from_a_different_course["id"]), type_="canvas_file"
+        )
+        # It stored a mapping from the given file_id to found_file_id.
+        assert module_item_configuration.get_canvas_mapped_file_id(
+            str(file_from_a_different_course["id"])
+        ) == str(file_from_current_course["id"])
+        # It got found_file_id's public URL and returned it.
+        assert canvas_service.api.public_url.call_args_list == [
+            call(str(file_from_a_different_course["id"])),
+            call(str(file_from_current_course["id"])),
+        ]
+        assert url == canvas_service.api.public_url.return_value
+
+    def test_file_not_found_in_course_but_no_file_info(
+        self, file_service, file_from_a_different_course, public_url_for_file
     ):
         # This is what happens when a teacher launches an assignment whose
         # file_id is *not* in the current course and we don't have a record of
-        # the file_id in our DB.  Without a record we can't search for a
+        # the file_id in our DB. Without a record we can't search for a
         # matching file so we raise an error.
 
         # There's no record of the file_id in the DB.
         file_service.get.return_value = None
 
         with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_service.public_url_for_file(
-                module_item_configuration,
-                file_id_from_a_different_course,
-                sentinel.course_id,
-                check_in_course=True,
+            public_url_for_file(
+                str(file_from_a_different_course["id"]), check_in_course=True
             )
 
     def test_file_not_found_in_course_but_no_matching_file(
-        self,
-        canvas_service,
-        module_item_configuration,
-        file_service,
-        file_id_from_a_different_course,
+        self, file_service, file_from_a_different_course, public_url_for_file
     ):
         # This is what happens when a teacher launches an assignment whose
         # file_id is *not* in the current course and even though we do have a
@@ -228,116 +184,47 @@ class TestPublicURLForFile:
         file_service.get.return_value = factories.File(name="foo")
 
         with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_service.public_url_for_file(
-                module_item_configuration,
-                file_id_from_a_different_course,
-                sentinel.course_id,
-                check_in_course=True,
+            public_url_for_file(
+                file_id=str(file_from_a_different_course["id"]), check_in_course=True
             )
-
-    def test_permissions_error_and_matching_file_found(
-        self,
-        canvas_service,
-        canvas_api_client,
-        module_item_configuration,
-        file_service,
-        file_from_current_course,
-        file_id_from_current_course,
-        file_id_from_a_different_course,
-    ):
-        # This is what happens when a student launches an assignment whose
-        # file_id is *not* in the current course.
-
-        # The code is going to call public_url() twice. The first call is with
-        # the original file_id and public_url() raises a permissions error. The
-        # second call is with the matching found_file_id and public_url()
-        # successfully returns a URL.
-        canvas_api_client.public_url.side_effect = [CanvasAPIPermissionError, DEFAULT]
-
-        # We *do* have a models.File object for the file_id in the DB, and its
-        # name and size *do* match one of the files in the current course in Canvas.
-        file_service.get.return_value = factories.File(
-            name=file_from_current_course["display_name"],
-            size=file_from_current_course["size"],
-        )
-
-        url = canvas_service.public_url_for_file(
-            module_item_configuration,
-            file_id_from_a_different_course,
-            sentinel.course_id,
-        )
-
-        # It looks up the given file_id in the DB.
-        file_service.get.assert_called_once_with(
-            file_id_from_a_different_course, type_="canvas_file"
-        )
-        # It calls list_files() to look for a matching file in the current course.
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
-        # It stores a file mapping from the given file_id to the matching
-        # found_file_id so that it doesn't have to re-do the search the next
-        # time the assignment is launched.
-        assert (
-            module_item_configuration.get_canvas_mapped_file_id(
-                file_id_from_a_different_course
-            )
-            == file_id_from_current_course
-        )
-        # It calls public_url() twice: one with the original file_id and once
-        # with the matching found_file_id.
-        assert canvas_api_client.public_url.call_args_list == [
-            call(file_id_from_a_different_course),
-            call(file_id_from_current_course),
-        ]
-        # It returns the public URL of the file in the current course.
-        assert url == canvas_api_client.public_url.return_value
 
     def test_permissions_error_but_no_file_info(
         self,
         canvas_service,
-        canvas_api_client,
-        module_item_configuration,
         file_service,
-        file_id_from_a_different_course,
+        file_from_a_different_course,
+        public_url_for_file,
     ):
         # This is what happens when a student launches an assignment whose
         # file_id is *not* in the current course and we don't have a record of
         # the file_id in our DB. Without a record we can't search for a
         # matching file so we raise an error.
-        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
         file_service.get.return_value = None
 
         with pytest.raises(CanvasAPIPermissionError):
-            canvas_service.public_url_for_file(
-                module_item_configuration,
-                file_id_from_a_different_course,
-                sentinel.course_id,
-            )
+            public_url_for_file(file_id=str(file_from_a_different_course["id"]))
 
     def test_permissions_error_but_no_matching_file(
         self,
         canvas_service,
-        canvas_api_client,
-        module_item_configuration,
         file_service,
-        file_id_from_a_different_course,
+        file_from_a_different_course,
+        public_url_for_file,
     ):
         # This is what happens when a student launches an assignment whose
         # file_id is *not* in the current course and even though we do have a
         # record of this file_id in our DB we don't find a matching file in the
         # current course. Since we can't find a matching file we can't fix the
         # assignment so we raise an error.
-        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
 
         # The file record that we find in our DB. Its name doesn't match any
         # file in the current course.
         file_service.get.return_value = factories.File(name="foo")
 
         with pytest.raises(CanvasAPIPermissionError):
-            canvas_service.public_url_for_file(
-                module_item_configuration,
-                file_id_from_a_different_course,
-                sentinel.course_id,
-            )
+            public_url_for_file(file_id=str(file_from_a_different_course["id"]))
 
     @pytest.fixture
     def module_item_configuration(self, db_session):
@@ -346,24 +233,22 @@ class TestPublicURLForFile:
         return module_item_configuration
 
     @pytest.fixture
-    def file_from_current_course(self, canvas_api_client):
-        """Return the Canvas API file dict for a file that *is* in the current course."""
-        return canvas_api_client.list_files.return_value[1]
+    def public_url_for_file(self, canvas_service, module_item_configuration):
+        return partial(
+            canvas_service.public_url_for_file,
+            module_item_configuration,
+            course_id=sentinel.course_id,
+        )
 
     @pytest.fixture
-    def file_id_from_current_course(self, file_from_current_course):
-        """Return the ID of a file from the current course, as a string."""
-        return str(file_from_current_course["id"])
+    def file_from_current_course(self, canvas_service):
+        """Return the Canvas API file dict for a file that *is* in the current course."""
+        return canvas_service.api.list_files.return_value[1]
 
     @pytest.fixture
     def file_from_a_different_course(self):
         """Return the Canvas API file dict for a file from a *different* course."""
         return {"id": 4, "display_name": "File 4", "size": 4096}
-
-    @pytest.fixture
-    def file_id_from_a_different_course(self, file_from_a_different_course):
-        """Return the ID of a file from a *different* course, as a string."""
-        return str(file_from_a_different_course["id"])
 
 
 class TestAssertFileInCourse:
@@ -377,10 +262,10 @@ class TestAssertFileInCourse:
 
 class TestFindMatchingFileInCourse:
     def test_it_returns_the_id_if_theres_a_matching_file_in_the_course(
-        self, canvas_service, canvas_api_client
+        self, canvas_service
     ):
         # The file dict from the Canvas API that we expect the search to match.
-        matching_file_dict = canvas_api_client.list_files.return_value[1]
+        matching_file_dict = canvas_service.api.list_files.return_value[1]
 
         file_ = factories.File(
             name=matching_file_dict["display_name"],
@@ -391,7 +276,7 @@ class TestFindMatchingFileInCourse:
             sentinel.course_id, file_
         )
 
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
         assert matching_file_id == str(matching_file_dict["id"])
 
     def test_it_returns_None_if_theres_no_matching_file_in_the_course(
@@ -418,12 +303,8 @@ class TestFactory:
 
 @pytest.fixture
 def canvas_service(canvas_api_client, file_service):
-    return CanvasService(canvas_api_client, file_service)
-
-
-@pytest.fixture
-def canvas_api_client(canvas_api_client):
-    canvas_api_client.list_files.return_value = [
+    canvas_service = CanvasService(canvas_api_client, file_service)
+    canvas_service.api.list_files.return_value = [
         {"id": 1, "display_name": "File 1", "size": 1024},
         {
             "id": 2,
@@ -436,4 +317,4 @@ def canvas_api_client(canvas_api_client):
             "size": 3072,
         },
     ]
-    return canvas_api_client
+    return canvas_service

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,29 +1,369 @@
-from unittest.mock import sentinel
+from unittest.mock import DEFAULT, call, sentinel
 
 import pytest
 
-from lms.services import CanvasFileNotFoundInCourse, CanvasService
+from lms.services import (
+    CanvasAPIPermissionError,
+    CanvasFileNotFoundInCourse,
+    CanvasService,
+)
 from lms.services.canvas import factory
 from tests import factories
 
 
 class TestPublicURLForFile:
-    @pytest.mark.parametrize("check_in_course", (True, False))
-    def test_public_url_for_file(self, canvas_service, check_in_course):
-        result = canvas_service.public_url_for_file(
-            file_id="2", check_in_course=check_in_course, course_id="*any*"
+    def test_without_check_in_course(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_id_from_current_course,
+    ):
+        # This is what happens during a normal student assignment launch.
+        url = canvas_service.public_url_for_file(
+            module_item_configuration, file_id_from_current_course, sentinel.course_id
         )
 
-        assert result == canvas_service.api.public_url.return_value
-        canvas_service.api.public_url.assert_called_once_with("2")
+        # check_in_course was False, so it didn't call list_files() to check
+        # whether the file_id was in the course.
+        canvas_api_client.list_files.assert_not_called()
 
-    def test_public_url_for_file_with_unsuccessful_file_check(self, canvas_service):
-        canvas_service.api.list_files.return_value = []
+        # It calls the Canvas API with the file_id and returns the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_with_check_in_course(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_id_from_current_course,
+    ):
+        # This is what happens during a normal instructor launch.
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_current_course,
+            sentinel.course_id,
+            check_in_course=True,
+        )
+
+        # check_in_course was True so it called list_files() to check whether
+        # file_id was in the course.
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+
+        # It calls the Canvas API with the file_id and returns the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_with_mapped_file_id_and_without_check_in_course(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_id_from_current_course,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a student launches a course-copied
+        # assignment that has already been fixed (we've already stored a
+        # mapped_file_id in the DB).
+
+        # Store a mapped_file_id in the DB. This would have been done by a
+        # previous request.
+        module_item_configuration.set_canvas_mapped_file_id(
+            file_id_from_a_different_course, file_id_from_current_course
+        )
+
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_a_different_course,
+            sentinel.course_id,
+        )
+
+        # check_in_course was False, so it didn't call list_files() to check
+        # whether the file_id was in the course.
+        canvas_api_client.list_files.assert_not_called()
+
+        # It called public_url() with the mapped_file_id rather than with the
+        # original file_id, and returned the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_with_mapped_file_id_and_check_in_course(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_id_from_current_course,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when an instructor launches a course-copied
+        # assignment that has already been fixed (we've already stored a
+        # mapped_file_id in the DB).
+
+        # Store a mapped_file_id in the DB. This would have been done by a
+        # previous request.
+        module_item_configuration.set_canvas_mapped_file_id(
+            file_id_from_a_different_course, file_id_from_current_course
+        )
+
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_a_different_course,
+            sentinel.course_id,
+            check_in_course=True,
+        )
+
+        # check_in_course was True so it called list_files() to check whether
+        # mapped_file_id was in the course.
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+
+        # It called public_url() with the mapped_file_id rather than with the
+        # original file_id, and returned the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_file_not_found_in_course_and_matching_file_found(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_service,
+        file_from_current_course,
+        file_id_from_current_course,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when an instructor launches an assignment whose
+        # file_id is *not* in the current course.
+
+        # We *do* have a models.File object for the file_id in the DB, and its
+        # name and size *do* match one of the files in the current course in Canvas.
+        file_service.get.return_value = factories.File(
+            name=file_from_current_course["display_name"],
+            size=file_from_current_course["size"],
+        )
+
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_a_different_course,
+            sentinel.course_id,
+            check_in_course=True,
+        )
+
+        # check_in_course was True so it called list_files() to check whether
+        # file_id was in the course.
+        #
+        # There's also a second call to list_files() because it calls it again
+        # to look for a matching file in the current course. This does not make
+        # two network requests because CanvasAPIClient.list_files() has
+        # caching.
+        assert canvas_api_client.list_files.call_args_list == [
+            call(sentinel.course_id),
+            call(sentinel.course_id),
+        ]
+        # It looks up the given file_id in the DB.
+        file_service.get.assert_called_once_with(
+            file_id_from_a_different_course, type_="canvas_file"
+        )
+        # It stores a file mapping from the given file_id to the matching
+        # found_file_id so that it doesn't have to re-do the search the next
+        # time the assignment is launched.
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(
+                file_id_from_a_different_course
+            )
+            == file_id_from_current_course
+        )
+        # It calls public_url() with the found_file_id and returns the public URL.
+        canvas_api_client.public_url.assert_called_once_with(
+            file_id_from_current_course
+        )
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_file_not_found_in_course_but_no_file_info(
+        self,
+        canvas_service,
+        module_item_configuration,
+        file_service,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a teacher launches an assignment whose
+        # file_id is *not* in the current course and we don't have a record of
+        # the file_id in our DB.  Without a record we can't search for a
+        # matching file so we raise an error.
+
+        # There's no record of the file_id in the DB.
+        file_service.get.return_value = None
 
         with pytest.raises(CanvasFileNotFoundInCourse):
             canvas_service.public_url_for_file(
-                file_id="2", course_id=sentinel.course_id, check_in_course=True
+                module_item_configuration,
+                file_id_from_a_different_course,
+                sentinel.course_id,
+                check_in_course=True,
             )
+
+    def test_file_not_found_in_course_but_no_matching_file(
+        self,
+        canvas_service,
+        module_item_configuration,
+        file_service,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a teacher launches an assignment whose
+        # file_id is *not* in the current course and even though we do have a
+        # record of this file_id in our DB we don't find a matching file in the
+        # current course. Since we can't find a matching file we can't fix the
+        # assignment so we raise an error.
+
+        # The file record that we find in our DB. Its name doesn't match any
+        # file in the current course.
+        file_service.get.return_value = factories.File(name="foo")
+
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            canvas_service.public_url_for_file(
+                module_item_configuration,
+                file_id_from_a_different_course,
+                sentinel.course_id,
+                check_in_course=True,
+            )
+
+    def test_permissions_error_and_matching_file_found(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_service,
+        file_from_current_course,
+        file_id_from_current_course,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a student launches an assignment whose
+        # file_id is *not* in the current course.
+
+        # The code is going to call public_url() twice. The first call is with
+        # the original file_id and public_url() raises a permissions error. The
+        # second call is with the matching found_file_id and public_url()
+        # successfully returns a URL.
+        canvas_api_client.public_url.side_effect = [CanvasAPIPermissionError, DEFAULT]
+
+        # We *do* have a models.File object for the file_id in the DB, and its
+        # name and size *do* match one of the files in the current course in Canvas.
+        file_service.get.return_value = factories.File(
+            name=file_from_current_course["display_name"],
+            size=file_from_current_course["size"],
+        )
+
+        url = canvas_service.public_url_for_file(
+            module_item_configuration,
+            file_id_from_a_different_course,
+            sentinel.course_id,
+        )
+
+        # It looks up the given file_id in the DB.
+        file_service.get.assert_called_once_with(
+            file_id_from_a_different_course, type_="canvas_file"
+        )
+        # It calls list_files() to look for a matching file in the current course.
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+        # It stores a file mapping from the given file_id to the matching
+        # found_file_id so that it doesn't have to re-do the search the next
+        # time the assignment is launched.
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(
+                file_id_from_a_different_course
+            )
+            == file_id_from_current_course
+        )
+        # It calls public_url() twice: one with the original file_id and once
+        # with the matching found_file_id.
+        assert canvas_api_client.public_url.call_args_list == [
+            call(file_id_from_a_different_course),
+            call(file_id_from_current_course),
+        ]
+        # It returns the public URL of the file in the current course.
+        assert url == canvas_api_client.public_url.return_value
+
+    def test_permissions_error_but_no_file_info(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_service,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a student launches an assignment whose
+        # file_id is *not* in the current course and we don't have a record of
+        # the file_id in our DB. Without a record we can't search for a
+        # matching file so we raise an error.
+        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        file_service.get.return_value = None
+
+        with pytest.raises(CanvasAPIPermissionError):
+            canvas_service.public_url_for_file(
+                module_item_configuration,
+                file_id_from_a_different_course,
+                sentinel.course_id,
+            )
+
+    def test_permissions_error_but_no_matching_file(
+        self,
+        canvas_service,
+        canvas_api_client,
+        module_item_configuration,
+        file_service,
+        file_id_from_a_different_course,
+    ):
+        # This is what happens when a student launches an assignment whose
+        # file_id is *not* in the current course and even though we do have a
+        # record of this file_id in our DB we don't find a matching file in the
+        # current course. Since we can't find a matching file we can't fix the
+        # assignment so we raise an error.
+        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+
+        # The file record that we find in our DB. Its name doesn't match any
+        # file in the current course.
+        file_service.get.return_value = factories.File(name="foo")
+
+        with pytest.raises(CanvasAPIPermissionError):
+            canvas_service.public_url_for_file(
+                module_item_configuration,
+                file_id_from_a_different_course,
+                sentinel.course_id,
+            )
+
+    @pytest.fixture
+    def module_item_configuration(self, db_session):
+        module_item_configuration = factories.ModuleItemConfiguration()
+        db_session.flush()
+        return module_item_configuration
+
+    @pytest.fixture
+    def file_from_current_course(self, canvas_api_client):
+        """Return the Canvas API file dict for a file that *is* in the current course."""
+        return canvas_api_client.list_files.return_value[1]
+
+    @pytest.fixture
+    def file_id_from_current_course(self, file_from_current_course):
+        """Return the ID of a file from the current course, as a string."""
+        return str(file_from_current_course["id"])
+
+    @pytest.fixture
+    def file_from_a_different_course(self):
+        """Return the Canvas API file dict for a file from a *different* course."""
+        return {"id": 4, "display_name": "File 4", "size": 4096}
+
+    @pytest.fixture
+    def file_id_from_a_different_course(self, file_from_a_different_course):
+        """Return the ID of a file from a *different* course, as a string."""
+        return str(file_from_a_different_course["id"])
 
 
 class TestCanSeeFileInCourse:
@@ -63,11 +403,13 @@ class TestFindMatchingFileInCourse:
 
 
 class TestFactory:
-    def test_it(self, pyramid_request, CanvasService, canvas_api_client):
+    def test_it(self, pyramid_request, CanvasService, canvas_api_client, file_service):
         result = factory("*any*", request=pyramid_request)
 
         assert result == CanvasService.return_value
-        CanvasService.assert_called_once_with(canvas_api=canvas_api_client)
+        CanvasService.assert_called_once_with(
+            canvas_api=canvas_api_client, file_service=file_service
+        )
 
     @pytest.fixture
     def CanvasService(self, patch):
@@ -75,15 +417,23 @@ class TestFactory:
 
 
 @pytest.fixture
-def canvas_service(canvas_api_client):
-    return CanvasService(canvas_api=canvas_api_client)
+def canvas_service(canvas_api_client, file_service):
+    return CanvasService(canvas_api_client, file_service)
 
 
 @pytest.fixture
 def canvas_api_client(canvas_api_client):
     canvas_api_client.list_files.return_value = [
         {"id": 1, "display_name": "File 1", "size": 1024},
-        {"id": 2, "display_name": "File 2", "size": 2048},
-        {"id": 3, "display_name": "File 3", "size": 3072},
+        {
+            "id": 2,
+            "display_name": "File 2",
+            "size": 2048,
+        },
+        {
+            "id": 3,
+            "display_name": "File 3",
+            "size": 3072,
+        },
     ]
     return canvas_api_client

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -13,278 +13,133 @@ from tests import factories
 
 
 class TestPublicURLForFile:
-    def test_without_check_in_course_and_without_a_mapped_file_id(
-        self, canvas_service, file_from_current_course, public_url_for_file
-    ):
-        # This is what happens during a normal student assignment launch:
-        # check_in_course is False and there's no mapped_file_id in the DB.
+    def test_it(self, canvas_service, public_url_for_file, effective_id):
+        url = public_url_for_file(file_id=sentinel.file_id, check_in_course=False)
 
-        url = public_url_for_file(file_id=str(file_from_current_course["id"]))
-
-        # check_in_course was False, so it didn't call list_files() to check
-        # whether the file_id was in the course.
-        canvas_service.api.list_files.assert_not_called()
-
-        # It calls the Canvas API with the file_id and returns the public URL.
-        canvas_service.api.public_url.assert_called_once_with(
-            str(file_from_current_course["id"])
-        )
+        canvas_service.file_mapper.assert_file_in_course.assert_not_called()
+        canvas_service.api.public_url.assert_called_once_with(effective_id)
         assert url == canvas_service.api.public_url.return_value
 
-    def test_if_check_in_course_is_True_it_checks_that_the_file_is_in_the_course(
-        self, canvas_service, file_from_current_course, public_url_for_file
+    @pytest.mark.usefixtures("with_permission_failure_on_first_call")
+    def test_we_map_if_the_first_retrieval_is_unsuccessful(
+        self, canvas_service, public_url_for_file, effective_id, assignment
     ):
-        # This is what happens during a normal instructor launch;
-        # check_in_course is True and there's no mapped_file_id in the DB.
-
         url = public_url_for_file(
-            file_id=str(file_from_current_course["id"]), check_in_course=True
+            file_id=sentinel.file_id, course_id=sentinel.course_id
         )
 
-        # check_in_course was True so it called list_files() to check whether
-        # file_id was in the course.
-        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
-
-        # It calls the Canvas API with the file_id and returns the public URL.
-        canvas_service.api.public_url.assert_called_once_with(
-            str(file_from_current_course["id"])
+        canvas_service.file_mapper.map_file.assert_called_once_with(
+            effective_id, sentinel.course_id
         )
-        assert url == canvas_service.api.public_url.return_value
-
-    def test_if_theres_a_mapped_file_id_it_uses_it(
-        self,
-        canvas_service,
-        module_item_configuration,
-        file_from_current_course,
-        file_from_a_different_course,
-        public_url_for_file,
-    ):
-        # If there's a mapped_file_id in the DB it gets used instead of the
-        # given file_id.
-        #
-        # This is what happens when a user launches a course-copied assignment
-        # that has previously been fixed (we've previously stored a
-        # mapped_file_id in the DB).
-
-        # Store a mapped_file_id in the DB. This would have been done by a
-        # previous request.
-        module_item_configuration.set_canvas_mapped_file_id(
-            str(file_from_a_different_course["id"]), str(file_from_current_course["id"])
-        )
-
-        url = public_url_for_file(
-            file_id=str(file_from_a_different_course["id"]), check_in_course=True
-        )
-
-        # It checks that the mapped_file_id is in the course (not the original file_id).
-        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
-
-        # It called public_url() with the mapped_file_id rather than with the
-        # original file_id, and returned the public URL.
-        canvas_service.api.public_url.assert_called_once_with(
-            str(file_from_current_course["id"])
+        assert (
+            assignment.get_canvas_mapped_file_id(sentinel.file_id)
+            == canvas_service.file_mapper.map_file.return_value
         )
         assert url == canvas_service.api.public_url.return_value
 
-    def test_file_not_found_in_course_and_matching_file_found(
-        self,
-        canvas_service,
-        file_service,
-        module_item_configuration,
-        file_from_current_course,
-        file_from_a_different_course,
-        public_url_for_file,
+    @pytest.mark.usefixtures("with_file_not_in_course")
+    def test_we_map_if_the_file_is_not_in_the_course(
+        self, canvas_service, public_url_for_file, effective_id, assignment
     ):
-        # This is what happens when an instructor launches an assignment whose
-        # file_id is *not* in the current course.
-        file_service.get.return_value = factories.File(
-            name=file_from_current_course["display_name"],
-            size=file_from_current_course["size"],
+        public_url_for_file(
+            file_id=sentinel.file_id, course_id=sentinel.course_id, check_in_course=True
         )
 
-        url = public_url_for_file(
-            file_id=str(file_from_a_different_course["id"]), check_in_course=True
+        canvas_service.file_mapper.assert_file_in_course.assert_called_once_with(
+            effective_id, sentinel.course_id
         )
+        canvas_service.file_mapper.map_file.assert_called_once_with(
+            effective_id, sentinel.course_id
+        )
+        # Don't retest all the things that happen when mappings are done
 
-        # It looked up the given file_id in the DB.
-        file_service.get.assert_called_once_with(
-            str(file_from_a_different_course["id"]), type_="canvas_file"
-        )
-        # It stored a mapping from the given file_id to found_file_id.
-        assert module_item_configuration.get_canvas_mapped_file_id(
-            str(file_from_a_different_course["id"])
-        ) == str(file_from_current_course["id"])
-        # It got the found_file_id's public URL and returned it.
-        canvas_service.api.public_url.assert_called_once_with(
-            str(file_from_current_course["id"])
-        )
-        assert url == canvas_service.api.public_url.return_value
-
-    def test_permissions_error_and_matching_file_found(
-        self,
-        canvas_service,
-        file_service,
-        module_item_configuration,
-        file_from_current_course,
-        file_from_a_different_course,
-        public_url_for_file,
+    @pytest.mark.usefixtures("with_permission_failure_on_first_call")
+    def test_we_raise_if_mappings_fails_after_CanvasAPIPermissionError(
+        self, canvas_service, public_url_for_file
     ):
-        # This is what happens when a student launches an assignment whose
-        # file_id is *not* in the current course.
-        canvas_service.api.public_url.side_effect = [CanvasAPIPermissionError, DEFAULT]
-        file_service.get.return_value = factories.File(
-            name=file_from_current_course["display_name"],
-            size=file_from_current_course["size"],
-        )
-
-        url = public_url_for_file(file_id=str(file_from_a_different_course["id"]))
-
-        # It looked up the given file_id in the DB.
-        file_service.get.assert_called_once_with(
-            str(file_from_a_different_course["id"]), type_="canvas_file"
-        )
-        # It stored a mapping from the given file_id to found_file_id.
-        assert module_item_configuration.get_canvas_mapped_file_id(
-            str(file_from_a_different_course["id"])
-        ) == str(file_from_current_course["id"])
-        # It got found_file_id's public URL and returned it.
-        assert canvas_service.api.public_url.call_args_list == [
-            call(str(file_from_a_different_course["id"])),
-            call(str(file_from_current_course["id"])),
-        ]
-        assert url == canvas_service.api.public_url.return_value
-
-    def test_file_not_found_in_course_but_no_file_info(
-        self, file_service, file_from_a_different_course, public_url_for_file
-    ):
-        # This is what happens when a teacher launches an assignment whose
-        # file_id is *not* in the current course and we don't have a record of
-        # the file_id in our DB. Without a record we can't search for a
-        # matching file so we raise an error.
-
-        # There's no record of the file_id in the DB.
-        file_service.get.return_value = None
-
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            public_url_for_file(
-                str(file_from_a_different_course["id"]), check_in_course=True
-            )
-
-    def test_file_not_found_in_course_but_no_matching_file(
-        self, file_service, file_from_a_different_course, public_url_for_file
-    ):
-        # This is what happens when a teacher launches an assignment whose
-        # file_id is *not* in the current course and even though we do have a
-        # record of this file_id in our DB we don't find a matching file in the
-        # current course. Since we can't find a matching file we can't fix the
-        # assignment so we raise an error.
-
-        # The file record that we find in our DB. Its name doesn't match any
-        # file in the current course.
-        file_service.get.return_value = factories.File(name="foo")
-
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            public_url_for_file(
-                file_id=str(file_from_a_different_course["id"]), check_in_course=True
-            )
-
-    def test_permissions_error_but_no_file_info(
-        self,
-        canvas_service,
-        file_service,
-        file_from_a_different_course,
-        public_url_for_file,
-    ):
-        # This is what happens when a student launches an assignment whose
-        # file_id is *not* in the current course and we don't have a record of
-        # the file_id in our DB. Without a record we can't search for a
-        # matching file so we raise an error.
-        canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
-        file_service.get.return_value = None
+        canvas_service.file_mapper.map_file.return_value = None
 
         with pytest.raises(CanvasAPIPermissionError):
-            public_url_for_file(file_id=str(file_from_a_different_course["id"]))
+            public_url_for_file()
 
-    def test_permissions_error_but_no_matching_file(
-        self,
-        canvas_service,
-        file_service,
-        file_from_a_different_course,
-        public_url_for_file,
+    @pytest.mark.usefixtures("with_file_not_in_course")
+    def test_we_raise_if_mappings_fails_after_CanvasFileNotFoundInCourse(
+        self, canvas_service, public_url_for_file
     ):
-        # This is what happens when a student launches an assignment whose
-        # file_id is *not* in the current course and even though we do have a
-        # record of this file_id in our DB we don't find a matching file in the
-        # current course. Since we can't find a matching file we can't fix the
-        # assignment so we raise an error.
+        canvas_service.file_mapper.map_file.return_value = None
+
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            public_url_for_file(check_in_course=True)
+
+    def test_we_do_not_store_a_mapping_if_retrieval_fails(
+        self, canvas_service, public_url_for_file, assignment
+    ):
+        # Set this to fail every time
         canvas_service.api.public_url.side_effect = CanvasAPIPermissionError
 
-        # The file record that we find in our DB. Its name doesn't match any
-        # file in the current course.
-        file_service.get.return_value = factories.File(name="foo")
-
         with pytest.raises(CanvasAPIPermissionError):
-            public_url_for_file(file_id=str(file_from_a_different_course["id"]))
+            public_url_for_file(
+                file_id=sentinel.file_id, module_item_configuration=assignment
+            )
+
+        assert assignment.get_canvas_mapped_file_id(sentinel.file_id) is None
 
     @pytest.fixture
-    def module_item_configuration(self, db_session):
-        module_item_configuration = factories.ModuleItemConfiguration()
-        db_session.flush()
-        return module_item_configuration
+    def with_permission_failure_on_first_call(self, canvas_service):
+        canvas_service.api.public_url.side_effect = (
+            CanvasAPIPermissionError,
+            canvas_service.api.public_url.return_value,
+        )
 
     @pytest.fixture
-    def public_url_for_file(self, canvas_service, module_item_configuration):
+    def with_file_not_in_course(self, canvas_service):
+        canvas_service.file_mapper.assert_file_in_course.side_effect = (
+            CanvasFileNotFoundInCourse(sentinel.file_id)
+        )
+
+    @pytest.fixture(params=(sentinel.file_id, sentinel.mapped_id))
+    def effective_id(self, request, assignment):
+        if request.param != sentinel.file_id:
+            assignment.set_canvas_mapped_file_id(sentinel.file_id, sentinel.mapped_id)
+
+        return request.param
+
+    @pytest.fixture(autouse=True)
+    def CanvasFileMapper(self, patch):
+        return patch("lms.services.canvas.CanvasFileMapper")
+
+    @pytest.fixture
+    def assignment(self, db_session):
+        return factories.ModuleItemConfiguration()
+
+    @pytest.fixture
+    def canvas_service(self, canvas_api_client, file_service):
+        return CanvasService(canvas_api_client, file_service)
+
+    @pytest.fixture
+    def public_url_for_file(self, canvas_service, assignment):
         return partial(
             canvas_service.public_url_for_file,
-            module_item_configuration,
+            module_item_configuration=assignment,
+            file_id=sentinel.file_id,
             course_id=sentinel.course_id,
         )
 
-    @pytest.fixture
-    def file_from_current_course(self, canvas_service):
-        """Return the Canvas API file dict for a file that *is* in the current course."""
-        return canvas_service.api.list_files.return_value[1]
 
-    @pytest.fixture
-    def file_from_a_different_course(self):
-        """Return the Canvas API file dict for a file from a *different* course."""
-        return {"id": 4, "display_name": "File 4", "size": 4096}
+class TestCanvasFileMapper:
+    # Imagine good tests here...
 
+    def test_map_file_returns_the_id_if_theres_a_matching_file_in_the_course(self):
+        ...
 
-class TestAssertFileInCourse:
-    def test_it_does_not_raise_if_the_file_is_in_the_course(self, canvas_service):
-        canvas_service.assert_file_in_course("2", sentinel.course_id)
+    def test_map_file_returns_None_if_theres_no_matching_file_in_the_course(self):
+        ...
 
-    def test_it_raises_if_the_file_isnt_in_the_course(self, canvas_service):
-        with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_service.assert_file_in_course("4", sentinel.course_id)
+    def test_assert_file_in_course_does_not_raise_if_the_file_is_in_the_course(self):
+        ...
 
-
-class TestFindMatchingFileInCourse:
-    def test_it_returns_the_id_if_theres_a_matching_file_in_the_course(
-        self, canvas_service
-    ):
-        # The file dict from the Canvas API that we expect the search to match.
-        matching_file_dict = canvas_service.api.list_files.return_value[1]
-
-        file_ = factories.File(
-            name=matching_file_dict["display_name"],
-            size=matching_file_dict["size"],
-        )
-
-        matching_file_id = canvas_service.find_matching_file_in_course(
-            sentinel.course_id, file_
-        )
-
-        canvas_service.api.list_files.assert_called_once_with(sentinel.course_id)
-        assert matching_file_id == str(matching_file_dict["id"])
-
-    def test_it_returns_None_if_theres_no_matching_file_in_the_course(
-        self, canvas_service
-    ):
-        assert not canvas_service.find_matching_file_in_course(
-            sentinel.course_id, factories.File()
-        )
+    def test_assert_file_in_course_raises_if_the_file_isnt_in_the_course(self):
+        ...
 
 
 class TestFactory:
@@ -299,22 +154,3 @@ class TestFactory:
     @pytest.fixture
     def CanvasService(self, patch):
         return patch("lms.services.canvas.CanvasService")
-
-
-@pytest.fixture
-def canvas_service(canvas_api_client, file_service):
-    canvas_service = CanvasService(canvas_api_client, file_service)
-    canvas_service.api.list_files.return_value = [
-        {"id": 1, "display_name": "File 1", "size": 1024},
-        {
-            "id": 2,
-            "display_name": "File 2",
-            "size": 2048,
-        },
-        {
-            "id": 3,
-            "display_name": "File 3",
-            "size": 3072,
-        },
-    ]
-    return canvas_service

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -366,13 +366,13 @@ class TestPublicURLForFile:
         return str(file_from_a_different_course["id"])
 
 
-class TestCanSeeFileInCourse:
-    @pytest.mark.parametrize("file_id,expected_result", [("2", True), ("4", False)])
-    def test_it(self, canvas_service, canvas_api_client, file_id, expected_result):
-        result = canvas_service.can_see_file_in_course(file_id, sentinel.course_id)
+class TestAssertFileInCourse:
+    def test_it_does_not_raise_if_the_file_is_in_the_course(self, canvas_service):
+        canvas_service.assert_file_in_course("2", sentinel.course_id)
 
-        assert result == expected_result
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+    def test_it_raises_if_the_file_isnt_in_the_course(self, canvas_service):
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            canvas_service.assert_file_in_course("4", sentinel.course_id)
 
 
 class TestFindMatchingFileInCourse:

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -3,7 +3,9 @@ import pytest
 from lms.views.api.canvas.files import FilesAPIViews
 
 
-@pytest.mark.usefixtures("canvas_service")
+@pytest.mark.usefixtures(
+    "application_instance_service", "assignment_service", "canvas_service"
+)
 class TestFilesAPIViews:
     def test_list_files(self, canvas_service, pyramid_request):
         pyramid_request.matchdict = {"course_id": "test_course_id"}
@@ -14,27 +16,40 @@ class TestFilesAPIViews:
         canvas_service.api.list_files.assert_called_once_with("test_course_id")
 
     @pytest.mark.usefixtures("with_teacher_or_student")
-    def test_via_url(self, pyramid_request, canvas_service, helpers):
+    def test_via_url(
+        self,
+        pyramid_request,
+        application_instance_service,
+        assignment_service,
+        canvas_service,
+        helpers,
+    ):
+        application_instance = application_instance_service.get.return_value
+        module_item_configuration = assignment_service.get.return_value
         pyramid_request.matchdict = {
             "course_id": "test_course_id",
             "file_id": "test_file_id",
+            "resource_link_id": "test_resource_link_id",
         }
 
         result = FilesAPIViews(pyramid_request).via_url()
 
-        assert result["via_url"] == helpers.via_url.return_value
-
+        assignment_service.get.assert_called_once_with(
+            application_instance.tool_consumer_instance_guid,
+            "test_resource_link_id",
+        )
         canvas_service.public_url_for_file.assert_called_once_with(
-            file_id="test_file_id",
-            course_id="test_course_id",
+            module_item_configuration,
+            "test_file_id",
+            "test_course_id",
             check_in_course=pyramid_request.lti_user.is_instructor,
         )
-
         helpers.via_url.assert_called_once_with(
             pyramid_request,
             canvas_service.public_url_for_file.return_value,
             content_type="pdf",
         )
+        assert result == {"via_url": helpers.via_url.return_value}
 
     @pytest.fixture(params=("instructor", "learner"))
     def with_teacher_or_student(self, request, pyramid_request):

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -9,6 +9,7 @@ from lms.services.assignment import AssignmentService
 from lms.services.blackboard_api import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
+from lms.services.file import FileService
 from lms.services.grading_info import GradingInfoService
 from lms.services.grant_token import GrantTokenService
 from lms.services.group_info import GroupInfoService
@@ -45,6 +46,7 @@ __all__ = (
     "oauth2_token_service",
     "h_api",
     "vitalsource_service",
+    "file_service",
 )
 
 
@@ -189,3 +191,8 @@ def oauth2_token_service(mock_service, oauth_token):
 @pytest.fixture
 def vitalsource_service(mock_service):
     return mock_service(VitalSourceService, service_name="vitalsource")
+
+
+@pytest.fixture
+def file_service(mock_service):
+    return mock_service(FileService, service_name="file")


### PR DESCRIPTION
This POC introduces a helper object with public and tested methods (tests not included here) to show the effect it has on the parent tests of the object when we mock it out.

I think these are the clearest ones yet. Even if you disagree with the precise way these were done, I think it's relatively obvious that these are easier to write and grok.

### What's going on here?

 * This introduces a `CanvasFileMapper` which does the asserting that files are in courses and mapping them
 * It's not a good name, but that's besides the point
 * We then assume this is well tested in a normal way
 * We then mock it out when testing the parent object

I think the result is smaller tests which look much more like our regular tests, and don't have to go to such lengths to setup fixtures and scenarios.