### PR TITLE
Handle errors getting blackboard access tokens

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -105,7 +105,7 @@ class JSConfig:
     def enable_oauth2_redirect_error_mode(
         self,
         error_details,
-        auth_url=None,
+        auth_route,
         is_scope_invalid=False,
         canvas_scopes=None,
     ):
@@ -118,14 +118,29 @@ class JSConfig:
 
         :param error_details: Technical details of the error
         :type error_details: str
-        :param auth_url: URL for the "Try again" button in the dialog
-        :type auth_url: str
+        :param auth_route: route for the "Try again" button in the dialog
+        :type auth_route: str
         :param is_scope_invalid: `True` if authorization failed because the
           OAuth client does not have access to all the necessary scopes
         :type is_scope_invalid: bool
         :param canvas_scopes: List of scopes that were requested
         :type canvas_scopes: list(str)
         """
+        if self._lti_user:
+            auth_url = self._request.route_url(
+                auth_route,
+                _query=[
+                    (
+                        "authorization",
+                        BearerTokenSchema(self._request).authorization_param(
+                            self._lti_user
+                        ),
+                    )
+                ],
+            )
+        else:
+            auth_url = None
+
         self._config.update(
             {
                 "mode": "oauth2-redirect-error",

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -104,8 +104,8 @@ class JSConfig:
 
     def enable_oauth2_redirect_error_mode(
         self,
-        error_details,
         auth_route,
+        error_details="",
         is_scope_invalid=False,
         canvas_scopes=None,
     ):
@@ -127,16 +127,12 @@ class JSConfig:
         :type canvas_scopes: list(str)
         """
         if self._lti_user:
+            bearer_token = BearerTokenSchema(self._request).authorization_param(
+                self._lti_user
+            )
             auth_url = self._request.route_url(
                 auth_route,
-                _query=[
-                    (
-                        "authorization",
-                        BearerTokenSchema(self._request).authorization_param(
-                            self._lti_user
-                        ),
-                    )
-                ],
+                _query=[("authorization", bearer_token)],
             )
         else:
             auth_url = None

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlencode, urlunparse
 
 from pyramid.httpexceptions import HTTPFound
-from pyramid.view import view_config
+from pyramid.view import exception_view_config, view_config
 
 from lms.security import Permissions
 from lms.validation.authentication import OAuthCallbackSchema
@@ -50,4 +50,22 @@ def authorize(request):
 )
 def oauth2_redirect(request):
     request.find_service(name="blackboard_api_client").get_token(request.params["code"])
+    return {}
+
+
+@exception_view_config(
+    request_method="GET",
+    route_name="blackboard_api.oauth.callback",
+    renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
+)
+@exception_view_config(
+    request_method="GET",
+    route_name="blackboard_api.oauth.authorize",
+    renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
+)
+def oauth2_redirect_error(request):
+    request.context.js_config.enable_oauth2_redirect_error_mode(
+        auth_route="blackboard_api.oauth.authorize"
+    )
+
     return {}

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -16,7 +16,7 @@ from pyramid.view import exception_view_config, view_config
 
 from lms.security import Permissions
 from lms.services import CanvasAPIServerError
-from lms.validation.authentication import BearerTokenSchema, OAuthCallbackSchema
+from lms.validation.authentication import OAuthCallbackSchema
 
 #: The Canvas API scopes that we need for our Canvas Files feature.
 FILES_SCOPES = (
@@ -112,18 +112,8 @@ def oauth2_redirect(request):
     renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
 )
 def oauth2_redirect_error(request):
-    auth_url = None
-    if request.lti_user:
-        authorization_param = BearerTokenSchema(request).authorization_param(
-            request.lti_user
-        )
-        auth_url = request.route_url(
-            "canvas_api.oauth.authorize",
-            _query=[("authorization", authorization_param)],
-        )
-
     request.context.js_config.enable_oauth2_redirect_error_mode(
-        auth_url=auth_url,
+        auth_route="canvas_api.oauth.authorize",
         error_details=request.params.get("error_description"),
         is_scope_invalid=request.params.get("error") == "invalid_scope",
         canvas_scopes=FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -1,7 +1,15 @@
+from unittest.mock import create_autospec
+
 import pytest
 from h_matchers import Any
 
-from lms.views.api.blackboard.authorize import authorize, oauth2_redirect
+from lms.resources._js_config import JSConfig
+from lms.resources.oauth2_redirect import OAuth2RedirectResource
+from lms.views.api.blackboard.authorize import (
+    authorize,
+    oauth2_redirect,
+    oauth2_redirect_error,
+)
 from tests.matchers import temporary_redirect_to
 
 
@@ -37,6 +45,25 @@ class TestAuthorize:
                 },
             )
         )
+
+
+class TestOAuth2RedirectError:
+    def test_it(self, pyramid_request):
+        template_variables = oauth2_redirect_error(pyramid_request)
+
+        pyramid_request.context.js_config.enable_oauth2_redirect_error_mode.assert_called_once_with(
+            auth_route="blackboard_api.oauth.authorize"
+        )
+        assert template_variables == {}
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.context = create_autospec(
+            OAuth2RedirectResource,
+            instance=True,
+            js_config=create_autospec(JSConfig, spec_set=True, instance=True),
+        )
+        return pyramid_request
 
 
 @pytest.mark.usefixtures("blackboard_api_client")

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -185,30 +185,11 @@ class TestOAuth2RedirectError:
 
         js_config = pyramid_request.context.js_config
         js_config.enable_oauth2_redirect_error_mode.assert_called_with(
-            auth_url=None,
+            auth_route="canvas_api.oauth.authorize",
             error_details=params.get("error_description"),
             is_scope_invalid=invalid_scope,
             canvas_scopes=scopes,
         )
