### PR TITLE
Add refresh info to Blackboard API error responses

### DIFF
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -113,9 +113,11 @@ class BasicClient:
         try:
             return self._oauth_http_service.request(method, url)
         except ExternalRequestError as err:
+            err.refreshable = getattr(err.response, "status_code", None) == 401
+
             error_dict = BlackboardErrorResponseSchema(err.response).parse()
 
             if error_dict.get("message") == "Bearer token is invalid":
-                raise OAuth2TokenError() from err
+                raise OAuth2TokenError(refreshable=err.refreshable) from err
 
             raise


### PR DESCRIPTION
# Testing

1. Enable the `frontend_refresh` feature flag:

       export FEATURE_FLAG_FRONTEND_REFRESH=true

2. Make sure you have a Blackboard access token in your DB: launch any Blackboard files or groups assignment and click through the authorization flow if you get it

## Refreshable error from Blackboard

1. Invalidate the access tokens in your DB:

       tox -qe dockercompose -- exec postgres psql -U postgres -c "update oauth2_token set access_token = 'foo';"

2. Launch any Blackboard files or groups assignment

3. No token refresh will happen because backend refreshing is disabled by the `frontend_refresh` feature flag and frontend refreshing hasn't been written yet. So you should see the authorization dialog

4. If you look at the bodies of the failed `via_url` and/or `sync` API requests you should see that refresh info is included:

   ```json
   {"refresh": {"method": "POST", "path": "/api/oauth/refresh"}}
   ```

## Non-refreshable error from Blackboard

There's any number of ways to produce a non-refreshable error from Blackboard. One way is to launch the **localhost (make devdata) Groups Assignment With No Groups** assignment. You should see an error dialog and in the body of the failed `sync` API response you should not see any refresh info.