### PR TITLE
Migration to add new grouping_membership table

### DIFF
--- a/lms/migrations/versions/f359b6f378a9_add_grouping_membership_table.py
+++ b/lms/migrations/versions/f359b6f378a9_add_grouping_membership_table.py
@@ -1,0 +1,46 @@
+"""
+Adds grouping_membership table.
+
+Revision ID: f359b6f378a9
+Revises: 2fd66b9ab1a1
+Create Date: 2021-11-23 14:59:33.455057
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f359b6f378a9"
+down_revision = "1693f6ade03d"
+
+
+def upgrade():
+    op.create_table(
+        "grouping_membership",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("grouping_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["grouping_id"],
+            ["grouping.id"],
+            name=op.f("fk__grouping_membership__grouping_id__grouping"),
+            ondelete="cascade",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            name=op.f("fk__grouping_membership__user_id__user"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint(
+            "grouping_id", "user_id", name=op.f("pk__grouping_membership")
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("grouping_membership")


### PR DESCRIPTION
Auto generated from: https://github.com/hypothesis/lms/pull/3419


# Testing

- On master
- `hdev alembic history`

`2fd66b9ab1a1 -> 1693f6ade03d (head), Enable MS OneDrive on instances that have previously been disabled.`

- On this branch
- `hdev alembic history`

`1693f6ade03d -> f359b6f378a9 (head), Adds grouping_membership table.`

- make db

```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 1693f6ade03d -> f359b6f378a9, Adds grouping_membership table.
```

- make sql
```
postgres=# \d grouping_membership 
                     Table "public.grouping_membership"
   Column    |            Type             | Collation | Nullable | Default 
-------------+-----------------------------+-----------+----------+---------
 created     | timestamp without time zone |           | not null | now()
 updated     | timestamp without time zone |           | not null | now()
 grouping_id | integer                     |           | not null | 
 user_id     | integer                     |           | not null | 
Indexes:
    "pk__grouping_membership" PRIMARY KEY, btree (grouping_id, user_id)
Foreign-key constraints:
    "fk__grouping_membership__grouping_id__grouping" FOREIGN KEY (grouping_id) REFERENCES "grouping"(id) ON DELETE CASCADE
    "fk__grouping_membership__user_id__user" FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE
```