### PR TITLE
Wrap dialog widths in media query for correct size on narrow screens

### DIFF
--- a/lms/static/styles/_frontend-shared.scss
+++ b/lms/static/styles/_frontend-shared.scss
@@ -7,14 +7,16 @@
 .LMS-Dialog {
   // The containing `Modal` component will take up 90vw on narrow screens.
   // For viewports that are wider, `Modal` sets a min-width, but it's a little
-  // narrow for several LMS Dialog interfaces.
+  // narrow for several LMS Dialog interfaces. `48rem` breakpoint is sourced
+  // from `frontend-shared`'s Dialog and Modal styling.
+  @media screen and (min-width: 48rem) {
+    &--medium {
+      width: min(90vw, 36rem);
+    }
 
-  &--medium {
-    width: min(90vw, 36rem);
-  }
-
-  &--wide {
-    width: min(90vw, 42rem);
+    &--wide {
+      width: min(90vw, 42rem);
+    }
   }
 
   // Set a preferred height on interfaces that should take up a good chunk


### PR DESCRIPTION
Dialogs influenced by local width styles were displaying off-center on
narrow screens in certain circumstances.

The rem-based widths in the LMS local dialog-width overrides were in
conflict with underlying styles for narrow screens. Narrow screens
already make dialogs the right size and position, and these adjustments
should only apply to wider breakpoints. The comment even hinted to that.

Fix by wrapping in a harmonious media query: dialogs will not appear
off-center on narrow screens.

Before:

<img width="735" alt="Screen Shot 2021-11-15 at 9 10 26 AM" src="https://user-images.githubusercontent.com/439947/141797163-9118a398-ab5a-4145-8d4e-0f3cb62db9cf.png">

After:

<img width="734" alt="Screen Shot 2021-11-15 at 9 11 25 AM" src="https://user-images.githubusercontent.com/439947/141797172-5a7ce07d-6c29-44a5-9055-8c25c01cd4b2.png">


