### PR TITLE
Bb missing integration dialog

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -1,4 +1,5 @@
 import functools
+from typing import List
 
 from lms.models import GroupInfo, HUser
 from lms.resources._js_config.file_picker_config import FilePickerConfig
@@ -102,12 +103,13 @@ class JSConfig:
         """
         return self._config
 
-    def enable_oauth2_redirect_error_mode(
+    def enable_oauth2_redirect_error_mode(  # pylint: disable=too-many-arguments
         self,
-        auth_route,
-        error_details="",
-        is_scope_invalid=False,
-        canvas_scopes=None,
+        auth_route: str,
+        error_code=None,
+        error_details: str = "",
+        is_scope_invalid: bool = False,
+        canvas_scopes: List[str] = None,
     ):
         """
         Configure the frontend to show the "Authorization failed" dialog.
@@ -116,15 +118,12 @@ class JSConfig:
         Canvas API or the Blackboard API fails after the redirect to the
         third-party authorization endpoint.
 
+        :param error_code: Code identifying a particular error
         :param error_details: Technical details of the error
-        :type error_details: str
         :param auth_route: route for the "Try again" button in the dialog
-        :type auth_route: str
         :param is_scope_invalid: `True` if authorization failed because the
           OAuth client does not have access to all the necessary scopes
-        :type is_scope_invalid: bool
         :param canvas_scopes: List of scopes that were requested
