### PR TITLE
Use a longer timeout for "user's groups" requests

### DIFF
--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -319,14 +319,23 @@ class CanvasAPIClient:
         :param include_users: Optionally include all the users in each group
         """
         params = {"only_own_groups": only_own_groups}
+        send_kwargs = {}
+
         if include_users:
             params["include[]"] = "users"
+
+            # It looks like Canvas's course groups API may sometimes be very
+            # slow when called with ?include[]=users (possibly for courses that
+            # have many users) so use a larger timeout for these particular
+            # requests.
+            send_kwargs["timeout"] = (20, 20)
 
         return self._client.send(
             "GET",
             f"courses/{course_id}/groups",
             params=params,
             schema=self._ListGroups,
+            **send_kwargs,
         )
 
     def current_user_groups(self, course_id, group_category_id=None):

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -187,8 +187,11 @@ class TestCanvasAPIClient:
             "per_page": Any.string(),
             "only_own_groups": str(only_own_groups),
         }
+        expected_timeout = Any()
+
         if include_users:
             expected_params["include[]"] = "users"
+            expected_timeout = (20, 20)  # pylint:disable=redefined-variable-type
 
         http_session.send.assert_called_once_with(
             Any.request(
@@ -197,7 +200,7 @@ class TestCanvasAPIClient:
                     expected_params
                 ),
             ),
-            timeout=Any(),
+            timeout=expected_timeout,
         )
 
     @pytest.mark.usefixtures("list_groups_response")


### PR DESCRIPTION
This is an attempt to fix https://github.com/hypothesis/lms/issues/3392.

Use `(20, 20)` (instead of the default `(10, 10)`) as the `requests` timeout only when making `courses/{course_id}/groups?include[]=users` requests. Keep the default timeout for all other requests.

This requires refactoring `BasicClient` and `AuthenticatedClient` to allow `CanvasAPIClient` to pass in a custom timeout only for the `courses/{course_id}/groups?include[]=users` calls. `CanvasAPIClient` needs to pass the custom timeout to `AuthenticatedClient.send()` which needs to pass it to `BasicClient.send()` which needs to pass it to `BasicClient._send_prepared()` which passes it to `requests.Session.send()`.