### PR TITLE
Add application_instance_id to GroupInfo, Oauth2Token and GradingInfo

### DIFF
--- a/lms/migrations/versions/407ff423b9e3_missing_application_instance_fk.py
+++ b/lms/migrations/versions/407ff423b9e3_missing_application_instance_fk.py
@@ -1,0 +1,81 @@
+"""
+Add missing application_instances FK.
+
+Revision ID: 407ff423b9e3
+Revises: 7a4812876915
+Create Date: 2022-03-03 16:45:18.847715
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "407ff423b9e3"
+down_revision = "7a4812876915"
+
+
+def upgrade():
+    # Add the new column as nullable
+    op.add_column(
+        "group_info", sa.Column("application_instance_id", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "lis_result_sourcedid",
+        sa.Column("application_instance_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "oauth2_token",
+        sa.Column("application_instance_id", sa.Integer(), nullable=True),
+    )
+
+    # Create PK indexes for all of them
+    op.create_foreign_key(
+        op.f("fk__group_info__application_instance_id__application_instances"),
+        "group_info",
+        "application_instances",
+        ["application_instance_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.create_foreign_key(
+        op.f(
+            "fk__lis_result_sourcedid__application_instance_id__application_instances"
+        ),
+        "lis_result_sourcedid",
+        "application_instances",
+        ["application_instance_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.create_foreign_key(
+        op.f("fk__oauth2_token__application_instance_id__application_instances"),
+        "oauth2_token",
+        "application_instances",
+        ["application_instance_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk__oauth2_token__application_instance_id__application_instances"),
+        "oauth2_token",
+        type_="foreignkey",
+    )
+    op.drop_column("oauth2_token", "application_instance_id")
+    op.drop_constraint(
+        op.f(
+            "fk__lis_result_sourcedid__application_instance_id__application_instances"
+        ),
+        "lis_result_sourcedid",
+        type_="foreignkey",
+    )
+    op.drop_column("lis_result_sourcedid", "application_instance_id")
+    op.drop_constraint(
+        op.f("fk__group_info__application_instance_id__application_instances"),
+        "group_info",
+        type_="foreignkey",
+    )
+    op.drop_column("group_info", "application_instance_id")


### PR DESCRIPTION
Adding the three columns in one migration to avoid extra bookkeeping and PR noise.

All columns added as null able in this first step.

The migration is auto generated from the model changes in: https://github.com/hypothesis/lms/pull/3749/files


# Testing
Run the migration:

- ```hdev alembic upgrade head```

```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 7a4812876915 -> 407ff423b9e3, Add missing application_instances FK.
```


- Check the new table structure, new column and FK

```tox -qe dockercompose -- exec postgres psql -U postgres -c "\d group_info" ```
```tox -qe dockercompose -- exec postgres psql -U postgres -c "\d lis_result_sourcedid" ```
```tox -qe dockercompose -- exec postgres psql -U postgres -c "\d oauth2_token" ```
