### PR TITLE
Add refresh token support to get_token()

### DIFF
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -63,18 +63,26 @@ class BasicClient:
         self._http_service = http_service
         self._oauth2_token_service = oauth2_token_service
 
-    def get_token(self, authorization_code):
+    def get_token(self, authorization_code=None, refresh_token=None):
+        data = {"redirect_uri": self.redirect_uri}
+
+        if authorization_code:
+            data["grant_type"] = "authorization_code"
+            data["code"] = authorization_code
+        elif refresh_token:
+            data["grant_type"] = "refresh_token"
+            data["refresh_token"] = refresh_token
+        else:
+            raise AssertionError(
+                "Either one of authorization_code or refresh_token must be given."
+            )
+
         # Send a request to Blackboard to get an access token.
         response = self._http_service.post(
             self._api_url("oauth2/token"),
-            data={
-                "grant_type": "authorization_code",
-                "redirect_uri": self.redirect_uri,
-                "code": authorization_code,
-            },
+            data=data,
             auth=(self.client_id, self.client_secret),
         )
-
         validated_data = OAuthTokenResponseSchema(response).parse()
 
         # Save the access token to the DB.
@@ -84,6 +92,8 @@ class BasicClient:
             # pylint:disable=no-member
             validated_data.get("expires_in"),
         )
+
+        return validated_data["access_token"]
 
     def request(self, method, path):
         try:

--- a/tests/unit/lms/services/blackboard_api/_basic_test.py
+++ b/tests/unit/lms/services/blackboard_api/_basic_test.py
@@ -67,7 +67,7 @@ class TestBasicClient:
             "expires_in": sentinel.expires_in,
         }
 
-        basic_client.get_token(sentinel.authorization_code)
+        basic_client.get_token(authorization_code=sentinel.authorization_code)
 
         # It calls the Blackboard API to get the access token.
         http_service.post.assert_called_once_with(
@@ -88,13 +88,54 @@ class TestBasicClient:
             sentinel.access_token, sentinel.refresh_token, sentinel.expires_in
         )
 
+    def test_get_token_with_refresh_token(
+        self,
+        basic_client,
+        http_service,
+        oauth2_token_service,
+        OAuthTokenResponseSchema,
+        oauth_token_response_schema,
+    ):
+        oauth_token_response_schema.parse.return_value = {
+            "access_token": sentinel.access_token,
+            "refresh_token": sentinel.refresh_token,
+            "expires_in": sentinel.expires_in,
+        }
+
+        basic_client.get_token(refresh_token=sentinel.refresh_token)
+
+        # It calls the Blackboard API to get the access token.
+        http_service.post.assert_called_once_with(
+            "https://blackboard.example.com/learn/api/public/v1/oauth2/token",
+            data={
+                "grant_type": "refresh_token",
+                "redirect_uri": sentinel.redirect_uri,
+                "refresh_token": sentinel.refresh_token,
+            },
+            auth=(sentinel.client_id, sentinel.client_secret),
+        )
+
+        # It validates the response.
+        OAuthTokenResponseSchema.assert_called_once_with(http_service.post.return_value)
+
+        # It saves the access token in the DB.
+        oauth2_token_service.save.assert_called_once_with(
+            sentinel.access_token, sentinel.refresh_token, sentinel.expires_in
+        )
+
+    def test_it_crashes_if_neither_authorization_code_nor_refresh_token_is_given(
+        self, basic_client
+    ):
+        with pytest.raises(AssertionError):
+            basic_client.get_token()
+
     def test_get_token_raises_HTTPError_if_the_HTTP_request_fails(
         self, basic_client, http_service
     ):
         http_service.post.side_effect = HTTPError
 
         with pytest.raises(HTTPError):
-            basic_client.get_token(sentinel.authorization_code)
+            basic_client.get_token(authorization_code=sentinel.authorization_code)
 
     def test_get_token_raises_ValidationError_if_Blackboards_response_is_invalid(
         self, basic_client, oauth_token_response_schema
@@ -102,7 +143,7 @@ class TestBasicClient:
         oauth_token_response_schema.parse.side_effect = ValidationError({})
 
         with pytest.raises(ValidationError):
-            basic_client.get_token(sentinel.authorization_code)
+            basic_client.get_token(authorization_code=sentinel.authorization_code)
 
     def test_get_token_if_theres_no_refresh_token_or_expires_in(
         self, basic_client, oauth2_token_service, oauth_token_response_schema
@@ -114,7 +155,7 @@ class TestBasicClient:
             "access_token": sentinel.access_token
         }
 
-        basic_client.get_token(sentinel.authorization_code)
+        basic_client.get_token(authorization_code=sentinel.authorization_code)
 
         oauth2_token_service.save.assert_called_once_with(
             sentinel.access_token, None, None


### PR DESCRIPTION
Add refresh token support to `services.blackboard_api._basic.py:BasicClient.get_token()`.

Nothing uses the new `refresh_token` parameter yet, that will come in a future PR.