### PR TITLE
Add `resourcekey` parameter to Google Drive PDF URLs

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -218,6 +218,28 @@ describe('GooglePickerClient', () => {
       });
     });
 
+    it('includes resource key if file has one', async () => {
+      const client = createClient();
+      let result = client.showPicker();
+
+      await fakeGoogleLibs.pickerVisible;
+
+      const pickerLib = fakeGoogleLibs.picker.api;
+      const builder = pickerLib.PickerBuilder();
+      const callback = builder.setCallback.getCall(0).callback;
+
+      callback({
+        action: pickerLib.Action.PICKED,
+        docs: [{ id: 'doc1', resourceKey: 'thekey' }],
+      });
+
+      result = await result;
+      assert.deepEqual(result, {
+        id: 'doc1',
+        url: 'https://drive.google.com/uc?id=doc1&export=download&resourcekey=thekey',
+      });
+    });
+
     it('rejects with a `PickerCanceledError` if the picker is canceled', async () => {
       const client = createClient();
       const result = client.showPicker();


### PR DESCRIPTION
If a user selects a PDF file for an assignment which has a "resource key" associated with it, capture this key from the Google
Picker-provided file metadata and add it to the file download URL as a `resourcekey` query parameter. This mirrors the updated download URL for affected files if you use the "Download" action for the file in the Google Drive UI.

The `resourceKey` field on file objects returned by the picker API is not documented at https://developers.google.com/picker/docs/reference#document but it is present in my testing.

It would still be preferable for us not to generate this URL ourselves, but this commit is an easy incremental change that captures the necessary information for files affected by the security update. I'm going to look into other ways to generate this URL as a follow-up.

----

**Testing:**

1. In Canvas create an assignment by choosing a PDF file from Google Drive which *is affected* by the security update. After configuring the assignment, the URL that is submitted back to Canvas (see the `url` query param in the "URL" field at the bottom of the "Configure external tool" dialog) should have a `resourcekey` parameter.
2. Repeat step 1, but choose a PDF file from Google Drive that *is not affected* by the security update. The URL submitted back to Canvas should not have a `resourcekey` parameter

Additionally the `resourcekey` query parameter can be seen in the client:

<img width="634" alt="Google Drive resourcekey" src="https://user-images.githubusercontent.com/2458/131114873-05c3d198-1ca6-4c86-a28a-ec445faf4a7b.png">

You can find PDF files in Google Drive which are affected by the security update by searching for `is:security_update_applied`. Example PDF: https://drive.google.com/drive/u/0/search?q=is:security_update_applied. Example: https://drive.google.com/file/d/0Bx7aaYEfzIONNGtseEZVV3JBWEU/view?usp=sharing&resourcekey=0-TMgSyIxJsVVArstX-G4Kog.

The URL that is generated for the assignment should match the one that you get if you click the "Download" button in Google Drive.