### PR TITLE
LTI Advantage service and LTI1.3 grading

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -44,11 +44,13 @@ _V11_TO_V13 = (
     ("tool_consumer_instance_guid", [f"{CLAIM_PREFIX}/tool_platform", "guid"]),
     (
         "tool_consumer_info_product_family_code",
-        [
-            f"{CLAIM_PREFIX}/tool_platform",
-            "product_family_code",
-        ],
+        [f"{CLAIM_PREFIX}/tool_platform", "product_family_code"],
     ),
+    (
+        "lis_outcome_service_url",
+        ["https://purl.imsglobal.org/spec/lti-ags/claim/endpoint", "lineitem"],
+    ),
+    ("lis_result_sourcedid", ["sub"]),
 )
 
 

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -21,6 +21,7 @@ from lms.services.launch_verifier import (
 )
 from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_registration import LTIRegistrationService
+from lms.services.ltia_http import LTIAHTTPService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 
@@ -85,3 +86,6 @@ def includeme(config):
     config.register_service_factory("lms.services.aes.factory", iface=AESService)
     config.register_service_factory("lms.services.jwt.factory", iface=JWTService)
     config.register_service_factory("lms.services.rsa_key.factory", iface=RSAKeyService)
+    config.register_service_factory(
+        "lms.services.ltia_http.factory", iface=LTIAHTTPService
+    )

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -52,7 +52,7 @@ def includeme(config):
         "lms.services.grading_info.GradingInfoService", name="grading_info"
     )
     config.register_service_factory(
-        "lms.services.lti_grading.factory", iface=LTIGradingService
+        "lms.services.lti_grading.service_factory", iface=LTIGradingService
     )
     config.register_service_factory(
         "lms.services.group_info.GroupInfoService", name="group_info"

--- a/lms/services/grading_info.py
+++ b/lms/services/grading_info.py
@@ -1,7 +1,7 @@
 from marshmallow import fields
 
 from lms.models import GradingInfo
-from lms.validation import PyramidRequestSchema, ValidationError
+from lms.validation import BasicLTILaunchSchema, ValidationError
 
 __all__ = ["GradingInfoService"]
 
@@ -9,15 +9,12 @@ __all__ = ["GradingInfoService"]
 class GradingInfoService:
     """Methods for interacting with GradingInfo records."""
 
-    class _ParamsSchema(PyramidRequestSchema):
+    class _ParamsSchema(BasicLTILaunchSchema):
         """Schema for the relevant parameters from the request."""
 
         location = "form"
         lis_result_sourcedid = fields.Str(required=True)
         lis_outcome_service_url = fields.Str(required=True)
-        context_id = fields.Str(required=True)
-        resource_link_id = fields.Str(required=True)
-        tool_consumer_info_product_family_code = fields.Str(load_default="")
 
     def __init__(self, _context, request):
         self._db = request.db

--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -95,6 +95,15 @@ class JWTService:
             LOG.debug("Invalid JWT. %s", str(err))
             return {}
 
+    @classmethod
+    def encode_with_private_key(cls, private_key, payload: dict, headers=None):
+        return jwt.encode(
+            payload,
+            private_key,
+            algorithm="RS256",
+            headers=headers,
+        )
+
     @staticmethod
     @lru_cache
     def _get_jwk_client(jwk_url: str):

--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -8,13 +8,15 @@ from jwt.exceptions import ExpiredSignatureError, InvalidTokenError, PyJWTError
 
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
 from lms.services.lti_registration import LTIRegistrationService
+from lms.services.rsa_key import RSAKeyService
 
 LOG = logging.getLogger(__name__)
 
 
 class JWTService:
-    def __init__(self, registration_service):
+    def __init__(self, registration_service, rsa_key_service):
         self._registration_service = registration_service
+        self._rsa_key_service = rsa_key_service
 
     @classmethod
     def decode_with_secret(cls, jwt_str, secret) -> dict:
@@ -95,13 +97,13 @@ class JWTService:
             LOG.debug("Invalid JWT. %s", str(err))
             return {}
 
-    @classmethod
-    def encode_with_private_key(cls, private_key, payload: dict, headers=None):
+    def encode_with_private_key(self, payload: dict):
+        key = self._rsa_key_service.get_random_key()
         return jwt.encode(
             payload,
-            private_key,
+            self._rsa_key_service.private_key(key),
             algorithm="RS256",
-            headers=headers,
+            headers={"kid": key.kid},
         )
 
     @staticmethod
@@ -117,7 +119,10 @@ class JWTService:
 
 
 def factory(_context, request):
-    return JWTService(registration_service=request.find_service(LTIRegistrationService))
+    return JWTService(
+        registration_service=request.find_service(LTIRegistrationService),
+        rsa_key_service=request.find_service(RSAKeyService),
+    )
 
 
 def _get_lti_jwt(request):

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -56,10 +56,3 @@ class LTI13GradingService(LTIGradingService):
             },
             headers={"Content-Type": "application/vnd.ims.lis.v2.lineitem+json"},
         )
