### PR TITLE
Babel automatic runtime (avoids `import {Fragment, createElement} 'preact';`)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,21 +1,34 @@
 {
   "presets": [
-    ["@babel/preset-react", {
-      "pragma": "createElement"
-    }],
+    [
+      "@babel/preset-react",
+      {
+        "runtime": "automatic",
+        "importSource": "preact"
+      }
+    ],
 
     // Compile JS for browser targets set by `browserslist` key in package.json.
-    ["@babel/preset-env", {
-       "bugfixes": true
-    }]
+    [
+      "@babel/preset-env",
+      {
+        "bugfixes": true
+      }
+    ]
   ],
   "env": {
     "development": {
       "presets": [
-        ["@babel/preset-react", {
-          "development": true,
-          "pragma": "createElement"
-        }]
+        [
+          "@babel/preset-react",
+          {
+            "development": true,
+            "runtime": "automatic",
+            // Use `preact/compat/jsx-dev-runtime` which is an alias for `preact/jsx-runtime`.
+            // See https://github.com/preactjs/preact/issues/2974.
+            "importSource": "preact/compat"
+          }
+        ]
       ]
     }
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,14 +1,15 @@
 {
-  "extends": [
-    "hypothesis",
-    "plugin:jsx-a11y/recommended"
-  ],
+  "extends": ["hypothesis", "plugin:jsx-a11y/recommended"],
   "rules": {
     "prefer-arrow-callback": "error",
     "prefer-const": ["error", { "destructuring": "all" }],
 
     // Handled by Prettier.
     "comma-dangle": "off",
+
+    // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off",
 
     // Prop validation is performed by TypeScript + JSDoc.
     "react/prop-types": "off"

--- a/lms/static/scripts/frontend_apps/components/AuthButton.js
+++ b/lms/static/scripts/frontend_apps/components/AuthButton.js
@@ -1,5 +1,5 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
+
 import { useCallback, useEffect, useRef } from 'preact/hooks';
 
 import AuthWindow from '../utils/AuthWindow';

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { createElement } from 'preact';
 
 import {
   useCallback,

--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -1,5 +1,5 @@
 import { LabeledButton, Modal } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
+
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import { useService, VitalSourceService } from '../services';

--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -5,7 +5,7 @@ import {
   TextInputWithButton,
   Thumbnail,
 } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
+
 import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { useService, VitalSourceService } from '../services';

--- a/lms/static/scripts/frontend_apps/components/Breadcrumbs.js
+++ b/lms/static/scripts/frontend_apps/components/Breadcrumbs.js
@@ -1,5 +1,4 @@
 import { LinkButton } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 
 /**
  * @template Item

--- a/lms/static/scripts/frontend_apps/components/ChapterList.js
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.js
@@ -1,5 +1,3 @@
-import { Fragment, createElement } from 'preact';
-
 import Table from './Table';
 
 /**
@@ -49,10 +47,10 @@ export default function ChapterList({
       onUseItem={onUseChapter}
       selectedItem={selectedChapter}
       renderItem={chapter => (
-        <Fragment>
+        <>
           <td aria-label={chapter.title}>{chapter.title}</td>
           <td>{chapter.page}</td>
-        </Fragment>
+        </>
       )}
     />
   );

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -1,5 +1,4 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
-import { Fragment, createElement } from 'preact';
 import { useContext, useMemo, useState } from 'preact/hooks';
 
 import { Config } from '../config';
@@ -185,7 +184,7 @@ export default function ContentSelector({
   };
 
   return (
-    <Fragment>
+    <>
       {isLoadingIndicatorVisible && <FullScreenSpinner />}
       <div className="ContentSelector__actions">
         <div className="ContentSelector__actions-buttons">
@@ -237,6 +236,6 @@ export default function ContentSelector({
         <div className="u-stretch" />
       </div>
       {dialog}
-    </Fragment>
+    </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/Dialog.js
+++ b/lms/static/scripts/frontend_apps/components/Dialog.js
@@ -2,7 +2,6 @@ import {
   LabeledButton,
   useElementShouldClose,
 } from '@hypothesis/frontend-shared';
-import { createElement, Fragment } from 'preact';
 import { useEffect, useLayoutEffect, useRef } from 'preact/hooks';
 import classNames from 'classnames';
 
@@ -104,7 +103,7 @@ export default function Dialog({
   }, [dialogDescriptionId]);
 
   return (
-    <Fragment>
+    <>
       <div
         className="Dialog__background"
         style={{ zIndex: zIndexScale.dialogBackground }}
@@ -141,6 +140,6 @@ export default function Dialog({
           </div>
         </div>
       </div>
-    </Fragment>
+    </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -1,5 +1,3 @@
-import { createElement } from 'preact';
-
 import ErrorDisplay from './ErrorDisplay';
 import Dialog from './Dialog';
 

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -1,4 +1,3 @@
-import { Fragment, createElement } from 'preact';
 import { useContext } from 'preact/hooks';
 
 import { Config } from '../config';
@@ -34,7 +33,7 @@ export default function ErrorDialogApp() {
   return (
     <Dialog title={title}>
       {error.code === 'reused_tool_guid' && (
-        <Fragment>
+        <>
           This Hypothesis installation&apos;s consumer key appears to have
           already been used on another site. This could be because:
           <ul>
@@ -63,7 +62,7 @@ export default function ErrorDialogApp() {
               .
             </li>
           </ul>
-        </Fragment>
+        </>
       )}
       <ErrorDisplay message={message} error={error} />
     </Dialog>

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -1,5 +1,3 @@
-import { createElement } from 'preact';
-
 /**
  * Generate a `mailto:` URL that prompts to send an email with pre-filled fields.
  *

--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -1,7 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-
 import classnames from 'classnames';
-import { Fragment, createElement } from 'preact';
 
 import Spinner from './Spinner';
 import Table from './Table';
@@ -59,7 +57,7 @@ export default function FileList({
         onSelectItem={onSelectFile}
         onUseItem={onUseFile}
         renderItem={(file, isSelected) => (
-          <Fragment>
+          <>
             <td aria-label={file.display_name} className="FileList__name-col">
               <div className="hyp-u-layout-row--center hyp-u-horizontal-spacing hyp-u-padding--left--2">
                 <SvgIcon
@@ -75,7 +73,7 @@ export default function FileList({
             <td className="FileList__date-col">
               {file.updated_at && formatDate(file.updated_at)}
             </td>
-          </Fragment>
+          </>
         )}
       />
       {!isLoading && files.length === 0 && noFilesMessage}

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -1,5 +1,4 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
-import { Fragment, createElement } from 'preact';
 import {
   useCallback,
   useContext,
@@ -128,7 +127,7 @@ export default function FilePickerApp({ onSubmit }) {
           {content ? (
             <i data-testid="content-summary">{contentDescription(content)}</i>
           ) : (
-            <Fragment>
+            <>
               <p>
                 You can select content for your assignment from one of the
                 following sources:
@@ -137,11 +136,11 @@ export default function FilePickerApp({ onSubmit }) {
                 onSelectContent={selectContent}
                 onError={setErrorInfo}
               />
-            </Fragment>
+            </>
           )}
         </div>
         {content && enableGroupConfig && (
-          <Fragment>
+          <>
             <div className="FilePickerApp__left-col">Group assignment</div>
             <div className="FilePickerApp__right-col">
               <GroupConfigSelector
@@ -158,7 +157,7 @@ export default function FilePickerApp({ onSubmit }) {
                 Continue
               </LabeledButton>
             </div>
-          </Fragment>
+          </>
         )}
         {content && (
           <FilePickerFormFields

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
@@ -1,5 +1,3 @@
-import { Fragment, createElement } from 'preact';
-
 import { contentItemForContent } from '../utils/content-item';
 
 /**
@@ -43,7 +41,7 @@ export default function FilePickerFormFields({
     contentItemForContent(ltiLaunchURL, content, extraParams)
   );
   return (
-    <Fragment>
+    <>
       {Object.entries(formFields).map(([field, value]) => (
         <input key={field} type="hidden" name={field} value={value} />
       ))}
@@ -53,6 +51,6 @@ export default function FilePickerFormFields({
         // view. Used in LMSes where assignments are configured on first launch.
         <input name="document_url" type="hidden" value={content.url} />
       )}
-    </Fragment>
+    </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/FullScreenSpinner.js
+++ b/lms/static/scripts/frontend_apps/components/FullScreenSpinner.js
@@ -1,5 +1,3 @@
-import { createElement } from 'preact';
-
 import Spinner from './Spinner';
 
 /**

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -1,5 +1,4 @@
 import { LabeledCheckbox } from '@hypothesis/frontend-shared';
-import { Fragment, createElement } from 'preact';
 import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
 
 import { Config } from '../config';
@@ -100,7 +99,7 @@ export default function GroupConfigSelector({
   const fetchingGroupSets = !groupSets && !fetchError && useGroupSet;
 
   return (
-    <Fragment>
+    <>
       <div>
         <LabeledCheckbox
           checked={useGroupSet}
@@ -123,17 +122,17 @@ export default function GroupConfigSelector({
           {fetchError && (
             // Currently all fetch errors are handled by attempting to re-authorize
             // and then re-fetch group sets.
-            <Fragment>
+            <>
               <p>Canvas needs your permission to fetch group sets</p>
               <AuthButton
                 authURL={/** @type {string} */ (listGroupSetsAPI.authUrl)}
                 authToken={authToken}
                 onAuthComplete={fetchGroupSets}
               />
-            </Fragment>
+            </>
           )}
           {!fetchError && (
-            <Fragment>
+            <>
               <label htmlFor={selectID}>Group set: </label>
               <select
                 disabled={fetchingGroupSets}
@@ -148,7 +147,7 @@ export default function GroupConfigSelector({
               >
                 {fetchingGroupSets && <option>Fetching group sets…</option>}
                 {groupSets && (
-                  <Fragment>
+                  <>
                     <option disabled selected={groupSet === null}>
                       Select group set
                     </option>
@@ -163,13 +162,13 @@ export default function GroupConfigSelector({
                         {gs.name}
                       </option>
                     ))}
-                  </Fragment>
+                  </>
                 )}
               </select>
-            </Fragment>
+            </>
           )}
         </div>
       )}
-    </Fragment>
+    </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -1,5 +1,4 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
-import { createElement, Fragment } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import { APIError, apiCall } from '../utils/api';
@@ -332,7 +331,7 @@ export default function LMSFilePicker({
       {warningOrError}
 
       {['reloading', 'fetched'].includes(dialogState.state) && (
-        <Fragment>
+        <>
           {withBreadcrumbs && (
             <Breadcrumbs
               items={folderPath}
@@ -353,7 +352,7 @@ export default function LMSFilePicker({
               />
             }
           />
-        </Fragment>
+        </>
       )}
     </Dialog>
   );

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
 import StudentSelector from './StudentSelector';

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -1,5 +1,5 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
+
 import { useRef } from 'preact/hooks';
 
 import Dialog from './Dialog';

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -1,5 +1,4 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
-import { Fragment, createElement } from 'preact';
 import { useContext } from 'preact/hooks';
 
 import { Config } from '../config';
@@ -74,7 +73,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
   return (
     <Dialog title={title} buttons={buttons}>
       {error.code === 'canvas_invalid_scope' && (
-        <Fragment>
+        <>
           <p>
             A Canvas admin needs to edit {"Hypothesis's"} developer key and add
             these scopes:
@@ -97,11 +96,11 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
             </a>
             .
           </p>
-        </Fragment>
+        </>
       )}
 
       {error.code === 'blackboard_missing_integration' && (
-        <Fragment>
+        <>
           <p>
             In order to allow Hypothesis to connect to files in Blackboard, your
             Blackboard admin needs to add or enable a REST API integration.
@@ -117,7 +116,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
             </a>
             .
           </p>
-        </Fragment>
+        </>
       )}
       <ErrorDisplay message={message} error={error} />
     </Dialog>

--- a/lms/static/scripts/frontend_apps/components/Spinner.js
+++ b/lms/static/scripts/frontend_apps/components/Spinner.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 
 /**
  * @typedef SpinnerProps

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 
 /**
  * @typedef Student

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -1,5 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
+
 import classNames from 'classnames';
 import { useEffect, useLayoutEffect, useState, useRef } from 'preact/hooks';
 

--- a/lms/static/scripts/frontend_apps/components/Table.js
+++ b/lms/static/scripts/frontend_apps/components/Table.js
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
+
 import { useRef } from 'preact/hooks';
 
 import Spinner from './Spinner';

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -1,5 +1,5 @@
 import { LabeledButton } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
+
 import { useRef } from 'preact/hooks';
 
 import Dialog from './Dialog';

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import classNames from 'classnames';
 

--- a/lms/static/scripts/frontend_apps/components/VitalSourceBookViewer.js
+++ b/lms/static/scripts/frontend_apps/components/VitalSourceBookViewer.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 
 /**

--- a/lms/static/scripts/frontend_apps/components/test/AuthButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AuthButton-test.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
+
 import { act } from 'preact/test-utils';
 
 import AuthButton, { $imports } from '../AuthButton';

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
+
 import { act } from 'preact/test-utils';
 
 import { Config } from '../../config';

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
+
 import { act } from 'preact/test-utils';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';

--- a/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import { waitFor, waitForElement } from '../../../test-util/wait';
 import { VitalSourceService, withServices } from '../../services';

--- a/lms/static/scripts/frontend_apps/components/test/Breadcrumbs-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Breadcrumbs-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import Breadcrumbs from '../Breadcrumbs';
 

--- a/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import ChapterList from '../ChapterList';
 

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable new-cap */
 
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
+
 import { act } from 'preact/test-utils';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';

--- a/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Dialog-test.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import { createElement, createRef } from 'preact';
+import { createRef } from 'preact';
 
 import Dialog from '../Dialog';
 import { checkAccessibility } from '../../../test-util/accessibility';

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import ErrorDialog, { $imports } from '../ErrorDialog';

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import { Config } from '../../config';
 

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import ErrorDisplay, { $imports } from '../ErrorDisplay';

--- a/lms/static/scripts/frontend_apps/components/test/FileList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FileList-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import FileList, { $imports } from '../FileList';
 import { checkAccessibility } from '../../../test-util/accessibility';

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -1,6 +1,5 @@
 /* eslint-disable new-cap */
 
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 import { mount } from 'enzyme';
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import { contentItemForContent } from '../../utils/content-item';
 

--- a/lms/static/scripts/frontend_apps/components/test/FullScreenSpinner-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FullScreenSpinner-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import FullScreenSpinner from '../FullScreenSpinner';
 

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { waitForElement } from '../../../test-util/wait';

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { Fragment, createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import { APIError } from '../../utils/api';
@@ -11,9 +10,9 @@ import { waitFor, waitForElement } from '../../../test-util/wait';
 describe('LMSFilePicker', () => {
   // eslint-disable-next-line react/prop-types
   const FakeDialog = ({ buttons, children }) => (
-    <Fragment>
+    <>
       {buttons} {children}
-    </Fragment>
+    </>
   );
 
   let fakeApiCall;

--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -1,5 +1,5 @@
 import { act } from 'preact/test-utils';
-import { createElement } from 'preact';
+
 import { mount } from 'enzyme';
 
 import LMSGrader, { $imports } from '../LMSGrader';

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
+
 import { act } from 'preact/test-utils';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import { Config } from '../../config';
 

--- a/lms/static/scripts/frontend_apps/components/test/Spinner-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Spinner-test.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import Spinner from '../Spinner';

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import StudentSelector, { $imports } from '../StudentSelector';

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../test-util/accessibility';

--- a/lms/static/scripts/frontend_apps/components/test/Table-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/Table-test.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import Table from '../Table';

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -1,4 +1,3 @@
-import { Fragment, createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import URLPicker, { $imports } from '../URLPicker';
@@ -7,9 +6,9 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 describe('URLPicker', () => {
   // eslint-disable-next-line react/prop-types
   const FakeDialog = ({ buttons, children }) => (
-    <Fragment>
+    <>
       {buttons} {children}
-    </Fragment>
+    </>
   );
   const renderUrlPicker = (props = {}) => mount(<URLPicker {...props} />);
 

--- a/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import ValidationMessage, { $imports } from '../ValidationMessage';

--- a/lms/static/scripts/frontend_apps/components/test/VitalSourceBookViewer-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/VitalSourceBookViewer-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import VitalSourceBookViewer from '../VitalSourceBookViewer';
 

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -1,5 +1,5 @@
 import 'focus-visible';
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 
 import { readConfig, Config } from './config';
 import BasicLTILaunchApp from './components/BasicLTILaunchApp';

--- a/lms/static/scripts/frontend_apps/services/index.js
+++ b/lms/static/scripts/frontend_apps/services/index.js
@@ -1,4 +1,4 @@
-import { createContext, createElement } from 'preact';
+import { createContext } from 'preact';
 import { useContext, useMemo } from 'preact/hooks';
 
 export { ClientRPC } from './client-rpc';

--- a/lms/static/scripts/frontend_apps/services/test/index-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/index-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import { Services, useService, withServices } from '../index';
 

--- a/lms/static/scripts/frontend_apps/utils/test/hooks-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/hooks-test.js
@@ -1,4 +1,4 @@
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 
 import { useUniqueId } from '../hooks';
 

--- a/lms/static/scripts/tsconfig.json
+++ b/lms/static/scripts/tsconfig.json
@@ -3,17 +3,13 @@
     "allowJs": true,
     "checkJs": true,
     "lib": ["es2018", "dom"],
-    "jsx": "react",
-    "jsxFactory": "createElement",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "module": "commonjs",
     "noEmit": true,
     "strict": true,
     "target": "ES2020"
   },
-  "include": [
-    "frontend_apps/**/*.js"
-  ],
-  "exclude": [
-    "frontend_apps/**/test/*.js"
-  ]
+  "include": ["frontend_apps/**/*.js"],
+  "exclude": ["frontend_apps/**/test/*.js"]
 }


### PR DESCRIPTION
This PR enables Babel `"runtime": "automatic"`. This features auto imports the functions that JSX transpiles to.

These are some advantages of enabling this option:
- improve ergonomics: no need to import createElement and Fragment from preact
- potentially an improvement in the bundle size, although not in our particular case (it has not impact)
- promotes the use of the Fragment shorter syntax, `<></>`

Identical to the `client` conversion in https://github.com/hypothesis/client/pull/2956
