### PR TITLE
Reorg application_instances fixtures to work together

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,6 +7,7 @@ from pyramid import testing
 from pyramid.request import apply_request_extensions
 
 from lms.db import SESSION
+from lms.models import ApplicationSettings
 from tests import factories
 from tests.conftest import TEST_SETTINGS, get_test_database_url
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -179,6 +180,9 @@ def httpretty_():
 def application_instance(pyramid_request):
     return factories.ApplicationInstance(
         consumer_key=pyramid_request.lti_user.oauth_consumer_key,
+        developer_key="TEST_DEVELOPER_KEY",
+        provisioning=True,
+        settings=ApplicationSettings({}),
     )
 
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -9,7 +9,6 @@ from lms.resources._js_config import JSConfig
 from lms.services import ApplicationInstanceNotFound, HAPIError
 
 pytestmark = pytest.mark.usefixtures(
-    "application_instance_service",
     "grading_info_service",
     "grant_token_service",
     "h_api",
@@ -17,6 +16,7 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
+@pytest.mark.usefixtures("application_instance_service")
 class TestEnableContentItemSelectionMode:
     def test_it(self, js_config):
         js_config.enable_content_item_selection_mode(
@@ -114,6 +114,7 @@ class TestEnableContentItemSelectionMode:
         return patch("lms.resources._js_config.FilePickerConfig")
 
 
+@pytest.mark.usefixtures("application_instance_service")
 class TestEnableLTILaunchMode:
     def test_it(self, bearer_token_schema, context, grant_token_service, js_config):
         js_config.enable_lti_launch_mode()
@@ -361,6 +362,7 @@ class TestMaybeEnableGrading:
         return pyramid_request
 
 
+@pytest.mark.usefixtures("application_instance_service")
 class TestMaybeSetFocusedUser:
     def test_it_does_nothing_if_theres_no_focused_user_param(
         self, js_config, pyramid_request
@@ -435,6 +437,7 @@ class TestJSConfigAuthToken:
         return config["api"]["authToken"]
 
 
+@pytest.mark.usefixtures("application_instance_service")
 class TestJSConfigAPISync:
     """Unit tests for the api.sync sub-dict of JSConfig."""
 
@@ -512,6 +515,7 @@ class TestJSConfigDebug:
         return config["debug"]
 
 
+@pytest.mark.usefixtures("application_instance_service")
 class TestJSConfigHypothesisClient:
     """Unit tests for the "hypothesisClient" sub-dict of JSConfig."""
 
@@ -584,6 +588,7 @@ class TestJSConfigHypothesisClient:
         context.canvas_groups_enabled = True
 
 
+@pytest.mark.usefixtures("application_instance_service")
 class TestJSConfigRPCServer:
     """Unit tests for the "rpcServer" sub-dict of JSConfig."""
 

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -52,10 +52,6 @@ class TestUserService:
             service.get(user.application_instance, "some-other-id")
 
     @pytest.fixture
-    def application_instance(self, application_instance_service):
-        return application_instance_service.get_by_consumer_key.return_value
-
-    @pytest.fixture
     def lti_user(self, application_instance):
         return factories.LTIUser(
             oauth_consumer_key=application_instance.consumer_key, roles="new_roles"

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from lms.models import ApplicationSettings
 from lms.services import CanvasService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
@@ -70,13 +69,7 @@ def mock_service(pyramid_config):
 
 
 @pytest.fixture
-def application_instance_service(mock_service):
-    application_instance = factories.ApplicationInstance(
-        consumer_key="TEST_OAUTH_CONSUMER_KEY",
-        developer_key="TEST_DEVELOPER_KEY",
-        provisioning=True,
-        settings=ApplicationSettings({}),
-    )
+def application_instance_service(mock_service, application_instance):
     application_instance.settings.set("canvas", "sections_enabled", True)
     application_instance.settings.set("canvas", "groups_enabled", False)
 


### PR DESCRIPTION
application_instance_service returns application_instance on get_current
otherwise two different, conflicting application_instances rows are
created on the DB.