### PR TITLE
Fix `factories.User.application_instance` subfactory

### DIFF
--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -2,7 +2,7 @@ from factory import Faker, SubFactory, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
-from lms.models import ApplicationInstance
+from tests.factories.application_instance import ApplicationInstance
 from tests.factories.attributes import H_USERID, USER_ID
 
 User = make_factory(


### PR DESCRIPTION
`factories.User()` has never worked: subfactories must be other factories not model objects.

Tip: a good way to test your factories is using `make shell`:

```python
$ make shell
...

Environment:
  ...
  f            The test factories for quickly creating objects.
  factories    The test factories for quickly creating objects.
  ...

>>> user = factories.User()
---------------------------------------------------------------------------
AssociatedClassError                      Traceback (most recent call last)
...
AssociatedClassError: <BuildStep for <StepBuilder(<SQLAlchemyOptions for UserFactory>, strategy='create')>>: Attempting to recursing into a non-factory object <class 'lms.models.application_instance.ApplicationInstance'>
```

The reason why the tests were still passing is that they never call `factories.User()` without passing in an `application_instance` argument.

This commit fixes it so that `factories.User()` with no `application_instance` uses `factories.ApplicationInstance` as a subfactory to generate a new `ApplicationInstance` for the user.