### PR TITLE
Change upsert_with_parent to return a list instead of a query

### DIFF
--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -38,7 +38,7 @@ class GroupingService:
         grouping_dicts: List[dict],
         type_: Grouping.Type,
         parent: Grouping,
-    ):
+    ) -> List[Grouping]:
         """
         Upsert a Grouping generating the authority_provided_id based on its parent.
 
@@ -78,7 +78,7 @@ class GroupingService:
             ],
             index_elements=["application_instance_id", "authority_provided_id"],
             update_columns=["lms_name", "extra", "updated"],
-        )
+        ).all()
 
     def upsert_grouping_memberships(self, user: User, groups: List[Grouping]):
         """

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -138,13 +138,13 @@ class TestUpsertWithParent:
 
         canvas_group = svc.upsert_with_parent(
             [common_grouping_args], parent=course, type_=Grouping.Type.CANVAS_GROUP
-        ).one()
+        )[0]
         canvas_section = svc.upsert_with_parent(
             [common_grouping_args], parent=course, type_=Grouping.Type.CANVAS_SECTION
-        ).one()
+        )[0]
         blackboard_group = svc.upsert_with_parent(
             [common_grouping_args], parent=course, type_=Grouping.Type.BLACKBOARD_GROUP
-        ).one()
+        )[0]
 
         # We've created three groupings with the same application_instance, parent and lms_id.
         assert (


### PR DESCRIPTION
This is causing: https://sentry.io/organizations/hypothesis/issues/2981919435/?project=259908&referrer=slack

In retrospect returning a query is the right call for `bulk_upsert` but not a good design (on top of being broken) for `upsert_with_parent`. This allows all the callers to forget about doing .all()/.one().


#  Testing notes

- On master, launch a canvas assignment, for example: https://hypothesis.instructure.com/courses/125/assignments/1833

You'll hit a ```TypeError: object of type 'Query' has no len()```

- Change to this branch. No crash.
