### PR TITLE
Take GUID from custom parameter in LTI1.3 certification tool

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -24,30 +24,38 @@ class LTIParams(dict):
         return LTIParams(_to_lti_v11(v13_params), v13_params)
 
 
-_V11_TO_V13 = {
-    # LTI 1.1 key -> [LTI 1.3 path in object]
-    "user_id": ["sub"],
-    "lis_person_name_given": ["given_name"],
-    "lis_person_name_family": ["family_name"],
-    "lis_person_name_full": ["name"],
-    "roles": [f"{CLAIM_PREFIX}/roles"],
-    "context_id": [f"{CLAIM_PREFIX}/context", "id"],
-    "context_title": [f"{CLAIM_PREFIX}/context", "title"],
-    "lti_version": [f"{CLAIM_PREFIX}/version"],
-    "lti_message_type": [f"{CLAIM_PREFIX}/message_type"],
-    "resource_link_id": [f"{CLAIM_PREFIX}/resource_link", "id"],
-    "tool_consumer_instance_guid": [f"{CLAIM_PREFIX}/tool_platform", "guid"],
-    "tool_consumer_info_product_family_code": [
-        f"{CLAIM_PREFIX}/tool_platform",
-        "product_family_code",
-    ],
-}
+_V11_TO_V13 = (
+    # LTI 1.1 key , [LTI 1.3 path in object]
+    # We use tuples instead of a dictionary to allow duplicate keys for multiple locations.
+    ("user_id", ["sub"]),
+    ("lis_person_name_given", ["given_name"]),
+    ("lis_person_name_family", ["family_name"]),
+    ("lis_person_name_full", ["name"]),
+    ("roles", [f"{CLAIM_PREFIX}/roles"]),
+    ("context_id", [f"{CLAIM_PREFIX}/context", "id"]),
+    ("context_title", [f"{CLAIM_PREFIX}/context", "title"]),
+    ("lti_version", [f"{CLAIM_PREFIX}/version"]),
+    ("lti_message_type", [f"{CLAIM_PREFIX}/message_type"]),
+    ("resource_link_id", [f"{CLAIM_PREFIX}/resource_link", "id"]),
+    # tool_consumer_instance_guid is not sent by the LTI1.3 certification tool but we include
+    # it as a custom parameter in the tool configuration
+    ("tool_consumer_instance_guid", [f"{CLAIM_PREFIX}/custom", "certification_guid"]),
+    # Usual LTI1.3 location for tool_consumer_instance_guid
+    ("tool_consumer_instance_guid", [f"{CLAIM_PREFIX}/tool_platform", "guid"]),
+    (
+        "tool_consumer_info_product_family_code",
+        [
+            f"{CLAIM_PREFIX}/tool_platform",
+            "product_family_code",
+        ],
+    ),
+)
 
 
 def _to_lti_v11(v13_params):
     v11_params = {}
 
-    for v11_key, v13_path in _V11_TO_V13.items():
+    for v11_key, v13_path in _V11_TO_V13:
         # Descend into the object for each item in the path
         found = False
         value = v13_params

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -145,4 +145,7 @@ def common_payload():
             ],
             "lineitems": "https://ltiadvantagevalidator.imsglobal.org/ltitool/rest/assignmentsgrades/10843/lineitems",
         },
+        "https://purl.imsglobal.org/spec/lti/claim/custom": {
+            "certification_guid": "GUID"
+        },
     }

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -145,6 +145,8 @@ def common_payload():
             ],
             "lineitems": "https://ltiadvantagevalidator.imsglobal.org/ltitool/rest/assignmentsgrades/10843/lineitems",
         },
+        # Mirror the custom param we set in the LTI compliance testing tool
+        # This gets around the fact it doesn't send a GUID by default
         "https://purl.imsglobal.org/spec/lti/claim/custom": {
             "certification_guid": "GUID"
         },

--- a/tests/functional/lti_certification/v13/core/test_bad_payloads.py
+++ b/tests/functional/lti_certification/v13/core/test_bad_payloads.py
@@ -33,7 +33,6 @@ class TestBadPayloads:
             in caplog.messages
         )
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_wrong_lti_version(self, make_jwt, test_payload, do_lti_launch):
         """The LTI version claim contains the wrong version"""
         test_payload["https://purl.imsglobal.org/spec/lti/claim/version"] = "11.3"
@@ -43,7 +42,6 @@ class TestBadPayloads:
         assert "There were problems with these request parameters" in response.text
         assert "lti_version" in response.text
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_no_lti_version(self, make_jwt, test_payload, do_lti_launch):
         """The LTI version claim is missing"""
         del test_payload["https://purl.imsglobal.org/spec/lti/claim/version"]
@@ -86,7 +84,6 @@ class TestBadPayloads:
         response = do_lti_launch({"id_token": make_jwt(test_payload)}, status=403)
         assert response.html
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_message_type_claim_missing(self, test_payload, assert_missing_claim):
         """The Required message_type Claim Not Present"""
         response = assert_missing_claim(
@@ -112,7 +109,6 @@ class TestBadPayloads:
             status=403,
         )
 
-    @pytest.mark.xfail(reason="Missing tool_guid", strict=True)
     def test_resource_link_id_claim_missing(self, test_payload, assert_missing_claim):
         """The Required resource_link_id Claim Not Present"""
         assert_missing_claim(

--- a/tests/functional/lti_certification/v13/core/test_valid_student_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_student_launches.py
@@ -5,7 +5,6 @@ import pytest
 from lms.resources._js_config import JSConfig
 
 
-@pytest.mark.xfail(cause="Work in progress", strict=True)
 class TestValidStudentLaunches:
     """
     Following the various valid instructor payload launches are valid Student/Learner payloads

--- a/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
@@ -5,7 +5,6 @@ import pytest
 from lms.resources._js_config import JSConfig
 
 
-@pytest.mark.xfail(cause="Work in progress", strict=True)
 class TestValidTeacherPayloads:
     """
     Following the known "bad" payload launches are valid Teacher payloads.


### PR DESCRIPTION
An alternative for https://github.com/hypothesis/lms/pull/3819

Using the custom variables feature of the certification tool we can include custom variables/values (which in LTI1.3 are all included under the `/custom` claim) and map one of those to the tool_consumer_instance_guid.

![Screenshot from 2022-04-19 15-55-01](https://user-images.githubusercontent.com/1433832/164020054-9f9ec2dd-3e0a-4117-acf6-1f3f1b68f806.png)

