### PR TITLE
Move exceptions into the files that raise them

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,21 +1,23 @@
+from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.canvas import CanvasService
 from lms.services.exceptions import (
-    ApplicationInstanceNotFound,
     BlackboardFileNotFoundInCourse,
     CanvasAPIError,
     CanvasAPIPermissionError,
     CanvasAPIServerError,
     CanvasFileNotFoundInCourse,
-    ConsumerKeyLaunchVerificationError,
     ExternalRequestError,
     HAPIError,
     HTTPError,
-    LTILaunchVerificationError,
-    LTIOAuthError,
     LTIOutcomesAPIError,
     OAuth2TokenError,
     ProxyAPIError,
     ServiceError,
+)
+from lms.services.launch_verifier import (
+    ConsumerKeyLaunchVerificationError,
+    LTILaunchVerificationError,
+    LTIOAuthError,
 )
 
 

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -1,7 +1,10 @@
 from functools import lru_cache
 
 from lms.models import ApplicationInstance
-from lms.services.exceptions import ApplicationInstanceNotFound
+
+
+class ApplicationInstanceNotFound(Exception):
+    """The requested ApplicationInstance wasn't found in the database."""
 
 
 class ApplicationInstanceService:

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -2,28 +2,6 @@ class ServiceError(Exception):
     """Base class for all :mod:`lms.services` exceptions."""
 
 
-class ApplicationInstanceNotFound(ServiceError):
-    """The requested ApplicationInstance wasn't found in the database."""
-
-
-class LTILaunchVerificationError(ServiceError):
-    """
-    Raised when LTI launch request verification fails.
-
-    This is the base class for all LTI launch request verification errors.
-    Different subclasses of this exception class are raised for specific
-    failure types.
-    """
-
-
-class ConsumerKeyLaunchVerificationError(LTILaunchVerificationError):
-    """Raised when a given ``consumer_key`` doesn't exist in the DB."""
-
-
-class LTIOAuthError(LTILaunchVerificationError):
-    """Raised when OAuth signature verification of a launch request fails."""
-
-
 class ExternalRequestError(ServiceError):
     """
     A problem with a network request to an external service.

--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -2,13 +2,24 @@
 from oauthlib.oauth1 import RequestValidator, SignatureOnlyEndpoint
 
 from lms import models
-from lms.services import (
-    ConsumerKeyLaunchVerificationError,
-    LTILaunchVerificationError,
-    LTIOAuthError,
-)
 
-__all__ = ["LaunchVerifier"]
+
+class LTILaunchVerificationError(Exception):
+    """
+    Raised when LTI launch request verification fails.
+
+    This is the base class for all LTI launch request verification errors.
+    Different subclasses of this exception class are raised for specific
+    failure types.
+    """
+
+
+class ConsumerKeyLaunchVerificationError(LTILaunchVerificationError):
+    """Raised when a given ``consumer_key`` doesn't exist in the DB."""
+
+
+class LTIOAuthError(LTILaunchVerificationError):
+    """Raised when OAuth signature verification of a launch request fails."""
 
 
 class LaunchVerifier:


### PR DESCRIPTION
These exception classes are actually only ever raised (and only intended to be raised) by these particular services, so move them into the same files with the service classes that they belong to. This discourages reused but that's the intention here, and doing this makes the intention clearer.