### PR TITLE
Fix missing test coverage on services/oauth2_token.

### DIFF
--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -58,14 +58,15 @@ class TestOAuth2TokenService:
     def oauth_token_in_db_or_not(
         self, request, db_session, lti_user, application_instance
     ):
-        """Get an OAuthToken which either is, or isn't in the DB."""
-        oauth_token = factories.OAuth2Token.build(
-            user_id=lti_user.user_id,
-            consumer_key=application_instance.consumer_key,
-            application_instance=application_instance,
-        )
-
+        """Get an OAuthToken or None based on the fixture params."""
+        oauth_token = None
         if request.param:
+            oauth_token = factories.OAuth2Token.build(
+                user_id=lti_user.user_id,
+                consumer_key=application_instance.consumer_key,
+                application_instance=application_instance,
+            )
+
             db_session.add(oauth_token)
 
         return oauth_token


### PR DESCRIPTION
This was broken inadvertently on b08857160cfedee385bb4937c79e15cc263e3ab0,
the sqla fix had the effect of, as stated in the removed comment, always
adding the object to the session and missing the creating part of save().

`oauth_token_in_db_or_not` is only used in this test and it doesn't need
the not in the DB OAuth2Token object so the fixture is changed to return
None instead of a not yet added to the session object.

Another alternative could be splitting the test into two explicit tests, one for each get/create paths of save. 

