### PR TITLE
Small refactor on blackboard.sync

### DIFF
--- a/lms/views/api/blackboard/sync.py
+++ b/lms/views/api/blackboard/sync.py
@@ -30,10 +30,6 @@ class Sync:
         self.grouping_service = self.request.find_service(name="grouping")
         self.blackboard_api = self.request.find_service(name="blackboard_api_client")
 
-        self.tool_consumer_instance_guid = self.request.parsed_params["lms"][
-            "tool_consumer_instance_guid"
-        ]
-
     @view_config(
         route_name="blackboard_api.sync",
         request_method="POST",
@@ -42,27 +38,33 @@ class Sync:
         schema=APIBlackboardSyncSchema,
     )
     def sync(self):
-        groups = self.get_blackboard_groups()
+        params = self.request.parsed_params
+        tool_consumer_instance_guid = params["lms"]["tool_consumer_instance_guid"]
+        course = self.get_course(
+            params["course"]["context_id"], tool_consumer_instance_guid
+        )
+        group_set_id = self.group_set(
+            tool_consumer_instance_guid, params["assignment"]["resource_link_id"]
+        )
 
-        self.sync_to_h(groups)
-
+        groups = self.get_blackboard_groups(
+            course, group_set_id, params.get("gradingStudentId")
+        )
+        self.request.find_service(name="lti_h").sync(groups, params["group_info"])
         authority = self.request.registry.settings["h_authority"]
         return [group.groupid(authority) for group in groups]
 
-    def get_blackboard_groups(self):
+    def get_blackboard_groups(self, course, group_set_id, grading_student_id=None):
         lti_user = self.request.lti_user
-        group_set_id = self.group_set()
-        course_id = self.request.parsed_params["course"]["context_id"]
-        course = self.get_course(course_id)
 
         if lti_user.is_learner:
             user = self.request.find_service(UserService).get(
-                self.request.find_service(name="application_instance").get_current(),
+                course.application_instance,
                 lti_user.user_id,
             )
 
             learner_groups = self.blackboard_api.course_groups(
-                course_id, group_set_id, current_student_own_groups_only=True
+                course.lms_id, group_set_id, current_student_own_groups_only=True
             )
             if not learner_groups:
                 raise BlackboardStudentNotInGroup(group_set=group_set_id)
@@ -71,7 +73,7 @@ class Sync:
             self.grouping_service.upsert_grouping_memberships(user, groups)
             return groups
 
-        if grading_student_id := self.request.parsed_params.get("gradingStudentId"):
+        if grading_student_id:
             return self.grouping_service.get_course_groupings_for_user(
                 course,
                 grading_student_id,
@@ -80,7 +82,7 @@ class Sync:
             )
 
         try:
-            groups = self.blackboard_api.group_set_groups(course_id, group_set_id)
+            groups = self.blackboard_api.group_set_groups(course.lms_id, group_set_id)
         except ExternalRequestError as bb_api_error:
             if bb_api_error.status_code == 404:
                 raise BlackboardGroupSetNotFound(
@@ -93,16 +95,6 @@ class Sync:
             raise BlackboardGroupSetEmpty(group_set=group_set_id)
 
         return self.to_groups_groupings(course, groups)
-
-    def group_set(self):
-        return (
-            self.request.find_service(name="assignment")
-            .get(
-                self.tool_consumer_instance_guid,
-                self.request.parsed_params["assignment"]["resource_link_id"],
-            )
-            .extra["group_set_id"]
-        )
 
     def to_groups_groupings(self, course, groups):
         return self.grouping_service.upsert_with_parent(
@@ -118,15 +110,20 @@ class Sync:
             type_=Grouping.Type.BLACKBOARD_GROUP,
         )
 
-    def sync_to_h(self, groups):
-        lti_h_svc = self.request.find_service(name="lti_h")
-        group_info = self.request.parsed_params["group_info"]
-        lti_h_svc.sync(groups, group_info)
+    def group_set(self, tool_consumer_instance_guid, resource_link_id):
+        return (
+            self.request.find_service(name="assignment")
+            .get(
+                tool_consumer_instance_guid,
+                resource_link_id,
+            )
+            .extra["group_set_id"]
+        )
 
-    def get_course(self, course_id):
+    def get_course(self, course_id, tool_consumer_instance_guid):
         course_service = self.request.find_service(name="course")
         return course_service.get(
             course_service.generate_authority_provided_id(
-                self.tool_consumer_instance_guid, course_id
+                tool_consumer_instance_guid, course_id
             )
         )

--- a/tests/unit/lms/views/api/blackboard/sync_test.py
+++ b/tests/unit/lms/views/api/blackboard/sync_test.py
@@ -65,7 +65,7 @@ def test_it_when_instructor_and_group_set_raises(
         Sync(pyramid_request).sync()
 
 
-@pytest.mark.usefixtures("user_is_learner", "application_instance_service")
+@pytest.mark.usefixtures("user_is_learner")
 def test_it_when_student(
     pyramid_request,
     assert_sync_and_return_groups,
@@ -73,6 +73,7 @@ def test_it_when_student(
     groups,
     grouping_service,
     user_service,
+    course_service,
 ):
     blackboard_api_client.course_groups.return_value = groups
 
@@ -80,7 +81,7 @@ def test_it_when_student(
 
     assert_sync_and_return_groups(result, groups=groups)
     blackboard_api_client.course_groups.assert_called_once_with(
-        pyramid_request.parsed_params["course"]["context_id"],
+        course_service.get.return_value.lms_id,
         "GROUP_SET_ID",
         current_student_own_groups_only=True,
     )
@@ -90,9 +91,7 @@ def test_it_when_student(
     )
 
 
-@pytest.mark.usefixtures(
-    "user_is_learner", "application_instance_service", "user_service"
-)
+@pytest.mark.usefixtures("user_is_learner", "user_service")
 def test_it_when_student_not_in_group(blackboard_api_client, pyramid_request):
     blackboard_api_client.course_groups.return_value = []
 


### PR DESCRIPTION
A similar refactor was present in https://github.com/hypothesis/lms/pull/3514/files#diff-90f5764bcb8a8235b8aa94b15c5954fcccee2a31caa8a7902d4c126fa17ae18bR23 but it was mixed there with other changes.

I think this changes makes `get_blackboard_groups` easier to read moving all the parameter handling to the main view method.