### PR TITLE
Rename `errorMessage` -> `serverMessage` on `APIError`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -137,7 +137,7 @@ export default function BasicLTILaunchApp() {
       // our own backend, of a known error code.
       setError(e);
       setErrorState(/** @type {ErrorState} */ (e.errorCode));
-    } else if (e instanceof APIError && !e.errorMessage && retry) {
+    } else if (e instanceof APIError && !e.serverMessage && retry) {
       // This is a special case expected by the back end. We're handling an
       // APIError resulting from an API request, but there are no further
       // details in the response body to guide us. This implicitly means that

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -31,7 +31,7 @@ function toSentence(str) {
  * @typedef ErrorLike
  * @prop {string} [message]
  * @prop {object|string} [details] - Optional JSON-serializable details of the error
- * @prop {string} [errorMessage] - Explanatory message provided by backend that
+ * @prop {string} [serverMessage] - Explanatory message provided by backend that
  *   will be preferred over `message` if it is present.
  */
 
@@ -118,11 +118,11 @@ Technical details: ${details || 'N/A'}
     `,
   });
 
-  // If `errorMessage` is extant on `error`, prefer it to `error.message` even
-  // if `errorMessage` is empty — In cases where we are displaying error
+  // If `serverMessage` is extant on `error`, prefer it to `error.message` even
+  // if `serverMessage` is empty — In cases where we are displaying error
   // information provided by the backend (i.e. `APIError`), we do not want
   // to render the JS Error instance's `message` as it likely does not apply
-  const message = error.errorMessage ?? error.message;
+  const message = error.serverMessage ?? error.message;
 
   return (
     <Scrollbox classes="LMS-Scrollbox">

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -183,7 +183,7 @@ export default function LMSFilePicker({
         }
         setDialogState({ state: 'fetched', files });
       } catch (error) {
-        if (error instanceof APIError && !error.errorMessage) {
+        if (error instanceof APIError && !error.serverMessage) {
           setDialogState({ state: 'authorizing', isRetry: isReload });
         } else {
           setDialogState({ state: 'error', error });

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -252,7 +252,7 @@ export default function LaunchErrorDialog({
       // to show here, as it's redundant and not useful
       return (
         <BaseDialog busy={busy} error={error} onRetry={onRetry}>
-          {!error?.errorMessage && (
+          {!error?.serverMessage && (
             <p>There was a problem fetching this Hypothesis assignment.</p>
           )}
         </BaseDialog>

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -151,7 +151,7 @@ describe('ErrorDisplay', () => {
     {
       error: {
         message: 'Default error message',
-        errorMessage: 'Server message',
+        serverMessage: 'Server message',
       },
       output: 'Server message.',
     },
@@ -159,7 +159,7 @@ describe('ErrorDisplay', () => {
       description: 'Something went wrong',
       error: {
         message: 'Default error message',
-        errorMessage: 'Server message',
+        serverMessage: 'Server message',
       },
       output: 'Something went wrong: Server message.',
     },
@@ -167,14 +167,14 @@ describe('ErrorDisplay', () => {
       description: 'Something went wrong',
       error: {
         message: 'Default error message',
-        errorMessage: '',
+        serverMessage: '',
       },
       output: 'Something went wrong.',
     },
     {
       error: {
         message: 'Default error message',
-        errorMessage: '',
+        serverMessage: '',
       },
     },
   ].forEach(({ description, error, output }, index) => {

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -175,10 +175,10 @@ describe('LMSFilePicker', () => {
     assert.deepEqual(pathItems3[1], fakeFolders[0]);
   });
 
-  it('shows the authorization prompt if fetching files fails with an APIError that has no `errorMessage`', async () => {
+  it('shows the authorization prompt if fetching files fails with an APIError that has no `serverMessage`', async () => {
     fakeApiCall.rejects(
       new APIError('Not authorized', {
-        /** without errorMessage */
+        /** without serverMessage */
       })
     );
 
@@ -216,7 +216,7 @@ describe('LMSFilePicker', () => {
   it('shows the "Authorize" and "Try again" buttons after 2 failed authorization requests', async () => {
     fakeApiCall.rejects(
       new APIError('Not authorized', {
-        /** without errorMessage */
+        /** without serverMessage */
       })
     );
 

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -102,11 +102,11 @@ describe('LaunchErrorDialog', () => {
   );
 
   it('only renders back-end messaging in "error-fetching" state, if provided', () => {
-    // The presence of `errorMessage` on the errorLike object will prevent the
+    // The presence of `serverMessage` on the errorLike object will prevent the
     // canned text from rendering
     const errorLike = {
       message: 'This is the JS error message',
-      errorMessage: 'This is the back-end error message',
+      serverMessage: 'This is the back-end error message',
     };
 
     const wrapper = renderDialog({

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -175,7 +175,7 @@ describe('SubmitGradeForm', () => {
     it('shows the error dialog when the grade request throws an error', () => {
       const wrapper = renderForm();
       const error = {
-        errorMessage: 'message',
+        serverMessage: 'message',
         details: 'details',
       };
       fakeGradingService.submitGrade.throws(error);
@@ -249,7 +249,7 @@ describe('SubmitGradeForm', () => {
 
     it('shows the error dialog when the grade request throws an error', () => {
       const error = {
-        errorMessage: 'message',
+        serverMessage: 'message',
         details: 'details',
       };
       fakeGradingService.fetchGrade.throws(error);

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -40,7 +40,7 @@ export class APIError extends Error {
      * May be empty if the server did not provide any details about what the
      * problem was.
      */
-    this.errorMessage = data.message ?? '';
+    this.serverMessage = data.message ?? '';
 
     /**
      * Server-provided details of the error.

--- a/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
@@ -60,7 +60,7 @@ describe('VitalSourceService', () => {
         err = e;
       }
       assert.instanceOf(err, APIError);
-      assert.equal(err.errorMessage, 'Book not found');
+      assert.equal(err.serverMessage, 'Book not found');
     });
   });
 
@@ -81,7 +81,7 @@ describe('VitalSourceService', () => {
         err = e;
       }
       assert.instanceOf(err, APIError);
-      assert.equal(err.errorMessage, 'Book not found');
+      assert.equal(err.serverMessage, 'Book not found');
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/test/errors-test.js
+++ b/lms/static/scripts/frontend_apps/test/errors-test.js
@@ -6,7 +6,7 @@ describe('APIError', () => {
 
     assert.isUndefined(error.details);
     assert.isUndefined(error.errorCode);
-    assert.equal(error.errorMessage, '');
+    assert.equal(error.serverMessage, '');
     assert.equal(error.message, 'API call failed');
     assert.equal(error.status, 404);
   });
@@ -22,7 +22,7 @@ describe('APIError', () => {
 
     assert.equal(error.details, details);
     assert.equal(error.errorCode, '4xx');
-    assert.equal(error.errorMessage, 'message');
+    assert.equal(error.serverMessage, 'message');
     assert.equal(error.message, 'API call failed');
     assert.equal(error.status, 404);
   });

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -107,9 +107,9 @@ describe('api', () => {
         assert.instanceOf(reason, APIError);
         assert.equal(reason.message, 'API call failed', '`Error.message`');
         assert.equal(
-          reason.errorMessage,
+          reason.serverMessage,
           expectedMessage,
-          '`APIError.errorMessage`'
+          '`APIError.serverMessage`'
         );
         assert.equal(reason.details, body.details, '`APIError.details`');
         assert.equal(reason.errorCode, null);


### PR DESCRIPTION
This PR follows up on a request made during review of https://github.com/hypothesis/lms/pull/3345 to name the `APIError` field pertaining to the back-end-provided error message something more clear to its meaning.

`errorMessage` is renamed `serverMessage`.