### PR TITLE
Only get needed fields from Blackboard API

### DIFF
--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from lms.services.blackboard_api._schemas import (
     BlackboardListFilesSchema,
     BlackboardPublicURLSchema,
@@ -31,7 +33,13 @@ class BlackboardAPIClient:
         """Return the list of files in the given course."""
 
         files = []
-        path = f"courses/uuid:{course_id}/resources?type=file&limit={PAGINATION_LIMIT}"
+        path = f"courses/uuid:{course_id}/resources?" + urlencode(
+            {
+                "type": "file",
+                "limit": PAGINATION_LIMIT,
+                "fields": "id,name,modified,mimeType",
+            }
+        )
 
         for _ in range(PAGINATION_MAX_REQUESTS):
             response = self._api.request("GET", path)
@@ -47,7 +55,8 @@ class BlackboardAPIClient:
 
         try:
             response = self._api.request(
-                "GET", f"courses/uuid:{course_id}/resources/{file_id}"
+                "GET",
+                f"courses/uuid:{course_id}/resources/{file_id}?fields=downloadUrl",
             )
         except HTTPError as err:
             if err.response.status_code == 404:

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -36,7 +36,8 @@ class TestListFiles:
         files = svc.list_files("COURSE_ID")
 
         basic_client.request.assert_called_once_with(
-            "GET", "courses/uuid:COURSE_ID/resources?type=file&limit=200"
+            "GET",
+            "courses/uuid:COURSE_ID/resources?type=file&limit=200&fields=id%2Cname%2Cmodified%2CmimeType",
         )
         BlackboardListFilesSchema.assert_called_once_with(
             basic_client.request.return_value
@@ -70,7 +71,10 @@ class TestListFiles:
 
         # It called the Blackboard API three times getting the three pages.
         assert basic_client.request.call_args_list == [
-            call("GET", "courses/uuid:COURSE_ID/resources?type=file&limit=200"),
+            call(
+                "GET",
+                "courses/uuid:COURSE_ID/resources?type=file&limit=200&fields=id%2Cname%2Cmodified%2CmimeType",
+            ),
             call("GET", "PAGE_2_PATH"),
             call("GET", "PAGE_3_PATH"),
         ]
@@ -113,7 +117,7 @@ class TestPublicURL:
         public_url = svc.public_url("COURSE_ID", "FILE_ID")
 
         basic_client.request.assert_called_once_with(
-            "GET", "courses/uuid:COURSE_ID/resources/FILE_ID"
+            "GET", "courses/uuid:COURSE_ID/resources/FILE_ID?fields=downloadUrl"
         )
         BlackboardPublicURLSchema.assert_called_once_with(
             basic_client.request.return_value


### PR DESCRIPTION
Save some time and bandwidth by only getting the fields that we actually need from the Blackboard API.

Fixes https://github.com/hypothesis/lms/issues/2963