### PR TITLE
Remove useless settings set in test

### DIFF
--- a/tests/unit/lms/validation/authentication/_oauth_test.py
+++ b/tests/unit/lms/validation/authentication/_oauth_test.py
@@ -156,9 +156,6 @@ class TestOauthCallbackSchema:
         pyramid_request.params["state"] = "test_state"
         pyramid_request.session["oauth2_csrf"] = "test_csrf"
         pyramid_request.lti_user = lti_user
-        pyramid_request.registry.settings = {
-            "oauth2_state_secret": "test_oauth2_state_secret"
-        }
         return pyramid_request
 
     @pytest.fixture


### PR DESCRIPTION
The settings are set a bit below, that's the line that sets them. The removed one doesn't have any effect as far as I can tell:

https://github.com/hypothesis/lms/blob/753b9c0fbcf7fe1634992228f2fd6d0b141c4524/tests/unit/lms/validation/authentication/_oauth_test.py#L165
