### PR TITLE
Keep Blackboard groups assignments if feature is disabled

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -205,9 +205,6 @@ class LTILaunchResource:
     @property
     def is_blackboard_group_launch(self):
         """Return True if the current assignment uses Blackboard groups."""
-        if not self.blackboard_groups_enabled:
-            return False
-
         tool_consumer_instance_guid = self._request.params[
             "tool_consumer_instance_guid"
         ]

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -342,11 +342,6 @@ class TestCanvasIsGroupLaunch:
 
 
 class TestIsBlackboardGroupLaunch:
-    def test_false_when_not_enabled(self, lti_launch_groups_enabled):
-        lti_launch_groups_enabled.blackboard_groups_enabled = False
-
-        assert not lti_launch_groups_enabled.is_blackboard_group_launch
-
     def test_false_when_no_assignment(
         self, lti_launch_groups_enabled, assignment_service
     ):


### PR DESCRIPTION
If the Blackboard Groups feature is enabled for an application instance and users create some groups assignments and then the feature gets disabled for the application instance those pre-existing groups assignments should remain groups assignments, theys shouldn't become course assignments.

Slack thread:

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1638379099478700