### PR TITLE
Remove `ApplicationInstance.product`

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,7 +1,6 @@
 import logging
 import secrets
 from datetime import datetime
-from enum import Enum
 from urllib.parse import urlparse
 
 import sqlalchemy as sa
@@ -18,16 +17,6 @@ LOG = logging.getLogger(__name__)
 
 class ApplicationInstance(BASE):
     """Class to represent a single lms install."""
-
-    class Product(str, Enum):
-        BLACKBOARD = "BlackboardLearn"
-        CANVAS = "canvas"
-        MOODLE = "moodle"
-        D2L = "desire2learn"
-        BLACKBAUD = "BlackbaudK12"
-        SCHOOLOGY = "schoology"
-        SAKAI = "sakai"
-        UNKNOWN = "unknown"
 
     __tablename__ = "application_instances"
 
@@ -166,15 +155,6 @@ class ApplicationInstance(BASE):
         ]:
 
             setattr(self, attr, params.get(attr))
-
-    @property
-    def product(self):
-        try:
-            product = self.Product(self.tool_consumer_info_product_family_code)
-        except ValueError:
-            product = self.Product.UNKNOWN
-
-        return product
 
     @classmethod
     def build_from_lms_url(  # pylint:disable=too-many-arguments

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -152,24 +152,6 @@ class TestApplicationInstance:
 
         assert application_instance.tool_consumer_instance_guid == "EXISTING_GUID"
 
-    @pytest.mark.parametrize(
-        "value,expected",
-        [
-            ("BlackboardLearn", ApplicationInstance.Product.BLACKBOARD),
-            ("canvas", ApplicationInstance.Product.CANVAS),
-            ("moodle", ApplicationInstance.Product.MOODLE),
-            ("desire2learn", ApplicationInstance.Product.D2L),
-            ("BlackbaudK12", ApplicationInstance.Product.BLACKBAUD),
-            ("schoology", ApplicationInstance.Product.SCHOOLOGY),
-            ("sakai", ApplicationInstance.Product.SAKAI),
-            ("wut", ApplicationInstance.Product.UNKNOWN),
-        ],
-    )
-    def test_product(self, value, expected, application_instance):
-        application_instance.tool_consumer_info_product_family_code = value
-
-        assert application_instance.product == expected
-
     @pytest.fixture
     def application_instance(self):
         """Return an ApplicationInstance with minimal required attributes."""

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from h_matchers import Any
 
-from lms.models import ApplicationInstance, GradingInfo, Grouping
+from lms.models import GradingInfo, Grouping
 from lms.resources import LTILaunchResource, OAuth2RedirectResource
 from lms.resources._js_config import JSConfig
 from lms.services import ApplicationInstanceNotFound, HAPIError
@@ -511,15 +511,12 @@ class TestJSConfigAPISync:
         pyramid_request.params["learner_canvas_user_id"] = "test_learner_canvas_user_id"
 
     @pytest.fixture
-    def blackboard_group_launch(self, context, application_instance_service):
+    def blackboard_group_launch(self, context):
         context.canvas_sections_enabled = False
         context.canvas_groups_enabled = False
 
         context.blackboard_groups_enabled = True
         context.is_blackboard_group_launch = True
-        application_instance_service.get_current.return_value.tool_consumer_info_product_family_code = (
-            ApplicationInstance.Product.BLACKBOARD
-        )
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/3461 and https://github.com/hypothesis/lms/pull/3462. It we merge both of those then `ApplicationInstance.product` will no longer be used.