### PR TITLE
Replace file and folder icons in file listings with shared icons

### DIFF
--- a/lms/static/scripts/frontend_apps/icons.js
+++ b/lms/static/scripts/frontend_apps/icons.js
@@ -1,27 +1,20 @@
 // @ts-nocheck - TS doesn't understand SVG imports.
 
-// LMS icons
-// TODO: replace these with shared versions when updating the file picker:
-// https://github.com/hypothesis/lms/issues/3189
-import folderIcon from '../../images/folder.svg';
-import pdfIcon from '../../images/file-pdf.svg';
-
 // TODO: Remove when `frontend-shared` provides a FullScreenSpinner component
 import spinnerIcon from '../../images/spinner.svg';
 
-// Shared icons
 import {
   arrowLeft,
   arrowRight,
   cancel,
   caretDown,
   check,
+  filePDFFilled,
+  folder,
 } from '@hypothesis/frontend-shared/lib/icons';
 
 export default {
-  // LMS icons
-  folder: folderIcon,
-  pdf: pdfIcon,
+  // LMS local icons
   spinner: spinnerIcon,
 
   // Shared icons
@@ -30,4 +23,6 @@ export default {
   cancel,
   'caret-down': caretDown,
   check,
+  folder,
+  pdf: filePDFFilled,
 };

--- a/lms/static/styles/components/_FileList.scss
+++ b/lms/static/styles/components/_FileList.scss
@@ -1,13 +1,11 @@
-@use '../variables' as var;
-
 .FileList {
   &__date-header {
     width: 10em;
   }
 
   &__icon {
-    // TODO: Update when updated SVGIcon component is available and has sizing
-    // patterns
+    // Make the file and folder icons proportionally larger than the filename
+    // text
     width: 1.5em;
     height: 1.5em;
   }


### PR DESCRIPTION
Use the recently-created file and folder icons from our common set in the LMS file picker file listings.

Before:

<img width="706" alt="Screen Shot 2021-10-28 at 8 45 45 AM" src="https://user-images.githubusercontent.com/439947/139257938-0fffc99a-2433-432c-bb86-a84b9b29e1c9.png">

After:

<img width="691" alt="Screen Shot 2021-10-28 at 8 45 14 AM" src="https://user-images.githubusercontent.com/439947/139257911-99af916a-c216-4fb4-ade5-a3b5151e98b0.png">
Fixes #3189