### PR TITLE
Rename `ExternalRequestError.details` to `extra_details`

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -11,15 +11,15 @@ class ExternalRequestError(Exception):
     :arg response: The external service's response to our HTTP request, if any
     :type response: requests.Response or ``None``
 
-    :arg details: Additional details about what went wrong, for debugging
-    :type details: JSON-serializable dict or ``None``
+    :arg extra_details: Extra details about what went wrong, for debugging
+    :type extra_details: JSON-serializable dict or None
     """
 
-    def __init__(self, message=None, response=None, details=None):
+    def __init__(self, message=None, response=None, extra_details=None):
         super().__init__()
         self.message = message
         self.response = response
-        self.details = details
+        self.extra_details = extra_details
 
     @property
     def status_code(self) -> Optional[int]:
@@ -65,7 +65,7 @@ class ExternalRequestError(Exception):
         # The name of this class or of a subclass if one inherits this method.
         class_name = self.__class__.__name__
 
-        return f"{class_name}(message={self.message!r}, details={self.details!r}, response={response})"
+        return f"{class_name}(message={self.message!r}, extra_details={self.extra_details!r}, response={response})"
 
     def __str__(self):
         return repr(self)
@@ -114,24 +114,24 @@ class CanvasAPIError(ExternalRequestError):
 
         exception_class = cls._exception_class(response)
 
-        details = {
+        extra_details = {
             "validation_errors": getattr(cause, "messages", None),
         }
 
         if response is None:
-            details["response"] = None
+            extra_details["response"] = None
         else:
-            details["response"] = {
+            extra_details["response"] = {
                 "status": f"{response.status_code} {response.reason}"
             }
-            details["response"]["body"] = response.text[:150]
+            extra_details["response"]["body"] = response.text[:150]
             if len(response.text) > 150:
-                details["response"]["body"] += "..."
+                extra_details["response"]["body"] += "..."
 
         raise exception_class(
             message="Calling the Canvas API failed",
             response=response,
-            details=details,
+            extra_details=extra_details,
         ) from cause
 
     @staticmethod
@@ -196,8 +196,8 @@ class CanvasFileNotFoundInCourse(Exception):
     error_code = "canvas_file_not_found_in_course"
 
     def __init__(self, file_id):
-        self.details = {"file_id": file_id}
-        super().__init__(self.details)
+        self.extra_details = {"file_id": file_id}
+        super().__init__(self.extra_details)
 
 
 class BlackboardFileNotFoundInCourse(Exception):
@@ -206,5 +206,5 @@ class BlackboardFileNotFoundInCourse(Exception):
     error_code = "blackboard_file_not_found_in_course"
 
     def __init__(self, file_id):
-        self.details = {"file_id": file_id}
-        super().__init__(self.details)
+        self.extra_details = {"file_id": file_id}
+        super().__init__(self.extra_details)

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -148,7 +148,7 @@ class LTIOutcomesClient:
                 pass
 
             raise ExternalRequestError(
-                message="LTI outcome request failed", details=description
+                message="LTI outcome request failed", extra_details=description
             )
 
         return body

--- a/lms/views/api/canvas/exceptions.py
+++ b/lms/views/api/canvas/exceptions.py
@@ -1,7 +1,7 @@
 class CanvasGroupError(Exception):
     def __init__(self, group_set):
-        self.details = {"group_set": group_set}
-        super().__init__(self.details)
+        self.extra_details = {"group_set": group_set}
+        super().__init__(self.extra_details)
 
 
 class CanvasGroupSetNotFound(CanvasGroupError):

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -110,7 +110,7 @@ class APIExceptionViews:
                 "body": self.context.text,
             },
         )
-        sentry_sdk.set_context("details", self.context.details)
+        sentry_sdk.set_context("extra_details", self.context.extra_details)
 
         report_exception()
 
@@ -121,7 +121,7 @@ class APIExceptionViews:
         # error dialog.
         message = self.context.message or "External request failed"
 
-        return self.error_response(message=message, details=self.context.details)
+        return self.error_response(message=message, details=self.context.extra_details)
 
     @exception_view_config(context=OAuth2TokenError)
     def oauth2_token_error(self):
@@ -165,7 +165,7 @@ class APIExceptionViews:
         if hasattr(self.context, "error_code"):
             return self.error_response(
                 error_code=self.context.error_code,
-                details=getattr(self.context, "details", None),
+                details=getattr(self.context, "extra_details", None),
             )
 
         # Exception details are not reported here to avoid leaking internal information.

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -35,13 +35,13 @@ class TestExternalRequestError:
         assert err.text is None
 
     @pytest.mark.parametrize(
-        "message,details,response,expected",
+        "message,extra_details,response,expected",
         [
             (
                 None,
                 None,
                 None,
-                "ExternalRequestError(message=None, details=None, response=Response(status_code=None, reason=None, text=None))",
+                "ExternalRequestError(message=None, extra_details=None, response=Response(status_code=None, reason=None, text=None))",
             ),
             (
                 "Connecting to Hypothesis failed",
@@ -51,12 +51,14 @@ class TestExternalRequestError:
                     reason="Bad Request",
                     raw="Name too long",
                 ),
-                "ExternalRequestError(message='Connecting to Hypothesis failed', details={'extra': 'details'}, response=Response(status_code=400, reason='Bad Request', text='Name too long'))",
+                "ExternalRequestError(message='Connecting to Hypothesis failed', extra_details={'extra': 'details'}, response=Response(status_code=400, reason='Bad Request', text='Name too long'))",
             ),
         ],
     )
-    def test_str(self, message, details, response, expected):
-        err = ExternalRequestError(message=message, details=details, response=response)
+    def test_str(self, message, extra_details, response, expected):
+        err = ExternalRequestError(
+            message=message, extra_details=extra_details, response=response
+        )
 
         assert str(err) == expected
 
@@ -132,7 +134,7 @@ class TestCanvasAPIError:
 
         assert raised_exception.__cause__ == cause
         assert raised_exception.response == cause.response
-        assert raised_exception.details == {
+        assert raised_exception.extra_details == {
             "validation_errors": None,
             "response": {"status": expected_status, "body": body},
         }
@@ -156,7 +158,7 @@ class TestCanvasAPIError:
         # request timed out) so there's nothing to set as the response
         # property.
         assert raised_exception.response is None
-        assert raised_exception.details == {
+        assert raised_exception.extra_details == {
             "response": None,
             "validation_errors": None,
         }
@@ -172,7 +174,7 @@ class TestCanvasAPIError:
 
         assert raised_exception.__cause__ == cause
         assert raised_exception.response == canvas_api_invalid_response
-        assert raised_exception.details == {
+        assert raised_exception.extra_details == {
             "response": {"body": "Invalid", "status": "200 OK"},
             "validation_errors": "The response was invalid.",
         }
@@ -184,7 +186,7 @@ class TestCanvasAPIError:
 
         raised_exception = self.assert_raises(cause, CanvasAPIServerError)
 
-        body = raised_exception.details["response"]["body"]
+        body = raised_exception.extra_details["response"]["body"]
         assert len(body) == 153
         assert body.endswith("...")
 

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -45,12 +45,15 @@ class TestExternalRequestError:
                     "body": context.text,
                 },
             ),
-            call("details", context.details),
+            call("extra_details", context.extra_details),
         ]
 
         report_exception.assert_called_once_with()
         assert pyramid_request.response.status_code == 400
-        assert json_data == {"message": context.message, "details": context.details}
+        assert json_data == {
+            "message": context.message,
+            "details": context.extra_details,
+        }
 
     @pytest.mark.parametrize("message", [None, ""])
     def test_it_injects_a_default_error_message(self, context, message, views):
@@ -67,7 +70,7 @@ class TestExternalRequestError:
             response=factories.requests.Response(
                 status_code=418, reason="I'm a teapot", raw="Body text"
             ),
-            details={"foo": "bar"},
+            extra_details={"foo": "bar"},
         )
 
 
@@ -109,14 +112,14 @@ class TestHTTPBadRequest:
 
 class TestAPIError:
     def test_it_with_a_CanvasAPIPermissionError(self, pyramid_request, views):
-        context = views.context = CanvasAPIPermissionError(details={"foo": "bar"})
+        context = views.context = CanvasAPIPermissionError(extra_details={"foo": "bar"})
 
         json_data = views.api_error()
 
         assert pyramid_request.response.status_code == 400
         assert json_data == {
             "error_code": context.error_code,
-            "details": context.details,
+            "details": context.extra_details,
         }
 
     def test_it_with_an_unexpected_error(self, pyramid_request, views):


### PR DESCRIPTION
When the API returns an error response to the frontend there's a top-level `"details"` dict in the JSON body that the frontend renders (blindly) into the **Error details** box in the error dialog:

https://github.com/hypothesis/lms/blob/e5cd21715c839ba2dbc6920db861f75b423b097c/lms/views/api/exceptions.py#L50-L51

My intention is that the `external_request_error()` exception view is going to stuff some information about the response into a sub-dict of the `details` dict, and then stuff any extra details that a service or view has added to `ExternalRequestError.extra_details` into another sub-dict. So the error responses to the frontend will look like this:

```python
{
  "message": "...",  # E.g. "External request failed"
  # The frontend shows the entire contents of this "details" dict in the *Error details*
  # box in the UI
  "details": {
    # Injected by the exception view for all ExternalRequestError's.
    "response": {
      "status_code": 500,
      ...
    }
    # Might have been added as ExternalRequestError.extra_details by service or view code.
    "extra_details": { <ExternalRequestError.extra_details> },
  }
}
```

The reason for renaming `ExternalRequestError.details` to `extra_details` is to distinguish it from the top-level `details` dict in the error response, associating it instead with the error response's `details.extra_details` sub-dict.