### PR TITLE
Integrate OneDrive file picker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -185,8 +185,8 @@ export default function ContentSelector({
   }
 
   const showGooglePicker = async () => {
+    setLoadingIndicatorVisible(true);
     try {
-      setLoadingIndicatorVisible(true);
       const picker = /** @type {GooglePickerClient} */ (googlePicker);
       const { id, url } = await picker.showPicker();
       await picker.enablePublicViewing(id);
@@ -203,28 +203,22 @@ export default function ContentSelector({
     }
   };
 
-  const showOneDrivePicker = () => {
+  const showOneDrivePicker = async () => {
     setLoadingIndicatorVisible(true);
-    const picker = /** @type {OneDrivePickerClient} */ (oneDrivePicker);
-    /** @param {any} file */
-    const success = file => {
-      const sharingURL = file.value[0].permissions[0].link.webUrl;
-      const url = OneDrivePickerClient.encodeSharingURL(sharingURL);
+    try {
+      const picker = /** @type {OneDrivePickerClient} */ (oneDrivePicker);
+      const { url } = await picker.showPicker();
       onSelectContent({ type: 'url', url });
-    };
-    const cancel = () => {
+    } catch (error) {
       setLoadingIndicatorVisible(false);
-    };
-    /** @param {Error} error */
-    const error = error => {
-      setLoadingIndicatorVisible(false);
-      console.error(error);
-      onError({
-        title: 'There was a problem choosing a file from OneDrive',
-        error,
-      });
-    };
-    picker.showPicker({ success, cancel, error });
+      if (!(error instanceof PickerCanceledError)) {
+        console.error(error);
+        onError({
+          title: 'There was a problem choosing a file from OneDrive',
+          error,
+        });
+      }
+    }
   };
 
   return (

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -443,7 +443,7 @@ describe('ContentSelector', () => {
     it('submits a OneDrive sharing URL when a file is selected', async () => {
       const onSelectContent = sinon.stub();
       const wrapper = renderContentSelector({ onSelectContent });
-      // Emulates the selection of a file in the picker.
+      // Emulate the selection of a file in the picker.
       picker.showPicker.resolves({
         url: 'https://api.onedrive.com/v1.0/shares/u!https://1drv.ms/b/s!AmH',
       });
@@ -460,7 +460,7 @@ describe('ContentSelector', () => {
     it('hides loading indicator if user cancels picker', async () => {
       const onError = sinon.stub();
       const wrapper = renderContentSelector({ onError });
-      // Emulates the cancellation of the picker.
+      // Emulate the cancellation of the picker.
       picker.showPicker.rejects(new PickerCanceledError());
 
       clickOneDriveButton(wrapper);
@@ -469,7 +469,6 @@ describe('ContentSelector', () => {
         return isLoadingIndicatorVisible(wrapper) === false;
       });
 
-      assert.isFalse(isLoadingIndicatorVisible(wrapper));
       assert.notCalled(onError);
     });
 
@@ -477,7 +476,7 @@ describe('ContentSelector', () => {
       const error = new Error('Some failure');
       const onError = sinon.stub();
       const wrapper = renderContentSelector({ onError });
-      // Emulates the invocation of a failure in the picker
+      // Emulate a failure in the picker
       picker.showPicker.rejects(error);
 
       clickOneDriveButton(wrapper);

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -72,7 +72,11 @@ import { createContext } from 'preact';
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey
  *   @prop {string} google.origin
- * @prop {object} vitalSource
+ * @prop {object} microsoftOneDrive
+ *   @prop {boolean} microsoftOneDrive.enabled
+ *   @prop {string} [microsoftOneDrive.clientId]
+ *   @prop {string} [microsoftOneDrive.redirectURI]
+ * @prop {Object} vitalSource
  *   @prop {boolean} vitalSource.enabled
  */
 

--- a/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
@@ -1,6 +1,12 @@
 import { PickerCanceledError } from './google-picker-client';
 import { loadOneDriveAPI } from './onedrive-api-client';
 
+/**
+ * A wrapper around the Microsoft OneDrive file picker.
+ *
+ * See https://docs.microsoft.com/en-us/onedrive/developer/controls/file-pickers/js-v72/open-file?view=odsp-graph-online
+ * for documentation on the underlying library.
+ */
 export class OneDrivePickerClient {
   /**
    * @param {object} options
@@ -8,7 +14,7 @@ export class OneDrivePickerClient {
    * @param {string} options.redirectURI - the URL that is used to launch the picker
    */
   constructor({ clientId, redirectURI }) {
-    this._onLoadOneDriveAPI = loadOneDriveAPI();
+    this._oneDriveAPI = loadOneDriveAPI();
     this._clientId = clientId;
     this._redirectURI = redirectURI;
   }
@@ -23,7 +29,7 @@ export class OneDrivePickerClient {
    *       the picker fails with internal or backend problem.
    */
   async showPicker() {
-    const oneDrive = await this._onLoadOneDriveAPI;
+    const oneDrive = await this._oneDriveAPI;
     return new Promise((resolve, reject) => {
       const success = (/** @type {any} */ file) => {
         const sharingURL = file.value[0].permissions[0].link.webUrl;

--- a/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
@@ -1,0 +1,55 @@
+import { loadOneDriveAPI } from './onedrive-api-client';
+
+export class OneDrivePickerClient {
+  /**
+   * @param {object} options
+   * @param {string} options.clientId
+   * @param {string} options.redirectURI - the URL that is used to launch the picker
+   */
+  constructor({ clientId, redirectURI }) {
+    loadOneDriveAPI();
+
+    this._filePickerOptions = {
+      clientId,
+      action: 'share',
+      multiSelect: false,
+      viewType: 'files', // The type of item that can be selected.
+      advanced: {
+        redirectUri: redirectURI,
+        filter: '.pdf',
+        createLinkParameters: { type: 'view', scope: 'anonymous' },
+      },
+    };
+  }
+
+  /**
+   * Opens the OneDrive picker
+   *
+   * @param {{success?: (file: any) => void, cancel?: () => void, error?: (e: Error) => void}} callbacks
+   * @throws {Error} - if the OneDrive client failed to load and hence
+   *   `window.OneDrive` is undefined
+   */
+  showPicker(callbacks = {}) {
+    window.OneDrive.open({ ...this._filePickerOptions, ...callbacks });
+  }
+
+  /**
+   * Encode sharing URL according to the MS specification
+   * https://docs.microsoft.com/en-us/graph/api/shares-get?view=graph-rest-1.0&tabs=http#encoding-sharing-urls
+   * 1. Use base64 encode the URL.
+   * 2. Convert the base64 encoded result to unpadded base64url format by
+   *   removing '=' characters from the end of the value, replacing '/'
+   *   with '_' and '+' with '-'
+   * 3. Append u! to be beginning of the string.
+   *
+   * @param {string} sharingURL
+   */
+  static encodeSharingURL(sharingURL) {
+    const b64SharedLink = btoa(sharingURL)
+      .replace(/=/g, '')
+      .replace(/\//g, '_')
+      .replace(/\+/g, '-');
+    // Append u! to be beginning of the string.
+    return `https://api.onedrive.com/v1.0/shares/u!${b64SharedLink}/root/content`;
+  }
+}

--- a/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
@@ -1,0 +1,90 @@
+import { OneDrivePickerClient, $imports } from '../onedrive-picker-client';
+
+describe('OneDrivePickerClient', () => {
+  let fakeLoadOneDriveAPI;
+
+  function createClient({
+    clientId = '12345',
+    redirectURI = 'https://redirect.uri',
+  } = {}) {
+    return new OneDrivePickerClient({ clientId, redirectURI });
+  }
+
+  beforeEach(() => {
+    fakeLoadOneDriveAPI = sinon.stub();
+
+    $imports.$mock({
+      './onedrive-api-client': {
+        loadOneDriveAPI: fakeLoadOneDriveAPI,
+      },
+    });
+    delete window.OneDrive;
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+    delete window.OneDrive;
+  });
+  describe('#constructor', () => {
+    it('calls `loadOneDriveAPI`', () => {
+      createClient();
+
+      // If `loadOneDriveAPI` fails to load the OneDrive client it raises an
+      // unhandled rejection, which possible to emulate and catch on a test but
+      // difficult hide from the output.
+      assert.calledOnce(fakeLoadOneDriveAPI);
+    });
+  });
+
+  describe('#showPicker', () => {
+    it('invokes `window.OneDrive.open` if OneDrive client loaded successfully', () => {
+      const callbacks = { success: () => {} };
+      const oneDrive = createClient();
+
+      // Emulate the successfully loading
+      window.OneDrive = {
+        open: sinon.stub(),
+      };
+      oneDrive.showPicker(callbacks);
+
+      assert.calledOnce(window.OneDrive.open);
+      assert.calledWith(
+        window.OneDrive.open,
+        sinon.match({
+          clientId: '12345',
+          advanced: { redirectUri: 'https://redirect.uri' },
+          ...callbacks,
+        })
+      );
+    });
+
+    it('fails to invoke `window.OneDrive.open` if OneDrive client failed to load', () => {
+      const oneDrive = createClient();
+      let expectedError;
+
+      // Emulate failure to load the OneDrive client:
+      // 1. an unhandled rejection raised in the constructor
+      // 2. window.OneDrive is undefined
+      try {
+        oneDrive.showPicker();
+      } catch (error) {
+        expectedError = error;
+      }
+
+      assert.instanceOf(expectedError, Error); // window.OneDrive is undefined
+    });
+  });
+
+  describe('#encodeSharingURL', () => {
+    it('calls `loadOneDriveAPI`', () => {
+      const url = OneDrivePickerClient.encodeSharingURL(
+        'https://1drv.ms/b/s!AmH'
+      );
+
+      assert.equal(
+        url,
+        'https://api.onedrive.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2IvcyFBbUg/root/content'
+      );
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
@@ -1,12 +1,14 @@
+import { PickerCanceledError } from '../google-picker-client';
 import { OneDrivePickerClient, $imports } from '../onedrive-picker-client';
 
 describe('OneDrivePickerClient', () => {
   let fakeLoadOneDriveAPI;
+  const clientOptions = {
+    clientId: '12345',
+    redirectURI: 'https://redirect.uri',
+  };
 
-  function createClient({
-    clientId = '12345',
-    redirectURI = 'https://redirect.uri',
-  } = {}) {
+  function createClient({ clientId, redirectURI } = clientOptions) {
     return new OneDrivePickerClient({ clientId, redirectURI });
   }
 
@@ -25,6 +27,7 @@ describe('OneDrivePickerClient', () => {
     $imports.$restore();
     delete window.OneDrive;
   });
+
   describe('#constructor', () => {
     it('calls `loadOneDriveAPI`', () => {
       createClient();
@@ -37,28 +40,7 @@ describe('OneDrivePickerClient', () => {
   });
 
   describe('#showPicker', () => {
-    it('invokes `window.OneDrive.open` if OneDrive client loaded successfully', () => {
-      const callbacks = { success: () => {} };
-      const oneDrive = createClient();
-
-      // Emulate the successfully loading
-      window.OneDrive = {
-        open: sinon.stub(),
-      };
-      oneDrive.showPicker(callbacks);
-
-      assert.calledOnce(window.OneDrive.open);
-      assert.calledWith(
-        window.OneDrive.open,
-        sinon.match({
-          clientId: '12345',
-          advanced: { redirectUri: 'https://redirect.uri' },
-          ...callbacks,
-        })
-      );
-    });
-
-    it('fails to invoke `window.OneDrive.open` if OneDrive client failed to load', () => {
+    it('fails to invoke `window.OneDrive.open` if OneDrive client failed to load', async () => {
       const oneDrive = createClient();
       let expectedError;
 
@@ -66,12 +48,86 @@ describe('OneDrivePickerClient', () => {
       // 1. an unhandled rejection raised in the constructor
       // 2. window.OneDrive is undefined
       try {
-        oneDrive.showPicker();
+        await oneDrive.showPicker();
       } catch (error) {
         expectedError = error;
       }
 
       assert.instanceOf(expectedError, Error); // window.OneDrive is undefined
+    });
+
+    it('resolves with a file object when a file is selected', async () => {
+      const oneDrive = createClient();
+
+      // Emulates the successful loading of the OneDrive client and the user
+      // selecting a file.
+      window.OneDrive = {
+        open: sinon.stub(),
+      };
+      const onSuccess = oneDrive.showPicker();
+      const { success } = window.OneDrive.open.getCall(0).args[0];
+      success({
+        value: [
+          { permissions: [{ link: { webUrl: 'https://1drv.ms/b/s!AmH' } }] },
+        ],
+      });
+      const { url } = await onSuccess;
+
+      const { clientId, redirectURI: redirectUri } = clientOptions;
+      assert.calledWith(
+        window.OneDrive.open,
+        sinon.match({
+          clientId,
+          advanced: { redirectUri },
+        })
+      );
+      assert.equal(
+        url,
+        'https://api.onedrive.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2IvcyFBbUg/root/content'
+      );
+    });
+
+    it('rejects with a `PickerCancelledError` if the user cancels the picker', async () => {
+      let expectedError;
+      const oneDrive = createClient();
+
+      // Emulates the successful loading of the OneDrive client and the user
+      // cancelling the picker.
+      window.OneDrive = {
+        open: sinon.stub(),
+      };
+      const onCancel = oneDrive.showPicker();
+      const { cancel } = window.OneDrive.open.getCall(0).args[0];
+      cancel();
+      try {
+        await onCancel;
+      } catch (error) {
+        expectedError = error;
+      }
+
+      assert.instanceOf(expectedError, PickerCanceledError);
+    });
+
+    it('rejects with an error if the picker has other problems', async () => {
+      const oneDrive = createClient();
+      const oneDriveError = new Error('OneDrive picker internal error');
+      let expectedError;
+
+      // Emulate the successful loading of the OneDrive client and the picker
+      // erroring while the user interacting with it.
+      window.OneDrive = {
+        open: sinon.stub(),
+      };
+      const onError = oneDrive.showPicker();
+      const { error } = window.OneDrive.open.getCall(0).args[0];
+      error(oneDriveError);
+      try {
+        await onError;
+      } catch (error) {
+        expectedError = error;
+      }
+
+      assert.equal(oneDriveError, expectedError);
     });
   });
 

--- a/lms/static/scripts/test-util/wait.js
+++ b/lms/static/scripts/test-util/wait.js
@@ -61,3 +61,8 @@ export function waitForElement(wrapper, selector, timeout = 10) {
     `"${selector}" to render`
   );
 }
+
+/** @param {number} ms */
+export function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
I created the `OneDrivePickerClient` class that uses the
`loadOneDriveAPI` to load the OneDrive JS bundle asynchronously.

`OneDrivePcikerClient` has a single method, `showPicker` to launch the
OneDrive picker. It is a callback based method.

To test this PR:

* Login into http://localhost:8001/admin
* Find  the following consumer key: `Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a`
* Click on the `Microsoft OneDrive enabled` checkbox
* Click Save

Then, you should be able to see the `Select PDF from OneDrive` option when setting an assignment in LMS:

![Screenshot 2021-09-22 at 14 52 03](https://user-images.githubusercontent.com/8555781/134346879-de48dc3c-dc47-4e2b-92ce-a4beebedf732.png)