### PR TITLE
Extend JWTService to support LTI 1.3 token decoding

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -96,6 +96,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.assets")
     config.include("lms.views")
     config.include("lms.services")
+    config.include("lms.services.jwt")
     config.include("lms.validation")
     config.include("lms.tweens")
     config.add_static_view(name="export", path="lms:static/export")

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -24,30 +24,38 @@ class LTIParams(dict):
         return LTIParams(_to_lti_v11(v13_params), v13_params)
 
 
-_V11_TO_V13 = {
-    # LTI 1.1 key -> [LTI 1.3 path in object]
-    "user_id": ["sub"],
-    "lis_person_name_given": ["given_name"],
-    "lis_person_name_family": ["family_name"],
-    "lis_person_name_full": ["name"],
-    "roles": [f"{CLAIM_PREFIX}/roles"],
-    "context_id": [f"{CLAIM_PREFIX}/context", "id"],
-    "context_title": [f"{CLAIM_PREFIX}/context", "title"],
-    "lti_version": [f"{CLAIM_PREFIX}/version"],
-    "lti_message_type": [f"{CLAIM_PREFIX}/message_type"],
-    "resource_link_id": [f"{CLAIM_PREFIX}/resource_link", "id"],
-    "tool_consumer_instance_guid": [f"{CLAIM_PREFIX}/tool_platform", "guid"],
-    "tool_consumer_info_product_family_code": [
-        f"{CLAIM_PREFIX}/tool_platform",
-        "product_family_code",
-    ],
-}
+_V11_TO_V13 = (
+    # LTI 1.1 key , [LTI 1.3 path in object]
+    # We use tuples instead of a dictionary to allow duplicate keys for multiple locations.
+    ("user_id", ["sub"]),
+    ("lis_person_name_given", ["given_name"]),
+    ("lis_person_name_family", ["family_name"]),
+    ("lis_person_name_full", ["name"]),
+    ("roles", [f"{CLAIM_PREFIX}/roles"]),
+    ("context_id", [f"{CLAIM_PREFIX}/context", "id"]),
+    ("context_title", [f"{CLAIM_PREFIX}/context", "title"]),
+    ("lti_version", [f"{CLAIM_PREFIX}/version"]),
+    ("lti_message_type", [f"{CLAIM_PREFIX}/message_type"]),
+    ("resource_link_id", [f"{CLAIM_PREFIX}/resource_link", "id"]),
+    # tool_consumer_instance_guid is not sent by the LTI1.3 certification tool but we include
+    # it as a custom parameter in the tool configuration
+    ("tool_consumer_instance_guid", [f"{CLAIM_PREFIX}/custom", "certification_guid"]),
+    # Usual LTI1.3 location for tool_consumer_instance_guid
+    ("tool_consumer_instance_guid", [f"{CLAIM_PREFIX}/tool_platform", "guid"]),
+    (
+        "tool_consumer_info_product_family_code",
+        [
+            f"{CLAIM_PREFIX}/tool_platform",
+            "product_family_code",
+        ],
+    ),
+)
 
 
 def _to_lti_v11(v13_params):
     v11_params = {}
 
-    for v11_key, v13_path in _V11_TO_V13.items():
+    for v11_key, v13_path in _V11_TO_V13:
         # Descend into the object for each item in the path
         found = False
         value = v13_params

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -13,7 +13,7 @@ from lms.services.exceptions import (
 )
 from lms.services.h_api import HAPIError
 from lms.services.jstor import JSTORService
-from lms.services.jwt import JWTService
+from lms.services.jwt import InvalidJWTError, JWTService
 from lms.services.launch_verifier import (
     ConsumerKeyLaunchVerificationError,
     LTILaunchVerificationError,
@@ -81,4 +81,4 @@ def includeme(config):
         "lms.services.lti_registration.factory", iface=LTIRegistrationService
     )
     config.register_service_factory("lms.services.aes.factory", iface=AESService)
-    config.register_service(JWTService(), iface=JWTService)
+    config.register_service_factory("lms.services.jwt.factory", iface=JWTService)

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -13,7 +13,7 @@ from lms.services.exceptions import (
 )
 from lms.services.h_api import HAPIError
 from lms.services.jstor import JSTORService
