### PR TITLE
Take resource_link_id from query params when speed grading

### DIFF
--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -115,6 +115,8 @@ class CanvasPreRecordHook:
             "focused_user": parsed_params["h_username"],
             "learner_canvas_user_id": parsed_params["learner_canvas_user_id"],
             "group_set": parsed_params.get("group_set"),
+            "ext_lti_assignment_id": parsed_params.get("ext_lti_assignment_id"),
+            "resource_link_id": parsed_params.get("resource_link_id"),
         }
 
         if parsed_params.get("document_url"):

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -18,12 +18,24 @@ class TestHGroup:
         assert lti_launch.h_group == mock.sentinel.course
 
 
-class TestResouceLinkIdk:
-    def test_it(self, pyramid_request):
-        assert (
-            LTILaunchResource(pyramid_request).resource_link_id
-            == pyramid_request.params["resource_link_id"]
-        )
+class TestResourceLinkIdk:
+    @pytest.mark.parametrize(
+        "learner_id,get_id,post_id,expected",
+        [
+            param(None, None, "POST_ID", "POST_ID", id="regular"),
+            param("USER_ID", "GET_ID", "POST_ID", "GET_ID", id="new_speedgrader"),
+            param("USER_ID", None, "POST_ID", "POST_ID", id="old_speedgrader"),
+        ],
+    )
+    def test_it(self, pyramid_request, learner_id, get_id, post_id, expected):
+        pyramid_request.POST = {
+            "resource_link_id": post_id,
+        }
+        pyramid_request.GET = {
+            "learner_canvas_user_id": learner_id,
+            "resource_link_id": get_id,
+        }
+        assert LTILaunchResource(pyramid_request).resource_link_id == expected
 
 
 class TestIsCanvas:


### PR DESCRIPTION
The `resource_link_id` provided by canvas on launches done while using
speedgrading is incorrectly set to the value of "context_id` (the course
ID). This is not causing any problems (apart from some orphan
assignments
on the DB) because we are using the `url` and `file_id` URL params to
get the assignment details.

This would become a problem once we switch to reading the assignments
info from the DB instead of the URL like we do for other LMS so it needs
to be fixed.

# Testing

On master:

- Delete your assignments:

`truncate module_item_configurations ;`

- Launch a canvas assignment as a student: https://hypothesis.instructure.com/courses/125/assignments/1967
 
- Check `module_item_configurations` new row on database with resource_link_id `ec05d6beddad805005f98816f7e1bf26707a346f`.

- Launch now the assigment as teacher speedgrading: https://hypothesis.instructure.com/courses/125/gradebook/speed_grader?assignment_id=1967&student_id=35

- Check `module_item_configurations` again, there will be now two row, the newest with a resource_link_id of `f3cd019017839c4630358662a05540f2f6ec5f93` which happens to be the course ID (so repeating this process on another assignment won't keep adding rows but modifing that one).


Repeat the process on this branch, only one row will be created.
