### PR TITLE
Streamline Karma configuration

### DIFF
--- a/lms/static/scripts/karma.config.js
+++ b/lms/static/scripts/karma.config.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 
 const path = require('path');
-const glob = require('glob');
 
 const chromeFlags = [];
 
@@ -14,27 +13,12 @@ if (process.env.RUNNING_IN_DOCKER) {
 }
 
 module.exports = function (config) {
-  let testFiles = ['**/*-test.js'];
-
-  if (config.grep) {
-    const allFiles = testFiles
-      .map(pattern => glob.sync(pattern, { cwd: __dirname }))
-      .flat();
-    testFiles = allFiles.filter(path => path.match(config.grep));
-
-    // eslint-disable-next-line no-console
-    console.log(`Running tests matching pattern "${config.grep}": `, testFiles);
-  }
-
   config.set({
-    // base path that will be used to resolve all patterns (eg. files, exclude)
+    // Base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: './',
 
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['mocha', 'chai', 'sinon', 'source-map-support'],
 
-    // list of files / patterns to load in the browser
     files: [
       // Test bundles.
       { pattern: '../../../build/scripts/tests.bundle.js', type: 'module' },
@@ -72,21 +56,6 @@ module.exports = function (config) {
     // for more helpful rendering of test failures
     reporters: ['mocha', 'coverage-istanbul'],
 
-    // web server port
-    port: 9876,
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
-
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
-
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['ChromeHeadless_Custom'],
 
     customLaunchers: {
@@ -95,10 +64,6 @@ module.exports = function (config) {
         flags: chromeFlags,
       },
     },
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
 
     // Log slow tests so we can fix them before they timeout
     reportSlowerThan: 500,


### PR DESCRIPTION
Streamline the Karma configuration to remove obsolete settings and make
it easier to see what non-default configuration we have supplied.

See similar change at https://github.com/hypothesis/client/pull/3852 for
more details.