### PR TITLE
Pick parameters from lti_params instead of the raw request.params

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -228,7 +228,7 @@ class JSConfig:
             # Only instructors can grade assignments.
             return
 
-        if "lis_outcome_service_url" not in self._request.params:
+        if "lis_outcome_service_url" not in self._context.lti_params:
             # Only "gradeable" assignments can be graded.
             # Assignments that don't have the lis_outcome_service_url param
             # aren't set as gradeable in the LMS.
@@ -241,8 +241,8 @@ class JSConfig:
 
         self._config["grading"] = {
             "enabled": True,
-            "courseName": self._request.params.get("context_title"),
-            "assignmentName": self._request.params.get("resource_link_title"),
+            "courseName": self._context.lti_params.get("context_title"),
+            "assignmentName": self._context.lti_params.get("resource_link_title"),
             "students": list(self._get_students()),
         }
 
@@ -395,8 +395,8 @@ class JSConfig:
         """
         grading_infos = self._grading_info_service.get_by_assignment(
             application_instance=self._application_instance,
-            context_id=self._request.params.get("context_id"),
-            resource_link_id=self._request.params.get("resource_link_id"),
+            context_id=self._context.lti_params.get("context_id"),
+            resource_link_id=self._context.lti_params.get("resource_link_id"),
         )
 
         # Yield a "student" dict for each GradingInfo.

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -133,7 +133,7 @@ class BasicLTILaunchViews:
         document_url = f"canvas://file/course/{course_id}/file_id/{file_id}"
         self.assignment_service.upsert(
             document_url=document_url,
-            tool_consumer_instance_guid=self.request.params[
+            tool_consumer_instance_guid=self.context.lti_params[
                 "tool_consumer_instance_guid"
             ],
             resource_link_id=self.context.resource_link_id,
@@ -155,11 +155,9 @@ class BasicLTILaunchViews:
         # The ``db_configured=True`` view predicate ensures that this view
         # won't be called if there isn't a matching document_url in the DB. So
         # here we can safely assume that the document_url exists.
-        tool_consumer_instance_guid = self.context.lti_params[
-            "tool_consumer_instance_guid"
-        ]
         document_url = self.assignment_service.get(
-            tool_consumer_instance_guid, self.context.resource_link_id
+            self.context.lti_params["tool_consumer_instance_guid"],
+            self.context.resource_link_id,
         ).document_url
         return self.basic_lti_launch(document_url)
 
@@ -171,12 +169,13 @@ class BasicLTILaunchViews:
     )
     def canvas_db_configured_basic_lti_launch(self):
         """Respond to a Canvas DB-configured assignment launch."""
-        tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
         resource_link_id = self.context.resource_link_id
         ext_lti_assignment_id = self.context.ext_lti_assignment_id
 
         assignments = self.assignment_service.get_for_canvas_launch(
-            tool_consumer_instance_guid, resource_link_id, ext_lti_assignment_id
+            self.context.lti_params["tool_consumer_instance_guid"],
+            resource_link_id,
+            ext_lti_assignment_id,
         )
 
         if len(assignments) == 2:
@@ -246,7 +245,9 @@ class BasicLTILaunchViews:
         :param original_resource_link_id: the resource_link_id of the original
             assignment that this assignment was copied from
         """
-        tool_consumer_instance_guid = self.request.params["tool_consumer_instance_guid"]
+        tool_consumer_instance_guid = self.context.lti_params[
+            "tool_consumer_instance_guid"
+        ]
 
         document_url = self.assignment_service.get(
             tool_consumer_instance_guid, original_resource_link_id
@@ -358,7 +359,7 @@ class BasicLTILaunchViews:
 
         self.assignment_service.upsert(
             document_url,
-            self.request.parsed_params["tool_consumer_instance_guid"],
+            self.context.lti_params["tool_consumer_instance_guid"],
             self.context.resource_link_id,
             extra=extra,
         )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,7 +28,7 @@ def lti_v11_params():
         "oauth_version": "1p0p0",
         "user_id": "TEST_USER_ID",
         "roles": "Instructor",
-        "tool_consumer_instance_guid": "TEST_GUID",
+        "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
         "tool_consumer_info_product_family_code": "whiteboard",
         "content_item_return_url": "https://www.example.com",
         "lti_version": "LTI-1p0",

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from h_matchers import Any
 
-from lms.models import ApplicationInstance, GradingInfo, Grouping
+from lms.models import ApplicationInstance, GradingInfo, Grouping, LTIParams
 from lms.resources import LTILaunchResource, OAuth2RedirectResource
 from lms.resources._js_config import JSConfig
 from lms.services import ApplicationInstanceNotFound, HAPIError
@@ -313,9 +313,9 @@ class TestMaybeEnableGrading:
         assert not js_config.asdict().get("grading")
 
     def test_it_does_nothing_if_theres_no_lis_outcome_service_url(
-        self, js_config, pyramid_request
+        self, js_config, context
     ):
-        del pyramid_request.params["lis_outcome_service_url"]
+        del context.lti_params["lis_outcome_service_url"]
 
         js_config.maybe_enable_grading()
 
@@ -737,7 +737,7 @@ def submission_params(config):
 
 
 @pytest.fixture
-def context():
+def context(pyramid_request):
     return mock.create_autospec(
         LTILaunchResource,
         spec_set=True,
@@ -748,6 +748,7 @@ def context():
         canvas_groups_enabled=False,
         canvas_is_group_launch=False,
         is_group_launch=False,
+        lti_params=LTIParams(pyramid_request.params),
     )
 
 

--- a/tests/unit/lms/validation/authentication/_lti_test.py
+++ b/tests/unit/lms/validation/authentication/_lti_test.py
@@ -30,7 +30,7 @@ class TestLTI11AuthSchema:
                 "lis_person_name_given": "TEST_GIVEN_NAME",
                 "oauth_signature": "TEST_OAUTH_SIGNATURE",
                 "roles": "Instructor",
-                "tool_consumer_instance_guid": "TEST_GUID",
+                "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
                 "user_id": "TEST_USER_ID",
                 "oauth_timestamp": "TEST_TIMESTAMP",
             },

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from lms.models import LTIParams
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
 from lms.views.basic_lti_launch import BasicLTILaunchViews
@@ -376,8 +377,8 @@ class TestFooCopiedBasicLTILaunch:
         # DB.
         assignment_service.upsert.assert_called_once_with(
             assignment_service.get.return_value.document_url,
-            pyramid_request.params["tool_consumer_instance_guid"],
-            pyramid_request.params["resource_link_id"],
+            context.lti_params["tool_consumer_instance_guid"],
+            context.lti_params["resource_link_id"],
         )
 
         # It adds the document URL to the JavaScript config.
@@ -508,8 +509,8 @@ def context(pyramid_request):
     context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
     context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
     context.is_canvas = False
-
     context.resource_link_id = pyramid_request.params["resource_link_id"]
+    context.lti_params = LTIParams(pyramid_request.params)
     return context
 
 


### PR DESCRIPTION
In preparation for LTI1.3

In LTI1.1 `lti_params` <-> `params`:

https://github.com/hypothesis/lms/blob/bdc06426d1a65ff198534bd9c55ec11505198fc2/lms/resources/lti_launch.py#L251


# Testing

Nothing should have changed for LTI1.1 launches. I'm launching a few assignments and doing a sanity check.

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1

https://hypothesis.instructure.com/courses/125/assignments/875

