### PR TITLE
Rename Object to object

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -1,7 +1,7 @@
 /**
  * Generate a `mailto:` URL that prompts to send an email with pre-filled fields.
  *
- * @param {Object} args
+ * @param {object} args
  * @param {string} args.address - Email address to sent to
  * @param {string} [args.subject] - Pre-filled subject line
  * @param {string} [args.body] - Pre-filled body
@@ -26,7 +26,7 @@ function toSentence(str) {
  *
  * @typedef ErrorLike
  * @prop {string} [message]
- * @prop {Object} [details] - Optional JSON-serializable details of the error
+ * @prop {object} [details] - Optional JSON-serializable details of the error
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -26,7 +26,7 @@ function toSentence(str) {
  *
  * @typedef ErrorLike
  * @prop {string} [message]
- * @prop {object} [details] - Optional JSON-serializable details of the error
+ * @prop {object|string} [details] - Optional JSON-serializable details of the error
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -10,7 +10,7 @@ import SubmitGradeForm from './SubmitGradeForm';
 
 /**
  * @typedef LMSGraderProps
- * @prop {Object} children - The <iframe> element displaying the assignment
+ * @prop {object} children - The <iframe> element displaying the assignment
  * @prop {ClientRPC} clientRPC - Service for communicating with Hypothesis client
  * @prop {string} courseName
  * @prop {string} assignmentName

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -19,7 +19,7 @@ import ErrorDisplay from './ErrorDisplay';
  *  - An optional "Try again" button
  *  - An optional detailed error message for use when contacting support
  *
- * @param {Object} props
+ * @param {object} props
  * @param {boolean} props.busy
  * @param {Children} props.children
  * @param {Error|null} [props.error]

--- a/lms/static/scripts/frontend_apps/components/VitalSourceBookViewer.js
+++ b/lms/static/scripts/frontend_apps/components/VitalSourceBookViewer.js
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'preact/hooks';
 /**
  * @typedef VitalSourceBookViewerProps
  * @prop {string} launchUrl - URL to submit the launch form to
- * @prop {Object.<string,string>} launchParams - Field names and values for the launch form
+ * @prop {Record<string,string>} launchParams - Field names and values for the launch form
  * @prop {(f: HTMLFormElement) => void} [willSubmitLaunchForm] - Test hook
  */
 

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -13,7 +13,7 @@ import { createContext } from 'preact';
  *   URL to display in a popup window if the call fails due to an authorization
  *   error. This is used when the API call requires an OAuth 2 authorization
  *   flow to be completed with eg. an external LMS's API
- * @prop {Object} [data]
+ * @prop {object} [data]
  */
 
 /**
@@ -38,7 +38,7 @@ import { createContext } from 'preact';
  * Data needed to record an assignment submission.
  *
  * @typedef SpeedGraderConfig
- * @prop {Object} submissionParams
+ * @prop {object} submissionParams
  */
 
 /**
@@ -49,7 +49,7 @@ import { createContext } from 'preact';
  *
  * @typedef VitalSourceConfig
  * @prop {string} launchUrl - URL for the `<form>` used to launch the viewer
- * @prop {Object.<string,string>} launchParams - Form field names and values
+ * @prop {Record<string,string>} launchParams - Form field names and values
  */
 
 /**
@@ -58,21 +58,21 @@ import { createContext } from 'preact';
  *
  * @typedef FilePickerConfig
  * @prop {string} formAction
- * @prop {Object.<string,string>} formFields
- * @prop {Object} blackboard
+ * @prop {Record<string,string>} formFields
+ * @prop {object} blackboard
  *   @prop {boolean} blackboard.enabled
  *   @prop {APICallInfo} blackboard.listFiles
- * @prop {Object} canvas
+ * @prop {object} canvas
  *   @prop {boolean} canvas.enabled
  *   @prop {boolean} canvas.groupsEnabled
  *   @prop {string} canvas.ltiLaunchUrl
  *   @prop {APICallInfo} canvas.listFiles
  *   @prop {APICallInfo} canvas.listGroupSets
- * @prop {Object} google
+ * @prop {object} google
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey
  *   @prop {string} google.origin
- * @prop {Object} vitalSource
+ * @prop {object} vitalSource
  *   @prop {boolean} vitalSource.enabled
  */
 
