### PR TITLE
RSA Key management and new JWK endpoint

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -22,6 +22,7 @@ from lms.models.lti_params import CLAIM_PREFIX, LTIParams
 from lms.models.lti_registration import LTIRegistration
 from lms.models.lti_user import LTIUser, display_name
 from lms.models.oauth2_token import OAuth2Token
+from lms.models.rsa_key import RSAKey
 from lms.models.user import User
 
 

--- a/lms/models/rsa_key.py
+++ b/lms/models/rsa_key.py
@@ -1,0 +1,32 @@
+import uuid
+
+import sqlalchemy as sa
+
+from lms.db import BASE
+from lms.models import CreatedUpdatedMixin
+
+
+class RSAKey(CreatedUpdatedMixin, BASE):
+    __tablename__ = "rsa_key"
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+
+    kid = sa.Column(sa.Unicode, default=lambda: uuid.uuid4().hex, nullable=False)
+    """Unique identifier exposed to third parties"""
+
+    public_key = sa.Column(sa.Unicode)
+    """Public key a json JWK string"""
+
+    private_key = sa.Column(sa.LargeBinary)
+    """PEM formatted private key. AES encrypted"""
+
+    aes_cipher_iv = sa.Column(sa.LargeBinary)
+    """IV for the private key AES encryption"""
+
+    expired = sa.Column(
+        sa.Boolean(),
+        default=False,
+        server_default=sa.sql.expression.false(),
+        nullable=False,
+    )
+    """Marks the key as expired"""

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -107,3 +107,4 @@ def includeme(config):
     config.add_route("admin.instance", "/admin/instance/{consumer_key}/")
 
     config.add_route("lti.oidc", "/lti/1.3/oidc")
+    config.add_route("lti.jwks", "/lti/1.3/jwks")

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -20,6 +20,7 @@ from lms.services.launch_verifier import (
     LTIOAuthError,
 )
 from lms.services.lti_registration import LTIRegistrationService
+from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 
 
@@ -82,3 +83,4 @@ def includeme(config):
     )
     config.register_service_factory("lms.services.aes.factory", iface=AESService)
     config.register_service_factory("lms.services.jwt.factory", iface=JWTService)
+    config.register_service_factory("lms.services.rsa_key.factory", iface=RSAKeyService)

--- a/lms/services/rsa_key.py
+++ b/lms/services/rsa_key.py
@@ -1,0 +1,69 @@
+import json
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jose import constants, jwk
+
+from lms.models import RSAKey
+from lms.services import AESService
+
+
+class RSAKeyService:
+    no_encryption = serialization.NoEncryption()
+
+    def __init__(self, db, aes_service):
+        self._db = db
+        self._aes_service = aes_service
+
+    def generate(self) -> RSAKey:
+        """Generate a new random RSA key pair."""
+        rsa_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+
+        # Generate an IV for the private key AES encryption
+        aes_iv = self._aes_service.build_iv()
+
+        key = RSAKey(
+            private_key=self._as_pem_private_key(rsa_key, aes_iv),
+            public_key=json.dumps(self._as_jwk_public_key(rsa_key)),
+            aes_cipher_iv=aes_iv,
+        )
+        self._db.add(key)
+        return key
+
+    def private_key(self, key: RSAKey):
+        """Decrypt the AES encrypted private key of `key`."""
+        return self._aes_service.decrypt(key.aes_cipher_iv, key.private_key)
+
+    def get_all_public_jwks(self):
+        """Get all non-expired keys."""
+        return [
+            dict(json.loads(key.public_key), use="sig", kid=key.kid)
+            for key in self._db.query(RSAKey).filter_by(expired=False).all()
+        ]
+
+    def _as_pem_private_key(self, rsa_key, aes_iv) -> bytes:
+        """Encode a `jose.jwt.RSAKey` as an AES encrypted PEM private key."""
+        pem_private_key = rsa_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=self.no_encryption,
+        )
+        return self._aes_service.encrypt(aes_iv, pem_private_key)
+
+    @staticmethod
+    def _as_jwk_public_key(rsa_key) -> dict:
+        """Encode a `jose.jwt.RSAKey` as a JWK public key."""
+        pem_public_key = rsa_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        return jwk.RSAKey(
+            algorithm=constants.Algorithms.RS256, key=pem_public_key.decode("utf-8")
+        ).to_dict()
+
+
+def factory(_context, request):
+    return RSAKeyService(request.db, request.find_service(AESService))

