### PR TITLE
Raise `ExternalRequestError` instead of `HTTPError`

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -8,7 +8,6 @@ from lms.services.exceptions import (
     ConsumerKeyError,
     ExternalRequestError,
     HAPIError,
-    HTTPError,
     LTILaunchVerificationError,
     LTIOAuthError,
     LTIOutcomesAPIError,

--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -1,6 +1,6 @@
 from marshmallow import INCLUDE, fields
 
-from lms.services.exceptions import HTTPError, OAuth2TokenError
+from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
 from lms.validation import RequestsResponseSchema, ValidationError
 
 
@@ -75,7 +75,7 @@ class BasicClient:
 
         try:
             return self._send(method, url)
-        except (OAuth2TokenError, HTTPError):
+        except ExternalRequestError:
             self._oauth_http_service.refresh_access_token(
                 self.token_url,
                 self.redirect_uri,
@@ -100,7 +100,7 @@ class BasicClient:
     def _send(self, method, url):
         try:
             return self._oauth_http_service.request(method, url)
-        except HTTPError as err:
+        except ExternalRequestError as err:
             error_dict = BlackboardErrorResponseSchema(err.response).parse()
 
             if error_dict.get("message") == "Bearer token is invalid":

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -4,7 +4,7 @@ from lms.services.blackboard_api._schemas import (
     BlackboardListFilesSchema,
     BlackboardPublicURLSchema,
 )
-from lms.services.exceptions import BlackboardFileNotFoundInCourse, HTTPError
+from lms.services.exceptions import BlackboardFileNotFoundInCourse, ExternalRequestError
 
 # The maxiumum number of paginated requests we'll make before returning.
 PAGINATION_MAX_REQUESTS = 25
@@ -24,8 +24,8 @@ class BlackboardAPIClient:
         """
         Save a new Blackboard access token for the current user to the DB.
 
-        :raise services.HTTPError: if something goes wrong with the access
-            token request to Blackboard
+        :raise services.ExternalRequestError: if something goes wrong with the
+            access token request to Blackboard
         """
         self._api.get_token(authorization_code)
 
@@ -69,7 +69,7 @@ class BlackboardAPIClient:
                 "GET",
                 f"courses/uuid:{course_id}/resources/{file_id}?fields=downloadUrl",
             )
-        except HTTPError as err:
+        except ExternalRequestError as err:
             if err.response.status_code == 404:
                 raise BlackboardFileNotFoundInCourse(file_id) from err
             raise

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -213,14 +213,6 @@ class CanvasFileNotFoundInCourse(ServiceError):
         super().__init__(self.details)
 
 
-class HTTPError(ServiceError):
-    """A problem with an HTTP request to an external service."""
-
-    def __init__(self, response=None):
-        super().__init__(response)
-        self.response = response
-
-
 class BlackboardFileNotFoundInCourse(ServiceError):
     """A Blackboard file ID wasn't found in the current course."""
 

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -3,7 +3,7 @@
 from h_api.bulk_api import BulkAPI, CommandBuilder
 
 from lms.models import HUser
-from lms.services import HAPIError, HTTPError
+from lms.services import ExternalRequestError, HAPIError
 
 __all__ = ["HAPI"]
 
@@ -87,7 +87,7 @@ class HAPI:
                 headers=headers,
                 **request_args,
             )
-        except HTTPError as err:
+        except ExternalRequestError as err:
             response = getattr(err, "response", None)
 
             raise HAPIError("Connecting to Hypothesis failed", response) from err

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -1,7 +1,7 @@
 import requests
 from requests import RequestException
 
-from lms.services.exceptions import HTTPError
+from lms.services.exceptions import ExternalRequestError
 
 
 class HTTPService:
@@ -58,21 +58,23 @@ class HTTPService:
             requests.Session().request():
             https://docs.python-requests.org/en/latest/api/#requests.Session.request
 
