### PR TITLE
Remove `HTTPError` (use `ExternalRequestError` instead)

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -7,7 +7,6 @@ from lms.services.exceptions import (
     CanvasAPIServerError,
     CanvasFileNotFoundInCourse,
     ExternalRequestError,
-    HTTPError,
     OAuth2TokenError,
 )
 from lms.services.h_api import HAPIError

--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -1,6 +1,6 @@
 from marshmallow import INCLUDE, fields
 
-from lms.services.exceptions import HTTPError, OAuth2TokenError
+from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
 from lms.validation import RequestsResponseSchema, ValidationError
 
 
@@ -75,7 +75,7 @@ class BasicClient:
 
         try:
             return self._send(method, url)
-        except (OAuth2TokenError, HTTPError):
+        except ExternalRequestError:
             self._oauth_http_service.refresh_access_token(
                 self.token_url,
                 self.redirect_uri,
@@ -100,7 +100,7 @@ class BasicClient:
     def _send(self, method, url):
         try:
             return self._oauth_http_service.request(method, url)
-        except HTTPError as err:
+        except ExternalRequestError as err:
             error_dict = BlackboardErrorResponseSchema(err.response).parse()
 
             if error_dict.get("message") == "Bearer token is invalid":

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -5,7 +5,7 @@ from lms.services.blackboard_api._schemas import (
     BlackboardListFilesSchema,
     BlackboardPublicURLSchema,
 )
-from lms.services.exceptions import BlackboardFileNotFoundInCourse, HTTPError
+from lms.services.exceptions import BlackboardFileNotFoundInCourse, ExternalRequestError
 
 # The maxiumum number of paginated requests we'll make before returning.
 PAGINATION_MAX_REQUESTS = 25
@@ -26,8 +26,8 @@ class BlackboardAPIClient:
         """
         Save a new Blackboard access token for the current user to the DB.
 
-        :raise services.HTTPError: if something goes wrong with the access
-            token request to Blackboard
+        :raise services.ExternalRequestError: if something goes wrong with the
+            access token request to Blackboard
         """
         self._api.get_token(authorization_code)
 
@@ -91,8 +91,8 @@ class BlackboardAPIClient:
                 "GET",
                 f"courses/uuid:{course_id}/resources/{file_id}?fields=downloadUrl",
             )
-        except HTTPError as err:
-            if err.response.status_code == 404:
+        except ExternalRequestError as err:
+            if getattr(err.response, "status_code", None) == 404:
                 raise BlackboardFileNotFoundInCourse(file_id) from err
             raise
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -163,14 +163,6 @@ class CanvasFileNotFoundInCourse(Exception):
         super().__init__(self.details)
 
 
-class HTTPError(Exception):
-    """A problem with an HTTP request to an external service."""
-
-    def __init__(self, response=None):
-        super().__init__(response)
-        self.response = response
-
-
 class BlackboardFileNotFoundInCourse(Exception):
     """A Blackboard file ID wasn't found in the current course."""
 

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -3,7 +3,7 @@
 from h_api.bulk_api import BulkAPI, CommandBuilder
 
 from lms.models import HUser
-from lms.services import ExternalRequestError, HTTPError
+from lms.services import ExternalRequestError
 
 
 class HAPIError(ExternalRequestError):
@@ -94,9 +94,7 @@ class HAPI:
                 headers=headers,
                 **request_args,
             )
-        except HTTPError as err:
-            response = getattr(err, "response", None)
-
-            raise HAPIError("Connecting to Hypothesis failed", response) from err
+        except ExternalRequestError as err:
+            raise HAPIError("Connecting to Hypothesis failed", err.response) from err
 
         return response

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -1,7 +1,7 @@
 import requests
 from requests import RequestException
 
-from lms.services.exceptions import HTTPError
+from lms.services.exceptions import ExternalRequestError
 
 
 class HTTPService:
@@ -58,21 +58,23 @@ class HTTPService:
             requests.Session().request():
             https://docs.python-requests.org/en/latest/api/#requests.Session.request
 
