### PR TITLE
JSTOR settings for application instance

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -223,6 +223,7 @@ class JSConfig:
                     "google": FilePickerConfig.google_files_config(*args),
                     "microsoftOneDrive": FilePickerConfig.microsoft_onedrive(*args),
                     "vitalSource": FilePickerConfig.vital_source_config(*args),
+                    "jstor": FilePickerConfig.jstor_config(*args),
                 },
             }
         )

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -101,3 +101,9 @@ class FilePickerConfig:
         """Get Vital Source config."""
         enabled = application_instance.settings.get("vitalsource", "enabled", False)
         return {"enabled": enabled}
+
+    @classmethod
+    def jstor_config(cls, _context, _request, application_instance):
+        """Get JSTOR config."""
+        enabled = application_instance.settings.get("jstor", "enabled", False)
+        return {"enabled": enabled}

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -65,6 +65,7 @@
         <legend class="label has-text-centered">Other settings</legend>
         {{ checkbox_field("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
         {{ checkbox_field("VitalSource enabled", "vitalsource", "enabled") }}
+        {{ checkbox_field("JSTOR enabled", "jstor", "enabled") }}
     </fieldset>
 
     {% call field_body(label="") %}

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -88,6 +88,7 @@ class AdminViews:
             ("blackboard", "groups_enabled"),
             ("microsoft_onedrive", "files_enabled"),
             ("vitalsource", "enabled"),
+            ("jstor", "enabled"),
         ):
             enabled = self.request.params.get(f"{setting}.{sub_setting}") == "on"
             ai.settings.set(setting, sub_setting, enabled)

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -44,6 +44,7 @@ class TestEnableContentItemSelectionMode:
             ("google_files_config", "google"),
             ("microsoft_onedrive", "microsoftOneDrive"),
             ("vital_source_config", "vitalSource"),
+            ("jstor_config", "jstor"),
         ),
     )
     def test_it_adds_picker_config(

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -164,6 +164,18 @@ class TestFilePickerConfig:
 
         assert config == {"enabled": enabled}
 
+    @pytest.mark.parametrize("enabled", (True, False))
+    def test_jstor_config(
+        self, context, pyramid_request, application_instance, enabled
+    ):
+        application_instance.settings.set("jstor", "enabled", enabled)
+
+        config = FilePickerConfig.jstor_config(
+            context, pyramid_request, application_instance
+        )
+
+        assert config == {"enabled": enabled}
+
     @pytest.fixture
     def canvas_files_enabled(self, context, pyramid_request, application_instance):
         context.is_canvas = True

--- a/tests/unit/lms/views/admin_test.py
+++ b/tests/unit/lms/views/admin_test.py
@@ -98,6 +98,7 @@ class TestAdminViews:
             ("blackboard", "groups_enabled"),
             ("microsoft_onedrive", "files_enabled"),
             ("vitalsource", "enabled"),
+            ("jstor", "enabled"),
         ),
     )
     @pytest.mark.parametrize("enabled", (True, False))


### PR DESCRIPTION
- New "jstor"->"enabled" in application_instance.settings
- Expose the new setting in "filePicker". Default to `False`.
- Admin pages changes to expose the toogle.


## Testing


- Start creating/editing an assignment, the response of `http://localhost:8001/content_item_selection` will contain a `<script type="application/json" class="js-config">`, the JSON there will contain:


```
jstor": {
      "enabled": false
    },
```


- Enable the JSTOR integration on http://localhost:8001/admin/instance using consumer_key `Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a` if testing in Canvas.

- Bring the content creating modal again, this time the value for jstor should be:


```
jstor": {
      "enabled": true
    },
```