-
-
-def factory(_context, request):
-    return LTI13GradingService(
-        grading_url=request.parsed_params["lis_outcome_service_url"],
-        ltia_service=request.find_service(LTIAHTTPService),
-    )

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timezone
+
+from lms.services.exceptions import ExternalRequestError
+from lms.services.lti_grading.interface import LTIGradingService
+from lms.services.ltia_http import LTIAHTTPService
+
+
+class LTI13GradingService(LTIGradingService):
+    # See: LTI1.3 Assignment and Grade Services https://www.imsglobal.org/spec/lti-ags/v2p0
+
+    LTIA_SCOPES = [
+        "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+        "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+        "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+    ]
+
+    def __init__(self, grading_url, ltia_service: LTIAHTTPService):
+        super().__init__(grading_url)
+        self._ltia_service = ltia_service
+
+    def read_result(self, grading_id):
+        try:
+            response = self._ltia_service.request(
+                "GET",
+                self.grading_url + "/results",
+                scopes=self.LTIA_SCOPES,
+                params={"user_id": grading_id},
+                headers={"Accept": "application/vnd.ims.lis.v2.resultcontainer+json"},
+            )
+        except ExternalRequestError as err:
+            if err.status_code == 404:
+                return None
+            raise
+
+        results = response.json()
+        if not results:
+            return None
+
+        try:
+            return results[-1]["resultScore"] / results[-1]["resultMaximum"]
+        except (ZeroDivisionError, KeyError, IndexError):
+            return None
+
+    def record_result(self, grading_id, score=None):  # pylint:disable=arguments-differ
+        return self._ltia_service.request(
+            "POST",
+            self.grading_url + "/scores",
+            scopes=self.LTIA_SCOPES,
+            json={
+                "scoreMaximum": 1,
+                "scoreGiven": score,
+                "userId": grading_id,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "activityProgress": "Completed",
+                "gradingProgress": "FullyGraded",
+            },
+            headers={"Content-Type": "application/vnd.ims.lis.v2.lineitem+json"},
+        )
+
+
+def factory(_context, request):
+    return LTI13GradingService(
+        grading_url=request.parsed_params["lis_outcome_service_url"],
+        ltia_service=request.find_service(LTIAHTTPService),
+    )

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -1,7 +1,19 @@
 from lms.services.lti_grading._v11 import LTI11GradingService
+from lms.services.lti_grading._v13 import LTI13GradingService
+from lms.services.ltia_http import LTIAHTTPService
 
 
 def service_factory(_context, request):
+    application_instance = request.find_service(
+        name="application_instance"
+    ).get_current()
+
+    if application_instance.lti_version == "1.3.0":
+        return LTI13GradingService(
+            grading_url=request.parsed_params["lis_outcome_service_url"],
+            ltia_service=request.find_service(LTIAHTTPService),
+        )
+
     return LTI11GradingService(
         grading_url=request.parsed_params["lis_outcome_service_url"],
         http_service=request.find_service(name="http"),

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -1,0 +1,68 @@
+import uuid
+from datetime import datetime, timedelta
+
+from lms.models import LTIRegistration
+from lms.services import JWTService
+
+
+class LTIAHTTPService:
+    """Send LTI Advantage requests and return the responses."""
+
+    def __init__(
+        self, lti_registration: LTIRegistration, jwt_service: JWTService, http
+    ):
+        self._lti_registration = lti_registration
+        self._jwt_service = jwt_service
+        self._http = http
+
+    def request(self, method, url, scopes, headers=None, **kwargs):
+        headers = headers or {}
+
+        assert "Authorization" not in headers
+
+        access_token = self._get_access_token(scopes)
+        headers["Authorization"] = f"Bearer {access_token}"
+
+        return self._http.request(method, url, headers=headers, **kwargs)
+
+    def _get_access_token(self, scopes):
+        """
+        Get an access token from the LMS to use in LTA services.
+
+        https://datatracker.ietf.org/doc/html/rfc7523
+        https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#post-login-oauth2-token
+        """
+        now = datetime.utcnow()
+        signed_jwt = self._jwt_service.encode_with_private_key(
+            {
+                "exp": now + timedelta(hours=1),
+                "iat": now,
+                "nonce": uuid.uuid4().hex,
+                "jti": uuid.uuid4().hex,
+                "iss": self._lti_registration.client_id,
+                "sub": self._lti_registration.client_id,
+                "aud": self._lti_registration.token_url,
+            }
+        )
+
+        response = self._http.post(
+            self._lti_registration.token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                "client_assertion": signed_jwt,
+                "scope": " ".join(scopes),
+            },
+        )
+
+        return response.json()["access_token"]
+
+
+def factory(_context, request):
+    return LTIAHTTPService(
+        request.find_service(name="application_instance")
+        .get_current()
+        .lti_registration,
+        request.find_service(JWTService),
+        request.find_service(name="http"),
+    )

--- a/lms/services/rsa_key.py
+++ b/lms/services/rsa_key.py
@@ -44,6 +44,15 @@ class RSAKeyService:
             for key in self._db.query(RSAKey).filter_by(expired=False).all()
         ]
 
