### PR TITLE
Move BasicBlackboardAPIClient into BlackboardAPIClient

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -22,9 +22,6 @@ from lms.services.exceptions import (
 def includeme(config):
     config.register_service_factory("lms.services.http.factory", name="http")
     config.register_service_factory(
-        "lms.services.basic_blackboard_api.factory", name="basic_blackboard_api_client"
-    )
-    config.register_service_factory(
         "lms.services.blackboard_api.blackboard_api_client_factory",
         name="blackboard_api_client",
     )

--- a/lms/services/blackboard_api/basic.py
+++ b/lms/services/blackboard_api/basic.py
@@ -43,7 +43,7 @@ class BlackboardErrorResponseSchema(RequestsResponseSchema):
             return {}
 
 
-class BasicBlackboardAPIClient:
+class BasicClient:
     """A low-level Blackboard API client."""
 
     def __init__(
@@ -84,10 +84,10 @@ class BasicBlackboardAPIClient:
         validated_data = OAuthTokenResponseSchema(response).parse()
 
         # Save the access token to the DB.
-        # pylint: disable=no-member
         self._oauth2_token_service.save(
             validated_data["access_token"],
             validated_data.get("refresh_token"),
+            # pylint:disable=no-member
             validated_data.get("expires_in"),
         )
 
@@ -111,17 +111,3 @@ class BasicBlackboardAPIClient:
             path = "/learn/api/public/v1/" + path
 
         return f"https://{self.blackboard_host}{path}"
-
-
-def factory(_context, request):
-    application_instance = request.find_service(name="application_instance").get()
-    settings = request.registry.settings
-
-    return BasicBlackboardAPIClient(
-        blackboard_host=application_instance.lms_host(),
-        client_id=settings["blackboard_api_client_id"],
-        client_secret=settings["blackboard_api_client_secret"],
-        redirect_uri=request.route_url("blackboard_api.oauth.callback"),
-        http_service=request.find_service(name="http"),
-        oauth2_token_service=request.find_service(name="oauth2_token"),
-    )

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -15,6 +15,8 @@ PAGINATION_LIMIT = 200
 class BlackboardAPIClient:
     """A high-level Blackboard API client."""
 
+    api = None
+
     def __init__(self, basic_client):
         self.api = basic_client
 

--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -1,5 +1,18 @@
+from lms.services.blackboard_api.basic import BasicClient
 from lms.services.blackboard_api.client import BlackboardAPIClient
 
 
 def blackboard_api_client_factory(_context, request):
-    return BlackboardAPIClient(request.find_service(name="basic_blackboard_api_client"))
+    application_instance = request.find_service(name="application_instance").get()
+    settings = request.registry.settings
+
+    return BlackboardAPIClient(
+        BasicClient(
+            blackboard_host=application_instance.lms_host(),
+            client_id=settings["blackboard_api_client_id"],
+            client_secret=settings["blackboard_api_client_secret"],
+            redirect_uri=request.route_url("blackboard_api.oauth.callback"),
+            http_service=request.find_service(name="http"),
+            oauth2_token_service=request.find_service(name="oauth2_token"),
+        )
+    )

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -49,7 +49,7 @@ def authorize(request):
     schema=OAuthCallbackSchema,
 )
 def oauth2_redirect(request):
-    request.find_service(name="basic_blackboard_api_client").get_token(
+    request.find_service(name="blackboard_api_client").api.get_token(
         request.params["code"]
     )
     return {}

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -39,16 +39,16 @@ class TestAuthorize:
         )
 
 
-@pytest.mark.usefixtures("basic_blackboard_api_client")
+@pytest.mark.usefixtures("blackboard_api_client")
 class TestOAuth2Redirect:
     def test_it_gets_a_new_access_token_for_the_user(
-        self, pyramid_request, basic_blackboard_api_client
+        self, pyramid_request, blackboard_api_client
     ):
         pyramid_request.params["code"] = "test_code"
 
         result = oauth2_redirect(pyramid_request)
 
-        basic_blackboard_api_client.get_token.assert_called_once_with("test_code")
+        blackboard_api_client.api.get_token.assert_called_once_with("test_code")
         assert result == {}
 
 

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -6,7 +6,7 @@ from lms.models import ApplicationSettings
 from lms.services import CanvasService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
-from lms.services.basic_blackboard_api import BasicBlackboardAPIClient
+from lms.services.blackboard_api.basic import BasicClient
 from lms.services.blackboard_api.client import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
@@ -31,7 +31,6 @@ __all__ = (
     # Individual services
     "application_instance_service",
     "assignment_service",
-    "basic_blackboard_api_client",
     "blackboard_api_client",
     "canvas_api_client",
     "canvas_service",
@@ -97,15 +96,14 @@ def assignment_service(mock_service):
 
 
 @pytest.fixture
-def basic_blackboard_api_client(mock_service):
-    return mock_service(
-        BasicBlackboardAPIClient, service_name="basic_blackboard_api_client"
-    )
-
-
-@pytest.fixture
 def blackboard_api_client(mock_service):
-    return mock_service(BlackboardAPIClient, service_name="blackboard_api_client")
+    blackboard_api_client = mock_service(
+        BlackboardAPIClient, service_name="blackboard_api_client"
+    )
+    blackboard_api_client.api = mock.create_autospec(
+        BasicClient, instance=True, spec_set=True
+    )
+    return blackboard_api_client
 
 
 @pytest.fixture


### PR DESCRIPTION
Rename the `BasicBlackboardAPIClient` class to just `BasicClient` and move it into `BlackboardAPIClient`. It's now accessible as `BlackboardAPIClient.api` and is no longer a top-level service.

Note that `BasicClient` is still public and is still used (via `BlackboardAPIClient.api`) by some external code. In a future PR it'll
become completely private.