### PR TITLE
Log a warning every time a Course is created from a LegacyCourse

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -1,8 +1,11 @@
 """Traversal resources for LTI launch views."""
 import functools
+import logging
 
 from lms.resources._js_config import JSConfig
 from lms.services import ApplicationInstanceNotFound
+
+LOG = logging.getLogger(__name__)
 
 
 class LTILaunchResource:
@@ -46,6 +49,12 @@ class LTILaunchResource:
             self._course_extra(),
             legacy_course.settings,
         )
+
+        if not self._request.db.is_modified(legacy_course) and not course.id:
+            LOG.warning(
+                "Created course from existing legacy course. consumer_key: %s",
+                legacy_course.consumer_key,
+            )
 
         return legacy_course, course
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -6,6 +6,7 @@ from pytest import param
 from lms.models import ApplicationSettings
 from lms.resources import LTILaunchResource
 from lms.services import ApplicationInstanceNotFound
+from tests import factories
 
 pytestmark = pytest.mark.usefixtures(
     "application_instance_service", "course_service", "assignment_service"
@@ -15,9 +16,10 @@ pytestmark = pytest.mark.usefixtures(
 class TestHGroup:
     @pytest.mark.usefixtures("has_course")
     def test_it(self, lti_launch, course_service):
-        course_service.upsert.return_value = mock.sentinel.course
+        course = factories.Course()
+        course_service.upsert.return_value = course
 
-        assert lti_launch.h_group == mock.sentinel.course
+        assert lti_launch.h_group == course
 
 
 class TestResourceLinkIdk:


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/3699

`LegacyCourse` doesn't have timestamps or an auto-increment primary key so having an exact idea of how often a Course is created from a LegacyCourse (instead of both being created for a new course) is tricky to check with SQL.

Adding a temporary logging statement which we can check on papertrail. 


### Testing


- Launch an assigment: https://hypothesis.instructure.com/courses/125/assignments/873. Nothing should be logged on the `make dev` console.

- Delete the courses (leaving only the LegacyCourse):

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "delete from grouping where type ='course'"
```

- Re launch the assigment https://hypothesis.instructure.com/courses/125/assignments/873

You'll get a a logging line:

```
web (stderr)         | 2022-03-16 10:48:10,170 WARNI [lms.resources.lti_launch:54][MainThread] Created course from existing legacy course. consumer_key: Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
```

- Re launch again, no logging.


