### PR TITLE
Break the loop between `web`, `devdata` and `services`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docker:
 
 .PHONY: run-docker
 run-docker:
-	@tox -e dockercompose -- up --force-recreate web
+	@tox -e dockercompose -- --env-file=.devdata.env up --force-recreate web
 
 .PHONY: backend-lint
 backend-lint: python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     # Unfortunately if we don't run as root `dev_host_bridge.sh` doesn't work
     user: root
     command: /bin/sh -c "/var/lib/lms/bin/dev_host_bridge.sh && bin/init-env supervisord -c conf/supervisord.conf"
-    env_file: .devdata.env
     environment:
       - DATABASE_URL=postgresql://postgres@lms_postgres_1/postgres
       - FEATURE_FLAGS_COOKIE_SECRET=not_a_secret
@@ -29,3 +28,23 @@ services:
       - VIA_SECRET=not_a_secret
       - SESSION_COOKIE_SECRET=notasecret
       - OAUTH2_STATE_SECRET=notasecret
+      - JWT_SECRET=${JWT_SECRET}
+      - LMS_SECRET=${LMS_SECRET}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_DEVELOPER_KEY=${GOOGLE_DEVELOPER_KEY}
+      - GOOGLE_APP_ID=${GOOGLE_APP_ID}
+      - ONEDRIVE_CLIENT_ID=${ONEDRIVE_CLIENT_ID}
+      - ADMIN_AUTH_GOOGLE_CLIENT_ID=${ADMIN_AUTH_GOOGLE_CLIENT_ID}
+      - ADMIN_AUTH_GOOGLE_CLIENT_SECRET=${ADMIN_AUTH_GOOGLE_CLIENT_SECRET}
+      - HASHED_PW=${HASHED_PW}
+      - SALT=${SALT}
+      - USERNAME=${USERNAME}
+      - H_CLIENT_ID=${H_CLIENT_ID}
+      - H_CLIENT_SECRET=${H_CLIENT_SECRET}
+      - H_JWT_CLIENT_ID=${H_JWT_CLIENT_ID}
+      - H_JWT_CLIENT_SECRET=${H_JWT_CLIENT_SECRET}
+      - BLACKBOARD_API_CLIENT_ID=${BLACKBOARD_API_CLIENT_ID}
+      - BLACKBOARD_API_CLIENT_SECRET=${BLACKBOARD_API_CLIENT_SECRET}
+      - VITALSOURCE_LTI_LAUNCH_KEY=${VITALSOURCE_LTI_LAUNCH_KEY}
+      - VITALSOURCE_LTI_LAUNCH_SECRET=${VITALSOURCE_LTI_LAUNCH_SECRET}
+      - VITALSOURCE_API_KEY=${VITALSOURCE_API_KEY}


### PR DESCRIPTION
An alternate solution to:

 * https://github.com/hypothesis/lms/pull/3575

Docker compose appears to check for the existence of the env file even if you aren't starting the web service and so will refuse to start the services if it's missing. Even though it should not play a role.

This causes a day 1 problem where you can't bootstrap the service if you don't already have devdata, and you can't get devdata without having the services.

By putting the command outside we break the loop.