### PR TITLE
Remove underscores from Blackboard sync API view

### DIFF
--- a/lms/views/api/blackboard/sync.py
+++ b/lms/views/api/blackboard/sync.py
@@ -7,11 +7,11 @@ from lms.services import UserService
 
 class Sync:
     def __init__(self, request):
-        self._request = request
-        self._grouping_service = self._request.find_service(name="grouping")
-        self._blackboard_api = self._request.find_service(name="blackboard_api_client")
+        self.request = request
+        self.grouping_service = self.request.find_service(name="grouping")
+        self.blackboard_api = self.request.find_service(name="blackboard_api_client")
 
-        self._tool_consumer_instance_guid = self._request.json["lms"][
+        self.tool_consumer_instance_guid = self.request.json["lms"][
             "tool_consumer_instance_guid"
         ]
 
@@ -22,57 +22,57 @@ class Sync:
         permission=Permissions.API,
     )
     def sync(self):
-        groups = self._get_blackboard_groups()
+        groups = self.get_blackboard_groups()
 
-        self._sync_to_h(groups)
+        self.sync_to_h(groups)
 
-        authority = self._request.registry.settings["h_authority"]
+        authority = self.request.registry.settings["h_authority"]
         return [group.groupid(authority) for group in groups]
 
-    def _get_blackboard_groups(self):
-        lti_user = self._request.lti_user
-        group_set_id = self._group_set()
-        course_id = self._request.json["course"]["context_id"]
-        course = self._get_course(course_id)
+    def get_blackboard_groups(self):
+        lti_user = self.request.lti_user
+        group_set_id = self.group_set()
+        course_id = self.request.json["course"]["context_id"]
+        course = self.get_course(course_id)
 
         if lti_user.is_learner:
-            user = self._request.find_service(UserService).get(
-                self._request.find_service(name="application_instance").get_current(),
+            user = self.request.find_service(UserService).get(
+                self.request.find_service(name="application_instance").get_current(),
                 lti_user.user_id,
             )
 
-            learner_groups = self._blackboard_api.course_groups(
+            learner_groups = self.blackboard_api.course_groups(
                 course_id, group_set_id, current_student_own_groups_only=True
             )
-            groups = self._to_groups_groupings(course, learner_groups)
-            self._grouping_service.upsert_grouping_memberships(user, groups)
+            groups = self.to_groups_groupings(course, learner_groups)
+            self.grouping_service.upsert_grouping_memberships(user, groups)
             return groups
 
-        if grading_student_id := self._request.json.get("gradingStudentId"):
-            return self._grouping_service.get_course_groupings_for_user(
+        if grading_student_id := self.request.json.get("gradingStudentId"):
+            return self.grouping_service.get_course_groupings_for_user(
                 course,
                 grading_student_id,
                 type_=Grouping.Type.BLACKBOARD_GROUP,
                 group_set_id=group_set_id,
             )
 
-        groups = self._blackboard_api.group_set_groups(course_id, group_set_id)
-        return self._to_groups_groupings(course, groups)
+        groups = self.blackboard_api.group_set_groups(course_id, group_set_id)
+        return self.to_groups_groupings(course, groups)
 
-    def _group_set(self):
+    def group_set(self):
         return (
-            self._request.find_service(name="assignment")
+            self.request.find_service(name="assignment")
             .get(
-                self._tool_consumer_instance_guid,
-                self._request.json["assignment"]["resource_link_id"],
+                self.tool_consumer_instance_guid,
+                self.request.json["assignment"]["resource_link_id"],
             )
             .extra["group_set_id"]
         )
 
-    def _to_groups_groupings(self, course, groups):
+    def to_groups_groupings(self, course, groups):
         return [
-            self._grouping_service.upsert_with_parent(
-                tool_consumer_instance_guid=self._tool_consumer_instance_guid,
+            self.grouping_service.upsert_with_parent(
+                tool_consumer_instance_guid=self.tool_consumer_instance_guid,
                 lms_id=group["id"],
                 lms_name=group["name"],
                 parent=course,
@@ -82,15 +82,15 @@ class Sync:
             for group in groups
         ]
 
-    def _sync_to_h(self, groups):
-        lti_h_svc = self._request.find_service(name="lti_h")
-        group_info = self._request.json["group_info"]
+    def sync_to_h(self, groups):
+        lti_h_svc = self.request.find_service(name="lti_h")
+        group_info = self.request.json["group_info"]
         lti_h_svc.sync(groups, group_info)
 
-    def _get_course(self, course_id):
-        course_service = self._request.find_service(name="course")
+    def get_course(self, course_id):
+        course_service = self.request.find_service(name="course")
         return course_service.get(
             course_service.generate_authority_provided_id(
-                self._tool_consumer_instance_guid, course_id
+                self.tool_consumer_instance_guid, course_id
             )
         )


### PR DESCRIPTION
The purpose of leading underscores is to distinguish a package/class/module's public interface from its private parts.

View classes don't have a public interface in the sense of attributes that're used by other parts of our code: we don't write code to call our views, they just get called by Pyramid.

The leading underscores could be useful to visually identify which things are going to be called by Pyramid (e.g. the actual view functions/methods) and which things are not called directly by Pyramid (e.g. helpers). But the actual view functions/methods are already identifiable by their `@view_config` decorators.

So I don't think there's any purpose to using leading underscores in view modules/classes (?), therefore there's no reason to ugly-up the code with them.

Note that we absolutely do use leading underscores in cases where they're necessary to distinguish things that're meant to be accessed by other parts of our code or by Pyramid versus things that are private. I'm just saying that underscores aren't needed for that purpose in view modules/classes.