### PR TITLE
Add `details` to `ExternalRequestError.__str__()`

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -65,7 +65,7 @@ class ExternalRequestError(Exception):
         # The name of this class or of a subclass if one inherits this method.
         class_name = self.__class__.__name__
 
-        return f"{class_name}(message={self.message!r}, response={response})"
+        return f"{class_name}(message={self.message!r}, details={self.details!r}, response={response})"
 
     def __str__(self):
         return repr(self)

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -35,26 +35,30 @@ class TestExternalRequestError:
         assert err.text is None
 
     @pytest.mark.parametrize(
-        "message,response,expected",
+        "message,details,response,expected",
         [
             (
                 None,
                 None,
-                "ExternalRequestError(message=None, response=Response(status_code=None, reason=None, text=None))",
+                None,
+                "ExternalRequestError(message=None, details=None, response=Response(status_code=None, reason=None, text=None))",
             ),
             (
                 "Connecting to Hypothesis failed",
+                {"extra": "details"},
                 factories.requests.Response(
                     status_code=400,
                     reason="Bad Request",
                     raw="Name too long",
                 ),
-                "ExternalRequestError(message='Connecting to Hypothesis failed', response=Response(status_code=400, reason='Bad Request', text='Name too long'))",
+                "ExternalRequestError(message='Connecting to Hypothesis failed', details={'extra': 'details'}, response=Response(status_code=400, reason='Bad Request', text='Name too long'))",
             ),
         ],
     )
-    def test_str(self, message, response, expected):
-        assert str(ExternalRequestError(message=message, response=response)) == expected
+    def test_str(self, message, details, response, expected):
+        err = ExternalRequestError(message=message, details=details, response=response)
+
+        assert str(err) == expected
 
 
 class TestCanvasAPIError:


### PR DESCRIPTION
The purpose of the `ExternalRequestError.details` is that [the exception view](https://github.com/hypothesis/lms/blob/2e5f76ab1edb8c82a0e4d24c8ba41470e1c62283/lms/views/api/exceptions.py#L102-L107) causes it to get sent to the frontend as the `details` dict in the error response JSON body. The frontend renders this as the contents of the **Error details** section in the error dialog.

Individual services and views can add whatever they want into `ExternalRequestError.details` and it'll get shown in the error dialog.

This PR also adds the `details` dict to `ExternalRequestError.__str__()` so that these details also appear in Papertrail etc.