### PR TITLE
Remove autodetecting of columns defined in the ORM on bulk_upsert

### DIFF
--- a/lms/services/file.py
+++ b/lms/services/file.py
@@ -1,3 +1,5 @@
+from sqlalchemy import func
+
 from lms.models import File
 from lms.services.upsert import bulk_upsert
 
@@ -23,13 +25,14 @@ class FileService:
         """Insert or update a batch of files."""
         for value in file_dicts:
             value["application_instance_id"] = self._application_instance.id
+            value["updated"] = func.now()
 
         return bulk_upsert(
             self._db,
             File,
             file_dicts,
             index_elements=["application_instance_id", "lms_id", "type", "course_id"],
-            update_columns=["name", "size"],
+            update_columns=["name", "size", "updated"],
         )
 
 


### PR DESCRIPTION
Remove some complexity to try to auto detect columns defined with "onupdate" on the ORM model.

This might not even be complex enough as SQLA has lots of edge cases for every feature.

Doing this only for some hardcoded condition (the name of the column is "updated" or that the class uses `CreatedUpdatedMixin) might achieve the same thing now but I think it will hide the fact that it's not doing it in general.

Just removing all of this and remembering to pass all the columns that need updating explicitly it's cleaner.