--- a/lms/views/lti/jwk.py
+++ b/lms/views/lti/jwk.py
@@ -1,0 +1,9 @@
+from pyramid.view import view_config
+
+from lms.services import RSAKeyService
+
+
+@view_config(route_name="lti.jwks", request_method="GET", renderer="json")
+def jwks(request):
+    """Expose RSA public keys for LMSs to verify our LTI Advantage API calls."""
+    return {"keys": request.find_service(RSAKeyService).get_all_public_jwks()}

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -48,6 +48,10 @@ cryptography==36.0.2
     # via
     #   -r requirements/requirements.txt
     #   pyjwt
+ecdsa==0.17.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 factory-boy==3.2.1
     # via -r requirements/bddtests.in
 faker==8.1.2
@@ -171,6 +175,7 @@ pyasn1==0.4.8
     # via
     #   -r requirements/requirements.txt
     #   pyasn1-modules
+    #   python-jose
     #   rsa
 pyasn1-modules==0.2.8
     # via
@@ -222,6 +227,8 @@ pytest==7.1.1
     # via -r requirements/bddtests.in
 python-dateutil==2.8.1
     # via faker
+python-jose[crypto]==3.3.0
+    # via -r requirements/requirements.txt
 requests==2.27.1
     # via
     #   -r requirements/requirements.txt
@@ -234,6 +241,7 @@ rsa==4.7.2
     # via
     #   -r requirements/requirements.txt
     #   google-auth
+    #   python-jose
 sentry-sdk==0.17.6
     # via
     #   -r requirements/requirements.txt
@@ -242,6 +250,7 @@ six==1.15.0
     # via
     #   -r requirements/requirements.txt
     #   behave
+    #   ecdsa
     #   google-auth
     #   jsonschema
     #   parse-type

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,6 +47,10 @@ cryptography==36.0.2
     #   pyjwt
 decorator==5.0.7
     # via ipython
+ecdsa==0.17.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 factory-boy==3.2.1
     # via -r requirements/dev.in
 faker==8.1.2
@@ -171,6 +175,7 @@ pyasn1==0.4.8
     # via
     #   -r requirements/requirements.txt
     #   pyasn1-modules
+    #   python-jose
     #   rsa
 pyasn1-modules==0.2.8
     # via
@@ -225,6 +230,8 @@ pyrsistent==0.17.3
     #   jsonschema
 python-dateutil==2.8.1
     # via faker
+python-jose[crypto]==3.3.0
+    # via -r requirements/requirements.txt
 requests==2.27.1
     # via
     #   -r requirements/requirements.txt
@@ -237,6 +244,7 @@ rsa==4.7.2
     # via
     #   -r requirements/requirements.txt
     #   google-auth
+    #   python-jose
 sentry-sdk==0.17.6
     # via
     #   -r requirements/requirements.txt
@@ -244,6 +252,7 @@ sentry-sdk==0.17.6
 six==1.15.0
     # via
     #   -r requirements/requirements.txt
+    #   ecdsa
     #   google-auth
     #   jsonschema
     #   python-dateutil

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -46,6 +46,10 @@ cryptography==36.0.2
     # via
     #   -r requirements/requirements.txt
     #   pyjwt
+ecdsa==0.17.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 factory-boy==3.2.1
     # via -r requirements/functests.in
 faker==8.1.2
@@ -163,6 +167,7 @@ pyasn1==0.4.8
     # via
     #   -r requirements/requirements.txt
     #   pyasn1-modules
+    #   python-jose
     #   rsa
 pyasn1-modules==0.2.8
     # via
@@ -214,6 +219,8 @@ pytest==7.1.1
     # via -r requirements/functests.in
 python-dateutil==2.8.1
     # via faker
+python-jose[crypto]==3.3.0
+    # via -r requirements/requirements.txt
 requests==2.27.1
     # via
     #   -r requirements/requirements.txt
@@ -226,6 +233,7 @@ rsa==4.7.2
     # via
     #   -r requirements/requirements.txt
     #   google-auth
+    #   python-jose
 sentry-sdk==0.17.6
     # via
     #   -r requirements/requirements.txt
@@ -233,6 +241,7 @@ sentry-sdk==0.17.6
 six==1.15.0
     # via
     #   -r requirements/requirements.txt
+    #   ecdsa
     #   google-auth
     #   jsonschema
     #   python-dateutil

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -82,6 +82,12 @@ cryptography==36.0.2
     #   pyjwt
 dill==0.3.4
     # via pylint
+ecdsa==0.17.0
+    # via
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   python-jose
 factory-boy==3.2.1
     # via
     #   -r requirements/bddtests.txt
@@ -304,6 +310,7 @@ pyasn1==0.4.8
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pyasn1-modules
+    #   python-jose
     #   rsa
 pyasn1-modules==0.2.8
     # via
@@ -402,6 +409,11 @@ python-dateutil==2.8.1
     #   -r requirements/tests.txt
     #   faker
     #   freezegun
+python-jose[crypto]==3.3.0
+    # via
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 requests==2.27.1
     # via
     #   -r requirements/bddtests.txt
