### PR TITLE
Add unique index for grouping.authority_provided_id

### DIFF
--- a/lms/migrations/versions/69265d3e6ffe_grouping_authority_index.py
+++ b/lms/migrations/versions/69265d3e6ffe_grouping_authority_index.py
@@ -1,0 +1,26 @@
+"""
+Creates an unique index on grouping.authority_provided_id.
+
+Revision ID: 69265d3e6ffe
+Revises: 6882c201b56e
+Create Date: 2022-01-26 11:18:46.851084
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "69265d3e6ffe"
+down_revision = "6882c201b56e"
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix__grouping_authority_provided_id"),
+        "grouping",
+        ["authority_provided_id"],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix__grouping_authority_provided_id"), table_name="grouping")

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -43,7 +43,9 @@ class Grouping(CreatedUpdatedMixin, BASE):
     application_instance = sa.orm.relationship("ApplicationInstance")
 
     #: The authority_provided_id of the Group that was created for this Grouping in h's DB.
-    authority_provided_id = sa.Column(sa.UnicodeText(), nullable=False)
+    authority_provided_id = sa.Column(
+        sa.UnicodeText(), nullable=False, unique=True, index=True
+    )
 
     #: The id of the parent grouping that this grouping belongs to.
     #:


### PR DESCRIPTION
The index part is not strictly necessary but will make upserts (with bulk_upsert) more efficient. 

I think the uniqueness should have been there form the start.