### PR TITLE
Backfill course in groupings from LegacyCourse

### DIFF
--- a/lms/migrations/versions/911d1f7da759_backfill_course_groupings.py
+++ b/lms/migrations/versions/911d1f7da759_backfill_course_groupings.py
@@ -1,0 +1,78 @@
+"""
+Backfill grouping with courses based on rows from `course` and `group_info`.
+
+Revision ID: 911d1f7da759
+Revises: 2119e1c621de
+Create Date: 2022-03-25 11:35:19.760847
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "911d1f7da759"
+down_revision = "34f28d992b18"
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    conn.execute(
+        """
+        INSERT INTO grouping
+            (
+                created,
+                updated,
+                application_instance_id,
+                authority_provided_id,
+                parent_id,
+                lms_id,
+                lms_name,
+                type,
+                settings,
+                extra
+            )
+        SELECT
+                -- Using a hard-coded value in the past to identify the rows added by the migration
+                '2022-03-25 00:00:00',
+                '2022-03-25 00:00:00',
+                application_instances.id,
+                group_info.authority_provided_id,
+                -- No parent
+                NULL,
+                group_info.context_id,
+                group_info.context_title,
+                'course',
+                course.settings,
+                CASE
+                    WHEN group_info.custom_canvas_course_id is null
+                    THEN  '{}'
+                    ELSE jsonb_build_object(
+                        'canvas', jsonb_build_object('custom_canvas_course_id', custom_canvas_course_id)
+                    )
+                END
+        FROM course
+        -- Make sure the group_info row is for the same course in the same application_instance
+        JOIN group_info
+            ON course.authority_provided_id = group_info.authority_provided_id
+            AND group_info.consumer_key = course.consumer_key
+        -- We'll get the application_instance_id from application_instances
+        JOIN application_instances
+            ON course.consumer_key = application_instances.consumer_key
+        WHERE
+            -- Ignore courses for application_instances for which we don't have a guid
+            application_instances.tool_consumer_instance_guid IS NOT NULL
+            -- Only bring courses for which the guid we have in application_instances matches the one in group_info
+            AND application_instances.tool_consumer_instance_guid = group_info.tool_consumer_instance_guid
+        -- Don't duplicate or update  courses we already have in grouping
+        ON CONFLICT (application_instance_id, authority_provided_id) DO NOTHING
+    """
+    )
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    conn.execute(
+        "DELETE FROM grouping WHERE created = '2022-03-25 00:00:00' AND type = 'course'"
+    )


### PR DESCRIPTION
For #3699 

`course` doesn't contain all the information we have in Grouping, missing most importantly the required:

- `lms_id`  (the ID of the course within the LMS)
- `custom_canvas_course_id` (required to build the `extra` dict)




## Testing

- Start with a fresh DB
```
git checkout 05a4712aad54ab0f99e15b6b5e21a5ad64de7617; docker stop lms_postgres_1; docker rm lms_postgres_1; make services db devdata; hdev alembic upgrade head
```

This needs to be done in a commit before:

```
commit 0908431ed5f3f01d00d092fa5ab8cae45a5272db (HEAD)
Author: Marcos Prieto <marcospri@gmail.com>
Date:   Mon Mar 14 10:45:41 2022 +0100

    Stop filling GroupInfo consumer_key
```

**Unfortunately that also implies a previous commit on dev data `773fd7e647d80852049472b2244f25644c8397d2`**

and a diff in LMS

```diff
diff --git a/bin/update_dev_data.py b/bin/update_dev_data.py
index 75a78024..cda35f54 100644
--- a/bin/update_dev_data.py
+++ b/bin/update_dev_data.py
@@ -114,7 +114,8 @@ def devdata():
             git_dir = os.path.join(tmpdirname, "devdata")
 
             subprocess.check_call(
-                ["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir]
+                # ["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir]
+                ["git", "clone", "/home/marcos/hypo/devdata", git_dir]
             )
```


- Open a couple of assignment from different courses:
    - https://hypothesis.instructure.com/courses/125/assignments/875
    - https://hypothesis.instructure.com/courses/252/assignments/1323


- Check the base data on the DB

    - course

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from course;"                                                                

                consumer_key                |          authority_provided_id           |                                             settings                                             
--------------------------------------------+------------------------------------------+--------------------------------------------------------------------------------------------------
 Hypothesis14af0fe87c9deb2e461f88be4a8d5364 | 5b21296ec1e16462793721c7222a223470512615 | {"blackboard": {"files_enabled": true, "groups_enabled": true}}
 Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a | 653e9620a656a954c684942f6443fa3e3410c03a | {"canvas": {"groups_enabled": true, "sections_enabled": true}, "vitalsource": {"enabled": true}}
(2 rows)
```



    - group_info

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from group_info where info->>'type' = 'course_group';"
 id |          authority_provided_id           |                consumer_key                | application_instance_id |                context_id                |                  context_title                  |         context_label          | tool_consumer_info_product_family_code | tool_consumer_info_version | tool_consumer_instance_name | tool_consumer_instance_description | tool_consumer_instance_url | tool_consumer_instance_contact_email |             tool_consumer_instance_guid             |  custom_canvas_api_domain  | custom_canvas_course_id |                                                                                                                                                        info                                                                                                                                                        
----+------------------------------------------+--------------------------------------------+-------------------------+------------------------------------------+-------------------------------------------------+--------------------------------+----------------------------------------+----------------------------+-----------------------------+------------------------------------+----------------------------+--------------------------------------+-----------------------------------------------------+----------------------------+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  1 | 653e9620a656a954c684942f6443fa3e3410c03a | Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a |                       8 | f3cd019017839c4630358662a05540f2f6ec5f93 | Developer Test Course with Sections Enabled     | Sections Enabled               | canvas                                 | cloud                      | University of Hypothesis    |                                    |                            | notifications@instructure.com        | VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms | hypothesis.instructure.com | 125                     | {"type": "course_group", "instructors": [{"email": "eng+canvasteacher@hypothes.is", "provider": "VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms", "username": "3a022b6c146dfd9df4ea8662178eac", "display_name": "Hypothesis 101 Teacher", "provider_unique_id": "969fc294ee26e3f1d0c9714af3351dc4eacfd6df"}]}
  5 | 5b21296ec1e16462793721c7222a223470512615 | Hypothesis14af0fe87c9deb2e461f88be4a8d5364 |                      16 | 7688d64e8c2d433597d80e9d18a8d373         | Developer Test Course with Original Course View | developer-test-course-original | BlackboardLearn                        | 3900.37.0-rel.9+37693ad    | Blackboard, Inc.            | Blackboard, Inc.                   |                            | admin@aunltd-test.blackboard.com     | 041c05b262b54282a0d9b61c42413ec0                    |                            |                         | {"type": "course_group", "instructors": [{"email": "", "provider": "041c05b262b54282a0d9b61c42413ec0", "username": "52140fb5154b791a0e1f4c5f917f0d", "display_name": "Blackboard Teacher", "provider_unique_id": "f58ba802d4cb4c1fbc3bff819e461af8"}]}
(2 rows)
```
 


    - Grouping


```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from grouping where type ='course';"                  


          created           |          updated           | id | application_instance_id |          authority_provided_id           | parent_id |                  lms_id                  |                    lms_name                     |  type  |                                             settings                                             |                     extra                      
----------------------------+----------------------------+----+-------------------------+------------------------------------------+-----------+------------------------------------------+-------------------------------------------------+--------+--------------------------------------------------------------------------------------------------+------------------------------------------------
 2022-03-25 10:57:00.281958 | 2022-03-25 10:57:00.281958 |  1 |                       8 | 653e9620a656a954c684942f6443fa3e3410c03a |           | f3cd019017839c4630358662a05540f2f6ec5f93 | Developer Test Course with Sections Enabled     | course | {"canvas": {"groups_enabled": true, "sections_enabled": true}, "vitalsource": {"enabled": true}} | {"canvas": {"custom_canvas_course_id": "125"}}
 2022-03-25 10:57:23.78836  | 2022-03-25 10:57:23.78836  |  5 |                      16 | 5b21296ec1e16462793721c7222a223470512615 |           | 7688d64e8c2d433597d80e9d18a8d373         | Developer Test Course with Original Course View | course | {"blackboard": {"files_enabled": true, "groups_enabled": true}}                                  | {}
(2 rows)
```
    


- Now delete one of the groupings

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "delete from grouping where type ='course' and authority_provided_id = '653e9620a656a954c684942f6443fa3e3410c03a';"
```

- Apply the migration on this branch:
```git checkout backfill-grouping; hdev alembic upgrade head```

- Compare that the new row is the same as the one that we deleted

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from grouping where type ='course';"
```


- Check the migration downgrade:
```hdev alembic downgrade 497b20c41fbb```

Only the non-removed row should be there now.

tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from grouping where type ='course';"

