### PR TITLE
Handle all async errors

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -6,8 +6,8 @@ from lms.services.exceptions import (
     CanvasAPIPermissionError,
     CanvasAPIServerError,
     CanvasFileNotFoundInCourse,
-    ExternalRequestError,
     ExternalAsyncRequestError,
+    ExternalRequestError,
     OAuth2TokenError,
 )
 from lms.services.h_api import HAPIError

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -7,6 +7,7 @@ from lms.services.exceptions import (
     CanvasAPIServerError,
     CanvasFileNotFoundInCourse,
     ExternalRequestError,
+    ExternalAsyncRequestError,
     OAuth2TokenError,
 )
 from lms.services.h_api import HAPIError

--- a/lms/services/async_oauth_http.py
+++ b/lms/services/async_oauth_http.py
@@ -44,6 +44,10 @@ class AsyncOAuthHTTPService:
 
 async def _async_request(aio_session, method, url, **kwargs):
     async with aio_session.request(method, url, **kwargs) as response:
+        # Calling `.text()` here caches the result in `response` but is still behind a coroutine.
+        # We assign it to another response attribute for it to be
+        # available in a sync context without needing to start coroutine.
+        response.sync_text = await response.text()
         return response
 
 

--- a/lms/services/async_oauth_http.py
+++ b/lms/services/async_oauth_http.py
@@ -66,9 +66,7 @@ async def _prepare_requests(method, urls, **kwargs):
             for task in tasks:
                 task.cancel()
 
-            raise ExternalAsyncRequestError(
-                message="Blackboard async request failed", exception=err
-            ) from err
+            raise ExternalAsyncRequestError() from err
 
 
 def factory(_context, request):

--- a/lms/services/async_oauth_http.py
+++ b/lms/services/async_oauth_http.py
@@ -3,7 +3,7 @@ from typing import List
 
 import aiohttp
 
-from lms.services import ExternalRequestError
+from lms.services import ExternalAsyncRequestError
 
 
 class AsyncOAuthHTTPService:

--- a/lms/services/async_oauth_http.py
+++ b/lms/services/async_oauth_http.py
@@ -30,7 +30,7 @@ class AsyncOAuthHTTPService:
             https://docs.aiohttp.org/en/stable/client_reference.html
 
         :raise OAuth2TokenError: if we don't have an access token for the user
-        :raise ExternalRequestError: if something goes wrong with the HTTP
+        :raise ExternalAsyncRequestError: if something goes wrong with the HTTP
             request
         """
         headers = headers or {}
@@ -66,7 +66,9 @@ async def _prepare_requests(method, urls, **kwargs):
             for task in tasks:
                 task.cancel()
 
-            raise ExternalRequestError("Blackboard async request failed") from err
+            raise ExternalAsyncRequestError(
+                message="Blackboard async request failed", exception=err
+            ) from err
 
 
 def factory(_context, request):

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -172,8 +172,6 @@ class BlackboardAPIClient:
                     continue
 
                 # Any other result is unexpected
-                raise ExternalAsyncRequestError(
-                    message="Error while getting course groups", response=response
-                )
+                raise ExternalAsyncRequestError(response=response)
 
         return self_enrollment_groups + instructor_only_groups

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -65,14 +65,14 @@ class ExternalRequestError(Exception):
 
 
 class ExternalAsyncRequestError(Exception):
-    def __init__(
-        self, message=None, request=None, response=None, validation_errors=None
-    ):
+    def __init__(self, response=None):
         super().__init__()
-        self.message = message
-        self.request = request
         self.response = response
-        self.validation_errors = validation_errors
+
+        # For compatibility with ExternalRequestError.
+        self.message = None
+        self.request = None
+        self.validation_errors = None
 
     @property
     def _request_info(self):

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -108,7 +108,7 @@ class ExternalAsyncRequestError(Exception):
     @property
     def response_body(self) -> None:
         """Return the response body."""
-        return None
+        return getattr(self.response, "sync_text", None)
 
     def __repr__(self) -> str:
         return _repr_external_request_exception(self)

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -92,6 +92,49 @@ class ExternalRequestError(Exception):
         return repr(self)
 
 
+class ExternalAsyncRequestError(ExternalRequestError):
+    def __init__(
+        self,
+        message=None,
+        response=None,
+        exception: Optional[Exception] = None,
+    ):
+        if exception and message:
+            message = f"{message}: {exception.__class__.__name__}"
+
+        super().__init__(message=message, response=response)
+        self.exception = exception
+
+        self._request_info = getattr(response, "request_info", None) or getattr(
+            exception, "request_info", None
+        )
+
+    @property
+    def url(self) -> Optional[str]:
+        """Return the request's URL."""
+        return str(url) if (url := getattr(self._request_info, "url", None)) else None
+
+    @property
+    def method(self) -> Optional[str]:
+        """Return the HTTP request method."""
+        return getattr(self._request_info, "method", None)
+
+    @property
+    def status_code(self) -> Optional[int]:
+        """Return the response's status code."""
+        return getattr(self.response, "status", None)
+
+    @property
+    def request_body(self) -> None:
+        """Return the request body."""
+        return None
+
+    @property
+    def response_body(self) -> None:
+        """Return the response body."""
+        return None
+
+
 class OAuth2TokenError(ExternalRequestError):
     """
     A problem with an OAuth 2 token for an external API.

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -57,56 +57,27 @@ class ExternalRequestError(Exception):
         """Return the response body."""
         return getattr(self.response, "text", None)
 
-    def __repr__(self):
-        # Include the details of the request and response for debugging. This
-        # appears in the logs and in tools like Sentry and Papertrail.
-        request = (
-            "Request("
-            f"method={self.method!r}, "
-            f"url={self.url!r}, "
-            f"body={self.request_body!r}"
-            ")"
-        )
-
-        response = (
-            "Response("
-            f"status_code={self.status_code!r}, "
-            f"reason={self.reason!r}, "
-            f"body={self.response_body!r}"
-            ")"
-        )
-
-        # The name of this class or of a subclass if one inherits this method.
-        class_name = self.__class__.__name__
-
-        return (
-            f"{class_name}("
-            f"message={self.message!r}, "
-            f"cause={self.__cause__!r}, "
-            f"request={request}, "
-            f"response={response}, "
-            f"validation_errors={self.validation_errors!r})"
-        )
+    def __repr__(self) -> str:
+        return _repr_external_request_exception(self)
 
     def __str__(self):
         return repr(self)
 
 
-class ExternalAsyncRequestError(ExternalRequestError):
+class ExternalAsyncRequestError(Exception):
     def __init__(
-        self,
-        message=None,
-        response=None,
-        exception: Optional[Exception] = None,
+        self, message=None, request=None, response=None, validation_errors=None
     ):
-        if exception and message:
-            message = f"{message}: {exception.__class__.__name__}"
+        super().__init__()
+        self.message = message
+        self.request = request
+        self.response = response
+        self.validation_errors = validation_errors
 
-        super().__init__(message=message, response=response)
-        self.exception = exception
-
-        self._request_info = getattr(response, "request_info", None) or getattr(
-            exception, "request_info", None
+    @property
+    def _request_info(self):
+        return getattr(self.response, "request_info", None) or getattr(
+            self.__cause__, "request_info", None
         )
 
     @property
@@ -130,9 +101,20 @@ class ExternalAsyncRequestError(ExternalRequestError):
         return None
 
     @property
+    def reason(self) -> Optional[str]:
+        """Return the response's HTTP reason string, e.g. 'Bad Request'."""
+        return getattr(self.response, "reason", None)
+
+    @property
     def response_body(self) -> None:
         """Return the response body."""
         return None
