### PR TITLE
Remove a pointless docstring

### DIFF
--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -46,7 +46,6 @@ class ExceptionViews:
         context=ValidationError, renderer="lms:templates/validation_error.html.jinja2"
     )
     def validation_error(self):
-        """Handle a ValidationError."""
         self.request.response.status_int = self.exception.status_int
         return {"error": self.exception}
 


### PR DESCRIPTION
It's clear that this method handles `ValidationError`'s:

```python
@exception_view_config(context=ValidationError, ...)
def validation_error(self):
    ...
```

A docstring saying "Handle a ValidationError" doesn't add anything.