### PR TITLE
Load MS OneDrive client

### DIFF
--- a/lms/static/scripts/frontend_apps/types.d.ts
+++ b/lms/static/scripts/frontend_apps/types.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare global {
+  interface Window {
+    OneDrive: {
+      open: (options: Record<string, any>) => void;
+    };
+  }
+}

--- a/lms/static/scripts/frontend_apps/utils/onedrive-api-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-api-client.js
@@ -1,0 +1,17 @@
+export async function loadOneDriveAPI() {
+  if (window.OneDrive) {
+    return window.OneDrive;
+  }
+
+  return new Promise((resolve, reject) => {
+    const oneDriveScript = document.createElement('script');
+    oneDriveScript.src = 'https://js.live.net/v7.2/OneDrive.js';
+    oneDriveScript.onload = () => {
+      resolve(window.OneDrive);
+    };
+    oneDriveScript.onerror = () => {
+      reject(new Error('Failed to load OneDrive API'));
+    };
+    document.body.appendChild(oneDriveScript);
+  });
+}

--- a/lms/static/scripts/frontend_apps/utils/test/onedrive-api-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/onedrive-api-client-test.js
@@ -1,0 +1,68 @@
+import { loadOneDriveAPI } from '../onedrive-api-client';
+
+describe('loadOneDriveAPI', () => {
+  let fakeScriptElement;
+
+  beforeEach(() => {
+    // Prevent the tests from making a real network request to load the real
+    // script.
+    fakeScriptElement = document.createElement('fake-script');
+    sinon.stub(document, 'createElement').returns(fakeScriptElement);
+    delete window.OneDrive;
+  });
+
+  afterEach(() => {
+    document.createElement.restore();
+    fakeScriptElement.remove();
+    delete window.OneDrive;
+  });
+
+  it('resolves if OneDrive script loads', async () => {
+    const onLoad = loadOneDriveAPI();
+    const options = { option: 'dummy' };
+
+    // Simulate successful script loading.
+    window.OneDrive = {
+      open: sinon.stub(),
+    };
+    fakeScriptElement.dispatchEvent(new Event('load'));
+    const oneDrive = await onLoad;
+    oneDrive.open(options);
+
+    assert.exists(fakeScriptElement.src);
+    assert.calledOnce(window.OneDrive.open);
+    assert.calledWith(window.OneDrive.open, options);
+  });
+
+  it('throws an error if OneDrive script fails to load', async () => {
+    const onLoad = loadOneDriveAPI();
+    let expectedError;
+
+    // Simulate unsuccessful script loading.
+    fakeScriptElement.dispatchEvent(new Event('error'));
+    try {
+      await onLoad;
+    } catch (error) {
+      expectedError = error;
+    }
+
+    assert.exists(fakeScriptElement.src);
+    assert.equal(expectedError.message, 'Failed to load OneDrive API');
+  });
+
+  it('immediately returns OneDrive if previously loaded', async () => {
+    // Set `window.OneDrive` before calling `loadOneDriveAPI` as if the loading
+    // has already happened.
+    window.OneDrive = {
+      open: sinon.stub(),
+    };
+    const options = { option: 'dummy' };
+
+    const oneDrive = await loadOneDriveAPI();
+    oneDrive.open(options);
+
+    assert.calledOnce(window.OneDrive.open);
+    assert.calledWith(window.OneDrive.open, options);
+    assert.notCalled(document.createElement);
+  });
+});

--- a/lms/static/scripts/tsconfig.json
+++ b/lms/static/scripts/tsconfig.json
@@ -11,6 +11,6 @@
     "target": "ES2020",
     "useUnknownInCatchVariables": false
   },
-  "include": ["frontend_apps/**/*.js"],
+  "include": ["frontend_apps/**/*.js", "frontend_apps/**/*d.ts"],
   "exclude": ["frontend_apps/**/test/*.js"]
 }


### PR DESCRIPTION
Added a function that creates the `<script>` element to load the
OneDrive client.

The `OneDrive` type has been globally added to the `window` similarly to
what happens with `window.gapi`.