### PR TITLE
Only show PDFs from Blackboard

### DIFF
--- a/lms/views/api/blackboard/_schemas.py
+++ b/lms/views/api/blackboard/_schemas.py
@@ -17,6 +17,7 @@ class _FileSchema(Schema):
     id = fields.Str(required=True)
     display_name = fields.Str(data_key="name", required=True)
     updated_at = fields.Str(data_key="modified", required=True)
+    mime_type = fields.Str(data_key="mimeType")
 
     @post_load
     def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
@@ -31,7 +32,15 @@ class BlackboardListFilesSchema(RequestsResponseSchema):
 
     @post_load
     def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
-        return data["results"]
+        pdf_files = []
+
+        for file in data["results"]:
+            if file.get("mime_type") == "application/pdf":
+                # Delete mime_type: we don't want to send it to the frontend.
+                del file["mime_type"]
+                pdf_files.append(file)
+
+        return pdf_files
 
 
 class BlackboardPublicURLSchema(RequestsResponseSchema, _FileSchema):

--- a/tests/unit/lms/views/api/blackboard/_schemas_test.py
+++ b/tests/unit/lms/views/api/blackboard/_schemas_test.py
@@ -99,12 +99,22 @@ def list_files_response():
                 "name": "File_0.pdf",
                 "downloadUrl": "https://example.com/file0.pdf",
                 "unknown_field": "this_should_be_excluded",
+                "mimeType": "application/pdf",
             },
             {
                 "id": "_7851_1",
                 "modified": "1983-05-26T02:37:23.000z",
                 "name": "File_1.pdf",
                 "downloadUrl": "https://example.com/file1.pdf",
+                "mimeType": "application/pdf",
+            },
+            # A non-PDF file. This should get filtered out.
+            {
+                "id": "_7851_2",
+                "modified": "1980-05-26T02:37:23.000z",
+                "name": "NOT_A_PDF.jpeg",
+                "downloadUrl": "https://example.com/NOT_A_PDF.jpeg",
+                "mimeType": "image/jpeg",
             },
         ]
     }


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2930

When getting the list of a course's files from the Blackboard API when creating an assignment only show PDF files.

As far as I can tell there's no Blackboard API parameter to request only a particular type of file. We just have to retrieve all the files ourselves and then filter them based on their `mimeType` field.

Blackboard API docs:

https://developer.blackboard.com/portal/displayApi