### PR TITLE
Split `services.ConsumerKeyError` into two

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -42,7 +42,7 @@ class JSConfig:
         """
         Return the current request's ApplicationInstance.
 
-        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
+        :raise ApplicationInstanceNotFound: if request.lti_user.oauth_consumer_key isn't in the DB
         """
         return self._request.find_service(name="application_instance").get()
 
@@ -174,7 +174,7 @@ class JSConfig:
 
         This mode launches an assignment.
 
-        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
+        :raise ApplicationInstanceNotFound: if request.lti_user.oauth_consumer_key isn't in the DB
         """
         self._config["mode"] = JSConfig.Mode.BASIC_LTI_LAUNCH
 
@@ -201,7 +201,7 @@ class JSConfig:
         :param form_fields: the fields (keys and values) to include in the
             HTML form that we submit
 
-        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
+        :raise ApplicationInstanceNotFound: if request.lti_user.oauth_consumer_key isn't in the DB
         """
 
         args = self._context, self._request, self._application_instance()
@@ -265,7 +265,7 @@ class JSConfig:
         In theory, though, the focused_user param could work outside of Canvas
         as well if we ever want it to.
 
-        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
+        :raise ApplicationInstanceNotFound: if request.lti_user.oauth_consumer_key isn't in the DB
         """
         focused_user = self._request.params.get("focused_user")
 
@@ -417,7 +417,7 @@ class JSConfig:
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
 
-        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
+        :raise ApplicationInstanceNotFound: if request.lti_user.oauth_consumer_key isn't in the DB
         """
         # This is a lazy-computed property so that if it's going to raise an
         # exception that doesn't happen until someone actually reads it.

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -3,7 +3,7 @@ import functools
 
 from lms.models._hashed_id import hashed_id
 from lms.resources._js_config import JSConfig
-from lms.services import ConsumerKeyError
+from lms.services import ApplicationInstanceNotFound
 
 
 class LTILaunchResource:
@@ -123,7 +123,7 @@ class LTILaunchResource:
 
         try:
             application_instance = self._application_instance_service.get()
-        except ConsumerKeyError:
+        except ApplicationInstanceNotFound:
             return False
 
         return bool(application_instance.developer_key)
@@ -144,7 +144,7 @@ class LTILaunchResource:
         """Return True if Canvas groups are enabled at the school/installation level."""
         try:
             application_instance = self._application_instance_service.get()
