### PR TITLE
PoC: Make a grading submission only on first annotation activity

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -246,9 +246,20 @@ export default function BasicLTILaunchApp() {
     }
   }, [authToken, canvas.speedGrader, contentReady]);
 
+  // Report a submission only after the first qualifying annotation activity
+  // (create or update an annotation or reply)
   useEffect(() => {
-    reportSubmission();
-  }, [reportSubmission]);
+    const unsubscribe = () =>
+      clientRPC.off('annotationActivity', onAnnotationActivity);
+
+    function onAnnotationActivity() {
+      reportSubmission().then(unsubscribe);
+    }
+
+    clientRPC.on('annotationActivity', onAnnotationActivity);
+
+    return unsubscribe;
+  }, [clientRPC, reportSubmission]);
 
   /**
    * Request the user's authorization to access the content, then try fetching

--- a/lms/static/scripts/postmessage_json_rpc/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server.js
@@ -162,7 +162,9 @@ export class Server {
 
     // Call the method and return the result response.
     try {
-      const result = await method();
+      const result = request.params
+        ? await method(...request.params)
+        : await method();
       return { jsonrpc: '2.0', result: result, id: request.id };
     } catch (e) {
       return {


### PR DESCRIPTION
This PR is a draft of an approach of making a grading submission only upon first qualifying annotation activity instead of on assignment launch. 

Part of https://github.com/hypothesis/lms/issues/3647

## Tasks

* [ ] Validate approach
* [ ] Schedule work: back-end support of dates from front-end on grading submissions: https://github.com/hypothesis/lms/issues/3669
* [ ] Add date to `data` sent to submission proxy API
* [ ] Make code production-ready and add tests