### PR TITLE
Expose the user.user_id while grading

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -413,6 +413,7 @@ class JSConfig:
             )
             yield {
                 "userid": h_user.userid(self._authority),
+                "lmsId": grading_info.user_id,
                 "displayName": h_user.display_name,
                 "LISResultSourcedId": grading_info.lis_result_sourcedid,
                 "LISOutcomeServiceUrl": grading_info.lis_outcome_service_url,

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -306,6 +306,7 @@ class TestMaybeEnableGrading:
                     "LISResultSourcedId": f"test_lis_result_sourcedid_{i}",
                     "displayName": f"test_h_display_name_{i}",
                     "userid": f"acct:test_h_username_{i}@TEST_AUTHORITY",
+                    "lmsId": f"test_user_id_{i}",
                 }
                 for i in range(3)
             ],
@@ -344,6 +345,7 @@ class TestMaybeEnableGrading:
                 lis_outcome_service_url=f"test_lis_outcomes_service_url_{i}",
                 h_username=f"test_h_username_{i}",
                 h_display_name=f"test_h_display_name_{i}",
+                user_id=f"test_user_id_{i}",
             )
             for i in range(3)
         ]


### PR DESCRIPTION
Will be later needed to get the value back on the sync API.