### PR TITLE
Add a generic `upsert()` helper function

### DIFF
--- a/lms/services/_upsert.py
+++ b/lms/services/_upsert.py
@@ -1,0 +1,16 @@
+"""A helper for upserting into DB tables."""
+
+from sqlalchemy.orm.exc import NoResultFound
+
+
+def upsert(db, model_class, query_kwargs, update_kwargs):
+    try:
+        model = db.query(model_class).filter_by(**query_kwargs).one()
+    except NoResultFound:
+        model = model_class(**query_kwargs)
+        db.add(model)
+
+    for key, value in update_kwargs.items():
+        setattr(model, key, value)
+
+    return model

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -33,7 +33,8 @@ class TestGroupingService:
         course = factories.Course()
         tool_consumer_instance_guid = (
             course.application_instance.tool_consumer_instance_guid
-        )
+        ) = "tcig"
+        db_session.flush()
         lms_id = "lms_id"
         old_name = "old_name"
         old_extra = {"extra": "old"}


### PR DESCRIPTION
To avoid having to re-write ORM upsert logic repeatedly (and potentially make mistakes).

## Todo

- [ ] I've only changed `GroupingService` to use this but there's probably some other places that could also use it?
- [ ] Tests

## Possible future optimization

The solution in this PR requires calling the `upsert()` helper once for each ORM object that you want to upsert (which is what the `GroupingService.upsert_with_parent()` method already does). In cases where a single request upserts lots of rows (for example: when a group has a large number of groups in it) I think we could potentially optimize this in future by using a bulk operation, so that the number of SQLAlchemy queries used doesn't increase with the number of rows being upserted. The existence of a single helper function for upserting would hopefully mean that we could optimize it once and get the benefit wherever we upsert things.

We actually already have a a [bulk `upsert()` helper](https://github.com/hypothesis/lms/blob/a0cb7f90628f554ee679e6a4176bc43c0edf7443/lms/db/_bulk_action.py#L65-L132) already but I'm not sure about using it for `GroupingService`:

* One problem is that it's hidden away in `lms/db/` where it's easily forgotten. Even though both Marcos and I were involved in reviewing this code when it was added five months ago we both forgot that it existed and didn't re-use it. The same is true of other stuff hiding in `lms/db/`: the [`columns()` method](https://github.com/hypothesis/lms/blob/a0cb7f90628f554ee679e6a4176bc43c0edf7443/lms/db/__init__.py#L24-L31) (though I doubt we need this?) and [`update_from_dict()`](https://github.com/hypothesis/lms/blob/a0cb7f90628f554ee679e6a4176bc43c0edf7443/lms/db/__init__.py#L33-L59). I think we may want to make these things standalone helper functions in `lms/services/_upsert.py` like the `upsert()` function in this PR is.

* The other problem is that it's very hard to understand. The `upsert()` function in this PR is 10 lines of straightforward SQLAlchemy ORM code. The existing bulk `upsert()` helper compromises:

  -  139 lines of code in `db/_bulk_action.py`: a "DB session extension" class with a `Config` inner dataclass with `__set_name__()` method, and then the `upsert()` method itself is 67 lines of more difficult SQLAlchemy Core code (including the `_get_columns_onupdate()` helper)
  - There's then a bit more code in `db/__init__.py` to do with how `BulkAction` session extension class is attached to a custom SQLAlchemy session subclass using `@cached_property` (and this `CustomSession` class is then passed to SQLAlchemy's `sessionmaker()`)

  The problem with all this is that even though I was involved in reviewing this code when it was written five months ago I don't feel comfortable using it now to bulk upsert groupings because I don't feel that I understand the code and don't want to spend the necessary re-learning time to get back to understanding it and being comfortable with it again. The bulk upsert code is probably faster and more efficient but we don't know how much more and whether it's significant, and it comes at a complexity and understanding / maintainability cost. Is it a premature optimization?

  So I'd prefer to ship Blackboard Groups using the much simpler and easier-to-understand non-bulk upserting at first, observe the performance of this in New Relic, and then if it looks worthwhile see if we can send a PR to replace the non-bulk upsert with a simple-as-possible bulk version (perhaps there's an easier way to write a bulk upser function?). We'll be able to weight the complexity cost of the code change against the performance benefit (we'd have to actually deploy the bulk version to really see how it performs and be willing to back it out if there's not much benefit and we feel the code is harder).