### PR TITLE
Add UI handling for empty group sets returned by API during assignment configuration

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -198,6 +198,20 @@ describe('GroupConfigSelector', () => {
     assert.equal(options.length, fakeGroupSets.length);
   });
 
+  it('shows a specific error message if the retrieved group set list is empty', async () => {
+    fakeAPICall.withArgs(groupSetsAPIRequest).resolves([]);
+
+    const wrapper = createComponent({
+      groupConfig: { useGroupSet: true, groupSet: null },
+    });
+
+    const errorModal = await waitForElement(wrapper, 'NoGroupsError');
+    assert.include(
+      errorModal.text(),
+      'we could not find any available group sets in this course'
+    );
+  });
+
   it('shows errors in a modal with a retry button', async () => {
     fakeIsAuthorizationError.returns(false);
     fakeAPICall.withArgs(groupSetsAPIRequest).rejects(new Error('Some error'));

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -28,6 +28,16 @@
  */
 
 /**
+ * Error raised when a course's list of groups is empty (as returned from the
+ * API).
+ */
+export class GroupListEmptyError extends Error {
+  constructor() {
+    super('This course has no groups');
+  }
+}
+
+/**
  * Error thrown when the user cancels file selection.
  */
 export class PickerCanceledError extends Error {


### PR DESCRIPTION
This PR adds UI handling for a state in which we get a valid response from the list-group-sets API service (either Canvas or Blackboard) but the list of groups is empty. This happens if an instructor-user is configuring an assignment to use group sets (i.e. checks the checkbox for "This is a group assignment") but there are no group sets for the current course.

In this case, we show an error message to the user explaining that there are no group sets available for the current course and link to some help documents about using groups.

The new modal looks like this: 

![image](https://user-images.githubusercontent.com/439947/151853535-c5ceb061-e7ca-4055-8d21-3356c813ca5e.png)

The diff looks larger than it "is" because I reorganized a few things in `GroupConfigSelector`, but did not alter any functionality outside of the changes at hand (all existing tests still passed).

### Testing

There are some instructions in the associated issue, #3480 , that explain how to trigger this error locally (one-liner change to a python module).

Fixes #3480