### PR TITLE
Fix canvas course copy 2

### DIFF
--- a/lms/models/module_item_configuration.py
+++ b/lms/models/module_item_configuration.py
@@ -52,7 +52,7 @@ class ModuleItemConfiguration(BASE):
     )
 
     def get_canvas_mapped_file_id(self, file_id):
-        return self.extra.get("canvas_file_mappings", {}).get(file_id)
+        return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)
 
     def set_canvas_mapped_file_id(self, file_id, mapped_file_id):
         self.extra.setdefault("canvas_file_mappings", {})[file_id] = mapped_file_id

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -30,12 +30,19 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
+        application_instance = self.request.find_service(
+            name="application_instance"
+        ).get()
+
+        module_item_configuration = self.request.find_service(name="assignment").get(
+            application_instance.tool_consumer_instance_guid,
+            self.request.matchdict["resource_link_id"],
+        )
+
         public_url = self.canvas.public_url_for_file(
-            file_id=self.request.matchdict["file_id"],
-            course_id=self.request.matchdict["course_id"],
-            # Teachers can have broad permissions and see files that aren't in
-            # the course. So do this slower check (extra API call) to warn the
-            # teacher that their students might not be able to see the file.
+            module_item_configuration,
+            self.request.matchdict["file_id"],
+            self.request.matchdict["course_id"],
             check_in_course=self.request.lti_user.is_instructor,
         )
 

--- a/tests/unit/lms/models/module_item_configuration_test.py
+++ b/tests/unit/lms/models/module_item_configuration_test.py
@@ -18,6 +18,11 @@ class TestModuleItemConfiguration:
 
         assert mic.get_canvas_mapped_file_id("original_file_id") == "new_mapped_file_id"
 
