### PR TITLE
Rename "reused tool GUID" to "reused consumer key"

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -21,7 +21,7 @@ class JSConfig:
     class ErrorCode(str, Enum):
         BLACKBOARD_MISSING_INTEGRATION = "blackboard_missing_integration"
         CANVAS_INVALID_SCOPE = "canvas_invalid_scope"
-        REUSED_TOOL_GUID = "reused_tool_guid"
+        REUSED_CONSUMER_KEY = "reused_consumer_key"
 
     def __init__(self, context, request):
         self._context = context

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -21,7 +21,7 @@ export default function ErrorDialogApp() {
   let message;
 
   switch (errorCode) {
-    case 'reused_tool_guid':
+    case 'reused_consumer_key':
       title = 'Consumer key registered with another site';
       message = 'Reused tool_consumer_instance_guid';
       break;
@@ -32,7 +32,7 @@ export default function ErrorDialogApp() {
 
   return (
     <Dialog title={title}>
-      {error.code === 'reused_tool_guid' && (
+      {error.code === 'reused_consumer_key' && (
         <>
           This Hypothesis installation&apos;s consumer key appears to have
           already been used on another site. This could be because:

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
@@ -31,8 +31,8 @@ describe('ErrorDialogApp', () => {
     assert.include(wrapper.text(), 'Unknown error occurred');
   });
 
-  it('shows dialog for reused tool_consumer_guid', () => {
-    fakeConfig.errorCode = 'reused_tool_guid';
+  it('shows dialog for reused_consumer_key', () => {
+    fakeConfig.errorCode = 'reused_consumer_key';
 
     const wrapper = renderApp();
     assert.include(

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -97,7 +97,7 @@ import { createContext } from 'preact';
  */
 
 /**
- * @typedef {'reused_tool_guid'} ErrorCode
+ * @typedef {'reused_consumer_key'} ErrorCode
  */
 
 /**

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -47,14 +47,14 @@ class ExceptionViews:
     @exception_view_config(
         ReusedConsumerKey, renderer="lms:templates/error_dialog.html.jinja2"
     )
-    def reused_tool_guid_error(self):
+    def reused_consumer_key(self):
         self.request.response.status_int = 400
 
         self.request.context.js_config.enable_error_dialog_mode(
-            self.request.context.js_config.ErrorCode.REUSED_TOOL_GUID,
+            self.request.context.js_config.ErrorCode.REUSED_CONSUMER_KEY,
             error_details={
-                "existing_tool_consumer_guid": self.exception.existing_guid,
-                "new_tool_consumer_guid": self.exception.new_guid,
+                "existing_tool_consumer_instance_guid": self.exception.existing_guid,
+                "new_tool_consumer_instance_guid": self.exception.new_guid,
             },
         )
 

--- a/tests/unit/lms/views/exceptions_test.py
+++ b/tests/unit/lms/views/exceptions_test.py
@@ -65,7 +65,7 @@ class TestExceptionViews:
             "reported and we'll try to fix it.",
         )
 
-    def test_reused_tool_guid_error(self, assert_response, pyramid_request):
+    def test_reused_consumer_key(self, assert_response, pyramid_request):
         pyramid_request.context = create_autospec(
             LTILaunchResource,
             instance=True,
@@ -79,16 +79,14 @@ class TestExceptionViews:
         )
         exception = ReusedConsumerKey(sentinel.existing_guid, sentinel.new_guid)
 
-        template_data = ExceptionViews(
-            exception, pyramid_request
-        ).reused_tool_guid_error()
+        template_data = ExceptionViews(exception, pyramid_request).reused_consumer_key()
 
         assert_response(template_data, 400)
         pyramid_request.context.js_config.enable_error_dialog_mode.assert_called_with(
-            error_code=JSConfig.ErrorCode.REUSED_TOOL_GUID,
+            error_code=JSConfig.ErrorCode.REUSED_CONSUMER_KEY,
             error_details={
-                "existing_tool_consumer_guid": sentinel.existing_guid,
-                "new_tool_consumer_guid": sentinel.new_guid,
+                "existing_tool_consumer_instance_guid": sentinel.existing_guid,
+                "new_tool_consumer_instance_guid": sentinel.new_guid,
             },
         )
 


### PR DESCRIPTION
The thing being reused here is called a "consumer key" (or "OAuth consumer key") in LTI not a "tool GUID". The LTI spec actually contains something else called a "tool GUID" (or "tool consumer instance GUID") so it's probably best not to use "tool GUID" in place of "consumer key".

There's a sense in which "tool GUID" is actually correct here. The LTI app (us) is called the "tool provider" and the LMS (Canvas etc) is the "tool consumer" and the thing that is shared between the two (the "application instance" in our own code's terminology) is the "tool". Since the OAuth consumer key is the thing that uniquely identifies a particular application instance I can see why you might call that the "tool GUID". Nonetheless, I think LTI always calls this the "consumer key", introducing our own terms is just going to introduce confusion, especially because of the similarity to "tool consumer instance GUID".