### PR TITLE
Return a dataclass from API exception views

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -1,5 +1,5 @@
 """Error views for the API."""
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from urllib.parse import urlparse, urlunparse
 
 import sentry_sdk
@@ -238,19 +238,7 @@ class ErrorBody:
         JSON-serialize for the response body. See:
         https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/renderers.html#using-a-custom-json-method
         """
-
-        body = {}
-
-        if self.error_code is not None:
-            body["error_code"] = self.error_code
-
-        if self.message is not None:
-            body["message"] = self.message
-
-        if self.details is not None:
-            body["details"] = self.details
-
-        return body
+        return {key: value for key, value in asdict(self).items() if value is not None}
 
 
 def strip_queryparams(url):


### PR DESCRIPTION
Return a dataclass from the API exception views.
    
This is to enable a future addition. Currently the exception views all call a `response_body()` helper method that returns a JSON-serializable dict:
    
```python
return self.error_response(
    message=...,
    details=...,
    ...
)
```

I now want to add refresh API information to some error responses but not others so I'd have to add a `refresh=True` argument to `error_response()` but that's going to trigger PyLint's "too-many-arguments" warning.
    
So this commit replaces the `error_response()` helper method with a JSON-serializable dataclass called `ErrorResponseBody`. Views can return instances of this dataclass directly and Pyramid's JSON renderer will serialize them to JSON for the response body:

```python
return ErrorResponseBody(
    message=...,
    details=...,
    ...
)
```
    
The `ErrorResponseBody.__json__()` method is basically the same method as the `error_response()` helper used to be but using `self` attrs instead of arguments.
    
A future commit can now add a new `refresh` attribute to `ErrorResponseBody` without triggering any PyLint warnings.

Slack thread: https://hypothes-is.slack.com/archives/C1MA4E9B9/p1644937953064909