### PR TITLE
Split the Canvas `oauth2_redirect_error()` exception view into multiple separate views

### DIFF
--- a/lms/services/canvas_api/_authenticated.py
+++ b/lms/services/canvas_api/_authenticated.py
@@ -81,7 +81,7 @@ class AuthenticatedClient:
         # https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#post-login-oauth2-token
         return self._send_token_request(
             grant_type="authorization_code",
-            code=authorization_code,
+            code="foo",
             redirect_uri=self._redirect_uri,
             replace_tokens=True,
         )

--- a/lms/services/canvas_api/_basic.py
+++ b/lms/services/canvas_api/_basic.py
@@ -86,6 +86,7 @@ class BasicClient:
         response = None
 
         try:
+            import pdb; pdb.set_trace()
             response = self._session.send(request, timeout=(10, 10))
             response.raise_for_status()
         except RequestException as err:

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -98,6 +98,7 @@ def oauth2_redirect(request):
     try:
         canvas_api_client.get_token(authorization_code)
     except CanvasAPIServerError as err:
+        import pdb; pdb.set_trace()
         raise HTTPInternalServerError("Authorizing with the Canvas API failed") from err
 
     return {}
@@ -113,7 +114,8 @@ def oauth2_redirect(request):
     route_name="canvas_api.oauth.authorize",
     renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
 )