-        :raise HTTPError: If sending the request or receiving the response
-            fails (DNS failure, refused connection, timeout, too many
+        :raise ExternalRequestError: If sending the request or receiving the
+            response fails (DNS failure, refused connection, timeout, too many
             redirects, etc).
 
             The original exception from requests will be available as
-            HTTPError.__cause__.
+            ExternalRequestError.__cause__.
 
-            In this case HTTPError.response will be None.
+            In this case ExternalRequestError.response will be None.
 
-        :raise HTTPError: If an error response (4xx or 5xx) is received.
+        :raise ExternalRequestError: If an error response (4xx or 5xx) is
+            received.
 
             The original exception from requests will be available as
-            HTTPError.__cause__.
+            ExternalRequestError.__cause__.
 
-            The error response will be available as HTTPError.response.
+            The error response will be available as
+            ExternalRequestError.response.
         """
         response = None
 
@@ -85,7 +87,7 @@ class HTTPService:
             )
             response.raise_for_status()
         except RequestException as err:
-            raise HTTPError(response) from err
+            raise ExternalRequestError(response=response) from err
 
         return response
 

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -2,7 +2,7 @@ from xml.parsers.expat import ExpatError
 
 import xmltodict
 
-from lms.services.exceptions import ExternalRequestError, HTTPError
+from lms.services.exceptions import ExternalRequestError
 
 __all__ = ["LTIOutcomesClient"]
 
@@ -105,10 +105,9 @@ class LTIOutcomesClient:
                 headers={"Content-Type": "application/xml"},
                 auth=self.oauth1_service.get_client(),
             )
-        except HTTPError as err:
-            raise ExternalRequestError(
-                "Error calling LTI Outcomes service", response
-            ) from err
+        except ExternalRequestError as err:
+            err.message = "Error calling LTI Outcomes service"
+            raise
 
         try:
             data = xmltodict.parse(response.text)

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -1,6 +1,6 @@
 from marshmallow import fields
 
-from lms.services import HTTPError, OAuth2TokenError
+from lms.services import ExternalRequestError, OAuth2TokenError
 from lms.validation import RequestsResponseSchema, ValidationError
 from lms.validation.authentication import OAuthTokenResponseSchema
 
@@ -44,7 +44,8 @@ class OAuthHTTPService:
         The given `headers` must not already contain an "Authorization" header.
 
         :raise OAuth2TokenError: if we don't have an access token for the user
-        :raise HTTPError: if something goes wrong with the HTTP request
+        :raise ExternalRequestError: if something goes wrong with the HTTP
+            request
         """
         headers = headers or {}
 
@@ -63,7 +64,7 @@ class OAuthHTTPService:
         (https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3) to get a
         new access token for the current user and save it to the DB.
 
-        :raise HTTPError: if the HTTP request fails
+        :raise ExternalRequestError: if the HTTP request fails
         :raise ValidationError: if the server's access token response is invalid
         """
         self._token_request(
@@ -85,7 +86,7 @@ class OAuthHTTPService:
         access token for the current user and save it to the DB.
 
         :raise OAuth2TokenError: if we don't have a refresh token for the user
-        :raise HTTPError: if the HTTP request fails
+        :raise ExternalRequestError: if the HTTP request fails
         :raise ValidationError: if the server's access token response is invalid
         """
         refresh_token = self._oauth2_token_service.get().refresh_token
@@ -100,7 +101,7 @@ class OAuthHTTPService:
                     "refresh_token": refresh_token,
                 },
             )
-        except HTTPError as err:
+        except ExternalRequestError as err:
             try:
                 error_dict = _OAuthAccessTokenErrorResponseSchema(err.response).parse()
             except ValidationError:

--- a/lms/services/vitalsource/client.py
+++ b/lms/services/vitalsource/client.py
@@ -1,7 +1,7 @@
 import oauthlib
 from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
 
-from lms.services.exceptions import ExternalRequestError, HTTPError
+from lms.services.exceptions import ExternalRequestError
 from lms.services.vitalsource._schemas import BookInfoSchema, BookTOCSchema
 
 
@@ -35,9 +35,9 @@ class VitalSourceService:
     def book_info(self, book_id: str):
         try:
             response = self.get(f"products/{book_id}")
