### PR TITLE
Remove the Grouping.Type enum

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
@@ -12,12 +10,6 @@ MAX_GROUP_NAME_LENGTH = 25
 
 
 class Grouping(CreatedUpdatedMixin, BASE):
-    class Type(str, Enum):
-        COURSE = "course"
-        CANVAS_SECTION = "canvas_section"
-        CANVAS_GROUP = "canvas_group"
-        BLACKBOARD_GROUP = "blackboard_group"
-
     __tablename__ = "grouping"
     __mapper_args__ = {"polymorphic_on": "type"}
     __table_args__ = (
@@ -106,19 +98,19 @@ class Grouping(CreatedUpdatedMixin, BASE):
 
 
 class CanvasSection(Grouping):
-    __mapper_args__ = {"polymorphic_identity": Grouping.Type.CANVAS_SECTION}
+    __mapper_args__ = {"polymorphic_identity": "canvas_section"}
 
 
 class CanvasGroup(Grouping):
-    __mapper_args__ = {"polymorphic_identity": Grouping.Type.CANVAS_GROUP}
+    __mapper_args__ = {"polymorphic_identity": "canvas_group"}
 
 
 class BlackboardGroup(Grouping):
-    __mapper_args__ = {"polymorphic_identity": Grouping.Type.BLACKBOARD_GROUP}
+    __mapper_args__ = {"polymorphic_identity": "blackboard_group"}
 
 
 class Course(Grouping):
-    __mapper_args__ = {"polymorphic_identity": Grouping.Type.COURSE}
+    __mapper_args__ = {"polymorphic_identity": "course"}
 
 
 class GroupingMembership(CreatedUpdatedMixin, BASE):

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -1,7 +1,7 @@
 import json
 from copy import deepcopy
 
-from lms.models import Course, CourseGroupsExportedFromH, Grouping, LegacyCourse
+from lms.models import Course, CourseGroupsExportedFromH, LegacyCourse
 from lms.services.grouping import GroupingService
 
 
@@ -131,7 +131,7 @@ class CourseService:
         globally uniquely identify a course.
         """
         return GroupingService.generate_authority_provided_id(
-            tool_consumer_instance_guid, context_id, None, Grouping.Type.COURSE
+            tool_consumer_instance_guid, context_id, None, "course"
         )
 
 

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -17,20 +17,18 @@ class GroupingService:
         tool_consumer_instance_guid,
         lms_id,
         parent: Optional[Grouping],
-        type_: Grouping.Type,
+        type_: str,
     ):
-        if type_ == Grouping.Type.COURSE:
+        if type_ == "course":
             return hashed_id(tool_consumer_instance_guid, lms_id)
 
         # For the rest of types, parent is mandatory
         assert parent is not None
 
-        if type_ == Grouping.Type.CANVAS_SECTION:
+        if type_ == "canvas_section":
             return hashed_id(tool_consumer_instance_guid, parent.lms_id, lms_id)
 
-        return hashed_id(
-            tool_consumer_instance_guid, parent.lms_id, type_.value, lms_id
-        )
+        return hashed_id(tool_consumer_instance_guid, parent.lms_id, type_, lms_id)
 
     def upsert_with_parent(  # pylint: disable=too-many-arguments
         self,
@@ -38,7 +36,7 @@ class GroupingService:
         lms_id,
         lms_name,
         parent: Grouping,
-        type_: Grouping.Type,
+        type_: str,
         extra=None,
     ):
         """
@@ -101,7 +99,7 @@ class GroupingService:
         self,
         course: Course,
         user_id: str,
-        type_: Grouping.Type,
+        type_: str,
         group_set_id: Optional[Union[str, int]] = None,
     ):
         """

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -1,6 +1,5 @@
 from pyramid.view import view_config
 
-from lms.models import Grouping
 from lms.security import Permissions
 from lms.services import CanvasAPIError
 from lms.views import (
@@ -127,7 +126,7 @@ class Sync:
                 lms_id=group["id"],
                 lms_name=group["name"],
                 parent=course,
-                type_=Grouping.Type.CANVAS_GROUP,
+                type_="canvas_group",
                 extra={"group_set_id": group["group_category_id"]},
             )
             for group in groups
@@ -143,7 +142,7 @@ class Sync:
                 lms_id=section["id"],
                 lms_name=section["name"],
                 parent=course,
-                type_=Grouping.Type.CANVAS_SECTION,
+                type_="canvas_section",
             )
             for section in sections
         ]

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -2,7 +2,7 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.models import CanvasGroup, Grouping, GroupingMembership
+from lms.models import CanvasGroup, GroupingMembership
 from lms.services.grouping import GroupingService, factory
 from tests import factories
 
@@ -24,7 +24,7 @@ class TestGroupingService:
             lms_id="lms_id",
             lms_name="lms_name",
             parent=course,
-            type_=Grouping.Type.CANVAS_GROUP,
+            type_="canvas_group",
         )
 
         assert db_session.query(CanvasGroup).one() == test_grouping
@@ -35,7 +35,7 @@ class TestGroupingService:
             "tool_consumer_instance_guid": course.application_instance.tool_consumer_instance_guid,
             "lms_id": "lms_id",
             "parent": course,
-            "type_": Grouping.Type.CANVAS_GROUP,
+            "type_": "canvas_group",
         }
         old_name = "old_name"
         old_extra = {"extra": "old"}
@@ -64,28 +64,28 @@ class TestGroupingService:
             "same_id",
             "group_name",
             course,
-            Grouping.Type.CANVAS_GROUP,
+            "canvas_group",
         )
         section = svc.upsert_with_parent(
             self.TOOL_CONSUMER_INSTANCE_GUID,
             "same_id",
             "section_name",
             course,
-            Grouping.Type.CANVAS_SECTION,
+            "canvas_section",
         )
 
         assert group.authority_provided_id == "078cc1b793e061085ed3ef91189b41a6f7dd26b8"
         assert (
             section.authority_provided_id == "867c2696d32eb4b5e9cf5c5304cb71c3e20bfd14"
         )
-        assert group.type == Grouping.Type.CANVAS_GROUP
-        assert section.type == Grouping.Type.CANVAS_SECTION
+        assert group.type == "canvas_group"
+        assert section.type == "canvas_section"
         assert group.parent_id == section.parent_id == course.id
 
     def test_generate_authority_provided_id_for_course(self, svc):
         assert (
             svc.generate_authority_provided_id(
-                self.TOOL_CONSUMER_INSTANCE_GUID, "lms_id", None, Grouping.Type.COURSE
+                self.TOOL_CONSUMER_INSTANCE_GUID, "lms_id", None, "course"
             )
             == "f56fc198fea84f419080e428f0ee2a7c0e2c132a"
         )
@@ -93,8 +93,8 @@ class TestGroupingService:
     @pytest.mark.parametrize(
         "type_,expected",
         [
-            (Grouping.Type.CANVAS_SECTION, "0d671acc7759d5a5d06c724bb4bf7bf26419b9ba"),
-            (Grouping.Type.CANVAS_GROUP, "aaab80699a478e9da17e734f2e3c8126687e6135"),
+            ("canvas_section", "0d671acc7759d5a5d06c724bb4bf7bf26419b9ba"),
+            ("canvas_group", "aaab80699a478e9da17e734f2e3c8126687e6135"),
         ],
     )
     def test_generate_authority_provided_id_with_parent(
@@ -138,7 +138,7 @@ class TestGroupingService:
         user, courses, group_a = with_group_memberships
 
         groupings = svc.get_course_groupings_for_user(
-            courses[0], user.user_id, Grouping.Type.CANVAS_GROUP
+            courses[0], user.user_id, "canvas_group"
         )
 
         assert len(groupings) == 1
@@ -152,7 +152,7 @@ class TestGroupingService:
         groupings = svc.get_course_groupings_for_user(
             courses[0],
             user.user_id,
-            Grouping.Type.CANVAS_GROUP,
+            "canvas_group",
             group_a.extra["group_set_id"],
         )
 
@@ -165,7 +165,7 @@ class TestGroupingService:
         user, courses, _ = with_group_memberships
 
         groupings = svc.get_course_groupings_for_user(
-            courses[0], user.user_id, Grouping.Type.CANVAS_GROUP, "ANOTHER_GROUP_SET_ID"
+            courses[0], user.user_id, "canvas_group", "ANOTHER_GROUP_SET_ID"
         )
 
         assert not groupings
@@ -176,7 +176,7 @@ class TestGroupingService:
         user, courses, _ = with_group_memberships
 
         groupings = svc.get_course_groupings_for_user(
-            courses[0], user.user_id, Grouping.Type.CANVAS_SECTION
+            courses[0], user.user_id, "canvas_section"
         )
 
         assert not groupings
@@ -187,7 +187,7 @@ class TestGroupingService:
         user, courses, _ = with_group_memberships
 
         groupings = svc.get_course_groupings_for_user(
-            courses[1], user.user_id, Grouping.Type.CANVAS_GROUP
+            courses[1], user.user_id, "canvas_group"
         )
 
         assert not groupings
@@ -199,7 +199,7 @@ class TestGroupingService:
         other_user = factories.User(application_instance=application_instance)
 
         groupings = svc.get_course_groupings_for_user(
-            courses[0], other_user.user_id, Grouping.Type.CANVAS_GROUP
+            courses[0], other_user.user_id, "canvas_group"
         )
 
         assert not groupings

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from lms.models import Grouping
 from lms.services import CanvasAPIError
 from lms.views import (
     CanvasGroupSetEmpty,
@@ -222,7 +221,7 @@ def assert_sync_and_return_sections(
                 lms_id=section["id"],
                 lms_name=section.get("name", f"Section {section['id']}"),
                 parent=course_service.get.return_value,
-                type_=Grouping.Type.CANVAS_SECTION,
+                type_="canvas_section",
             )
             for section in sections
         ]
@@ -251,7 +250,7 @@ def assert_sync_and_return_groups(
                 lms_id=group["id"],
                 lms_name=group.get("name", f"Group {group['id']}"),
                 parent=course_service.get.return_value,
-                type_=Grouping.Type.CANVAS_GROUP,
+                type_="canvas_group",
                 extra={"group_set_id": group["group_category_id"]},
             )
             for group in groups


### PR DESCRIPTION
Now that we have a DB-level constraint to ensure that the `grouping` table can't contain invalid types (https://github.com/hypothesis/lms/pull/3432/) is it easier to just type `"course"` rather than having to do `from lms.models import Grouping` and then use `Grouping.Type.COURSE`?