### PR TITLE
Make URLPicker not accept local file:// URIs

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -1,6 +1,11 @@
-import { LabeledButton, Modal, TextInput } from '@hypothesis/frontend-shared';
+import {
+  LabeledButton,
+  Modal,
+  SvgIcon,
+  TextInput,
+} from '@hypothesis/frontend-shared';
 
-import { useRef } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 
 /**
  * @typedef URLPickerProps
@@ -19,13 +24,28 @@ export default function URLPicker({ onCancel, onSelectURL }) {
   const input = useRef(/** @type {HTMLInputElement|null} */ (null));
   const form = useRef(/** @type {HTMLFormElement|null} */ (null));
 
+  // Holds an error message corresponding to client-side validation of the
+  // input field
+  const [error, setError] = useState(/** @type {string|null} */ (null));
+
   /** @param {Event} event */
   const submit = event => {
     event.preventDefault();
-    if (form.current.checkValidity()) {
-      onSelectURL(input.current.value);
-    } else {
-      form.current.reportValidity();
+    try {
+      const url = new URL(input.current.value);
+      if (!url.protocol.startsWith('http')) {
+        if (url.protocol.startsWith('file')) {
+          setError(
+            'URLs that start with "file" are files on your own computer. Please use a URL that starts with "http" or "https".'
+          );
+        } else {
+          setError('Please use a URL that starts with "http" or "https"');
+        }
+      } else {
+        onSelectURL(input.current.value);
+      }
+    } catch (e) {
+      setError('Please enter a URL, e.g. "https://www.example.com"');
     }
   };
 
@@ -40,25 +60,41 @@ export default function URLPicker({ onCancel, onSelectURL }) {
       ]}
       initialFocus={input}
     >
-      <p>Enter the URL of any publicly available web page or PDF.</p>
-      <form
-        ref={form}
-        className="hyp-u-layout-row--align-center"
-        onSubmit={submit}
-      >
-        <label className="label" htmlFor="url">
-          URL:{' '}
-        </label>
+      <div className="hyp-u-vertical-spacing">
+        <p>Enter the URL of any publicly available web page or PDF:</p>
+        <form
+          ref={form}
+          className="hyp-u-layout-row--align-center"
+          onSubmit={submit}
+        >
+          <label className="label" htmlFor="url">
+            URL:{' '}
+          </label>
 
-        <TextInput
-          classes="hyp-u-stretch"
-          inputRef={input}
-          name="url"
-          placeholder="https://example.com/article.pdf"
-          required
-          type="url"
-        />
-      </form>
+          <TextInput
+            classes="hyp-u-stretch"
+            hasError={!!error}
+            inputRef={input}
+            name="url"
+            placeholder="e.g. https://example.com/article.pdf"
+            required
+          />
+        </form>
+        {/** setting a height here "preserves space" for this error display
+         * and prevents the dialog size from jumping when an error is rendered */}
+        <div
+          className="hyp-u-layout-row--center hyp-u-horizontal-spacing hyp-u-color--error"
+          data-testid="error-message"
+          style="height: 1rem"
+        >
+          {!!error && (
+            <>
+              <SvgIcon name="cancel" />
+              <div className="hyp-u-stretch">{error}</div>
+            </>
+          )}
+        </div>
+      </div>
     </Modal>
   );
 }


### PR DESCRIPTION
This PR updates the validation for the `URLPicker` component to give more nuanced error messages for users to prevent them from using the `file:///` (local file) protocol, as entered URLs need to be publicly available.

My first implementation of this involved piggy-backing on the built-in HTML5 validation based on `[input type="url"]` but when experimenting, I found the built-in browser input errors to feel a little kludgy and unreliable. Sometimes they wouldn't pop up if I pressed "enter" instead of clicking the submit button. And they look inconsistent with our other error messaging in the app. I've made them consistent with the error display pattern used in the VitalSource book picker.

There's a pattern here (form field error display) that will need to be extracted at some point for consistent reuse.

The validation now distinguishes between values that are just not URLs at all:

![image](https://user-images.githubusercontent.com/439947/137532574-6d8325f5-35ff-45e4-8bbf-62fe03336fb8.png)

versus non-http(s) protocols:

![image](https://user-images.githubusercontent.com/439947/137495682-bfc6e826-0148-4670-b5b7-42d1c87a6aab.png)

versus a local file:

![image](https://user-images.githubusercontent.com/439947/137495917-89e2e009-adce-4b3e-9f36-3c78d2104157.png)

Fixes https://github.com/hypothesis/support/issues/230