-        :raise HTTPError: If sending the request or receiving the response
-            fails (DNS failure, refused connection, timeout, too many
+        :raise ExternalRequestError: If sending the request or receiving the
+            response fails (DNS failure, refused connection, timeout, too many
             redirects, etc).
 
             The original exception from requests will be available as
-            HTTPError.__cause__.
+            ExternalRequestError.__cause__.
 
-            In this case HTTPError.response will be None.
+            In this case ExternalRequestError.response will be None.
 
-        :raise HTTPError: If an error response (4xx or 5xx) is received.
+        :raise ExternalRequestError: If an error response (4xx or 5xx) is
+            received.
 
             The original exception from requests will be available as
-            HTTPError.__cause__.
+            ExternalRequestError.__cause__.
 
-            The error response will be available as HTTPError.response.
+            The error response will be available as
+            ExternalRequestError.response.
         """
         response = None
 
@@ -85,7 +87,7 @@ class HTTPService:
             )
             response.raise_for_status()
         except RequestException as err:
-            raise HTTPError(response) from err
+            raise ExternalRequestError(response=response) from err
 
         return response
 

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -3,7 +3,7 @@ from xml.parsers.expat import ExpatError
 
 import xmltodict
 
-from lms.services.exceptions import HTTPError, LTIOutcomesAPIError
+from lms.services.exceptions import ExternalRequestError, LTIOutcomesAPIError
 
 log = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ class LTIOutcomesClient:
                 headers={"Content-Type": "application/xml"},
                 auth=self.oauth1_service.get_client(),
             )
-        except HTTPError as err:
+        except ExternalRequestError as err:
             raise LTIOutcomesAPIError(
                 "Error calling LTI Outcomes service", response
             ) from err

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -1,6 +1,6 @@
 from marshmallow import fields
 
-from lms.services import HTTPError, OAuth2TokenError
+from lms.services import ExternalRequestError, OAuth2TokenError
 from lms.validation import RequestsResponseSchema, ValidationError
 from lms.validation.authentication import OAuthTokenResponseSchema
 
@@ -44,7 +44,8 @@ class OAuthHTTPService:
         The given `headers` must not already contain an "Authorization" header.
 
         :raise OAuth2TokenError: if we don't have an access token for the user
-        :raise HTTPError: if something goes wrong with the HTTP request
+        :raise ExternalRequestError: if something goes wrong with the HTTP
+            request
         """
         headers = headers or {}
 
@@ -63,7 +64,7 @@ class OAuthHTTPService:
         (https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3) to get a
         new access token for the current user and save it to the DB.
 
-        :raise HTTPError: if the HTTP request fails
+        :raise ExternalRequestError: if the HTTP request fails
         :raise ValidationError: if the server's access token response is invalid
         """
         self._token_request(
@@ -85,7 +86,7 @@ class OAuthHTTPService:
         access token for the current user and save it to the DB.
 
         :raise OAuth2TokenError: if we don't have a refresh token for the user
-        :raise HTTPError: if the HTTP request fails
+        :raise ExternalRequestError: if the HTTP request fails
         :raise ValidationError: if the server's access token response is invalid
         """
         refresh_token = self._oauth2_token_service.get().refresh_token
@@ -100,7 +101,7 @@ class OAuthHTTPService:
                     "refresh_token": refresh_token,
                 },
             )
-        except HTTPError as err:
+        except ExternalRequestError as err:
             try:
                 error_dict = _OAuthAccessTokenErrorResponseSchema(err.response).parse()
             except ValidationError:

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -7,7 +7,7 @@ from lms.services.blackboard_api.client import (
     PAGINATION_MAX_REQUESTS,
     BlackboardAPIClient,
 )
-from lms.services.exceptions import BlackboardFileNotFoundInCourse, HTTPError
+from lms.services.exceptions import BlackboardFileNotFoundInCourse, ExternalRequestError
 from tests import factories
 
 
@@ -141,21 +141,21 @@ class TestPublicURL:
     def test_it_raises_BlackboardFileNotFoundInCourse_if_the_Blackboard_API_404s(
         self, svc, basic_client
     ):
