### PR TITLE
Add route to verify lms domain on MS app for one drive

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -53,6 +53,10 @@ def includeme(config):
     config.add_route(
         "onedrive.filepicker.redirect_uri", "/onedrive/filepicker/redirect"
     )
+    config.add_route(
+        "onedrive.filepicker.verify_domain",
+        "/.well-known/microsoft-identity-association.json",
+    )
 
     config.add_route(
         "canvas_api.oauth.authorize",

--- a/lms/views/onedrive.py
+++ b/lms/views/onedrive.py
@@ -13,3 +13,16 @@ def redirect_uri(_request):
     This view's URL is provided to One Drive's frontend config as target to open the filepicker in.
     """
     return {}
+
+
+@view_config(
+    request_method="GET",
+    route_name="onedrive.filepicker.verify_domain",
+    renderer="json",
+)
+def verify_domain(request):
+    return {
+        "associatedApplications": [
+            {"applicationId": request.registry.settings["onedrive_client_id"]}
+        ]
+    }

--- a/tests/unit/lms/views/onedrive_test.py
+++ b/tests/unit/lms/views/onedrive_test.py
@@ -1,5 +1,15 @@
-from lms.views.onedrive import redirect_uri
+from unittest.mock import sentinel
+
+from lms.views.onedrive import redirect_uri, verify_domain
 
 
 def test_redirect_uri(pyramid_request):
     assert redirect_uri(pyramid_request) == {}
+
+
+def test_verify_domain(pyramid_request):
+    pyramid_request.registry.settings["onedrive_client_id"] = sentinel.client_id
+
+    assert verify_domain(pyramid_request) == {
+        "associatedApplications": [{"applicationId": sentinel.client_id}]
+    }


### PR DESCRIPTION
One Drive consent screen still shows a "unverified" notice despite we having verified the "web.hypothes.is" domain with a static file on word press.

![Screenshot from 2021-09-30 15-24-04](https://user-images.githubusercontent.com/1433832/135471288-004977e7-b215-4b20-ba71-b6293ffc8268.png)

Is hard to be sure but this could be due to us verifying one subdomain while having the oauth redirect point to another one (the lms one).

With this PR we get to also verify both the qa and prod apps which might come handy for testing.

The verifying instructions look like:
![Screenshot from 2021-09-30 16-14-54](https://user-images.githubusercontent.com/1433832/135472410-c98ccd9a-692c-4cab-b4cc-f90d5315b312.png)


# Testing:

- Go to http://localhost:8001/.well-known/microsoft-identity-association.json,  get some json back.

