### PR TITLE
Don't populate sync API with just groups enabled

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -446,7 +446,7 @@ class JSConfig:
     def _sync_api(self):
         if (
             not self._context.canvas_sections_enabled
-            and not self._context.canvas_groups_enabled
+            and not self._context.canvas_is_group_launch
         ):
             return None
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -449,6 +449,10 @@ class TestJSConfigAPISync:
             "group_set": None,
         }
 
+    @pytest.mark.usefixtures("canvas_groups_launch")
+    def test_present_if_group_assignment(self, sync):
+        assert sync is not None
+
     def test_its_None_if_section_and_groups_arent_enabled(self, sync):
         assert sync is None
 
@@ -555,10 +559,6 @@ class TestJSConfigHypothesisClient:
         js_config.enable_lti_launch_mode()
 
         return config["hypothesisClient"]
-
-    @pytest.fixture
-    def canvas_groups_launch(self, context):
-        context.canvas_is_group_launch = True
 
     @pytest.fixture
     def canvas_groups_on(self, context):
@@ -681,6 +681,11 @@ def context():
 @pytest.fixture
 def canvas_sections_on(context):
     context.canvas_sections_enabled = True
+
+
+@pytest.fixture
+def canvas_groups_launch(context):
+    context.canvas_is_group_launch = True
 
 
 @pytest.fixture


### PR DESCRIPTION
# Reproduce (on `master)

- Force this if to evaluate to false (no sections scopes) https://github.com/hypothesis/lms/blob/4fd826744a269ce0117d0dfd57e1c9ed7d65668e/lms/views/api/canvas/authorize.py#L52
 (`False and` is the easiest, or remove any courses with sections locally)


- Also disable sections here https://github.com/hypothesis/lms/blob/4fd826744a269ce0117d0dfd57e1c9ed7d65668e/lms/resources/lti_launch.py#L133


- Enable groups and disable sections here: http://localhost:8001/admin/instance/Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a/

- Launch a non group assignment, it will  get  in an auth loop (eg https://hypothesis.instructure.com/courses/125/assignments/1069)


# Fix 

- While on this branch, with the same setup, the assignment will launch without problems