+    def test_get_canvas_mapped_file_id_returns_the_given_file_id_if_no_mapping_exists(
+        self, mic
+    ):
+        assert mic.get_canvas_mapped_file_id("file_id") == "file_id"
+
     @pytest.fixture
     def mic(self, db_session):
         mic = ModuleItemConfiguration(

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -1,73 +1,270 @@
-from unittest.mock import sentinel
+from functools import partial
+from unittest.mock import call, sentinel
 
 import pytest
 
-from lms.services import CanvasFileNotFoundInCourse, CanvasService
-from lms.services.canvas import factory
+from lms.services import (
+    CanvasAPIPermissionError,
+    CanvasFileNotFoundInCourse,
+    CanvasService,
+)
+from lms.services.canvas import CanvasFileFinder, factory
 from tests import factories
 
 
 class TestPublicURLForFile:
-    @pytest.mark.parametrize("check_in_course", (True, False))
-    def test_public_url_for_file(self, canvas_service, check_in_course):
-        result = canvas_service.public_url_for_file(
-            file_id="2", check_in_course=check_in_course, course_id="*any*"
+    @pytest.mark.parametrize("check_in_course", [True, False])
+    def test_the_happy_path(
+        self,
+        canvas_api_client,
+        canvas_file_finder,
+        check_in_course,
+        file_service,
+        public_url_for_file,
+        CanvasFileFinder,
+    ):
+        url = public_url_for_file(sentinel.file_id, check_in_course=check_in_course)
+
+        CanvasFileFinder.assert_called_once_with(canvas_api_client, file_service)
+        if check_in_course:
+            canvas_file_finder.assert_file_in_course.assert_called_once_with(
+                sentinel.course_id, sentinel.file_id
+            )
+        else:
+            canvas_file_finder.assert_file_in_course.assert_not_called()
+        canvas_api_client.public_url.assert_called_once_with(sentinel.file_id)
+        assert url == canvas_api_client.public_url.return_value
+
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_theres_a_mapped_file_id_it_uses_it(
+        self, canvas_api_client, canvas_file_finder, public_url_for_file
+    ):
+        url = public_url_for_file(sentinel.file_id, check_in_course=True)
+
+        canvas_file_finder.assert_file_in_course.assert_called_once_with(
+            sentinel.course_id, sentinel.mapped_file_id
+        )
+        canvas_api_client.public_url.assert_called_once_with(sentinel.mapped_file_id)
+        assert url == canvas_api_client.public_url.return_value
+
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_the_file_isnt_in_the_course_it_finds_a_matching_file_instead(
+        self,
+        canvas_api_client,
+        canvas_file_finder,
+        module_item_configuration,
+        public_url_for_file,
+    ):
+        canvas_file_finder.assert_file_in_course.side_effect = (
+            CanvasFileNotFoundInCourse(sentinel.file_id)
+        )
+        canvas_file_finder.find_matching_file_in_course.return_value = (
+            sentinel.found_file_id
         )
 
-        assert result == canvas_service.api.public_url.return_value
-        canvas_service.api.public_url.assert_called_once_with("2")
+        url = public_url_for_file(sentinel.file_id, check_in_course=True)
 
-    def test_public_url_for_file_with_unsuccessful_file_check(self, canvas_service):
-        canvas_service.api.list_files.return_value = []
+        canvas_file_finder.find_matching_file_in_course.assert_called_once_with(
+            sentinel.course_id, sentinel.mapped_file_id
+        )
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(sentinel.file_id)
+            == sentinel.found_file_id
+        )
+        canvas_api_client.public_url.assert_called_once_with(sentinel.found_file_id)
+        assert url == canvas_api_client.public_url.return_value
+
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_the_file_isnt_in_the_course_and_theres_no_matching_file_it_raises(
+        self, canvas_file_finder, public_url_for_file
+    ):
+        canvas_file_finder.assert_file_in_course.side_effect = (
+            CanvasFileNotFoundInCourse(sentinel.file_id)
+        )
+        canvas_file_finder.find_matching_file_in_course.return_value = None
 
         with pytest.raises(CanvasFileNotFoundInCourse):
-            canvas_service.public_url_for_file(
-                file_id="2", course_id=sentinel.course_id, check_in_course=True
-            )
+            public_url_for_file(sentinel.file_id, check_in_course=True)
 
-
-class TestCanSeeFileInCourse:
-    @pytest.mark.parametrize("file_id,expected_result", [("2", True), ("4", False)])
-    def test_it(self, canvas_service, canvas_api_client, file_id, expected_result):
-        result = canvas_service.can_see_file_in_course(file_id, sentinel.course_id)
-
-        assert result == expected_result
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
-
-
-class TestFindMatchingFileInCourse:
-    def test_it_returns_the_id_if_theres_a_matching_file_in_the_course(
-        self, canvas_service, canvas_api_client
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_theres_a_permissions_error_it_finds_a_matching_file_instead(
+        self,
+        canvas_api_client,
+        canvas_file_finder,
+        module_item_configuration,
+        public_url_for_file,
     ):
-        # The file dict from the Canvas API that we expect the search to match.
-        matching_file_dict = canvas_api_client.list_files.return_value[1]
+        canvas_api_client.public_url.side_effect = [
+            CanvasAPIPermissionError,
+            sentinel.url,
+        ]
+        canvas_file_finder.find_matching_file_in_course.return_value = (
+            sentinel.found_file_id
+        )
 
-        file_ = factories.File(
+        url = public_url_for_file(sentinel.file_id)
+
+        canvas_file_finder.find_matching_file_in_course.assert_called_once_with(
+            sentinel.course_id, sentinel.mapped_file_id
+        )
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(sentinel.file_id)
+            == sentinel.found_file_id
+        )
+        assert canvas_api_client.public_url.call_args_list == [
+            call(sentinel.mapped_file_id),
+            call(sentinel.found_file_id),
+        ]
+        assert url == sentinel.url
+
+    @pytest.mark.usefixtures("with_mapped_file_id")
+    def test_if_theres_a_permissions_error_and_theres_no_matching_file_it_raises(
+        self, canvas_api_client, canvas_file_finder, public_url_for_file
+    ):
+        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        canvas_file_finder.find_matching_file_in_course.return_value = None
+
+        with pytest.raises(CanvasAPIPermissionError):
+            public_url_for_file(sentinel.file_id)
+
+    def test_it_doesnt_save_a_mapped_file_id_if_getting_that_files_public_url_fails(
+        self,
+        canvas_api_client,
+        canvas_file_finder,
+        module_item_configuration,
+        public_url_for_file,
+    ):
+        canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
+        canvas_file_finder.find_matching_file_in_course.return_value = (
+            sentinel.found_file_id
+        )
+
+        with pytest.raises(CanvasAPIPermissionError):
+            public_url_for_file(sentinel.file_id)
+
+        assert (
+            module_item_configuration.get_canvas_mapped_file_id(sentinel.file_id)
+            == sentinel.file_id
+        )
+
+    @pytest.fixture
+    def module_item_configuration(self, db_session):
+        module_item_configuration = factories.ModuleItemConfiguration()
+        db_session.flush()
+        return module_item_configuration
+
+    @pytest.fixture
+    def with_mapped_file_id(self, module_item_configuration):
+        module_item_configuration.set_canvas_mapped_file_id(
+            sentinel.file_id, sentinel.mapped_file_id
+        )
+
+    @pytest.fixture
+    def public_url_for_file(self, canvas_service, module_item_configuration):
+        return partial(
+            canvas_service.public_url_for_file,
+            module_item_configuration,
+            course_id=sentinel.course_id,
+        )
+
+    @pytest.fixture(autouse=True)
+    def CanvasFileFinder(self, patch):
+        return patch("lms.services.canvas.CanvasFileFinder")
+
+    @pytest.fixture
+    def canvas_file_finder(self, CanvasFileFinder):
+        return CanvasFileFinder.return_value
+
+
+class TestCanvasFileFinder:
+    def test_assert_file_in_course_doesnt_raise_if_the_file_is_in_the_course(
+        self, finder, canvas_api_client
+    ):
+        canvas_api_client.list_files.return_value = [
+            {"id": sentinel.file_id},
+            {"id": sentinel.other_file_id},
+        ]
+
+        finder.assert_file_in_course(sentinel.course_id, str(sentinel.file_id))
+
+    def test_assert_file_in_course_raises_if_the_file_isnt_in_the_course(
+        self, finder, canvas_api_client
+    ):
+        canvas_api_client.list_files.return_value = [{"id": sentinel.other_file_id}]
+
+        with pytest.raises(CanvasFileNotFoundInCourse):
+            finder.assert_file_in_course(sentinel.course_id, sentinel.file_id)
+
+    def test_find_matching_file_in_course_returns_the_matching_file_id(
+        self, finder, canvas_api_client, file_service
+    ):
+        file_service.get.return_value = factories.File()
+        canvas_api_client.list_files.return_value = [
+            {"id": 1, "display_name": "File 1", "size": 1024},
+            {
+                "id": sentinel.matching_file_id,
+                "display_name": file_service.get.return_value.name,
+                "size": file_service.get.return_value.size,
+            },
+        ]
+
+        matching_file_id = finder.find_matching_file_in_course(
+            sentinel.course_id, sentinel.file_id
+        )
+
+        file_service.get.assert_called_once_with(sentinel.file_id, type_="canvas_file")
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+        assert matching_file_id == str(sentinel.matching_file_id)
+
+    def test_find_matching_file_in_course_returns_None_if_theres_file_in_the_db(
+        self, finder, file_service
+    ):
+        file_service.get.return_value = None
+
+        assert not finder.find_matching_file_in_course(
+            sentinel.course_id, sentinel.file_id
+        )
+
+    def test_find_matching_file_in_course_returns_None_if_theres_no_match(
+        self, finder, file_service
+    ):
+        file_service.get.return_value = factories.File(name="foo")
+
+        assert not finder.find_matching_file_in_course(
+            sentinel.course_id, sentinel.file_id
+        )
+
+    def test_find_matching_file_in_course_doesnt_return_the_same_file(
+        self, finder, canvas_api_client, file_service
+    ):
+        # If the response from the Canvas API contains a "matching" file dict
+        # that happens to be the *same* file as the one we're searching for (it
+        # has the same id) find_matching_file_in_course() should not return
+        # the same file_id as it was asked to search for a match for.
+        matching_file_dict = canvas_api_client.list_files.return_value[1]
+        file_service.get.return_value = factories.File(
+            lms_id=str(matching_file_dict["id"]),
             name=matching_file_dict["display_name"],
             size=matching_file_dict["size"],
         )
 
-        matching_file_id = canvas_service.find_matching_file_in_course(
-            sentinel.course_id, file_
+        assert not finder.find_matching_file_in_course(
+            sentinel.course_id, sentinel.file_id
         )
 
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
-        assert matching_file_id == str(matching_file_dict["id"])
-
-    def test_it_returns_None_if_theres_no_matching_file_in_the_course(
-        self, canvas_service
-    ):
-        assert not canvas_service.find_matching_file_in_course(
-            sentinel.course_id, factories.File()
-        )
+    @pytest.fixture
+    def finder(self, canvas_api_client, file_service):
+        return CanvasFileFinder(canvas_api_client, file_service)
 
 
 class TestFactory:
-    def test_it(self, pyramid_request, CanvasService, canvas_api_client):
+    def test_it(self, pyramid_request, CanvasService, canvas_api_client, file_service):
         result = factory("*any*", request=pyramid_request)
 
         assert result == CanvasService.return_value
-        CanvasService.assert_called_once_with(canvas_api=canvas_api_client)
+        CanvasService.assert_called_once_with(
+            canvas_api=canvas_api_client, file_service=file_service
+        )
 
     @pytest.fixture
     def CanvasService(self, patch):
@@ -75,15 +272,5 @@ class TestFactory:
 
 
 @pytest.fixture
-def canvas_service(canvas_api_client):
-    return CanvasService(canvas_api=canvas_api_client)
-
-
-@pytest.fixture
-def canvas_api_client(canvas_api_client):
-    canvas_api_client.list_files.return_value = [
-        {"id": 1, "display_name": "File 1", "size": 1024},
-        {"id": 2, "display_name": "File 2", "size": 2048},
-        {"id": 3, "display_name": "File 3", "size": 3072},
-    ]
-    return canvas_api_client
+def canvas_service(canvas_api_client, file_service):
+    return CanvasService(canvas_api_client, file_service)

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -3,7 +3,9 @@ import pytest
 from lms.views.api.canvas.files import FilesAPIViews
 
 
-@pytest.mark.usefixtures("canvas_service")
+@pytest.mark.usefixtures(
+    "application_instance_service", "assignment_service", "canvas_service"
+)
 class TestFilesAPIViews:
     def test_list_files(self, canvas_service, pyramid_request):
         pyramid_request.matchdict = {"course_id": "test_course_id"}
@@ -14,27 +16,40 @@ class TestFilesAPIViews:
         canvas_service.api.list_files.assert_called_once_with("test_course_id")
 
     @pytest.mark.usefixtures("with_teacher_or_student")
-    def test_via_url(self, pyramid_request, canvas_service, helpers):
+    def test_via_url(
+        self,
+        pyramid_request,
+        application_instance_service,
+        assignment_service,
+        canvas_service,
+        helpers,
+    ):
+        application_instance = application_instance_service.get.return_value
+        module_item_configuration = assignment_service.get.return_value
         pyramid_request.matchdict = {
             "course_id": "test_course_id",
             "file_id": "test_file_id",
+            "resource_link_id": "test_resource_link_id",
         }
 
         result = FilesAPIViews(pyramid_request).via_url()
 
-        assert result["via_url"] == helpers.via_url.return_value
-
+        assignment_service.get.assert_called_once_with(
+            application_instance.tool_consumer_instance_guid,
+            "test_resource_link_id",
+        )
         canvas_service.public_url_for_file.assert_called_once_with(
-            file_id="test_file_id",
-            course_id="test_course_id",
+            module_item_configuration,
+            "test_file_id",
+            "test_course_id",
             check_in_course=pyramid_request.lti_user.is_instructor,
         )
-
         helpers.via_url.assert_called_once_with(
             pyramid_request,
             canvas_service.public_url_for_file.return_value,
             content_type="pdf",
         )
+        assert result == {"via_url": helpers.via_url.return_value}
 
     @pytest.fixture(params=("instructor", "learner"))
     def with_teacher_or_student(self, request, pyramid_request):

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -9,6 +9,7 @@ from lms.services.assignment import AssignmentService
 from lms.services.blackboard_api import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
+from lms.services.file import FileService
 from lms.services.grading_info import GradingInfoService
 from lms.services.grant_token import GrantTokenService
 from lms.services.group_info import GroupInfoService
@@ -45,6 +46,7 @@ __all__ = (
     "oauth2_token_service",
     "h_api",
     "vitalsource_service",
+    "file_service",
 )
 
 
@@ -189,3 +191,8 @@ def oauth2_token_service(mock_service, oauth_token):
 @pytest.fixture
 def vitalsource_service(mock_service):
     return mock_service(VitalSourceService, service_name="vitalsource")
+
+
+@pytest.fixture
+def file_service(mock_service):
+    return mock_service(FileService, service_name="file")


### PR DESCRIPTION
A total clone of https://github.com/hypothesis/lms/pull/2899, purely for the purposes of making review easier as the other PR is lousy with comment.

Fixes https://github.com/hypothesis/lms/issues/2764.

Testing
=====

All the test cases should work with our [Canvas test site](https://hypothesis.instructure.com/).

You need to run `make devdata` in the LMS project to make sure you have the latest development data.

To get to an SQL shell (to run the various example SQL commands in the test cases below) run `make sql`.

Test data:

* [Developer Test Course with Sections Enabled][] is the original (non-copied) test course
  * [localhost (make devdata) Canvas Files Assignment] is a Canvas Files assignment in this course
  * File **798** (`Françoise_Hardy.pdf`) is a PDF file in this course that the assignment uses
  * `eng+canvasteacher@hypothes.is` is a teacher in this course (all user passwords are in 1Password)
  * `eng+canvasstudent@hypothes.is` is a student in this course

* [Copy of Developer Test Course with Sections Enabled][] is a copied course
  * [localhost (make devdata) Canvas Files Assignment (copy)][] is a copied Canvas Files assignment in this course
  * `eng+canvasteacher@hypothes.is` is a teacher who is in both the copied course and the original course
  * `eng+canvasstudent@hypothes.is` is a student who is in both the copied course and the original course
  * `eng+coursecopyteacher` is a teacher who is in the copied course but *not* the original course
  * `eng+coursecopystudent` is a student who is in the copied course but *not* the original course

Launching a non-course-copied assignment
----------------------------------------

Launch [localhost (make devdata) Canvas Files Assignment][] from [Developer Test Course with Sections Enabled][] as both a teacher and a student.

The assignment should launch successfully.

You should not have any mappings in your DB:

```sql
postgres=# select * from module_item_configurations where extra != '{}';
 id | resource_link_id | tool_consumer_instance_guid | document_url | extra
----+------------------+-----------------------------+--------------+-------
(0 rows)
```

Launching a course-copied assignment: teacher also belongs to original course
-----------------------------------------------------------------------------

Launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+canvasteacher@hypothes.is`.

The assignment should launch successfully.

Even though the teacher could access the original file (since they belong to the original course) we detect that the file isn't in the current course and map it to the matching file in the current course. The mapping means that other users who *aren't* in the original course will be able to launch the assignment. You should find that a mapping has been created in the DB:

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

Launching a course-copied assignment: student also belongs to original course
-----------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+canvasstudent@hypothes.is`.

The assignment should launch successfully.

You should not have any mappings in your DB:

```sql
postgres=# select * from module_item_configurations where extra != '{}';
 id | resource_link_id | tool_consumer_instance_guid | document_url | extra
----+------------------+-----------------------------+--------------+-------
(0 rows)
```

Since the student belongs to the original course they're able to access the original file. When students launch assignments we **don't** check to make sure that the file is in the current course because that check requires extra network requests, so no mapping gets created.

If you first launch the assignment as `eng+canvasteacher@hypothes.is` (thus creating a mapping) and _then_ launch the assignment as `eng+canvasstudent@hypothes.is` then it should find and use the existing mapping.

Launching a course-copied assignment: teacher does not belong to original course
--------------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+coursecopyteacher@hypothes.is`.

The assignment should launch successfully.

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

Launching a course-copied assignment: student does not belong to original course
--------------------------------------------------------------------------------

First delete any existing file mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][] as `eng+coursecopystudent@hypothes.is`.

The assignment should launch successfully.

```sql
postgres=# select extra from module_item_configurations where extra != '{}';
                  extra
------------------------------------------
 {"canvas_file_mappings": {"798": "799"}}
(1 row)
```

Try launching the assignment again and you should find that it just launches using the existing mapping, without creating any new mappings or making extra API requests to find matching files.

When we don't have a record of the original course's files
----------------------------------------------------------

The creation of "mappings" in order to fix course copied assignments depends on us having information about the assignment's original file in our DB (the file used by the original assignment in the original course, this is the file whose ID comes to us in the `file_id` parameter whenever the original or a copied assignment is launched.

If you have created or launched any assignment in the original course as a teacher then we will have downloaded the info about all of the original course's files (as they were at the time of your launch).

Launching assignments as a student does not download info about the course's files.

It is possible that a user could be launching a course-copied assignment and we don't have info about the assignment's original file in our DB. For example this could happen if the course was copied before we had deployed the file info tracking feature.

First, delete all the file info from your DB:

```sql
postgres=# delete from file;
DELETE 12
```

Also delete any previously created mappings from your DB:

```sql
postgres=# update module_item_configurations set extra = '{}';
UPDATE 18
```

Now launch [localhost (make devdata) Canvas Files Assignment (copy)][] from [Copy of Developer Test Course with Sections Enabled][].

If you launch the assignment as a teacher (member of the original course or not) you'll run into a **Hypothesis couldn't find the file in the course** error message.

If you launch the assignment as a student who isn't a member of the original course you'll get a **Couldn't get the file from Canvas** error.

If you launch the assignment as a student who is also a member of the original course it will launch successfully.

Deleted files
-------------

If you launch [localhost (make devdata) Canvas Files Assignment Whose File Has Been Deleted](https://hypothesis.instructure.com/courses/125/assignments/1370) in [Developer Test Course with Sections Enabled][] as a teacher you'll get the **Hypothesis couldn't find the file in the course** error.

We notice that the file isn't in the course which triggers us to think that the assignment might have been course copied and to look for a matching file that _is_ in the course. We won't find a matching file in the course (since Canvas omits deleted files from its list-files API responses) to the look up fails and we just fall back to the error dialog.

If you launch this assignment as a student it will launch successfully. (This is because Canvas doesn't seem to actually delete files when you delete them. Ever. Students can still download them.)

Deleting and re-uploading a file
--------------------------------

What if you delete an assignment's file from Canvas and then re-upload the same file again? This will create a new file in Canvas with a new file ID. But the new file will have the same filenamena and size as the deleted one.

If you now launch the assignment whose file was deleted as a student it will just launch successfully downloading the original (deleted) file since students can still download deleted files from Canvas.

But if you launch the assignment as a teacher we'll notice that the assignment's file ID isn't in the course and will find the new file in the course with the same name and size and will create a mapping and "fix" the assignment :)

Unpublished files
-----------------

Files can be marked as "unpublished" in Canvas which means that teachers can see them but students can't.

[localhost (make devdata) Canvas Files Assignment Whose File Is Unpublished](https://hypothesis.instructure.com/courses/125/assignments/1371) is an assignment for an unpublished file.

The assignment will launch successfully for teachers but students get a **Couldn't get the file from Canvas** error.

**But** if the course has another file with the same name and size then when a student launched the assignment we would create a mapping to that file and the launch would succeed :)

Editing assignments
-------------------

What if we store a mapping in our DB and then a user edits the assignment and changes its file?

Since the mappings map one file ID to another if the user changes the `file_id` in Canvas the previous mapping will no longer apply. (So editing works as expected.)

Renaming files
----------------------

TODO

[localhost (make devdata) Canvas Files Assignment]: https://hypothesis.instructure.com/courses/125/assignments/875/
[Developer Test Course with Sections Enabled]: https://hypothesis.instructure.com/courses/125
[Copy of Developer Test Course with Sections Enabled]: https://hypothesis.instructure.com/courses/252
[localhost (make devdata) Canvas Files Assignment (copy)]: https://hypothesis.instructure.com/courses/252/assignments/1321