### PR TITLE
Add caching to `OAuth2TokenService.get()`

### DIFF
--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -1,4 +1,5 @@
 import datetime
+from functools import lru_cache
 
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -42,6 +43,7 @@ class OAuth2TokenService:
         oauth2_token.expires_in = expires_in
         oauth2_token.received_at = datetime.datetime.utcnow()
 
+    @lru_cache
     def get(self):
         """
         Return the user's saved OAuth 2 token from the DB.


### PR DESCRIPTION
`OAuth2TokenService.get()` can get called more than once per request. For example the Canvas API client code will call it during view processing to get the access token to use in requests to Canvas. If a request to Canvas fails with a refreshable error then the `OAuth2TokenService.get()` will also get called during exception view processing because the exception view needs to know whether we have an access token for this user or not.

Remove this duplicate SQL query by adding per-request caching to `OAuth2TokenService.get()` using `lru_cache`.

This relies in the fact that `OAuth2TokenService` is registered with `pyramid_services` using `register_service_factory()` which means that `pyramid_services` constructs one instance of `OAuth2TokenService` *per request*.

Testing
-------

1. Enable SQLAlchemy debug logging so that you can see which SQL queries are being sent to the DB:

   ```diff
   diff --git a/lms/db/__init__.py b/lms/db/__init__.py
   index d29fcf62..60cfff5b 100644
   --- a/lms/db/__init__.py
   +++ b/lms/db/__init__.py
   @@ -16,6 +16,9 @@ __all__ = ("BASE", "init")
    LOG = logging.getLogger(__name__)
    
    
   +logging.getLogger("sqlalchemy.engine").setLevel(logging.DEBUG)
   +
   +
    class BaseClass:
        """Functions common to all SQLAlchemy models."""
   ``` 

2. Enable the `frontend_refresh` feature flag:

       export FEATURE_FLAG_FRONTEND_REFRESH=true

3. Trigger a refreshable error from Canvas. One way to do this is to invalidate all the access tokens in your DB:

       tox -qe dockercompose -- exec postgres psql -U postgres -c "update oauth2_token set access_token = 'foo';"

4. Launch [localhost (make devdata) Canvas Files Assignment](https://hypothesis.instructure.com/courses/125/assignments/875)

5. You should see two failed API requests in the browser's dev tools: `via_url` and `sync`. Both error response bodies should include `"refresh"` info.

6. Look for `SELECT oauth2_token.id ...` queries in the logs.

   On master you'll see four of these queries: two from each API request.
   
   On this branch you'll only see two queries: one from each request.