### PR TITLE
Add more of the response body to Sentry

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -1,4 +1,5 @@
 """Error views for the API."""
+import sentry_sdk
 from h_pyramid_sentry import report_exception
 from pyramid import i18n
 from pyramid.httpexceptions import HTTPBadRequest
@@ -101,6 +102,15 @@ class APIExceptionViews:
 
     @exception_view_config(context=ExternalRequestError)
     def external_request_error(self):
+        sentry_sdk.set_context(
+            "response",
+            {
+                "status_code": self.context.status_code,
+                "reason": self.context.reason,
+                "body": self.context.text,
+            },
+        )
+
         report_exception()
 
         # It's important that this exception view always returns a non-empty


### PR DESCRIPTION
This just squeezes a few more characters of the response body into the Sentry report, compared to `ExternalRequestError.__str__()` (which already appears in the Sentry report).

I think this general approach (of the exception view calling `sentry_sdk.set_context()` to add more details to the Sentry report) is likely to become more important in future. We're likely going to be adding more stuff to `ExternalRequestError`. Specifically, details about the _request_: URL, method, body. That stuff is likely going to be added to `ExternalRequestError.__str__()` for Papertrail, so that whenever an `ExternalRequestError` gets logged you can see both the request that was made and the response that was received as part of the log entry. That means that even more of `ExternalRequestError.__str__()` will get truncated by Sentry. But we will use `set_context()` to add both the request and response details to Sentry separately and independently from `__str__()`.

Note that `__str__()` is still necessary because that's what appears in Papertrail and New Relic, even though we now have `set_context()` for Sentry.

Here's what `__str__()` gets you in Sentry:

![Screenshot from 2021-10-26 14-47-48](https://user-images.githubusercontent.com/22498/138893232-f8bba190-90ca-47c1-8b64-e17319dbcc0b.png)

The response body gets truncated by Sentry. But note that `__str__()` also appears in New Relic and in Papertrail (where more, hopefully all, of the response body will appear).

And here's what the new `set_context()` call gets you in Sentry:

![Screenshot from 2021-10-26 14-48-23](https://user-images.githubusercontent.com/22498/138893732-3a4b8ec2-f4ea-4b89-8ed0-427fa656f19c.png)

It just squeezes in a few more characters of the response body, which could be the difference between having the information we need to understand something and not.

This is a minor benefit to be sure but the cost is also low (just a single call to `set_context()`)

In the future it may become a bigger benefit because we may add an _additional_ `set_context()` call to add the _request_ as _another_ context section in the Sentry report. This will give us the same amount of characters again, but dedicated to the request.

