### PR TITLE
Assignment service uses new ext_lti_assignment_id column

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -1,6 +1,9 @@
+import logging
 from functools import lru_cache
 
 from lms.models import Assignment
+
+log = logging.getLogger(__name__)
 
 
 class AssignmentService:
@@ -10,54 +13,120 @@ class AssignmentService:
         self._db = db
 
     @lru_cache(maxsize=128)
-    def get(self, tool_consumer_instance_guid, resource_link_id):
-        return (
-            self._db.query(Assignment)
-            .filter_by(
-                tool_consumer_instance_guid=tool_consumer_instance_guid,
-                resource_link_id=resource_link_id,
-            )
-            .one_or_none()
+    def get(
+        self,
+        tool_consumer_instance_guid,
+        resource_link_id=None,
+        ext_lti_assignment_id=None,
+    ):
+        """Get an assignment using using resource_link_id, ext_lti_assignment_id or both."""
+
+        query = self._db.query(Assignment).filter(
+            Assignment.tool_consumer_instance_guid == tool_consumer_instance_guid
         )
 
-    def get_document_url(self, tool_consumer_instance_guid, resource_link_id):
+        if resource_link_id and not ext_lti_assignment_id:
+            # Non canvas assignments
+            query = query.filter(Assignment.resource_link_id == resource_link_id)
+        elif not resource_link_id and ext_lti_assignment_id:
+            # creating/editing a canvas assignment
+            query = query.filter(
+                Assignment.ext_lti_assignment_id == ext_lti_assignment_id
+            )
+        elif resource_link_id and ext_lti_assignment_id:
+            # Canvas launch, potentially the first one where resource_link_id is not yet in the DB
+            query = query.filter(
+                Assignment.ext_lti_assignment_id == ext_lti_assignment_id,
+                (
+                    (Assignment.resource_link_id == resource_link_id)
+                    | (Assignment.resource_link_id.is_(None))
+                ),
+            )
+        else:
+            log.exception(
+                "Can't get an assignment without neither resource_link_id or ext_lti_assignment_id"
+            )
+            return None
+
+        assignment = query.one_or_none()
+        if not assignment:
+            return None
+
+        if resource_link_id and not assignment.resource_link_id:
+            # First lunch of a canvas assignment, fill the resource_link_id now
+            assignment.resource_link_id = resource_link_id
+
+        return assignment
+
+    def get_document_url(
+        self,
+        tool_consumer_instance_guid,
+        resource_link_id=None,
+        ext_lti_assignment_id=None,
+    ):
         """
         Return the matching document URL or None.
 
         Return the document URL for the assignment with the given
         tool_consumer_instance_guid and resource_link_id, or None.
         """
-        assignment = self.get(tool_consumer_instance_guid, resource_link_id)
-
+        assignment = self.get(
+            tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
+        )
         return assignment.document_url if assignment else None
 
+    def create(
+        self,
+        tool_consumer_instance_guid,
+        document_url,
+        resource_link_id=None,
+        ext_lti_assignment_id=None,
+    ):
+        assignment = Assignment(
+            tool_consumer_instance_guid=tool_consumer_instance_guid,
+            document_url=document_url,
+            resource_link_id=resource_link_id,
+            ext_lti_assignment_id=ext_lti_assignment_id,
+        )
+        self._db.add(assignment)
+        return assignment
+
     def set_document_url(
-        self, tool_consumer_instance_guid, resource_link_id, document_url
+        self,
+        tool_consumer_instance_guid,
+        document_url,
+        resource_link_id=None,
+        ext_lti_assignment_id=None,
     ):
         """
-        Save the given document_url.
+        Save the given document_url in an existing assignment or create new one.
 
         Set the document_url for the assignment that matches
-        tool_consumer_instance_guid and resource_link_id. Any existing document
-        URL for this assignment will be overwritten.
+        tool_consumer_instance_guid and resource_link_id/ext_lti_assignment_id
+        or create a new one if none exist on the DB.
+
+        Any existing document URL for this assignment will be overwritten.
         """
-        assignment = self.get(tool_consumer_instance_guid, resource_link_id)
+        assignment = self.get(
+            tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
+        )
 
         if assignment:
             assignment.document_url = document_url
         else:
-            self._db.add(
-                Assignment(
-                    document_url=document_url,
-                    resource_link_id=resource_link_id,
-                    tool_consumer_instance_guid=tool_consumer_instance_guid,
-                )
+            assignment = self.create(
+                document_url=document_url,
+                resource_link_id=resource_link_id,
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
+                ext_lti_assignment_id=ext_lti_assignment_id,
             )
 
         # Clear the cache (@lru_cache) on self.get because we've changed the
         # contents of the DB. (Python's @lru_cache doesn't have a way to remove
         # just one key from the cache, you have to clear the entire cache.)
         self.get.cache_clear()
+
+        return assignment
 
 
 def factory(_context, request):

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -25,21 +25,24 @@ class AssignmentService:
                 "Can't get an assignment without neither resource_link_id or ext_lti_assignment_id"
             )
 
-        # Non canvas assignments, just use `resource_link_id`
-        if resource_link_id and not ext_lti_assignment_id:
-            return self._get_by_resource_link_id(
-                tool_consumer_instance_guid, resource_link_id
+        if all([resource_link_id, ext_lti_assignment_id]):
+            # When launching an assignment in Canvas there are both resource_link_id and
+            # ext_lti_assignment_id launch params.
+            return self._get_for_canvas_launch(
+                tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
             )
 
-        # Creating/editing a canvas assignment, only `ext_lti_assignment_id` is available
-        if not resource_link_id and ext_lti_assignment_id:
-            return self._get_by_ext_lti_assignment(
+        if not resource_link_id:
+            # When creating or editing an assignment Canvas launches us with an
+            # ext_lti_assignment_id but no resource_link_id.
+            return self._get_for_canvas_assignment_config(
                 tool_consumer_instance_guid, ext_lti_assignment_id
             )
 
-        # We have both ext_lti_assignment_id and resource_link_id, canvas launch.
-        return self._get_for_canvas_launch(
-            tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
+        # Non-Canvas assignment launches always have a resource_link_id and never
+        # have an ext_lti_assignment_id.
+        return self._get_by_resource_link_id(
+            tool_consumer_instance_guid, resource_link_id
         )
 
     def exists(
@@ -56,22 +59,6 @@ class AssignmentService:
             return False
         else:
             return True
-
-    def create(
-        self,
-        tool_consumer_instance_guid,
-        document_url,
-        resource_link_id=None,
-        ext_lti_assignment_id=None,
-    ):
-        assignment = Assignment(
-            tool_consumer_instance_guid=tool_consumer_instance_guid,
-            document_url=document_url,
-            resource_link_id=resource_link_id,
-            ext_lti_assignment_id=ext_lti_assignment_id,
-        )
-        self._db.add(assignment)
-        return assignment
 
     def set_document_url(
         self,
@@ -93,14 +80,16 @@ class AssignmentService:
             assignment = self.get(
                 tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
             )
-            assignment.document_url = document_url
         except NoResultFound:
-            assignment = self.create(
+            assignment = Assignment(
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
                 document_url=document_url,
                 resource_link_id=resource_link_id,
-                tool_consumer_instance_guid=tool_consumer_instance_guid,
                 ext_lti_assignment_id=ext_lti_assignment_id,
             )
+            self._db.add(assignment)
+
+        assignment.document_url = document_url
 
         # Clear the cache (@lru_cache) on self.get because we've changed the
         # contents of the DB. (Python's @lru_cache doesn't have a way to remove
@@ -108,33 +97,6 @@ class AssignmentService:
         self.get.cache_clear()
 
         return assignment
-
-    def _merge_canvas_assignments(self, assignments):
-        # We stored a canvas file assignment before (storing its resource_link_id)
-        # we later configured it (storing its ext_lti_assignment_id) in a new row
-        # and now we are launching it, we want to merge those two assignments
-
-        # order is guaranteed by the query's `order by`
-        old_assignment, new_assignment = assignments
-
-        assert not old_assignment.ext_lti_assignment_id
-        assert not new_assignment.resource_link_id
-
-        old_extra = dict(old_assignment.extra)
-        assert not old_extra or (
-            len(old_extra) == 1 and "canvas_file_mappings" in old_extra
-        )
-
-        self._db.delete(old_assignment)
-        # Flushing early so the `resource_link_id` constraints doesn't
-        # conflict between the deleted record and new_assignment .
-        self._db.flush()
-
-        if old_canvas_file_mappings := old_extra.get("canvas_file_mappings"):
-            new_assignment.extra["canvas_file_mappings"] = old_canvas_file_mappings
-
-        new_assignment.resource_link_id = old_assignment.resource_link_id
-        return new_assignment
 
     def _get_by_resource_link_id(self, tool_consumer_instance_guid, resource_link_id):
         return (
@@ -146,18 +108,6 @@ class AssignmentService:
             .one()
         )
 
-    def _get_by_ext_lti_assignment(
-        self, tool_consumer_instance_guid, ext_lti_assignment_id
-    ):
-        return (
-            self._db.query(Assignment)
-            .filter_by(
-                tool_consumer_instance_guid=tool_consumer_instance_guid,
-                ext_lti_assignment_id=ext_lti_assignment_id,
-            )
-            .one()
-        )
-
     def _get_for_canvas_launch(
         self,
         tool_consumer_instance_guid,
@@ -165,6 +115,8 @@ class AssignmentService:
         ext_lti_assignment_id,
     ):
         """Get a canvas assignment by both resource_link_id and ext_lti_assignment_id."""
+        assert resource_link_id and ext_lti_assignment_id
+
         assignments = (
             self._db.query(Assignment)
             .filter(
@@ -202,11 +154,18 @@ class AssignmentService:
             # ext_lti_assignment_id and no resource_link_id.
             #
             # We need to merge the two assignments into one.
-            assignment = self._merge_canvas_assignments(assignments)
+
+            # order is guaranteed by the query's `order by`
+            old_assignment, new_assignment = assignments
+
+            assert not old_assignment.ext_lti_assignment_id
+            assert not new_assignment.resource_link_id
+
+            assignment = self._merge_canvas_assignments(old_assignment, new_assignment)
         else:
             assignment = assignments[0]
 
-        if resource_link_id and not assignment.resource_link_id:
+        if not assignment.resource_link_id:
             # We found an assignment with an ext_lti_assignment_id but no resource_link_id.
             # This happens the first time a new Canvas assignment is launched: the assignment got created
             # during content-item-selection with an ext_lti_assignment_id but no resource_link_id,
@@ -215,6 +174,41 @@ class AssignmentService:
 
         # We found an assignment with the matching resource_link_id and ext_lti_assignment_id.kk
         return assignment
+
+    def _get_for_canvas_assignment_config(
+        self, tool_consumer_instance_guid, ext_lti_assignment_id
+    ):
+        return (
+            self._db.query(Assignment)
+            .filter_by(
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
+                ext_lti_assignment_id=ext_lti_assignment_id,
+            )
+            .one()
+        )
+
+    def _merge_canvas_assignments(self, old_assignment, new_assignment):
+        """
+        Merge two Canvas assignments into one and return the merged assignment.
+
+        Merge old_assignment into new_assignment, delete old_assignment, and return the updated
+        new_assignment.
+        """
+        old_extra = dict(old_assignment.extra)
+        # Legacy Canvas assignments in the DB were only ever saved with
+        # `"canvas_file_mappings"` or nothing in the `extra` column.
+        assert list(old_extra.keys()) in ([], ["canvas_file_mappings"])
+
+        self._db.delete(old_assignment)
+        # Flushing early so the `resource_link_id` constraints doesn't
+        # conflict between the deleted record and new_assignment .
+        self._db.flush()
+
+        if old_canvas_file_mappings := old_extra.get("canvas_file_mappings"):
+            new_assignment.extra["canvas_file_mappings"] = old_canvas_file_mappings
+
+        new_assignment.resource_link_id = old_assignment.resource_link_id
+        return new_assignment
 
 
 def factory(_context, request):

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -1,6 +1,8 @@
 import logging
 from functools import lru_cache
 
+from sqlalchemy.orm.exc import NoResultFound
+
 from lms.models import Assignment
 
 log = logging.getLogger(__name__)
@@ -21,87 +23,42 @@ class AssignmentService:
     ):
         """Get an assignment using using resource_link_id, ext_lti_assignment_id or both."""
 
-        query = self._db.query(Assignment).filter(
-            Assignment.tool_consumer_instance_guid == tool_consumer_instance_guid
-        )
-        if resource_link_id and not ext_lti_assignment_id:
-            # Non canvas assignments
-            query = query.filter(Assignment.resource_link_id == resource_link_id)
-        elif not resource_link_id and ext_lti_assignment_id:
-            # creating/editing a canvas assignment
-            query = query.filter(
-                Assignment.ext_lti_assignment_id == ext_lti_assignment_id
-            )
-        elif resource_link_id and ext_lti_assignment_id:
-            query = query.filter(
-                (
-                    # Regular canvas launch
-                    (
-                        (Assignment.resource_link_id == resource_link_id)
-                        & (Assignment.ext_lti_assignment_id == ext_lti_assignment_id)
-                    )
-                    # Configuring a file assignment that was stored in the DB
-                    # before all canvas assignments were stored in the DB
-                    | (
-                        (Assignment.resource_link_id == resource_link_id)
-                        & (Assignment.ext_lti_assignment_id.is_(None))
-                    )
-                    #  First launch of a newly configured assignment
-                    | (
-                        (Assignment.resource_link_id.is_(None))
-                        & (Assignment.ext_lti_assignment_id == ext_lti_assignment_id)
-                    )
-                )
-            )
-        else:
-            log.exception(
+        if not any([resource_link_id, ext_lti_assignment_id]):
+            raise ValueError(
                 "Can't get an assignment without neither resource_link_id or ext_lti_assignment_id"
             )
-            return None
 
-        assignments = query.all()
-        if not assignments:
-            return None
-
-        if len(assignments) == 2:
-            # We stored a canvas file assignment before (storing its resource_link_id)
-            # we later configured it (storing its ext_lti_assignment_id) in a new row
-            # and now we are launching it, we want to merge those two assignments
-            old_assignment = (
-                assignments[0] if assignments[0].resource_link_id else assignments[1]
+        # Non canvas assignments, just use `resource_link_id`
+        if resource_link_id and not ext_lti_assignment_id:
+            return self._get_by_resource_link_id(
+                tool_consumer_instance_guid, resource_link_id
             )
-            assignment = (
-                assignments[0]
-                if assignments[0].ext_lti_assignment_id
-                else assignments[1]
+
+        # Creating/editing a canvas assignment, only `ext_lti_assignment_id` is available
+        if not resource_link_id and ext_lti_assignment_id:
+            return self._get_by_ext_lti_assignment(
+                tool_consumer_instance_guid, ext_lti_assignment_id
             )
-            self._db.delete(old_assignment)
-            self._db.flush()
-        else:
-            assignment = assignments[0]
 
-        if resource_link_id and not assignment.resource_link_id:
-            # First lunch of a canvas assignment, fill the resource_link_id now
-            assignment.resource_link_id = resource_link_id
+        # We have both ext_lti_assignment_id and resource_link_id, canvas launch.
+        return self._get_for_canvas_launch(
+            tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
+        )
 
-        return assignment
-
-    def get_document_url(
+    def exists(
         self,
         tool_consumer_instance_guid,
         resource_link_id=None,
         ext_lti_assignment_id=None,
-    ):
-        """
-        Return the matching document URL or None.
-
-        Return the document URL for the assignment with the given
-        tool_consumer_instance_guid and resource_link_id, or None.
-        """
-        assignment = self.get(
-            tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
-        )
-        return assignment.document_url if assignment else None
+    ) -> bool:
+        try:
+            self.get(
+                tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
+            )
+        except (NoResultFound, ValueError):
+            return False
+        else:
+            return True
 
     def create(
         self,
@@ -135,13 +92,12 @@ class AssignmentService:
 
         Any existing document URL for this assignment will be overwritten.
         """
-        assignment = self.get(
-            tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
-        )
-
-        if assignment:
+        try:
+            assignment = self.get(
+                tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
+            )
             assignment.document_url = document_url
-        else:
+        except NoResultFound:
             assignment = self.create(
                 document_url=document_url,
                 resource_link_id=resource_link_id,
@@ -154,6 +110,105 @@ class AssignmentService:
         # just one key from the cache, you have to clear the entire cache.)
         self.get.cache_clear()
 
+        return assignment
+
+    def _merge_canvas_assignments(self, assignments):
+        # We stored a canvas file assignment before (storing its resource_link_id)
+        # we later configured it (storing its ext_lti_assignment_id) in a new row
+        # and now we are launching it, we want to merge those two assignments
+
+        # order is guaranteed by the query's `order by`
+        old_assignment, new_assignment = assignments
+
+        assert not old_assignment.ext_lti_assignment_id
+        assert not new_assignment.resource_link_id
+
+        self._db.delete(old_assignment)
+        # Flushing early so the `resource_link_id` constraints doesn't
+        # conflict between the deleted record and new_assignment .
+        self._db.flush()
+
+        new_assignment.resource_link_id = old_assignment.resource_link_id
+        return new_assignment
+
+    def _get_by_resource_link_id(self, tool_consumer_instance_guid, resource_link_id):
+        return (
+            self._db.query(Assignment)
+            .filter_by(
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
+                resource_link_id=resource_link_id,
+            )
+            .one()
+        )
+
+    def _get_by_ext_lti_assignment(
+        self, tool_consumer_instance_guid, ext_lti_assignment_id
+    ):
+        return (
+            self._db.query(Assignment)
+            .filter_by(
+                tool_consumer_instance_guid=tool_consumer_instance_guid,
+                ext_lti_assignment_id=ext_lti_assignment_id,
+            )
+            .one()
+        )
+
+    def _get_for_canvas_launch(
+        self,
+        tool_consumer_instance_guid,
+        resource_link_id,
+        ext_lti_assignment_id,
+    ):
+        """Get a canvas assignment by both resource_link_id and ext_lti_assignment_id."""
+        assignments = (
+            self._db.query(Assignment)
+            .filter(
+                Assignment.tool_consumer_instance_guid == tool_consumer_instance_guid,
+                (
+                    (
+                        (Assignment.resource_link_id == resource_link_id)
+                        & (Assignment.ext_lti_assignment_id == ext_lti_assignment_id)
+                    )
+                    | (
+                        (Assignment.resource_link_id == resource_link_id)
+                        & (Assignment.ext_lti_assignment_id.is_(None))
+                    )
+                    | (
+                        (Assignment.resource_link_id.is_(None))
+                        & (Assignment.ext_lti_assignment_id == ext_lti_assignment_id)
+                    )
+                ),
+            )
+            .order_by(Assignment.resource_link_id.asc())
+            .all()
+        )
+
+        if not assignments:
+            raise NoResultFound()
+
+        if len(assignments) == 2:
+            # We found two assignments: one with the matching resource_link_id and no ext_lti_assignment_id
+            # and one with the matching ext_lti_assignment_id and no resource_link_id.
+            #
+            # This happens because legacy code used to store Canvas assignments in the DB with a
+            # resource_link_id and no ext_lti_assignment_id, see https://github.com/hypothesis/lms/pull/2780
+            #
+            # Whereas current code stores Canvas assignments during content-item-selection with an
+            # ext_lti_assignment_id and no resource_link_id.
+            #
+            # We need to merge the two assignments into one.
+            assignment = self._merge_canvas_assignments(assignments)
+        else:
+            assignment = assignments[0]
+
+        if resource_link_id and not assignment.resource_link_id:
+            # We found an assignment with an ext_lti_assignment_id but no resource_link_id.
+            # This happens the first time a new Canvas assignment is launched: the assignment got created
+            # during content-item-selection with an ext_lti_assignment_id but no resource_link_id,
+            # and then the first time the assignment is launched we add the resource_link_id.
+            assignment.resource_link_id = resource_link_id
+
+        # We found an assignment with the matching resource_link_id and ext_lti_assignment_id.kk
         return assignment
 
 

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -162,9 +162,9 @@ class BasicLTILaunchViews:
         # here we can safely assume that the document_url exists.
         tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
         resource_link_id = self.request.params["resource_link_id"]
-        document_url = self.assignment_service.get_document_url(
+        document_url = self.assignment_service.get(
             tool_consumer_instance_guid, resource_link_id
-        )
+        ).document_url
         return self.basic_lti_launch(document_url)
 
     @view_config(blackboard_copied=True)
@@ -206,9 +206,9 @@ class BasicLTILaunchViews:
         tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
         resource_link_id = self.request.params["resource_link_id"]
 
-        document_url = self.assignment_service.get_document_url(
+        document_url = self.assignment_service.get(
             tool_consumer_instance_guid, original_resource_link_id
-        )
+        ).document_url
 
         self.assignment_service.set_document_url(
             tool_consumer_instance_guid, document_url, resource_link_id=resource_link_id

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -114,11 +114,11 @@ class BasicLTILaunchViews:
         # being around in future code.
         self.assignment_service.set_document_url(
             self.request.params["tool_consumer_instance_guid"],
-            resource_link_id,
             # This URL is mostly for show. We just want to ensure that a module
             # configuration exists. If we're going to do that we might as well
             # make sure this URL is meaningful.
             document_url=f"canvas://file/course/{course_id}/file_id/{file_id}",
+            resource_link_id=resource_link_id,
         )
 
         self.context.js_config.add_canvas_file_id(course_id, resource_link_id, file_id)
@@ -211,7 +211,7 @@ class BasicLTILaunchViews:
         )
 
         self.assignment_service.set_document_url(
-            tool_consumer_instance_guid, resource_link_id, document_url
+            tool_consumer_instance_guid, document_url, resource_link_id=resource_link_id
         )
 
         return self.basic_lti_launch(document_url)
@@ -310,8 +310,8 @@ class BasicLTILaunchViews:
 
         self.assignment_service.set_document_url(
             self.request.parsed_params["tool_consumer_instance_guid"],
-            self.request.parsed_params["resource_link_id"],
             document_url,
+            resource_link_id=self.request.parsed_params["resource_link_id"],
         )
 
         self.context.js_config.add_document_url(document_url)

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -35,13 +35,10 @@ class DBConfigured(Base):
         resource_link_id = request.params.get("resource_link_id")
         tool_consumer_instance_guid = request.params.get("tool_consumer_instance_guid")
 
-        has_document_url = bool(
-            assignment_svc.get_document_url(
-                tool_consumer_instance_guid, resource_link_id
-            )
+        return (
+            assignment_svc.exists(tool_consumer_instance_guid, resource_link_id)
+            == self.value
         )
-
-        return has_document_url == self.value
 
 
 class _CourseCopied(Base, ABC):
@@ -111,10 +108,9 @@ class _CourseCopied(Base, ABC):
                 # Look for the document URL of the previous assignment that
                 # this one was copied from.
                 assignment_service = request.find_service(name="assignment")
-                previous_document_url = assignment_service.get_document_url(
+                is_newly_copied = assignment_service.exists(
                     tool_consumer_instance_guid, original_resource_link_id
                 )
-                is_newly_copied = bool(previous_document_url)
 
         return is_newly_copied == self.value
 

--- a/tests/factories/assignment.py
+++ b/tests/factories/assignment.py
@@ -10,4 +10,5 @@ Assignment = make_factory(
     resource_link_id=RESOURCE_LINK_ID,
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     document_url=Faker("uri"),
+    ext_lti_assignment_id=None,
 )

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -60,6 +60,26 @@ class TestAssignmentService:
         )
         assert retrieved_assignment == assignment_canvas
 
+    def test_get_merge_existing(self, svc, assignment, assignment_canvas_not_launched):
+        # pylint:disable=protected-access
+        # Make both assignments belong to the same school
+        assignment.tool_consumer_instance_guid = (
+            assignment_canvas_not_launched.tool_consumer_instance_guid
+        )
+        svc._db.flush()
+        assert svc._db.query(Assignment).count() == 3 + 2  # noise + fixtures
+
+        retrieved_assignment = svc.get(
+            assignment_canvas_not_launched.tool_consumer_instance_guid,
+            resource_link_id=assignment.resource_link_id,
+            ext_lti_assignment_id=assignment_canvas_not_launched.ext_lti_assignment_id,
+        )
+
+        # We merged both into the newest one, the one with a non-null ext_lti_assignment_id
+        assert retrieved_assignment.id == assignment_canvas_not_launched.id
+        assert retrieved_assignment.resource_link_id == assignment.resource_link_id
+        assert svc._db.query(Assignment).count() == 3 + 1  # Deleted one assigment
+
     def test_create(self, svc):
         assignment = svc.create(
             "TOOL_CONSUMER_INSTANCE_GUID",

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -1,18 +1,22 @@
+import uuid
 from unittest.mock import sentinel
 
 import pytest
 
+from lms.models import Assignment
 from lms.services.assignment import AssignmentService, factory
 from tests import factories
 
 
 class TestAssignmentService:
-    def test_get(self, svc, assignment):
-        retrieved_assignment = svc.get(
-            assignment.tool_consumer_instance_guid, assignment.resource_link_id
+    def test_get_without_ids(self, svc, assignment):
+        assignment = svc.get(
+            assignment.tool_consumer_instance_guid,
+            resource_link_id=None,
+            ext_lti_assignment_id=None,
         )
 
-        assert retrieved_assignment == assignment
+        assert assignment is None
 
     def test_get_returns_None_if_theres_no_matching_assignment(self, svc):
         retrieved_assignment = svc.get(
@@ -20,6 +24,61 @@ class TestAssignmentService:
         )
 
         assert retrieved_assignment is None
+
+    def test_get_by_resource_link_id_only(self, svc, assignment):
+        retrieved_assignment = svc.get(
+            assignment.tool_consumer_instance_guid, assignment.resource_link_id
+        )
+
+        assert retrieved_assignment == assignment
+
+    def test_get_by_ext_lti_id_only(self, svc, assignment_canvas_not_launched):
+        retrieved_assignment = svc.get(
+            assignment_canvas_not_launched.tool_consumer_instance_guid,
+            ext_lti_assignment_id=assignment_canvas_not_launched.ext_lti_assignment_id,
+        )
+
+        assert retrieved_assignment == assignment_canvas_not_launched
+
+    def test_get_by_both_ids_not_launched(self, svc, assignment_canvas_not_launched):
+        assert assignment_canvas_not_launched.resource_link_id is None
+
+        retrieved_assignment = svc.get(
+            assignment_canvas_not_launched.tool_consumer_instance_guid,
+            resource_link_id="RESOURCE_LINK_ID",
+            ext_lti_assignment_id=assignment_canvas_not_launched.ext_lti_assignment_id,
+        )
+
+        assert retrieved_assignment == assignment_canvas_not_launched
+        assert assignment_canvas_not_launched.resource_link_id == "RESOURCE_LINK_ID"
+
+    def test_get_by_both_ids_launched(self, svc, assignment_canvas):
+        retrieved_assignment = svc.get(
+            assignment_canvas.tool_consumer_instance_guid,
+            resource_link_id=assignment_canvas.resource_link_id,
+            ext_lti_assignment_id=assignment_canvas.ext_lti_assignment_id,
+        )
+        assert retrieved_assignment == assignment_canvas
+
+    def test_create(self, svc):
+        assignment = svc.create(
+            "TOOL_CONSUMER_INSTANCE_GUID",
+            "NEW_DOCUMENT_URL",
+            "RESOURCE_LINK_ID",
+            "EXT_LTI_ASSIGNMENT_ID",
+        )
+
+        assert (
+            svc._db.query(Assignment)  # pylint:disable=protected-access
+            .filter_by(
+                tool_consumer_instance_guid="TOOL_CONSUMER_INSTANCE_GUID",
+                resource_link_id="RESOURCE_LINK_ID",
+                ext_lti_assignment_id="EXT_LTI_ASSIGNMENT_ID",
+                document_url="NEW_DOCUMENT_URL",
+            )
+            .one()
+            == assignment
+        )
 
     def test_get_document_url_returns_the_document_url(self, svc, assignment):
         document_url = svc.get_document_url(
@@ -40,8 +99,8 @@ class TestAssignmentService:
     def test_set_document_url_saves_the_document_url(self, svc):
         svc.set_document_url(
             "TOOL_CONSUMER_INSTANCE_GUID",
-            "RESOURCE_LINK_ID",
             "NEW_DOCUMENT_URL",
+            "RESOURCE_LINK_ID",
         )
 
         assert (
@@ -54,8 +113,8 @@ class TestAssignmentService:
     ):
         svc.set_document_url(
             assignment.tool_consumer_instance_guid,
-            assignment.resource_link_id,
             "NEW_DOCUMENT_URL",
+            assignment.resource_link_id,
         )
 
         assert assignment.document_url == "NEW_DOCUMENT_URL"
@@ -63,6 +122,16 @@ class TestAssignmentService:
     @pytest.fixture
     def assignment(self):
         return factories.Assignment()
+
+    @pytest.fixture
+    def assignment_canvas_not_launched(self):
+        return factories.Assignment(
+            resource_link_id=None, ext_lti_assignment_id=str(uuid.uuid4())
+        )
+
+    @pytest.fixture
+    def assignment_canvas(self):
+        return factories.Assignment(ext_lti_assignment_id=str(uuid.uuid4()))
 
     @pytest.fixture(autouse=True)
     def noise(self):

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -304,7 +304,7 @@ class TestDBConfiguredBasicLTILaunch:
         db_configured_basic_lti_launch_caller(context, pyramid_request)
 
         context.js_config.add_document_url.assert_called_once_with(
-            assignment_service.get_document_url.return_value
+            assignment_service.get.return_value.document_url
         )
 
 
@@ -331,7 +331,7 @@ class TestFooCopiedBasicLTILaunch:
 
         # It gets the original assignment settings
         # from the DB.
-        assignment_service.get_document_url.assert_called_once_with(
+        assignment_service.get.assert_called_once_with(
             pyramid_request.params["tool_consumer_instance_guid"],
             pyramid_request.params[param_name],
         )
@@ -340,13 +340,13 @@ class TestFooCopiedBasicLTILaunch:
         # DB.
         assignment_service.set_document_url.assert_called_once_with(
             pyramid_request.params["tool_consumer_instance_guid"],
-            assignment_service.get_document_url.return_value,
+            assignment_service.get.return_value.document_url,
             resource_link_id=pyramid_request.params["resource_link_id"],
         )
 
         # It adds the document URL to the JavaScript config.
         context.js_config.add_document_url.assert_called_once_with(
-            assignment_service.get_document_url.return_value
+            assignment_service.get.return_value.document_url
         )
 
 

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -287,8 +287,8 @@ class TestCanvasFileBasicLTILaunch:
 
         assignment_service.set_document_url.assert_called_once_with(
             pyramid_request.params["tool_consumer_instance_guid"],
-            pyramid_request.params["resource_link_id"],
             document_url=f"canvas://file/course/{course_id}/file_id/{file_id}",
+            resource_link_id=pyramid_request.params["resource_link_id"],
         )
 
 
@@ -340,8 +340,8 @@ class TestFooCopiedBasicLTILaunch:
         # DB.
         assignment_service.set_document_url.assert_called_once_with(
             pyramid_request.params["tool_consumer_instance_guid"],
-            pyramid_request.params["resource_link_id"],
             assignment_service.get_document_url.return_value,
+            resource_link_id=pyramid_request.params["resource_link_id"],
         )
 
         # It adds the document URL to the JavaScript config.
@@ -372,8 +372,8 @@ class TestConfigureAssignment:
 
         assignment_service.set_document_url.assert_called_once_with(
             pyramid_request.parsed_params["tool_consumer_instance_guid"],
-            pyramid_request.parsed_params["resource_link_id"],
             pyramid_request.parsed_params["document_url"],
+            resource_link_id=pyramid_request.parsed_params["resource_link_id"],
         )
 
     def test_it_enables_frontend_grading(self, context, pyramid_request):


### PR DESCRIPTION
This code should behave exactly as without any changes until further PRs are merged.

More context in https://github.com/hypothesis/lms/pull/3127

## Testing

- No behavior changes, launch and configure URL and canvas file assignments.