### PR TITLE
Don't convert groups assignments to sections in sync API

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from lms.models import ApplicationInstance, GroupInfo, HUser
 from lms.resources._js_config.file_picker_config import FilePickerConfig
-from lms.services import HAPIError
+from lms.services import CanvasService, HAPIError
 from lms.validation.authentication import BearerTokenSchema
 from lms.views.helpers import via_url
 
@@ -532,7 +532,7 @@ class JSConfig:
     def _sync_api(self):
         if self._context.is_canvas and (
             self._context.canvas_sections_enabled
-            or self._context.canvas_is_group_launch
+            or CanvasService.is_group_launch(self._request)
         ):
             return self._canvas_sync_api()
 

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -63,6 +63,38 @@ class CanvasService:
 
             return url
 
+    @staticmethod
+    def is_speedgrader(request) -> bool:
+        if "learner_canvas_user_id" in request.GET:
+            # Location while launching an assignment
+            return bool(request.GET["learner_canvas_user_id"])
+
+        # Location when using the Sync API
+        try:
+            return "learner" in request.json
+        except:  # pylint:disable=bare-except
+            return False
+
+    @staticmethod
+    def group_set(request) -> int:
+        if "group_set" in request.params:
+            # Location while launching an assignment
+            value = request.params["group_set"]
+        else:
+            # Location when using the Sync API
+            value = request.json["learner"].get("group_set")
+
+        return int(value)
+
+    @staticmethod
+    def is_group_launch(request) -> bool:
+        try:
+            CanvasService.group_set(request)
+        except (KeyError, ValueError, TypeError):
+            return False
+        else:
+            return True
+
 
 class CanvasFileFinder:
     """A helper for finding file IDs in the Canvas API."""

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -2,7 +2,7 @@ from pyramid.view import view_config
 
 from lms.models import Grouping
 from lms.security import Permissions
