### PR TITLE
Replace `query-string` dependency with URLSearchParams

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/AuthWindow.js
+++ b/lms/static/scripts/frontend_apps/utils/AuthWindow.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 /**
  * Manages an LMS authentication popup window.
  */
@@ -43,11 +41,12 @@ export default class AuthWindow {
     const height = 560;
     const left = Math.round(window.screen.width / 2 - width / 2);
     const top = Math.round(window.screen.height / 2 - height / 2);
-    const settings = queryString
-      .stringify({ left, top, width, height })
-      .replace(/&/g, ',');
-    const authQuery = queryString.stringify({ authorization: this._authToken });
-    const authUrl = `${this._authUrl}?${authQuery}`;
+    const settings = `left=${left},top=${top},width=${width},height=${height}`;
+
+    const params = new URLSearchParams();
+    params.set('authorization', this._authToken);
+    const authUrl = `${this._authUrl}?${params}`;
+
     this._authWin = window.open(
       authUrl,
       `Allow access to Canvas files`,

--- a/lms/static/scripts/frontend_apps/utils/AuthWindow.js
+++ b/lms/static/scripts/frontend_apps/utils/AuthWindow.js
@@ -43,12 +43,11 @@ export default class AuthWindow {
     const top = Math.round(window.screen.height / 2 - height / 2);
     const settings = `left=${left},top=${top},width=${width},height=${height}`;
 
-    const params = new URLSearchParams();
-    params.set('authorization', this._authToken);
-    const authURL = `${this._authURL}?${params}`;
+    const authURL = new URL(this._authURL);
+    authURL.searchParams.set('authorization', this._authToken);
 
     this._authWin = window.open(
-      authURL,
+      authURL.toString(),
       `Allow access to Canvas files`,
       settings
     );

--- a/lms/static/scripts/frontend_apps/utils/AuthWindow.js
+++ b/lms/static/scripts/frontend_apps/utils/AuthWindow.js
@@ -11,7 +11,7 @@ export default class AuthWindow {
    */
   constructor({ authToken, authUrl }) {
     this._authToken = authToken;
-    this._authUrl = authUrl;
+    this._authURL = authUrl;
   }
 
   close() {
@@ -45,10 +45,10 @@ export default class AuthWindow {
 
     const params = new URLSearchParams();
     params.set('authorization', this._authToken);
-    const authUrl = `${this._authUrl}?${params}`;
+    const authURL = `${this._authURL}?${params}`;
 
     this._authWin = window.open(
-      authUrl,
+      authURL,
       `Allow access to Canvas files`,
       settings
     );

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -1,5 +1,3 @@
-import { stringify } from 'querystring';
-
 /** @typedef {import('../api-types').File} File */
 
 /**
@@ -37,7 +35,6 @@ import { stringify } from 'querystring';
  */
 export function contentItemForContent(ltiLaunchURL, content, extraParams) {
   const params = { ...extraParams };
-
   switch (content.type) {
     case 'file':
       params.canvas_file = 'true';
@@ -53,13 +50,18 @@ export function contentItemForContent(ltiLaunchURL, content, extraParams) {
       break;
   }
 
+  const queryParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) =>
+    queryParams.append(key, value)
+  );
+
   return {
     '@context': 'http://purl.imsglobal.org/ctx/lti/v1/ContentItem',
     '@graph': [
       {
         '@type': 'LtiLinkItem',
         mediaType: 'application/vnd.ims.lti.v1.ltilink',
-        url: `${ltiLaunchURL}?${stringify(params)}`,
+        url: `${ltiLaunchURL}?${queryParams}`,
       },
     ],
   };

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -50,9 +50,9 @@ export function contentItemForContent(ltiLaunchURL, content, extraParams) {
       break;
   }
 
-  const queryParams = new URLSearchParams();
+  const url = new URL(ltiLaunchURL);
   Object.entries(params).forEach(([key, value]) =>
-    queryParams.append(key, value)
+    url.searchParams.append(key, value)
   );
 
   return {
@@ -61,7 +61,7 @@ export function contentItemForContent(ltiLaunchURL, content, extraParams) {
       {
         '@type': 'LtiLinkItem',
         mediaType: 'application/vnd.ims.lti.v1.ltilink',
-        url: `${ltiLaunchURL}?${queryParams}`,
+        url: url.toString(),
       },
     ],
   };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "normalize.css": "^8.0.1",
     "postcss": "^8.3.5",
     "preact": "10.5.13",
-    "query-string": "^5.0.0",
     "sass": "^1.35.2",
     "stringify": "^5.2.0",
     "through2": "^4.0.2",
@@ -60,7 +59,6 @@
   "devDependencies": {
     "@types/classnames": "^2.3.1",
     "@types/gapi": "^0.0.41",
-    "@types/query-string": "^5.0.0",
     "axe-core": "^4.3.1",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-mockable-imports": "^1.7.1",

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -74,7 +74,7 @@ module.exports = function createBundle(config, buildOpts) {
     //
     // See node_modules/browserify/lib/builtins.js to find out which
     // modules provide the implementations of these.
-    builtins: ['console', '_process', 'querystring'],
+    builtins: ['console', '_process'],
     insertGlobalVars: {
       // The Browserify polyfill for the `Buffer` global is large and
       // unnecessary, but can get pulled into the bundle by modules that can

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,11 +1076,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
   integrity sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A==
 
-"@types/query-string@^5.0.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/query-string/-/query-string-5.1.0.tgz#7f40cdea49ddafa0ea4f3db35fb6c24d3bfd4dcc"
-  integrity sha512-9/sJK+T04pNq7uwReR0CLxqXj1dhxiTapZ1tIxA0trEsT6FRS0bz09YMcMb7tsVBTm4RJ0NEBYGsAjoEmqoFXg==
-
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
@@ -5145,7 +5140,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -5705,15 +5700,6 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
-
-query-string@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
-  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
 
 querystring-es3@~0.2.0:
   version "0.2.1"
@@ -6458,11 +6444,6 @@ streamroller@^2.2.4:
     date-format "^2.1.0"
     debug "^4.1.1"
     fs-extra "^8.1.0"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Simplify our dependencies by replacing `query-string` with `URLSearchParams`. An accidental use of Browserify's polyfill for Node's `querystring` module was also replaced. This has the same API as `query-string` (in other words, we accidentally used two different implementations).