### PR TITLE
Extract common `PickerCanceledError` to a common path

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -2,10 +2,8 @@ import { LabeledButton } from '@hypothesis/frontend-shared';
 import { useContext, useMemo, useState } from 'preact/hooks';
 
 import { Config } from '../config';
-import {
-  GooglePickerClient,
-  PickerCanceledError,
-} from '../utils/google-picker-client';
+import { PickerCanceledError } from '../errors';
+import { GooglePickerClient } from '../utils/google-picker-client';
 import { OneDrivePickerClient } from '../utils/onedrive-picker-client';
 
 import BookPicker from './BookPicker';

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -7,7 +7,7 @@ import { act } from 'preact/test-utils';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { delay, waitFor } from '../../../test-util/wait';
 import { Config } from '../../config';
-import { PickerCanceledError } from '../../utils/google-picker-client';
+import { PickerCanceledError } from '../../errors';
 import ContentSelector, { $imports } from '../ContentSelector';
 
 function interact(wrapper, callback) {

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -1,0 +1,8 @@
+/**
+ * Error thrown when the user cancels file selection.
+ */
+export class PickerCanceledError extends Error {
+  constructor() {
+    super('Dialog was canceled');
+  }
+}

--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.js
@@ -1,3 +1,4 @@
+import { PickerCanceledError } from '../errors';
 import { loadLibraries } from './google-api-client';
 
 export const GOOGLE_DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive';
@@ -17,15 +18,6 @@ function addHttps(origin) {
     return origin;
   }
   return 'https://' + origin;
-}
-
-/**
- * Error thrown when the user cancels file selection.
- */
-export class PickerCanceledError extends Error {
-  constructor() {
-    super('Dialog was canceled');
-  }
 }
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
@@ -1,4 +1,4 @@
-import { PickerCanceledError } from './google-picker-client';
+import { PickerCanceledError } from '../errors';
 import { loadOneDriveAPI } from './onedrive-api-client';
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -1,9 +1,9 @@
 /* eslint-disable new-cap */
 
+import { PickerCanceledError } from '../../errors';
 import {
   GOOGLE_DRIVE_SCOPE,
   GooglePickerClient,
-  PickerCanceledError,
   $imports,
 } from '../google-picker-client';
 

--- a/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
@@ -1,5 +1,5 @@
 import { delay } from '../../../test-util/wait';
-import { PickerCanceledError } from '../google-picker-client';
+import { PickerCanceledError } from '../../errors';
 import { OneDrivePickerClient, $imports } from '../onedrive-picker-client';
 
 describe('OneDrivePickerClient', () => {


### PR DESCRIPTION
Both `GooglePickerClient` and `OneDrivePickerClient` use
`PickerCanceledError`. @robertknight suggested to extract this error and
move it to a common location:
https://github.com/hypothesis/lms/pull/3134#discussion_r717529172