### PR TITLE
Improve the string representation of `ExternalRequestErrors`

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -102,9 +102,15 @@ class APIExceptionViews:
     @exception_view_config(context=ExternalRequestError)
     def external_request_error(self):
         report_exception()
-        return self.error_response(
-            message=self.context.message, details=self.context.details
-        )
+
+        # It's important that this exception view always returns a non-empty
+        # message even if ExternalRequestError.message is None because an error
+        # response JSON body of {} tells the frontend to show the authorization
+        # dialog, whereas {"message": "..."} tells the frontend to show the
+        # error dialog.
+        message = self.context.message or "External request failed"
+
+        return self.error_response(message=message, details=self.context.details)
 
     @exception_view_config(context=OAuth2TokenError)
     def oauth2_token_error(self):

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -35,7 +35,7 @@ class ExceptionViews:
 
     @exception_view_config(context=HAPIError)
     def hapi_error(self):
-        return self.error_response(500, str(self.exception))
+        return self.error_response(500, self.exception.message)
 
     @exception_view_config(
         context=ValidationError, renderer="lms:templates/validation_error.html.jinja2"

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -40,6 +40,14 @@ class TestExternalRequestError:
             "details": {"foo": "bar"},
         }
 
+    @pytest.mark.parametrize("message", [None, ""])
+    def test_it_injects_a_default_error_message(self, context, message, views):
+        context.message = message
+
+        json_data = views.external_request_error()
+
+        assert json_data["message"] == "External request failed"
+
     @pytest.fixture
     def context(self):
         return CanvasAPIError(message="test_message", details={"foo": "bar"})


### PR DESCRIPTION
Improve the string representation of `ExternalRequestError`'s (which appears in New Relic, Sentry, Papertrail, etc) to be more detailed and explicit.

This changes the string representation to:

    "ExternalRequestError(message='...', response=Response(status_code=xxx, reason='...', text='...')"