### PR TITLE
Injection of LTI1.3 params doesn't fail when missing

### DIFF
--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -38,7 +38,7 @@ class LTIV11CoreSchema(PyramidRequestSchema):
     @pre_load
     def _decode_jwt(self, data, **_kwargs):
         """Use the values encoded in the `id_token` JWT if present."""
-        if "id_token" not in self.context["request"].POST:
+        if not self.context["request"].lti_jwt:
             return data
 
         params = LTIParams.from_v13(self.context["request"].lti_jwt)

--- a/lms/validation/authentication/_lti.py
+++ b/lms/validation/authentication/_lti.py
@@ -90,10 +90,13 @@ class LTI13AuthSchema(LTIV11CoreSchema):
     deployment_id = marshmallow.fields.Str(required=True)
 
     @marshmallow.pre_load
-    def _lti_v3_fields(self, data, **_kwargs):  # pylint:disable=no-self-use
-        data["iss"] = data.v13["iss"]
-        data["aud"] = data.v13["aud"]
-        data["deployment_id"] = data.v13[f"{CLAIM_PREFIX}/deployment_id"]
+    def _lti_v13_fields(self, data, **_kwargs):  # pylint:disable=no-self-use
+        if not self.context["request"].lti_jwt:
+            return data
+
+        data["iss"] = data.v13.get("iss")
+        data["aud"] = data.v13.get("aud")
+        data["deployment_id"] = data.v13.get(f"{CLAIM_PREFIX}/deployment_id")
 
         return data
 

--- a/tests/functional/lti_certification/v13/core/test_bad_payloads.py
+++ b/tests/functional/lti_certification/v13/core/test_bad_payloads.py
@@ -54,9 +54,6 @@ class TestBadPayloads:
         assert "There were problems with these request parameters" in response.text
         assert "lti_version" in response.text
 
-    @pytest.mark.xfail(
-        reason="Missing error handling for missing JWT fields", strict=True
-    )
     def test_invalid_lti_message(self, make_jwt, do_lti_launch):
         """The provided JSON is NOT a 1.3 JWT launch"""
         payload = {"name": "badltilaunch"}
@@ -65,9 +62,6 @@ class TestBadPayloads:
 
         assert response.status_code == 403
 
-    @pytest.mark.xfail(
-        reason="Missing error handling for missing JWT fields", strict=True
-    )
     def test_missing_lti_claims(self, test_payload, do_lti_launch, make_jwt):
         """The provided 1.3 JWT launch is missing one or more required claims"""
         missing_claims = [
@@ -111,9 +105,6 @@ class TestBadPayloads:
             status=403,
         )
 
-    @pytest.mark.xfail(
-        reason="Missing error handling for missing JWT fields", strict=True
-    )
     def test_deployment_id_claim_missing(self, test_payload, assert_missing_claim):
         """The Required deployment_id Claim Not Present"""
         assert_missing_claim(
@@ -122,9 +113,7 @@ class TestBadPayloads:
             status=403,
         )
 
-    @pytest.mark.xfail(
-        reason="Missing error handling for missing JWT fields", strict=True
-    )
+    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_resource_link_id_claim_missing(self, test_payload, assert_missing_claim):
         """The Required resource_link_id Claim Not Present"""
         assert_missing_claim(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,7 +97,7 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
     pyramid_request.lti_user = factories.LTIUser(
         application_instance_id=application_instance.id
     )
-    pyramid_request.lti_jwt = None
+    pyramid_request.lti_jwt = {}
 
     # The DummyRequest request lacks a content_type property which the real
     # request has

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -300,6 +300,7 @@ class TestConfigureAssignmentSchema:
     @pytest.fixture
     def pyramid_request(self):
         pyramid_request = testing.DummyRequest()
+        pyramid_request.lti_jwt = {}
         pyramid_request.params["lti_version"] = "LTI-1p0"
         pyramid_request.params["roles"] = "INSTRUCTOR"
 

--- a/tests/unit/lms/validation/authentication/_lti_test.py
+++ b/tests/unit/lms/validation/authentication/_lti_test.py
@@ -120,6 +120,16 @@ class TestLTI13AuthSchema:
         with pytest.raises(ValidationError):
             schema.lti_user()
 
+    def test_it_missing_lti_jwt(self, pyramid_request):
+        pyramid_request.lti_jwt = {}
+
+        with pytest.raises(ValidationError) as err_info:
+            LTI13AuthSchema(pyramid_request).parse()
+
+        assert set(["deployment_id", "iss", "aud"]) == set(
+            err_info.value.messages["form"].keys()
+        )
+
     @pytest.fixture
     def schema(self, pyramid_request):
         return LTI13AuthSchema(pyramid_request)


### PR DESCRIPTION
Any missing parameters should make their way to the schema and fail the
validation step, not cause an exception.


These conditions don't occur in normal operation but when they happen, for example in the LTI certification, this PR makes the schema handle the missing data instead of raising some `KeyError` or `AttributeError`