-from lms.services.jwt import InvalidJWTError, JWTService
+from lms.services.jwt import JWTService
 from lms.services.launch_verifier import (
     ConsumerKeyLaunchVerificationError,
     LTILaunchVerificationError,

--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import logging
 from functools import lru_cache
 
 import jwt
@@ -7,6 +8,8 @@ from jwt.exceptions import ExpiredSignatureError, InvalidTokenError, PyJWTError
 
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
 from lms.services.lti_registration import LTIRegistrationService
+
+LOG = logging.getLogger(__name__)
 
 
 class JWTService:
@@ -58,6 +61,40 @@ class JWTService:
 
         return jwt_str
 
+    def decode_lti_token(self, id_token: str) -> dict:
+        """
+        Decode an LTI `id_token` JWT.
+
+        The JWT is validated against its corresponding LTIRegistration public key
+        """
+        if not id_token:
+            return {}
+
+        if not jwt.get_unverified_header(id_token).get("kid"):
+            LOG.debug("Missing 'kid' value in JWT header")
+            return {}
+
+        unverified_payload = jwt.decode(id_token, options={"verify_signature": False})
+        iss, aud = unverified_payload.get("iss"), unverified_payload.get("aud")
+
+        # Find the registration based on the token's claimed issuer & audience
+        registration = self._registration_service.get(iss, aud)
+        if not registration:
+            LOG.debug("Unknown registration for lti_token. iss:%s aud:%s.", iss, aud)
+            return {}
+
+        try:
+            signing_key = self._get_jwk_client(
+                registration.key_set_url
+            ).get_signing_key_from_jwt(id_token)
+
+            return jwt.decode(
+                id_token, key=signing_key.key, audience=aud, algorithms=["RS256"]
+            )
+        except PyJWTError as err:
+            LOG.debug("Invalid JWT. %s", str(err))
+            return {}
+
     @staticmethod
     @lru_cache
     def _get_jwk_client(jwk_url: str):
@@ -69,31 +106,16 @@ class JWTService:
         """
         return jwt.PyJWKClient(jwk_url)
 
-    def decode_lti_token(self, id_token):
-        header = jwt.get_unverified_header(id_token)
-        if not header.get("kid"):
-            raise InvalidJWTError("Missing 'kid' value in JWT header")
-
-        unverified_payload = jwt.decode(id_token, options={"verify_signature": False})
-        iss, aud = unverified_payload.get("iss"), unverified_payload.get("aud")
-
-        registration = self._registration_service.get(iss, aud)
-        if not registration:
-            raise InvalidJWTError(
-                f"Unknown registration for lti_token. iss:'{iss}' aud:'{aud}'."
-            )
-
-        try:
-            signing_key = self._get_jwk_client(
-                registration.key_set_url
-            ).get_signing_key_from_jwt(id_token)
-
-            return jwt.decode(
-                id_token, key=signing_key.key, audience=aud, algorithms=["RS256"]
-            )
-        except PyJWTError as err:
-            raise InvalidJWTError(str(err)) from err
-
 
 def factory(_context, request):
     return JWTService(registration_service=request.find_service(LTIRegistrationService))
+
+
+def _get_lti_jwt(request):
+    return request.find_service(JWTService).decode_lti_token(
+        request.params.get("id_token")
+    )
+
+
+def includeme(config):
+    config.add_request_method(_get_lti_jwt, name="lti_jwt", property=True, reify=True)

--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -1,12 +1,18 @@
 import copy
 import datetime
+from functools import lru_cache
 
 import jwt
+from jwt.exceptions import ExpiredSignatureError, InvalidTokenError, PyJWTError
 
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
+from lms.services.lti_registration import LTIRegistrationService
 
 
 class JWTService:
+    def __init__(self, registration_service):
+        self._registration_service = registration_service
+
     @classmethod
     def decode_with_secret(cls, jwt_str, secret) -> dict:
         """
@@ -26,9 +32,9 @@ class JWTService:
             payload = jwt.decode(
                 jwt_str, secret, algorithms=["HS256"], options={"require": ["exp"]}
             )
-        except jwt.ExpiredSignatureError as err:
+        except ExpiredSignatureError as err:
             raise ExpiredJWTError() from err
-        except jwt.InvalidTokenError as err:
+        except InvalidTokenError as err:
             raise InvalidJWTError() from err
 
         del payload["exp"]
@@ -51,3 +57,44 @@ class JWTService:
         jwt_str = jwt.encode(payload, secret, algorithm="HS256")
 
         return jwt_str
+
+    @staticmethod
+    @lru_cache
+    def _get_jwk_client(jwk_url: str):
+        """
+        Get a PyJWKClient for the given key set URL.
+
+        PyJWKClient maintains a cache of keys it has seen we want to keep
+        the clients around with `lru_cache` in case we can reuse that internal cache
+        """
+        return jwt.PyJWKClient(jwk_url)
+
+    def decode_lti_token(self, id_token):
+        header = jwt.get_unverified_header(id_token)
+        if not header.get("kid"):
+            raise InvalidJWTError("Missing 'kid' value in JWT header")
+
+        unverified_payload = jwt.decode(id_token, options={"verify_signature": False})
+        iss, aud = unverified_payload.get("iss"), unverified_payload.get("aud")
+        registration = self._registration_service.get(iss, aud)
+        if not registration:
+            raise InvalidJWTError(
+                f"Unknown registration for lti_token. iss:'{iss}' aud:'{aud}'."
+            )
+
+        try:
+            signing_key = self._get_jwk_client(
+                registration.key_set_url
+            ).get_signing_key_from_jwt(id_token)
+            return jwt.decode(
+                id_token,
+                key=signing_key.key,
+                audience=aud,
+                algorithms=["RS256"],
+            )
+        except PyJWTError as err:
+            raise InvalidJWTError(str(err)) from err
+
+
+def factory(_context, request):
+    return JWTService(registration_service=request.find_service(LTIRegistrationService))

--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -76,6 +76,7 @@ class JWTService:
 
         unverified_payload = jwt.decode(id_token, options={"verify_signature": False})
         iss, aud = unverified_payload.get("iss"), unverified_payload.get("aud")
+
         registration = self._registration_service.get(iss, aud)
         if not registration:
             raise InvalidJWTError(
@@ -86,11 +87,9 @@ class JWTService:
             signing_key = self._get_jwk_client(
                 registration.key_set_url
             ).get_signing_key_from_jwt(id_token)
+
             return jwt.decode(
-                id_token,
-                key=signing_key.key,
-                audience=aud,
-                algorithms=["RS256"],
+                id_token, key=signing_key.key, audience=aud, algorithms=["RS256"]
             )
         except PyJWTError as err:
             raise InvalidJWTError(str(err)) from err

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -145,4 +145,7 @@ def common_payload():
             ],
             "lineitems": "https://ltiadvantagevalidator.imsglobal.org/ltitool/rest/assignmentsgrades/10843/lineitems",
         },
