### PR TITLE
Constrain the `grouping.type` column to valid values

### DIFF
--- a/lms/migrations/versions/6882c201b56e_add_type_constraint_to_grouping_table.py
+++ b/lms/migrations/versions/6882c201b56e_add_type_constraint_to_grouping_table.py
@@ -1,0 +1,20 @@
+"""Add type column values constraint to grouping table."""
+from alembic import op
+
+revision = "6882c201b56e"
+down_revision = "4a4c2539c666"
+
+constraint_name = "grouping_type_must_be_a_valid_value"
+table_name = "grouping"
+
+
+def upgrade():
+    op.create_check_constraint(
+        constraint_name,
+        table_name=table_name,
+        condition="type in ('course', 'canvas_section', 'canvas_group', 'blackboard_group')",
+    )
+
+
+def downgrade():
+    op.drop_constraint(constraint_name, table_name=table_name, type_="check")

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -27,6 +27,10 @@ class Grouping(CreatedUpdatedMixin, BASE):
             "(type='course' AND parent_id IS NULL) OR (type!='course' AND parent_id IS NOT NULL)",
             name="courses_must_NOT_have_parents_and_other_groupings_MUST_have_parents",
         ),
+        sa.CheckConstraint(
+            "type in ('course', 'canvas_section', 'canvas_group', 'blackboard_group')",
+            name="grouping_type_must_be_a_valid_value",
+        ),
     )
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)


### PR DESCRIPTION
This means that each time we add a new type of grouping we'll need to do a simple DB migration to widen this constraint. For that cost we get the benefit of ensuring at the DB-level that the `type` column can only contain valid values.

The code actually contains a [`Grouping` model](https://github.com/hypothesis/lms/blob/67d2266f919a63adaf14e4274bd838ced9aba053/lms/models/grouping.py#L14-L96) which is the base class for the [`CanvasSection`, `CanvasGroup`, `BlackboardGroup` and `Course` models](https://github.com/hypothesis/lms/blob/67d2266f919a63adaf14e4274bd838ced9aba053/lms/models/grouping.py#L99-L112). But it's never valid to actually instantiate the `Grouping` model: all groupings must be a Canvas section, Canvas group, Blackboard group or course, never just a "grouping".

By adding a DB-level constraint that `type` must be `'course'`, `'canvas_section'`, `'canvas_group'` or `'blackboard_group'` this PR prevents code from instantiating a `Grouping` and adding it to the DB.

Maybe the `Grouping` model should also be an abstract class? And maybe it should be private, renamed to `_Grouping` and not exposed as a top-level `lms.models.*` name?