### PR TITLE
Fix misuse of `ExternalRequestError` by `VitalSourceAPIViews`

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -1,6 +1,7 @@
 """Error views for the API."""
 from h_pyramid_sentry import report_exception
 from pyramid import i18n
+from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.view import (
     exception_view_config,
     forbidden_view_config,
@@ -108,6 +109,12 @@ class APIExceptionViews:
     @exception_view_config(context=OAuth2TokenError)
     def oauth2_token_error(self):
         return self.error_response()
+
+    @exception_view_config(context=HTTPBadRequest)
+    def http_bad_request(self):
+        return self.error_response(
+            status=self.context.code, message=self.context.detail
+        )
 
     @exception_view_config(
         # It's unfortunately necessary to mention CanvasAPIPermissionError

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -1,9 +1,9 @@
 import re
 
+from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
-from lms.services import ExternalRequestError
 
 
 @view_defaults(renderer="json", permission=Permissions.API)
@@ -33,9 +33,7 @@ class VitalSourceAPIViews:
     def _get_book_id(self):
         book_id = self.request.matchdict["book_id"]
         if not self._is_valid_book_id(book_id):
-            raise ExternalRequestError(
-                "Invalid `book_id`. It must only contain [0-9A-Z-]."
-            )
+            raise HTTPBadRequest("Invalid `book_id`. It must only contain [0-9A-Z-].")
 
         return book_id
 

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -1,4 +1,5 @@
 import pytest
+from pyramid.httpexceptions import HTTPBadRequest
 
 from lms.services import CanvasAPIError, CanvasAPIPermissionError
 from lms.validation import ValidationError
@@ -66,6 +67,18 @@ class TestForbidden:
         result = views.forbidden()
 
         assert result["message"] == "You're not authorized to view this page."
+
+
+class TestHTTPBadRequest:
+    def test_it(self, pyramid_request, views):
+        json_data = views.http_bad_request()
+
+        assert pyramid_request.response.status_int == 400
+        assert json_data == {"message": "test_explanation"}
+
+    @pytest.fixture
+    def context(self):
+        return HTTPBadRequest("test_explanation")
 
 
 class TestAPIError:

--- a/tests/unit/lms/views/api/vitalsource_test.py
+++ b/tests/unit/lms/views/api/vitalsource_test.py
@@ -1,6 +1,6 @@
 import pytest
+from pyramid.httpexceptions import HTTPBadRequest
 
-from lms.services import ExternalRequestError
 from lms.views.api.vitalsource import VitalSourceAPIViews
 
 pytestmark = pytest.mark.usefixtures("http_service")
@@ -33,7 +33,7 @@ class TestVitalSourceAPIViews:
     def test_book_info_invalid_book_id(self, pyramid_request):
         pyramid_request.matchdict["book_id"] = "invalid_book_id"
 
-        with pytest.raises(ExternalRequestError):
+        with pytest.raises(HTTPBadRequest):
             VitalSourceAPIViews(pyramid_request).book_info()
 
     def test_table_of_contents_returns_chapter_data(
@@ -49,7 +49,7 @@ class TestVitalSourceAPIViews:
     def test_book_toc_invalid_book_id(self, pyramid_request):
         pyramid_request.matchdict["book_id"] = "invalid_book_id"
 
-        with pytest.raises(ExternalRequestError):
+        with pytest.raises(HTTPBadRequest):
             VitalSourceAPIViews(pyramid_request).table_of_contents()
 
     @pytest.fixture


### PR DESCRIPTION
If the frontend sends a request to the backend's `/api/vitalsource/books/{book_id}` or `/api/vitalsource/books/{book_id}/toc` API with an invalid `{book_id}` in the URL then `VitalSourceAPIViews` raises `ExternalRequestError`.

This is a misuse of `ExternalRequestError`: there hasn't been a problem with a request to an external service. The frontend's request to our API was bad.

So fix it to raise Pyramid's `HTTPBadRequest` instead of `ExternalRequestError`.

This requires adding a new API exception view for `HTTPBadRequest` because the fallback exception view (for `Exception`) doesn't seem to catch `HTTPBadRequest`'s. The `HTTPBadRequest` ends up not getting caught by any exception view and sending back Pyramid's builtin HTML 400 response. I guess Pyramid treats `HTTPException`'s specially and doesn't send them through exception views unless the exception view is registered for an `HTTPException` class?

This change means that these "Invalid `book_id`" errors from `VitalSourceAPIViews` will no longer be reported to Sentry, which is probably a good thing? We could easily add Sentry reporting to the new exception view if we want.

Testing
-------

Turn on the `vitalsource` feature flag:

```terminal
export FEATURE_FLAG_VITALSOURCE="true"
```

Then hack the code to trigger the exception:

```diff
diff --git a/lms/views/api/vitalsource.py b/lms/views/api/vitalsource.py
index 685095fc..51cee7cb 100644
--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -39,4 +39,4 @@ class VitalSourceAPIViews:

     @staticmethod
     def _is_valid_book_id(book_id):
-        return bool(re.match(r"^[0-9A-Z-]+$", book_id))
+        return False  #bool(re.match(r"^[0-9A-Z-]+$", book_id))
```

Create a new assignment and click <kbd>Select book from VitalSource</kbd>.

Paste in a VitalSource book URL (e.g. `https://bookshelf.vitalsource.com/reader/books/9781400847402/pages/recent`) then click the <kbd>→</kbd> button (not the <kbd>Select book</kbd> button).

You should see that the frontend's `http://localhost:8001/api/vitalsource/books/9781400847402` request gets a 400 response with this JSON body:

```json
{"message": "Invalid `book_id`. It must only contain [0-9A-Z-]."}
```

And you should see the <q>Invalid `book_id`. It must only contain [0-9A-Z-]</q> error message displayed in the frontend.