+        "https://purl.imsglobal.org/spec/lti/claim/custom": {
+            "certification_guid": "GUID"
+        },
     }

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -145,6 +145,8 @@ def common_payload():
             ],
             "lineitems": "https://ltiadvantagevalidator.imsglobal.org/ltitool/rest/assignmentsgrades/10843/lineitems",
         },
+        # Mirror the custom param we set in the LTI compliance testing tool
+        # This gets around the fact it doesn't send a GUID by default
         "https://purl.imsglobal.org/spec/lti/claim/custom": {
             "certification_guid": "GUID"
         },

--- a/tests/functional/lti_certification/v13/core/test_bad_payloads.py
+++ b/tests/functional/lti_certification/v13/core/test_bad_payloads.py
@@ -20,10 +20,7 @@ class TestBadPayloads:
 
         do_lti_launch({"id_token": make_jwt(test_payload, jwt_headers)}, status=403)
 
-        assert (
-            "Error decoding id_token JWT. Missing 'kid' value in JWT header"
-            in caplog.messages
-        )
+        assert "Missing 'kid' value in JWT header" in caplog.messages
 
     def test_incorrect_kid_in_jwt_header(
         self, jwt_headers, test_payload, do_lti_launch, make_jwt, caplog
@@ -32,7 +29,7 @@ class TestBadPayloads:
 
         do_lti_launch({"id_token": make_jwt(test_payload, jwt_headers)}, status=403)
         assert (
-            'Error decoding id_token JWT. Unable to find a signing key that matches: "imstester_66067"'
+            'Invalid JWT. Unable to find a signing key that matches: "imstester_66067"'
             in caplog.messages
         )
 

--- a/tests/functional/lti_certification/v13/core/test_bad_payloads.py
+++ b/tests/functional/lti_certification/v13/core/test_bad_payloads.py
@@ -33,7 +33,6 @@ class TestBadPayloads:
             in caplog.messages
         )
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_wrong_lti_version(self, make_jwt, test_payload, do_lti_launch):
         """The LTI version claim contains the wrong version"""
         test_payload["https://purl.imsglobal.org/spec/lti/claim/version"] = "11.3"
