### PR TITLE
Read envvars from `.devdata.env`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,10 @@ docker:
 
 .PHONY: run-docker
 run-docker:
-	# To run the Docker container locally first build the Docker image using
-	# `make docker` and then set the environment variables below to appropriate
-	# values. You can find the environment variables needed for development in
-	# .devdata.env (after running `make devdata`) and in tox.ini.
+	# To run the Docker container locally:
+	# 1. make devdata
+	# 2. make docker
+	# 3. make run-docker
 	@docker run \
 		--add-host host.docker.internal:host-gateway \
 		--net lms_default \
@@ -122,6 +122,7 @@ run-docker:
 		-e VIA_SECRET=not_a_secret \
 		-e SESSION_COOKIE_SECRET=notasecret \
 		-e OAUTH2_STATE_SECRET=notasecret \
+		--env-file .devdata.env \
 		-p 8001:8001 \
 		hypothesis/lms:$(DOCKER_TAG)
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/devdata/pull/44

Automatically read in envvars from the `.devdata.env` file created by the `make devdata` command.

# Problem

The `make devdata` command writes several environment variables that are needed for development to the git-ignored `.devdata.env` file. When you run `make dev` a tox plugin reads `.devdata.env` into tox. But the `make run-docker` command that runs the app locally in Docker rather than tox doesn't read from the `.devdata.env` file. The user needs to manually copy envvars from `.devdata.env` into `Makefile` before running `make run-docker`, as explained by the comment in `Makefile`:

https://github.com/hypothesis/lms/blob/f7d1d5c0e016de139f8edd7e328f08895411e2df/Makefile#L106-L126

This `Makefile` change can't be committed to git because the missing envvars are sensitive and can't be published.

# Solution

This PR adds `--env-file .devdata.env` to the `docker run` command in `Makefile` to make Docker read the envvars from the `.devdata.env` file.

# Testing

On this branch:

1. Run each of the other apps (h, Via, and Via HTML) with the normal `make services`, `make devdata` then `make dev`
2. Run LMS in Docker with `make services`, `make devdata` then `make run-docker`
3. Go to https://hypothesis.instructure.com/ and the various types of localhost test assignments should be working, including HTML, PDF, Google Drive, OneDrive, etc. You shouldn't need to make any changes to `Makefile` to get things working

# Further Work

## De-duplication of settings in `development.ini`, `tox.ini` and `Makefile`

On this branch there's still a duplicated list of envvars before the `--env-file` in the `docker run` command:

https://github.com/hypothesis/lms/blob/f9ec9a407a19166721643eb74e3e17b8bb517ecb/Makefile#L112-L127

These are the non-sensitive envvars that aren't created by the `make devdata` command and aren't in the `.devdata.env` file. When you run `make dev` tox (or the app running in tox) reads some of these settings from `conf/development.ini` and some from envvars specified in `tox.ini`.

As long as the duplicate list of envvars in `Makefile` is correct then things will work fine but the duplicated list will tend to get out of sync over time and the `make run-docker` command will tend to break as a result.

This should be fixed by moving the non-sensitive settings and environment variables out of `conf/development.ini`, `tox.ini` and `Makefile` and into a second env file that is tracked in git. `make run-docker` can then read this second env file with a second `--env-file` argument (I've tested: multiple `--env-file` arguments do work), and `make dev` can read the second env file with a suitable change to [the tox plugin that we use to read env files](https://github.com/seanh/tox-envfile). Once the envvars are no longer duplicated they'll no longer get out of sync and `make run-docker` will no longer tend to break over time.

Note that at least one envvar is currently different for docker versus tox: the `host.docker.internal` in `H_API_URL_PRIVATE`. If necessary this can go in a third env file that only docker reads.

## Making files easier to template

As a side-benefit moving envvars into an env file will also make `conf/development.ini`, `tox.ini` and `Makefile` more consistent across projects since they'll no longer contain project-specific settings and envvars, which will make these files easier to template if we want to create a cookiecutter template for our apps in future.

