### PR TITLE
Enable MS OneDrive on instances where it was explicitly disabled.

### DIFF
--- a/lms/migrations/versions/1693f6ade03d_enable_ms_one_drive.py
+++ b/lms/migrations/versions/1693f6ade03d_enable_ms_one_drive.py
@@ -1,0 +1,27 @@
+"""
+Enable MS OneDrive on instances that have previously been disabled.
+
+Revision ID: 1693f6ade03d
+Revises: 2fd66b9ab1a1
+Create Date: 2021-11-18 10:47:24.773542
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1693f6ade03d"
+down_revision = "2fd66b9ab1a1"
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    conn.execute(
+        """UPDATE application_instances SET settings = settings || jsonb '{"microsoft_onedrive":{"files_enabled": true}}'
+            WHERE settings -> 'microsoft_onedrive' -> 'files_enabled' = 'false';"""
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Even if OneDrive is enabled by default any application instance that had previously a "false" value on the DB will override the default.

# Testing

(on master)

- Leave only the devdata AI to compare:

`docker stop lms_postgres_1; docker rm lms_postgres_1; make services db devdata`

- Disable OneDrive an add a bunch of settings to one of the instances, on `make sql`:

`update application_instances set settings = '{"canvas": {"groups_enabled": false, "sections_enabled": false}, "blackboard": {"files_enabled": true}, "microsoft_onedrive": {"files_enabled": false}}' where id = 11;`

- Check the values of settings
`select id, settings from application_instances;`


(switch to this branch)

- `make db` to run the migration
- `select id, settings from application_instances;` ID 11 should have now the value set to true, the rest should have not been changed.