### PR TITLE
Add `user` to the request

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -190,6 +190,14 @@ def _get_lti_user(request):
     return lti_user
 
 
+def _get_user(request):
+    return request.find_service(UserService).get(
+        request.find_service(name="application_instance").get_current(),
+        request.lti_user.user_id,
+    )
+
+
 def includeme(config):
     config.set_security_policy(SecurityPolicy(config.registry.settings["lms_secret"]))
     config.add_request_method(_get_lti_user, name="lti_user", property=True, reify=True)
+    config.add_request_method(_get_user, name="user", property=True, reify=True)

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -13,6 +13,7 @@ from lms.security import (
     Permissions,
     SecurityPolicy,
     _get_lti_user,
+    _get_user,
     includeme,
 )
 from lms.validation import ValidationError
@@ -564,3 +565,14 @@ class TestGetLTIUser:
     @pytest.fixture
     def launch_params_auth_schema(self, LaunchParamsAuthSchema):
         return LaunchParamsAuthSchema.return_value
+
+
+class TestGetUser:
+    def test_it(self, pyramid_request, user_service, application_instance_service):
+        user = _get_user(pyramid_request)
+
+        user_service.get.assert_called_once_with(
+            application_instance_service.get_current.return_value,
+            pyramid_request.lti_user.user_id,
+        )
+        assert user == user_service.get.return_value


### PR DESCRIPTION
This adds `user` alongside `lti_user` to the request object for convince.


This PR doesn't yet use the new request property.


# Testing

No functional changes here. Just launch any assignment as a sanity check. 


A diff like 

```diff
diff --git a/lms/views/basic_lti_launch.py b/lms/views/basic_lti_launch.py
index 7eefdde1..c88078b4 100644
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -58,6 +58,8 @@ class BasicLTILaunchViews:
 
         self.context.js_config.add_document_url(document_url)
 
+        print("USER" * 10, self.request.user)
+
         return {}
 
     def sync_lti_data_to_h(self):

```

can force access to the new property on launching for example: https://hypothesis.instructure.com/courses/125/assignments/875
