### PR TITLE
Log and monitor external request details (method, URL and body)

### DIFF
--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -87,7 +87,7 @@ class HTTPService:
             )
             response.raise_for_status()
         except RequestException as err:
-            raise ExternalRequestError(response=response) from err
+            raise ExternalRequestError(request=err.request, response=response) from err
 
         return response
 

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -25,39 +25,46 @@ class TestExternalRequestError:
 
         assert err.status_code == 418
         assert err.reason == "I'm a teapot"
-        assert err.text == "Body text"
+        assert err.response_body == "Body text"
 
     def test_it_when_theres_no_response(self):
         err = ExternalRequestError()
 
         assert err.status_code is None
         assert err.reason is None
-        assert err.text is None
+        assert err.response_body is None
 
     @pytest.mark.parametrize(
-        "message,extra_details,response,expected",
+        "message,extra_details,request_,response,expected",
         [
             (
                 None,
                 None,
                 None,
-                "ExternalRequestError(message=None, extra_details=None, response=Response(status_code=None, reason=None, text=None))",
+                None,
+                "ExternalRequestError(message=None, extra_details=None, request=Request(method=None, url=None, body=None), response=Response(status_code=None, reason=None, body=None))",
             ),
             (
                 "Connecting to Hypothesis failed",
                 {"extra": "details"},
+                requests.Request(
+                    "GET", "https://example.com", data="request_body"
+                ).prepare(),
                 factories.requests.Response(
                     status_code=400,
                     reason="Bad Request",
                     raw="Name too long",
                 ),
-                "ExternalRequestError(message='Connecting to Hypothesis failed', extra_details={'extra': 'details'}, response=Response(status_code=400, reason='Bad Request', text='Name too long'))",
+                "ExternalRequestError(message='Connecting to Hypothesis failed', extra_details={'extra': 'details'}, request=Request(method='GET', url='https://example.com/', body='request_body'), response=Response(status_code=400, reason='Bad Request', body='Name too long'))",
             ),
         ],
     )
-    def test_str(self, message, extra_details, response, expected):
+    def test_str(self, message, extra_details, request_, response, expected):
         err = ExternalRequestError(
-            message=message, extra_details=extra_details, response=response
+            message=message,
+            extra_details=extra_details,
+            request=request_,
+            response=response,
         )
 
         assert str(err) == expected


### PR DESCRIPTION
When an HTTP request fails add details of the request (method, URL and body) to Papertrail, Sentry and the frontend's error dialog, alongside the details of the *response* (status and body) that are already present.

### Error dialog

![Screenshot from 2021-10-27 22-38-03](https://user-images.githubusercontent.com/22498/139151014-706fd7a5-69fb-406d-ad6c-03cbb7a3c4b7.png)

Note that the request and response bodies are omitted from the frontend for security reasons.

Any query params are also stripped from the URL before sending it to the frontend, again for security reasons.

The full request and response bodies and URL with query params _are_ logged and sent to Sentry.

### Logs

```
lms.services.exceptions.ExternalRequestError: ExternalRequestError(message=None, extra_details=None, request=Request(method='GET', url='http://httpbin.org/status/418', body=None), response=Response(status_code=418, reason="I'M A TEAPOT", body='\n    -=[ teapot ]=-\n\n       _...._\n     .\'  _ _ `.\n    | ."` ^ `". _,\n    \\_;`"---"`|//\n      |       ;/\n      \\_     _/\n        `"""`\n'))
```

### Sentry

![Screenshot from 2021-10-27 22-36-52](https://user-images.githubusercontent.com/22498/139150844-1a4b8ed7-4398-4e83-a190-56be7b97d171.png)
