### PR TITLE
Store bb files

### DIFF
--- a/lms/migrations/versions/d9c9e65c463e_files_parent_id.py
+++ b/lms/migrations/versions/d9c9e65c463e_files_parent_id.py
@@ -1,0 +1,22 @@
+"""
+Adds File.parent_lms_id.
+
+Revision ID: d9c9e65c463e
+Revises: da66efab9e5f
+Create Date: 2021-08-09 16:39:49.615988
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d9c9e65c463e"
+down_revision = "da66efab9e5f"
+
+
+def upgrade():
+    op.add_column("file", sa.Column("parent_lms_id", sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("file", "parent_lms_id")

--- a/lms/models/file.py
+++ b/lms/models/file.py
@@ -44,6 +44,9 @@ class File(CreatedUpdatedMixin, BASE):
     lms_id = sa.Column(sa.UnicodeText(), nullable=False)
     """The natural id of the file in the LMS."""
 
+    parent_lms_id = sa.Column(sa.UnicodeText(), nullable=True)
+    """Parent ID of the file in the LMS for LMSes that support file/folder hierarchies"""
+
     course_id = sa.Column(sa.UnicodeText())
     """If the file is associated with a specific course set it here."""
 

--- a/lms/services/blackboard_api/_schemas.py
+++ b/lms/services/blackboard_api/_schemas.py
@@ -22,6 +22,8 @@ class BlackboardListFilesSchema(RequestsResponseSchema):
         modified = fields.Str(required=True)
         type = fields.Str(required=True)
         mimeType = fields.Str()
+        size = fields.Integer()
+        parentId = fields.Str()
 
     results = fields.List(fields.Nested(FileSchema), required=True)
 

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -17,8 +17,9 @@ PAGINATION_LIMIT = 200
 class BlackboardAPIClient:
     """A high-level Blackboard API client."""
 
-    def __init__(self, basic_client):
+    def __init__(self, basic_client, request):
         self._api = basic_client
+        self._request = request
 
     def get_token(self, authorization_code):
         """

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -45,7 +45,7 @@ class BlackboardAPIClient:
             + urlencode(
                 {
                     "limit": PAGINATION_LIMIT,
-                    "fields": "id,name,type,modified,mimeType",
+                    "fields": "id,name,type,modified,mimeType,size,parentId",
                 }
             )
         )

--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -14,5 +14,6 @@ def blackboard_api_client_factory(_context, request):
             redirect_uri=request.route_url("blackboard_api.oauth.callback"),
             http_service=request.find_service(name="http"),
             oauth_http_service=request.find_service(name="oauth_http"),
-        )
+        ),
+        request=request,
     )

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -37,7 +37,7 @@ class TestListFiles:
 
         basic_client.request.assert_called_once_with(
             "GET",
-            "courses/uuid:COURSE_ID/resources?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType",
+            "courses/uuid:COURSE_ID/resources?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType%2Csize%2CparentId",
         )
         BlackboardListFilesSchema.assert_called_once_with(
             basic_client.request.return_value
@@ -55,7 +55,7 @@ class TestListFiles:
 
         basic_client.request.assert_called_once_with(
             "GET",
-            "courses/uuid:COURSE_ID/resources/FOLDER_ID/children?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType",
+            "courses/uuid:COURSE_ID/resources/FOLDER_ID/children?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType%2Csize%2CparentId",
         )
 
     def test_it_with_pagination(self, svc, basic_client, blackboard_list_files_schema):
@@ -87,7 +87,7 @@ class TestListFiles:
         assert basic_client.request.call_args_list == [
             call(
                 "GET",
-                "courses/uuid:COURSE_ID/resources?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType",
+                "courses/uuid:COURSE_ID/resources?limit=200&fields=id%2Cname%2Ctype%2Cmodified%2CmimeType%2Csize%2CparentId",
             ),
             call("GET", "PAGE_2_PATH"),
             call("GET", "PAGE_3_PATH"),

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, create_autospec, sentinel
+from unittest.mock import MagicMock, call, create_autospec, sentinel
 
 import pytest
 
@@ -27,11 +27,8 @@ class TestListFiles:
         blackboard_list_files_schema,
     ):
         basic_client.request.return_value = factories.requests.Response(json_data={})
-        blackboard_list_files_schema.parse.return_value = [
-            sentinel.file_1,
-            sentinel.file_2,
-            sentinel.file_3,
-        ]
+        blackboard_files = [MagicMock() for _ in range(3)]
+        blackboard_list_files_schema.parse.return_value = blackboard_files
 
         files = svc.list_files("COURSE_ID")
 
@@ -73,12 +70,13 @@ class TestListFiles:
             ),
             factories.requests.Response(json_data={}),
         ]
