### PR TITLE
Bulk upsert helper

### DIFF
--- a/lms/db/_bulk_action.py
+++ b/lms/db/_bulk_action.py
@@ -11,13 +11,8 @@ Why is this here, rather than services?
 For more see: https://stackoverflow.com/c/hypothesis/questions/477
 """
 
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import List
-
-from sqlalchemy import inspect
-from sqlalchemy.dialects.postgresql import insert
-from zope.sqlalchemy import mark_changed
 
 
 class BulkAction:
@@ -69,71 +64,17 @@ class BulkAction:
         :param model_class: The model type to upsert
         :param values: Dicts of values to upsert
         """
-        if not values:
-            # Don't attempt to upsert an empty list of values into the DB.
-            #
-            # This would be worse than pointless: it would actually crash in
-            # some cases. This SQLAlchemy code:
-            #
-            #     insert(MyModel).values([])
-            #
-            # produces this SQL:
-            #
-            #     INSERT INTO my_table DEFAULT VALUES RETURNING my_table.id
-            #
-            # which tells the DB to insert one row into my_table using the
-            # default values for all of the columns. If my_table has a column
-            # with a NOT NULLABLE constraint and no default value this will
-            # cause a "null value violates not-null constraint" crash.
-            return []
-
         config = model_class.BULK_CONFIG
 
