### PR TITLE
Make `ErrorDisplay` render `children`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -19,6 +19,7 @@ export default function ErrorDialogApp() {
     details: errorDialog?.errorDetails ?? '',
   };
 
+  let description;
   let title;
 
   switch (error.code) {
@@ -26,49 +27,49 @@ export default function ErrorDialogApp() {
       title = 'Consumer key registered with another site';
       break;
     default:
+      description =
+        'An error occurred when launching the Hypothesis application';
       title = 'An error occurred';
   }
 
   return (
     <Dialog title={title}>
-      {error.code === 'reused_consumer_key' ? (
-        <>
-          This Hypothesis installation&apos;s consumer key appears to have
-          already been used on another site. This could be because:
-          <ul>
-            <li>
-              This consumer key has already been used on another site. A site
-              admin must{' '}
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://web.hypothes.is/get-help/"
-              >
-                request a new consumer key
-              </a>{' '}
-              for this site and re-install Hypothesis.
-            </li>
-            <li>
-              This site&apos;s tool_consumer_instance_guid has changed. A site
-              admin must{' '}
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://web.hypothes.is/get-help/"
-              >
-                ask us to update the consumer key
-              </a>
-              .
-            </li>
-          </ul>
-          <ErrorDisplay error={error} />
-        </>
-      ) : (
-        <ErrorDisplay
-          error={error}
-          description="An error occurred when launching the Hypothesis application"
-        />
-      )}
+      <ErrorDisplay error={error} description={description}>
+        {error.code === 'reused_consumer_key' && (
+          <>
+            <p>
+              This Hypothesis {"installation's"} consumer key appears to have
+              already been used on another site. This could be because:
+            </p>
+            <ul>
+              <li>
+                This consumer key has already been used on another site. A site
+                admin must{' '}
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://web.hypothes.is/get-help/"
+                >
+                  request a new consumer key
+                </a>{' '}
+                for this site and re-install Hypothesis.
+              </li>
+              <li>
+                This {"site's"} tool_consumer_instance_guid has changed. A site
+                admin must{' '}
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://web.hypothes.is/get-help/"
+                >
+                  ask us to update the consumer key
+                </a>
+                .
+              </li>
+            </ul>
+          </>
+        )}
+      </ErrorDisplay>
     </Dialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -78,7 +78,10 @@ function ErrorDetails({ error }) {
 }
 
 /**
+ * @typedef {import("preact").ComponentChildren} Children
+ *
  * @typedef ErrorDisplayProps
+ * @prop {Children} [children]
  * @prop {string|null} [description] -
  *   A short message explaining the error and its human-facing relevance.
  *   This is typically a general message like
@@ -113,7 +116,7 @@ function ErrorDetails({ error }) {
  *
  * @param {ErrorDisplayProps} props
  */
-export default function ErrorDisplay({ description, error }) {
+export default function ErrorDisplay({ children, description, error }) {
   const details = formatErrorDetails(error);
 
   const supportLink = emailLink({
@@ -128,6 +131,7 @@ Technical details: ${details || 'N/A'}
 
   return (
     <div className="ErrorDisplay">
+      {children}
       {description && (
         <p data-testid="message">
           {description}

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -56,8 +56,7 @@ function BaseDialog({
         )
       }
     >
-      {children}
-      {error && <ErrorDisplay error={error} />}
+      {error ? <ErrorDisplay error={error}>{children}</ErrorDisplay> : children}
     </Dialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -76,53 +76,55 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
 
   return (
     <Dialog title={title} buttons={buttons}>
-      {error.code === 'canvas_invalid_scope' && (
-        <>
-          <p>
-            A Canvas admin needs to edit {"Hypothesis's"} developer key and add
-            these scopes:
-          </p>
-          <ol>
-            {canvasScopes.map(scope => (
-              <li key={scope}>
-                <code>{scope}</code>
-              </li>
-            ))}
-          </ol>
-          <p>
-            For more information see:{' '}
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
-            >
-              Canvas API Endpoints Used by the Hypothesis LMS App
-            </a>
-            .
-          </p>
-        </>
-      )}
+      <ErrorDisplay error={error} description={description}>
+        {error.code === 'canvas_invalid_scope' && (
+          <>
+            <p>
+              A Canvas admin needs to edit {"Hypothesis's"} developer key and
+              add these scopes:
+            </p>
+            <ol>
+              {canvasScopes.map(scope => (
+                <li key={scope}>
+                  <code>{scope}</code>
+                </li>
+              ))}
+            </ol>
+            <p>
+              For more information see:{' '}
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
+              >
+                Canvas API Endpoints Used by the Hypothesis LMS App
+              </a>
+              .
+            </p>
+          </>
+        )}
 
-      {error.code === 'blackboard_missing_integration' && (
-        <>
-          <p>
-            In order to allow Hypothesis to connect to files in Blackboard, your
-            Blackboard admin needs to add or enable a REST API integration.
-          </p>
-          <p>
-            For more information, please have your Blackboard admin read:{' '}
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://web.hypothes.is/help/enable-the-hypothesis-integration-with-blackboard-files/"
-            >
-              Enable the Hypothesis Integration With Blackboard Files
-            </a>
-            .
-          </p>
-        </>
-      )}
-      <ErrorDisplay description={description} error={error} />
+        {error.code === 'blackboard_missing_integration' && (
+          <>
+            <p>
+              In order to allow Hypothesis to connect to files in Blackboard,
+              your Blackboard admin needs to add or enable a REST API
+              integration.
+            </p>
+            <p>
+              For more information, please have your Blackboard admin read:{' '}
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://web.hypothes.is/help/enable-the-hypothesis-integration-with-blackboard-files/"
+              >
+                Enable the Hypothesis Integration With Blackboard Files
+              </a>
+              .
+            </p>
+          </>
+        )}
+      </ErrorDisplay>
     </Dialog>
   );
 }


### PR DESCRIPTION
Make `ErrorDisplay` able to render children, and thus be able to render
everything pertinent to an error. This will allow for more straightforward
overflow and scroll control as we transition to shared components.

We have to manage the display of error information in a wild assortment
of contexts and viewports, so it's easier to manage if error UI is more
encapsulated.

No significant user-facing changes here. Scroll behavior is slightly different in very constrained viewports: the entirety of the modal content (excepting heading, buttons) will scroll. It would be lovely to just scroll the error details section, when expanded, but some of the error description text is so long that it leaves just a tiny, bitty space for error details in constrained viewports. 

Before:

![scrolling-before](https://user-images.githubusercontent.com/439947/135903159-a34da532-67c9-4725-8026-14c6149375c9.gif)

After:

![scrolling-after](https://user-images.githubusercontent.com/439947/135903190-3d705dee-bbc0-4192-a9d8-32c2f9956b85.gif)

I've got more tricks up my sleeve to make the overflow and scroll handling a little nicer in follow-up work here.

Part of https://github.com/hypothesis/lms/issues/3139