### PR TITLE
Add more convenience properties to `ExternalRequestError`

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -31,6 +31,26 @@ class ExternalRequestError(Exception):
         """
         return getattr(self.response, "status_code", None)
 
+    @property
+    def reason(self) -> Optional[str]:
+        """
+        Return the HTTP reason of the external service's response.
+
+        Sometimes there is no response (e.g. if the request timed out). In
+        these cases ExternalRequestError.reason will be None.
+        """
+        return getattr(self.response, "reason", None)
+
+    @property
+    def text(self) -> Optional[str]:
+        """
+        Return the body content of the external service's response.
+
+        Sometimes there is no response (e.g. if the request timed out). In
+        these cases ExternalRequestError.text will be None.
+        """
+        return getattr(self.response, "text", None)
+
     def __str__(self):
         if self.response is None:
             return self.message

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -1,4 +1,5 @@
 import json
+from io import BytesIO
 from unittest import mock
 
 import httpretty
@@ -26,6 +27,29 @@ class TestExternalRequestError:
 
     def test_status_code_returns_None_if_theres_no_response(self):
         assert ExternalRequestError().status_code is None
+
+    def test_reason_returns_the_responses_reason(self):
+        response = requests.Response()
+        response.reason = "I'm a teapot"
+
+        err = ExternalRequestError(response=response)
+
+        assert err.reason == "I'm a teapot"
+
+    def test_reason_returns_None_if_theres_no_response(self):
+        assert ExternalRequestError().reason is None
+
+    def test_text_returns_the_responses_body_text(self):
+        response = requests.Response()
+        response.encoding = "utf8"
+        response.raw = BytesIO("Body text".encode(response.encoding))
+
+        err = ExternalRequestError(response=response)
+
+        assert err.text == "Body text"
+
+    def test_text_returns_None_if_theres_no_response(self):
+        assert ExternalRequestError().text is None
 
     def test_str_with_no_response_or_message(self):
         assert str(ExternalRequestError()) == "External request failed"


### PR DESCRIPTION
Add a couple more convenience properties to `ExternalRequestError`. These will simplify upcoming code