### PR TITLE
Validate params on BB sync API

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -44,6 +44,7 @@ suitable validation schema's ``__init__()`` method and then call the schema's
         ...
 """
 from lms.validation._api import (
+    APIBlackboardSyncSchema,
     APICreateAssignmentSchema,
     APIReadResultSchema,
     APIRecordResultSchema,

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -1,12 +1,10 @@
 """Schema for JSON APIs exposed to the frontend."""
 
 import marshmallow
-from marshmallow import Schema, ValidationError, validates_schema
+from marshmallow import INCLUDE, Schema, ValidationError, validates_schema
 from webargs import fields
 
 from lms.validation._base import JSONPyramidRequestSchema, PyramidRequestSchema
-
-__all__ = ["APIRecordSpeedgraderSchema", "APIReadResultSchema", "APIRecordResultSchema"]
 
 
 class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
@@ -132,3 +130,25 @@ class APICreateAssignmentSchema(PyramidRequestSchema):
             raise ValidationError(
                 "both bookID and cfi are mandatory with type is 'vitalsource'"
             )
+
+
+class APIBlackboardSyncSchema(PyramidRequestSchema):
+    class LMS(Schema):
+        tool_consumer_instance_guid = fields.Str(required=True)
+
+    class Course(Schema):
+        context_id = fields.Str(required=True)
+
+    class Assignment(Schema):
+        resource_link_id = fields.Str(required=True)
+
+    class GroupInfo(Schema):
+        class Meta:
+            unknown = INCLUDE
+
+    lms = fields.Nested(LMS, required=True)
+    course = fields.Nested(Course, required=True)
+    assignment = fields.Nested(Assignment, required=True)
+    group_info = fields.Nested(GroupInfo, required=True)
+
+    gradingStudentId = fields.Str(required=False, allow_none=True)

--- a/tests/unit/lms/views/api/blackboard/sync_test.py
+++ b/tests/unit/lms/views/api/blackboard/sync_test.py
@@ -42,7 +42,7 @@ def test_it_when_student(
 
     assert_sync_and_return_groups(result, groups=groups)
     blackboard_api_client.course_groups.assert_called_once_with(
-        pyramid_request.json["course"]["context_id"],
+        pyramid_request.parsed_params["course"]["context_id"],
         "GROUP_SET_ID",
         current_student_own_groups_only=True,
     )
@@ -59,7 +59,7 @@ def test_it_when_grading(
     course_service,
     assignment_service,
 ):
-    pyramid_request.json["gradingStudentId"] = "GRADING_STUDENT_ID"
+    pyramid_request.parsed_params["gradingStudentId"] = "GRADING_STUDENT_ID"
     grouping_service.get_course_groupings_for_user.return_value = [Mock()]
 
     result = Sync(pyramid_request).sync()
@@ -133,5 +133,5 @@ def assignment_service(assignment_service):
 
 @pytest.fixture
 def pyramid_request(pyramid_request, request_json):
-    pyramid_request.json = request_json
+    pyramid_request.parsed_params = request_json
     return pyramid_request


### PR DESCRIPTION
A more focused version of https://github.com/hypothesis/lms/pull/3514 with only the param validation.

Left on that PR are:

- A refactor or the sync view. Fetch most params on the main view function and pass them along to helper functions.

- Validate also the params the backed sends to the frontend so they are in sync in both directions.

for which I made a note to revisit once the rest of the BB sprint issues are closed.



# Testing 

No new feature or behavior changes. 

Open a BB group assignment as both a teacher and student.
