### PR TITLE
Add subfolder support for Blackboard files in LMSFilePicker

### DIFF
--- a/lms/static/images/folder.svg
+++ b/lms/static/images/folder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M4 5v14h16V7h-8.414l-2-2H4zm8.414 0H21a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h7.414l2 2z"/></svg>

--- a/lms/static/scripts/frontend_apps/components/Breadcrumbs.js
+++ b/lms/static/scripts/frontend_apps/components/Breadcrumbs.js
@@ -1,0 +1,50 @@
+import { LinkButton } from '@hypothesis/frontend-shared';
+import { createElement } from 'preact';
+
+/**
+ * @template Item
+ * @typedef BreadcrumbProps
+ * @prop {Item[]} items
+ * @prop {(i: Item) => void} onSelectItem
+ * @prop {(i: Item) => any} [renderItem]
+ */
+
+/**
+ * @template Item
+ * @param {Item} item
+ */
+const defaultRenderItem = item => item;
+
+/**
+ * Render a collection of breadcrumbs. All but the last breadcrumb is clickable,
+ * and will invoke the `onSelectItem` when clicked.
+ *
+ * @template Item
+ * @param {BreadcrumbProps<Item>} props
+ */
+export default function Breadcrumbs({
+  items,
+  onSelectItem,
+  renderItem = defaultRenderItem,
+}) {
+  if (!items.length) {
+    return null;
+  }
+  const breadcrumbs = items.slice(0, -1);
+  const currentItem = items[items.length - 1];
+  return (
+    <ul className="Breadcrumbs hyp-u-layout-row">
+      {breadcrumbs.map((item, idx) => (
+        <li className="Breadcrumbs__item Breadcrumbs__item--path" key={idx}>
+          <LinkButton onClick={() => onSelectItem(item)}>
+            {renderItem(item)}
+          </LinkButton>
+          <span className="Breadcrumbs__divider">›</span>
+        </li>
+      ))}
+      <li className="Breadcrumbs__item Breadcrumbs__item--current">
+        <LinkButton disabled>{renderItem(currentItem)}</LinkButton>
+      </li>
+    </ul>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -149,6 +149,7 @@ export default function ContentSelector({
           // An alias we maintain that provides multiple external documentation links for
           // different versions of Blackboard (Classic vs. Ultra)
           missingFilesHelpLink={'https://web.hypothes.is/help/bb-files'}
+          withBreadcrumbs
         />
       );
       break;

--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -1,3 +1,5 @@
+import { SvgIcon } from '@hypothesis/frontend-shared';
+
 import classnames from 'classnames';
 import { Fragment, createElement } from 'preact';
 
@@ -59,15 +61,16 @@ export default function FileList({
         renderItem={(file, isSelected) => (
           <Fragment>
             <td aria-label={file.display_name} className="FileList__name-col">
-              <img
-                className={classnames(
-                  'FileList__icon',
-                  isSelected && 'is-selected'
-                )}
-                src="/static/images/file-pdf.svg"
-                alt="PDF icon"
-              />
-              <span className="FileList__name">{file.display_name}</span>
+              <div className="hyp-u-layout-row--center hyp-u-horizontal-spacing hyp-u-padding--left--2">
+                <SvgIcon
+                  inline
+                  name={file.type && file.type === 'Folder' ? 'folder' : 'pdf'}
+                  className={classnames('FileList__icon', {
+                    'is-selected': isSelected,
+                  })}
+                />
+                <span className="FileList__name">{file.display_name}</span>
+              </div>
             </td>
             <td className="FileList__date-col">
               {file.updated_at && formatDate(file.updated_at)}

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -152,7 +152,9 @@ export default function LMSFilePicker({
         // flight. "fetching" will not render the Dialog, while "reloading" will
         // render the Dialog, with a loading indicator.
         const nextState =
-          state === 'fetched' || continueAction === 'reload'
+          state === 'fetched' ||
+          state === 'reloading' ||
+          continueAction === 'reload'
             ? 'reloading'
             : 'fetching';
         return {
@@ -168,6 +170,19 @@ export default function LMSFilePicker({
           path: getNextAPICallInfo().path,
         })
       );
+
+      // Handle the case in which a subsequent fetch request for a
+      // different path's files was dispatched before this request resolved.
+      // Give preference to the later request: If the path has changed
+      // since this request was made, ignore the results of this request.
+      let pathChanged = false;
+      setFolderPath(path => {
+        pathChanged = path !== folderPath;
+        return path;
+      });
+      if (pathChanged) {
+        return;
+      }
 
       const continueAction =
         files.length === 0 ? 'reload' : INITIAL_DIALOG_STATE.continueAction;

--- a/lms/static/scripts/frontend_apps/components/test/Breadcrumbs-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Breadcrumbs-test.js
@@ -1,0 +1,60 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import Breadcrumbs from '../Breadcrumbs';
+
+describe('Breadcrumbs', () => {
+  const itemFixtures = ['Thing 1', 'Thing 2', 'Thing 3', 'Thing 4'];
+  let fakeOnSelectItem;
+
+  const renderBreadcrumbs = (props = {}) =>
+    mount(
+      <Breadcrumbs
+        items={itemFixtures}
+        onSelectItem={fakeOnSelectItem}
+        {...props}
+      />
+    );
+
+  beforeEach(() => {
+    fakeOnSelectItem = sinon.stub();
+  });
+
+  it('renders each item as a button', () => {
+    const wrapper = renderBreadcrumbs();
+
+    assert.equal(wrapper.find('LinkButton').length, 4);
+  });
+
+  it('renders empty if no items are provided', () => {
+    const emptyItems = [];
+    const wrapper = renderBreadcrumbs({ items: emptyItems });
+
+    assert.isTrue(wrapper.find('Breadcrumbs').isEmptyRender());
+  });
+
+  it('disables the selection of the last item', () => {
+    const wrapper = renderBreadcrumbs();
+
+    assert.isTrue(wrapper.find('LinkButton').last().props().disabled);
+  });
+
+  it('invokes the onSelectItem callback when one of the items is clicked', () => {
+    const wrapper = renderBreadcrumbs();
+
+    wrapper.find('LinkButton').first().props().onClick();
+    assert.calledOnce(fakeOnSelectItem);
+    assert.calledWith(fakeOnSelectItem, itemFixtures[0]);
+  });
+
+  it('renders items using the provided callback', () => {
+    const wrapper = renderBreadcrumbs({
+      renderItem: item => `whee ${item} whee`,
+    });
+
+    assert.equal(
+      wrapper.find('LinkButton').first().text(),
+      'whee Thing 1 whee'
+    );
+  });
+});

--- a/lms/static/scripts/frontend_apps/icons.js
+++ b/lms/static/scripts/frontend_apps/icons.js
@@ -8,6 +8,8 @@ export default {
   // LMS icons
   'caret-down': require('../../images/caret-down.svg'),
   check: require('../../images/check.svg'),
+  folder: require('../../images/folder.svg'),
+  pdf: require('../../images/file-pdf.svg'),
   spinner: require('../../images/spinner.svg'),
 
   // Shared icons

--- a/lms/static/styles/components/_Breadcrumbs.scss
+++ b/lms/static/styles/components/_Breadcrumbs.scss
@@ -1,0 +1,27 @@
+.Breadcrumbs {
+  // Disable browser-default margin and padding for <ul>
+  margin: 0;
+  padding: 0;
+  // FIXME: For now, allow crumbs to wrap onto a second line if they
+  // run out of room. This could be more elegant.
+  flex-wrap: wrap;
+
+  &__item {
+    display: inline-flex;
+    list-style-type: none;
+  }
+
+  &__item--current {
+    button {
+      // The button is disabled, so don't show a pointer cursor
+      // FIXME: The shared button components should handle their cursors
+      // correctly
+      cursor: default;
+    }
+  }
+
+  &__divider {
+    margin: 0 0.5rem;
+    font-size: 1em;
+  }
+}

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -1,7 +1,5 @@
 @use "../variables" as var;
 
-$file-list-icon-size: 24px;
-
 .FileList {
   position: relative;
 
@@ -24,17 +22,10 @@ $file-list-icon-size: 24px;
 }
 
 .FileList__icon {
-  margin-left: 10px;
-  margin-right: 10px;
-  width: $file-list-icon-size;
-  height: $file-list-icon-size;
-  vertical-align: middle;
-
-  &.is-selected {
-    // nb. Argument must be passed to `invert` even though "1" is the default
-    // to work around https://bugs.chromium.org/p/chromium/issues/detail?id=964696.
-    filter: #{'invert(1)'}; // Quoted to avoid conflict with SASS mixin.
-  }
+  // TODO: Update when updated SVGIcon component is available and has sizing
+  // patterns
+  width: 1.5em;
+  height: 1.5em;
 }
 
 .FileList__name-col {

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -12,6 +12,7 @@
 // Preact components
 @use 'components/BasicLTILaunchApp';
 @use 'components/BookSelector';
+@use 'components/Breadcrumbs';
 @use 'components/ContentSelector';
 @use 'components/Dialog';
 @use 'components/ErrorDisplay';


### PR DESCRIPTION
This PR is a cleaned-up implementation, with tests, of https://github.com/hypothesis/lms/pull/3010 . It adds subfolder support, with breadcrumbs, for the `LMSFilePicker` component, specifically to support Blackboard files' subfolders, but available to other integrations.

In a brief nutshell:

* A new `Breadcrumbs` component is added. I've tried to be straightforward and relatively generic here. There are several known follow-up tasks for this component, including handling elision and a11y affordances (e.g. ARIA roles).
* `LMSFilePicker` is extended to maintain state about path, and re-fetch files when the "path" changes (i.e. retrieve files in sub-folders).
* `FileList` is updated to differentiate between files and folders when determining which icon to render

Screen video of current behavior:

![poc-ready-for-cleanup](https://user-images.githubusercontent.com/439947/127652804-ac8b1049-6c08-4b49-a597-bf337c8d1fea.gif)

Expected behavior:

* You should be able to navigate into subfolders by
  * double-clicking on a folder in the file list
  * Clicking once/selecting a folder in the file list and then clicking the "Select" button
* You should be able to navigate back up to higher-level folders by clicking on them in the breadcrumbs
* You should be able to select a file as before, whether in a top-level directory or a sub-directory
* Breadcrumb "path elements" should appear as you navigate down
* Folders should display with a folder icon; files with a PDF icon
* Navigating into an empty folder should display a message about there not being any files in that folder

Behavior that has been updated to be acceptable for now, but needs tuning:

* The Modal may change height, but should not entirely disappear, when navigating between folders
* Very long breadcrumb paths should wrap to a second line
* `LMSFilePicker` is overripe for refactor. I've been able to extend it for short-term implementation of this feature, but acknowledge that its state is Byzantine, and these changes worsen that situation. This is evident in the complexity of a few of the tests, also. I've done my best to comment where it's most potentially confusing.

#### Short-term Follow-up issues

* https://github.com/hypothesis/lms/issues/3022
* https://github.com/hypothesis/lms/issues/3023
* https://github.com/hypothesis/lms/issues/3021


### Testing this out

1. Check out and run this branch
2. Log in to https://aunltd-test.blackboard.com/ as `blackboardteacher`
3. Create a new assignment in [this course](https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline) (Content -> Build Content -> Hypothesis, localhost, make devdata) (All you need to do is give it a name and click Submit)
4. Launch the unconfigured assignment and click the "Select PDF from Blackboard" button.

A large part of https://github.com/hypothesis/lms/issues/2943