### PR TITLE
Fix `ExternalRequestError.__str__()` crashes

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -19,14 +19,16 @@ class ExternalRequestError(Exception):
         self.details = details
 
     def __str__(self):
+        explanation = self.explanation or "ExternalRequestError"
+
         if self.response is None:
-            return self.explanation
+            return explanation
 
         # Log the details of the response. This goes to both Sentry and the
         # application's logs. It's helpful for debugging to know how the
         # external service responded.
         parts = [
-            self.explanation + ":",
+            explanation + ":",
             str(self.response.status_code or ""),
             self.response.reason,
             self.response.text,

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -16,10 +16,25 @@ from lms.validation import ValidationError
 
 
 class TestExternalRequestError:
+    def test_str_with_no_response_or_explanation(self):
+        assert str(ExternalRequestError()) == "ExternalRequestError"
+
     def test_str_with_explanation_but_no_response(self):
         err = ExternalRequestError("Connecting to Hypothesis failed")
 
         assert str(err) == "Connecting to Hypothesis failed"
+
+    def test_str_with_response_but_no_explanation(self):
+        response = mock.create_autospec(
+            requests.Response,
+            instance=True,
+            status_code=400,
+            reason="Bad Request",
+            text="Name too long",
+        )
+        err = ExternalRequestError(response=response)
+
+        assert str(err) == "ExternalRequestError: 400 Bad Request Name too long"
 
     # If a ``response`` arg is given to ExternalRequestError() then it uses the
     # Response object's attributes to format a more informative string


### PR DESCRIPTION
`ExternalRequestError.__str__()` is based on `self.explanation` and `self.response`. Both of these are optional arguments to `ExternalRequestError.__init__()` so there are four possible cases:
    
1. Both `response` and `explanation` are `None`: `ExternalRequestError()`
2. `explanation` is a string but `response` is `None`: `ExternalRequestError("Something went wrong")`
3. `response` is a `Response` but `explanation` is `None`: `ExternalRequestError(response=response)`
4. `explanation` is a string and `response` is a `Response`: `ExternalRequestError(explanation, response)`
    
Two of these cases were missing from the tests and were actually resulting in `__str__()` crashing. Add tests and fix the cases.
    
I'd like to also change the format of `ExternalRequestError`'s string representations (it's a bit of a mess) but that's for another PR.
