### PR TITLE
Convert remaining CommonJS imports to ES imports

### DIFF
--- a/lms/static/scripts/frontend_apps/icons.js
+++ b/lms/static/scripts/frontend_apps/icons.js
@@ -1,19 +1,30 @@
-// @ts-nocheck - TS doesn't understand `require('.../icon.svg')`
+// @ts-nocheck - TS doesn't understand SVG imports.
+
+// LMS icons
+import caretDownIcon from '../../images/caret-down.svg';
+import checkIcon from '../../images/check.svg';
+import folderIcon from '../../images/folder.svg';
+import pdfIcon from '../../images/file-pdf.svg';
+import spinnerIcon from '../../images/spinner.svg';
+
+// Shared icons
+import arrowLeftIcon from '@hypothesis/frontend-shared/images/icons/arrow-left.svg';
+import arrowRightIcon from '@hypothesis/frontend-shared/images/icons/arrow-right.svg';
+import cancelIcon from '@hypothesis/frontend-shared/images/icons/cancel.svg';
 
 /**
- * Set of icons used by the LMS frontend via the `SvgIcon`
- * component.
+ * Set of icons used by the LMS frontend via the `SvgIcon` component.
  */
 export default {
   // LMS icons
-  'caret-down': require('../../images/caret-down.svg'),
-  check: require('../../images/check.svg'),
-  folder: require('../../images/folder.svg'),
-  pdf: require('../../images/file-pdf.svg'),
-  spinner: require('../../images/spinner.svg'),
+  'caret-down': caretDownIcon,
+  check: checkIcon,
+  folder: folderIcon,
+  pdf: pdfIcon,
+  spinner: spinnerIcon,
 
   // Shared icons
-  'arrow-left': require('@hypothesis/frontend-shared/images/icons/arrow-left.svg'),
-  'arrow-right': require('@hypothesis/frontend-shared/images/icons/arrow-right.svg'),
-  cancel: require('@hypothesis/frontend-shared/images/icons/cancel.svg'),
+  'arrow-left': arrowLeftIcon,
+  'arrow-right': arrowRightIcon,
+  cancel: cancelIcon,
 };


### PR DESCRIPTION
This is a prerequisite for moving to a modern ES-module oriented bundler
such as Rollup. See also https://github.com/hypothesis/client/pull/3795.