@@ -43,7 +42,6 @@ class TestBadPayloads:
         assert "There were problems with these request parameters" in response.text
         assert "lti_version" in response.text
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_no_lti_version(self, make_jwt, test_payload, do_lti_launch):
         """The LTI version claim is missing"""
         del test_payload["https://purl.imsglobal.org/spec/lti/claim/version"]
@@ -86,7 +84,6 @@ class TestBadPayloads:
         response = do_lti_launch({"id_token": make_jwt(test_payload)}, status=403)
         assert response.html
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_message_type_claim_missing(self, test_payload, assert_missing_claim):
         """The Required message_type Claim Not Present"""
         response = assert_missing_claim(
@@ -112,7 +109,6 @@ class TestBadPayloads:
             status=403,
         )
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_resource_link_id_claim_missing(self, test_payload, assert_missing_claim):
         """The Required resource_link_id Claim Not Present"""
         assert_missing_claim(

--- a/tests/functional/lti_certification/v13/core/test_valid_student_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_student_launches.py
@@ -5,7 +5,6 @@ import pytest
 from lms.resources._js_config import JSConfig
 
 
-@pytest.mark.xfail(cause="Work in progress", strict=True)
 class TestValidStudentLaunches:
     """
     Following the various valid instructor payload launches are valid Student/Learner payloads

--- a/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
@@ -5,7 +5,6 @@ import pytest
 from lms.resources._js_config import JSConfig
 
 
-@pytest.mark.xfail(cause="Work in progress", strict=True)
 class TestValidTeacherPayloads:
     """
     Following the known "bad" payload launches are valid Teacher payloads.

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -12,12 +12,10 @@ from lms.security import (
     LTISecurityPolicy,
     Permissions,
     SecurityPolicy,
-    _get_lti_jwt,
     _get_lti_user,
     _get_user,
     includeme,
 )
-from lms.services import InvalidJWTError
 from lms.validation import ValidationError
 from tests import factories
 
@@ -582,24 +580,3 @@ class TestGetUser:
             pyramid_request.lti_user.user_id,
         )
         assert user == user_service.get.return_value
-
-
-class TestGetLTIJWT:
-    def test_it_when_no_token(self, pyramid_request):
-        assert not _get_lti_jwt(pyramid_request)
-
-    def test_it_invalid_jwt(self, pyramid_request, jwt_service):
-        pyramid_request.params["id_token"] = "JWT"
-        jwt_service.decode_lti_token.side_effect = InvalidJWTError
-
-        assert not _get_lti_jwt(pyramid_request)
-
-    def test_it(self, pyramid_request, jwt_service):
-        pyramid_request.params["id_token"] = "JWT"
-
-        lti_jwt = _get_lti_jwt(pyramid_request)
-
-        jwt_service.decode_lti_token.assert_called_once_with(
-            "JWT",
-        )
-        assert jwt_service.decode_lti_token.return_value == lti_jwt

--- a/tests/unit/lms/services/jwt_test.py
+++ b/tests/unit/lms/services/jwt_test.py
@@ -64,21 +64,15 @@ class TestJWTService:
     def test_decode_lti_token_with_no_kid(self, svc):
         jwt_str = self.encode_jwt({"key": "value"}, headers={"key": "value"})
 
-        with pytest.raises(InvalidJWTError) as err_info:
+        with pytest.raises(InvalidJWTError):
             svc.decode_lti_token(jwt_str)
-
-        assert "Missing 'kid' value in JWT header" in str(err_info.value)
 
     def test_decode_lti_token_with_no_registration(self, svc, lti_registration_service):
         jwt_str = self.encode_jwt({"aud": "AUD", "iss": "ISS"}, headers={"kid": "KID"})
         lti_registration_service.get.return_value = None
 
-        with pytest.raises(InvalidJWTError) as err_info:
+        with pytest.raises(InvalidJWTError):
             svc.decode_lti_token(jwt_str)
