### PR TITLE
Handle Blackboard  groups edge cases

### DIFF
--- a/lms/views/__init__.py
+++ b/lms/views/__init__.py
@@ -1,5 +1,4 @@
 from lms.views.api.canvas.exceptions import (
-    CanvasGroupError,
     CanvasGroupSetEmpty,
     CanvasGroupSetNotFound,
     CanvasStudentNotInGroup,

--- a/lms/views/api/canvas/exceptions.py
+++ b/lms/views/api/canvas/exceptions.py
@@ -1,22 +1,19 @@
-class CanvasGroupError(Exception):
-    def __init__(self, group_set):
-        self.details = {"group_set": group_set}
-        super().__init__(self.details)
+from lms.views.api.exceptions import GroupError
 
 
-class CanvasGroupSetNotFound(CanvasGroupError):
+class CanvasGroupSetNotFound(GroupError):
     """A Canvas GroupSet not found on Canvas API."""
 
     error_code = "canvas_group_set_not_found"
 
 
-class CanvasGroupSetEmpty(CanvasGroupError):
+class CanvasGroupSetEmpty(GroupError):
     """Canvas GroupSet doesn't contain any groups."""
 
     error_code = "canvas_group_set_empty"
 
 
-class CanvasStudentNotInGroup(CanvasGroupError):
+class CanvasStudentNotInGroup(GroupError):
     """Student doesn't belong to any of the groups in a group set assignment."""
 
     error_code = "canvas_student_not_in_group"

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -22,6 +22,12 @@ from lms.validation import ValidationError
 _ = i18n.TranslationStringFactory(__package__)
 
 
+class GroupError(Exception):
+    def __init__(self, group_set):
+        self.details = {"group_set": group_set}
+        super().__init__(self.details)
+
+
 @view_defaults(path_info="^/api/.*", renderer="json")
 class APIExceptionViews:
     """


### PR DESCRIPTION
Handles `blackboard_student_not_in_group` and `blackboard_group_set_empty`

Sync API returns

```
{
    "error_code": "blackboard_student_not_in_group",
    "details": {
        "group_set": "_55_1"
    }
}
```


## Testing

- Use `localhost (make devdata) Groups Assignment With No Groups` and `localhost (make devdata) Groups Assignment with No Members` to  trigger the error conditions.