-        basic_client.request.side_effect = HTTPError(
-            factories.requests.Response(status_code=404)
+        basic_client.request.side_effect = ExternalRequestError(
+            response=factories.requests.Response(status_code=404)
         )
 
         with pytest.raises(BlackboardFileNotFoundInCourse):
             svc.public_url("COURSE_ID", "FILE_ID")
 
-    def test_it_raises_HTTPError_if_the_Blackboard_API_fails_in_any_other_way(
+    def test_it_raises_ExternalRequestError_if_the_Blackboard_API_fails_in_any_other_way(
         self, svc, basic_client
     ):
-        basic_client.request.side_effect = HTTPError(
-            factories.requests.Response(status_code=400)
+        basic_client.request.side_effect = ExternalRequestError(
+            response=factories.requests.Response(status_code=400)
         )
 
-        with pytest.raises(HTTPError):
+        with pytest.raises(ExternalRequestError):
             svc.public_url("COURSE_ID", "FILE_ID")
 
 

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -7,7 +7,7 @@ from h_matchers import Any
 from lms.models import HUser
 from lms.services import HAPIError
 from lms.services.h_api import HAPI
-from lms.services.http import HTTPError
+from lms.services.http import ExternalRequestError
 
 pytestmark = pytest.mark.usefixtures("http_service")
 
@@ -88,7 +88,7 @@ class TestHAPI:
     def test__api_request_raises_HAPIError_for_request_errors(
         self, h_api, http_service
     ):
-        exception = HTTPError()
+        exception = ExternalRequestError()
         http_service.request.side_effect = exception
 
         with pytest.raises(HAPIError) as exc_info:

--- a/tests/unit/lms/services/http_test.py
+++ b/tests/unit/lms/services/http_test.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 from h_matchers import Any
 
-from lms.services.exceptions import HTTPError
+from lms.services.exceptions import ExternalRequestError
 from lms.services.http import HTTPService, factory
 
 
@@ -91,7 +91,7 @@ class TestHTTPService:
         session.request.side_effect = exception
         svc = HTTPService(session)
 
-        with pytest.raises(HTTPError) as exc_info:
+        with pytest.raises(ExternalRequestError) as exc_info:
             svc.request("GET", "https://example.com")
 
         assert exc_info.value.response is None
@@ -101,7 +101,7 @@ class TestHTTPService:
     def test_it_raises_if_the_response_is_an_error(self, svc, url, status):
         httpretty.register_uri("GET", url, status=status)
 
-        with pytest.raises(HTTPError) as exc_info:
+        with pytest.raises(ExternalRequestError) as exc_info:
             svc.request("GET", url)
 
         assert isinstance(exc_info.value.__cause__, requests.HTTPError)

--- a/tests/unit/lms/services/lti_outcomes_test.py
+++ b/tests/unit/lms/services/lti_outcomes_test.py
@@ -5,7 +5,7 @@ import pytest
 import xmltodict
 from h_matchers import Any
 
-from lms.services.exceptions import HTTPError, LTIOutcomesAPIError
+from lms.services.exceptions import ExternalRequestError, LTIOutcomesAPIError
 from lms.services.lti_outcomes import LTIOutcomesClient
 from tests import factories
 
@@ -120,7 +120,7 @@ class TestLTIOutcomesClient:
         )
 
     def test_requests_fail_if_the_third_party_request_fails(self, svc, http_service):
-        http_service.post.side_effect = HTTPError
+        http_service.post.side_effect = ExternalRequestError
 
         with pytest.raises(LTIOutcomesAPIError):
             svc.read_result(self.GRADING_ID)


### PR DESCRIPTION
Raise `ExternalRequestError` from `HTTPService` instead of `HTTPError`.

This fixes the reporting of failed HTTP requests by `HTTPService` to Sentry (adding details of the error response to Sentry) and removes an unnecessary class (we don't need both `HTTPError` and `ExternalRequestError`).

When `HTTPService` was written (quite recently) a new `HTTPError` class was added for it to raise:

```python
class HTTPError(ServiceError):
    """A problem with an HTTP request to an external service."""

    def __init__(self, response=None):
        super().__init__(response)
        self.response = response
```

I think this was probably a mistake. There was already an existing `ExternalRequestError` class in the code and that class contains code for stringifying the exception nicely for Sentry:

```python
class ExternalRequestError(ServiceError):
    def __init__(self, explanation=None, response=None, details=None):
        super().__init__()
        self.explanation = explanation
        self.response = response
        self.details = details

    def __str__(self):
        if self.response is None:
            return self.explanation

        # Log the details of the response. This goes to both Sentry and the
        # application's logs. It's helpful for debugging to know how the
        # external service responded.
        parts = [
            self.explanation + ":",
            str(self.response.status_code or ""),
            self.response.reason,
            self.response.text,
        ]
        return " ".join([part for part in parts if part])
```

`HTTPService` should have used `ExternalRequestError` all along to get this `__str__()` and to avoid adding a second exception class for the same thing.

The name `HTTPError` is kind of nicer than `ExternalRequestError` (it's shorter for one thing) but I think it's probably best to stick with `ExternalRequestError` to avoid confusion with `pyramid.httpexceptions.HTTPError` or requests.HTTPError`.

### Testing

TODO. `HTTPError` was used by `BlackboardAPIClient`, `HAPI` (client), and `LTIOutcomesClient` (the grading feature in non-Canvas LMS's) so all three need to be tested. We need to test what's shown in the frontend's error dialog when an exception happens and also what gets reported to Sentry.