### PR TITLE
Make sure ExternalRequestError's always have an explanation

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -12,23 +12,23 @@ class ExternalRequestError(Exception):
     :type details: JSON-serializable dict or ``None``
     """
 
-    def __init__(self, explanation=None, response=None, details=None):
+    def __init__(
+        self, explanation="External request failed", response=None, details=None
+    ):
         super().__init__()
         self.explanation = explanation
         self.response = response
         self.details = details
 
     def __str__(self):
-        explanation = self.explanation or "ExternalRequestError"
-
         if self.response is None:
-            return explanation
+            return self.explanation
 
         # Log the details of the response. This goes to both Sentry and the
         # application's logs. It's helpful for debugging to know how the
         # external service responded.
         parts = [
-            explanation + ":",
+            self.explanation + ":",
             str(self.response.status_code or ""),
             self.response.reason,
             self.response.text,

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -17,7 +17,7 @@ from lms.validation import ValidationError
 
 class TestExternalRequestError:
     def test_str_with_no_response_or_explanation(self):
-        assert str(ExternalRequestError()) == "ExternalRequestError"
+        assert str(ExternalRequestError()) == "External request failed"
 
     def test_str_with_explanation_but_no_response(self):
         err = ExternalRequestError("Connecting to Hypothesis failed")
@@ -34,7 +34,7 @@ class TestExternalRequestError:
         )
         err = ExternalRequestError(response=response)
 
-        assert str(err) == "ExternalRequestError: 400 Bad Request Name too long"
+        assert str(err) == "External request failed: 400 Bad Request Name too long"
 
     # If a ``response`` arg is given to ExternalRequestError() then it uses the
     # Response object's attributes to format a more informative string


### PR DESCRIPTION
Make sure that `ExternalRequestError` objects always have an `explanation` attribute, defaulting to `"External request failed"`.

The exception view uses the `explanation` attribute as the `message` in the API's JSON error response:

https://github.com/hypothesis/lms/blob/1b293991e21659d963fb65c9a05535e6303b8316/lms/views/api/exceptions.py#L106

API error responses have to have either an `error_code` or a `message`, otherwise the frontend will treat them as an access token error and show the authorization dialog instead of the error dialog:

https://github.com/hypothesis/lms/blob/1b293991e21659d963fb65c9a05535e6303b8316/lms/views/api/exceptions.py#L46-L48

Currently if a view raises an `ExternalRequestError` with no `message` (`ExternalRequestError()` or `ExternalRequestError(response=response)`) the `external_request_error()` exception view will end up sending an error response with a JSON body of `{}` which results in an authorization dialog not an error dialog.

Fix this by making sure that `ExternalRequestError`'s always have a `message`.