### PR TITLE
Disable sections by default for new installs

### DIFF
--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -32,7 +32,7 @@ def create_application_instance(request):
         request.registry.settings["aes_secret"],
         settings={
             "canvas": {
-                "sections_enabled": bool(developer_key),
+                "sections_enabled": False,
                 "groups_enabled": bool(developer_key),
             }
         },

--- a/tests/unit/lms/views/application_instance_test.py
+++ b/tests/unit/lms/views/application_instance_test.py
@@ -52,7 +52,7 @@ class TestCreateApplicationInstance:
 
     @pytest.mark.parametrize(
         "developer_key,canvas_sections_enabled",
-        [("test_developer_key", True), ("", False)],
+        [("test_developer_key", False), ("", False)],
     )
     def test_it_sets_canvas_sections_enabled(
         self, pyramid_request, developer_key, canvas_sections_enabled


### PR DESCRIPTION
Disable sections by default for new installs.

Fixes https://github.com/hypothesis/product-backlog/issues/1276

# Testing

1. Go to <http://localhost:8001/welcome> and register a new application instance **with** a Canvas developer ID and developer key. You can just enter fake values for all fields, including the developer ID and key

2. Inspect the new application instance in your DB. On master, because you provided a developer key, the application instance will have sections enabled. On this branch sections will be disabled (but groups will still be enabled):

   ```
   tox -qe dockercompose -- exec postgres psql -U postgres -c "SELECT settings FROM application_instances WHERE consumer_key = '<CONSUMER_KEY>';"
                               settings                            
   ----------------------------------------------------------------
    {"canvas": {"groups_enabled": true, "sections_enabled": false}}
   (1 row)

3. Create another application instance *without* a developer ID and key. It should have both sections and groups disabled.

