### PR TITLE
Model changes to make consumer_keys nullables in tables with new FK

### DIFF
--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -17,10 +17,10 @@ class GradingInfo(CreatedUpdatedMixin, BASE):
     Data persisted here allows us to make use of APIs that support the LTI Basic
     Outcomes spec and configure the Hypothesis client appropriately for grading.
 
-    The combination of ``oauth_consumer_key``, ``user_id``, ``context_id``,
+    The combination of `application_instance`, `user_id`, `context_id`,
     and ``resource_link_id`` uniquely identifies a user-assignment
-    (``user_id``, ``resource_link_id``) launch within a particular course
-    (``context_id``) and application install (``oauth_consumer_key``). The
+    (`user_id`, `resource_link_id`) launch within a particular course
+    (`context_id`) and application instance (`application_instance_id`). The
     uniqueness constraint here indicates that we should only ever have one
     record per user-assignment-course-install combination.
 
@@ -40,14 +40,14 @@ class GradingInfo(CreatedUpdatedMixin, BASE):
     __tablename__ = "lis_result_sourcedid"
     __table_args__ = (
         sa.UniqueConstraint(
-            "oauth_consumer_key", "user_id", "context_id", "resource_link_id"
+            "application_instance_id", "user_id", "context_id", "resource_link_id"
         ),
     )
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
     lis_result_sourcedid = sa.Column(sa.UnicodeText(), nullable=False)
     lis_outcome_service_url = sa.Column(sa.UnicodeText(), nullable=False)
-    oauth_consumer_key = sa.Column(sa.UnicodeText(), nullable=False)
+    oauth_consumer_key = sa.Column(sa.UnicodeText(), nullable=True)
 
     #: The ApplicationInstance FK that this grading info belongs to
     application_instance_id = sa.Column(

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -34,11 +34,7 @@ class GroupInfo(BASE):
 
     #: The LTI consumer_key (oauth_consumer_key) of the application instance
     #: that this access token belongs to.
-    consumer_key = sa.Column(
-        sa.Unicode(),
-        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
-        nullable=False,
-    )
+    consumer_key = sa.Column(sa.Unicode(), nullable=True)
 
     #: The ApplicationInstance that this group belongs to foreign key
     application_instance_id = sa.Column(

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -18,7 +18,7 @@ class OAuth2Token(BASE):
     """
 
     __tablename__ = "oauth2_token"
-    __table_args__ = (sa.UniqueConstraint("user_id", "consumer_key"),)
+    __table_args__ = (sa.UniqueConstraint("user_id", "application_instance_id"),)
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
 
@@ -27,11 +27,7 @@ class OAuth2Token(BASE):
 
     #: The LTI consumer_key (oauth_consumer_key) of the application instance
     #: that this access token belongs to.
-    consumer_key = sa.Column(
-        sa.Unicode(),
-        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
-        nullable=False,
-    )
+    consumer_key = sa.Column(sa.Unicode(), nullable=True)
 
     #: The ApplicationInstance that this token belongs to foreign key
     application_instance_id = sa.Column(

--- a/tests/unit/lms/models/grading_info_test.py
+++ b/tests/unit/lms/models/grading_info_test.py
@@ -27,7 +27,6 @@ class TestGradingInfo:
         [
             "lis_result_sourcedid",
             "lis_outcome_service_url",
-            "oauth_consumer_key",
             "application_instance_id",
             "user_id",
             "context_id",

--- a/tests/unit/lms/models/oauth2_token_test.py
+++ b/tests/unit/lms/models/oauth2_token_test.py
@@ -42,16 +42,6 @@ class TestOAuth2Token:
         ):
             db_session.flush()
 
-    def test_consumer_key_cant_be_None(self, db_session, init_kwargs):
-        del init_kwargs["consumer_key"]
-        db_session.add(OAuth2Token(**init_kwargs))
-
-        with pytest.raises(
-            sqlalchemy.exc.IntegrityError,
-            match='null value in column "consumer_key" violates not-null constraint',
-        ):
-            db_session.flush()
-
     def test_setting_consumer_key_sets_application_instance(
         self, application_instance, db_session, init_kwargs
     ):


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/3719
Migration in https://github.com/hypothesis/lms/pull/3753

### Testing

- Set the DB

```shell
git checkout master
docker stop lms_postgres_1
docker rm lms_postgres_1
make services db devdata
git checkout ai-fk-nullable-key-model
hdev alembic upgrade head
```

Same as in https://github.com/hypothesis/lms/issues/3719, copy pasting it here:

#### GroupInfo
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate group_info;"`
- Launch https://hypothesis.instructure.com/courses/125/assignments/875

- Check the new rows

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select consumer_key from group_info;"
                consumer_key                
--------------------------------------------
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
(4 rows)
```
We are still storing consumer_keys (but we could not!)

#### GradingInfo
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate lis_result_sourcedid;"`

- Launch the blackboard assignment `localhost (make devdata) HTML Assignment` as the student user `blackboardstudent2`
https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1

- Check the new rows:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select oauth_consumer_key from lis_result_sourcedid;"
             oauth_consumer_key             
--------------------------------------------
 Hypothesis14af0fe87c9deb2e461f88be4a8d5364
(1 row)
```

#### Oauth2Token
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"`
- Launch https://hypothesis.instructure.com/courses/125/assignments/875

- Check the rows again:

``` 
tox -qe dockercompose -- exec postgres psql -U postgres -c "select consumer_key from oauth2_token;"
                consumer_key                
--------------------------------------------
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
(1 row)