### PR TITLE
Deep Linking in LTI1.3 launches

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -51,6 +51,17 @@ _V11_TO_V13 = (
         ["https://purl.imsglobal.org/spec/lti-ags/claim/endpoint", "lineitem"],
     ),
     ("lis_result_sourcedid", ["sub"]),
+    (
+        "content_item_return_url",
+        [
+            "https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings",
+            "deep_link_return_url",
+        ],
+    ),
+    (
+        "deep_linking_settings",
+        ["https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings"],
+    ),
 )
 
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -214,6 +214,27 @@ class JSConfig:
             }
         )
 
+    def add_deep_linking_api(self):
+        """
+        Add the details of the "DeepLinking API" in LMS where we support deep linking.
+
+        This API will be used by the frontend to retrieve the form fields required
+        for the deep linking submission while on CONTENT_ITEM_SELECTION mode to store the
+        selected content on the LMS.
+        """
+        self._config.setdefault("filePicker", {})
+        self._config["filePicker"]["deepLinkingAPI"] = {
+            "path": self._request.route_path("lti.deep_linking.form_fields"),
+            "data": {
+                "content_item_return_url": self._context.lti_params[
+                    "content_item_return_url"
+                ],
+                "deep_linking_settings": self._context.lti_params.get(
+                    "deep_linking_settings"
+                ),
+            },
+        }
+
     def maybe_enable_grading(self):
         """Enable our LMS app's built-in assignment grading UI, if appropriate."""
 

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -108,3 +108,6 @@ def includeme(config):
 
     config.add_route("lti.oidc", "/lti/1.3/oidc")
     config.add_route("lti.jwks", "/lti/1.3/jwks")
+    config.add_route(
+        "lti.deep_linking.form_fields", "/lti/1.3/deep_linking/form_fields"
+    )

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -15,6 +15,27 @@ class LTIAHTTPService:
         self._jwt_service = jwt_service
         self._http = http
 
+    def sign(self, payload: dict):
+        """
+        Sign a payload with one of our private keys.
+
+        We include the default values needed for LTIA APIs
+        Those default claims are defined here:
+
+            https://www.imsglobal.org/spec/security/v1p0/#id-token
+        """
+        now = datetime.utcnow()
+        payload = {
+            "exp": now + timedelta(hours=1),
+            "iat": now,
+            "nonce": uuid.uuid4().hex,
+            "iss": self._lti_registration.client_id,
+            "sub": self._lti_registration.client_id,
+            "aud": self._lti_registration.issuer,
+            **payload,
+        }
+        return self._jwt_service.encode_with_private_key(payload)
+
     def request(self, method, url, scopes, headers=None, **kwargs):
         headers = headers or {}
 
@@ -32,16 +53,10 @@ class LTIAHTTPService:
         https://datatracker.ietf.org/doc/html/rfc7523
         https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#post-login-oauth2-token
         """
-        now = datetime.utcnow()
-        signed_jwt = self._jwt_service.encode_with_private_key(
+        signed_jwt = self.sign(
             {
-                "exp": now + timedelta(hours=1),
-                "iat": now,
-                "nonce": uuid.uuid4().hex,
-                "jti": uuid.uuid4().hex,
-                "iss": self._lti_registration.client_id,
-                "sub": self._lti_registration.client_id,
                 "aud": self._lti_registration.token_url,
+                "jti": uuid.uuid4().hex,
             }
         )
 

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -71,6 +71,7 @@ import { createContext } from 'preact';
  * @typedef FilePickerConfig
  * @prop {string} formAction
  * @prop {Record<string,string>} formFields
+ * @prop {APICallInfo} [deepLinkingAPI]
  * @prop {string} ltiLaunchUrl
  * @prop {object} blackboard
  *   @prop {boolean} blackboard.enabled

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -178,8 +178,11 @@ class DeepLinkingLTILaunchSchema(_CommonLTILaunchSchema):
     """Schema for deep linking LTI launches."""
 
     lti_message_type = fields.Str(
-        validate=OneOf(["ContentItemSelectionRequest"]), required=True
+        validate=OneOf(["ContentItemSelectionRequest", "LtiDeepLinkingRequest"]),
+        required=True,
     )
+
+    content_item_return_url = fields.Str(required=True)
 
 
 class ConfigureAssignmentSchema(_CommonLTILaunchSchema):

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -1,43 +1,57 @@
 """
