### PR TITLE
LTIRegistration model and service

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -18,6 +18,7 @@ from lms.models.grouping import (
 )
 from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
+from lms.models.lti_registration import LTIRegistration
 from lms.models.lti_user import LTIUser, display_name
 from lms.models.oauth2_token import OAuth2Token
 from lms.models.user import User

--- a/lms/models/lti_registration.py
+++ b/lms/models/lti_registration.py
@@ -1,0 +1,35 @@
+import sqlalchemy as sa
+
+from lms.db import BASE
+from lms.models import CreatedUpdatedMixin
+
+
+class LTIRegistration(CreatedUpdatedMixin, BASE):
+    """
+    LTI1.3 registration details.
+
+    From http://www.imsglobal.org/spec/lti/v1p3/migr:
+
+     - LTI 1.3 separates the registration of the tool (security and configuration) from its actual deployment.
+
+     - A tool registration is identified as a client_id issued by the learning platform (the issuer).
+    """
+
+    __tablename__ = "lti_registration"
+    __table_args__ = (sa.UniqueConstraint("issuer", "client_id"),)
+
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    issuer = sa.Column(sa.UnicodeText, nullable=False)
+    """Identifier of the platform of this registration"""
+
+    client_id = sa.Column(sa.UnicodeText, nullable=False)
+    """Unique identifier of the registration at the issuer"""
+
+    auth_login_url = sa.Column(sa.UnicodeText, nullable=False)
+    """URL to redirect the clients in the OIDC flow"""
+
+    key_set_url = sa.Column(sa.UnicodeText, nullable=False)
+    """Location of the public keys provied by the issuer for this registration"""
+    token_url = sa.Column(sa.UnicodeText, nullable=False)
+    """Endpoint to request new oauth tokens to use with LTIA APIs"""

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -17,6 +17,7 @@ from lms.services.launch_verifier import (
     LTILaunchVerificationError,
     LTIOAuthError,
 )
+from lms.services.lti_registration import LTIRegistrationService
 from lms.services.user import UserService
 
 
@@ -74,3 +75,6 @@ def includeme(config):
     config.register_service_factory("lms.services.grouping.factory", name="grouping")
     config.register_service_factory("lms.services.file.factory", name="file")
     config.register_service_factory("lms.services.jstor.factory", iface=JSTORService)
+    config.register_service_factory(
+        "lms.services.lti_registration.factory", iface=LTIRegistrationService
+    )

--- a/lms/services/lti_registration.py
+++ b/lms/services/lti_registration.py
@@ -1,0 +1,23 @@
+from lms.models import LTIRegistration
+
+
+class LTIRegistrationService:
+    def __init__(self, db):
+        self._db = db
+
+    def get(self, issuer, client_id):
+        """
+        Get a LTIRegistration based on the uniqueness of issuer + client_id.
+
+        - issuer is provided by the platform (ie the LMS) and is generally a URL identifying the LMS.
+        - client_id is also provided by the LMS and it should be unique within the issuer.
+        """
+        return (
+            self._db.query(LTIRegistration)
+            .filter_by(issuer=issuer, client_id=client_id)
+            .one_or_none()
+        )
+
+
+def factory(_context, request):
+    return LTIRegistrationService(db=request.db)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -22,6 +22,7 @@ from tests.factories.group_info import GroupInfo
 from tests.factories.grouping import BlackboardGroup, CanvasGroup, CanvasSection, Course
 from tests.factories.h_user import HUser
 from tests.factories.legacy_course import LegacyCourse
+from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_user import LTIUser
 from tests.factories.oauth2_token import OAuth2Token
 from tests.factories.user import User

--- a/tests/factories/lti_registration.py
+++ b/tests/factories/lti_registration.py
@@ -1,0 +1,14 @@
+from factory import Faker, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+LTIRegistration = make_factory(
+    models.LTIRegistration,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    issuer=Faker("hostname"),
+    client_id=Faker("hexify", text="^" * 40),
+    auth_login_url=Faker("uri"),
+    key_set_url=Faker("uri"),
+    token_url=Faker("uri"),
+)

--- a/tests/unit/lms/services/lti_registration_test.py
+++ b/tests/unit/lms/services/lti_registration_test.py
@@ -1,0 +1,32 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.lti_registration import LTIRegistrationService, factory
+from tests import factories
+
+
+class TestLTIRegistrationService:
+    def test_get(self, svc, registration):
+        assert svc.get(registration.issuer, registration.client_id) == registration
+
+    @pytest.fixture
+    def registration(self):
+        return factories.LTIRegistration()
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return LTIRegistrationService(db_session)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, LTIRegistrationService):
+        service = factory(sentinel.context, pyramid_request)
+
+        LTIRegistrationService.assert_called_once_with(pyramid_request.db)
+
+        assert service == LTIRegistrationService.return_value
+
+    @pytest.fixture
+    def LTIRegistrationService(self, patch):
+        return patch("lms.services.lti_registration.LTIRegistrationService")


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/3689


This is missing the migration, I'll auto-generate it when we think we are going to merge it.


I think the model and service are small enough to be together in this PR

## Testing 

This is not used yet in any of the existing code paths but can be quickly tested on the shell:

- Start with a fresh DB

```docker stop lms_postgres_1; docker rm lms_postgres_1; make services db devdata``` 


- `make shell`

```
In [1]: db.add(models.LTIRegistration(issuer="https://canvas.instructure.com", client_id="93820000000000200", auth_login_url="https://canvas.instructure.com/api/lti/auth
   ...: orize_redirect", key_set_url="https://canvas.instructure.com/api/lti/security/jwks", token_url="ttps://canvas.instructure.com/api/lti/authorize"))
In [2]: tm.commit()
```


```
In [4]: from lms.services import LTIRegistrationServiceIn 
In [5]: rs = request.find_service(LTIRegistrationService)
In [6]: tm.begin()

In [8]: rs.get("WHAT", "WAT") is None
Out[8]: True

In [9]: rs.get(issuer="https://canvas.instructure.com", client_id="93820000000000200")
Out[9]: LTIRegistration(created=datetime.datetime(2022, 3, 15, 16, 3, 36, 824441), updated=datetime.datetime(2022, 3, 15, 16, 3, 36, 824441), id=1, issuer='https://canvas.instructure.com', client_id='93820000000000200', auth_login_url='https://canvas.instructure.com/api/lti/authorize_redirect', key_set_url='https://canvas.instructure.com/api/lti/security/jwks', token_url='ttps://canvas.instructure.com/api/lti/authorize')
```


