### PR TITLE
Via url endpoint for canvas files takes a document_url

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -46,27 +46,6 @@ class JSConfig:
         """
         return self._request.find_service(name="application_instance").get()
 
-    def add_canvas_file_id(self, course_id, resource_link_id, canvas_file_id):
-        """
-        Set the document to the Canvas file with the given canvas_file_id.
-
-        This configures the frontend to make an API call to get the URL to use
-        as the src for the Via iframe.
-
-        :raise HTTPBadRequest: if a request param needed to generate the config
-            is missing
-        """
-        self._config["api"]["viaUrl"] = {
-            "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
-            "path": self._request.route_path(
-                "canvas_api.files.via_url",
-                course_id=course_id,
-                resource_link_id=resource_link_id,
-                file_id=canvas_file_id,
-            ),
-        }
-        self._add_canvas_speedgrader_settings(canvas_file_id=canvas_file_id)
-
     def add_document_url(self, document_url):
         """
         Set the document to the document at the given document_url.
@@ -88,14 +67,17 @@ class JSConfig:
                 ),
             }
         elif document_url.startswith("canvas://"):
-            course_id = self._request.params["custom_canvas_course_id"]
-            file_id = self._request.params["file_id"]
-            resource_link_id = self._request.params["resource_link_id"]
-
-            self.add_canvas_file_id(course_id, resource_link_id, file_id)
+            self._config["api"]["viaUrl"] = {
+                "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
+                "path": self._request.route_path(
+                    "canvas_api.files.via_url",
+                    resource_link_id=self._request.params["resource_link_id"],
+                ),
+            }
         else:
             self._config["viaUrl"] = via_url(self._request, document_url)
-            self._add_canvas_speedgrader_settings(document_url=document_url)
+
+        self._add_canvas_speedgrader_settings(document_url=document_url)
 
     def add_vitalsource_launch_config(self, book_id, cfi=None):
         vitalsource_svc = self._request.find_service(name="vitalsource")

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -77,7 +77,7 @@ def includeme(config):
     )
     config.add_route(
         "canvas_api.files.via_url",
-        "/api/canvas/courses/{course_id}/assignments/{resource_link_id}/files/{file_id}/via_url",
+        "/api/canvas/assignments/{resource_link_id}/via_url",
     )
     config.add_route(
         "canvas_api.courses.group_sets.list",

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -114,7 +114,11 @@ class URLConfiguredBasicLTILaunchSchema(BasicLTILaunchSchema):
         #
         # See https://github.com/instructure/canvas-lms/issues/1486
         url = _data["url"]
-        if url.lower().startswith("http%3a") or url.lower().startswith("https%3a"):
+        if (
+            url.lower().startswith("http%3a")
+            or url.lower().startswith("https%3a")
+            or url.lower().startswith("canvas%3a")
+        ):
             url = unquote(url)
             _data["url"] = url
 

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -1,9 +1,17 @@
 """Proxy API views for files-related Canvas API endpoints."""
+import re
+
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
 from lms.services.canvas import CanvasService
 from lms.views import helpers
+
+#: A regex for parsing the COURSE_ID and FILE_ID parts out of one of our custom
+#: canvas://file/course/COURSE_ID/file_id/FILE_ID URLs.
+DOCUMENT_URL_REGEX = re.compile(
+    r"canvas:\/\/file\/course\/(?P<course_id>[^\/]*)\/file_id\/(?P<file_id>[^\/]*)"
+)
 
 
 @view_defaults(permission=Permissions.API, renderer="json")
@@ -33,16 +41,16 @@ class FilesAPIViews:
         application_instance = self.request.find_service(
             name="application_instance"
         ).get()
-
         assignment = self.request.find_service(name="assignment").get(
             application_instance.tool_consumer_instance_guid,
             self.request.matchdict["resource_link_id"],
         )
 
+        document_url_match = DOCUMENT_URL_REGEX.search(assignment.document_url)
         public_url = self.canvas.public_url_for_file(
             assignment,
-            self.request.matchdict["file_id"],
-            self.request.matchdict["course_id"],
+            document_url_match["file_id"],
+            document_url_match["course_id"],
             check_in_course=self.request.lti_user.is_instructor,
         )
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -152,31 +152,6 @@ class TestEnableLTILaunchMode:
             js_config.enable_lti_launch_mode()
 
 
-class TestAddCanvasFileID:
-    """Unit tests for JSConfig.add_canvas_file_id()."""
-
-    def test_it_adds_the_viaUrl_api_config(self, js_config):
-        js_config.add_canvas_file_id(
-            "example_canvas_course_id",
-            "example_resource_link_id",
-            "example_canvas_file_id",
-        )
-
-        assert js_config.asdict()["api"]["viaUrl"] == {
-            "authUrl": "http://example.com/api/canvas/oauth/authorize",
-            "path": "/api/canvas/courses/example_canvas_course_id/assignments/example_resource_link_id/files/example_canvas_file_id/via_url",
-        }
-
-    def test_it_sets_the_canvas_file_id(self, js_config, submission_params):
-        js_config.add_canvas_file_id(
-            "example_canvas_course_id",
-            "example_resource_link_id",
-            "example_canvas_file_id",
-        )
-
-        assert submission_params()["canvas_file_id"] == "example_canvas_file_id"
-
-
 class TestAddDocumentURL:
     """Unit tests for JSConfig.add_document_url()."""
 
@@ -207,13 +182,60 @@ class TestAddDocumentURL:
 
         assert js_config.asdict()["api"]["viaUrl"] == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
-            "path": "/api/canvas/courses/125/assignments/TEST_RESOURCE_LINK_ID/files/100/via_url",
+            "path": "/api/canvas/assignments/TEST_RESOURCE_LINK_ID/via_url",
         }
 
     def test_it_sets_the_document_url(self, js_config, submission_params):
         js_config.add_document_url("example_document_url")
 
         assert submission_params()["document_url"] == "example_document_url"