+
+    def __repr__(self) -> str:
+        return _repr_external_request_exception(self)
+
+    def __str__(self):
+        return repr(self)
 
 
 class OAuth2TokenError(ExternalRequestError):
@@ -261,3 +243,35 @@ class BlackboardFileNotFoundInCourse(Exception):
     def __init__(self, file_id):
         self.details = {"file_id": file_id}
         super().__init__(self.details)
+
+
+def _repr_external_request_exception(exception):
+    # Include the details of the request and response for debugging. This
+    # appears in the logs and in tools like Sentry and Papertrail.
+    request = (
+        "Request("
+        f"method={exception.method!r}, "
+        f"url={exception.url!r}, "
+        f"body={exception.request_body!r}"
+        ")"
+    )
+
+    response = (
+        "Response("
+        f"status_code={exception.status_code!r}, "
+        f"reason={exception.reason!r}, "
+        f"body={exception.response_body!r}"
+        ")"
+    )
+
+    # The name of this class or of a subclass if one inherits this method.
+    class_name = exception.__class__.__name__
+
+    return (
+        f"{class_name}("
+        f"message={exception.message!r}, "
+        f"cause={exception.__cause__!r}, "
+        f"request={request}, "
+        f"response={response}, "
+        f"validation_errors={exception.validation_errors!r})"
+    )

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -14,6 +14,7 @@ from pyramid.view import (
 
 from lms.services import (
     CanvasAPIPermissionError,
+    ExternalAsyncRequestError,
     ExternalRequestError,
     OAuth2TokenError,
 )
@@ -109,6 +110,7 @@ class APIExceptionViews:
         )
 
     @exception_view_config(context=ExternalRequestError)
