### PR TITLE
Don't send canvas config when not in Canvas

### DIFF
--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -30,8 +30,10 @@ class FilePickerConfig:
     @classmethod
     def canvas_config(cls, context, request, application_instance):
         """Get Canvas files config."""
+        if not context.is_canvas:
+            return None
 
-        enabled = context.is_canvas and (
+        enabled = (
             "custom_canvas_course_id" in request.params
             and application_instance.developer_key is not None
         )

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -32,6 +32,7 @@ class TestFilePickerConfig:
         }
 
     def test_canvas_config(self, context, pyramid_request, application_instance):
+        context.is_canvas = True
         pyramid_request.params["custom_canvas_course_id"] = "COURSE_ID"
 
         config = FilePickerConfig.canvas_config(
@@ -52,17 +53,26 @@ class TestFilePickerConfig:
             "ltiLaunchUrl": "http://example.com/lti_launches",
         }
 
+    def test_canvas_config_when_non_canvas(
+        self, context, pyramid_request, application_instance
+    ):
+        context.is_canvas = False
+
+        config = FilePickerConfig.canvas_config(
+            context, pyramid_request, application_instance
+        )
+
+        assert not config
+
     @pytest.mark.parametrize(
         "missing_value",
-        (None, "is_canvas", "course_id", "developer_key"),
+        (None, "course_id", "developer_key"),
     )
     @pytest.mark.usefixtures("canvas_files_enabled")
     def test_canvas_config_enabled(
         self, context, pyramid_request, application_instance, missing_value
     ):
-        if missing_value == "is_canvas":
-            context.is_canvas = False
-        elif missing_value == "course_id":
+        if missing_value == "course_id":
             pyramid_request.params.pop("custom_canvas_course_id")
         elif missing_value == "developer_key":
             application_instance.developer_key = None


### PR DESCRIPTION
While working on the BB groups PoC we found that the value "config.canvas.ltiLaunchUrl" is always used even outside canvas which doesn't seem right.  

https://github.com/hypothesis/lms/pull/3351#discussion_r745618316

In this PR the canvas config is just "{}" when not in canvas and configuring assignments on blackboard results in `Uncaught (in promise) TypeError: Failed to construct 'URL': Invalid URL` 

I think the fix might be guarding against null before this line https://github.com/hypothesis/lms/blob/e4bdc1ec49c1c46a03d14bcd61aa1b435997fa35/lms/static/scripts/frontend_apps/utils/content-item.js#L53 but I'm not sure if the type definitions need tweaking or it might have wider implications.