+        blackboard_files = [MagicMock() for _ in range(8)]
 
         # Each Blackboard API response contains a page of results.
         blackboard_list_files_schema.parse.side_effect = [
-            [sentinel.file_1, sentinel.file_2, sentinel.file_3],
-            [sentinel.file_4, sentinel.file_5, sentinel.file_6],
-            [sentinel.file_7, sentinel.file_8],
+            blackboard_files[0:3],
+            blackboard_files[3:6],
+            blackboard_files[6:8],
         ]
 
         files = svc.list_files("COURSE_ID")
@@ -93,16 +91,7 @@ class TestListFiles:
             call("GET", "PAGE_3_PATH"),
         ]
         # It returned all three pages of files as a single list.
-        assert files == [
-            sentinel.file_1,
-            sentinel.file_2,
-            sentinel.file_3,
-            sentinel.file_4,
-            sentinel.file_5,
-            sentinel.file_6,
-            sentinel.file_7,
-            sentinel.file_8,
-        ]
+        assert files == blackboard_files
 
     def test_it_doesnt_send_paginated_requests_forever(
         self, svc, basic_client, blackboard_list_files_schema

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -2,9 +2,9 @@ from unittest.mock import MagicMock, call, create_autospec, sentinel
 
 import pytest
 from h_matchers import Any
+from pyramid.registry import Registry
 
 from lms.events import FilesDiscoveredEvent
-from pyramid.registry import Registry
 from lms.services.blackboard_api._basic import BasicClient
 from lms.services.blackboard_api.client import (
     PAGINATION_MAX_REQUESTS,
@@ -128,6 +128,50 @@ class TestListFiles:
         assert len(files) == PAGINATION_MAX_REQUESTS * len(
             blackboard_list_files_schema.parse.return_value
         )
+
+    @pytest.mark.parametrize("size,type_", [(1, "File"), (3, "File"), (3, "Folder")])
+    def test_it_emits_files_discover_event(
+        self, svc, basic_client, blackboard_list_files_schema, registry, size, type_
+    ):
+        # pylint: disable=protected-access
+        svc._request.registry = registry
+        basic_client.request.return_value = factories.requests.Response(json_data={})
+        blackboard_list_files_schema.parse.return_value = [
+            self.blackboard_file_dict(id_, type_=type_) for id_ in range(size)
+        ]
+
+        svc.list_files("COURSE_ID")
+
+        svc._request.registry.notify.assert_called_once_with(
+            FilesDiscoveredEvent(
+                request=svc._request,
+                values=[
+                    Any.dict.containing(
+                        {
+                            "lms_id": id_ + 1,
+                            "type": "blackboard_file"
+                            if type_ == "File"
+                            else "blackboard_folder",
+                        }
+                    )
+                    for id_ in range(size)
+                ],
+            )
+        )
+
+    def blackboard_file_dict(self, id_=1, type_="File"):
+        return {
+            "type": type_,
+            "course_id": "COURSE_ID",
+            "id": id_ + 1,
+            "name": f"file_entry_{id_}",
+            "size": id_ * 2,
+            "parentId": id_ * 4,
+        }
+
+    @pytest.fixture
+    def registry(self):
+        return create_autospec(Registry, instance=True, spec_set=True)
 
 
 class TestPublicURL:

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -165,8 +165,8 @@ def basic_client():
 
 
 @pytest.fixture
-def svc(basic_client):
-    return BlackboardAPIClient(basic_client)
+def svc(basic_client, pyramid_request):
+    return BlackboardAPIClient(basic_client, pyramid_request)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/services/blackboard_api/factory_test.py
+++ b/tests/unit/lms/services/blackboard_api/factory_test.py
@@ -26,7 +26,9 @@ def test_blackboard_api_client_factory(
         http_service=http_service,
         oauth_http_service=oauth_http_service,
     )
-    BlackboardAPIClient.assert_called_once_with(BasicClient.return_value)
+    BlackboardAPIClient.assert_called_once_with(
+        BasicClient.return_value, pyramid_request
+    )
     assert service == BlackboardAPIClient.return_value
 
 


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/3012

(includes the commits of https://github.com/hypothesis/lms/pull/3045 and https://github.com/hypothesis/lms/pull/3044 that need to be rebased out after merging those)

- Adds a new parent_lms_id nullable column to File  which seems like important  information to store on the DB in case we need to back the file tree without making a lot of API calls. Canvas has the same concept (but it's called `folder_id` not `parent_id`)
- Request `size` and parentId from BB API 
- Emit event and store files in the DB

# Testing

- Clear your files table `makes sql` & `truncate file ;`
- Go over https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline
- At the top `Build Content" -> Hypothesis (localhost, make devdata), give it a name 
- Launch the assignment and pick "blackboard files"
- Check files are now present on the table `select * from file;`
- Navigate over the directories and more files will be added