### PR TITLE
Update labeling related to "chapters" in VitalSource book picker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.js
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.js
@@ -30,6 +30,10 @@ import ErrorDisplay from './ErrorDisplay';
  * which chapter to use from that book. Once both are chosen the `onSelectBook`
  * callback is called.
  *
+ * Note: The component logic is consistent about using the terminology of
+ * "chapter" for content segments in a VitalSource eBook, but presents this
+ * to the user as "location" and other slightly less precise language.
+ *
  * @param {BookPickerProps} props
  */
 export default function BookPicker({ onCancel, onSelectBook }) {
@@ -88,7 +92,7 @@ export default function BookPicker({ onCancel, onSelectBook }) {
       title={
         step === 'select-book'
           ? 'Paste link to VitalSource book'
-          : 'Select chapter'
+          : 'Pick where to start reading' // "Select a chapter"
       }
       buttons={[
         <LabeledButton
@@ -107,7 +111,7 @@ export default function BookPicker({ onCancel, onSelectBook }) {
           }}
           variant="primary"
         >
-          {step === 'select-book' ? 'Select book' : 'Select chapter'}
+          {step === 'select-book' ? 'Select book' : 'Select'}
         </LabeledButton>,
       ]}
     >
@@ -132,7 +136,7 @@ export default function BookPicker({ onCancel, onSelectBook }) {
           description={
             step === 'select-book'
               ? 'Unable to fetch books'
-              : 'Unable to fetch chapters'
+              : 'Unable to fetch book contents'
           }
           error={error}
         />

--- a/lms/static/scripts/frontend_apps/components/ChapterList.js
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.js
@@ -33,7 +33,7 @@ export default function ChapterList({
       label: 'Title',
     },
     {
-      label: 'Page',
+      label: 'Location',
       classes: 'w-32',
     },
   ];

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -169,7 +169,10 @@ describe('BookPicker', () => {
 
     const errorDisplay = await waitForElement(picker, 'ErrorDisplay');
 
-    assert.equal(errorDisplay.prop('description'), 'Unable to fetch chapters');
+    assert.equal(
+      errorDisplay.prop('description'),
+      'Unable to fetch book contents'
+    );
     assert.equal(errorDisplay.prop('error'), error);
     assert.isFalse(picker.exists('ChapterList'));
 


### PR DESCRIPTION
Use alternate vocabulary for "chapter" and "page" as these concepts
don't map consistently to VitalSource eBooks.

Change Modal title, column header and submit button text.

No functional changes, just wording in UI.

Before:

![image](https://user-images.githubusercontent.com/439947/152533705-43a84afe-c8ca-454f-bf86-f6fc47cc64d6.png)

After:

![image](https://user-images.githubusercontent.com/439947/152533481-f63c23b4-115b-4eb0-bc29-5dd66f7ebf25.png)


Fixes https://github.com/hypothesis/product-backlog/issues/1269