### PR TITLE
Get rcp groups for canvas groups only when the assignment has them enabled

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -436,7 +436,10 @@ class JSConfig:
         }
 
     def _groups(self):
-        if self._context.canvas_sections_enabled or self._context.canvas_groups_enabled:
+        if (
+            self._context.canvas_sections_enabled
+            or self._context.canvas_is_group_launch
+        ):
             return "$rpc:requestGroups"
         return [self._context.h_group.groupid(self._authority)]
 

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -141,13 +141,26 @@ class LTILaunchResource:
 
     @property
     def canvas_groups_enabled(self):
-        """Return True if Canvas groups is enabled for this request."""
+        """Return True if Canvas groups are enabled at the school/installation level."""
         try:
             application_instance = self._application_instance_service.get()
         except ConsumerKeyError:
             return False
 
         return bool(application_instance.settings.get("canvas", "groups_enabled"))
+
+    @property
+    def canvas_is_group_launch(self):
+        """Return True if the current assignment uses canvas groups."""
+        if not self.canvas_groups_enabled:
+            return False
+
+        try:
+            int(self._request.params["group_set"])
+        except (KeyError, ValueError, TypeError):
+            return False
+        else:
+            return True
 
     def _course_extra(self):
         """Extra information to store for courses."""

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -519,13 +519,21 @@ class TestJSConfigHypothesisClient:
 
         assert groups == [context.h_group.groupid.return_value]
 
+    @pytest.mark.usefixtures("canvas_groups_on")
+    def test_it_includes_the_group_with_canvas_group_on_but_no_group_launch(
+        self, config, context
+    ):
+        groups = config["services"][0]["groups"]
+
+        assert groups == [context.h_group.groupid.return_value]
+
     @pytest.mark.usefixtures("canvas_sections_on")
     def test_configures_the_client_to_fetch_the_groups_over_RPC_with_sections(
         self, config
     ):
         assert config["services"][0]["groups"] == "$rpc:requestGroups"
 
-    @pytest.mark.usefixtures("canvas_groups_on")
+    @pytest.mark.usefixtures("canvas_groups_on", "canvas_groups_launch")
     def test_it_configures_the_client_to_fetch_the_groups_over_RPC_with_groups(
         self, config
     ):
@@ -547,6 +555,15 @@ class TestJSConfigHypothesisClient:
         js_config.enable_lti_launch_mode()
 
         return config["hypothesisClient"]
+
+    @pytest.fixture
+    def canvas_groups_launch(self, context):
+        context.canvas_is_group_launch = True
+
+    @pytest.fixture
+    def canvas_groups_on(self, context):
+        """Canvas groups feature enabled but not used in the current lti launch."""
+        context.canvas_groups_enabled = True
 
 
 class TestJSConfigRPCServer:
@@ -657,17 +674,13 @@ def context():
         is_canvas=True,
         canvas_sections_enabled=False,
         canvas_groups_enabled=False,
+        canvas_is_group_launch=False,
     )
 
 
 @pytest.fixture
 def canvas_sections_on(context):
     context.canvas_sections_enabled = True
-
-
-@pytest.fixture
-def canvas_groups_on(context):
-    context.canvas_groups_enabled = True
 
 
 @pytest.fixture

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -214,6 +214,33 @@ class TestCanvasGroupsEnabled:
         assert lti_launch.canvas_groups_enabled == settings_value
 
 
+class TestCanvasIsGroupLaunch:
+    def test_false_when_no_application_instance(self, lti_launch_groups_enabled):
+        lti_launch_groups_enabled.canvas_groups_enabled = False
+
+        assert not lti_launch_groups_enabled.canvas_is_group_launch
+
+    @pytest.mark.parametrize("group_set", ["", "not a number", None])
+    def test_false_invalid_group_set_param(
+        self, pyramid_request, lti_launch_groups_enabled, group_set
+    ):
+        pyramid_request.params.update({"group_set": group_set})
+
+        assert not lti_launch_groups_enabled.canvas_is_group_launch
+
+    def test_it(self, pyramid_request, lti_launch_groups_enabled):
+        pyramid_request.params.update({"group_set": 1})
+
+        assert lti_launch_groups_enabled.canvas_is_group_launch
+
+    @pytest.fixture
+    def lti_launch_groups_enabled(self, pyramid_request):
+        class TestableLTILaunchResource(LTILaunchResource):
+            canvas_groups_enabled = True
+
+        return TestableLTILaunchResource(pyramid_request)
+
+
 @pytest.fixture
 def lti_launch(pyramid_request):
     return LTILaunchResource(pyramid_request)


### PR DESCRIPTION
It's not enough that groups are enabled at the AI level, the assignment itself needs to be a groups one otherwise we run into a bug where if sections are disabled and groups are enabled, the sync API will still return sections groups for a non-groups assignment.

# Testing notes

## Reproduce the bug

- Disable sections, either on the DB course or just return False around here https://github.com/hypothesis/lms/blob/4fd826744a269ce0117d0dfd57e1c9ed7d65668e/lms/resources/lti_launch.py#L133
- http://localhost:8001/admin/instance/Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a/ Enable groups
- Launch https://hypothesis.instructure.com/courses/125/assignments/873
- The groups in the client are "Section 1..."


## Fix

- Change to this branch
- Keep sections disabled and groups enabled
- Launch https://hypothesis.instructure.com/courses/125/assignments/873
- Group displayed on the client is the course one `Developer Test Course wi…`
- Check also a group assignment,  https://hypothesis.instructure.com/courses/125/assignments/1833, the groups on the client are the group set ones.




