### PR TITLE
Make it possible to run `make run-docker` and get a functioning system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,28 +105,7 @@ docker:
 
 .PHONY: run-docker
 run-docker:
-	# To run the Docker container locally, first build the Docker image using
-	# `make docker` and then set the environment variables below to appropriate
-	# values (see conf/development.ini for non-production quality examples).
-	@docker run \
-		--net lms_default \
-		-e DATABASE_URL=postgresql://postgres@postgres/postgres \
-		-e FEATURE_FLAGS_COOKIE_SECRET \
-		-e H_API_URL_PRIVATE \
-		-e H_API_URL_PUBLIC \
-		-e H_AUTHORITY \
-		-e H_CLIENT_ID \
-		-e H_CLIENT_SECRET  \
-		-e H_JWT_CLIENT_ID \
-		-e H_JWT_CLIENT_SECRET \
-		-e JWT_SECRET \
-		-e LMS_SECRET \
-		-e RPC_ALLOWED_ORIGINS \
-		-e VIA_URL \
-		-e SESSION_COOKIE_SECRET \
-		-e OAUTH2_STATE_SECRET \
-		-p 8001:8001 \
-		hypothesis/lms:$(DOCKER_TAG)
+	@tox -e dockercompose -- up --force-recreate web
 
 .PHONY: backend-lint
 backend-lint: python

--- a/bin/dev_host_bridge.sh
+++ b/bin/dev_host_bridge.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Write the network of the host to the /etc/hosts file if "host.docker.internal"
+# is not supported on the system.
+# From: https://dev.to/bufferings/access-host-from-a-docker-container-4099
+
+# Check if we are on a supported system
+HOST_DOMAIN="host.docker.internal"
+ping -q -c1 $HOST_DOMAIN > /dev/null 2>&1
+
+# If not, then write find our IP and map "host.docker.internal" to it
+if [ $? -ne 0 ]; then
+  HOST_IP=$(ip route | awk 'NR==1 {print $3}')
+  echo -e "$HOST_IP\t$HOST_DOMAIN" >> /etc/hosts
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+
 services:
   postgres:
     image: postgres:11.5-alpine
@@ -7,3 +8,24 @@ services:
     healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
         interval: 1s
+
+  web:
+    image: hypothesis/lms:dev
+    profiles: ["web"]
+    ports:
+      - '127.0.0.1:8001:8001'
+    # Unfortunately if we don't run as root `dev_host_bridge.sh` doesn't work
+    user: root
+    command: /bin/sh -c "/var/lib/lms/bin/dev_host_bridge.sh && bin/init-env supervisord -c conf/supervisord.conf"
+    env_file: .devdata.env
+    environment:
+      - DATABASE_URL=postgresql://postgres@lms_postgres_1/postgres
+      - FEATURE_FLAGS_COOKIE_SECRET=not_a_secret
+      - H_API_URL_PRIVATE=http://host.docker.internal:5000/api/
+      - H_API_URL_PUBLIC=http://localhost:5000/api/
+      - H_AUTHORITY=lms.hypothes.is
+      - RPC_ALLOWED_ORIGINS=http://localhost:5000
+      - VIA_URL=http://localhost:9083
+      - VIA_SECRET=not_a_secret
+      - SESSION_COOKIE_SECRET=notasecret
+      - OAUTH2_STATE_SECRET=notasecret


### PR DESCRIPTION
Currently in LMS the `make run-docker` command doesn't work and contains instructions saying you should fill out all the environment variables.

Even if you do this, there's no route by default from the container to the host, so it wouldn't work. 

This attempts to automate the process by filling in some values and loading directly from devdata. It turns out (after many blind alleys), that `docker-compose` is completely setup to read directly from our env file already. Which is nice. We then steal some tricks from ViaHTML to get a stable name for the host IP.

## Testing notes

 * `make devdata`
 * `make docker`
 * `make run-docker`
 * Start all the other services
 * Visit some testing assignments

You should now have a functioning LMS instance hopefully