### PR TITLE
Re-enable canvas_db_configured_basic_lti_launch view

### DIFF
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -165,9 +165,8 @@ class BasicLTILaunchViews:
 
     @view_config(
         db_configured=True,
-        canvas_file=False,
+        legacy_speedgrader=False,
         request_param="ext_lti_assignment_id",
-        url_configured=False,
     )
     def canvas_db_configured_basic_lti_launch(self):
         """Respond to a Canvas DB-configured assignment launch."""

--- a/tests/functional/views/basic_lti_launch_test.py
+++ b/tests/functional/views/basic_lti_launch_test.py
@@ -69,6 +69,16 @@ class TestBasicLTILaunch:
                 "legacy_speedgrader_assignment",
                 id="canvas url launch, with existing legacy SpeedGrader DB row",
             ),
+            param(
+                "canvas_url_legacy_speedgrader_launch_params",
+                "legacy_speedgrader_assignment",
+                id="legacy SpeedGrader canvas url launch, with existing legacy SpeedGrader DB row",
+            ),
+            param(
+                "canvas_url_legacy_speedgrader_launch_params",
+                None,
+                id="legacy SpeedGrader canvas url launch, with no DB rows",
+            ),
         ],
     )
     def test_basic_lti_launch(
@@ -318,6 +328,18 @@ class TestBasicLTILaunch:
                 lti_params,
                 url="https://url-configured.com/document.pdf",
                 ext_lti_assignment_id="EXT_LTI_ASSIGNMENT_ID",
+            )
+        )
+
+    @pytest.fixture
+    def canvas_url_legacy_speedgrader_launch_params(
+        self, canvas_url_launch_params, sign_lti_params
+    ):
+        _, post_params = canvas_url_launch_params
+        return {"learner_canvas_user_id": "USER_ID"}, sign_lti_params(
+            dict(
+                post_params,
+                resource_link_id=post_params["context_id"],
             )
         )
 


### PR DESCRIPTION
Until canvas assignments are stored on the DB on creation/editing this view will only handle launches of already present in the DB canvas file assignments (regular and SpeedGrader launches).

The view was disabled after the problems with legacy SpeedGrader launches. This enables it again with a `legacy_speedgrader=False` to guard against those problems.

In summary, before https://github.com/hypothesis/lms/pull/3126 is merged, in this PR:


- All url configured assignments (ie all no canvas-files assignments) use the  `url_configured_basic_lti_launch` view. That includes legacy speedgrader url assignments which where not covered by the functional tests yet.

- Newly created canvas file assignment will be handled `legacy_canvas_file_basic_lti_launch` (which will create a new row in the DB)

- Subsequent launches of those canvas file assignments will be handled by `canvas_db_configured_basic_lti_launch`

- Except, when launched as legacy speedgrader, where they will still be handled by  `legacy_canvas_file_basic_lti_launch`
