### PR TITLE
Log and monitor external requests and responses that fail validation

### DIFF
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -1,7 +1,7 @@
 from marshmallow import INCLUDE, fields
 
 from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
-from lms.validation import RequestsResponseSchema, ValidationError
+from lms.validation import RequestsResponseSchema
 
 
 class BlackboardErrorResponseSchema(RequestsResponseSchema):
@@ -38,7 +38,7 @@ class BlackboardErrorResponseSchema(RequestsResponseSchema):
     def parse(self, *args, **kwargs):
         try:
             return super().parse(*args, **kwargs)
-        except ValidationError:
+        except ExternalRequestError:
             return {}
 
 

--- a/lms/services/canvas_api/_basic.py
+++ b/lms/services/canvas_api/_basic.py
@@ -6,8 +6,7 @@ from urllib.parse import urlencode
 import requests
 from requests import RequestException, Session
 
-from lms.services import CanvasAPIError
-from lms.validation import ValidationError
+from lms.services import CanvasAPIError, ExternalRequestError
 
 
 class BasicClient:
@@ -95,8 +94,8 @@ class BasicClient:
         result = None
         try:
             result = schema(response).parse()
-        except ValidationError as err:
-            CanvasAPIError.raise_from(err, request, response)
+        except ExternalRequestError as err:
+            CanvasAPIError.raise_from(err, request, response, err.validation_errors)
 
         # Handle pagination links. See:
         # https://canvas.instructure.com/doc/api/file.pagination.html

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -1,7 +1,7 @@
 from marshmallow import fields
 
 from lms.services import ExternalRequestError, OAuth2TokenError
-from lms.validation import RequestsResponseSchema, ValidationError
+from lms.validation import RequestsResponseSchema
 from lms.validation.authentication import OAuthTokenResponseSchema
 
 
@@ -104,7 +104,7 @@ class OAuthHTTPService:
         except ExternalRequestError as err:
             try:
                 error_dict = _OAuthAccessTokenErrorResponseSchema(err.response).parse()
-            except ValidationError:
+            except ExternalRequestError:
                 pass
             else:
                 if error_dict["error"] == "invalid_grant":

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -120,6 +120,7 @@ class APIExceptionViews:
                 "body": self.context.response_body,
             },
         )
+        sentry_sdk.set_context("validation_errors", self.context.validation_errors)
 
         report_exception()
 
@@ -141,6 +142,7 @@ class APIExceptionViews:
                     "status_code": self.context.status_code,
                     "reason": self.context.reason,
                 },
+                "validation_errors": self.context.validation_errors,
             },
         )
 

--- a/tests/unit/lms/services/blackboard_api/_schemas_test.py
+++ b/tests/unit/lms/services/blackboard_api/_schemas_test.py
@@ -4,7 +4,7 @@ from lms.services.blackboard_api._schemas import (
     BlackboardListFilesSchema,
     BlackboardPublicURLSchema,
 )
-from lms.validation._exceptions import ValidationError
+from lms.services.exceptions import ExternalRequestError
 from tests import factories
 
 
@@ -136,5 +136,5 @@ def assert_raises(schema_class, json_data):
     """Assert that the schema raises when parsing json_data."""
     schema = schema_class(factories.requests.Response(json_data=json_data))
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ExternalRequestError):
         schema.parse()

--- a/tests/unit/lms/validation/_base_test.py
+++ b/tests/unit/lms/validation/_base_test.py
@@ -1,11 +1,14 @@
 import json
+from unittest.mock import sentinel
 
 import pytest
 from marshmallow import fields
 from pyramid.httpexceptions import HTTPUnsupportedMediaType
 from pyramid.testing import DummyRequest
 
-from lms.validation._base import JSONPyramidRequestSchema
+from lms.services import ExternalRequestError
+from lms.validation._base import JSONPyramidRequestSchema, RequestsResponseSchema
+from tests import factories
 
 
 class TestJSONPyramidRequestSchema:
@@ -30,3 +33,48 @@ class TestJSONPyramidRequestSchema:
 
         with pytest.raises(HTTPUnsupportedMediaType):
             self.ExampleSchema(request).parse()
+
+
+class TestRequestsResponseSchema:
+    class MySchema(RequestsResponseSchema):
+        test_field = fields.Str(required=True)
+
+    def test_it_returns_the_parsed_data_if_the_response_is_valid(self):
+        response = factories.requests.Response(json_data={"test_field": "test_value"})
+        schema = self.MySchema(response)
+
+        parsed_data = schema.parse()
+
+        assert parsed_data == {"test_field": "test_value"}
+
+    @pytest.mark.parametrize(
+        "response_body,validation_errors",
+        [
+            pytest.param(
+                "{}",
+                {"test_field": ["Missing data for required field."]},
+                id="Valid JSON but doesn't match the schema",
+            ),
+            pytest.param(
+                "foo",
+                {"_schema": ["response doesn't have a valid JSON body"]},
+                id="Not valid JSON at all",
+            ),
+        ],
+    )
+    def test_it_raises_ExternalRequestError_if_the_response_is_invalid(
+        self, response_body, validation_errors
+    ):
+        response = factories.requests.Response(
+            raw=response_body, request=sentinel.request
+        )
+        schema = self.MySchema(response)
+
+        with pytest.raises(ExternalRequestError) as exc_info:
+            schema.parse()
+
+        exc = exc_info.value
+        assert isinstance(exc, ExternalRequestError)
+        assert exc.request == sentinel.request
+        assert exc.response == response
+        assert exc.validation_errors == validation_errors

