### PR TITLE
Show only files (not folders) from Blackboard

### DIFF
--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -38,7 +38,7 @@ class BlackboardFilesAPIViews:
         course_id = self.request.matchdict["course_id"]
 
         files = []
-        path = f"courses/uuid:{course_id}/resources?limit={PAGINATION_LIMIT}"
+        path = f"courses/uuid:{course_id}/resources?type=file&limit={PAGINATION_LIMIT}"
 
         for _ in range(PAGINATION_MAX_REQUESTS):
             response = self.blackboard_api_client.request("GET", path)

--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -33,7 +33,7 @@ class TestListFiles:
         files = view()
 
         blackboard_api_client.request.assert_called_once_with(
-            "GET", "courses/uuid:COURSE_ID/resources?limit=200"
+            "GET", "courses/uuid:COURSE_ID/resources?type=file&limit=200"
         )
         BlackboardListFilesSchema.assert_called_once_with(
             blackboard_api_client.request.return_value
@@ -69,7 +69,7 @@ class TestListFiles:
 
         # It called the Blackboard API three times getting the three pages.
         assert blackboard_api_client.request.call_args_list == [
-            call("GET", "courses/uuid:COURSE_ID/resources?limit=200"),
+            call("GET", "courses/uuid:COURSE_ID/resources?type=file&limit=200"),
             call("GET", "PAGE_2_PATH"),
             call("GET", "PAGE_3_PATH"),
         ]


### PR DESCRIPTION
When getting a course's list of files from the Blackboard API show only files, not folders.

Note that this only shows the top-level files. It doesn't return files within folders within the course. I think we may need to do more work to support folders and part of that work will likely involve _removing_ this `?type=file` parameter so that we can get both files and folders and then treat folders specially. But for now we have no folders support. Our frontend does not understand folders and thinks they're files, it lets users select folders as if they were files and then create broken assignments. So this PR at least makes it so that we have _clean_ "Blackboard Files without folders" support for now.

Blackboard's API docs are here: https://developer.blackboard.com/portal/displayApi

See also: https://github.com/hypothesis/lms/issues/2930