### PR TITLE
Refresh expired access tokens from the frontend

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -17,11 +17,13 @@ import { APIError } from '../errors';
  */
 
 /**
- * @param {any} response
- * @return {response is RefreshError}
+ * Check if an API error response indicates that a token refresh is needed.
+ *
+ * @param {any} data - Parsed body of an API error response
+ * @return {data is RefreshError}
  */
-function isRefreshError(response) {
-  return response && response.refresh && typeof response.refresh === 'object';
+function isRefreshError(data) {
+  return data && data.refresh && typeof data.refresh === 'object';
 }
 
 /**
@@ -43,7 +45,9 @@ const activeRefreshCalls = new Map();
  *   @param {string} options.authToken - Session authorization token
  *   @param {string} [options.method] - Custom HTTP method for call
  *   @param {object} [options.data] - JSON-serializable body of the request
- *   @param {boolean} [options.allowRefresh]
+ *   @param {boolean} [options.allowRefresh] - If the request fails due to
+ *     an expired access token for an external API, this flag specifies whether
+ *     to attempt to refresh the token.
  *   @param {Record<string, string>} [options.params] - Query parameters
  * @return {Promise<any>} - Parsed JSON response. TODO: Convert this to `Promise<unknown>`
  */

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -84,13 +84,13 @@ export async function apiCall(options) {
     body,
     headers,
   });
