### PR TITLE
Model changes making application_instance_id not nullable

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -89,7 +89,7 @@ class ApplicationInstance(BASE):
     access_tokens = sa.orm.relationship(
         "OAuth2Token",
         back_populates="application_instance",
-        foreign_keys="OAuth2Token.consumer_key",
+        foreign_keys="OAuth2Token.application_instance_id",
     )
 
     #: A list of all the courses for this application instance.
@@ -99,7 +99,7 @@ class ApplicationInstance(BASE):
     group_infos = sa.orm.relationship(
         "GroupInfo",
         back_populates="application_instance",
-        foreign_keys="GroupInfo.consumer_key",
+        foreign_keys="GroupInfo.application_instance_id",
     )
 
     #: A list of all the files for this application instance.

--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -49,12 +49,15 @@ class GradingInfo(CreatedUpdatedMixin, BASE):
     lis_outcome_service_url = sa.Column(sa.UnicodeText(), nullable=False)
     oauth_consumer_key = sa.Column(sa.UnicodeText(), nullable=False)
 
-    #: The ApplicationInstance that this group belongs to foreign key
+    #: The ApplicationInstance FK that this grading info belongs to
     application_instance_id = sa.Column(
         sa.Integer(),
         sa.ForeignKey("application_instances.id", ondelete="cascade"),
-        nullable=True,
+        nullable=False,
     )
+
+    #: The ApplicationInstance that this access grading info belongs to.
+    application_instance = sa.orm.relationship("ApplicationInstance")
 
     user_id = sa.Column(sa.UnicodeText(), nullable=False)
     context_id = sa.Column(sa.UnicodeText(), nullable=False)

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -44,12 +44,14 @@ class GroupInfo(BASE):
     application_instance_id = sa.Column(
         sa.Integer(),
         sa.ForeignKey("application_instances.id", ondelete="cascade"),
-        nullable=True,
+        nullable=False,
     )
 
     #: The ApplicationInstance that this group belongs to.
     application_instance = sa.orm.relationship(
-        "ApplicationInstance", back_populates="group_infos", foreign_keys=[consumer_key]
+        "ApplicationInstance",
+        back_populates="group_infos",
+        foreign_keys=[application_instance_id],
     )
 
     #: The value of the context_id param this group was last launched with.

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -33,18 +33,18 @@ class OAuth2Token(BASE):
         nullable=False,
     )
 
-    #: The ApplicationInstance that this group belongs to foreign key
+    #: The ApplicationInstance that this token belongs to foreign key
     application_instance_id = sa.Column(
         sa.Integer(),
         sa.ForeignKey("application_instances.id", ondelete="cascade"),
-        nullable=True,
+        nullable=False,
     )
 
     #: The ApplicationInstance that this access token belongs to.
     application_instance = sa.orm.relationship(
         "ApplicationInstance",
         back_populates="access_tokens",
-        foreign_keys=[consumer_key],
+        foreign_keys=[application_instance_id],
     )
 
     #: The OAuth 2.0 access token, as received from the authorization server.

--- a/tests/factories/grading_info.py
+++ b/tests/factories/grading_info.py
@@ -1,7 +1,8 @@
-from factory import Faker, make_factory
+from factory import Faker, SubFactory, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
+from tests.factories.application_instance import ApplicationInstance
 from tests.factories.attributes import (
     H_DISPLAY_NAME,
     H_USERNAME,
@@ -27,4 +28,5 @@ GradingInfo = make_factory(
     ),
     h_username=H_USERNAME,
     h_display_name=H_DISPLAY_NAME,
+    application_instance=SubFactory(ApplicationInstance),
 )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -198,5 +198,7 @@ def lti_user(pyramid_request):
 @pytest.fixture
 def oauth_token(lti_user, application_instance):
     return factories.OAuth2Token(
-        user_id=lti_user.user_id, application_instance=application_instance
+        user_id=lti_user.user_id,
+        consumer_key=application_instance.consumer_key,
+        application_instance=application_instance,
     )

--- a/tests/unit/lms/models/grading_info_test.py
+++ b/tests/unit/lms/models/grading_info_test.py
@@ -2,7 +2,6 @@ import pytest
 import sqlalchemy.exc
 
 from lms.models import GradingInfo
-from tests import factories
 
 
 class TestGradingInfo:
@@ -15,6 +14,7 @@ class TestGradingInfo:
         assert lrs.lis_result_sourcedid == "result_sourcedid"
         assert lrs.lis_outcome_service_url == "https://somewhere.else"
         assert lrs.oauth_consumer_key == application_instance.consumer_key
+        assert lrs.application_instance_id == application_instance.id
         assert lrs.user_id == "339483948"
         assert lrs.context_id == "random context"
         assert lrs.resource_link_id == "random resource link id"
@@ -28,6 +28,7 @@ class TestGradingInfo:
             "lis_result_sourcedid",
             "lis_outcome_service_url",
             "oauth_consumer_key",
+            "application_instance_id",
             "user_id",
             "context_id",
             "resource_link_id",