+
+    def test_it_sets_the_canvas_submission_params(
+        self, pyramid_request, submission_params, js_config
+    ):
+
+        js_config.add_document_url("canvas://file/course_id/COURSE_ID/file_id/FILE_ID")
+
+        assert (
+            submission_params()["h_username"]
+            == pyramid_request.lti_user.h_user.username
+        )
+        assert (
+            submission_params()["lis_outcome_service_url"]
+            == "example_lis_outcome_service_url"
+        )
+        assert (
+            submission_params()["lis_result_sourcedid"]
+            == "example_lis_result_sourcedid"
+        )
+        assert submission_params()["learner_canvas_user_id"] == "test_user_id"
+
+    def test_it_doesnt_set_the_speedGrader_settings_if_the_LMS_isnt_Canvas(
+        self, context, js_config
+    ):
+        context.is_canvas = False
+
+        js_config.add_document_url("example_document_url")
+
+        assert "speedGrader" not in js_config.asdict()["canvas"]
+
+    def test_it_doesnt_set_the_speedGrader_settings_if_theres_no_lis_result_sourcedid(
+        self, js_config, pyramid_request
+    ):
+        del pyramid_request.params["lis_result_sourcedid"]
+
+        js_config.add_document_url("canvas://file/course_id/COURSE_ID/file_id/FILE_ID")
+
+        assert "speedGrader" not in js_config.asdict()["canvas"]
+
+    def test_it_doesnt_set_the_speedGrader_settings_if_theres_no_lis_outcome_service_url(
+        self, js_config, pyramid_request
+    ):
+        del pyramid_request.params["lis_outcome_service_url"]
+
+        js_config.add_document_url("canvas://file/course_id/COURSE_ID/file_id/FILE_ID")
+
+        assert "speedGrader" not in js_config.asdict()["canvas"]
 
 
 class TestAddVitalsourceLaunchConfig:
@@ -249,77 +271,6 @@ class TestAddVitalsourceLaunchConfig:
             mock.sentinel.launch_params,
         )
         return vitalsource_service
