### PR TITLE
Migration to allow null consumer_keys in tables with a new FK

### DIFF
--- a/lms/migrations/versions/497b20c41fbb_nullable_consumer_keys.py
+++ b/lms/migrations/versions/497b20c41fbb_nullable_consumer_keys.py
@@ -1,0 +1,107 @@
+"""
+Allow nullable consumer keys in tables with a new application_instance_id.
+
+Revision ID: 497b20c41fbb
+Revises: 2119e1c621de
+Create Date: 2022-03-24 12:55:46.664755
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "497b20c41fbb"
+down_revision = "2119e1c621de"
+
+
+def upgrade():
+    # Allow nulls in the old consumer_key columns
+    op.alter_column(
+        "group_info", "consumer_key", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.alter_column(
+        "lis_result_sourcedid",
+        "oauth_consumer_key",
+        existing_type=sa.TEXT(),
+        nullable=True,
+    )
+    op.alter_column(
+        "oauth2_token", "consumer_key", existing_type=sa.VARCHAR(), nullable=True
+    )
+
+    # Drop existing FK constraints
+    op.drop_constraint(
+        "fk__group_info__consumer_key__application_instances",
+        "group_info",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk__oauth2_token__consumer_key__application_instances",
+        "oauth2_token",
+        type_="foreignkey",
+    )
+
+    # Adjust existing unique constraint based on consumer_key to use application_instance_id
+    op.drop_constraint("uq__oauth2_token__user_id", "oauth2_token", type_="unique")
+    op.drop_constraint(
+        "uq__lis_result_sourcedid__oauth_consumer_key",
+        "lis_result_sourcedid",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq__lis_result_sourcedid__application_instance_id"),
+        "lis_result_sourcedid",
+        ["application_instance_id", "user_id", "context_id", "resource_link_id"],
+    )
+    op.create_unique_constraint(
+        op.f("uq__oauth2_token__user_id"),
+        "oauth2_token",
+        ["user_id", "application_instance_id"],
+    )
+
+
+def downgrade():
+    op.create_foreign_key(
+        "fk__oauth2_token__consumer_key__application_instances",
+        "oauth2_token",
+        "application_instances",
+        ["consumer_key"],
+        ["consumer_key"],
+        ondelete="CASCADE",
+    )
+    op.drop_constraint(
+        op.f("uq__oauth2_token__user_id"), "oauth2_token", type_="unique"
+    )
+    op.create_unique_constraint(
+        "uq__oauth2_token__user_id", "oauth2_token", ["user_id", "consumer_key"]
+    )
+    op.alter_column(
+        "oauth2_token", "consumer_key", existing_type=sa.VARCHAR(), nullable=False
+    )
+    op.drop_constraint(
+        op.f("uq__lis_result_sourcedid__application_instance_id"),
+        "lis_result_sourcedid",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq__lis_result_sourcedid__oauth_consumer_key",
+        "lis_result_sourcedid",
+        ["oauth_consumer_key", "user_id", "context_id", "resource_link_id"],
+    )
+    op.alter_column(
+        "lis_result_sourcedid",
+        "oauth_consumer_key",
+        existing_type=sa.TEXT(),
+        nullable=False,
+    )
+    op.create_foreign_key(
+        "fk__group_info__consumer_key__application_instances",
+        "group_info",
+        "application_instances",
+        ["consumer_key"],
+        ["consumer_key"],
+        ondelete="CASCADE",
+    )
+    op.alter_column(
+        "group_info", "consumer_key", existing_type=sa.VARCHAR(), nullable=False
+    )


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/3719

- Allow nulls in consumer_key 
- Remove consumer_keys FKs
- Use the new `application_instance_id` for unique constraint instead of consumer_key.

auto-generated from: https://github.com/hypothesis/lms/pull/3768.

### Testing

Nothing should have changed but let's exercise the services that directly handle this tables.

- Start with a fresh DB and apply the migration:

```shell
git checkout master
docker stop lms_postgres_1
docker rm lms_postgres_1
make services db devdata
git checkout ai-fk-nullable-key
hdev alembic upgrade head
```

#### GroupInfo
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate group_info;"`
- Launch https://hypothesis.instructure.com/courses/125/assignments/875

- Check the new rows

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select consumer_key from group_info;"
                consumer_key                
--------------------------------------------
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
(4 rows)
```
We are still storing consumer_keys (but we could not!)


#### GradingInfo
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate lis_result_sourcedid;"`

- Launch the blackboard assignment `localhost (make devdata) HTML Assignment` as the student user `blackboardstudent2`
https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1

- Check the new rows:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select oauth_consumer_key from lis_result_sourcedid;"
             oauth_consumer_key             
--------------------------------------------
 Hypothesis14af0fe87c9deb2e461f88be4a8d5364
(1 row)
```


#### Oauth2Token
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"`
- Launch https://hypothesis.instructure.com/courses/125/assignments/875

- Check the rows again:

``` 
tox -qe dockercompose -- exec postgres psql -U postgres -c "select consumer_key from oauth2_token;"
                consumer_key                
--------------------------------------------
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
(1 row)