-Views for handling deep linking launches.
+Deep Linking related views.
 
-A deep linking request is an LTI launch request (so it's a form
-submission containing all the usual launch params, including the OAuth 1
-signature) that's used by LMS's during the assignment creation process.
+If an LMS (like Canvas) is configured for "deep linking" then we need to send
+the results of the file picker to the LMS instead of storing it ourselves. This
+is done by the front-end.
 
-When an instructor creates a Hypothesis assignment in an LMS that supports
-deep linking the LMS launches our app in order for us to present an
-interface for the user to select a "content item" (in our case: a document to
-be annotated) for use with the assignment.
+When the LMS launches us with a deep linked assignment, we will get the
+document url as part of the launch params, instead of reading it from the DB in
+`module_item_configurations`.
 
-The spec requires that deep linking requests have an ``lti_message_type``
-parameter with the value ``ContentItemSelectionRequest``,
-but we don't actually require the requests to have this parameter: instead we
-use a separate URL to distinguish deep linking launches.
+The flow is:
 
-When the user selects a document we get the browser to POST the selection back
-to the LMS in a form submission with the ``lti_message_type`` parameter set to
-``ContentItemSelection``. The original ``ContentItemSelectionRequest``
-launch's ``content_item_return_url`` parameter gives us the URL to POST this
-form submission to. The LMS saves the selection and passes it back to us in the
-launch params whenever this assignment is launched in future.
+ - LMS calls us on `deep_linking_launch`
 
-For more details see the LTI Deep Linking spec:
+    The spec requires that deep linking requests have an ``lti_message_type``
+    identifying the launch as a deep linking one but we don't actually rely
+    on this parameter: instead we use a separate URL
+    to distinguish deep linking launches.
 
-https://www.imsglobal.org/specs/lticiv1p0
+ - In the case of LTI1.3:
 
-Especially this page:
+    * We add configuration to enable a call back to `file_picker_to_form_fields_v13`
+    * This provides the form data the front end requires to submit to the LMS
 
-https://www.imsglobal.org/specs/lticiv1p0/specification-3
+ - In the case of LTI1.1:
+
+    * The frontend constructs itself the form it needs to send to the LMS
+
+
+For more details see the LTI Deep Linking specs:
+
+ - LTI 1.1 https://www.imsglobal.org/specs/lticiv1p0
+
+   Especially this page:
+
+     https://www.imsglobal.org/specs/lticiv1p0/specification-3
+
+ - LTI 1.3 https://www.imsglobal.org/spec/lti-dl/v2p0
 
 Canvas LMS's Content Item docs are also useful:
 
