### PR TITLE
Expose `submitted_at` in canvas grading API 

### DIFF
--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -47,6 +47,9 @@ class APIRecordSpeedgraderSchema(JSONPyramidRequestSchema):
     ext_lti_assignment_id = fields.Str(required=False, allow_none=True)
     """Canvas doesn't send this value on speed grader launches"""
 
+    submitted_at = fields.DateTime(required=False, allow_none=True)
+    """Date we'll send to canvas linked to this submission"""
+
 
 class APIReadResultSchema(PyramidRequestSchema):
     """Schema for validating proxy requests to LTI Outcomes API for reading grades."""

--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -104,7 +104,8 @@ class CanvasPreRecordHook:
         # an existing submission then the existing submission is updated
         # rather than creating a new submission.
         request_body["submissionDetails"] = {
-            "submittedAt": datetime.datetime(2001, 1, 1, tzinfo=timezone.utc)
+            "submittedAt": self.request.parsed_params.get("submitted_at")
+            or datetime.datetime(2001, 1, 1, tzinfo=timezone.utc)
         }
 
         return request_body


### PR DESCRIPTION
For #3647 


Added as an optional parameter first to make the deployment/rollout easier. As of now there's no code that that sets the date in the frontend so all submissions still should use the default 2001 date.


# Testing

- Create a new assignment in canvas as a techer https://hypothesis.instructure.com/courses/125/assignments/new?submission_types=none&name=&due_at=null&points_possible=0&assignment_group_id=166

- Launch the assignment as `eng+canvasstudent@hypothes.is`

- Back to the teacher account, open the assignment in speed-grader, the date of the submission will be `Submitted:
Dec 31, 2000 at 5pm`

