### PR TITLE
Add refresh API info to Canvas error responses

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -19,13 +19,19 @@ class ExternalRequestError(Exception):
     """
 
     def __init__(
-        self, message=None, request=None, response=None, validation_errors=None
-    ):
+        self,
+        message=None,
+        request=None,
+        response=None,
+        validation_errors=None,
+        refreshable=False,
+    ):  # pylint: disable=too-many-arguments
         super().__init__()
         self.message = message
         self.request = request
         self.response = response
         self.validation_errors = validation_errors
+        self.refreshable = refreshable
 
     @property
     def url(self) -> Optional[str]:
@@ -181,7 +187,7 @@ class CanvasAPIError(ExternalRequestError):
         error_description = response_json.get("error_description", "")
 
         if {"message": "Invalid access token."} in errors:
-            raise OAuth2TokenError(**kwargs) from cause
+            raise OAuth2TokenError(refreshable=True, **kwargs) from cause
 
         if error_description == "refresh_token not found":
             raise OAuth2TokenError(**kwargs) from cause

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -244,6 +244,17 @@ class TestCanvasAPIError:
         assert raised_exception.response == response
         assert raised_exception.validation_errors == sentinel.validation_errors
 
+    def test_it_marks_access_token_errors_as_retryable(self):
+        cause = requests.RequestException()
+        response = factories.requests.Response(
+            status_code=401,
+            raw=json.dumps({"errors": [{"message": "Invalid access token."}]}),
+        )
+
+        raised_exception = self.assert_raises(cause, response, OAuth2TokenError)
+
+        assert raised_exception.refreshable
+
     @pytest.mark.parametrize(
         "cause",
         [


### PR DESCRIPTION
Add information to some of our API's error responses instructing the frontend to make a refresh request and try again.

This covers Canvas only, Blackboard is to come later.

Testing
=======

[localhost (make devdata) Canvas Files Assignment](https://hypothesis.instructure.com/courses/125/assignments/875) is a suitable assignment for testing this.

Enable the `frontend_refresh` feature flag
------------------------------------------

You need the [`frontend_refresh` feature flag](https://github.com/hypothesis/lms/pull/3695) on to test this PR:

```
export FEATURE_FLAG_FRONTEND_REFRESH=true
```

Note that the feature flag doesn't actually enable frontend refreshing code (the frontend code hasn't been written yet) it just _disables_ backend refreshing code.

Refreshable error from Canvas
-----------------------------

1. Launch the assignment to make sure that you have an access token in your DB (click through the authorization dialog if you get it)

2. Invalidate all the access tokens in your DB:

   ```
   tox -qe dockercompose -- exec postgres psql -U postgres -c "update oauth2_token set access_token = 'foo';"
   ```

3. Re-launch the assignment.

   No refresh request will happen because the feature flag has disabled backend refreshing and the frontend refreshing code hasn't been written yet. Instead you'll see the authorization dialog.
   
   If you open dev tools and look at the failed `via_url` and `sync` API response bodies you'll see that they contain refresh info for the frontend:
   
   ```json
   {"refresh": {"method": "POST", "path": "/api/canvas/oauth/refresh"}}
   ```

Non-refreshable error from Canvas
---------------------------------

There's all kinds of ways to produce a non-refreshable error from the Canvas API. You could pick any. Let's go with forcing an unexpected error response from Canvas:

1. Apply this diff to cause Canvas to send us unexpected errors:

   ```diff
   diff --git a/lms/services/canvas_api/client.py b/lms/services/canvas_api/client.py
   index e88d5016..f1ff8529 100644
   --- a/lms/services/canvas_api/client.py
   +++ b/lms/services/canvas_api/client.py
   @@ -279,7 +279,7 @@ class CanvasAPIClient:
            # https://canvas.instructure.com/doc/api/files.html#method.files.public_url
    
            return self._client.send(
   -            "GET", f"files/{file_id}/public_url", schema=self._PublicURLSchema
   +            "GET", f"files/foo/public_url", schema=self._PublicURLSchema
            )["public_url"]
 
        class _PublicURLSchema(RequestsResponseSchema):
   ```

2. Launch the assignment

   You'll see an error dialog and if you look at the response body of the failed `via_url` request it won't contain any refresh info.