### PR TITLE
Ensure that child groupings must belong to the same application instance as their parents

### DIFF
--- a/lms/migrations/versions/f581d8a273cc_constrain_child_groupings_to_parents_.py
+++ b/lms/migrations/versions/f581d8a273cc_constrain_child_groupings_to_parents_.py
@@ -1,0 +1,45 @@
+"""
+Constrain child groupings to belong to their parent's application instance.
+
+Revision ID: f581d8a273cc
+Revises: 6882c201b56e
+Create Date: 2022-01-25 17:57:55.813338
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f581d8a273cc"
+down_revision = "6882c201b56e"
+
+
+def upgrade():
+    op.drop_constraint(
+        "fk__grouping__parent_id__grouping", "grouping", type_="foreignkey"
+    )
+    op.create_unique_constraint(
+        op.f("uq__grouping__id"), "grouping", ["id", "application_instance_id"]
+    )
+    op.create_foreign_key(
+        op.f("fk__grouping__parent_id__grouping"),
+        "grouping",
+        "grouping",
+        ["parent_id", "application_instance_id"],
+        ["id", "application_instance_id"],
+        ondelete="cascade",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk__grouping__parent_id__grouping"), "grouping", type_="foreignkey"
+    )
+    op.drop_constraint(op.f("uq__grouping__id"), "grouping", type_="unique")
+    op.create_foreign_key(
+        "fk__grouping__parent_id__grouping",
+        "grouping",
+        "grouping",
+        ["parent_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -10,7 +10,7 @@ from lms.models._hashed_id import hashed_id
 class GroupingService:
     def __init__(self, db, application_instance_service):
         self._db = db
-        self._application_instance = application_instance_service.get_current()
+        self.application_instance = application_instance_service.get_current()
 
     @staticmethod
     def generate_authority_provided_id(
@@ -58,7 +58,7 @@ class GroupingService:
         grouping = (
             self._db.query(Grouping)
             .filter_by(
-                application_instance=self._application_instance,
+                application_instance=self.application_instance,
                 authority_provided_id=authority_provided_id,
             )
             .one_or_none()
@@ -66,7 +66,7 @@ class GroupingService:
 
         if not grouping:
             grouping = Grouping(
-                application_instance=self._application_instance,
+                application_instance=self.application_instance,
                 authority_provided_id=authority_provided_id,
                 lms_id=lms_id,
                 parent_id=parent.id,


### PR DESCRIPTION
### Problem

On master it's possible to create a grouping (e.g. a Blackboard group) whose parent grouping (a Blackboard course) belongs to a different application instance, which makes no sense.

For example this first creates `PARENT_GROUPING` with `application_instance_id` `1` and then creates `CHILD_GROUPING` with `application_instance_id` `2` and with `PARENT_GROUPING` (`parent_id` `1`) as its parent:

```sql
postgres=# INSERT INTO grouping (application_instance_id, authority_provided_id, lms_id, lms_name, type) VALUES (1, 'authority_provided_id', 'lms_id_1', 'PARENT_GROUPING', 'course');
INSERT 0 1
postgres=# INSERT INTO grouping (application_instance_id, authority_provided_id, parent_id, lms_id, lms_name, type) VALUES (2, 'authority_provided_id', 1, 'lms_id_2', 'CHILD_GROUPING', 'blackboard_group');
INSERT 0 1
postgres=# select * from grouping;
-[ RECORD 1 ]-----------+---------------------------
created                 | 2021-12-03 18:00:03.412114
updated                 | 2021-12-03 18:00:03.412114
id                      | 1
application_instance_id | 1
authority_provided_id   | authority_provided_id
parent_id               | 
lms_id                  | lms_id_1
lms_name                | PARENT_GROUPING
type                    | course
settings                | {}
extra                   | {}
-[ RECORD 2 ]-----------+---------------------------
created                 | 2021-12-03 18:00:11.305157
updated                 | 2021-12-03 18:00:11.305157
id                      | 2
application_instance_id | 2
authority_provided_id   | authority_provided_id
parent_id               | 1
lms_id                  | lms_id_2
lms_name                | CHILD_GROUPING
type                    | blackboard_group
settings                | {}
extra                   | {}
```

Or the same thing in Python, on master:

```python
>>> db.add(models.Grouping(application_instance_id=1, authority_provided_id="authority_provided_id", lms_id="lms_id_1", lms_name="PARENT_GROUPING", type="course"))
>>> db.add(models.Grouping(application_instance_id=2, authority_provided_id="authority_provided_id", lms_id="lms_id_2", lms_name="CHILD_GROUPING", type="blackboard_group", parent_id=1))
>>> tm.commit()
>>> tm.begin()
<transaction._transaction.Transaction at 0x7f2254e8bdc0>
>>> db.query(models.Grouping).all()
[Course(created=datetime.datetime(2021, 12, 3, 18, 12, 24, 386936), updated=datetime.datetime(2021, 12, 3, 18, 12, 24, 386936), id=1, application_instance_id=1, authority_provided_id='authority_provided_id', parent_id=None, lms_id='lms_id_1', lms_name='PARENT_GROUPING', type='course', settings=ApplicationSettings({}), extra={}),
 BlackboardGroup(created=datetime.datetime(2021, 12, 3, 18, 12, 24, 386936), updated=datetime.datetime(2021, 12, 3, 18, 12, 24, 386936), id=2, application_instance_id=2, authority_provided_id='authority_provided_id', parent_id=1, lms_id='lms_id_2', lms_name='CHILD_GROUPING', type='blackboard_group', settings=ApplicationSettings({}), extra={})]
```

### Solution

This branch changes the the `grouping.parent_id -> grouping.id` foreign key constraint to a compound foreign key constraint `(grouping.parent_id, grouping.application_instance_id) -> (grouping.id, grouping.application_instance_id)`. Matching up the `application_instance_id`'s isn't necessary to find/identify the parent grouping, but it ensures that the parent grouping's `application_instance_id` must be the same as the child's.

On **this branch** the second SQL query will fail with a foreign key constraint violation:

```sql
postgres=# INSERT INTO grouping (application_instance_id, authority_provided_id, lms_id, lms_name, type) VALUES (1, 'authority_provided_id', 'lms_id_1', 'PARENT_GROUPING', 'course');
INSERT 0 1
postgres=# INSERT INTO grouping (application_instance_id, authority_provided_id, parent_id, lms_id, lms_name, type) VALUES (2, 'authority_provided_id', 1, 'lms_id_2', 'CHILD_GROUPING', 'blackboard_group');
ERROR:  insert or update on table "grouping" violates foreign key constraint "fk__grouping__parent_id__grouping"
DETAIL:  Key (parent_id, application_instance_id)=(1, 2) is not present in table "grouping".
```

On **this branch**:

```python
>>> db.add(models.Grouping(application_instance_id=1, authority_provided_id="authority_provided_id", lms_id="lms_id_1", lms_name="PARENT_GROUPING", type="course"))
>>> db.add(models.Grouping(application_instance_id=2, authority_provided_id="authority_provided_id", lms_id="lms_id_2", lms_name="CHILD_GROUPING", type="blackboard_group", parent_id=1))
>>> tm.commit()
---------------------------------------------------------------------------
ForeignKeyViolation                       Traceback (most recent call last)
...
ForeignKeyViolation: insert or update on table "grouping" violates foreign key constraint "fk__grouping__parent_id__grouping"
DETAIL:  Key (parent_id, application_instance_id)=(1, 2) is not present in table "grouping".


The above exception was the direct cause of the following exception:

IntegrityError                            Traceback (most recent call last)
...
IntegrityError: (psycopg2.errors.ForeignKeyViolation) insert or update on table "grouping" violates foreign key constraint "fk__grouping__parent_id__grouping"
DETAIL:  Key (parent_id, application_instance_id)=(1, 2) is not present in table "grouping".

[SQL: INSERT INTO grouping (application_instance_id, authority_provided_id, parent_id, lms_id, lms_name, type) VALUES (%(application_instance_id)s, %(authority_provided_id)s, %(parent_id)s, %(lms_id)s, %(lms_name)s, %(type)s) RETURNING grouping.id]
[parameters: ({'application_instance_id': 1, 'authority_provided_id': 'authority_provided_id', 'parent_id': None, 'lms_id': 'lms_id_1', 'lms_name': 'PARENT_GROUPING', 'type': 'course'}, {'application_instance_id': 2, 'authority_provided_id': 'authority_provided_id', 'parent_id': 1, 'lms_id': 'lms_id_2', 'lms_name': 'CHILD_GROUPING', 'type': 'blackboard_group'})]
...
```