-        except HTTPError as exp:
-            if exp.response.status_code == 404:
-                raise ExternalRequestError(f"Book {book_id} not found") from exp
+        except ExternalRequestError as err:
+            if getattr(err.response, "status_code", None) == 404:
+                err.message = f"Book {book_id} not found"
 
             raise
 
@@ -46,9 +46,9 @@ class VitalSourceService:
     def book_toc(self, book_id: str):
         try:
             response = self.get(f"products/{book_id}/toc")
-        except HTTPError as exp:
-            if exp.response.status_code == 404:
-                raise ExternalRequestError(f"Book {book_id} not found") from exp
+        except ExternalRequestError as err:
+            if getattr(err.response, "status_code", None) == 404:
+                err.message = f"Book {book_id} not found"
 
             raise
 

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -10,7 +10,7 @@ from lms.services.blackboard_api.client import (
     PAGINATION_MAX_REQUESTS,
     BlackboardAPIClient,
 )
-from lms.services.exceptions import BlackboardFileNotFoundInCourse, HTTPError
+from lms.services.exceptions import BlackboardFileNotFoundInCourse, ExternalRequestError
 from tests import factories
 
 
@@ -195,21 +195,21 @@ class TestPublicURL:
     def test_it_raises_BlackboardFileNotFoundInCourse_if_the_Blackboard_API_404s(
         self, svc, basic_client
     ):
