### PR TITLE
Tweak the Blackboard sync API params

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -517,6 +517,8 @@ class JSConfig:
                 },
                 "course": {
                     "context_id": req.params["context_id"],
+                },
+                "assignment": {
                     "resource_link_id": req.params["resource_link_id"],
                 },
                 "group_info": {

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -471,6 +471,8 @@ class TestJSConfigAPISync:
             "data": {
                 "course": {
                     "context_id": "test_context_id",
+                },
+                "assignment": {
                     "resource_link_id": "test_resource_link_id",
                 },
                 "lms": {


### PR DESCRIPTION
The `resource_link_id` param is part of the assignment (it's a unique identifier for the assignment), not part of the course.