### PR TITLE
Store VS assignments on the DB

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -74,23 +74,19 @@ class JSConfig:
                     resource_link_id=self._request.params["resource_link_id"],
                 ),
             }
+        elif document_url.startswith("vitalsource://"):
+            vitalsource_svc = self._request.find_service(name="vitalsource")
+            launch_url, launch_params = vitalsource_svc.get_launch_params(
+                document_url, self._request.lti_user
+            )
+            self._config["vitalSource"] = {
+                "launchUrl": launch_url,
+                "launchParams": launch_params,
+            }
         else:
             self._config["viaUrl"] = via_url(self._request, document_url)
 
         self._add_canvas_speedgrader_settings(document_url=document_url)
-
-    def add_vitalsource_launch_config(self, book_id, cfi=None):
-        vitalsource_svc = self._request.find_service(name="vitalsource")
-        launch_url, launch_params = vitalsource_svc.get_launch_params(
-            book_id, cfi, self._request.lti_user
-        )
-        self._config["vitalSource"] = {
-            "launchUrl": launch_url,
-            "launchParams": launch_params,
-        }
-        self._add_canvas_speedgrader_settings(
-            vitalsource_book_id=book_id, vitalsource_cfi=cfi
-        )
 
     def asdict(self):
         """

--- a/lms/services/vitalsource/client.py
+++ b/lms/services/vitalsource/client.py
@@ -1,8 +1,16 @@
+import re
+
 import oauthlib
 from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
 
 from lms.services.exceptions import ExternalRequestError
 from lms.services.vitalsource._schemas import BookInfoSchema, BookTOCSchema
+
+#: A regex for parsing the BOOK_ID and CFI parts out of one of our custom
+#: vitalsource://book/bookID/BOOK_ID/cfi/CFI URLs.
+DOCUMENT_URL_REGEX = re.compile(
+    r"vitalsource:\/\/book\/bookID\/(?P<book_id>[^\/]*)\/cfi\/(?P<cfi>.*)"
+)
 
 
 class VitalSourceService:
@@ -54,7 +62,11 @@ class VitalSourceService:
 
         return BookTOCSchema(response).parse()
 
-    def get_launch_params(self, book_id, cfi, lti_user):
+    @staticmethod
+    def parse_document_url(document_url):
+        return DOCUMENT_URL_REGEX.search(document_url).groupdict()
+
+    def get_launch_params(self, document_url, lti_user):
         """
         Return the form params needed to launch the VitalSource book viewer.
 
@@ -64,11 +76,13 @@ class VitalSourceService:
 
         See https://developer.vitalsource.com/hc/en-us/articles/215612237-POST-LTI-Create-a-Bookshelf-Launch
 
