### PR TITLE
Allow `ErrorDisplay` to render any `error.message` it is provided

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -133,11 +133,18 @@ export default function BasicLTILaunchApp() {
         'canvas_student_not_in_group',
       ].includes(e.errorCode)
     ) {
+      // In this case, we're dealing with an APIError from an API request to
+      // our own backend, of a known error code.
       setError(e);
       setErrorState(/** @type {ErrorState} */ (e.errorCode));
     } else if (e instanceof APIError && !e.errorMessage && retry) {
+      // This is a special case expected by the back end. We're handling an
+      // APIError resulting from an API request, but there are no further
+      // details in the response body to guide us. This implicitly means that
+      // we're facing an authorization-related error.
       setErrorState('error-authorizing');
     } else {
+      // Handle other types of errors, which may be APIError or Error
       setError(e);
       setErrorState(state);
     }

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -123,7 +123,7 @@ export default function BasicLTILaunchApp() {
 
     if (
       e instanceof APIError &&
-      e.errorCode !== null &&
+      e.errorCode &&
       [
         'blackboard_file_not_found_in_course',
         'canvas_api_permission_error',

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -18,7 +18,7 @@ import ErrorDisplay from './ErrorDisplay';
  */
 export default function ErrorDialog({
   onCancel,
-  description = 'Error',
+  description,
   error,
   cancelLabel,
 }) {

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -95,7 +95,8 @@ export default function LaunchErrorDialog({
     case 'error-authorizing':
       // nb. There are no error details shown here, since failing to authorize
       // is a "normal" event which will happen if the user has not authorized before
-      // or the authorization has expired or been revoked.
+      // or the authorization has expired or been revoked. This is handled
+      // specially here by not passing the `error` on to `BaseDialog`
       return (
         <BaseDialog
           busy={busy}

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -127,50 +127,27 @@ describe('ErrorDisplay', () => {
   [
     {
       description: 'Not a sentence',
-      output: 'Not a sentence',
+      output: 'Not a sentence.',
     },
     {
-      description: 'A sentence',
-      output: 'A sentence',
-    },
-    {
-      description: 'Oh no',
-      error: 'Tech details',
-      output: 'Oh no: Tech details.',
+      description: 'A sentence.',
+      output: 'A sentence.',
     },
     {
       description: 'Oh no',
-      error: 'Tech details.',
+      message: 'Tech details',
       output: 'Oh no: Tech details.',
     },
-  ].forEach(({ description, error, output }, index) => {
-    it(`formats error.message as sentence (${index})`, () => {
+    {
+      message: 'Tech details',
+      output: 'Tech details.',
+    },
+  ].forEach(({ description, message, output }, index) => {
+    it(`formats description and/or message appropriately (${index})`, () => {
       const wrapper = mount(
-        <ErrorDisplay description={description} error={{ message: error }} />
+        <ErrorDisplay description={description} error={{ message }} />
       );
       assert.equal(wrapper.find('p').first().text(), output);
-    });
-  });
-
-  [
-    {
-      description: 'Provided by client',
-      error: 'Provided by server',
-      output: 'Provided by client: Provided by server.',
-    },
-    {
-      description: 'Provided by client',
-      output: 'Provided by client',
-    },
-  ].forEach(({ description, error, output }, index) => {
-    it(`shows the appropriate error message if provided (${index})`, () => {
-      const wrapper = mount(
-        <ErrorDisplay description={description} error={{ message: error }} />
-      );
-      assert.equal(
-        wrapper.find('p[data-testid="error-message"]').text(),
-        output
-      );
     });
   });
 

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -20,9 +20,7 @@ export class APIError extends Error {
    *   @param {any} [data.details]
    */
   constructor(status, data) {
-    // If message is omitted, pass a default error message.
-    const message = data.message || 'API call failed';
-    super(message);
+    super('API call failed');
 
     /**
      * HTTP response status.
@@ -34,15 +32,15 @@ export class APIError extends Error {
      *
      * This can be used to show custom error dialogs for specific issues.
      */
-    this.errorCode = data.error_code || null;
+    this.errorCode = data.error_code;
 
     /**
      * Server-provided error message.
      *
-     * May be `null` if the server did not provide any details about what the
+     * May be empty if the server did not provide any details about what the
      * problem was.
      */
-    this.errorMessage = data.message || null;
+    this.errorMessage = data.message ?? '';
 
     /**
      * Server-provided details of the error.

--- a/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
@@ -60,7 +60,7 @@ describe('VitalSourceService', () => {
         err = e;
       }
       assert.instanceOf(err, APIError);
-      assert.equal(err.message, 'Book not found');
+      assert.equal(err.errorMessage, 'Book not found');
     });
   });
 
@@ -81,7 +81,7 @@ describe('VitalSourceService', () => {
         err = e;
       }
       assert.instanceOf(err, APIError);
-      assert.equal(err.message, 'Book not found');
+      assert.equal(err.errorMessage, 'Book not found');
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/test/errors-test.js
+++ b/lms/static/scripts/frontend_apps/test/errors-test.js
@@ -5,8 +5,8 @@ describe('APIError', () => {
     const error = new APIError(404, {});
 
     assert.isUndefined(error.details);
-    assert.isNull(error.errorCode);
-    assert.isNull(error.errorMessage);
+    assert.isUndefined(error.errorCode);
+    assert.equal(error.errorMessage, '');
     assert.equal(error.message, 'API call failed');
     assert.equal(error.status, 404);
   });
@@ -23,7 +23,7 @@ describe('APIError', () => {
     assert.equal(error.details, details);
     assert.equal(error.errorCode, '4xx');
     assert.equal(error.errorMessage, 'message');
-    assert.equal(error.message, 'message');
+    assert.equal(error.message, 'API call failed');
     assert.equal(error.status, 404);
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -79,7 +79,7 @@ describe('api', () => {
       {
         status: 403,
         body: { message: null, details: {} },
-        expectedMessage: 'API call failed',
+        expectedMessage: '',
       },
       {
         status: 400,
@@ -105,10 +105,10 @@ describe('api', () => {
         }
 
         assert.instanceOf(reason, APIError);
-        assert.equal(reason.message, expectedMessage, '`Error.message`');
+        assert.equal(reason.message, 'API call failed', '`Error.message`');
         assert.equal(
           reason.errorMessage,
-          body.message,
+          expectedMessage,
           '`APIError.errorMessage`'
         );
         assert.equal(reason.details, body.details, '`APIError.details`');


### PR DESCRIPTION
This PR attempts to fix https://github.com/hypothesis/lms/issues/3259, that is, assure that any text content provided in the `data.message` property of JSON response bodies from problematic requests to our proxy API is shown to the user, no matter what else is going on, while still making sure we _don't_ show a message if there isn't a useful one to show. It makes this fix by adjusting `APIError` and allowing `ErrorDisplay` to render any `error.message` it is provided.

### Explanation

`APIError` is intended to be used to handle error responses arising from requests to our own API. In these cases, it is expected that we use error information from the server to populate error instance attributes. The response _may_ contain a `data.message` property that, if present, should be rendered as part of the output of the `ErrorDisplay` component.

In the past, an attempt to make sure that an `APIError` instance always _has_ a `message` was introduced, by setting a default value (“API request failed”) if the backend didn’t provide `data.message`. The problem is that when this `APIError` is sent along to `ErrorDisplay`, it would be unhelpfully rendered to the user—i.e. we don’t want to display that message as it is not useful.

In the interim, some convoluted logic (I can describe it that way because I did it) was added to `ErrorDisplay`  that would only display `message` in certain cases, but I got it wrong and it’s weird and complicated and puts the onus on `ErrorDisplay`  to reason about different error situations. No bueno. Plus it didn’t get it right.

As I see it, there are a couple of ways of solving the problem, which I’d summarize as allowing `ErrorDisplay` to render any `message` property that is present on its `error` prop without having to worry about it, so that this component can be used to render errors from any number of sources:

1. Set an empty `message` on `APIError` instances if the backend has not provided `data.message`. This is the direction I’ve gone here. A `message` really _should_ be provided to an `Error` constructor, but [it is, strictly speaking, optional](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error)  and [defaults to empty string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message). Setting an empty-string `message` when `data.message` is not present allows `APIError`s to be passed along to `ErrorDisplay` without having to mess with ‘em. We do know we never want to let users see the (previous) default message of "API call failed."
2. Set a default error message on `APIError` instances as before, but intercept any error that might be an `APIError` before passing it on to `ErrorDisplay` and construct an `{ErrorLike}` object [^1]  from them, only including a message if `errorMessage` is set on the `APIError` instance. This is doable, but a bit fiddly and more code and results in a meaningless `message` string in some cases, so I opted for the first option.

Immediate next steps after this work:

* Finish https://github.com/hypothesis/lms/issues/3191 so error states can be documented and previewed
* Make changes to the canned text in `ErrorDisplay` https://github.com/hypothesis/support/issues/240

### Testing it

Although I have walked through all of the types of errors and tested them on this branch, I'm going to hold this in draft until I can get a reproducible test case for the specific context alluded to in the issue description of #3259

Until https://github.com/hypothesis/lms/issues/3191 is addressed, https://github.com/hypothesis/lms/pull/3160 's description can be used as a source of how to get into a bunch of different error states if anyone wants to take this for a spin. Ironically, there are (laughing right now) no user-visible changes here until I can get a test case in which the backend provides a `message` but not a recognized `errorCode` (as alluded to in previous paragraph).

(I _did_ create a fake `APIError` based on the notion of that test case and passed it to `ErrorDisplay` and it did what I would have expected. But I'd like a real path to test.)


Fixes #3259 

[^1]: `{ErrorLike}` type is [defined here](https://github.com/hypothesis/lms/blob/585e1ebf66ce10399cd116123ed4502f22075e80/lms/static/scripts/frontend_apps/components/ErrorDisplay.js#L26-L31)