### PR TITLE
Merges upsert_canvas_section and upsert_canvas_group methods

### DIFF
--- a/tests/factories/grouping.py
+++ b/tests/factories/grouping.py
@@ -12,4 +12,5 @@ Grouping = make_factory(
     authority_provided_id=factory.Faker("hexify", text="^" * 40),
     lms_id=factory.Faker("hexify", text="^" * 40),
     lms_name=factory.Sequence(lambda n: f"Test Group {n}"),
+    type=models.Grouping.Type.GROUPING,
 )

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -1,10 +1,8 @@
 from unittest.mock import sentinel
 
 import pytest
-from sqlalchemy.orm import make_transient
 
-from lms.models import Grouping
-from lms.models._hashed_id import hashed_id
+from lms.models import CanvasGroup, Grouping
 from lms.services.grouping import GroupingService, factory
 from tests import factories
 
@@ -15,100 +13,88 @@ class TestGroupingService:
     CONTEXT_ID = "context_id"
     TOOL_CONSUMER_INSTANCE_GUID = "t_c_i_guid"
 
-    def test_upsert_inserts(self, svc, db_session):
-        # Start with no groupings
-        assert not db_session.query(Grouping).count()
+    def test_upsert_with_parents_inserts(self, svc, db_session):
+        course = factories.Course()
 
