### PR TITLE
Stop filling OAuth2Token consumer_key

### DIFF
--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -34,12 +34,11 @@ class OAuth2TokenService:
             oauth2_token = self.get()
         except OAuth2TokenError:
             oauth2_token = OAuth2Token(
-                consumer_key=self._application_instance.consumer_key,
+                application_instance=self._application_instance,
                 user_id=self._user_id,
             )
             self._db.add(oauth2_token)
 
-        oauth2_token.application_instance_id = self._application_instance.id
         oauth2_token.access_token = access_token
         oauth2_token.refresh_token = refresh_token
         oauth2_token.expires_in = expires_in
@@ -56,7 +55,7 @@ class OAuth2TokenService:
             return (
                 self._db.query(OAuth2Token)
                 .filter_by(
-                    consumer_key=self._application_instance.consumer_key,
+                    application_instance=self._application_instance,
                     user_id=self._user_id,
                 )
                 .one()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -199,6 +199,5 @@ def lti_user(pyramid_request):
 def oauth_token(lti_user, application_instance):
     return factories.OAuth2Token(
         user_id=lti_user.user_id,
-        consumer_key=application_instance.consumer_key,
         application_instance=application_instance,
     )

--- a/tests/unit/lms/models/oauth2_token_test.py
+++ b/tests/unit/lms/models/oauth2_token_test.py
@@ -13,7 +13,6 @@ class TestOAuth2Token:
         db_session.add(
             OAuth2Token(
                 user_id="test_user_id",
-                consumer_key=application_instance.consumer_key,
                 application_instance_id=application_instance.id,
                 access_token="test_access_token",
                 refresh_token="test_refresh_token",
@@ -24,7 +23,6 @@ class TestOAuth2Token:
 
         token = db_session.query(OAuth2Token).one()
         assert token.user_id == "test_user_id"
-        assert token.consumer_key == application_instance.consumer_key
         assert token.application_instance_id == application_instance.id
         assert token.application_instance == application_instance
         assert token.access_token == "test_access_token"
@@ -41,15 +39,6 @@ class TestOAuth2Token:
             match='null value in column "user_id" violates not-null constraint',
         ):
             db_session.flush()
-
-    def test_setting_consumer_key_sets_application_instance(
-        self, application_instance, db_session, init_kwargs
-    ):
-        token = OAuth2Token(**init_kwargs)
-        db_session.add(token)
-        db_session.flush()
-
-        assert token.application_instance == application_instance
 
     def test_setting_application_instance_sets_fk(
         self, application_instance, db_session, init_kwargs
@@ -106,6 +95,5 @@ class TestOAuth2Token:
         return dict(
             user_id="test_user_id",
             access_token="test_access_token",
-            consumer_key=application_instance.consumer_key,
             application_instance_id=application_instance.id,
         )


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/3719


Stop filling the old column now that it can hold nulls.



#### Oauth2Token
- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"`
- Launch https://hypothesis.instructure.com/courses/125/assignments/875

- Check the rows again:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select consumer_key, application_instance_id from oauth2_token;"
 consumer_key | application_instance_id 
--------------+-------------------------
              |                       8
(1 row)
```