-        upsert_update_elements = list(config.upsert_update_elements)
-
-        if config.upsert_use_onupdate:
-            onupdate_columns = self._get_columns_onupdate(model_class)
-
-            for column_name, onupdate_value in onupdate_columns:
-                upsert_update_elements.append(column_name)
-
-                # SQL alchemy wraps functions passed to onupdate or default and
-                # could potentially take a "context" argument getting a
-                # suitable context at this point of the execution it's not
-                # possible so we don't support it so we just pass None
-                # https://docs.sqlalchemy.org/en/14/core/defaults.html#context-sensitive-default-functions
-                default_value = (
-                    onupdate_value(None) if callable(onupdate_value) else onupdate_value
-                )
-
-                # Copy the values, we don't want to mess with the caller's data
-                values = deepcopy(values)
-                for row in values:
-                    row[column_name] = default_value
-
-        stmt = insert(model_class).values(values)
-        stmt = stmt.on_conflict_do_update(
-            # The columns to use to find matching rows.
-            index_elements=config.upsert_index_elements,
-            # The columns to update.
-            set_={
-                element: getattr(stmt.excluded, element)
-                for element in upsert_update_elements
-            },
+        from lms.services._upsert import (  # pylint:disable=import-outside-toplevel
+            bulk_upsert,
         )
 
-        result = self._session.execute(stmt)
-
-        # Let SQLAlchemy know that something has changed, otherwise it will
-        # never commit the transaction we are working on and it will get rolled
-        # back
-        mark_changed(self._session)
-
-        return result
-
-    @staticmethod
-    def _get_columns_onupdate(model_class):
-        """Get which columns which have an onupdate clause and its value."""
-        model_details = inspect(model_class)
-
-        return [(c.name, c.onupdate.arg) for c in model_details.c if c.onupdate]
+        return bulk_upsert(
+            self._session,
+            model_class,
+            values,
+            config.upsert_index_elements,
+            config.upsert_update_elements,
+            config.upsert_use_onupdate,
+        )

--- a/lms/services/_upsert.py
+++ b/lms/services/_upsert.py
@@ -1,6 +1,7 @@
 """A helper for upserting into DB tables."""
 
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy import or_, and_
 
 
 def upsert(db, model_class, query_kwargs, update_kwargs):
@@ -14,3 +15,52 @@ def upsert(db, model_class, query_kwargs, update_kwargs):
         setattr(model, key, value)
 
     return model
+
+
+def bulk_upsert(db, models, search_columns, update_columns):
+    def _search_criteria_values(model, search_columns):
+        return {column: getattr(model, column.key) for column in search_columns}
+
+    if not models:
+        return []
+
+    ModelsClass = models[0].__class__
+    assert all((model.__class__ == ModelsClass for model in models))
+
+    search_criteria = []
+    existing_models_by_search = {}
+    for model in models:
+        model_search_criteria = _search_criteria_values(model, search_columns)
+        model_search_values = tuple(model_search_criteria.values())
+
+        # Build a lookup dict from the value of the search column to the model
+        existing_models_by_search[model_search_values] = model
+
+        # For every model we have to "and" the search columns
+        search_criteria.append(
+            and_(*[column == value for column, value in model_search_criteria.items()])
+        )
+
+    # Aggregate all search criteria in a big "or" to find all existing columns
+    db_models = db.query(ModelsClass).filter(or_(*search_criteria)).all()
+
+    for db_model in db_models:
+        model_search_criteria = _search_criteria_values(db_model, search_columns)
+        model_search_values = tuple(model_search_criteria.values())
+
+        # For every existing model, update the neccessary columns finding the original model in the lookup dict
+        update_model = existing_models_by_search[model_search_values]
+        for update_column in update_columns:
+            setattr(
+                db_model,
+                update_column.key,
+                getattr(update_model, update_column.key),
+            )
+
+        del existing_models_by_search[model_search_values]
+
+    # We deleted models from the lookup dict as we went through the existing ones.
+    # The only ones left are the ones that need an insert.
+    (db.add(model) for model in existing_models_by_search)
+
+    return list(existing_models_by_search.values()) + db_models

--- a/lms/services/_upsert.py
+++ b/lms/services/_upsert.py
@@ -1,0 +1,16 @@
+"""A helper for upserting into DB tables."""
+
+from sqlalchemy.orm.exc import NoResultFound
+
+
+def upsert(db, model_class, query_kwargs, update_kwargs):
+    try:
+        model = db.query(model_class).filter_by(**query_kwargs).one()
+    except NoResultFound:
+        model = model_class(**query_kwargs)
+        db.add(model)
+
+    for key, value in update_kwargs.items():
+        setattr(model, key, value)
+
+    return model

--- a/lms/services/_upsert.py
+++ b/lms/services/_upsert.py
@@ -1,7 +1,11 @@
 """A helper for upserting into DB tables."""
 
+from copy import deepcopy
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import inspect, column
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy import or_, and_
+from sqlalchemy import or_, and_, tuple_
+from zope.sqlalchemy import mark_changed
 
 
 def upsert(db, model_class, query_kwargs, update_kwargs):
@@ -17,7 +21,7 @@ def upsert(db, model_class, query_kwargs, update_kwargs):
     return model
 
 
-def bulk_upsert(db, models, search_columns, update_columns):
+def bulk_orm_upsert(db, models, search_columns, update_columns):
     def _search_criteria_values(model, search_columns):
         return {column: getattr(model, column.key) for column in search_columns}
 
@@ -48,7 +52,7 @@ def bulk_upsert(db, models, search_columns, update_columns):
         model_search_criteria = _search_criteria_values(db_model, search_columns)
         model_search_values = tuple(model_search_criteria.values())
 
-        # For every existing model, update the neccessary columns finding the original model in the lookup dict
+        # For every existing model, update the necessary columns finding the original model in the lookup dict
         update_model = existing_models_by_search[model_search_values]
         for update_column in update_columns:
             setattr(
@@ -64,3 +68,80 @@ def bulk_upsert(db, models, search_columns, update_columns):
     (db.add(model) for model in existing_models_by_search)
 
     return list(existing_models_by_search.values()) + db_models
+
+
+def bulk_upsert(
+    db, ModelsClass, values, index_elements, update_columns, use_on_update=True
+):
+    """
+    Create or update the specified values in the table.
+
+    :param model_class: The model type to upsert
+    :param values: Dicts of values to upsert
+    """
+
+    def _get_columns_onupdate(model_class):
+        """Get which columns which have an onupdate clause and its value."""
+        model_details = inspect(model_class)
+
+        return [(c.name, c.onupdate.arg) for c in model_details.c if c.onupdate]
+
+    if not values:
+        # Don't attempt to upsert an empty list of values into the DB.
+        #
+        # This would be worse than pointless: it would actually crash in
+        # some cases. This SQLAlchemy code:
+        #
+        #     insert(MyModel).values([])
+        #
+        # produces this SQL:
+        #
+        #     INSERT INTO my_table DEFAULT VALUES RETURNING my_table.id
+        #
+        # which tells the DB to insert one row into my_table using the
+        # default values for all of the columns. If my_table has a column
+        # with a NOT NULLABLE constraint and no default value this will
+        # cause a "null value violates not-null constraint" crash.
+        return []
+
+    if use_on_update:
+        onupdate_columns = _get_columns_onupdate(ModelsClass)
+
+        for column_name, onupdate_value in onupdate_columns:
+            update_columns.append(column_name)
+
+            # SQL alchemy wraps functions passed to onupdate or default and
+            # could potentially take a "context" argument getting a
+            # suitable context at this point of the execution it's not
+            # possible so we don't support it so we just pass None
+            # https://docs.sqlalchemy.org/en/14/core/defaults.html#context-sensitive-default-functions
+            default_value = (
+                onupdate_value(None) if callable(onupdate_value) else onupdate_value
+            )
+
+            # Copy the values, we don't want to mess with the caller's data
+            values = deepcopy(values)
+            for row in values:
+                row[column_name] = default_value
+
+    index_elements_columns = [column(c) for c in index_elements]
+
+    stmt = insert(ModelsClass).values(values)
+    stmt = stmt.on_conflict_do_update(
+        # The columns to use to find matching rows.
+        index_elements=index_elements,
+        # The columns to update.
+        set_={element: getattr(stmt.excluded, element) for element in update_columns},
+    ).returning(*index_elements_columns)
+
+    result = db.execute(stmt).all()
+
+    # Let SQLAlchemy know that something has changed, otherwise it will
+    # never commit the transaction we are working on and it will get rolled
+    # back
+    mark_changed(db)
+
+    # Return ORM objects based on index_elements
+    return (
+        db.query(ModelsClass).filter(tuple_(*index_elements_columns).in_(result)).all()
+    )

--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import aliased
 
 from lms.models import Course, Grouping, GroupingMembership, User
 from lms.models._hashed_id import hashed_id
+from lms.models.grouping import Grouping
+from lms.services._upsert import upsert
 
 
 class GroupingService:
@@ -55,29 +57,19 @@ class GroupingService:
             tool_consumer_instance_guid, lms_id, parent, type_
         )
 
-        grouping = (
-            self._db.query(Grouping)
-            .filter_by(
-                application_instance=self._application_instance,
-                authority_provided_id=authority_provided_id,
-            )
-            .one_or_none()
+        return upsert(
+            self._db,
+            Grouping,
+            query_kwargs={
+                "application_instance": self._application_instance,
+                "authority_provided_id": authority_provided_id,
+                # These aren't really needed for querying, only for creating a new one.
+                "lms_id": lms_id,
+                "parent_id": parent.id,
+                "type": type_,
+            },
+            update_kwargs={"lms_name": lms_name, "extra": extra},
         )
-
-        if not grouping:
-            grouping = Grouping(
-                application_instance=self._application_instance,
-                authority_provided_id=authority_provided_id,
-                lms_id=lms_id,
-                parent_id=parent.id,
-                type=type_,
-            )
-            self._db.add(grouping)
-
-        grouping.lms_name = lms_name
-        grouping.extra = extra
-
-        return grouping
 
     def upsert_grouping_memberships(self, user: User, groups: List[Grouping]):
         """

--- a/lms/views/api/blackboard/sync.py
+++ b/lms/views/api/blackboard/sync.py
@@ -70,17 +70,19 @@ class Sync:
         )
 
     def to_groups_groupings(self, course, groups):
-        return [
-            self.grouping_service.upsert_with_parent(
-                tool_consumer_instance_guid=self.tool_consumer_instance_guid,
-                lms_id=group["id"],
-                lms_name=group["name"],
-                parent=course,
-                type_=Grouping.Type.BLACKBOARD_GROUP,
-                extra={"group_set_id": group["groupSetId"]},
-            )
-            for group in groups
-        ]
+        return self.grouping_service.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=self.tool_consumer_instance_guid,
+                    lms_id=group["id"],
+                    lms_name=group["name"],
+                    parent=course,
+                    type_=Grouping.Type.BLACKBOARD_GROUP,
+                    extra={"group_set_id": group["groupSetId"]},
+                )
+                for group in groups
+            ]
+        )
 
     def sync_to_h(self, groups):
         lti_h_svc = self.request.find_service(name="lti_h")

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -121,32 +121,36 @@ class Sync:
         tool_guid = self._request.json["lms"]["tool_consumer_instance_guid"]
         course = self._get_course()
 
-        return [
-            self._grouping_service.upsert_with_parent(
-                tool_consumer_instance_guid=tool_guid,
-                lms_id=group["id"],
-                lms_name=group["name"],
-                parent=course,
-                type_=Grouping.Type.CANVAS_GROUP,
-                extra={"group_set_id": group["group_category_id"]},
-            )
-            for group in groups
-        ]
+        return self._grouping_service.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=tool_guid,
+                    lms_id=group["id"],
+                    lms_name=group["name"],
+                    parent=course,
+                    type_=Grouping.Type.CANVAS_GROUP,
+                    extra={"group_set_id": group["group_category_id"]},
+                )
+                for group in groups
+            ]
+        )
 
     def _to_section_groupings(self, sections):
         tool_guid = self._request.json["lms"]["tool_consumer_instance_guid"]
         course = self._get_course()
 
-        return [
-            self._grouping_service.upsert_with_parent(
-                tool_consumer_instance_guid=tool_guid,
-                lms_id=section["id"],
-                lms_name=section["name"],
-                parent=course,
-                type_=Grouping.Type.CANVAS_SECTION,
-            )
-            for section in sections
-        ]
+        return self._grouping_service.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=tool_guid,
+                    lms_id=section["id"],
+                    lms_name=section["name"],
+                    parent=course,
+                    type_=Grouping.Type.CANVAS_SECTION,
+                )
+                for section in sections
+            ]
+        )
 
     def _get_course(self):
         tool_guid = self._request.json["lms"]["tool_consumer_instance_guid"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -177,13 +177,15 @@ def httpretty_():
 
 
 @pytest.fixture
-def application_instance(pyramid_request):
-    return factories.ApplicationInstance(
+def application_instance(db_session, pyramid_request):
+    ai = factories.ApplicationInstance(
         consumer_key=pyramid_request.lti_user.oauth_consumer_key,
         developer_key="TEST_DEVELOPER_KEY",
         provisioning=True,
         settings=ApplicationSettings({}),
     )
+    db_session.flush()
+    return ai
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -13,43 +13,51 @@ class TestGroupingService:
     CONTEXT_ID = "context_id"
     TOOL_CONSUMER_INSTANCE_GUID = "t_c_i_guid"
 
-    def test_upsert_with_parents_inserts(self, svc, db_session):
-        course = factories.Course()
-
+    def test_upsert_with_parents_inserts(self, svc, db_session, course):
         # Start with no CanvasGroup
         assert not db_session.query(CanvasGroup).count()
 
-        test_grouping = svc.upsert_with_parent(
-            tool_consumer_instance_guid=course.application_instance.tool_consumer_instance_guid,
-            lms_id="lms_id",
-            lms_name="lms_name",
-            parent=course,
-            type_=Grouping.Type.CANVAS_GROUP,
+        test_groupings = svc.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=course.application_instance.tool_consumer_instance_guid,
+                    lms_id="lms_id",
+                    lms_name="lms_name",
+                    parent=course,
+                    type=Grouping.Type.CANVAS_GROUP,
+                )
+            ]
         )
 
-        assert db_session.query(CanvasGroup).one() == test_grouping
+        assert db_session.query(CanvasGroup).one() == test_groupings[0]
 
-    def test_upsert_with_parent_updates_existing_groupings(self, svc, db_session):
-        course = factories.Course()
+    def test_upsert_with_parent_updates_existing_groupings(
+        self, svc, db_session, course
+    ):
         kwargs = {
             "tool_consumer_instance_guid": course.application_instance.tool_consumer_instance_guid,
             "lms_id": "lms_id",
             "parent": course,
-            "type_": Grouping.Type.CANVAS_GROUP,
+            "type": Grouping.Type.CANVAS_GROUP,
         }
         old_name = "old_name"
         old_extra = {"extra": "old"}
         new_name = "new_name"
         new_extra = {"extra": "new"}
         # Insert an existing grouping into the DB.
-        svc.upsert_with_parent(lms_name=old_name, extra=old_extra, **kwargs)
+        svc.bulk_upsert_with_parent(
+            [dict(lms_name=old_name, extra=old_extra, **kwargs)]
+        )
 
         # upsert_with_parent() should find and update the existing grouping.
-        grouping = svc.upsert_with_parent(lms_name=new_name, extra=new_extra, **kwargs)
+        groupings = svc.bulk_upsert_with_parent(
+            [dict(lms_name=new_name, extra=new_extra, **kwargs)]
+        )
+        assert len(groupings) == 1
 
         # It should return a grouping with the updated values.
-        assert grouping.lms_name == new_name
-        assert grouping.extra == new_extra
+        assert groupings[0].lms_name == new_name
+        assert groupings[0].extra == new_extra
         # The values should have been updated in the DB as well.
         db_grouping = db_session.query(CanvasGroup).one()
         assert db_grouping.lms_name == new_name
@@ -59,21 +67,33 @@ class TestGroupingService:
         course = factories.Course(lms_id=self.CONTEXT_ID)
         db_session.flush()
 
-        group = svc.upsert_with_parent(
-            self.TOOL_CONSUMER_INSTANCE_GUID,
-            "same_id",
-            "group_name",
-            course,
-            Grouping.Type.CANVAS_GROUP,
-        )
-        section = svc.upsert_with_parent(
-            self.TOOL_CONSUMER_INSTANCE_GUID,
-            "same_id",
-            "section_name",
-            course,
-            Grouping.Type.CANVAS_SECTION,
+        groups = svc.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=self.TOOL_CONSUMER_INSTANCE_GUID,
+                    lms_id="same_id",
+                    lms_name="group_name",
+                    parent=course,
+                    type=Grouping.Type.CANVAS_GROUP,
+                )
+            ]
         )
 
+        sections = svc.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=self.TOOL_CONSUMER_INSTANCE_GUID,
+                    lms_id="same_id",
+                    lms_name="section_name",
+                    parent=course,
+                    type=Grouping.Type.CANVAS_SECTION,
+                )
+            ]
+        )
+
+        assert len(groups) == len(sections) == 1
+        group = groups[0]
+        section = sections[0]
         assert group.authority_provided_id == "078cc1b793e061085ed3ef91189b41a6f7dd26b8"
         assert (
             section.authority_provided_id == "867c2696d32eb4b5e9cf5c5304cb71c3e20bfd14"
@@ -248,6 +268,12 @@ class TestGroupingService:
     @pytest.fixture
     def svc(self, db_session, application_instance_service):
         return GroupingService(db_session, application_instance_service)
+
+    @pytest.fixture
+    def course(self, db_session):
+        course = factories.Course()
+        db_session.flush()
+        return course
 
 
 class TestFactory:

--- a/tests/unit/lms/views/api/blackboard/sync_test.py
+++ b/tests/unit/lms/views/api/blackboard/sync_test.py
@@ -48,7 +48,7 @@ def test_it_when_student(
     )
     grouping_service.upsert_grouping_memberships.assert_called_once_with(
         user_service.get.return_value,
-        [grouping_service.upsert_with_parent.return_value for _ in groups],
+        grouping_service.bulk_upsert_with_parent.return_value,
     )
 
 
@@ -88,17 +88,19 @@ def assert_sync_and_return_groups(
     tool_guid = request_json["lms"]["tool_consumer_instance_guid"]
 
     def assert_return_values(groupids, groups):
-        expected_groups = [
-            grouping_service.upsert_with_parent(
-                tool_consumer_instance_guid=tool_guid,
-                lms_id=group["id"],
-                lms_name=group.get("name", f"Group {group['id']}"),
-                parent=course_service.get.return_value,
-                type_=Grouping.Type.CANVAS_GROUP,
-                extra={"group_set_id": group["groupSetId"]},
-            )
-            for group in groups
-        ]
+        expected_groups = grouping_service.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=tool_guid,
+                    lms_id=group["id"],
+                    lms_name=group.get("name", f"Group {group['id']}"),
+                    parent=course_service.get.return_value,
+                    type_=Grouping.Type.CANVAS_GROUP,
+                    extra={"group_set_id": group["groupSetId"]},
+                )
+                for group in groups
+            ]
+        )
 
         lti_h_service.sync.assert_called_once_with(
             expected_groups, request_json["group_info"]

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -216,16 +216,18 @@ def assert_sync_and_return_sections(
     tool_guid = request_json["lms"]["tool_consumer_instance_guid"]
 
     def assert_return_values(groupids, sections):
-        expected_groups = [
-            grouping_service.upsert_with_parent(
-                tool_consumer_instance_guid=tool_guid,
-                lms_id=section["id"],
-                lms_name=section.get("name", f"Section {section['id']}"),
-                parent=course_service.get.return_value,
-                type_=Grouping.Type.CANVAS_SECTION,
-            )
-            for section in sections
-        ]
+        expected_groups = grouping_service.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=tool_guid,
+                    lms_id=section["id"],
+                    lms_name=section.get("name", f"Section {section['id']}"),
+                    parent=course_service.get.return_value,
+                    type_=Grouping.Type.CANVAS_SECTION,
+                )
+                for section in sections
+            ]
+        )
 
         lti_h_service.sync.assert_called_once_with(
             expected_groups, request_json["group_info"]
@@ -245,17 +247,19 @@ def assert_sync_and_return_groups(
     tool_guid = request_json["lms"]["tool_consumer_instance_guid"]
 
     def assert_return_values(groupids, groups):
-        expected_groups = [
-            grouping_service.upsert_with_parent(
-                tool_consumer_instance_guid=tool_guid,
-                lms_id=group["id"],
-                lms_name=group.get("name", f"Group {group['id']}"),
-                parent=course_service.get.return_value,
-                type_=Grouping.Type.CANVAS_GROUP,
-                extra={"group_set_id": group["group_category_id"]},
-            )
-            for group in groups
-        ]
+        expected_groups = grouping_service.bulk_upsert_with_parent(
+            [
+                dict(
+                    tool_consumer_instance_guid=tool_guid,
+                    lms_id=group["id"],
+                    lms_name=group.get("name", f"Group {group['id']}"),
+                    parent=course_service.get.return_value,
+                    type_=Grouping.Type.CANVAS_GROUP,
+                    extra={"group_set_id": group["group_category_id"]},
+                )
+                for group in groups
+            ]
+        )
 
         lti_h_service.sync.assert_called_once_with(
             expected_groups, request_json["group_info"]


### PR DESCRIPTION
I initially had this a branch against your upsert-helper one but had to rebase here so now the diff is a mess. Pointing to master for now.

I wrote a couple of version of this: 

- https://github.com/hypothesis/lms/pull/3518/commits/f34ac448181ad5f94a89fb9d2e8ad49ebe0c9548 using only the ORM. 

There's a lot of bookkeeping there which make the code not that clear and it's also less performatn and it does have a race condition (between the getting and the creation, the one row version in master also has that problem).


- https://github.com/hypothesis/lms/pull/3518/commits/6c2cda0dd6fef8c61c2df7df5bf85794ac5e46a4 using both the core api and the ORM

This is the version you'll see also if you look at the full diff. This is 90% of what we already have on "bulk_actions" but just as a function.

Maybe this makes the upsert code even more scattered through tthe code base but all the DB logic is now on the function and the existing "bulk_action" just calls that with the config in the model.

I don't think we necessary want to configure the upsert functionally at the model level, seems to me more like a query you might want to use with different parameters in different situations rather than something more intrinsic to the model.

