### PR TITLE
Make BasicClient private

### DIFF
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -64,12 +64,6 @@ class BasicClient:
         self._oauth2_token_service = oauth2_token_service
 
     def get_token(self, authorization_code):
-        """
-        Get an access token from Blackboard and save it in the DB.
-
-        :raise services.HTTPError: if something goes wrong with the access
-            token request to Blackboard
-        """
         # Send a request to Blackboard to get an access token.
         response = self._http_service.post(
             self._api_url("oauth2/token"),

--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -1,4 +1,4 @@
-from lms.services.blackboard_api.basic import BasicClient
+from lms.services.blackboard_api._basic import BasicClient
 from lms.services.blackboard_api.client import BlackboardAPIClient
 
 

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -49,7 +49,5 @@ def authorize(request):
     schema=OAuthCallbackSchema,
 )
 def oauth2_redirect(request):
-    request.find_service(name="blackboard_api_client").api.get_token(
-        request.params["code"]
-    )
+    request.find_service(name="blackboard_api_client").get_token(request.params["code"])
     return {}

--- a/tests/unit/lms/services/blackboard_api/_basic_test.py
+++ b/tests/unit/lms/services/blackboard_api/_basic_test.py
@@ -2,7 +2,10 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.services.blackboard_api.basic import BasicClient, BlackboardErrorResponseSchema
+from lms.services.blackboard_api._basic import (
+    BasicClient,
+    BlackboardErrorResponseSchema,
+)
 from lms.services.exceptions import HTTPError, OAuth2TokenError
 from lms.validation import ValidationError
 from tests import factories
@@ -173,7 +176,7 @@ class TestBasicClient:
 
 @pytest.fixture(autouse=True)
 def OAuthTokenResponseSchema(patch):
-    return patch("lms.services.blackboard_api.basic.OAuthTokenResponseSchema")
+    return patch("lms.services.blackboard_api._basic.OAuthTokenResponseSchema")
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -2,13 +2,20 @@ from unittest.mock import call, create_autospec, sentinel
 
 import pytest
 
-from lms.services.blackboard_api.basic import BasicClient
+from lms.services.blackboard_api._basic import BasicClient
 from lms.services.blackboard_api.client import (
     PAGINATION_MAX_REQUESTS,
     BlackboardAPIClient,
 )
 from lms.services.exceptions import BlackboardFileNotFoundInCourse, HTTPError
 from tests import factories
+
+
+class TestGetToken:
+    def test_it(self, svc, basic_client):
+        svc.get_token(sentinel.authorization_code)
+
+        basic_client.get_token.assert_called_once_with(sentinel.authorization_code)
 
 
 class TestListFiles:

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -48,7 +48,7 @@ class TestOAuth2Redirect:
 
         result = oauth2_redirect(pyramid_request)
 
-        blackboard_api_client.api.get_token.assert_called_once_with("test_code")
+        blackboard_api_client.get_token.assert_called_once_with("test_code")
         assert result == {}
 
 

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -6,7 +6,6 @@ from lms.models import ApplicationSettings
 from lms.services import CanvasService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
-from lms.services.blackboard_api.basic import BasicClient
 from lms.services.blackboard_api.client import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
@@ -97,13 +96,7 @@ def assignment_service(mock_service):
 
 @pytest.fixture
 def blackboard_api_client(mock_service):
-    blackboard_api_client = mock_service(
-        BlackboardAPIClient, service_name="blackboard_api_client"
-    )
-    blackboard_api_client.api = mock.create_autospec(
-        BasicClient, instance=True, spec_set=True
-    )
-    return blackboard_api_client
+    return mock_service(BlackboardAPIClient, service_name="blackboard_api_client")
 
 
 @pytest.fixture


### PR DESCRIPTION
Make `BasicClient` a private helper of `BlackboardAPIClient`. It's no longer directly accessible to external code via
`BlackboardAPIClient.api`. Instead `BlackboardAPIClient` exposes its own public methods that delegate privately to `BasicClient`.