### PR TITLE
Handle VitalSource assignments in the creation endpoint schema

### DIFF
--- a/tests/unit/lms/validation/_api_test.py
+++ b/tests/unit/lms/validation/_api_test.py
@@ -153,17 +153,35 @@ class TestAPIRecordResultSchema:
 
 
 class TestAPICreateAssignmentSchema:
-    def test_it_doesnt_raise_valid_url_assignment(self, json_request, url_assignment):
-        request = json_request(url_assignment)
+    @pytest.mark.parametrize(
+        "assignment_fixture_name",
+        ["url_assignment", "file_assignment", "vitalsource_assignment"],
+    )
+    def test_it_doesnt_raise_valid__assignment(
+        self, json_request, assignment_fixture_name, request
+    ):
+        assignment_body = request.getfixturevalue(assignment_fixture_name)
+
+        request = json_request(assignment_body)
         schema = APICreateAssignmentSchema(request)
 
         schema.parse()
 
-    def test_it_doesnt_raise_valid_file_assignment(self, json_request, file_assignment):
-        request = json_request(file_assignment)
+    def test_it_raises_for_missing_book_id(self, json_request, vitalsource_assignment):
+        del vitalsource_assignment["content"]["bookID"]
+        request = json_request(vitalsource_assignment)
         schema = APICreateAssignmentSchema(request)
 
-        schema.parse()
+        with pytest.raises(ValidationError):
+            schema.parse()
+
+    def test_it_raises_for_missing_cfi(self, json_request, vitalsource_assignment):
+        del vitalsource_assignment["content"]["cfi"]
+        request = json_request(vitalsource_assignment)
+        schema = APICreateAssignmentSchema(request)
+
+        with pytest.raises(ValidationError):
+            schema.parse()
 
     def test_it_raises_for_missing_url(self, json_request, url_assignment):
         del url_assignment["content"]["url"]
@@ -180,6 +198,18 @@ class TestAPICreateAssignmentSchema:
 
         with pytest.raises(ValidationError):
             schema.parse()
+
+    @pytest.fixture
+    def vitalsource_assignment(self):
+        return {
+            "content": {
+                "type": "vitalsource",
+                "bookID": "BOOK_ID",
+                "cfi": "CFI",
+            },
+            "course_id": "COURSE_ID",
+            "ext_lti_assignment_id": "EXT_LTI_ASSIGNMENT_ID",
+        }
 
     @pytest.fixture
     def url_assignment(self):


### PR DESCRIPTION
# Testing

- On https://github.com/hypothesis/lms/pull/3126, try to create a VS assignment. Fail.
- Rebase that branch onto this one, the creation will still fail, but the message won't be marshmallow's validation one.