@@ -114,17 +114,17 @@ import { createContext } from 'preact';
  *
  * @typedef ConfigObject
  * @prop {string} mode
- * @prop {Object} api
+ * @prop {object} api
  *   @prop {string} api.authToken
  *   @prop {APICallInfo} api.sync
  *   @prop {APICallInfo} api.viaUrl
- * @prop {Object} canvas
+ * @prop {object} canvas
  *   @prop {SpeedGraderConfig} canvas.speedGrader
  * @prop {boolean} dev
  * @prop {FilePickerConfig} filePicker
  * @prop {GradingConfig} grading
- * @prop {Object} hypothesisClient
- * @prop {Object} rpcServer
+ * @prop {object} hypothesisClient
+ * @prop {object} rpcServer
  *   @prop {string[]} rpcServer.allowedOrigins
  * @prop {string} viaUrl
  * @prop {OAuthErrorConfig} OAuth2RedirectError

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -42,7 +42,7 @@ export class ClientRPC {
   /**
    * Setup the RPC server used to communicate with the Hypothesis client.
    *
-   * @param {Object} options
+   * @param {object} options
    *   @param {string[]} options.allowedOrigins -
    *     Origins that are allowed to request client configuration
    *   @param {string} options.authToken -

--- a/lms/static/scripts/frontend_apps/utils/AuthWindow.js
+++ b/lms/static/scripts/frontend_apps/utils/AuthWindow.js
@@ -3,7 +3,7 @@
  */
 export default class AuthWindow {
   /**
-   * @param {Object} options
+   * @param {object} options
    * @param {string} options.authToken -
    *   Authorization token used for API requests between frontend and backend
    * @param {string} options.authUrl -

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -54,10 +54,10 @@ export class APIError extends Error {
 /**
  * Make an API call to the LMS app backend.
  *
- * @param {Object} options
+ * @param {object} options
  *   @param {string} options.path - The `/api/...` path of the endpoint to call
  *   @param {string} options.authToken
- *   @param {Object} [options.data] - JSON-serializable body of the request
+ *   @param {object} [options.data] - JSON-serializable body of the request
  *   @param {Record<string, string>} [options.params] - Query parameters
  */
 export async function apiCall({ path, authToken, data, params }) {

--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.js
@@ -55,7 +55,7 @@ export class PickerCanceledError extends Error {
  */
 export class GooglePickerClient {
   /**
-   * @param {Object} options
+   * @param {object} options
    * @param {string} options.developerKey -
    *   API key obtained from the Google API console.
    * @param {string} options.clientId -

--- a/lms/static/scripts/postmessage_json_rpc/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server.js
@@ -13,7 +13,7 @@
  *
  * @typedef JsonRpcResponse
  * @prop {'2.0'} jsonrpc
- * @prop {Object} [result]
+ * @prop {object} [result]
  * @prop {JsonRpcError} [error]
  * @prop {string|null} id
  */
@@ -24,7 +24,7 @@
  * @typedef JsonRpcError
  * @prop {number} code
  * @prop {string} message
- * @prop {Object} [data]
+ * @prop {object} [data]
  */
 
 /**


### PR DESCRIPTION
For the past few months, we have started to use the `object` type instead of `Object`. Both are almost interchangeable, but we prefer `object` for simplicity.

This PR substitutes all `Object` to `object` and `Object.<...>` to `Record<...>` and makes the code more consistent.

* First commit is an automatic transformation
* Second commit is a manual fix of a few types