### PR TITLE
Show real filenames for Google-, OneDrive-picked LMS files 

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -183,9 +183,9 @@ export default function ContentSelector({
     setLoadingIndicatorVisible(true);
     try {
       const picker = /** @type {GooglePickerClient} */ (googlePicker);
-      const { id, url } = await picker.showPicker();
+      const { id, name, url } = await picker.showPicker();
       await picker.enablePublicViewing(id);
-      onSelectContent({ type: 'url', url });
+      onSelectContent({ name, type: 'url', url });
     } catch (error) {
       if (!(error instanceof PickerCanceledError)) {
         console.error(error);
@@ -203,8 +203,8 @@ export default function ContentSelector({
     setLoadingIndicatorVisible(true);
     try {
       const picker = /** @type {OneDrivePickerClient} */ (oneDrivePicker);
-      const { url } = await picker.showPicker();
-      onSelectContent({ type: 'url', url });
+      const { name, url } = await picker.showPicker();
+      onSelectContent({ name, type: 'url', url });
     } catch (error) {
       if (!(error instanceof PickerCanceledError)) {
         console.error(error);

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -250,6 +250,7 @@ describe('ContentSelector', () => {
       const picker = FakeGooglePickerClient();
       picker.showPicker.resolves({
         id: 'doc1',
+        name: 'Floops.pdf',
         url: 'https://files.google.com/doc1',
       });
       picker.enablePublicViewing.resolves();
@@ -302,6 +303,7 @@ describe('ContentSelector', () => {
       await delay(0);
 
       assert.calledWith(onSelectContent, {
+        name: 'Floops.pdf',
         type: 'url',
         url: 'https://files.google.com/doc1',
       });
@@ -430,6 +432,7 @@ describe('ContentSelector', () => {
       const wrapper = renderContentSelector({ onSelectContent });
       // Emulate the selection of a file in the picker.
       picker.showPicker.resolves({
+        name: 'Floops.pdf',
         url: 'https://api.onedrive.com/v1.0/shares/u!https://1drv.ms/b/s!AmH',
       });
 
@@ -437,6 +440,7 @@ describe('ContentSelector', () => {
       await delay(0);
 
       assert.calledWith(onSelectContent, {
+        name: 'Floops.pdf',
         type: 'url',
         url: 'https://api.onedrive.com/v1.0/shares/u!https://1drv.ms/b/s!AmH',
       });

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -158,6 +158,14 @@ describe('FilePickerApp', () => {
         {
           content: {
             type: 'url',
+            name: 'Super-cali-fragi-listic.pdf',
+            url: 'https://could.be.anything.com/really.pdf',
+          },
+          summary: 'Super-cali-fragi-listic.pdf',
+        },
+        {
+          content: {
+            type: 'url',
             url: 'blackboard://content-resource/_8615_1/',
           },
           summary: 'PDF file in Blackboard',

--- a/lms/static/scripts/frontend_apps/utils/content-item.js
+++ b/lms/static/scripts/frontend_apps/utils/content-item.js
@@ -8,6 +8,8 @@
  * @typedef URLContent
  * @prop {'url'} type
  * @prop {string} url
+ * @prop {string} [name] - (file)name of selected content (used for display
+ *                         purposes only)
  *
  * @typedef VitalSourceBookContent
  * @prop {'vitalsource'} type

--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.js
@@ -27,6 +27,7 @@ function addHttps(origin) {
  *
  * @typedef PickerDocument
  * @prop {string} id
+ * @prop {string} name - Filename
  * @prop {string} url
  * @prop {string} [resourceKey] - A key which is present on a subset of older
  *   Google Drive files. If present this needs to be provided to various
@@ -90,10 +91,10 @@ export class GooglePickerClient {
    * Show the Google file picker and return the document ID and
    * URL of the selected file.
    *
-   * @return {Promise<{ id: string, url: string }>}
-   *   Document ID and download URL of the selected file. The download URL is
-   *   only available by users who have access to the file. To make it accessible
-   *   to everyone, use `enablePublicViewing`.
+   * @return {Promise<{ id: string, name: string, url: string }>}
+   *   Document ID, filename and download URL of the selected file.
+   *   The download URL is only available by users who have access to the file.
+   *   To make it accessible to everyone, use `enablePublicViewing`.
    */
   async showPicker() {
     const pickerLib = await this._gapiPicker;
@@ -133,7 +134,7 @@ export class GooglePickerClient {
         if (doc.resourceKey) {
           url.searchParams.append('resourcekey', doc.resourceKey);
         }
-        resolve({ id: doc.id, url: url.toString() });
+        resolve({ id: doc.id, name: doc.name, url: url.toString() });
       } else if (action === pickerLib.Action.CANCEL) {
         reject(new PickerCanceledError());
       }

--- a/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
@@ -22,7 +22,7 @@ export class OneDrivePickerClient {
   /**
    * Opens the OneDrive picker
    *
-   * @returns Promise<{url: string}> - the URL of the file
+   * @return {Promise<{ name: string, url: string }>} The (file) name and URL
    * @throws {Error} - there are two types of errors:
    *   - PickerCancelledError: raised when the user cancels the OneDrive dialog picker
    *   - Error: raised when (1) the OneDrive client fails to load, or when (2)
@@ -32,9 +32,10 @@ export class OneDrivePickerClient {
     const oneDrive = await this._oneDriveAPI;
     return new Promise((resolve, reject) => {
       const success = (/** @type {any} */ file) => {
+        const name = file.value[0].name;
         const sharingURL = file.value[0].permissions[0].link.webUrl;
         const url = OneDrivePickerClient.downloadURL(sharingURL);
-        resolve({ url });
+        resolve({ name, url });
       };
       const cancel = () => reject(new PickerCanceledError());
       const error = (/** @type {Error} */ error) => reject(error);

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -213,11 +213,15 @@ describe('GooglePickerClient', () => {
       const builder = pickerLib.PickerBuilder();
       const callback = builder.setCallback.getCall(0).callback;
 
-      callback({ action: pickerLib.Action.PICKED, docs: [{ id: 'doc1' }] });
+      callback({
+        action: pickerLib.Action.PICKED,
+        docs: [{ id: 'doc1', name: 'Floops.pdf' }],
+      });
 
       result = await result;
       assert.deepEqual(result, {
         id: 'doc1',
+        name: 'Floops.pdf',
         url: 'https://drive.google.com/uc?id=doc1&export=download',
       });
     });
@@ -234,12 +238,13 @@ describe('GooglePickerClient', () => {
 
       callback({
         action: pickerLib.Action.PICKED,
-        docs: [{ id: 'doc1', resourceKey: 'thekey' }],
+        docs: [{ id: 'doc1', name: 'Flaps.pdf', resourceKey: 'thekey' }],
       });
 
       result = await result;
       assert.deepEqual(result, {
         id: 'doc1',
+        name: 'Flaps.pdf',
         url: 'https://drive.google.com/uc?id=doc1&export=download&resourcekey=thekey',
       });
     });

--- a/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/onedrive-picker-client-test.js
@@ -47,7 +47,7 @@ describe('OneDrivePickerClient', () => {
       assert.equal(expectedError, errorLoading);
     });
 
-    it('resolves with a URL when a file is selected', async () => {
+    it('resolves with a name and a URL when a file is selected', async () => {
       fakeLoadOneDriveAPI.resolves(fakeOneDrive);
       const oneDrive = createClient();
 
@@ -57,10 +57,13 @@ describe('OneDrivePickerClient', () => {
       const { success } = fakeOneDrive.open.getCall(0).args[0];
       success({
         value: [
-          { permissions: [{ link: { webUrl: 'https://1drv.ms/b/s!AmH' } }] },
+          {
+            name: 'Flumpy.pdf',
+            permissions: [{ link: { webUrl: 'https://1drv.ms/b/s!AmH' } }],
+          },
         ],
       });
-      const { url } = await pickResult;
+      const { name, url } = await pickResult;
 
       const { clientId, redirectURI: redirectUri } = clientOptions;
       assert.calledWith(
@@ -70,6 +73,7 @@ describe('OneDrivePickerClient', () => {
           advanced: { redirectUri },
         })
       );
+      assert.equal(name, 'Flumpy.pdf');
       assert.equal(
         url,
         'https://api.onedrive.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2IvcyFBbUg/root/content'


### PR DESCRIPTION
When configuring an assignment in an LMS with some sort of groups (Canvas, Blackboard) enabled, there is a second step after choosing content for configuring groups. On this step, we show the user information about the content they just selected. These changes make the actual filename show up for selected Google and OneDrive PDFs in this case, instead of meaningless URLs.

## Before and After

### Google Drive: Before

<img width="542" alt="Screen Shot 2021-12-07 at 3 24 35 PM" src="https://user-images.githubusercontent.com/439947/145101362-fe1c92b2-464f-4e94-a1e9-59d6f0714e82.png">

### Google Drive: After

<img width="531" alt="Screen Shot 2021-12-07 at 3 25 36 PM" src="https://user-images.githubusercontent.com/439947/145101423-54453d86-525e-440a-8570-7db435c9454b.png">

With long filenames, I've elected to harshly wrap vs. truncate the filename, as sometimes the most important part of the filename is at the beginning, and sometimes the end, and I don't think this is a big crisis, e.g.:

<img width="535" alt="Screen Shot 2021-12-07 at 3 32 28 PM" src="https://user-images.githubusercontent.com/439947/145101935-ab4c8aa9-4626-4238-9ede-0039d44410bd.png">


### OneDrive: Before

<img width="545" alt="Screen Shot 2021-12-07 at 3 24 21 PM" src="https://user-images.githubusercontent.com/439947/145101538-29e4725a-5d5e-4416-93bf-516504d00141.png">

### OneDrive: After

<img width="537" alt="Screen Shot 2021-12-07 at 3 23 58 PM" src="https://user-images.githubusercontent.com/439947/145101566-8807c81c-4c9a-4472-94a3-d1dcc77c8a44.png">

## Testing

On this branch, configure a groups-enabled assignment (Canvas or BB) and select OneDrive and/or Google Drive content.

Fixes https://github.com/hypothesis/lms/issues/3365