### PR TITLE
Support VS launches in SpeedGrader

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -216,8 +216,10 @@ export default function BasicLTILaunchApp() {
       return;
     }
 
-    // Don't report a submission until the URL has been successfully fetched.
-    if (!contentUrl) {
+    // Don't report a submission until we have the data needed to display the assignment content
+    // contentUrl will be resolved from an API call to viaUrlApi.path except on VitalSource assignments
+    // where vitalSourceConfig will be present directly on the config instead.
+    if (!contentUrl && !vitalSourceConfig) {
       return;
     }
     try {
@@ -233,7 +235,7 @@ export default function BasicLTILaunchApp() {
       // submission.
       handleError(e, 'error-reporting-submission', false);
     }
-  }, [authToken, canvas.speedGrader, contentUrl]);
+  }, [authToken, canvas.speedGrader, contentUrl, vitalSourceConfig]);
 
   useEffect(() => {
     reportSubmission();

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -18,6 +18,12 @@ class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
     canvas_file_id = fields.Str()
     """ID of the Canvas file for this assignment."""
 
+    vitalsource_book_id = fields.Str()
+    """ID of the VitalSource book for this assignment."""
+
+    vitalsource_cfi = fields.Str()
+    """CFI of the VitalSource book for this assignment."""
+
     h_username = fields.Str(required=True)
     """h username generated for the active user."""
 

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -121,9 +121,13 @@ class CanvasPreRecordHook:
 
         if parsed_params.get("document_url"):
             params["url"] = parsed_params.get("document_url")
+        elif book_id := parsed_params.get("vitalsource_book_id"):
+            params["vitalsource_book"] = "true"
+            params["book_id"] = book_id
+            params["cfi"] = parsed_params["vitalsource_cfi"]
         else:
             assert parsed_params.get("canvas_file_id"), (
-                "All Canvas launches should have either a 'document_url' or "
+                "All Canvas launches should have either a 'document_url' a 'vitalsource_book_id' or "
                 "a 'canvas_file_id' parameter."
             )
             params["canvas_file"] = "true"

--- a/tests/unit/lms/views/api/lti_test.py
+++ b/tests/unit/lms/views/api/lti_test.py
@@ -67,6 +67,10 @@ class TestCanvasPreRecordHook:
         [
             [{"document_url": "https://example.com"}, {"url": ["https://example.com"]}],
             [
+                {"vitalsource_book_id": "BOOK_ID", "vitalsource_cfi": "CFI"},
+                {"vitalsource_book": ["true"], "book_id": ["BOOK_ID"], "cfi": ["CFI"]},
+            ],
+            [
                 {"canvas_file_id": "file123"},
                 {"canvas_file": ["true"], "file_id": ["file123"]},
             ],


### PR DESCRIPTION
# Testing

- Create a new VitalSource assignment (for example 0077383966) so there's no SG submissions
- Launch in SpeedGrader, there won't be any submissions.
- Launch as a student
- Back at SpeedGrader, refresh, there will be one submission now.