-        :param book_id: The VitalSource book ID ("vbid")
-        :param cfi: Book location, as a Canonical Fragment Identifier, for deep linking.
+        :param document_url: `vitalsource://` type URL identifying the document.
         :param lti_user: Current LTI user information, from the LTI launch request
         :type lti_user: LTIUser
         """
+        url_params = self.parse_document_url(document_url)
+        book_id = url_params["book_id"]
+        cfi = url_params["cfi"]
 
         launch_url = f"https://bc.vitalsource.com/books/{book_id}"
         book_location = "/cfi" + cfi

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -234,8 +234,8 @@ export default function BasicLTILaunchApp() {
       return;
     }
 
-    // Don't report a submission until the URL has been successfully fetched.
-    if (!contentUrl) {
+    // Don't report a submission until we have the data needed to display the assignment content
+    if (!contentUrl && !vitalSourceConfig) {
       return;
     }
     try {
@@ -251,7 +251,7 @@ export default function BasicLTILaunchApp() {
       // submission.
       handleError(e, 'error-reporting-submission', false);
     }
-  }, [authToken, canvas.speedGrader, contentUrl]);
+  }, [authToken, canvas.speedGrader, contentUrl, vitalSourceConfig]);
 
   useEffect(() => {
     reportSubmission();

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -118,6 +118,7 @@ class URLConfiguredBasicLTILaunchSchema(BasicLTILaunchSchema):
             url.lower().startswith("http%3a")
             or url.lower().startswith("https%3a")
             or url.lower().startswith("canvas%3a")
+            or url.lower().startswith("vitalsource%3a")
         ):
             url = unquote(url)
             _data["url"] = url

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -122,26 +122,6 @@ class BasicLTILaunchViews:
         )
         return self.basic_lti_launch(document_url=document_url, grading_supported=False)
 
-    @view_config(vitalsource_book=True)
-    def vitalsource_lti_launch(self):
-        """
-        Respond to a VitalSource book launch.
-
-        The book and chapter to show are configured by `book_id` and `cfi` request
-        parameters. VitalSource book launches involve a second LTI launch.
-        Hypothesis's LMS app generates the form parameters needed to load
-        VitalSource's book viewer using an LTI launch. The LMS frontend then
-        renders these parameters into a form and auto-submits the form to perform
-        an authenticated launch of the VS book viewer.
-        """
-        self.sync_lti_data_to_h()
-        self.store_lti_data()
-        self.context.js_config.maybe_enable_grading()
-        self.context.js_config.add_vitalsource_launch_config(
-            self.request.params["book_id"], self.request.params.get("cfi")
-        )
-        return {}
-
     @view_config(db_configured=True, canvas_file=False, url_configured=False)
     def db_configured_basic_lti_launch(self):
         """

--- a/lms/views/predicates/__init__.py
+++ b/lms/views/predicates/__init__.py
@@ -14,7 +14,6 @@ from lms.views.predicates._lti_launch import (
     DBConfigured,
     LegacySpeedGrader,
     URLConfigured,
-    VitalSourceBook,
 )
 
 
@@ -25,7 +24,6 @@ def includeme(config):
         BrightspaceCopied,
         CanvasFile,
         URLConfigured,
-        VitalSourceBook,
         Configured,
         AuthorizedToConfigureAssignments,
         LegacySpeedGrader,

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -186,13 +186,6 @@ class CanvasFile(Base):
         return ("canvas_file" in request.params) == self.value
 
 
