### PR TITLE
Support for LTI1.3 single tenant flow

### DIFF
--- a/tests/unit/lms/services/lti_registration_test.py
+++ b/tests/unit/lms/services/lti_registration_test.py
@@ -10,6 +10,9 @@ class TestLTIRegistrationService:
     def test_get(self, svc, registration):
         assert svc.get(registration.issuer, registration.client_id) == registration
 
+    def test_without_client_id(self, svc, registration):
+        assert svc.get(registration.issuer) == registration
+
     @pytest.fixture
     def registration(self):
         return factories.LTIRegistration()

--- a/tests/unit/lms/views/lti/oidc_test.py
+++ b/tests/unit/lms/views/lti/oidc_test.py
@@ -16,6 +16,7 @@ class TestOIDC:
         lti_registration.get.return_value.auth_login_url = (
             "https://lms.com/auth_login_url"
         )
+        lti_registration.get.return_value.client_id = "REGISTRATION_CLIENT_ID"
 
         result = oidc_view(pyramid_request)
 
@@ -34,7 +35,7 @@ class TestOIDC:
                 "prompt": "none",
                 "login_hint": pyramid_request.parsed_params["login_hint"],
                 "lti_message_hint": pyramid_request.parsed_params["lti_message_hint"],
-                "client_id": pyramid_request.parsed_params["client_id"],
+                "client_id": "REGISTRATION_CLIENT_ID",
                 "state": Any(),
                 "nonce": Any(),
                 "redirect_uri": pyramid_request.parsed_params["target_link_uri"],


### PR DESCRIPTION
The single tenant vs multi tenant distinction in the LTI spec is supported in our data model where:
 - single tenant: 1 to 1 relationship between LTIRegistration.issuer <-> ApplicationInstance
 - multi tenant: 1 to many relationship between them.


All LMS I've tried use the multi tenant setup (and the spec recommends it) but the certification tool uses the single tenant model and, as there's only one registration -> application instance per "issuer" it doesn't seen the `client_id` value on the OIDC request.

For that case we have to make `client_id` optional and take it form the DB.

## Testing


### Setup


- `make shell`
```python
db.add(
    models.LTIRegistration(
        issuer="https://canvas.instructure.com", 
        client_id="93820000000000200", 
        auth_login_url="https://canvas.instructure.com/api/lti/authorize_redirect",                 
        key_set_url="https://canvas.instructure.com/api/lti/security/jwks", 
        token_url="ttps://canvas.instructure.com/api/lti/authorize"
    )
)

tm.commit()
```


```python
ai = db.query(models.ApplicationInstance).order_by(models.ApplicationInstance.id.desc()).first()

ai.lti_registration_id = db.query(models.LTIRegistration).one().id
ai.deployment_id = "609:6ed5aff92b5257ab607ec9c629844ea8586fde68"

tm.commit()
```


You can launch https://hypothesis.instructure.com/courses/319/assignments/2781 and the OIDC flow should work correctly.

Copy the `http://localhost:8001/lti/1.3/oidc` request made by canvas as curl and remove the `client_id` parameter to end up with something like:

```
curl 'http://localhost:8001/lti/1.3/oidc' \
  -H 'Connection: keep-alive' \
  -H 'Cache-Control: max-age=0' \
  -H 'sec-ch-ua: " Not A;Brand";v="99", "Chromium";v="99", "Google Chrome";v="99"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Linux"' \
  -H 'Upgrade-Insecure-Requests: 1' \
  -H 'Origin: null' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
  -H 'Sec-Fetch-Site: cross-site' \
  -H 'Sec-Fetch-Mode: navigate' \
  -H 'Sec-Fetch-Dest: iframe' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  --data-raw 'iss=https%3A%2F%2Fcanvas.instructure.com&login_hint=969fc294ee26e3f1d0c9714af3351dc4eacfd6df&target_link_uri=http%3A%2F%2Flocalhost%3A8001%2Flti_launches%3Furl%3Dhttps%253A%252F%252Felpais.es&lti_message_hint=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJpZmllciI6IjhhZGU2OGIzMzE0ZTVjYjQwNzk4ZGFkNjgzYTAwM2I0OGI3OWM4OGY1MWEzYTUyNWFlODQ0YTU3MTZiMmY4ODgwOTc5MmRiMjhiNjBkMmZlNDkyODZmMzdjMmIwMjc1OWQ3ZWI0NjYyODRkZjQ5MGZmY2RjOGIyNGUxYTRjZDE4IiwiY2FudmFzX2RvbWFpbiI6Imh5cG90aGVzaXMuaW5zdHJ1Y3R1cmUuY29tIiwiY29udGV4dF90eXBlIjoiQ291cnNlIiwiY29udGV4dF9pZCI6OTM4MjAwMDAwMDAwMDAzMTksImNhbnZhc19sb2NhbGUiOiJlbiIsImV4cCI6MTY0OTI0MzAxMX0.xUBYax3t2Via3mftAHi9Wh4DLjJLRJYe3xZIjCJwev4&canvas_region=us-east-1' \
  --compressed
```

which will return a 302 in this branch but a 403 in `master`.


No LMS use this model so it's no possible to test it direclty.