### PR TITLE
Refactor LMSFilePicker internal state

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -60,22 +60,41 @@ function NoFilesMessage({ href, inSubfolder }) {
  */
 
 /**
- * @typedef DialogState
- * @prop {'fetching'|'reloading'|'fetched'|'authorizing'|'error'} state
- * @prop {string} title - Dialog title
- * @prop {'select'|'authorize'|'authorize_retry'|'retry'|'reload'} continueAction - Action for the continue button
- * @prop {File[]|null} files - List of fetched files
- * @prop {Error|null} error - Details of current error, if `state` is 'error'
+ * @typedef FetchingState
+ * @prop {'fetching'} state
+ * @prop {boolean} isReload - Flag indicating that files are being re-fetched after clicking "Reload"
+ *
+ * @typedef FetchedState
+ * @prop {'fetched'} state
+ * @prop {File[]} files
+ *
+ * @typedef AuthorizingState
+ * @prop {'authorizing'} state
+ * @prop {boolean} isRetry - Flag indicating that authorization has previously
+ *  been attempted
+ *
+ * @typedef ErrorState
+ * @prop {'error'} state
+ * @prop {Error} error
+ *
+ * @typedef {FetchingState|FetchedState|AuthorizingState|ErrorState} LMSFilePickerState
  */
 
-/** @type {DialogState} */
-const INITIAL_DIALOG_STATE = {
-  state: 'fetching',
-  title: 'Select a file',
-  continueAction: 'select',
-  files: null,
-  error: null,
-};
+/**
+ * @typedef AuthorizeAction
+ * @prop {'authorize'} type
+ * @prop {string} label
+ *
+ * @typedef ReloadAction
+ * @prop {'reload'} type
+ *
+ * @typedef SelectAction
+ * @prop {'select'} type
+ * @prop {string} label
+ * @prop {boolean} disabled
+ *
+ * @typedef {AuthorizeAction|ReloadAction|SelectAction} ContinueAction
+ */
 
 /**
  * A file picker dialog that allows the user to choose files from their
@@ -94,13 +113,13 @@ export default function LMSFilePicker({
   missingFilesHelpLink,
   withBreadcrumbs = false,
 }) {
-  // The main state of the dialog and associated data.
-  const [dialogState, setDialogState] = useState(INITIAL_DIALOG_STATE);
+  const [dialogState, setDialogState] = useState(
+    /** @type {LMSFilePickerState} */ ({ state: 'fetching', isReload: false })
+  );
 
-  // Authorization attempt was made. Set after state transitions to "authorizing".
-  const [authorizationAttempted, setAuthorizationAttempted] = useState(false);
+  // Has the first attempt to fetch the list of files in the LMS completed?
+  const [initialFetch, setInitialFetch] = useState(true);
 
-  // The file or folder within `files` which is currently selected.
   const [selectedFile, setSelectedFile] = useState(
     /** @type {File|null} */ (null)
   );
