### PR TITLE
Feature flag Blackboard refresh tokens

### DIFF
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -53,11 +53,13 @@ class BasicClient:
         redirect_uri,
         http_service,
         oauth_http_service,
+        refresh_enabled,
     ):  # pylint:disable=too-many-arguments
         self.blackboard_host = blackboard_host
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
+        self.refresh_enabled = refresh_enabled
 
         self._http_service = http_service
         self._oauth_http_service = oauth_http_service
@@ -76,12 +78,15 @@ class BasicClient:
         try:
             return self._send(method, url)
         except ExternalRequestError:
-            self._oauth_http_service.refresh_access_token(
-                self.token_url,
-                self.redirect_uri,
-                auth=(self.client_id, self.client_secret),
-            )
-            return self._send(method, url)
+            if self.refresh_enabled:
+                self._oauth_http_service.refresh_access_token(
+                    self.token_url,
+                    self.redirect_uri,
+                    auth=(self.client_id, self.client_secret),
+                )
+                return self._send(method, url)
+
+            raise
 
     @property
     def token_url(self):

--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -16,6 +16,7 @@ def blackboard_api_client_factory(_context, request):
             redirect_uri=request.route_url("blackboard_api.oauth.callback"),
             http_service=request.find_service(name="http"),
             oauth_http_service=request.find_service(name="oauth_http"),
+            refresh_enabled=not request.feature("frontend_refresh"),
         ),
         request=request,
         file_service=request.find_service(name="file"),

--- a/tests/unit/lms/services/blackboard_api/_basic_test.py
+++ b/tests/unit/lms/services/blackboard_api/_basic_test.py
@@ -88,6 +88,7 @@ class TestBasicClientRequest:
     def test_it_refreshes_and_tries_again_if_the_first_request_fails(
         self, basic_client, oauth_http_service
     ):
+        basic_client.refresh_enabled = True
         # Make the first attempt at the request fail but the second succeed.
         oauth_http_service.request.side_effect = [ExternalRequestError, DEFAULT]
 
@@ -150,4 +151,5 @@ def basic_client(http_service, oauth_http_service):
         redirect_uri=sentinel.redirect_uri,
         http_service=http_service,
         oauth_http_service=oauth_http_service,
+        refresh_enabled=False,
     )

--- a/tests/unit/lms/services/blackboard_api/factory_test.py
+++ b/tests/unit/lms/services/blackboard_api/factory_test.py
@@ -26,6 +26,7 @@ def test_blackboard_api_client_factory(
         redirect_uri=pyramid_request.route_url("blackboard_api.oauth.callback"),
         http_service=http_service,
         oauth_http_service=oauth_http_service,
+        refresh_enabled=True,
     )
     BlackboardAPIClient.assert_called_once_with(
         BasicClient.return_value, pyramid_request, file_service


### PR DESCRIPTION
Same as we [already did for Canvas](https://github.com/hypothesis/lms/pull/3695).

Testing:

1. Make sure you have a Blackboard access token in your DB: launch any Blackboard files or groups assignment and click through the authorization flow if you get it

2. Invalidate the access tokens in your DB:

       tox -qe dockercompose -- exec postgres psql -U postgres -c "update oauth2_token set access_token = 'foo';"

3. Re-launch the assignmnent.

   With the `frontend_refresh` feature flag enabled (`export FEATURE_FLAG_FRONTEND_REFRESH=true`) no refresh should be attempted and you should get an authorization dialog.

   With the feature flag _disabled_ your access token should be automatically refreshed and the assignment should launch without asking you for authorization.