### PR TITLE
Provide link to create a support ticket from an error

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -1,5 +1,5 @@
 import { useContext } from 'preact/hooks';
-import { Modal } from '@hypothesis/frontend-shared';
+import { Link, Modal } from '@hypothesis/frontend-shared';
 
 import { Config } from '../config';
 
@@ -53,25 +53,17 @@ export default function ErrorDialogApp() {
               <li>
                 This consumer key has already been used on another site. A site
                 admin must{' '}
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://web.hypothes.is/get-help/"
-                >
+                <Link target="_blank" href="https://web.hypothes.is/get-help/">
                   request a new consumer key
-                </a>{' '}
+                </Link>{' '}
                 for this site and re-install Hypothesis.
               </li>
               <li>
                 This {"site's"} tool_consumer_instance_guid has changed. A site
                 admin must{' '}
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://web.hypothes.is/get-help/"
-                >
+                <Link target="_blank" href="https://web.hypothes.is/get-help/">
                   ask us to update the consumer key
-                </a>
+                </Link>
                 .
               </li>
             </ul>

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -17,14 +17,14 @@ export default function ErrorDialogApp() {
   const { errorDialog } = useContext(Config);
 
   const error = {
-    code: errorDialog?.errorCode,
+    errorCode: errorDialog?.errorCode,
     details: errorDialog?.errorDetails ?? '',
   };
 
   let description;
   let title;
 
-  switch (error.code) {
+  switch (error.errorCode) {
     case 'reused_consumer_key':
       title = 'Consumer key registered with another site';
       break;
@@ -43,7 +43,7 @@ export default function ErrorDialogApp() {
       contentClass="LMS-Dialog LMS-Dialog--medium"
     >
       <ErrorDisplay error={error} description={description}>
-        {error.code === 'reused_consumer_key' && (
+        {error.errorCode === 'reused_consumer_key' && (
           <>
             <p>
               This Hypothesis {"installation's"} consumer key appears to have

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -82,7 +82,7 @@ function ErrorDetails({ error }) {
  * @param {ErrorLike} error
  * @returns {string}
  */
-function formatSupportURL(errorMessage, error) {
+function supportURL(errorMessage, error) {
   const supportURL = new URL('https://web.hypothes.is/get-help/');
 
   supportURL.searchParams.append('product', 'LMS_app');
@@ -150,7 +150,7 @@ export default function ErrorDisplay({ children, description = '', error }) {
         {children}
         <p data-testid="error-links">
           If the problem persists, you can{' '}
-          <Link href={formatSupportURL(errorMessage, error)} target="_blank">
+          <Link href={supportURL(errorMessage, error)} target="_blank">
             open a support ticket
           </Link>{' '}
           or visit our{' '}

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -1,4 +1,4 @@
-import { LabeledButton, Modal } from '@hypothesis/frontend-shared';
+import { LabeledButton, Link, Modal } from '@hypothesis/frontend-shared';
 
 import { useRef } from 'preact/hooks';
 
@@ -127,13 +127,12 @@ export default function LaunchErrorDialog({
             <li>
               You don{"'"}t have permission to read the file: an instructor
               needs to{' '}
-              <a
-                target="_blank"
+              <Link
                 rel="noreferrer"
                 href="https://web.hypothes.is/help/creating-hypothesis-enabled-readings-in-blackboard/"
               >
                 give students read permission for the file
-              </a>
+              </Link>
             </li>
           </ul>
         </BaseDialog>
@@ -182,13 +181,12 @@ export default function LaunchErrorDialog({
 
           <p>
             To fix the issue,{' '}
-            <a
+            <Link
               target="_blank"
-              rel="noreferrer"
               href="https://web.hypothes.is/help/fixing-a-broken-canvas-file-link/"
             >
               edit the assignment and re-select the file
-            </a>
+            </Link>
             .
           </p>
         </BaseDialog>

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -26,12 +26,12 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
 
   const {
     authUrl = null,
-    errorCode = null,
+    errorCode,
     errorDetails = '',
     canvasScopes = /** @type {string[]} */ ([]),
   } = OAuth2RedirectError ?? {};
 
-  const error = { code: errorCode, details: errorDetails };
+  const error = { errorCode, details: errorDetails };
 
   let title;
   let description;
@@ -76,7 +76,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
       title={title}
     >
       <ErrorDisplay error={error} description={description}>
-        {error.code === 'canvas_invalid_scope' && (
+        {errorCode === 'canvas_invalid_scope' && (
           <>
             <p>
               A Canvas admin needs to edit {"Hypothesis's"} developer key and
@@ -103,7 +103,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
           </>
         )}
 
-        {error.code === 'blackboard_missing_integration' && (
+        {errorCode === 'blackboard_missing_integration' && (
           <>
             <p>
               In order to allow Hypothesis to connect to files in Blackboard,

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -1,4 +1,4 @@
-import { LabeledButton, Modal } from '@hypothesis/frontend-shared';
+import { LabeledButton, Link, Modal } from '@hypothesis/frontend-shared';
 import { useContext } from 'preact/hooks';
 
 import { Config } from '../config';
@@ -91,13 +91,12 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
             </ol>
             <p>
               For more information see:{' '}
-              <a
+              <Link
                 target="_blank"
-                rel="noopener noreferrer"
                 href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
               >
                 Canvas API Endpoints Used by the Hypothesis LMS App
-              </a>
+              </Link>
               .
             </p>
           </>
@@ -112,13 +111,12 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
             </p>
             <p>
               For more information, please have your Blackboard admin read:{' '}
-              <a
+              <Link
                 target="_blank"
-                rel="noopener noreferrer"
                 href="https://web.hypothes.is/help/enable-the-hypothesis-integration-with-blackboard-files/"
               >
                 Enable the Hypothesis Integration With Blackboard Files
-              </a>
+              </Link>
               .
             </p>
           </>

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -62,18 +62,30 @@ describe('OAuth2RedirectErrorApp', () => {
     assert.notInclude(wrapper.text(), 'A Canvas admin needs to edit');
   });
 
-  it('renders error details', () => {
+  it('renders generic error details when error code not set', () => {
     fakeConfig.errorDetails = 'Technical details';
-
     const wrapper = renderApp();
 
     const errorDisplay = wrapper.find('ErrorDisplay');
     assert.include(errorDisplay.props(), {
       description: 'Something went wrong when authorizing Hypothesis',
     });
+
+    assert.include(errorDisplay.prop('error'), {
+      details: fakeConfig.errorDetails,
+    });
+  });
+
+  it('passes on error details and error code for display', () => {
+    fakeConfig.errorDetails = 'Technical details';
+    fakeConfig.errorCode = 'blackboard_missing_integration';
+
+    const wrapper = renderApp();
+
+    const errorDisplay = wrapper.find('ErrorDisplay');
     assert.deepEqual(errorDisplay.prop('error'), {
       details: fakeConfig.errorDetails,
-      code: null,
+      errorCode: 'blackboard_missing_integration',
     });
   });
 


### PR DESCRIPTION
This PR provides a link to create a support issue from the current error wherever we display information about errors to users. It reworks the text shown to remove the "send us an email" option, and updates the link to create a support ticket to prefill the ticket form with relevant error information. This aims to make it easier for the support team to understand what a user is having trouble with.

Because the time was ripe, this PR also converts all links within help text to use the shared `Link` component. This does change the appearance of links, making them look like our "standard" (red) links.

I am going to open this PR in draft because there are still some nuances to work through, and I want to be sure to get input from @mattdricker .

The URL generated for the "open a support ticket" link:

* Always selects "LMS App (Moodle, Canvas, etc.)" for the "Hypothesis Service" field
* Always provides some sort of value for "Summary of help request". This value is dynamic based on the specific error and what kinds of meta-information we have access to about the error.
* Often provides text in the "Detailed description" field. There will be further error details in this field if the back end has provided an error code or further details (or both).

Fixes https://github.com/hypothesis/support/issues/240

### Things to consider

Removing the "send us an email" option from the help text requires reworking what remains. I've gone with _If the problem persists, you can **open a support ticket** or visit our **help documents**._ (Bolded text is linked). Input appreciated.

When pre-populating the "Detailed description" field, I think it's important not to elbow the user entirely out of the way (i.e. give them space to enter some of their own details if they'd like). I also think it's nice to give some context as to why there's a bunch of technical gobbledegook in the field. I've opted to add a human-readable prefix to values put into this field, like so:

![image](https://user-images.githubusercontent.com/439947/141187175-0bafb608-20c3-42bb-884d-f33c78e8e721.png)

Note the blank line at top to give the user space to put their cursor and start typing.

This may be way off the mark; input appreciated!

### Some examples of pre-filled form

_Note_: I've expanded the description field in this form manually by dragging it larger; by default it is quite small.

From missing scope keys error:

![image](https://user-images.githubusercontent.com/439947/141187419-7ee933f0-8ff8-423d-978f-94aa8f9ec4b4.png)

Canvas file not in course:

![image](https://user-images.githubusercontent.com/439947/141187496-8d050382-fc92-487a-9c2d-e2204bafe7ce.png)

Problem communicating with Canvas API:

![image](https://user-images.githubusercontent.com/439947/141188151-9f8631cf-e704-420f-b9e0-45de28332364.png)

### Updated link color

![image](https://user-images.githubusercontent.com/439947/141188502-ae6571d8-023e-4b41-b8f5-b85b5e89ec8d.png)

![image](https://user-images.githubusercontent.com/439947/141188542-b55658ab-62e6-47a1-92b2-a71acb30f092.png)
