### PR TITLE
Debounce fetching students grades

### DIFF
--- a/lms/static/scripts/frontend_apps/services/grading.js
+++ b/lms/static/scripts/frontend_apps/services/grading.js
@@ -10,7 +10,7 @@ import { apiCall } from '../utils/api';
  * The fetched grade success result.
  *
  * @typedef FetchGradeResult
- * @prop {number} currentScore - The fetched grade
+ * @prop {number|null} currentScore - The fetched grade
  */
 
 /**

--- a/lms/static/scripts/tsconfig.json
+++ b/lms/static/scripts/tsconfig.json
@@ -9,7 +9,8 @@
     "noEmit": true,
     "strict": true,
     "target": "ES2020",
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "esModuleInterop": true
   },
   "include": ["frontend_apps/**/*.js", "frontend_apps/**/*d.ts"],
   "exclude": ["frontend_apps/**/test/*.js"]

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "focus-visible": "^5.2.0",
     "gulp": "^4.0.2",
     "karma-chrome-launcher": "^3.1.0",
+    "lodash.debounce": "^4.0.8",
     "normalize.css": "^8.0.1",
     "postcss": "^8.4.5",
     "preact": "10.6.4",
@@ -56,6 +57,7 @@
   },
   "devDependencies": {
     "@types/gapi": "^0.0.41",
+    "@types/lodash.debounce": "^4.0.6",
     "axe-core": "^4.3.5",
     "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-mockable-imports": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,6 +1166,18 @@
   resolved "https://registry.yarnpkg.com/@types/gapi/-/gapi-0.0.41.tgz#c477ee4f0951c005869219fd10b456ae2bba437e"
   integrity sha512-tmHO66z/f91JZCDqinj/nNvQEszsz/hBT4+MvCSKT5sDzl5Ld/oXZ8WaecCBjRLw2uWKUInUHM9MhEXWkOiNjw==
 
+"@types/lodash.debounce@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz#c5a2326cd3efc46566c47e4c0aa248dc0ee57d60"
+  integrity sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+
 "@types/node@*":
   version "14.0.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.10.tgz#dbfaa170bd9eafccccb6d7060743a761b0844afd"


### PR DESCRIPTION
In the LMS grader, every time that the next or previous arrow is pressed it
makes a network request. This could cause a big number of meaningless
requests. In order to avoid this, we have debounced the requests of
student grades, so that only the last request made within the last 200
milliseconds is executed, the rest are ignored.

This causes a delay of 200 milliseconds also when a specific user is
selected via the dropdown.

I have also fixed the following issue that I noticed: if you give a zero
to an student, navigate to another student and come back to the terrible
student the zero grade was not showing. I corrected that.