### PR TITLE
Enable `reportActivity` setting on the client config on canvas instances

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -16,7 +16,7 @@ session_cookie_secret = "notasecret"
 
 # The secret string that's used to sign the feature flags cookie.
 feature_flags_cookie_secret = "notasecret"
-feature_flags_allowed_in_cookie = vitalsource
+feature_flags_allowed_in_cookie = vitalsource submit_on_annotation
 
 # The secret string that's used to sign the OAuth2 state param.
 oauth2_state_secret = "notasecret"

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -338,6 +338,10 @@ class JSConfig:
         # Enable the LMS frontend to receive notifications on annotation activity
         # We'll use this information to only send the submission to canvas on first annotation.
         if self._request.feature("submit_on_annotation"):
+            # The `reportActivity` setting causes the front-end to make a call
+            # back to the parent iframe for the specified events. The method in
+            # the iframe happens to be called `reportActivity` too, but this is
+            # a co-incidence. It could have any name.
             self._hypothesis_client["reportActivity"] = {
                 "method": "reportActivity",
                 "events": ["create", "update"],

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -337,10 +337,11 @@ class JSConfig:
         }
         # Enable the LMS frontend to receive notifications on annotation activity
         # We'll use this information to only send the submission to canvas on first annotation.
-        self._hypothesis_client["reportActivity"] = {
-            "method": "reportActivity",
-            "events": ["create", "update"],
-        }
+        if self._request.feature("submit_on_annotation"):
+            self._hypothesis_client["reportActivity"] = {
+                "method": "reportActivity",
+                "events": ["create", "update"],
+            }
 
     def _auth_token(self):
         """Return the authToken setting."""

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -335,6 +335,12 @@ class JSConfig:
                 **kwargs,
             },
         }
+        # Enable the LMS frontend to receive notifications on annotation activity
+        # We'll use this information to only send the submission to canvas on first annotation.
+        self._hypothesis_client["reportActivity"] = {
+            "method": "reportActivity",
+            "events": ["create", "update"],
+        }
 
     def _auth_token(self):
         """Return the authToken setting."""


### PR DESCRIPTION
Following the conversation here:

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1650458302131809?thread_ts=1650415818.372909&cid=C4K6M7P5E


Added the new config option only for canvas. Leaving it out for other LMSs


## Testing 

- Launch https://hypothesis.instructure.com/courses/125/assignments/2947, check the configuration at `http://localhost:8001/lti_launches?url=https://example.com`.
- Ctrl+F for `hypothesisClient` in the response. Nothing has changed, the config doesn't include the new property:

    ```hypothesisClient": {"services"...}```


- Enable `submit_on_annotation` on  http://localhost:8001/flags

- Refresh the launch and check the response again for `http://localhost:8001/lti_launches?url=https://example.com`, Ctrl+F for `hypothesisClient`. 

    The new `{"reportActivity": {"events": ["create", "update"], "method": "reportActivity"}` should be there.