### PR TITLE
Show only currently-focused-student's groups in grading mode

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSGrader-test.js
@@ -2,11 +2,15 @@ import { act } from 'preact/test-utils';
 
 import { mount } from 'enzyme';
 
+import { Config } from '../../config';
 import LMSGrader, { $imports } from '../LMSGrader';
 import { checkAccessibility } from '../../../test-util/accessibility';
+import { waitFor } from '../../../test-util/wait';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('LMSGrader', () => {
+  let fakeApiCall;
+  let fakeConfig;
   let fakeStudents;
   let fakeOnChange;
   let fakeClientRPC;
@@ -27,18 +31,26 @@ describe('LMSGrader', () => {
   }
 
   beforeEach(() => {
+    fakeApiCall = sinon.stub();
+    fakeConfig = {
+      api: {
+        authToken: 'dummyAuthToken',
+      },
+    };
     fakeStudents = [
       {
         userid: 'acct:student1@authority',
         displayName: 'Student 1',
         LISResultSourcedId: 1,
         LISOutcomeServiceUrl: '',
+        lmsId: '123',
       },
       {
         userid: 'acct:student2@authority',
         displayName: 'Student 2',
         LISResultSourcedId: 2,
         LISOutcomeServiceUrl: '',
+        lmsId: '456',
       },
     ];
     fakeOnChange = sinon.spy();
@@ -47,6 +59,11 @@ describe('LMSGrader', () => {
     };
 
     $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../utils/api': {
+        apiCall: fakeApiCall,
+      },
+    });
   });
 
   afterEach(() => {
@@ -55,16 +72,18 @@ describe('LMSGrader', () => {
 
   const renderGrader = (props = {}) => {
     return mount(
-      <LMSGrader
-        onChangeSelectedUser={fakeOnChange}
-        students={fakeStudents}
-        courseName={'course name'}
-        assignmentName={'course assignment'}
-        clientRPC={fakeClientRPC}
-        {...props}
-      >
-        <div title="The assignment content iframe" />
-      </LMSGrader>
+      <Config.Provider value={fakeConfig}>
+        <LMSGrader
+          onChangeSelectedUser={fakeOnChange}
+          students={fakeStudents}
+          courseName={'course name'}
+          assignmentName={'course assignment'}
+          clientRPC={fakeClientRPC}
+          {...props}
+        >
+          <div title="The assignment content iframe" />
+        </LMSGrader>
+      </Config.Provider>
     );
   };
 
@@ -123,34 +142,6 @@ describe('LMSGrader', () => {
     );
   });
 
-  it('updates the order if the `students` prop changes', () => {
-    // Un-order students
-    fakeStudents = [
-      {
-        displayName: 'Beta',
-      },
-      {
-        displayName: 'Alpha',
-      },
-    ];
-    const wrapper = renderGrader();
-    let orderedStudentNames = getDisplayNames(wrapper);
-    assert.match(['Alpha', 'Beta'], orderedStudentNames);
-    // New list of students
-    wrapper.setProps({
-      students: [
-        {
-          displayName: 'Beta',
-        },
-        {
-          displayName: 'Gamma',
-        },
-      ],
-    });
-    orderedStudentNames = getDisplayNames(wrapper);
-    assert.match(['Beta', 'Gamma'], orderedStudentNames);
-  });
-
   it('puts students with empty displayNames at the beginning of sorted students', () => {
     // Un-order students
     fakeStudents = [
@@ -183,7 +174,94 @@ describe('LMSGrader', () => {
       wrapper.find('StudentSelector').props().onSelectStudent(0); // note: initial index is -1
     });
 
-    assert.calledWith(fakeClientRPC.setFocusedUser, fakeStudents[0]);
+    assert.calledWith(
+      fakeClientRPC.setFocusedUser,
+      fakeStudents[0],
+      null /* groups */
+    );
+    assert.notCalled(fakeApiCall);
+  });
+
+  describe("Syncing focused user's groups when setting focused user", () => {
+    let studentGroups;
+
+    beforeEach(() => {
+      sinon.stub(console, 'error');
+      fakeConfig.api.sync = {
+        path: '/fake/path',
+        data: { foo: 'bar' },
+      };
+      studentGroups = [{ groupid: 'group1' }, { groupid: 'group2' }];
+      fakeApiCall.resolves(studentGroups);
+    });
+
+    afterEach(() => {
+      console.error.restore();
+    });
+
+    it("fetches the focused user's groups from the sync API", async () => {
+      const wrapper = renderGrader();
+
+      // Initial call on first render sets focused user to null
+      assert.calledOnce(fakeClientRPC.setFocusedUser);
+
+      act(() => {
+        wrapper.find('StudentSelector').props().onSelectStudent(0);
+      });
+
+      await waitFor(() => fakeApiCall.called);
+
+      assert.calledWith(
+        fakeApiCall,
+        sinon.match({
+          authToken: 'dummyAuthToken',
+          path: '/fake/path',
+          data: { foo: 'bar', gradingStudentId: '123' },
+        })
+      );
+      assert.notCalled(console.error);
+    });
+
+    it('Passes fetched student groups to RPC method', async () => {
+      const wrapper = renderGrader();
+
+      act(() => {
+        wrapper.find('StudentSelector').props().onSelectStudent(0);
+      });
+
+      await waitFor(() => fakeApiCall.called);
+
+      // Second call to set a "real" focused user
+      assert.equal(fakeClientRPC.setFocusedUser.callCount, 2);
+      assert.calledWith(
+        fakeClientRPC.setFocusedUser,
+        fakeStudents[0],
+        studentGroups
+      );
+    });
+
+    it('logs an error to the console if fetching from sync API fails', async () => {
+      fakeApiCall.rejects();
+      const wrapper = renderGrader();
+
+      act(() => {
+        wrapper.find('StudentSelector').props().onSelectStudent(0);
+      });
+
+      await waitFor(() => fakeApiCall.called);
+
+      assert.calledOnce(console.error);
+      assert.calledWith(
+        console.error,
+        'Unable to fetch student groups from sync API'
+      );
+      // Still set the focused user, but don't pass any groups
+      assert.calledWith(
+        fakeClientRPC.setFocusedUser,
+        fakeStudents[0],
+        /* groups */ null
+      );
+    });
   });
 
   it('does not set a focus user when the user index is invalid', () => {
@@ -192,7 +270,11 @@ describe('LMSGrader', () => {
       wrapper.find('StudentSelector').props().onSelectStudent(-1); // invalid choice
     });
 
-    assert.calledWith(fakeClientRPC.setFocusedUser, null);
+    assert.calledWith(
+      fakeClientRPC.setFocusedUser,
+      null /* user */,
+      null /* groups */
+    );
   });
 
   it(

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -27,9 +27,10 @@ import { createContext } from 'preact';
 /**
  * @typedef StudentInfo
  * @prop {string} displayName
- * @prop {string} userid
+ * @prop {string} userid - Identifier for student user in `h`
  * @prop {string} LISResultSourcedId - Unique outcome identifier
  * @prop {string} LISOutcomeServiceUrl - API URL for posting outcome results
+ * @prop {string} lmsId - LMS-generated identifier for student user
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -118,8 +118,10 @@ export class ClientRPC {
    * This may be called any number of times.
    *
    * @param {User|null} user
+   * @param {string[]|null} groups - Array of `groupid`s representing the
+   *  focused user's groups
    */
-  async setFocusedUser(user) {
+  async setFocusedUser(user, groups) {
     const sidebar = await this._server.sidebarWindow;
     rpcCall(sidebar.frame, sidebar.origin, 'changeFocusModeUser', [
       {
@@ -129,6 +131,7 @@ export class ClientRPC {
         // changed to `userid` once the client no longer references `username`.
         username: user ? user.userid : undefined,
         displayName: user ? user.displayName : undefined,
+        groups: groups ?? undefined,
       },
     ]);
   }

--- a/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
@@ -190,11 +190,15 @@ describe('ClientRPC', () => {
   describe('setFocusedUser', () => {
     it('sets focused user in client when user is passed', async () => {
       const clientRPC = createClientRPC();
+      const studentGroups = [{ groupid: '1' }, { groupid: '2' }];
 
-      await clientRPC.setFocusedUser({
-        userid: 'acct:123@lms.hypothes.is',
-        displayName: 'Student A',
-      });
+      await clientRPC.setFocusedUser(
+        {
+          userid: 'acct:123@lms.hypothes.is',
+          displayName: 'Student A',
+        },
+        studentGroups
+      );
 
       assert.calledWith(
         fakeRpcCall,
@@ -205,6 +209,7 @@ describe('ClientRPC', () => {
           {
             username: 'acct:123@lms.hypothes.is',
             displayName: 'Student A',
+            groups: studentGroups,
           },
         ]
       );
@@ -224,6 +229,7 @@ describe('ClientRPC', () => {
           {
             username: undefined,
             displayName: undefined,
+            groups: undefined,
           },
         ]
       );


### PR DESCRIPTION
This PR adds support for passing a set of focused-user groups along to the `setFocusedUser` RPC call to the client. 

Depends on corresponding changes in the client app (however, these changes appear innocuous if run without client-side support). Please see https://github.com/hypothesis/client/pull/3991 for further details of the bigger picture.

Based on discussions with team members, further error handling will be taken care of as a subsequent task. The failure mode in these changes is that all of the groups in the group set would show up in the sidebar (instead of just the focused-student's groups). That is identical to what currently happens anyway, without these changes.

Part of https://github.com/hypothesis/lms/issues/3416