### PR TITLE
Call `setLoadingIndicatorVisible(false)`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -190,7 +190,6 @@ export default function ContentSelector({
       await picker.enablePublicViewing(id);
       onSelectContent({ type: 'url', url });
     } catch (error) {
-      setLoadingIndicatorVisible(false);
       if (!(error instanceof PickerCanceledError)) {
         console.error(error);
         onError({
@@ -198,6 +197,8 @@ export default function ContentSelector({
           error,
         });
       }
+    } finally {
+      setLoadingIndicatorVisible(false);
     }
   };
 
@@ -208,7 +209,6 @@ export default function ContentSelector({
       const { url } = await picker.showPicker();
       onSelectContent({ type: 'url', url });
     } catch (error) {
-      setLoadingIndicatorVisible(false);
       if (!(error instanceof PickerCanceledError)) {
         console.error(error);
         onError({
@@ -216,6 +216,8 @@ export default function ContentSelector({
           error,
         });
       }
+    } finally {
+      setLoadingIndicatorVisible(false);
     }
   };
 


### PR DESCRIPTION
Currently, `setLoadingIndicatorVisible(false)` is only call when the
pickers encounter an error. However, it would be more correct to call
`setLoadingIndicatorVisible(false)` always, either on success or on
error. Thus I move the line inside a `finally` clause. Suggested by
@robertknight here:
https://github.com/hypothesis/lms/pull/3134#discussion_r718334171