### PR TITLE
Clarify that we are not going to add additional error handling for student groups sync in grading mode

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LMSGrader.js
+++ b/lms/static/scripts/frontend_apps/components/LMSGrader.js
@@ -87,7 +87,13 @@ export default function LMSGrader({
             data: studentGroupsCallData,
           });
         } catch (e) {
-          // TODO: Improved error handling
+          // An error could plausibly occur when fetching a student's groups
+          // from the sync API. This is unlikely (there are no known specific
+          // use cases that would lead to an error), and the failure mode is
+          // so benign — the interface would display all course groups instead
+          // of this student's groups — that there is no nuanced error handling
+          // here at present. This can change in the future if desired.
+          // See https://github.com/hypothesis/lms/issues/3417
           console.error('Unable to fetch student groups from sync API');
         }
       }


### PR DESCRIPTION
On initial launch into grading mode, an instructor's full set of course groups are fetched and available in the client's group menu. Error- and authorization-handling are part of this launch process and are all sorted. Once in the grading mode, the instructor can page through to different students (we call this "focusing" on a given student). When a student is focused, the UI layer makes a request to the sync API to ask for a list of just that student's groups. 

The initial objective had been to add error handling to these requests for a focused-student's groups. However, in poking around for a while, @marcospri and I were unable to come up with a plausible likely error path that justified the effort of implementing additional error handling. The failure mode is quite benign: the UI will display all of the course groups instead of just the focused student's, which is identical to the behavior of the grading interface before the enhancement of just showing the focused-user's groups was added. According to Marcos, it is unlikely (or maybe impossible?) that we'd run into an authorization need here.

We can absolutely revisit this later as desired. This PR adds a comment to clarify this.

Fixes https://github.com/hypothesis/lms/issues/3417