### PR TITLE
Use headers as a dict instead of specific shortcuts

### DIFF
--- a/lms/views/onedrive.py
+++ b/lms/views/onedrive.py
@@ -37,6 +37,8 @@ def verify_domain(request):
     )
     return Response(
         text=response_text,
-        content_length=str(len(response_text)),
-        content_type="application/json",
+        headers={
+            "Content-Length": str(len(response_text)),
+            "Content-Type": "application/json",
+        },
     )


### PR DESCRIPTION
Using content_length vs headers={"content-length"... doesn't produce the same result only getting the header in the response with the latter.