--- a/tests/unit/lms/validation/authentication/_oauth_test.py
+++ b/tests/unit/lms/validation/authentication/_oauth_test.py
@@ -1,6 +1,7 @@
 import pytest
 from pyramid import testing
 
+from lms.services import ExternalRequestError
 from lms.validation import ValidationError
 from lms.validation.authentication import (
     ExpiredJWTError,
@@ -250,10 +251,10 @@ class TestOAuthTokenResponseSchema:
             factories.requests.Response(json_data=json_data)
         )
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ExternalRequestError) as exc_info:
             schema.parse()
 
-        assert exc_info.value.messages == messages
+        assert exc_info.value.validation_errors == messages
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import call
+from unittest.mock import call, sentinel
 
 import pytest
 import requests
@@ -54,6 +54,7 @@ class TestExternalRequestError:
                     "body": context.response_body,
                 },
             ),
+            call("validation_errors", context.validation_errors),
         ]
 
         report_exception.assert_called_once_with()
@@ -69,6 +70,7 @@ class TestExternalRequestError:
                     "status_code": context.status_code,
                     "reason": context.reason,
                 },
+                "validation_errors": context.validation_errors,
             },
         }
 
@@ -90,6 +92,7 @@ class TestExternalRequestError:
             response=factories.requests.Response(
                 status_code=418, reason="I'm a teapot", raw="Body text"
             ),
+            validation_errors=sentinel.validation_errors,
         )
 
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/3326. Fixes https://github.com/hypothesis/lms/issues/3319

This works by changing `RequestsResponseSchema` to raise `ExternalRequestError`'s which will be handled by the same `external_request_error()` exception view that handles `ExternalRequestError`'s from `HTTPService`. A new `validation_errors` attr is added to `ExternalRequestError` so that it can record any validation errors along with the request and response.

### Testing

Let's break some of the Blackboard and Canvas schemas to trigger some validation errors:

```diff
diff --git a/lms/services/blackboard_api/_schemas.py b/lms/services/blackboard_api/_schemas.py
index 3f609e14..1c9e8300 100644
--- a/lms/services/blackboard_api/_schemas.py
+++ b/lms/services/blackboard_api/_schemas.py
@@ -36,6 +36,7 @@ class BlackboardPublicURLSchema(RequestsResponseSchema):
     """Schema for Blackboard /courses/{courseId}/resources/{resourceId} responses."""
 
     downloadUrl = fields.Str(required=True)
+    foo = fields.Str(required=True)
 
     @post_load
     def post_load(self, data, **_kwargs):  # pylint:disable=no-self-use
diff --git a/lms/services/canvas_api/client.py b/lms/services/canvas_api/client.py
index 14556e09..985a09db 100644
--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -288,6 +288,7 @@ class CanvasAPIClient:
         """Schema for the public_url response."""
 
         public_url = fields.Str(required=True)
+        foo = fields.Str(required=True)
 
     def course_group_categories(self, course_id):
         return self._client.send(
```

Now:

- [x] Launch a Blackboard Files assignment
- [x] Launch any Canvas assignment

In all cases you should see the request, response and validation errors in the error dialog, logs and Sentry. 

Also test:

- [x] Launching Blackboard Files and Canvas assignments with and without an access token in the DB. (_Without_ breaking the code)

### Result

![Screenshot from 2021-11-02 13-26-42](https://user-images.githubusercontent.com/22498/139855874-d98f511b-4997-49aa-8f24-4ed737345883.png)

Sentry:

![Screenshot from 2021-11-02 13-27-47](https://user-images.githubusercontent.com/22498/139856009-94898c26-55a3-4fde-a1c0-2332497f7d6c.png)

Papertrail:

```
lms.services.exceptions.ExternalRequestError: ExternalRequestError(message=None, extra_details=None, request=Request(method='GET', url='https://hypothesis.instructure.com/api/v1/files/652/public_url', body=None), response=Response(status_code=200, reason='OK', body='{"public_url":"https://inst-fs-iad-prod.inscloudgate.net/files/46a48d16-c57c-4d22-97f6-d1fd11aba4e2/A%20Third%20File.pdf?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2MzU4NDE5NzIsInVzZXJfaWQiOm51bGwsInJlc291cmNlIjoiL2ZpbGVzLzQ2YTQ4ZDE2LWM1N2MtNGQyMi05N2Y2LWQxZmQxMWFiYTRlMi9BJTIwVGhpcmQlMjBGaWxlLnBkZiIsImp0aSI6ImMwOTA4NDM5LTNlZDctNDYxMC04ODRjLTk5MjBmZWI3ZDM5OCIsImhvc3QiOm51bGwsImV4cCI6MTYzNTkyODM3Mn0.OzXMbBpxSQnrUhz48nH_NkK8_eZbQL0yy2MZL6LM1IMa3HLEKO02gz1HqoaR4vkCVURmulhSlFp8kYqLbw8mQw"}'), validation_errors={'foo': ['Missing data for required field.']})
```