### PR TITLE
Data migration for enabling canvas groups

### DIFF
--- a/lms/migrations/versions/da66efab9e5f_enable_canvas_groups.py
+++ b/lms/migrations/versions/da66efab9e5f_enable_canvas_groups.py
@@ -1,0 +1,29 @@
+"""
+Enable canvas groups in all installations craeted since Jan 1st, 2019.
+
+Revision ID: da66efab9e5f
+Revises: bf67a1e68cea
+Create Date: 2021-08-02 08:18:29.729262
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "da66efab9e5f"
+down_revision = "bf67a1e68cea"
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    conn.execute(
+        "UPDATE application_instances SET settings = jsonb_set(settings, '{canvas,groups_enabled}', 'true') WHERE created >= '2019-01-01'::date and settings <> '{}' and developer_key is not null"
+    )
+    conn.execute(
+        """UPDATE application_instances SET settings = '{"canvas": {"groups_enabled": true}}' WHERE created >= '2019-01-01'::date and settings = '{}' and developer_key is not null"""
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
(For https://github.com/hypothesis/product-backlog/issues/1221)

# Testing

Using `make sql`:

- Remove existing AIs
 `truncate application_instances cascade;`
- Insert new test ones

```
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key, developer_key) values ('test1', 'test1', 'test1', 'test1', now(), '{}', 'test1');
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test2', 'test2', 'test2', 'test2', now(), '{"canvas": {"sections_enabled": false}}$', 'test1');
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test3', 'test3', 'test3', 'test3', now(), '{"canvas": {"groups_enabled": true, "sections_enabled": false}, "blackboard": {"files_enabled": false}, "microsoft_onedrive": {"files_enabled": false}}', 'test1');
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test4', 'test4', 'test4', 'test4', now(), '{"canvas": {"groups_enabled": true, "sections_enabled": true}, "blackboard": {"files_enabled": false}, "microsoft_onedrive": {"files_enabled": false}}', 'test1');
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test5', 'test5', 'test5', 'test5', now(), '{"canvas": {"groups_enabled": false, "sections_enabled": true}, "blackboard": {"files_enabled": false}, "microsoft_onedrive": {"files_enabled": false}}', 'test1');
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test6', 'test6', 'test6', 'test6', now(), '{"canvas": {"sections_enabled": true}}', 'test1');
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test7', 'test7', 'test7', 'test7', now(), '{"canvas": {"groups_enabled": true, "sections_enabled": true}}', 'test1');
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test8', 'test8', 'test8', 'test8', now(), '{"canvas": {"groups_enabled": false, "sections_enabled": false}, "blackboard": {"files_enabled": false}, "microsoft_onedrive": {"files_enabled": false}}', 'test1');
-- Older dates
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test9', 'test9', 'test9', 'test9', '2018-01-01'::date, '{"canvas": {"groups_enabled": false}}', 'test1');
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test10', 'test10', 'test10', 'test10', '2018-01-01'::date, '{}', 'test1');
-- No dev key
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test11', 'test11', 'test11', 'test1', now(), '{}', null);
insert into application_instances (consumer_key, shared_secret, lms_url, requesters_email, created, settings, developer_key) values ('test12', 'test12', 'test12', 'test12', now(), '{"canvas": {"groups_enabled": false}}', null);
```

- Get the current values for the settings:

`select id, created, settings from application_instances order by id asc;`


- Run the migration with for example `make db`

```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade bf67a1e68cea -> da66efab9e5f, enable_canvas_groups
```

- Compare the values after the update 
`select id, created, settings from application_instances order by id asc;`

- Every row should have `groups_enabled": true` while maintaining any other values






