### PR TITLE
Take resouce_link_id from a context property

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -79,6 +79,10 @@ class LTILaunchResource:
         return course
 
     @property
+    def resource_link_id(self):
+        return self._request.params.get("resource_link_id")
+
+    @property
     def is_canvas(self):
         """Return True if Canvas is the LMS that launched us."""
         if (

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -102,10 +102,8 @@ class BasicLTILaunchViews:
         Via. We have to re-do this file-ID-for-download-URL exchange on every
         single launch because Canvas's download URLs are temporary.
         """
-
         course_id = self.request.params["custom_canvas_course_id"]
         file_id = self.request.params["file_id"]
-        resource_link_id = self.request.params["resource_link_id"]
 
         # Normally this would be done during `configure_assignment()` but
         # Canvas skips that step. We are doing this to ensure that there is a
@@ -120,7 +118,7 @@ class BasicLTILaunchViews:
             tool_consumer_instance_guid=self.request.params[
                 "tool_consumer_instance_guid"
             ],
-            resource_link_id=resource_link_id,
+            resource_link_id=self.context.resource_link_id,
         )
         return self.basic_lti_launch(document_url=document_url, grading_supported=False)
 
@@ -160,9 +158,8 @@ class BasicLTILaunchViews:
         # won't be called if there isn't a matching document_url in the DB. So
         # here we can safely assume that the document_url exists.
         tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
-        resource_link_id = self.request.params["resource_link_id"]
         document_url = self.assignment_service.get(
-            tool_consumer_instance_guid, resource_link_id
+            tool_consumer_instance_guid, self.context.resource_link_id
         ).document_url
         return self.basic_lti_launch(document_url)
 
@@ -203,14 +200,13 @@ class BasicLTILaunchViews:
             assignment that this assignment was copied from
         """
         tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
-        resource_link_id = self.request.params["resource_link_id"]
 
         document_url = self.assignment_service.get(
             tool_consumer_instance_guid, original_resource_link_id
         ).document_url
 
         self.assignment_service.upsert(
-            document_url, tool_consumer_instance_guid, resource_link_id
+            document_url, tool_consumer_instance_guid, self.context.resource_link_id
         )
 
         return self.basic_lti_launch(document_url)
@@ -310,7 +306,7 @@ class BasicLTILaunchViews:
         self.assignment_service.upsert(
             document_url,
             self.request.parsed_params["tool_consumer_instance_guid"],
-            self.request.parsed_params["resource_link_id"],
+            self.context.resource_link_id,
         )
 
         self.context.js_config.add_document_url(document_url)

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -32,11 +32,10 @@ class DBConfigured(Base):
 
     def __call__(self, context, request):
         assignment_svc = request.find_service(name="assignment")
-        resource_link_id = request.params.get("resource_link_id")
         tool_consumer_instance_guid = request.params.get("tool_consumer_instance_guid")
 
         return (
-            assignment_svc.exists(tool_consumer_instance_guid, resource_link_id)
+            assignment_svc.exists(tool_consumer_instance_guid, context.resource_link_id)
             == self.value
         )
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -18,6 +18,14 @@ class TestHGroup:
         assert lti_launch.h_group == mock.sentinel.course
 
 
+class TestResouceLinkIdk:
+    def test_it(self, pyramid_request):
+        assert (
+            LTILaunchResource(pyramid_request).resource_link_id
+            == pyramid_request.params["resource_link_id"]
+        )
+
+
 class TestIsCanvas:
     @pytest.mark.parametrize(
         "parsed_params,is_canvas",

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -446,10 +446,12 @@ class TestVitalsourceLTILaunch:
 
 
 @pytest.fixture
-def context():
+def context(pyramid_request):
     context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
     context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
     context.is_canvas = False
+
+    context.resource_link_id = pyramid_request.params["resource_link_id"]
     return context
 
 


### PR DESCRIPTION
Using `resouce_link_id` in a launch is going to become more complex, involving conditionals so we might as well centralize the behavior first.