### PR TITLE
Make the refresh API not Canvas-specific

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -28,6 +28,7 @@ def includeme(config):
     )
 
     config.add_route("api.grant_token", "/api/grant_token", request_method="GET")
+    config.add_route("api.oauth.refresh", "/api/oauth/refresh")
 
     config.add_route("api.assignments.create", "/api/assignment", request_method="POST")
 
@@ -77,7 +78,6 @@ def includeme(config):
         "/canvas_oauth_callback",
         factory="lms.resources.OAuth2RedirectResource",
     )
-    config.add_route("canvas_api.oauth.refresh", "/api/canvas/oauth/refresh")
     config.add_route(
         "canvas_api.courses.files.list", "/api/canvas/courses/{course_id}/files"
     )

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -256,7 +256,7 @@ class ErrorBody:
             else:
                 body["refresh"] = {
                     "method": "POST",
-                    "path": request.route_path("canvas_api.oauth.refresh"),
+                    "path": request.route_path("api.oauth.refresh"),
                 }
 
         return body

--- a/lms/views/api/refresh.py
+++ b/lms/views/api/refresh.py
@@ -5,7 +5,7 @@ from lms.security import Permissions
 
 @view_config(
     request_method="POST",
-    route_name="canvas_api.oauth.refresh",
+    route_name="api.oauth.refresh",
     permission=Permissions.API,
     renderer="json",
 )
@@ -13,8 +13,8 @@ def get_refreshed_token(request):
     """
     Refresh the user's access token.
 
-    Send a request to Canvas to get a refreshed access token for the
-    authenticated user and save it to the DB.
+    Send a request to get a refreshed access token for the authenticated user
+    and save it to the DB.
     """
     canvas_api = request.find_service(name="canvas_api_client")
     oauth2_token_service = request.find_service(name="oauth2_token")

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -208,7 +208,7 @@ class TestErrorBody:
 
         assert body["refresh"] == {
             "method": "POST",
-            "path": pyramid_request.route_path("canvas_api.oauth.refresh"),
+            "path": pyramid_request.route_path("api.oauth.refresh"),
         }
 
     @pytest.mark.usefixtures("with_refreshable_exception")

--- a/tests/unit/lms/views/api/refresh_test.py
+++ b/tests/unit/lms/views/api/refresh_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lms.views.api.canvas.refresh import get_refreshed_token
+from lms.views.api.refresh import get_refreshed_token
 
 pytestmark = pytest.mark.usefixtures("canvas_api_client", "oauth2_token_service")
 


### PR DESCRIPTION
Move the refresh API into a non-Canvas-specific location, rename the route to be non-Canvas-specific, etc.

The actual body code of the view still only supports Canvas, but a future PR will extend it to add Blackboard support.