-from lms.services import CanvasAPIError, UserService
+from lms.services import CanvasAPIError, CanvasService, UserService
 from lms.views import (
     CanvasGroupSetEmpty,
     CanvasGroupSetNotFound,
@@ -14,7 +14,7 @@ class Sync:
     def __init__(self, request):
         self._request = request
         self._grouping_service = self._request.find_service(name="grouping")
-        self._canvas_api = self._request.find_service(name="canvas_api_client")
+        self._canvas: CanvasService = self._request.find_service(iface=CanvasService)
         self._course_service = self._request.find_service(name="course")
 
     @view_config(
@@ -24,7 +24,7 @@ class Sync:
         permission=Permissions.API,
     )
     def sync(self):
-        if self._is_group_launch:
+        if self._canvas.is_group_launch(self._request):
             groups = self._get_canvas_groups()
         else:
             groups = self._to_section_groupings(self._get_sections())
@@ -34,34 +34,9 @@ class Sync:
         authority = self._request.registry.settings["h_authority"]
         return [group.groupid(authority) for group in groups]
 
-    @property
-    def _is_speedgrader(self):
-        return "learner" in self._request.json
-
-    def group_set(self):
-        if self._is_speedgrader:
-            return int(self._request.json["learner"].get("group_set"))
-
-        return int(self._request.json["course"].get("group_set"))
-
-    @property
-    def _is_group_launch(self):
-        application_instance = self._request.find_service(
-            name="application_instance"
-        ).get_current()
-        if not application_instance.settings.get("canvas", "groups_enabled"):
-            return False
-
-        try:
-            self.group_set()
-        except (KeyError, ValueError, TypeError):
-            return False
-        else:
-            return True
-
     def _get_canvas_groups(self):
         lti_user = self._request.lti_user
-        group_set_id = self.group_set()
+        group_set_id = self._canvas.group_set(self._request)
         if lti_user.is_learner:
             user = self._request.find_service(UserService).get(
                 self._request.find_service(name="application_instance").get_current(),
@@ -69,7 +44,7 @@ class Sync:
             )
 
             # For learners, the groups they belong within the course
-            learner_groups = self._canvas_api.current_user_groups(
+            learner_groups = self._canvas.api.current_user_groups(
                 self._request.json["course"]["custom_canvas_course_id"],
                 group_set_id,
             )
@@ -81,19 +56,19 @@ class Sync:
 
             return groups
 
-        if self._is_speedgrader:
+        if self._canvas.is_speedgrader(self._request):
             # SpeedGrader requests are made by the teacher, get the student we are grading
             return self._to_groups_groupings(
-                self._canvas_api.user_groups(
+                self._canvas.api.user_groups(
                     self._request.json["course"]["custom_canvas_course_id"],
                     int(self._request.json["learner"]["canvas_user_id"]),
-                    self.group_set(),
+                    group_set_id,
                 )
             )
 
         try:
             # If not grading return all the groups in the course so the teacher can toggle between them.
-            groups = self._canvas_api.group_category_groups(group_set_id)
+            groups = self._canvas.api.group_category_groups(group_set_id)
         except CanvasAPIError as canvas_api_error:
             raise CanvasGroupSetNotFound(group_set=group_set_id) from canvas_api_error
 
@@ -109,12 +84,12 @@ class Sync:
         if lti_user.is_learner:
             # For learners we only want the client to show the sections that
             # the student belongs to, so fetch only the user's sections.
-            return self._canvas_api.authenticated_users_sections(course_id)
+            return self._canvas.api.authenticated_users_sections(course_id)
 
         # For non-learners (e.g. instructors, teaching assistants) we want the
         # client to show all of the course's sections.
-        sections = self._canvas_api.course_sections(course_id)
-        if not self._is_speedgrader:
+        sections = self._canvas.api.course_sections(course_id)
+        if not CanvasService.is_speedgrader(self._request):
             return sections
 
         # SpeedGrader requests are made by the teacher, but we want the
@@ -122,7 +97,7 @@ class Sync:
         # we will just use them to filter the course sections
         user_id = self._request.json["learner"]["canvas_user_id"]
         learner_section_ids = {
-            sec["id"] for sec in self._canvas_api.users_sections(user_id, course_id)
+            sec["id"] for sec in self._canvas.api.users_sections(user_id, course_id)
         }
 
         return [sec for sec in sections if sec["id"] in learner_section_ids]

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -13,6 +13,7 @@ pytestmark = pytest.mark.usefixtures(
     "grant_token_service",
     "h_api",
     "vitalsource_service",
+    "canvas_service",
 )
 
 
@@ -736,7 +737,6 @@ def context():
         is_canvas=True,
         canvas_sections_enabled=False,
         canvas_groups_enabled=False,
-        canvas_is_group_launch=False,
         is_group_launch=False,
     )
 
@@ -763,6 +763,7 @@ def pyramid_request(pyramid_request):
             "ext_lti_assignment_id": "ext_lti_assignment_id",
         }
     )
+    pyramid_request.json = {}
     return pyramid_request
 
 

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -111,6 +111,9 @@ def canvas_service(mock_service, canvas_api_client):
     canvas_service = mock_service(CanvasService)
     canvas_service.api = canvas_api_client
 
+    canvas_service.is_group_launch.return_value = False
+    canvas_service.is_speedgrader.return_value = False
+
     return canvas_service
 
 


### PR DESCRIPTION
This PR could be replaced with the much simpler: https://github.com/hypothesis/lms/pull/3586

---


f355d8d060b1f824886bfe73f73c0ec1239793c7 had a couple of problems:

- Left the same AI setting check in `lms/views/api/canvas/sync.py`.
- The scopes used are still based on the AI setting. (But enabling and disabling seems to work until the token is deleted).


There's some duplication between `lms/views/api/canvas/sync.py` and `lms/resources/lti_launch.py`


Not sure where we could put some canvas shared code functions. Directly on `CanvasService`? There's only  `public_url_for_file` there at the moment.