### PR TITLE
canvas_is_group_launch doesn't depend on the AI setting.

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -219,9 +219,6 @@ class LTILaunchResource:
     @property
     def canvas_is_group_launch(self):
         """Return True if the current assignment uses canvas groups."""
-        if not self.canvas_groups_enabled:
-            return False
-
         try:
             int(self._request.params["group_set"])
         except (KeyError, ValueError, TypeError):

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -329,30 +329,16 @@ class TestCanvasGroupsEnabled:
 
 
 class TestCanvasIsGroupLaunch:
-    def test_false_when_no_application_instance(self, lti_launch_groups_enabled):
-        lti_launch_groups_enabled.canvas_groups_enabled = False
-
-        assert not lti_launch_groups_enabled.canvas_is_group_launch
-
     @pytest.mark.parametrize("group_set", ["", "not a number", None])
-    def test_false_invalid_group_set_param(
-        self, pyramid_request, lti_launch_groups_enabled, group_set
-    ):
+    def test_false_invalid_group_set_param(self, pyramid_request, group_set):
         pyramid_request.params.update({"group_set": group_set})
 
-        assert not lti_launch_groups_enabled.canvas_is_group_launch
+        assert not LTILaunchResource(pyramid_request).canvas_is_group_launch
 
-    def test_it(self, pyramid_request, lti_launch_groups_enabled):
+    def test_it(self, pyramid_request):
         pyramid_request.params.update({"group_set": 1})
 
-        assert lti_launch_groups_enabled.canvas_is_group_launch
-
-    @pytest.fixture
-    def lti_launch_groups_enabled(self, pyramid_request):
-        class TestableLTILaunchResource(LTILaunchResource):
-            canvas_groups_enabled = True
-
-        return TestableLTILaunchResource(pyramid_request)
+        assert LTILaunchResource(pyramid_request).canvas_is_group_launch
 
 
 class TestIsBlackboardGroupLaunch:


### PR DESCRIPTION
Before this fix disabling the groups feature at the AI level
will silently convert all existing groups assignments to sections ones.

With this commit the AI toggle only enables/disable the possibility to
create new groups assignments.