### PR TITLE
Update `baseURL` for pattern library

### DIFF
--- a/lms/static/scripts/ui-playground/index.js
+++ b/lms/static/scripts/ui-playground/index.js
@@ -4,5 +4,6 @@ import { startApp } from '@hypothesis/frontend-shared/lib/pattern-library';
 import lmsIcons from '../frontend_apps/icons.js';
 
 startApp({
+  baseURL: '/ui-playground',
   icons: lmsIcons,
 });


### PR DESCRIPTION
The Pattern Library no longer serves by default at `/ui-playground`, so we need to set a `baseURL`.

This will make the Pattern Library serve correctly again at https://lms.hypothes.is/ui-playground/

You can see it locally at http://localhost:8001/ui-playground