### PR TITLE
POC: Front-end navigation for Blackboard files with subfolders

### DIFF
--- a/lms/static/images/folder.svg
+++ b/lms/static/images/folder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M22 8v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V7h19a1 1 0 0 1 1 1zm-9.586-3H2V4a1 1 0 0 1 1-1h7.414l2 2z"/></svg>

--- a/lms/static/scripts/frontend_apps/components/Breadcrumbs.js
+++ b/lms/static/scripts/frontend_apps/components/Breadcrumbs.js
@@ -1,0 +1,48 @@
+import { LinkButton } from '@hypothesis/frontend-shared';
+import { createElement } from 'preact';
+
+/**
+ * @template Item
+ * @typedef BreadcrumbProps
+ * @prop {Item[]} items
+ * @prop {(i: Item) => void} onSelectItem
+ * @prop {(i: Item) => any} [renderItem]
+ */
+
+/**
+ * @template Item
+ * @param {Item} item
+ * @returns {Item}
+ */
+const defaultRenderItem = item => item;
+
+/**
+ * Render a collection of breadcrumbs. All but the last breadcrumb is clickable,
+ * and will invoke the `onSelectItem` when clicked.
+ *
+ * @template Item
+ * @param {BreadcrumbProps<Item>} props
+ */
+export default function Breadcrumbs({
+  items,
+  onSelectItem,
+  renderItem = defaultRenderItem,
+}) {
+  const breadcrumbs = items.slice(0, -1);
+  const currentItem = items[items.length - 1];
+  return (
+    <ul className="Breadcrumbs hyp-u-layout-row">
+      {breadcrumbs.map((item, idx) => (
+        <li className="Breadcrumbs__crumb Breadcrumbs__crumb--path" key={idx}>
+          <LinkButton onClick={() => onSelectItem(item)}>
+            {renderItem(item)}
+          </LinkButton>
+          <span className="Breadcrumbs__crumb-divider">›</span>
+        </li>
+      ))}
+      <li className="Breadcrumbs__crumb Breadcrumbs__crumb--current">
+        <LinkButton disabled>{renderItem(currentItem)}</LinkButton>
+      </li>
+    </ul>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -1,3 +1,5 @@
+import { SvgIcon } from '@hypothesis/frontend-shared';
+
 import classnames from 'classnames';
 import { Fragment, createElement } from 'preact';
 
@@ -59,15 +61,16 @@ export default function FileList({
         renderItem={(file, isSelected) => (
           <Fragment>
             <td aria-label={file.display_name} className="FileList__name-col">
-              <img
-                className={classnames(
-                  'FileList__icon',
-                  isSelected && 'is-selected'
-                )}
-                src="/static/images/file-pdf.svg"
-                alt="PDF icon"
-              />
-              <span className="FileList__name">{file.display_name}</span>
+              <div className="hyp-u-layout-row--center hyp-u-horizontal-spacing hyp-u-padding--left--2">
+                <SvgIcon
+                  inline
+                  name={file.type && file.type === 'Folder' ? 'folder' : 'pdf'}
+                  className={classnames('FileList__icon', {
+                    'is-selected': isSelected,
+                  })}
+                />
+                <span className="FileList__name">{file.display_name}</span>
+              </div>
             </td>
             <td className="FileList__date-col">
               {file.updated_at && formatDate(file.updated_at)}

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -1,10 +1,11 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
+import { createElement, Fragment } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import { APIError, apiCall } from '../utils/api';
 
 import AuthButton from './AuthButton';
+import Breadcrumbs from './Breadcrumbs';
 import Dialog from './Dialog';
 import ErrorDisplay from './ErrorDisplay';
 import FileList from './FileList';
@@ -17,6 +18,7 @@ import FileList from './FileList';
 /**
  * @typedef NoFilesMessageProps
  * @prop {string} href - Helpful documentation URL to link to
+ * @prop {boolean} [inSubfolder=false] - has the user navigated to a sub-folder?
  */
 
 /**
@@ -25,13 +27,14 @@ import FileList from './FileList';
  *
  * @param {NoFilesMessageProps} props
  */
-function NoFilesMessage({ href }) {
+function NoFilesMessage({ href, inSubfolder = false }) {
+  const documentContext = inSubfolder ? 'folder' : 'course';
   return (
     <div className="FileList__no-files-message">
       <p>
-        There are no PDFs in this course.{' '}
+        There are no PDFs in this {documentContext}.{' '}
         <a href={href} target="_blank" rel="noreferrer">
-          Upload some files to the course
+          Upload some files to the {documentContext}
         </a>{' '}
         and try again.
       </p>
@@ -92,35 +95,74 @@ export default function LMSFilePicker({
   // Authorization attempt was made. Set after state transitions to "authorizing".
   const [authorizationAttempted, setAuthorizationAttempted] = useState(false);
 
-  // The file within `files` which is currently selected.
-  const [selectedFile, selectFile] = useState(/** @type {File|null} */ (null));
+  // The file or folder within `files` which is currently selected.
+  const [selectedFile, setSelectedFile] = useState(
+    /** @type {File|null} */ (null)
+  );
+
+  // An array of File objects representing the  "path" to the current
+  // list of files being displayed. This always starts at the root. The last
+  // element represents the current directory path.
+  const [folderPath, setFolderPath] = useState(
+    /** @type File[] */ ([
+      {
+        display_name: 'Files',
+        type: 'Folder',
+        contents: listFilesApi,
+        id: '__root__',
+      },
+    ])
+  );
+
+  /**
+   * Change to a new folder path.
+   *
+   * @param {File} folder
+   */
+  const onChangePath = folder => {
+    const currentIndex = folderPath.findIndex(file => file.id === folder.id);
+    if (currentIndex >= 0) {
+      // If the selected folder is already in the path, remove any entries
+      // below (after) it to make it the last entry
+      setFolderPath(folderPath.slice(0, currentIndex + 1));
+    } else {
+      // Otherwise, append it to the current path
+      setFolderPath([...folderPath, folder]);
+    }
+  };
 
   // Fetches files or shows a prompt to authorize access.
   const fetchFiles = useCallback(async () => {
+    const getNextAPICallInfo = () => {
+      return folderPath[folderPath.length - 1]?.contents || listFilesApi;
+    };
     try {
       // Show the fetching state, but preserve the existing continueAction to
       // prevent the button label changing. See:
       // https://github.com/hypothesis/lms/pull/2219#issuecomment-721833947
-      setDialogState(({ continueAction }) => ({
-        ...INITIAL_DIALOG_STATE,
-        state: continueAction === 'reload' ? 'reloading' : 'fetching',
-        continueAction,
-      }));
+      setDialogState(({ continueAction, state }) => {
+        // Determine the appropriate state to move to. If files have been
+        // fetched, or a reload is indicated by continueAction, put the dialog
+        // in a "reloading" state instead of a (fresh) "fetching" state. This
+        // applies the appropriate loading state while the fetch request is in
+        // flight. "fetching" will not render the Dialog, while "reloading" will
+        // render the Dialog, with a loading indicator.
+        const nextState =
+          state === 'fetched' || continueAction === 'reload'
+            ? 'reloading'
+            : 'fetching';
+        return {
+          ...INITIAL_DIALOG_STATE,
+          state: nextState,
+          continueAction,
+        };
+      });
+
       const files = /** @type {File[]} */ (
         await apiCall({
           authToken,
-          path: listFilesApi.path,
+          path: getNextAPICallInfo().path,
         })
-      );
-
-      // FIXME: This is a temporary fix for the updated file API response for
-      // BlackBoard files. A File returned by the BlackBoard files API may be
-      // either a `File` or a `Folder`. Until `FileList` and this component
-      // have has been updated to render and handle `Folder`-type objects,
-      // filter them out of the file list: i.e. hide them.
-
-      const filteredFiles = files.filter(
-        file => !file.type || file.type === 'File'
       );
 
       const continueAction =
@@ -128,7 +170,7 @@ export default function LMSFilePicker({
       setDialogState({
         ...INITIAL_DIALOG_STATE,
         state: 'fetched',
-        files: filteredFiles,
+        files,
         continueAction,
       });
     } catch (e) {
@@ -157,17 +199,24 @@ export default function LMSFilePicker({
         });
       }
     }
-  }, [authToken, listFilesApi, authorizationAttempted]);
+  }, [authToken, folderPath, authorizationAttempted, listFilesApi]);
 
-  // On the initial load, fetch files or prompt to authorize if we know that
-  // authorization will be required.
+  // Update the file list any time the path changes
   useEffect(() => {
     fetchFiles();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [folderPath]);
 
-  const useSelectedFile = () =>
-    onSelectFile(/** @type {File} */ (selectedFile));
+  const useSelectedItem = () => {
+    if (!selectedFile) {
+      return;
+    }
+    if (!selectedFile.type || selectedFile.type === 'File') {
+      onSelectFile(selectedFile);
+    } else if (selectedFile.type === 'Folder') {
+      onChangePath(selectedFile);
+    }
+  };
 
   const options = {
     select: {
@@ -175,7 +224,7 @@ export default function LMSFilePicker({
         <LabeledButton
           variant="primary"
           disabled={selectedFile === null}
-          onClick={useSelectedFile}
+          onClick={useSelectedItem}
           data-testid="select"
         >
           Select
@@ -263,14 +312,26 @@ export default function LMSFilePicker({
       {warningOrError}
 
       {['reloading', 'fetched'].includes(dialogState.state) && (
-        <FileList
-          files={dialogState.files ?? []}
-          isLoading={dialogState.state === 'reloading'}
-          selectedFile={selectedFile}
-          onUseFile={onSelectFile}
-          onSelectFile={selectFile}
-          noFilesMessage={<NoFilesMessage href={missingFilesHelpLink} />}
-        />
+        <Fragment>
+          <Breadcrumbs
+            items={folderPath}
+            onSelectItem={onChangePath}
+            renderItem={item => item.display_name}
+          />
+          <FileList
+            files={dialogState.files ?? []}
+            isLoading={dialogState.state === 'reloading'}
+            selectedFile={selectedFile}
+            onUseFile={useSelectedItem}
+            onSelectFile={setSelectedFile}
+            noFilesMessage={
+              <NoFilesMessage
+                href={missingFilesHelpLink}
+                inSubfolder={folderPath.length > 1}
+              />
+            }
+          />
+        </Fragment>
       )}
     </Dialog>
   );

--- a/lms/static/scripts/frontend_apps/icons.js
+++ b/lms/static/scripts/frontend_apps/icons.js
@@ -8,6 +8,8 @@ export default {
   // LMS icons
   'caret-down': require('../../images/caret-down.svg'),
   check: require('../../images/check.svg'),
+  folder: require('../../images/folder.svg'),
+  pdf: require('../../images/file-pdf.svg'),
   spinner: require('../../images/spinner.svg'),
 
   // Shared icons

--- a/lms/static/styles/components/_Breadcrumbs.scss
+++ b/lms/static/styles/components/_Breadcrumbs.scss
@@ -1,0 +1,26 @@
+.Breadcrumbs {
+  margin: 0;
+  padding: 0;
+  // FIXME: For now, allow crumbs to wrap onto a second line if they
+  // run out of room. This could be more elegant.
+  flex-wrap: wrap;
+
+  &__crumb {
+    display: inline-flex;
+    list-style-type: none;
+  }
+
+  &__crumb-divider {
+    margin: 0 0.5rem;
+    font-size: 1rem;
+  }
+
+  &__crumb--current {
+    button {
+      // The button is disabled, so don't show a pointer cursor
+      // FIXME: The shared button components should handle their cursors
+      // correctly
+      cursor: default;
+    }
+  }
+}

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -1,7 +1,5 @@
 @use "../variables" as var;
 
-$file-list-icon-size: 24px;
-
 .FileList {
   position: relative;
 
@@ -24,17 +22,10 @@ $file-list-icon-size: 24px;
 }
 
 .FileList__icon {
-  margin-left: 10px;
-  margin-right: 10px;
-  width: $file-list-icon-size;
-  height: $file-list-icon-size;
-  vertical-align: middle;
-
-  &.is-selected {
-    // nb. Argument must be passed to `invert` even though "1" is the default
-    // to work around https://bugs.chromium.org/p/chromium/issues/detail?id=964696.
-    filter: #{'invert(1)'}; // Quoted to avoid conflict with SASS mixin.
-  }
+  // TODO: Update when updated SVGIcon component is available and has sizing
+  // patterns
+  width: 1.5em;
+  height: 1.5em;
 }
 
 .FileList__name-col {

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -12,6 +12,7 @@
 // Preact components
 @use 'components/BasicLTILaunchApp';
 @use 'components/BookSelector';
+@use 'components/Breadcrumbs';
 @use 'components/ContentSelector';
 @use 'components/Dialog';
 @use 'components/ErrorDisplay';


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/2950

This is a POC to demonstrate a possible approach for the core logic of navigating amongst, and selecting a file from, Blackboard files sub-folders. Code is prototype quality and does not include tests.

State management is handled in the `LMSFilePicker` component here. A new `Breadcrumbs` component is introduced.

Expected behavior:

* You should be able to navigate into subfolders by:
  * double-clicking on a folder in the file list
  * Clicking once/selecting a folder in the file list and then clicking the "Select" button
* You should be able to navigate back up to higher-level folders by clicking on them in the breadcrumbs
* You should be able to select a file as before, whether in a top-level directory or a sub-directory
* Breadcrumb "path elements" should appear as you navigate down

Not in scope in this POC:

* All layout and styling here is provisional
* ~~Loading states~~ updated: an interim loading state fix has been implemented. It's not polished, but it's more acceptable
* ~~Iconography for folders (they use the same PDF image for the moment)~~ updated: a folder icon has been added and used
* Dialog overflow and positioning
* Consideration of non-happy paths
* Breadcrumb elision or other nuance

I'm looking for feedback and input around the structure and state management of the relevant components here. Or if there is anything that looks like it conflict with other integrations (e.g. Canvas files).

### Try it out

Follow the instructions on https://github.com/hypothesis/lms/pull/3007, with this branch checked out.

![bb-files-poc](https://user-images.githubusercontent.com/439947/127201716-2d01f261-b5c9-4555-8270-3d20a20058b3.gif)
