### PR TITLE
Use different transformation for Sharepoint URLs

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
@@ -119,26 +119,32 @@ describe('OneDrivePickerClient', () => {
   describe('.encodeSharingURL', () => {
     [
       {
+        sharingURL: 'https://test-account.sharepoint.com/FILE_ID',
+        expectedResult:
+          'https://test-account.sharepoint.com/FILE_ID?download=1',
+        reason: 'Sharepoint, appends query param',
+      },
+      {
         sharingURL: atob('aHR0cHM6Ly8xZHJ2Lm1zL2IvaQ=='), // https://1drv.ms/b/i
         expectedResult:
           'https://api.onedrive.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2IvaQ/root/content',
-        reason: 'removing the trailing `=` characters ',
+        reason: 'OneDrive, removing the trailing `=` characters ',
       },
       {
         sharingURL: atob('aHR0cHM6Ly8xZHJ2Lm1zL2Iv++8='), // https://1drv.ms/b/ûï
         expectedResult:
           'https://api.onedrive.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2Iv--8/root/content',
-        reason: 'removing the `+` characters ',
+        reason: 'OneDrive, removing the `+` characters ',
       },
       {
         sharingURL: atob('aHR0cHM6Ly8xZHJ2Lm1zL2Iva///'), // https://1drv.ms/b/kÿÿ
         expectedResult:
           'https://api.onedrive.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2Iva___/root/content',
-        reason: 'removing the `/` characters ',
+        reason: 'OneDrive, removing the `/` characters ',
       },
     ].forEach(({ sharingURL, expectedResult, reason }) => {
-      it(`encodes the sharing URL by ${reason} in the base64 representation`, () => {
-        const url = OneDrivePickerClient.encodeSharingURL(sharingURL);
+      it(`creates the download URL for ${reason}`, () => {
+        const url = OneDrivePickerClient.downloadURL(sharingURL);
 
         assert.equal(url, expectedResult);
       });


### PR DESCRIPTION
Needed for #3256 

## Testing 

On the filepicker select "switch account" and pick

```
Work or school account
Created by your IT department
[eng@list.hypothes.is](mailto:eng@list.hypothes.is)
```

(or use `eng@list.hypothes.is` & password and pick the work option if not yet logged in)

with that account the PDF sent to canvas should have `&download=1` attached to it. 

It should use the other formatting if using 

```	
Personal account
Created by you
eng@list.hypothes.is
```

or any other one drive personal account.


Note that the share-point ones will not yet work with via (pending https://github.com/hypothesis/via/pull/648)  of but if opened directly on the browser the resulting URL should lead to the PDF directly (not to a HTML page with the embedded PDF).