### PR TITLE
Fill application_instance_id in GradingInfo

### DIFF
--- a/lms/services/grading_info.py
+++ b/lms/services/grading_info.py
@@ -75,7 +75,7 @@ class GradingInfoService:
             context_id=parsed_params["context_id"],
             resource_link_id=parsed_params["resource_link_id"],
         )
-
+        grading_info.application_instance_id = application_instance.id
         grading_info.h_username = request.lti_user.h_user.username
         grading_info.h_display_name = request.lti_user.h_user.display_name
 

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -94,6 +94,7 @@ class TestUpsertFromRequest:
         # Check the LTI user data are there
         assert result.oauth_consumer_key == application_instance.consumer_key
         assert result.user_id == pyramid_request.lti_user.user_id
+        assert result.application_instance_id == application_instance.id
 
     def test_it_updates_existing_record_if_matching_exists(
         self, svc, pyramid_request, lti_user, application_instance


### PR DESCRIPTION
Fills the new column for new and "in fly" rows. Next step will be a migration to fill up the rest and mark the column as non-nullable.

## Testing 

### Inserting

-  Remove existing grading info

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate lis_result_sourcedid;"```


- Launch the blackboard assignment `localhost (make devdata) HTML Assignment` as the student user `blackboardstudent2`
- https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1

The new columns is filled in the new row:

`tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from  lis_result_sourcedid;"`


### Updating


- Set application_instance_id to null

`tox -qe dockercompose -- exec postgres psql -U postgres -c "update lis_result_sourcedid set application_instance_id = null;"`


- Launch the assignment again

`tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from  lis_result_sourcedid;"`

The column will have a value again.