-
-
-class TestAddCanvasFileIDAddDocumentURLCommon:
-    """Tests common to both add_canvas_file_id() and add_document_url()."""
-
-    def test_it_sets_the_canvas_submission_params(
-        self, pyramid_request, method_caller, submission_params
-    ):
-        method_caller()
-
-        assert (
-            submission_params()["h_username"]
-            == pyramid_request.lti_user.h_user.username
-        )
-        assert (
-            submission_params()["lis_outcome_service_url"]
-            == "example_lis_outcome_service_url"
-        )
-        assert (
-            submission_params()["lis_result_sourcedid"]
-            == "example_lis_result_sourcedid"
-        )
-        assert submission_params()["learner_canvas_user_id"] == "test_user_id"
-
-    def test_it_doesnt_set_the_speedGrader_settings_if_the_LMS_isnt_Canvas(
-        self, context, method_caller, js_config
-    ):
-        context.is_canvas = False
-
-        method_caller()
-
-        assert "speedGrader" not in js_config.asdict()["canvas"]
-
-    def test_it_doesnt_set_the_speedGrader_settings_if_theres_no_lis_result_sourcedid(
-        self, method_caller, js_config, pyramid_request
-    ):
-        del pyramid_request.params["lis_result_sourcedid"]
-
-        method_caller()
-
-        assert "speedGrader" not in js_config.asdict()["canvas"]
-
-    def test_it_doesnt_set_the_speedGrader_settings_if_theres_no_lis_outcome_service_url(
-        self, method_caller, js_config, pyramid_request
-    ):
-        del pyramid_request.params["lis_outcome_service_url"]
-
-        method_caller()
-
-        assert "speedGrader" not in js_config.asdict()["canvas"]
-
-    @pytest.fixture(
-        params=[
-            {
-                "method": "add_canvas_file_id",
-                "args": [
-                    "example_canvas_course_id",
-                    "example_resource_link_id",
-                    "example_canvas_file_id",
-                ],
-            },
-            {"method": "add_document_url", "args": ["example_document_url"]},
-        ]
-    )
-    def method_caller(self, js_config, request):
-        """Return a function that calls the method-under-test with default args."""
-
-        def method_caller():
-            return getattr(js_config, request.param["method"])(*request.param["args"])
-
-        return method_caller
 
 
 class TestMaybeEnableGrading:

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -137,6 +137,10 @@ class TestURLConfiguredBasicLTILaunchSchema:
                 "http%3a%2F%2Fexample.com%2Fpath%3Fparam%3Dvalue",
                 "http://example.com/path?param=value",
             ),
+            (
+                "canvas%3A%2F%2Ffile%2Fcourse_id%2FCOURSE_ID%2Ffile_if%2FFILE_ID",
+                "canvas://file/course_id/COURSE_ID/file_if/FILE_ID",
+            ),
         ],
     )
     def test_it_decodes_url_if_percent_encoded(

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -24,14 +24,13 @@ class TestFilesAPIViews:
         canvas_service,
         helpers,
     ):
+        document_url = "canvas://file/course/COURSE_ID/file_id/FILE_ID"
         application_instance = application_instance_service.get.return_value
         assignment = assignment_service.get.return_value
+        assignment.document_url = document_url
         pyramid_request.matchdict = {
-            "course_id": "test_course_id",
-            "file_id": "test_file_id",
             "resource_link_id": "test_resource_link_id",
         }
-
         result = FilesAPIViews(pyramid_request).via_url()
 
         assignment_service.get.assert_called_once_with(
@@ -40,8 +39,8 @@ class TestFilesAPIViews:
         )
         canvas_service.public_url_for_file.assert_called_once_with(
             assignment,
-            "test_file_id",
-            "test_course_id",
+            "FILE_ID",
+            "COURSE_ID",
             check_in_course=pyramid_request.lti_user.is_instructor,
         )
         helpers.via_url.assert_called_once_with(


### PR DESCRIPTION
Changes the parameters the via url endpoint takes, from course and file ids as separate arguments to one `canvas://` like URL with both params encoded there.