### PR TITLE
Fix missing test coverage for lms.assets

### DIFF
--- a/tests/unit/lms/assets_test.py
+++ b/tests/unit/lms/assets_test.py
@@ -1,0 +1,8 @@
+from lms.assets import includeme
+
+
+def test_includeme(pyramid_config):
+    includeme(pyramid_config)
+
+    assets_env = pyramid_config.registry["assets_env"]
+    assert assets_env.assets_base_url == "/assets"


### PR DESCRIPTION
Another bit of coverage missing. 

This is a bit light on asserts. Not sure what's important here https://github.com/hypothesis/lms/blob/70f52f90cac40658e74ad0103205a0a2aa012996/lms/assets.py that might be worth explicilty testing for. 

Before most of this file was move to `h_assets` the include had a `no cover`.