### PR TITLE
Add support for `reportActivity` method

### DIFF
--- a/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
@@ -168,6 +168,22 @@ describe('ClientRPC', () => {
     });
   });
 
+  describe('reportActivity', () => {
+    it('calls registered callback with annotation activity parameters', () => {
+      const clientRPC = createClientRPC();
+      const callback = sinon.stub();
+      const [, serverMethod] = fakeServerInstance.register.args.find(
+        ([method]) => method === 'reportActivity'
+      );
+      clientRPC.on('annotationActivity', callback);
+
+      const result = serverMethod('create', 'foo');
+
+      assert.isTrue(result);
+      assert.calledWith(callback, 'create', 'foo');
+    });
+  });
+
   it('registers "requestGroups" RPC handler', () => {
     createClientRPC();
     assert.calledWith(fakeServerInstance.register, 'requestGroups');

--- a/lms/static/scripts/postmessage_json_rpc/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server.js
@@ -162,7 +162,9 @@ export class Server {
 
     // Call the method and return the result response.
     try {
-      const result = await method();
+      const result = request.params
+        ? await method(...request.params)
+        : await method();
       return { jsonrpc: '2.0', result: result, id: request.id };
     } catch (e) {
       return {

--- a/lms/static/scripts/postmessage_json_rpc/test/server-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/test/server-test.js
@@ -69,6 +69,22 @@ describe('Server', () => {
       ]);
     });
 
+    it('calls the registered method with the provided params', () => {
+      const request = validRequest();
+      request.params = ['foo', 5];
+      window.postMessage(request, serversOrigin);
+
+      return Promise.race([
+        new Promise(resolve => {
+          receiveMessage.callsFake(() => {
+            assert.calledWith(registeredMethod, 'foo', 5);
+            resolve();
+          });
+        }),
+        rejectAfterDelay("Server's response wasn't received"),
+      ]);
+    });
+
     it('calls the registered method that throws an error', () => {
       window.postMessage(
         validRequest('registeredMethodErrorName'),


### PR DESCRIPTION
This PR breaks off a piece of the https://github.com/hypothesis/lms/pull/3825 PoC. It registers a `reportActivity` method on the "RPC" server. Nothing is using this yet. Adding this independently allows related configuration (which will "turn this on" and cause the client to send requests to that method) to be landed independently. 

Part of https://github.com/hypothesis/lms/issues/3647