### PR TITLE
Fix exception view name

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -100,7 +100,7 @@ class APIExceptionViews:
         )
 
     @exception_view_config(context=OAuth2TokenError)
-    def proxy_api_access_token_error(self):
+    def oauth2_token_error(self):
         return self.error_response()
 
     @exception_view_config(

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -20,9 +20,9 @@ class TestSchemaValidationError:
         return ValidationError(messages="foobar")
 
 
-class TestProxyAPIAccessTokenError:
+class TestOAuth2TokenError:
     def test_it(self, pyramid_request, views):
-        json_data = views.proxy_api_access_token_error()
+        json_data = views.oauth2_token_error()
 
         assert pyramid_request.response.status_code == 400
         assert json_data == {}


### PR DESCRIPTION
Fix this exception view's name to match the name of the exception class that it catches.

The view just didn't get renamed when the exception class was renamed.