### PR TITLE
GroupInfoService test fixtures simplification

### DIFF
--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -18,6 +18,7 @@ from tests.factories.attributes import (
 )
 from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo
+from tests.factories.group_info import GroupInfo
 from tests.factories.grouping import BlackboardGroup, CanvasGroup, CanvasSection, Course
 from tests.factories.h_user import HUser
 from tests.factories.legacy_course import LegacyCourse

--- a/tests/factories/group_info.py
+++ b/tests/factories/group_info.py
@@ -1,0 +1,11 @@
+from factory import SubFactory, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.application_instance import ApplicationInstance
+
+GroupInfo = make_factory(
+    models.GroupInfo,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    application_instance=SubFactory(ApplicationInstance),
+)

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -140,35 +140,10 @@ class TestGroupInfoUpsert:
 
         return pre_existing_group
 
-    @pytest.fixture
-    def application_instance(self):
-        """Return the application instance that the test group infos belong to."""
-        return factories.ApplicationInstance()
-
     @pytest.fixture(autouse=True)
-    def group_infos(self, application_instance, pyramid_request):
-        """Add some "noise" group infos."""
-        # Add some "noise" group infos to the DB for every test, to make the
-        # tests more realistic.
-        group_infos = [
-            GroupInfo(
-                authority_provided_id="NOISE_ID_1",
-                consumer_key="NOISE_CONSUMER_KEY_1",
-                application_instance=application_instance,
-            ),
-            GroupInfo(
-                authority_provided_id="NOISE_ID_2",
-                consumer_key="NOISE_CONSUMER_KEY_2",
-                application_instance=application_instance,
-            ),
-            GroupInfo(
-                authority_provided_id="NOISE_ID_3",
-                consumer_key="NOISE_CONSUMER_KEY_3",
-                application_instance=application_instance,
-            ),
-        ]
-        pyramid_request.db.add_all(group_infos)
-        return group_infos
+    def with_existing_group_infos(self):
+        """Add some "noise" GroupInfo to make the tests more realistic."""
+        factories.GroupInfo.build_batch(3)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
- Use the global `application_instance` fixture
- Use a factory instead of creating models directly to be align to our testing style.

I few test here could use a deeper refactor but this is a start and gets in the way of another PR.