### PR TITLE
Simplify the blackboard_groups_enabled property

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -200,9 +200,6 @@ class LTILaunchResource:
         except ApplicationInstanceNotFound:
             return False
 
-        if application_instance.product != application_instance.Product.BLACKBOARD:
-            return False
-
         return bool(application_instance.settings.get("blackboard", "groups_enabled"))
 
     @property

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -283,7 +283,7 @@ class TestCourseExtra:
 
 @pytest.mark.usefixtures("has_course")
 class TestBlackboardGroupsEnabled:
-    def test_false_when_no_application_instance(
+    def test_it_returns_False_if_theres_no_ApplicationInstance(
         self, application_instance_service, lti_launch
     ):
         application_instance_service.get_current.side_effect = (
@@ -293,24 +293,16 @@ class TestBlackboardGroupsEnabled:
         assert not lti_launch.blackboard_groups_enabled
 
     @pytest.mark.parametrize(
-        "setting_value,product,expected",
-        [
-            (True, "canvas", False),
-            (True, "BlackboardLearn", True),
-            (False, "canvas", False),
-            (False, "BlackboardLearn", False),
-        ],
+        "setting_value,expected",
+        [(True, True), (False, False), (None, False)],
     )
-    def test_it(
-        self, setting_value, product, expected, application_instance_service, lti_launch
+    def test_it_returns_the_setting_from_the_ApplicationInstance(
+        self, setting_value, expected, application_instance_service, lti_launch
     ):
         settings = ApplicationSettings(
             {"blackboard": {"groups_enabled": setting_value}}
         )
         application_instance_service.get_current.return_value.settings = settings
-        application_instance_service.get_current.return_value.tool_consumer_info_product_family_code = (
-            product
-        )
 
         assert lti_launch.blackboard_groups_enabled == expected
 


### PR DESCRIPTION
If `LTILaunchResource.blackboard_groups_enabled` checks `application_instance.product` (and returns `False` if `tool_consumer_info_product_family_code` isn't `"BlackboardLearn"`) we run the risk of the Blackboard Groups feature being disabled when it should be enabled if there are Blackboard instances that use a different `tool_consumer_info_product_family_code`. The code is also more complicated.

On the other hand if `LTILaunchResource.blackboard_groups_enabled` just checks the value of `application_instance.settings.get("blackboard", "groups_enabled")` without checking the product then the risk is that we'll enable Blackboard Groups in a non-Blackboard LMS. This would result in broken behaviour, but:

* It would only happen if a Hypothesis admin incorrectly enabled Blackboard Groups for a non-Blackboard application instance

* It could be fixed by support by using the admin pages to disable Blackboard Groups for the application instance

The resulting code is also simpler.

One of the benefits of simpler code is that it's easier to see all the possible cases, hence I was able to spot that the unit tests were missing the case where `application_instance.settings.get("blackboard", "groups_enabled")` returns `None` and I added a test case for that.