### PR TITLE
Load JS bundles as ES modules

### DIFF
--- a/lms/static/scripts/browser_check/.babelrc
+++ b/lms/static/scripts/browser_check/.babelrc
@@ -1,13 +1,14 @@
 // Custom compilation settings for the `browser_check` bundle. This is intended
 // to work in old browsers that are not supported by the main LMS frontend.
+//
+// This baseline here is based on browsers that support `<script type="module">`.
 {
   "presets": [
     ["@babel/preset-env", {
        "targets": {
-         "chrome": "40",
-         "firefox": "38",
-         "safari": "9",
-         "ie": "11"
+         "chrome": "61",
+         "firefox": "60",
+         "safari": "10"
       }
     }]
   ]

--- a/lms/templates/api/oauth2/redirect_error.html.jinja2
+++ b/lms/templates/api/oauth2/redirect_error.html.jinja2
@@ -14,6 +14,6 @@
 {% block scripts %}
   {{ super() }}
   {% for url in asset_urls("frontend_apps_js") %}
-    <script async defer src="{{ url }}"></script>
+    <script type="module" src="{{ url }}"></script>
   {% endfor %}
 {% endblock %}

--- a/lms/templates/application_instances/new_application_instance.html.jinja2
+++ b/lms/templates/application_instances/new_application_instance.html.jinja2
@@ -2,7 +2,7 @@
 {% extends "templates/base.html.jinja2" %}
 {% block scripts %}
 {% for url in asset_urls("new_application_instance_js") %}
-<script src="{{ url }}"></script>
+<script type="module" src="{{ url }}"></script>
 {% endfor %}
 {% endblock %}
 

--- a/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
+++ b/lms/templates/basic_lti_launch/basic_lti_launch.html.jinja2
@@ -13,6 +13,6 @@
 {% block scripts %}
   {{ super() }}
   {% for url in asset_urls("frontend_apps_js") %}
-    <script defer src="{{ url }}"></script>
+    <script type="module" src="{{ url }}"></script>
   {% endfor %}
 {% endblock %}

--- a/lms/templates/error_dialog.html.jinja2
+++ b/lms/templates/error_dialog.html.jinja2
@@ -14,6 +14,6 @@
 {% block scripts %}
   {{ super() }}
   {% for url in asset_urls("frontend_apps_js") %}
-    <script async defer src="{{ url }}"></script>
+    <script type="module" src="{{ url }}"></script>
   {% endfor %}
 {% endblock %}

--- a/lms/templates/file_picker.html.jinja2
+++ b/lms/templates/file_picker.html.jinja2
@@ -13,6 +13,6 @@
 {% block scripts %}
   {{ super() }}
   {% for url in asset_urls("frontend_apps_js") %}
-    <script async defer src="{{ url }}"></script>
+    <script type="module" src="{{ url }}"></script>
   {% endfor %}
 {% endblock %}

--- a/lms/templates/ui-playground.html.jinja2
+++ b/lms/templates/ui-playground.html.jinja2
@@ -11,7 +11,7 @@
 <body>
   <div id="app"></div>
   {% for url in asset_urls("ui_playground_js") %}
-    <script src="{{ url }}"></script>
+    <script type="module" src="{{ url }}"></script>
   {% endfor %}
 </body>
 </html>

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -27,7 +27,7 @@ function bundleConfig(name, entryFile) {
     },
     output: {
       dir: 'build/scripts/',
-      format: 'iife',
+      format: 'es',
       chunkFileNames: '[name].bundle.js',
       entryFileNames: '[name].bundle.js',
     },


### PR DESCRIPTION
The Hypothesis client now relies on loading scripts as native ES modules, so it
makes sense to do the same in the LMS app.

There are no immediate benefits from this, but it will make loading
functionality on-demand (using `import()`) or code splitting easier in future.

As part of this, the baseline for the browser-compatibility check script
has been bumped to browsers which support `<script type="module">`.
Older browsers won't see any errors at all. Recent usage data indicates
that this will affect very few users.