### PR TITLE
Stop filling Grading.info consumer_key

### DIFF
--- a/lms/migrations/versions/497b20c41fbb_nullable_consumer_keys.py
+++ b/lms/migrations/versions/497b20c41fbb_nullable_consumer_keys.py
@@ -1,0 +1,107 @@
+"""
+Allow nullable consumer keys in tables with a new application_instance_id.
+
+Revision ID: 497b20c41fbb
+Revises: 2119e1c621de
+Create Date: 2022-03-24 12:55:46.664755
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "497b20c41fbb"
+down_revision = "2119e1c621de"
+
+
+def upgrade():
+    # Allow nulls in the old consumer_key columns
+    op.alter_column(
+        "group_info", "consumer_key", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.alter_column(
+        "lis_result_sourcedid",
+        "oauth_consumer_key",
+        existing_type=sa.TEXT(),
+        nullable=True,
+    )
+    op.alter_column(
+        "oauth2_token", "consumer_key", existing_type=sa.VARCHAR(), nullable=True
+    )
+
+    # Drop existing FK constraints
+    op.drop_constraint(
+        "fk__group_info__consumer_key__application_instances",
+        "group_info",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk__oauth2_token__consumer_key__application_instances",
+        "oauth2_token",
+        type_="foreignkey",
+    )
+
+    # Adjust existing unique constraint based on consumer_key to use application_instance_id
+    op.drop_constraint("uq__oauth2_token__user_id", "oauth2_token", type_="unique")
+    op.drop_constraint(
+        "uq__lis_result_sourcedid__oauth_consumer_key",
+        "lis_result_sourcedid",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq__lis_result_sourcedid__application_instance_id"),
+        "lis_result_sourcedid",
+        ["application_instance_id", "user_id", "context_id", "resource_link_id"],
+    )
+    op.create_unique_constraint(
+        op.f("uq__oauth2_token__user_id"),
+        "oauth2_token",
+        ["user_id", "application_instance_id"],
+    )
+
+
+def downgrade():
+    op.create_foreign_key(
+        "fk__oauth2_token__consumer_key__application_instances",
+        "oauth2_token",
+        "application_instances",
+        ["consumer_key"],
+        ["consumer_key"],
+        ondelete="CASCADE",
+    )
+    op.drop_constraint(
+        op.f("uq__oauth2_token__user_id"), "oauth2_token", type_="unique"
+    )
+    op.create_unique_constraint(
+        "uq__oauth2_token__user_id", "oauth2_token", ["user_id", "consumer_key"]
+    )
+    op.alter_column(
+        "oauth2_token", "consumer_key", existing_type=sa.VARCHAR(), nullable=False
+    )
+    op.drop_constraint(
+        op.f("uq__lis_result_sourcedid__application_instance_id"),
+        "lis_result_sourcedid",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq__lis_result_sourcedid__oauth_consumer_key",
+        "lis_result_sourcedid",
+        ["oauth_consumer_key", "user_id", "context_id", "resource_link_id"],
+    )
+    op.alter_column(
+        "lis_result_sourcedid",
+        "oauth_consumer_key",
+        existing_type=sa.TEXT(),
+        nullable=False,
+    )
+    op.create_foreign_key(
+        "fk__group_info__consumer_key__application_instances",
+        "group_info",
+        "application_instances",
+        ["consumer_key"],
+        ["consumer_key"],
+        ondelete="CASCADE",
+    )
+    op.alter_column(
+        "group_info", "consumer_key", existing_type=sa.VARCHAR(), nullable=False
+    )

--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -17,10 +17,10 @@ class GradingInfo(CreatedUpdatedMixin, BASE):
     Data persisted here allows us to make use of APIs that support the LTI Basic
     Outcomes spec and configure the Hypothesis client appropriately for grading.
 
-    The combination of ``oauth_consumer_key``, ``user_id``, ``context_id``,
+    The combination of `application_instance`, `user_id`, `context_id`,
     and ``resource_link_id`` uniquely identifies a user-assignment
-    (``user_id``, ``resource_link_id``) launch within a particular course
-    (``context_id``) and application install (``oauth_consumer_key``). The
+    (`user_id`, `resource_link_id`) launch within a particular course
+    (`context_id`) and application instance (`application_instance_id`). The
     uniqueness constraint here indicates that we should only ever have one
     record per user-assignment-course-install combination.
 
@@ -40,14 +40,14 @@ class GradingInfo(CreatedUpdatedMixin, BASE):
     __tablename__ = "lis_result_sourcedid"
     __table_args__ = (
         sa.UniqueConstraint(
-            "oauth_consumer_key", "user_id", "context_id", "resource_link_id"
+            "application_instance_id", "user_id", "context_id", "resource_link_id"
         ),
     )
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
     lis_result_sourcedid = sa.Column(sa.UnicodeText(), nullable=False)
     lis_outcome_service_url = sa.Column(sa.UnicodeText(), nullable=False)
-    oauth_consumer_key = sa.Column(sa.UnicodeText(), nullable=False)
+    oauth_consumer_key = sa.Column(sa.UnicodeText(), nullable=True)
 
     #: The ApplicationInstance FK that this grading info belongs to
     application_instance_id = sa.Column(

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -34,11 +34,7 @@ class GroupInfo(BASE):
 
     #: The LTI consumer_key (oauth_consumer_key) of the application instance
     #: that this access token belongs to.
-    consumer_key = sa.Column(
-        sa.Unicode(),
-        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
-        nullable=False,
-    )
+    consumer_key = sa.Column(sa.Unicode(), nullable=True)
 
     #: The ApplicationInstance that this group belongs to foreign key
     application_instance_id = sa.Column(

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -18,7 +18,7 @@ class OAuth2Token(BASE):
     """
 
     __tablename__ = "oauth2_token"
