### PR TITLE
Store student group memberships for canvas sections

### DIFF
--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -65,10 +65,7 @@ class Sync:
         lti_user = self._request.lti_user
         group_set_id = self.group_set()
         if lti_user.is_learner:
-            user = self._request.find_service(UserService).get(
-                self._request.find_service(name="application_instance").get_current(),
-                lti_user.user_id,
-            )
+            user = self._get_user(lti_user.user_id)
 
             # For learners, the groups they belong within the course
             learner_groups = self._canvas_api.current_user_groups(
@@ -169,6 +166,12 @@ class Sync:
 
         return self._course_service.get(
             self._course_service.generate_authority_provided_id(tool_guid, context_id)
+        )
+
+    def _get_user(self, user_id):
+        return self._request.find_service(UserService).get(
+            self._request.find_service(name="application_instance").get_current(),
+            user_id,
         )
 
     def _sync_to_h(self, groups):

--- a/lms/views/api/canvas/sync.py
+++ b/lms/views/api/canvas/sync.py
@@ -106,10 +106,15 @@ class Sync:
         lti_user = self._request.lti_user
 
         if lti_user.is_learner:
+            user = self._get_user(lti_user.user_id)
+
             # For learners we only want the client to show the sections that
             # the student belongs to, so fetch only the user's sections.
-            sections = self._canvas_api.authenticated_users_sections(course_id)
-            return self._to_section_groupings(sections)
+            sections = self._to_section_groupings(
+                self._canvas_api.authenticated_users_sections(course_id)
+            )
+            self._grouping_service.upsert_grouping_memberships(user, sections)
+            return sections
 
         # For non-learners (e.g. instructors, teaching assistants) we want the
         # client to show all of the course's sections.

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -25,13 +25,19 @@ def test_sections_sync_when_the_user_is_a_learner(
     pyramid_request,
     canvas_api_client,
     sections,
+    grouping_service,
     assert_sync_and_return_sections,
     request_json,
+    user_service,
 ):
     groupids = Sync(pyramid_request).sync()
 
     course_id = request_json["course"]["custom_canvas_course_id"]
     canvas_api_client.authenticated_users_sections.assert_called_once_with(course_id)
+    grouping_service.upsert_grouping_memberships.assert_called_once_with(
+        user_service.get.return_value,
+        grouping_service.upsert_with_parent.return_value,
+    )
 
     assert_sync_and_return_sections(groupids, sections=sections.authenticated_user)
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/3640

Store memberships of students/sections


# Testing

- Start with an empty table `truncate grouping_membership`

- Launch https://hypothesis.instructure.com/courses/125/assignments/873 **as a student**

- `select * from grouping join grouping_membership on grouping.id = grouping_membership.grouping_id;`


```
-[ RECORD 1 ]-----------+-----------------------------------------
created                 | 2022-01-27 10:49:53.646926
updated                 | 2022-02-07 12:00:35.725194
id                      | 116
application_instance_id | 8
authority_provided_id   | d2871e5e1c36b58f207d9ef5b22dcb7829f52e61
parent_id               | 115
lms_id                  | 144
lms_name                | Section 1
type                    | canvas_section
settings                | {}
extra                   | null
created                 | 2022-02-07 12:00:35.725194
updated                 | 2022-02-07 12:00:35.725194
grouping_id             | 116
user_id                 | 7
```


After this we are still missing membership information for the course group.