### PR TITLE
Fix Canvas API errors

### DIFF
--- a/lms/services/canvas_api/_basic.py
+++ b/lms/services/canvas_api/_basic.py
@@ -88,13 +88,13 @@ class BasicClient:
             response = self._session.send(request, timeout=9)
             response.raise_for_status()
         except RequestException as err:
-            CanvasAPIError.raise_from(err)
+            CanvasAPIError.raise_from(err, request, response)
 
         result = None
         try:
             result = schema(response).parse()
         except ValidationError as err:
-            CanvasAPIError.raise_from(err)
+            CanvasAPIError.raise_from(err, request, response)
 
         # Handle pagination links. See:
         # https://canvas.instructure.com/doc/api/file.pagination.html
@@ -106,7 +106,9 @@ class BasicClient:
                 CanvasAPIError.raise_from(
                     TypeError(
                         "Canvas returned paginated results but we expected a single value"
-                    )
+                    ),
+                    request,
+                    response,
                 )
 
             # Don't make requests forever

--- a/lms/services/canvas_api/_basic.py
+++ b/lms/services/canvas_api/_basic.py
@@ -84,6 +84,8 @@ class BasicClient:
         )
 
     def _send_prepared(self, request, schema, request_depth=1):
+        response = None
+
         try:
             response = self._session.send(request, timeout=9)
             response.raise_for_status()


### PR DESCRIPTION
### Problem

We've recently done work to add the details of the request and response to Papertrail, Sentry, and the frontend's error dialog when an external HTTP request fails: https://github.com/hypothesis/lms/pull/3300, https://github.com/hypothesis/lms/pull/3299, https://github.com/hypothesis/lms/pull/3286, https://github.com/hypothesis/lms/pull/3264.

This doesn't work for Canvas: trigger an external request error from the Canvas API and you'll see that the request and response details are missing from the logs, Sentry and the error dialog.

### What's Happening?

We've added `ExternalRequestError.request` and `ExternalRequestError.response` properties and used these properties in `ExternalRequestError.__str__()` (for Papertrail) and in the `external_request_error()` exception view (for Sentry and the frontend).

The Canvas API code uses its own Canvas-specific `ExternalRequestError` subclasses but that's okay: these subclasses still inherit the recent `ExternalRequestError` work and are still handled by the same `external_request_error()` exception view :+1:

The problem is that we also did some recent work on `HTTPService`: it [passes the `request` and `response` to `ExternalRequestError` when raising](https://github.com/hypothesis/lms/blob/a312fde56b4af81448d15dbaf2892d7dfd40e9c4/lms/services/http.py#L90). The Canvas API code doesn't use `HTTPService`: it calls `requests` itself and raises its`ExternalRequestError` subclasses itself, and it's not passing the `request` or `response` when it raises these.

### Solution

The fix is simple in theory: whenever the Canvas API code raises one of its `ExternalRequestError` subclasses it just has to pass the `request` and `response` to `ExternalRequestError.__init__()` and then it'll automatically benefit from the new `request`-handing stuff in the `__str__()` method and in the exception view.

In practice what this means is that it needs to pass the `request` and `response` to `CanvasAPIError.raise_from()` and then `raise_from()` needs to pass them to the `ExternalRequestError` subclass that it raises.

I then had to update a bunch of tests and fix a couple of bugs that this exposed.

### Testing

#### Error response from the Canvas API

Hack the code to fake an error response from the Canvas API:

```diff
diff --git a/lms/services/canvas_api/_basic.py b/lms/services/canvas_api/_basic.py
index 692cae17..086783a8 100644
--- a/lms/services/canvas_api/_basic.py
+++ b/lms/services/canvas_api/_basic.py
@@ -84,6 +84,8 @@ class BasicClient:
         )
 
     def _send_prepared(self, request, schema, request_depth=1):
+        request.url = "http://httpbin.org/status/418"
+
         try:
             response = self._session.send(request, timeout=9)
             response.raise_for_status()
```

Then launch an assignment. You should see that the request and response details are shown in the frontend, printed to the terminal, and sent to Sentry.

#### Timeout from the Canvas API

```diff
diff --git a/lms/services/canvas_api/_basic.py b/lms/services/canvas_api/_basic.py
index 692cae17..6cc1bfab 100644
--- a/lms/services/canvas_api/_basic.py
+++ b/lms/services/canvas_api/_basic.py
@@ -84,6 +84,8 @@ class BasicClient:
         )
 
     def _send_prepared(self, request, schema, request_depth=1):
+        request.url = "http://xyz123.com/"
+
         try:
             response = self._session.send(request, timeout=9)
             response.raise_for_status()
```

Same deal: you'll see the request in the frontend, logs, and Sentry. In this case you won't see the response since there isn't one.

#### Successful but unexpected response from the Canvas API

```diff
diff --git a/lms/services/canvas_api/client.py b/lms/services/canvas_api/client.py
index 14556e09..985a09db 100644
--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -288,6 +288,7 @@ class CanvasAPIClient:
         """Schema for the public_url response."""
 
         public_url = fields.Str(required=True)
+        foo = fields.Str(required=True)
 
     def course_group_categories(self, course_id):
         return self._client.send(
```

Now launch a Canvas Files assignment. Again you should see the request and response (as well as the `ValidationError`) in the error dialog, logs and Sentry.