### PR TITLE
Inline application instance finding methods into the service

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -119,11 +119,6 @@ class ApplicationInstance(BASE):
 
         return lms_host
 
-    @classmethod
-    def get_by_consumer_key(cls, db, consumer_key):
-        """Return the ApplicationInstance with the given consumer_key or None."""
-        return db.query(cls).filter_by(consumer_key=consumer_key).one_or_none()
-
     def update_lms_data(self, params: dict):
         """
         Update all the LMS-related attributes present in `params`.

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -82,25 +82,6 @@ class TestApplicationInstance:
         with pytest.raises(ValueError):
             application_instance.lms_host()
 
-    def test_get_returns_the_matching_ApplicationInstance(
-        self, db_session, application_instance
-    ):
-        assert (
-            ApplicationInstance.get_by_consumer_key(
-                db_session, application_instance.consumer_key
-            )
-            == application_instance
-        )
-
-    @pytest.mark.usefixtures("application_instance")
-    def test_get_returns_None_if_theres_no_matching_ApplicationInstance(
-        self, db_session
-    ):
-        assert (
-            ApplicationInstance.get_by_consumer_key(db_session, "unknown_consumer_key")
-            is None
-        )
-
     def test_decrypted_developer_secret_returns_the_decrypted_developer_secret(
         self, application_instance, pyramid_request
     ):


### PR DESCRIPTION
## In this PR:

 * Inlines the `get_by_consumer_key` method from the model
 * Creates a new `get_by_consumer_key` method on the service where the consumer key is mandatory
 * Move the reading of the request user into the service
 * This is to prevent a dependency loop between the launch verifier and the service

## Why?

 * It's confusing that the behavior for this is spread between two places
 * The name `get()` is impossible to grep for (see: https://github.com/hypothesis/lms/pull/3230)
 * I need to change this to make it also constrain it to the tool consumer GUID