@@ -420,6 +432,7 @@ rsa==4.7.2
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   google-auth
+    #   python-jose
 sentry-sdk==0.17.6
     # via
     #   -r requirements/bddtests.txt
@@ -432,6 +445,7 @@ six==1.15.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   behave
+    #   ecdsa
     #   google-auth
     #   jsonschema
     #   parse-type

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,6 +12,7 @@ oauthlib
 psycopg2
 pycryptodomex
 PyJWT[crypto]
+python-jose[crypto]
 pyramid
 pyramid-exclog
 pyramid-googleauth

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,6 +30,8 @@ charset-normalizer==2.0.1
     #   requests
 cryptography==36.0.2
     # via pyjwt
+ecdsa==0.17.0
+    # via python-jose
 frozenlist==1.2.0
     # via
     #   aiohttp
@@ -105,6 +107,7 @@ psycopg2==2.9.3
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
+    #   python-jose
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
@@ -144,6 +147,8 @@ pyramid-tm==2.5
     # via -r requirements/requirements.in
 pyrsistent==0.17.3
     # via jsonschema
+python-jose[crypto]==3.3.0
+    # via -r requirements/requirements.in
 requests==2.27.1
     # via
     #   -r requirements/requirements.in
@@ -153,11 +158,14 @@ requests-oauthlib==1.3.1
     #   -r requirements/requirements.in
     #   google-auth-oauthlib
 rsa==4.7.2
-    # via google-auth
+    # via
+    #   google-auth
+    #   python-jose
 sentry-sdk==0.17.6
     # via h-pyramid-sentry
 six==1.15.0
     # via
+    #   ecdsa
     #   google-auth
     #   jsonschema
 sqlalchemy==1.4.35

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -50,6 +50,10 @@ cryptography==36.0.2
     # via
     #   -r requirements/requirements.txt
     #   pyjwt
+ecdsa==0.17.0
+    # via
+    #   -r requirements/requirements.txt
+    #   python-jose
 factory-boy==3.2.1
     # via -r requirements/tests.in
 faker==8.1.2
@@ -169,6 +173,7 @@ pyasn1==0.4.8
     # via
     #   -r requirements/requirements.txt
     #   pyasn1-modules
+    #   python-jose
     #   rsa
 pyasn1-modules==0.2.8
     # via
@@ -222,6 +227,8 @@ python-dateutil==2.8.1
     # via
     #   faker
     #   freezegun
+python-jose[crypto]==3.3.0
+    # via -r requirements/requirements.txt
 requests==2.27.1
     # via
     #   -r requirements/requirements.txt
@@ -234,6 +241,7 @@ rsa==4.7.2
     # via
     #   -r requirements/requirements.txt
     #   google-auth
+    #   python-jose
 sentry-sdk==0.17.6
     # via
     #   -r requirements/requirements.txt
@@ -241,6 +249,7 @@ sentry-sdk==0.17.6
 six==1.15.0
     # via
     #   -r requirements/requirements.txt
+    #   ecdsa
     #   google-auth
     #   jsonschema
     #   python-dateutil

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -25,6 +25,7 @@ from tests.factories.legacy_course import LegacyCourse
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_user import LTIUser
 from tests.factories.oauth2_token import OAuth2Token
+from tests.factories.rsa_key import RSAKey
 from tests.factories.user import User
 
 

--- a/tests/factories/rsa_key.py
+++ b/tests/factories/rsa_key.py
@@ -1,0 +1,8 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+RSAKey = make_factory(
+    models.RSAKey, FACTORY_CLASS=SQLAlchemyModelFactory, public_key="{}"
+)

--- a/tests/unit/lms/models/rsa_key_test.py
+++ b/tests/unit/lms/models/rsa_key_test.py
@@ -1,0 +1,13 @@
+from lms.models import RSAKey
+
+
+class TestRSAKey:
+    def test_kid(self, db_session):
+        rsa_key = RSAKey()
+        # Add to the session and commit to force the model's `default`
+        db_session.add(rsa_key)
+        db_session.commit()
+
+        assert rsa_key.kid
+        assert isinstance(rsa_key.kid, str)
+        assert len(rsa_key.kid) == 32

