### PR TITLE
Store group set on the assignment while configuring it

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -217,7 +217,7 @@ class LTILaunchResource:
         assignment = self._assignment_service.get(
             tool_consumer_instance_guid, self.resource_link_id
         )
-        return bool(assignment and assignment.extra.get("group_set"))
+        return bool(assignment and assignment.extra.get("group_set_id"))
 
     @property
     def canvas_is_group_launch(self):

--- a/lms/validation/_assignment.py
+++ b/lms/validation/_assignment.py
@@ -17,3 +17,4 @@ class ConfigureAssignmentSchema(PyramidRequestSchema):
     user_id = fields.Str(required=True)
     context_id = fields.Str(required=True)
     context_title = fields.Str(required=True)
+    group_set = fields.Str(required=False, allow_none=True)

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -348,12 +348,17 @@ class BasicLTILaunchViews:
         And we also send back the assignment launch page, passing the chosen
         URL to Via, as the direct response to the content item form submission.
         """
+        extra = {}
+        if group_set := self.request.parsed_params.get("group_set"):
+            extra["group_set_id"] = group_set
+
         document_url = self.request.parsed_params["document_url"]
 
         self.assignment_service.upsert(
             document_url,
             self.request.parsed_params["tool_consumer_instance_guid"],
             self.context.resource_link_id,
+            extra=extra,
         )
 
         self.context.js_config.add_document_url(document_url)

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -384,7 +384,7 @@ class TestIsBlackboardGroupLaunch:
         assert not lti_launch_groups_enabled.is_blackboard_group_launch
 
     def test_it(self, lti_launch_groups_enabled, assignment_service):
-        assignment_service.get.return_value.extra = {"group_set": "ID"}
+        assignment_service.get.return_value.extra = {"group_set_id": "ID"}
 
         assert lti_launch_groups_enabled.is_blackboard_group_launch
 


### PR DESCRIPTION
Store the group set of the assignment on extra for DB configured ones.

Note the change from "group_set" -> "group_set_id". We are storing currently the same value for canvas on the groupings themselves and it's probably  nicer if the names match between different extras even if they are in different tables.

```
select extra from grouping where type = 'canvas_group' and extra is not null  order by id desc limit 5;
{"group_set_id": 2631}
{"group_set_id": 2631}
{"group_set_id": 2631}
{"group_set_id": 2631}
{"group_set_id": 2631}
```

As a follow up this values in devdata will need to change: https://github.com/hypothesis/devdata/blob/1e24cf8f088c51cfd13439de4f4420fd763a3f7e/lms/devdata.json#L290