### PR TITLE
Exclude canvas_files assignment from any other views

### DIFF
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -145,7 +145,7 @@ class BasicLTILaunchViews:
         )
         return {}
 
-    @view_config(db_configured=True)
+    @view_config(db_configured=True, canvas_file=False, url_configured=False)
     def db_configured_basic_lti_launch(self):
         """
         Respond to a DB-configured assignment launch.
@@ -166,7 +166,12 @@ class BasicLTILaunchViews:
         ).document_url
         return self.basic_lti_launch(document_url)
 
-    @view_config(db_configured=True, request_param="ext_lti_assignment_id")
+    @view_config(
+        db_configured=True,
+        canvas_file=False,
+        request_param="ext_lti_assignment_id",
+        url_configured=False,
+    )
     def canvas_db_configured_basic_lti_launch(self):
         """Respond to a Canvas DB-configured assignment launch."""
         tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]


### PR DESCRIPTION
With the modifications form the revert on c81561785d5cf060eb0ed24516fc798c42a85b2b the new views were now taking priority over the new ones.

That shouldn't be case now until 

- speed grading issues are fixed
- Frontend changes to create new assignments are merged.