### PR TITLE
Use bulk_upsert for gruping memberships

### DIFF
--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -205,9 +205,10 @@ class TestGroupingService:
         assert not groupings
 
     @pytest.fixture
-    def with_course_memberships(self, svc, application_instance):
+    def with_course_memberships(self, svc, db_session, application_instance):
         courses = factories.Course.create_batch(5)
         user = factories.User(application_instance=application_instance)
+        db_session.flush()
 
         svc.upsert_grouping_memberships(user, courses)
 


### PR DESCRIPTION
## Testing

- `truncate grouping_membership` on `make sql`
- Launch a groups assignment in blackboard.
- `select * from grouping_membership;` should return rows.
- Launch the assignment again.
- `select * from grouping_membership;` created` should be different than `updated`.