### PR TITLE
Replace is_scope_invalid flag with an error code

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -103,12 +103,11 @@ class JSConfig:
         """
         return self._config
 
-    def enable_oauth2_redirect_error_mode(  # pylint: disable=too-many-arguments
+    def enable_oauth2_redirect_error_mode(
         self,
         auth_route: str,
         error_code=None,
         error_details: str = "",
-        is_scope_invalid: bool = False,
         canvas_scopes: List[str] = None,
     ):
         """
@@ -121,8 +120,6 @@ class JSConfig:
         :param error_code: Code identifying a particular error
         :param error_details: Technical details of the error
         :param auth_route: route for the "Try again" button in the dialog
-        :param is_scope_invalid: `True` if authorization failed because the
-          OAuth client does not have access to all the necessary scopes
         :param canvas_scopes: List of scopes that were requested
         """
         if self._lti_user:
@@ -141,7 +138,6 @@ class JSConfig:
                 "mode": "oauth2-redirect-error",
                 "OAuth2RedirectError": {
                     "authUrl": auth_url,
-                    "invalidScope": is_scope_invalid,
                     "errorCode": error_code,
                     "errorDetails": error_details,
                     "canvasScopes": canvas_scopes or [],

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -22,7 +22,6 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
   const {
     OAuth2RedirectError: {
       authUrl = /** @type {string|null} */ (null),
-      invalidScope = false,
       errorCode = /** @type {string|null} */ (null),
       errorDetails = '',
       canvasScopes = /** @type {string[]} */ ([]),
@@ -32,7 +31,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
   const error = { code: errorCode, details: errorDetails };
 
   const title = (() => {
-    if (invalidScope) {
+    if (errorCode === 'canvas_invalid_scope') {
       return 'Developer key scopes missing';
     }
 
@@ -43,12 +42,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
     return 'Authorization failed';
   })();
 
-  const message = (() => {
-    if (invalidScope) {
-      return null;
-    }
-    return 'Something went wrong when authorizing Hypothesis';
-  })();
+  const message = 'Something went wrong when authorizing Hypothesis';
 
   const retry = () => {
     location.href = /** @type {string} */ (authUrl);
@@ -79,7 +73,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
 
   return (
     <Dialog title={title} buttons={buttons}>
-      {invalidScope && (
+      {error.code === 'canvas_invalid_scope' && (
         <Fragment>
           <p>
             A Canvas admin needs to edit {"Hypothesis's"} developer key and add

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -23,7 +23,6 @@ describe('OAuth2RedirectErrorApp', () => {
 
   beforeEach(() => {
     fakeConfig = {
-      invalidScope: false,
       authUrl: null,
       canvasScopes: [],
     };
@@ -40,7 +39,7 @@ describe('OAuth2RedirectErrorApp', () => {
   });
 
   it('shows a scope error if the scope is invalid', () => {
-    fakeConfig.invalidScope = true;
+    fakeConfig.errorCode = 'canvas_invalid_scope';
     fakeConfig.canvasScopes = ['scope_a', 'scope_b'];
 
     const wrapper = renderApp();

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -77,7 +77,8 @@ import { createContext } from 'preact';
  */
 
 /**
- * @typedef {'blackboard_missing_integration'} OAuthErrorCode
+ * @typedef {'blackboard_missing_integration' |
+ *  'canvas_invalid_scope' } OAuthErrorCode
  */
 
 /**
@@ -86,7 +87,6 @@ import { createContext } from 'preact';
  *
  * @typedef OAuthErrorConfig
  * @prop {string|null} authUrl
- * @prop {boolean} invalidScope
  * @prop {string} errorDetails
  * @prop {OAuthErrorCode|null} errorCode
  * @prop {string[]} canvasScopes

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -115,7 +115,9 @@ def oauth2_redirect_error(request):
     request.context.js_config.enable_oauth2_redirect_error_mode(
         auth_route="canvas_api.oauth.authorize",
         error_details=request.params.get("error_description"),
-        is_scope_invalid=request.params.get("error") == "invalid_scope",
+        error_code="canvas_invalid_scope"
+        if request.params.get("error") == "invalid_scope"
+        else None,
         canvas_scopes=FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
     )
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -583,19 +583,17 @@ class TestJSConfigRPCServer:
 
 class TestEnableOAuth2RedirectErrorMode:
     @pytest.mark.parametrize(
-        "error_details,is_scope_invalid,canvas_scopes",
+        "error_details,error_code,canvas_scopes",
         [
-            ("Technical error", True, ["scope_a", "scope_b"]),
-            ("Some error", False, None),
+            ("Technical error", "canvas_invalid_scope", ["scope_a", "scope_b"]),
+            ("Some error", None, None),
         ],
     )
-    def test_scope_error(
-        self, js_config, error_details, is_scope_invalid, canvas_scopes
-    ):
+    def test_scope_error(self, js_config, error_details, error_code, canvas_scopes):
         js_config.enable_oauth2_redirect_error_mode(
             auth_route="auth_route",
+            error_code=error_code,
             error_details=error_details,
-            is_scope_invalid=is_scope_invalid,
             canvas_scopes=canvas_scopes,
         )
 
@@ -603,8 +601,7 @@ class TestEnableOAuth2RedirectErrorMode:
         assert config["mode"] == "oauth2-redirect-error"
         assert config["OAuth2RedirectError"] == {
             "authUrl": "http://example.com/auth?authorization=Bearer%3A+token_value",
-            "invalidScope": is_scope_invalid,
-            "errorCode": None,
+            "errorCode": error_code,
             "errorDetails": error_details,
             "canvasScopes": canvas_scopes if canvas_scopes is not None else [],
         }

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -157,15 +157,15 @@ class TestOAuth2Redirect:
 
 class TestOAuth2RedirectError:
     @pytest.mark.parametrize(
-        "params,invalid_scope",
+        "params,error_code",
         [
-            ({"error": "invalid_scope"}, True),
-            ({"error": "unknown_error"}, False),
-            ({"foo": "bar"}, False),
-            ({"error_description": "Something went wrong"}, False),
+            ({"error": "invalid_scope"}, "canvas_invalid_scope"),
+            ({"error": "unknown_error"}, None),
+            ({"foo": "bar"}, None),
+            ({"error_description": "Something went wrong"}, None),
         ],
     )
-    def test_it_configures_frontend_app(self, pyramid_request, params, invalid_scope):
+    def test_it_configures_frontend_app(self, pyramid_request, params, error_code):
         pyramid_request.params.clear()
         pyramid_request.params.update(params)
         pyramid_request.lti_user = None
@@ -186,8 +186,8 @@ class TestOAuth2RedirectError:
         js_config = pyramid_request.context.js_config
         js_config.enable_oauth2_redirect_error_mode.assert_called_with(
             auth_route="canvas_api.oauth.authorize",
+            error_code=error_code,
             error_details=params.get("error_description"),
-            is_scope_invalid=invalid_scope,
             canvas_scopes=scopes,
         )
 


### PR DESCRIPTION
Small refactor to remove the boolean field and just use an error code


# Testing

- Change the requested scopes at https://github.com/hypothesis/lms/blob/c66700613707002b52309f0e83303e04895346f3/lms/views/api/canvas/authorize.py#L22 (just change one line or modify one to FILES_SCOPES)
- Launch an assignment (eg: https://hypothesis.instructure.com/courses/125/assignments/873) The modal should show up