### PR TITLE
Fill application_instance_id in OAuth2TokenService

### DIFF
--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -39,6 +39,7 @@ class OAuth2TokenService:
             )
             self._db.add(oauth2_token)
 
+        oauth2_token.application_instance_id = self._application_instance.id
         oauth2_token.access_token = access_token
         oauth2_token.refresh_token = refresh_token
         oauth2_token.expires_in = expires_in

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -23,6 +23,7 @@ class TestOAuth2TokenService:
         assert oauth2_token == Any.object(OAuth2Token).with_attrs(
             {
                 "consumer_key": application_instance.consumer_key,
+                "application_instance_id": application_instance.id,
                 "user_id": lti_user.user_id,
                 "access_token": "access_token",
                 "refresh_token": "refresh_token",


### PR DESCRIPTION
Fills the new column for new and "in fly" rows. Next step will be a migration to fill up the rest and mark the column as non-nullable.

## Testing 

### Updating

-  Remove existing tokens

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"```


- On the branch `ai-fk-model`, launch https://hypothesis.instructure.com/courses/125/assignments/875

You'll get a new token with a null application_instance_id

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from oauth2_token;"


 application_instance_id 
-------------------------
                        
(1 row)
```


- Switch to this branch and invalidate the token with:

```tox -qe dockercompose -- exec postgres psql -U postgres -c "update oauth2_token set access_token = 'nope';"```


- Launch the assignment again, application_instance_id will get the correct value

```

tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from oauth2_token;"                        


 application_instance_id 
-------------------------
                       8
(1 row)
```


### Inserting


-  Remove existing tokens

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"```



- Launch the assignment again, application_instance_id will get the correct value

```

tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from oauth2_token;"  