### PR TITLE
Migration to backfill application_instance_id

### DIFF
--- a/lms/migrations/versions/0a3bfcc14133_backfill_application_instance_id.py
+++ b/lms/migrations/versions/0a3bfcc14133_backfill_application_instance_id.py
@@ -1,0 +1,85 @@
+"""
+Bakfill application_instance_id in group_info, lis_result_sourcedid and oauth2_token.
+
+Revision ID: 0a3bfcc14133
+Revises: 407ff423b9e3
+Create Date: 2022-03-04 11:39:06.573269
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0a3bfcc14133"
+down_revision = "407ff423b9e3"
+
+
+def upgrade():
+    conn = op.get_bind()
+    # Fist backfill the new application_instance_id columns based on the existing consumer_key columns
+    conn.execute(
+        """
+            UPDATE group_info
+                set application_instance_id = application_instances.id
+                from application_instances
+                where application_instances.consumer_key = group_info.consumer_key and application_instance_id is null
+        """
+    )
+    conn.execute(
+        """
+            UPDATE lis_result_sourcedid
+                set application_instance_id = application_instances.id
+                from application_instances
+                where application_instances.consumer_key = lis_result_sourcedid.oauth_consumer_key and application_instance_id is null
+        """
+    )
+    conn.execute(
+        """
+            UPDATE oauth2_token
+                set application_instance_id = application_instances.id
+                from application_instances
+                where application_instances.consumer_key = oauth2_token.consumer_key and application_instance_id is null
+        """
+    )
+
+    # Mark application_instance_id as non nullable
+    op.alter_column(
+        "group_info",
+        "application_instance_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+    )
+    op.alter_column(
+        "lis_result_sourcedid",
+        "application_instance_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+    )
+
+    op.alter_column(
+        "oauth2_token",
+        "application_instance_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "oauth2_token",
+        "application_instance_id",
+        existing_type=sa.INTEGER(),
+        nullable=True,
+    )
+    op.alter_column(
+        "lis_result_sourcedid",
+        "application_instance_id",
+        existing_type=sa.INTEGER(),
+        nullable=True,
+    )
+    op.alter_column(
+        "group_info",
+        "application_instance_id",
+        existing_type=sa.INTEGER(),
+        nullable=True,
+    )


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/3719

Model changes in: https://github.com/hypothesis/lms/pull/3754

As:

- https://github.com/hypothesis/lms/pull/3752
- https://github.com/hypothesis/lms/pull/3751
- https://github.com/hypothesis/lms/pull/3750

are already merged all new rows should have `application_instance_id`

A quick query on metabase to check that:

```
select 'group_info', application_instance_id from group_info where application_instance_id is not null
union
select 'token', application_instance_id from oauth2_token where application_instance_id is not null
union
select 'grading', application_instance_id from lis_result_sourcedid where application_instance_id is not null
```



### Testing

Ideally we could test this on a LMS's DB dump to get an ballpark figure of how long is going to take.

In any case the migration can be run with:

```hdev alembic upgrade head```

```                                                      
dev installed: *** listing modules disabled by tox-pip-sync in pyproject.toml ***
dev run-test-pre: PYTHONHASHSEED='230568549'
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 407ff423b9e3 -> 0a3bfcc14133, Bakfill application_instance_id in group_info, lis_result_sourcedid and oauth2_token.
```

