### PR TITLE
Add `ExternalRequestError.details` to Sentry

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -110,6 +110,7 @@ class APIExceptionViews:
                 "body": self.context.text,
             },
         )
+        sentry_sdk.set_context("details", self.context.details)
 
         report_exception()
 


### PR DESCRIPTION
Add `ExternalRequestError.details` to Sentry as a separate "context", in case `details` got truncated from `ExternalRequestError.__str__()` (which is also shown in Sentry).

This adds `details` as its own context section in the Sentry report. For example in this screenshot `ExternalRequestError.details` was `{"extra": "details"}`:

![Screenshot from 2021-10-27 15-39-53](https://user-images.githubusercontent.com/22498/139088802-9126dc86-b446-4c9a-a879-71c8fe2581f9.png)
