### PR TITLE
Fix user unique constraint

### DIFF
--- a/lms/migrations/versions/7a4812876915_fix_user_id_unique_constraint.py
+++ b/lms/migrations/versions/7a4812876915_fix_user_id_unique_constraint.py
@@ -1,0 +1,39 @@
+"""
+Fix user_id unique constraint.
+
+Revision ID: 7a4812876915
+Revises: 6882c201b56e
+Create Date: 2022-01-25 16:07:34.805966
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "7a4812876915"
+down_revision = "f581d8a273cc"
+
+
+def upgrade():
+    op.drop_constraint("uq__user__application_instance_id", "user")
+
+    op.create_unique_constraint(
+        "uq__user__application_instance_id__user_id",
+        "user",
+        ["application_instance_id", "user_id"],
+    )
+    op.create_unique_constraint(
+        "uq__user__application_instance_id__h_userid",
+        "user",
+        ["application_instance_id", "h_userid"],
+    )
+
+
+def downgrade():
+    op.drop_constraint("uq__user__application_instance_id__user_id", "user")
+    op.drop_constraint("uq__user__application_instance_id__h_userid", "user")
+
+    op.create_unique_constraint(
+        "uq__user__application_instance_id",
+        "user",
+        ["application_instance_id", "user_id", "h_userid"],
+    )

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -9,7 +9,16 @@ class User(CreatedUpdatedMixin, BASE):
 
     __tablename__ = "user"
     __table_args__ = (
-        sa.UniqueConstraint("application_instance_id", "user_id", "h_userid"),
+        sa.UniqueConstraint(
+            "application_instance_id",
+            "user_id",
+            name="uq__user__application_instance_id__user_id",
+        ),
+        sa.UniqueConstraint(
+            "application_instance_id",
+            "h_userid",
+            name="uq__user__application_instance_id__h_userid",
+        ),
     )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)


### PR DESCRIPTION
`user_id` (the LTI user ID) should be unique (within an application instance).

And, separetely from that, `h_userid` (the user ID of the corresponding h user) should also be unique (again, within an application instance).

But those are two separate unique constraints not one. The current constraint allows two users to have the same LTI ID as long as they have different h IDs and vice-versa:

```sql
INSERT INTO public.user (application_instance_id, user_id, h_userid) VALUES (1, 'user_id_1', 'h_userid_1');

-- Insert a second user with the same user_id as the first.
INSERT INTO public.user (application_instance_id, user_id, h_userid) VALUES (1, 'user_id_1', 'h_userid_2');

--Insert a second user with the same h_userid as the first.
INSERT INTO public.user (application_instance_id, user_id, h_userid) VALUES (1, 'user_id_2', 'h_userid_1');

SELECT application_instance_id, user_id, h_userid FROM public.user;
 application_instance_id |  user_id  |  h_userid  
-------------------------+-----------+------------
                       1 | user_id_1 | h_userid_1
                       1 | user_id_1 | h_userid_2
                       1 | user_id_2 | h_userid_1
(3 rows)
```

This PR splits it into two separate constraints so that we can't have two users with the same LTI ID or two users with the same h ID within the same application instance:

```sql
INSERT INTO public.user (application_instance_id, user_id, h_userid) VALUES (1, 'user_id_1', 'h_userid_1');

-- Inserting a second user with the same user_id as the first fails.
INSERT INTO public.user (application_instance_id, user_id, h_userid) VALUES (1, 'user_id_1', 'h_userid_2');
ERROR:  duplicate key value violates unique constraint "uq__user__user_id"
DETAIL:  Key (user_id, application_instance_id)=(user_id_1, 1) already exists.

--Inserting a second user with the same h_userid as the first fails.
INSERT INTO public.user (application_instance_id, user_id, h_userid) VALUES (1, 'user_id_2', 'h_userid_1');
ERROR:  duplicate key value violates unique constraint "uq__user__h_userid"
DETAIL:  Key (h_userid, application_instance_id)=(h_userid_1, 1) already exists.
```