### PR TITLE
Add ErrorComponents page to local pattern library

### DIFF
--- a/lms/static/scripts/ui-playground/components/ErrorComponents.js
+++ b/lms/static/scripts/ui-playground/components/ErrorComponents.js
@@ -1,0 +1,96 @@
+import { useState } from 'preact/hooks';
+
+import { LabeledButton } from '@hypothesis/frontend-shared';
+
+import ErrorDisplay from '../../frontend_apps/components/ErrorDisplay';
+import ErrorDialog from '../../frontend_apps/components/ErrorDialog';
+
+// TODO: Update after https://github.com/hypothesis/frontend-shared/issues/179
+// is resolved
+import Library from '@hypothesis/frontend-shared/lib/pattern-library/components/Library';
+
+const fakeError = {
+  message:
+    'This is a the value of a `message` property on an {ErrorLike} object',
+  details: {
+    foo: { bar: 'These fake details...' },
+    errorNonsense:
+      'Are JSON-stringified from a `details` property on an {ErrorLike} object',
+  },
+};
+
+function ErrorDialogExample() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  if (!dialogOpen) {
+    return (
+      <LabeledButton
+        onClick={() => setDialogOpen(!dialogOpen)}
+        variant="primary"
+      >
+        Show ErrorDialog Example
+      </LabeledButton>
+    );
+  } else {
+    return (
+      <ErrorDialog
+        error={fakeError}
+        onCancel={() => setDialogOpen(false)}
+        description="Sample Error"
+      />
+    );
+  }
+}
+
+export default function ErrorComponents() {
+  return (
+    <Library.Page title="Errors">
+      <Library.Pattern title="ErrorDisplay">
+        <Library.Example>
+          <p>
+            The <code>ErrorDisplay</code> component renders information about an
+            error. It is the entire body/contents of the{' '}
+            <code>ErrorDialog</code> component. It is also used by several other
+            components (<code>BookPicker</code>, <code>LaunchErrorDialog</code>,{' '}
+            <code>LMSFilePicker</code>, <code>OAuth2RedirectErrorApp</code>...)
+          </p>
+          <p>
+            It is intended to be used within a Modal context, and provides a{' '}
+            <code>Scrollbox</code> to scroll content if it is too tall for the
+            containing element.
+          </p>
+          <p>The instructive text is hard-coded at present.</p>
+          <Library.Demo withSource>
+            <ErrorDisplay
+              error={fakeError}
+              description="This is a hard-coded description provided in the 'description' prop"
+            />
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+      <Library.Pattern title="ErrorDialog">
+        <Library.Example>
+          <p>
+            <code>ErrorDialog</code> uses the shared <code>Modal</code>{' '}
+            component to render information about an {'error-like'} object.
+            <ul>
+              <li>The Modal title is always {'"Something went wrong"'}</li>
+              <li>
+                The <code>description</code> (optional) and <code>error</code>{' '}
+                props are forwarded to <code>ErrorDisplay</code>, which is
+                rendered as the body of the Modal.
+              </li>
+              <li>
+                The label on the cancel/close button may be set with the{' '}
+                <code>cancelLabel</code> prop
+              </li>
+            </ul>
+          </p>
+          <Library.Demo>
+            <ErrorDialogExample />
+          </Library.Demo>
+        </Library.Example>
+      </Library.Pattern>
+    </Library.Page>
+  );
+}

--- a/lms/static/scripts/ui-playground/index.js
+++ b/lms/static/scripts/ui-playground/index.js
@@ -1,9 +1,22 @@
 // Entry point for local webserver pattern-library bundle
 import { startApp } from '@hypothesis/frontend-shared/lib/pattern-library';
 
+import ErrorComponents from './components/ErrorComponents';
+
 import lmsIcons from '../frontend_apps/icons.js';
+
+/** @type {import('@hypothesis/frontend-shared/lib/pattern-library').PlaygroundRoute[]} */
+const extraRoutes = [
+  {
+    route: '/errors',
+    title: 'Errors',
+    component: ErrorComponents,
+    group: 'components',
+  },
+];
 
 startApp({
   baseURL: '/ui-playground',
+  extraRoutes,
   icons: lmsIcons,
 });

--- a/lms/static/styles/_frontend-shared.scss
+++ b/lms/static/styles/_frontend-shared.scss
@@ -39,7 +39,10 @@
     // bottom border of the Dialog header. In this case we want to explicitly
     // disable the top margin so that it can be up against the header.
     margin-top: 0;
-    // The Scrollbox border in this case is distracting.
-    border: none;
   }
+}
+
+.LMS-Scrollbox {
+  // The Scrollbox border in this case is distracting.
+  border: none;
 }


### PR DESCRIPTION
Establish an ErrorComponents component page for the local pattern library
as a place to corral error-related UI patterns.

Add `ErrorDisplay` and `ErrorDialog` to start.

Additional error UI patterns will come in further PRs. This starting point verifies that the patterns are rendering in the pattern library as they render in apps, now that CSS reset, pattern library CSS de-duplication and Jinja templating have been better sorted out.

To see the starting point here, run `make dev` and visit http://localhost:8001/ui-playground/errors

Part of https://github.com/hypothesis/lms/issues/3191