@@ -59,11 +60,6 @@ class TestGradingInfo:
             db_session.flush()
 
     @pytest.fixture
-    def application_instance(self):
-        """Return the ApplicationInstance that the GradingInfos belong to."""
-        return factories.ApplicationInstance()
-
-    @pytest.fixture
     def grading_info(self, grading_info_params):
         return GradingInfo(**grading_info_params)
 
@@ -83,6 +79,7 @@ class TestGradingInfo:
             "lis_result_sourcedid": "result_sourcedid",
             "lis_outcome_service_url": "https://somewhere.else",
             "oauth_consumer_key": application_instance.consumer_key,
+            "application_instance_id": application_instance.id,
             "user_id": "339483948",
             "context_id": "random context",
             "resource_link_id": "random resource link id",

--- a/tests/unit/lms/models/group_info_test.py
+++ b/tests/unit/lms/models/group_info_test.py
@@ -7,17 +7,6 @@ from tests import factories
 
 
 class TestGroupInfo:
-    def test_persist_and_retrieve(self, application_instance, db_session, group_info):
-        db_session.add(group_info)
-
-        retrieved_group_info = db_session.query(GroupInfo).one()
-
-        assert retrieved_group_info.id
-        assert (
-            retrieved_group_info.authority_provided_id == "test_authority_provided_id"
-        )
-        assert retrieved_group_info.consumer_key == application_instance.consumer_key
-
     def test_application_instance_relation(
         self, application_instance, db_session, group_info
     ):
@@ -27,21 +16,13 @@ class TestGroupInfo:
 
         assert retrieved_group_info.application_instance == application_instance
 
-    def test_authority_provided_id_cant_be_None(self, db_session, group_info):
-        group_info.authority_provided_id = None
-        db_session.add(group_info)
-
-        with pytest.raises(
-            IntegrityError, match='"authority_provided_id" violates not-null constrain'
-        ):
-            db_session.flush()
-
     def test_application_instance_cant_be_None(self, db_session, group_info):
         group_info.application_instance = None
         db_session.add(group_info)
 
         with pytest.raises(
-            IntegrityError, match='"consumer_key" violates not-null constrain'
+            IntegrityError,
+            match='"application_instance_id" violates not-null constrain',
         ):
             db_session.flush()
 
@@ -117,4 +98,5 @@ class TestGroupInfo:
         return GroupInfo(
             authority_provided_id="test_authority_provided_id",
             application_instance=application_instance,
+            consumer_key=application_instance.consumer_key,
         )

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -13,9 +13,9 @@ pytestmark = pytest.mark.usefixtures("application_instance_service")
 
 
 class TestGetByAssignment:
-    def test_it(self, svc, matching_grading_infos):
+    def test_it(self, svc, matching_grading_infos, application_instance):
         grading_infos = svc.get_by_assignment(
-            "matching_oauth_consumer_key",
+            application_instance.consumer_key,
             "matching_context_id",
             "matching_resource_link_id",
         )
@@ -55,11 +55,12 @@ class TestGetByAssignment:
         assert not list(grading_infos)
 
     @pytest.fixture(autouse=True)
-    def matching_grading_infos(self):
+    def matching_grading_infos(self, application_instance):
         """Add some GradingInfo's that should match the DB query in the test above."""
         return factories.GradingInfo.create_batch(
             size=3,
-            oauth_consumer_key="matching_oauth_consumer_key",
+            oauth_consumer_key=application_instance.consumer_key,
+            application_instance_id=application_instance.id,
             context_id="matching_context_id",
             resource_link_id="matching_resource_link_id",
         )

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -132,6 +132,7 @@ class TestGroupInfoUpsert:
                 id=None,
                 authority_provided_id=self.AUTHORITY,
                 consumer_key=application_instance.consumer_key,
+                application_instance_id=application_instance.id,
             )
         )
 


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/3719

Migration at https://github.com/hypothesis/lms/pull/3753 required to be merged before this.

The rest are tweaks to the tests that stop passing once application_instance_id is not nullable


## Testing

The PRs that fill up application_instance_id on the services:

- https://github.com/hypothesis/lms/pull/3752
- https://github.com/hypothesis/lms/pull/3751
- https://github.com/hypothesis/lms/pull/3750

are already merged and the migration at https://github.com/hypothesis/lms/pull/3753 that backfills the ids in the new columns should be merged as well.


After that, as sanity check on each model/service check the following:

- Switch to this branch, apply migrations:

```hdev alembic upgrade head```

#### GroupInfo
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate group_info;"`
- Launch https://hypothesis.instructure.com/courses/125/assignments/875
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from group_info;"`

#### GradingInfo
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate lis_result_sourcedid;"`

- Launch the blackboard assignment localhost (make devdata) HTML Assignment as the student user blackboardstudent2
https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1

- `tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from lis_result_sourcedid;"`


#### Oauth2Token
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"`
- Launch https://hypothesis.instructure.com/courses/125/assignments/875
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "select application_instance_id from oauth2_token;"`