@@ -126,6 +145,7 @@ export default function LMSFilePicker({
    * @param {File} folder
    */
   const onChangePath = folder => {
+    setSelectedFile(null);
     const currentIndex = folderPath.findIndex(file => file.id === folder.id);
     if (currentIndex >= 0) {
       // If the selected folder is already in the path, remove any entries
@@ -138,88 +158,43 @@ export default function LMSFilePicker({
   };
 
   // Fetches files or shows a prompt to authorize access.
-  const fetchFiles = useCallback(async () => {
-    const getNextAPICallInfo = () => {
-      return folderPath[folderPath.length - 1]?.contents || listFilesApi;
-    };
-    try {
-      // Show the fetching state, but preserve the existing continueAction to
-      // prevent the button label changing. See:
-      // https://github.com/hypothesis/lms/pull/2219#issuecomment-721833947
-      setDialogState(({ continueAction, state }) => {
-        // Determine the appropriate state to move to. If files have been
-        // fetched, or a reload is indicated by continueAction, put the dialog
-        // in a "reloading" state instead of a (fresh) "fetching" state. This
-        // applies the appropriate loading state while the fetch request is in
-        // flight.
-        const nextState =
-          state === 'fetched' ||
-          state === 'reloading' ||
-          continueAction === 'reload'
-            ? 'reloading'
-            : 'fetching';
-        return {
-          ...INITIAL_DIALOG_STATE,
-          state: nextState,
-          continueAction,
-        };
-      });
-
-      const files = /** @type {File[]} */ (
-        await apiCall({
-          authToken,
-          path: getNextAPICallInfo().path,
-        })
-      );
-
-      // Handle the case in which a subsequent fetch request for a
-      // different path's files was dispatched before this request resolved.
-      // Give preference to the later request: If the path has changed
-      // since this request was made, ignore the results of this request.
-      let pathChanged = false;
-      setFolderPath(path => {
-        pathChanged = path !== folderPath;
-        return path;
-      });
-      if (pathChanged) {
-        return;
-      }
-
-      const continueAction =
-        files.length === 0 ? 'reload' : INITIAL_DIALOG_STATE.continueAction;
-      setDialogState({
-        ...INITIAL_DIALOG_STATE,
-        state: 'fetched',
-        files,
-        continueAction,
-      });
-    } catch (e) {
-      if (e instanceof APIError && !e.errorMessage) {
-        const continueAction = authorizationAttempted
-          ? 'authorize_retry'
-          : 'authorize';
-
-        // If the server returned an error, but provided no details, assume
-        // an authorization failure.
-        setDialogState({
-          ...INITIAL_DIALOG_STATE,
-          state: 'authorizing',
-          title: 'Allow file access',
-          continueAction,
+  const fetchFiles = useCallback(
+    async (isReload = false) => {
+      const getNextAPICallInfo = () => {
+        return folderPath[folderPath.length - 1]?.contents || listFilesApi;
+      };
+      try {
+        setDialogState({ state: 'fetching', isReload });
+        const files = /** @type {File[]} */ (
+          await apiCall({
+            authToken,
+            path: getNextAPICallInfo().path,
+          })
+        );
+        // Handle the case in which a subsequent fetch request for a
+        // different path's files was dispatched before this request resolved.
+        // Give preference to the later request: If the path has changed
+        // since this request was made, ignore the results of this request.
+        let pathChanged = false;
+        setFolderPath(path => {
+          pathChanged = path !== folderPath;
+          return path;
         });
-        setAuthorizationAttempted(true);
-      } else {
-        // Otherwise, display the error to the user.
-        setDialogState({
-          ...INITIAL_DIALOG_STATE,
-          state: 'error',
-          title: 'Error accessing files',
-          error: e,
-          continueAction: 'retry',
-        });
+        if (pathChanged) {
+          return;
+        }
+        setDialogState({ state: 'fetched', files });
+      } catch (error) {
+        if (error instanceof APIError && !error.errorMessage) {
+          setDialogState({ state: 'authorizing', isRetry: isReload });
+        } else {
+          setDialogState({ state: 'error', error });
+        }
       }
-    }
-  }, [authToken, folderPath, authorizationAttempted, listFilesApi]);
+      setInitialFetch(false);
+    },
+    [authToken, folderPath, listFilesApi]
+  );
 
   // Update the file list any time the path changes
   useEffect(() => {
@@ -239,111 +214,114 @@ export default function LMSFilePicker({
     }
   };
 
-  const options = {
-    select: {
-      continueButton: (
+  /** @type {ContinueAction} */
+  let continueAction;
+
+  switch (dialogState.state) {
+    case 'fetching':
+      continueAction = {
+        type: 'select',
+
+        // When the user clicks the "Reload" button, we maintain the button label
+        // until the file list is fetched.
+        label: dialogState.isReload ? 'Reload' : 'Select',
+        disabled: true,
+      };
+      break;
+    case 'fetched':
+      if (dialogState.files.length === 0) {
+        continueAction = { type: 'reload' };
+      } else {
+        continueAction = {
+          type: 'select',
+          label: 'Select',
+          disabled: selectedFile === null,
+        };
+      }
+      break;
+    case 'authorizing':
+      continueAction = {
+        type: 'authorize',
+        label: dialogState.isRetry ? 'Try again' : 'Authorize',
+      };
+      break;
+    case 'error':
+      continueAction = {
+        type: 'authorize',
+        label: 'Try again',
+      };
+      break;
+  }
+
+  let continueButton;
+  switch (continueAction.type) {
+    case 'authorize':
+      continueButton = (
+        <AuthButton
+          authURL={/** @type {string} */ (listFilesApi.authUrl)}
+          authToken={authToken}
+          label={continueAction.label}
+          onAuthComplete={() => fetchFiles(true /* reload */)}
+        />
+      );
+      break;
+    case 'reload':
+      continueButton = (
         <LabeledButton
           variant="primary"
-          disabled={selectedFile === null}
-          onClick={() => confirmSelectedItem()}
-          data-testid="select"
-        >
-          Select
-        </LabeledButton>
-      ),
-      warningOrError: null,
-    },
-    authorize: {
-      continueButton: (
-        <AuthButton
-          authURL={/** @type {string} */ (listFilesApi.authUrl)}
-          authToken={authToken}
-          onAuthComplete={fetchFiles}
-        />
-      ),
-      warningOrError: (
-        <p data-testid="authorization warning">
-          To select a file, you must authorize Hypothesis to access your files.
-        </p>
-      ),
-    },
-    authorize_retry: {
-      continueButton: (
-        <AuthButton
-          authURL={/** @type {string} */ (listFilesApi.authUrl)}
-          authToken={authToken}
-          label="Try again"
-          onAuthComplete={fetchFiles}
-          data-testid="try-again"
-        />
-      ),
-      warningOrError: (
-        <ErrorDisplay
-          message={'Failed to authorize file access'}
-          error={new Error('')}
-        />
-      ),
-    },
-    retry: {
-      continueButton: (
-        <AuthButton
-          authURL={/** @type {string} */ (listFilesApi.authUrl)}
-          authToken={authToken}
-          label="Try again"
-          onAuthComplete={fetchFiles}
-          data-testid="try-again"
-        />
-      ),
-      warningOrError: (
-        <ErrorDisplay
-          message="There was a problem fetching files"
-          error={/** @type {Error} */ (dialogState.error)}
-        />
-      ),
-    },
-    reload: {
-      continueButton: (
-        <LabeledButton
-          disabled={dialogState.state === 'reloading'}
-          onClick={fetchFiles}
-          variant="primary"
+          onClick={() => fetchFiles(true /* reload */)}
           data-testid="reload"
         >
           Reload
         </LabeledButton>
-      ),
-      warningOrError: null,
-    },
-  };
+      );
+      break;
+    case 'select':
+      continueButton = (
+        <LabeledButton
+          variant="primary"
+          disabled={continueAction.disabled}
+          onClick={() => confirmSelectedItem()}
+          data-testid="select"
+        >
+          {continueAction.label}
+        </LabeledButton>
+      );
+      break;
+  }
 
-  const { continueButton, warningOrError } =
-    options[dialogState.continueAction];
+  const withFileUI = ['fetching', 'fetched'].includes(dialogState.state);
 
-  // During the first fetch and load, we don't know yet whether we'll have
-  // success fetching files, or whether we'll need auth'z or hit another
-  // error. To avoid hopscotching between modals, show only
-  // a full-screen spinner during this state.
-  const isLoading = dialogState.state === 'fetching';
-  // During subsequent file/folder fetches, represent the loading state within
-  // the file list UI (do not show a full-screen spinner)
-  const isReloading = dialogState.state === 'reloading';
-  // Render the file list and breadcrumbs UI in certain states. This also
-  // requires more real estate in the <Modal>, and applies an appropriate CSS
-  // class
-  const withFileUI = ['reloading', 'fetched'].includes(dialogState.state);
-
-  if (isLoading) {
+  if (dialogState.state === 'fetching' && initialFetch) {
     return <FullScreenSpinner />;
   }
 
   return (
     <Modal
       contentClass={withFileUI ? 'LMSFilePicker' : ''}
-      title={dialogState.title}
+      title="Select file"
       onCancel={onCancel}
       buttons={continueButton}
     >
-      {warningOrError}
+      {dialogState.state === 'authorizing' && (
+        <p data-testid="authorization warning">
+          {dialogState.isRetry ? (
+            <span>Unable to authorize file access.</span>
+          ) : (
+            <span>
+              To select a file, you must authorize Hypothesis to access your
+              files.
+            </span>
+          )}
+        </p>
+      )}
+
+      {dialogState.state === 'error' && (
+        <ErrorDisplay
+          message="There was a problem fetching files"
+          error={/** @type {Error} */ (dialogState.error)}
+        />
+      )}
 
       {withFileUI && (
         <>
@@ -355,8 +333,8 @@ export default function LMSFilePicker({
             />
           )}
           <FileList
-            files={dialogState.files ?? []}
-            isLoading={isReloading}
+            files={dialogState.state === 'fetched' ? dialogState.files : []}
+            isLoading={dialogState.state === 'fetching'}
             selectedFile={selectedFile}
             onUseFile={confirmSelectedItem}
             onSelectFile={setSelectedFile}


### PR DESCRIPTION
This PR refactors the `LMSFilePicker` component's internal state to make them more clearly typed, extensible and comprehensible. This work builds on @robertknight 's initial refactor spike here: https://github.com/hypothesis/lms/pull/2736

This primarily follows the lead in https://github.com/hypothesis/lms/pull/2736 with a few tweaks:

* There was a state/action combination missing from what was previously called "auth_retry". This state represents the situation in which a user has been prompted for authz and goes through that flow but we're still unable to fetch files in a way that looks to us like an authz failure. In this state, the user should see different text in the authorization messaging. I've added this by adding a prop to `AuthorizingState` (`isRetry`) and hooking into the `isReload` parameter to the `fetchFiles` function.
* I've reworked a few tests to (I hope) make them just a bit easier to, as Rob would say, "reason about in future"

Fixes https://github.com/hypothesis/lms/issues/3021
