### PR TITLE
Split out `OAuthHTTPService` from `HTTPService`

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -22,6 +22,9 @@ from lms.services.exceptions import (
 def includeme(config):
     config.register_service_factory("lms.services.http.factory", name="http")
     config.register_service_factory(
+        "lms.services.oauth_http.factory", name="oauth_http"
+    )
+    config.register_service_factory(
         "lms.services.blackboard_api.blackboard_api_client_factory",
         name="blackboard_api_client",
     )

--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -53,6 +53,7 @@ class BasicClient:
         client_secret,
         redirect_uri,
         http_service,
+        oauth_http_service,
         oauth2_token_service,
     ):  # pylint:disable=too-many-arguments
         self.blackboard_host = blackboard_host
@@ -61,6 +62,7 @@ class BasicClient:
         self.redirect_uri = redirect_uri
 
         self._http_service = http_service
+        self._oauth_http_service = oauth_http_service
         self._oauth2_token_service = oauth2_token_service
 
     def get_token(self, authorization_code):
@@ -87,7 +89,7 @@ class BasicClient:
 
     def request(self, method, path):
         try:
-            return self._http_service.request(method, self._api_url(path), oauth=True)
+            return self._oauth_http_service.request(method, self._api_url(path))
         except HTTPError as err:
             error_dict = BlackboardErrorResponseSchema(err.response).parse()
 

--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -13,6 +13,7 @@ def blackboard_api_client_factory(_context, request):
             client_secret=settings["blackboard_api_client_secret"],
             redirect_uri=request.route_url("blackboard_api.oauth.callback"),
             http_service=request.find_service(name="http"),
+            oauth_http_service=request.find_service(name="oauth_http"),
             oauth2_token_service=request.find_service(name="oauth2_token"),
         )
     )

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -7,9 +7,7 @@ from lms.services.exceptions import HTTPError
 class HTTPService:
     """Send HTTP requests with `requests` and receive the responses."""
 
-    def __init__(self, oauth2_token_service, _session=None):
-        self._oauth2_token_service = oauth2_token_service
-
+    def __init__(self, _session=None):
         # A requests session is used so that cookies are persisted across
         # requests and urllib3 connection pooling is used (which means that
         # underlying TCP connections are re-used when making multiple requests
@@ -33,7 +31,7 @@ class HTTPService:
     def delete(self, *args, **kwargs):
         return self.request("DELETE", *args, **kwargs)
 
-    def request(self, method, url, timeout=(10, 10), oauth=False, **kwargs):
+    def request(self, method, url, timeout=(10, 10), **kwargs):
         """
         Send a request with `requests` and return the requests.Response object.
 
@@ -56,12 +54,6 @@ class HTTPService:
             response download. It's a time limit on how long to wait *between
             bytes from the server*. The entire download can take much longer.
 
-        :param oauth: Include an OAuth 2 access token in the request.
-            If oauth=True the current user's access token will be looked up in
-            the database and included in an Authorization header in the
-            request.
-        :type oauth: bool
-
         :param kwargs: Any other keyword arguments will be passed directly to
             requests.Session().request():
             https://docs.python-requests.org/en/latest/api/#requests.Session.request
@@ -81,17 +73,8 @@ class HTTPService:
             HTTPError.__cause__.
 
             The error response will be available as HTTPError.response.
-
-        :raise OAuth2TokenError: If oauth=True was given but we don't have an
-            access token for the current user in our DB
         """
         response = None
