### PR TITLE
Fix Canvas API timeout

### DIFF
--- a/lms/services/canvas_api/_basic.py
+++ b/lms/services/canvas_api/_basic.py
@@ -86,7 +86,7 @@ class BasicClient:
         response = None
 
         try:
-            response = self._session.send(request, timeout=9)
+            response = self._session.send(request, timeout=(10, 10))
             response.raise_for_status()
         except RequestException as err:
             CanvasAPIError.raise_from(err, request, response)


### PR DESCRIPTION
Fix the Canvas API code to use the same timeout as used by HTTP service.
This is a slightly longer timeout (10s instead of 9s) to follow the
requests docs advice:

>  It's a good practice to set connect timeouts to slightly larger than
> a multiple of 3, which is the default TCP packet retransmission
> window.

See:

https://docs.python-requests.org/en/latest/user/advanced/#timeouts

We also pass both timeouts separately, even though they're the same
value, just to be explicit that there are separate connect and read
timeouts.