### PR TITLE
Merge the `canvas_api_error()` and `api_error()` exception views

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -103,7 +103,12 @@ class ExceptionViews:
     def proxy_api_access_token_error(self):
         return self.error_response()
 
-    @exception_view_config(context=CanvasAPIPermissionError)
+    @exception_view_config(
+        # It's unfortunately necessary to mention CanvasAPIPermissionError
+        # specifically here because otherwise the proxy_api_error() exception
+        # view above would catch CanvasAPIPermissionError's.
+        context=CanvasAPIPermissionError
+    )
     @exception_view_config(path_info="/api/*", context=Exception)
     def api_error(self):
         """

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -106,7 +106,26 @@ class ExceptionViews:
     @exception_view_config(context=CanvasAPIPermissionError)
     @exception_view_config(path_info="/api/*", context=Exception)
     def api_error(self):
-        """Fallback error handler for frontend API requests."""
+        """
+        General fallback error handler for API requests.
+
+        If the exception has an `error_code` attribute then:
+
+        1. The `error_code` attribute will be used as the "error_code" field in
+           the response's JSON body
+
+        2. The response's HTTP status will be 400
+
+        3. If the exception also has a `details` attribute this will be used as
+           "details" field in the response's body
+
+        If the exception does not have an `error_code` attribute then:
+
+        1. The response's HTTP status will be 500
+
+        2. A fixed string (see below) will be used as the "message" field in
+           the response's JSON body
+        """
 
         if hasattr(self.context, "error_code"):
             return self.error_response(

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -28,21 +28,6 @@ class TestProxyAPIAccessTokenError:
         assert json_data == {}
 
 
-class TestCanvasAPIPermissionError:
-    def test_it(self, context, pyramid_request, views):
-        json_data = views.canvas_api_error()
-
-        assert pyramid_request.response.status_code == 400
-        assert json_data == {
-            "error_code": context.error_code,
-            "details": context.details,
-        }
-
-    @pytest.fixture
-    def context(self):
-        return CanvasAPIPermissionError(details={"foo": "bar"})
-
-
 class TestCanvasAPIError:
     def test_it(self, pyramid_request, views):
         json_data = views.proxy_api_error()
@@ -100,7 +85,20 @@ class TestForbidden:
 
 
 class TestAPIError:
-    def test_it(self, pyramid_request, views):
+    def test_it_with_a_CanvasAPIPermissionError(self, pyramid_request, views):
+        context = views.context = CanvasAPIPermissionError(details={"foo": "bar"})
+
+        json_data = views.api_error()
+
+        assert pyramid_request.response.status_code == 400
+        assert json_data == {
+            "error_code": context.error_code,
+            "details": context.details,
+        }
+
+    def test_it_with_an_unexpected_error(self, pyramid_request, views):
+        views.context = RuntimeError("Totally unexpected")
+
         json_data = views.api_error()
 
         assert pyramid_request.response.status_code == 500


### PR DESCRIPTION
Merge the `canvas_api_error()` exception view into the general `api_error()` one (the one that catches the base `Exception` class).

The `canvas_api_error()` exception view was getting a little silly because it has an ever-growing list of `@exception_view_config()`'s on it:

```python
@exception_view_config(context=BlackboardFileNotFoundInCourse)
@exception_view_config(context=CanvasAPIPermissionError)
@exception_view_config(context=CanvasFileNotFoundInCourse)
@exception_view_config(context=CanvasGroupError)
def canvas_api_error(self):
    ...
```

And more need to be added in future.

The name `canvas_api_error()` has become out of date because the view now catches:

1. Blackboard exceptions not just Canvas ones
2. Not all Canvas exceptions. Some other `CanvasAPIerror` subclasses go to other exception views

It's not possible to change the exception view to catch a common base class of all these different exception classes because the exception classes come from disparate locations in the exception tree. There's no base class that's common to all the exception classes we want to catch while not also belonging to some other exception classes we don't want to catch.

What's actually going on here is that `canvas_api_error()` is for exception objects that have an `error_code` attribute and an optional `details` attribute. When combined with the `400` response status and JSON body format that `canvas_api_error()` returns, the `error_code` attributes trigger custom error dialogs from the frontend.

This commit deletes the `canvas_api_error()` exception view and allows these exception classes to fall through to the catch-all `api_error()` exception view. This commit then enhances the `api_error()` exception view to use a duck-typing approach to turn exceptions with an `error_code` attribute into the necessary `400` error response will still turning other unexpected exceptions into `500`'s:

```python
@exception_view_config(context=CanvasAPIPermissionError)
@exception_view_config(path_info="/api/*", context=Exception)
def api_error(self):
    if hasattr(self.context, "error_code"):
        return self.error_response(
            error_code=self.context.error_code,
            details=getattr(self.context, "details", None),
        )

    return self.error_response(
        500,
        message=_("A problem occurred..."),
    )
```

The `@exception_view_config(context=CanvasAPIPermissionError)` is unfortunately necessary because otherwise `CanvasAPIPermissionError` would get caught by the `proxy_api_error()` exception view further up in the file.

This will make it easy to add new exception classes of this special-error-code type in future. The new exception classes can be
anywhere in the exception class hierarchy and, as long as they aren't caught by any other exception view, they be caught by the general `api_error()` view and handled specially because they have an `error_code` attribute.

Slack thread: https://hypothes-is.slack.com/archives/C1MA4E9B9/p1632239895060000