### PR TITLE
Remove MS OneDrive verification endpoint

### DIFF
--- a/lms/views/onedrive.py
+++ b/lms/views/onedrive.py
@@ -1,6 +1,3 @@
-import textwrap
-
-from pyramid.response import Response
 from pyramid.view import view_config
 
 
@@ -16,29 +13,3 @@ def redirect_uri(_request):
     This view's URL is provided to One Drive's frontend config as target to open the filepicker in.
     """
     return {}
-
-
-@view_config(
-    request_method="GET",
-    route_name="onedrive.filepicker.verify_domain",
-    renderer="json",
-)
-def verify_domain(request):
-    application_id = request.registry.settings["onedrive_client_id"]
-    response_text = textwrap.dedent(
-        f"""\
-    {{
-      "associatedApplications": [
-        {{
-          "applicationId": "{application_id}"
-        }}
-      ]
-    }}"""
-    )
-    return Response(
-        text=response_text,
-        headers={
-            "Content-Length": str(len(response_text)),
-            "Content-Type": "application/json",
-        },
-    )

--- a/tests/unit/lms/views/onedrive_test.py
+++ b/tests/unit/lms/views/onedrive_test.py
@@ -1,24 +1,5 @@
-import json
-from unittest.mock import sentinel
-
-from lms.views.onedrive import redirect_uri, verify_domain
+from lms.views.onedrive import redirect_uri
 
 
 def test_redirect_uri(pyramid_request):
     assert redirect_uri(pyramid_request) == {}
-
-
-def test_verify_domain(pyramid_request):
-    pyramid_request.registry.settings["onedrive_client_id"] = sentinel.client_id
-
-    assert json.loads(verify_domain(pyramid_request).text) == {
-        "associatedApplications": [{"applicationId": f"{sentinel.client_id}"}]
-    }
-
-
-def test_verify_domain_includes_length(pyramid_request):
-    pyramid_request.registry.settings["onedrive_client_id"] = sentinel.client_id
-
-    response = verify_domain(pyramid_request)
-
-    assert response.content_length == len(response.text)


### PR DESCRIPTION
This never worked and it's not needed anymore.

Verification using Azure's "app registrations" option using this never worked and we ended
up using the "Microsoft Partner Network" instead where verification could be done with a TXT record on the DNS.