### PR TITLE
Add CourseService.generate_authority_provided_id

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -1,7 +1,6 @@
 """Traversal resources for LTI launch views."""
 import functools
 
-from lms.models._hashed_id import hashed_id
 from lms.resources._js_config import JSConfig
 from lms.services import ApplicationInstanceNotFound
 
@@ -34,14 +33,9 @@ class LTILaunchResource:
         tool_consumer_instance_guid = params["tool_consumer_instance_guid"]
         context_id = params["context_id"]
 
-        # Generate the authority_provided_id based on the LTI
-        # tool_consumer_instance_guid and context_id parameters.
-        # These are "recommended" LTI parameters (according to the spec) that in
-        # practice are provided by all of the major LMS's.
-        # tool_consumer_instance_guid uniquely identifies an instance of an LMS,
-        # and context_id uniquely identifies a course within an LMS. Together they
-        # globally uniquely identify a course.
-        authority_provided_id = hashed_id(tool_consumer_instance_guid, context_id)
+        authority_provided_id = course_service.generate_authority_provided_id(
+            tool_consumer_instance_guid, context_id
+        )
 
         legacy_course = course_service.get_or_create(authority_provided_id)
         course = course_service.upsert(

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -2,6 +2,7 @@ import json
 from copy import deepcopy
 
 from lms.models import Course, CourseGroupsExportedFromH, LegacyCourse
+from lms.models._hashed_id import hashed_id
 
 
 class CourseService:
@@ -117,6 +118,19 @@ class CourseService:
         return bool(
             self._db.query(CourseGroupsExportedFromH).get(authority_provided_id)
         )
+
+    @staticmethod
+    def generate_authority_provided_id(tool_consumer_instance_guid, context_id):
+        """
+        Generate the authority_provided_id based on the LTI  tool_consumer_instance_guid and context_id parameters.
+
+        These are "recommended" LTI parameters (according to the spec) that in
+        practice are provided by all of the major LMS's.
+        tool_consumer_instance_guid uniquely identifies an instance of an LMS,
+        and context_id uniquely identifies a course within an LMS. Together they
+        globally uniquely identify a course.
+        """
+        return hashed_id(tool_consumer_instance_guid, context_id)
 
 
 def course_service_factory(_context, request):

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -42,11 +42,11 @@ class GroupingService:
             tool_consumer_instance_guid, context_id, section_id
         )
 
-        course_authority_provided_id = hashed_id(
-            tool_consumer_instance_guid, context_id
+        course = self._course_service.get(
+            self._course_service.generate_authority_provided_id(
+                tool_consumer_instance_guid, context_id
+            )
         )
-
-        course = self._course_service.get(course_authority_provided_id)
 
         return self.upsert(
             CanvasSection(

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -222,15 +222,12 @@ class TestCanvasSectionsSupported:
 
 @pytest.mark.usefixtures("has_course")
 class TestCanvasSectionsEnabled:
-    def test_its_enabled_when_everything_is_right(
-        self, lti_launch, course_service, hashed_id
-    ):
-        hashed_id.return_value = mock.sentinel.authority_provided_id
-
+    def test_its_enabled_when_everything_is_right(self, lti_launch, course_service):
         assert lti_launch.canvas_sections_enabled
 
+        course_service.generate_authority_provided_id.assert_called_once()
         course_service.get_or_create.assert_called_with(
-            mock.sentinel.authority_provided_id
+            course_service.generate_authority_provided_id.return_value
         )
 
     def test_its_disabled_if_sections_are_not_supported(
@@ -252,10 +249,6 @@ class TestCanvasSectionsEnabled:
         course_service.get_or_create.return_value.settings = settings
 
         return settings
-
-    @pytest.fixture
-    def hashed_id(self, patch):
-        return patch("lms.resources.lti_launch.hashed_id")
 
     @pytest.fixture(autouse=True)
     def canvas_sections_supported(self):

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -112,6 +112,12 @@ class TestCourseService:
         assert db_session.query(Course).count() == 1
         assert course.authority_provided_id == "new authority_provided_id"
 
+    def test_generate_authority_provided_id(self, svc):
+        assert (
+            svc.generate_authority_provided_id("tool", "context_id")
+            == "bc8f8d2c5de70a0f3975268832174fabecfb32d9"
+        )
+
     @pytest.fixture
     def add_courses_with_settings(self, application_instance):
         def add_courses_with_settings(

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -57,8 +57,11 @@ class TestGroupingService:
             "section_name",
         )
 
+        course_service.generate_authority_provided_id.assert_called_once_with(
+            self.TOOL_CONSUMER_INSTANCE_GUID, self.CONTEXT_ID
+        )
         course_service.get.assert_called_once_with(
-            hashed_id(self.TOOL_CONSUMER_INSTANCE_GUID, self.CONTEXT_ID),
+            course_service.generate_authority_provided_id.return_value
         )
         assert grouping.parent_id == course_service.get.return_value.id
 


### PR DESCRIPTION
This was a bit scattered around. 

We don't usually receive an authority_provided_id so calling the course service it's a bit awkward, construct the authority_provided_id then call get with it so maybe another version of `get` could be useful but I reckon this goes in the right direction anyway.