+    def get_random_key(self) -> RSAKey:
+        """Get one random key from the valid ones to spread usage between them."""
+        return (
+            self._db.query(RSAKey)
+            .filter_by(expired=False)
+            .order_by(func.random())
+            .first()
+        )
+
     def _as_pem_private_key(self, rsa_key, aes_iv) -> bytes:
         """Encode a `jose.jwt.RSAKey` as an AES encrypted PEM private key."""
         pem_private_key = rsa_key.private_bytes(

--- a/lms/services/rsa_key.py
+++ b/lms/services/rsa_key.py
@@ -4,6 +4,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from jose import constants, jwk
+from sqlalchemy import func
 
 from lms.models import RSAKey
 from lms.services import AESService

--- a/tests/functional/lti_certification/v13/grading/test_assignment_and_grading.py
+++ b/tests/functional/lti_certification/v13/grading/test_assignment_and_grading.py
@@ -1,0 +1,74 @@
+class TestAssignmentAndGradingSerices:
+    """
+    From: https://www.imsglobal.org/spec/lti/v1p3/cert/#assignment-and-grade-services-testing
+
+    Assignments and Grade Services (AGS) is tested as pure service (without any UI).
+    The Tool is required to acquire the OAuth2 tokens from the IMS Global
+    testing OAuth2 server necessary to interact with the AGS system.
+    Testing for AGS for the Tool is very different from all other testing
+    in the Certification Suite.
+
+    Since it is possible to jump directly to testing for AGS, the Certification
+    Suite provides the place to launch a standard, Learner-based LTI 1.3
+    launch into your Tool. However, that is the only prescribed test in the
+    Certification Suite.
+
+    After that launch it is the responsibility of the Tool alone to work with
+    the AGS API to create lineitems and scores in the Certification Suite.
+    All interaction with the Gradebook simulated by the Certification Suite
+    can be viewed on the Results page
+    """
+
+    def test_it(self):
+        """
+        Due to the nature of this test in the certification no actual testing
+        happens here.
+
+        The test in the certification tool expects the tool to initiate
+        communication with the service but it's not tied to any launch or real
+        flow in the app.
+
+        We include here the script used for the certification for completeness.
+        ```
+        # These are included in the JWT sent by the testing tool
+        # https://purl.imsglobal.org/spec/lti/claim/resource_link -> id
+        RESOURCE_LINK_ID = "7a3f7bed2844419caa4edf74c93f4375"
+        # https://purl.imsglobal.org/spec/lti-ags/claim/endpoint -> lineitmems
+        LINEITEMS = "https://ltiadvantagevalidator.imsglobal.org/ltitool/rest/assignmentsgrades/11151/lineitems"
+
+
+        from lms.services.lti_grading._v13 import LTI13GradingService
+        from lms.services import *
+
+        application_instance = (
+            db.query(models.ApplicationInstance)
+            .join(models.LTIRegistration)
+            .filter_by(issuer="https://ltiadvantagevalidator.imsglobal.org")
+            .one()
+        )
+        ltia_service = LTIAHTTPService(
+            application_instance.lti_registration,
+            request.find_service(JWTService),
+            request.find_service(name="http"),
+        )
+        grading_service = LTI13GradingService(LINEITEMS, ltia_service)
+
+
+        response = ltia_service.request(
+            "POST",
+            LINEITEMS,
+            headers={"Content-Type": "application/vnd.ims.lis.v2.lineitem+json"},
+            scopes=LTI13GradingService.LTIA_SCOPES,
+            json={
+                "scoreMaximum": 1,
+                "label": "Introduction Assignment",
+                "resourceId": RESOURCE_LINK_ID,
+                "tag": "certification_grade",
+            },
+        )
+        grading_service.grading_url = response.json()["id"]
+        grading_service.record_result("40899", 0.8)
+        grade = grading_service.read_result("40899")
+        print("Grade:", grade)
+        ```
+        """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -95,7 +95,8 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
         lambda feature: False, return_value=False  # pragma: no cover
     )
     pyramid_request.lti_user = factories.LTIUser(
-        application_instance_id=application_instance.id
+        application_instance_id=application_instance.id,
+        user_id=lti_v11_params["user_id"],
     )
     pyramid_request.lti_jwt = {}
 

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -62,7 +62,6 @@ class TestLTI13GradingService:
 
     @freeze_time("2022-04-04")
     def test_record_result(self, svc, ltia_http_service):
