### PR TITLE
Jenkinsfile update - Canada rebuild

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ onlyOnMaster {
             ca: {
 		// Workaround to ensure all parallel builds happen. See https://hypothes-is.slack.com/archives/CR3E3S7K8/p1625041642057400
                 sleep 2
-                deployApp(image: img, app: "lms-ca", env: "prod", region: "ca-central-1")
+                // deployApp(image: img, app: "lms-ca", env: "prod", region: "ca-central-1")
             }
         )
     }


### PR DESCRIPTION
The `ca` stage has been commented out in the parallel block that
controls prod deployments.