### PR TITLE
upsert_grouping_memberships flushes when necessary

### DIFF
--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -87,6 +87,9 @@ class GroupingService:
         :param user:  User the that belongs to the groups
         :param groups: List of groups the `user` belongs to
         """
+        if not user.id or any((group.id is None for group in groups)):
+            # Ensure all ORM objects have their PK populated
+            self._db.flush()
 
         bulk_upsert(
             self._db,

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -178,11 +178,13 @@ class TestUpsertWithParent:
 
 
 class TestUpsertGroupingMemberships:
-    def test_it(self, db_session, svc):
+    @pytest.mark.parametrize("flushing", [True, False])
+    def test_it(self, db_session, svc, flushing):
         user = factories.User()
         groups = []
         # Create a group that the user is already a member of.
         group_that_user_was_already_a_member_of = factories.Course()
+
         groups.append(group_that_user_was_already_a_member_of)
         db_session.add(
             GroupingMembership(
@@ -192,7 +194,9 @@ class TestUpsertGroupingMemberships:
         )
         # Add a group that the user is not yet a member of.
         groups.append(factories.CanvasGroup())
-        db_session.flush()
+        if flushing:
+            # upsert_grouping_memberships should flush itself if not done from the caller
+            db_session.flush()
 
         svc.upsert_grouping_memberships(user, groups)
 


### PR DESCRIPTION
For newly created users or groupings the ORM objects will be present in the session but might not be yet flushed and their `.id` fields will be `None` causing upsert to fail.


Fixes https://sentry.io/organizations/hypothesis/issues/2978797202/?project=259908&referrer=slack