-
-        assert "Unknown registration for lti_token. iss:'ISS' aud:'AUD'." in str(
-            err_info.value
-        )
 
     def test_decode_lti_token_with_invalid_jwt(self, svc, jwt):
         jwt.decode.side_effect = [{"aud": "AUD", "iss": "ISS"}, InvalidTokenError()]

--- a/tests/unit/lms/services/jwt_test.py
+++ b/tests/unit/lms/services/jwt_test.py
@@ -1,17 +1,19 @@
 import copy
 import datetime
 import json
-from unittest.mock import sentinel
+from unittest.mock import create_autospec, sentinel
 
 import httpretty
 import jwt
 import pytest
 from freezegun import freeze_time
 from jwt.exceptions import InvalidTokenError
+from pyramid.config import Configurator
 from pytest import param
 
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
-from lms.services.jwt import JWTService, factory
+from lms.services.jwt import JWTService, _get_lti_jwt, factory, includeme
+from tests import factories
 
 
 class TestJWTService:
@@ -61,45 +63,49 @@ class TestJWTService:
         )
         assert encoded_jwt == jwt.encode.return_value
 
-    def test_decode_lti_token_with_no_kid(self, svc):
-        jwt_str = self.encode_jwt({"key": "value"}, headers={"key": "value"})
-
-        with pytest.raises(InvalidJWTError):
-            svc.decode_lti_token(jwt_str)
-
-    def test_decode_lti_token_with_no_registration(self, svc, lti_registration_service):
-        jwt_str = self.encode_jwt({"aud": "AUD", "iss": "ISS"}, headers={"kid": "KID"})
-        lti_registration_service.get.return_value = None
-
-        with pytest.raises(InvalidJWTError):
-            svc.decode_lti_token(jwt_str)
-
-    def test_decode_lti_token_with_invalid_jwt(self, svc, jwt):
-        jwt.decode.side_effect = [{"aud": "AUD", "iss": "ISS"}, InvalidTokenError()]
-        jwt_str = self.encode_jwt({"key": "value"}, headers={"kid": "KID"})
-
-        with pytest.raises(InvalidJWTError):
-            svc.decode_lti_token(jwt_str)
-
     def test_decode_lti_token(self, svc, jwt, lti_registration_service):
+        registration = factories.LTIRegistration(key_set_url="http://jwk.com")
+        lti_registration_service.get.return_value = registration
         jwt.decode.return_value = {"aud": "AUD", "iss": "ISS"}
 
-        payload = svc.decode_lti_token(sentinel.token)
+        payload = svc.decode_lti_token(sentinel.id_token)
 
+        jwt.get_unverified_header.assert_called_once_with(sentinel.id_token)
         lti_registration_service.get.assert_called_once_with("ISS", "AUD")
         jwt.PyJWKClient.assert_called_once_with(
             lti_registration_service.get.return_value.key_set_url
         )
