### PR TITLE
Revert "Enable canvas assignment creation API"

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -74,19 +74,23 @@ class JSConfig:
                     resource_link_id=self._request.params["resource_link_id"],
                 ),
             }
-        elif document_url.startswith("vitalsource://"):
-            vitalsource_svc = self._request.find_service(name="vitalsource")
-            launch_url, launch_params = vitalsource_svc.get_launch_params(
-                document_url, self._request.lti_user
-            )
-            self._config["vitalSource"] = {
-                "launchUrl": launch_url,
-                "launchParams": launch_params,
-            }
         else:
             self._config["viaUrl"] = via_url(self._request, document_url)
 
         self._add_canvas_speedgrader_settings(document_url=document_url)
+
+    def add_vitalsource_launch_config(self, book_id, cfi=None):
+        vitalsource_svc = self._request.find_service(name="vitalsource")
+        launch_url, launch_params = vitalsource_svc.get_launch_params(
+            book_id, cfi, self._request.lti_user
+        )
+        self._config["vitalSource"] = {
+            "launchUrl": launch_url,
+            "launchParams": launch_params,
+        }
+        self._add_canvas_speedgrader_settings(
+            vitalsource_book_id=book_id, vitalsource_cfi=cfi
+        )
 
     def asdict(self):
         """

--- a/lms/services/vitalsource/client.py
+++ b/lms/services/vitalsource/client.py
@@ -1,16 +1,8 @@
-import re
-
 import oauthlib
 from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1, SIGNATURE_TYPE_BODY
 
 from lms.services.exceptions import ExternalRequestError
 from lms.services.vitalsource._schemas import BookInfoSchema, BookTOCSchema
-
-#: A regex for parsing the BOOK_ID and CFI parts out of one of our custom
-#: vitalsource://book/bookID/BOOK_ID/cfi/CFI URLs.
-DOCUMENT_URL_REGEX = re.compile(
-    r"vitalsource:\/\/book\/bookID\/(?P<book_id>[^\/]*)\/cfi\/(?P<cfi>.*)"
-)
 
 
 class VitalSourceService:
@@ -62,11 +54,7 @@ class VitalSourceService:
 
         return BookTOCSchema(response).parse()
 
-    @staticmethod
-    def parse_document_url(document_url):
-        return DOCUMENT_URL_REGEX.search(document_url).groupdict()
-
-    def get_launch_params(self, document_url, lti_user):
+    def get_launch_params(self, book_id, cfi, lti_user):
         """
         Return the form params needed to launch the VitalSource book viewer.
 
@@ -76,13 +64,11 @@ class VitalSourceService:
 
         See https://developer.vitalsource.com/hc/en-us/articles/215612237-POST-LTI-Create-a-Bookshelf-Launch
 
