### PR TITLE
Make VitalSource `BookSelector` use back-end-provided error message

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -65,7 +65,7 @@ export default function BookSelector({
       const book = await vsService.fetchBook(bookID);
       onSelectBook(book);
     } catch (err) {
-      setError(err.message);
+      setError(err.serverMessage ?? err.message);
     } finally {
       setIsLoadingBook(false);
     }


### PR DESCRIPTION
This tiny PR is an interim fix to address a regression introduced to the VitalSource book picker interface by recent error-logic changes. I have a path forward to fix this in a more sensible way—a more sensible way including providing a utility function that components can use to get a properly-formatted user-facing message for any error—but it has a dependency on #3361 and I wanted to get a quick fix out.

When a user enters a valid-looking ISBN or VitalSource book URL, but the corresponding book doesn't exist/isn't available, we should show the backend-provided API error message, not the JS Error's `message` prop.

Updated: Here is a PR with a [more thought-through overall fix](https://github.com/hypothesis/lms/pull/3367).

Before:

<img width="692" alt="Screen Shot 2021-11-11 at 8 43 51 AM" src="https://user-images.githubusercontent.com/439947/141308845-e901d7d7-0528-46ab-81fc-a3714c26c230.png">

After:

<img width="691" alt="Screen Shot 2021-11-11 at 8 42 05 AM" src="https://user-images.githubusercontent.com/439947/141308859-ba198dfc-e1fa-4969-8057-08d18b528fc9.png">


The resulting, displayed error message after these changes still needs some finesse, but it is, at least, accurate.