-  const resultJson = await result.json();
+  const resultJSON = await result.json();
 
   if (result.status >= 400 && result.status < 600) {
     // Refresh expired access tokens for external APIs, if required. Only one
     // such request should be issued by the frontend for a given API at a time.
-    if (allowRefresh && result.status === 400 && isRefreshError(resultJson)) {
-      const { method, path } = resultJson.refresh;
+    if (allowRefresh && result.status === 400 && isRefreshError(resultJSON)) {
+      const { method, path } = resultJSON.refresh;
 
       // Refresh the access token for the external API.
       if (activeRefreshCalls.has(path)) {
@@ -114,8 +114,8 @@ export async function apiCall(options) {
       return apiCall({ ...options, allowRefresh: false });
     }
 
-    throw new APIError(result.status, resultJson);
+    throw new APIError(result.status, resultJSON);
   }
 
-  return resultJson;
+  return resultJSON;
 }

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -41,24 +41,27 @@ const activeRefreshCalls = new Map();
  * Make an API call to the LMS app backend.
  *
  * @param {object} options
- *   @param {string} options.path - The `/api/...` path of the endpoint to call
  *   @param {string} options.authToken - Session authorization token
- *   @param {string} [options.method] - Custom HTTP method for call
- *   @param {object} [options.data] - JSON-serializable body of the request
+ *   @param {string} options.path - The `/api/...` path of the endpoint to call
  *   @param {boolean} [options.allowRefresh] - If the request fails due to
  *     an expired access token for an external API, this flag specifies whether
  *     to attempt to refresh the token.
+ *   @param {object} [options.data] - JSON-serializable body of the request
+ *   @param {string} [options.method] - Custom HTTP method for call. Defaults
+ *     to GET, or POST if `data` is set.
  *   @param {Record<string, string>} [options.params] - Query parameters
  * @return {Promise<any>} - Parsed JSON response. TODO: Convert this to `Promise<unknown>`
  */
 export async function apiCall(options) {
   const {
-    allowRefresh = true,
     authToken,
+    path,
+
+    // Optional fields.
+    allowRefresh = true,
     data,
     method,
     params,
-    path,
   } = options;
 
   let body;

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -1,15 +1,62 @@
 import { APIError } from '../errors';
 
 /**
+ * Error response when a call fails due to expiry of an access token for an
+ * external API.
+ *
+ * @typedef RefreshError
+ * @prop {RefreshCall} refresh
+ */
+
+/**
+ * Parameters for an API call that will refresh an expired access token.
+ *
+ * @typedef RefreshCall
+ * @prop {string} method
+ * @prop {string} path
+ */
+
+/**
+ * @param {any} response
+ * @return {response is RefreshError}
+ */
+function isRefreshError(response) {
+  return response && response.refresh && typeof response.refresh === 'object';
+}
+
+/**
+ * Map of request path to result promise for access token refresh requests that are
+ * in flight.
+ *
+ * This is used to avoid triggering concurrent refresh requests for the same
+ * external API.
+ *
+ * @type {Map<string, Promise<void>>}
+ */
+const activeRefreshCalls = new Map();
+
+/**
  * Make an API call to the LMS app backend.
  *
  * @param {object} options
  *   @param {string} options.path - The `/api/...` path of the endpoint to call
- *   @param {string} options.authToken
+ *   @param {string} options.authToken - Session authorization token
+ *   @param {string} [options.method] - Custom HTTP method for call
  *   @param {object} [options.data] - JSON-serializable body of the request
+ *   @param {boolean} [options.allowRefresh]
  *   @param {Record<string, string>} [options.params] - Query parameters
+ * @return {Promise<any>} - Parsed JSON response. TODO: Convert this to `Promise<unknown>`
  */
-export async function apiCall({ path, authToken, data, params }) {
+export async function apiCall(options) {
+  const {
+    allowRefresh = true,
+    authToken,
+    data,
+    method,
+    params,
+    path,
+  } = options;
+
   let body;
 
   /** @type {Record<string,string>} */
@@ -31,14 +78,42 @@ export async function apiCall({ path, authToken, data, params }) {
     query = '?' + urlParams.toString();
   }
 
+  const defaultMethod = data === undefined ? 'GET' : 'POST';
   const result = await fetch(path + query, {
-    method: data === undefined ? 'GET' : 'POST',
+    method: method ?? defaultMethod,
     body,
     headers,
   });
   const resultJson = await result.json();
 
   if (result.status >= 400 && result.status < 600) {
+    // Refresh expired access tokens for external APIs, if required. Only one
+    // such request should be issued by the frontend for a given API at a time.
+    if (allowRefresh && result.status === 400 && isRefreshError(resultJson)) {
+      const { method, path } = resultJson.refresh;
+
+      // Refresh the access token for the external API.
+      if (activeRefreshCalls.has(path)) {
+        await activeRefreshCalls.get(path);
+      } else {
+        const refreshDone = apiCall({
+          authToken,
+          method,
+          path,
+          allowRefresh: false,
+        });
+        activeRefreshCalls.set(path, refreshDone);
+        try {
+          await refreshDone;
+        } finally {
+          activeRefreshCalls.delete(path);
+        }
+      }
+
+      // Retry the original API call.
+      return apiCall({ ...options, allowRefresh: false });
+    }
+
     throw new APIError(result.status, resultJson);
   }
 

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -1,22 +1,36 @@
 import { APIError } from '../../errors';
 import { apiCall } from '../api';
 
+function createResponse(status, body) {
+  return {
+    status,
+    json: sinon.stub().resolves(body),
+  };
+}
+
 describe('api', () => {
   let fakeResponse;
 
   beforeEach(() => {
-    fakeResponse = {
-      status: 200,
-      json: sinon
-        .stub()
-        .resolves([{ id: 123, display_name: 'foo', updated_at: '2019-01-01' }]),
-    };
+    fakeResponse = createResponse(200, {
+      id: 123,
+      display_name: 'foo',
+      updated_at: '2019-01-01',
+    });
     sinon.stub(window, 'fetch').resolves(fakeResponse);
+
+    window.fetch
+      .withArgs('/api/canvas/refresh')
+      .resolves(createResponse(200, null));
   });
 
   afterEach(() => {
     window.fetch.restore();
   });
+
+  function getFetchPaths() {
+    return window.fetch.args.map(fetchArgs => fetchArgs[0]);
+  }
 
   describe('apiCall', () => {
     it('makes a GET request if no body is provided', async () => {
@@ -148,5 +162,114 @@ describe('api', () => {
 
     assert.instanceOf(reason, TypeError);
     assert.equal(reason.message, 'Parse failed');
+  });
+
+  it('refreshes access tokens for external APIs', async () => {
+    const refreshNeededResponse = createResponse(400, {
+      refresh: { method: 'POST', path: '/api/canvas/refresh' },
+    });
+    window.fetch
+      .withArgs('/api/test')
+      .onFirstCall()
+      .resolves(refreshNeededResponse);
+
+    const result = await apiCall({ path: '/api/test', authToken: 'auth' });
+
+    // Expect initial request, followed by token refresh, followed by a retry
+    // of the original request.
+    assert.deepEqual(getFetchPaths(), [
+      '/api/test',
+      '/api/canvas/refresh',
+      '/api/test',
+    ]);
+
+    const refreshCall = window.fetch.secondCall;
+    assert.deepEqual(refreshCall.args[1], {
+      method: 'POST',
+      body: undefined,
+      headers: { Authorization: 'auth' },
+    });
+
+    assert.deepEqual(result, await fakeResponse.json());
+  });
+
+  it('only attempts a token refresh once per call', async () => {
+    const refreshNeededResponse = createResponse(400, {
+      refresh: { method: 'POST', path: '/api/canvas/refresh' },
+    });
+
+    // Make both the initial request and the request after the successful refresh
+    // fail.
+    window.fetch.resolves(refreshNeededResponse);
+
+    let error;
+    try {
+      await apiCall({ path: '/api/test', authToken: 'auth' });
+    } catch (e) {
+      error = e;
+    }
+
+    assert.instanceOf(error, APIError);
+    assert.equal(error.message, 'API call failed');
+    assert.equal(error.status, 400);
+  });
+
+  it('rethrows token refresh failures', async () => {
+    const refreshNeededResponse = createResponse(400, {
+      refresh: { method: 'POST', path: '/api/canvas/refresh' },
+    });
+    window.fetch.resolves(refreshNeededResponse);
+    window.fetch.withArgs('/api/canvas/refresh').resolves(
+      createResponse(400, {
+        message: 'Token refresh failed',
+      })
+    );
+
+    let error;
+    try {
+      await apiCall({ path: '/api/test', authToken: 'auth' });
+    } catch (e) {
+      error = e;
+    }
+
+    assert.deepEqual(getFetchPaths(), ['/api/test', '/api/canvas/refresh']);
+    assert.ok(error);
+    assert.equal(error.message, 'API call failed');
+    assert.equal(error.serverMessage, 'Token refresh failed');
+  });
+
+  it('prevents concurrent access token refreshes', async () => {
+    const refreshNeededResponse = createResponse(400, {
+      refresh: { method: 'POST', path: '/api/canvas/refresh' },
+    });
+    window.fetch
+      .withArgs('/api/test')
+      .onCall(0)
+      .resolves(refreshNeededResponse);
+    window.fetch
+      .withArgs('/api/test')
+      .onCall(1)
+      .resolves(refreshNeededResponse);
+
+    const firstCallPromise = apiCall({ path: '/api/test', authToken: 'auth' });
+    const secondCallPromise = apiCall({ path: '/api/test', authToken: 'auth' });
+
+    const [firstCallResult, secondCallResult] = await Promise.all([
+      firstCallPromise,
+      secondCallPromise,
+    ]);
+
+    // Expect two calls to `/api/test` that will fail due to a needed refresh,
+    // followed by a refresh, followed by two retries of the original requests.
+    assert.deepEqual(getFetchPaths(), [
+      '/api/test',
+      '/api/test',
+      '/api/canvas/refresh',
+      '/api/test',
+      '/api/test',
+    ]);
+
+    assert.deepEqual(firstCallResult, await fakeResponse.json());
+    assert.deepEqual(secondCallResult, await fakeResponse.json());
   });
 });


### PR DESCRIPTION
Implement frontend-coordinated refresh [1] of expired access tokens for external
APIs (Canvas, Blackboard). When a frontend API call fails because due to expiry
of an access token for an external API, initiate a refresh from the frontend.

Initiating the request from the frontend has the advantage that a client can
prevent concurrent refreshes, at least from the same browser session within
the scope of a single page load.

[1] https://github.com/hypothesis/lms/issues/3667#issuecomment-1049063194

Part of https://github.com/hypothesis/lms/issues/3667. Will close that issue once the feature flag is turned on.

For testing, I followed [Sean's detailed instructions here](https://github.com/hypothesis/lms/issues/3667#issuecomment-1049063194). 

