### PR TITLE
Simplify query for canvas assignment launch.

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 
+from sqlalchemy import or_
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from lms.models import Assignment
@@ -64,24 +65,13 @@ class AssignmentService:
             self._db.query(Assignment)
             .filter(
                 Assignment.tool_consumer_instance_guid == tool_consumer_instance_guid,
-                (
-                    (
-                        (Assignment.resource_link_id == resource_link_id)
-                        & (Assignment.ext_lti_assignment_id == ext_lti_assignment_id)
-                    )
-                    | (
-                        (Assignment.resource_link_id == resource_link_id)
-                        & (Assignment.ext_lti_assignment_id.is_(None))
-                    )
-                    | (
-                        (Assignment.resource_link_id.is_(None))
-                        & (Assignment.ext_lti_assignment_id == ext_lti_assignment_id)
-                    )
+                or_(
+                    Assignment.resource_link_id == resource_link_id,
+                    Assignment.ext_lti_assignment_id == ext_lti_assignment_id,
                 ),
             )
             .order_by(Assignment.resource_link_id.asc())
-            .all()
-        )
+        ).all()
 
         if not assignments:
             raise NoResultFound()


### PR DESCRIPTION
The previous query was used in other cases but after a number of refactors it was left intact.