### PR TITLE
Update `TextInput` prop (shared component)

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -136,7 +136,7 @@ export default function BookSelector({ selectedBook, onSelectBook }) {
             name="vitalSourceURL"
             onChange={onChangeURL}
             onKeyDown={onKeyDown}
-            placeholder="e.g. https://bookshelf.vitalsource.com/#/book/012345678..."
+            placeholder="e.g. https://bookshelf.vitalsource.com/#/books/012345678..."
           />
           <IconButton
             disabled={isLoadingBook}

--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -131,7 +131,7 @@ export default function BookSelector({ selectedBook, onSelectBook }) {
         <TextInputWithButton>
           <TextInput
             disabled={isLoadingBook}
-            error={!!error}
+            hasError={!!error}
             inputRef={inputRef}
             name="vitalSourceURL"
             onChange={onChangeURL}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-react": "^7.14.5",
-    "@hypothesis/frontend-shared": "3.4.0",
+    "@hypothesis/frontend-shared": "3.5.0",
     "@types/gapi": "^0.0.40",
     "autoprefixer": "^10.3.0",
     "babelify": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -985,10 +985,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@hypothesis/frontend-shared@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.4.0.tgz#19f12bb1fa97f87e3c9823ef9873d002aaed1271"
-  integrity sha512-igf6518Ye6Ekto+tD6pMea/tJshvaUP9Viw+RotaoPfh4t39FiXwuQboljV60W0jfKi6dPODMJWSbAz/KoyJxw==
+"@hypothesis/frontend-shared@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.5.0.tgz#519ee41d7a8b3c4eb1080f0d744a306746eb5689"
+  integrity sha512-lFvA9d4x7xY1iqCVZAxMpPNZQ6RUG6Qqle9VvjkubLou8omwUsDWTa+UaTiMczPYdYvhBASeUaWqywx5ZZOqJg==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
This PR bumps `@hypothesis/frontend-shared` to v3.5.0. That version has a breaking change to a prop for `TextInput`, which is updated here in the same commit.

There is an additional tiny commit here to fix a little typo in a placeholder URL in that same `TextInput`.