### PR TITLE
Revert "Via url endpoint for canvas files takes a document_url"

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -77,7 +77,7 @@ def includeme(config):
     )
     config.add_route(
         "canvas_api.files.via_url",
-        "/api/canvas/assignments/{resource_link_id}/via_url",
+        "/api/canvas/courses/{course_id}/assignments/{resource_link_id}/files/{file_id}/via_url",
     )
     config.add_route(
         "canvas_api.courses.group_sets.list",

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -114,11 +114,7 @@ class URLConfiguredBasicLTILaunchSchema(BasicLTILaunchSchema):
         #
         # See https://github.com/instructure/canvas-lms/issues/1486
         url = _data["url"]
-        if (
-            url.lower().startswith("http%3a")
-            or url.lower().startswith("https%3a")
-            or url.lower().startswith("canvas%3a")
-        ):
+        if url.lower().startswith("http%3a") or url.lower().startswith("https%3a"):
             url = unquote(url)
             _data["url"] = url
 

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -1,17 +1,9 @@
 """Proxy API views for files-related Canvas API endpoints."""
-import re
-
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
 from lms.services.canvas import CanvasService
 from lms.views import helpers
-
-#: A regex for parsing the COURSE_ID and FILE_ID parts out of one of our custom
-#: canvas://file/course/COURSE_ID/file_id/FILE_ID URLs.
-DOCUMENT_URL_REGEX = re.compile(
-    r"canvas:\/\/file\/course\/(?P<course_id>[^\/]*)\/file_id\/(?P<file_id>[^\/]*)"
-)
 
 
 @view_defaults(permission=Permissions.API, renderer="json")
@@ -41,16 +33,16 @@ class FilesAPIViews:
         application_instance = self.request.find_service(
             name="application_instance"
         ).get()
+
         assignment = self.request.find_service(name="assignment").get(
             application_instance.tool_consumer_instance_guid,
             self.request.matchdict["resource_link_id"],
         )
 
-        document_url_match = DOCUMENT_URL_REGEX.search(assignment.document_url)
         public_url = self.canvas.public_url_for_file(
             assignment,
-            document_url_match["file_id"],
-            document_url_match["course_id"],
+            self.request.matchdict["file_id"],
+            self.request.matchdict["course_id"],
             check_in_course=self.request.lti_user.is_instructor,
         )
 

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -137,10 +137,6 @@ class TestURLConfiguredBasicLTILaunchSchema:
                 "http%3a%2F%2Fexample.com%2Fpath%3Fparam%3Dvalue",
                 "http://example.com/path?param=value",
             ),
-            (
-                "canvas%3A%2F%2Ffile%2Fcourse_id%2FCOURSE_ID%2Ffile_if%2FFILE_ID",
-                "canvas://file/course_id/COURSE_ID/file_if/FILE_ID",
-            ),
         ],
     )
     def test_it_decodes_url_if_percent_encoded(

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -24,13 +24,14 @@ class TestFilesAPIViews:
         canvas_service,
         helpers,
     ):
-        document_url = "canvas://file/course/COURSE_ID/file_id/FILE_ID"
         application_instance = application_instance_service.get.return_value
         assignment = assignment_service.get.return_value
-        assignment.document_url = document_url
         pyramid_request.matchdict = {
+            "course_id": "test_course_id",
+            "file_id": "test_file_id",
             "resource_link_id": "test_resource_link_id",
         }
+
         result = FilesAPIViews(pyramid_request).via_url()
 
         assignment_service.get.assert_called_once_with(
@@ -39,8 +40,8 @@ class TestFilesAPIViews:
         )
         canvas_service.public_url_for_file.assert_called_once_with(
             assignment,
-            "FILE_ID",
-            "COURSE_ID",
+            "test_file_id",
+            "test_course_id",
             check_in_course=pyramid_request.lti_user.is_instructor,
         )
         helpers.via_url.assert_called_once_with(


### PR DESCRIPTION
Reverts hypothesis/lms#3186

I'm seeing strange behavior around speed grader and I'm not sure if it's caused by the changes in this PR but I rather investigate with the revert merged.