### PR TITLE
Reset iframe border to simple Hypothesis border

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -296,7 +296,7 @@ export default function BasicLTILaunchApp() {
     />
   ) : (
     <iframe
-      className="BasicLTILaunchApp__iframe"
+      className="BasicLTILaunchApp__iframe hyp-u-border"
       src={contentUrl || ''}
       title="Course content with Hypothesis annotation viewer"
     />


### PR DESCRIPTION
Override browser `iframe` styling defaults (inset border, etc.) with
Hypothesis-standard border