### PR TITLE
Log refresh token changes

### DIFF
--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -1,9 +1,12 @@
 import datetime
+import logging
 
 from sqlalchemy.orm.exc import NoResultFound
 
 from lms.models import OAuth2Token
 from lms.services import OAuth2TokenError
+
+logger = logging.getLogger(__name__)
 
 
 class OAuth2TokenService:
@@ -36,6 +39,16 @@ class OAuth2TokenService:
                 consumer_key=self._consumer_key, user_id=self._user_id
             )
             self._db.add(oauth2_token)
+        else:
+            if (
+                oauth2_token.refresh_token
+                and oauth2_token.refresh_token != refresh_token
+            ):
+                logger.warning(
+                    "Oauth2 refresh token new value for %s:%s",
+                    self._consumer_key,
+                    self._user_id,
+                )
 
         oauth2_token.access_token = access_token
         oauth2_token.refresh_token = refresh_token

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from unittest import mock
 
@@ -31,6 +32,46 @@ class TestOAuth2TokenService:
             }
         )
 
+    @pytest.mark.parametrize(
+        "original_token,expect_log", [(None, False), ("token", True)]
+    )
+    def test_save_new_refresh_token(
+        self,
+        original_token,
+        expect_log,
+        svc,
+        db_session,
+        application_instance,
+        lti_user,
+        caplog,
+    ):
+        oauth_token = factories.OAuth2Token.build(
+            user_id=lti_user.user_id,
+            consumer_key=application_instance.consumer_key,
+            application_instance=application_instance,
+            refresh_token=original_token,
+        )
+
+        db_session.add(oauth_token)
+
+        svc.save(
+            access_token=oauth_token.access_token,
+            refresh_token="NEW REFRESH TOKEN",
+            expires_in=1234,
+        )
+
+        oauth2_token = db_session.query(OAuth2Token).one()
+
+        assert oauth2_token.refresh_token == "NEW REFRESH TOKEN"
+        if expect_log:
+            assert caplog.record_tuples == [
+                (
+                    "lms.services.oauth2_token",
+                    logging.WARNING,
+                    f"Oauth2 refresh token new value for {oauth2_token.consumer_key}:{svc._user_id}",  # pylint:disable=protected-access
+                )
+            ]
+
     def test_get_returns_token_when_present(self, svc, oauth_token):
         result = svc.get()
 
@@ -46,7 +87,7 @@ class TestOAuth2TokenService:
                 "consumer_key": application_instance.consumer_key,
                 "user_id": lti_user.user_id,
                 wrong_param: "WRONG",
-            }
+            },
         )
 
         with pytest.raises(OAuth2TokenError):


### PR DESCRIPTION
We seem to be prompting the users to complete an oauth more often than before in canvas: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1632415274068500

This should only happen if the refresh token is no longer valid which seem to happen from time to time: https://my.papertrailapp.com/groups/14104911/events?q=refresh_token+not+found

A refresh token could be no longer valid if canvas decides that's the case or, if canvas sent us a new one and we still used the old one.

The refresh token changing should to not occur according to Canvas's docs: `The response to this request will not contain a new refresh token; the same refresh token is to be reused.`  https://canvas.instructure.com/doc/api/file.oauth.html but I'd like to log that to confirm it.

If refresh tokens did in fact change we could be hitting a bug where two almost simultaneous API request request and new access_token, one of them getting a new refresh_token while the other one uses the one not yet updated refresh token present in the DB.

 