### PR TITLE
Extract message- and details-formatting logic to `errors` module

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -8,6 +8,7 @@ import {
 
 import { useEffect, useRef, useState } from 'preact/hooks';
 
+import { formatErrorMessage } from '../errors';
 import { useService, VitalSourceService } from '../services';
 import { extractBookID } from '../utils/vitalsource';
 
@@ -65,7 +66,7 @@ export default function BookSelector({
       const book = await vsService.fetchBook(bookID);
       onSelectBook(book);
     } catch (err) {
-      setError(err.message);
+      setError(formatErrorMessage(err));
     } finally {
       setIsLoadingBook(false);
     }

--- a/lms/static/scripts/frontend_apps/components/ErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialog.js
@@ -6,7 +6,7 @@ import ErrorDisplay from './ErrorDisplay';
  * @typedef ErrorDialogProps
  * @prop {() => any} onCancel
  * @prop {string} [description] - Message to drill down to `ErrorDisplay`
- * @prop {import('./ErrorDisplay').ErrorLike} error
+ * @prop {import('../errors').ErrorLike} error
  * @prop {string} [cancelLabel]
  */
 

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -1,6 +1,10 @@
 import { Link, Scrollbox } from '@hypothesis/frontend-shared';
 
 /**
+ * @typedef {import('../errors').ErrorLike} ErrorLike
+ */
+
+/**
  * Adds punctuation to a string if missing.
  *
  * @param {string} str
@@ -8,19 +12,6 @@ import { Link, Scrollbox } from '@hypothesis/frontend-shared';
 function toSentence(str) {
   return str.match(/[.!?]$/) ? str : str + '.';
 }
-
-/**
- * An `Error` or `Error`-like object. This allows this component to be used
- * by just passing through an `Error` without meddling with it, or manual
- * control of `message` and/or `details` if so desired.
- *
- * @typedef ErrorLike
- * @prop {string} [message]
- * @prop {object|string} [details] - Optional JSON-serializable details of the error
- * @prop {string} [errorCode] - Provided by back-end to identify error state
- * @prop {string} [serverMessage] - Explanatory message provided by backend that
- *   will be preferred over `message` if it is present.
- */
 
 /**
  * JSON-stringify `error.details` if it is extant and an object

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -1,5 +1,6 @@
 import { Link, Scrollbox } from '@hypothesis/frontend-shared';
 
+import { formatErrorMessage } from '../errors';
 /**
  * @typedef {import('../errors').ErrorLike} ErrorLike
  */
@@ -118,30 +119,17 @@ Details: ${formatErrorDetails(error) || 'N/A'}
  * @param {ErrorDisplayProps} props
  */
 export default function ErrorDisplay({ children, description = '', error }) {
-  // If `serverMessage` is extant on `error`, prefer it to `error.message` even
-  // if `serverMessage` is empty — In cases where we are displaying error
-  // information provided by the backend (i.e. `APIError`), we do not want
-  // to render the JS Error instance's `message` as it likely does not apply
-  const message = error.serverMessage ?? error.message ?? '';
-
-  // Create an error status message from the combination of `description` and
-  // `message`. As neither of these are guaranteed to be present, the
-  // resulting string may be empty.
-  const errorMessage = `${description}${
-    description && message ? ': ' : ''
-  }${message}`;
+  const message = formatErrorMessage(error, /** prefix */ description);
 
   return (
     <Scrollbox classes="LMS-Scrollbox">
       <div className="hyp-u-vertical-spacing hyp-u-padding--top--4">
-        {errorMessage && (
-          <p data-testid="error-message">{toSentence(errorMessage)}</p>
-        )}
+        {message && <p data-testid="error-message">{toSentence(message)}</p>}
 
         {children}
         <p data-testid="error-links">
           If the problem persists, you can{' '}
-          <Link href={supportURL(errorMessage, error)} target="_blank">
+          <Link href={supportURL(message, error)} target="_blank">
             open a support ticket
           </Link>{' '}
           or visit our{' '}

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -1,6 +1,7 @@
 import { Link, Scrollbox } from '@hypothesis/frontend-shared';
 
 import { formatErrorDetails, formatErrorMessage } from '../errors';
+
 /**
  * @typedef {import('../errors').ErrorLike} ErrorLike
  */
@@ -17,6 +18,9 @@ function toSentence(str) {
 /**
  * @typedef ErrorDetailsProps
  * @prop {ErrorLike} error
+ */
+
+/**
  *
  * Render pre-formatted JSON details of an error
  *
@@ -106,7 +110,7 @@ Details: ${formatErrorDetails(error) || 'N/A'}
  * @param {ErrorDisplayProps} props
  */
 export default function ErrorDisplay({ children, description = '', error }) {
-  const message = formatErrorMessage(error, /** prefix */ description);
+  const message = formatErrorMessage(error, /* prefix */ description);
 
   return (
     <Scrollbox classes="LMS-Scrollbox">

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -1,6 +1,6 @@
 import { Link, Scrollbox } from '@hypothesis/frontend-shared';
 
-import { formatErrorMessage } from '../errors';
+import { formatErrorDetails, formatErrorMessage } from '../errors';
 /**
  * @typedef {import('../errors').ErrorLike} ErrorLike
  */
@@ -12,23 +12,6 @@ import { formatErrorMessage } from '../errors';
  */
 function toSentence(str) {
   return str.match(/[.!?]$/) ? str : str + '.';
-}
-
-/**
- * JSON-stringify `error.details` if it is extant and an object
- *
- * @param {ErrorLike} error
- */
-function formatErrorDetails(error) {
-  let details = error.details ?? '';
-  if (error?.details && typeof error.details === 'object') {
-    try {
-      details = JSON.stringify(error.details, null, 2 /* indent */);
-    } catch (e) {
-      // ignore
-    }
-  }
-  return details;
 }
 
 /**
@@ -55,7 +38,11 @@ function ErrorDetails({ error }) {
   }
 
   return (
-    <details className="hyp-u-border" onToggle={onDetailsToggle}>
+    <details
+      className="hyp-u-border"
+      onToggle={onDetailsToggle}
+      data-testid="error-details"
+    >
       <summary className="hyp-u-bg-color--grey-1 hyp-u-padding ErrorDetails__summary">
         Error Details
       </summary>

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -6,9 +6,7 @@ import ErrorDisplay from './ErrorDisplay';
 
 /**
  * @typedef {import("preact").ComponentChildren} Children
- *
  * @typedef {import('./BasicLTILaunchApp').ErrorState} ErrorState
- *
  * @typedef {import('../errors').ErrorLike} ErrorLike
  */
 

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -9,7 +9,7 @@ import ErrorDisplay from './ErrorDisplay';
  *
  * @typedef {import('./BasicLTILaunchApp').ErrorState} ErrorState
  *
- * @typedef {import('./ErrorDisplay').ErrorLike} ErrorLike
+ * @typedef {import('../errors').ErrorLike} ErrorLike
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -17,7 +17,7 @@ const GRADE_MULTIPLIER = 10;
 
 /**
  * @typedef {import('../config').StudentInfo} StudentInfo
- * @typedef {import('./ErrorDisplay').ErrorLike} ErrorLike
+ * @typedef {import('../errors').ErrorLike} ErrorLike
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
@@ -18,6 +18,7 @@ const fakeBookData = {
 };
 
 describe('BookSelector', () => {
+  let fakeFormatErrorMessage;
   let fakeVitalSourceService;
   let fakeExtractBookID;
 
@@ -36,11 +37,15 @@ describe('BookSelector', () => {
 
   beforeEach(() => {
     fakeExtractBookID = sinon.stub().returns('book1');
+    fakeFormatErrorMessage = sinon.stub();
     fakeVitalSourceService = {
       fetchBook: sinon.stub().callsFake(async bookID => fakeBookData[bookID]),
     };
 
     $imports.$mock({
+      '../errors': {
+        formatErrorMessage: fakeFormatErrorMessage,
+      },
       '../utils/vitalsource': {
         extractBookID: fakeExtractBookID,
       },
@@ -274,7 +279,8 @@ describe('BookSelector', () => {
 
     context('book metadata fetch failed', () => {
       it('shows error from service exception', async () => {
-        const error = new Error('Something went wrong');
+        fakeFormatErrorMessage.returns('Something went wrong');
+        const error = new Error('Any old error');
         fakeVitalSourceService.fetchBook.rejects(error);
 
         const wrapper = renderBookSelector();
@@ -282,6 +288,7 @@ describe('BookSelector', () => {
 
         await waitForElement(wrapper, '[data-testid="error-message"]');
 
+        assert.calledWith(fakeFormatErrorMessage, error);
         const errorMessage = wrapper.find('[data-testid="error-message"]');
         assert.include(errorMessage.text(), 'Something went wrong');
       });

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -12,6 +12,19 @@
  */
 
 /**
+ * An `Error` or error-like object. This allows components in the application
+ * to work with plain-old JavaScript objects representing an error without
+ * requiring `Error` instances.
+ *
+ * @typedef ErrorLike
+ * @prop {string} [message]
+ * @prop {object|string} [details] - Optional JSON-serializable details of the error
+ * @prop {string} [errorCode] - Provided by back-end to identify error state
+ * @prop {string} [serverMessage] - Explanatory message provided by backend that
+ *   will be preferred over `message` if it is present.
+ */
+
+/**
  * Error thrown when the user cancels file selection.
  */
 export class PickerCanceledError extends Error {
@@ -67,7 +80,7 @@ export class APIError extends Error {
 }
 
 /**
- * Should the error object be treated as an authorization error?
+ * Should the error be treated as an authorization error?
  *
  * This is a special case. We're handling an APIError resulting from an API
  * request, but there are no further details in the response body to guide us.
@@ -76,7 +89,7 @@ export class APIError extends Error {
  * Put another way, if an APIError has neither an errorCode nor a serverMessage,
  * it is considered an "authorization error".
  *
- * @param {Error} error
+ * @param {ErrorLike} error
  * @returns {boolean}
  */
 export function isAuthorizationError(error) {
@@ -84,11 +97,11 @@ export function isAuthorizationError(error) {
 }
 
 /**
- * Does the current error object represent an API Error with a recognized
+ * Does the error represent an API Error with a recognized
  * backend-provided `errorCode` related to a failed attempt to launch an
  * assignment?
  *
- * @param {Error} error
+ * @param {ErrorLike} error
  * @returns {error is APIError}
  */
 export function isLTILaunchServerError(error) {

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -139,3 +139,25 @@ export function formatErrorMessage(error, prefix = '') {
   // resulting string may be empty.
   return `${prefix}${prefix && message ? ': ' : ''}${message}`;
 }
+
+/**
+ * Return a string representing error details. If `error.details` is an
+ * object, attempt to JSON-stringify it. If details is already a string, return
+ * it as-is. Return the empty string otherwise.
+ *
+ * @param {ErrorLike} error
+ * @returns {String}
+ */
+export function formatErrorDetails(error) {
+  let details = '';
+  if (error.details && typeof error.details === 'object') {
+    try {
+      details = JSON.stringify(error.details, null, 2 /* indent */);
+    } catch (e) {
+      // ignore
+    }
+  } else if (error.details) {
+    details = error.details;
+  }
+  return details;
+}

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -124,14 +124,12 @@ export function isLTILaunchServerError(error) {
  * prefix, using the appropriate message information.
  *
  * @param {ErrorLike} error
- * @param {String} [prefix]
- * @returns {String}
+ * @param {string} [prefix]
+ * @returns {string}
  */
 export function formatErrorMessage(error, prefix = '') {
-  // If `serverMessage` is extant on `error`, prefer it to `error.message` even
-  // if `serverMessage` is empty . In cases where we are displaying error
-  // information provided by the backend (i.e. `APIError`), we do not want
-  // to render the JS Error instance's `message` as it likely does not apply
+  // If any message is provided by the backend as `error.serverMessage`,
+  // prefer this for display to users even if it is empty.
   const message = error.serverMessage ?? error.message ?? '';
 
   // Create an error status message from the combination of `description` and
@@ -146,7 +144,7 @@ export function formatErrorMessage(error, prefix = '') {
  * it as-is. Return the empty string otherwise.
  *
  * @param {ErrorLike} error
- * @returns {String}
+ * @returns {string}
  */
 export function formatErrorDetails(error) {
   let details = '';

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -118,3 +118,24 @@ export function isLTILaunchServerError(error) {
     ].includes(error.errorCode)
   );
 }
+
+/**
+ * Format a user-facing message based on this error and optional contextual
+ * prefix, using the appropriate message information.
+ *
+ * @param {ErrorLike} error
+ * @param {String} [prefix]
+ * @returns {String}
+ */
+export function formatErrorMessage(error, prefix = '') {
+  // If `serverMessage` is extant on `error`, prefer it to `error.message` even
+  // if `serverMessage` is empty . In cases where we are displaying error
+  // information provided by the backend (i.e. `APIError`), we do not want
+  // to render the JS Error instance's `message` as it likely does not apply
+  const message = error.serverMessage ?? error.message ?? '';
+
+  // Create an error status message from the combination of `description` and
+  // `message`. As neither of these are guaranteed to be present, the
+  // resulting string may be empty.
+  return `${prefix}${prefix && message ? ': ' : ''}${message}`;
+}

--- a/lms/static/scripts/frontend_apps/test/errors-test.js
+++ b/lms/static/scripts/frontend_apps/test/errors-test.js
@@ -137,7 +137,7 @@ describe('formatErrorDetails', () => {
   [
     {
       error: { details: { foo: 'bar' } },
-      expected: JSON.stringify({ foo: 'bar' }, null, /** indent */ 2),
+      expected: JSON.stringify({ foo: 'bar' }, null, /* indent */ 2),
     },
     {
       error: {},
@@ -149,7 +149,7 @@ describe('formatErrorDetails', () => {
     },
     {
       error: new APIError(400, { details: { foo: 'bar' } }),
-      expected: JSON.stringify({ foo: 'bar' }, null, /** indent */ 2),
+      expected: JSON.stringify({ foo: 'bar' }, null, /* indent */ 2),
     },
     {
       error: { details: null },

--- a/lms/static/scripts/frontend_apps/test/errors-test.js
+++ b/lms/static/scripts/frontend_apps/test/errors-test.js
@@ -1,5 +1,6 @@
 import {
   APIError,
+  formatErrorMessage,
   isAuthorizationError,
   isLTILaunchServerError,
 } from '../errors';
@@ -88,6 +89,45 @@ describe('isLTILaunchServerError', () => {
   ].forEach(testCase => {
     it('should return `true` if the error has a recognized error code', () => {
       assert.equal(isLTILaunchServerError(testCase.error), testCase.expected);
+    });
+  });
+});
+
+describe('formatErrorMessage', () => {
+  [
+    {
+      error: new Error('This is any old error'),
+      expected: 'This is any old error',
+    },
+    {
+      error: new APIError(400, { message: 'This is a server error' }),
+      expected: 'This is a server error',
+    },
+    {
+      error: new APIError(400, {}),
+      expected: '',
+    },
+    {
+      error: new APIError(400, {}),
+      prefix: 'Something went wrong',
+      expected: 'Something went wrong',
+    },
+    {
+      error: new APIError(404, { message: 'This is a server explanation' }),
+      prefix: 'Something went wrong',
+      expected: 'Something went wrong: This is a server explanation',
+    },
+    {
+      error: new Error('Any old error'),
+      prefix: 'Something went wrong',
+      expected: 'Something went wrong: Any old error',
+    },
+  ].forEach((testCase, idx) => {
+    it(`should format the error message (${idx})`, () => {
+      assert.equal(
+        formatErrorMessage(testCase.error, testCase.prefix),
+        testCase.expected
+      );
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/test/errors-test.js
+++ b/lms/static/scripts/frontend_apps/test/errors-test.js
@@ -1,5 +1,6 @@
 import {
   APIError,
+  formatErrorDetails,
   formatErrorMessage,
   isAuthorizationError,
   isLTILaunchServerError,
@@ -128,6 +129,43 @@ describe('formatErrorMessage', () => {
         formatErrorMessage(testCase.error, testCase.prefix),
         testCase.expected
       );
+    });
+  });
+});
+
+describe('formatErrorDetails', () => {
+  [
+    {
+      error: { details: { foo: 'bar' } },
+      expected: JSON.stringify({ foo: 'bar' }, null, /** indent */ 2),
+    },
+    {
+      error: {},
+      expected: '',
+    },
+    {
+      error: new APIError(400, { details: 'Hiya' }),
+      expected: 'Hiya',
+    },
+    {
+      error: new APIError(400, { details: { foo: 'bar' } }),
+      expected: JSON.stringify({ foo: 'bar' }, null, /** indent */ 2),
+    },
+    {
+      error: { details: null },
+      expected: '',
+    },
+    {
+      error: { details: {} },
+      expected: '{}',
+    },
+    {
+      error: { details: new Error('foo') },
+      expected: '{}',
+    },
+  ].forEach(testCase => {
+    it('should format error details', () => {
+      assert.equal(formatErrorDetails(testCase.error), testCase.expected);
     });
   });
 });


### PR DESCRIPTION
Depends on #3361 

This PR extracts the logic used to format error messages and error details into the `errors` module, and moves the `ErrorLike` type into this module as well. 

The goal is to centralize some of this logic so that we don't end up with regressions like https://github.com/hypothesis/lms/pull/3366 aims to address. This work represents a more "proper" fix than https://github.com/hypothesis/lms/pull/3366, but it has a dependency. This work could supersede that work if the dependency lands quickly.