-
-        if oauth:
-            kwargs.setdefault("headers", {})
-            assert "Authorization" not in kwargs["headers"]
-            access_token = self._oauth2_token_service.get().access_token
-            kwargs["headers"]["Authorization"] = f"Bearer {access_token}"
 
         try:
             response = self._session.request(
@@ -107,5 +90,5 @@ class HTTPService:
         return response
 
 
-def factory(_context, request):
-    return HTTPService(request.find_service(name="oauth2_token"))
+def factory(_context, _request):
+    return HTTPService()

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -1,0 +1,49 @@
+class OAuthHTTPService:
+    """Send OAuth 2.0 requests and return the responses."""
+
+    def __init__(self, http_service, oauth2_token_service):
+        self._http_service = http_service
+        self._oauth2_token_service = oauth2_token_service
+
+    def get(self, *args, **kwargs):
+        return self.request("GET", *args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        return self.request("PUT", *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self.request("POST", *args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        return self.request("PATCH", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self.request("DELETE", *args, **kwargs)
+
+    def request(self, method, url, headers=None, **kwargs):
+        """
+        Send an access token-authenticated request and return the response.
+
+        This will look up the user's access token in the DB and insert it into
+        the `headers` dict as an OAuth 2-formatted "Authorization" header.
+        Otherwise this method behaves the same as HTTPService.request().
+
+        The given `headers` must not already contain an "Authorization" header.
+
+        :raise OAuth2TokenError: if we don't have an access token for the user
+        :raise HTTPError: if something goes wrong with the HTTP request
+        """
+        headers = headers or {}
+
+        assert "Authorization" not in headers
+
+        access_token = self._oauth2_token_service.get().access_token
+        headers["Authorization"] = f"Bearer {access_token}"
+
+        return self._http_service.request(method, url, headers=headers, **kwargs)
+
+
+def factory(_context, request):
+    return OAuthHTTPService(
+        request.find_service(name="http"), request.find_service(name="oauth2_token")
+    )

--- a/tests/unit/lms/services/blackboard_api/_basic_test.py
+++ b/tests/unit/lms/services/blackboard_api/_basic_test.py
@@ -131,16 +131,16 @@ class TestBasicClient:
             ("/foo/bar/", "https://blackboard.example.com/foo/bar/"),
         ],
     )
-    def test_request(self, basic_client, http_service, path, expected_url):
+    def test_request(self, basic_client, oauth_http_service, path, expected_url):
         response = basic_client.request("GET", path)
 
-        http_service.request.assert_called_once_with("GET", expected_url, oauth=True)
-        assert response == http_service.request.return_value
+        oauth_http_service.request.assert_called_once_with("GET", expected_url)
+        assert response == oauth_http_service.request.return_value
 
     def test_request_raises_OAuth2TokenError_if_our_access_token_isnt_working(
-        self, basic_client, http_service
+        self, basic_client, oauth_http_service
     ):
-        http_service.request.side_effect = HTTPError(
+        oauth_http_service.request.side_effect = HTTPError(
             factories.requests.Response(
                 json_data={"status": 401, "message": "Bearer token is invalid"}
             )
@@ -150,9 +150,9 @@ class TestBasicClient:
             basic_client.request("GET", "foo/bar/")
 
     def test_request_raises_HTTPError_if_the_HTTP_request_fails(
-        self, basic_client, http_service
+        self, basic_client, oauth_http_service
     ):
-        http_service.request.side_effect = HTTPError(
+        oauth_http_service.request.side_effect = HTTPError(
             factories.requests.Response(
                 # Just some unrecognized error response from Blackboard.
                 json_data={"foo": "bar"}
@@ -163,13 +163,14 @@ class TestBasicClient:
             basic_client.request("GET", "foo/bar/")
 
     @pytest.fixture
-    def basic_client(self, http_service, oauth2_token_service):
+    def basic_client(self, http_service, oauth_http_service, oauth2_token_service):
         return BasicClient(
             blackboard_host="blackboard.example.com",
             client_id=sentinel.client_id,
             client_secret=sentinel.client_secret,
             redirect_uri=sentinel.redirect_uri,
             http_service=http_service,
+            oauth_http_service=oauth_http_service,
             oauth2_token_service=oauth2_token_service,
         )
 

--- a/tests/unit/lms/services/blackboard_api/factory_test.py
+++ b/tests/unit/lms/services/blackboard_api/factory_test.py
@@ -8,6 +8,7 @@ from lms.services.blackboard_api.factory import blackboard_api_client_factory
 def test_blackboard_api_client_factory(
     application_instance_service,
     http_service,
+    oauth_http_service,
     oauth2_token_service,
     pyramid_request,
     BasicClient,
@@ -24,6 +25,7 @@ def test_blackboard_api_client_factory(
         client_secret=settings["blackboard_api_client_secret"],
         redirect_uri=pyramid_request.route_url("blackboard_api.oauth.callback"),
         http_service=http_service,
+        oauth_http_service=oauth_http_service,
         oauth2_token_service=oauth2_token_service,
     )
     BlackboardAPIClient.assert_called_once_with(BasicClient.return_value)

--- a/tests/unit/lms/services/oauth_http_test.py
+++ b/tests/unit/lms/services/oauth_http_test.py
@@ -1,0 +1,73 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.exceptions import HTTPError, OAuth2TokenError
+from lms.services.oauth_http import OAuthHTTPService, factory
+
+
+class TestOAuthHTTPService:
+    def test_it(self, svc, http_service, oauth2_token_service):
+        response = svc.request(sentinel.method, sentinel.url, headers={"Foo": "bar"})
+
+        http_service.request.assert_called_once_with(
+            sentinel.method,
+            sentinel.url,
+            headers={
+                "Authorization": f"Bearer {oauth2_token_service.get.return_value.access_token}",
+                "Foo": "bar",
+            },
+        )
+        assert response == http_service.request.return_value
+
+    @pytest.mark.parametrize("method", ["GET", "PUT", "POST", "PATCH", "DELETE"])
+    def test_convenience_methods(self, method, svc, http_service, oauth2_token_service):
+        service_method = getattr(svc, method.lower())
+
+        response = service_method(sentinel.url, headers={"Foo": "bar"})
+
+        http_service.request.assert_called_once_with(
+            method,
+            sentinel.url,
+            headers={
+                "Authorization": f"Bearer {oauth2_token_service.get.return_value.access_token}",
+                "Foo": "bar",
+            },
+        )
+        assert response == http_service.request.return_value
+
+    def test_it_crashes_if_theres_already_an_Authorization_header(self, svc):
+        with pytest.raises(AssertionError):
+            svc.request(sentinel.method, sentinel.url, headers={"Authorization": "foo"})
+
+    def test_it_raises_if_theres_no_access_token_for_the_user(
+        self, svc, oauth2_token_service
+    ):
+        oauth2_token_service.get.side_effect = OAuth2TokenError
+
+        with pytest.raises(OAuth2TokenError):
+            svc.request(sentinel.method, sentinel.url)
+
+    def test_it_raises_if_the_HTTP_request_fails(self, svc, http_service):
+        http_service.request.side_effect = HTTPError
+
+        with pytest.raises(HTTPError):
+            svc.request(sentinel.method, sentinel.url)
+
+    @pytest.fixture
+    def svc(self, http_service, oauth2_token_service):
+        return OAuthHTTPService(http_service, oauth2_token_service)
+
+
+class TestFactory:
+    def test_it(
+        self, http_service, oauth2_token_service, pyramid_request, OAuthHTTPService
+    ):
+        service = factory(sentinel.context, pyramid_request)
+
+        OAuthHTTPService.assert_called_once_with(http_service, oauth2_token_service)
+        assert service == OAuthHTTPService.return_value
+
+    @pytest.fixture
+    def OAuthHTTPService(self, patch):
+        return patch("lms.services.oauth_http.OAuthHTTPService")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -21,6 +21,7 @@ from lms.services.lti_h import LTIHService
 from lms.services.lti_outcomes import LTIOutcomesClient
 from lms.services.oauth1 import OAuth1Service
 from lms.services.oauth2_token import OAuth2TokenService
+from lms.services.oauth_http import OAuthHTTPService
 from lms.services.vitalsource import VitalSourceService
 from tests import factories
 
@@ -39,6 +40,7 @@ __all__ = (
     "group_info_service",
     "grouping_service",
     "http_service",
+    "oauth_http_service",
     "launch_verifier",
     "lti_h_service",
     "lti_outcomes_client",
@@ -158,6 +160,13 @@ def http_service(mock_service):
     http_service.request.return_value = factories.requests.Response()
 
     return http_service
+
+
+@pytest.fixture
+def oauth_http_service(mock_service):
+    oauth_http_service = mock_service(OAuthHTTPService, service_name="oauth_http")
+    oauth_http_service.request.return_value = factories.requests.Response()
+    return oauth_http_service
 
 
 @pytest.fixture


### PR DESCRIPTION
Split `HTTPService` into two classes `HTTPService` and `OAuthHTTPService`. Two smaller classes instead of one bigger one. This will make more sense when `OAuthHTTPService.request()` is extended with more OAuth-related functionality.