### PR TITLE
Add refresh API

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -77,6 +77,7 @@ def includeme(config):
         "/canvas_oauth_callback",
         factory="lms.resources.OAuth2RedirectResource",
     )
+    config.add_route("canvas_api.oauth.refresh", "/api/canvas/oauth/refresh")
     config.add_route(
         "canvas_api.courses.files.list", "/api/canvas/courses/{course_id}/files"
     )

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -59,6 +59,9 @@ class CanvasAPIClient:
         """
         return self._client.get_token(authorization_code)
 
+    def get_refreshed_token(self, refresh_token):
+        return self._client.get_refreshed_token(refresh_token)
+
     # Getting authenticated users sections
     # ------------------------------------
     #

--- a/lms/views/api/canvas/refresh.py
+++ b/lms/views/api/canvas/refresh.py
@@ -1,0 +1,24 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+
+
+@view_config(
+    request_method="POST",
+    route_name="canvas_api.oauth.refresh",
+    permission=Permissions.API,
+    renderer="json",
+)
+def get_refreshed_token(request):
+    """
+    Refresh the user's access token.
+
+    Send a request to Canvas to get a refreshed access token for the
+    authenticated user and save it to the DB.
+    """
+    canvas_api = request.find_service(name="canvas_api_client")
+    oauth2_token_service = request.find_service(name="oauth2_token")
+
+    refresh_token = oauth2_token_service.get().refresh_token
+
+    canvas_api.get_refreshed_token(refresh_token)

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -18,6 +18,14 @@ class TestCanvasAPIClient:
         )
         assert token == authenticated_client.get_token.return_value
 
+    def test_get_refreshed_token(self, canvas_api_client, authenticated_client):
+        refreshed_token = canvas_api_client.get_refreshed_token(sentinel.refresh_token)
+
+        authenticated_client.get_refreshed_token.assert_called_once_with(
+            sentinel.refresh_token
+        )
+        assert refreshed_token == authenticated_client.get_refreshed_token.return_value
+
     @pytest.fixture
     def authenticated_client(self):
         return create_autospec(AuthenticatedClient, instance=True, spec_set=True)

--- a/tests/unit/lms/views/api/canvas/refresh_test.py
+++ b/tests/unit/lms/views/api/canvas/refresh_test.py
@@ -1,0 +1,13 @@
+import pytest
+
+from lms.views.api.canvas.refresh import get_refreshed_token
+
+pytestmark = pytest.mark.usefixtures("canvas_api_client", "oauth2_token_service")
+
+
+def test_get_refreshed_token(pyramid_request, canvas_api_client, oauth2_token_service):
+    get_refreshed_token(pyramid_request)
+
+    canvas_api_client.get_refreshed_token.assert_called_once_with(
+        oauth2_token_service.get.return_value.refresh_token
+    )


### PR DESCRIPTION
Add a new `POST /api/canvas/oauth/refresh` API for the frontend to call that causes the backend to refresh the current user's Canvas access token.

The refreshed access token is just stored in the DB (not sent back to the frontend).

# Testing a successful request

You first need to get an access token in your DB to refresh, and you need to generate a bearer token to use in test requests.

1. Log in to Canvas as the __Canvas: Instructor (Testing Account)__ user (in 1Password) and launch an assignment so that you have an access token for this user in your DB

2. Get a bearer token for the user to use in test requests:

   ```python
   $ make shell
   >>> from lms.validation.authentication import BearerTokenSchema
   >>> bearer_token_schema = BearerTokenSchema(request)
   >>> user = db.query(models.User).filter_by(h_userid="acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is").one()
   >>> lti_user = factories.LTIUser(user_id=user.user_id, oauth_consumer_key=user.application_instance.consumer_key, tool_consumer_instance_guid=user.application_instance.tool_consumer_instance_guid)
   >>> authorization_param = bearer_token_schema.authorization_param(lti_user)
   >>> authorization_param
   'Bearer eyJ***t-Y'
   ```

3. Check the value of the user's access token in your DB:

   ```
   tox -qe dockercompose -- exec postgres psql -U postgres -c "SELECT oauth2_token.access_token FROM oauth2_token, public.user WHERE oauth2_token.user_id = public.user.user_id AND public.user.h_userid = 'acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is';"
   ```

4. Use the bearer token to make a test request to the new refresh API. You should get a 200 OK response with no body. In the examples below I'm using [httpie](https://httpie.io/) to make requests:

   ```terminal
   $ http POST 'http://localhost:8001/api/canvas/oauth/refresh' Authorization:'Bearer eyJ***t-Y'
   HTTP/1.1 200 OK
   Connection: close
   Content-Length: 4
   Content-Type: application/json
   Date: Mon, 14 Feb 2022 14:14:01 GMT
   Server: gunicorn

   null
   ```

5. Check the user's access token in your DB again: it should have changed

# Testing when we get an error from Canvas

Hack the code to trigger an error response from Canvas by sending an invalid refresh request:

```diff
diff --git a/lms/services/canvas_api/_authenticated.py b/lms/services/canvas_api/_authenticated.py
index aedf81a2..74311fbc 100644
--- a/lms/services/canvas_api/_authenticated.py
+++ b/lms/services/canvas_api/_authenticated.py
@@ -95,7 +95,7 @@ class AuthenticatedClient:
         :return: A new access token string
         """
         return self._send_token_request(
-            grant_type="refresh_token", refresh_token=refresh_token
+            grant_type="foo", refresh_token=refresh_token
         )
 
     def _send_token_request(self, grant_type, refresh_token=None, **kwargs):

