### PR TITLE
Remove obsolete Dependabot `ignore` configuration for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,17 +14,6 @@ updates:
     interval: weekly
     time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: query-string
-    versions:
-    - "> 5.1.1"
-  - dependency-name: superagent
-    versions:
-    - "> 3.8.3"
-  - dependency-name: "@types/query-string"
-    versions:
-    - ">= 6.a"
-    - "< 7"
 
 - package-ecosystem: docker
   directory: "/"


### PR DESCRIPTION
The lms frontend no longer uses the ignored packages.