### PR TITLE
Remove a pointless docstring

### DIFF
--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -33,7 +33,6 @@ class ExceptionViews:
 
     @exception_view_config(context=HTTPClientError)
     def http_client_error(self):
-        """Handle an HTTP 4xx (client error) exception."""
         self.request.response.status_int = self.exception.status_int
         return {"message": str(self.exception)}
 


### PR DESCRIPTION
It's pretty obvious that this method handles `HTTPClientError`'s:

```python
@exception_view_config(context=HTTPClientError)
def http_client_error(self):
    ...
```

So a docstring that says "Handle an HTTP 4xx (client error) exception" really isn't adding much (except possibly explaining that `HTTPClientError` = 4xx?).