-        test_grouping = Grouping(
-            application_instance=factories.ApplicationInstance(),
-            authority_provided_id="ID",
+        # Start with no CanvasGroup
+        assert not db_session.query(CanvasGroup).count()
+
+        test_grouping = svc.upsert_with_parent(
+            tool_consumer_instance_guid=course.application_instance.tool_consumer_instance_guid,
             lms_id="lms_id",
             lms_name="lms_name",
+            parent=course,
+            type_=Grouping.Type.CANVAS_GROUP,
         )
 
-        svc.upsert(test_grouping)
+        assert db_session.query(CanvasGroup).one() == test_grouping
 
-        assert db_session.query(Grouping).one() == test_grouping
+    def test_upsert_with_parents_updates(self, svc, db_session):
+        course = factories.Course()
+        tool_consumer_instance_guid = (
+            course.application_instance.tool_consumer_instance_guid
+        )
+        lms_id = "lms_id"
+        old_name = "old_name"
+        old_extra = {"extra": "old"}
+        new_name = "new_name"
+        new_extra = {"extra": "new"}
 
-    def test_upsert_updates(self, svc, db_session):
-        grouping = factories.Grouping()
+        # Insert a new grouping.
+        svc.upsert_with_parent(
+            tool_consumer_instance_guid=tool_consumer_instance_guid,
+            lms_id=lms_id,
+            lms_name=old_name,
+            parent=course,
+            type_=Grouping.Type.CANVAS_GROUP,
+            extra=old_extra,
+        )
+
+        # Update the previously-inserted grouping with new values.
+        grouping = svc.upsert_with_parent(
+            tool_consumer_instance_guid=tool_consumer_instance_guid,
+            lms_id=lms_id,
+            lms_name=new_name,
+            parent=course,
+            type_=Grouping.Type.CANVAS_GROUP,
+            extra=new_extra,
+        )
+
+        # upsert_with_parent() should return a Grouping that has the updated values.
+        assert grouping.lms_name == new_name
+        assert grouping.extra == new_extra
+
+        # The Grouping's values should have been updated in the DB as well.
+        db_grouping = db_session.query(CanvasGroup).one()
+        assert db_grouping.lms_name == new_name
+        assert db_grouping.extra == new_extra
+
+    def test_canvas_group_and_sections_dont_conflict(self, svc, db_session):
+        course = factories.Course(lms_id=self.CONTEXT_ID)
         db_session.flush()
 
-        # Treat `grouping` as it was a freshly created object
-        make_transient(grouping)
-
-        grouping.lms_name = "new_name"
-        grouping.extra = {"extra": "extra"}
-
-        grouping = svc.upsert(grouping)
-
-        db_grouping = db_session.query(Grouping).one()
-        assert db_grouping.lms_name == "new_name"
-        assert db_grouping.extra == {"extra": "extra"}
-
-    def test_canvas_section_finds_course(self, svc, course_service, db_session):
-        course_service.get.return_value = factories.Course()
-        db_session.flush()
-
-        grouping = svc.upsert_canvas_section(
+        group = svc.upsert_with_parent(
             self.TOOL_CONSUMER_INSTANCE_GUID,
-            self.CONTEXT_ID,
-            "section_id",
-            "section_name",
-        )
-
-        course_service.generate_authority_provided_id.assert_called_once_with(
-            self.TOOL_CONSUMER_INSTANCE_GUID, self.CONTEXT_ID
-        )
-        course_service.get.assert_called_once_with(
-            course_service.generate_authority_provided_id.return_value
-        )
-        assert grouping.parent_id == course_service.get.return_value.id
-
-    def test_canvas_group_finds_course(self, svc, course_service, db_session):
-        course_service.get.return_value = factories.Course()
-        db_session.flush()
-
-        grouping = svc.upsert_canvas_group(
-            self.TOOL_CONSUMER_INSTANCE_GUID,
-            self.CONTEXT_ID,
-            "group_id",
-            "group_name",
-            "group_set_id",
-        )
-
-        course_service.get.assert_called_once_with(
-            hashed_id(self.TOOL_CONSUMER_INSTANCE_GUID, self.CONTEXT_ID),
-        )
-        assert grouping.parent_id == course_service.get.return_value.id
-
-    def test_canvas_group_and_sections_dont_conflict(
-        self, svc, course_service, db_session
-    ):
-        course_service.get.return_value = factories.Course(lms_id=self.CONTEXT_ID)
-        db_session.flush()
-
-        group = svc.upsert_canvas_group(
-            self.TOOL_CONSUMER_INSTANCE_GUID,
-            self.CONTEXT_ID,
             "same_id",
             "group_name",
-            "group_set_id",
+            course,
+            Grouping.Type.CANVAS_GROUP,
         )
-        section = svc.upsert_canvas_section(
+        section = svc.upsert_with_parent(
             self.TOOL_CONSUMER_INSTANCE_GUID,
-            self.CONTEXT_ID,
             "same_id",
             "section_name",
+            course,
+            Grouping.Type.CANVAS_SECTION,
         )
 
         assert group.authority_provided_id == "078cc1b793e061085ed3ef91189b41a6f7dd26b8"
         assert (
             section.authority_provided_id == "867c2696d32eb4b5e9cf5c5304cb71c3e20bfd14"
         )
-        assert (
-            group.parent_id == section.parent_id == course_service.get.return_value.id
-        )
+        assert group.type == Grouping.Type.CANVAS_GROUP
+        assert section.type == Grouping.Type.CANVAS_SECTION
+        assert group.parent_id == section.parent_id == course.id
 
     def test_generate_authority_provided_id_for_course(self, svc):
         assert (
@@ -131,7 +117,6 @@ class TestGroupingService:
         course = factories.Course(lms_id="course_id")
         db_session.flush()
 
-        print(course.lms_id)
         assert (
             svc.generate_authority_provided_id(
                 self.TOOL_CONSUMER_INSTANCE_GUID, "lms_id", course, type_
@@ -140,8 +125,8 @@ class TestGroupingService:
         )
 
     @pytest.fixture
-    def svc(self, db_session, course_service, application_instance_service):
-        return GroupingService(db_session, application_instance_service, course_service)
+    def svc(self, db_session, application_instance_service):
+        return GroupingService(db_session, application_instance_service)
 
 
 class TestFactory:


### PR DESCRIPTION
Merges `upsert_canvas_section` and `upsert_canvas_group` methods of the grouping service into one.

This is in anticipation for what would become `upsert_blackboard_group`

- Renamed the existing upsert to `_upsert`
- New method is named `upsert_with_parent` and takes a non optional parent grouping.
- `upsert_with_parent` generates the authority_provided_id based on a `type_` param. It doesn't handle `type_` as in the current data model course don't have a parent grouping.