-class VitalSourceBook(Base):
-    name = "vitalsource_book"
-
-    def __call__(self, context, request):
-        return ("vitalsource_book" in request.params) == self.value
-
-
 class URLConfigured(Base):
     """
     Allow invoking an LTI launch view only for URL-configured assignments.
@@ -248,7 +241,6 @@ class Configured(Base):
         self.db_configured = DBConfigured(True, config)
         self.blackboard_copied = BlackboardCopied(True, config)
         self.brightspace_copied = BrightspaceCopied(True, config)
-        self.vitalsource_book = VitalSourceBook(True, config)
 
     def __call__(self, context, request):
         configured = any(
@@ -258,7 +250,6 @@ class Configured(Base):
                 self.db_configured(context, request),
                 self.blackboard_copied(context, request),
                 self.brightspace_copied(context, request),
-                self.vitalsource_book(context, request),
             ]
         )
         return configured == self.value

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -151,25 +151,6 @@ def configure_assignment_caller(context, pyramid_request):
     return views.configure_assignment()
 
 
-def vitalsource_lti_launch_caller(context, pyramid_request):
-    """
-    Call BasicLTILaunchViews.vitalsource_lti_launch().
-
-    Set up the appropriate conditions and then call
-    BasicLTILaunchViews.vitalsource_lti_launch(), and return whatever
-    BasicLTILaunchViews.vitalsource_lti_launch() returns.
-    """
-
-    # The book_id and cfi params are assumed present when vitalsource_lti_launch()
-    # is called.
-    pyramid_request.params["book_id"] = "book-id"
-    pyramid_request.params["cfi"] = "/abc"
-
-    views = BasicLTILaunchViews(context, pyramid_request)
-
-    return views.vitalsource_lti_launch()
-
-
 class TestBasicLTILaunchViewsInit:
     """Unit tests for BasicLTILaunchViews.__init__()."""
 
@@ -247,7 +228,6 @@ class TestCommon:
             brightspace_copied_basic_lti_launch_caller,
             url_configured_basic_lti_launch_caller,
             configure_assignment_caller,
-            vitalsource_lti_launch_caller,
         ]
     )
     def view_caller(self, request):
@@ -476,19 +456,6 @@ class TestUnconfiguredBasicLTILaunchNotAuthorized:
         ).unconfigured_basic_lti_launch_not_authorized()
 
         assert data == {}
-
-
-class TestVitalsourceLTILaunch:
-    def test_it_adds_vitalsource_launch_config(self, context, pyramid_request):
-        pyramid_request.params.update(
-            {"vitalsource_book": "true", "book_id": "book-id", "cfi": "/abc"}
-        )
-
-        BasicLTILaunchViews(context, pyramid_request).vitalsource_lti_launch()
-
-        context.js_config.add_vitalsource_launch_config.assert_called_once_with(
-            "book-id", "/abc"
-        )
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/predicates/__init___test.py
+++ b/tests/unit/lms/views/predicates/__init___test.py
@@ -10,7 +10,6 @@ from lms.views.predicates._lti_launch import (
     DBConfigured,
     LegacySpeedGrader,
     URLConfigured,
-    VitalSourceBook,
 )
 
 
@@ -25,7 +24,6 @@ def test_includeme_adds_the_view_predicates():
         mock.call("brightspace_copied", BrightspaceCopied),
         mock.call("canvas_file", CanvasFile),
         mock.call("url_configured", URLConfigured),
-        mock.call("vitalsource_book", VitalSourceBook),
         mock.call("configured", Configured),
         mock.call(
             "authorized_to_configure_assignments", AuthorizedToConfigureAssignments

--- a/tests/unit/lms/views/predicates/_lti_launch_test.py
+++ b/tests/unit/lms/views/predicates/_lti_launch_test.py
@@ -13,7 +13,6 @@ from lms.views.predicates import (
     DBConfigured,
     LegacySpeedGrader,
     URLConfigured,
-    VitalSourceBook,
 )
 from tests import factories
 
@@ -151,23 +150,6 @@ class TestCanvasFile:
         assert predicate(context, pyramid_request) is expected
 
 
-class TestVitalSourceBook:
-    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
-    def test_when_assignment_is_vitalsource_book(self, value, expected):
-        request = DummyRequest(params={"vitalsource_book": "true"})
-        predicate = VitalSourceBook(value, mock.sentinel.config)
-
-        assert predicate(mock.sentinel.context, request) is expected
-
-    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
-    def test_when_assignment_is_not_vitalsource_book(
-        self, value, expected, pyramid_request
-    ):
-        predicate = VitalSourceBook(value, mock.sentinel.config)
-
-        assert predicate(mock.sentinel.context, pyramid_request) is expected
-
-
 class TestURLConfigured:
     @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
     def test_when_assignment_is_url_configured(
@@ -215,15 +197,6 @@ class TestConfigured:
     ):
         assignment_service.exists.return_value = True
 
-        predicate = Configured(value, mock.sentinel.config)
-
-        assert predicate(context, pyramid_request) is expected
-
-    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
-    def test_when_assignment_is_vitalsource_book(
-        self, pyramid_request, value, expected, context
-    ):
-        pyramid_request.params = {"vitalsource_book": True}
         predicate = Configured(value, mock.sentinel.config)
 
         assert predicate(context, pyramid_request) is expected


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/3329

Handles VitalSource assignments like any other type of assignment on Canvas.

Testing as https://github.com/hypothesis/lms/pull/3126 but using VS assignments as well.