-        jwt.decode(
-            sentinel.token,
+        jwt.decode.assert_called_with(
+            sentinel.id_token,
             key=jwt.PyJWKClient.return_value.get_signing_key_from_jwt.return_value.key,
             audience="AUD",
             algorithms=["RS256"],
         )
-        assert payload == jwt.decode.return_value
+        assert payload == {"aud": "AUD", "iss": "ISS"}
 
+    def test_decode_lti_token_with_empty_token(self, svc):
+        assert not svc.decode_lti_token("")
+
+    def test_decode_lti_token_with_no_kid(self, svc):
+        jwt_str = self.encode_jwt({"key": "value"}, headers={"key": "value"})
+
+        assert not svc.decode_lti_token(jwt_str)
+
+    def test_decode_lti_token_with_no_registration(
+        self, svc, jwt, lti_registration_service
+    ):
+        jwt.decode.return_value = {"aud": "AUD", "iss": "ISS"}
+        lti_registration_service.get.return_value = None
+
+        assert not svc.decode_lti_token(sentinel.id_token)
+
+    def test_decode_lti_token_with_invalid_jwt(self, svc, jwt):
+        jwt.decode.side_effect = [{"aud": "AUD", "iss": "ISS"}, InvalidTokenError()]
+
+        assert not svc.decode_lti_token(sentinel.id_token)
+
+    @staticmethod
     def encode_jwt(
-        self,
         payload,
         secret="test_secret",
         algorithm="HS256",
@@ -116,7 +122,7 @@ class TestJWTService:
 
     @pytest.fixture(autouse=True)
     def jwk_endpoint(self):
-        keys = {"keys": [{"kid": "KID", "kty": "RSA", "n": "...", "e": "..."}]}
+        keys = {"keys": [{"kid": "KID", "kty": "RSA", "n": "1000", "e": "500"}]}
 
         httpretty.register_uri("GET", "http://jwk.com", body=json.dumps(keys))
 
@@ -142,3 +148,28 @@ class TestFactory:
     @pytest.fixture
     def JWTService(self, patch):
         return patch("lms.services.jwt.JWTService")
+
+
+class TestGetLTIJWT:
+    def test_it(self, jwt_service, pyramid_request):
+        pyramid_request.params["id_token"] = "JWT"
+
+        jwt_params = _get_lti_jwt(pyramid_request)
+
+        jwt_service.decode_lti_token.assert_called_with(
+            pyramid_request.params["id_token"]
+        )
+        assert jwt_params == jwt_service.decode_lti_token.return_value
+
+
+class TestIncludeMe:
+    def test_it_sets_lti_jwt(self, configurator):
+        includeme(configurator)
+
+        configurator.add_request_method.assert_called_once_with(
+            _get_lti_jwt, name="lti_jwt", property=True, reify=True
+        )
+
+    @pytest.fixture()
+    def configurator(self):
+        return create_autospec(Configurator, spec_set=True, instance=True)

--- a/tests/unit/lms/views/lti/oidc_test.py
+++ b/tests/unit/lms/views/lti/oidc_test.py
@@ -6,21 +6,21 @@ from lms.views.lti.oidc import oidc_view
 
 
 class TestOIDC:
-    def test_missing_registration(self, lti_registration, pyramid_request):
-        lti_registration.get.return_value = None
+    def test_missing_registration(self, lti_registration_service, pyramid_request):
+        lti_registration_service.get.return_value = None
 
         with pytest.raises(HTTPForbidden):
             oidc_view(pyramid_request)
 
-    def test_it(self, lti_registration, pyramid_request):
-        lti_registration.get.return_value.auth_login_url = (
+    def test_it(self, lti_registration_service, pyramid_request):
+        lti_registration_service.get.return_value.auth_login_url = (
             "https://lms.com/auth_login_url"
         )
-        lti_registration.get.return_value.client_id = "REGISTRATION_CLIENT_ID"
+        lti_registration_service.get.return_value.client_id = "REGISTRATION_CLIENT_ID"
 
         result = oidc_view(pyramid_request)
 
-        lti_registration.get.assert_called_once_with(
+        lti_registration_service.get.assert_called_once_with(
             pyramid_request.parsed_params["iss"],
             pyramid_request.parsed_params["client_id"],
         )

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -51,7 +51,7 @@ __all__ = (
     "launch_verifier",
     "lti_h_service",
     "lti_outcomes_client",
-    "lti_registration",
+    "lti_registration_service",
     "oauth1_service",
     "oauth2_token_service",
     "oauth_http_service",
@@ -237,5 +237,5 @@ def file_service(mock_service):
 
 
 @pytest.fixture
-def lti_registration(mock_service):
+def lti_registration_service(mock_service):
     return mock_service(LTIRegistrationService)


### PR DESCRIPTION
## Testing

Nothing should have change but while in master we had a warning about using insecure JWTs now that can be removed as we are verifying them.

- `make shell`
```python
db.add(
    models.LTIRegistration(
        issuer="https://canvas.instructure.com", 
        client_id="93820000000000200", 
        auth_login_url="https://canvas.instructure.com/api/lti/authorize_redirect",                 
        key_set_url="https://canvas.instructure.com/api/lti/security/jwks", 
        token_url="ttps://canvas.instructure.com/api/lti/authorize"
    )
)

tm.commit()
```


```python
ai = db.query(models.ApplicationInstance).order_by(models.ApplicationInstance.id.desc()).first()

ai.lti_registration_id = db.query(models.LTIRegistration).one().id
ai.deployment_id = "609:6ed5aff92b5257ab607ec9c629844ea8586fde68"

tm.commit()
```


You should be able to launch https://hypothesis.instructure.com/courses/319/assignments/2781 
