### PR TITLE
JSTOR assignment configuration workflow (front-end)

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -7,6 +7,7 @@ import { GooglePickerClient } from '../utils/google-picker-client';
 import { OneDrivePickerClient } from '../utils/onedrive-picker-client';
 
 import BookPicker from './BookPicker';
+import JSTORPicker from './JSTORPicker';
 import LMSFilePicker from './LMSFilePicker';
 import URLPicker from './URLPicker';
 
@@ -17,7 +18,7 @@ import URLPicker from './URLPicker';
  *
  * @typedef {import('./FilePickerApp').ErrorInfo} ErrorInfo
  *
- * @typedef {'blackboardFile'|'canvasFile'|'url'|'vitalSourceBook'|null} DialogType
+ * @typedef {'blackboardFile'|'canvasFile'|'jstor'|'url'|'vitalSourceBook'|null} DialogType
  *
  * @typedef {import('../utils/content-item').Content} Content
  */
@@ -52,6 +53,7 @@ export default function ContentSelector({
         developerKey: googleDeveloperKey,
         origin: googleOrigin,
       },
+      jstor: { enabled: jstorEnabled },
       microsoftOneDrive: {
         enabled: oneDriveFilesEnabled,
         clientId: oneDriveClientId,
@@ -170,6 +172,9 @@ export default function ContentSelector({
         />
       );
       break;
+    case 'jstor':
+      dialog = <JSTORPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
+      break;
     case 'vitalSourceBook':
       dialog = (
         <BookPicker
@@ -259,6 +264,15 @@ export default function ContentSelector({
               data-testid="google-drive-button"
             >
               Select PDF from Google Drive
+            </LabeledButton>
+          )}
+          {jstorEnabled && (
+            <LabeledButton
+              onClick={() => selectDialog('jstor')}
+              variant="primary"
+              data-testid="jstor-button"
+            >
+              Select JSTOR article
             </LabeledButton>
           )}
           {oneDriveFilesEnabled && (

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -48,11 +48,13 @@ function formatContentURL(content) {
   if (content.name) {
     return content.name;
   }
-  // All Blackboard file URLs start with the literal string `blackboard:`
-  if (content.url.startsWith('blackboard:')) {
+
+  if (content.url.startsWith('jstor://')) {
+    return 'JSTOR article';
+  }
+  if (content.url.startsWith('blackboard://')) {
     return 'PDF file in Blackboard';
   }
-  // All VitalSource file URLs start with the literal string `vitalsource://`
   if (content.url.startsWith('vitalsource://')) {
     return 'Book from VitalSource';
   }

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -1,0 +1,148 @@
+import {
+  Icon,
+  IconButton,
+  LabeledButton,
+  Modal,
+  Thumbnail,
+  TextInputWithButton,
+  TextInput,
+} from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import { useRef, useState } from 'preact/hooks';
+
+import { toJSTORUrl } from '../utils/jstor';
+
+/**
+ * @typedef JSTORPickerProps
+ * @prop {() => void} onCancel
+ * @prop {(url: string) => void} onSelectURL - Callback to set the assignment's
+ *   content to a JSTOR article URL
+ */
+
+/**
+ * A picker that allows a user to enter a URL corresponding to a JSTOR article.
+ *
+ * @param {JSTORPickerProps} props
+ */
+export default function JSTORPicker({ onCancel, onSelectURL }) {
+  const [error, setError] = useState(/** @type {string|null} */ (null));
+  const [selectedURL, setSelectedURL] = useState(
+    /** @type {string|null} */ (null)
+  );
+
+  const inputRef = /** @type {{ current: HTMLInputElement }} */ (useRef());
+  // The last value of the URL-entry text input
+  const previousURL = useRef(/** @type {string|null} */ (null));
+
+  const confirmSelection = () => {
+    if (selectedURL) {
+      onSelectURL(selectedURL);
+    }
+  };
+
+  /**
+   * @param {boolean} [confirmSelectedUrl=false]
+   */
+  const onUpdateURL = (confirmSelectedUrl = false) => {
+    const url = inputRef?.current?.value;
+    if (url && url === previousURL.current) {
+      if (confirmSelectedUrl) {
+        confirmSelection();
+      }
+      return;
+    }
+
+    previousURL.current = url;
+    setSelectedURL(null);
+
+    if (!url) {
+      // If the field is empty, there's nothing to do
+      return;
+    }
+
+    const jstorUrl = toJSTORUrl(url);
+
+    if (jstorUrl) {
+      setError(null);
+      setSelectedURL(jstorUrl);
+    } else {
+      setError("That doesn't look like a JSTOR article link");
+    }
+  };
+
+  /**
+   * Capture "Enter" keystrokes, and avoid submitting the entire parent `<form>`
+   *
+   * @param {KeyboardEvent} event
+   */
+  const onKeyDown = event => {
+    if (event.key === 'Enter') {
+      onUpdateURL(true /* confirmSelectedUrl */);
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  return (
+    <Modal
+      initialFocus={inputRef}
+      onCancel={onCancel}
+      contentClass={classnames('LMS-Dialog LMS-Dialog--wide')}
+      title="Select JSTOR article"
+      buttons={[
+        <LabeledButton
+          data-testid="select-button"
+          disabled={!selectedURL}
+          key="submit"
+          onClick={confirmSelection}
+          variant="primary"
+        >
+          Submit
+        </LabeledButton>,
+      ]}
+    >
+      <div className="flex flex-row space-x-3">
+        <Thumbnail classes="w-32 h-40" />
+        <div className="space-y-2 grow">
+          <p>Paste a link to the JSTOR article you&apos;d like to use:</p>
+
+          <TextInputWithButton>
+            <TextInput
+              inputRef={inputRef}
+              name="jstorURL"
+              onChange={() => onUpdateURL(false /* confirmSelectedUrl */)}
+              onKeyDown={onKeyDown}
+              placeholder="e.g. https://www.jstor.org/stable/1234"
+            />
+            <IconButton
+              icon="arrowRight"
+              onClick={() => onUpdateURL(false /* confirmSelectedUrl */)}
+              variant="dark"
+              title="Find article"
+            />
+          </TextInputWithButton>
+
+          {selectedURL && (
+            <div
+              className="flex flex-row items-center space-x-2"
+              data-testid="selected-book"
+            >
+              <Icon name="check" classes="text-green-success" />
+              <div className="grow font-bold italic">JSTOR article</div>
+            </div>
+          )}
+
+          {error && (
+            <div
+              className="flex flex-row items-center space-x-2 text-red-error"
+              data-testid="error-message"
+            >
+              <Icon name="cancel" />
+              <div className="grow">{error}</div>
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -48,6 +48,9 @@ describe('ContentSelector', () => {
           },
         },
         google: {},
+        jstor: {
+          enabled: false,
+        },
         microsoftOneDrive: {
           enabled: true,
           clientId: '12345',
@@ -479,49 +482,92 @@ describe('ContentSelector', () => {
     });
   });
 
-  it('renders VitalSource picker button if enabled', () => {
-    fakeConfig.filePicker.vitalSource.enabled = true;
-    const wrapper = renderContentSelector();
-    assert.isTrue(
-      wrapper.exists('LabeledButton[data-testid="vitalsource-button"]')
-    );
+  describe('VitalSource picker', () => {
+    it('renders VitalSource picker button if enabled', () => {
+      fakeConfig.filePicker.vitalSource.enabled = true;
+      const wrapper = renderContentSelector();
+      assert.isTrue(
+        wrapper.exists('LabeledButton[data-testid="vitalsource-button"]')
+      );
+    });
+
+    it('shows VitalSource book picker when VitalSource button is clicked', () => {
+      fakeConfig.filePicker.vitalSource.enabled = true;
+      const onSelectContent = sinon.stub();
+      const wrapper = renderContentSelector({ onSelectContent });
+
+      const button = wrapper.find(
+        'LabeledButton[data-testid="vitalsource-button"]'
+      );
+      interact(wrapper, () => {
+        button.props().onClick();
+      });
+
+      assert.isTrue(wrapper.exists('BookPicker'));
+    });
+
+    it('submits VitalSource chapter URL', () => {
+      const onSelectContent = sinon.stub();
+      const wrapper = renderContentSelector({
+        defaultActiveDialog: 'vitalSourceBook',
+        onSelectContent,
+      });
+
+      const picker = wrapper.find('BookPicker');
+      interact(wrapper, () => {
+        picker
+          .props()
+          .onSelectBook(
+            { id: 'test-book' },
+            { url: 'vitalsource://book/BOOK_ID/cfi/CFI' }
+          );
+      });
+
+      assert.calledWith(onSelectContent, {
+        type: 'url',
+        url: 'vitalsource://book/BOOK_ID/cfi/CFI',
+      });
+    });
   });
 
-  it('shows VitalSource book picker when VitalSource button is clicked', () => {
-    fakeConfig.filePicker.vitalSource.enabled = true;
-    const onSelectContent = sinon.stub();
-    const wrapper = renderContentSelector({ onSelectContent });
-
-    const button = wrapper.find(
-      'LabeledButton[data-testid="vitalsource-button"]'
-    );
-    interact(wrapper, () => {
-      button.props().onClick();
+  describe('JSTOR picker', () => {
+    it('renders JSTOR picker button if enabled', () => {
+      fakeConfig.filePicker.jstor.enabled = true;
+      const wrapper = renderContentSelector();
+      assert.isTrue(
+        wrapper.exists('LabeledButton[data-testid="jstor-button"]')
+      );
     });
 
-    assert.isTrue(wrapper.exists('BookPicker'));
-  });
+    it('shows JSTOR picker when JSTOR button is clicked', () => {
+      fakeConfig.filePicker.jstor.enabled = true;
+      const onSelectContent = sinon.stub();
+      const wrapper = renderContentSelector({ onSelectContent });
 
-  it('submits VitalSource chapter URL', () => {
-    const onSelectContent = sinon.stub();
-    const wrapper = renderContentSelector({
-      defaultActiveDialog: 'vitalSourceBook',
-      onSelectContent,
+      const button = wrapper.find('LabeledButton[data-testid="jstor-button"]');
+      interact(wrapper, () => {
+        button.props().onClick();
+      });
+
+      assert.isTrue(wrapper.exists('JSTORPicker'));
     });
 
-    const picker = wrapper.find('BookPicker');
-    interact(wrapper, () => {
-      picker
-        .props()
-        .onSelectBook(
-          { id: 'test-book' },
-          { url: 'vitalsource://book/BOOK_ID/cfi/CFI' }
-        );
-    });
+    it('submits JSTOR URL', () => {
+      const onSelectContent = sinon.stub();
+      const wrapper = renderContentSelector({
+        defaultActiveDialog: 'jstor',
+        onSelectContent,
+      });
 
-    assert.calledWith(onSelectContent, {
-      type: 'url',
-      url: 'vitalsource://book/BOOK_ID/cfi/CFI',
+      const picker = wrapper.find('JSTORPicker');
+      interact(wrapper, () => {
+        picker.props().onSelectURL('jstor://1234');
+      });
+
+      assert.calledWith(onSelectContent, {
+        type: 'url',
+        url: 'jstor://1234',
+      });
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -178,6 +178,10 @@ describe('FilePickerApp', () => {
           content: { type: 'url', url: 'vitalsource://bookID/BOOK/cfi/CFI' },
           summary: 'Book from VitalSource',
         },
+        {
+          content: { type: 'url', url: 'jstor://1234' },
+          summary: 'JSTOR article',
+        },
       ].forEach(({ content, summary }) => {
         it('displays a summary of the assignment content', () => {
           const wrapper = renderFilePicker();

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -1,0 +1,189 @@
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+import JSTORPicker, { $imports } from '../JSTORPicker';
+
+describe('JSTORPicker', () => {
+  let fakeToJSTORUrl;
+
+  function interact(wrapper, callback) {
+    act(callback);
+    wrapper.update();
+  }
+
+  const renderJSTORPicker = (props = {}) => mount(<JSTORPicker {...props} />);
+
+  beforeEach(() => {
+    fakeToJSTORUrl = sinon.stub().returns('jstor://1234');
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../utils/jstor': {
+        toJSTORUrl: fakeToJSTORUrl,
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  const getInput = wrapper => wrapper.find('TextInput').find('input');
+
+  // Set the value of the input field but do not fire any events
+  const setURL = (wrapper, url) => {
+    const input = getInput(wrapper);
+    input.getDOMNode().value = url;
+  };
+
+  // Set the value of the input field AND fire `change` event
+  const updateURL = (wrapper, url) => {
+    setURL(wrapper, url);
+    const input = getInput(wrapper);
+    input.simulate('change');
+  };
+
+  describe('initial focus', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('focuses the URL text input element', () => {
+      const beforeFocused = document.activeElement;
+
+      const wrapper = mount(<JSTORPicker onSelectURL={sinon.stub()} />, {
+        attachTo: container,
+      });
+
+      const focused = document.activeElement;
+      const input = wrapper.find('input[name="jstorURL"]').getDOMNode();
+
+      assert.notEqual(beforeFocused, focused);
+      assert.equal(focused, input);
+    });
+  });
+
+  context('entering, changing and submitting article URL', () => {
+    it('validates entered URL when the value of the text input changes', () => {
+      const wrapper = renderJSTORPicker();
+
+      updateURL(wrapper, 'foo');
+
+      assert.calledOnce(fakeToJSTORUrl);
+      assert.calledWith(fakeToJSTORUrl, 'foo');
+
+      updateURL(wrapper, 'bar');
+
+      assert.equal(
+        fakeToJSTORUrl.callCount,
+        2,
+        're-validates if entered URL value changes'
+      );
+      assert.calledWith(fakeToJSTORUrl, 'bar');
+
+      updateURL(wrapper, 'bar');
+
+      assert.equal(
+        fakeToJSTORUrl.callCount,
+        2,
+        'Does not validate URL if it has not changed from previous value'
+      );
+    });
+
+    it('validates entered URL when input is focused and "Enter" is pressed', () => {
+      const wrapper = renderJSTORPicker();
+      const input = getInput(wrapper);
+      const keyEvent = new Event('keydown');
+      keyEvent.key = 'Enter';
+
+      setURL(wrapper, 'https://www.jstor.org/stable/1234');
+
+      input.getDOMNode().dispatchEvent(keyEvent);
+
+      assert.calledOnce(fakeToJSTORUrl);
+      assert.calledWith(fakeToJSTORUrl, 'https://www.jstor.org/stable/1234');
+    });
+
+    it('confirms the validated URL if "Enter" is pressed subsequently', () => {
+      const onSelectURL = sinon.stub();
+      const wrapper = renderJSTORPicker({ onSelectURL });
+      const input = getInput(wrapper);
+      const keyEvent = new Event('keydown');
+      keyEvent.key = 'Enter';
+
+      setURL(wrapper, 'https://www.jstor.org/stable/1234');
+
+      // First enter press will validate URL
+      interact(wrapper, () => {
+        input.getDOMNode().dispatchEvent(keyEvent);
+      });
+
+      assert.calledOnce(fakeToJSTORUrl);
+
+      // Second enter press should "confirm" the valid URL
+      input.getDOMNode().dispatchEvent(keyEvent);
+
+      assert.calledOnce(onSelectURL);
+      assert.calledWith(onSelectURL, 'jstor://1234');
+    });
+
+    it('validates entered URL when `IconButton` is clicked', () => {
+      const wrapper = renderJSTORPicker();
+      setURL(wrapper, 'foo');
+
+      wrapper.find('IconButton button[title="Find article"]').simulate('click');
+
+      assert.calledOnce(fakeToJSTORUrl);
+      assert.calledWith(fakeToJSTORUrl, 'foo');
+    });
+
+    it('does not attempt to check the URL format if the field value is empty', () => {
+      const wrapper = renderJSTORPicker();
+      updateURL(wrapper, 'foo');
+
+      assert.calledOnce(fakeToJSTORUrl);
+
+      updateURL(wrapper, '');
+
+      assert.calledOnce(fakeToJSTORUrl);
+    });
+
+    it('shows an error if entered URL format is invalid', () => {
+      fakeToJSTORUrl.returns(null);
+
+      const wrapper = renderJSTORPicker();
+      updateURL(wrapper, 'foo');
+
+      const errorMessage = wrapper.find('[data-testid="error-message"]');
+
+      assert.isTrue(errorMessage.exists());
+      assert.include(
+        errorMessage.text(),
+        "That doesn't look like a JSTOR article link"
+      );
+      assert.isTrue(errorMessage.find('Icon[name="cancel"]').exists());
+    });
+  });
+
+  it('enables submit button when a valid JSTOR URL is entered', () => {
+    const wrapper = renderJSTORPicker();
+    const buttonSelector = 'LabeledButton[data-testid="select-button"]';
+
+    assert.isTrue(wrapper.find(buttonSelector).props().disabled);
+
+    interact(wrapper, () => {
+      updateURL(wrapper, 'foo');
+    });
+
+    assert.isFalse(wrapper.find(buttonSelector).props().disabled);
+    assert.equal(wrapper.find(buttonSelector).text(), 'Submit');
+  });
+});

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -84,6 +84,8 @@ import { createContext } from 'preact';
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey
  *   @prop {string} google.origin
+ * @prop {object} jstor
+ *   @prop {boolean} jstor.enabled
  * @prop {object} microsoftOneDrive
  *   @prop {boolean} microsoftOneDrive.enabled
  *   @prop {string} [microsoftOneDrive.clientId]

--- a/lms/static/scripts/frontend_apps/utils/jstor.js
+++ b/lms/static/scripts/frontend_apps/utils/jstor.js
@@ -1,0 +1,55 @@
+/**
+ * Transform a provided URL to a via-recognizable identifier pointing
+ * to a JSTOR article.
+ *
+ * Accepts URLS of the form:
+ * - http[s]://www.jstor.org/stable/<articleID> OR
+ * - http[s]://www.jstor.org/stable/<doiPrefix>/<doiSuffix>
+ *
+ * (Query string is ignored on provided URLs)
+ *
+ * and returns, respectively:
+ * - jstor://<articleID> OR
+ * - jstor://<doiPrefix>/<doiSuffix>
+ *
+ * Return `null` if provided string is not a URL or does not match one of the
+ * accepted formats.
+ *
+ * @param {string} url
+ * @returns {string|null}
+ */
+export function toJSTORUrl(url) {
+  let testURL;
+
+  try {
+    testURL = new URL(url);
+  } catch (e) {
+    return null;
+  }
+
+  // Split path and remove any empty entries representing leading or trailing slashes
+  const pathSegments = testURL.pathname.split('/').filter(segment => !!segment);
+
+  if (testURL.hostname === 'www.jstor.org' && pathSegments[0] === 'stable') {
+    pathSegments.shift();
+    switch (pathSegments.length) {
+      case 1:
+        // Supplied URL is of the format
+        // http[s]://www.jstor.org/stable/<articleID>
+        return `jstor://${pathSegments[0]}`;
+      case 2:
+        // Supplied URL is of the format
+        // http[s]://www.jstor.org/stable/<doiPrefix>/<doiSuffix>
+        // Ensure <doiPrefix> starts with `10.` and contains only digits or
+        // periods
+        if (pathSegments[0].match(/10\.[\d.]*$/)) {
+          return `jstor://${pathSegments[0]}/${pathSegments[1]}`;
+        }
+        break;
+      default:
+        return null;
+    }
+  }
+
+  return null;
+}

--- a/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
@@ -1,0 +1,39 @@
+import { toJSTORUrl } from '../jstor';
+
+describe('utils/jstor', () => {
+  describe('toJSTORUrl', () => {
+    [
+      // GOOD URLS
+      // URL with article ID
+      ['https://www.jstor.org/stable/1234', 'jstor://1234'],
+      // Querystring ignored
+      ['https://www.jstor.org/stable/1234?q=bananas&bar=baz', 'jstor://1234'],
+      // Trailing slash(es) ignored
+      ['https://www.jstor.org/stable/1234/', 'jstor://1234'],
+      ['https://www.jstor.org/stable/1234//', 'jstor://1234'],
+      // http protocol OK
+      ['http://www.jstor.org/stable/1234', 'jstor://1234'],
+      // DOI Prefx and DOI suffix
+      ['https://www.jstor.org/stable/10.1086/508573', 'jstor://10.1086/508573'],
+      [
+        'https://www.jstor.org/stable/10.1086.3333.9/508573',
+        'jstor://10.1086.3333.9/508573',
+      ],
+
+      // BAD URLS
+      // Not a URL
+      ['foo', null],
+      // Missing "/stable/"
+      ['http://www.jstor.org/1234', null],
+      ['https://www.jstor.org/10.1086/508573', null],
+      // Bad DOI Prefix format
+      ['https://www.jstor.org/stable/10.1086k/508573', null],
+      // Bad hostname
+      ['https://jstor.org/stable/1234', null],
+      // Too many path segments
+      ['https://www.jstor.org/stable/10.1086/508573/34434', null],
+    ].forEach(([input, expected]) => {
+      assert.equal(toJSTORUrl(input), expected);
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/3761
Part of https://github.com/hypothesis/product-backlog/issues/1329

This is a PoC of a possible flow for configuring assignments to use JSTOR content.

## To Try it out

* Check out and run this branch
* Enable JSTOR for your local LMS application_instance. To do this:
    * Locate your app instance `consumer key`. For the `localhost` Canvas-with-sections install, it is `Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a`. You can see other `consumer key` values in the [`devdata` project's LMS data](https://github.com/hypothesis/devdata/blob/master/lms/devdata.json)
    * Go to http://localhost:8001/admin , enter your consumer key and hit the checkbox for "JSTOR enabled"
* Configure an assignment...

In Canvas with JSTOR enabled, you should see something like this:

<img width="820" alt="image" src="https://user-images.githubusercontent.com/439947/157084919-6fa06469-9aa7-4ab0-a0bb-ee34a7b9045c.png">

If you click the "Select JSTOR article" button, you should see:

<img width="824" alt="image" src="https://user-images.githubusercontent.com/439947/157084995-9c1400fc-b861-4601-b325-3afa3264e8bc.png">

If you enter a non-URL or a URL that doesn't match this POC's naive sense of what a JSTOR article's URL should look like, you should see:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/439947/157085156-1fb94480-67c9-4891-ba2e-031e579941d3.png">

If you enter a "valid JSTOR URL", you should see:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/439947/157085226-c8136045-515e-4094-89c2-8f15e992a6e1.png">

Pressing `Enter` again or clicking `Submit` should then take you to a screen that looks like:

<img width="817" alt="image" src="https://user-images.githubusercontent.com/439947/157085277-7fe29b1d-31f9-4119-a584-a4a6d62c18f1.png">

## Known shortcomings and questions

* There's a `Thumbnail` component used on the picker which could be nice if it displayed a cover image (likewise, it could be nice to display a title or other metadata). We may want to pull this for now if we don't think we can get at such metadata soon.
* The component logic just submits a URL at the end of the day. We'll need to tweak if there is some special sauce that needs to get sprinkled on JSTOR URLs before submission.
* URL validation, etc., is of course naive and incomplete.
* There is some duplication between `BookSelector`, `BookPicker` and `JSTORPicker`. That can be ironed out and refactored later.