### PR TITLE
Pin pip3 version after broken 21.3 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --virtual build-deps \
     build-base \
     postgresql-dev \
     python3-dev \
-  && pip3 install --no-cache-dir -U pip \
+  && pip3 install --no-cache-dir -U pip==21.2.4 \
   && pip3 install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 


### PR DESCRIPTION
New pip release seem to have broken the build:

https://jenkins.hypothes.is/job/lms/job/PR-3186/13/console

This pip issues seem to resolve themselves after all the libraries etc catch up but we better pin the version until then.