-    __table_args__ = (sa.UniqueConstraint("user_id", "consumer_key"),)
+    __table_args__ = (sa.UniqueConstraint("user_id", "application_instance_id"),)
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
 
@@ -27,11 +27,7 @@ class OAuth2Token(BASE):
 
     #: The LTI consumer_key (oauth_consumer_key) of the application instance
     #: that this access token belongs to.
-    consumer_key = sa.Column(
-        sa.Unicode(),
-        sa.ForeignKey("application_instances.consumer_key", ondelete="cascade"),
-        nullable=False,
-    )
+    consumer_key = sa.Column(sa.Unicode(), nullable=True)
 
     #: The ApplicationInstance that this token belongs to foreign key
     application_instance_id = sa.Column(

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -394,7 +394,7 @@ class JSConfig:
         and had grading info recorded for them.
         """
         grading_infos = self._grading_info_service.get_by_assignment(
-            oauth_consumer_key=self._application_instance.consumer_key,
+            application_instance=self._application_instance,
             context_id=self._request.params.get("context_id"),
             resource_link_id=self._request.params.get("resource_link_id"),
         )

--- a/lms/services/grading_info.py
+++ b/lms/services/grading_info.py
@@ -23,27 +23,22 @@ class GradingInfoService:
         self._db = request.db
         self._authority = request.registry.settings["h_authority"]
 
-    def get_by_assignment(self, oauth_consumer_key, context_id, resource_link_id):
+    def get_by_assignment(self, application_instance, context_id, resource_link_id):
         """
         Return all GradingInfo's for a given assignment.
 
         The returned list will contain one GradingInfo for each student who has
         launched this assignment (and had GradingInfo data persisted for them).
 
-        :param oauth_consumer_key: the assignment's oauth_consumer_key
+        :param application_instance: the assignment's application_instance
             (identifies a deployment of our app in an LMS)
-        :type oauth_consumer_key: str
-
         :param context_id: the assignment's context_id
             (identifies the course within the LMS)
-        :type context_id: str
-
         :param resource_link_id: the assignment's resource_link_id
             (identifies the assignment within the LMS course)
-        :type resource_link_id: str
         """
         return self._db.query(GradingInfo).filter_by(
-            oauth_consumer_key=oauth_consumer_key,
+            application_instance=application_instance,
             context_id=context_id,
             resource_link_id=resource_link_id,
         )
@@ -70,12 +65,11 @@ class GradingInfoService:
         ).get_current()
 
         grading_info = self._find_or_create(
-            oauth_consumer_key=application_instance.consumer_key,
+            application_instance=application_instance,
             user_id=request.lti_user.user_id,
             context_id=parsed_params["context_id"],
             resource_link_id=parsed_params["resource_link_id"],
         )
-        grading_info.application_instance_id = application_instance.id
         grading_info.h_username = request.lti_user.h_user.username
         grading_info.h_display_name = request.lti_user.h_user.display_name
 

--- a/tests/factories/grading_info.py
+++ b/tests/factories/grading_info.py
@@ -6,7 +6,6 @@ from tests.factories.application_instance import ApplicationInstance
 from tests.factories.attributes import (
     H_DISPLAY_NAME,
     H_USERNAME,
-    OAUTH_CONSUMER_KEY,
     RESOURCE_LINK_ID,
     USER_ID,
 )
@@ -18,7 +17,6 @@ GradingInfo = make_factory(
     lis_outcome_service_url=Faker(
         "numerify", text="https://example.com/test-lis-outcome-service-url-#"
     ),
-    oauth_consumer_key=OAUTH_CONSUMER_KEY,
     user_id=USER_ID,
     context_id=Faker("hexify", text="^" * 32),
     resource_link_id=RESOURCE_LINK_ID,

--- a/tests/unit/lms/models/grading_info_test.py
+++ b/tests/unit/lms/models/grading_info_test.py
@@ -27,7 +27,6 @@ class TestGradingInfo:
         [
             "lis_result_sourcedid",
             "lis_outcome_service_url",
-            "oauth_consumer_key",
             "application_instance_id",
             "user_id",
             "context_id",

--- a/tests/unit/lms/models/grading_info_test.py
+++ b/tests/unit/lms/models/grading_info_test.py
@@ -13,7 +13,6 @@ class TestGradingInfo:
 
         assert lrs.lis_result_sourcedid == "result_sourcedid"
         assert lrs.lis_outcome_service_url == "https://somewhere.else"
-        assert lrs.oauth_consumer_key == application_instance.consumer_key
         assert lrs.application_instance_id == application_instance.id
         assert lrs.user_id == "339483948"
         assert lrs.context_id == "random context"
@@ -77,7 +76,6 @@ class TestGradingInfo:
         return {
             "lis_result_sourcedid": "result_sourcedid",
             "lis_outcome_service_url": "https://somewhere.else",
-            "oauth_consumer_key": application_instance.consumer_key,
             "application_instance_id": application_instance.id,
             "user_id": "339483948",
             "context_id": "random context",

--- a/tests/unit/lms/models/oauth2_token_test.py
+++ b/tests/unit/lms/models/oauth2_token_test.py
@@ -42,16 +42,6 @@ class TestOAuth2Token:
         ):
             db_session.flush()
 
-    def test_consumer_key_cant_be_None(self, db_session, init_kwargs):
-        del init_kwargs["consumer_key"]
-        db_session.add(OAuth2Token(**init_kwargs))
-
-        with pytest.raises(
-            sqlalchemy.exc.IntegrityError,
-            match='null value in column "consumer_key" violates not-null constraint',
-        ):
-            db_session.flush()
-
     def test_setting_consumer_key_sets_application_instance(
         self, application_instance, db_session, init_kwargs
     ):

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -287,7 +287,7 @@ class TestMaybeEnableGrading:
 
         grading_info_service.get_by_assignment.assert_called_once_with(
             context_id="test_course_id",
-            oauth_consumer_key=application_instance_service.get_current.return_value.consumer_key,
+            application_instance=application_instance_service.get_current.return_value,
             resource_link_id="TEST_RESOURCE_LINK_ID",
         )
         assert js_config.asdict()["grading"] == {


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/3719


Stop filling the old column now that it can hold nulls.


#### GradingInfo
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate lis_result_sourcedid;"`

- Launch the blackboard assignment `localhost (make devdata) HTML Assignment` as the student user `blackboardstudent2`
https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1

- Check the new rows:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select oauth_consumer_key, application_instance_id from lis_result_sourcedid;"

 oauth_consumer_key | application_instance_id 
--------------------+-------------------------
                    |                      16
(1 row)
```


- Login now as `blackboardteacher` and launch the assignment again https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1

`Blackboard Student 2` should show up in the grading bar student selector.

