### PR TITLE
Include `application_instance_id` in LTIUser

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 from lms.models import HUser
 
@@ -23,6 +23,9 @@ class LTIUser(NamedTuple):
 
     email: str = ""
     """The user's email address."""
+
+    application_instance_id: Optional[int] = None
+    """ID of the application instance this user belongs to"""
 
     @property
     def h_user(self):

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -61,6 +61,7 @@ class BearerTokenSchema(PyramidRequestSchema):
 
     user_id = marshmallow.fields.Str(required=True)
     oauth_consumer_key = marshmallow.fields.Str(required=True)
+    application_instance_id = marshmallow.fields.Int(required=False, allow_none=True)
     roles = marshmallow.fields.Str(required=True)
     tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
     display_name = marshmallow.fields.Str(required=True)

--- a/lms/validation/authentication/_launch_params.py
+++ b/lms/validation/authentication/_launch_params.py
@@ -60,6 +60,7 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
         return LTIUser(
             user_id=kwargs["user_id"],
             oauth_consumer_key=kwargs["oauth_consumer_key"],
+            application_instance_id=None,
             roles=kwargs["roles"],
             tool_consumer_instance_guid=kwargs["tool_consumer_instance_guid"],
             display_name=display_name(

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,4 +1,4 @@
-from factory import Faker, make_factory
+from factory import Faker, fuzzy, make_factory
 
 from lms import models
 from tests.factories.attributes import (
@@ -11,6 +11,7 @@ LTIUser = make_factory(
     models.LTIUser,
     user_id=USER_ID,
     oauth_consumer_key=OAUTH_CONSUMER_KEY,
+    application_instance_id=fuzzy.FuzzyInteger(1, 9999999999),
     roles=Faker("random_element", elements=["Learner", "Instructor"]),
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     display_name=Faker("name"),

--- a/tests/unit/lms/validation/authentication/_launch_params_test.py
+++ b/tests/unit/lms/validation/authentication/_launch_params_test.py
@@ -19,6 +19,7 @@ class TestLaunchParamsAuthSchema:
         assert lti_user == LTIUser(
             user_id="TEST_USER_ID",
             oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
+            application_instance_id=None,
             roles="TEST_ROLES",
             tool_consumer_instance_guid="TEST_TOOL_CONSUMER_INSTANCE_GUID",
             display_name=display_name.return_value,


### PR DESCRIPTION
The final goal is to only have the reference to application_instance_id instead of any LTI1/1.3 specific parameters to identify application_instances.


# Testing 

- On `master`, start with no users: 

`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate \"user\", grouping_membership"`

- Launch this assignment: https://hypothesis.instructure.com/courses/125/assignments/875 


- There's should be now one `user` related to one application_instance

`tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from \"user\""`



- Switch to this branch, re-launch the assignment. The same user still in the DB, related to the same AI.

- Check the value of the token in the `Authentication` header for the `http://localhost:8001/api/canvas/sync` request:


```
base64.urlsafe_b64decode(token+ "==")
b'{"typ":"JWT","alg":"HS256"}{"oauth_consumer_key":"Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a","tool_consumer_instance_guid":"VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms","application_instance_id":8,"display_name":"Hypothesis 101 Teacher","user_id":"969fc294ee26e3f1d0c9714af3351dc4eacfd6df","email":"eng+canvasteacher@hypothes.is","roles":"Instructor","exp":1646401427}\x14\xb7dq\x0cV\xa6\x1ec\x9b\x13u\xec\x16\\@d">\x95\xf4\xd0q\x16\xd25\xb1\xe2P\xb6\xc0\xb3'
```
the `application_instance_id` should match the one in "user".


This is the LTIUSer from the launch params, serialized into a BearerToken.



### Test migration for existing session/tokens


#### BearerToken

- Switch to master, and start configuring one assignment stop when seeing the different buttons.
- Switch to this branch and click the "Select PDF from canvas"
- Check that the authorization token sent was the one from `master` in the request to 
`http://localhost:8001/api/canvas/courses/125/files`


```
{"typ":"JWT","alg":"HS256"}{"roles":"Instructor","oauth_consumer_key":"Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a","tool_consumer_instance_guid":"VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms","user_id":"969fc294ee26e3f1d0c9714af3351dc4eacfd6df","email":"eng+canvasteacher@hypothes.is","display_name":"Hypothesis 101 Teacher","exp":1646404045}
```

the decoded token doesn't have an `application_instance_id`

To try a broken version of this, remove the default `None` value in https://github.com/hypothesis/lms/blob/lti-user-ai/lms/models/lti_user.py#L27, repeat the process and now trying to pick a canvas file will cause an exception.


#### OAuthCallbackSchema

- Switch to `master`, and start configuring one assignment. Stop when seeing the different buttons.


- Delete all the tokens to trigger an authorization 

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"```

- Launch https://hypothesis.instructure.com/courses/125/assignments/873, click authorize and leave the popup window open, don't authorize there yet.

Check the query params for `https://hypothesis.instructure.com/login/oauth2/auth`, the decoded `state` param will contain only `oauth_consumer_key`

```
{"typ":"JWT","alg":"HS256"}{"user":{"user_id":"969fc294ee26e3f1d0c9714af3351dc4eacfd6df","oauth_consumer_key":"Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a","roles":"Instructor","tool_consumer_instance_guid":"VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms","display_name":"Hypothesis 101 Teacher","email":"eng+canvasteacher@hypothes.is"},"csrf":"29f07417816b73ead2f4b490f3c426556fb90029c65152640e0b7ad715e5416d","exp":1646408001}
```

- Switch to this branch; `lti-user-ai`

Click "authorize". The authorization will be successful. 






