### PR TITLE
Make errorDetails always a dict

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -1,6 +1,6 @@
 import functools
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 from lms.models import GroupInfo, HUser
 from lms.resources._js_config.file_picker_config import FilePickerConfig
@@ -107,7 +107,7 @@ class JSConfig:
         self,
         auth_route: str,
         error_code=None,
-        error_details: str = "",
+        error_details: Optional[dict] = None,
         canvas_scopes: List[str] = None,
     ):
         """
@@ -118,7 +118,7 @@ class JSConfig:
         third-party authorization endpoint.
 
         :param error_code: Code identifying a particular error
-        :param error_details: Technical details of the error
+        :param error_details: JSON-serializable technical details about the error
         :param auth_route: route for the "Try again" button in the dialog
         :param canvas_scopes: List of scopes that were requested
         """
@@ -139,22 +139,24 @@ class JSConfig:
                 "OAuth2RedirectError": {
                     "authUrl": auth_url,
                     "errorCode": error_code,
-                    "errorDetails": error_details,
                     "canvasScopes": canvas_scopes or [],
                 },
             }
         )
 
-    def enable_error_dialog_mode(self, error_code, error_details=""):
+        if error_details:
+            self._config["OAuth2RedirectError"]["errorDetails"] = error_details
+
+    def enable_error_dialog_mode(self, error_code, error_details=None):
         self._config.update(
             {
                 "mode": JSConfig.Mode.ERROR_DIALOG,
-                "errorDialog": {
-                    "errorCode": error_code,
-                    "errorDetails": error_details,
-                },
+                "errorDialog": {"errorCode": error_code},
             }
         )
+
+        if error_details:
+            self._config["errorDialog"]["errorDetails"] = error_details
 
     def enable_lti_launch_mode(self):
         """

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -114,16 +114,13 @@ def oauth2_redirect(request):
     renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
 )
 def oauth2_redirect_error(request):
-    if request.params.get("error") == "invalid_scope":
-        error_code = request.context.js_config.ErrorCode.CANVAS_INVALID_SCOPE
-    else:
-        error_code = None
-
     kwargs = {
         "auth_route": "canvas_api.oauth.authorize",
-        "error_code": error_code,
         "canvas_scopes": FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
     }
+
+    if request.params.get("error") == "invalid_scope":
+        kwargs["error_code"] = request.context.js_config.ErrorCode.CANVAS_INVALID_SCOPE
 
     if error_description := request.params.get("error_description"):
         kwargs["error_details"] = {"error_description": error_description}

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -114,13 +114,20 @@ def oauth2_redirect(request):
     renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
 )
 def oauth2_redirect_error(request):
-    request.context.js_config.enable_oauth2_redirect_error_mode(
-        auth_route="canvas_api.oauth.authorize",
-        error_details={"error_description": request.params.get("error_description")},
-        error_code=request.context.js_config.ErrorCode.CANVAS_INVALID_SCOPE
-        if request.params.get("error") == "invalid_scope"
-        else None,
-        canvas_scopes=FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
-    )
+    if request.params.get("error") == "invalid_scope":
+        error_code = request.context.js_config.ErrorCode.CANVAS_INVALID_SCOPE
+    else:
+        error_code = None
+
+    kwargs = {
+        "auth_route": "canvas_api.oauth.authorize",
+        "error_code": error_code,
+        "canvas_scopes": FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
+    }
+
+    if error_description := request.params.get("error_description"):
+        kwargs["error_details"] = {"error_description": error_description}
+
+    request.context.js_config.enable_oauth2_redirect_error_mode(**kwargs)
 
     return {}

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -116,7 +116,7 @@ def oauth2_redirect(request):
 def oauth2_redirect_error(request):
     request.context.js_config.enable_oauth2_redirect_error_mode(
         auth_route="canvas_api.oauth.authorize",
-        error_details=request.params.get("error_description"),
+        error_details={"error_description": request.params.get("error_description")},
         error_code=request.context.js_config.ErrorCode.CANVAS_INVALID_SCOPE
         if request.params.get("error") == "invalid_scope"
         else None,

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -624,12 +624,13 @@ class TestEnableOAuth2RedirectErrorMode:
 
         assert config["OAuth2RedirectError"]["authUrl"] is None
 
-    def test_error_details_defaults_to_an_empty_string(self, js_config):
+    def test_it_omits_errorDetails_if_no_error_details_argument_is_given(
+        self, js_config
+    ):
         js_config.enable_oauth2_redirect_error_mode(auth_route="auth_route")
         config = js_config.asdict()
 
-        # pylint:disable=compare-to-empty-string
-        assert config["OAuth2RedirectError"]["errorDetails"] == ""
+        assert "errorDetails" not in config["OAuth2RedirectError"]
 
     def test_canvas_scopes_defaults_to_an_empty_list(self, js_config):
         js_config.enable_oauth2_redirect_error_mode(auth_route="auth_route")
@@ -661,12 +662,13 @@ class TestEnableErrorDialogMode:
             "errorDetails": mock.sentinel.error_details,
         }
 
-    def test_error_details_defaults_to_an_empty_string(self, js_config):
+    def test_it_omits_errorDetails_if_no_error_details_argument_is_given(
+        self, js_config
+    ):
         js_config.enable_error_dialog_mode(mock.sentinel.error_code)
         config = js_config.asdict()
 
-        # pylint:disable=compare-to-empty-string
-        assert config["errorDialog"]["errorDetails"] == ""
+        assert "errorDetails" not in config["errorDialog"]
 
     @pytest.fixture
     def context(self):

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -187,7 +187,7 @@ class TestOAuth2RedirectError:
         js_config.enable_oauth2_redirect_error_mode.assert_called_with(
             auth_route="canvas_api.oauth.authorize",
             error_code=error_code,
-            error_details=params.get("error_description"),
+            error_details={"error_description": params.get("error_description")},
             canvas_scopes=scopes,
         )
 

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -161,7 +161,6 @@ class TestOAuth2RedirectError:
 
         pyramid_request.context.js_config.enable_oauth2_redirect_error_mode.assert_called_with(
             auth_route="canvas_api.oauth.authorize",
-            error_code=None,
             canvas_scopes=FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
         )
         assert template_data == {}


### PR DESCRIPTION
Make the `errorDetails` that the backend sends to the frontend in the `JSConfig` object always be a dict, rather than sometimes a dict and sometimes a string.

The purpose of `errorDetails` is that the frontend renders it in the **Error Details** box in the error dialog. Other than expecting it to be a dict (or "object" in JavaScript terms) the frontend treats it as an opaque value.

Depends on https://github.com/hypothesis/lms/pull/3336/

Fixes https://github.com/hypothesis/lms/issues/3333