-        except ConsumerKeyError:
+        except ApplicationInstanceNotFound:
             return False
 
         return bool(application_instance.settings.get("canvas", "groups_enabled"))

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,3 +1,4 @@
+from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.canvas import CanvasService
 from lms.services.exceptions import (
     BlackboardFileNotFoundInCourse,
@@ -5,16 +6,18 @@ from lms.services.exceptions import (
     CanvasAPIPermissionError,
     CanvasAPIServerError,
     CanvasFileNotFoundInCourse,
-    ConsumerKeyError,
     ExternalRequestError,
     HTTPError,
-    LTILaunchVerificationError,
-    LTIOAuthError,
     LTIOutcomesAPIError,
     OAuth2TokenError,
     ProxyAPIError,
 )
 from lms.services.h_api import HAPIError
+from lms.services.launch_verifier import (
+    ConsumerKeyLaunchVerificationError,
+    LTILaunchVerificationError,
+    LTIOAuthError,
+)
 
 
 def includeme(config):

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -1,7 +1,10 @@
 from functools import lru_cache
 
 from lms.models import ApplicationInstance
-from lms.services import ConsumerKeyError
+
+
+class ApplicationInstanceNotFound(Exception):
+    """The requested ApplicationInstance wasn't found in the database."""
 
 
 class ApplicationInstanceService:
@@ -18,7 +21,8 @@ class ApplicationInstanceService:
         ApplicationInstance (the ApplicationInstance whose consumer_key matches
         request.lti_user.oauth_consumer_key).
 
-        :raise ConsumerKeyError: if the consumer_key isn't in the database
+        :raise ApplicationInstanceNotFound: if there's no ApplicationInstance
+            with consumer_key in the database
         """
         consumer_key = consumer_key or self._default_consumer_key
 
@@ -27,7 +31,7 @@ class ApplicationInstanceService:
         )
 
         if application_instance is None:
-            raise ConsumerKeyError()
+            raise ApplicationInstanceNotFound()
 
         return application_instance
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,21 +1,3 @@
-class LTILaunchVerificationError(Exception):
-    """
-    Raised when LTI launch request verification fails.
-
-    This is the base class for all LTI launch request verification errors.
-    Different subclasses of this exception class are raised for specific
-    failure types.
-    """
-
-
-class ConsumerKeyError(LTILaunchVerificationError):
-    """Raised when a given ``consumer_key`` doesn't exist in the DB."""
-
-
-class LTIOAuthError(LTILaunchVerificationError):
-    """Raised when OAuth signature verification of a launch request fails."""
-
-
 class ExternalRequestError(Exception):
     """
     A problem with a network request to an external service.

--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -15,7 +15,7 @@ class LTILaunchVerificationError(Exception):
 
 
 class ConsumerKeyLaunchVerificationError(LTILaunchVerificationError):
-    """Raised when a given ``consumer_key`` doesn't exist in the DB."""
+    """Raised when the request's consumer_key doesn't exist in the DB."""
 
 
 class LTIOAuthError(LTILaunchVerificationError):

--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -42,11 +42,11 @@ class LaunchVerifier:
           launch request. Different :exc:`LTILaunchVerificationError`
           subclasses are raised for different types of verification failure.
 
-        :raise NoConsumerKey: If the request has no ``oauth_consumer_key``
+        :raise NoConsumerKey: If the request has no oauth_consumer_key
           parameter (maybe it's not an LTI launch request at all?)
 
         :raise ConsumerKeyLaunchVerificationError: If the request's
-          ``oauth_consumer_key`` parameter isn't found in our database (this
+          oauth_consumer_key parameter isn't found in our database (this
           appears to be an invalid LTI launch request).
 
         :raise LTIOAuthError: If OAuth 1.0 verification of the request and its

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -41,7 +41,7 @@ class LTIHService:
             models.GroupInfo
 
         :raise HTTPInternalServerError: if we can't sync to h for any reason
-        :raise ConsumerKeyError: if request.lti_user.oauth_consumer_key isn't in the DB
+        :raise ApplicationInstanceNotFound: if request.lti_user.oauth_consumer_key isn't in the DB
         """
 
         if not self._application_instance_service.get().provisioning:

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -7,7 +7,7 @@ from pyramid.view import (
 )
 
 from lms.security import Permissions
-from lms.services import ConsumerKeyError
+from lms.services import ApplicationInstanceNotFound
 
 
 @forbidden_view_config(path_info="/admin/*")
@@ -52,7 +52,7 @@ class AdminViews:
 
         try:
             ai = self.application_instance_service.get(consumer_key)
-        except ConsumerKeyError:
+        except ApplicationInstanceNotFound:
             self.request.session.flash(
                 f'No application instance found for {self.request.params["query"]}',
                 "errors",
@@ -103,5 +103,5 @@ class AdminViews:
     def _get_ai_or_404(self, consumer_key):
         try:
             return self.application_instance_service.get(consumer_key)
-        except ConsumerKeyError as err:
+        except ApplicationInstanceNotFound as err:
             raise HTTPNotFound() from err

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -6,7 +6,7 @@ from h_matchers import Any
 from lms.models import GradingInfo, Grouping
 from lms.resources import LTILaunchResource, OAuth2RedirectResource
 from lms.resources._js_config import JSConfig
-from lms.services import ConsumerKeyError, HAPIError
+from lms.services import ApplicationInstanceNotFound, HAPIError
 
 pytestmark = pytest.mark.usefixtures(
     "application_instance_service",
@@ -106,9 +106,9 @@ class TestEnableLTILaunchMode:
     def test_it_raises_if_theres_no_ApplicationInstance(
         self, application_instance_service, js_config
     ):
-        application_instance_service.get.side_effect = ConsumerKeyError
+        application_instance_service.get.side_effect = ApplicationInstanceNotFound
 
-        with pytest.raises(ConsumerKeyError):
+        with pytest.raises(ApplicationInstanceNotFound):
             js_config.enable_lti_launch_mode()
 
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -5,7 +5,7 @@ from pytest import param
 
 from lms.models import ApplicationSettings
 from lms.resources import LTILaunchResource
-from lms.services import ConsumerKeyError
+from lms.services import ApplicationInstanceNotFound
 
 pytestmark = pytest.mark.usefixtures("application_instance_service", "course_service")
 
@@ -118,7 +118,7 @@ class TestCanvasSectionsSupported:
     def test_if_application_instance_service_raises(
         self, lti_launch, application_instance_service
     ):
-        application_instance_service.get.side_effect = ConsumerKeyError
+        application_instance_service.get.side_effect = ApplicationInstanceNotFound
         assert not lti_launch.canvas_sections_supported()
 
     @pytest.fixture(autouse=True)
@@ -200,7 +200,7 @@ class TestCanvasGroupsEnabled:
     def test_false_when_no_application_instance(
         self, application_instance_service, lti_launch
     ):
-        application_instance_service.get.side_effect = ConsumerKeyError
+        application_instance_service.get.side_effect = ApplicationInstanceNotFound
 
         assert not lti_launch.canvas_groups_enabled
 

--- a/tests/unit/lms/services/application_instance_service_test.py
+++ b/tests/unit/lms/services/application_instance_service_test.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from lms.services import ConsumerKeyError
+from lms.services import ApplicationInstanceNotFound
 from lms.services.application_instance import factory
 from tests import factories
 
@@ -20,15 +20,19 @@ class TestApplicationInstanceService:
 
         assert svc.get() == application_instance
 
-    def test_get_raises_ConsumerKeyError_if_consumer_key_doesnt_exist(self, svc):
-        with pytest.raises(ConsumerKeyError):
+    def test_get_raises_ApplicationInstanceNotFound_if_consumer_key_doesnt_exist(
+        self, svc
+    ):
+        with pytest.raises(ApplicationInstanceNotFound):
             assert svc.get("NOPE") is None
 
-    def test_get_raises_ConsumerKeyError_if_consumer_key_is_None(self, pyramid_request):
+    def test_get_raises_ApplicationInstanceNotFound_if_consumer_key_is_None(
+        self, pyramid_request
+    ):
         pyramid_request.lti_user = None
         svc = factory(mock.sentinel.context, pyramid_request)
 
-        with pytest.raises(ConsumerKeyError):
+        with pytest.raises(ApplicationInstanceNotFound):
             svc.get(None)
 
     @pytest.fixture

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -5,7 +5,7 @@ from h_api.bulk_api import CommandBuilder
 from pyramid.httpexceptions import HTTPInternalServerError
 
 from lms.models import Grouping
-from lms.services import ConsumerKeyError, HAPIError
+from lms.services import ApplicationInstanceNotFound, HAPIError
 from lms.services.lti_h import LTIHService
 from tests import factories
 
@@ -77,9 +77,9 @@ class TestSync:
     def test_sync_raises_if_theres_no_ApplicationInstance(
         self, application_instance_service, grouping, lti_h_svc
     ):
-        application_instance_service.get.side_effect = ConsumerKeyError
+        application_instance_service.get.side_effect = ApplicationInstanceNotFound
 
-        with pytest.raises(ConsumerKeyError):
+        with pytest.raises(ApplicationInstanceNotFound):
             lti_h_svc.sync([grouping], sentinel.params)
 
 

--- a/tests/unit/lms/views/admin_test.py
+++ b/tests/unit/lms/views/admin_test.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound
 
-from lms.services import ConsumerKeyError
+from lms.services import ApplicationInstanceNotFound
 from lms.views.admin import AdminViews, logged_out, notfound
 from tests.matchers import temporary_redirect_to
 
@@ -30,7 +30,7 @@ class TestAdminViews:
     def test_find_instance_not_found(
         self, pyramid_request, application_instance_service
     ):
-        application_instance_service.get.side_effect = ConsumerKeyError
+        application_instance_service.get.side_effect = ApplicationInstanceNotFound
         pyramid_request.params["query"] = "some-value"
         response = AdminViews(pyramid_request).find_instance()
 
@@ -60,7 +60,7 @@ class TestAdminViews:
         )
 
     def test_show_not_found(self, pyramid_request, application_instance_service):
-        application_instance_service.get.side_effect = ConsumerKeyError
+        application_instance_service.get.side_effect = ApplicationInstanceNotFound
         pyramid_request.matchdict["consumer_key"] = sentinel.consumer_key
 
         with pytest.raises(HTTPNotFound):
@@ -111,7 +111,7 @@ class TestAdminViews:
     def test_update_instance_not_found(
         self, pyramid_request, application_instance_service
     ):
-        application_instance_service.get.side_effect = ConsumerKeyError
+        application_instance_service.get.side_effect = ApplicationInstanceNotFound
         pyramid_request.matchdict["consumer_key"] = sentinel.consumer_key
 
         with pytest.raises(HTTPNotFound):


### PR DESCRIPTION
**Problem:** `services.ConsumerKeyError` is being abused for two different purposes.  `ConsumerKeyError` is a subclass of `LTILaunchVerificationError` and as such it's *supposed* to be raised by the `LTILaunchVerifier` service when LTI launch verification fails. But `ConsumerKeyError` is *also* being raised by `ApplicationInstanceService.get(consumer_key)` when there's no `ApplicationInstance` for the given `consumer_key` in the DB. This second case
is not an LTI launch verification error and is not an appropriate use of an `LTILaunchVerificationError` subclass.

**Solution:** split `services.ConsumerKeyError` into two separate classes:

1. `services.ConsumerKeyLaunchVerificationError(LTILaunchVerificationError)`:

   This is raised by the `LTILaunchVerifier` service when LTI launch verification fails because the consumer key given in the request was not found in our database.  It's a subclass of `LTILaunchVerificationError` which is the base class for all LTI launch verification failures raised by `LTILaunchVerifier`.

2. `services.ApplicationInstanceNotFound(Exception)`:

   This is raised by `ApplicationInstanceService.get(consumer_key)` when there's no `ApplicationInstance` with the requested `consumer_key` in the DB.

   Lots of methods throughout the codebase indirectly raise `ApplicationInstanceNotFound` (because they call `ApplicationInstanceService.get()` and don't catch it) and lots of methods catch `ApplicationInstanceNotFound`.