### PR TITLE
Prefer `error.errorMessage` over `error.message` when displaying error details in `ErrorDisplay`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -133,11 +133,18 @@ export default function BasicLTILaunchApp() {
         'canvas_student_not_in_group',
       ].includes(e.errorCode)
     ) {
+      // In this case, we're dealing with an APIError from an API request to
+      // our own backend, of a known error code.
       setError(e);
       setErrorState(/** @type {ErrorState} */ (e.errorCode));
     } else if (e instanceof APIError && !e.errorMessage && retry) {
+      // This is a special case expected by the back end. We're handling an
+      // APIError resulting from an API request, but there are no further
+      // details in the response body to guide us. This implicitly means that
+      // we're facing an authorization-related error.
       setErrorState('error-authorizing');
     } else {
+      // Handle other types of errors, which may be APIError or Error
       setError(e);
       setErrorState(state);
     }

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -123,7 +123,7 @@ export default function BasicLTILaunchApp() {
 
     if (
       e instanceof APIError &&
-      e.errorCode !== null &&
+      e.errorCode &&
       [
         'blackboard_file_not_found_in_course',
         'canvas_api_permission_error',

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -18,7 +18,7 @@ import ErrorDisplay from './ErrorDisplay';
  */
 export default function ErrorDialog({
   onCancel,
-  description = 'Error',
+  description,
   error,
   cancelLabel,
 }) {

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -8,6 +8,8 @@ import ErrorDisplay from './ErrorDisplay';
  * @typedef {import("preact").ComponentChildren} Children
  *
  * @typedef {import('./BasicLTILaunchApp').ErrorState} ErrorState
+ *
+ * @typedef {import('./ErrorDisplay').ErrorLike} ErrorLike
  */
 
 /**
@@ -22,7 +24,7 @@ import ErrorDisplay from './ErrorDisplay';
  * @param {object} props
  * @param {boolean} props.busy
  * @param {Children} props.children
- * @param {Error|null} [props.error]
+ * @param {ErrorLike|null} [props.error]
  * @param {() => void} [props.onRetry]
  * @param {string} [props.retryLabel]
  * @param {string} [props.title]
@@ -72,7 +74,7 @@ function BaseDialog({
  *   Flag indicating that the app is busy and should not allow the user to
  *   click the "Try again" button
  * @prop {ErrorState} errorState - What kind of error occurred?
- * @prop {Error|null} error - Detailed information about the error
+ * @prop {ErrorLike|null} error - Detailed information about the error
  * @prop {() => void} onRetry -
  *   Callback invoked when user clicks the "Try again" button
  */
@@ -246,9 +248,13 @@ export default function LaunchErrorDialog({
       );
 
     case 'error-fetching':
+      // Do not display canned text if there is a back-end-provided message
+      // to show here, as it's redundant and not useful
       return (
         <BaseDialog busy={busy} error={error} onRetry={onRetry}>
-          <p>There was a problem fetching this Hypothesis assignment.</p>
+          {!error?.errorMessage && (
+            <p>There was a problem fetching this Hypothesis assignment.</p>
+          )}
         </BaseDialog>
       );
     case 'error-reporting-submission':

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -95,7 +95,8 @@ export default function LaunchErrorDialog({
     case 'error-authorizing':
       // nb. There are no error details shown here, since failing to authorize
       // is a "normal" event which will happen if the user has not authorized before
-      // or the authorization has expired or been revoked.
+      // or the authorization has expired or been revoked. This is handled
+      // specially here by not passing the `error` on to `BaseDialog`
       return (
         <BaseDialog
           busy={busy}

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -127,50 +127,69 @@ describe('ErrorDisplay', () => {
   [
     {
       description: 'Not a sentence',
-      output: 'Not a sentence',
+      error: {},
+      output: 'Not a sentence.',
     },
     {
-      description: 'A sentence',
-      output: 'A sentence',
-    },
-    {
-      description: 'Oh no',
-      error: 'Tech details',
-      output: 'Oh no: Tech details.',
+      description: 'A sentence.',
+      error: {},
+      output: 'A sentence.',
     },
     {
       description: 'Oh no',
-      error: 'Tech details.',
+      error: {
+        message: 'Tech details',
+      },
       output: 'Oh no: Tech details.',
     },
-  ].forEach(({ description, error, output }, index) => {
-    it(`formats error.message as sentence (${index})`, () => {
-      const wrapper = mount(
-        <ErrorDisplay description={description} error={{ message: error }} />
-      );
-      assert.equal(wrapper.find('p').first().text(), output);
-    });
-  });
-
-  [
     {
-      description: 'Provided by client',
-      error: 'Provided by server',
-      output: 'Provided by client: Provided by server.',
+      error: {
+        message: 'Tech details',
+      },
+      output: 'Tech details.',
     },
     {
-      description: 'Provided by client',
-      output: 'Provided by client',
+      error: {
+        message: 'Default error message',
+        errorMessage: 'Server message',
+      },
+      output: 'Server message.',
+    },
+    {
+      description: 'Something went wrong',
+      error: {
+        message: 'Default error message',
+        errorMessage: 'Server message',
+      },
+      output: 'Something went wrong: Server message.',
+    },
+    {
+      description: 'Something went wrong',
+      error: {
+        message: 'Default error message',
+        errorMessage: '',
+      },
+      output: 'Something went wrong.',
+    },
+    {
+      error: {
+        message: 'Default error message',
+        errorMessage: '',
+      },
     },
   ].forEach(({ description, error, output }, index) => {
-    it(`shows the appropriate error message if provided (${index})`, () => {
+    it(`formats description and/or message appropriately (${index})`, () => {
       const wrapper = mount(
-        <ErrorDisplay description={description} error={{ message: error }} />
+        <ErrorDisplay description={description} error={error} />
       );
-      assert.equal(
-        wrapper.find('p[data-testid="error-message"]').text(),
-        output
-      );
+      if (output) {
+        assert.equal(
+          wrapper.find('p[data-testid="error-message"]').text(),
+          output
+        );
+      } else {
+        assert.isFalse(wrapper.find('p[data-testid="error-message"]').exists());
+      }
     });
   });
 

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -101,6 +101,25 @@ describe('LaunchErrorDialog', () => {
     }
   );
 
+  it('only renders back-end messaging in "error-fetching" state, if provided', () => {
+    // The presence of `errorMessage` on the errorLike object will prevent the
+    // canned text from rendering
+    const errorLike = {
+      message: 'This is the JS error message',
+      errorMessage: 'This is the back-end error message',
+    };
+
+    const wrapper = renderDialog({
+      error: errorLike,
+      errorState: 'error-fetching',
+    });
+
+    assert.notInclude(
+      wrapper.text(),
+      'There was a problem fetching this Hypothesis assignment'
+    );
+  });
+
   it('initiates retry when "Try again" button is clicked', () => {
     const wrapper = renderDialog();
 

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -20,9 +20,7 @@ export class APIError extends Error {
    *   @param {any} [data.details]
    */
   constructor(status, data) {
-    // If message is omitted, pass a default error message.
-    const message = data.message || 'API call failed';
-    super(message);
+    super('API call failed');
 
     /**
      * HTTP response status.
@@ -34,15 +32,15 @@ export class APIError extends Error {
      *
      * This can be used to show custom error dialogs for specific issues.
      */
-    this.errorCode = data.error_code || null;
+    this.errorCode = data.error_code;
 
     /**
      * Server-provided error message.
      *
-     * May be `null` if the server did not provide any details about what the
+     * May be empty if the server did not provide any details about what the
      * problem was.
      */
-    this.errorMessage = data.message || null;
+    this.errorMessage = data.message ?? '';
 
     /**
      * Server-provided details of the error.

--- a/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
@@ -60,7 +60,7 @@ describe('VitalSourceService', () => {
         err = e;
       }
       assert.instanceOf(err, APIError);
-      assert.equal(err.message, 'Book not found');
+      assert.equal(err.errorMessage, 'Book not found');
     });
   });
 
@@ -81,7 +81,7 @@ describe('VitalSourceService', () => {
         err = e;
       }
       assert.instanceOf(err, APIError);
-      assert.equal(err.message, 'Book not found');
+      assert.equal(err.errorMessage, 'Book not found');
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/test/errors-test.js
+++ b/lms/static/scripts/frontend_apps/test/errors-test.js
@@ -5,8 +5,8 @@ describe('APIError', () => {
     const error = new APIError(404, {});
 
     assert.isUndefined(error.details);
-    assert.isNull(error.errorCode);
-    assert.isNull(error.errorMessage);
+    assert.isUndefined(error.errorCode);
+    assert.equal(error.errorMessage, '');
     assert.equal(error.message, 'API call failed');
     assert.equal(error.status, 404);
   });
@@ -23,7 +23,7 @@ describe('APIError', () => {
     assert.equal(error.details, details);
     assert.equal(error.errorCode, '4xx');
     assert.equal(error.errorMessage, 'message');
-    assert.equal(error.message, 'message');
+    assert.equal(error.message, 'API call failed');
     assert.equal(error.status, 404);
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -79,7 +79,7 @@ describe('api', () => {
       {
         status: 403,
         body: { message: null, details: {} },
-        expectedMessage: 'API call failed',
+        expectedMessage: '',
       },
       {
         status: 400,
@@ -105,10 +105,10 @@ describe('api', () => {
         }
 
         assert.instanceOf(reason, APIError);
-        assert.equal(reason.message, expectedMessage, '`Error.message`');
+        assert.equal(reason.message, 'API call failed', '`Error.message`');
         assert.equal(
           reason.errorMessage,
-          body.message,
+          expectedMessage,
           '`APIError.errorMessage`'
         );
         assert.equal(reason.details, body.details, '`APIError.details`');


### PR DESCRIPTION
This PR updates the `ErrorDisplay` component and `APIError` to help ensure that the "message" that gets displayed by `ErrorDisplay`, if any, is the appropriate one for the given error context.

In cases where the `ErrorLike` object passed to `ErrorDisplay` as the `error` prop has an extant `errorMessage`, that will get displayed (superseding `error.message`). In the case of APIErrors, the `errorMessage` field is populated from response data from the backend, or set to an empty string if the backend does not provide a message.

This prevents `ErrorDisplay` from rendering a generic message in these cases, but ensures that a server-provided message _will_ get displayed.

Some logic requiring the presence of `description` to render a message in `ErrorDisplay` has been removed, thankfully.

This PR also adds a few comments to help explain some error contexts.

A third commit prevents "canned" text from being displayed in the case of the "special"[^1] error type of `error-fetching` in `LaunchErrorDialog` if a server-provided message is _also_ present.

~~At this time, I do not know of any user-visible changes to known error states introduced by these changes. I will do another thorough review of all states once I get a test case for #3259 and as such am putting this PR in draft.~~

### Testing

There are some test cases described in https://github.com/hypothesis/lms/issues/3259 — these require some very minor hacking of python modules locally to reproduce. 

Fixes #3259

[^1]: Most of the valid values for `ErrorState` defined in `BasicLTILaunchApp` correspond to server-provided known `errorCode`s, and in these cases, showing canned text based on these codes is appropriate. There are three somewhat-special cases that do not conform to this: `error-fetching`, `error-authorizing` and `error-reporting-submission`. These are not true error codes, as such. The final commit here attempts to address making `error-fetching` do what is desired of it, but `error-authorizing` and `error-reporting-submission` types could probably use some scrutiny at some point, or perhaps a refactor is called for here, splitting out true "error code"-based types from types that are based on front-end logic.