### PR TITLE
canvas sync API `is_group_launch` doesn't depend on AI setting

### DIFF
--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -46,12 +46,6 @@ class Sync:
 
     @property
     def _is_group_launch(self):
-        application_instance = self._request.find_service(
-            name="application_instance"
-        ).get_current()
-        if not application_instance.settings.get("canvas", "groups_enabled"):
-            return False
-
         try:
             self.group_set()
         except (KeyError, ValueError, TypeError):

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -136,26 +136,20 @@ def test_get_canvas_groups_instructor_not_found_group_set(
 
 
 @pytest.mark.parametrize(
-    "groups_enabled,group_set_value,expected_value",
+    "group_set_value,expected_value",
     [
-        (True, None, False),
-        (True, "a", False),
-        (True, "1", True),
-        (True, 1, True),
-        (False, "1", False),
+        (None, False),
+        ("a", False),
+        ("1", True),
+        (1, True),
     ],
 )
 def test_is_group_launch(
-    groups_enabled,
     group_set_value,
     expected_value,
     pyramid_request,
     request_json,
-    application_instance_service,
 ):
-    application_instance_service.get_current.return_value.settings = {
-        "canvas": {"groups_enabled": groups_enabled}
-    }
     # pylint: disable=protected-access
     request_json["course"] = {"group_set": group_set_value}
 
@@ -163,26 +157,17 @@ def test_is_group_launch(
 
 
 @pytest.mark.parametrize(
-    "groups_enabled,group_set_value,expected_value",
+    "group_set_value,expected_value",
     [
-        (True, None, False),
-        (True, "a", False),
-        (True, "1", True),
-        (True, 1, True),
-        (False, 1, False),
+        (None, False),
+        ("a", False),
+        ("1", True),
+        (1, True),
     ],
 )
 def test_is_group_launch_in_speed_grader(
-    groups_enabled,
-    group_set_value,
-    expected_value,
-    pyramid_request,
-    request_json,
-    application_instance_service,
+    group_set_value, expected_value, pyramid_request, request_json
 ):
-    application_instance_service.get_current.return_value.settings = {
-        "canvas": {"groups_enabled": groups_enabled}
-    }
     # pylint: disable=protected-access
     request_json["course"] = {"group_set": group_set_value}
 


### PR DESCRIPTION
An alternative too: https://github.com/hypothesis/lms/pull/3586

---

Completes: https://github.com/hypothesis/lms/commit/f355d8d060b1f824886bfe73f73c0ec1239793c7