### PR TITLE
Add a `CHECK` constraint to the grouping table

### DIFF
--- a/lms/migrations/versions/4a4c2539c666_add_check_constraint_to_grouping_table.py
+++ b/lms/migrations/versions/4a4c2539c666_add_check_constraint_to_grouping_table.py
@@ -1,0 +1,20 @@
+"""Add a CHECK constraint to the grouping table."""
+from alembic import op
+
+revision = "4a4c2539c666"
+down_revision = "f359b6f378a9"
+
+constraint_name = "courses_must_NOT_have_parents_and_other_groupings_MUST_have_parents"
+table_name = "grouping"
+
+
+def upgrade():
+    op.create_check_constraint(
+        constraint_name,
+        table_name=table_name,
+        condition="(type='course' AND parent_id IS NULL) OR (type!='course' AND parent_id IS NOT NULL)",
+    )
+
+
+def downgrade():
+    op.drop_constraint(constraint_name, table_name=table_name, type_="check")

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -23,6 +23,10 @@ class Grouping(CreatedUpdatedMixin, BASE):
     __table_args__ = (
         sa.UniqueConstraint("application_instance_id", "authority_provided_id"),
         sa.UniqueConstraint("lms_id", "application_instance_id", "parent_id", "type"),
+        sa.CheckConstraint(
+            "(type='course' AND parent_id IS NULL) OR (type!='course' AND parent_id IS NOT NULL)",
+            name="courses_must_NOT_have_parents_and_other_groupings_MUST_have_parents",
+        ),
     )
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)


### PR DESCRIPTION
Course groupings cannot have parents, whilst all non-course groupings must have parents. This is true of the production data currently. This commit adds a DB-level constraint to ensure it.