### PR TITLE
Add some response details to error dialogs

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -121,7 +121,16 @@ class APIExceptionViews:
         # error dialog.
         message = self.context.message or "External request failed"
 
-        return self.error_response(message=message, details=self.context.extra_details)
+        return self.error_response(
+            message=message,
+            details={
+                "response": {
+                    "status_code": self.context.status_code,
+                    "reason": self.context.reason,
+                },
+                "extra_details": self.context.extra_details,
+            },
+        )
 
     @exception_view_config(context=OAuth2TokenError)
     def oauth2_token_error(self):

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -52,7 +52,13 @@ class TestExternalRequestError:
         assert pyramid_request.response.status_code == 400
         assert json_data == {
             "message": context.message,
-            "details": context.extra_details,
+            "details": {
+                "response": {
+                    "status_code": context.status_code,
+                    "reason": context.reason,
+                },
+                "extra_details": context.extra_details,
+            },
         }
 
     @pytest.mark.parametrize("message", [None, ""])


### PR DESCRIPTION
When there's a problem with a server-to-server request to a third-party service (an `ExternalRequestError`) add some details of the error response from the third-party to the error dialog that we show to users.

This is to assist in debugging (for example when users send us screenshots of the error dialog).

This commit adds the HTTP status code and reason of the response to the error dialog. We also discussed adding the requested URL (minus query params for security reasons) but this commit doesn't do that yet.

We don't want to show the response body to users for security reasons.

This partially addresses https://github.com/hypothesis/lms/issues/2998 but doesn't entirely fix it yet.

### Testing

You need to trigger an `ExternalRequestError` to happen. One way (of many) to do this is to apply this diff:

```diff
diff --git a/lms/services/blackboard_api/_basic.py b/lms/services/blackboard_api/_basic.py
index 54b78336..84249703 100644
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -72,6 +72,7 @@ class BasicClient:
 
     def request(self, method, path):
         url = self._api_url(path)
+        url = "http://httpbin.org/status/418"
 
         try:
             return self._send(method, url)
```

Then launch a Blackboard Files assignment.

You should see this:

![Screenshot from 2021-10-27 18-40-01](https://user-images.githubusercontent.com/22498/139117784-a8990752-9e8b-4b25-beb3-64820c2d84b8.png)

On master the **Error Details** section would be completely missing.

Note that the error response from our backend is actually this:

```json
{
  "message": "External request failed",
  "details": {
    "response": {
      "status_code": 418,
      "reason": "I'M A TEAPOT"
    },
  "extra_details": null
  }
}
```

But due to a known bug in the frontend the `"External request failed"` isn't shown in the UI.

