### PR TITLE
Accept URL OR ISBN/VBID in BookPicker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -9,7 +9,7 @@ import {
 import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { useService, VitalSourceService } from '../services';
-import { bookIDFromURL } from '../utils/vitalsource';
+import { extractBookID } from '../utils/vitalsource';
 
 /**
  * @typedef {import('../api-types').Book} Book
@@ -113,9 +113,9 @@ export default function BookSelector({
       return;
     }
 
-    const bookID = bookIDFromURL(url);
+    const bookID = extractBookID(url);
     if (!bookID) {
-      setError("That doesn't look like a VitalSource book link");
+      setError("That doesn't look like a VitalSource book link or ISBN");
       return;
     }
     fetchBook(bookID);
@@ -158,7 +158,9 @@ export default function BookSelector({
         </Thumbnail>
       </div>
       <div className="hyp-u-stretch hyp-u-vertical-spacing--3">
-        <div>Paste a link to the VitalSource book you&apos;d like to use:</div>
+        <div>
+          Paste a link or ISBN for the VitalSource book you&apos;d like to use:
+        </div>
 
         <TextInputWithButton>
           <TextInput

--- a/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
@@ -19,7 +19,7 @@ const fakeBookData = {
 
 describe('BookSelector', () => {
   let fakeVitalSourceService;
-  let fakeBookIDFromURL;
+  let fakeExtractBookID;
 
   const BookSelectorWrapper = withServices(BookSelector, () => [
     [VitalSourceService, fakeVitalSourceService],
@@ -35,14 +35,14 @@ describe('BookSelector', () => {
     );
 
   beforeEach(() => {
-    fakeBookIDFromURL = sinon.stub().returns('book1');
+    fakeExtractBookID = sinon.stub().returns('book1');
     fakeVitalSourceService = {
       fetchBook: sinon.stub().callsFake(async bookID => fakeBookData[bookID]),
     };
 
     $imports.$mock({
       '../utils/vitalsource': {
-        bookIDFromURL: fakeBookIDFromURL,
+        extractBookID: fakeExtractBookID,
       },
     });
   });
@@ -102,22 +102,22 @@ describe('BookSelector', () => {
 
       updateURL(wrapper, 'foo');
 
-      assert.calledOnce(fakeBookIDFromURL);
-      assert.calledWith(fakeBookIDFromURL, 'foo');
+      assert.calledOnce(fakeExtractBookID);
+      assert.calledWith(fakeExtractBookID, 'foo');
 
       updateURL(wrapper, 'bar');
 
       assert.equal(
-        fakeBookIDFromURL.callCount,
+        fakeExtractBookID.callCount,
         2,
         're-validates if entered URL value changes'
       );
-      assert.calledWith(fakeBookIDFromURL, 'bar');
+      assert.calledWith(fakeExtractBookID, 'bar');
 
       updateURL(wrapper, 'bar');
 
       assert.equal(
-        fakeBookIDFromURL.callCount,
+        fakeExtractBookID.callCount,
         2,
         'Does not validate URL if it has not changed from previous value'
       );
@@ -133,8 +133,8 @@ describe('BookSelector', () => {
 
       input.getDOMNode().dispatchEvent(keyEvent);
 
-      assert.calledOnce(fakeBookIDFromURL);
-      assert.calledWith(fakeBookIDFromURL, 'http://www.example.com');
+      assert.calledOnce(fakeExtractBookID);
+      assert.calledWith(fakeExtractBookID, 'http://www.example.com');
     });
 
     it('confirms the selected book if "Enter" is pressed subsequently', () => {
@@ -150,7 +150,7 @@ describe('BookSelector', () => {
       // First enter press will "look up" book from entered URL
       input.getDOMNode().dispatchEvent(keyEvent);
 
-      assert.calledOnce(fakeBookIDFromURL);
+      assert.calledOnce(fakeExtractBookID);
 
       // Second enter press should "confirm" the book looked up after the
       // first press
@@ -166,23 +166,23 @@ describe('BookSelector', () => {
 
       wrapper.find('IconButton button[title="Find book"]').simulate('click');
 
-      assert.calledOnce(fakeBookIDFromURL);
-      assert.calledWith(fakeBookIDFromURL, 'foo');
+      assert.calledOnce(fakeExtractBookID);
+      assert.calledWith(fakeExtractBookID, 'foo');
     });
 
     it('does not attempt to check the URL format if the field value is empty', () => {
       const wrapper = renderBookSelector();
       updateURL(wrapper, 'foo');
 
-      assert.calledOnce(fakeBookIDFromURL);
+      assert.calledOnce(fakeExtractBookID);
 
       updateURL(wrapper, '');
 
-      assert.calledOnce(fakeBookIDFromURL);
+      assert.calledOnce(fakeExtractBookID);
     });
 
     it('shows an error if entered URL format is invalid', () => {
-      fakeBookIDFromURL.returns(null);
+      fakeExtractBookID.returns(null);
 
       const wrapper = renderBookSelector();
       updateURL(wrapper, 'foo');

--- a/lms/static/scripts/frontend_apps/utils/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/vitalsource-test.js
@@ -1,44 +1,52 @@
-import { bookIDFromURL } from '../vitalsource';
+import { extractBookID } from '../vitalsource';
 
-describe('bookIDFromURL', () => {
+describe('extractBookID', () => {
   [
-    'https://bookshelf.vitalsource.com/#/books/9781400847402',
+    'https://bookshelf.vitalsource.com/#/books/9781400847402X',
 
     // It does not matter if there are path elements after the book ID
-    'https://bookshelf.vitalsource.com/#/books/9781400847402/foo/bar',
+    'https://bookshelf.vitalsource.com/#/books/9781400847402X/foo/bar',
 
     // It doesn't matter what the domain is
-    'https://whatever.com/#/books/9781400847402',
+    'https://whatever.com/#/books/9781400847402X',
+
+    // Trailing slash
+    'https://whatever.com/#/books/9781400847402X/',
 
     // It doesn't even matter if it's a URL
-    'whatever/books/9781400847402/boo',
+    'whatever/books/9781400847402X/boo',
 
-    // Minimum thing that will match
-    'books/9781400847402',
-  ].forEach(url => {
-    it('should parse book ID from URL', () => {
-      assert.equal(bookIDFromURL(url), '9781400847402');
+    // Minimum path variant that will match
+    'books/9781400847402X',
+
+    // It should take the first match and ignore other alpha-numeric strings
+    // in URL
+    'books/9781400847402X/far/out/9781400847402X',
+    'books/9781400847402X/far/out/1234567890',
+    'books/9781400847402X/far/books/1234567890/ding/dong',
+
+    // Another alphanumeric string earlier in URL should be ignored
+    'https://bookshelf.vitalsource.com/1039439489/#/books/9781400847402X/foo/bar',
+
+    '9781400847402X',
+  ].forEach(input => {
+    it(`should parse book ID from "${input}""`, () => {
+      assert.equal(extractBookID(input), '9781400847402X');
     });
   });
 
   [
+    // Lower-case alpha characters do not match
+    '9781400847402x',
+    // Non-recognized character in string (!)
+    '9781400!847402X',
     // `book` is singular
     'https://bookshelf.vitalsource.com/#/book/9781400847402',
-
-    // missing slash in path
+    // `/` missing after `books`
     'https://bookshelf.vitalsource.com/#/books9781400847402',
-
-    // vbid by itself (at some point we might want to accept this),
-    '9781400847402',
-
-    // Non-matching character '!' in ID
-    'https://bookshelf.vitalsource.com/#/books/9781400!847402',
-
-    // Missing 'books' path element
-    'https://bookshelf.vitalsource.com/#/9781400847402',
-  ].forEach(url => {
-    it('should return `null` if no book ID found in string', () => {
-      assert.equal(bookIDFromURL(url), null);
+  ].forEach(input => {
+    it(`should return null if no book ID found in string "${input}"`, () => {
+      assert.isNull(extractBookID(input));
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/vitalsource.js
+++ b/lms/static/scripts/frontend_apps/utils/vitalsource.js
@@ -1,26 +1,35 @@
 /**
- * A naive regex matcher for a VBID in a URL-like string. The matcher looks
- * for a VitalSource book ID (VBID) in the string formatted as `books/<bookID>`.
+ * Attempt to parse a book ID out of a string. A book ID may be either a VBID
+ * (VitalSource Book ID) or an ISBN.
  *
- * `bookID` may be of any length, but must consist only of upper-case alpha and
+ * A valid input string has one of two possible patterns:
+ * 1. A URL- or path-like string that contains a substring
+ *   'books/<bookID>', OR
+ * 2. A string consisting _only_ of a bookID
+ *
+ * A book ID may be of any length, but must consist only of upper-case alpha and
  * numeric characters, or dashes (`-`).
- *
- * The rest of the URL string other than `books/<bookID>` is ignored/irrelevant.
  *
  * Examples:
  * - https://bookshelf.vitalsource.com/#/books/12345678 -> '12345678'
  * - https://bookshelf.vitalsource.com/#/books/12345678/foo/bar -> '12345678'
  * - https://bookshelf.vitalsource.com/#/books/1A2345678Q-9 -> '1A2345678Q-9'
+ * - https://bookshelf.vitalsource.com/#/foo/1P44349834/books/1A2345678Q-9 -> '1A2345678Q-9'
  * - books/BANANAS-47/other-parts-ignored -> 'BANANAS-47'
+ * - 12345678X -> '12345678X'
  *
- * @param {string} url
- * @returns {string|null} VBID, or `null` if nothing looks like a VBID in `url`
+ * @param {string} input
+ * @returns {string|null} bookID, or `null` if nothing looks like a bookID in
+ *  `input`
  */
-export function bookIDFromURL(url) {
-  const bookIdPattern = /books\/([0-9A-Z-]+)(\/|$)/;
-  const matches = url.match(bookIdPattern);
-  if (!matches) {
-    return null;
+export function extractBookID(input) {
+  const urlMatches = input.match(/books\/([0-9A-Z-]+)(\/|$)/);
+  if (urlMatches) {
+    return urlMatches[1];
   }
-  return matches[1];
+  const bookIDMatches = input.match(/^([0-9A-Z-]+)$/);
+  if (bookIDMatches) {
+    return bookIDMatches[1];
+  }
+  return null;
 }


### PR DESCRIPTION
This PR updates the parsing of user-entered strings in the VitalSource assignment configuration workflow (`BookPicker`) such that a user may enter _either_ a link (URL) to a VitalSource book—this was previously supported—_or_ a ISBN/VBID directly—this is new.

![image](https://user-images.githubusercontent.com/439947/136836771-51618ddf-adda-445f-b71e-2fb13c557ffe.png)

The resulting regexp for parsing is mildly complex, but I hope the commenting and tests shine a light on what it's doing. I've renamed the relevant utility function from `bookIDFromURL` to `parseBookID` as its purpose has changed.

There is still some improvement in error messages needed, one of which will require backend support, so I'm not addressing that here.

### To test

Running your local `lms` environment on this branch, use our Canvas instance[^1] and configure a localhost assignment. Select the `VitalSource` option from the content option buttons. You should be able to paste in any of these ISBNs and load a book:

* 0077383966
* 9780131378421
* 9781260165821

You should also be able to use a URL, e.g.

* https://bookshelf.vitalsource.com/#/books/9781400847402
* https://bookshelf.vitalsource.com/#/books/BOOKSHELF-TUTORIAL

Entering in something that doesn't "look like" an ISBN should give you a relatively friendly error, e.g.

* 9781260foo!165821

Entering in a random alphanumeric string (i.e. could be an ISBN, but isn't a real one) should get you a less user-friendly error (it comes from the backend; addressing the friendliness is a separate issue):

* 97812222WEREWOLF60165821

Fixes #3208

[^1]: The VitalSource assignment configuration picker works in Blackboard, too, but selecting a chapter throws an error currently. 