### PR TITLE
Move "marshalling" code from schemas to views

### DIFF
--- a/lms/services/blackboard_api/_schemas.py
+++ b/lms/services/blackboard_api/_schemas.py
@@ -8,46 +8,32 @@ from marshmallow import EXCLUDE, Schema, fields, post_load
 from lms.validation._base import RequestsResponseSchema
 
 
-class _FileSchema(Schema):
-    """Shared base schema for Blackboard file dicts."""
-
-    class Meta:
-        unknown = EXCLUDE
-
-    id = fields.Str(required=True)
-    display_name = fields.Str(data_key="name", required=True)
-    updated_at = fields.Str(data_key="modified", required=True)
-    mime_type = fields.Str(data_key="mimeType")
-
-    @post_load
-    def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
-        data["id"] = f"blackboard://content-resource/{data['id']}/"
-        return data
-
-
 class BlackboardListFilesSchema(RequestsResponseSchema):
     """Schema for Blackboard API /courses/{courseId}/resources responses."""
 
-    results = fields.List(fields.Nested(_FileSchema), required=True)
+    class FileSchema(Schema):
+        """Schema for individual Blackboard file dicts."""
+
+        class Meta:
+            unknown = EXCLUDE
+
+        id = fields.Str(required=True)
+        name = fields.Str(required=True)
+        modified = fields.Str(required=True)
+        mimeType = fields.Str()
+
+    results = fields.List(fields.Nested(FileSchema), required=True)
 
     @post_load
     def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
-        pdf_files = []
-
-        for file in data["results"]:
-            if file.get("mime_type") == "application/pdf":
-                # Delete mime_type: we don't want to send it to the frontend.
-                del file["mime_type"]
-                pdf_files.append(file)
-
-        return pdf_files
+        return data["results"]
 
 
-class BlackboardPublicURLSchema(RequestsResponseSchema, _FileSchema):
+class BlackboardPublicURLSchema(RequestsResponseSchema):
     """Schema for Blackboard /courses/{courseId}/resources/{resourceId} responses."""
 
     downloadUrl = fields.Str(required=True)
 
     @post_load
-    def post_load(self, data, **_kwargs):
+    def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
         return data["downloadUrl"]

--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -23,9 +23,25 @@ class BlackboardFilesAPIViews:
     def list_files(self):
         """Return the list of files in the given course."""
 
-        return self.blackboard_api_client.list_files(
+        files = self.blackboard_api_client.list_files(
             self.request.matchdict["course_id"]
         )
+
+        pdf_files = []
+
+        for file in files:
+            if file.get("mimeType") != "application/pdf":
+                continue
+
+            pdf_files.append(
+                {
+                    "id": f"blackboard://content-resource/{file['id']}/",
+                    "display_name": file["name"],
+                    "updated_at": file["modified"],
+                }
+            )
+
+        return pdf_files
 
     @view_config(request_method="GET", route_name="blackboard_api.files.via_url")
     def via_url(self):

--- a/tests/unit/lms/services/blackboard_api/_schemas_test.py
+++ b/tests/unit/lms/services/blackboard_api/_schemas_test.py
@@ -18,14 +18,22 @@ class TestBlackboardListFilesSchema:
 
         assert result == [
             {
-                "id": "blackboard://content-resource/_7851_0/",
-                "updated_at": "2008-05-06T07:26:35.000z",
-                "display_name": "File_0.pdf",
+                "id": "_7851_0",
+                "modified": "2008-05-06T07:26:35.000z",
+                "name": "File_0.pdf",
+                "mimeType": "application/pdf",
             },
             {
-                "id": "blackboard://content-resource/_7851_1/",
-                "updated_at": "1983-05-26T02:37:23.000z",
-                "display_name": "File_1.pdf",
+                "id": "_7851_1",
+                "modified": "1983-05-26T02:37:23.000z",
+                "name": "File_1.pdf",
+                "mimeType": "application/pdf",
+            },
+            {
+                "id": "_7851_2",
+                "modified": "1980-05-26T02:37:23.000z",
+                "name": "NOT_A_PDF.jpeg",
+                "mimeType": "image/jpeg",
             },
         ]
 
@@ -67,7 +75,7 @@ class TestBlackboardPublicURLSchema:
     def test_it_raises_if_a_the_body_isnt_a_dict(self):
         assert_raises(BlackboardPublicURLSchema, [])
 
-    @pytest.mark.parametrize("missing_field", ["id", "modified", "name"])
+    @pytest.mark.parametrize("missing_field", ["downloadUrl"])
     def test_it_raises_if_a_required_field_is_missing(
         self, single_file_response, missing_field
     ):
@@ -75,7 +83,7 @@ class TestBlackboardPublicURLSchema:
 
         assert_raises(BlackboardPublicURLSchema, single_file_response)
 
-    @pytest.mark.parametrize("invalid_field", ["id", "modified", "name"])
+    @pytest.mark.parametrize("invalid_field", ["downloadUrl"])
     def test_it_raises_if_a_field_is_invalid(self, single_file_response, invalid_field):
         single_file_response[invalid_field] = 23
 

--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -7,10 +7,42 @@ pytestmark = pytest.mark.usefixtures("oauth2_token_service", "blackboard_api_cli
 
 class TestListFiles:
     def test_it(self, view, blackboard_api_client):
+        blackboard_api_client.list_files.return_value = [
+            {
+                "id": "_7851_0",
+                "modified": "2008-05-06T07:26:35.000z",
+                "name": "File_0.pdf",
+                "mimeType": "application/pdf",
+            },
+            {
+                "id": "_7851_1",
+                "modified": "1983-05-26T02:37:23.000z",
+                "name": "File_1.pdf",
+                "mimeType": "application/pdf",
+            },
+            {
+                "id": "_7851_2",
+                "modified": "1980-05-26T02:37:23.000z",
+                "name": "NOT_A_PDF.jpeg",
+                "mimeType": "image/jpeg",
+            },
+        ]
+
         files = view()
 
         blackboard_api_client.list_files.assert_called_once_with("COURSE_ID")
-        assert files == blackboard_api_client.list_files.return_value
+        assert files == [
+            {
+                "id": "blackboard://content-resource/_7851_0/",
+                "updated_at": "2008-05-06T07:26:35.000z",
+                "display_name": "File_0.pdf",
+            },
+            {
+                "id": "blackboard://content-resource/_7851_1/",
+                "updated_at": "1983-05-26T02:37:23.000z",
+                "display_name": "File_1.pdf",
+            },
+        ]
 
     @pytest.fixture(autouse=True)
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
Make the `BlackboardAPIClient` service (and its schemas) just return Blackboard API dicts in the format given by the Blackboard API, without modifying them.

The service *does* remove unwanted fields that we don't care about from the dicts. In the future we'll actually add Blackboard API query params to request only the fields we want and save network bytes.

The service does also validate that the Blackboard dicts are as we expect.

But it doesn't mutate them any further. Instead it's the view's job to not about our proxy API's response format and transform the dicts into that format.