-        :type canvas_scopes: list(str)
         """
         if self._lti_user:
             bearer_token = BearerTokenSchema(self._request).authorization_param(
@@ -143,6 +142,7 @@ class JSConfig:
                 "OAuth2RedirectError": {
                     "authUrl": auth_url,
                     "invalidScope": is_scope_invalid,
+                    "errorCode": error_code,
                     "errorDetails": error_details,
                     "canvasScopes": canvas_scopes or [],
                 },

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -23,20 +23,32 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
     OAuth2RedirectError: {
       authUrl = /** @type {string|null} */ (null),
       invalidScope = false,
+      errorCode = /** @type {string|null} */ (null),
       errorDetails = '',
       canvasScopes = /** @type {string[]} */ ([]),
     },
   } = useContext(Config);
 
-  const title = invalidScope
-    ? 'Developer key scopes missing'
-    : 'Authorization failed';
+  const error = { code: errorCode, details: errorDetails };
 
-  const message = invalidScope
-    ? null
-    : 'Something went wrong when authorizing Hypothesis';
+  const title = (() => {
+    if (invalidScope) {
+      return 'Developer key scopes missing';
+    }
 
-  const error = { details: errorDetails };
+    if (errorCode === 'blackboard_missing_integration') {
+      return 'Missing Blackboard REST API integration';
+    }
+
+    return 'Authorization failed';
+  })();
+
+  const message = (() => {
+    if (invalidScope) {
+      return null;
+    }
+    return 'Something went wrong when authorizing Hypothesis';
+  })();
 
   const retry = () => {
     location.href = /** @type {string} */ (authUrl);
@@ -88,6 +100,26 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
               href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
             >
               Canvas API Endpoints Used by the Hypothesis LMS App
+            </a>
+            .
+          </p>
+        </Fragment>
+      )}
+
+      {error.code === 'blackboard_missing_integration' && (
+        <Fragment>
+          <p>
+            In order to allow Hypothesis to connect to files in Blackboard, your
+            Blackboard admin needs to add or enable a REST API integration.
+          </p>
+          <p>
+            For more information, please have your Blackboard admin read:{' '}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://web.hypothes.is/help/enable-the-hypothesis-integration-with-blackboard-files/"
+            >
+              Enable the Hypothesis Integration With Blackboard Files
             </a>
             .
           </p>

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -53,6 +53,16 @@ describe('OAuth2RedirectErrorApp', () => {
     );
   });
 
+  it('shows a different title and message for blackboard_missing_integration', () => {
+    fakeConfig.errorCode = 'blackboard_missing_integration';
+    const wrapper = renderApp();
+    assert.include(wrapper.text(), 'Missing Blackboard REST API integration');
+    assert.include(
+      wrapper.text(),
+      'Something went wrong when authorizing Hypothesis'
+    );
+  });
+
   it('shows a generic error if the scope is valid', () => {
     const wrapper = renderApp();
     assert.notInclude(wrapper.text(), 'A Canvas admin needs to edit');
@@ -69,6 +79,7 @@ describe('OAuth2RedirectErrorApp', () => {
     });
     assert.deepEqual(errorDisplay.prop('error'), {
       details: fakeConfig.errorDetails,
+      code: null,
     });
   });
 

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -77,6 +77,10 @@ import { createContext } from 'preact';
  */
 
 /**
+ * @typedef {'blackboard_missing_integration'} OAuthErrorCode
+ */
+
+/**
  * Configuration for the error dialog shown if authorizing access to an
  * OAuth API fails.
  *
@@ -84,6 +88,7 @@ import { createContext } from 'preact';
  * @prop {string|null} authUrl
  * @prop {boolean} invalidScope
  * @prop {string} errorDetails
+ * @prop {OAuthErrorCode|null} errorCode
  * @prop {string[]} canvasScopes
  */
 

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -65,7 +65,11 @@ def oauth2_redirect(request):
 )
 def oauth2_redirect_error(request):
     request.context.js_config.enable_oauth2_redirect_error_mode(
-        auth_route="blackboard_api.oauth.authorize"
+        error_code="blackboard_missing_integration"
+        if request.params.get("error_description")
+        in ["Application not enabled for site", "Application not registered with site"]
+        else None,
+        auth_route="blackboard_api.oauth.authorize",
     )
 
     return {}

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -604,6 +604,7 @@ class TestEnableOAuth2RedirectErrorMode:
         assert config["OAuth2RedirectError"] == {
             "authUrl": "http://example.com/auth?authorization=Bearer%3A+token_value",
             "invalidScope": is_scope_invalid,
+            "errorCode": None,
             "errorDetails": error_details,
             "canvasScopes": canvas_scopes if canvas_scopes is not None else [],
         }

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -53,7 +53,19 @@ class TestOAuth2RedirectError:
 
         pyramid_request.context.js_config.enable_oauth2_redirect_error_mode.assert_called_once_with(
             error_code=None,
-            error_details=None,
+            auth_route="blackboard_api.oauth.authorize",
+        )
+        assert template_variables == {}
+
+    def test_missing_integration_error(self, pyramid_request):
+        pyramid_request.params = {
+            "error_description": "Application not enabled for site"
+        }
+
+        template_variables = oauth2_redirect_error(pyramid_request)
+
+        pyramid_request.context.js_config.enable_oauth2_redirect_error_mode.assert_called_once_with(
+            error_code="blackboard_missing_integration",
             auth_route="blackboard_api.oauth.authorize",
         )
         assert template_variables == {}

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -52,7 +52,9 @@ class TestOAuth2RedirectError:
         template_variables = oauth2_redirect_error(pyramid_request)
 
         pyramid_request.context.js_config.enable_oauth2_redirect_error_mode.assert_called_once_with(
-            auth_route="blackboard_api.oauth.authorize"
+            error_code=None,
+            error_details=None,
+            auth_route="blackboard_api.oauth.authorize",
         )
         assert template_variables == {}
 


### PR DESCRIPTION
For #2024 

# Testing

- Log in as admin on BB
- https://aunltd-test.blackboard.com/ultra/admin -> Integrations -> Rest API Integrations and here either disable (`Make unavaialble") Hypothesis Dev or remove it.
- Launch an assignment that uses BB API (eg `localhost (make devdata) Blackboard Files Assignment` or/and try to create a new BB files assignment.
- You should get an "authorize" modal followed by another modal explaining the situation
![Screenshot from 2021-08-16 15-44-24](https://user-images.githubusercontent.com/1433832/129573588-83688a97-715e-462c-b39f-4a75d69b485f.png)


- After testing re-enable the Rest integration (or recreate it using application id: `b7a1baf5-3545-4f5d-897f-c036b0d5bd5b` and learn user `administrator`
