### PR TITLE
Query params (url and file_id) take precedence over DB configured values

### DIFF
--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -162,8 +162,6 @@ class CanvasFile(Base):
     """
     Allow invoking an LTI launch view only for Canvas file assignments.
 
-    Newer Canvas file assignment are already present in the DB so they behave like DB Configured ones.
-
     Pass ``canvas_file=True`` to a view config to allow invoking the view only
     for Canvas file assignments, or ``canvas_file=False`` to allow it only for
     other types of assignment. For example::
@@ -173,16 +171,10 @@ class CanvasFile(Base):
             ...
     """
 
-    def __init__(self, value, config):
-        super().__init__(value, config)
-        self.db_configured = DBConfigured(True, config)
-
     name = "canvas_file"
 
     def __call__(self, context, request):
-        return ("canvas_file" in request.params) == self.value and self.db_configured(
-            context, request
-        ) != self.value
+        return ("canvas_file" in request.params) == self.value
 
 
 class VitalSourceBook(Base):
@@ -214,14 +206,8 @@ class URLConfigured(Base):
 
     name = "url_configured"
 
-    def __init__(self, value, config):
-        super().__init__(value, config)
-        self.db_configured = DBConfigured(True, config)
-
     def __call__(self, context, request):
-        return ("url" in request.params) == self.value and self.db_configured(
-            context, request
-        ) != self.value
+        return ("url" in request.params) == self.value
 
 
 class Configured(Base):


### PR DESCRIPTION
To fix issues with speedgrader