### PR TITLE
Minor improvements in google-*-client-test.js

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/google-api-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-api-client-test.js
@@ -13,6 +13,7 @@ describe('loadLibraries', () => {
 
   afterEach(() => {
     document.createElement.restore();
+    dummyScript.remove();
   });
 
   it('loads API script', async () => {

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -113,8 +113,12 @@ describe('GooglePickerClient', () => {
     });
   });
 
+  afterEach(() => {
+    $imports.$restore();
+  });
+
   describe('#constructor', () => {
-    it('loads Google API client', async () => {
+    it('loads Google API client', () => {
       createClient();
       assert.calledWith(fakeLoadLibraries, ['auth2', 'client', 'picker']);
     });


### PR DESCRIPTION
While working on the OneDrive support I modelled my tests on the google
drive tests and I noticed a few minor issues:

* google-api-client-test.js leaves some HTML elements in the body

* google-picker-client-test.js is not restoring the mocked imports

* an unnecessary async