### PR TITLE
Update LMSFilePicker to filter out folders from BB files API results

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -4,12 +4,21 @@
  */
 
 /**
- * Object representing a file in the LMS's file storage.
+ * @typedef {import("./config").APICallInfo} APICallInfo
+ */
+
+/**
+ * Object representing a file or folder resource in the LMS's file storage.
  *
  * @typedef File
- * @prop {string} id - Identifier for the file within the LMS's file storage
- * @prop {string} display_name - Name of the file to present in the file picker
+ * @prop {string} id - Identifier for the resource within the LMS's file storage
+ * @prop {string} display_name - Name of the resource to present in the file picker
  * @prop {string} updated_at - An ISO 8601 date string
+ * @prop {'File'|'Folder'} [type]
+ * @prop {APICallInfo} [contents] - APICallInfo for fetching a folders's
+ *   content. Only present if `type` is 'Folder'.
+ * @prop {string|null} [parent_id] - Only present if `type` is 'Folder'. A
+ *   folder may have a parent folder.
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -112,12 +112,23 @@ export default function LMSFilePicker({
           path: listFilesApi.path,
         })
       );
+
+      // FIXME: This is a temporary fix for the updated file API response for
+      // BlackBoard files. A File returned by the BlackBoard files API may be
+      // either a `File` or a `Folder`. Until `FileList` and this component
+      // have has been updated to render and handle `Folder`-type objects,
+      // filter them out of the file list: i.e. hide them.
+
+      const filteredFiles = files.filter(
+        file => !file.type || file.type === 'File'
+      );
+
       const continueAction =
         files.length === 0 ? 'reload' : INITIAL_DIALOG_STATE.continueAction;
       setDialogState({
         ...INITIAL_DIALOG_STATE,
         state: 'fetched',
-        files,
+        files: filteredFiles,
         continueAction,
       });
     } catch (e) {

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -35,7 +35,10 @@ describe('LMSFilePicker', () => {
   };
 
   beforeEach(() => {
-    fakeApiCall = sinon.stub().resolves(['one file']);
+    fakeApiCall = sinon.stub().resolves([
+      { type: 'File', display_name: 'A file' },
+      { type: 'Folder', display_name: 'A folder' },
+    ]);
 
     fakeListFilesApi = {
       path: 'https://lms.anno.co/files/course123',
@@ -64,7 +67,9 @@ describe('LMSFilePicker', () => {
       authToken: 'auth-token',
       path: fakeListFilesApi.path,
     });
-    const expectedFiles = await fakeApiCall.returnValues[0];
+    const returnedFiles = await fakeApiCall.returnValues[0];
+    // Component currently filters out Folders
+    const expectedFiles = returnedFiles.filter(file => file.type !== 'Folder');
     wrapper.update();
     const fileList = wrapper.find('FileList');
     assert.deepEqual(fileList.prop('files'), expectedFiles);
@@ -92,7 +97,7 @@ describe('LMSFilePicker', () => {
     assert.isTrue(authButton.exists());
 
     // Click the "Authorize" button and check that files are re-fetched.
-    const expectedFiles = [];
+    const expectedFiles = ['a file'];
     fakeApiCall.reset();
     fakeApiCall.resolves(expectedFiles);
 
@@ -105,7 +110,7 @@ describe('LMSFilePicker', () => {
     });
 
     const fileList = wrapper.find('FileList');
-    assert.equal(fileList.prop('files'), expectedFiles);
+    assert.deepEqual(fileList.prop('files'), expectedFiles);
   });
 
   it('shows the "Authorize" and "Try again" buttons after 2 failed authorization requests', async () => {
@@ -263,7 +268,9 @@ describe('LMSFilePicker', () => {
 
   it('fetches and displays files from the LMS', async () => {
     const wrapper = renderFilePicker();
-    const expectedFiles = await fakeApiCall.returnValues[0];
+    const returnedFiles = await fakeApiCall.returnValues[0];
+    // Component currently filters out Folders
+    const expectedFiles = returnedFiles.filter(file => file.type !== 'Folder');
     wrapper.update();
     assert.called(fakeApiCall);
 


### PR DESCRIPTION
This is an interim change that makes the front-end file-picker for Blackboard files function on top of changes to the proxy API to retrieve a list of files. The returned results now contains some extra properties, and include both files and folders.

For the moment, make `LMSFilePicker` filter out folders such that the interface behaves as it did before the API change: present only root-level files.

The net result is that the behavior is the same as before #2950 — the picker shows a list of root-level files, only.

### To try this out

This branch depends on #2950 

1. Check out this branch
3. Navigate to or create a localhost Blackboard assignment on https://aunltd-test.blackboard.com/ . I have had luck with the `blackboardteacher` user (see 1Password for credentials).
4. Launch the unconfigured assignment and click the "Select PDF from Blackboard" button. You should see several PDFs and no Folders, like so:

![image](https://user-images.githubusercontent.com/439947/127033191-ab9d47f8-fbd1-4006-a03f-5e39ec488fa2.png)

If you were to take the same steps against `add-Blackboard-Files-folder-support`, without this branch, you'd see Folders appearing as if they were files, and definitely not working right if you try to select them:

![22EB82C3-A310-4A50-94E7-9F96ECA6D526](https://user-images.githubusercontent.com/439947/127033317-f3772a97-83b9-4034-8262-79714036d732.png)

Of course, our immediate next steps will be to implement folder support on the front end, but this enables us to land #2950 without having to wait for all the front-end work to be complete.
