### PR TITLE
Rename "URL-configured" assignments to "legacy Canvas" assignments

### DIFF
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -259,7 +259,7 @@ class BasicLTILaunchViews:
         return self.basic_lti_launch(document_url)
 
     @view_config(url_configured=True, schema=URLConfiguredBasicLTILaunchSchema)
-    def url_configured_basic_lti_launch(self):
+    def legacy_canvas_lti_launch(self):
         """
         Respond to a URL-configured assignment launch.
 


### PR DESCRIPTION
URL-configured assignments were only ever used in Canvas and are now legacy.