### PR TITLE
Add Blackboard refresh token support

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -22,6 +22,9 @@ from lms.services.exceptions import (
 def includeme(config):
     config.register_service_factory("lms.services.http.factory", name="http")
     config.register_service_factory(
+        "lms.services.oauth_http.factory", name="oauth_http"
+    )
+    config.register_service_factory(
         "lms.services.blackboard_api.blackboard_api_client_factory",
         name="blackboard_api_client",
     )

--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -13,6 +13,7 @@ def blackboard_api_client_factory(_context, request):
             client_secret=settings["blackboard_api_client_secret"],
             redirect_uri=request.route_url("blackboard_api.oauth.callback"),
             http_service=request.find_service(name="http"),
+            oauth_http_service=request.find_service(name="oauth_http"),
             oauth2_token_service=request.find_service(name="oauth2_token"),
         )
     )

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -7,9 +7,7 @@ from lms.services.exceptions import HTTPError
 class HTTPService:
     """Send HTTP requests with `requests` and receive the responses."""
 
-    def __init__(self, oauth2_token_service, _session=None):
-        self._oauth2_token_service = oauth2_token_service
-
+    def __init__(self, _session=None):
         # A requests session is used so that cookies are persisted across
         # requests and urllib3 connection pooling is used (which means that
         # underlying TCP connections are re-used when making multiple requests
@@ -33,7 +31,7 @@ class HTTPService:
     def delete(self, *args, **kwargs):
         return self.request("DELETE", *args, **kwargs)
 
-    def request(self, method, url, timeout=(10, 10), oauth=False, **kwargs):
+    def request(self, method, url, timeout=(10, 10), **kwargs):
         """
         Send a request with `requests` and return the requests.Response object.
 
@@ -56,12 +54,6 @@ class HTTPService:
             response download. It's a time limit on how long to wait *between
             bytes from the server*. The entire download can take much longer.
 
-        :param oauth: Include an OAuth 2 access token in the request.
-            If oauth=True the current user's access token will be looked up in
-            the database and included in an Authorization header in the
-            request.
-        :type oauth: bool
-
         :param kwargs: Any other keyword arguments will be passed directly to
             requests.Session().request():
             https://docs.python-requests.org/en/latest/api/#requests.Session.request
@@ -81,17 +73,8 @@ class HTTPService:
             HTTPError.__cause__.
 
             The error response will be available as HTTPError.response.
-
-        :raise OAuth2TokenError: If oauth=True was given but we don't have an
-            access token for the current user in our DB
         """
         response = None
-
-        if oauth:
-            kwargs.setdefault("headers", {})
-            assert "Authorization" not in kwargs["headers"]
-            access_token = self._oauth2_token_service.get().access_token
-            kwargs["headers"]["Authorization"] = f"Bearer {access_token}"
 
         try:
             response = self._session.request(
@@ -107,5 +90,5 @@ class HTTPService:
         return response
 
 
-def factory(_context, request):
-    return HTTPService(request.find_service(name="oauth2_token"))
+def factory(_context, _request):
+    return HTTPService()

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -1,0 +1,52 @@
+from lms.services import HTTPError
+
+
+class OAuthHTTPService:
+    """Send OAuth 2.0 requests and return the responses."""
+
+    def __init__(self, http_service, oauth2_token_service):
+        self._http_service = http_service
+        self._oauth2_token_service = oauth2_token_service
+
+    def get(self, *args, **kwargs):
+        return self.request("GET", *args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        return self.request("PUT", *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self.request("POST", *args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        return self.request("PATCH", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self.request("DELETE", *args, **kwargs)
+
+    def request(self, method, url, refresh=None, **kwargs):
+        oauth2_token = self._oauth2_token_service.get()
+        access_token = oauth2_token.access_token
+        refresh_token = oauth2_token.refresh_token
+
+        kwargs.setdefault("headers", {})
+        assert "Authorization" not in kwargs["headers"]
+
+        def send_request():
+            kwargs["headers"]["Authorization"] = f"Bearer {access_token}"
+            return self._http_service.request(method, url, **kwargs)
+
+        try:
+            return send_request()
+        except HTTPError:
+            if not refresh_token or not refresh:
+                raise
+
+        access_token = refresh(refresh_token=refresh_token)
+
+        return send_request()
+
+
+def factory(_context, request):
+    return OAuthHTTPService(
+        request.find_service(name="http"), request.find_service(name="oauth2_token")
+    )


### PR DESCRIPTION
Fixes: https://github.com/hypothesis/lms/issues/2033

Design:

* When an HTTP request fails we need to send a refresh request to get a new access token and then re-try the original request with the new access token, all without bothering the user. The design aim is to implement this "send with refresh and retry" logic in one place where it can be unit tested directly, and then be able to re-use it for each of the Blackboard API methods (list files, get public URL, etc).

* `HTTPService` is split into two:

  1. `HTTPService`, which only knows about HTTP not OAuth
  2. `OAuthHTTPService`. Built on top of `HTTPService` and adds generic OAuth-stuff (not specific to Blackboard)
  
  This change isn't really necessary but it just might be nice to split these into two smaller services

  The `oauth=True` argument that used to be in `HTTPService` has moved into `OAuthHTTPService`. And the new refresh token support is implemented in `OAuthHTTPService` not in `HTTPService`.
  
* Blackboard's `BasicClient` uses `OAuthHTTPService` instead of `HTTPService`

* Blackboard's `get_token()` method gains support for refresh tokens as well as authorization codes

* `OAuthHTTPService` contains the generic "send with refresh and retry" logic where, if a request fails for any reason, we try to use our refresh token to get a new access token and then re-try the original request with the new access token.

  This "send with refresh and retry" is generic (not Blackboard-specific) apart from the using-the-refresh-token part. Sending a request to the Blackboard API to exchange a refresh token for a new access token is Blackboard specific. It's implemented in `BlackboardAPIClient`'s `BasicClient.get_token()`. So `OAuthHTTPService.request()` accepts a `refresh` callable as argument.

  Once we have two or three things using `OAuthHTTPService` we might look to see whether refreshing tokens is actually generic and perhaps users could pass in a couple of parameters instead of a full callable. But for now I think it's probably best to hold off and just do the simplest and most universal thing and just accept a callable. (The same could be said about _getting_ access token in the first place: might be some opportunity for code reuse there one day.)

Known issues:

- [ ] Don't show an error message to the user if the refresh request fails. Just show them the authorization dialog. Refresh tokens expiring or being revoked is normal, not an error
  - [ ] We may want to vary this depending on the specific error message from Blackboard. If the error from Blackboard says "That refresh token is invalid" (or unknown, expired, etc) that's normal and we don't want to show an error to the user. If the refresh token request to Blackboard comes back with some other error then something unexpected _has_ happened and we _do_ want to show an error dialog to the user. As usual this depends on our ability to distinguish one type of third-party error response from another when they probably don't have proper error codes
- [ ] Do show an error message to the user if the second attempt at the API request with a new access token fails. This indicates that something is going wrong and it doesn't seem to be to do with the access token having expired or been revoked, since re-trying with a fresh access token also failed