### PR TITLE
Close connection on functional tests

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -67,3 +67,4 @@ def db_session(db_engine):
     finally:
         factories.clear_sqlalchemy_session()
         session.close()
+        conn.close()


### PR DESCRIPTION
We were only closing the session but the connection was kept open and every  tests was creating a new one, eventually reaching the connection limit.


This is not a problem in master as we don't seem to have enough tests to hit the connection limit.


We already do this for unit tests: https://github.com/hypothesis/lms/blob/c1e6bdfc06d9e98cf8a9490b853933a1d0b1851a/tests/unit/conftest.py#L147