### PR TITLE
Remove unused npm deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "normalize.css": "^8.0.1",
     "postcss": "^8.3.5",
     "preact": "10.5.13",
-    "prop-types": "^15.7.2",
     "query-string": "^5.0.0",
     "sass": "^1.35.2",
     "stringify": "^5.2.0",
@@ -62,7 +61,6 @@
   "devDependencies": {
     "@types/classnames": "^2.3.1",
     "@types/gapi": "^0.0.39",
-    "@types/prop-types": "^15.7.3",
     "@types/query-string": "^5.0.0",
     "axe-core": "^4.2.3",
     "babel-plugin-istanbul": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@hypothesis/frontend-shared": "3.4.0",
     "@types/gapi": "^0.0.39",
     "autoprefixer": "^10.3.0",
-    "babel-plugin-transform-async-to-promises": "^0.8.15",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
     "classnames": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,11 +1076,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
   integrity sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A==
 
-"@types/prop-types@^15.7.3":
-  version "15.7.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
 "@types/query-string@^5.0.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/query-string/-/query-string-5.1.0.tgz#7f40cdea49ddafa0ea4f3db35fb6c24d3bfd4dcc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1500,11 +1500,6 @@ babel-plugin-polyfill-regenerator@^0.2.2:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.2"
 
-babel-plugin-transform-async-to-promises@^0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz#13b6d8ef13676b4e3c576d3600b85344bb1ba346"
-  integrity sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==
-
 babelify@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/babelify/-/babelify-10.0.0.tgz#fe73b1a22583f06680d8d072e25a1e0d1d1d7fb5"


### PR DESCRIPTION
Remove three unused npm dependencies:

- prop-types
- @types/prop-types
- babel-plugin-transform-async-to-promises

See commit messages for more details.