### PR TITLE
Handle Blackboard file permission errors

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -225,13 +225,11 @@ class HTTPValidationError(HTTPError):
     """An invalid HTTP response from an external service."""
 
 
-class BlackboardFileNotFoundInCourse(Exception):
+class BlackboardFileNotFoundInCourse(ServiceError):
     """A Blackboard file ID wasn't found in the current course."""
 
-    explanation = (
-        "Hypothesis couldn't find the assignment's PDF file in the Blackboard course."
-    )
+    error_code = "blackboard_file_not_found_in_course"
 
-    def __init__(self, document_url):
-        self.details = {"document_url": document_url}
+    def __init__(self, file_id):
+        self.details = {"file_id": file_id}
         super().__init__(self.details)

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -26,12 +26,14 @@ import VitalSourceBookViewer from './VitalSourceBookViewer';
  * offered to remedy the problem.
  *
  * Note the two different naming conventions here:
+ *  - "blackboard_*" for the Blackboard specific cases where ErrorState matches the string coming from the backend and are all handled the same way
  *  - "canvas_*" for the canvas specific cases where ErrorState matches the string coming from the backend and are all handled the same way
  *  - "error-*" for the rest
  *
  * @typedef {'error-fetching'|
  *           'error-authorizing'|
  *           'error-reporting-submission'|
+ *           'blackboard_file_not_found_in_course'|
  *           'canvas_api_permission_error'|
  *           'canvas_file_not_found_in_course'|
  *           'canvas_group_set_not_found'|
@@ -123,6 +125,7 @@ export default function BasicLTILaunchApp() {
       e instanceof APIError &&
       e.errorCode !== null &&
       [
+        'blackboard_file_not_found_in_course',
         'canvas_api_permission_error',
         'canvas_file_not_found_in_course',
         'canvas_group_set_not_found',

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -102,6 +102,35 @@ export default function LaunchErrorDialog({
           <p>Hypothesis needs your authorization to launch this assignment.</p>
         </BaseDialog>
       );
+    case 'blackboard_file_not_found_in_course':
+      return (
+        <BaseDialog
+          busy={busy}
+          error={error}
+          onRetry={onRetry}
+          title="Hypothesis couldn't find the file in the course"
+        >
+          <p>This might have happened because:</p>
+
+          <ul>
+            <li>
+              The file has been deleted from Blackboard: an instructor needs to
+              re-create the assignment with a new file
+            </li>
+            <li>
+              You don{"'"}t have permission to read the file: an instructor
+              needs to{' '}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://web.hypothes.is/help/creating-hypothesis-enabled-readings-in-blackboard/"
+              >
+                give students read permission for the file
+              </a>
+            </li>
+          </ul>
+        </BaseDialog>
+      );
     case 'canvas_api_permission_error':
       return (
         <BaseDialog

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -42,6 +42,10 @@ describe('LaunchErrorDialog', () => {
       retryAction: 'Authorize',
     },
     {
+      errorState: 'blackboard_file_not_found_in_course',
+      expectedText: 'The file has been deleted from Blackboard',
+    },
+    {
       errorState: 'canvas_api_permission_error',
       expectedText: "Hypothesis couldn't get the assignment's file from Canvas",
     },

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -101,7 +101,6 @@ class ExceptionViews:
         )
 
     @exception_view_config(context=ProxyAPIError)
-    @exception_view_config(context=BlackboardFileNotFoundInCourse)
     def proxy_api_error(self):
         return self.error_response(
             message=self.context.explanation, details=self.context.details
@@ -111,6 +110,7 @@ class ExceptionViews:
     def proxy_api_access_token_error(self):
         return self.error_response()
 
+    @exception_view_config(context=BlackboardFileNotFoundInCourse)
     @exception_view_config(context=CanvasAPIPermissionError)
     @exception_view_config(context=CanvasFileNotFoundInCourse)
     @exception_view_config(context=CanvasGroupError)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2990

Add a helpful error dialog for the case when the user doesn't have permission to read a Blackboard Files assignment's file.

### Problem

If the user launching a Blackboard Files assignment (probably a student) doesn't have permission to read the assignment's file then Blackboard's public URL API returns an error message like this:

```json
{
  "message": "Target folder or file (xid-9911_1) does not exist or user does not have Read|Write permission.",
  "status": 404
}
```

We currently show a generic error dialog in response to this, which doesn't help the user to understand what is wrong or what they can do to fix it. The **Error Details** aren't much use either:

![Screenshot from 2021-07-22 12-10-32](https://user-images.githubusercontent.com/22498/126630241-3345ceb2-3a66-443a-86e3-c1a21512d92a.png)

### Solution

This PR special-cases 404s from Blackboard's public URL API and shows a more helpful error message:

![Screenshot from 2021-07-22 11-41-20](https://user-images.githubusercontent.com/22498/126630130-a50d031c-0650-42e0-8815-393f8d8b8e45.png)

**Note:** The weird "**API call failed**" bit in the error dialog is a pre-existing bug (https://github.com/hypothesis/lms/issues/2997), ignore that.

### Testing

1. Re-run `make devdata` to get the latest Blackboard assignments
2. Log in to https://aunltd-test.blackboard.com/ as a student
3. Go to [Developer Test Course with Original Course View](https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline)
4. Launch **localhost (make devdata) Blackboard Files Assignments: Student's Can't Read The File**
6. You should see the new error dialog. On master you'd see the old dialog.
7. Also launch **localhost (make devdata) Blackboard Files Assignment Whose File Has Been Deleted**. You should see the same error dialog (we can't tell the difference between a file that has been deleted and one that the user lacks read permission for)

### Known limitations

* When the teacher launches the assignment it will probably work because the teacher probably has access to the file. So they'll think the assignment's fine. Then when their students try to launch it they'll get the error dialog. It would be better if we could detect the problem and warn teachers of it when teachers launch the assignment, but I don't know of any way to do that with the Blackboard API.

* The **Error Details** in the error dialog aren't very useful. They just say `{"file_id": "_10704_1"}`. It would be better to include the full error response from Blackboard here. Separate issue: https://github.com/hypothesis/lms/issues/2998