### PR TITLE
Migration for application_instances.uuid

### DIFF
--- a/lms/migrations/versions/ca440a2514d9_application_instance_uuid.py
+++ b/lms/migrations/versions/ca440a2514d9_application_instance_uuid.py
@@ -1,0 +1,32 @@
+"""
+Adds application_instance.uuid.
+
+Revision ID: ca440a2514d9
+Revises: 7a4812876915
+Create Date: 2022-03-02 12:39:51.591719
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "ca440a2514d9"
+down_revision = "7a4812876915"
+
+
+def upgrade():
+    op.add_column(
+        "application_instances",
+        sa.Column("uuid", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_unique_constraint(
+        op.f("uq__application_instances__uuid"), "application_instances", ["uuid"]
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("uq__application_instances__uuid"), "application_instances", type_="unique"
+    )
+    op.drop_column("application_instances", "uuid")


### PR DESCRIPTION
First step for #3703. Adding a new secondary unique key on application_instance that will be exposed on for example "BearerToken".


There's not a lot of practical difference between `lti_user.application_instance_id` and `application_instance_uuid` but having the uuid field doesn't required a lot of effort anyway so we might as well "do it right".


Added as nullable until the values are backfilled.

This is just the migration that needs to be merged and deployed before the model changes. Model changes in https://github.com/hypothesis/lms/pull/3745


## Testing

- Apply the migration

```hdev alembic upgrade head```

- Check the new column is there

`tox -qe dockercompose -- exec postgres psql -U postgres -c "\d application_instances"`


```
 uuid                                   | uuid                        |           |          |
```


- Check all values are nulls


```tox -qe dockercompose -- exec postgres psql -U postgres -c "select uuid from application_instances"```
