### PR TITLE
POC: Add `onAnnotationActivity` configuration, RPC method to LMS frontend

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server.js
@@ -162,7 +162,12 @@ export class Server {
 
     // Call the method and return the result response.
     try {
-      const result = await method();
+      let result;
+      if (request.params) {
+        result = await method(...request.params);
+      } else {
+        result = await method();
+      }
       return { jsonrpc: '2.0', result: result, id: request.id };
     } catch (e) {
       return {


### PR DESCRIPTION
These changes propose a basic method for adding a new RPC method to the RPC server (`onAnnotationActivity`) and sending an additional configuration value to the client that indicates the client should send relevant annotation activity notifications to that RPC method. It also adds support for args/parameters to registered RPC methods.

I'm posing this as a POC before writing tests as writing tests to save myself some time if this approach isn't what we want.

Specifically looking to answer:

* Use of `EventEmitter` OK?
* Is manner of adding new property to `ServiceConfig` OK?

## Test this out

Run this branch on LMS. Apply this patch on the `client` (do not take this patch as anything meaningful, just demonstrates the round-trip on this method):

```
diff --git a/src/sidebar/config/fetch-config.js b/src/sidebar/config/fetch-config.js
index fb5a31462..fab711d7f 100644
--- a/src/sidebar/config/fetch-config.js
+++ b/src/sidebar/config/fetch-config.js
@@ -131,6 +131,14 @@ function fetchConfigEmbed(appConfig, hostPageConfig) {
  * @return {Promise<object>} - The merged settings.
  */
 async function fetchConfigRpc(appConfig, parentFrame, origin) {
+  const response = await postMessageJsonRpc.call(
+    parentFrame,
+    origin,
+    'onAnnotationActivity',
+    ['foobar'],
+    3000
+  );
+  console.log(response);
   const remoteConfig = await postMessageJsonRpc.call(
     parentFrame,
     origin,
```

Launch any localhost Canvas assignment and you should see `foobar` logged to console.

Part of https://github.com/hypothesis/lms/issues/3647