### PR TITLE
Don't register API exception views for non-API requests and vice-versa

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -21,7 +21,7 @@ class JSConfig:
     class ErrorCode(str, Enum):
         BLACKBOARD_MISSING_INTEGRATION = "blackboard_missing_integration"
         CANVAS_INVALID_SCOPE = "canvas_invalid_scope"
-        REUSED_TOOL_GUID = "reused_tool_guid"
+        REUSED_CONSUMER_KEY = "reused_consumer_key"
 
     def __init__(self, context, request):
         self._context = context

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -21,7 +21,7 @@ export default function ErrorDialogApp() {
   let message;
 
   switch (errorCode) {
-    case 'reused_tool_guid':
+    case 'reused_consumer_key':
       title = 'Consumer key registered with another site';
       message = 'Reused tool_consumer_instance_guid';
       break;
@@ -32,7 +32,7 @@ export default function ErrorDialogApp() {
 
   return (
     <Dialog title={title}>
-      {error.code === 'reused_tool_guid' && (
+      {error.code === 'reused_consumer_key' && (
         <>
           This Hypothesis installation&apos;s consumer key appears to have
           already been used on another site. This could be because:

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
@@ -31,8 +31,8 @@ describe('ErrorDialogApp', () => {
     assert.include(wrapper.text(), 'Unknown error occurred');
   });
 
-  it('shows dialog for reused tool_consumer_guid', () => {
-    fakeConfig.errorCode = 'reused_tool_guid';
+  it('shows dialog for reused_consumer_key', () => {
+    fakeConfig.errorCode = 'reused_consumer_key';
 
     const wrapper = renderApp();
     assert.include(

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -97,7 +97,7 @@ import { createContext } from 'preact';
  */
 
 /**
- * @typedef {'reused_tool_guid'} ErrorCode
+ * @typedef {'reused_consumer_key'} ErrorCode
  */
 
 /**

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -13,8 +13,8 @@ from lms.validation import ValidationError
 _ = i18n.TranslationStringFactory(__package__)
 
 
-@view_defaults(renderer="json")
-class ExceptionViews:
+@view_defaults(path_info="^/api/.*", renderer="json")
+class APIExceptionViews:
     """
     Exception views for the API.
 
@@ -109,7 +109,7 @@ class ExceptionViews:
         # view above would catch CanvasAPIPermissionError's.
         context=CanvasAPIPermissionError
     )
-    @exception_view_config(path_info="/api/*", context=Exception)
+    @exception_view_config(context=Exception)
     def api_error(self):
         """
         General fallback error handler for API requests.
@@ -146,13 +146,13 @@ class ExceptionViews:
             ),
         )
 
-    @forbidden_view_config(path_info="/api/*")
+    @forbidden_view_config()
     def forbidden(self):
         return self.error_response(
             403, message=_("You're not authorized to view this page.")
         )
 
-    @notfound_view_config(path_info="/api/*")
+    @notfound_view_config()
     def notfound(self):
         return self.error_response(404, message=_("Endpoint not found."))
 

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -23,23 +23,19 @@ class ExceptionViews:
 
     @notfound_view_config()
     def notfound(self):
-        self.request.response.status_int = 404
-        return {"message": _("Page not found")}
+        return self.error_response(404, _("Page not found"))
 
     @forbidden_view_config()
     def forbidden(self):
-        self.request.response.status_int = 403
-        return {"message": _("You're not authorized to view this page")}
+        return self.error_response(403, _("You're not authorized to view this page"))
 
     @exception_view_config(context=HTTPClientError)
     def http_client_error(self):
-        self.request.response.status_int = self.exception.status_int
-        return {"message": str(self.exception)}
+        return self.error_response(self.exception.status_int, str(self.exception))
 
     @exception_view_config(context=HAPIError)
     def hapi_error(self):
-        self.request.response.status_int = 500
-        return {"message": str(self.exception)}
+        return self.error_response(500, str(self.exception))
 
     @exception_view_config(
         context=ValidationError, renderer="lms:templates/validation_error.html.jinja2"
@@ -64,11 +60,16 @@ class ExceptionViews:
 
     @exception_view_config(context=Exception)
     def error(self):
-        self.request.response.status_int = 500
-        return {
-            "message": _(
+        return self.error_response(
+            500,
+            _(
                 "Sorry, but something went wrong. "
                 "The issue has been reported and we'll try to "
                 "fix it."
-            )
-        }
+            ),
+        )
+
+    def error_response(self, status, message):
+        """Set the response status and return template data for error.html.jinja2."""
+        self.request.response.status_int = status
+        return {"message": message}

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -48,6 +48,8 @@ class ExceptionViews:
         ReusedConsumerKey, renderer="lms:templates/error_dialog.html.jinja2"
     )
     def reused_tool_guid_error(self):
+        self.request.response.status_int = 400
+
         self.request.context.js_config.enable_error_dialog_mode(
             self.request.context.js_config.ErrorCode.REUSED_TOOL_GUID,
             error_details={

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -5,6 +5,7 @@ from pyramid.view import (
     exception_view_config,
     forbidden_view_config,
     notfound_view_config,
+    view_defaults,
 )
 
 from lms.models import ReusedConsumerKey
@@ -13,83 +14,78 @@ from lms.validation import ValidationError
 
 _ = i18n.TranslationStringFactory(__package__)
 
-DEFAULT_RENDERER = "lms:templates/error.html.jinja2"
 
+@view_defaults(path_info=not_("^/api/.*"), renderer="lms:templates/error.html.jinja2")
+class ExceptionViews:
+    def __init__(self, exception, request):
+        self.exception = exception
+        self.request = request
 
-@notfound_view_config(renderer=DEFAULT_RENDERER)
-def notfound(_exc, request):
-    request.response.status_int = 404
-    return {"message": _("Page not found")}
+    @notfound_view_config()
+    def notfound(self):
+        self.request.response.status_int = 404
+        return {"message": _("Page not found")}
 
+    @forbidden_view_config()
+    def forbidden(self):
+        self.request.response.status_int = 403
+        return {"message": _("You're not authorized to view this page")}
 
-@forbidden_view_config(renderer=DEFAULT_RENDERER)
-def forbidden(_exc, request):
-    request.response.status_int = 403
-    return {"message": _("You're not authorized to view this page")}
+    @exception_view_config(context=HTTPClientError)
+    def http_client_error(self):
+        """Handle an HTTP 4xx (client error) exception."""
+        self.request.response.status_int = self.exception.status_int
+        return {"message": str(self.exception)}
 
+    @exception_view_config(context=HAPIError)
+    def hapi_error(self):
+        self.request.response.status_int = 500
+        return {"message": str(self.exception)}
 
-@exception_view_config(context=HTTPClientError, renderer=DEFAULT_RENDERER)
-def http_client_error(exc, request):
-    """Handle an HTTP 4xx (client error) exception."""
-    request.response.status_int = exc.status_int
-    return {"message": str(exc)}
-
-
-@exception_view_config(context=HAPIError, renderer=DEFAULT_RENDERER)
-def hapi_error(exc, request):
-    request.response.status_int = 500
-    return {"message": str(exc)}
-
-
-@exception_view_config(
-    context=ValidationError,
-    path_info=not_("^/api/.*"),
-    renderer="lms:templates/validation_error.html.jinja2",
-)
-def validation_error(exc, request):
-    """Handle a ValidationError."""
-    request.response.status_int = exc.status_int
-    return {"error": exc}
-
-
-@exception_view_config(
-    ReusedConsumerKey,
-    renderer="lms:templates/error_dialog.html.jinja2",
-)
-def reused_tool_guid_error(exc, request):
-    request.context.js_config.enable_error_dialog_mode(
-        request.context.js_config.ErrorCode.REUSED_TOOL_GUID,
-        error_details={
-            "existing_tool_consumer_guid": exc.existing_guid,
-            "new_tool_consumer_guid": exc.new_guid,
-        },
+    @exception_view_config(
+        context=ValidationError, renderer="lms:templates/validation_error.html.jinja2"
     )
+    def validation_error(self):
+        """Handle a ValidationError."""
+        self.request.response.status_int = self.exception.status_int
+        return {"error": self.exception}
 
-    return {}
-
-
-@exception_view_config(context=Exception, renderer=DEFAULT_RENDERER)
-def error(_exc, request):
-    """
-    Handle an unexpected exception.
-
-    If the code raises an unexpected exception (anything not caught by any
-    of the more specific exception views above) then we assume it was a
-    bug. When this happens we:
-
-    1. Set the response status to 500 Server Error.
-    2. Show the user an error page containing only a generic error message
-       (don't show them the exception message).
-
-    These issues also get reported to Sentry but we don't have to
-    do that here -- non-HTTPError exceptions are automatically
-    reported by the Pyramid Sentry integration.
-    """
-    request.response.status_int = 500
-    return {
-        "message": _(
-            "Sorry, but something went wrong. "
-            "The issue has been reported and we'll try to "
-            "fix it."
+    @exception_view_config(
+        ReusedConsumerKey, renderer="lms:templates/error_dialog.html.jinja2"
+    )
+    def reused_tool_guid_error(self):
+        self.request.context.js_config.enable_error_dialog_mode(
+            self.request.context.js_config.ErrorCode.REUSED_TOOL_GUID,
+            error_details={
+                "existing_tool_consumer_guid": self.exception.existing_guid,
+                "new_tool_consumer_guid": self.exception.new_guid,
+            },
         )
-    }
+
+        return {}
+
+    @exception_view_config(context=Exception)
+    def error(self):
+        """
+        Handle an unexpected exception.
+
+        If the code raises an unexpected exception (anything not caught by any
+        of the more specific exception views above) then we assume it was a
+        bug. When this happens we:
+
+        1. Set the response status to 500 Server Error.
+        2. Show the user an error page containing only a generic error message
+        (don't show them the exception message).
+
+        These issues also get reported to Sentry but we don't have to
+        do that here -- non-HTTPError exceptions are automatically
+        reported by the Pyramid Sentry integration.
+        """
+        self.request.response.status_int = 500
+        return {
+            "message": _(
+                "Sorry, but something went wrong. "
+                "The issue has been reported and we'll try to "
+                "fix it."
+            )
+        }

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -45,7 +45,6 @@ class ExceptionViews:
         context=ValidationError, renderer="lms:templates/validation_error.html.jinja2"
     )
     def validation_error(self):
-        """Handle a ValidationError."""
         self.request.response.status_int = self.exception.status_int
         return {"error": self.exception}
 

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -33,7 +33,6 @@ class ExceptionViews:
 
     @exception_view_config(context=HTTPClientError)
     def http_client_error(self):
-        """Handle an HTTP 4xx (client error) exception."""
         self.request.response.status_int = self.exception.status_int
         return {"message": str(self.exception)}
 

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -47,14 +47,14 @@ class ExceptionViews:
     @exception_view_config(
         ReusedConsumerKey, renderer="lms:templates/error_dialog.html.jinja2"
     )
-    def reused_tool_guid_error(self):
+    def reused_consumer_key(self):
         self.request.response.status_int = 400
 
         self.request.context.js_config.enable_error_dialog_mode(
-            self.request.context.js_config.ErrorCode.REUSED_TOOL_GUID,
+            self.request.context.js_config.ErrorCode.REUSED_CONSUMER_KEY,
             error_details={
-                "existing_tool_consumer_guid": self.exception.existing_guid,
-                "new_tool_consumer_guid": self.exception.new_guid,
+                "existing_tool_consumer_instance_guid": self.exception.existing_guid,
+                "new_tool_consumer_instance_guid": self.exception.new_guid,
             },
         )
 

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -64,21 +64,6 @@ class ExceptionViews:
 
     @exception_view_config(context=Exception)
     def error(self):
-        """
-        Handle an unexpected exception.
-
-        If the code raises an unexpected exception (anything not caught by any
-        of the more specific exception views above) then we assume it was a
-        bug. When this happens we:
-
-        1. Set the response status to 500 Server Error.
-        2. Show the user an error page containing only a generic error message
-        (don't show them the exception message).
-
-        These issues also get reported to Sentry but we don't have to
-        do that here -- non-HTTPError exceptions are automatically
-        reported by the Pyramid Sentry integration.
-        """
         self.request.response.status_int = 500
         return {
             "message": _(

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from lms.services import CanvasAPIError, CanvasAPIPermissionError, LTIOutcomesAPIError
 from lms.validation import ValidationError
-from lms.views.api.exceptions import ExceptionViews
+from lms.views.api.exceptions import APIExceptionViews
 
 
 class TestSchemaValidationError:
@@ -117,4 +117,4 @@ def context():
 
 @pytest.fixture
 def views(context, pyramid_request):
-    return ExceptionViews(context, pyramid_request)
+    return APIExceptionViews(context, pyramid_request)

--- a/tests/unit/lms/views/exceptions_test.py
+++ b/tests/unit/lms/views/exceptions_test.py
@@ -83,7 +83,7 @@ class TestExceptionViews:
             exception, pyramid_request
         ).reused_tool_guid_error()
 
-        assert_response(template_data, 200)
+        assert_response(template_data, 400)
         pyramid_request.context.js_config.enable_error_dialog_mode.assert_called_with(
             error_code=JSConfig.ErrorCode.REUSED_TOOL_GUID,
             error_details={

--- a/tests/unit/lms/views/exceptions_test.py
+++ b/tests/unit/lms/views/exceptions_test.py
@@ -65,7 +65,7 @@ class TestExceptionViews:
             "reported and we'll try to fix it.",
         )
 
-    def test_reused_tool_guid_error(self, assert_response, pyramid_request):
+    def test_reused_consumer_key(self, assert_response, pyramid_request):
         pyramid_request.context = create_autospec(
             LTILaunchResource,
             instance=True,
@@ -79,16 +79,14 @@ class TestExceptionViews:
         )
         exception = ReusedConsumerKey(sentinel.existing_guid, sentinel.new_guid)
 
-        template_data = ExceptionViews(
-            exception, pyramid_request
-        ).reused_tool_guid_error()
+        template_data = ExceptionViews(exception, pyramid_request).reused_consumer_key()
 
         assert_response(template_data, 400)
         pyramid_request.context.js_config.enable_error_dialog_mode.assert_called_with(
-            error_code=JSConfig.ErrorCode.REUSED_TOOL_GUID,
+            error_code=JSConfig.ErrorCode.REUSED_CONSUMER_KEY,
             error_details={
-                "existing_tool_consumer_guid": sentinel.existing_guid,
-                "new_tool_consumer_guid": sentinel.new_guid,
+                "existing_tool_consumer_instance_guid": sentinel.existing_guid,
+                "new_tool_consumer_instance_guid": sentinel.new_guid,
             },
         )
 


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/3148

Use a `path_info=not_("^/api/.*")` view predicate to ensure that the non-API exception views are never used for API requests, and a similar `path_info="^/api/.*"` predicate to ensure that API exception views are _only_ used for API requests.

The exception views in `views/exceptions.py` are only intended to be used for non-API requests but in fact most of them are registered for all requests not just non-API requests. If one of these exceptions was raised during an API request, and not caught by a more specifically-configured exception view in `views/api/exceptions.py`, then it would be caught by a `views/exceptions.py` exception view. This would result in an HTML error page being sent as in API response.

Fix this by registering all the exception views in `views/exceptions.py` for `/api/*` requests only.

To do this I indented the exception views into a class so that the `path_info` view predicate could go in a `@view_defaults` decorator.  This avoids repeating the `path_info` predicate and also means that it'll get applied to any new views that're added to this class in future.

I also moved the `DEFAULT_RENDERER` constant into the `@view_defaults`.

The view methods themselves needed some light rewriting now that they're part of a class, they need to use `self`. Other than that this commit shouldn't change the views themselves at all.

The tests also needed to be adjusted as the views need to be called differently now that they're methods of a class, and I rewrote the tests to use pytest fixtures in the typical way rather than using a subclass.  This is less novel and makes the tests easier to understand and to change.
