### PR TITLE
Take consumer_key directly from AI, not LTIUSer in JSConfig

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -35,9 +35,6 @@ class JSConfig:
         return self._lti_user.h_user
 
     @property
-    def _consumer_key(self):
-        return self._lti_user.oauth_consumer_key
-
     def _application_instance(self):
         """
         Return the current request's ApplicationInstance.
@@ -202,7 +199,7 @@ class JSConfig:
         :raise ApplicationInstanceNotFound: if request.lti_user.oauth_consumer_key isn't in the DB
         """
 
-        args = self._context, self._request, self._application_instance()
+        args = self._context, self._request, self._application_instance
 
         self._config.update(
             {
@@ -402,7 +399,7 @@ class JSConfig:
         and had grading info recorded for them.
         """
         grading_infos = self._grading_info_service.get_by_assignment(
-            oauth_consumer_key=self._consumer_key,
+            oauth_consumer_key=self._application_instance.consumer_key,
             context_id=self._request.params.get("context_id"),
             resource_link_id=self._request.params.get("resource_link_id"),
         )
@@ -442,7 +439,7 @@ class JSConfig:
         # mutable. You can do self._hypothesis_client["foo"] = "bar" and the
         # mutation will be preserved.
 
-        if not self._application_instance().provisioning:
+        if not self._application_instance.provisioning:
             return {}
 
         api_url = self._request.registry.settings["h_api_url_public"]
@@ -537,8 +534,7 @@ class JSConfig:
             return self._canvas_sync_api()
 
         if (
-            self._application_instance().product
-            == ApplicationInstance.Product.BLACKBOARD
+            self._application_instance.product == ApplicationInstance.Product.BLACKBOARD
             and self._context.is_blackboard_group_launch
         ):
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -271,13 +271,13 @@ class TestAddDocumentURL:
 
 class TestMaybeEnableGrading:
     def test_it_adds_the_grading_settings(
-        self, js_config, grading_info_service, pyramid_request
+        self, js_config, grading_info_service, application_instance_service
     ):
         js_config.maybe_enable_grading()
 
         grading_info_service.get_by_assignment.assert_called_once_with(
             context_id="test_course_id",
-            oauth_consumer_key=pyramid_request.lti_user.oauth_consumer_key,
+            oauth_consumer_key=application_instance_service.get_current.return_value.consumer_key,
             resource_link_id="TEST_RESOURCE_LINK_ID",
         )
         assert js_config.asdict()["grading"] == {


### PR DESCRIPTION
A small refactor showing which I think should be the first of a series of PRs to remove the usage of `LTIUser.oauth_consumer_key` in favor of using it directly from the application instance.

Currently `get_current` itself gets the consumer_key value from LTIUSer. This is fine now but it will be a problem when `get_current` needs to use either LTI1.1 or LTI1.3 parameters.

Note that **get_current shouldn't get the value directly from the request params** as in some cases, when using BearerToken, the right value comes securely in the token, then added into the LTIUser.

Independently of the LTI update having consumer_key directly on LTIUser seems to leak one detail of application instance and "join" with application instance in the wrong field like we do in some DB tables. 
