### PR TITLE
Move `HAPIError` into the file that raises it

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -7,7 +7,6 @@ from lms.services.exceptions import (
     CanvasFileNotFoundInCourse,
     ConsumerKeyError,
     ExternalRequestError,
-    HAPIError,
     HTTPError,
     LTILaunchVerificationError,
     LTIOAuthError,
@@ -16,6 +15,7 @@ from lms.services.exceptions import (
     ProxyAPIError,
     ServiceError,
 )
+from lms.services.h_api import HAPIError
 
 
 def includeme(config):

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -66,15 +66,6 @@ class OAuth2TokenError(ExternalRequestError):
     """
 
 
-class HAPIError(ExternalRequestError):
-    """
-    A problem with an h API request.
-
-    Raised whenever an h API request times out or when an unsuccessful, invalid
-    or unexpected response is received from the h API.
-    """
-
-
 class ProxyAPIError(ExternalRequestError):
     """
     A problem with a third-party API request.

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -3,9 +3,16 @@
 from h_api.bulk_api import BulkAPI, CommandBuilder
 
 from lms.models import HUser
-from lms.services import HAPIError, HTTPError
+from lms.services import ExternalRequestError, HTTPError
 
-__all__ = ["HAPI"]
+
+class HAPIError(ExternalRequestError):
+    """
+    A problem with an h API request.
+
+    Raised whenever an h API request times out or when an unsuccessful, invalid
+    or unexpected response is received from the h API.
+    """
 
 
 class HAPI:


### PR DESCRIPTION
`HAPIError` is only ever raised (and only ever intended to be raised) by the `HAPI` service so move it into the same file with `HAPI` service. This discourages reuse but that's the intention here, and doing this makes the intention clearer.

A downside of this change is that it's now harder to see all the `ExternalRequestError` subclasses (they're no longer all in one file).