### PR TITLE
Remove `LTIUser.oauth_consumer_key` and make `LTIUser.application_instance_id` required

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from lms.models import HUser
 
@@ -9,9 +9,6 @@ class LTIUser(NamedTuple):
     user_id: str
     """The user_id LTI launch parameter."""
 
-    oauth_consumer_key: str
-    """The oauth_consumer_key LTI launch parameter."""
-
     roles: str
     """The user's LTI roles."""
 
@@ -21,11 +18,11 @@ class LTIUser(NamedTuple):
     display_name: str
     """The user's display name."""
 
+    application_instance_id: int
+    """ID of the application instance this user belongs to"""
+
     email: str = ""
     """The user's email address."""
-
-    application_instance_id: Optional[int] = None
-    """ID of the application instance this user belongs to"""
 
     @property
     def h_user(self):

--- a/lms/security.py
+++ b/lms/security.py
@@ -146,7 +146,7 @@ def _authenticated_userid(lti_user):
     # decode it.
     safe_user_id = safe_user_id_bytes.decode("ascii")
 
-    return ":".join([safe_user_id, lti_user.oauth_consumer_key])
+    return ":".join([safe_user_id, str(lti_user.application_instance_id)])
 
 
 def _permits(policy, request, _context, permission):

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -19,15 +19,17 @@ class ApplicationInstanceService:
         """
         Return the the current request's `ApplicationInstance`.
 
-        This is the `ApplicationInstance` with `consumer_key` matching
-        `request.lti_user.oauth_consumer_key`.
+        This is the `ApplicationInstance` with `id` matching
+        `request.application_instance_id`.
 
         :raise ApplicationInstanceNotFound: if there's no matching
             `ApplicationInstance`
         """
-
-        if self._request.lti_user:
-            return self.get_by_consumer_key(self._request.lti_user.oauth_consumer_key)
+        if self._request.lti_user and self._request.lti_user.application_instance_id:
+            if application_instance := self._db.query(ApplicationInstance).get(
+                self._request.lti_user.application_instance_id
+            ):
+                return application_instance
 
         raise ApplicationInstanceNotFound()
 

--- a/lms/services/grading_info.py
+++ b/lms/services/grading_info.py
@@ -48,7 +48,7 @@ class GradingInfoService:
             resource_link_id=resource_link_id,
         )
 
-    def upsert_from_request(self, request, h_user, lti_user):
+    def upsert_from_request(self, request, h_user, user_id, application_instance):
         """
         Update or create a record based on the LTI params found in the request.
 
@@ -57,9 +57,8 @@ class GradingInfoService:
 
         :arg request: A pyramid request
         :arg h_user: The h user this record is associated with
-        :type h_user: models.HUser
-        :arg lti_user: The LTI-provided user that this record is associated with
-        :type lti_user: models.LTIUser
+        :arg user_id: The LTI-provided user that this record is associated with
+        :arg application_instance: The application_instance the user belongs to
         """
         try:
             parsed_params = self._ParamsSchema(request).parse()
@@ -70,8 +69,8 @@ class GradingInfoService:
             return
 
         grading_info = self._find_or_create(
-            oauth_consumer_key=lti_user.oauth_consumer_key,
-            user_id=lti_user.user_id,
+            oauth_consumer_key=application_instance.consumer_key,
+            user_id=user_id,
             context_id=parsed_params["context_id"],
             resource_link_id=parsed_params["resource_link_id"],
         )

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -16,7 +16,6 @@ class LTIHService:
     """
 
     def __init__(self, _context, request):
-        self._lti_user = request.lti_user
         self._h_user = request.lti_user.h_user
 
         self._authority = request.registry.settings["h_authority"]
@@ -40,8 +39,9 @@ class LTIHService:
         :raise HTTPInternalServerError: if we can't sync to h for any reason
         :raise ApplicationInstanceNotFound: if request.lti_user.oauth_consumer_key isn't in the DB
         """
+        application_instance = self._application_instance_service.get_current()
 
