### PR TITLE
Extend `config` typing and add `AppConfigError`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -2,6 +2,7 @@ import { useContext } from 'preact/hooks';
 import { Modal } from '@hypothesis/frontend-shared';
 
 import { Config } from '../config';
+import { AppConfigError } from '../errors';
 
 import ErrorDisplay from './ErrorDisplay';
 
@@ -16,15 +17,15 @@ import ErrorDisplay from './ErrorDisplay';
 export default function ErrorDialogApp() {
   const { errorDialog } = useContext(Config);
 
-  const error = {
-    code: errorDialog?.errorCode,
-    details: errorDialog?.errorDetails ?? '',
-  };
+  const error = new AppConfigError({
+    errorCode: errorDialog?.errorCode,
+    errorDetails: errorDialog?.errorDetails ?? '',
+  });
 
   let description;
   let title;
 
-  switch (error.code) {
+  switch (error.errorCode) {
     case 'reused_consumer_key':
       title = 'Consumer key registered with another site';
       break;
@@ -43,7 +44,7 @@ export default function ErrorDialogApp() {
       contentClass="LMS-Dialog LMS-Dialog--medium"
     >
       <ErrorDisplay error={error} description={description}>
-        {error.code === 'reused_consumer_key' && (
+        {error.errorCode === 'reused_consumer_key' && (
           <>
             <p>
               This Hypothesis {"installation's"} consumer key appears to have

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -2,6 +2,7 @@ import { LabeledButton, Modal } from '@hypothesis/frontend-shared';
 import { useContext } from 'preact/hooks';
 
 import { Config } from '../config';
+import { AppConfigError } from '../errors';
 
 import ErrorDisplay from './ErrorDisplay';
 
@@ -24,18 +25,17 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
   const { OAuth2RedirectError = /** @type {OAuthErrorConfig} */ ({}) } =
     useContext(Config);
 
-  const {
-    authUrl = null,
-    errorCode = null,
-    errorDetails = '',
-    canvasScopes = /** @type {string[]} */ ([]),
-  } = OAuth2RedirectError ?? {};
+  const { authUrl = null, canvasScopes = /** @type {string[]} */ ([]) } =
+    OAuth2RedirectError ?? {};
 
-  const error = { code: errorCode, details: errorDetails };
+  const error = new AppConfigError({
+    errorCode: OAuth2RedirectError?.errorCode,
+    errorDetails: OAuth2RedirectError.errorDetails,
+  });
 
   let title;
   let description;
-  switch (errorCode) {
+  switch (error.errorCode) {
     case 'canvas_invalid_scope':
       title = 'Developer key scopes missing';
       break;
@@ -76,7 +76,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
       title={title}
     >
       <ErrorDisplay error={error} description={description}>
-        {error.code === 'canvas_invalid_scope' && (
+        {error.errorCode === 'canvas_invalid_scope' && (
           <>
             <p>
               A Canvas admin needs to edit {"Hypothesis's"} developer key and
@@ -103,7 +103,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
           </>
         )}
 
-        {error.code === 'blackboard_missing_integration' && (
+        {error.errorCode === 'blackboard_missing_integration' && (
           <>
             <p>
               In order to allow Hypothesis to connect to files in Blackboard,

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
+import { AppConfigError } from '../../errors';
 
 import ErrorDialogApp from '../ErrorDialogApp';
 
@@ -24,6 +25,13 @@ describe('ErrorDialogApp', () => {
       errorCode: null,
       errorDetails: '',
     };
+  });
+
+  it('renders information about the error', () => {
+    const wrapper = renderApp();
+
+    const error = wrapper.find('ErrorDisplay').prop('error');
+    assert.instanceOf(error, AppConfigError);
   });
 
   it('shows dialog for unknown error code', () => {

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
+import { AppConfigError } from '../../errors';
 
 import OAuth2RedirectErrorApp from '../OAuth2RedirectErrorApp';
 
@@ -71,10 +72,9 @@ describe('OAuth2RedirectErrorApp', () => {
     assert.include(errorDisplay.props(), {
       description: 'Something went wrong when authorizing Hypothesis',
     });
-    assert.deepEqual(errorDisplay.prop('error'), {
-      details: fakeConfig.errorDetails,
-      code: null,
-    });
+    const error = errorDisplay.prop('error');
+    assert.instanceOf(error, AppConfigError);
+    assert.equal(error.details, 'Technical details');
   });
 
   it(`closes the window when the dialog's "Close" button is clicked`, () => {

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -17,6 +17,14 @@ import { createContext } from 'preact';
  */
 
 /**
+ * Configuration determining which "mode" the frontend app should operate in.
+ * Each mode maps to an app-level UI component.
+ *
+ * @typedef {'basic-lti-launch'|'content-item-selection'|'error-dialog'|'oauth2-redirect-error'} AppMode
+ *
+ */
+
+/**
  * @typedef StudentInfo
  * @prop {string} displayName
  * @prop {string} userid
@@ -82,31 +90,37 @@ import { createContext } from 'preact';
  */
 
 /**
- * @typedef {'blackboard_missing_integration' |
- *  'canvas_invalid_scope' } OAuthErrorCode
- */
-
-/**
- * Configuration for the error dialog shown if authorizing access to an
- * OAuth API fails.
  *
- * @typedef OAuthErrorConfig
- * @prop {string|null} authUrl
- * @prop {string} errorDetails
- * @prop {OAuthErrorCode|null} errorCode
- * @prop {string[]} canvasScopes
- */
-
-/**
- * @typedef {'reused_consumer_key'} ErrorCode
- */
-
-/**
- * Configuration for general error dialogs
+ * @typedef {'blackboard_missing_integration' | 'canvas_invalid_scope' | 'reused_consumer_key'} ConfigErrorCode
  *
- * @typedef ErrorDialogConfig
- * @prop {string} errorDetails
- * @prop {ErrorCode} errorCode
+ * Base interface for error information provided through this configuration object.
+ *
+ * @typedef ConfigErrorBase
+ * @prop {ConfigErrorCode} [errorCode]
+ * @prop {object|string} [errorDetails]
+ */
+
+/**
+ * Configuration for information describing general errors for use in
+ * `error-dialog` mode.
+ *
+ * @typedef ErrorDialogConfigBase
+ * @prop {Extract<'reused_consumer_key', ConfigErrorCode>} [errorCode]
+ *
+ * @typedef {ConfigErrorBase & ErrorDialogConfigBase} ErrorDialogConfig
+ */
+
+/**
+ * Configuration for information describing errors specific to
+ * OAuth API fails for use in `oauth2-redirect-error` mode. This adds a couple
+ * of additional optional properties to the base ConfigErrorCode type.
+ *
+ * @typedef OAuthErrorConfigBase
+ * @prop {Extract<'blackboard_missing_integration' | 'canvas_invalid_scope', ConfigErrorCode>} [errorCode]
+ * @prop {string} [authUrl]
+ * @prop {string[]} [canvasScopes]
+ *
+ * @typedef {ConfigErrorBase & OAuthErrorConfigBase} OAuthErrorConfig
  */
 
 /**
@@ -118,7 +132,7 @@ import { createContext } from 'preact';
  * the backend code.
  *
  * @typedef ConfigObject
- * @prop {string} mode
+ * @prop {AppMode} mode
  * @prop {object} api
  *   @prop {string} api.authToken
  *   @prop {APICallInfo} api.sync

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -8,8 +8,26 @@ export class PickerCanceledError extends Error {
 }
 
 /**
- * Error returned when an API call fails with a 4xx or 5xx response and
- * JSON body.
+ * @typedef {import('./config').ConfigErrorBase} ConfigErrorBase
+ */
+
+/**
+ * Error returned when error data is provided in application configuration JSON
+ * and application is in an error mode ('error-dialog' or 'oauth2-redirect-error')
+ */
+export class AppConfigError extends Error {
+  /**
+   * @param {ConfigErrorBase} data
+   */
+  constructor(data) {
+    super();
+    this.errorCode = data.errorCode;
+    this.details = data.errorDetails;
+  }
+}
+
+/**
+ * Error returned when an API call fails.
  */
 export class APIError extends Error {
   /**


### PR DESCRIPTION
This PR attempts to add some clarity around error data pertaining to errors that are inferred from the backend-provided `config` JS object.

It clarifies some typing in the `config` module to establish a base "interface" of expected fields about config-provided errors (`errorCode`, `errorDetails`). A new `AppConfigError` class is added, and instances of this are created in the two relevant error "mode" app components, `ErrorDialogApp` and `OAuth2RedirectErrorApp`. 

There is no change in functionality from these changes; they are a step on the path toward making it so that `ErrorDisplay` and `ErrorDialog` can be dumber, and not expected to mind-read/reason about a bewildering array of possible error constructs, enabling the completion of https://github.com/hypothesis/lms/issues/3333