### PR TITLE
Handle Blackboard Groups assignments whose group set no longer exists

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -131,16 +131,17 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
+    case 'blackboard_group_set_not_found':
     case 'canvas_group_set_not_found':
       return (
         <ErrorModal
           busy={busy}
           error={error}
-          title="Assignment's group set no longer exists in Canvas"
+          title="Assignment's group set no longer exists"
         >
           <p>
             Hypothesis couldn&apos;t load this assignment because the
-            assignment&apos;s group set no longer exists in Canvas.
+            assignment&apos;s group set no longer exists.
           </p>
           <p>
             <b>

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -65,11 +65,20 @@ describe('LaunchErrorDialog', () => {
     {
       errorState: 'canvas_group_set_not_found',
       expectedText:
-        "Hypothesis couldn't load this assignment because the assignment's group set no longer exists in Canvas.To fix this problem, an instructor needs to edit the assignment settings and select a new group set.",
-      expectedTitle: "Assignment's group set no longer exists in Canvas",
+        "Hypothesis couldn't load this assignment because the assignment's group set no longer exists.To fix this problem, an instructor needs to edit the assignment settings and select a new group set.",
+      expectedTitle: "Assignment's group set no longer exists",
       hasRetry: false,
       withError: true,
     },
+    {
+      errorState: 'blackboard_group_set_not_found',
+      expectedText:
+        "Hypothesis couldn't load this assignment because the assignment's group set no longer exists.To fix this problem, an instructor needs to edit the assignment settings and select a new group set.",
+      expectedTitle: "Assignment's group set no longer exists",
+      hasRetry: false,
+      withError: true,
+    },
+
     {
       errorState: 'blackboard_group_set_empty',
       expectedText: 'The group set for this Hypothesis assignment is empty',

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -5,6 +5,7 @@
  *
  * @typedef {'blackboard_file_not_found_in_course'|
  *           'blackboard_group_set_empty' |
+ *           'blackboard_group_set_not_found' |
  *           'blackboard_student_not_in_group' |
  *           'canvas_api_permission_error'|
  *           'canvas_file_not_found_in_course'|
@@ -113,6 +114,7 @@ export function isLTILaunchServerError(error) {
     [
       'blackboard_file_not_found_in_course',
       'blackboard_group_set_empty',
+      'blackboard_group_set_not_found',
       'blackboard_student_not_in_group',
       'canvas_api_permission_error',
       'canvas_file_not_found_in_course',


### PR DESCRIPTION
For #3479 


## Testing 

- Open `localhost (make devdata) Groups Assignment Whose Group Set Has Been Deleted` as a instructor. You should see an error dialog.