### PR TITLE
Remove unused attributes from ExternalAsyncRequestError

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -65,14 +65,14 @@ class ExternalRequestError(Exception):
 
 
 class ExternalAsyncRequestError(Exception):
-    def __init__(
-        self, message=None, request=None, response=None, validation_errors=None
-    ):
+    def __init__(self, response=None):
         super().__init__()
-        self.message = message
-        self.request = request
         self.response = response
-        self.validation_errors = validation_errors
+
+        # For compatibility with ExternalRequestError.
+        self.message = None
+        self.request = None
+        self.validation_errors = None
 
     @property
     def _request_info(self):

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -141,30 +141,24 @@ class TestExternalAsyncRequestError:
         assert err.status_code == expected
 
     @pytest.mark.parametrize(
-        "message,request_,response,cause,expected",
+        "response,cause,expected",
         [
             (
-                None,
-                None,
                 None,
                 None,
                 "ExternalAsyncRequestError(message=None, cause=None, request=Request(method=None, url=None, body=None), response=Response(status_code=None, reason=None, body=None), validation_errors=None)",
             ),
             (
-                "Some message",
-                None,
                 Mock(
                     status=400, reason="OK", request_info=Mock(method="POST", url="URL")
                 ),
                 KeyError("cause"),
-                "ExternalAsyncRequestError(message='Some message', cause=KeyError('cause'), request=Request(method='POST', url='URL', body=None), response=Response(status_code=400, reason='OK', body=None), validation_errors=None)",
+                "ExternalAsyncRequestError(message=None, cause=KeyError('cause'), request=Request(method='POST', url='URL', body=None), response=Response(status_code=400, reason='OK', body=None), validation_errors=None)",
             ),
         ],
     )
-    def test_str(self, message, request_, response, cause, expected):
+    def test_str(self, response, cause, expected):
         err = ExternalAsyncRequestError(
-            message=message,
-            request=request_,
             response=response,
         )
         err.__cause__ = cause


### PR DESCRIPTION
# Testing 

Nothing really changed but as a sanity check:

- Open a BB group assignment as a student with these diffs:

- Requests without response:

   ```diff
   diff --git a/lms/services/async_oauth_http.py b/lms/services/async_oauth_http.py
   index d00a1152..3e5dd9fe 100644
   --- a/lms/services/async_oauth_http.py
   +++ b/lms/services/async_oauth_http.py
   @@ -55,7 +55,7 @@ async def _prepare_requests(method, urls, **kwargs):
                    _async_request(
                        session,
                        method,
   -                    url,
   +                    "https://notreallyadomainthatworks.com/",
                        **kwargs,
                    )
                )
   ```

   Error dialog:

   
![Screenshot from 2022-02-03 13-52-01](https://user-images.githubusercontent.com/1433832/152346490-166ae595-a78f-4f58-a78d-78982a450b60.png)



   Sentry event: 

   https://sentry.io/organizations/hypothesis/issues/2985295889/?project=5952630&query=is%3Aunresolved



- Failed request with a response:

   ```diff
   diff --git a/lms/services/async_oauth_http.py b/lms/services/async_oauth_http.py
   index d00a1152..a042cd30 100644
   --- a/lms/services/async_oauth_http.py
   +++ b/lms/services/async_oauth_http.py
   @@ -55,7 +55,7 @@ async def _prepare_requests(method, urls, **kwargs):
                    _async_request(
                        session,
                        method,
   -                    url,
   +                    "http://httpbin.org/status/418",
                        **kwargs,
                    )
                )
   ```

   Error dialog:
   
![Screenshot from 2022-02-03 13-57-33](https://user-images.githubusercontent.com/1433832/152347470-c290ad04-651d-44af-a86f-2053400c34e8.png)   

   

   Sentry event:  https://sentry.io/organizations/hypothesis/issues/2985309778/events/c5d593cbe0544891975434e6e027f16d/?project=5952630&query=is%3Aunresolved 

 