### PR TITLE
Remove `LTIOutcomesAPIError`

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -8,7 +8,6 @@ from lms.services.exceptions import (
     CanvasFileNotFoundInCourse,
     ExternalRequestError,
     HTTPError,
-    LTIOutcomesAPIError,
     OAuth2TokenError,
 )
 from lms.services.h_api import HAPIError

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -153,15 +153,6 @@ class CanvasAPIServerError(CanvasAPIError):
     """
 
 
-class LTIOutcomesAPIError(ExternalRequestError):
-    """
-    A problem with a request to an LTI Outcomes-compliant API.
-
-    Raised whenever an LTI outcomes API request times out or when an
-    unsuccessful, invalid or unexpected response is received from the API.
-    """
-
-
 class CanvasFileNotFoundInCourse(Exception):
     """A Canvas file ID wasn't found in the current course."""
 

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -2,7 +2,7 @@ from xml.parsers.expat import ExpatError
 
 import xmltodict
 
-from lms.services.exceptions import HTTPError, LTIOutcomesAPIError
+from lms.services.exceptions import ExternalRequestError, HTTPError
 
 __all__ = ["LTIOutcomesClient"]
 
@@ -87,7 +87,7 @@ class LTIOutcomesClient:
         :arg request_body: The content to send as the POX body element of the
                            request
 
-        :raise LTIOutcomesAPIError: if the request fails for any reason
+        :raise ExternalRequestError: if the request fails for any reason
 
         :return: The returned POX body element
         :rtype: dict
@@ -106,20 +106,20 @@ class LTIOutcomesClient:
                 auth=self.oauth1_service.get_client(),
             )
         except HTTPError as err:
-            raise LTIOutcomesAPIError(
+            raise ExternalRequestError(
                 "Error calling LTI Outcomes service", response
             ) from err
 
         try:
             data = xmltodict.parse(response.text)
         except ExpatError as err:
-            raise LTIOutcomesAPIError(
+            raise ExternalRequestError(
                 "Unable to parse XML response from LTI Outcomes service", response
             ) from err
 
         try:
             return self._get_body(data)
-        except LTIOutcomesAPIError as err:
+        except ExternalRequestError as err:
             err.response = response
             raise
 
@@ -135,7 +135,7 @@ class LTIOutcomesClient:
             ]
 
         except KeyError as err:
-            raise LTIOutcomesAPIError("Malformed LTI outcome response") from err
+            raise ExternalRequestError("Malformed LTI outcome response") from err
 
         if status != "success":
             description = None
@@ -148,7 +148,7 @@ class LTIOutcomesClient:
             except KeyError:
                 pass
 
-            raise LTIOutcomesAPIError(
+            raise ExternalRequestError(
                 explanation="LTI outcome request failed", details=description
             )
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/3242

This exception subclass isn't providing any functionality, nothing catches it or handles it specially. Just use the base class `ExternalRequestError` directly instead.

### Testing

Here's one way to trigger an `LTIOutcomesAPIError`:

```diff
diff --git a/lms/services/lti_outcomes.py b/lms/services/lti_outcomes.py
index 8757ef98..dab9d56c 100644
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -133,6 +133,7 @@ class LTIOutcomesClient:
             status = header["imsx_POXResponseHeaderInfo"]["imsx_statusInfo"][
                 "imsx_codeMajor"
             ]
+            foo = data["foo"]
 
         except KeyError as err:
             raise ExternalRequestError("Malformed LTI outcome response") from err
```

Then launch an assignment _as a student_. The error response from the `/submissions` API should look the same and the error dialog shown by the frontend should be the same.

One difference that this PR makes compared to master is that LTI Outcomes API errors will not appears as `ExternalRequestError` in Papertrail and Sentry which does make them less easy to distinguish. You can still see which route the exception came from (`lti_api.submissions.record`) and the `explanation` string that was passed though, so you can still distinguish them.