### PR TITLE
Remove `ExternalRequestError.extra_details`

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -13,17 +13,13 @@ class ExternalRequestError(Exception):
 
     :arg response: The response that was received
     :type response: requests.Response
-
-    :arg extra_details: Extra details about what went wrong, for debugging
-    :type extra_details: JSON-serializable dict
     """
 
-    def __init__(self, message=None, request=None, response=None, extra_details=None):
+    def __init__(self, message=None, request=None, response=None):
         super().__init__()
         self.message = message
         self.request = request
         self.response = response
-        self.extra_details = extra_details
 
     @property
     def url(self) -> Optional[str]:
@@ -77,7 +73,7 @@ class ExternalRequestError(Exception):
         # The name of this class or of a subclass if one inherits this method.
         class_name = self.__class__.__name__
 
-        return f"{class_name}(message={self.message!r}, extra_details={self.extra_details!r}, request={request}, response={response})"
+        return f"{class_name}(message={self.message!r}, request={request}, response={response})"
 
     def __str__(self):
         return repr(self)
@@ -125,12 +121,7 @@ class CanvasAPIError(ExternalRequestError):
         exception_class = cls._exception_class(response)
 
         raise exception_class(
-            message="Calling the Canvas API failed",
-            request=request,
-            response=response,
-            extra_details={
-                "validation_errors": getattr(cause, "messages", None),
-            },
+            message="Calling the Canvas API failed", request=request, response=response
         ) from cause
 
     @staticmethod
@@ -199,8 +190,8 @@ class CanvasFileNotFoundInCourse(Exception):
     error_code = "canvas_file_not_found_in_course"
 
     def __init__(self, file_id):
-        self.extra_details = {"file_id": file_id}
-        super().__init__(self.extra_details)
+        self.details = {"file_id": file_id}
+        super().__init__(self.details)
 
 
 class BlackboardFileNotFoundInCourse(Exception):
@@ -209,5 +200,5 @@ class BlackboardFileNotFoundInCourse(Exception):
     error_code = "blackboard_file_not_found_in_course"
 
     def __init__(self, file_id):
-        self.extra_details = {"file_id": file_id}
-        super().__init__(self.extra_details)
+        self.details = {"file_id": file_id}
+        super().__init__(self.details)

--- a/lms/services/lti_outcomes.py
+++ b/lms/services/lti_outcomes.py
@@ -137,19 +137,7 @@ class LTIOutcomesClient:
             raise ExternalRequestError("Malformed LTI outcome response") from err
 
         if status != "success":
-            description = None
-            try:
-                # Look for an imsx_description to pass along to the client, but it is possible this field
-                # may not exist.
-                description = header["imsx_POXResponseHeaderInfo"]["imsx_statusInfo"][
-                    "imsx_description"
-                ]
-            except KeyError:
-                pass
-
-            raise ExternalRequestError(
-                message="LTI outcome request failed", extra_details=description
-            )
+            raise ExternalRequestError(message="LTI outcome request failed")
 
         return body
 

--- a/lms/views/api/canvas/exceptions.py
+++ b/lms/views/api/canvas/exceptions.py
@@ -1,7 +1,7 @@
 class CanvasGroupError(Exception):
     def __init__(self, group_set):
-        self.extra_details = {"group_set": group_set}
-        super().__init__(self.extra_details)
+        self.details = {"group_set": group_set}
+        super().__init__(self.details)
 
 
 class CanvasGroupSetNotFound(CanvasGroupError):

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -120,7 +120,6 @@ class APIExceptionViews:
                 "body": self.context.response_body,
             },
         )
-        sentry_sdk.set_context("extra_details", self.context.extra_details)
 
         report_exception()
 
@@ -142,7 +141,6 @@ class APIExceptionViews:
                     "status_code": self.context.status_code,
                     "reason": self.context.reason,
                 },
-                "extra_details": self.context.extra_details,
             },
         )
 
@@ -188,7 +186,7 @@ class APIExceptionViews:
         if hasattr(self.context, "error_code"):
             return self.error_response(
                 error_code=self.context.error_code,
-                details=getattr(self.context, "extra_details", None),
+                details=getattr(self.context, "details", None),
             )
 
         # Exception details are not reported here to avoid leaking internal information.

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -35,18 +35,16 @@ class TestExternalRequestError:
         assert err.response_body is None
 
     @pytest.mark.parametrize(
-        "message,extra_details,request_,response,expected",
+        "message,request_,response,expected",
         [
             (
                 None,
                 None,
                 None,
-                None,
-                "ExternalRequestError(message=None, extra_details=None, request=Request(method=None, url=None, body=None), response=Response(status_code=None, reason=None, body=None))",
+                "ExternalRequestError(message=None, request=Request(method=None, url=None, body=None), response=Response(status_code=None, reason=None, body=None))",
             ),
             (
                 "Connecting to Hypothesis failed",
-                {"extra": "details"},
                 requests.Request(
                     "GET", "https://example.com", data="request_body"
                 ).prepare(),
@@ -55,14 +53,13 @@ class TestExternalRequestError:
                     reason="Bad Request",
                     raw="Name too long",
                 ),
-                "ExternalRequestError(message='Connecting to Hypothesis failed', extra_details={'extra': 'details'}, request=Request(method='GET', url='https://example.com/', body='request_body'), response=Response(status_code=400, reason='Bad Request', body='Name too long'))",
+                "ExternalRequestError(message='Connecting to Hypothesis failed', request=Request(method='GET', url='https://example.com/', body='request_body'), response=Response(status_code=400, reason='Bad Request', body='Name too long'))",
             ),
         ],
     )
-    def test_str(self, message, extra_details, request_, response, expected):
+    def test_str(self, message, request_, response, expected):
         err = ExternalRequestError(
             message=message,
-            extra_details=extra_details,
             request=request_,
             response=response,
         )
@@ -137,7 +134,6 @@ class TestCanvasAPIError:
 
         assert raised_exception.__cause__ == cause
         assert raised_exception.response == response
-        assert raised_exception.extra_details == {"validation_errors": None}
 
     @pytest.mark.parametrize(
         "cause",
@@ -162,7 +158,6 @@ class TestCanvasAPIError:
 
         assert raised_exception.__cause__ == cause
         assert raised_exception.response is None
-        assert raised_exception.extra_details == {"validation_errors": None}
 
     def test_it_raises_CanvasAPIServerError_for_a_successful_but_invalid_response(
         self, canvas_api_invalid_response
@@ -177,9 +172,6 @@ class TestCanvasAPIError:
 
         assert raised_exception.__cause__ == cause
         assert raised_exception.response == canvas_api_invalid_response
-        assert raised_exception.extra_details == {
-            "validation_errors": "The response was invalid."
-        }
 
     def assert_raises(self, cause, response, expected_exception_class):
         with pytest.raises(

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -54,7 +54,6 @@ class TestExternalRequestError:
                     "body": context.response_body,
                 },
             ),
-            call("extra_details", context.extra_details),
         ]
 
         report_exception.assert_called_once_with()
@@ -70,7 +69,6 @@ class TestExternalRequestError:
                     "status_code": context.status_code,
                     "reason": context.reason,
                 },
-                "extra_details": context.extra_details,
             },
         }
 
@@ -92,7 +90,6 @@ class TestExternalRequestError:
             response=factories.requests.Response(
                 status_code=418, reason="I'm a teapot", raw="Body text"
             ),
-            extra_details={"foo": "bar"},
         )
 
 
@@ -134,15 +131,12 @@ class TestHTTPBadRequest:
 
 class TestAPIError:
     def test_it_with_a_CanvasAPIPermissionError(self, pyramid_request, views):
-        context = views.context = CanvasAPIPermissionError(extra_details={"foo": "bar"})
+        context = views.context = CanvasAPIPermissionError()
 
         json_data = views.api_error()
 
         assert pyramid_request.response.status_code == 400
-        assert json_data == {
-            "error_code": context.error_code,
-            "details": context.extra_details,
-        }
+        assert json_data == {"error_code": context.error_code}
 
     def test_it_with_an_unexpected_error(self, pyramid_request, views):
         views.context = RuntimeError("Totally unexpected")


### PR DESCRIPTION
`ExternalRequestError` is starting to have too many attributes, especially since I want to add a new `ExternalRequestError.validation_errors` attr in a future PR.

The `ExternalRequestError.extra_details` attr isn't really necessary and isn't used for anything that we really need, so this commit removes it.