-
         response = svc.record_result(self.GRADING_ID, sentinel.score)
 
         ltia_http_service.request.assert_called_once_with(

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -1,0 +1,99 @@
+from unittest.mock import Mock, sentinel
+
+import pytest
+from freezegun import freeze_time
+
+from lms.services.exceptions import ExternalRequestError
+from lms.services.lti_grading._v13 import LTI13GradingService
+
+
+class TestLTI13GradingService:
+    SERVICE_URL = "http://example.com/service_url"
+    GRADING_ID = "lis_result_sourcedid"
+
+    def test_read_lti_result(self, svc, response, ltia_http_service):
+        ltia_http_service.request.return_value.json.return_value = response
+
+        score = svc.read_result(self.GRADING_ID)
+
+        ltia_http_service.request.assert_called_once_with(
+            "GET",
+            self.SERVICE_URL + "/results",
+            scopes=svc.LTIA_SCOPES,
+            params={"user_id": self.GRADING_ID},
+            headers={"Accept": "application/vnd.ims.lis.v2.resultcontainer+json"},
+        )
+        assert score == response[-1]["resultScore"] / response[-1]["resultMaximum"]
+
+    def test_read_lti_result_empty(self, svc, ltia_http_service):
+        ltia_http_service.request.side_effect = ExternalRequestError(
+            response=Mock(status_code=404)
+        )
+
+        score = svc.read_result(self.GRADING_ID)
+
+        assert not score
+
+    def test_read_lti_result_raises(self, svc, ltia_http_service):
+        ltia_http_service.request.side_effect = ExternalRequestError(
+            response=Mock(status_code=500)
+        )
+
+        with pytest.raises(ExternalRequestError):
+            svc.read_result(self.GRADING_ID)
+
+    def test_read_empty_lti_result(self, svc, ltia_http_service):
+        ltia_http_service.request.return_value.json.return_value = []
+
+        assert not svc.read_result(self.GRADING_ID)
+
+    @pytest.mark.parameterize(
+        "bad_response",
+        (
+            [{"resultScore": 1, "resultMaximum": 0}],
+            [{"resultScore": 1}],
+            [{"resultMaximum": 10}],
+        ),
+    )
+    def test_read_bad_response_lti_result(self, svc, ltia_http_service, bad_response):
+        ltia_http_service.request.return_value.json.return_value = bad_response
+
+        assert not svc.read_result(self.GRADING_ID)
+
+    @freeze_time("2022-04-04")
+    def test_record_result(self, svc, ltia_http_service):
+
+        response = svc.record_result(self.GRADING_ID, sentinel.score)
+
+        ltia_http_service.request.assert_called_once_with(
+            "POST",
+            self.SERVICE_URL + "/scores",
+            scopes=svc.LTIA_SCOPES,
+            json={
+                "scoreMaximum": 1,
+                "scoreGiven": sentinel.score,
+                "userId": self.GRADING_ID,
+                "timestamp": "2022-04-04T00:00:00+00:00",
+                "activityProgress": "Completed",
+                "gradingProgress": "FullyGraded",
+            },
+            headers={"Content-Type": "application/vnd.ims.lis.v2.lineitem+json"},
+        )
+        assert response == ltia_http_service.request.return_value
+
+    @pytest.fixture
+    def response(self):
+        return [
+            {
+                "id": "https://lms.example.com/context/2923/lineitems/1/results/5323497",
+                "scoreOf": "https://lms.example.com/context/2923/lineitems/1",
+                "userId": "5323497",
+                "resultScore": 0.83,
+                "resultMaximum": 1,
+                "comment": "This is exceptional work.",
+            }
+        ]
+
+    @pytest.fixture
+    def svc(self, ltia_http_service):
+        return LTI13GradingService(self.SERVICE_URL, ltia_http_service)

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import sentinel
+from unittest.mock import Mock, sentinel
 
 import pytest
 
@@ -9,16 +9,37 @@ class TestFactory:
     def test_v11(
         self,
         pyramid_request,
+        application_instance_service,
         LTI11GradingService,
         http_service,
         oauth1_service,
     ):
+        application_instance_service.get_current.return_value = Mock(lti_version="1.1")
+
         svc = service_factory(sentinel.context, pyramid_request)
 
         LTI11GradingService.assert_called_once_with(
             sentinel.grading_url, http_service, oauth1_service
         )
         assert svc == LTI11GradingService.return_value
+
+    def test_v13(
+        self,
+        pyramid_request,
+        LTI13GradingService,
+        application_instance_service,
+        ltia_http_service,
+    ):
+        application_instance_service.get_current.return_value = Mock(
+            lti_version="1.3.0"
+        )
+
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        LTI13GradingService.assert_called_once_with(
+            sentinel.grading_url, ltia_http_service
+        )
+        assert svc == LTI13GradingService.return_value
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -30,3 +51,7 @@ class TestFactory:
     @pytest.fixture
     def LTI11GradingService(self, patch):
         return patch("lms.services.lti_grading.factory.LTI11GradingService")
+
+    @pytest.fixture
+    def LTI13GradingService(self, patch):
+        return patch("lms.services.lti_grading.factory.LTI13GradingService")

--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from unittest.mock import sentinel
+
+import pytest
+from freezegun import freeze_time
+
+from lms.services.ltia_http import LTIAHTTPService, factory
+from tests import factories
+
+
+class TestLTIAHTTPService:
+    @freeze_time("2022-04-04")
+    def test_request(self, svc, jwt_service, application_instance, uuid, http_service):
+        response = svc.request("POST", "https://example.com", ["SCOPE_1", "SCOPE_2"])
+
+        jwt_service.encode_with_private_key.assert_called_once_with(
+            {
+                "aud": application_instance.lti_registration.token_url,
+                "exp": datetime(2022, 4, 4, 1, 0),
+                "iat": datetime(2022, 4, 4, 0, 0),
+                "nonce": uuid.uuid4.return_value.hex,
+                "iss": application_instance.lti_registration.client_id,
+                "sub": application_instance.lti_registration.client_id,
+                "jti": uuid.uuid4.return_value.hex,
+            }
+        )
+        http_service.post.assert_called_once_with(
+            application_instance.lti_registration.token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                "client_assertion": jwt_service.encode_with_private_key.return_value,
+                "scope": "SCOPE_1 SCOPE_2",
+            },
+        )
+        http_service.request.assert_called_once_with(
+            "POST",
+            "https://example.com",
+            headers={
+                "Authorization": f"Bearer {http_service.post.return_value.json.return_value['access_token']}"
+            },
+        )
+        assert response == http_service.request.return_value
+
+    @pytest.fixture
+    def svc(self, application_instance, jwt_service, http_service):
+        return LTIAHTTPService(
+            application_instance.lti_registration, jwt_service, http_service
+        )
+
+    @pytest.fixture
+    def uuid(self, patch):
+        return patch("lms.services.ltia_http.uuid")
+
+
+class TestFactory:
+    @pytest.mark.usefixtures("application_instance_service")
+    def test_it(
+        self,
+        pyramid_request,
+        LTIAHTTPService,
+        application_instance,
+        http_service,
+        jwt_service,
+    ):
+        ltia_http_service = factory(sentinel.context, pyramid_request)
+
+        LTIAHTTPService.assert_called_once_with(
+            application_instance.lti_registration, jwt_service, http_service
+        )
+        assert ltia_http_service == LTIAHTTPService.return_value
+
+    @pytest.fixture
+    def LTIAHTTPService(self, patch):
+        return patch("lms.services.ltia_http.LTIAHTTPService")
+
+
+@pytest.mark.usefixtures("db_session")
+@pytest.fixture
+def application_instance(application_instance):
+    application_instance.lti_registration = factories.LTIRegistration()
+    return application_instance

