### PR TITLE
Add Blackboard Files folder support

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -42,6 +42,10 @@ def includeme(config):
         "blackboard_api.courses.files.list", "/api/blackboard/courses/{course_id}/files"
     )
     config.add_route(
+        "blackboard_api.courses.files.list_folder",
+        "/api/blackboard/courses/{course_id}/folders/{folder_id}]files",
+    )
+    config.add_route(
         "blackboard_api.files.via_url", "/api/blackboard/courses/{course_id}/via_url"
     )
 

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -43,7 +43,7 @@ def includeme(config):
     )
     config.add_route(
         "blackboard_api.courses.files.list_folder",
-        "/api/blackboard/courses/{course_id}/folders/{folder_id}]files",
+        "/api/blackboard/courses/{course_id}/folders/{folder_id}/files",
     )
     config.add_route(
         "blackboard_api.files.via_url", "/api/blackboard/courses/{course_id}/via_url"

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -24,6 +24,9 @@ def includeme(config):
         "lms.services.blackboard_api.factory", name="blackboard_api_client"
     )
     config.register_service_factory(
+        "lms.services.blackboard.factory", name="blackboard"
+    )
+    config.register_service_factory(
         "lms.services.canvas_api.canvas_api_client_factory", name="canvas_api_client"
     )
     config.register_service_factory("lms.services.canvas.factory", iface=CanvasService)

--- a/lms/services/blackboard.py
+++ b/lms/services/blackboard.py
@@ -1,0 +1,44 @@
+from lms.views.api.blackboard._schemas import BlackboardListFilesSchema
+
+
+class BlackboardService:
+    """A high-level Blackboard API service."""
+
+    api = None
+
+    # The maxiumum number of paginated requests we'll make before returning.
+    PAGINATION_MAX_REQUESTS = 25
+
+    # The maximum number of results to request per paginated response.
+    # 200 is the highest number that Blackboard will accept here.
+    PAGINATION_LIMIT = 200
+
+    def __init__(self, blackboard_api_client):
+        self.api = blackboard_api_client
+
+    def get_files(self, course_id, folder_id=None):
+        """Return the list of files and folders in a course or folder."""
+
+        path = f"courses/uuid:{course_id}/resources"
+
+        if folder_id:
+            # Get the files and folders in the given folder instead of the
+            # course's top-level files and folders.
+            path += f"/{folder_id}/children"
+
+        path += f"?limit={self.PAGINATION_LIMIT}"
+
+        results = []
+
+        for _ in range(self.PAGINATION_MAX_REQUESTS):
+            response = self.api.request("GET", path)
+            results.extend(BlackboardListFilesSchema(response).parse())
+            path = response.json().get("paging", {}).get("nextPage")
+            if not path:
+                break
+
+        return results
+
+
+def factory(_context, request):
+    return BlackboardService(request.find_service(name="blackboard_api_client"))

--- a/lms/services/blackboard_api.py
+++ b/lms/services/blackboard_api.py
@@ -44,6 +44,8 @@ class BlackboardErrorResponseSchema(RequestsResponseSchema):
 
 
 class BlackboardAPIClient:
+    """A low-level Blackboard API client."""
+
     def __init__(
         self,
         blackboard_host,

--- a/lms/views/api/blackboard/_schemas.py
+++ b/lms/views/api/blackboard/_schemas.py
@@ -17,6 +17,7 @@ class _FileSchema(Schema):
     id = fields.Str(required=True)
     display_name = fields.Str(data_key="name", required=True)
     updated_at = fields.Str(data_key="modified", required=True)
+    type = fields.Str(required=True)
     mime_type = fields.Str(data_key="mimeType")
 
     @post_load
@@ -34,11 +35,15 @@ class BlackboardListFilesSchema(RequestsResponseSchema):
     def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
         pdf_files = []
 
-        for file in data["results"]:
-            if file.get("mime_type") == "application/pdf":
+        for result in data["results"]:
+            if (
+                result["type"] == "Folder"
+                or result.get("mime_type") == "application/pdf"
+            ):
+                pdf_files.append(result)
+
                 # Delete mime_type: we don't want to send it to the frontend.
-                del file["mime_type"]
-                pdf_files.append(file)
+                result.pop("mime_type", None)
 
         return pdf_files
 

--- a/lms/views/api/blackboard/_schemas.py
+++ b/lms/views/api/blackboard/_schemas.py
@@ -20,11 +20,6 @@ class _FileSchema(Schema):
     type = fields.Str(required=True)
     mime_type = fields.Str(data_key="mimeType")
 
-    @post_load
-    def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
-        data["id"] = f"blackboard://content-resource/{data['id']}/"
-        return data
-
 
 class BlackboardListFilesSchema(RequestsResponseSchema):
     """Schema for Blackboard API /courses/{courseId}/resources responses."""
@@ -33,19 +28,7 @@ class BlackboardListFilesSchema(RequestsResponseSchema):
 
     @post_load
     def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
-        pdf_files = []
-
-        for result in data["results"]:
-            if (
-                result["type"] == "Folder"
-                or result.get("mime_type") == "application/pdf"
-            ):
-                pdf_files.append(result)
-
-                # Delete mime_type: we don't want to send it to the frontend.
-                result.pop("mime_type", None)
-
-        return pdf_files
+        return data["results"]
 
 
 class BlackboardPublicURLSchema(RequestsResponseSchema, _FileSchema):

--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -33,14 +33,26 @@ class BlackboardFilesAPIViews:
         self.blackboard_api_client = request.find_service(name="blackboard_api_client")
 
     @view_config(request_method="GET", route_name="blackboard_api.courses.files.list")
+    @view_config(
+        request_method="GET", route_name="blackboard_api.courses.files.list_folder"
+    )
     def list_files(self):
         """Return the list of files in the given course."""
         course_id = self.request.matchdict["course_id"]
+        folder_id = self.request.matchdict.get("folder_id")
 
         files = []
-        path = f"courses/uuid:{course_id}/resources?type=file&limit={PAGINATION_LIMIT}"
+        path = f"courses/uuid:{course_id}/resources"
+
+        if folder_id:
+            # Get the files and folders in the given folder instead of the
+            # course's top-level files and folders.
+            path += f"/{folder_id}/children"
+
+        path += f"?limit={PAGINATION_LIMIT}"
 
         for _ in range(PAGINATION_MAX_REQUESTS):
+            import pdb; pdb.set_trace()
             response = self.blackboard_api_client.request("GET", path)
             files.extend(BlackboardListFilesSchema(response).parse())
             path = response.json().get("paging", {}).get("nextPage")

--- a/tests/unit/lms/views/api/blackboard/_schemas_test.py
+++ b/tests/unit/lms/views/api/blackboard/_schemas_test.py
@@ -21,11 +21,19 @@ class TestBlackboardListFilesSchema:
                 "id": "blackboard://content-resource/_7851_0/",
                 "updated_at": "2008-05-06T07:26:35.000z",
                 "display_name": "File_0.pdf",
+                "type": "File",
             },
             {
                 "id": "blackboard://content-resource/_7851_1/",
                 "updated_at": "1983-05-26T02:37:23.000z",
                 "display_name": "File_1.pdf",
+                "type": "File",
+            },
+            {
+                "id": "blackboard://content-resource/_7851_2/",
+                "updated_at": "1983-05-26T02:37:23.000z",
+                "display_name": "Folder_1",
+                "type": "Folder",
             },
         ]
 
@@ -98,22 +106,32 @@ def list_files_response():
                 "modified": "2008-05-06T07:26:35.000z",
                 "name": "File_0.pdf",
                 "downloadUrl": "https://example.com/file0.pdf",
-                "unknown_field": "this_should_be_excluded",
+                "type": "File",
                 "mimeType": "application/pdf",
