### PR TITLE
Feature flag Canvas refresh tokens

### DIFF
--- a/lms/services/canvas_api/_authenticated.py
+++ b/lms/services/canvas_api/_authenticated.py
@@ -18,7 +18,13 @@ class AuthenticatedClient:
     """
 
     def __init__(  # pylint: disable=too-many-arguments
-        self, basic_client, oauth2_token_service, client_id, client_secret, redirect_uri
+        self,
+        basic_client,
+        oauth2_token_service,
+        client_id,
+        client_secret,
+        redirect_uri,
+        refresh_enabled,
     ):
         """
         Create an AuthenticatedClient object for making authenticated calls.
@@ -36,6 +42,8 @@ class AuthenticatedClient:
         self._client_id = client_id
         self._client_secret = client_secret
         self._redirect_uri = redirect_uri
+
+        self._refresh_enabled = refresh_enabled
 
     def send(
         self, method, path, schema, timeout=DEFAULT_TIMEOUT, params=None
@@ -60,7 +68,7 @@ class AuthenticatedClient:
                 *call_args, headers={"Authorization": f"Bearer {access_token}"}
             )
         except OAuth2TokenError:
-            if not refresh_token:
+            if not refresh_token or not self._refresh_enabled:
                 raise
 
         new_access_token = self.get_refreshed_token(refresh_token)

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -26,6 +26,7 @@ def canvas_api_client_factory(_context, request):
         client_id=application_instance.developer_key,
         client_secret=developer_secret,
         redirect_uri=request.route_url("canvas_api.oauth.callback"),
+        refresh_enabled=not request.feature("frontend_refresh"),
     )
 
     return CanvasAPIClient(

--- a/tests/unit/lms/services/canvas_api/conftest.py
+++ b/tests/unit/lms/services/canvas_api/conftest.py
@@ -25,4 +25,5 @@ def authenticated_client(basic_client, oauth2_token_service):
         client_id=sentinel.client_id,
         client_secret=sentinel.client_secret,
         redirect_uri=sentinel.redirect_uri,
+        refresh_enabled=True,
     )

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -47,6 +47,7 @@ class TestCanvasAPIClientFactory:
                 pyramid_request.registry.settings["aes_secret"]
             ),
             redirect_uri=pyramid_request.route_url("canvas_api.oauth.callback"),
+            refresh_enabled=True,
         )
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Add a new `"frontend_refresh"` feature flag and disable backend Canvas refresh requests when this feature flag is enabled.

Note that there are also backend *Blackboard* refresh requests that should be disabled by the same feature flag but aren't yet.

I haven't bothered to write unit tests for the feature flag-based behaviour because it's temporary. The feature flag and the whole backend refresh-and-retry logic will be deleted soon.

# Testing

Feature flags are disabled by default which means that backend Canvas refresh requests will be _enabled_ by default and deploying this PR should have no effect. To test, simulate an expired access token by breaking the access tokens in your DB:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "update oauth2_token set access_token = 'foo';"
```

Now launch [localhost (make devdata) Canvas Files Assignment](https://hypothesis.instructure.com/courses/125/assignments/875). The assignment should launch successfully without re-authorization because the "expired" access token will be automatically refreshed.

Now enable the feature flag and "expire" the access tokens in your DB again:

```
export FEATURE_FLAG_FRONTEND_REFRESH=true
tox -qe dockercompose -- exec postgres psql -U postgres -c "update oauth2_token set access_token = 'foo';"
```

Re-launch the assignment and you should be shown an authorization dialog because the automatic refreshing has been disabled.