-def oauth2_redirect_error(request):
+def oauth2_redirect_error(context, request):
+    import pdb; pdb.set_trace()
     kwargs = {
         "auth_route": "canvas_api.oauth.authorize",
         "canvas_scopes": FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,


### PR DESCRIPTION
### Problem

The single `oauth2_redirect_error()` exception view currently handles several different cases. The result is quite confusing and is making it difficult for me to make changes that I want to make for https://github.com/hypothesis/lms/issues/3322. I want to extend the view code to handle `ExternalRequestError`'s more thoroughly (report them to Sentry etc), but any changes that I make to the view that expect `context` to be an `ExternalRequestError` end up crashing in the various situations where `context` is some completely different exception.

The use of a single exception view here is also just obscuring things: there are actually several completely different things that can go wrong here and that are handled differently, but the code doesn't look like it.

The several different cases that go through this view also all result in the same generic "Something went wrong" error dialog. There's no indication of what went wrong, no way to distinguish between the different cases.

Nothing gets reported to Sentry for any of the error cases either (because the exception is always handled by an exception view that always returns a 200 OK status for the error page).

### Solution

A separate exception view for each case will bring out the different cases more clearly and will make the code easier to maintain (making changes to one error case without breaking the other cases).

### Testing

Some (all?) of the different cases that currently go through the single `oauth2_redirect_error()` exception view are:

1. If the `authorize()` view (`"canvas_api.oauth.authorize"` route) raises `ApplicationInstanceNotFound`:

   ```diff
   diff --git a/lms/services/application_instance.py b/lms/services/application_instance.py
   index e2eef774..feef7569 100644
   --- a/lms/services/application_instance.py
   +++ b/lms/services/application_instance.py
   @@ -27,7 +27,12 @@ class ApplicationInstanceService:
            """
 
            if self._request.lti_user:
   -            return self.get_by_consumer_key(self._request.lti_user.oauth_consumer_key)
   +            consumer_key = self._request.lti_user.oauth_consumer_key
   +
   +            if self._request.path == '/api/canvas/oauth/authorize':
   +                consumer_key = "foo"
   +
   +            return self.get_by_consumer_key(consumer_key)
 
            raise ApplicationInstanceNotFound()
   ```
   
   In this case the `oauth2_redirect_error()` view will be called and the `context` argument will be an `ApplicationInstanceNotFound` exception. The exception view ends up calling `enable_oauth2_redirect_error_mode()` with no `error_code` or `error_details` which results in a generic "Something went wrong" error dialog from the frontend.

2. If the same `authorize()` view raises `ValueError`:

   ```diff
   diff --git a/lms/models/application_instance.py b/lms/models/application_instance.py
   index 28439c7a..21ed374b 100644
   --- a/lms/models/application_instance.py
   +++ b/lms/models/application_instance.py
   @@ -109,7 +109,7 @@ class ApplicationInstance(BASE):
            :raise ValueError: if the ApplicationInstance's lms_url can't be parsed
            """
            # urlparse() or .netloc will raise ValueError for some invalid URLs.
   -        lms_host = urlparse(self.lms_url).netloc
   +        lms_host = ""
 
            # For some URLs urlparse(url).netloc returns an empty string.
            if not lms_host:
   ```

   In this case the exception view gets called with `ValueError("Couldn't parse self.lms_url (https://hypothesis.instructure.com): urlparse() returned an empty netloc")` as the `context` argument. The exception view ends up calling `enable_oauth2_redirect_error_mode()` with no `error_code` or `error_details` which results in a generic "Something went wrong" error dialog from the frontend.

3. If a request to the `oauth2_redirect()` view isn't authorized.

   Requests to the `oauth2_redirect()` need to be authorized by an OAuth 2.0 `state` param in the query string. It's easy to send an unauthorized request:

   ```terminal
   $ curl http://localhost:8001/canvas_oauth_callback
   ```

   The request will be unauthenticated and will fail the `oauth2_redirect()` view's `permission=Permissions.API` predicate. Pyramid will then call the `oauth2_redirect_error()` view with an `HTTPForbidden` exception as the `context`. The exception view ends up calling `enable_oauth2_redirect_error_mode()` with no `error_code` or `error_details` which results in a generic "Something went wrong" error dialog from the frontend.

4. If the `oauth2_redirect()` view's schema raises a `ValidationError`.

   ```diff
   diff --git a/lms/validation/authentication/_oauth.py 
   b/lms/validation/authentication/_oauth.py
   index ffd7dcc3..be551dfc 100644
   --- a/lms/validation/authentication/_oauth.py
   +++ b/lms/validation/authentication/_oauth.py
   @@ -63,6 +63,7 @@ class OAuthCallbackSchema(PyramidRequestSchema):
        location = "querystring"
        code = fields.Str(required=True)
        state = fields.Str(required=True)
   +    foo = fields.Str(required=True)
 
        def __init__(self, request):
            super().__init__(request)
   ```

   The `oauth2_redirect()` view's `schema=OAuthCallbackSchema` predicate fails so Pyramid doesn't call the view. Instead Pyramid calls the `oauth2_redirect_error()` view with an [`lms.validation.ValidationError`](https://github.com/hypothesis/lms/blob/2b54b642eba408461a82f71a2d914902f2e6821f/lms/validation/_exceptions.py#L11-L44) as the `context` argument. The exception view ends up calling `enable_oauth2_redirect_error_mode()` with no `error_code` or `error_details` which results in a generic "Something went wrong" error dialog from the frontend.

5. If the `oauth2_redirect()` view (`"canvas_api.oauth.callback"` route) raises `HTTPInternalServerError` because something went wrong with the access token request to Canvas:

   ```diff
   diff --git a/lms/services/canvas_api/_authenticated.py b/lms/services/canvas_api/_authenticated.py
   index 241517f7..33bc9f16 100644
   --- a/lms/services/canvas_api/_authenticated.py
   +++ b/lms/services/canvas_api/_authenticated.py
   @@ -81,7 +81,7 @@ class AuthenticatedClient:
            # https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#post-login-oauth2-token
            return self._send_token_request(
                grant_type="authorization_code",
   -            code=authorization_code,
   +            code="foo",
                redirect_uri=self._redirect_uri,
                replace_tokens=True,
            )
   ```
   
   In this case what happens **in development** is quite confusing:
   
   1. We make the access token request to Canvas
   1. Canvas responds by redirecting our server to its own `redirect_uri`. This is not a sensible thing for Canvas to do, see: https://github.com/instructure/canvas-lms/issues/1976.
   2. `requests` automatically follows the redirect and our server makes a request to itself
   3. There's a 10s pause while our server waits for the response to its request to itself. (The development environment only has one Gunicorn worker, so the request is queued.)
   4. `requests` raises a timeout: `requests.exceptions.ReadTimeout: HTTPConnectionPool(host='localhost', port=8001): Read timed out. (read timeout=10)`
   5. `CanvasAPIError.raise_from()` wraps this in a `CanvasAPIServerError`
   6. The view wraps the `CanvasAPIServerError` in a `HTTPInternalServerError`
   5. The exception view is called with the `HTTPInternalServerError` as the `context`. `context.__cause__.__cause__` is the original `ReadTimeout` exception from `requests`
   6. The exception view ends up calling `enable_oauth2_redirect_error_mode()` with no `error_code` or `error_details` which results in a generic "Something went wrong" error dialog from the frontend.
   7. At this point the response has already been sent back to the frontend so nothing else really matters. Nonetheless, the app now receives the request that it previously sent to itself. The app already timed out waiting for the response to this request so nothing is waiting for the response now. But the app nonetheless receives the request and responds to it. The request is to the `"canvas_api.oauth.callback"` route but it contains no authentication parameter or header so it lacks the `permission=Permissions.API` permission required by that route's view (the `oauth2_redirect()` view) so Pyramid doesn't call the view. Instead the exception view gets called again with an `HTTPForbidden` exception as the `context` argument.
   8. The request in this case actually does have an `error_description` param because the URL that Canvas redirects us to is `/canvas_oauth_callback?error=invalid_grant&error_description=authorization_code+not+found`. So the exception view ends up calling `enable_oauth2_redirect_error_mode()` with an `error_details` argument. I'm not sure whether this would work though since it doesn't pass an `error_code` argument. It doesn't matter anyway: the response isn't going to the frontend, it's going back to the backend (which is no longer waiting for it).
   
      Note also that the fact that this request does contain the `error_description` param that the exception view is looking for is a coincidence. If Canvas did what it was supposed to do then instead of a redirect it would send us an [RFC 6749 Section 5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) HTTP 400 JSON response with `error` and `error_description` in the body. This spec-compliant OAuth 2.0 error response seems to be what the `oauth2_redirect_error()` exception was written to expect. Perhaps Canvas did send correct error responses when the view was written. The fact that Canvas's now incorrect redirect response does contain one of the parameters that the exception view code is looking for is a coincidence.

6. If the `oauth2_redirect()` view raises `HTTPInternalServerError` **in production**. In production this will happen differently in development because in production there are multiple Gunicorn workers, so when Canvas directs us to make a request to ourselves we'll actually receive the response from ourselves. We can simulate production by changing the development environment to have two workers, and also hacking the code to trigger an error from Canvas's access token endpoint:

   ```diff
   diff --git a/gunicorn.conf.py b/gunicorn.conf.py
   index 2c774da0..b35497c4 100644
   --- a/gunicorn.conf.py
   +++ b/gunicorn.conf.py
   @@ -1,3 +1,4 @@
    reload = True
    timeout = 0
    bind = ":8001"
   +workers = 2
   diff --git a/lms/services/canvas_api/_authenticated.py 
   b/lms/services/canvas_api/_authenticated.py
   index 241517f7..33bc9f16 100644
   --- a/lms/services/canvas_api/_authenticated.py
   +++ b/lms/services/canvas_api/_authenticated.py
   @@ -81,7 +81,7 @@ class AuthenticatedClient:
            # https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#post-login-oauth2-token
            return self._send_token_request(
                grant_type="authorization_code",
   -            code=authorization_code,
   +            code="foo",
                redirect_uri=self._redirect_uri,
                replace_tokens=True,
            )
   diff --git a/lms/views/api/canvas/authorize.py b/lms/views/api/canvas/authorize.py
   index 4290f5b0..fda1828f 100644
   --- a/lms/views/api/canvas/authorize.py
   +++ b/lms/views/api/canvas/authorize.py
   @@ -113,7 +113,7 @@ def oauth2_redirect(request):
        route_name="canvas_api.oauth.authorize",
        renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
    )
   -def oauth2_redirect_error(request):
   +def oauth2_redirect_error(context, request):
        kwargs = {
            "auth_route": "canvas_api.oauth.authorize",
            "canvas_scopes": FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
   ```

   What happens is:

   1. We send the access token request to Canvas
   2. Canvas redirects us to ourselves
   3. `requests` follows the redirect
   4. Our app receives the request from `requests`. It's unauthenticated so the `oauth2_redirect_error()` is called with an `HTTPForbidden` and responds with a 200 OK and an HTML & JavaScript error dialog page.
   5. This response fails to pass the `OAuthTokenResponseSchema` that we use to validate it, which results in the `oauth2_redirect_error()` exception view being called again with an `HTTPInternalServerError`
   6. The end result in the browser is a generic "Something went wrong when authorizing Hypothesis" error dialog.

7. Valid OAuth 2 error response from Canvas.

   This is currently difficult to test because Canvas's access token endpoint is broken and doesn't send valid error responses. But if Canvas worked correctly and did send a valid error response that case would also be handled by the `oauth2_redirect_error()` exception view.

   To test this I first hacked [Via Test App](https://github.com/hypothesis/via_test_app) to send valid [RFC 6749 Section 5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) error responses at <http://localhost:9101/oauth2/access-token>:

   ```diff
   diff --git a/via_test_app/app.py b/via_test_app/app.py
   index 07d12dd..adb251d 100644
   --- a/via_test_app/app.py
   +++ b/via_test_app/app.py
   @@ -39,6 +39,8 @@ def create_app(_, **settings):
            config.add_route("vary.duplicate", "/vary/duplicate")
            config.add_route("vary.invalid", "/vary/invalid")
 
   +        config.add_route("oauth2.access_token", "/oauth2/access-token")
   +
            # Serve static files.
            config.add_static_view(name="static", path="via_test_app:static")
 
   diff --git a/via_test_app/views/oauth2.py b/via_test_app/views/oauth2.py
   new file mode 100644
   index 0000000..7dbf23b
   --- /dev/null
   +++ b/via_test_app/views/oauth2.py
   @@ -0,0 +1,10 @@
   +from pyramid.view import view_config
   +
   +
   +@view_config(route_name="oauth2.access_token", renderer="json")
   +def index(request):
   +    request.response.status_code = 400
   +    return {
   +        "error": "invalid_grant",
   +        "error_description": "Your authorization code was invalid",
   +    }
   ```

   Next, hack the LMS app to send access token requests to this Via Test App endpoint instead of to Canvas:

   ```diff
   diff --git a/lms/services/canvas_api/_basic.py b/lms/services/canvas_api/_basic.py
   index 407ca24c..e3349186 100644
   --- a/lms/services/canvas_api/_basic.py
   +++ b/lms/services/canvas_api/_basic.py
   @@ -85,6 +85,9 @@ class BasicClient:
        def _send_prepared(self, request, schema, request_depth=1):
            response = None
 
   +        if request.url.startswith("https://hypothesis.instructure.com/login/oauth2/token"):
   +            request.url = "http://localhost:9101/oauth2/access-token"
   +
            try:
                response = self._session.send(request, timeout=(10, 10))
                response.raise_for_status()
   ```

   The `oauth2_redirect_error()` exception view ends up getting called with an `HTTPServerError` as the `context`. `context.__cause__.__cause__` is the original `requests.exceptions.HTTPError`. `context.__cause__.response` is the `requests.Response` object. The exception view ends up calling `enable_oauth2_redirect_error_mode()` with no `error_code` or `error_details` which results in a generic "Something went wrong" error dialog from the frontend.

8. Canvas redirects the browser to the `oauth2_redirect()` view (`"canvas_api.oauth.callback"` route) with an error.

   One way to reproduce this is to click <kbd>Cancel</kbd> rather than <kbd>Authorise</kbd> in Canvas's authorization dialog. Canvas redirects the browser back to our `oauth2_redirect()` view. The browser's redirected request is actually authenticated with a `state` query param so it passes the view's permissions check. But it fails the view's `schema=OAuthCallbackSchema` check.

   Pyramid then calls the `oauth2_redirect_error()` view. The `context` is a `ValidationError`. The request actually does have an `error` param but its value is not `"invalid_scope"` so the exception view's code doesn't use it. The request has no `error_description` param. The exception view ends up calling `enable_oauth2_redirect_error_mode()` with no `error_code` or `error_details` which results in a generic "Something went wrong" error dialog from the frontend.

9. Canvas redirects the browser to the `oauth2_redirect()` view with a scopes-related error.

   ```diff
   diff --git a/lms/views/api/canvas/authorize.py b/lms/views/api/canvas/authorize.py
   index 4290f5b0..935eb403 100644
   --- a/lms/views/api/canvas/authorize.py
   +++ b/lms/views/api/canvas/authorize.py
   @@ -22,6 +22,7 @@ from lms.validation.authentication import OAuthCallbackSchema
    FILES_SCOPES = (
        "url:GET|/api/v1/courses/:course_id/files",
        "url:GET|/api/v1/files/:id/public_url",
   +    "foo",
    )
 
    #: The Canvas API scopes that we need for our Sections feature.
   ```

   In this case Canvas _doesn't_ include the `state` param in the URL that it redirects the browser to, so the browser's redirect request is unauthenticated and Pyramid calls the exception view with an `HTTPForbidden` as the `context`.

   Here, finally, is where the code in the exception view comes into play: the request does contain an `error` param whose value is `invalid_scope` and does contain an `error_description` param. The view passes these to `enable_oauth2_redirect_error_mode()` and a custom error dialog about scopes is displayed. This is the only case that results in anything other than a generic "Something went wrong" dialog.