### PR TITLE
Prepare for next version of `frontend-shared` (tailwind tweaks)

### DIFF
--- a/lms/static/styles/ui-playground.scss
+++ b/lms/static/styles/ui-playground.scss
@@ -1,6 +1,10 @@
 // CSS Entry point for the local pattern library for LMS.
 // These styles are used in addition to the `frontend_apps` stylesheet.
 
+@use 'base';
+@use 'components';
+@use 'utilities';
+
 // The `frontend_apps` CSS uses utility and component styles, but not pattern styles.
 // Include them here so that the patterns in the Patterns section of pages
 // are styled.

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,10 +1,14 @@
 import tailwindConfig from '@hypothesis/frontend-shared/lib/tailwind.preset.js';
 
+const successGreen =
+  tailwindConfig.theme?.extend?.colors?.green?.success ?? '#00a36d';
+
 export default {
   presets: [tailwindConfig],
   content: [
     './lms/static/scripts/frontend_apps/**/*.js',
     './lms/static/scripts/ui-playground/**/*.js',
+    './node_modules/@hypothesis/frontend-shared/lib/**/*.js',
   ],
   theme: {
     extend: {
@@ -15,7 +19,7 @@ export default {
       },
       colors: {
         green: {
-          success: '#00a36d',
+          success: successGreen,
         },
         yellow: {
           notice: '#fbc168',
@@ -38,7 +42,7 @@ export default {
       },
       keyframes: {
         gradeSubmitSuccess: {
-          from: { backgroundColor: tailwindConfig.theme.colors.success },
+          from: { backgroundColor: successGreen },
           to: { backgroundColor: 'transparent' },
         },
         validationMessageOpen: {


### PR DESCRIPTION
This PR makes a few tweaks such that this project is ready for a forthcoming release of `frontend-shared`, which will provide pattern-library styling via tailwind.

The upcoming pattern-library styles will assume that all Tailwind layers (base, components, utilities) are enabled, and adds some rules to base and components layers. Thus, local pattern-library stylesheet entry point needs to activate those layers (this is already done in the `client`).

The next release of `frontend-shared` contains an updated tailwind preset that will provide the "success-green" color, but in a slightly different location than the current local tailwind configuration expects. There is a little conditional here for the interim to allow it to find that color in different places as we change over.

It also adds the `frontend-shared`'s JSX source to the globs of Tailwind `content` so that utility styles used or applied in `frontend-shared` will get picked up in the local CSS build.

The only visible changes here is that some spacing and layout in the local pattern library feels a touch awkward, but not unusable. The next `frontend-shared` release will rectify this.

We are getting there...

### Testing

Does it build? We're good.