### PR TITLE
Add redirect page for MS OneDrive authentication (OAuth)

### DIFF
--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -82,6 +82,7 @@ class FilePickerConfig:
         return {
             "enabled": True,
             "clientId": request.registry.settings["onedrive_client_id"],
+            "redirectURI": request.route_url("onedrive.filepicker.redirect_uri"),
         }
 
     @classmethod

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -51,6 +51,10 @@ def includeme(config):
     )
 
     config.add_route(
+        "onedrive.filepicker.redirect_uri", "/onedrive/filepicker/redirect"
+    )
+
+    config.add_route(
         "canvas_api.oauth.authorize",
         "/api/canvas/oauth/authorize",
         factory="lms.resources.OAuth2RedirectResource",

--- a/lms/templates/onedrive.html.jinja2
+++ b/lms/templates/onedrive.html.jinja2
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang=en>
+  <head>
+    <meta charset=utf-8>
+  </head>
+  <body>
+      <script type="text/javascript" src="https://js.live.net/v7.2/OneDrive.js"></script>
+  </body>
+</html>

--- a/lms/views/onedrive.py
+++ b/lms/views/onedrive.py
@@ -1,0 +1,15 @@
+from pyramid.view import view_config
+
+
+@view_config(
+    request_method="GET",
+    route_name="onedrive.filepicker.redirect_uri",
+    renderer="lms:templates/onedrive.html.jinja2",
+)
+def redirect_uri(_request):
+    """
+    Return a basic HTML page with One Drive's JS SDK loaded.
+
+    This view's URL is provided to One Drive's frontend config as target to open the filepicker in.
+    """
+    return {}

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -105,6 +105,9 @@ class TestFilePickerConfig:
         expected = {"enabled": enabled}
         if enabled:
             expected["clientId"] = sentinel.client_id
+            expected["redirectURI"] = pyramid_request.route_url(
+                "onedrive.filepicker.redirect_uri"
+            )
 
         assert config == expected
 

--- a/tests/unit/lms/views/onedrive_test.py
+++ b/tests/unit/lms/views/onedrive_test.py
@@ -1,0 +1,5 @@
+from lms.views.onedrive import redirect_uri
+
+
+def test_redirect_uri(pyramid_request):
+    assert redirect_uri(pyramid_request) == {}


### PR DESCRIPTION
By default the OneDrive picker uses the page it was launched from as the redirect
URL for authentication. In the LMS context, the OneDrive picker opens a
window with the URL '/content_item_selection' and some AOuth specific parameters (`?oauth=....`). That causes the LMS to return a 404 `Page not found`.

OneDrive has a `redirectUri` option to launch the picker in a different
URL (see
https://docs.microsoft.com/en-us/onedrive/developer/controls/file-pickers/js-v72/open-file?view=odsp-graph-online).
This URL must be registered on the app's registration portal as a
redirect URL.

The redirect page for authentication must content the OneDrive JS
bundle.