### PR TITLE
Refresh format requirements

### DIFF
--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -6,7 +6,7 @@
 #
 black==21.10b0
     # via -r requirements/format.in
-click==7.1.2
+click==8.0.3
     # via black
 isort==5.10.1
     # via -r requirements/format.in
@@ -14,11 +14,11 @@ mypy-extensions==0.4.3
     # via black
 pathspec==0.9.0
     # via black
-platformdirs==2.2.0
+platformdirs==2.4.0
     # via black
-regex==2021.4.4
+regex==2021.11.10
     # via black
-tomli==1.0.4
+tomli==1.2.2
     # via black
-typing-extensions==3.10.0.1
+typing-extensions==4.0.0
     # via black


### PR DESCRIPTION
On master:

`hdev requirements` fails as it can't satisfy a constraint on `tomli`

I removed `requirements/format.txt`, run `hdev requirements` and this is the result.