### PR TITLE
Improve OneDrive permission error

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -16,6 +16,8 @@ import FilePickerFormFields from './FilePickerFormFields';
 import GroupConfigSelector from './GroupConfigSelector';
 
 /**
+ * @typedef {import("preact").ComponentChildren} Children
+ *
  * @typedef {import('../api-types').File} File
  * @typedef {import('../utils/content-item').Content} Content
  * @typedef {import('../utils/content-item').URLContent} URLContent
@@ -31,8 +33,9 @@ import GroupConfigSelector from './GroupConfigSelector';
 
 /**
  * @typedef ErrorInfo
- * @prop {string} message
+ * @prop {string} description
  * @prop {Error} error
+ * @prop {Children} [children]
  */
 
 /**
@@ -195,11 +198,7 @@ export default function FilePickerApp({ onSubmit }) {
       </form>
       {shouldSubmit && <FullScreenSpinner />}
       {errorInfo && (
-        <ErrorModal
-          description={errorInfo.message}
-          error={errorInfo.error}
-          onCancel={() => setErrorInfo(null)}
-        />
+        <ErrorModal {...errorInfo} onCancel={() => setErrorInfo(null)} />
       )}
     </main>
   );

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -7,7 +7,7 @@ import { act } from 'preact/test-utils';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { delay, waitFor } from '../../../test-util/wait';
 import { Config } from '../../config';
-import { PickerCanceledError } from '../../errors';
+import { PickerCanceledError, PickerPermissionError } from '../../errors';
 import ContentSelector, { $imports } from '../ContentSelector';
 
 function interact(wrapper, callback) {
@@ -326,7 +326,7 @@ describe('ContentSelector', () => {
       await delay(0);
 
       assert.calledWith(onError, {
-        message: 'There was a problem choosing a file from Google Drive',
+        description: 'There was a problem choosing a file from Google Drive',
         error,
       });
     });
@@ -461,18 +461,35 @@ describe('ContentSelector', () => {
       assert.notCalled(onError);
     });
 
-    it('shows error message if OneDrive Picker errors', async () => {
-      const error = new Error('Some failure');
+    it('shows error message if OneDrive Picker raises a permission error', async () => {
+      const error = new PickerPermissionError();
       const onError = sinon.stub();
       const wrapper = renderContentSelector({ onError });
-      // Emulate a failure in the picker
+      // Emulate a permission error of the picker.
       picker.showPicker.rejects(error);
 
       clickOneDriveButton(wrapper);
       await delay(0);
 
       assert.calledWith(onError, {
-        message: 'There was a problem choosing a file from OneDrive',
+        description: 'There was a problem choosing a file from OneDrive',
+        error,
+        children: sinon.match.object,
+      });
+    });
+
+    it('shows error message if OneDrive Picker errors', async () => {
+      const error = new Error('Some failure');
+      const onError = sinon.stub();
+      const wrapper = renderContentSelector({ onError });
+      // Emulate a generic failure in the picker
+      picker.showPicker.rejects(error);
+
+      clickOneDriveButton(wrapper);
+      await delay(0);
+
+      assert.calledWith(onError, {
+        description: 'There was a problem choosing a file from OneDrive',
         error,
       });
       assert.calledWith(console.error, error);

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -47,6 +47,15 @@ export class PickerCanceledError extends Error {
 }
 
 /**
+ * Error thrown when the user is unable to change the permission of a file.
+ */
+export class PickerPermissionError extends Error {
+  constructor() {
+    super('Unable to update file sharing permissions');
+  }
+}
+
+/**
  * Error returned when an API call fails with a 4xx or 5xx response and
  * JSON body.
  */


### PR DESCRIPTION
Currently, if MS SharePoint is setup in such a way that doesn't allow to
create public links, the OneDrive error message caused is not very
helpful.

We have created a new error type, `PickerPermissionError`, that is throw
when such permission restrictions are encountered. The new error message
contains more information about the error and a link to additional
resources.

### Before

![image](https://user-images.githubusercontent.com/8555781/153837007-bfe3da0a-eaf9-4ad1-ad9e-fd5448adfcbf.png)


### After

![error-message-one-drive](https://user-images.githubusercontent.com/8555781/153836858-2df7b50b-10ee-4609-b671-d0d5b48062b7.png)

Closes https://github.com/hypothesis/product-backlog/issues/1245