-        if not self._application_instance_service.get_current().provisioning:
+        if not application_instance.provisioning:
             return
 
         self._h_api.execute_bulk(commands=self._yield_commands(h_groups))
@@ -50,7 +50,7 @@ class LTIHService:
         for h_group in h_groups:
             self._group_info_service.upsert(
                 h_group=h_group,
-                consumer_key=self._lti_user.oauth_consumer_key,
+                consumer_key=application_instance.consumer_key,
                 params=group_info_params,
             )
 

--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -19,13 +19,11 @@ class OAuth1Service:
 
         :rtype: OAuth1
         """
-
-        consumer_key = self._request.lti_user.oauth_consumer_key
-        shared_secret = self._application_instance_service.get_current().shared_secret
+        application_instance = self._application_instance_service.get_current()
 
         return OAuth1(
-            client_key=consumer_key,
-            client_secret=shared_secret,
+            client_key=application_instance.consumer_key,
+            client_secret=application_instance.shared_secret,
             signature_method="HMAC-SHA1",
             signature_type="auth_header",
             # Include the body when signing the request, this defaults to

--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -10,16 +10,16 @@ from lms.services import OAuth2TokenError
 class OAuth2TokenService:
     """Save and retrieve OAuth2Tokens from the DB."""
 
-    def __init__(self, db, consumer_key, user_id):
+    def __init__(self, db, application_instance, user_id):
         """
         Return a new TokenStore.
 
         :param db: the SQLAlchemy session
-        :param consumer_key: the LTI consumer key to use for tokens
+        :param application_instance: the ApplicationInstance to use for tokens
         :param user_id: the LTI user ID to user for tokens
         """
         self._db = db
-        self._consumer_key = consumer_key
+        self._application_instance = application_instance
         self._user_id = user_id
 
     def save(self, access_token, refresh_token, expires_in):
@@ -34,7 +34,8 @@ class OAuth2TokenService:
             oauth2_token = self.get()
         except OAuth2TokenError:
             oauth2_token = OAuth2Token(
-                consumer_key=self._consumer_key, user_id=self._user_id
+                consumer_key=self._application_instance.consumer_key,
+                user_id=self._user_id,
             )
             self._db.add(oauth2_token)
 
@@ -53,7 +54,10 @@ class OAuth2TokenService:
         try:
             return (
                 self._db.query(OAuth2Token)
-                .filter_by(consumer_key=self._consumer_key, user_id=self._user_id)
+                .filter_by(
+                    consumer_key=self._application_instance.consumer_key,
+                    user_id=self._user_id,
+                )
                 .one()
             )
         except NoResultFound as err:
@@ -64,5 +68,7 @@ class OAuth2TokenService:
 
 def oauth2_token_service_factory(_context, request):
     return OAuth2TokenService(
-        request.db, request.lti_user.oauth_consumer_key, request.lti_user.user_id
+        request.db,
+        request.find_service(name="application_instance").get_current(),
+        request.lti_user.user_id,
     )

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -65,7 +65,7 @@ class UserService:
         return (
             self._db.query(User)
             .filter_by(
-                application_instance=model_user.application_instance,
+                application_instance_id=model_user.application_instance_id,
                 user_id=model_user.user_id,
             )
             .one_or_none()
@@ -73,9 +73,7 @@ class UserService:
 
     def _from_lti_user(self, lti_user: LTIUser) -> User:
         return User(
-            application_instance=self._application_instance_service.get_by_consumer_key(
-                lti_user.oauth_consumer_key
-            ),
+            application_instance_id=lti_user.application_instance_id,
             user_id=lti_user.user_id,
             roles=lti_user.roles,
             h_userid=lti_user.h_user.userid(self._h_authority),

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -38,7 +38,7 @@ class BearerTokenSchema(PyramidRequestSchema):
 
         >>> # Deserialize the request's authorization param into an LTI user.
         >>> schema.lti_user()
-        LTIUser(user_id='...', oauth_consumer_key='...', ...)
+        LTIUser(user_id='...', application_instance_id='...', ...)
 
     The above are convenience methods that wrap webargs and marshmallow. But
     this class is also a marshmallow schema and can be used via the usual
@@ -49,19 +49,18 @@ class BearerTokenSchema(PyramidRequestSchema):
         {'authorization': 'Bearer eyJ...YoM'}
 
         >>> schema.load({'authorization': 'Bearer eyJ...YoM'}).data
-        LTIUser(user_id='...', oauth_consumer_key='...', ...)
+        LTIUser(user_id='...', application_instance_id='...', ...)
 
     Or to parse an models.LTIUser out of a Pyramid
     request's authorization param using webargs::
 
         >>> from webargs.pyramidparser import parser
         >>> parser.parse(s, request)
-        LTIUser(user_id='...', oauth_consumer_key='...', ...)
+        LTIUser(user_id='...', application_instance_id='...', ...)
     """
 
     user_id = marshmallow.fields.Str(required=True)
