### PR TITLE
Update ChapterList to use shared Table component

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -1,3 +1,5 @@
+import classnames from 'classnames';
+
 import { LabeledButton, Modal } from '@hypothesis/frontend-shared';
 
 import { useCallback, useEffect, useState } from 'preact/hooks';
@@ -77,6 +79,9 @@ export default function BookPicker({ onCancel, onSelectBook }) {
       // sub-components
       initialFocus={null}
       onCancel={onCancel}
+      contentClass={classnames('BookPicker', {
+        'BookPicker--select-chapter': step === 'select-chapter',
+      })}
       title={
         step === 'select-book'
           ? 'Paste link to VitalSource book'

--- a/lms/static/scripts/frontend_apps/components/ChapterList.js
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.js
@@ -1,4 +1,4 @@
-import Table from './Table';
+import { Table } from '@hypothesis/frontend-shared';
 
 /**
  * @typedef {import('../api-types').Chapter} Chapter
@@ -34,13 +34,15 @@ export default function ChapterList({
     },
     {
       label: 'Page',
+      classes: 'ChapterList__page-heading',
     },
   ];
 
   return (
     <Table
       accessibleLabel="Table of Contents"
-      columns={columns}
+      classes="ChapterList"
+      tableHeaders={columns}
       isLoading={isLoading}
       items={chapters}
       onSelectItem={onSelectChapter}

--- a/lms/static/styles/components/_BookPicker.scss
+++ b/lms/static/styles/components/_BookPicker.scss
@@ -1,0 +1,12 @@
+.BookPicker {
+  // The containing `Modal` component will take up 90vw on narrow screens.
+  // For viewports that are wider, `Modal` sets a min-width, but it's a little
+  // narrow for this particular interface. The book-selector feels about right
+  // at 36em where space allows. 42em minimum here allows for at least 3em
+  // of horizontal breathing room on each side of the modal's contents.
+  width: min(90vw, 42rem);
+}
+
+.BookPicker--select-chapter {
+  height: min(90vh, 25rem);
+}

--- a/lms/static/styles/components/_BookSelector.scss
+++ b/lms/static/styles/components/_BookSelector.scss
@@ -1,13 +1,4 @@
 .BookSelector {
-  // The containing `Modal` component will take up 90vw on narrow screens.
-  // For viewports that are wider, `Modal` sets a min-width, but it's a little
-  // narrow for this particular interface. The book-selector feels about right
-  // at 36em where space allows. 42em minimum here allows for at least 3em
-  // of horizontal breathing room on each side of the modal's contents.
-  @media screen and (min-width: 42rem) {
-    min-width: 36rem;
-  }
-
   &__thumbnail {
     width: 110px;
     height: 150px;

--- a/lms/static/styles/components/_ChapterList.scss
+++ b/lms/static/styles/components/_ChapterList.scss
@@ -1,0 +1,5 @@
+.ChapterList {
+  & &__page-heading {
+    width: 8em;
+  }
+}

--- a/lms/static/styles/frontend_apps.scss
+++ b/lms/static/styles/frontend_apps.scss
@@ -14,7 +14,9 @@
 
 // Preact components
 @use 'components/BasicLTILaunchApp';
+@use 'components/BookPicker';
 @use 'components/BookSelector';
+@use 'components/ChapterList';
 @use 'components/Breadcrumbs';
 @use 'components/ContentSelector';
 @use 'components/Dialog';


### PR DESCRIPTION
Update ChapterList to use a shared Table component, which standardizes
the loading state as well. Update some styling to set some dimensions
on the related modals.

Before, Blackboard:

![before-blackboard](https://user-images.githubusercontent.com/439947/132744741-471dfa25-8edf-4848-8419-d6f6021d91b4.gif)

After, Blackboard:

![after-blackboard](https://user-images.githubusercontent.com/439947/132744758-0fb28563-69aa-4d1d-9e09-18af21c9c857.gif)

Before, Canvas:

![before-canvas](https://user-images.githubusercontent.com/439947/132744778-f653c24f-4b9e-4c5b-b145-13ad80f0e234.gif)

After, Canvas:

![after-canvas](https://user-images.githubusercontent.com/439947/132744786-f139571d-7048-40f2-9305-ad1c8edcbd35.gif)


Fixes #3096

### To test

1. Check out and run this branch.
2. Enable VitalSource feature flag by visiting http://localhost:8001/flags

#### Blackboard

1. Log in to https://aunltd-test.blackboard.com/ as `blackboardteacher`
2. Create a new assignment in [this course](https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline) (Content -> Build Content -> Hypothesis, localhost, make devdata) (All you need to do is give it a name and click Submit)
3. Launch the unconfigured assignment and click the “Select book from VitalSource” button.

#### Canvas

1. Go to the [Sections Enabled course](https://hypothesis.instructure.com/courses/125/) (Log in as eng+canvasteacher@hypothes.is)
2. In the “scratch” assignments area, add a new assignment or launch and reconfigure (“Edit Assignment Settings”) an existing assignment. The assignment’s “External Tool” needs to be configured to use the “localhost” install. A bit more info on this is [available here](https://github.com/hypothesis/lms/wiki/Testing-the-LTI-App-in-Canvas)
3. In the “External Tool” configuration, click the “Select book from VitalSource” button.
