### PR TITLE
Generalize `enable_canvas_oauth2_redirect_error_mode()`

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -129,11 +129,11 @@ class JSConfig:
         self._config.update(
             {
                 "mode": "oauth2-redirect-error",
-                "oAuth2RedirectError": {
+                "OAuth2RedirectError": {
                     "authUrl": auth_url,
                     "invalidScope": is_scope_invalid,
                     "errorDetails": error_details,
-                    "canvas_scopes": canvas_scopes or [],
+                    "canvasScopes": canvas_scopes or [],
                 },
             }
         )

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -102,18 +102,19 @@ class JSConfig:
         """
         return self._config
 
-    def enable_canvas_oauth2_redirect_error_mode(
+    def enable_oauth2_redirect_error_mode(
         self,
         error_details,
         auth_url=None,
         is_scope_invalid=False,
-        requested_scopes=None,
+        canvas_scopes=None,
     ):
         """
-        Configure the frontend to show the "Canvas authorization failed" dialog.
+        Configure the frontend to show the "Authorization failed" dialog.
 
-        This is shown when authorizing with the Canvas API fails, following the
-        redirect to Canvas's OAuth 2 authorization endpoint.
+        This is shown when authorizing with a third-party OAuth API like the
+        Canvas API or the Blackboard API fails after the redirect to the
+        third-party authorization endpoint.
 
         :param error_details: Technical details of the error
         :type error_details: str
@@ -122,17 +123,17 @@ class JSConfig:
         :param is_scope_invalid: `True` if authorization failed because the
           OAuth client does not have access to all the necessary scopes
         :type is_scope_invalid: bool
-        :param requested_scopes: List of Canvas API scopes that were requested
-        :type requested_scopes: list(str)
+        :param canvas_scopes: List of scopes that were requested
+        :type canvas_scopes: list(str)
         """
         self._config.update(
             {
-                "mode": "canvas-oauth2-redirect-error",
-                "canvasOAuth2RedirectError": {
+                "mode": "oauth2-redirect-error",
+                "oAuth2RedirectError": {
                     "authUrl": auth_url,
                     "invalidScope": is_scope_invalid,
                     "errorDetails": error_details,
-                    "scopes": requested_scopes or [],
+                    "canvas_scopes": canvas_scopes or [],
                 },
             }
         )

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -120,7 +120,7 @@ class OAuthHTTPService:
         self._oauth2_token_service.save(
             validated_data["access_token"],
             validated_data.get("refresh_token"),
-            validated_data.get("expires_in"),
+            validated_data.get("expires_in"),  # pylint:disable=no-member
         )
 
         return validated_data["access_token"]

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -20,11 +20,11 @@ import Dialog from './Dialog';
  */
 export default function OAuth2RedirectErrorApp({ location = window.location }) {
   const {
-    oAuth2RedirectError: {
+    OAuth2RedirectError: {
       authUrl = /** @type {string|null} */ (null),
       invalidScope = false,
       errorDetails = '',
-      canvas_scopes = /** @type {string[]} */ ([]),
+      canvasScopes = /** @type {string[]} */ ([]),
     },
   } = useContext(Config);
 
@@ -74,7 +74,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
             these scopes:
           </p>
           <ol>
-            {canvas_scopes.map(scope => (
+            {canvasScopes.map(scope => (
               <li key={scope}>
                 <code>{scope}</code>
               </li>

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -8,25 +8,23 @@ import ErrorDisplay from './ErrorDisplay';
 import Dialog from './Dialog';
 
 /**
- * @typedef CanvasOAuth2RedirectErrorAppProps
+ * @typedef OAuth2RedirectErrorAppProps
  * @prop {Location} [location] - Test seam
  */
 
 /**
- * Error dialog displayed when authorization of Canvas API access via OAuth
+ * Error dialog displayed when authorization with a third-party API via OAuth
  * fails.
  *
- * @param {CanvasOAuth2RedirectErrorAppProps} props
+ * @param {OAuth2RedirectErrorAppProps} props
  */
-export default function CanvasOAuth2RedirectErrorApp({
-  location = window.location,
-}) {
+export default function OAuth2RedirectErrorApp({ location = window.location }) {
   const {
-    canvasOAuth2RedirectError: {
+    oAuth2RedirectError: {
       authUrl = /** @type {string|null} */ (null),
       invalidScope = false,
       errorDetails = '',
-      scopes = /** @type {string[]} */ ([]),
+      canvas_scopes = /** @type {string[]} */ ([]),
     },
   } = useContext(Config);
 
@@ -76,7 +74,7 @@ export default function CanvasOAuth2RedirectErrorApp({
             these scopes:
           </p>
           <ol>
-            {scopes.map(scope => (
+            {canvas_scopes.map(scope => (
               <li key={scope}>
                 <code>{scope}</code>
               </li>

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -11,7 +11,7 @@ describe('OAuth2RedirectErrorApp', () => {
 
   const renderApp = () => {
     const config = {
-      oAuth2RedirectError: fakeConfig,
+      OAuth2RedirectError: fakeConfig,
     };
 
     return mount(
@@ -25,7 +25,7 @@ describe('OAuth2RedirectErrorApp', () => {
     fakeConfig = {
       invalidScope: false,
       authUrl: null,
-      canvas_scopes: [],
+      canvasScopes: [],
     };
 
     fakeLocation = {
@@ -41,14 +41,14 @@ describe('OAuth2RedirectErrorApp', () => {
 
   it('shows a scope error if the scope is invalid', () => {
     fakeConfig.invalidScope = true;
-    fakeConfig.canvas_scopes = ['scope_a', 'scope_b'];
+    fakeConfig.canvasScopes = ['scope_a', 'scope_b'];
 
     const wrapper = renderApp();
     assert.include(
       wrapper.text(),
       "A Canvas admin needs to edit Hypothesis's developer key"
     );
-    fakeConfig.canvas_scopes.forEach(scope =>
+    fakeConfig.canvasScopes.forEach(scope =>
       assert.include(wrapper.text(), scope)
     );
   });

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -3,20 +3,20 @@ import { createElement } from 'preact';
 
 import { Config } from '../../config';
 
-import CanvasOAuth2RedirectErrorApp from '../CanvasOAuth2RedirectErrorApp';
+import OAuth2RedirectErrorApp from '../OAuth2RedirectErrorApp';
 
-describe('CanvasOAuth2RedirectErrorApp', () => {
+describe('OAuth2RedirectErrorApp', () => {
   let fakeConfig;
   let fakeLocation;
 
   const renderApp = () => {
     const config = {
-      canvasOAuth2RedirectError: fakeConfig,
+      oAuth2RedirectError: fakeConfig,
     };
 
     return mount(
       <Config.Provider value={config}>
-        <CanvasOAuth2RedirectErrorApp location={fakeLocation} />
+        <OAuth2RedirectErrorApp location={fakeLocation} />
       </Config.Provider>
     );
   };
@@ -25,7 +25,7 @@ describe('CanvasOAuth2RedirectErrorApp', () => {
     fakeConfig = {
       invalidScope: false,
       authUrl: null,
-      scopes: [],
+      canvas_scopes: [],
     };
 
     fakeLocation = {
@@ -41,14 +41,16 @@ describe('CanvasOAuth2RedirectErrorApp', () => {
 
   it('shows a scope error if the scope is invalid', () => {
     fakeConfig.invalidScope = true;
-    fakeConfig.scopes = ['scope_a', 'scope_b'];
+    fakeConfig.canvas_scopes = ['scope_a', 'scope_b'];
 
     const wrapper = renderApp();
     assert.include(
       wrapper.text(),
       "A Canvas admin needs to edit Hypothesis's developer key"
     );
-    fakeConfig.scopes.forEach(scope => assert.include(wrapper.text(), scope));
+    fakeConfig.canvas_scopes.forEach(scope =>
+      assert.include(wrapper.text(), scope)
+    );
   });
 
   it('shows a generic error if the scope is valid', () => {

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -77,14 +77,14 @@ import { createContext } from 'preact';
  */
 
 /**
- * Configuration for the error dialog shown if authorizing access to the
- * Canvas API fails.
+ * Configuration for the error dialog shown if authorizing access to an
+ * OAuth API fails.
  *
- * @typedef CanvasAuthErrorConfig
+ * @typedef oAuthErrorConfig
  * @prop {string|null} authUrl
  * @prop {boolean} invalidScope
  * @prop {string} errorDetails
- * @prop {string[]} scopes
+ * @prop {string[]} canvas_scopes
  */
 
 /**
@@ -110,7 +110,7 @@ import { createContext } from 'preact';
  * @prop {Object} rpcServer
  *   @prop {string[]} rpcServer.allowedOrigins
  * @prop {string} viaUrl
- * @prop {CanvasAuthErrorConfig} canvasOAuth2RedirectError
+ * @prop {oAuthErrorConfig} oAuth2RedirectError
  * @prop {VitalSourceConfig} [vitalSource]
  */
 

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -80,11 +80,11 @@ import { createContext } from 'preact';
  * Configuration for the error dialog shown if authorizing access to an
  * OAuth API fails.
  *
- * @typedef oAuthErrorConfig
+ * @typedef OAuthErrorConfig
  * @prop {string|null} authUrl
  * @prop {boolean} invalidScope
  * @prop {string} errorDetails
- * @prop {string[]} canvas_scopes
+ * @prop {string[]} canvasScopes
  */
 
 /**
@@ -110,7 +110,7 @@ import { createContext } from 'preact';
  * @prop {Object} rpcServer
  *   @prop {string[]} rpcServer.allowedOrigins
  * @prop {string} viaUrl
- * @prop {oAuthErrorConfig} oAuth2RedirectError
+ * @prop {OAuthErrorConfig} OAuth2RedirectError
  * @prop {VitalSourceConfig} [vitalSource]
  */
 

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -3,7 +3,7 @@ import { createElement, render } from 'preact';
 
 import { readConfig, Config } from './config';
 import BasicLTILaunchApp from './components/BasicLTILaunchApp';
-import CanvasOAuth2RedirectErrorApp from './components/CanvasOAuth2RedirectErrorApp';
+import OAuth2RedirectErrorApp from './components/OAuth2RedirectErrorApp';
 import FilePickerApp from './components/FilePickerApp';
 import {
   ClientRPC,
@@ -57,8 +57,8 @@ switch (config.mode) {
     );
     app = <FilePickerApp />;
     break;
-  case 'canvas-oauth2-redirect-error':
-    app = <CanvasOAuth2RedirectErrorApp />;
+  case 'oauth2-redirect-error':
+    app = <OAuth2RedirectErrorApp />;
     break;
 }
 

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -122,11 +122,11 @@ def oauth2_redirect_error(request):
             _query=[("authorization", authorization_param)],
         )
 
-    request.context.js_config.enable_canvas_oauth2_redirect_error_mode(
+    request.context.js_config.enable_oauth2_redirect_error_mode(
         auth_url=auth_url,
         error_details=request.params.get("error_description"),
         is_scope_invalid=request.params.get("error") == "invalid_scope",
-        requested_scopes=FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
+        canvas_scopes=FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
     )
 
     return {}

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -576,11 +576,11 @@ class TestEnableOAuth2RedirectErrorMode:
         config = js_config.asdict()
 
         assert config["mode"] == "oauth2-redirect-error"
-        assert config["oAuth2RedirectError"] == {
+        assert config["OAuth2RedirectError"] == {
             "authUrl": None,
             "invalidScope": True,
             "errorDetails": "Technical error",
-            "canvas_scopes": ["scope_a", "scope_b"],
+            "canvasScopes": ["scope_a", "scope_b"],
         }
 
     def test_other_error(self, js_config):
@@ -592,11 +592,11 @@ class TestEnableOAuth2RedirectErrorMode:
         config = js_config.asdict()
 
         assert config["mode"] == "oauth2-redirect-error"
-        assert config["oAuth2RedirectError"] == {
+        assert config["OAuth2RedirectError"] == {
             "authUrl": auth_url,
             "invalidScope": False,
             "errorDetails": "Some error",
-            "canvas_scopes": [],
+            "canvasScopes": [],
         }
 
     @pytest.fixture

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -564,39 +564,39 @@ class TestJSConfigRPCServer:
         return config["rpcServer"]
 
 
-class TestEnableCanvasOauth2RedirectErrorMode:
+class TestEnableOAuth2RedirectErrorMode:
     def test_scope_error(self, js_config):
-        js_config.enable_canvas_oauth2_redirect_error_mode(
+        js_config.enable_oauth2_redirect_error_mode(
             auth_url=None,
             error_details="Technical error",
             is_scope_invalid=True,
-            requested_scopes=["scope_a", "scope_b"],
+            canvas_scopes=["scope_a", "scope_b"],
         )
 
         config = js_config.asdict()
 
-        assert config["mode"] == "canvas-oauth2-redirect-error"
-        assert config["canvasOAuth2RedirectError"] == {
+        assert config["mode"] == "oauth2-redirect-error"
+        assert config["oAuth2RedirectError"] == {
             "authUrl": None,
             "invalidScope": True,
             "errorDetails": "Technical error",
-            "scopes": ["scope_a", "scope_b"],
+            "canvas_scopes": ["scope_a", "scope_b"],
         }
 
     def test_other_error(self, js_config):
         auth_url = "https://lms.hypothes.is/auth/url"
-        js_config.enable_canvas_oauth2_redirect_error_mode(
+        js_config.enable_oauth2_redirect_error_mode(
             auth_url=auth_url, error_details="Some error"
         )
 
         config = js_config.asdict()
 
-        assert config["mode"] == "canvas-oauth2-redirect-error"
-        assert config["canvasOAuth2RedirectError"] == {
+        assert config["mode"] == "oauth2-redirect-error"
+        assert config["oAuth2RedirectError"] == {
             "authUrl": auth_url,
             "invalidScope": False,
             "errorDetails": "Some error",
-            "scopes": [],
+            "canvas_scopes": [],
         }
 
     @pytest.fixture

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -184,11 +184,11 @@ class TestOAuth2RedirectError:
         authorize.oauth2_redirect_error(pyramid_request)
 
         js_config = pyramid_request.context.js_config
-        js_config.enable_canvas_oauth2_redirect_error_mode.assert_called_with(
+        js_config.enable_oauth2_redirect_error_mode.assert_called_with(
             auth_url=None,
             error_details=params.get("error_description"),
             is_scope_invalid=invalid_scope,
-            requested_scopes=scopes,
+            canvas_scopes=scopes,
         )
 
     # Test the URL that the backend provides to the frontend for the "Try again"
@@ -206,8 +206,8 @@ class TestOAuth2RedirectError:
             "canvas_api.oauth.authorize", _query=[("authorization", "auth-param")]
         )
         js_config = pyramid_request.context.js_config
-        js_config.enable_canvas_oauth2_redirect_error_mode.assert_called_once()
-        _, kwargs = js_config.enable_canvas_oauth2_redirect_error_mode.call_args
+        js_config.enable_oauth2_redirect_error_mode.assert_called_once()
+        _, kwargs = js_config.enable_oauth2_redirect_error_mode.call_args
         assert kwargs["auth_url"] == expected_auth_url
 
     @pytest.fixture


### PR DESCRIPTION
This is mostly not Canvas-specific (except for the scopes) and we now need to re-use it for Blackboard, so generalize  `enable_canvas_oauth2_redirect_error_mode()` to just  `enable_oauth2_redirect_error_mode()` and remove all unnecessary references to Canvas.

### Testing

* Delete all the access tokens from your DB so that the authorization flow is triggered when you launch an assignment:

  ```
  tox -qe dockercompose -- exec postgres psql -U postgres -c 'DELETE FROM oauth2_token;'
  ```

* Log in to https://hypothesis.instructure.com/ as either a teacher or a student and launch [localhost (make devdata) Canvas Files Assignment](https://hypothesis.instructure.com/courses/125/assignments/875)

* Click **Authorize**

- [ ] In the popup window click **Cancel** instead of **Authorize**. You should see an error dialog with a **Try again** button that takes you back to Canvas's authorization page

- [ ] Hack the code so that the server-to-server request that happens after you click **Authorize** in the popup window fails:

  ```diff
  diff --git a/lms/services/canvas_api/client.py b/lms/services/canvas_api/client.py
  index 0a47abf3..e000d51a 100644
  --- a/lms/services/canvas_api/client.py
  +++ b/lms/services/canvas_api/client.py
  @@ -59,7 +59,7 @@ class CanvasAPIClient:
               to exchange for an access token
           :return: An access token string
           """
  -        return self._client.get_token(authorization_code)
  +        return self._client.get_token("foo")
   
       # Getting authenticated users sections
       # ------------------------------------
  ```

  Open the popup window again and click **Authorize**. You should get a nice error dialog again.

- [ ] Un-hack the code, re-open the popup window, click **Authorize**, and the assignment should launch successfully