### PR TITLE
New get method on UserService

### DIFF
--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -6,12 +6,12 @@ from h_matchers import Any
 
 from lms.models import User
 from lms.services import UserService
-from lms.services.user import factory
+from lms.services.user import UserNotFound, factory
 from tests import factories
 
 
 class TestUserService:
-    def test_it_with_a_new_user(
+    def test_store_lti_user(
         self, service, lti_user, db_session, application_instance_service
     ):
         service.store_lti_user(lti_user)
@@ -31,15 +31,25 @@ class TestUserService:
             }
         )
 
-    def test_it_with_an_existing_user(self, service, user, lti_user, db_session):
+    def test_store_lti_user_with_an_existing_user(
+        self, service, user, lti_user, db_session
+    ):
         service.store_lti_user(lti_user)
 
-        users = list(db_session.query(User))
-        print(users)
+        list(db_session.query(User))
 
         saved_user = db_session.query(User).one()
         assert saved_user.id == user.id
         assert saved_user.roles == lti_user.roles
+
+    def test_get(self, user, service):
+        db_user = service.get(user.application_instance, user.user_id)
+
+        assert db_user == user
+
+    def test_get_not_found(self, user, service):
+        with pytest.raises(UserNotFound):
+            service.get(user.application_instance, "some-other-id")
 
     @pytest.fixture
     def application_instance(self, application_instance_service):
@@ -63,9 +73,9 @@ class TestUserService:
     @pytest.fixture
     def service(self, db_session, application_instance_service):
         return UserService(
+            application_instance_service,
+            db_session,
             h_authority="authority.example.com",
-            db_session=db_session,
-            application_instance_service=application_instance_service,
         )
 
 
@@ -74,9 +84,9 @@ class TestFactory:
         user_service = factory(sentinel.context, pyramid_request)
 
         UserService.assert_called_once_with(
-            application_instance_service=application_instance_service,
-            db_session=pyramid_request.db,
-            h_authority=pyramid_request.registry.settings["h_authority"],
+            application_instance_service,
+            pyramid_request.db,
+            pyramid_request.registry.settings["h_authority"],
         )
         assert user_service == UserService.return_value
 


### PR DESCRIPTION
Note that the service is no longer a dataclass as it was not possible to use `lru_cache` without extra modification.

Between having to either have to play with different dataclass option and/or having to add a __hash__ method I prefer switching to a traditional class, there's no really data here. Renamed a db_session to db and added `_` for all fields to match other services.