### PR TITLE
Conditionally submit empty grading submission after activity, if configured as such

### DIFF
--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -133,6 +133,31 @@ import { createContext } from 'preact';
  */
 
 /**
+ * @typedef ServiceConfig
+ * @prop {string} grantToken
+ */
+
+/**
+ * The subset of the Hypothesis client configuration that this app directly references.
+ *
+ * The backend will add other properties which are intentionally not included here,
+ * even as an index signature. This other configuration is simply forwarded to
+ * the client.
+ *
+ * See https://h.readthedocs.io/projects/client/en/latest/publishers/config/.
+ *
+ * @typedef ClientConfig
+ * @prop {[ServiceConfig]} services - Annotation configuration for the client.
+ *   In the LMS context this will always consist of exactly one entry.
+ * @prop {object} [reportActivity] - When present, enables communication of
+ *   annotation activity from the client sidebar's frame to this one.
+ *   The details of this object can be considered opaque to this application,
+ *   but its presence indicates that Canvas empty grading submissions should
+ *   only be submitted for a student after qualifying annotation activity
+ *   occurs (not immediately at launch).
+ */
+
+/**
  * Data/configuration needed for frontend applications in the LMS app.
  * The `mode` property specifies which frontend application should load and
  * the available configuration/data depends on the mode and LTI user role.
@@ -151,7 +176,7 @@ import { createContext } from 'preact';
  * @prop {boolean} dev
  * @prop {FilePickerConfig} filePicker
  * @prop {GradingConfig} grading
- * @prop {object} hypothesisClient
+ * @prop {ClientConfig} hypothesisClient
  * @prop {object} rpcServer
  *   @prop {string[]} rpcServer.allowedOrigins
  * @prop {string} viaUrl

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -11,22 +11,7 @@ import { JWT } from '../utils/jwt';
  */
 
 /**
- * @typedef ServiceConfig
- * @prop {string} grantToken
- */
-
-/**
- * The subset of the Hypothesis client configuration that `ClientRPC` directly references.
- *
- * The backend will add other properties which are intentionally not included here,
- * even as an index signature. This other configuration is simply forwarded to
- * the client but not touched by `ClientRPC`.
- *
- * See https://h.readthedocs.io/projects/client/en/latest/publishers/config/.
- *
- * @typedef ClientConfig
- * @prop {[ServiceConfig]} services - Annotation configuration for the client.
- *   In the LMS context this will always consist of exactly one entry.
+ * @typedef {import('../config').ClientConfig} ClientConfig
  */
 
 /**


### PR DESCRIPTION
This PR adds front-end support to hold off on submitting an empty grading submission in Canvas until after first annotation activity if configured to do so (i.e. in this case, if the feature flag is enabled), and it will send a "meaningful date" for the submission in these cases.

Otherwise, behavior should remain unchanged: submit empty grading submission on launch, with no associated date (backend will use "dummy" date).

## Testing


*NB: It's not expected that a reviewer will run through this _entire_ set of tests if it does not feel useful.*

Make sure to pull latest `master` for the `client` and run this branch locally.

I'd suggest creating new (grading-enabled) assignments for both branches of testing here, as the situation can be muddied/hard to test with an existing assignment that has been launched before by student users, as empty grading submissions already exist.

### Test new behavior

Before running through these tests: Go to http://localhost:8001/flags and make sure `submit_on_annotation` feature flag is enabled.

#### Testing that submissions are not made before first activity

1. Launch a grading-enabled local Canvas assignment as a *student* user (we'll call this "Student A"). Do not create, edit or reply to any annotations.
3. Log out.
4. Log in as an instructor for the course.
5. Launch the assignment.
6. Go into Speed Grader.
7. You should not see a submission for Student A.

#### Testing submission after annotation creation

1. Log in as Student A.
2. Launch the assignment.
3. Create an annotation and save it.
4. Wait a moment. Create a second annotation.
5. Log out.
8. Log in as instructor.
9. Launch assignment; go to Speed Grader.
10. You should see *one* submission for Student A, and it should have a date associated with it that seems appropriate. Note that our Canvas instance is in Mountain Time (US).

#### Testing submission after annotation edit

1. Log in as Student A.
2. Launch the assignment.
3. Edit a pre-existing annotation.
4. Wait a moment. Edit an annotation again.
5. Log out.
6. Log in as instructor.
7. Launch assignment; go to Speed Grader.
8. You should see *two* submissions for Student A, and they should have a dates associated with them that seem appropriate.

#### Testing submission after annotation reply

1. Log in as Student A.
2. Launch the assignment.
3. Reply to an existing annotation.
5. Log out.
8. Log in as instructor.
9. Launch assignment; go to Speed Grader.
10. You should see *three* submission for Student A, and it they should have dates associated with them that seem appropriate.

### Test old Behavior

Suggest creating a new assignment.

Go to http://localhost:8001/flags and make sure `submit_on_annotation` feature flag is *disabled*.

#### Testing submission on launch

1. Log in as Student A.
2. Launch assignment.
3. Do not create or edit any annotations.
4. Log out.
5. Log in as instructor.
6. Launch assignment.
7. Go to Speed Grader.
8. You should see a submission for Student A with old dummy date.

#### Testing against duplicate submissions

1. Log in as Student A.
2. Launch assignment.
3. Do not create or edit any annotations. Well, you can but it shouldn't matter here.
4. Log out.
5. Log in as instructor.
6. Launch assignment.
7. Go to Speed Grader.
8. You should still see *one* submission for Student A with old dummy date.


### Mix it up

Go to http://localhost:8001/flags and make sure `submit_on_annotation` feature flag is *enabled*.

Use the same assignment as for "Test old Behavior."

#### Testing submission after activity on assignment previously configured to submit on launch

1. Log in as Student A.
2. Launch assignment.
3. Create an annotation.
4. Log out.
5. Log in as instructor.
6. Launch assignment.
7. Go to Speed Grader.
8. You should see two submissions for Student A: a pre-existing one from an on-launch submission with an old dummy date, and a newer one with an appropriate date.

Fixes https://github.com/hypothesis/lms/issues/3647