### PR TITLE
BlackboardListGroups schema exposes enrollment.type

### DIFF
--- a/lms/services/blackboard_api/_schemas.py
+++ b/lms/services/blackboard_api/_schemas.py
@@ -4,6 +4,7 @@ Schemas for Blackboard API responses.
 See: https://developer.blackboard.com/portal/displayApi
 """
 from marshmallow import EXCLUDE, Schema, fields, post_load
+from marshmallow.validate import OneOf
 
 from lms.validation._base import RequestsResponseSchema
 
@@ -57,14 +58,23 @@ class BlackboardListGroupSetsSchema(RequestsResponseSchema):
         return data["results"]
 
 
-class BlackboardListGroupSetGroups(RequestsResponseSchema):
+class BlackboardListGroups(RequestsResponseSchema):
     class GroupSchema(Schema):
         class Meta:
             unknown = EXCLUDE
 
+        class EnrollmentSchema(Schema):
+            class Meta:
+                unknown = EXCLUDE
+
+            type = fields.Str(
+                validate=OneOf(["InstructorOnly", "SelfEnrollment"]), required=True
+            )
+
         id = fields.Str(required=True)
         name = fields.Str(required=True)
         groupSetId = fields.Str(required=False, allow_none=True)
+        enrollment = fields.Nested(EnrollmentSchema, required=True)
 
     results = fields.List(fields.Nested(GroupSchema), required=True)
 

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 from lms.events import FilesDiscoveredEvent
 from lms.services.blackboard_api._schemas import (
     BlackboardListFilesSchema,
-    BlackboardListGroupSetGroups,
+    BlackboardListGroups,
     BlackboardListGroupSetsSchema,
     BlackboardPublicURLSchema,
 )
@@ -113,4 +113,4 @@ class BlackboardAPIClient:
             "GET",
             f"/learn/api/public/v2/courses/uuid:{course_id}/groups/sets/{group_set_id}/groups",
         )
-        return BlackboardListGroupSetGroups(response).parse()
+        return BlackboardListGroups(response).parse()

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -237,7 +237,7 @@ class TestGroupSetGroups:
         self,
         svc,
         basic_client,
-        BlackboardListGroupSetGroups,
+        BlackboardListGroups,
         blackboard_list_group_set_groups,
     ):
         group_sets = svc.group_set_groups("COURSE_ID", "GROUP_SET_ID")
@@ -246,9 +246,7 @@ class TestGroupSetGroups:
             "GET",
             "/learn/api/public/v2/courses/uuid:COURSE_ID/groups/sets/GROUP_SET_ID/groups",
         )
-        BlackboardListGroupSetGroups.assert_called_once_with(
-            basic_client.request.return_value
-        )
+        BlackboardListGroups.assert_called_once_with(basic_client.request.return_value)
         assert group_sets == blackboard_list_group_set_groups.parse.return_value
 
 
@@ -293,10 +291,10 @@ def blackboard_list_groupsets_schema(BlackboardListGroupSetsSchema):
 
 
 @pytest.fixture
-def blackboard_list_group_set_groups(BlackboardListGroupSetGroups):
-    return BlackboardListGroupSetGroups.return_value
+def blackboard_list_group_set_groups(BlackboardListGroups):
+    return BlackboardListGroups.return_value
 
 
 @pytest.fixture(autouse=True)
-def BlackboardListGroupSetGroups(patch):
-    return patch("lms.services.blackboard_api.client.BlackboardListGroupSetGroups")
+def BlackboardListGroups(patch):
+    return patch("lms.services.blackboard_api.client.BlackboardListGroups")


### PR DESCRIPTION
It will be necessary to distinguish between groups can see but don't
necessary belong to (SelfEnrollment) and groups the student can only see if the
are member (InstructorOnly)