### PR TITLE
Move `access_token_request()` into `OAuthHTTPService`

### DIFF
--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -14,6 +14,5 @@ def blackboard_api_client_factory(_context, request):
             redirect_uri=request.route_url("blackboard_api.oauth.callback"),
             http_service=request.find_service(name="http"),
             oauth_http_service=request.find_service(name="oauth_http"),
-            oauth2_token_service=request.find_service(name="oauth2_token"),
         )
     )

--- a/tests/unit/lms/services/blackboard_api/_basic_test.py
+++ b/tests/unit/lms/services/blackboard_api/_basic_test.py
@@ -7,7 +7,6 @@ from lms.services.blackboard_api._basic import (
     BlackboardErrorResponseSchema,
 )
 from lms.services.exceptions import HTTPError, OAuth2TokenError
-from lms.validation import ValidationError
 from tests import factories
 
 
@@ -53,71 +52,14 @@ class TestBlackboardErrorResponseSchema:
 
 
 class TestBasicClient:
-    def test_get_token(
-        self,
-        basic_client,
-        http_service,
-        oauth2_token_service,
-        OAuthTokenResponseSchema,
-        oauth_token_response_schema,
-    ):
-        oauth_token_response_schema.parse.return_value = {
-            "access_token": sentinel.access_token,
-            "refresh_token": sentinel.refresh_token,
-            "expires_in": sentinel.expires_in,
-        }
-
+    def test_get_token(self, basic_client, oauth_http_service):
         basic_client.get_token(sentinel.authorization_code)
 