+    @exception_view_config(context=ExternalAsyncRequestError)
     def external_request_error(self):
         sentry_sdk.set_context(
             "request",

--- a/tests/unit/lms/services/async_oauth_http_test.py
+++ b/tests/unit/lms/services/async_oauth_http_test.py
@@ -4,8 +4,8 @@ import pytest
 from aiohttp import TooManyRedirects
 from aioresponses import aioresponses
 
-from lms.services import ExternalRequestError
 from lms.services.async_oauth_http import AsyncOAuthHTTPService, factory
+from lms.services.exceptions import ExternalAsyncRequestError
 
 
 class TestAsyncOAuthHTTPService:
@@ -29,7 +29,7 @@ class TestAsyncOAuthHTTPService:
 
     @pytest.mark.usefixtures("with_one_failed_response")
     def test_request_with_failure(self, svc, urls):
-        with pytest.raises(ExternalRequestError):
+        with pytest.raises(ExternalAsyncRequestError):
             svc.request("GET", urls)
 
     @pytest.fixture

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -8,7 +8,11 @@ from lms.services.blackboard_api.client import (
     PAGINATION_MAX_REQUESTS,
     BlackboardAPIClient,
 )
-from lms.services.exceptions import BlackboardFileNotFoundInCourse, ExternalRequestError
+from lms.services.exceptions import (
+    BlackboardFileNotFoundInCourse,
+    ExternalAsyncRequestError,
+    ExternalRequestError,
+)
 from tests import factories
 
 
@@ -317,6 +321,15 @@ class TestGroupCourseGroups:
         groups = svc.course_groups("COURSE_ID", current_student_own_groups_only=True)
 
         assert len(groups) == 2
+
+    def test_it_request_error(
+        self, svc, blackboard_list_groups, groups, async_oauth_http_service
+    ):
+        blackboard_list_groups.parse.return_value = groups
+        async_oauth_http_service.request.return_value = [Mock(status=500)]
+
+        with pytest.raises(ExternalAsyncRequestError):
+            svc.course_groups("COURSE_ID", current_student_own_groups_only=True)
 
     @pytest.fixture
     def groups(self):

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -150,10 +150,13 @@ class TestExternalAsyncRequestError:
             ),
             (
                 Mock(
-                    status=400, reason="OK", request_info=Mock(method="POST", url="URL")
+                    sync_text="Body text",
+                    status=400,
+                    reason="OK",
+                    request_info=Mock(method="POST", url="URL"),
                 ),
                 KeyError("cause"),
-                "ExternalAsyncRequestError(message=None, cause=KeyError('cause'), request=Request(method='POST', url='URL', body=None), response=Response(status_code=400, reason='OK', body=None), validation_errors=None)",
+                "ExternalAsyncRequestError(message=None, cause=KeyError('cause'), request=Request(method='POST', url='URL', body=None), response=Response(status_code=400, reason='OK', body='Body text'), validation_errors=None)",
             ),
         ],
     )

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import sentinel, Mock
+from unittest.mock import Mock, sentinel
 
 import httpretty
 import pytest
@@ -9,8 +9,8 @@ from lms.services import (
     CanvasAPIError,
     CanvasAPIPermissionError,
     CanvasAPIServerError,
-    ExternalRequestError,
     ExternalAsyncRequestError,
+    ExternalRequestError,
     OAuth2TokenError,
 )
 from lms.validation import ValidationError

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -141,30 +141,24 @@ class TestExternalAsyncRequestError:
         assert err.status_code == expected
 
     @pytest.mark.parametrize(
-        "message,request_,response,cause,expected",
+        "response,cause,expected",
         [
             (
-                None,
-                None,
                 None,
                 None,
                 "ExternalAsyncRequestError(message=None, cause=None, request=Request(method=None, url=None, body=None), response=Response(status_code=None, reason=None, body=None), validation_errors=None)",
             ),
             (
-                "Some message",
-                None,
                 Mock(
                     status=400, reason="OK", request_info=Mock(method="POST", url="URL")
                 ),
                 KeyError("cause"),
-                "ExternalAsyncRequestError(message='Some message', cause=KeyError('cause'), request=Request(method='POST', url='URL', body=None), response=Response(status_code=400, reason='OK', body=None), validation_errors=None)",
+                "ExternalAsyncRequestError(message=None, cause=KeyError('cause'), request=Request(method='POST', url='URL', body=None), response=Response(status_code=400, reason='OK', body=None), validation_errors=None)",
             ),
         ],
     )
-    def test_str(self, message, request_, response, cause, expected):
+    def test_str(self, response, cause, expected):
         err = ExternalAsyncRequestError(
-            message=message,
-            request=request_,
             response=response,
         )
         err.__cause__ = cause


### PR DESCRIPTION


## Testing

- Make a change similar to:

```diff
diff --git a/lms/services/blackboard_api/client.py b/lms/services/blackboard_api/client.py
index 838dfd85..03ba6b97 100644
--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -156,7 +156,7 @@ class BlackboardAPIClient:
                 self_enrollment_groups.append(group)
                 self_enrollment_check_urls.append(
                     self._api._api_url(  # pylint: disable=protected-access
-                        f"/learn/api/public/v2/courses/uuid:{course_id}/groups/{group['id']}"
+                        f"/learn/api/public/v25/courses/uuid:{course_id}/groups/{group['id']}"
                     )
                 )

```

- Launch `localhost (make devdata) Groups Assignment` has a student.
- You should get a dialog with some details about the failed request.

![Screenshot from 2022-01-20 16-15-23](https://user-images.githubusercontent.com/1433832/150366771-aba6ddf3-5dcf-4c0d-b474-631eace27d96.png)
 