### PR TITLE
Rename tailwind colors related to state to be less ambiguous

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -184,14 +184,14 @@ export default function BookSelector({
             className="flex flex-row items-center space-x-2"
             data-testid="selected-book"
           >
-            <Icon name="check" classes="text-success" />
+            <Icon name="check" classes="text-green-success" />
             <div className="grow font-bold italic">{selectedBook.title}</div>
           </div>
         )}
 
         {error && (
           <div
-            className="flex flex-row items-center space-x-2 text-error"
+            className="flex flex-row items-center space-x-2 text-red-error"
             data-testid="error-message"
           >
             <Icon name="cancel" />

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -82,7 +82,7 @@ export default function URLPicker({ onCancel, onSelectURL }) {
         {/** setting a height here "preserves space" for this error display
          * and prevents the dialog size from jumping when an error is rendered */}
         <div
-          className="h-4 flex flex-row items-center space-x-1 text-error"
+          className="h-4 flex flex-row items-center space-x-1 text-red-error"
           data-testid="error-message"
         >
           {!!error && (

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -43,7 +43,7 @@ export default function ValidationMessage({
       onClick={closeValidationError}
       className={classnames(
         'absolute z-10 h-touch-minimum shadow',
-        'text-white border-0 bg-error whitespace-nowrap overflow-hidden',
+        'text-white border-0 bg-red-error whitespace-nowrap overflow-hidden',
         // Narrow viewports position the message to the right of the input
         'left-full',
         // Sm and larger breakpoints position the message to the left of the input

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -13,6 +13,17 @@ export default {
         validationMessageOpen: 'validationMessageOpen 0.3s forwards',
         validationMessageClose: 'validationMessageClose 0.3s forwards',
       },
+      colors: {
+        green: {
+          success: '#00a36d',
+        },
+        yellow: {
+          notice: '#fbc168',
+        },
+        red: {
+          error: '#d93c3f',
+        },
+      },
       fontFamily: {
         sans: [
           '"Helvetica Neue"',


### PR DESCRIPTION
This is based on some reviewer feedback on a previous PR and some rumination of my own.

Naming a color (token/variable) `success` or `error` means that some of the tailwind- generated utility classnames are less than crystal clear in some contexts. For example, `.text-error` doesn't clearly communicate that it is setting foreground/text color.

For this reason, I've elected to change these to `green-success`, `yellow-notice` and `red-error`. I believe this communicates more clearly the meaning of these utility classes (e.g `.text-red-error`).

Once this is landed, we can make this change to the global preset in `frontend-shared` and remove this local `tailwind.config` change.