### PR TITLE
Migration for the new RSAKey model

### DIFF
--- a/lms/migrations/versions/34f28d992b18_new_rsa_key_table.py
+++ b/lms/migrations/versions/34f28d992b18_new_rsa_key_table.py
@@ -1,0 +1,39 @@
+"""
+New rsa_key table.
+
+Revision ID: 34f28d992b18
+Revises: 497b20c41fbb
+Create Date: 2022-04-21 11:08:09.946604
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "34f28d992b18"
+down_revision = "497b20c41fbb"
+
+
+def upgrade():
+    op.create_table(
+        "rsa_key",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("kid", sa.Unicode(), nullable=False),
+        sa.Column("public_key", sa.Unicode(), nullable=True),
+        sa.Column("private_key", sa.LargeBinary(), nullable=True),
+        sa.Column("aes_cipher_iv", sa.LargeBinary(), nullable=True),
+        sa.Column(
+            "expired", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__rsa_key")),
+    )
+
+
+def downgrade():
+    op.drop_table("rsa_key")


### PR DESCRIPTION
Model defined in #3862 and autogenerated with alembic.


## Testing 

- Start with a clean DB, from `master`:

`git checkout master; docker stop lms_postgres_1; docker rm lms_postgres_1; make services db devdata`


- In this branch, `rsa-key-migration`, run the migration:

```
hdev alembic upgrade head
dev installed: *** listing modules disabled by tox-pip-sync in pyproject.toml ***
dev run-test-pre: PYTHONHASHSEED='834933708'
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 497b20c41fbb -> 34f28d992b18, New rsa_key table.
```

