### PR TITLE
Explicitly include content type header

### DIFF
--- a/lms/views/onedrive.py
+++ b/lms/views/onedrive.py
@@ -37,6 +37,6 @@ def verify_domain(request):
     )
     return Response(
         text=response_text,
+        content_length=str(len(response_text)),
         content_type="application/json",
-        headers={"Content-Length": str(len(response_text))},
     )


### PR DESCRIPTION
https://github.com/hypothesis/lms/pull/3199 broke the inclusion of `content-type`

On this PR:

```
 curl -I  http://localhost:8001/.well-known/microsoft-identity-association.json 
HTTP/1.1 200 OK
Server: gunicorn
Date: Tue, 05 Oct 2021 15:28:00 GMT
Connection: close
Content-Length: 111
Content-Type: application/json
```

