### PR TITLE
Raise if a course grouping has a parent

### DIFF
--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -21,10 +21,10 @@ class GroupingService:
         type_: Grouping.Type,
     ):
         if type_ == Grouping.Type.COURSE:
+            assert parent is None, "Course groupings can't have a parent"
             return hashed_id(tool_consumer_instance_guid, lms_id)
 
-        # For the rest of types, parent is mandatory
-        assert parent is not None
+        assert parent is not None, "Non-course groupings must have a parent"
 
         if type_ == Grouping.Type.CANVAS_SECTION:
             return hashed_id(tool_consumer_instance_guid, parent.lms_id, lms_id)

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -20,6 +20,16 @@ class TestGenerateAuthorityProvidedID:
             == "f56fc198fea84f419080e428f0ee2a7c0e2c132a"
         )
 
+    def test_it_raises_if_a_course_grouping_has_a_parent(
+        self, generate_authority_provided_id
+    ):
+        with pytest.raises(
+            AssertionError, match="Course groupings can't have a parent"
+        ):
+            generate_authority_provided_id(
+                parent=factories.Course(), type_=Grouping.Type.COURSE
+            )
+
     @pytest.mark.parametrize(
         "type_",
         [
@@ -31,7 +41,9 @@ class TestGenerateAuthorityProvidedID:
     def test_it_raises_if_a_child_grouping_has_no_parent(
         self, generate_authority_provided_id, type_
     ):
-        with pytest.raises(AssertionError):
+        with pytest.raises(
+            AssertionError, match="Non-course groupings must have a parent"
+        ):
             generate_authority_provided_id(parent=None, type_=type_)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
`generate_authority_provided_id()` raises if you try to generate an `authority_provided_id` for a non-course grouping with no parent. For good measure it should also raise if you try to generate one for a _course_ grouping _with_ a parent: if `type_ == Grouping.Type.COURSE` then the `parent` argument would not be used to it makes no sense to call `generate_authority_provided_id()` in this way.