-        basic_client.request.side_effect = HTTPError(
-            factories.requests.Response(status_code=404)
+        basic_client.request.side_effect = ExternalRequestError(
+            response=factories.requests.Response(status_code=404)
         )
 
         with pytest.raises(BlackboardFileNotFoundInCourse):
             svc.public_url("COURSE_ID", "FILE_ID")
 
-    def test_it_raises_HTTPError_if_the_Blackboard_API_fails_in_any_other_way(
+    def test_it_raises_ExternalRequestError_if_the_Blackboard_API_fails_in_any_other_way(
         self, svc, basic_client
     ):
-        basic_client.request.side_effect = HTTPError(
-            factories.requests.Response(status_code=400)
+        basic_client.request.side_effect = ExternalRequestError(
+            response=factories.requests.Response(status_code=400)
         )
 
-        with pytest.raises(HTTPError):
+        with pytest.raises(ExternalRequestError):
             svc.public_url("COURSE_ID", "FILE_ID")
 
 

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -7,7 +7,7 @@ from h_matchers import Any
 from lms.models import HUser
 from lms.services import HAPIError
 from lms.services.h_api import HAPI
-from lms.services.http import HTTPError
+from lms.services.http import ExternalRequestError
 
 pytestmark = pytest.mark.usefixtures("http_service")
 
@@ -88,7 +88,7 @@ class TestHAPI:
     def test__api_request_raises_HAPIError_for_request_errors(
         self, h_api, http_service
     ):
-        exception = HTTPError()
+        exception = ExternalRequestError()
         http_service.request.side_effect = exception
 
         with pytest.raises(HAPIError) as exc_info:

--- a/tests/unit/lms/services/http_test.py
+++ b/tests/unit/lms/services/http_test.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 from h_matchers import Any
 
-from lms.services.exceptions import HTTPError
+from lms.services.exceptions import ExternalRequestError
 from lms.services.http import HTTPService, factory
 
 
@@ -91,7 +91,7 @@ class TestHTTPService:
         session.request.side_effect = exception
         svc = HTTPService(session)
 
-        with pytest.raises(HTTPError) as exc_info:
+        with pytest.raises(ExternalRequestError) as exc_info:
             svc.request("GET", "https://example.com")
 
         assert exc_info.value.response is None
@@ -101,7 +101,7 @@ class TestHTTPService:
     def test_it_raises_if_the_response_is_an_error(self, svc, url, status):
         httpretty.register_uri("GET", url, status=status)
 
-        with pytest.raises(HTTPError) as exc_info:
+        with pytest.raises(ExternalRequestError) as exc_info:
             svc.request("GET", url)
 
         assert isinstance(exc_info.value.__cause__, requests.HTTPError)

--- a/tests/unit/lms/services/lti_outcomes_test.py
+++ b/tests/unit/lms/services/lti_outcomes_test.py
@@ -5,7 +5,7 @@ import pytest
 import xmltodict
 from h_matchers import Any
 
-from lms.services.exceptions import ExternalRequestError, HTTPError
+from lms.services.exceptions import ExternalRequestError
 from lms.services.lti_outcomes import LTIOutcomesClient
 from tests import factories
 
@@ -120,7 +120,7 @@ class TestLTIOutcomesClient:
         )
 
     def test_requests_fail_if_the_third_party_request_fails(self, svc, http_service):
-        http_service.post.side_effect = HTTPError
+        http_service.post.side_effect = ExternalRequestError
 
         with pytest.raises(ExternalRequestError):
             svc.read_result(self.GRADING_ID)

--- a/tests/unit/lms/services/vitalsource/client_test.py
+++ b/tests/unit/lms/services/vitalsource/client_test.py
@@ -5,7 +5,7 @@ import pytest
 from h_matchers import Any
 from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
 
-from lms.services.exceptions import ExternalRequestError, HTTPError
+from lms.services.exceptions import ExternalRequestError
 from lms.services.vitalsource import VitalSourceService, factory
 from tests import factories
 
@@ -90,18 +90,24 @@ class TestVitalSourceService:
         with mock.patch.object(
             VitalSourceService,
             "get",
-            side_effect=HTTPError(factories.requests.Response(status_code=404)),
+            side_effect=ExternalRequestError(
+                response=factories.requests.Response(status_code=404)
+            ),
         ):
-            with pytest.raises(ExternalRequestError):
+            with pytest.raises(ExternalRequestError) as exc_info:
                 svc.book_info("BOOK_ID")
+
+            assert exc_info.value.message == "Book BOOK_ID not found"
 
     def test_book_info_error(self, svc):
         with mock.patch.object(
             VitalSourceService,
             "get",
-            side_effect=HTTPError(factories.requests.Response(status_code=500)),
+            side_effect=ExternalRequestError(
+                response=factories.requests.Response(status_code=500)
+            ),
         ):
-            with pytest.raises(HTTPError):
+            with pytest.raises(ExternalRequestError):
                 svc.book_info("BOOK_ID")
 
     def test_book_toc_api(self, svc, book_toc_schema):
@@ -115,18 +121,24 @@ class TestVitalSourceService:
         with mock.patch.object(
             VitalSourceService,
             "get",
-            side_effect=HTTPError(factories.requests.Response(status_code=404)),
+            side_effect=ExternalRequestError(
+                response=factories.requests.Response(status_code=404)
+            ),
         ):
-            with pytest.raises(ExternalRequestError):
+            with pytest.raises(ExternalRequestError) as exc_info:
                 svc.book_toc("BOOK_ID")
+
+            assert exc_info.value.message == "Book BOOK_ID not found"
 
     def test_book_toc_error(self, svc):
         with mock.patch.object(
             VitalSourceService,
             "get",
-            side_effect=HTTPError(factories.requests.Response(status_code=500)),
+            side_effect=ExternalRequestError(
+                response=factories.requests.Response(status_code=500)
+            ),
         ):
-            with pytest.raises(HTTPError):
+            with pytest.raises(ExternalRequestError):
                 svc.book_toc("BOOK_ID")
 
     @pytest.fixture


### PR DESCRIPTION
`HTTPError` is the exception class raised by `HTTPService` whenever anything goes wrong with a server-to-server HTTP request.

`HTTPService` is almost always used when sending HTTP requests: `HAPI`, `LTIOutcomesAPIClient`, `VitalSourceService` and `BlackboardAPIClient` all use `HTTPService`. `CanvasAPIClient` is the one thing that sends external HTTP requests without using `HTTPService` and that's only because `CanvasAPIClient`'s code is unusual and can't be easily refactored to work like the others do.

`HTTPError` is kind of the same thing as `ExternalRequestError` but with fewer attributes and less functionality:

```python
class ExternalRequestError(Exception):
    """
    A problem with a network request to an external service.

    ...
    """
    
    def __init__(self, explanation=None, response=None, details=None):
        super().__init__()
        self.explanation = explanation
        self.response = response
        self.details = details

    def __str__(self):
        ...

class HTTPError(Exception):
    """A problem with an HTTP request to an external service."""

    def __init__(self, response=None):
        super().__init__(response)
        self.response = response
```

This PR deletes `HTTPError` and changes `HTTPService` to raise `ExternalRequestError` instead.

As a result all the services that use `HTTPService` will now get better error reporting: details of error responses from third-party services will be sent to Papertrail and Sentry.

Testing
=======

Blackboard API Errors
---------------------

Hack the code to simulate an error from the Blackboard API:


```diff
diff --git a/lms/services/blackboard_api/_basic.py b/lms/services/blackboard_api/_basic.py
index 54b78336..8235b76f 100644
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -72,6 +72,7 @@ class BasicClient:
 
     def request(self, method, path):
         url = self._api_url(path)
+        url = "http://httpbin.org/status/403"
 
         try:
             return self._send(method, url)
```

Then launch a test Blackboard Files assignment from https://aunltd-test.blackboard.com/.

* The `/via_url` API request gets a 400 error response with `{"message": "External request failed"}`
* A generic "Something went wrong: There was a problem fetching this Hypothesis assignment" error dialog is shown.
  * Note that the `"External request failed"` error message that the backend returned is not displayed by the frontend. This is an existing issue: https://github.com/hypothesis/lms/issues/3259

You can also try launching the **localhost (make devdata) Blackboard Files Assignment Whose File Has Been Deleted** assignment and see that the `{"error_code": "blackboard_file_not_found_in_course", "details": {"file_id": "_9019_1"}}` response is sent and triggers the **Hypothesis couldn't find the file in the course** error dialog from the frontend.

h API Errors
------------

Hack the code to simulate an error from h's sync API:

```diff
diff --git a/lms/services/h_api.py b/lms/services/h_api.py
index 9a9204b8..806866b3 100644
--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -86,10 +86,15 @@ class HAPI:
         if body is not None:
             request_args["data"] = body
 
+        url = self._base_url + path.lstrip("/")
+
+        if self._request.url.endswith("/sync"):
+            url = "http://httpbin.org/status/500"
+
         try:
             response = self._http_service.request(
                 method=method,
-                url=self._base_url + path.lstrip("/"),
+                url=url,
                 auth=self._http_auth,
                 headers=headers,
                 **request_args,
```

Then launch any Canvas assignment. The `/sync` API request will get a 400 response with this JSON body:

```json
{"message": "Connecting to Hypothesis failed"}
```

This will trigger an error dialog from the frontend.

LTI Outcomes API Errors
-----------------------

Hack the code to simulate an error from the LTI Outcomes API:

```diff
diff --git a/lms/services/lti_outcomes.py b/lms/services/lti_outcomes.py
index 15c476e2..c9088042 100644
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -99,7 +99,7 @@ class LTIOutcomesClient:
         response = None
 
         response = self.http_service.post(
-            url=self.service_url,
+            url="http://httpbin.org/status/500",
             data=xml_body,
             headers={"Content-Type": "application/xml"},
             auth=self.oauth1_service.get_client(),
```

Then launch any Canvas assignment as a student. The `/submissions` API request will get a 400 response with this body:

```json
{"message": "Error calling LTI Outcomes service"}
```

Which will trigger an error dialog from the frontend.

Here's another way to break the LTI Outcomes API that will get the same result:

```diff
diff --git a/lms/services/lti_outcomes.py b/lms/services/lti_outcomes.py
index 1792e164..885e2587 100644
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -110,7 +110,7 @@ class LTIOutcomesClient:
             raise
 
         try:
-            data = xmltodict.parse(response.text)
+            data = xmltodict.parse("blah blah")
         except ExpatError as err:
             raise ExternalRequestError(
                 "Unable to parse XML response from LTI Outcomes service", response
```

And another:

```diff
diff --git a/lms/services/lti_outcomes.py b/lms/services/lti_outcomes.py
index 1792e164..fe9d0893 100644
--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -132,6 +132,7 @@ class LTIOutcomesClient:
             status = header["imsx_POXResponseHeaderInfo"]["imsx_statusInfo"][
                 "imsx_codeMajor"
             ]
+            data["foo"]
 
         except KeyError as err:
             raise ExternalRequestError("Malformed LTI outcome response") from err
```