-    oauth_consumer_key = marshmallow.fields.Str(required=True)
-    application_instance_id = marshmallow.fields.Int(required=False, allow_none=True)
+    application_instance_id = marshmallow.fields.Int(required=True)
     roles = marshmallow.fields.Str(required=True)
     tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
     display_name = marshmallow.fields.Str(required=True)

--- a/lms/validation/authentication/_launch_params.py
+++ b/lms/validation/authentication/_launch_params.py
@@ -73,7 +73,6 @@ class LaunchParamsAuthSchema(PyramidRequestSchema):
 
         return LTIUser(
             user_id=kwargs["user_id"],
-            oauth_consumer_key=kwargs["oauth_consumer_key"],
             application_instance_id=application_instance.id,
             roles=kwargs["roles"],
             tool_consumer_instance_guid=kwargs["tool_consumer_instance_guid"],

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -43,9 +43,10 @@ class BasicLTILaunchViews:
         self.context.js_config.enable_lti_launch_mode()
         self.context.js_config.maybe_set_focused_user()
 
-        request.find_service(name="application_instance").get_current().update_lms_data(
-            self.request.params
-        )
+        self.application_instance = request.find_service(
+            name="application_instance"
+        ).get_current()
+        self.application_instance.update_lms_data(self.request.params)
 
     def basic_lti_launch(self, document_url, grading_supported=True):
         """Do a basic LTI launch with the given document_url."""
@@ -89,7 +90,7 @@ class BasicLTILaunchViews:
         if not lti_user.is_instructor and not self.context.is_canvas:
             # Create or update a record of LIS result data for a student launch
             request.find_service(name="grading_info").upsert_from_request(
-                request, h_user=lti_user.h_user, lti_user=lti_user
+                request, lti_user.h_user, lti_user.user_id, self.application_instance
             )
 
     @view_config(vitalsource_book=True)

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -89,9 +89,7 @@ class BasicLTILaunchViews:
 
         if not lti_user.is_instructor and not self.context.is_canvas:
             # Create or update a record of LIS result data for a student launch
-            request.find_service(name="grading_info").upsert_from_request(
-                request, lti_user.h_user, lti_user.user_id, self.application_instance
-            )
+            request.find_service(name="grading_info").upsert_from_request(request)
 
     @view_config(vitalsource_book=True)
     def legacy_vitalsource_lti_launch(self):

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,16 +1,11 @@
 from factory import Faker, fuzzy, make_factory
 
 from lms import models
-from tests.factories.attributes import (
-    OAUTH_CONSUMER_KEY,
-    TOOL_CONSUMER_INSTANCE_GUID,
-    USER_ID,
-)
+from tests.factories.attributes import TOOL_CONSUMER_INSTANCE_GUID, USER_ID
 
 LTIUser = make_factory(
     models.LTIUser,
     user_id=USER_ID,
-    oauth_consumer_key=OAUTH_CONSUMER_KEY,
     application_instance_id=fuzzy.FuzzyInteger(1, 9999999999),
     roles=Faker("random_element", elements=["Learner", "Instructor"]),
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -281,13 +281,13 @@ class TestAddDocumentURL:
 
 class TestMaybeEnableGrading:
     def test_it_adds_the_grading_settings(
-        self, js_config, grading_info_service, pyramid_request
+        self, js_config, grading_info_service, application_instance_service
     ):
         js_config.maybe_enable_grading()
 
         grading_info_service.get_by_assignment.assert_called_once_with(
             context_id="test_course_id",
-            oauth_consumer_key=pyramid_request.lti_user.oauth_consumer_key,
+            oauth_consumer_key=application_instance_service.get_current.return_value.consumer_key,
             resource_link_id="TEST_RESOURCE_LINK_ID",
         )
         assert js_config.asdict()["grading"] == {

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -412,16 +412,16 @@ class TestAuthenticatedUserID:
             (
                 factories.LTIUser(
                     user_id="sam",
-                    oauth_consumer_key="Hypothesisf301584250a2dece14f021ab8424018a",
+                    application_instance_id=100,
                 ),
-                "c2Ft:Hypothesisf301584250a2dece14f021ab8424018a",
+                "c2Ft:100",
             ),
             (
                 factories.LTIUser(
                     user_id="Sam:Smith",
-                    oauth_consumer_key="Hypothesisf301584250a2dece14f021ab8424018a",
+                    application_instance_id=200,
                 ),
-                "U2FtOlNtaXRo:Hypothesisf301584250a2dece14f021ab8424018a",
+                "U2FtOlNtaXRo:200",
             ),
         ],
     )

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -193,10 +193,7 @@ class TestLTISecurityPolicy:
     def test_forget(self, pyramid_request):
         LTISecurityPolicy().forget(pyramid_request)
 
-    def test_permits_allow(
-        self,
-        pyramid_request,
-    ):
+    def test_permits_allow(self, pyramid_request):
         pyramid_request.lti_user = factories.LTIUser()
         policy = LTISecurityPolicy()
         is_allowed = policy.permits(
@@ -224,13 +221,6 @@ class TestLTISecurityPolicy:
                     application_instance_id=100,
                 ),
                 "c2Ft:100",
-            ),
-            (
-                factories.LTIUser(
-                    user_id="Sam:Smith",
-                    application_instance_id=200,
-                ),
-                "U2FtOlNtaXRo:200",
             ),
         ],
     )

