### PR TITLE
Always update `updated` on User

### DIFF
--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from typing import Optional
 
+from sqlalchemy import func
 from sqlalchemy.exc import NoResultFound
 
 from lms.models import LTIUser, User
@@ -34,6 +35,9 @@ class UserService:
             # Update the existing user from the fields which can change on a
             # new one
             existing_user.roles = new_user.roles
+            # Always update `updated`.  The onupdate declared in the model will only trigger
+            # if any other field also changed.
+            existing_user.updated = func.now()
 
         else:
             self._db.add(new_user)


### PR DESCRIPTION
In practice this will serve as a `last_login` field and it's also in line with `File.updated` and `GroupMembership.updated` which also get updated every time they are seen instead of only when something changed.


Note that once that https://github.com/hypothesis/lms/issues/3639 gets done nothing on the current User table will ever change, so without this change, created == updated always.

## Testing

- Remove your users: 

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate \"user\", grouping_membership"```


- Launch any assignment, for example: https://hypothesis.instructure.com/courses/125/assignments/873

- Check the updated field:

```tox -qe dockercompose -- exec postgres psql -U postgres -c "select updated from \"user\""```


- Wait at least a millisecond and launch the assignment again, re-query the updated field. It will be the same.

- Switch to this branch, re-launch and query. The date will update on every launch.