### PR TITLE
Add Blackboard refresh-and-retry support

### DIFF
--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -120,7 +120,7 @@ class OAuthHTTPService:
         self._oauth2_token_service.save(
             validated_data["access_token"],
             validated_data.get("refresh_token"),
-            validated_data.get("expires_in"),  # pylint:disable=no-member
+            validated_data.get("expires_in"),
         )
 
         return validated_data["access_token"]

--- a/tests/unit/lms/services/blackboard_api/_basic_test.py
+++ b/tests/unit/lms/services/blackboard_api/_basic_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import sentinel
+from unittest.mock import DEFAULT, call, sentinel
 
 import pytest
 
@@ -75,15 +75,62 @@ class TestBasicClientRequest:
             ("/foo/bar/", "https://blackboard.example.com/foo/bar/"),
         ],
     )
-    def test_it(self, basic_client, oauth_http_service, path, expected_url):
+    def test_it_sends_the_request_and_returns_the_response(
+        self, basic_client, oauth_http_service, path, expected_url
+    ):
         response = basic_client.request("GET", path)
 
         oauth_http_service.request.assert_called_once_with("GET", expected_url)
         assert response == oauth_http_service.request.return_value
 
-    def test_it_raises_OAuth2TokenError_if_our_access_token_isnt_working(
+    # If the request fails on first attempt request() sends a refresh token
+    # request and then re-tries the original request.
+    def test_it_refreshes_and_tries_again_if_the_first_request_fails(
         self, basic_client, oauth_http_service
     ):
+        # Make the first attempt at the request fail but the second succeed.
+        oauth_http_service.request.side_effect = [HTTPError, DEFAULT]
+
+        response = basic_client.request("GET", "/foo")
+
+        assert oauth_http_service.request.call_args_list == [
+            call("GET", "https://blackboard.example.com/foo"),
+            call("GET", "https://blackboard.example.com/foo"),
+        ]
+        oauth_http_service.refresh_access_token.assert_called_once_with(
+            token_url="https://blackboard.example.com/learn/api/public/v1/oauth2/token",
+            redirect_uri=sentinel.redirect_uri,
+            auth=(sentinel.client_id, sentinel.client_secret),
+        )
+        assert response == oauth_http_service.request.return_value
+
+    # If the request fails on first attempt and then the refresh token request
+    # also raises then request() raises.
+    def test_it_raises_if_the_refresh_request_fails(
+        self, basic_client, oauth_http_service
+    ):
+        # Make the API request fail.
+        oauth_http_service.request.side_effect = HTTPError
+        # Make the refresh token request also fail.
+        oauth_http_service.refresh_access_token.side_effect = HTTPError
+
+        with pytest.raises(HTTPError):
+            basic_client.request("GET", "/foo")
+
+    # If both attempts at the API request fail then request() raises.
+    def test_request_raises_if_the_second_request_fails(
+        self, basic_client, oauth_http_service
+    ):
+        # Make the API request fail both times.
+        oauth_http_service.request.side_effect = HTTPError
+
+        with pytest.raises(HTTPError):
+            basic_client.request("GET", "/foo")
+
+    def test_it_raises_OAuth2TokenError_if_the_request_fails_with_an_access_token_error(
+        self, basic_client, oauth_http_service
+    ):
+        # Make the API request fail both times.
         oauth_http_service.request.side_effect = HTTPError(
             factories.requests.Response(
                 json_data={"status": 401, "message": "Bearer token is invalid"}
@@ -91,20 +138,7 @@ class TestBasicClientRequest:
         )
 
         with pytest.raises(OAuth2TokenError):
-            basic_client.request("GET", "foo/bar/")
-
-    def test_it_raises_HTTPError_if_the_HTTP_request_fails(
-        self, basic_client, oauth_http_service
-    ):
-        oauth_http_service.request.side_effect = HTTPError(
-            factories.requests.Response(
-                # Just some unrecognized error response from Blackboard.
-                json_data={"foo": "bar"}
-            )
-        )
-
-        with pytest.raises(HTTPError):
-            basic_client.request("GET", "foo/bar/")
+            basic_client.request("GET", "/foo")
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2033.

When a Blackboard API request fails for any reason try to get a new access token without user interaction by doing a refresh token request and then re-try the original API request once more.

If the refresh token request fails raise an `OAuth2TokenError` which will trigger the **Authorize Hypothesis** dialog to get a new access token with user interaction.

If the refresh token request succeeds but then the second attempt at the API request still fails raise an `HTTPError` which will trigger an error dialog (with **Try again** button).

Testing
=======

Delete all the access tokens from your DB. This will make the tests below easier to do by removing irrelevant access tokens from the DB:

    tox -qe dockercompose -- exec postgres psql -U postgres -c "DELETE FROM oauth2_token;"

Log in to https://aunltd-test.blackboard.com/ as either a teacher or a student, navigate to [Developer Test Course with Original Course View](https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline) and then:

- [x] Launch **localhost (make devdata) Blackboard Files Assignment**. You will have to click through the **Authorize** dialog and then the assignment should launch successfully.

  **The popup window might just open and then immediately close automatically**. This happens because the user has already authorized our app in Blackboard and Blackboard remembers this. If you want to actually see Blackboard's authorization dialog you have to go to [Tools > Application Authorization](https://aunltd-test.blackboard.com/ultra/tools/lti/launchFrame?toolHref=https:~2F~2Faunltd-test.blackboard.com~2Fwebapps~2Fblackboard~2Fexecute~2Fblti~2FlaunchPlacement%3Fblti_placement_id%3D_2_1%26wrapped%3Dtrue%26from_ultra%3Dtrue) and revoke Hypothesis Dev.

- [x] Launch the assignment again. This time it should launch successfully without asking you to authorize because it should re-use your previously saved access token. **The popup window should not appear and then close automatically**. You shouldn't see the popup window at all.

- [x] Break the access token in your DB. This simulates the access token having expired or having been revoked etc:

  ```
  tox -qe dockercompose -- exec postgres psql -U postgres -c "UPDATE oauth2_token SET access_token = 'foo';"
  ```

  Launch the assignment again. It should launch successfully **without** asking you to re-authorize because it should automatically use the refresh token to get a new access token. This is the whole point of refresh token support: it changes the user experience by not asking you to re-authorize as often. Again,  **the popup window should not appear and then close automatically**. You shouldn't see the popup window at all.

  You should see that a new access token has been saved to your DB and the access token is no longer `"foo"`:

  ```
  tox -qe dockercompose -- exec postgres psql -U postgres -c "SELECT access_token FROM oauth2_token;"
   access_token
  --------------
   8Pl***Znw
  (1 row)
  ```

- [x] Break the access token **and** refresh token in the DB. This will trigger a refresh request when we get an access token error and then the refresh request will fail:

  ```
  tox -qe dockercompose -- exec postgres psql -U postgres -c "UPDATE oauth2_token SET access_token = 'foo', refresh_token = 'bar';"
  ```

  Launch the assignment again. You should see the **Authorize Hypothesis** dialog and **not** an error dialog.

- [x] Break the code so that the public URL API request fails. This simulates something else going wrong with the API request (rather than our access and/or refresh token being expired or revoked):

  ```diff
  diff --git a/lms/services/blackboard_api/client.py b/lms/services/blackboard_api/client.py
  index caa788ce..4e59b533 100644
  --- a/lms/services/blackboard_api/client.py
  +++ b/lms/services/blackboard_api/client.py
  @@ -56,7 +56,7 @@ class BlackboardAPIClient:
           try:
               response = self._api.request(
                   "GET",
  -                f"courses/uuid:{course_id}/resources/{file_id}?fields=downloadUrl",
  +                f"foo",
               )
           except HTTPError as err:
               if err.response.status_code == 404:
  ```

  Launch the assignment again. You should see a **Something went wrong** error dialog with the details of the failed API request. The specific diff shown above will trigger a _Hypothesis couldn't find the assignment's PDF file in the Blackboard course_ error (because it triggers a 404 from Blackboard which makes our code think that the assignment's file can't be found). A change that triggers a different (non-404) error response from Blackboard error dialog (_A problem occurred while handling this request. Hypothesis has been notified._).

  Note that the code will do a refresh token request and re-try the API request a second time when this happens even though the error message from Blackboard was not related to our access token. We're deliberately being "dumb" here and doing refresh-and-retry in response to *any* error rather than trying to single out the specific access token-related errors that refresh-and-retry might actually fix. This is the simplest and most robust approach, giving us the highest chance of succeeding. Trying to filter out only those errors that refresh-and-retry will fix would mean more complicated code and would introduce the possibility of false negatives where refresh-and-retry would have worked but we didn't try it.


