### PR TITLE
Fill application_instance_id in GroupInfo

### DIFF
--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -26,7 +26,7 @@ class GroupInfoService:
         self._db = request.db
         self._lti_user = request.lti_user
 
-    def upsert(self, h_group, consumer_key, params):
+    def upsert(self, h_group, application_instance, params):
         """
         Upsert a row into the `group_info` DB table.
 
@@ -43,7 +43,7 @@ class GroupInfoService:
         :param h_group: the group to upsert
         :type h_group: models.HGroup
 
-        :param consumer_key: the GroupInfo.consumer_key value to set
+        :param application_instance: the ApplicationInstance this group belongs to
 
         :param params: the other GroupInfo columns to set
         :type params: dict
@@ -58,11 +58,12 @@ class GroupInfoService:
         if not group_info:
             group_info = GroupInfo(
                 authority_provided_id=h_group.authority_provided_id,
-                consumer_key=consumer_key,
+                consumer_key=application_instance.consumer_key,
             )
             self._db.add(group_info)
 
-        group_info.consumer_key = consumer_key
+        group_info.consumer_key = application_instance.consumer_key
+        group_info.application_instance_id = application_instance.id
         group_info.update_from_dict(
             params, skip_keys={"authority_provided_id", "id", "info"}
         )

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -50,7 +50,7 @@ class LTIHService:
         for h_group in h_groups:
             self._group_info_service.upsert(
                 h_group=h_group,
-                consumer_key=application_instance.consumer_key,
+                application_instance=application_instance,
                 params=group_info_params,
             )
 

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -15,7 +15,7 @@ class TestGroupInfoUpsert:
     ):
         group_info_svc.upsert(
             factories.Course(authority_provided_id=self.AUTHORITY),
-            consumer_key=application_instance.consumer_key,
+            application_instance=application_instance,
             params=params,
         )
 
@@ -39,7 +39,7 @@ class TestGroupInfoUpsert:
 
         group_info_svc.upsert(
             factories.Course(authority_provided_id=self.AUTHORITY),
-            consumer_key=application_instance.consumer_key,
+            application_instance=application_instance,
             params=dict(params, context_title="NEW_TITLE"),
         )
 
@@ -55,7 +55,7 @@ class TestGroupInfoUpsert:
     ):
         group_info_svc.upsert(
             factories.Course(authority_provided_id=self.AUTHORITY),
-            consumer_key=application_instance.consumer_key,
+            application_instance=application_instance,
             params=dict(
                 params,
                 id="IGNORE ME 1",
@@ -75,7 +75,7 @@ class TestGroupInfoUpsert:
     ):
         group_info_svc.upsert(
             factories.Course(authority_provided_id=self.AUTHORITY),
-            consumer_key=application_instance.consumer_key,
+            application_instance=application_instance,
             params={},
         )
 
@@ -94,7 +94,7 @@ class TestGroupInfoUpsert:
     ):
         group_info_svc.upsert(
             factories.Course(authority_provided_id=self.AUTHORITY),
-            consumer_key=application_instance.consumer_key,
+            application_instance=application_instance,
             params={},
         )
 

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -92,7 +92,7 @@ class TestGroupInfoUpdating:
 
         group_info_service.upsert.assert_called_once_with(
             h_group=grouping,
-            consumer_key=application_instance_service.get_current.return_value.consumer_key,
+            application_instance=application_instance_service.get_current.return_value,
             params=sentinel.params,
         )
 


### PR DESCRIPTION
Fills the new column for new and "in fly" rows. Next step will be a migration to fill up the rest and mark the column as non-nullable.

## Testing 

### Inserting

-  Remove existing group_info

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate group_info;"```


- Launch https://hypothesis.instructure.com/courses/125/assignments/875

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from group_info;"
```

you'll get one row per section and one for the course. All with the `application_instance_id`


`tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from  lis_result_sourcedid;"`


### Updating


- Set application_instance_id to null

```tox -qe dockercompose -- exec postgres psql -U postgres -c "update group_info set application_instance_id = NULL;"```


- Relaunch - https://hypothesis.instructure.com/courses/125/assignments/875


No more nulls in application_instance_id.