### PR TITLE
Add Blackboard Files pagination support

### DIFF
--- a/lms/services/blackboard_api.py
+++ b/lms/services/blackboard_api.py
@@ -102,7 +102,13 @@ class BlackboardAPIClient:
 
     def _api_url(self, path):
         """Return the full Blackboard API URL for the given path."""
-        return f"https://{self.blackboard_host}/learn/api/public/v1/{path}"
+
+        if not path.startswith("/"):
+            # Paths that don't start with "/" are treated as relative to this
+            # common Blackboard API path prefix.
+            path = "/learn/api/public/v1/" + path
+
+        return f"https://{self.blackboard_host}{path}"
 
 
 def factory(_context, request):

--- a/tests/unit/lms/services/blackboard_api_test.py
+++ b/tests/unit/lms/services/blackboard_api_test.py
@@ -122,14 +122,21 @@ class TestBlackboardAPIClient:
             sentinel.access_token, None, None
         )
 
-    def test_request(self, svc, http_service):
-        response = svc.request("GET", "foo/bar/")
+    @pytest.mark.parametrize(
+        "path,expected_url",
+        [
+            ("foo/bar/", "https://blackboard.example.com/learn/api/public/v1/foo/bar/"),
+            (
+                "/learn/api/public/v1/foo/bar/",
+                "https://blackboard.example.com/learn/api/public/v1/foo/bar/",
+            ),
+            ("/foo/bar/", "https://blackboard.example.com/foo/bar/"),
+        ],
+    )
+    def test_request(self, svc, http_service, path, expected_url):
+        response = svc.request("GET", path)
 
-        http_service.request.assert_called_once_with(
-            "GET",
-            "https://blackboard.example.com/learn/api/public/v1/foo/bar/",
-            oauth=True,
-        )
+        http_service.request.assert_called_once_with("GET", expected_url, oauth=True)
         assert response == http_service.request.return_value
 
     def test_request_raises_OAuth2TokenError_if_our_access_token_isnt_working(


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2031

This adds a little logic to a view but it's only a little: one `for`, one `if` and one `break`. I think it's acceptable. The view is still only  13 lines (including blanks) and I don't think its tests will be too difficult.

**Let's not generalize this:** it's probable that the `paging.nextPage` field is a common field that the Blackboard API sends in responses to different endpoints, and that this code could be put in a generic place where it could be re-used by multiple endpoints.  I haven't investigated that because I don't need to for the Blackboard Files feature. `list_files()` is the only Blackboard API endpoint that we call that returns a list of results. And we have no current plans to add any other Blackboard API-related features. If and when we do add support for another paginated Blackboard API endpoint we can make this code generic then.