### PR TITLE
One drive verify size

### DIFF
--- a/lms/views/onedrive.py
+++ b/lms/views/onedrive.py
@@ -1,3 +1,6 @@
+import textwrap
+
+from pyramid.response import Response
 from pyramid.view import view_config
 
 
@@ -21,8 +24,15 @@ def redirect_uri(_request):
     renderer="json",
 )
 def verify_domain(request):
-    return {
-        "associatedApplications": [
-            {"applicationId": request.registry.settings["onedrive_client_id"]}
-        ]
-    }
+    application_id = request.registry.settings["onedrive_client_id"]
+    response_text = textwrap.dedent(
+        f"""\
+    {{
+      "associatedApplications": [
+        {{
+          "applicationId": "{application_id}"
+        }}
+      ]
+    }}"""
+    )
+    return Response(text=response_text, content_type="application/json")

--- a/tests/unit/lms/views/onedrive_test.py
+++ b/tests/unit/lms/views/onedrive_test.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import sentinel
 
 from lms.views.onedrive import redirect_uri, verify_domain
@@ -10,6 +11,14 @@ def test_redirect_uri(pyramid_request):
 def test_verify_domain(pyramid_request):
     pyramid_request.registry.settings["onedrive_client_id"] = sentinel.client_id
 
-    assert verify_domain(pyramid_request) == {
-        "associatedApplications": [{"applicationId": sentinel.client_id}]
+    assert json.loads(verify_domain(pyramid_request).text) == {
+        "associatedApplications": [{"applicationId": f"{sentinel.client_id}"}]
     }
+
+
+def test_verify_domain_includes_length(pyramid_request):
+    pyramid_request.registry.settings["onedrive_client_id"] = sentinel.client_id
+
+    response = verify_domain(pyramid_request)
+
+    assert response.content_length == len(response.text)


### PR DESCRIPTION
Set the exact same content and answer with a content-length header.

## Testing 
Set application_id to `f49d0253-f947-43f1-9735-ce73fde94af3` and compare the output with https://web.hypothes.is/.well-known/microsoft-identity-association.json

```
curl  https://web.hypothes.is/.well-known/microsoft-identity-association.json | md5sum 
1814193bf1f9c27500f60a05077b43b2                         
                     
curl  http://localhost:8001/.well-known/microsoft-identity-association.json | md5sum
1814193bf1f9c27500f60a05077b43b2 
````