### PR TITLE
Add `ExternalRequestError.status_code`

### DIFF
--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -92,7 +92,7 @@ class BlackboardAPIClient:
                 f"courses/uuid:{course_id}/resources/{file_id}?fields=downloadUrl",
             )
         except ExternalRequestError as err:
-            if getattr(err.response, "status_code", None) == 404:
+            if err.status_code == 404:
                 raise BlackboardFileNotFoundInCourse(file_id) from err
             raise
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+
 class ExternalRequestError(Exception):
     """
     A problem with a network request to an external service.
@@ -17,6 +20,16 @@ class ExternalRequestError(Exception):
         self.message = message
         self.response = response
         self.details = details
+
+    @property
+    def status_code(self) -> Optional[int]:
+        """
+        Return the HTTP status code of the external service's response.
+
+        Sometimes there is no response (e.g. if the request timed out). In
+        these cases ExternalRequestError.status_code will be None.
+        """
+        return getattr(self.response, "status_code", None)
 
     def __str__(self):
         if self.response is None:

--- a/lms/services/vitalsource/client.py
+++ b/lms/services/vitalsource/client.py
@@ -36,7 +36,7 @@ class VitalSourceService:
         try:
             response = self.get(f"products/{book_id}")
         except ExternalRequestError as err:
-            if getattr(err.response, "status_code", None) == 404:
+            if err.status_code == 404:
                 err.message = f"Book {book_id} not found"
 
             raise
@@ -47,7 +47,7 @@ class VitalSourceService:
         try:
             response = self.get(f"products/{book_id}/toc")
         except ExternalRequestError as err:
-            if getattr(err.response, "status_code", None) == 404:
+            if err.status_code == 404:
                 err.message = f"Book {book_id} not found"
 
             raise

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -84,6 +84,17 @@ class TestExternalRequestError:
 
         assert str(err) == expected
 
+    def test_status_code_returns_the_responses_status_code(self):
+        response = requests.Response()
+        response.status_code = 204
+
+        err = ExternalRequestError(response=response)
+
+        assert err.status_code == 204
+
+    def test_status_code_returns_None_if_theres_no_response(self):
+        assert ExternalRequestError().status_code is None
+
 
 class TestCanvasAPIError:
     @pytest.mark.parametrize(


### PR DESCRIPTION
As [suggested by @marcospri](https://github.com/hypothesis/lms/pull/3251/files#r733417242): this deduplicates code that was doing `getattr(err.response, "status_code", None)` in multiple places and makes the mistake of accessing `err.response.status_code` without `getattr()` less likely.