### PR TITLE
Update @hypothesis/frontend-shared@4.0.0

### DIFF
--- a/lms/static/scripts/ui-playground/index.js
+++ b/lms/static/scripts/ui-playground/index.js
@@ -1,5 +1,5 @@
 // Entry point for local webserver pattern-library bundle
-import { startApp } from '@hypothesis/frontend-shared/lib-cjs/pattern-library';
+import { startApp } from '@hypothesis/frontend-shared/lib/pattern-library';
 
 import lmsIcons from '../frontend_apps/icons.js';
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
     "@hypothesis/frontend-build": "^1.1.0",
-    "@hypothesis/frontend-shared": "3.14.0",
+    "@hypothesis/frontend-shared": "4.0.0",
     "@rollup/plugin-alias": "^3.1.8",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -31,6 +31,11 @@ function bundleConfig(name, entryFile) {
       chunkFileNames: '[name].bundle.js',
       entryFileNames: '[name].bundle.js',
     },
+    // Suppress a warning (https://rollupjs.org/guide/en/#error-this-is-undefined)
+    // due to https://github.com/babel/babel/issues/9149.
+    //
+    // Any code string other than "undefined" which evaluates to `undefined` will work here.
+    context: 'void(0)',
     plugins: [
       alias({
         entries: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,10 +1103,10 @@
     fancy-log "^1.3.3"
     glob "^7.2.0"
 
-"@hypothesis/frontend-shared@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.14.0.tgz#0dc3f1f0df22841b19428840ea1318fcf3c8b6d1"
-  integrity sha512-vkgVGruGJyku8pVegV1/mxyyQjyeg1xLZNxFHaGkqZ9Ho5GYHgkmqv40Z6tfZbSXpcUpAGlHRVy5+fasgwhhOA==
+"@hypothesis/frontend-shared@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-4.0.0.tgz#dbd136e7636e5eab37aa1b7690aacca8ce2a7f5a"
+  integrity sha512-zg6NH+te8ghqP6nUeC3fqIr6i0Er1njs7ySwFaZq4NIlZJTN+4ImK/DSMJF3aE8AWL0UwQpTfpJQKeaJuR51OA==
   dependencies:
     normalize.css "^8.0.1"
 


### PR DESCRIPTION
This required a couple of changes to adapt to the removal of the
CommonJS build. Some modules from the pattern library web app triggered
a Babel warning about top-level `this`. I copied across the workaround
from `rollup.config.js` in the @hypothesis/frontend-shared library.