### PR TITLE
Request additional fields from BB files API

### DIFF
--- a/lms/services/blackboard_api/_schemas.py
+++ b/lms/services/blackboard_api/_schemas.py
@@ -22,6 +22,8 @@ class BlackboardListFilesSchema(RequestsResponseSchema):
         modified = fields.Str(required=True)
         type = fields.Str(required=True)
         mimeType = fields.Str()
+        size = fields.Integer()
+        parentId = fields.Str()
 
     results = fields.List(fields.Nested(FileSchema), required=True)
 

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -45,7 +45,7 @@ class BlackboardAPIClient:
             + urlencode(
                 {
                     "limit": PAGINATION_LIMIT,
-                    "fields": "id,name,type,modified,mimeType",
+                    "fields": "id,name,type,modified,mimeType,size,parentId",
                 }
             )
         )

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -37,7 +37,7 @@ class TestListFiles:
 
         basic_client.request.assert_called_once_with(
             "GET",
-            "courses/uuid:COURSE_ID/resources?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType",
+            "courses/uuid:COURSE_ID/resources?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType%2Csize%2CparentId",
         )
         BlackboardListFilesSchema.assert_called_once_with(
             basic_client.request.return_value
@@ -55,7 +55,7 @@ class TestListFiles:
 
         basic_client.request.assert_called_once_with(
             "GET",
-            "courses/uuid:COURSE_ID/resources/FOLDER_ID/children?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType",
+            "courses/uuid:COURSE_ID/resources/FOLDER_ID/children?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType%2Csize%2CparentId",
         )
 
     def test_it_with_pagination(self, svc, basic_client, blackboard_list_files_schema):
@@ -87,7 +87,7 @@ class TestListFiles:
         assert basic_client.request.call_args_list == [
             call(
                 "GET",
-                "courses/uuid:COURSE_ID/resources?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType",
+                "courses/uuid:COURSE_ID/resources?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType%2Csize%2CparentId",
             ),
             call("GET", "PAGE_2_PATH"),
             call("GET", "PAGE_3_PATH"),


### PR DESCRIPTION
In preparation to store the files in the DB

More a question than a real PR, but what fields should we request from the API (and which one later store on the DB) for an hypothetical BB course copy.

Available fields on the API are:

```
"id": "string",
"name": "string",
"type": "File",
"size": 0,
"hasLinks": true,
"parentId": "string",
"creatorId": "string",
"created": "2021-08-03T11:26:34.413Z",
"modified": "2021-08-03T11:26:34.413Z",
"mimeType": "string",
"version": 0,
"downloadUrl": "string"
```

should we just do all of them?