```

Now call the API and you should get a 400 with an error message:

```terminal
$  http POST 'http://localhost:8001/api/canvas/oauth/refresh' Authorization:'Bearer eyJ***t-Y'
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 562
Content-Type: application/json
Date: Mon, 14 Feb 2022 15:13:05 GMT
Server: gunicorn

{
    "details": {
        "request": {
            "method": "POST",
            "url": "https://hypothesis.instructure.com/login/oauth2/token"
        },
        "response": {
            "reason": "Bad Request",
            "status_code": 400
        },
        "validation_errors": null
    },
    "message": "Calling the Canvas API failed"
}

```

# Testing when we have no access token for the user

1. Delete the access token from your DB:

   ```terminal
   tox -qe dockercompose -- exec postgres psql -U postgres -c "DELETE FROM oauth2_token;"
   ```

2. Call the API and you should get a 400 with an empty JSON object as its body:

   ```terminal
   $ http POST 'http://localhost:8001/api/canvas/oauth/refresh' Authorization:'Bearer eyJ***6Rc'
   HTTP/1.1 400 Bad Request
   Connection: close
   Content-Length: 2
   Content-Type: application/json
   Date: Mon, 14 Feb 2022 18:30:03 GMT
   Server: gunicorn

   {}
   ```

   While this may seem like a strange response I think it's actually correct: a 400 is the response that the backend already uses when it wants to say to the frontend "Authenticating with Canvas failed, you need to show the user the **Authorize** dialog." The empty JSON body signals to the frontend that no error message should be shown to the user. (If the backend wanted the frontend to show an error dialog it'd include a `message` or `error_code` and perhaps an `error_details` on the JSON body.)

# Testing with invalid authentication

Call the API with an invalid bearer token and you should get a 403:

```terminal
$ http POST 'http://localhost:8001/api/canvas/oauth/refresh' Authorization:'Bearer foo'
HTTP/1.1 403 Forbidden
Connection: close
Content-Length: 55
Content-Type: application/json
Date: Mon, 14 Feb 2022 18:28:12 GMT
Server: gunicorn

{
    "message": "You're not authorized to view this page."
}
```

# Testing with no authentication

Call the API with no bearer token and you should get a 403:

```terminal
$ http POST 'http://localhost:8001/api/canvas/oauth/refresh'
HTTP/1.1 403 Forbidden
Connection: close
Content-Length: 55
Content-Type: application/json
Date: Mon, 14 Feb 2022 18:29:08 GMT
Server: gunicorn

{
    "message": "You're not authorized to view this page."
}
```