-
-    # Test the URL that the backend provides to the frontend for the "Try again"
-    # button.
-    def test_it_configures_auth_url(self, pyramid_request, BearerTokenSchema):
-        schema = BearerTokenSchema.return_value
-        schema.authorization_param.return_value = "auth-param"
-
-        authorize.oauth2_redirect_error(pyramid_request)
-
-        BearerTokenSchema.assert_called_once_with(pyramid_request)
-        schema.authorization_param.assert_called_once_with(pyramid_request.lti_user)
-
-        expected_auth_url = pyramid_request.route_url(
-            "canvas_api.oauth.authorize", _query=[("authorization", "auth-param")]
-        )
-        js_config = pyramid_request.context.js_config
-        js_config.enable_oauth2_redirect_error_mode.assert_called_once()
-        _, kwargs = js_config.enable_oauth2_redirect_error_mode.call_args
-        assert kwargs["auth_url"] == expected_auth_url
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, OAuth2RedirectResource):
@@ -220,11 +201,6 @@ class TestOAuth2RedirectError:
     @pytest.fixture(autouse=True)
     def OAuth2RedirectResource(self, patch):
         return patch("lms.resources.OAuth2RedirectResource")
-
-
-@pytest.fixture(autouse=True)
-def BearerTokenSchema(patch):
-    return patch("lms.views.api.canvas.authorize.BearerTokenSchema")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/2760

## Testing

Some of the tests below are testing existing behaviours that were implemented for Canvas and are just being inherited by Blackboard and aren't really implemented by the code in this PR. But there's no harm in re-testing everything to do with our popup window UX. And some of the tests _are_ testing what's actually in this PR.

* Log in to https://aunltd-test.blackboard.com/ as either a teacher or a student

* Delete all the access tokens from your DB in order to trigger the authorization process when you launch a Blackboard Files assignment:

  ```
  tox -qe dockercompose -- exec postgres psql -U postgres -c 'DELETE FROM oauth2_token;'
  ```

* Revoke your Blackboard API authorization so that Blackboard's authorization popup window doesn't immediately close when it pops up. Go to [Tools > Application Authorization](https://aunltd-test.blackboard.com/ultra/tools/lti/launchFrame?toolHref=https:~2F~2Faunltd-test.blackboard.com~2Fwebapps~2Fblackboard~2Fexecute~2Fblti~2FlaunchPlacement%3Fblti_placement_id%3D_2_1%26wrapped%3Dtrue%26from_ultra%3Dtrue) and revoke Hypothesis Dev

* Go to [Developer Test Course with Original Course View](https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline) and launch **localhost (make devdata) Blackboard Files Assignment**

* Click **Authorize**

- [ ] Close the authorization popup window (by clicking the **x** in the top-right) _without_ clicking **Allow**. Back in the original browser tab it should still be showing the **Authorize** button and clicking it should re-open the popup window.

  https://user-images.githubusercontent.com/22498/126667499-ff418cbb-173c-403e-88b4-65c1b98a8001.mp4

- [ ] If you lose the popup window (don't close it, but just go back to the original tab) then clicking **Authorize** in the original tab should re-raise the popup window

  https://user-images.githubusercontent.com/22498/126667671-168ea427-9922-4246-b2ec-a69274a594ae.mp4

- [ ] In the popup window click **Deny** instead of **Allow**. You should see an **Authorization failed** error message with a **Try again** button that takes you back to Blackboard's authorization page.

  https://user-images.githubusercontent.com/22498/126667819-7b03d0c2-2f47-429a-9784-b77a6b74e0ea.mp4

- [ ] If you click **Deny** and then click **Close** instead of **Try again** then back in the original tab it should still be showing the **Authorize** button which should re-open the window

- [ ] Hack the code so that the server-to-server access token request that happens when you click **Allow** will fail:

  ```diff
  diff --git a/lms/services/blackboard_api/client.py b/lms/services/blackboard_api/client.py
  index caa788ce..bc266d22 100644
  --- a/lms/services/blackboard_api/client.py
  +++ b/lms/services/blackboard_api/client.py
  @@ -27,7 +27,7 @@ class BlackboardAPIClient:
           :raise services.HTTPError: if something goes wrong with the access
               token request to Blackboard
           """
  -        self._api.get_token(authorization_code)
  +        self._api.get_token("foo")
   
       def list_files(self, course_id):
           """Return the list of files in the given course."""
  ```

  Now open the popup window and click **Allow**. You should see an error dialog with a **Try again** button.

  **Known limitation:** It'd be useful if details from the error response from Blackboard were included in this dialog when this happens. There's a separate issue for that: https://github.com/hypothesis/lms/issues/2998

- [ ] Finally, un-hack the code again, re-open the popup window and click **Allow** again. The assignment should launch successfully. If you then re-launch the assignment it should not ask you for authorization again (not even opening a popup window that closes by itself) because it should have saved your access token.