--- a/tests/unit/lms/services/rsa_key_service_test.py
+++ b/tests/unit/lms/services/rsa_key_service_test.py
@@ -65,6 +65,11 @@ class TestAESService:
         ]
         assert keys == Any.list.containing(expected_keys).only()
 
+    def test_get_random_key(self, svc, valid_keys):
+        key = svc.get_random_key()
+
+        assert key in valid_keys
+
     @pytest.fixture
     def valid_keys(self):
         # Create some noise with some expired keys.

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -36,6 +36,7 @@ __all__ = (
     # Meta fixture for creating service fixtures
     "mock_service",
     # Individual services
+    "aes_service",
     "application_instance_service",
     "assignment_service",
     "async_oauth_http_service",
@@ -50,20 +51,19 @@ __all__ = (
     "grouping_service",
     "h_api",
     "http_service",
+    "jstor_service",
+    "jwt_service",
     "launch_verifier",
-    "lti_h_service",
     "lti_grading_service",
+    "lti_h_service",
     "lti_registration_service",
+    "ltia_http_service",
     "oauth1_service",
     "oauth2_token_service",
     "oauth_http_service",
+    "rsa_key_service",
     "user_service",
     "vitalsource_service",
-    "jstor_service",
-    "aes_service",
-    "jwt_service",
-    "rsa_key_service",
-    "ltia_http_service",
 )
 
 
@@ -94,6 +94,11 @@ def application_instance_service(mock_service, application_instance):
     application_instance_service.get_by_consumer_key.return_value = application_instance
 
     return application_instance_service
+
+
+@pytest.fixture
+def aes_service(mock_service):
+    return mock_service(AESService)
 
 
 @pytest.fixture
@@ -129,6 +134,11 @@ def canvas_service(mock_service, canvas_api_client):
 @pytest.fixture
 def course_service(mock_service):
     return mock_service(CourseService, service_name="course")
+
+
+@pytest.fixture
+def file_service(mock_service):
+    return mock_service(FileService, service_name="file")
 
 
 @pytest.fixture
@@ -168,6 +178,16 @@ def http_service(mock_service):
 
 
 @pytest.fixture
+def jstor_service(mock_service):
+    return mock_service(JSTORService)
+
+
+@pytest.fixture
+def jwt_service(mock_service):
+    return mock_service(JWTService)
+
+
+@pytest.fixture
 def oauth_http_service(mock_service):
     oauth_http_service = mock_service(OAuthHTTPService, service_name="oauth_http")
     oauth_http_service.request.return_value = factories.requests.Response()
@@ -198,6 +218,16 @@ def lti_h_service(mock_service):
 
 
 @pytest.fixture
+def lti_registration_service(mock_service):
+    return mock_service(LTIRegistrationService)
+
+
+@pytest.fixture
+def ltia_http_service(mock_service):
+    return mock_service(LTIAHTTPService)
+
+
+@pytest.fixture
 def oauth1_service(mock_service):
     return mock_service(OAuth1Service, service_name="oauth1")
 
@@ -211,45 +241,15 @@ def oauth2_token_service(mock_service, oauth_token):
 
 
 @pytest.fixture
-def user_service(mock_service):
-    return mock_service(UserService)
-
-
-@pytest.fixture
-def jstor_service(mock_service):
-    return mock_service(JSTORService)
-
-
-@pytest.fixture
-def aes_service(mock_service):
-    return mock_service(AESService)
-
-
-@pytest.fixture
-def jwt_service(mock_service):
-    return mock_service(JWTService)
-
-
-@pytest.fixture
-def vitalsource_service(mock_service):
-    return mock_service(VitalSourceService, service_name="vitalsource")
-
-
-@pytest.fixture
-def file_service(mock_service):
-    return mock_service(FileService, service_name="file")
-
-
-@pytest.fixture
-def lti_registration_service(mock_service):
-    return mock_service(LTIRegistrationService)
-
-
-@pytest.fixture
 def rsa_key_service(mock_service):
     return mock_service(RSAKeyService)
 
 
 @pytest.fixture
-def ltia_http_service(mock_service):
-    return mock_service(LTIAHTTPService)
+def user_service(mock_service):
+    return mock_service(UserService)
+
+
+@pytest.fixture
+def vitalsource_service(mock_service):
+    return mock_service(VitalSourceService, service_name="vitalsource")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -23,6 +23,7 @@ from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_h import LTIHService
 from lms.services.lti_registration import LTIRegistrationService
+from lms.services.ltia_http import LTIAHTTPService
 from lms.services.oauth1 import OAuth1Service
 from lms.services.oauth2_token import OAuth2TokenService
 from lms.services.oauth_http import OAuthHTTPService
@@ -62,6 +63,7 @@ __all__ = (
     "aes_service",
     "jwt_service",
     "rsa_key_service",
+    "ltia_http_service",
 )
 
 
@@ -246,3 +248,8 @@ def lti_registration_service(mock_service):
 @pytest.fixture
 def rsa_key_service(mock_service):
     return mock_service(RSAKeyService)
+
+
+@pytest.fixture
+def ltia_http_service(mock_service):
+    return mock_service(LTIAHTTPService)


### PR DESCRIPTION
## Testing

- Start the server with more than one worker so the LMS can make a request to the `/lti/1.3/jwks` endpoint while the server handles another request.


```diff
diff --git a/conf/supervisord-dev.conf b/conf/supervisord-dev.conf
index 63063eb8..aec0ab0d 100644
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -3,7 +3,7 @@ nodaemon = true
 silent = true
 
 [program:web]
-command=gunicorn --workers 1 --paste conf/development.ini
+command=gunicorn --workers 2 --paste conf/development.ini
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL
```


- `make devdata` 

- Start a tunnel to `blackboard-jon`

`loophole http 8001 --hostname blackboard-jon`

- Launch https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_664_1&displayName=Test+with+grading&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_88_1%26content_id%3D_664_1%26course_id%3D_19_1 as a teacher (you might need to configure it)

(Or if you need to create a new assignment use `Hypothesis LTI1.3` from the build content dropdown)

 
- Launch it as `Blackboard Student 2`
- Launch the assignment again as a teacher. You should get the grading bar with one student in the dropdown now.
- Switch to the student on the drop-down. You'll get a empty grade.
- Grade the student
- Relaunch the assignment and select the student again. You'll get the submitted grade.



