### PR TITLE
Add `BlackboardAPIClient.refresh_access_token()`

### DIFF
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -70,6 +70,13 @@ class BasicClient:
             authorization_code=authorization_code,
         )
 
+    def refresh_access_token(self):
+        self._oauth_http_service.refresh_access_token(
+            self.token_url,
+            self.redirect_uri,
+            auth=(self.client_id, self.client_secret),
+        )
+
     def request(self, method, path):
         url = self._api_url(path)
 

--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -37,6 +37,15 @@ class BlackboardAPIClient:
         """
         self._api.get_token(authorization_code)
 
+    def refresh_access_token(self):
+        """
+        Refresh the current user's access token in the DB.
+
+        :raise services.ExternalRequestError: if something goes wrong with the
+            refresh token request to Blackboard
+        """
+        self._api.refresh_access_token()
+
     def list_files(self, course_id, folder_id=None):
         """Return the list of files in the given course or folder."""
 

--- a/tests/unit/lms/services/blackboard_api/_basic_test.py
+++ b/tests/unit/lms/services/blackboard_api/_basic_test.py
@@ -63,6 +63,17 @@ class TestBasicClientGetToken:
         )
 
 
+class TestBasicClientRefreshAccessToken:
+    def test_it(self, basic_client, oauth_http_service):
+        basic_client.refresh_access_token()
+
+        oauth_http_service.refresh_access_token.assert_called_once_with(
+            "https://blackboard.example.com/learn/api/public/v1/oauth2/token",
+            sentinel.redirect_uri,
+            auth=(sentinel.client_id, sentinel.client_secret),
+        )
+
+
 class TestBasicClientRequest:
     @pytest.mark.parametrize(
         "path,expected_url",

--- a/tests/unit/lms/services/blackboard_api/client_test.py
+++ b/tests/unit/lms/services/blackboard_api/client_test.py
@@ -23,6 +23,13 @@ class TestGetToken:
         basic_client.get_token.assert_called_once_with(sentinel.authorization_code)
 
 
+class TestRefreshAccessToken:
+    def test_it(self, svc, basic_client):
+        svc.refresh_access_token()
+
+        basic_client.refresh_access_token.assert_called_once_with()
+
+
 class TestListFiles:
     def test_it_returns_the_courses_top_level_contents(
         self,


### PR DESCRIPTION
Expose `BlackboardAPIClient.refresh_access_token()` as a public service method so that the refresh API view can call it in a future PR.

Same as `BlackboardAPIClient.get_token()`, just forwards to `OAuthHTTPService` (injecting Blackboard-specific details like the token URL).