### PR TITLE
Simplify JSConfig._sync_api()

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -540,12 +540,7 @@ class JSConfig:
         ):
             return self._canvas_sync_api()
 
-        if (
-            self._application_instance().product
-            == ApplicationInstance.Product.BLACKBOARD
-            and self._context.is_blackboard_group_launch
-        ):
-
+        if self._context.is_blackboard_group_launch:
             return self._blackboard_sync_api()
 
         return None

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -754,6 +754,7 @@ def context():
         canvas_groups_enabled=False,
         canvas_is_group_launch=False,
         is_group_launch=False,
+        is_blackboard_group_launch=False,
     )
 
 


### PR DESCRIPTION
This doesn't need to check whether `application_instance.product` is `BLACKBOARD`: it wouldn't have been possible to create a Blackboard groups assignment for this application instance in the first place if the LMS wasn't Blackboard.

Also, if the assignment's settings say that it's a Blackboard Groups assignment then we should obey those and launch it as a Blackboard Groups assignment.