### PR TITLE
Explicitly set Content-Length header

### DIFF
--- a/lms/views/onedrive.py
+++ b/lms/views/onedrive.py
@@ -35,4 +35,8 @@ def verify_domain(request):
       ]
     }}"""
     )
-    return Response(text=response_text, content_type="application/json")
+    return Response(
+        text=response_text,
+        content_type="application/json",
+        headers={"Content-Length": str(len(response_text))},
+    )


### PR DESCRIPTION
Length header is not present when deployed 

````
curl -I --http1.1  https://qa-lms.hypothes.is/.well-known/microsoft-identity-association.json
````
(same result without the I --http1.1 flag)

I'm not sure if this will fix/change anything it but adding the header explicitly to the Response here.