### PR TITLE
Stop filling GroupInfo consumer_key

### DIFF
--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -12,7 +12,7 @@ class GroupInfoService:
     Usage::
 
         group_info = request.find_service(name="group_info")
-        group_info.upsert(authority_provided_id, consumer_key, request.params)
+        group_info.upsert(h_group, application_instance, request.params)
     """
 
     GROUPING_TYPES = {
@@ -26,13 +26,13 @@ class GroupInfoService:
         self._db = request.db
         self._lti_user = request.lti_user
 
-    def upsert(self, h_group, application_instance, params):
+    def upsert(self, h_group, application_instance, params: dict):
         """
         Upsert a row into the `group_info` DB table.
 
         Find the models.GroupInfo matching the given h_group or create it if
-        none exists. Then update the GroupInfo's consumer_key to the given
-        consumer_key, and update its other columns from the items in `params`.
+        none exists. Then update the GroupInfo's application_instance to the given
+        application_instance, and update its other columns from the items in `params`.
 
         params["id"], params["authority_provided_id"], and params["info"] will
         be ignored if present--these columns can't be updated.
@@ -46,8 +46,6 @@ class GroupInfoService:
         :param application_instance: the ApplicationInstance this group belongs to
 
         :param params: the other GroupInfo columns to set
-        :type params: dict
-
         """
         group_info = (
             self._db.query(GroupInfo)
@@ -58,11 +56,10 @@ class GroupInfoService:
         if not group_info:
             group_info = GroupInfo(
                 authority_provided_id=h_group.authority_provided_id,
-                consumer_key=application_instance.consumer_key,
+                application_instance=application_instance,
             )
             self._db.add(group_info)
 
-        group_info.consumer_key = application_instance.consumer_key
         group_info.application_instance_id = application_instance.id
         group_info.update_from_dict(
             params, skip_keys={"authority_provided_id", "id", "info"}

--- a/tests/unit/lms/models/group_info_test.py
+++ b/tests/unit/lms/models/group_info_test.py
@@ -98,5 +98,4 @@ class TestGroupInfo:
         return GroupInfo(
             authority_provided_id="test_authority_provided_id",
             application_instance=application_instance,
-            consumer_key=application_instance.consumer_key,
         )

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -21,7 +21,7 @@ class TestGroupInfoUpsert:
 
         group_info = self.get_inserted_group_info(db_session)
 
-        assert group_info.consumer_key == application_instance.consumer_key
+        assert group_info.application_instance == application_instance
         assert group_info.context_title == params["context_title"]
         assert group_info.context_label == params["context_label"]
         assert group_info.type == "course_group"
@@ -45,7 +45,7 @@ class TestGroupInfoUpsert:
 
         group_info = self.get_inserted_group_info(db_session)
 
-        assert group_info.consumer_key == application_instance.consumer_key
+        assert group_info.application_instance == application_instance
         assert group_info.context_label == params["context_label"]
         assert group_info.context_title == "NEW_TITLE"
         assert group_info.type == "course_group"
@@ -131,7 +131,6 @@ class TestGroupInfoUpsert:
                 params,
                 id=None,
                 authority_provided_id=self.AUTHORITY,
-                consumer_key=application_instance.consumer_key,
                 application_instance_id=application_instance.id,
             )
         )


### PR DESCRIPTION
Before merging this changes need to be make on the sparky side to join on application_instance_id instead of consumer_key. 

The analytics side should be already be prepared as we recreate the consumer_key column there using the new FK.
---

For https://github.com/hypothesis/lms/issues/3719


Stop filling the old column now that it can hold nulls.

- `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token;"`
- Launch https://hypothesis.instructure.com/courses/125/assignments/875

- Check the rows:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select consumer_key, application_instance_id from group_info;"
```
```
 consumer_key | application_instance_id 
--------------+-------------------------
              |                       8
              |                       8
              |                       8
              |                       8
(4 rows)
```