### PR TITLE
Increase the timeout in one LMSFilePicker test

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -431,7 +431,7 @@ describe('LMSFilePicker', () => {
   it('updates the folder path when a user chooses a folder', async () => {
     const onSelectFile = sinon.stub();
     const wrapper = renderFilePicker({ onSelectFile, withBreadcrumbs: true });
-    await waitFor(() => fakeApiCall.called);
+    await waitFor(() => fakeApiCall.calledOnce);
     wrapper.update();
 
     const file = fakeFiles[1]; // This is a folder
@@ -439,7 +439,7 @@ describe('LMSFilePicker', () => {
     // Folders cannot be selected as a file...
     assert.notCalled(onSelectFile);
 
-    await waitFor(() => fakeApiCall.calledTwice);
+    await waitFor(() => fakeApiCall.calledTwice, 50);
     wrapper.update();
 
     // ...Instead, the path state is updated (and "navigated to") and added


### PR DESCRIPTION
From time to time we see the following errors in the CI/CD (specially in
GH):

> FAILED TESTS:
>   LMSFilePicker
>     ✖ updates the folder path when a user chooses a folder
>       Chrome Headless 94.0.4606.61 (Linux x86_64)
>     Error: waitFor(() => fakeApiCall.calledTwice) failed after 10 ms
>         at /tmp/test-util/wait.js:36:16 <- /tmp/e36ef211e9dc3af9693aa007befe49a6.browserify.js:43841:16a

I was able to reproduce this error locally if I attempted the test
several times. Increasing the timeout seems to solve the issue.