--- a/tests/unit/lms/services/application_instance_service_test.py
+++ b/tests/unit/lms/services/application_instance_service_test.py
@@ -43,11 +43,8 @@ class TestApplicationInstanceService:
         return ApplicationInstanceService(db=db_session, request=pyramid_request)
 
     @pytest.fixture(autouse=True)
-    def application_instance(self, application_instance):
-        # Some noise
+    def with_application_instance_noise(self):
         factories.ApplicationInstance.create_batch(size=3)
-
-        return application_instance
 
 
 class TestFactory:

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -134,9 +134,3 @@ class TestCourseService:
     def svc(self, pyramid_request, application_instance_service, application_instance):
         application_instance_service.get_current.return_value = application_instance
         return course_service_factory(sentinel.context, pyramid_request)
-
-    @pytest.fixture(autouse=True)
-    def application_instance(self, pyramid_request):
-        return factories.ApplicationInstance(
-            consumer_key=pyramid_request.lti_user.oauth_consumer_key, settings={}
-        )

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -86,13 +86,13 @@ class TestSync:
 
 class TestGroupInfoUpdating:
     def test_sync_upserts_the_GroupInfo_into_the_db(
-        self, group_info_service, lti_h_svc, pyramid_request, grouping
+        self, group_info_service, lti_h_svc, grouping, application_instance_service
     ):
         lti_h_svc.sync([grouping], sentinel.params)
 
         group_info_service.upsert.assert_called_once_with(
             h_group=grouping,
-            consumer_key=pyramid_request.lti_user.oauth_consumer_key,
+            consumer_key=application_instance_service.get_current.return_value.consumer_key,
             params=sentinel.params,
         )
 

