### PR TITLE
Front-end support for assignment configuration with BB groups

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -215,6 +215,12 @@ class JSConfig:
                     "formAction": form_action,
                     "formFields": form_fields,
                     "createAssignmentAPI": self._create_assignment_api(),
+                    # The "content item selection" that we submit to Canvas's
+                    # content_item_return_url is actually an LTI launch URL with
+                    # the selected document URL or file_id as a query parameter. To
+                    # construct these launch URLs our JavaScript code needs the
+                    # base URL of our LTI launch endpoint.
+                    "ltiLaunchUrl": self._request.route_url("lti_launches"),
                     # Specific config for pickers
                     "blackboard": FilePickerConfig.blackboard_config(*args),
                     "canvas": FilePickerConfig.canvas_config(*args),

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -4,63 +4,67 @@ class FilePickerConfig:
     @classmethod
     def blackboard_config(cls, context, request, application_instance):
         """Get Blackboard files config."""
-
-        enabled = application_instance.settings.get("blackboard", "files_enabled")
+        files_enabled = application_instance.settings.get("blackboard", "files_enabled")
+        groups_enabled = context.blackboard_groups_enabled
 
         auth_url = request.route_url("blackboard_api.oauth.authorize")
         course_id = request.params.get("context_id")
 
-        return {
-            "enabled": enabled,
-            "groupsEnabled": context.blackboard_groups_enabled,
-            "listFiles": {
+        config = {
+            "enabled": files_enabled,
+            "groupsEnabled": groups_enabled,
+        }
+
+        if files_enabled:
+            config["listFiles"] = {
                 "authUrl": auth_url,
                 "path": request.route_path(
                     "blackboard_api.courses.files.list", course_id=course_id
                 ),
-            },
-            "listGroupSets": {
+            }
+
+        if groups_enabled:
+            config["listGroupSets"] = {
                 "authUrl": auth_url,
                 "path": request.route_path(
                     "blackboard_api.courses.group_sets.list", course_id=course_id
                 ),
-            },
-        }
+            }
+
+        return config
 
     @classmethod
     def canvas_config(cls, context, request, application_instance):
         """Get Canvas files config."""
-
         enabled = context.is_canvas and (
             "custom_canvas_course_id" in request.params
             and application_instance.developer_key is not None
         )
+        groups_enabled = context.canvas_groups_enabled
 
         auth_url = request.route_url("canvas_api.oauth.authorize")
         course_id = request.params.get("custom_canvas_course_id")
 
