### PR TITLE
Don't crash if `tool_consumer_instance_guid` changes

### DIFF
--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -67,7 +67,6 @@ class UserService:
             .filter_by(
                 application_instance=model_user.application_instance,
                 user_id=model_user.user_id,
-                h_userid=model_user.h_userid,
             )
             .one_or_none()
         )


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/3604

If an LMS changes its `tool_consumer_instance_guid` (or if a `consumer_key` gets installed in a second LMS with a different `tool_consumer_instance_guid`) we're supposed to refuse to launch and show an error dialog: https://github.com/hypothesis/lms/pull/3053

But since we added a new DB constraint (https://github.com/hypothesis/lms/pull/3494) we're now crashing with an `IntegrityError` instead.

The reason is that the changed `tool_consumer_instance_guid` causes us to generate a different `h_userid` and then when looking for the user in the DB we unnecessarily include the `h_userid` in the query. Fix it by removing the `h_userid` from the query so that we do find the existing user with the same `user_id` and `application_instance` even though the `h_userid` is different.

Slack threads:

1. https://hypothes-is.slack.com/archives/C1MA4E9B9/p1643209011047900
2. https://hypothes-is.slack.com/archives/C01RAT0PE72/p1643214772002300
3. https://hypothes-is.slack.com/archives/C2BLQDKHA/p1643220371904379