### PR TITLE
Prevent `SubmitGradeForm` styling from applying to error dialogs

### DIFF
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -161,50 +161,58 @@ export default function SubmitGradeForm({ student }) {
   const disabled = !student;
 
   return (
-    <form className="SubmitGradeForm" autoComplete="off">
-      {validationMessage && (
-        <ValidationMessage
-          message={validationMessage}
-          open={showValidationError}
-          onClose={() => {
-            // Sync up the state when the ValidationMessage is closed
-            setValidationError(false);
-          }}
-        />
-      )}
-      <label className="SubmitGradeForm__label" htmlFor={gradeId}>
-        Grade (Out of 10)
-      </label>
-      <span className="SubmitGradeForm__grade-wrapper">
-        <input
-          className={classNames('SubmitGradeForm__grade', {
-            'is-saved': gradeSaved,
-          })}
+    <>
+      <form className="SubmitGradeForm" autoComplete="off">
+        {validationMessage && (
+          <ValidationMessage
+            message={validationMessage}
+            open={showValidationError}
+            onClose={() => {
+              // Sync up the state when the ValidationMessage is closed
+              setValidationError(false);
+            }}
+          />
+        )}
+        <label className="SubmitGradeForm__label" htmlFor={gradeId}>
+          Grade (Out of 10)
+        </label>
+        <span className="SubmitGradeForm__grade-wrapper">
+          <input
+            className={classNames('SubmitGradeForm__grade', {
+              'is-saved': gradeSaved,
+            })}
+            disabled={disabled}
+            id={gradeId}
+            ref={inputRef}
+            onInput={handleKeyDown}
+            type="input"
+            // @ts-expect-error - `defaultValue` is missing from `<input>` prop types.
+            defaultValue={grade}
+            key={student ? student.LISResultSourcedId : null}
+          />
+          <Spinner
+            className={classNames('SubmitGradeForm__fetch-spinner', {
+              'is-active': gradeLoading,
+              'is-fade-away':
+                !gradeLoading && student && student.LISResultSourcedId,
+            })}
+          />
+        </span>
+        <button
+          type="submit"
+          className="SubmitGradeForm__submit"
           disabled={disabled}
-          id={gradeId}
-          ref={inputRef}
-          onInput={handleKeyDown}
-          type="input"
-          // @ts-expect-error - `defaultValue` is missing from `<input>` prop types.
-          defaultValue={grade}
-          key={student ? student.LISResultSourcedId : null}
-        />
-        <Spinner
-          className={classNames('SubmitGradeForm__fetch-spinner', {
-            'is-active': gradeLoading,
-            'is-fade-away':
-              !gradeLoading && student && student.LISResultSourcedId,
-          })}
-        />
-      </span>
-      <button
-        type="submit"
-        className="SubmitGradeForm__submit"
-        disabled={disabled}
-        onClick={onSubmitGrade}
-      >
-        <Icon classes="SubmitGradeForm__check-icon" name="check" /> Submit Grade
-      </button>
+          onClick={onSubmitGrade}
+        >
+          <Icon classes="SubmitGradeForm__check-icon" name="check" /> Submit
+          Grade
+        </button>
+        {gradeSaving && (
+          <div className="SubmitGradeForm__loading-backdrop">
+            <Spinner className="SubmitGradeForm__submit-spinner" />
+          </div>
+        )}
+      </form>
       {!!submitGradeError && (
         <ErrorDialog
           description="Unable to submit grade"
@@ -225,11 +233,6 @@ export default function SubmitGradeForm({ student }) {
           cancelLabel="Close"
         />
       )}
-      {gradeSaving && (
-        <div className="SubmitGradeForm__loading-backdrop">
-          <Spinner className="SubmitGradeForm__submit-spinner" />
-        </div>
-      )}
-    </form>
+    </>
   );
 }


### PR DESCRIPTION
Render `ErrorDialog`s (when relevant) outside of the component's
`<form>` element to prevent form styling, etc., from interfering with
the dialog contents.

The cause of #3352 specifically was a `white-space: nowrap` rule applied to `.SubmitGradingForm`. This was being applied to dialog contents (because the dialog was inside of `form.SubmitGradingForm`), causing the dialog to have horizontal scroll.

## Before

This is on Chrome. In some browsers/OSes, this will look different, e.g. may have a scrollbar always visible:

The description is cut off on the right mid-sentence:

<img width="613" alt="Screen Shot 2021-11-08 at 11 36 44 AM" src="https://user-images.githubusercontent.com/439947/140783243-a6580577-54eb-4e25-9872-98b23abdf9e0.png">

Scrolling right looks like:

<img width="599" alt="Screen Shot 2021-11-08 at 11 36 53 AM" src="https://user-images.githubusercontent.com/439947/140783305-94626770-8481-45c6-83ff-19432288238d.png">

## After

Everything fits as expected:

<img width="608" alt="Screen Shot 2021-11-08 at 11 36 22 AM" src="https://user-images.githubusercontent.com/439947/140783329-5c3d826b-59c3-4494-bd39-b88598a41003.png">


Fixes #3352

## Testing

There are steps to reproduces this error in the original issue #3352