### PR TITLE
Use tool_consumer_instance_guid from the DB if not present in the request params

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -49,7 +49,14 @@ class LTIUser(NamedTuple):
             user_id=lti_core_schema["user_id"],
             application_instance_id=application_instance.id,
             roles=lti_core_schema["roles"],
-            tool_consumer_instance_guid=lti_core_schema["tool_consumer_instance_guid"],
+            # If we are creating a new LTIUser from request params
+            # ApplicationInstance.update_lms_data won't have been executed yet
+            # meaning that application_instance.tool_consumer_instance_guid
+            # will be null on the first launch so we'll prefer the one coming from the request params.
+            tool_consumer_instance_guid=lti_core_schema.get(
+                "tool_consumer_instance_guid"
+            )
+            or application_instance.tool_consumer_instance_guid,
             display_name=display_name(
                 lti_core_schema["lis_person_name_given"],
                 lti_core_schema["lis_person_name_family"],

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -34,11 +34,6 @@ class JSConfig:
     def _h_user(self):
         return self._lti_user.h_user
 
-    @property
-    def _application_instance(self):
-        """Return the current request's ApplicationInstance."""
-        return self._request.find_service(name="application_instance").get_current()
-
     def add_document_url(self, document_url):
         """
         Set the document to the document at the given document_url.
@@ -195,7 +190,7 @@ class JSConfig:
             HTML form that we submit
         """
 
-        args = self._context, self._request, self._application_instance
+        args = self._context, self._request, self._context.application_instance
 
         self._config.update(
             {
@@ -394,7 +389,7 @@ class JSConfig:
         and had grading info recorded for them.
         """
         grading_infos = self._grading_info_service.get_by_assignment(
-            application_instance=self._application_instance,
+            application_instance=self._context.application_instance,
             context_id=self._request.params.get("context_id"),
             resource_link_id=self._request.params.get("resource_link_id"),
         )
@@ -432,7 +427,7 @@ class JSConfig:
         # mutable. You can do self._hypothesis_client["foo"] = "bar" and the
         # mutation will be preserved.
 
-        if not self._application_instance.provisioning:
+        if not self._context.application_instance.provisioning:
             return {}
 
         api_url = self._request.registry.settings["h_api_url_public"]
@@ -527,7 +522,8 @@ class JSConfig:
             return self._canvas_sync_api()
 
         if (
-            self._application_instance.product == ApplicationInstance.Product.BLACKBOARD
+            self._context.application_instance.product
+            == ApplicationInstance.Product.BLACKBOARD
             and self._context.is_blackboard_group_launch
         ):
 

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -29,7 +29,8 @@ class LTIV11CoreSchema(PyramidRequestSchema):
 
     user_id = fields.Str(required=True)
     roles = fields.Str(required=True)
-    tool_consumer_instance_guid = fields.Str(required=True)
+    # When tool_consumer_instance_guid is not present on the schema we'll use the prerecorded one in the DB.
+    tool_consumer_instance_guid = fields.Str(required=False, allow_none=True)
     lis_person_name_given = fields.Str(load_default="")
     lis_person_name_family = fields.Str(load_default="")
     lis_person_name_full = fields.Str(load_default="")

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -43,7 +43,7 @@ class BasicLTILaunchViews:
         self.context.js_config.enable_lti_launch_mode()
         self.context.js_config.maybe_set_focused_user()
 
-        self.context.application_instance.update_lms_data(self.request.params)
+        self.context.application_instance.update_lms_data(context.lti_params)
 
     def basic_lti_launch(self, document_url, grading_supported=True):
         """Do a basic LTI launch with the given document_url."""

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -50,7 +50,7 @@ from lms.validation import ContentItemSelectionLTILaunchSchema
 )
 def content_item_selection(context, request):
     request.find_service(name="application_instance").get_current().update_lms_data(
-        request.params
+        context.lti_params
     )
 
     context.get_or_create_course()

--- a/tests/functional/lti_certification/v13/core/test_bad_payloads.py
+++ b/tests/functional/lti_certification/v13/core/test_bad_payloads.py
@@ -33,7 +33,6 @@ class TestBadPayloads:
             in caplog.messages
         )
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_wrong_lti_version(self, make_jwt, test_payload, do_lti_launch):
         """The LTI version claim contains the wrong version"""
         test_payload["https://purl.imsglobal.org/spec/lti/claim/version"] = "11.3"
@@ -43,7 +42,6 @@ class TestBadPayloads:
         assert "There were problems with these request parameters" in response.text
         assert "lti_version" in response.text
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_no_lti_version(self, make_jwt, test_payload, do_lti_launch):
         """The LTI version claim is missing"""
         del test_payload["https://purl.imsglobal.org/spec/lti/claim/version"]
@@ -86,7 +84,6 @@ class TestBadPayloads:
         response = do_lti_launch({"id_token": make_jwt(test_payload)}, status=403)
         assert response.html
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_message_type_claim_missing(self, test_payload, assert_missing_claim):
         """The Required message_type Claim Not Present"""
         response = assert_missing_claim(
@@ -112,7 +109,6 @@ class TestBadPayloads:
             status=403,
         )
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_resource_link_id_claim_missing(self, test_payload, assert_missing_claim):
         """The Required resource_link_id Claim Not Present"""
         assert_missing_claim(

--- a/tests/functional/lti_certification/v13/core/test_valid_student_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_student_launches.py
@@ -5,7 +5,6 @@ import pytest
 from lms.resources._js_config import JSConfig
 
 
-@pytest.mark.xfail(cause="Work in progress", strict=True)
 class TestValidStudentLaunches:
     """
     Following the various valid instructor payload launches are valid Student/Learner payloads

--- a/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
@@ -5,7 +5,6 @@ import pytest
 from lms.resources._js_config import JSConfig
 
 
-@pytest.mark.xfail(cause="Work in progress", strict=True)
 class TestValidTeacherPayloads:
     """
     Following the known "bad" payload launches are valid Teacher payloads.

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -104,20 +104,32 @@ class TestApplicationInstance:
 
     def test_update_lms_data(self, application_instance, lms_data):
         lms_data["tool_consumer_instance_guid"] = "GUID"
+
         application_instance.update_lms_data(lms_data)
 
         for k, v in lms_data.items():
             assert getattr(application_instance, k) == v
 
-    def test_update_lms_data_no_guid_doesnt_change_values(
+    def test_update_lms_data_missing_tool_guid(self, application_instance, lms_data):
+        lms_data["tool_consumer_instance_guid"] = None
+        application_instance.tool_consumer_instance_guid = None
+
+        with pytest.raises(ValueError):
+            application_instance.update_lms_data(lms_data)
+
+    def test_update_lms_data_keeps_existing_guid_none_in_params(
         self, application_instance, lms_data
     ):
+        lms_data["tool_consumer_instance_guid"] = None
+        application_instance.tool_consumer_instance_guid = "EXISTING_GUID"
+
         application_instance.update_lms_data(lms_data)
 
-        assert application_instance.tool_consumer_instance_guid is None
-        assert application_instance.tool_consumer_info_product_family_code is None
+        assert application_instance.tool_consumer_instance_guid == "EXISTING_GUID"
 
-    def test_update_lms_data_existing_guid(self, application_instance, lms_data):
+    def test_update_lms_data_existing_guid_new_in_params(
+        self, application_instance, lms_data
+    ):
         application_instance.tool_consumer_instance_guid = "EXISTING_GUID"
         lms_data["tool_consumer_instance_guid"] = "NEW GUID"
 

--- a/tests/unit/lms/models/lti_user_test.py
+++ b/tests/unit/lms/models/lti_user_test.py
@@ -58,6 +58,16 @@ class TestLTIUser:
         )
         assert lti_user.application_instance_id == application_instance.id
 
+    def test_from_auth_params_with_no_guid(self, application_instance, auth_params):
+        del auth_params["tool_consumer_instance_guid"]
+
+        lti_user = LTIUser.from_auth_params(application_instance, auth_params)
+
+        assert (
+            lti_user.tool_consumer_instance_guid
+            == application_instance.tool_consumer_instance_guid
+        )
+
     @pytest.fixture
     def auth_params(self):
         return {

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -5,7 +5,6 @@ from pytest import param
 
 from lms.models import ApplicationSettings
 from lms.resources import LTILaunchResource
-from lms.services import ApplicationInstanceNotFound
 from tests import factories
 
 pytestmark = pytest.mark.usefixtures(
@@ -205,14 +204,8 @@ class TestCanvasSectionsSupported:
     def test_it_depends_on_application_instance_service(
         self, lti_launch, application_instance_service
     ):
-        application_instance_service.get_current.return_value.developer_key = None
-        assert not lti_launch.canvas_sections_supported()
-
-    def test_if_application_instance_service_raises(
-        self, lti_launch, application_instance_service
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound
+        application_instance_service.get_current.return_value = mock.Mock(
+            developer_key=None
         )
         assert not lti_launch.canvas_sections_supported()
 
@@ -285,15 +278,6 @@ class TestCourseExtra:
 
 @pytest.mark.usefixtures("has_course")
 class TestBlackboardGroupsEnabled:
-    def test_it_returns_False_if_theres_no_ApplicationInstance(
-        self, application_instance_service, lti_launch
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound
-        )
-
-        assert not lti_launch.blackboard_groups_enabled
-
     @pytest.mark.parametrize(
         "setting_value,expected",
         [(True, True), (False, False), (None, False)],
@@ -311,15 +295,6 @@ class TestBlackboardGroupsEnabled:
 
 @pytest.mark.usefixtures("has_course")
 class TestCanvasGroupsEnabled:
-    def test_false_when_no_application_instance(
-        self, application_instance_service, lti_launch
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound
-        )
-
-        assert not lti_launch.canvas_groups_enabled
-
     @pytest.mark.parametrize("settings_value", [True, False])
     def test_returns_settings_value(
         self, settings_value, application_instance_service, lti_launch

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -87,7 +87,7 @@ class TestBasicLTILaunchSchema:
 
     @pytest.mark.parametrize(
         "required_param",
-        ["oauth_consumer_key", "tool_consumer_instance_guid", "user_id"],
+        ["oauth_consumer_key", "user_id"],
     )
     def test_it_raises_ValidationError_if_a_non_reportable_field_is_missing(
         self, pyramid_request, required_param
@@ -231,7 +231,6 @@ class TestContentItemSelectionLTILaunchSchema:
             "context_title",
             "lti_message_type",
             "lti_version",
-            "tool_consumer_instance_guid",
             "user_id",
             "roles",
         ],

--- a/tests/unit/lms/validation/authentication/_lti_test.py
+++ b/tests/unit/lms/validation/authentication/_lti_test.py
@@ -67,7 +67,6 @@ class TestLTI11AuthSchema:
         [
             "user_id",
             "roles",
-            "tool_consumer_instance_guid",
             "oauth_consumer_key",
             "oauth_nonce",
             "oauth_signature",

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -296,9 +296,7 @@ class TestCanvasFileBasicLTILaunch:
 
         assignment_service.upsert.assert_called_once_with(
             document_url=f"canvas://file/course/{course_id}/file_id/{file_id}",
-            tool_consumer_instance_guid=pyramid_request.params[
-                "tool_consumer_instance_guid"
-            ],
+            tool_consumer_instance_guid=context.application_instance.tool_consumer_instance_guid,
             resource_link_id=pyramid_request.params["resource_link_id"],
         )
 


### PR DESCRIPTION
`tool_consumer_instance_guid` is an optional parameter in the LTI spec but
required in our app.

In general all LMS do send it as a request parameters so ApplicationInstance.update_lms_data will set the right value on the DB.

For LMS that don't send it (only the LTI1.3 certification tool as of today) we'll allow the request params to be absent but we'll rely on the application_instance row to have the tool_consumer_instance_guid value pre-filled.


### On the removed error handling for accessing application_instance


Having an application instance is fundamental to any LTI launch so `resources/lti_launch` should assume it's already there.

If for any reason it's not there, the exception should bubble up and produce an error instead of disabling some features, and then produce an error.

We are also picking the tool_consumer_guid from the DB instead of the request param.



##  Testing

### Testing GUID changes

#### Testing the case where the GUID is not sent.

We'll rely on the functional tests to test this case as no other LMS behaves like this.


#### Testing existing behavior hasn't changed

- Checkout `master`
- https://hypothesis.instructure.com/courses/125/assignments/873, create an annotation there.
- Checkout `simplify-error-handling`
- Reload - https://hypothesis.instructure.com/courses/125/assignments/873, the annotation should still be there.



### Testing simplifying error handling


#### Current behavior in master

- Checkout `master`
- Log in as a teacher in Canvas and edit an assignment, try to configure an assignment and mark it as a groups one selecting any group set.

https://hypothesis.instructure.com/courses/125/assignments/2754/edit?name=TEMP+-+marcos&due_at=null&points_possible=0

- Now remove your application_instances

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "delete from application_instances;"
```

- Try to edit the assignment again
- You'll get an 404 from the backend and a sad H page as a response.
- This is because the line at:

https://github.com/hypothesis/lms/blob/948d2fc8135c077e18a1c7018ac80cedf4629bfd/lms/services/launch_verifier.py#L153


#### New behavior in this branch

- Switch to `simplify-error-handling`
- `make devdata` to get your application instances back
- Again try to configure an assignment as a groups one

https://hypothesis.instructure.com/courses/125/assignments/2754/edit?name=TEMP+-+marcos&due_at=null&points_possible=0

- It should work as expected 
- Delete your application instances

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "delete from application_instances;"
```

- And try configure the assignment again


https://hypothesis.instructure.com/courses/125/assignments/2754/edit?name=TEMP+-+marcos&due_at=null&points_possible=0

- Same behavior as before, a 404 and an error page.