-        :param document_url: `vitalsource://` type URL identifying the document.
+        :param book_id: The VitalSource book ID ("vbid")
+        :param cfi: Book location, as a Canonical Fragment Identifier, for deep linking.
         :param lti_user: Current LTI user information, from the LTI launch request
         :type lti_user: LTIUser
         """
-        url_params = self.parse_document_url(document_url)
-        book_id = url_params["book_id"]
-        cfi = url_params["cfi"]
 
         launch_url = f"https://bc.vitalsource.com/books/{book_id}"
         book_location = "/cfi" + cfi

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -216,8 +216,8 @@ export default function BasicLTILaunchApp() {
       return;
     }
 
-    // Don't report a submission until we have the data needed to display the assignment content
-    if (!contentUrl && !vitalSourceConfig) {
+    // Don't report a submission until the URL has been successfully fetched.
+    if (!contentUrl) {
       return;
     }
     try {
@@ -233,7 +233,7 @@ export default function BasicLTILaunchApp() {
       // submission.
       handleError(e, 'error-reporting-submission', false);
     }
-  }, [authToken, canvas.speedGrader, contentUrl, vitalSourceConfig]);
+  }, [authToken, canvas.speedGrader, contentUrl]);
 
   useEffect(() => {
     reportSubmission();

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
@@ -13,7 +13,6 @@ import { contentItemForContent } from '../utils/content-item';
  * @prop {Record<string,string>} formFields - Form fields provided by the backend
  *   that should be included in the response without any changes
  * @prop {string|null} groupSet
- * @prop {string|null} extLTIAssignmentId
  */
 
 /**
@@ -35,13 +34,9 @@ export default function FilePickerFormFields({
   formFields,
   groupSet,
   ltiLaunchURL,
-  extLTIAssignmentId,
 }) {
   /** @type {Record<string,string>} */
   const extraParams = groupSet ? { group_set: groupSet } : {};
-  if (extLTIAssignmentId) {
-    extraParams.ext_lti_assignment_id = extLTIAssignmentId;
-  }
   const contentItem = JSON.stringify(
     contentItemForContent(ltiLaunchURL, content, extraParams)
   );

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -64,23 +64,6 @@ describe('FilePickerFormFields', () => {
     );
   });
 
-  it('adds `ext_lti_assignment_id` query param to LTI launch URL if `extLTIAssignmentId` prop is specified', () => {
-    const content = { type: 'url', url: 'https://example.com/' };
-    const formFields = createComponent({
-      content,
-      extLTIAssignmentId: 'EXT_LTI_ASSIGNMENT_ID',
-    });
-    const contentItems = JSON.parse(
-      formFields.find('input[name="content_items"]').prop('value')
-    );
-    assert.deepEqual(
-      contentItems,
-      contentItemForContent(launchURL, content, {
-        ext_lti_assignment_id: 'EXT_LTI_ASSIGNMENT_ID',
-      })
-    );
-  });
-
   it('renders `document_url` field for URL content', () => {
     const formFields = createComponent({
       content: { type: 'url', url: 'https://example.com/' },

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -118,7 +118,6 @@ class URLConfiguredBasicLTILaunchSchema(BasicLTILaunchSchema):
             url.lower().startswith("http%3a")
             or url.lower().startswith("https%3a")
             or url.lower().startswith("canvas%3a")
-            or url.lower().startswith("vitalsource%3a")
         ):
             url = unquote(url)
             _data["url"] = url

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -165,8 +165,9 @@ class BasicLTILaunchViews:
 
     @view_config(
         db_configured=True,
-        legacy_speedgrader=False,
+        canvas_file=False,
         request_param="ext_lti_assignment_id",
+        url_configured=False,
     )
     def canvas_db_configured_basic_lti_launch(self):
         """Respond to a Canvas DB-configured assignment launch."""

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -122,6 +122,26 @@ class BasicLTILaunchViews:
         )
         return self.basic_lti_launch(document_url=document_url, grading_supported=False)
 
+    @view_config(vitalsource_book=True)
+    def vitalsource_lti_launch(self):
+        """
+        Respond to a VitalSource book launch.
+
+        The book and chapter to show are configured by `book_id` and `cfi` request
+        parameters. VitalSource book launches involve a second LTI launch.
+        Hypothesis's LMS app generates the form parameters needed to load
+        VitalSource's book viewer using an LTI launch. The LMS frontend then
+        renders these parameters into a form and auto-submits the form to perform
+        an authenticated launch of the VS book viewer.
+        """
+        self.sync_lti_data_to_h()
+        self.store_lti_data()
+        self.context.js_config.maybe_enable_grading()
+        self.context.js_config.add_vitalsource_launch_config(
+            self.request.params["book_id"], self.request.params.get("cfi")
+        )
+        return {}
+
     @view_config(db_configured=True, canvas_file=False, url_configured=False)
     def db_configured_basic_lti_launch(self):
         """

--- a/lms/views/predicates/__init__.py
+++ b/lms/views/predicates/__init__.py
@@ -14,6 +14,7 @@ from lms.views.predicates._lti_launch import (
     DBConfigured,
     LegacySpeedGrader,
     URLConfigured,
+    VitalSourceBook,
 )
 
 
@@ -24,6 +25,7 @@ def includeme(config):
         BrightspaceCopied,
         CanvasFile,
         URLConfigured,
+        VitalSourceBook,
         Configured,
         AuthorizedToConfigureAssignments,
         LegacySpeedGrader,

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -186,6 +186,13 @@ class CanvasFile(Base):
         return ("canvas_file" in request.params) == self.value
 
 
