### PR TITLE
Bulk upsert returning

### DIFF
--- a/lms/services/grouping.py
+++ b/lms/services/grouping.py
@@ -50,6 +50,8 @@ class GroupingService:
         :param parent: Parent grouping for all upserted groups
         :param type_: Type of the groupings
         """
+        if not grouping_dicts:
+            return []
 
         if not parent.id:
             # Make sure we have a PK for the parent before upserting

--- a/lms/services/upsert.py
+++ b/lms/services/upsert.py
@@ -40,7 +40,10 @@ def bulk_upsert(
         # default values for all of the columns. If my_table has a column
         # with a NOT NULLABLE constraint and no default value this will
         # cause a "null value violates not-null constraint" crash.
-        return []
+        #
+        # We do a wasteful query here to maintain
+        # the same return type in all branches.
+        return db.query(model_class).filter(False)
 
     index_elements_columns = [column(c) for c in index_elements]
 

--- a/tests/unit/lms/services/grouping_test.py
+++ b/tests/unit/lms/services/grouping_test.py
@@ -75,6 +75,15 @@ class TestGenerateAuthorityProvidedID:
 
 
 class TestUpsertWithParent:
+    def test_when_empty(self, svc):
+        course = factories.Course()
+
+        assert not svc.upsert_with_parent(
+            [],
+            type_=Grouping.Type.CANVAS_GROUP,
+            parent=course,
+        )
+
     def test_it(self, db_session, svc):
         # Create a parent course for the groupings to belong to.
         # The course has to belong to svc.application_instance.

--- a/tests/unit/lms/services/upsert_test.py
+++ b/tests/unit/lms/services/upsert_test.py
@@ -55,7 +55,9 @@ class TestBulkAction:
                 "other": model.other,
             } in expected_rows
 
-    def test_upsert_does_nothing_if_given_an_empty_list_of_values(self, db_session):
+    def test_upsert_return_empty_query_if_given_an_empty_list_of_values(
+        self, db_session
+    ):
         assert (
             bulk_upsert(
                 db_session,
@@ -63,7 +65,7 @@ class TestBulkAction:
                 [],
                 self.INDEX_ELEMENTS,
                 self.UPDATE_COLUMNS,
-            )
+            ).all()
             == []
         )
 


### PR DESCRIPTION
For https://sentry.io/organizations/hypothesis/issues/2982856751/?referrer=slack

This involves a hacky workaround in bulk_upsert to always return the same type.

Also handled the same case directly in Grouping.upsert_with_parent.

I don't think the change in Grouping.upsert_with_parent is enough as it would leave this surprising behaviour in bulk_upsert.

An alternative would be to always return a list in `bulk_upsert` but that will cause a query and serializing the results in File.upsert but it's definitely less hacky.


# Testing 
- Switch to master
- Apply a diff similar to:


```diff --git a/lms/views/api/canvas/sync.py b/lms/views/api/canvas/sync.py
index 80af13c1..580e915c 100644
--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -83,12 +83,12 @@ class Sync:
 
         if self._is_speedgrader:
             # SpeedGrader requests are made by the teacher, get the student we are grading
-            return self._to_groups_groupings(
-                self._canvas_api.user_groups(
-                    self._request.json["course"]["custom_canvas_course_id"],
-                    int(self._request.json["learner"]["canvas_user_id"]),
-                    self.group_set(),
-                )
+            return self._to_groups_groupings([]
+                #self._canvas_api.user_groups(
+                #    self._request.json["course"]["custom_canvas_course_id"],
+                #    int(self._request.json["learner"]["canvas_user_id"]),
+                #    self.group_set(),
+                #)
             )
 
         try:
```

- Speedgrade any canvas assignment. You get a crash like the sentry one.
- Keeping the diff switch to this branch. No crash. No groups either, this is a edge case on speedgrader.
```
