### PR TITLE
Take ext_lti_assignment_id from query params when speed grading

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -101,6 +101,17 @@ class LTILaunchResource:
         return self._request.POST.get("resource_link_id")
 
     @property
+    def ext_lti_assignment_id(self):
+        # Canvas SpeedGrader launches don't provide ext_lti_assignment_id
+        # but include it on the SpeedGrader URL we submit to canvas.
+        if self._is_speed_grader and (
+            ext_lti_assignment_id := self._request.GET.get("ext_lti_assignment_id")
+        ):
+            return ext_lti_assignment_id
+
+        return self._request.POST.get("ext_lti_assignment_id")
+
+    @property
     def is_canvas(self):
         """Return True if Canvas is the LMS that launched us."""
         if (

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -170,8 +170,8 @@ class BasicLTILaunchViews:
     def canvas_db_configured_basic_lti_launch(self):
         """Respond to a Canvas DB-configured assignment launch."""
         tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
-        resource_link_id = self.request.params["resource_link_id"]
-        ext_lti_assignment_id = self.request.params["ext_lti_assignment_id"]
+        resource_link_id = self.context.resource_link_id
+        ext_lti_assignment_id = self.context.ext_lti_assignment_id
 
         assignments = self.assignment_service.get_for_canvas_launch(
             tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -32,14 +32,13 @@ class DBConfigured(Base):
 
     def __call__(self, context, request):
         assignment_svc = request.find_service(name="assignment")
-        ext_lti_assignment_id = request.params.get("ext_lti_assignment_id")
         tool_consumer_instance_guid = request.params.get("tool_consumer_instance_guid")
 
         return (
             assignment_svc.exists(
                 tool_consumer_instance_guid,
                 context.resource_link_id,
-                ext_lti_assignment_id,
+                context.ext_lti_assignment_id,
             )
             == self.value
         )

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -38,6 +38,25 @@ class TestResourceLinkIdk:
         assert LTILaunchResource(pyramid_request).resource_link_id == expected
 
 
+class TestExtLTIAssignmentID:
+    @pytest.mark.parametrize(
+        "learner_id,get_id,post_id,expected",
+        [
+            param(None, None, "POST_ID", "POST_ID", id="regular"),
+            param("USER_ID", "GET_ID", "POST_ID", "GET_ID", id="new_speedgrader"),
+        ],
+    )
+    def test_it(self, pyramid_request, learner_id, get_id, post_id, expected):
+        pyramid_request.POST = {
+            "ext_lti_assignment_id": post_id,
+        }
+        pyramid_request.GET = {
+            "learner_canvas_user_id": learner_id,
+            "ext_lti_assignment_id": get_id,
+        }
+        assert LTILaunchResource(pyramid_request).ext_lti_assignment_id == expected
+
+
 class TestIsCanvas:
     @pytest.mark.parametrize(
         "parsed_params,is_canvas",


### PR DESCRIPTION
Same as the work previously done for `resource_link
t_id` https://github.com/hypothesis/lms/pull/3227 but now applying to `ext_lti_assignment_id`.

Note that ext_lti_assignment_id is never sent on SpeedGrader so `resource_link
t_id` should be enough to identify the assignment but getting both will make regular and speed grading launches to behave exactly the same.