### PR TITLE
Add error handling UI for group-set configuration for Blackboard and Canvas

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AuthorizationModal.js
+++ b/lms/static/scripts/frontend_apps/components/AuthorizationModal.js
@@ -1,0 +1,62 @@
+import AuthButton from './AuthButton';
+import ErrorModal from './ErrorModal';
+
+/**
+ * @typedef {import('./ErrorModal').ErrorModalProps} ErrorModalProps
+ * @typedef {import("preact").ComponentChildren} Children
+ */
+
+/**
+ * @typedef AuthorizationModalBaseProps
+ * @prop {string} authURL - Initial URL for the authorization popup. See `AuthWindow`.
+ * @prop {string} authToken - Auth token between the LMS frontend and backend. See `AuthWindow`.
+ * @prop {string} [cancelLabel="Cancel"] - Set the default Cancel button text. Only relevant
+ *   if `onCancel` is provided (passed through to `ErrorModal`)
+ * @prop {Children} [children]
+ * @prop {() => void} onAuthComplete - Callback invoked when the authorization flow completes.
+ *   This does not guarantee that authorization was successful. Instead
+ *   the caller should retry whatever operation triggered the authorization
+ *   prompt and check whether it succeeds.
+ * @prop {string} [title="Authorize Hypothesis"]
+ *
+ */
+
+/**
+ * @typedef {Omit<ErrorModalProps, "cancelLabel"|"children"|"title"> & AuthorizationModalBaseProps} AuthorizationModalProps
+ * */
+
+/**
+ * Render an Authorization modal.
+ *
+ * @param {AuthorizationModalProps} props
+ */
+export default function AuthorizationModal({
+  authToken,
+  authURL,
+  cancelLabel = 'Cancel',
+  children,
+  onAuthComplete,
+  title = 'Authorize Hypothesis',
+
+  // Other props to forward on to ErrorModal
+  ...restProps
+}) {
+  const buttons = (
+    <AuthButton
+      authURL={authURL}
+      authToken={authToken}
+      onAuthComplete={onAuthComplete}
+    />
+  );
+
+  return (
+    <ErrorModal
+      buttons={buttons}
+      cancelLabel={cancelLabel}
+      title={title}
+      {...restProps}
+    >
+      {children}
+    </ErrorModal>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -149,6 +149,7 @@ export default function GroupConfigSelector({
           )}
           {fetchError && !isAuthorizationError(fetchError) && (
             <ErrorModal
+              cancelLabel="Cancel"
               description="There was a problem fetching group sets"
               error={fetchError}
               onCancel={onErrorCancel}

--- a/lms/static/scripts/frontend_apps/components/test/AuthorizationModal-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AuthorizationModal-test.js
@@ -1,0 +1,48 @@
+import { mount } from 'enzyme';
+
+import AuthorizationModal from '../AuthorizationModal';
+
+describe('AuthorizationModal', () => {
+  let fakeOnAuthComplete;
+
+  const createComponent = (props = {}) =>
+    mount(
+      <AuthorizationModal
+        authToken="123456"
+        authURL="http://https://example.com/authorize"
+        onAuthComplete={fakeOnAuthComplete}
+        {...props}
+      />
+    );
+
+  beforeEach(() => {
+    fakeOnAuthComplete = sinon.stub();
+  });
+
+  it('provides an authorization button', () => {
+    const wrapper = createComponent();
+    const authorizeButton = wrapper.find('LabeledButton');
+
+    assert.equal(authorizeButton.length, 1);
+    assert.equal(authorizeButton.text(), 'Authorize');
+  });
+
+  it('displays a cancel button if onCancel provided', () => {
+    const onCancel = sinon.stub();
+    const wrapper = createComponent({ onCancel });
+
+    const cancelButton = wrapper.find(
+      'LabeledButton[data-testid="cancel-button"]'
+    );
+
+    assert.equal(cancelButton.text(), 'Cancel');
+    assert.equal(cancelButton.props().onClick, onCancel);
+  });
+
+  it('sets a default title', () => {
+    const wrapper = createComponent();
+    const wrappedErrorModal = wrapper.find('ErrorModal');
+
+    assert.equal(wrappedErrorModal.props().title, 'Authorize Hypothesis');
+  });
+});


### PR DESCRIPTION
This PR adds error-handling UI for errors encountered during configuring assignments with groups in both Blackboard and Canvas. 

Previously, if any error was encountered in the request to the proxied groups API, the UI would treat it as an authorization error and would provide an auth button in the interface like so (this screen shot is from Canvas, but it also did this in Blackboard):

### Before

![image](https://user-images.githubusercontent.com/439947/151171568-1f2ef81f-6aa0-419c-b822-e8c86e13af33.png)

Clicking that button does indeed trigger the auth process, but if the underlying problem wasn't one of authorization, this could lead to a confusing loop for the user.

After these changes, authorization errors are handled with a (new) `AuthorizationModal` UI and other errors with the pre-existing `ErrorModal` component. All are now displayed in modal dialogs.

Logic detail: Group-set retrieval is triggered by the checking of the "This is a group assignment" checkbox. If the user encounters an error (Authorization or other) and clicks the "Cancel" button or closes the modal, that means the underlying issue wasn't resolved, and we don't have a list of group sets to provide to the user. In this case, the user-facing result is that the "This is a group assignment" checkbox will be un-checked.

## Testing

To test the error paths out, you'll need to get into the assignment-configuration step for either Blackboard and Canvas. In Canvas, you can re-configure an existing assignment (Edit Settings), but in Blackboard you'll need to create a new assignment (or configure an assignment that hasn't been configured yet, in any case).

I believe at this time, groups are enabled for both Blackboard and Canvas localhost installs, so you should see the second step of assignment configuration after choosing content, e.g.:

![image](https://user-images.githubusercontent.com/439947/151173764-3255ec5e-336c-453f-8052-486e3c314274.png)

To see that the happy path still works, you can step through this in Blackboard and/or Canvas if you desire.

### Auth errors

Have a terminal window open to your local `lms` project. Step through selecting a file/whatever for content and get to the screen that allows you to choose whether or not to use groups. At this point, stop before clicking the checkbox and run the following command in your terminal:

`tox -qe dockercompose -- exec postgres psql -U postgres -c "DELETE FROM oauth2_token;"`

Now check the checkbox. You should see an authorization window and get taken through the auth process:

![image](https://user-images.githubusercontent.com/439947/151174987-9e2e3130-f94e-4ec5-a384-d14192e8dd73.png), 
...and then the list of groups should load successfully.

This should work in both Blackboard and Canvas.

(_Note_: Running the SQL command _after_ selecting content makes sure that re-auth-ing for file access doesn't prevent the auth trigger in the group-selection step).

### Other errors

Apply the following patch:

```diff
diff --git a/lms/services/blackboard_api/client.py b/lms/services/blackboard_api/client.py
index e8acae7e..4ebcf63d 100644
--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -103,7 +103,7 @@ class BlackboardAPIClient:
     def course_group_sets(self, course_id):
         response = self._api.request(
             "GET",
-            f"/learn/api/public/v2/courses/uuid:{course_id}/groups/sets",
+            "/foo",
         )
 
         return BlackboardListGroupSetsSchema(response).parse()
diff --git a/lms/services/canvas_api/client.py b/lms/services/canvas_api/client.py
index c4e7d707..1ab17548 100644
--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -292,7 +292,7 @@ class CanvasAPIClient:
     def course_group_categories(self, course_id):
         return self._client.send(
             "GET",
-            f"courses/{course_id}/group_categories",
+            f"courses/foo/group_categories",
             schema=self._ListGroupCategories,
         )
``` 


Walking through the process of configuration again, you should get an error modal when you check the "This is a group assignment" checkbox.

In Blackboard:

![image](https://user-images.githubusercontent.com/439947/151176246-92c312a0-a66f-47f2-95a0-44df44cd8899.png)

In Canvas:

![image](https://user-images.githubusercontent.com/439947/151176353-22c861d5-f1ec-442f-9707-f27a1015279c.png)

If you click "Try Again" in either case, you'll get the same error again, because it's non-resolvable. Now act like a likely user would and click "Cancel". You should see the "This is a group assignment" checkbox un-select itself. While this overall result is arguably not completely satisfying for the user, it's the best I could think of to allow them to keep moving forward.

----

Note that we do have control over the title of the error modal and the text that comes before the colon (`:`) in the initial error message. So we can change those at will.

----

Not in scope here: handling non-error responses that return an empty group list (which is a quasi-error state from the user's perspective). That's captured here: https://github.com/hypothesis/lms/issues/3480

This work should complete the front-end pieces of https://github.com/hypothesis/lms/issues/3473