-        # It calls the Blackboard API to get the access token.
-        http_service.post.assert_called_once_with(
-            "https://blackboard.example.com/learn/api/public/v1/oauth2/token",
-            data={
-                "grant_type": "authorization_code",
-                "redirect_uri": sentinel.redirect_uri,
-                "code": sentinel.authorization_code,
-            },
+        oauth_http_service.get_access_token.assert_called_once_with(
+            token_url="https://blackboard.example.com/learn/api/public/v1/oauth2/token",
+            redirect_uri=sentinel.redirect_uri,
             auth=(sentinel.client_id, sentinel.client_secret),
-        )
-
-        # It validates the response.
-        OAuthTokenResponseSchema.assert_called_once_with(http_service.post.return_value)
-
-        # It saves the access token in the DB.
-        oauth2_token_service.save.assert_called_once_with(
-            sentinel.access_token, sentinel.refresh_token, sentinel.expires_in
-        )
-
-    def test_get_token_raises_HTTPError_if_the_HTTP_request_fails(
-        self, basic_client, http_service
-    ):
-        http_service.post.side_effect = HTTPError
-
-        with pytest.raises(HTTPError):
-            basic_client.get_token(sentinel.authorization_code)
-
-    def test_get_token_raises_ValidationError_if_Blackboards_response_is_invalid(
-        self, basic_client, oauth_token_response_schema
-    ):
-        oauth_token_response_schema.parse.side_effect = ValidationError({})
-
-        with pytest.raises(ValidationError):
-            basic_client.get_token(sentinel.authorization_code)
-
-    def test_get_token_if_theres_no_refresh_token_or_expires_in(
-        self, basic_client, oauth2_token_service, oauth_token_response_schema
-    ):
-        # refresh_token and expires_in are optional fields in
-        # OAuthTokenResponseSchema so get_token() has to still work if they're
-        # missing from the validated data.
-        oauth_token_response_schema.parse.return_value = {
-            "access_token": sentinel.access_token
-        }
-
-        basic_client.get_token(sentinel.authorization_code)
-
-        oauth2_token_service.save.assert_called_once_with(
-            sentinel.access_token, None, None
+            authorization_code=sentinel.authorization_code,
         )
 
     @pytest.mark.parametrize(
@@ -163,7 +105,7 @@ class TestBasicClient:
             basic_client.request("GET", "foo/bar/")
 
     @pytest.fixture
-    def basic_client(self, http_service, oauth_http_service, oauth2_token_service):
+    def basic_client(self, http_service, oauth_http_service):
         return BasicClient(
             blackboard_host="blackboard.example.com",
             client_id=sentinel.client_id,
@@ -171,15 +113,4 @@ class TestBasicClient:
             redirect_uri=sentinel.redirect_uri,
             http_service=http_service,
             oauth_http_service=oauth_http_service,
-            oauth2_token_service=oauth2_token_service,
         )
-
-
-@pytest.fixture(autouse=True)
-def OAuthTokenResponseSchema(patch):
-    return patch("lms.services.blackboard_api._basic.OAuthTokenResponseSchema")
-
-
-@pytest.fixture
-def oauth_token_response_schema(OAuthTokenResponseSchema):
-    return OAuthTokenResponseSchema.return_value

--- a/tests/unit/lms/services/blackboard_api/factory_test.py
+++ b/tests/unit/lms/services/blackboard_api/factory_test.py
@@ -9,7 +9,6 @@ def test_blackboard_api_client_factory(
     application_instance_service,
     http_service,
     oauth_http_service,
-    oauth2_token_service,
     pyramid_request,
     BasicClient,
     BlackboardAPIClient,
@@ -26,7 +25,6 @@ def test_blackboard_api_client_factory(
         redirect_uri=pyramid_request.route_url("blackboard_api.oauth.callback"),
         http_service=http_service,
         oauth_http_service=oauth_http_service,
-        oauth2_token_service=oauth2_token_service,
     )
     BlackboardAPIClient.assert_called_once_with(BasicClient.return_value)
     assert service == BlackboardAPIClient.return_value

--- a/tests/unit/lms/services/oauth_http_test.py
+++ b/tests/unit/lms/services/oauth_http_test.py
@@ -4,10 +4,11 @@ import pytest
 
 from lms.services.exceptions import HTTPError, OAuth2TokenError
 from lms.services.oauth_http import OAuthHTTPService, factory
+from lms.validation import ValidationError
 
 
 class TestOAuthHTTPService:
-    def test_it(self, svc, http_service, oauth2_token_service):
+    def test_request(self, svc, http_service, oauth2_token_service):
         response = svc.request(sentinel.method, sentinel.url, headers={"Foo": "bar"})
 
         http_service.request.assert_called_once_with(
@@ -36,11 +37,11 @@ class TestOAuthHTTPService:
         )
         assert response == http_service.request.return_value
 
-    def test_it_crashes_if_theres_already_an_Authorization_header(self, svc):
+    def test_request_crashes_if_theres_already_an_Authorization_header(self, svc):
         with pytest.raises(AssertionError):
             svc.request(sentinel.method, sentinel.url, headers={"Authorization": "foo"})
 
-    def test_it_raises_if_theres_no_access_token_for_the_user(
+    def test_request_raises_if_theres_no_access_token_for_the_user(
         self, svc, oauth2_token_service
     ):
         oauth2_token_service.get.side_effect = OAuth2TokenError
@@ -48,15 +49,89 @@ class TestOAuthHTTPService:
         with pytest.raises(OAuth2TokenError):
             svc.request(sentinel.method, sentinel.url)
 
-    def test_it_raises_if_the_HTTP_request_fails(self, svc, http_service):
+    def test_request_raises_if_the_HTTP_request_fails(self, svc, http_service):
         http_service.request.side_effect = HTTPError
 
         with pytest.raises(HTTPError):
             svc.request(sentinel.method, sentinel.url)
 
+    def test_get_access_token(
+        self,
+        call_get_access_token,
+        http_service,
+        OAuthTokenResponseSchema,
+        oauth_token_response_schema,
+        oauth2_token_service,
+    ):
+        validated_data = oauth_token_response_schema.parse.return_value = {
+            "access_token": "access_token",
+            "refresh_token": "refresh_token",
+            "expires_in": 1234,
+        }
+
+        call_get_access_token()
+
+        http_service.post.assert_called_once_with(
+            sentinel.token_url,
+            data={
+                "grant_type": "authorization_code",
+                "redirect_uri": sentinel.redirect_uri,
+                "code": sentinel.authorization_code,
+            },
+            auth=sentinel.auth,
+        )
+        OAuthTokenResponseSchema.assert_called_once_with(http_service.post.return_value)
+        oauth2_token_service.save.assert_called_once_with(
+            validated_data["access_token"],
+            validated_data["refresh_token"],
+            validated_data["expires_in"],
+        )
+
+    def test_get_access_token_if_theres_no_refresh_token_or_expires_in(
+        self, call_get_access_token, oauth_token_response_schema, oauth2_token_service
+    ):
+        # refresh_token and expires_in are optional fields in
+        # OAuthTokenResponseSchema so get_access_token() has to still work
+        # if they're missing from the validated data.
+        oauth_token_response_schema.parse.return_value = {
+            "access_token": "access_token"
+        }
+
+        call_get_access_token()
+
+        oauth2_token_service.save.assert_called_once_with("access_token", None, None)
+
+    def test_get_access_token_raises_HTTPError_if_the_HTTP_request_fails(
+        self, call_get_access_token, http_service
+    ):
+        http_service.post.side_effect = HTTPError
+
+        with pytest.raises(HTTPError):
+            call_get_access_token()
+
+    def test_get_access_token_raises_ValidationError_if_the_response_is_invalid(
+        self, call_get_access_token, oauth_token_response_schema
+    ):
+        oauth_token_response_schema.parse.side_effect = ValidationError({})
+
+        with pytest.raises(ValidationError):
+            call_get_access_token()
+
     @pytest.fixture
     def svc(self, http_service, oauth2_token_service):
         return OAuthHTTPService(http_service, oauth2_token_service)
+
+    @pytest.fixture
+    def call_get_access_token(self, svc):
+        def call_get_access_token():
+            svc.get_access_token(
+                sentinel.token_url,
+                sentinel.redirect_uri,
+                sentinel.auth,
+                sentinel.authorization_code,
+            )
+
+        return call_get_access_token
 
 
 class TestFactory:
@@ -71,3 +146,13 @@ class TestFactory:
     @pytest.fixture
     def OAuthHTTPService(self, patch):
         return patch("lms.services.oauth_http.OAuthHTTPService")
+
+
+@pytest.fixture(autouse=True)
+def OAuthTokenResponseSchema(patch):
+    return patch("lms.services.oauth_http.OAuthTokenResponseSchema")
+
+
+@pytest.fixture
+def oauth_token_response_schema(OAuthTokenResponseSchema):
+    return OAuthTokenResponseSchema.return_value


### PR DESCRIPTION
Move the Blackboard API client's `BasicClient.get_token()` to `OAuthHTTPService.access_token_request()` .

This is mostly because I want a future commit to add `refresh_token_request()` to `OAuthHTTPService` as well, and `access_token_request()` and `refresh_token_request()` go together (they even share code).

The method was renamed from `get_token()` to `access_token_request()` because I think `access_token_request()` is a better name as it sends an "access token request" (what the OAuth 2.0 spec calls this particular request), and the name goes nicely with `refresh_token_request()` which will be added in a future commit (and which will send what the spec calls a "refresh token request") and with the existing `request()`.

I'm not sure that this `access_token_request()` method is fully generic yet. It sends the type of access token requests that the Blackboard API requires. In particular it sends the client ID and secret in a basic HTTP auth header. I think some servers may require these in the body. We can adapt the method as needed as we add more servers.