--- a/tests/unit/lms/services/oauth1_test.py
+++ b/tests/unit/lms/services/oauth1_test.py
@@ -10,19 +10,21 @@ pytestmark = pytest.mark.usefixtures("application_instance_service")
 
 class TestOAuth1Service:
     def test_we_configure_OAuth1_correctly(
-        self, service, OAuth1, pyramid_request, application_instance_service
+        self, service, OAuth1, application_instance_service
     ):
         service.get_client()
 
         OAuth1.assert_called_once_with(
-            client_key=pyramid_request.lti_user.oauth_consumer_key,
+            client_key=application_instance_service.get_current.return_value.consumer_key,
             client_secret=application_instance_service.get_current.return_value.shared_secret,
             signature_method="HMAC-SHA1",
             signature_type="auth_header",
             force_include_body=True,
         )
 
-    def test_we_can_be_used_to_sign_a_request(self, service, pyramid_request):
+    def test_we_can_be_used_to_sign_a_request(
+        self, service, application_instance_service
+    ):
         request = Request(
             "POST",
             url="http://example.com",
@@ -37,7 +39,7 @@ class TestOAuth1Service:
         assert auth_header.startswith("OAuth")
         assert 'oauth_version="1.0"' in auth_header
         assert (
-            f'oauth_consumer_key="{pyramid_request.lti_user.oauth_consumer_key}"'
+            f'oauth_consumer_key="{application_instance_service.get_current.return_value.consumer_key}"'
             in auth_header
         )
         assert 'oauth_signature_method="HMAC-SHA1"' in auth_header

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -11,18 +11,13 @@ from tests import factories
 
 
 class TestUserService:
-    def test_store_lti_user(
-        self, service, lti_user, db_session, application_instance_service
-    ):
+    def test_store_lti_user(self, service, lti_user, db_session):
         service.store_lti_user(lti_user)
 
-        application_instance_service.get_by_consumer_key.assert_called_once_with(
-            lti_user.oauth_consumer_key
-        )
         assert db_session.query(User).one() == Any.instance_of(User).with_attrs(
             {
                 "id": Any.int(),
-                "application_instance": application_instance_service.get_by_consumer_key.return_value,
+                "application_instance_id": lti_user.application_instance_id,
                 "created": Any.instance_of(datetime),
                 "updated": Any.instance_of(datetime),
                 "user_id": lti_user.user_id,
@@ -50,12 +45,6 @@ class TestUserService:
     def test_get_not_found(self, user, service):
         with pytest.raises(UserNotFound):
             service.get(user.application_instance, "some-other-id")
-
-    @pytest.fixture
-    def lti_user(self, application_instance):
-        return factories.LTIUser(
-            oauth_consumer_key=application_instance.consumer_key, roles="new_roles"
-        )
 
     @pytest.fixture
     def user(self, lti_user, application_instance):

--- a/tests/unit/lms/validation/authentication/_bearer_token_test.py
+++ b/tests/unit/lms/validation/authentication/_bearer_token_test.py
@@ -75,34 +75,15 @@ class TestBearerTokenSchema:
             "headers": {"authorization": ["Invalid session token"]}
         }
 
-    def test_it_raises_if_the_user_id_param_is_missing(self, schema, _jwt):
-        del _jwt.decode_jwt.return_value["user_id"]
+    @pytest.mark.parametrize("param", ["user_id", "application_instance_id", "roles"])
+    def test_it_raises_if_the_user_id_param_is_missing(self, schema, _jwt, param):
+        del _jwt.decode_jwt.return_value[param]
 
         with pytest.raises(ValidationError) as exc_info:
             schema.lti_user("headers")
 
         assert exc_info.value.messages == {
-            "headers": {"user_id": ["Missing data for required field."]},
-        }
-
-    def test_it_raises_if_the_oauth_consumer_key_param_is_missing(self, schema, _jwt):
-        del _jwt.decode_jwt.return_value["oauth_consumer_key"]
-
-        with pytest.raises(ValidationError) as exc_info:
-            schema.lti_user("headers")
-
-        assert exc_info.value.messages == {
-            "headers": {"oauth_consumer_key": ["Missing data for required field."]},
-        }
-
-    def test_it_raises_if_the_roles_param_is_missing(self, schema, _jwt):
-        del _jwt.decode_jwt.return_value["roles"]
-
-        with pytest.raises(ValidationError) as exc_info:
-            schema.lti_user("headers")
-
-        assert exc_info.value.messages == {
-            "headers": {"roles": ["Missing data for required field."]},
+            "headers": {param: ["Missing data for required field."]},
         }
 
     def test_serialize_and_deserialize_via_marshmallow_api(self, lti_user, schema):

--- a/tests/unit/lms/validation/authentication/_launch_params_test.py
+++ b/tests/unit/lms/validation/authentication/_launch_params_test.py
@@ -21,7 +21,6 @@ class TestLaunchParamsAuthSchema:
         )
         assert lti_user == LTIUser(
             user_id="TEST_USER_ID",
-            oauth_consumer_key="TEST_OAUTH_CONSUMER_KEY",
             application_instance_id=application_instance_service.get_by_consumer_key.return_value.id,
             roles="TEST_ROLES",
             tool_consumer_instance_guid="TEST_TOOL_CONSUMER_INSTANCE_GUID",

--- a/tests/unit/lms/views/application_instance_test.py
+++ b/tests/unit/lms/views/application_instance_test.py
@@ -9,9 +9,8 @@ from lms.views.application_instances import (
 
 class TestCreateApplicationInstance:
     def test_it_creates_an_application_instance(self, pyramid_request):
-        create_application_instance(pyramid_request)
+        application_instance = self.create_application_instance(pyramid_request)
 
-        application_instance = pyramid_request.db.query(ApplicationInstance).one()
         assert application_instance.lms_url == "canvas.example.com"
         assert application_instance.requesters_email == "email@example.com"
         assert application_instance.developer_key is None
@@ -23,9 +22,8 @@ class TestCreateApplicationInstance:
         pyramid_request.params["developer_key"] = "example_key"
         pyramid_request.params["developer_secret"] = "example_secret"
 
-        create_application_instance(pyramid_request)
+        application_instance = self.create_application_instance(pyramid_request)
 
-        application_instance = pyramid_request.db.query(ApplicationInstance).one()
         assert application_instance.developer_key == "example_key"
         assert application_instance.developer_secret
 
@@ -44,9 +42,8 @@ class TestCreateApplicationInstance:
         pyramid_request.params["developer_key"] = developer_key
         pyramid_request.params["developer_secret"] = developer_secret
 
-        create_application_instance(pyramid_request)
+        application_instance = self.create_application_instance(pyramid_request)
 
-        application_instance = pyramid_request.db.query(ApplicationInstance).one()
         assert application_instance.developer_key is None
         assert application_instance.developer_secret is None
 
@@ -60,9 +57,8 @@ class TestCreateApplicationInstance:
         pyramid_request.params["developer_key"] = developer_key
         pyramid_request.params["developer_secret"] = "test_developer_secret"
 
-        create_application_instance(pyramid_request)
+        application_instance = self.create_application_instance(pyramid_request)
 
-        application_instance = pyramid_request.db.query(ApplicationInstance).one()
         assert (
             bool(application_instance.settings.get("canvas", "sections_enabled"))
             == canvas_sections_enabled
@@ -78,12 +74,20 @@ class TestCreateApplicationInstance:
         pyramid_request.params["developer_key"] = developer_key
         pyramid_request.params["developer_secret"] = "test_developer_secret"
 
-        create_application_instance(pyramid_request)
+        application_instance = self.create_application_instance(pyramid_request)
 
-        application_instance = pyramid_request.db.query(ApplicationInstance).one()
         assert (
             bool(application_instance.settings.get("canvas", "groups_enabled"))
             == canvas_groups_enabled
+        )
+
+    def create_application_instance(self, pyramid_request):
+        result = create_application_instance(pyramid_request)
+
+        return (
+            pyramid_request.db.query(ApplicationInstance)
+            .filter_by(consumer_key=result["consumer_key"])
+            .one()
         )
 
     @pytest.fixture

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -210,15 +210,11 @@ class TestCommon:
         pyramid_request,
         grading_info_service,
         view_caller,
-        application_instance,
     ):
         view_caller(context, pyramid_request)
 
         grading_info_service.upsert_from_request.assert_called_once_with(
-            pyramid_request,
-            pyramid_request.lti_user.h_user,
-            pyramid_request.lti_user.user_id,
-            application_instance,
+            pyramid_request
         )
 
     def test_it_does_not_call_grading_info_upsert_if_instructor(

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -205,14 +205,20 @@ class TestCommon:
 
     @pytest.mark.usefixtures("user_is_learner")
     def test_it_calls_grading_info_upsert(
-        self, context, pyramid_request, grading_info_service, view_caller
+        self,
+        context,
+        pyramid_request,
+        grading_info_service,
+        view_caller,
+        application_instance,
     ):
         view_caller(context, pyramid_request)
 
         grading_info_service.upsert_from_request.assert_called_once_with(
             pyramid_request,
-            h_user=pyramid_request.lti_user.h_user,
-            lti_user=pyramid_request.lti_user,
+            pyramid_request.lti_user.h_user,
+            pyramid_request.lti_user.user_id,
+            application_instance,
         )
 
     def test_it_does_not_call_grading_info_upsert_if_instructor(


### PR DESCRIPTION
Needs https://github.com/hypothesis/lms/pull/3746 to be merged for at least 24h, the longest expiration time of the affected tokens.

-- edit --

#3746 Merged 10/03 at 10:15am


## Testing 

Same as https://github.com/hypothesis/lms/pull/3746. This PR assumes #3746  has been merged for at least 24 so all tokens in flight should be either expired or already include application_instance_id.


- Launch https://hypothesis.instructure.com/courses/125/assignments/873
- A successful launch means that LTIUser has been correctly created from the LTI parameters.
- The authorization token now contains `application_instance_id` but not the consumer_key on the call to
`http://localhost:8001/api/canvas/courses/125/files`

```
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyb2xlcyI6Ikluc3RydWN0b3IiLCJkaXNwbGF5X25hbWUiOiJIeXBvdGhlc2lzIDEwMSBUZWFjaGVyIiwiZW1haWwiOiJlbmcrY2FudmFzdGVhY2hlckBoeXBvdGhlcy5pcyIsInRvb2xfY29uc3VtZXJfaW5zdGFuY2VfZ3VpZCI6IlZDU3k4REFLQ0ZJUVlhSXRwU0d5WGhPWElsazVBNk5XZHVWVkcxdTM6Y2FudmFzLWxtcyIsInVzZXJfaWQiOiI5NjlmYzI5NGVlMjZlM2YxZDBjOTcxNGFmMzM1MWRjNGVhY2ZkNmRmIiwiYXBwbGljYXRpb25faW5zdGFuY2VfaWQiOjgsImV4cCI6MTY0NjQ4NzUwNX0.L121pnlC6w79aGSVf4UdSYtuFr51i4rnG1_NrZlaI8o
```

```
{"typ":"JWT","alg":"HS256"}{"roles":"Instructor","display_name":"Hypothesis 101 Teacher","email":"eng+canvasteacher@hypothes.is","tool_consumer_instance_guid":"VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms","user_id":"969fc294ee26e3f1d0c9714af3351dc4eacfd6df","application_instance_id":8,"exp":1646487505}miPÿZ%_GRbۅbkfV
```


### Existing tokens

Existing tokens non expired tokens will have both consumer_key, and application_instance_id

### `BearerTokenSchema` 

The removal of consumer_key from the schema takes care of the difference.


- Switch to `lti-user-ai`, and start configuring one assignment. Stop when seeing the different buttons.

- Apply a diff like to see the values of the recieved token, and the data used to create an LTIUser


```diff --git a/lms/validation/authentication/_bearer_token.py b/lms/validation/authentication/_bearer_token.py
index 2c0cf4b2..f647ed45 100644
--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -161,7 +161,9 @@ class BearerTokenSchema(PyramidRequestSchema):
         jwt = data["authorization"][len("Bearer ") :]
 
         try:
-            return _jwt.decode_jwt(jwt, self.context["secret"])
+            data = _jwt.decode_jwt(jwt, self.context["secret"])
+            print("Token", data)
+            return data
         except ExpiredJWTError as err:
             raise marshmallow.ValidationError(
                 "Expired session token", "authorization"
@@ -174,4 +176,5 @@ class BearerTokenSchema(PyramidRequestSchema):
     @marshmallow.post_load
     def _make_user(self, data, **_kwargs):  # pylint:disable=no-self-use
         # See https://marshmallow.readthedocs.io/en/2.x-line/quickstart.html#deserializing-to-objects
+        print("Schema", data)
         return LTIUser(**data)
```

- Switch to this branch and click the "Select PDF from canvas". It'll work and you can see the difference between the two sets of keys:

```
Token {'oauth_consumer_key': 'Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a', 'roles': 'Instructor', 'display_name': 'Hypothesis 101 Teacher', 'email': 'eng+canvasteacher@hypothes.is', 'tool_consumer_instance_guid': 'VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms', 'user_id': '969fc294ee26e3f1d0c9714af3351dc4eacfd6df', 'application_instance_id': 8}

Schema {'roles': 'Instructor', 'user_id': '969fc294ee26e3f1d0c9714af3351dc4eacfd6df', 'display_name': 'Hypothesis 101 Teacher', 'application_instance_id': 8, 'tool_consumer_instance_guid': 'VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms', 'email': 'eng+canvasteacher@hypothes.is'}
```


#### OAuthCallbackSchema

- Switch to `lti-user-ai`, and start configuring one assignment. Stop when seeing the different buttons.


- Delete all the tokens to trigger an authorization 

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"```

- Launch https://hypothesis.instructure.com/courses/125/assignments/873, click authorize and leave the popup window open, don't authorize there yet.

Check the query params for `https://hypothesis.instructure.com/login/oauth2/auth`, the decoded `state` param will contain both `application_instance_id` and `oauth_consumer_key`

```
{"typ":"JWT","alg":"HS256"}{"user":{"user_id":"969fc294ee26e3f1d0c9714af3351dc4eacfd6df","oauth_consumer_key":"Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a","roles":"Instructor","tool_consumer_instance_guid":"VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms","display_name":"Hypothesis 101 Teacher","email":"eng+canvasteacher@hypothes.is","application_instance_id":8},"csrf":"6190ffb9a6c7645b1125dfa9f9e8474920473432429333bcae3c1fd6a9954b2b","exp":1646406048}4EM蒔&}B#AZ+%
```

- Switch to this branch; `lti-user-consumer`

Apply a diff like;

```
diff --git a/lms/validation/authentication/_oauth.py b/lms/validation/authentication/_oauth.py
index 6ee529de..08d09e58 100644
--- a/lms/validation/authentication/_oauth.py
+++ b/lms/validation/authentication/_oauth.py
@@ -116,7 +116,7 @@ class OAuthCallbackSchema(PyramidRequestSchema):
         #
         # This can be deleted 24 hours after deployed;
         # All token containing both attributes will have expired
-        decoded_user.pop("oauth_consumer_key", None)
+        print(decoded_user.pop("oauth_consumer_key", None))
 
         return LTIUser(**decoded_user)
```


-  Click "authorize". The authorization will be successful and you see a consumer_key on the server's output

```web                  | Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a```



