### PR TITLE
Use the setting and sub-setting name to generate the form field name

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -27,7 +27,7 @@
 {%  macro checkbox_field(label, setting, sub_setting, field_name) %}
     {% call field_body(label) %}
         <label class="checkbox">
-          <input {% if instance.settings.get(setting, sub_setting) %}checked {% endif%} type="checkbox" name="{{ field_name }}">
+          <input {% if instance.settings.get(setting, sub_setting) %}checked {% endif%} type="checkbox" name="{{ setting }}.{{ sub_setting }}">
         </label>
     {% endcall %}
 {% endmacro %}
@@ -49,10 +49,10 @@
 
     {{ text_field("Custom Canvas API domain", instance.custom_canvas_api_domain) }}
 
-    {{ checkbox_field("Sections enabled", "canvas", "sections_enabled", "sections_enabled") }}
-    {{ checkbox_field("Groups enabled", "canvas", "groups_enabled", "groups_enabled") }}
-    {{ checkbox_field("Blackboard files enabled", "blackboard", "files_enabled", "blackboard_files_enabled") }}
-    {{ checkbox_field("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", "microsoft_onedrive.files_enabled") }}
+    {{ checkbox_field("Sections enabled", "canvas", "sections_enabled") }}
+    {{ checkbox_field("Groups enabled", "canvas", "groups_enabled") }}
+    {{ checkbox_field("Blackboard files enabled", "blackboard", "files_enabled") }}
+    {{ checkbox_field("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled") }}
 
     {% call field_body(label="") %}
         <input type="submit" class="button is-primary" value="Save" />

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -81,13 +81,13 @@ class AdminViews:
     def update_instance(self):
         ai = self._get_ai_or_404(self.request.matchdict["consumer_key"])
 
-        for setting, sub_setting, form_field in (
-            ("canvas", "sections_enabled", "sections_enabled"),
-            ("canvas", "groups_enabled", "groups_enabled"),
-            ("blackboard", "files_enabled", "blackboard_files_enabled"),
-            ("microsoft_onedrive", "files_enabled", "microsoft_onedrive.files_enabled"),
+        for setting, sub_setting in (
+            ("canvas", "sections_enabled"),
+            ("canvas", "groups_enabled"),
+            ("blackboard", "files_enabled"),
+            ("microsoft_onedrive", "files_enabled"),
         ):
-            enabled = self.request.params.get(form_field) == "on"
+            enabled = self.request.params.get(f"{setting}.{sub_setting}") == "on"
             ai.settings.set(setting, sub_setting, enabled)
 
         self.request.session.flash(

--- a/tests/unit/lms/views/admin_test.py
+++ b/tests/unit/lms/views/admin_test.py
@@ -82,12 +82,12 @@ class TestAdminViews:
         )
 
     @pytest.mark.parametrize(
-        "setting,sub_setting,field_name",
+        "setting,sub_setting",
         (
-            ("canvas", "groups_enabled", "groups_enabled"),
-            ("canvas", "sections_enabled", "sections_enabled"),
-            ("blackboard", "files_enabled", "blackboard_files_enabled"),
-            ("microsoft_onedrive", "files_enabled", "microsoft_onedrive.files_enabled"),
+            ("canvas", "groups_enabled"),
+            ("canvas", "sections_enabled"),
+            ("blackboard", "files_enabled"),
+            ("microsoft_onedrive", "files_enabled"),
         ),
     )
     @pytest.mark.parametrize("enabled", (True, False))
@@ -97,12 +97,11 @@ class TestAdminViews:
         application_instance_service,
         setting,
         sub_setting,
-        field_name,
         enabled,
     ):
         pyramid_request.matchdict["consumer_key"] = sentinel.consumer_key
         if enabled:
-            pyramid_request.params[field_name] = "on"
+            pyramid_request.params[f"{setting}.{sub_setting}"] = "on"
 
         AdminViews(pyramid_request).update_instance()
 


### PR DESCRIPTION
Instead of having a different field name for each setting, just use the setting and sub-setting names to generate it.