### PR TITLE
Refactor grading service V11 tests

### DIFF
--- a/tests/unit/lms/services/lti_grading/_v11_test.py
+++ b/tests/unit/lms/services/lti_grading/_v11_test.py
@@ -23,22 +23,18 @@ class TestLTI11GradingService:
         }
         assert score == 0.95
 
+    @pytest.mark.parametrize("score", [None, "", "not-a-float"])
+    def test_read_result_returns_none_if_score_not_a_float(
+        self, svc, respond_with, score
+    ):
+        respond_with(score=score)
+
+        assert svc.read_result(sentinel.grading_id) is None
+
     def test_read_result_returns_none_if_no_score(self, svc, respond_with):
         respond_with(include_score=False)
 
-        score = svc.read_result(sentinel.grading_id)
-
-        assert score is None
-
-    @pytest.mark.parametrize("score_text", [None, "", "not-a-float"])
-    def test_read_result_returns_none_if_score_not_a_float(
-        self, svc, respond_with, score_text
-    ):
-        respond_with(score=score_text)
-
-        score = svc.read_result(sentinel.grading_id)
-
-        assert score is None
+        assert svc.read_result(sentinel.grading_id) is None
 
     @pytest.mark.usefixtures("with_response")
     @pytest.mark.parametrize(

--- a/tests/unit/lms/services/lti_grading/_v11_test.py
+++ b/tests/unit/lms/services/lti_grading/_v11_test.py
@@ -49,7 +49,7 @@ class TestLTI11GradingService:
 
         assert score is None
 
-    @pytest.mark.usefixtures("response")
+    @pytest.mark.usefixtures("with_response")
     def test_record_result_sends_sourcedid(self, svc, http_service):
         svc.record_result(sentinel.grading_id)
 
@@ -62,7 +62,7 @@ class TestLTI11GradingService:
 
         assert sourced_id == "sentinel.grading_id"
 
-    @pytest.mark.usefixtures("response")
+    @pytest.mark.usefixtures("with_response")
     @pytest.mark.parametrize(
         "score_provided,score_in_record",
         [
@@ -82,7 +82,7 @@ class TestLTI11GradingService:
 
         assert score == score_in_record
 
-    @pytest.mark.usefixtures("response")
+    @pytest.mark.usefixtures("with_response")
     def test_record_result_calls_hook(self, svc, http_service):
         my_hook = Mock(return_value={"my_dict": 1})
 
@@ -237,7 +237,7 @@ class TestLTI11GradingService:
         )
 
     @pytest.fixture
-    def response(self, respond_with):
+    def with_response(self, respond_with):
         respond_with()
 
     @pytest.fixture

--- a/tests/unit/lms/services/lti_grading/_v11_test.py
+++ b/tests/unit/lms/services/lti_grading/_v11_test.py
@@ -11,22 +11,16 @@ from tests import factories
 
 @pytest.mark.usefixtures("oauth1_service", "http_service")
 class TestLTI11GradingService:
-    def test_read_result_sends_expected_request(self, svc, respond_with, http_service):
+    def test_read_result(self, svc, respond_with, http_service):
         respond_with(score=0.95)
 
-        svc.read_result(sentinel.grading_id)
+        score = svc.read_result(sentinel.grading_id)
 
         assert self.sent_pox_body(http_service) == {
             "readResultRequest": {
                 "resultRecord": {"sourcedGUID": {"sourcedId": "sentinel.grading_id"}}
             }
         }
-
-    def test_read_result_returns_float_score(self, svc, respond_with):
-        respond_with(score=0.95)
-
-        score = svc.read_result(sentinel.grading_id)
-
         assert score == 0.95
 
     def test_read_result_returns_none_if_no_score(self, svc, respond_with):

--- a/tests/unit/lms/services/lti_grading/_v11_test.py
+++ b/tests/unit/lms/services/lti_grading/_v11_test.py
@@ -9,9 +9,8 @@ from lms.services.exceptions import ExternalRequestError
 from lms.services.lti_grading._v11 import LTI11GradingService
 from tests import factories
 
-pytestmark = pytest.mark.usefixtures("oauth1_service", "http_service")
 
-
+@pytest.mark.usefixtures("oauth1_service", "http_service")
 class TestLTI11GradingService:
     def test_read_result_sends_expected_request(self, svc, respond_with, http_service):
         respond_with(score=0.95)


### PR DESCRIPTION
This is a grab bag of various improvements. Each has been put in it's own commit for easy reference.

Highlights:

 * Using sentinels
 * Making test which apply to both methods use both methods
 * Collapsing some tests together
 * More declarative comparisons with dicts