+                "unknown_field": "this_should_be_excluded",
             },
             {
                 "id": "_7851_1",
                 "modified": "1983-05-26T02:37:23.000z",
                 "name": "File_1.pdf",
                 "downloadUrl": "https://example.com/file1.pdf",
+                "type": "File",
                 "mimeType": "application/pdf",
+            },
+            # A folder (notice: these have no downloadUrl or mimeType).
+            {
+                "id": "_7851_2",
+                "modified": "1983-05-26T02:37:23.000z",
+                "name": "Folder_1",
+                "type": "Folder",
             },
             # A non-PDF file. This should get filtered out.
             {
-                "id": "_7851_2",
+                "id": "_7851_3",
                 "modified": "1980-05-26T02:37:23.000z",
                 "name": "NOT_A_PDF.jpeg",
                 "downloadUrl": "https://example.com/NOT_A_PDF.jpeg",
+                "type": "File",
                 "mimeType": "image/jpeg",
             },
         ]

--- a/tests/unit/lms/views/api/blackboard/_schemas_test.py
+++ b/tests/unit/lms/views/api/blackboard/_schemas_test.py
@@ -18,19 +18,19 @@ class TestBlackboardListFilesSchema:
 
         assert result == [
             {
-                "id": "blackboard://content-resource/_7851_0/",
+                "id": "_7851_0",
                 "updated_at": "2008-05-06T07:26:35.000z",
                 "display_name": "File_0.pdf",
                 "type": "File",
             },
             {
-                "id": "blackboard://content-resource/_7851_1/",
+                "id": "_7851_1",
                 "updated_at": "1983-05-26T02:37:23.000z",
                 "display_name": "File_1.pdf",
                 "type": "File",
             },
             {
-                "id": "blackboard://content-resource/_7851_2/",
+                "id": "_7851_2",
                 "updated_at": "1983-05-26T02:37:23.000z",
                 "display_name": "Folder_1",
                 "type": "Folder",

--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -33,7 +33,7 @@ class TestListFiles:
         files = view()
 
         blackboard_api_client.request.assert_called_once_with(
-            "GET", "courses/uuid:COURSE_ID/resources?type=file&limit=200"
+            "GET", "courses/uuid:COURSE_ID/resources?limit=200"
         )
         BlackboardListFilesSchema.assert_called_once_with(
             blackboard_api_client.request.return_value
@@ -69,7 +69,7 @@ class TestListFiles:
 
         # It called the Blackboard API three times getting the three pages.
         assert blackboard_api_client.request.call_args_list == [
-            call("GET", "courses/uuid:COURSE_ID/resources?type=file&limit=200"),
+            call("GET", "courses/uuid:COURSE_ID/resources?limit=200"),
             call("GET", "PAGE_2_PATH"),
             call("GET", "PAGE_3_PATH"),
         ]


### PR DESCRIPTION
Labeled **do not merge** because this PR only has the backend changes for folder support, which breaks the frontend. The corresponding frontend changes are needed before merging this.

This PR:

1. Adds a new API `/api/blackboard/courses/{course_id}/folders/{folder_id}/files` for getting all the files and folders in a given sub-folder of a course

2. Changes both the existing `/api/blackboard/courses/{course_id}/files` API (all top-level files and folders in a course) and the new `/api/blackboard/courses/{course_id}/folders/{folder_id}/files` API to return both files and folders.

   Files look the same as they did before but with a new `type: "File"` field.

   Folders have an `id` that is *not* wrapped in a `blackboard://` URL, they have a `parent_id` (the ID of the parent folder or `None`) and they have a `contents` URL for the API call to get the contents of the folder. Plus they have `type: "Folder"`

## Code design

The layers I've gone for here are:

1. The already-existing `BlackboardAPIClient` service is the low-level Blackboard API client with just a generic `request()` method. Things that are general to all Blackboard API requests go here. For example: prepending the Blackboard host to URL paths; handling access token-related errors; getting and refreshing access tokens.

2. The new `BlackboardService` is the high-level Blackboard service built on top of `BlackboardAPIClient`. `BlackboardService` knows about particular Blackboard API endpoints and provides high-level convenience methods for them. For example `BlackboardService.list_files(course_id, folder_id)` constructs the necessary URL to call to get the files for `course_id` and `folder_id` and calls `BlackboardAPIClient` to make the request.

   The `BlackboardListFilesSchema` that knows about the expected format of list files responses lives in `BlackboardService`, so `BlackboardService.list_files(...)` will either return a list of dicts in the expected format or it'll raise.

   Pagination also lives in `BlackboardService.list_files()`. Pagination is probably actually general and belongs in the lower-level `BlackboardAPIClient`. But for now `list_files()` is the only endpoint that we do pagination for so it's not generalized and just lives in here.

   `BlackboardService` does not know anything about our proxy API and the consistent response format that our proxy API returns (as expected by our frontend) which is different from the particular response formats of APIs like Blackboard's or Canvas's. `BlackboardService` just returns the lists of dicts as returned by Blackboard (but it validates them to make sure Blackboard isn't sending us unexpected responses).

3. `BlackboardFilesAPIViews` implements our Blackboard proxy API. It knows what the path params and or query params of our proxy API are: reading `course_id` and `folder_id` out of `request.matchdict`. It calls `BlackboardService` to get the list of files. And it knows what the response format of our proxy API is: it loops over the list of files from `BlackboardService` and mutates them.

So that's:

1. `BlackboardAPIClient`: low-level stuff that applies to all Blackboard API requests
2. `BlackboardService`: specific high-level Blackboard API methods like `list_files(course_id, folder_id)` and validation
3. `BlackboardFilesAPIViews`: layers our proxy API on top of `BlackboardService`

### Alternatives considered

#### Just put it all in the view

All I'm actually trying to do is add folder support to `BlackboardFilesAPIViews.list_files()`. So I could just skip the `BlackboardService` and put all the code in the view. This has the advantage of keeping everything together in one place, instead of distributing work and knowledge between service and view. The only downside to this is that it might be making the view too long, adding too much logic to the view:

```python
    @view_config(request_method="GET", route_name="blackboard_api.courses.files.list")
    @view_config(
        request_method="GET", route_name="blackboard_api.courses.files.list_folder"
    )
    def list_files(self):
        """Return the list of files in the given course."""

        course_id = self.request.matchdict["course_id"]
        folder_id = self.request.matchdict.get("folder_id")

        results = []
        path = f"courses/uuid:{course_id}/resources"

        if folder_id:
            # Get the files and folders in the given folder instead of the
            # course's top-level files and folders.
            path += f"/{folder_id}/children"

        path += f"?limit={PAGINATION_LIMIT}"

        for _ in range(PAGINATION_MAX_REQUESTS):
            response = self.blackboard_api_client.request("GET", path)
            results.extend(BlackboardListFilesSchema(response).parse())
            path = response.json().get("paging", {}).get("nextPage")
            if not path:
                break

        for result in results:
            if result["type"] == "File":
                result["id"] = f"blackboard://content-resource/{result['id']}/"
            elif result["type"] == "Folder":
                result["parent_id"] = folder_id
                result["contents"] = self.request.route_url(
                    "blackboard_api.courses.files.list_folder",
                    course_id=course_id,
                    folder_id=result["id"],
                )

        return results
```

#### Split out local view helpers

Instead of a service just split out a couple of local helpers for the `list_files()` view that can be unit-tested separately:

```python
    @view_config(request_method="GET", route_name="blackboard_api.courses.files.list")
    @view_config(
        request_method="GET", route_name="blackboard_api.courses.files.list_folder"
    )
    def list_files(self):
        """Return the list of files in the given course."""

        course_id = self.request.matchdict["course_id"]
        folder_id = self.request.matchdict.get("folder_id")

        results = FilesGetter(self.blackboard_api_client).get(course_id, folder_id)

        return FilesPresenter(self.request.route_url).present(results)
```