### PR TITLE
Add a separate `CanvasAPIInsufficientScopesError`

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -3,6 +3,7 @@ from lms.services.canvas import CanvasService
 from lms.services.exceptions import (
     BlackboardFileNotFoundInCourse,
     CanvasAPIError,
+    CanvasAPIInsufficientScopesError,
     CanvasAPIPermissionError,
     CanvasAPIServerError,
     CanvasFileNotFoundInCourse,

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -195,12 +195,16 @@ class CanvasAPIError(ExternalRequestError):
             status_code == 401
             and {"message": "Insufficient scopes on access token."} in errors
         ):
-            return OAuth2TokenError
+            return CanvasAPIInsufficientScopesError
 
         if status_code == 401:
             return CanvasAPIPermissionError
 
         return CanvasAPIServerError
+
+
+class CanvasAPIInsufficientScopesError(CanvasAPIError):
+    """A Canvas access token lacked one or more of the required scopes."""
 
 
 class CanvasAPIPermissionError(CanvasAPIError):

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -14,6 +14,7 @@ from pyramid.view import (
 )
 
 from lms.services import (
+    CanvasAPIInsufficientScopesError,
     CanvasAPIPermissionError,
     ExternalAsyncRequestError,
     ExternalRequestError,
@@ -162,6 +163,10 @@ class APIExceptionViews:
 
     @exception_view_config(context=OAuth2TokenError)
     def oauth2_token_error(self):  # pylint:disable=no-self-use
+        return ErrorBody()
+
+    @exception_view_config(context=CanvasAPIInsufficientScopesError)
+    def insufficient_scopes_error(self):  # pylint:disable=no-self-use
         return ErrorBody()
 
     @exception_view_config(context=HTTPBadRequest)

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -7,6 +7,7 @@ import requests
 
 from lms.services import (
     CanvasAPIError,
+    CanvasAPIInsufficientScopesError,
     CanvasAPIPermissionError,
     CanvasAPIServerError,
     ExternalAsyncRequestError,
@@ -193,7 +194,7 @@ class TestCanvasAPIError:
                 json.dumps(
                     {"errors": [{"message": "Insufficient scopes on access token."}]}
                 ),
-                OAuth2TokenError,
+                CanvasAPIInsufficientScopesError,
             ),
             # A 400 Bad Request response from Canvas, because our refresh token
             # was expired or deleted.

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -33,6 +33,14 @@ class TestOAuth2TokenError:
         assert error_body == ErrorBody()
 
 
+class TestInsufficientScopesError:
+    def test_it(self, pyramid_request, views):
+        error_body = views.insufficient_scopes_error()
+
+        assert pyramid_request.response.status_code == 400
+        assert error_body == ErrorBody()
+
+
 class TestExternalRequestError:
     def test_it(self, context, pyramid_request, views, report_exception, sentry_sdk):
         error_body = views.external_request_error()


### PR DESCRIPTION
So far this does exactly the same thing as `OAuth2TokenError` but in the future the two exception views will behave differently: `OAuth2TokenError`'s can happen because the user's access token has expired, which can potentially be fixed by refreshing the access token. But scopes errors can't be fixed by refreshing because the refreshed access token would have the same scopes as the original.

# Testing

1. Delete any access tokens from your DB:

   ```
   tox -qe dockercompose -- exec postgres psql -U postgres -c "DELETE FROM oauth2_token;"
   ```

2. Hack the code so that, when we get a new access token, we don't ask for all the scopes that we need:

   ```diff
   diff --git a/lms/views/api/canvas/authorize.py b/lms/views/api/canvas/authorize.py
   index 4290f5b0..53da83e8 100644
   --- a/lms/views/api/canvas/authorize.py
   +++ b/lms/views/api/canvas/authorize.py
   @@ -21,7 +21,6 @@ from lms.validation.authentication import OAuthCallbackSchema
    #: The Canvas API scopes that we need for our Canvas Files feature.
    FILES_SCOPES = (
        "url:GET|/api/v1/courses/:course_id/files",
   -    "url:GET|/api/v1/files/:id/public_url",
    )
   ```

3. Launch [localhost (make devdata) Canvas Files Assignment](https://hypothesis.instructure.com/courses/125/assignments/875) and click through the authorization dialog so that you get an access token with the missing scope.

   (Due to the bug created by the diff above you'll be in a re-authorization loop but that's fine. We're just trying to get an invalid access token into your DB.)

4. Undo the diff from step 2 and re-launch the assignment. A `CanvasAPIInsufficientScopesError` will be raised (you'll see it in the logs) and the authorization dialog (not an error dialog) will be shown. Click through the authorization process and you'll get a new access token _with_ the missing scope and the assignment will launch successfully