### PR TITLE
Expose cause on ExternalRequestError

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -82,6 +82,7 @@ class ExternalRequestError(Exception):
         return (
             f"{class_name}("
             f"message={self.message!r}, "
+            f"cause={self.__cause__!r}, "
             f"request={request}, "
             f"response={response}, "
             f"validation_errors={self.validation_errors!r})"

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -140,6 +140,7 @@ class APIExceptionViews:
         return self.error_response(
             message=message,
             details={
+                "cause": repr(self.context.__cause__),
                 "request": {
                     "method": self.context.method,
                     "url": strip_queryparams(self.context.url),

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -36,14 +36,15 @@ class TestExternalRequestError:
         assert err.response_body is None
 
     @pytest.mark.parametrize(
-        "message,request_,response,validation_errors,expected",
+        "message,request_,response,validation_errors,cause,expected",
         [
             (
                 None,
                 None,
                 None,
                 None,
-                "ExternalRequestError(message=None, request=Request(method=None, url=None, body=None), response=Response(status_code=None, reason=None, body=None), validation_errors=None)",
+                None,
+                "ExternalRequestError(message=None, cause=None, request=Request(method=None, url=None, body=None), response=Response(status_code=None, reason=None, body=None), validation_errors=None)",
             ),
             (
                 "Connecting to Hypothesis failed",
@@ -56,17 +57,19 @@ class TestExternalRequestError:
                     raw="Name too long",
                 ),
                 {"foo": ["bar"]},
-                "ExternalRequestError(message='Connecting to Hypothesis failed', request=Request(method='GET', url='https://example.com/', body='request_body'), response=Response(status_code=400, reason='Bad Request', body='Name too long'), validation_errors={'foo': ['bar']})",
+                KeyError("cause"),
+                "ExternalRequestError(message='Connecting to Hypothesis failed', cause=KeyError('cause'), request=Request(method='GET', url='https://example.com/', body='request_body'), response=Response(status_code=400, reason='Bad Request', body='Name too long'), validation_errors={'foo': ['bar']})",
             ),
         ],
     )
-    def test_str(self, message, request_, response, validation_errors, expected):
+    def test_str(self, message, request_, response, validation_errors, cause, expected):
         err = ExternalRequestError(
             message=message,
             request=request_,
             response=response,
             validation_errors=validation_errors,
         )
+        err.__cause__ = cause
 
         assert str(err) == expected
 

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -62,6 +62,7 @@ class TestExternalRequestError:
         assert json_data == {
             "message": context.message,
             "details": {
+                "cause": "ValueError('foo')",
                 "request": {
                     "method": context.method,
                     "url": "https://example.com/",  # The URL without query string.
@@ -84,7 +85,7 @@ class TestExternalRequestError:
 
     @pytest.fixture
     def context(self):
-        return ExternalRequestError(
+        context = ExternalRequestError(
             message="test_message",
             request=requests.Request(
                 "GET", "https://example.com?foo=bar", data="request_body"
@@ -94,6 +95,8 @@ class TestExternalRequestError:
             ),
             validation_errors=sentinel.validation_errors,
         )
+        context.__cause__ = ValueError("foo")
+        return context
 
 
 class TestNotFound:


### PR DESCRIPTION
Based on comments from https://github.com/hypothesis/lms/pull/3503.
![Screenshot from 2022-01-25 10-06-25](https://user-images.githubusercontent.com/1433832/150946145-1de7f12c-79ab-4280-b77a-e5c34f27997f.png)

