### PR TITLE
Add content class to constrain width of URLPicker Modal

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -51,6 +51,7 @@ export default function URLPicker({ onCancel, onSelectURL }) {
 
   return (
     <Modal
+      contentClass="LMS-Dialog LMS-Dialog--medium"
       title="Enter URL"
       onCancel={onCancel}
       buttons={[


### PR DESCRIPTION
Set preferred width on this modal such that longer error strings don't cause the modal to change width. The error displayed when a user enters a local-file URL was making the modal too wide:

![image](https://user-images.githubusercontent.com/439947/139474749-730b1f72-785c-4bf0-b834-9c18cf7dedfe.png)


And is now fixed:

![image](https://user-images.githubusercontent.com/439947/139474797-394e6ed1-63b8-49a9-b5f9-6b50000e3703.png)