### PR TITLE
Add partial types for OneDrive file picker responses

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
@@ -2,10 +2,48 @@ import { PickerCanceledError } from '../errors';
 import { loadOneDriveAPI } from './onedrive-api-client';
 
 /**
+ * Partial type for OneDrive share links.
+ *
+ * See https://docs.microsoft.com/en-us/graph/api/resources/sharinglink?view=graph-rest-1.0
+ *
+ * @typedef SharingLink
+ * @prop {string} webUrl
+ */
+
+/**
+ * Partial type for OneDrive item permissions.
+ *
+ * See https://docs.microsoft.com/en-us/graph/api/resources/permission?view=graph-rest-1.0
+ *
+ * @typedef Permission
+ * @prop {SharingLink} link
+ */
+
+/**
+ * Partial type for OneDrive items.
+ *
+ * See https://docs.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0.
+ *
+ * @typedef DriveItem
+ * @prop {string} name
+ * @prop {Permission[]} permissions
+ */
+
+/**
+ * Result of successful file picker response.
+ *
+ * See https://docs.microsoft.com/en-us/onedrive/developer/controls/file-pickers/js-v72/open-file?view=odsp-graph-online#4-handling-the-picker-response-object.
+ *
+ * @typedef PickerResponse
+ * @prop {DriveItem[]} value
+ */
+
+/**
  * A wrapper around the Microsoft OneDrive file picker.
  *
  * See https://docs.microsoft.com/en-us/onedrive/developer/controls/file-pickers/js-v72/open-file?view=odsp-graph-online
- * for documentation on the underlying library.
+ * for documentation on the underlying library. The picker is built on the
+ * Microsoft Graph API and responses etc. use types associated with that API.
  */
 export class OneDrivePickerClient {
   /**
@@ -31,9 +69,16 @@ export class OneDrivePickerClient {
   async showPicker() {
     const oneDrive = await this._oneDriveAPI;
     return new Promise((resolve, reject) => {
-      const success = (/** @type {any} */ file) => {
-        const name = file.value[0].name;
-        const sharingURL = file.value[0].permissions[0].link.webUrl;
+      /** @param {PickerResponse} result */
+      const success = result => {
+        // TODO - Clarify nullability of properties and lengths of arrays.
+        // We think there are some situations where these properties won't exist
+        // or the arrays may be empty.
+        //
+        // See https://hypothes-is.slack.com/archives/C2BLQDKHA/p1643309746775569.
+        const driveItem = result.value[0];
+        const name = driveItem.name;
+        const sharingURL = driveItem.permissions[0].link.webUrl;
         const url = OneDrivePickerClient.downloadURL(sharingURL);
         resolve({ name, url });
       };


### PR DESCRIPTION
We've seen some situations where certain properties may be missing or
arrays may be empty [1]. We haven't clarified the details yet, but as a step
towards using types to enforce checking of potentially missing fields,
add some partial types for OneDrive picker responses.

The OneDrive picker is loaded from a remote source and doesn't have its
own types. Microsoft do publish a package,
@microsoft/microsoft-graph-types, for the Microsoft Graph API, but it is
huge, which will slow down tsc, and also doesn't provide good
information on the nullability of properties. Everything is simply listed as
nullable. Therefore I think it may be sensible for us to define our own
partial types based on what we use and observed behavior of the API.

[1] https://hypothes-is.slack.com/archives/C2BLQDKHA/p1643309746775569