### PR TITLE
Don't wrap `HAPIError` in `HTTPInternalServerError`

### DIFF
--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -1,7 +1,4 @@
 from h_api.bulk_api import CommandBuilder
-from pyramid.httpexceptions import HTTPInternalServerError
-
-from lms.services import HAPIError
 
 
 class LTIHService:
@@ -47,11 +44,7 @@ class LTIHService:
         if not self._application_instance_service.get().provisioning:
             return
 
-        try:
-            self._h_api.execute_bulk(commands=self._yield_commands(h_groups))
-
-        except HAPIError as err:
-            raise HTTPInternalServerError(explanation=err.explanation) from err
+        self._h_api.execute_bulk(commands=self._yield_commands(h_groups))
 
         # Keep a note of the groups locally for reporting purposes.
         for h_group in h_groups:

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -2,7 +2,6 @@ from unittest.mock import create_autospec, sentinel
 
 import pytest
 from h_api.bulk_api import CommandBuilder
-from pyramid.httpexceptions import HTTPInternalServerError
 
 from lms.models import Grouping
 from lms.services import ApplicationInstanceNotFound, HAPIError
@@ -29,7 +28,7 @@ class TestSync:
     ):
         h_api.execute_bulk.side_effect = HAPIError
 
-        with pytest.raises(HTTPInternalServerError):
+        with pytest.raises(HAPIError):
             lti_h_svc.sync([grouping], sentinel.params)
 
         group_info_service.assert_not_called()

--- a/tests/unit/lms/views/exceptions_test.py
+++ b/tests/unit/lms/views/exceptions_test.py
@@ -1,10 +1,11 @@
 from unittest import mock
 
 import pytest
-from pyramid.httpexceptions import HTTPBadRequest, HTTPServerError
+from pyramid.httpexceptions import HTTPBadRequest
 
 from lms.models import ReusedConsumerKey
 from lms.resources._js_config import JSConfig
+from lms.services import HAPIError
 from lms.validation import ValidationError
 from lms.views import exceptions
 
@@ -75,13 +76,13 @@ class TestHTTPClientError(ExceptionViewTest):
     expected_result = {"message": exception.args[0]}
 
 
-class TestHTTPServerError(ExceptionViewTest):
-    view = exceptions.http_server_error
-    exception = HTTPServerError("This is the error message")
+class TestHAPIError(ExceptionViewTest):
+    view = exceptions.hapi_error
+    exception = HAPIError("This is the error message")
 
     response_status = 500
     report_to_sentry = True
-    expected_result = {"message": exception.args[0]}
+    expected_result = {"message": "This is the error message"}
 
 
 class TestValidationError(ExceptionViewTest):


### PR DESCRIPTION
I'm not sure why the code does this: `LTIHService` doesn't need to raise an `HAPIError` wrapped in an `HTTPInternalServerError`. It can just raise the `HAPIError` directly and the exception view can catch `HAPIError`.

This is easier to follow because you can just see that the `HAPI` service raises `HAPIError` and the exception view catches `HAPIError` and you can see what the exception view does with that error. Rather than having to know that the `HAPI` service raises `HAPIError` which `LTIHService` catches and turns into an `HTTPInternalServerError` which
is then caught by the exception view for `HTTPServerError` (a parent class of `HTTPInternalServerError`).

Note that the exception view previously caught `HTTPServerError` and all its subclasses, which is all the Pyramid 5xx `httpexception`'s. But I think the `HAPIError` wrapped in an `HTTPInternalServerError` was the only case where any `HTTPServerError` was actually being raised. So I don't think there's any unintended change in behaviour here.