-        return {
+        config = {
             "enabled": enabled,
-            "groupsEnabled": context.canvas_groups_enabled,
-            # The "content item selection" that we submit to Canvas's
-            # content_item_return_url is actually an LTI launch URL with
-            # the selected document URL or file_id as a query parameter. To
-            # construct these launch URLs our JavaScript code needs the
-            # base URL of our LTI launch endpoint.
-            "ltiLaunchUrl": request.route_url("lti_launches"),
+            "groupsEnabled": groups_enabled,
             "listFiles": {
                 "authUrl": auth_url,
                 "path": request.route_path(
                     "canvas_api.courses.files.list", course_id=course_id
                 ),
             },
-            "listGroupSets": {
+        }
+
+        if groups_enabled:
+            config["listGroupSets"] = {
                 "authUrl": auth_url,
                 "path": request.route_path(
                     "canvas_api.courses.group_sets.list", course_id=course_id
                 ),
-            },
-        }
+            }
+
+        return config
 
     @classmethod
     def google_files_config(cls, context, request, application_instance):

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -35,6 +35,21 @@ import GroupConfigSelector from './GroupConfigSelector';
  */
 
 /**
+ * Blackboard files are of a "url" content type, but the URL is opaque and
+ * not helpful to the user. In those cases, use a canned message, otherwise
+ * truncate the content URL for display.
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+function formatContentURL(url) {
+  // All Blackboard file URLs start with the literal string `blackboard:`
+  if (url.includes('blackboard:')) {
+    return 'PDF file in Blackboard';
+  }
+  return truncateURL(url, 65 /* maxLength */);
+}
+/**
  * Return a human-readable description of assignment content.
  *
  * @param {Content} content - Type and details of assignment content
@@ -43,7 +58,7 @@ import GroupConfigSelector from './GroupConfigSelector';
 function contentDescription(content) {
   switch (content.type) {
     case 'url':
-      return truncateURL(content.url, 65 /* maxLength */);
+      return formatContentURL(content.url);
     case 'file':
       return 'PDF file in Canvas';
     case 'vitalsource':

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -63,14 +63,12 @@ function contentDescription(content) {
 export default function FilePickerApp({ onSubmit }) {
   const submitButton = /** @type {{ current: HTMLInputElement }} */ (useRef());
   const {
-    filePicker: {
-      formAction,
-      formFields,
-      canvas: { groupsEnabled: enableGroupConfig, ltiLaunchUrl },
-    },
+    filePicker: { formAction, formFields, ltiLaunchUrl, blackboard, canvas },
   } = useContext(Config);
 
   const [content, setContent] = useState(/** @type {Content|null} */ (null));
+
+  const enableGroupConfig = blackboard?.groupsEnabled || canvas?.groupsEnabled;
 
   const [groupConfig, setGroupConfig] = useState(
     /** @type {GroupConfig} */ ({

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.js
@@ -45,6 +45,7 @@ export default function FilePickerFormFields({
       {Object.entries(formFields).map(([field, value]) => (
         <input key={field} type="hidden" name={field} value={value} />
       ))}
+      {groupSet && <input type="hidden" name="group_set" value={groupSet} />}
       <input type="hidden" name="content_items" value={contentItem} />
       {content.type === 'url' && (
         // Set the `document_url` form field which is used by the `configure_assignment`

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -62,10 +62,10 @@ export default function GroupConfigSelector({
 
   const {
     api: { authToken },
-    filePicker: {
-      canvas: { listGroupSets: listGroupSetsAPI },
-    },
+    filePicker: { blackboard, canvas },
   } = useContext(Config);
+
+  const listGroupSetsAPI = canvas?.listGroupSets ?? blackboard?.listGroupSets;
 
   const fetchGroupSets = useCallback(async () => {
     setFetchError(null);
@@ -123,7 +123,7 @@ export default function GroupConfigSelector({
             // Currently all fetch errors are handled by attempting to re-authorize
             // and then re-fetch group sets.
             <>
-              <p>Canvas needs your permission to fetch group sets</p>
+              <p>Hypothesis needs your permission to fetch group sets</p>
               <AuthButton
                 authURL={/** @type {string} */ (listGroupSetsAPI.authUrl)}
                 authToken={authToken}

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -156,6 +156,13 @@ describe('FilePickerApp', () => {
           summary: 'https://example.com',
         },
         {
+          content: {
+            type: 'url',
+            url: 'blackboard://content-resource/_8615_1/',
+          },
+          summary: 'PDF file in Blackboard',
+        },
+        {
           content: { type: 'file', id: 'abcd' },
           summary: 'PDF file in Canvas',
         },

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -47,21 +47,33 @@ describe('FilePickerFormFields', () => {
     assert.deepEqual(contentItems, contentItemForContent(launchURL, content));
   });
 
-  it('adds `group_set` query param to LTI launch URL if `groupSet` prop is specified', () => {
-    const content = { type: 'url', url: 'https://example.com/' };
-    const formFields = createComponent({
-      content,
-      groupSet: 'groupSet1',
+  context('`groupSet` prop is specified', () => {
+    it('adds `group_set` query param to LTI launch URL', () => {
+      const content = { type: 'url', url: 'https://example.com/' };
+      const formFields = createComponent({
+        content,
+        groupSet: 'groupSet1',
+      });
+      const contentItems = JSON.parse(
+        formFields.find('input[name="content_items"]').prop('value')
+      );
+      assert.deepEqual(
+        contentItems,
+        contentItemForContent(launchURL, content, {
+          group_set: 'groupSet1',
+        })
+      );
     });
-    const contentItems = JSON.parse(
-      formFields.find('input[name="content_items"]').prop('value')
-    );
-    assert.deepEqual(
-      contentItems,
-      contentItemForContent(launchURL, content, {
-        group_set: 'groupSet1',
-      })
-    );
+
+    it('adds a `group_set` hidden form field', () => {
+      const content = { type: 'url', url: 'https://example.com/' };
+      const formFields = createComponent({
+        content,
+        groupSet: 'groupSet1',
+      });
+
+      assert.isTrue(formFields.find('input[name="group_set"]').exists());
+    });
   });
 
   it('renders `document_url` field for URL content', () => {

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -210,4 +210,34 @@ describe('GroupConfigSelector', () => {
 
     assert.isFalse(wrapper.exists('AuthButton'));
   });
+
+  context('Blackboard groups', () => {
+    // Component functionality should be identical for either canvas or
+    // blackboard groups; this exercises the blackboard path specifically
+    it('fetches blackboard groups if activated in config', async () => {
+      fakeConfig.filePicker = {
+        blackboard: {
+          listGroupSets: {
+            authUrl: authURL,
+            path: groupSetsAPIRequest.path,
+          },
+        },
+      };
+      const wrapper = createComponent({
+        groupConfig: { useGroupSet: true, groupConfig: null },
+      });
+
+      // Once group sets are fetched, they should be rendered as `<option>`s.
+      const options = await waitForElement(
+        wrapper,
+        'option[data-testid="groupset-option"]'
+      );
+      assert.equal(options.length, fakeGroupSets.length);
+
+      fakeGroupSets.forEach((gs, i) => {
+        assert.equal(options.at(i).text(), gs.name);
+        assert.equal(options.at(i).prop('value'), gs.id);
+      });
+    });
+  });
 });

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -68,6 +68,7 @@ import { createContext } from 'preact';
  * @prop {string} formAction
  * @prop {Record<string,string>} formFields
  * @prop {APICallInfo} createAssignmentAPI
+ * @prop {string} ltiLaunchUrl
  * @prop {object} blackboard
  *   @prop {boolean} blackboard.enabled
  *   @prop {boolean} blackboard.groupsEnabled
@@ -76,7 +77,6 @@ import { createContext } from 'preact';
  * @prop {object} canvas
  *   @prop {boolean} canvas.enabled
  *   @prop {boolean} canvas.groupsEnabled
- *   @prop {string} canvas.ltiLaunchUrl
  *   @prop {APICallInfo} canvas.listFiles
  *   @prop {APICallInfo} canvas.listGroupSets
  * @prop {object} google

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -8,61 +8,97 @@ from lms.resources._js_config import FilePickerConfig
 
 
 class TestFilePickerConfig:
-    def test_blackboard_config(self, context, pyramid_request, application_instance):
+    @pytest.mark.parametrize(
+        "files_enabled,groups_enabled",
+        [
+            (False, False),
+            (True, False),
+            (False, True),
+            (True, True),
+        ],
+    )
+    def test_blackboard_config(
+        self,
+        context,
+        pyramid_request,
+        blackboard_application_instance,
+        files_enabled,
+        groups_enabled,
+    ):
+
         pyramid_request.params["context_id"] = "COURSE_ID"
-        application_instance.settings.set(
-            "blackboard", "files_enabled", sentinel.enabled
+        blackboard_application_instance.settings.set(
+            "blackboard", "files_enabled", files_enabled
         )
+        context.blackboard_groups_enabled = groups_enabled
 
         config = FilePickerConfig.blackboard_config(
-            context, pyramid_request, application_instance
+            context, pyramid_request, blackboard_application_instance
         )
 
-        assert config == {
-            "enabled": sentinel.enabled,
-            "groupsEnabled": False,
-            "listFiles": {
-                "authUrl": "http://example.com/api/blackboard/oauth/authorize",
-                "path": "/api/blackboard/courses/COURSE_ID/files",
-            },
-            "listGroupSets": {
-                "authUrl": "http://example.com/api/blackboard/oauth/authorize",
-                "path": "/api/blackboard/courses/COURSE_ID/group_sets",
-            },
+        expected_config = {
+            "enabled": files_enabled,
+            "groupsEnabled": groups_enabled,
         }
 
-    def test_canvas_config(self, context, pyramid_request, application_instance):
+        if files_enabled:
+            expected_config["listFiles"] = {
+                "authUrl": "http://example.com/api/blackboard/oauth/authorize",
+                "path": "/api/blackboard/courses/COURSE_ID/files",
+            }
+
+        if groups_enabled:
+            expected_config["listGroupSets"] = {
+                "authUrl": "http://example.com/api/blackboard/oauth/authorize",
+                "path": "/api/blackboard/courses/COURSE_ID/group_sets",
+            }
+
+        assert config == expected_config
+
+    @pytest.mark.usefixtures("with_is_canvas")
+    @pytest.mark.parametrize(
+        "groups_enabled",
+        [
+            False,
+            True,
+        ],
+    )
+    def test_canvas_config(
+        self, context, pyramid_request, application_instance, groups_enabled
+    ):
         pyramid_request.params["custom_canvas_course_id"] = "COURSE_ID"
+        context.canvas_groups_enabled = groups_enabled
 
         config = FilePickerConfig.canvas_config(
             context, pyramid_request, application_instance
         )
 
-        assert config == {
+        expected_config = {
             "enabled": Any(),
-            "groupsEnabled": False,
+            "groupsEnabled": groups_enabled,
             "listFiles": {
                 "authUrl": "http://example.com/api/canvas/oauth/authorize",
                 "path": "/api/canvas/courses/COURSE_ID/files",
             },
-            "listGroupSets": {
+        }
+
+        if groups_enabled:
+            expected_config["listGroupSets"] = {
                 "authUrl": "http://example.com/api/canvas/oauth/authorize",
                 "path": "/api/canvas/courses/COURSE_ID/group_sets",
-            },
-            "ltiLaunchUrl": "http://example.com/lti_launches",
-        }
+            }
+
+        assert config == expected_config
 
     @pytest.mark.parametrize(
         "missing_value",
-        (None, "is_canvas", "course_id", "developer_key"),
+        (None, "course_id", "developer_key"),
     )
     @pytest.mark.usefixtures("canvas_files_enabled")
     def test_canvas_config_enabled(
         self, context, pyramid_request, application_instance, missing_value
     ):
-        if missing_value == "is_canvas":
-            context.is_canvas = False
-        elif missing_value == "course_id":
+        if missing_value == "course_id":
             pyramid_request.params.pop("custom_canvas_course_id")
         elif missing_value == "developer_key":
             application_instance.developer_key = None
@@ -137,6 +173,16 @@ class TestFilePickerConfig:
         application_instance.lms_url = None
 
         return application_instance
+
+    @pytest.fixture
+    def blackboard_application_instance(self, application_instance):
+        application_instance.tool_consumer_info_product_family_code = "BlackboardLearn"
+
+        return application_instance
+
+    @pytest.fixture
+    def with_is_canvas(self, context):
+        context.is_canvas = True
 
     @pytest.fixture
     def context(self):


### PR DESCRIPTION
This PR contains front-end support for configuring assignments with Blackboard groups. It does not support grading these assignments; that will come later.

## Current structure of this branch

This branch contains frontend implementation, including tests, for configuring assignments with Blackboard groups. Several leading commits on this branch represent related backend changes that underpin the work. For each of these back-end commits, we'll need to determine:

* Whether the commit belongs with this set of work at all or not;
* Whether the commit can be landed independently of these changes, or;
* Whether the commit is a direct dependency for these changes directly and perhaps _should_ be included on this branch (tests needed). The `ltiLaunchUrl` configuration change and not returning `blackboard` or `canvas` file-picker configuration when not applicable commits may be candidates for inclusion, as they are both necessary for these changes to function and cannot be landed on `master` independently without breaking the existing frontend.

I'll continue to discuss with @marcospri and will leave this PR in draft until we have a clear plan.

## Test it out/what to expect

1. Check out this branch
2. Run `make db` and `make devdata`
3. `make dev`

You should be able to select a group set (or not) and the configured assignment should launch correctly.

Also updated here in a separate commit: the text displayed to users on the group-configuration step when the selected content is a Blackboard file has been improved.

Before:

<img width="596" alt="Screen Shot 2021-11-30 at 11 52 37 AM" src="https://user-images.githubusercontent.com/439947/144114037-c4dacc7f-7419-41cc-a574-36e5c660ab6d.png">

After:

<img width="565" alt="Screen Shot 2021-11-30 at 1 10 32 PM" src="https://user-images.githubusercontent.com/439947/144114056-7b925b1d-3eae-4f86-807d-e766e62ff447.png">

Fixes https://github.com/hypothesis/lms/issues/3415