### PR TITLE
Expose ExternalAsyncRequestError.response_body

### DIFF
--- a/lms/services/async_oauth_http.py
+++ b/lms/services/async_oauth_http.py
@@ -44,6 +44,10 @@ class AsyncOAuthHTTPService:
 
 async def _async_request(aio_session, method, url, **kwargs):
     async with aio_session.request(method, url, **kwargs) as response:
+        # Calling `.text()` here caches the result in `response` but is still behind a coroutine.
+        # We assign it to another response attribute for it to be
+        # available in a sync context without needing to start coroutine.
+        response.sync_text = await response.text()
         return response
 
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -108,7 +108,7 @@ class ExternalAsyncRequestError(Exception):
     @property
     def response_body(self) -> None:
         """Return the response body."""
-        return None
+        return getattr(self.response, "sync_text", None)
 
     def __repr__(self) -> str:
         return _repr_external_request_exception(self)

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -150,10 +150,13 @@ class TestExternalAsyncRequestError:
             ),
             (
                 Mock(
-                    status=400, reason="OK", request_info=Mock(method="POST", url="URL")
+                    sync_text="Body text",
+                    status=400,
+                    reason="OK",
+                    request_info=Mock(method="POST", url="URL"),
                 ),
                 KeyError("cause"),
-                "ExternalAsyncRequestError(message=None, cause=KeyError('cause'), request=Request(method='POST', url='URL', body=None), response=Response(status_code=400, reason='OK', body=None), validation_errors=None)",
+                "ExternalAsyncRequestError(message=None, cause=KeyError('cause'), request=Request(method='POST', url='URL', body=None), response=Response(status_code=400, reason='OK', body='Body text'), validation_errors=None)",
             ),
         ],
     )


### PR DESCRIPTION
# Testing 

- Same as https://github.com/hypothesis/lms/pull/3643

- Requests without response, no changes, there's no body.
- Requests with response:

   Error dialog: Same error dialog as the response is not rendered here

![Screenshot from 2022-02-03 14-08-24](https://user-images.githubusercontent.com/1433832/152348835-4001d837-2169-4695-9e39-49b213b4530d.png)


   Sentry event: The event includes the response text.

   https://sentry.io/organizations/hypothesis/issues/2985309778/events/4b6d0dd6ef7c46bfb6671d9713a2a7b9/?project=5952630&query=is%3Aunresolved


