### PR TITLE
Fix httppretty fixture in basic_lti_launch functional tests

### DIFF
--- a/tests/functional/api/basic_lti_launch_test.py
+++ b/tests/functional/api/basic_lti_launch_test.py
@@ -116,20 +116,13 @@ class TestBasicLTILaunch:
         return params
 
     @pytest.fixture(autouse=True)
-    def http_intercept(self, _http_intercept):
+    def http_intercept(self):
         """
         Monkey-patch Python's socket core module to mock all HTTP responses.
 
         We will catch calls to H's API and return 200. All other calls will
         raise an exception, allowing to you see who are are trying to call.
         """
-        # We only need to reset once per tests, all other setup can be done
-        # once in `_http_intercept()`
-        yield
-        httpretty.reset()
-
-    @pytest.fixture(scope="session")
-    def _http_intercept(self):
         # Mock all calls to the H API
         httpretty.register_uri(
             method=Any(),


### PR DESCRIPTION
The usage of scope="session" on the setup meant it  only triggered once while the test scoped fixture calling .reset() will remove any registered URLs making httppretty to only apply to the first test that run.