### PR TITLE
Include assignment IDs on speedgrader params

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -341,6 +341,13 @@ class JSConfig:
                 "lis_outcome_service_url": lis_outcome_service_url,
                 "learner_canvas_user_id": self._request.params["custom_canvas_user_id"],
                 "group_set": self._request.params.get("group_set"),
+                # Canvas doesn't send the right value for this on speed grader launches
+                # sending instead the same value as for "context_id"
+                "resource_link_id": self._request.params.get("resource_link_id"),
+                # Canvas doesn't send this value at all on speed grader submissions
+                "ext_lti_assignment_id": self._request.params.get(
+                    "ext_lti_assignment_id"
+                ),
                 **kwargs,
             },
         }

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -36,6 +36,13 @@ class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
     group_set = fields.Int(required=False, allow_none=True)
     """Canvas group_set ID for assignments that use the small groups feature."""
 
+    resource_link_id = fields.Str(required=False, allow_none=True)
+    """Canvas doesn't seen the right value on speed grader launches
+    so we keep track of the correct one ourselves"""
+
+    ext_lti_assignment_id = fields.Str(required=False, allow_none=True)
+    """Canvas doesn't send this value on speed grader launches"""
+
 
 class APIReadResultSchema(PyramidRequestSchema):
     """Schema for validating proxy requests to LTI Outcomes API for reading grades."""

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -273,6 +273,15 @@ class TestAddCanvasFileIDAddDocumentURLCommon:
         )
         assert submission_params()["learner_canvas_user_id"] == "test_user_id"
 
+        assert (
+            submission_params()["resource_link_id"]
+            == pyramid_request.params["resource_link_id"]
+        )
+        assert (
+            submission_params()["ext_lti_assignment_id"]
+            == pyramid_request.params["ext_lti_assignment_id"]
+        )
+
     def test_it_doesnt_set_the_speedGrader_settings_if_the_LMS_isnt_Canvas(
         self, context, method_caller, js_config
     ):


### PR DESCRIPTION
Canvas doesn't set the right values for either resource_link_id or
ext_lti_assignment_id in speed grader launches so we are going to start
sending them ourselves as parameters.

In this PR we start sending them but don't use them yet.