-https://canvas.instructure.com/doc/api/file.content_item.html
+  https://canvas.instructure.com/doc/api/file.content_item.html
+
 """
-from pyramid.view import view_config
+from urllib.parse import urlencode, urlparse
+
+from pyramid.view import view_config, view_defaults
+from webargs import fields
 
 from lms.security import Permissions
+from lms.services import LTIAHTTPService
 from lms.validation import DeepLinkingLTILaunchSchema
+from lms.validation._base import JSONPyramidRequestSchema
 
 
 @view_config(
@@ -49,20 +63,97 @@ from lms.validation import DeepLinkingLTILaunchSchema
     schema=DeepLinkingLTILaunchSchema,
 )
 def deep_linking_launch(context, request):
-    request.find_service(name="application_instance").get_current().update_lms_data(
-        request.params
-    )
+    """Handle deep linking launches."""
+    application_instance = request.find_service(
+        name="application_instance"
+    ).get_current()
+    application_instance.update_lms_data(request.params)
 
     context.get_or_create_course()
 
     request.find_service(name="lti_h").sync([context.h_group], request.params)
 
     context.js_config.enable_file_picker_mode(
-        form_action=request.params["content_item_return_url"],
+        form_action=request.parsed_params["content_item_return_url"],
         form_fields={
             "lti_message_type": "ContentItemSelection",
-            "lti_version": request.params["lti_version"],
+            "lti_version": request.parsed_params["lti_version"],
         },
     )
 
+    if application_instance.lti_version == "1.3.0":
+        context.js_config.add_deep_linking_api()
     return {}
+
+
+class DeepLinkingFieldsRequestSchema(JSONPyramidRequestSchema):
+    deep_linking_settings = fields.Dict(required=False, allow_none=True)
+    content_item_return_url = fields.Str(required=True)
+    content = fields.Dict(required=True)
+
+    extra_params = fields.Dict(required=False)
+
+
+@view_defaults(
+    request_method="POST", renderer="json", schema=DeepLinkingFieldsRequestSchema
+)
+class DeepLinkingFieldsViews:
+    """
+    Views that return the required form fields to complete a deep linking request to the LMS.
+
+    After the user picks a document to be annotated the frontend will call these views
+    to get all the necessary fields to configure the assignment submitting them in a form to the LMS.
+    """
+
+    def __init__(self, request):
+        self.request = request
+
+        self.application_instance = self.request.find_service(
+            name="application_instance"
+        ).get_current()
+
+    @view_config(route_name="lti.deep_linking.form_fields")
+    def file_picker_to_form_fields_v13(self):
+        url = self._content_to_url(
+            self.request.route_url("lti_launches"),
+            self.request.parsed_params["content"],
+            self.request.parsed_params.get("extra_params"),
+        )
+
+        # In LTI1.3 there's just one `JWT` field which includes all the necessary information
+        return {
+            "JWT": self.request.find_service(LTIAHTTPService).sign(
+                {
+                    "https://purl.imsglobal.org/spec/lti/claim/deployment_id": self.application_instance.deployment_id,
+                    "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiDeepLinkingResponse",
+                    "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+                    "https://purl.imsglobal.org/spec/lti-dl/claim/content_items": [
+                        {"type": "ltiResourceLink", "url": url}
+                    ],
+                    "https://purl.imsglobal.org/spec/lti-dl/claim/data": self.request.parsed_params[
+                        "deep_linking_settings"
+                    ],
+                }
+            )
+        }
+
+    @staticmethod
+    def _content_to_url(lti_launch_url, content, extra_params):
+        """
+        Translate content information from the frontend to a launch URL.
+
+        We submit the content information to the LMS as an URL pointing to our
+        `lti_launches` endpoint with any information required to identity
+        the content as query parameters.
+        """
+        params = dict(extra_params or {})
+
+        if content["type"] == "file":
+            params["canvas_file"] = "true"
+            params["file_id"] = content["file"]["id"]
+        elif content["type"] == "url":
+            params["url"] = content["url"]
+        else:
+            raise ValueError(f"Unknown content type: '{content['type']}'")
+
+        return urlparse(lti_launch_url)._replace(query=urlencode(params)).geturl()

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -255,7 +255,11 @@ class TestDeepLinkingLTILaunchSchema:
             ),
             (
                 {"lti_message_type": "invalid message type"},
-                {"lti_message_type": ["Must be one of: ContentItemSelectionRequest."]},
+                {
+                    "lti_message_type": [
+                        "Must be one of: ContentItemSelectionRequest, LtiDeepLinkingRequest."
+                    ]
+                },
             ),
         ],
     )

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -1,20 +1,33 @@
 from unittest import mock
+from unittest.mock import create_autospec, sentinel
 
 import pytest
+from h_matchers import Any
 
+from lms.models import ApplicationInstance
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
-from lms.views.lti.deep_linking import deep_linking_launch
-
-pytestmark = pytest.mark.usefixtures(
-    "application_instance_service", "course_service", "lti_h_service"
-)
+from lms.views.lti.deep_linking import DeepLinkingFieldsViews, deep_linking_launch
 
 
-class TestDeeplinkingLaunch:
-    def test_it_enables_content_item_selection_mode(self, context, pyramid_request):
+@pytest.mark.usefixtures("application_instance_service", "lti_h_service")
+class TestDeepLinkingLaunch:
+    def test_it(
+        self, context, pyramid_request, lti_h_service, application_instance_service
+    ):
+        application_instance_service.get_current.return_value = create_autospec(
+            ApplicationInstance, spec_set=True, instance=True
+        )
+
         deep_linking_launch(context, pyramid_request)
 
+        application_instance_service.get_current.return_value.update_lms_data.assert_called_once_with(
+            pyramid_request.params
+        )
+        context.get_or_create_course.assert_called_once_with()
+        lti_h_service.sync.assert_called_once_with(
+            [context.h_group], pyramid_request.params
+        )
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="TEST_CONTENT_ITEM_RETURN_URL",
             form_fields={
@@ -22,15 +35,20 @@ class TestDeeplinkingLaunch:
                 "lti_version": "TEST_LTI_VERSION",
             },
         )
+        context.js_config.add_deep_linking_api.assert_not_called()
 
-    def test_it_records_the_course_in_the_DB(self, context, pyramid_request):
+    def test_it_enables_content_item_selection_mode_lti_v13(
+        self, context, pyramid_request, application_instance
+    ):
+        application_instance.lti_registration_id = 100
+
         deep_linking_launch(context, pyramid_request)
 
-        context.get_or_create_course.assert_called_once_with()
+        context.js_config.add_deep_linking_api.assert_called_once()
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {
+        pyramid_request.parsed_params = {
             "content_item_return_url": "TEST_CONTENT_ITEM_RETURN_URL",
             "lti_version": "TEST_LTI_VERSION",
         }
@@ -41,3 +59,74 @@ class TestDeeplinkingLaunch:
         context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
         context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
         return context
+
+
+@pytest.mark.usefixtures("application_instance_service")
+class TestDeepLinkingFieldsView:
+    def test_it(self, ltia_http_service, application_instance, pyramid_request):
+        fields = DeepLinkingFieldsViews(
+            pyramid_request
+        ).file_picker_to_form_fields_v13()
+
+        expected_url = Any.url.matching("http://example.com/lti_launches").with_query()
+        ltia_http_service.sign.assert_called_once_with(
+            {
+                "https://purl.imsglobal.org/spec/lti/claim/deployment_id": application_instance.deployment_id,
+                "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiDeepLinkingResponse",
+                "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+                "https://purl.imsglobal.org/spec/lti-dl/claim/content_items": [
+                    {"type": "ltiResourceLink", "url": expected_url}
+                ],
+                "https://purl.imsglobal.org/spec/lti-dl/claim/data": sentinel.deep_linking_settings,
+            }
+        )
+        assert fields["JWT"] == ltia_http_service.sign.return_value
+
+    @pytest.mark.parametrize(
+        "content,output_params",
+        [
+            (
+                {"type": "file", "file": {"id": 1}},
+                {"canvas_file": "true", "file_id": "1"},
+            ),
+            (
+                {"type": "url", "url": "https://example.com"},
+                {"url": "https://example.com"},
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("extra_params", ({}, {"extra": "value"}))
+    def test_it_with_different_file_types(
+        self, content, output_params, extra_params, ltia_http_service, pyramid_request
+    ):
+        pyramid_request.parsed_params.update(
+            {"content": content, "extra_params": extra_params}
+        )
+
+        DeepLinkingFieldsViews(pyramid_request).file_picker_to_form_fields_v13()
+
+        output_params.update(extra_params)
+        ltia_http_service.sign.assert_called_once_with(
+            Any.dict.containing(
+                {
+                    "https://purl.imsglobal.org/spec/lti-dl/claim/content_items": [
+                        Any.dict.containing({"url": Any.url.with_query(output_params)})
+                    ]
+                }
+            )
+        )
+
+    def test_it_with_unknown_file_type(self, pyramid_request):
+        pyramid_request.parsed_params.update({"content": {"type": "other"}})
+
+        with pytest.raises(ValueError):
+            DeepLinkingFieldsViews(pyramid_request).file_picker_to_form_fields_v13()
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.parsed_params = {
+            "deep_linking_settings": sentinel.deep_linking_settings,
+            "content": {"type": "url", "url": "https://example.com"},
+            "extra_params": {},
+        }
+        return pyramid_request


### PR DESCRIPTION
For: #3911 

First half of https://github.com/hypothesis/lms/pull/3908

Here we only make changes for LTI1.3 launches:

- We set a new "deeplinkingAPI" field in the config the backend sends to the frontend.
- When that's present the frontend calls the new API with the content selected by the user and the backend answers with the form fields required for the deeplinking form submission. For LT1.3 that's only a `JWT` field with all the encoded fields in it.
- The frontend submits the form to canvas as usual.


## Testing 

Log into canvas as a teacher

### LTI1.3


- `make devdata` 
- Edit https://hypothesis.instructure.com/courses/319/assignments/2781  using the `Hypothesis LTI1.3 (localhost)` install

There will be now a call to `http://localhost:8001/lti/1.3/deeplinking/formfields` showing up on the network tab of your browser.  This happens right after the last "continue" button in the configuring assignment screen.

- Saving the assignment will store the new document.


### LTI1.1

- Nothing should have change here, edit a LTI1.1 assignment, https://hypothesis.instructure.com/courses/125/assignments/873

- Not call to http://localhost:8001/lti/1.3/deeplinking/formfields



