### PR TITLE
Use rpc groups sync for both canvas groups and sections

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -424,7 +424,7 @@ class JSConfig:
         }
 
     def _groups(self):
-        if self._context.canvas_sections_enabled:
+        if self._context.canvas_sections_enabled or self._context.canvas_groups_enabled:
             return "$rpc:requestGroups"
         return [self._context.h_group.groupid(self._authority)]
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -420,7 +420,7 @@ class TestJSConfigAuthToken:
 class TestJSConfigAPISync:
     """Unit tests for the api.sync sub-dict of JSConfig."""
 
-    @pytest.mark.usefixtures("section_groups_on")
+    @pytest.mark.usefixtures("canvas_sections_on")
     def test_it(self, sync, pyramid_request, GroupInfo):
         assert sync == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
@@ -442,7 +442,7 @@ class TestJSConfigAPISync:
             },
         }
 
-    @pytest.mark.usefixtures("section_groups_on", "learner_canvas_user_id")
+    @pytest.mark.usefixtures("canvas_sections_on", "learner_canvas_user_id")
     def test_it_adds_learner_canvas_user_id_for_SpeedGrader_launches(self, sync):
         assert sync["data"]["learner"] == {
             "canvas_user_id": "test_learner_canvas_user_id",
@@ -519,8 +519,16 @@ class TestJSConfigHypothesisClient:
 
         assert groups == [context.h_group.groupid.return_value]
 
-    @pytest.mark.usefixtures("section_groups_on")
-    def test_it_configures_the_client_to_fetch_the_groups_over_RPC(self, config):
+    @pytest.mark.usefixtures("canvas_sections_on")
+    def test_configures_the_client_to_fetch_the_groups_over_RPC_with_sections(
+        self, config
+    ):
+        assert config["services"][0]["groups"] == "$rpc:requestGroups"
+
+    @pytest.mark.usefixtures("canvas_groups_on")
+    def test_it_configures_the_client_to_fetch_the_groups_over_RPC_with_groups(
+        self, config
+    ):
         assert config["services"][0]["groups"] == "$rpc:requestGroups"
 
     @pytest.mark.usefixtures("provisioning_disabled")
@@ -647,8 +655,13 @@ def context():
 
 
 @pytest.fixture
-def section_groups_on(context):
+def canvas_sections_on(context):
     context.canvas_sections_enabled = True
+
+
+@pytest.fixture
+def canvas_groups_on(context):
+    context.canvas_groups_enabled = True
 
 
 @pytest.fixture


### PR DESCRIPTION
This is something I missed when we did this, the condition to get the groups via rpc is was only checking sections. Now it checks that either sections or groups are enabled

# Testing

(on `master`, to reproduce the problem)

- Disable sections on http://localhost:8001/admin/instance/Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a/

- Open https://hypothesis.instructure.com/courses/125/assignments/1575 check that the groups the client renders are the group set's ones (Test group, another test group...)

- Force `lms/resources/lti_launch.py::canvas_sections_supported` to return False

- Check  https://hypothesis.instructure.com/courses/125/assignments/1575. Now the group in the client is `Developer Test Course`

(switch to this branch, keep `lms/resources/lti_launch.py::canvas_sections_supported` to returning False)

- Check  https://hypothesis.instructure.com/courses/125/assignments/1575. The client should display the groups set's groups again.
