### PR TITLE
Blackboard course groups

### DIFF
--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -274,8 +274,7 @@ class TestGroupCourseGroups:
             "COURSE_ID", "OTHER_GROUP_SET", current_student_own_groups_only=False
         )
 
-        assert len(groups) == 1
-        assert groups[0]["groupSetId"] == "OTHER_GROUP_SET"
+        assert [group["groupSetId"] for group in groups] == ["OTHER_GROUP_SET"]
 
     def test_it_own_groups_all_instructor_only(
         self, svc, blackboard_list_groups, groups, async_oauth_http_service
@@ -286,8 +285,7 @@ class TestGroupCourseGroups:
             "COURSE_ID", "GROUP_SET", current_student_own_groups_only=True
         )
 
-        assert len(groups) == 1
-        assert groups[0]["enrollment"]["type"] == "InstructorOnly"
+        assert [group["enrollment"]["type"] for group in groups] == ["InstructorOnly"]
         async_oauth_http_service.request.assert_not_called()
 
     def test_it_own_groups_all_self_enrollment(

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -5,6 +5,7 @@ import pytest
 from lms.services import CanvasService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
+from lms.services.async_oauth_http import AsyncOAuthHTTPService
 from lms.services.blackboard_api.client import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
@@ -31,6 +32,7 @@ __all__ = (
     # Individual services
     "application_instance_service",
     "assignment_service",
+    "async_oauth_http_service",
     "blackboard_api_client",
     "canvas_api_client",
     "canvas_service",
@@ -158,6 +160,14 @@ def oauth_http_service(mock_service):
     oauth_http_service = mock_service(OAuthHTTPService, service_name="oauth_http")
     oauth_http_service.request.return_value = factories.requests.Response()
     return oauth_http_service
+
+
+@pytest.fixture
+def async_oauth_http_service(mock_service):
+    async_oauth_http_service = mock_service(
+        AsyncOAuthHTTPService, service_name="async_oauth_http"
+    )
+    return async_oauth_http_service
 
 
 @pytest.fixture


### PR DESCRIPTION
~~This PR includes the commits from https://github.com/hypothesis/lms/pull/3446~~

Method to get groups of a course it needs more complexity that initially thought:
- Using AsyncOauthService to make multiple request the the API 
- Make those request only for self-enrollment groups.