### PR TITLE
Ensure frontend errors show appropriate error messages depending on context

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -126,7 +126,7 @@ export default function BookPicker({ onCancel, onSelectBook }) {
       )}
       {error && (
         <ErrorDisplay
-          message={
+          description={
             step === 'select-book'
               ? 'Unable to fetch books'
               : 'Unable to fetch chapters'

--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -73,6 +73,9 @@ export default function BookPicker({ onCancel, onSelectBook }) {
   const canSubmit =
     (step === 'select-book' && book) || (step === 'select-chapter' && chapter);
 
+  // Provide a spacious modal UI when listing chapters (taller modal)
+  const showChapters = step === 'select-chapter' && !error;
+
   return (
     <Modal
       // Opt out of Modal's automatic focus handling; route focus manually in
@@ -80,7 +83,7 @@ export default function BookPicker({ onCancel, onSelectBook }) {
       initialFocus={null}
       onCancel={onCancel}
       contentClass={classnames('BookPicker', {
-        'BookPicker--select-chapter': step === 'select-chapter',
+        'BookPicker--select-chapter': showChapters,
       })}
       title={
         step === 'select-book'

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -212,7 +212,7 @@ export default function ContentSelector({
       if (!(error instanceof PickerCanceledError)) {
         console.error(error);
         onError({
-          title: 'There was a problem choosing a file from OneDrive',
+          message: 'There was a problem choosing a file from OneDrive',
           error,
         });
       }

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -18,9 +18,7 @@ import URLPicker from './URLPicker';
  * @typedef {import('../api-types').File} File
  * @typedef {import('../api-types').Chapter} Chapter
  *
- * @typedef ErrorInfo
- * @prop {string} title
- * @prop {Error} error
+ * @typedef {import('./FilePickerApp').ErrorInfo} ErrorInfo
  *
  * @typedef {'blackboardFile'|'canvasFile'|'url'|'vitalSourceBook'|null} DialogType
  *
@@ -196,7 +194,7 @@ export default function ContentSelector({
       if (!(error instanceof PickerCanceledError)) {
         console.error(error);
         onError({
-          title: 'There was a problem choosing a file from Google Drive',
+          message: 'There was a problem choosing a file from Google Drive',
           error,
         });
       }

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -4,7 +4,7 @@ import Dialog from './Dialog';
 /**
  * @typedef ErrorDialogProps
  * @prop {() => any} [onCancel]
- * @prop {string} [message] - Message to drill down to `ErrorDisplay`
+ * @prop {string} [description] - Message to drill down to `ErrorDisplay`
  * @prop {import('./ErrorDisplay').ErrorLike} error
  * @prop {string} [cancelLabel]
  */
@@ -17,7 +17,7 @@ import Dialog from './Dialog';
  */
 export default function ErrorDialog({
   onCancel,
-  message = 'Error',
+  description = 'Error',
   error,
   cancelLabel,
 }) {
@@ -28,7 +28,7 @@ export default function ErrorDialog({
       onCancel={onCancel}
       cancelLabel={cancelLabel}
     >
-      <ErrorDisplay message={message} error={error} />
+      <ErrorDisplay description={description} error={error} />
     </Dialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -4,7 +4,7 @@ import Dialog from './Dialog';
 /**
  * @typedef ErrorDialogProps
  * @prop {() => any} [onCancel]
- * @prop {string} title
+ * @prop {string} [message] - Message to drill down to `ErrorDisplay`
  * @prop {import('./ErrorDisplay').ErrorLike} error
  * @prop {string} [cancelLabel]
  */
@@ -15,7 +15,12 @@ import Dialog from './Dialog';
  *
  * @param {ErrorDialogProps} props
  */
-export default function ErrorDialog({ onCancel, title, error, cancelLabel }) {
+export default function ErrorDialog({
+  onCancel,
+  message = 'Error',
+  error,
+  cancelLabel,
+}) {
   return (
     <Dialog
       role="alertdialog"
@@ -23,7 +28,7 @@ export default function ErrorDialog({ onCancel, title, error, cancelLabel }) {
       onCancel={onCancel}
       cancelLabel={cancelLabel}
     >
-      <ErrorDisplay message={title} error={error} />
+      <ErrorDisplay message={message} error={error} />
     </Dialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -8,7 +8,8 @@ import Dialog from './Dialog';
 /**
  * A general-purpose error dialog displayed when a frontend application cannot be launched.
  *
- * There are more specific error dialogs for some use cases (eg. OAuth2RedirectErrorApp).
+ * There are more specific error dialogs for some use cases
+ * (e.g. OAuth2RedirectErrorApp, LaunchErrorDialog).
  */
 export default function ErrorDialogApp() {
   const {
@@ -18,16 +19,13 @@ export default function ErrorDialogApp() {
   const error = { code: errorCode, details: errorDetails };
 
   let title;
-  let message;
 
   switch (errorCode) {
     case 'reused_consumer_key':
       title = 'Consumer key registered with another site';
-      message = 'Reused tool_consumer_instance_guid';
       break;
     default:
       title = 'An error occurred';
-      message = 'Unknown error occurred';
   }
 
   return (
@@ -62,9 +60,14 @@ export default function ErrorDialogApp() {
               .
             </li>
           </ul>
+          <ErrorDisplay error={error} />
         </>
+      ) : (
+        <ErrorDisplay
+          error={error}
+          message="An error occurred when launching the Hypothesis application"
+        />
       )}
-      <ErrorDisplay message={message} error={error} />
     </Dialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -12,15 +12,16 @@ import Dialog from './Dialog';
  * (e.g. OAuth2RedirectErrorApp, LaunchErrorDialog).
  */
 export default function ErrorDialogApp() {
-  const {
-    errorDialog: { errorCode, errorDetails = '' },
-  } = useContext(Config);
+  const { errorDialog } = useContext(Config);
 
-  const error = { code: errorCode, details: errorDetails };
+  const error = {
+    code: errorDialog?.errorCode,
+    details: errorDialog?.errorDetails ?? '',
+  };
 
   let title;
 
-  switch (errorCode) {
+  switch (error.code) {
     case 'reused_consumer_key':
       title = 'Consumer key registered with another site';
       break;
@@ -30,7 +31,7 @@ export default function ErrorDialogApp() {
 
   return (
     <Dialog title={title}>
-      {error.code === 'reused_consumer_key' && (
+      {error.code === 'reused_consumer_key' ? (
         <>
           This Hypothesis installation&apos;s consumer key appears to have
           already been used on another site. This could be because:

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -66,7 +66,7 @@ export default function ErrorDialogApp() {
       ) : (
         <ErrorDisplay
           error={error}
-          message="An error occurred when launching the Hypothesis application"
+          description="An error occurred when launching the Hypothesis application"
         />
       )}
     </Dialog>

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -35,7 +35,6 @@ function toSentence(str) {
  * @param {ErrorLike} error
  */
 function formatErrorDetails(error) {
-  /** @type {string|object} */
   let details = error.details ?? '';
   if (error?.details && typeof error.details === 'object') {
     try {
@@ -80,25 +79,41 @@ function ErrorDetails({ error }) {
 
 /**
  * @typedef ErrorDisplayProps
- * @prop {string|null} [message] -
- *   A short message to display explaining that a problem happened. This is
- *   typically a general message like "There was a problem fetching this assignment".
- *   In cases where the the error originates from the server, this message may not
- *   be necessary, but in other cases where the `error.message` is generic and perhaps
- *   originates from an exception in the client, then this prop can be used to
- *   provide additional specifics.
- * @prop {ErrorLike} error -
- *   An `Error`-like object with specific details of the problem. If `error` contains
- *   a `message` property, then that string will be rendered.
+ * @prop {string|null} [description] -
+ *   A short message explaining the error and its human-facing relevance.
+ *   This is typically a general message like
+ *   "There was a problem fetching this assignment". This description
+ *   always comes from (this) LMS client app.
+ *
+ *   The presence of a `description` indicates that this `ErrorDisplay` is
+ *   responsible for explaining the error to the user in some fashion. Along
+ *   with this `description`, anything available in `error.message` is also
+ *   shown.
+ *
+ *   When `description` is absent, it indicates that the main explaining of
+ *   the error's relevance to the user is handled elsewhere, and no additional
+ *   error messaging is necessary. This is the case, for example, with some
+ *   of the well-explained error states in `OAuth2RedirectErrorApp` or
+ *   `LaunchErrorDialog`: these don't need additional error messaging that is,
+ *   for the most part, redundant or useless.
+ *
+ *   Available `error.details` and support/email instructions are always
+ *   shown regardless of the presence of this prop.
+ *
+ * @prop {ErrorLike} error - Error-like object containing further `details`
+ *   or `message` about this error state. The value of `details` and `message`
+ *   may come from a server response.
  */
 
 /**
- * Displays details of an error, such as a failed API call and provide the user
- * with information on how to get help with it.
+ * Displays human-facing details of an error, including:
+ * - Explanation/message (if `description` is provided)
+ * - Instructions for contacting support and getting help
+ * - Stringified-JSON details of the error (if `error.details` is populated)
  *
  * @param {ErrorDisplayProps} props
  */
-export default function ErrorDisplay({ message, error }) {
+export default function ErrorDisplay({ description, error }) {
   const details = formatErrorDetails(error);
 
   const supportLink = emailLink({
@@ -113,9 +128,9 @@ Technical details: ${details || 'N/A'}
 
   return (
     <div className="ErrorDisplay">
-      {message && (
+      {description && (
         <p data-testid="message">
-          {message}
+          {description}
           {error.message && (
             <>
               : <i>{toSentence(error.message)}</i>

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -172,7 +172,7 @@ export default function FilePickerApp({ onSubmit }) {
       {shouldSubmit && <FullScreenSpinner />}
       {errorInfo && (
         <ErrorDialog
-          title={errorInfo.title}
+          message={errorInfo.title}
           error={errorInfo.error}
           onCancel={() => setErrorInfo(null)}
         />

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -30,6 +30,12 @@ import GroupConfigSelector from './GroupConfigSelector';
  */
 
 /**
+ * @typedef ErrorInfo
+ * @prop {string} message
+ * @prop {Error} error
+ */
+
+/**
  * Return a human-readable description of assignment content.
  *
  * @param {Content} content - Type and details of assignment content
@@ -73,12 +79,6 @@ export default function FilePickerApp({ onSubmit }) {
       groupSet: null,
     })
   );
-
-  /**
-   * @typedef ErrorInfo
-   * @prop {string} title
-   * @prop {Error} error
-   */
 
   const [errorInfo, setErrorInfo] = useState(
     /** @type {ErrorInfo|null} */ (null)
@@ -172,7 +172,7 @@ export default function FilePickerApp({ onSubmit }) {
       {shouldSubmit && <FullScreenSpinner />}
       {errorInfo && (
         <ErrorDialog
-          message={errorInfo.title}
+          message={errorInfo.message}
           error={errorInfo.error}
           onCancel={() => setErrorInfo(null)}
         />

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -172,7 +172,7 @@ export default function FilePickerApp({ onSubmit }) {
       {shouldSubmit && <FullScreenSpinner />}
       {errorInfo && (
         <ErrorDialog
-          message={errorInfo.message}
+          description={errorInfo.message}
           error={errorInfo.error}
           onCancel={() => setErrorInfo(null)}
         />

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -314,7 +314,7 @@ export default function LMSFilePicker({
 
       {dialogState.state === 'error' && (
         <ErrorDisplay
-          message="There was a problem fetching files"
+          description="There was a problem fetching files"
           error={/** @type {Error} */ (dialogState.error)}
         />
       )}

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -29,19 +29,20 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
 
   const error = { code: errorCode, details: errorDetails };
 
-  const title = (() => {
-    if (errorCode === 'canvas_invalid_scope') {
-      return 'Developer key scopes missing';
-    }
-
-    if (errorCode === 'blackboard_missing_integration') {
-      return 'Missing Blackboard REST API integration';
-    }
-
-    return 'Authorization failed';
-  })();
-
-  const message = 'Something went wrong when authorizing Hypothesis';
+  let title;
+  let message;
+  switch (errorCode) {
+    case 'canvas_invalid_scope':
+      title = 'Developer key scopes missing';
+      break;
+    case 'blackboard_missing_integration':
+      title = 'Missing Blackboard REST API integration';
+      break;
+    default:
+      title = 'Authorization failed';
+      message = 'Something went wrong when authorizing Hypothesis';
+      break;
+  }
 
   const retry = () => {
     location.href = /** @type {string} */ (authUrl);

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -6,6 +6,8 @@ import { Config } from '../config';
 import ErrorDisplay from './ErrorDisplay';
 import Dialog from './Dialog';
 
+/** @typedef {import('../config').OAuthErrorConfig} OAuthErrorConfig */
+
 /**
  * @typedef OAuth2RedirectErrorAppProps
  * @prop {Location} [location] - Test seam
@@ -18,14 +20,15 @@ import Dialog from './Dialog';
  * @param {OAuth2RedirectErrorAppProps} props
  */
 export default function OAuth2RedirectErrorApp({ location = window.location }) {
+  const { OAuth2RedirectError = /** @type {OAuthErrorConfig} */ ({}) } =
+    useContext(Config);
+
   const {
-    OAuth2RedirectError: {
-      authUrl = /** @type {string|null} */ (null),
-      errorCode = /** @type {string|null} */ (null),
-      errorDetails = '',
-      canvasScopes = /** @type {string[]} */ ([]),
-    },
-  } = useContext(Config);
+    authUrl = null,
+    errorCode = null,
+    errorDetails = '',
+    canvasScopes = /** @type {string[]} */ ([]),
+  } = OAuth2RedirectError ?? {};
 
   const error = { code: errorCode, details: errorDetails };
 

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -33,7 +33,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
   const error = { code: errorCode, details: errorDetails };
 
   let title;
-  let message;
+  let description;
   switch (errorCode) {
     case 'canvas_invalid_scope':
       title = 'Developer key scopes missing';
@@ -43,7 +43,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
       break;
     default:
       title = 'Authorization failed';
-      message = 'Something went wrong when authorizing Hypothesis';
+      description = 'Something went wrong when authorizing Hypothesis';
       break;
   }
 
@@ -122,7 +122,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
           </p>
         </>
       )}
-      <ErrorDisplay message={message} error={error} />
+      <ErrorDisplay description={description} error={error} />
     </Dialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -212,7 +212,7 @@ export default function SubmitGradeForm({ student }) {
       </button>
       {!!submitGradeError && (
         <ErrorDialog
-          message="Unable to submit grade"
+          description="Unable to submit grade"
           error={submitGradeError}
           onCancel={() => {
             setSubmitGradeError(null);
@@ -222,7 +222,7 @@ export default function SubmitGradeForm({ student }) {
       )}
       {!!fetchGradeError && (
         <ErrorDialog
-          message="Unable to fetch grade"
+          description="Unable to fetch grade"
           error={fetchGradeError}
           onCancel={() => {
             setFetchGradeError(null);

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -212,7 +212,7 @@ export default function SubmitGradeForm({ student }) {
       </button>
       {!!submitGradeError && (
         <ErrorDialog
-          title="Unable to submit grade"
+          message="Unable to submit grade"
           error={submitGradeError}
           onCancel={() => {
             setSubmitGradeError(null);
@@ -222,7 +222,7 @@ export default function SubmitGradeForm({ student }) {
       )}
       {!!fetchGradeError && (
         <ErrorDialog
-          title="Unable to fetch grade"
+          message="Unable to fetch grade"
           error={fetchGradeError}
           onCancel={() => {
             setFetchGradeError(null);

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -172,5 +172,12 @@ describe('BookPicker', () => {
     assert.equal(errorDisplay.prop('description'), 'Unable to fetch chapters');
     assert.equal(errorDisplay.prop('error'), error);
     assert.isFalse(picker.exists('ChapterList'));
+
+    // The modal content should not have the class applied for showing the
+    // list of chapters. That class makes the modal too tall for comfort when
+    // displaying an error
+    const modalContent = picker.find('div[role="dialog"]');
+    assert.isTrue(modalContent.hasClass('BookPicker'));
+    assert.isFalse(modalContent.hasClass('BookPicker--select-chapter'));
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -169,7 +169,7 @@ describe('BookPicker', () => {
 
     const errorDisplay = await waitForElement(picker, 'ErrorDisplay');
 
-    assert.equal(errorDisplay.prop('message'), 'Unable to fetch chapters');
+    assert.equal(errorDisplay.prop('description'), 'Unable to fetch chapters');
     assert.equal(errorDisplay.prop('error'), error);
     assert.isFalse(picker.exists('ChapterList'));
   });

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -331,7 +331,7 @@ describe('ContentSelector', () => {
       }
 
       assert.calledWith(onError, {
-        title: 'There was a problem choosing a file from Google Drive',
+        message: 'There was a problem choosing a file from Google Drive',
         error,
       });
     });

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -483,7 +483,7 @@ describe('ContentSelector', () => {
       await delay(0);
 
       assert.calledWith(onError, {
-        title: 'There was a problem choosing a file from OneDrive',
+        message: 'There was a problem choosing a file from OneDrive',
         error,
       });
       assert.calledWith(console.error, error);

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
@@ -14,7 +14,7 @@ describe('ErrorDialog', () => {
 
   it('displays details of the error', () => {
     const err = new Error('Something went wrong');
-    const wrapper = mount(<ErrorDialog title="Oh no!" error={err} />);
+    const wrapper = mount(<ErrorDialog message="Oh no!" error={err} />);
 
     assert.include(wrapper.find('ErrorDisplay').props(), {
       message: 'Oh no!',

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialog-test.js
@@ -14,10 +14,10 @@ describe('ErrorDialog', () => {
 
   it('displays details of the error', () => {
     const err = new Error('Something went wrong');
-    const wrapper = mount(<ErrorDialog message="Oh no!" error={err} />);
+    const wrapper = mount(<ErrorDialog description="Oh no!" error={err} />);
 
     assert.include(wrapper.find('ErrorDisplay').props(), {
-      message: 'Oh no!',
+      description: 'Oh no!',
       error: err,
     });
   });

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
@@ -28,7 +28,7 @@ describe('ErrorDialogApp', () => {
 
   it('shows dialog for unknown error code', () => {
     const wrapper = renderApp();
-    assert.include(wrapper.text(), 'Unknown error occurred');
+    assert.include(wrapper.text(), 'An error occurred');
   });
 
   it('shows dialog for reused_consumer_key', () => {

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -25,7 +25,7 @@ describe('ErrorDisplay', () => {
     error.details = { someTechnicalDetail: 123 };
 
     const wrapper = mount(
-      <ErrorDisplay message="Failed to fetch files" error={error} />
+      <ErrorDisplay description="Failed to fetch files" error={error} />
     );
 
     const href = getSupportEmailLink(wrapper);
@@ -43,7 +43,7 @@ describe('ErrorDisplay', () => {
     error.details = { someTechnicalDetail: 123 };
 
     const wrapper = mount(
-      <ErrorDisplay message="Failed to fetch files" error={error} />
+      <ErrorDisplay description="Failed to fetch files" error={error} />
     );
     const href = getSupportEmailLink(wrapper);
 
@@ -54,7 +54,7 @@ describe('ErrorDisplay', () => {
     const error = new Error('Something went wrong');
 
     const wrapper = mount(
-      <ErrorDisplay message="Failed to fetch files" error={error} />
+      <ErrorDisplay description="Failed to fetch files" error={error} />
     );
     const href = getSupportEmailLink(wrapper);
 
@@ -62,13 +62,16 @@ describe('ErrorDisplay', () => {
   });
 
   [
-    { message: '' },
-    { message: 'Oh no', details: null },
-    { message: 'Oh no', details: '' },
+    { description: '' },
+    { description: 'Oh no', details: null },
+    { description: 'Oh no', details: '' },
   ].forEach(error => {
     it('omits technical details if not provided', () => {
       const wrapper = mount(
-        <ErrorDisplay message="Something went wrong" error={error} />
+        <ErrorDisplay
+          message="Something went wrong"
+          error={{ message: '', details: error.details }}
+        />
       );
 
       const details = wrapper.find('pre');
@@ -123,27 +126,27 @@ describe('ErrorDisplay', () => {
 
   [
     {
-      message: 'Not a sentence',
+      description: 'Not a sentence',
       output: 'Not a sentence',
     },
     {
-      message: 'A sentence',
+      description: 'A sentence',
       output: 'A sentence',
     },
     {
-      message: 'Oh no',
+      description: 'Oh no',
       error: 'Tech details',
       output: 'Oh no: Tech details.',
     },
     {
-      message: 'Oh no',
+      description: 'Oh no',
       error: 'Tech details.',
       output: 'Oh no: Tech details.',
     },
-  ].forEach(({ message, error, output }, index) => {
+  ].forEach(({ description, error, output }, index) => {
     it(`formats error.message as sentence (${index})`, () => {
       const wrapper = mount(
-        <ErrorDisplay message={message} error={{ message: error }} />
+        <ErrorDisplay description={description} error={{ message: error }} />
       );
       assert.equal(wrapper.find('p').first().text(), output);
     });
@@ -151,18 +154,18 @@ describe('ErrorDisplay', () => {
 
   [
     {
-      message: 'Provided by client',
+      description: 'Provided by client',
       error: 'Provided by server',
       output: 'Provided by client: Provided by server.',
     },
     {
-      message: 'Provided by client',
+      description: 'Provided by client',
       output: 'Provided by client',
     },
-  ].forEach(({ message, error, output }, index) => {
+  ].forEach(({ description, error, output }, index) => {
     it(`shows the appropriate error message if provided (${index})`, () => {
       const wrapper = mount(
-        <ErrorDisplay message={message} error={{ message: error }} />
+        <ErrorDisplay description={description} error={{ message: error }} />
       );
       assert.equal(wrapper.find('p[data-testid="message"]').text(), output);
     });

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -34,10 +34,11 @@ describe('ErrorDisplay', () => {
     assert.equal(href.pathname, 'support@hypothes.is');
     assert.equal(href.searchParams.get('subject'), 'Hypothesis LMS support');
     assert.include(href.searchParams.get('body'), 'Canvas says no');
+    assert.include(href.searchParams.get('body'), 'Failed to fetch files');
     assert.include(href.searchParams.get('body'), '"someTechnicalDetail": 123');
   });
 
-  it('omits "Error message" from support email body if error has no message', () => {
+  it('handles missing error message when composing email body', () => {
     const error = new Error('');
     error.details = { someTechnicalDetail: 123 };
 
@@ -46,11 +47,10 @@ describe('ErrorDisplay', () => {
     );
     const href = getSupportEmailLink(wrapper);
 
-    assert.include(href.searchParams.get('body'), 'Technical details');
-    assert.notInclude(href.searchParams.get('body'), 'Error message');
+    assert.include(href.searchParams.get('body'), 'Error message: N/A');
   });
 
-  it('omits "Technical details" from support email body if error has no details', () => {
+  it('handles missing technical details when composing email body', () => {
     const error = new Error('Something went wrong');
 
     const wrapper = mount(
@@ -58,8 +58,7 @@ describe('ErrorDisplay', () => {
     );
     const href = getSupportEmailLink(wrapper);
 
-    assert.notInclude(href.searchParams.get('body'), 'Technical details');
-    assert.include(href.searchParams.get('body'), 'Error message');
+    assert.include(href.searchParams.get('body'), 'Technical details: N/A');
   });
 
   [
@@ -125,11 +124,11 @@ describe('ErrorDisplay', () => {
   [
     {
       message: 'Not a sentence',
-      output: 'Not a sentence.',
+      output: 'Not a sentence',
     },
     {
       message: 'A sentence',
-      output: 'A sentence.',
+      output: 'A sentence',
     },
     {
       message: 'Oh no',
@@ -142,7 +141,7 @@ describe('ErrorDisplay', () => {
       output: 'Oh no: Tech details.',
     },
   ].forEach(({ message, error, output }, index) => {
-    it(`formats errors as sentences (${index})`, () => {
+    it(`formats error.message as sentence (${index})`, () => {
       const wrapper = mount(
         <ErrorDisplay message={message} error={{ message: error }} />
       );
@@ -158,15 +157,7 @@ describe('ErrorDisplay', () => {
     },
     {
       message: 'Provided by client',
-      output: 'Provided by client.',
-    },
-    {
-      error: 'Provided by server',
-      output: 'Provided by server.',
-    },
-    {
-      // Should not show any messages
-      output: 'An unknown error occurred.',
+      output: 'Provided by client',
     },
   ].forEach(({ message, error, output }, index) => {
     it(`shows the appropriate error message if provided (${index})`, () => {

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -295,7 +295,7 @@ describe('LMSFilePicker', () => {
 
       const errorDetails = wrapper.find('ErrorDisplay');
       assert.include(errorDetails.props(), {
-        message: 'There was a problem fetching files',
+        description: 'There was a problem fetching files',
         error,
       });
 

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -51,7 +51,7 @@ describe('OAuth2RedirectErrorApp', () => {
     );
   });
 
-  it('shows a different title and message for blackboard_missing_integration', () => {
+  it('shows a different title and description for blackboard_missing_integration', () => {
     fakeConfig.errorCode = 'blackboard_missing_integration';
     const wrapper = renderApp();
     assert.include(wrapper.text(), 'Missing Blackboard REST API integration');
@@ -69,7 +69,7 @@ describe('OAuth2RedirectErrorApp', () => {
 
     const errorDisplay = wrapper.find('ErrorDisplay');
     assert.include(errorDisplay.props(), {
-      message: 'Something went wrong when authorizing Hypothesis',
+      description: 'Something went wrong when authorizing Hypothesis',
     });
     assert.deepEqual(errorDisplay.prop('error'), {
       details: fakeConfig.errorDetails,

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -55,10 +55,6 @@ describe('OAuth2RedirectErrorApp', () => {
     fakeConfig.errorCode = 'blackboard_missing_integration';
     const wrapper = renderApp();
     assert.include(wrapper.text(), 'Missing Blackboard REST API integration');
-    assert.include(
-      wrapper.text(),
-      'Something went wrong when authorizing Hypothesis'
-    );
   });
 
   it('shows a generic error if the scope is valid', () => {


### PR DESCRIPTION
## Summary

There is a huge amount of information in this PR description, but in summary:

This work ensures that auto-generated, useless error messaging doesn't get displayed by the front-end apps when there is already other contextual error information present. It does this by adjusting logic about how error descriptions and messages are displayed (or not displayed) within the `ErrorDisplay` component.

It also:

* Makes the "error app" components `ErrorDialogApp` and `OAuth2RedirectErrorApp` not crash in edge cases where error information is not present (this may not be a valid real-world state).
* Fixes a small visual bug in which the VitalSource book picker modal was too tall when an error is present.

What follows is a lot of explanation and screenshots, but a lot of this is documentation of how to trigger different errors and their contexts. It is not expected that a reviewer will review every error or trigger every error _ad nauseum_.

This work does not include several other planned error improvements, including UI updates to newer, shared variants of Modals and Dialogs. Hang tight.

The world's longest PR description and yak-shaving exercise to fix this innocuous-sounding little:

Fixes https://github.com/hypothesis/lms/issues/2997

Part of https://github.com/hypothesis/lms/issues/3139

### Displaying (or not displaying) error descriptions/messages in `ErrorDisplay`

The `ErrorDisplay` component is used widely to render information about an error, including:

* error message/description
* how to contact support and get help
* JSON-stringified error details, if available

The changes here impact the first item listed: error messages/descriptions will now only render in certain cases. The `description` prop on `ErrorDisplay` (renamed from `message`) now has this to say about itself:

```
 * @prop {string|null} [description] -
 *   A short message explaining the error and its human-facing relevance.
 *   This is typically a general message like
 *   "There was a problem fetching this assignment". This description
 *   always comes from (this) client app.
 *
 *   The presence of a `description` indicates that this `ErrorDisplay` is
 *   responsible for explaining the error to the user in some fashion. Along
 *   with this `description`, anything available in `error.message` is also
 *   shown.
 *
 *   When `description` is absent, it indicates that the main explaining of
 *   the error's relevance to the user is handled elsewhere, and no additional
 *   error messaging is necessary. This is the case, for example, with some
 *   of the well-explained error states in `OAuth2RedirectErrorApp` or
 *   `LaunchErrorDialog`: these don't need additional error messaging that is,
 *   for the most part, redundant or useless.
 *
 *   Available `error.details` and support/email instructions are always
 *   shown regardless of the presence of this prop.
```

In some previous work, it was implied that sometimes it was necessary to invent/cook up a `description` (formerly `message`) when the provided value was `null`  or not present and/or that the value sometimes came from server data. I walked through each and every type of error this app handles (fun) before satisfying myself that this isn’t the case: instead, the front-end app should be responsible for determining error context and setting (or not setting) this property’s value.

### Testing

Below you’ll find an incredible wall of text. I’m not implying that a reviewer needs to exhaustively read everything and trigger every type of error that the app handles, but the information is there if you need it. Screenshots there, too, if that’s enough proof.

Testing instructions below assume that you’ve checked out this branch and are running your local `lms` app and its bits and bots.

### Different types of error contexts

There are four front-end app “modes”, dictated by server-provided configuration, handled by four corresponding app-level components. Each of these top-level app components handle errors in their own way. These app components are:

* `ErrorDialogApp`  - General error mode
* `OAuth2RedirectErrorApp` - Authz-related error mode
* `BasicLTILaunchApp` - Launch an assignment mode (if any mode could be considered the most common or “default”, this would be it)
* `FilePickerApp` - Configure an assignment mode

### Error mode error strategy

For `ErrorDialogApp` and `OAuth2RedirectErrorApp`, the following strategy is used as of these changes:

* If the error (i.e. error code) is recognized, render its nice canned text. Suppress error message/description as it’s not going to be useful. (Remember, support instructions and any available error *details* are still always shown in a summary/disclosure element).
* If the error is not of a recognized type, _do_ show a description and any available `error.message` as it might possibly be useful, and we don’t have any other contextual information to show.

###  `ErrorDialogApp` 

`ErrorDialogApp` (`error-dialog` mode in the config) describes itself as 

>  A general-purpose error dialog displayed when a frontend application cannot be launched.  

It renders an error in a dialog with no buttons (cannot be closed).

It has two error states:

* Reused consumer key error
* Any other/unknown/default error

#### Reproduce

Reused GUID error: ~~Edit `application_instance` model as follows:~~

Since initial writing, the name of this error has changed from `tool_consumer_instance_guid` to `reused_consumer_key`. Otherwise, the following approach should work conceptually.

```
diff --git a/lms/models/application_instance.py b/lms/models/application_instance.py
index 55662337..e1815c44 100644
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -138,7 +138,8 @@ class ApplicationInstance(BASE):
             return
 
         if (
-            self.tool_consumer_instance_guid
+            True
+            or self.tool_consumer_instance_guid
             and self.tool_consumer_instance_guid != tool_consumer_instance_guid
         ):
             # If we already have a LMS guid linked to the AI
```

and then launch any `localhost` assignment.

How to reproduce unknown error:
		* Edit  the frontend app's `index.js` and set `config.mode` = `'error-dialog'` just before `switch`-ing on `config.mode`. This will cause the app to go into this mode. Because there is no additional error information in the `config` (because the server would normally populate the config with additional error info in this mode/scenario), launching an assignment now would show a useless, ultra generic error. Before these changes, it would crash: `ErrorDialogApp` assumed the presence of several additional configuration properties. I’ve updated the logic to not crash. This scenario “shouldn’t really happen in real life,” but I’d prefer not crashing.
		* Edit `ErrorDialogApp` and set a default `error.code` of `reused_tool_guid` to see the main error TODO

#### Screenshots

##### reused_tool_guid error

After these changes, extraneous messaging will not be shown.

Before:

<img width="736" alt="ErrorDialogApp-reused_tool_guid" src="https://user-images.githubusercontent.com/439947/135139537-d5dba621-efa3-477f-80e7-fe41108ba6fa.png">

After:

<img width="752" alt="ErrorDialogApp-reused_tool_guid" src="https://user-images.githubusercontent.com/439947/135139565-bafb129c-df5b-4616-a091-17424428ce84.png">


##### Unknown error/fallback

If there is error information missing in the configuration in tis mode, the application will no longer crash. It is possible that this combination would never happen in real life, but handling seems preferable to crashing. I'm not going to try to argue that this error is useful.

After:

<img width="700" alt="ErrorDialogApp-fallback" src="https://user-images.githubusercontent.com/439947/135139763-04506d93-39f3-4b98-a5bf-70df010c59e8.png">

### `OAuth2RedirectErrorApp`

 `OAuth2RedirectErrorApp`  (`oauth2-redirect-error` mode) handles authz-related errors:

* Missing developer scope keys
* Missing BlackBoard REST API integration
* Any other/unknown/default authz-related error

#### Reproduce

Real: 
* https://hypothesis.instructure.com/courses/121/assignments/850 is a localhost assignment with bad scopes (real)

Fake: 
* You can fake a particular OAuth error by setting the app’s `mode` to `oauth2-redirect-error` (in `index.js`) and manipulating the default error code in  `OAuth2RedirectErrorApp` 

#### Screenshots

##### Missing scope keys error

Before:

<img width="677" alt="OAuthErrorApp-scope-keys" src="https://user-images.githubusercontent.com/439947/135139910-763fe734-8608-4a80-9750-5bee474132b2.png">

After:

<img width="680" alt="OAuthErrorApp-scope-keys" src="https://user-images.githubusercontent.com/439947/135139959-5f9dc8f6-56e4-4e46-8825-f66e45b3e95d.png">


##### Unknown/Fallback error

Similar to the new fallback in `ErrorDialogApp`:

Before: Crash

After:

<img width="711" alt="OAuthErrorApp-fallback" src="https://user-images.githubusercontent.com/439947/135140082-eb7c6054-242e-4dac-84c2-448de702b691.png">

### Assignment Launch mode:  `BasicLTILaunchApp`

 `BasicLTILaunchApp` is used in the app’s `basic-lti-launch` mode.

Obviously, this component handles more than error states. The errors it handles arise from API interactions with the backend or a client failure to communicate with the API during an assignment launch. There are currently 9 error states it handles, and it does not deal with unknown errors (i.e. all errors are of a defined type). User error information for all of these errors is rendered by `LaunchErrorDialog`.

Each error state handled in `LaunchErrorDialog` comes with solid canned explanatory text, so error messages/descriptions are unnecessary here and are no longer shown (details are).

Sub-component `SubmitGradingForm` renders errors (from grading API) in an `ErrorDialog` and does display descriptions.

#### Reproduce

I’ve created a few `localhost` assignments here: https://hypothesis.instructure.com/courses/125/assignments under “Lyza errors on localhost”.  Call me loosey-goosey, but I don’t feel it’s necessary to re-test every single possible error state here, as they are handled identically, and there are no "unknown" error states.

#### Screenshots

##### Empty Group Set

Before:

<img width="684" alt="LaunchApp-empty-group-set" src="https://user-images.githubusercontent.com/439947/135140199-1e8a82ff-8319-411a-9174-355ec35eda6e.png">

After:

<img width="681" alt="LaunchApp-empty-group-set" src="https://user-images.githubusercontent.com/439947/135140217-1023ef27-84d5-496a-8f95-de90130fb3a6.png">

##### Deleted Canvas File

Before:

<img width="690" alt="LaunchApp-deleted-canvas-file" src="https://user-images.githubusercontent.com/439947/135140239-6abb4df3-7650-460a-af4e-71ee39973187.png">

After:

<img width="681" alt="LaunchApp-deleted-canvas-file" src="https://user-images.githubusercontent.com/439947/135140287-8e0f605b-f22c-4130-b69a-730614194955.png">

### Assignment configuration mode: `FilePickerApp`

 `FilePickerApp` is used in the app’s `content-item-selection` mode.

The errors that this component handles directly arise from Google Picker (and presumably, soon, One Drive picker) integrations, and originate from those APIs. We don’t have canned display text for these errors, so they _do_ render a description and message. They are rendered the `ErrorDialog` component (just to add another layer of abstraction. I don’t think this detail is terribly relevant in terms of the overall thrust here, though. `ErrorDialog` passes `description` through to `ErrorDisplay`).

Sub-components `BookPicker` and `LMSFilePicker` render error information within dialogs they control. Both display error descriptions.

#### Reproduce

These involve launching a non-configured assignment and walking through some content-picking steps.

* Google Picker: Hand-edit `ContentSelector` and add `throw new Error(‘some message to display’);` near the top of the `try` block for `showGooglePicker`. You should see an error dialog if you “Select PDF from Google Drive” in assignment configuration
* VitalSource (VitalSource feature flag needs to be enabled): Use the “Select book from VitalSource” button.  Paste `https://bookshelf.vitalsource.com/#/books/9781400847402` into the input field and submit _but do not click Select Book_ just yet. Now, disable your network in browser devtools. _Now_, click _Select Book_.
* Blackboard Files: Enter into “Select PDF from Blackboard”, let the file listing load, disable your network in browser in devtools. Click on a folder icon. You should see a fetch error.

#### Screenshots

##### Browser/fetch error

Before:

<img width="676" alt="FilePicker-fetch-fail" src="https://user-images.githubusercontent.com/439947/135140457-efccf6b7-8ab4-41a3-b975-0f972185e963.png">

After: No change


##### Google Picker API error

Before:

<img width="690" alt="FilePicker-Googlefail" src="https://user-images.githubusercontent.com/439947/135140528-0d52711a-3809-47a1-9b24-6610c1a25291.png">

After: No change

##### VitalSource Book Picker error

These changes remedy a modal that was too tall.

Before:

<img width="703" alt="FilePicker-VitalSource-fail" src="https://user-images.githubusercontent.com/439947/135140584-b87c8041-5ab0-4d4e-a6b7-5570ac435832.png">

After:

<img width="698" alt="FilePicker-VitalSource-fetch-fail" src="https://user-images.githubusercontent.com/439947/135140614-d5d16fd6-b727-48af-99f0-3c4f03114188.png">



