### PR TITLE
Re-enable_lti_launch_mode on basic_lti_launch.configure_assignment

### DIFF
--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -423,6 +423,7 @@ class TestConfigureAssignment:
         pyramid_request,
         parsed_params,
         expected_extras,
+        JSConfig,
     ):
         configure_assignment_caller(context, pyramid_request, parsed_params)
 
@@ -436,6 +437,16 @@ class TestConfigureAssignment:
             pyramid_request.parsed_params["document_url"]
         )
         context.js_config.maybe_enable_grading.assert_called_once_with()
+
+        JSConfig._hypothesis_client.fget.cache_clear.assert_called_once_with()  # pylint: disable=protected-access
+        # One in __init__, one in `configure_assignment`
+        context.js_config.enable_lti_launch_mode.assert_has_calls(
+            [mock.call(), mock.call()]
+        )
+
+    @pytest.fixture
+    def JSConfig(self, patch):
+        return patch("lms.views.basic_lti_launch.JSConfig")
 
 
 class TestUnconfiguredBasicLTILaunch:


### PR DESCRIPTION
After the assignment is configure parts of the JSConfig might have
changed so we need to re-enable lti launch mode.

The existing case this fix is while configuring a groups assignments.
The first call to enable_lti_launch_mode on `__init__` won't populate
the sync API but once the assignment is configured a second call will.

As parts of js_config are memoized we need to manually clear its cache.