+class VitalSourceBook(Base):
+    name = "vitalsource_book"
+
+    def __call__(self, context, request):
+        return ("vitalsource_book" in request.params) == self.value
+
+
 class URLConfigured(Base):
     """
     Allow invoking an LTI launch view only for URL-configured assignments.
@@ -241,6 +248,7 @@ class Configured(Base):
         self.db_configured = DBConfigured(True, config)
         self.blackboard_copied = BlackboardCopied(True, config)
         self.brightspace_copied = BrightspaceCopied(True, config)
+        self.vitalsource_book = VitalSourceBook(True, config)
 
     def __call__(self, context, request):
         configured = any(
@@ -250,6 +258,7 @@ class Configured(Base):
                 self.db_configured(context, request),
                 self.blackboard_copied(context, request),
                 self.brightspace_copied(context, request),
+                self.vitalsource_book(context, request),
             ]
         )
         return configured == self.value

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -171,25 +171,6 @@ class TestAddDocumentURL:
             "path": "/api/blackboard/courses/test_course_id/via_url?document_url=blackboard%3A%2F%2Fcontent-resource%2Fxyz123",
         }
 
-    def test_vitalsource_sets_config(
-        self, js_config, vitalsource_service, pyramid_request
-    ):
-        vitalsource_url = "vitalsource://book/bookID/book-id/cfi//abc"
-        vitalsource_service.get_launch_params.return_value = (
-            mock.sentinel.launch_url,
-            mock.sentinel.launch_params,
-        )
-
-        js_config.add_document_url(vitalsource_url)
-
-        vitalsource_service.get_launch_params.assert_called_with(
-            vitalsource_url, pyramid_request.lti_user
-        )
-        assert js_config.asdict()["vitalSource"] == {
-            "launchUrl": mock.sentinel.launch_url,
-            "launchParams": mock.sentinel.launch_params,
-        }
-
     def test_it_adds_the_viaUrl_api_config_for_Canvas_documents(
         self, js_config, pyramid_request
     ):
@@ -266,6 +247,41 @@ class TestAddDocumentURL:
         js_config.add_document_url("canvas://file/course_id/COURSE_ID/file_id/FILE_ID")
 
         assert "speedGrader" not in js_config.asdict()["canvas"]
+
+
+class TestAddVitalsourceLaunchConfig:
+    """Unit tests for JSConfig.add_vitalsource_launch_config()."""
+
+    def test_it_sets_vitalsource_config(
+        self, js_config, pyramid_request, vitalsource_service
+    ):
+        js_config.add_vitalsource_launch_config("book-id", "/abc")
+
+        vitalsource_service.get_launch_params.assert_called_with(
+            "book-id", "/abc", pyramid_request.lti_user
+        )
+        assert js_config.asdict()["vitalSource"] == {
+            "launchUrl": mock.sentinel.launch_url,
+            "launchParams": mock.sentinel.launch_params,
+        }
+
+    def test_it_sets_submission_params(self, js_config, submission_params):
+        js_config.add_vitalsource_launch_config("book-id", "/abc")
+
+        assert submission_params() == Any.dict.containing(
+            {
+                "vitalsource_book_id": "book-id",
+                "vitalsource_cfi": "/abc",
+            }
+        )
+
+    @pytest.fixture
+    def vitalsource_service(self, vitalsource_service):
+        vitalsource_service.get_launch_params.return_value = (
+            mock.sentinel.launch_url,
+            mock.sentinel.launch_params,
+        )
+        return vitalsource_service
 
 
 class TestMaybeEnableGrading:

--- a/tests/unit/lms/services/vitalsource/client_test.py
+++ b/tests/unit/lms/services/vitalsource/client_test.py
@@ -26,23 +26,8 @@ class TestVitalSourceService:
         with pytest.raises(ValueError, match="VitalSource credentials are missing"):
             VitalSourceService(http_service, lti_key, lti_secret, api_key)
 
-    @pytest.mark.parametrize(
-        "url,book_id,cfi",
-        [
-            ("vitalsource://book/bookID/book-id/cfi//abc", "book-id", "/abc"),
-            ("vitalsource://book/bookID/book-id/cfi/abc", "book-id", "abc"),
-        ],
-    )
-    def test_parse_document_url(self, svc, url, book_id, cfi):
-        assert svc.parse_document_url(url) == {
-            "book_id": book_id,
-            "cfi": cfi,
-        }
-
     def test_it_generates_lti_launch_form_params(self, svc, lti_user):
-        launch_url, params = svc.get_launch_params(
-            "vitalsource://book/bookID/book-id/cfi//abc", lti_user
-        )
+        launch_url, params = svc.get_launch_params("book-id", "/abc", lti_user)
 
         # Ignore OAuth signature params in this test.
         params = {k: v for (k, v) in params.items() if not k.startswith("oauth_")}
@@ -61,7 +46,7 @@ class TestVitalSourceService:
     def test_it_uses_correct_launch_key_and_secret_to_sign_params(
         self, svc, lti_user, OAuth1Client
     ):
-        svc.get_launch_params("vitalsource://book/bookID/book-id/cfi//abc", lti_user)
+        svc.get_launch_params("book-id", "/cfi", lti_user)
 
         OAuth1Client.assert_called_with(
             "lti_launch_key",
@@ -71,9 +56,7 @@ class TestVitalSourceService:
         )
 
     def test_it_signs_lti_launch_form_params(self, svc, lti_user):
-        _, params = svc.get_launch_params(
-            "vitalsource://book/bookID/book-id/cfi//abc", lti_user
-        )
+        _, params = svc.get_launch_params("book-id", "/cfi", lti_user)
 
         # Ignore non-OAuth signature params in this test.
         params = {k: v for (k, v) in params.items() if k.startswith("oauth_")}

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -151,6 +151,25 @@ def configure_assignment_caller(context, pyramid_request):
     return views.configure_assignment()
 
 
+def vitalsource_lti_launch_caller(context, pyramid_request):
+    """
+    Call BasicLTILaunchViews.vitalsource_lti_launch().
+
+    Set up the appropriate conditions and then call
+    BasicLTILaunchViews.vitalsource_lti_launch(), and return whatever
+    BasicLTILaunchViews.vitalsource_lti_launch() returns.
+    """
+
+    # The book_id and cfi params are assumed present when vitalsource_lti_launch()
+    # is called.
+    pyramid_request.params["book_id"] = "book-id"
+    pyramid_request.params["cfi"] = "/abc"
+
+    views = BasicLTILaunchViews(context, pyramid_request)
+
+    return views.vitalsource_lti_launch()
+
+
 class TestBasicLTILaunchViewsInit:
     """Unit tests for BasicLTILaunchViews.__init__()."""
 
@@ -228,6 +247,7 @@ class TestCommon:
             brightspace_copied_basic_lti_launch_caller,
             url_configured_basic_lti_launch_caller,
             configure_assignment_caller,
+            vitalsource_lti_launch_caller,
         ]
     )
     def view_caller(self, request):
@@ -456,6 +476,19 @@ class TestUnconfiguredBasicLTILaunchNotAuthorized:
         ).unconfigured_basic_lti_launch_not_authorized()
 
         assert data == {}
+
+
+class TestVitalsourceLTILaunch:
+    def test_it_adds_vitalsource_launch_config(self, context, pyramid_request):
+        pyramid_request.params.update(
+            {"vitalsource_book": "true", "book_id": "book-id", "cfi": "/abc"}
+        )
+
+        BasicLTILaunchViews(context, pyramid_request).vitalsource_lti_launch()
+
+        context.js_config.add_vitalsource_launch_config.assert_called_once_with(
+            "book-id", "/abc"
+        )
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/predicates/__init___test.py
+++ b/tests/unit/lms/views/predicates/__init___test.py
@@ -10,6 +10,7 @@ from lms.views.predicates._lti_launch import (
     DBConfigured,
     LegacySpeedGrader,
     URLConfigured,
+    VitalSourceBook,
 )
 
 
@@ -24,6 +25,7 @@ def test_includeme_adds_the_view_predicates():
         mock.call("brightspace_copied", BrightspaceCopied),
         mock.call("canvas_file", CanvasFile),
         mock.call("url_configured", URLConfigured),
+        mock.call("vitalsource_book", VitalSourceBook),
         mock.call("configured", Configured),
         mock.call(
             "authorized_to_configure_assignments", AuthorizedToConfigureAssignments

--- a/tests/unit/lms/views/predicates/_lti_launch_test.py
+++ b/tests/unit/lms/views/predicates/_lti_launch_test.py
@@ -13,6 +13,7 @@ from lms.views.predicates import (
     DBConfigured,
     LegacySpeedGrader,
     URLConfigured,
+    VitalSourceBook,
 )
 from tests import factories
 
@@ -150,6 +151,23 @@ class TestCanvasFile:
         assert predicate(context, pyramid_request) is expected
 
 
+class TestVitalSourceBook:
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_vitalsource_book(self, value, expected):
+        request = DummyRequest(params={"vitalsource_book": "true"})
+        predicate = VitalSourceBook(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, False), (False, True)])
+    def test_when_assignment_is_not_vitalsource_book(
+        self, value, expected, pyramid_request
+    ):
+        predicate = VitalSourceBook(value, mock.sentinel.config)
+
+        assert predicate(mock.sentinel.context, pyramid_request) is expected
+
+
 class TestURLConfigured:
     @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
     def test_when_assignment_is_url_configured(
@@ -197,6 +215,15 @@ class TestConfigured:
     ):
         assignment_service.exists.return_value = True
 
+        predicate = Configured(value, mock.sentinel.config)
+
+        assert predicate(context, pyramid_request) is expected
+
+    @pytest.mark.parametrize("value,expected", [(True, True), (False, False)])
+    def test_when_assignment_is_vitalsource_book(
+        self, pyramid_request, value, expected, context
+    ):
+        pyramid_request.params = {"vitalsource_book": True}
         predicate = Configured(value, mock.sentinel.config)
 
         assert predicate(context, pyramid_request) is expected


### PR DESCRIPTION
Reverts hypothesis/lms#3126

We seem to be missing a value for `ext_lti_assignment_id` while configuring the assignment on some Canvas instances.

https://hypothes-is.slack.com/archives/C01RAT0PE72/p1636982594002600

To test it, create assignments using master:

1. Configured but never launched (will only have ext_lti_assignment_id)
2. Configured and launched (will have values for both ext_lti_assignment_id and resource_link_id)

Launch them in this branch, they should launch successfully and to the same document.