### PR TITLE
Don't format query strings ourselves

### DIFF
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -85,9 +85,11 @@ class BasicClient:
             validated_data.get("expires_in"),
         )
 
-    def request(self, method, path):
+    def request(self, method, path, **kwargs):
         try:
-            return self._http_service.request(method, self._api_url(path), oauth=True)
+            return self._http_service.request(
+                method, self._api_url(path), oauth=True, **kwargs
+            )
         except HTTPError as err:
             error_dict = BlackboardErrorResponseSchema(err.response).parse()
 

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlencode
-
 from lms.services.blackboard_api._schemas import (
     BlackboardListFilesSchema,
     BlackboardPublicURLSchema,
@@ -33,16 +31,18 @@ class BlackboardAPIClient:
         """Return the list of files in the given course."""
 
         files = []
-        path = f"courses/uuid:{course_id}/resources?" + urlencode(
-            {
-                "type": "file",
-                "limit": PAGINATION_LIMIT,
-                "fields": "id,name,modified,mimeType",
-            }
-        )
+        path = f"courses/uuid:{course_id}/resources"
 
         for _ in range(PAGINATION_MAX_REQUESTS):
-            response = self._api.request("GET", path)
+            response = self._api.request(
+                "GET",
+                path,
+                params={
+                    "type": "file",
+                    "limit": PAGINATION_LIMIT,
+                    "fields": "id,name,modified,mimeType",
+                },
+            )
             files.extend(BlackboardListFilesSchema(response).parse())
             path = response.json().get("paging", {}).get("nextPage")
             if not path:

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, create_autospec, sentinel
+from unittest.mock import ANY, call, create_autospec, sentinel
 
 import pytest
 
@@ -37,7 +37,12 @@ class TestListFiles:
 
         basic_client.request.assert_called_once_with(
             "GET",
-            "courses/uuid:COURSE_ID/resources?type=file&limit=200&fields=id%2Cname%2Cmodified%2CmimeType",
+            "courses/uuid:COURSE_ID/resources",
+            params={
+                "type": "file",
+                "limit": 200,
+                "fields": "id,name,modified,mimeType",
+            },
         )
         BlackboardListFilesSchema.assert_called_once_with(
             basic_client.request.return_value
@@ -73,10 +78,11 @@ class TestListFiles:
         assert basic_client.request.call_args_list == [
             call(
                 "GET",
-                "courses/uuid:COURSE_ID/resources?type=file&limit=200&fields=id%2Cname%2Cmodified%2CmimeType",
+                "courses/uuid:COURSE_ID/resources",
+                params=ANY,
             ),
-            call("GET", "PAGE_2_PATH"),
-            call("GET", "PAGE_3_PATH"),
+            call("GET", "PAGE_2_PATH", params=ANY),
+            call("GET", "PAGE_3_PATH", params=ANY),
         ]
         # It returned all three pages of files as a single list.
         assert files == [


### PR DESCRIPTION
We don't need to format query strings ourselves: we're using `requests`.