### PR TITLE
Don't unnecessarily manually report things to Sentry

### DIFF
--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -1,4 +1,3 @@
-import h_pyramid_sentry
 from pyramid import i18n
 from pyramid.config import not_
 from pyramid.httpexceptions import HTTPClientError
@@ -43,7 +42,6 @@ def http_client_error(exc, request):
 
 @exception_view_config(context=HAPIError, renderer=DEFAULT_RENDERER)
 def hapi_error(exc, request):
-    h_pyramid_sentry.report_exception()
     request.response.status_int = 500
     return {"message": str(exc)}
 


### PR DESCRIPTION
If an exception is handled by an exception view then Sentry's Pyramid integration won't automatically report the exception *unless* the exception view results in a 500 response. Since this exception view does always result in a 500 there's no need for us to manually report the exception.