### PR TITLE
Make `factories.User.h_userid` unique

### DIFF
--- a/tests/factories/attributes.py
+++ b/tests/factories/attributes.py
@@ -1,6 +1,6 @@
 """Shared attributes used by test factories."""
 
-from factory import Faker
+from factory import Faker, Sequence
 
 OAUTH_CONSUMER_KEY = Faker("hexify", text="Hypothesis" + "^" * 32)
 SHARED_SECRET = Faker("hexify", text="^" * 64)
@@ -9,7 +9,7 @@ ACCESS_TOKEN = REFRESH_TOKEN = Faker("hexify", text="^" * 32)
 USER_ID = Faker("hexify", text="^" * 40)
 H_USERNAME = Faker("hexify", text="^" * 30)
 H_DISPLAY_NAME = Faker("name")
-H_USERID = Faker("hexify", text="acct:^@example.com")
+H_USERID = Sequence(lambda n: f"acct:user_{n + 1}@example.com")
 
 RESOURCE_LINK_ID = Faker("hexify", text="^" * 32)
 TOOL_CONSUMER_INSTANCE_GUID = Faker("hexify", text="^" * 40)


### PR DESCRIPTION
`factories.User.h_userid` is using a single random hex digit to try to make each user ID different from the previous:

```python
Faker("hexify", text="acct:^@example.com")
```

This quickly results in duplicate user IDs being generated:

```
$ make shell
>>> factories.User()
User(..., h_userid='acct:f@example.com')

>>> factories.User()
User(..., h_userid='acct:4@example.com')

>>> factories.User()
User(..., h_userid='acct:4@example.com')
```

Change it to use a sequence number instead, which is guaranteed to never generate the same ID twice:

```python
$ make shell
>>> factories.User()
User(..., h_userid='acct:user_1@example.com')

>>> factories.User()
User(..., h_userid='acct:user_2@example.com')

>>> factories.User()
User(..., h_userid='acct:user_3@example.com')
```