### PR TITLE
Deduplicate some code with a helper method

### DIFF
--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -23,23 +23,19 @@ class ExceptionViews:
 
     @notfound_view_config()
     def notfound(self):
-        self.request.response.status_int = 404
-        return {"message": _("Page not found")}
+        return self.error_response(404, _("Page not found"))
 
     @forbidden_view_config()
     def forbidden(self):
-        self.request.response.status_int = 403
-        return {"message": _("You're not authorized to view this page")}
+        return self.error_response(403, _("You're not authorized to view this page"))
 
     @exception_view_config(context=HTTPClientError)
     def http_client_error(self):
-        self.request.response.status_int = self.exception.status_int
-        return {"message": str(self.exception)}
+        return self.error_response(self.exception.status_int, str(self.exception))
 
     @exception_view_config(context=HAPIError)
     def hapi_error(self):
-        self.request.response.status_int = 500
-        return {"message": str(self.exception)}
+        return self.error_response(500, str(self.exception))
 
     @exception_view_config(
         context=ValidationError, renderer="lms:templates/validation_error.html.jinja2"
@@ -64,11 +60,16 @@ class ExceptionViews:
 
     @exception_view_config(context=Exception)
     def error(self):
-        self.request.response.status_int = 500
-        return {
-            "message": _(
+        return self.error_response(
+            500,
+            _(
                 "Sorry, but something went wrong. "
                 "The issue has been reported and we'll try to "
                 "fix it."
-            )
-        }
+            ),
+        )
+
+    def error_response(self, status, message):
+        """Set the response status and return template data for error.html.jinja2."""
+        self.request.response.status_int = status
+        return {"message": message}


### PR DESCRIPTION
It was tempting to also change the `validation_error()` view to use the helper method:

```python
@exception_view_config(context=ValidationError, renderer="lms:templates/validation_error.html.jinja2")
def validation_error(self):
    self.request.response.status_int = self.exception.status_int
    return {"error": self.exception}
```

The `error_response()` would need to optionally accept either a `message` or an `error` kwarg and return either `{"message": message}` or `{"error": error}`. I decided it wasn't worth adding the complexity to `error_response()` just to reduce `validation_error()`'s two lines to one. `validation_error()` is legitimately different to the other views: it's returning data for the `validation_error.hml.jinja2` template instead of the `error.html.jinja2` template.

The `reused_tool_guid_error()` view also doesn't use the `error_response()` helper for the same reason: it uses the `error_dialog.html.jinja2` template.