### PR TITLE
BB sync API returns all groups in the group set for all users

### DIFF
--- a/lms/views/api/blackboard/sync.py
+++ b/lms/views/api/blackboard/sync.py
@@ -1,17 +1,72 @@
 from pyramid.view import view_config
 
+from lms.models import Grouping
 from lms.security import Permissions
 
 
 class Sync:
     def __init__(self, request):
         self._request = request
+        self._assignment_service = self._request.find_service(name="assignment")
+        self._grouping_service = self._request.find_service(name="grouping")
+        self._course_service = self._request.find_service(name="course")
+        self._blackboard_api = self._request.find_service(name="blackboard_api_client")
+
+        self._tool_consumer_instance_guid = self._request.json["lms"][
+            "tool_consumer_instance_guid"
+        ]
 
     @view_config(
         route_name="blackboard_api.sync",
         request_method="POST",
         renderer="json",
         permission=Permissions.API,
-    )  # pylint: disable=no-self-use
+    )
     def sync(self):
-        return []
+        groups = self._get_blackboard_groups()
+
+        self._sync_to_h(groups)
+
+        authority = self._request.registry.settings["h_authority"]
+        return [group.groupid(authority) for group in groups]
+
+    def _get_blackboard_groups(self):
+        group_set_id = self._group_set()
+        course_id = self._request.json["course"]["context_id"]
+        groups = self._blackboard_api.group_set_groups(course_id, group_set_id)
+
+        return self._to_groups_groupings(groups)
+
+    def _group_set(self):
+        return self._assignment_service.get(
+            self._tool_consumer_instance_guid,
+            self._request.json["assignment"]["resource_link_id"],
+        ).extra["group_set_id"]
+
+    def _to_groups_groupings(self, groups):
+        course = self._get_course()
+
+        return [
+            self._grouping_service.upsert_with_parent(
+                tool_consumer_instance_guid=self._tool_consumer_instance_guid,
+                lms_id=group["id"],
+                lms_name=group["name"],
+                parent=course,
+                type_=Grouping.Type.BLACKBOARD_GROUP,
+                extra={"group_set_id": group["groupSetId"]},
+            )
+            for group in groups
+        ]
+
+    def _sync_to_h(self, groups):
+        lti_h_svc = self._request.find_service(name="lti_h")
+        group_info = self._request.json["group_info"]
+        lti_h_svc.sync(groups, group_info)
+
+    def _get_course(self):
+        return self._course_service.get(
+            self._course_service.generate_authority_provided_id(
+                self._tool_consumer_instance_guid,
+                self._request.json["course"]["context_id"],
+            )
+        )

--- a/tests/unit/lms/views/api/blackboard/sync_test.py
+++ b/tests/unit/lms/views/api/blackboard/sync_test.py
@@ -1,7 +1,72 @@
+import pytest
+
+from lms.models import Grouping
 from lms.views.api.blackboard.sync import Sync
+from tests.conftest import TEST_SETTINGS
+
+pytestmark = pytest.mark.usefixtures(
+    "assignment_service",
+    "lti_h_service",
+    "grouping_service",
+    "course_service",
+    "blackboard_api_client",
+)
 
 
-def test_it(pyramid_request):
+def test_it(pyramid_request, assert_sync_and_return_groups, blackboard_api_client):
+    groups = [{"name": "GROUP", "id": "1", "groupSetId": "2"}]
+    blackboard_api_client.group_set_groups.return_value = groups
+
     result = Sync(pyramid_request).sync()
 
-    assert result == []
+    assert_sync_and_return_groups(result, groups=groups)
+
+
+@pytest.fixture
+def assert_sync_and_return_groups(
+    lti_h_service, request_json, grouping_service, course_service
+):
+    tool_guid = request_json["lms"]["tool_consumer_instance_guid"]
+
+    def assert_return_values(groupids, groups):
+        expected_groups = [
+            grouping_service.upsert_with_parent(
+                tool_consumer_instance_guid=tool_guid,
+                lms_id=group["id"],
+                lms_name=group.get("name", f"Group {group['id']}"),
+                parent=course_service.get.return_value,
+                type_=Grouping.Type.CANVAS_GROUP,
+                extra={"group_set_id": group["groupSetId"]},
+            )
+            for group in groups
+        ]
+
+        lti_h_service.sync.assert_called_once_with(
+            expected_groups, request_json["group_info"]
+        )
+
+        assert groupids == [
+            group.groupid(TEST_SETTINGS["h_authority"]) for group in expected_groups
+        ]
+
+    return assert_return_values
+
+
+@pytest.fixture
+def request_json():
+    return {
+        "course": {
+            "context_id": "test_context_id",
+        },
+        "assignment": {
+            "resource_link_id": "test_resource_link_id",
+        },
+        "lms": {"tool_consumer_instance_guid": "test_tool_consumer_instance_guid"},
+        "group_info": {"foo": "bar"},
+    }
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request, request_json):
+    pyramid_request.json = request_json
+    return pyramid_request


### PR DESCRIPTION
This takes the current sync API that returns just [] and change it to return all the groups in the group set.

- No error handling for non existing group set or no groups in it.
- No error handling for the student not having access to that particular endpoint

This doesn't add much value on itself but I think it easier to review here the private methods and the consecutive PRs that add the conditionals (if student/teacher/grading) and error handling will be more focused.


# Testing

- Switch to `bb-poc-testing`
- Pick this branch there `git cherry-pick bb-sync-teacher`
- Create a new assignment on BB, select group assignment and pick a group set.
- Launching the assignment as a teacher should diplay all the groups in the group set.