### PR TITLE
Temporarily rename BlackboardAPIClient to BasicBlackboardAPIClient

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -21,7 +21,7 @@ from lms.services.exceptions import (
 def includeme(config):
     config.register_service_factory("lms.services.http.factory", name="http")
     config.register_service_factory(
-        "lms.services.blackboard_api.factory", name="blackboard_api_client"
+        "lms.services.basic_blackboard_api.factory", name="basic_blackboard_api_client"
     )
     config.register_service_factory(
         "lms.services.canvas_api.canvas_api_client_factory", name="canvas_api_client"

--- a/lms/services/basic_blackboard_api.py
+++ b/lms/services/basic_blackboard_api.py
@@ -43,7 +43,9 @@ class BlackboardErrorResponseSchema(RequestsResponseSchema):
             return {}
 
 
-class BlackboardAPIClient:
+class BasicBlackboardAPIClient:
+    """A low-level Blackboard API client."""
+
     def __init__(
         self,
         blackboard_host,
@@ -115,7 +117,7 @@ def factory(_context, request):
     application_instance = request.find_service(name="application_instance").get()
     settings = request.registry.settings
 
-    return BlackboardAPIClient(
+    return BasicBlackboardAPIClient(
         blackboard_host=application_instance.lms_host(),
         client_id=settings["blackboard_api_client_id"],
         client_secret=settings["blackboard_api_client_secret"],

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -49,5 +49,7 @@ def authorize(request):
     schema=OAuthCallbackSchema,
 )
 def oauth2_redirect(request):
-    request.find_service(name="blackboard_api_client").get_token(request.params["code"])
+    request.find_service(name="basic_blackboard_api_client").get_token(
+        request.params["code"]
+    )
     return {}

--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -30,7 +30,9 @@ PAGINATION_LIMIT = 200
 class BlackboardFilesAPIViews:
     def __init__(self, request):
         self.request = request
-        self.blackboard_api_client = request.find_service(name="blackboard_api_client")
+        self.blackboard_api_client = request.find_service(
+            name="basic_blackboard_api_client"
+        )
 
     @view_config(request_method="GET", route_name="blackboard_api.courses.files.list")
     def list_files(self):

--- a/tests/unit/lms/services/basic_blackboard_api_test.py
+++ b/tests/unit/lms/services/basic_blackboard_api_test.py
@@ -3,8 +3,8 @@ from unittest.mock import sentinel
 import pytest
 
 from lms.services import HTTPError
-from lms.services.blackboard_api import (
-    BlackboardAPIClient,
+from lms.services.basic_blackboard_api import (
+    BasicBlackboardAPIClient,
     BlackboardErrorResponseSchema,
     OAuth2TokenError,
     factory,
@@ -166,7 +166,7 @@ class TestBlackboardAPIClient:
 
     @pytest.fixture
     def svc(self, http_service, oauth2_token_service):
-        return BlackboardAPIClient(
+        return BasicBlackboardAPIClient(
             blackboard_host="blackboard.example.com",
             client_id=sentinel.client_id,
             client_secret=sentinel.client_secret,
@@ -186,14 +186,14 @@ class TestFactory:
         http_service,
         oauth2_token_service,
         pyramid_request,
-        BlackboardAPIClient,
+        BasicBlackboardAPIClient,
     ):
         application_instance = application_instance_service.get.return_value
         settings = pyramid_request.registry.settings
 
         service = factory(sentinel.context, pyramid_request)
 
-        BlackboardAPIClient.assert_called_once_with(
+        BasicBlackboardAPIClient.assert_called_once_with(
             blackboard_host=application_instance.lms_host(),
             client_id=settings["blackboard_api_client_id"],
             client_secret=settings["blackboard_api_client_secret"],
@@ -201,16 +201,16 @@ class TestFactory:
             http_service=http_service,
             oauth2_token_service=oauth2_token_service,
         )
-        assert service == BlackboardAPIClient.return_value
+        assert service == BasicBlackboardAPIClient.return_value
 
     @pytest.fixture(autouse=True)
-    def BlackboardAPIClient(self, patch):
-        return patch("lms.services.blackboard_api.BlackboardAPIClient")
+    def BasicBlackboardAPIClient(self, patch):
+        return patch("lms.services.basic_blackboard_api.BasicBlackboardAPIClient")
 
 
 @pytest.fixture(autouse=True)
 def OAuthTokenResponseSchema(patch):
-    return patch("lms.services.blackboard_api.OAuthTokenResponseSchema")
+    return patch("lms.services.basic_blackboard_api.OAuthTokenResponseSchema")
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -39,16 +39,16 @@ class TestAuthorize:
         )
 
 
-@pytest.mark.usefixtures("blackboard_api_client")
+@pytest.mark.usefixtures("basic_blackboard_api_client")
 class TestOAuth2Redirect:
     def test_it_gets_a_new_access_token_for_the_user(
-        self, pyramid_request, blackboard_api_client
+        self, pyramid_request, basic_blackboard_api_client
     ):
         pyramid_request.params["code"] = "test_code"
 
         result = oauth2_redirect(pyramid_request)
 
-        blackboard_api_client.get_token.assert_called_once_with("test_code")
+        basic_blackboard_api_client.get_token.assert_called_once_with("test_code")
         assert result == {}
 
 

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -6,7 +6,7 @@ from lms.models import ApplicationSettings
 from lms.services import CanvasService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
-from lms.services.blackboard_api import BlackboardAPIClient
+from lms.services.basic_blackboard_api import BasicBlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
 from lms.services.file import FileService
@@ -30,7 +30,7 @@ __all__ = (
     # Individual services
     "application_instance_service",
     "assignment_service",
-    "blackboard_api_client",
+    "basic_blackboard_api_client",
     "canvas_api_client",
     "canvas_service",
     "course_service",
@@ -95,8 +95,10 @@ def assignment_service(mock_service):
 
 
 @pytest.fixture
-def blackboard_api_client(mock_service):
-    return mock_service(BlackboardAPIClient, service_name="blackboard_api_client")
+def basic_blackboard_api_client(mock_service):
+    return mock_service(
+        BasicBlackboardAPIClient, service_name="basic_blackboard_api_client"
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
This is a temporary step to make way for a new high-level client that's going to be called `BlackboardAPIClient`.

In a future commit `BasicBlackboardAPIClient` will no longer be a service and will become a private helper of `BlackboardAPIClient`.