### PR TITLE
Use an ApplicationInstance switch to toggle VitalSource on/off

### DIFF
--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -97,7 +97,7 @@ class FilePickerConfig:
         }
 
     @classmethod
-    def vital_source_config(cls, _context, request, _application_instance):
+    def vital_source_config(cls, _context, _request, application_instance):
         """Get Vital Source config."""
-
-        return {"enabled": request.feature("vitalsource")}
+        enabled = application_instance.settings.get("vitalsource", "enabled", False)
+        return {"enabled": enabled}

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -64,6 +64,7 @@
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Other settings</legend>
         {{ checkbox_field("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
+        {{ checkbox_field("VitalSource enabled", "vitalsource", "enabled") }}
     </fieldset>
 
     {% call field_body(label="") %}

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -87,6 +87,7 @@ class AdminViews:
             ("blackboard", "files_enabled"),
             ("blackboard", "groups_enabled"),
             ("microsoft_onedrive", "files_enabled"),
+            ("vitalsource", "enabled"),
         ):
             enabled = self.request.params.get(f"{setting}.{sub_setting}") == "on"
             ai.settings.set(setting, sub_setting, enabled)

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -152,15 +152,17 @@ class TestFilePickerConfig:
 
         assert config == expected
 
-    def test_vital_source_config(self, context, pyramid_request, application_instance):
-        pyramid_request.feature.return_value = sentinel.enabled
+    @pytest.mark.parametrize("enabled", (True, False))
+    def test_vital_source_config(
+        self, context, pyramid_request, application_instance, enabled
+    ):
+        application_instance.settings.set("vitalsource", "enabled", enabled)
 
         config = FilePickerConfig.vital_source_config(
             context, pyramid_request, application_instance
         )
 
-        assert config == {"enabled": sentinel.enabled}
-        pyramid_request.feature.assert_called_once_with("vitalsource")
+        assert config == {"enabled": enabled}
 
     @pytest.fixture
     def canvas_files_enabled(self, context, pyramid_request, application_instance):

--- a/tests/unit/lms/views/admin_test.py
+++ b/tests/unit/lms/views/admin_test.py
@@ -97,6 +97,7 @@ class TestAdminViews:
             ("blackboard", "files_enabled"),
             ("blackboard", "groups_enabled"),
             ("microsoft_onedrive", "files_enabled"),
+            ("vitalsource", "enabled"),
         ),
     )
     @pytest.mark.parametrize("enabled", (True, False))

--- a/tests/unit/lms/views/admin_test.py
+++ b/tests/unit/lms/views/admin_test.py
@@ -95,6 +95,7 @@ class TestAdminViews:
             ("canvas", "groups_enabled"),
             ("canvas", "sections_enabled"),
             ("blackboard", "files_enabled"),
+            ("blackboard", "groups_enabled"),
             ("microsoft_onedrive", "files_enabled"),
         ),
     )


### PR DESCRIPTION
For https://github.com/hypothesis/product-backlog/issues/1255

# Testing

- Create/Edit a Canvas assignment
- The VitalSource option won't be present
- Toggle the VS settings for `Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a` on http://localhost:8001/admin
- Edit the assignment again, the VS option will be present.
