### PR TITLE
Adjust Enter keypress handling and focus flow for VS book selector

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -104,7 +104,11 @@ export default function BookPicker({ onCancel, onSelectBook }) {
       ]}
     >
       {step === 'select-book' && !error && (
-        <BookSelector selectedBook={book} onSelectBook={setBook} />
+        <BookSelector
+          selectedBook={book}
+          onConfirmBook={confirmBook}
+          onSelectBook={setBook}
+        />
       )}
       {step === 'select-chapter' && !error && (
         <ChapterList

--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -184,10 +184,8 @@ export default function BookSelector({
             data-testid="selected-book"
           >
             <SvgIcon name="check" className="hyp-u-color--success" />
-            <div className="hyp-u-stretch">
-              <strong>
-                <em>{selectedBook.title}</em>
-              </strong>
+            <div className="hyp-u-stretch BookSelector__title">
+              {selectedBook.title}
             </div>
           </div>
         )}

--- a/lms/static/styles/components/_BookSelector.scss
+++ b/lms/static/styles/components/_BookSelector.scss
@@ -12,4 +12,12 @@
     width: 110px;
     height: 150px;
   }
+
+  // TODO: These class-based rules should be replaced with an appropriate
+  // utility class or font pattern when available from the `frontend-shared`
+  // package
+  &__title {
+    font-weight: bold;
+    font-style: italic;
+  }
 }


### PR DESCRIPTION
This PR addresses two tuning issues for the VitalSource book-picking flow:

* It makes it possible to press "Enter" again after a book is looked up in the BookSelector to "confirm" that book and move on to the select-chapter state. This is a convenience for users who are using their keyboard to navigate.
* It eliminates some pseudo-semantic markup that isn't really (semantic).

As part of supporting the first objective, focus strategy needed to be adjusted for the `TextInput` and `IconButton` elements in `BookSelector`. 

Previously, they set their underlying elements (`input` and `button`) to be `disabled` when fetch requests were in flight. The objective was to keep users from changing the URL value and attempting to re-submit it while a request was outstanding. However, `disabled` elements are not `focusable`. What would happen previously is that the focus would be lost on the input or button when they were disabled and "flung" out the `body` element. This made subsequent interactions a pain, and it was not possible to respond usefully to keypresses as none of the elements in the component at hand had focus anymore.

The same objective—making it so the URL entered in the text field can't be modified while a request is outstanding—can be achieved by setting the `input` element to `readOnly` during that duration. The `IconButton` doesn't really need to be disabled at all, ever.

This retains focus on whatever the focus was on when the fetch was initiated, allowing keypress handling to be implemented as needed for this feature.

### To test this out

Follow the [directions in this PR's description](https://github.com/hypothesis/lms/pull/2953). Once you get to the point of pasting URLs into the input field (some URLs are provided for you in that PR), try out hitting "Enter" instead of clicking the buttons. 

Fixes https://github.com/hypothesis/lms/issues/2952
Fixes https://github.com/hypothesis/lms/issues/2958