--- a/tests/unit/lms/services/rsa_key_service_test.py
+++ b/tests/unit/lms/services/rsa_key_service_test.py
@@ -1,0 +1,98 @@
+from unittest.mock import sentinel
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from h_matchers import Any
+from jose import constants
+
+from lms.models import RSAKey
+from lms.services.rsa_key import RSAKeyService, factory
+from tests import factories
+
+
+class TestAESService:
+    def test_generate(self, svc, aes_service, rsa, jwk):
+        jwk.RSAKey.return_value.to_dict.return_value = {}
+
+        key = svc.generate()
+
+        rsa.generate_private_key.assert_called_once_with(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+
+        # Private key
+        aes_service.build_iv.assert_called_once_with()
+        rsa.generate_private_key.return_value.private_bytes.assert_called_once_with(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=svc.no_encryption,
+        )
+        aes_service.encrypt.assert_called_once_with(
+            aes_service.build_iv.return_value,
+            rsa.generate_private_key.return_value.private_bytes.return_value,
+        )
+
+        # Public key
+        public_bytes = (
+            rsa.generate_private_key.return_value.public_key.return_value.public_bytes
+        )
+        public_bytes.assert_called_once_with(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        jwk.RSAKey.assert_called_once_with(
+            algorithm=constants.Algorithms.RS256,
+            key=public_bytes.return_value.decode("utf-8"),
+        )
+
+        assert key.private_key == aes_service.encrypt.return_value
+        assert key.aes_cipher_iv == aes_service.build_iv.return_value
+
+    def test_private_key(self, aes_service, svc):
+        key = RSAKey(aes_cipher_iv=sentinel.iv, private_key=sentinel.private_key)
+
+        private_key = svc.private_key(key)
+
+        aes_service.decrypt.assert_called_once_with(sentinel.iv, sentinel.private_key)
+        assert private_key == aes_service.decrypt.return_value
+
+    def test_get_all_public_jwks(self, svc, valid_keys):
+        keys = svc.get_all_public_jwks()
+
+        expected_keys = [
+            {"use": "sig", "kid": key.kid, "key": "value"} for key in valid_keys
+        ]
+        assert keys == Any.list.containing(expected_keys).only()
+
+    @pytest.fixture
+    def valid_keys(self):
+        # Create some noise with some expired keys.
+        factories.RSAKey.create_batch(size=3, expired=True)
+        return factories.RSAKey.create_batch(
+            size=3, expired=False, public_key='{"key": "value"}'
+        )
+
+    @pytest.fixture
+    def svc(self, db_session, aes_service):
+        return RSAKeyService(db_session, aes_service)
+
+    @pytest.fixture
+    def jwk(self, patch):
+        return patch("lms.services.rsa_key.jwk")
+
+    @pytest.fixture
+    def rsa(self, patch):
+        return patch("lms.services.rsa_key.rsa")
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, RSAKeyService, aes_service, db_session):
+        rsa_key_service = factory(sentinel.context, pyramid_request)
+
+        RSAKeyService.assert_called_once_with(db_session, aes_service)
+        assert rsa_key_service == RSAKeyService.return_value
+
+    @pytest.fixture
+    def RSAKeyService(self, patch):
+        return patch("lms.services.rsa_key.RSAKeyService")

--- a/tests/unit/lms/views/lti/jwk_test.py
+++ b/tests/unit/lms/views/lti/jwk_test.py
@@ -1,0 +1,8 @@
+from lms.views.lti.jwk import jwks
+
+
+def test_jwks(rsa_key_service, pyramid_request):
+    result = jwks(pyramid_request)
+
+    rsa_key_service.get_all_public_jwks.assert_called_once_with()
+    assert result == {"keys": rsa_key_service.get_all_public_jwks.return_value}

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -26,6 +26,7 @@ from lms.services.lti_registration import LTIRegistrationService
 from lms.services.oauth1 import OAuth1Service
 from lms.services.oauth2_token import OAuth2TokenService
 from lms.services.oauth_http import OAuthHTTPService
+from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.vitalsource import VitalSourceService
 from tests import factories
@@ -60,6 +61,7 @@ __all__ = (
     "jstor_service",
     "aes_service",
     "jwt_service",
+    "rsa_key_service",
 )
 
 
@@ -239,3 +241,8 @@ def file_service(mock_service):
 @pytest.fixture
 def lti_registration_service(mock_service):
     return mock_service(LTIRegistrationService)
+
+
+@pytest.fixture
+def rsa_key_service(mock_service):
+    return mock_service(RSAKeyService)


### PR DESCRIPTION
Requires:

 * https://github.com/hypothesis/lms/pull/3876

## Testing

- Run the migration to create the new table 

```hdev alembic upgrade head```

- Create a couple of keys in `make shell`

```
from lms.services import RSAKeyService

rsa_service = request.find_service(RSAKeyService)

key_1 = rsa_service.generate()

key_2 = rsa_service.generate()
tm.commit()
```

- Check the new endpoint exposing them: http://localhost:8001/lti/1.3/jwks
  

- Mark one of the as expired in a new `make shell`

```
key = session.query(models.RSAKey).first()
key.expired=True
tm.commit()
```


- Check http://localhost:8001/lti/1.3/jwks only exposes one key now.




