### PR TITLE
Migration for new ext_lti_assignment_id column

### DIFF
--- a/lms/migrations/versions/a58605fdd398_add_ext_lti_assignment_id.py
+++ b/lms/migrations/versions/a58605fdd398_add_ext_lti_assignment_id.py
@@ -1,0 +1,58 @@
+"""
+Adds module_item_configurations.ext_lti_assignment_id and a new CHECK constraint.
+
+Revision ID: a58605fdd398
+Revises: d9c9e65c463e
+Create Date: 2021-09-17 07:59:11.487484
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a58605fdd398"
+down_revision = "d9c9e65c463e"
+
+
+def upgrade():
+    op.add_column(
+        "module_item_configurations",
+        sa.Column("ext_lti_assignment_id", sa.UnicodeText(), nullable=True),
+    )
+    op.alter_column(
+        "module_item_configurations",
+        "resource_link_id",
+        existing_type=sa.VARCHAR(),
+        nullable=True,
+    )
+    op.create_unique_constraint(
+        op.f("uq__module_item_configurations__tool_consumer_instance_guid"),
+        "module_item_configurations",
+        ["tool_consumer_instance_guid", "ext_lti_assignment_id"],
+    )
+
+    op.create_check_constraint(
+        "nullable_resource_link_id_ext_lti_assignment_id",
+        table_name="module_item_configurations",
+        condition="NOT(resource_link_id IS NULL AND ext_lti_assignment_id IS NULL)",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("uq__module_item_configurations__tool_consumer_instance_guid"),
+        "module_item_configurations",
+        type_="unique",
+    )
+    op.alter_column(
+        "module_item_configurations",
+        "resource_link_id",
+        existing_type=sa.VARCHAR(),
+        nullable=False,
+    )
+    op.drop_constraint(
+        "nullable_resource_link_id_ext_lti_assignment_id",
+        table_name="module_item_configurations",
+        type_="check",
+    )
+    op.drop_column("module_item_configurations", "ext_lti_assignment_id")


### PR DESCRIPTION
For #2527

Generated from model changes in https://github.com/hypothesis/lms/pull/3118

Test migrating forward and backwards:

- `hdev alembic upgrade head`
- `hdev alembic downgrade d9c9e65c463e`

and check the output of `\d module_item_configurations` on `make sql`'s prompt