### PR TITLE
Update the admin page to allow text field input + some refactors

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -18,54 +18,69 @@
     </div>
 {% endmacro %}
 
-{% macro text_field(label, value) %}
+{% macro read_only_field(label, value) %}
     {% call field_body(label) %}
         <input class="input" disabled type="text" value="{{value}}">
     {% endcall %}
 {% endmacro %}
 
-{%  macro checkbox_field(label, setting, sub_setting, field_name, default=False) %}
+{% macro settings_checkbox(label, setting, sub_setting, field_name, default=False) %}
     {% call field_body(label) %}
         <label class="checkbox">
-          <input {% if instance.settings.get(setting, sub_setting, default) %}checked {% endif%} type="checkbox" name="{{ setting }}.{{ sub_setting }}">
+            <input
+                {% if instance.settings.get(setting, sub_setting, default) %}checked {% endif%}
+                type="checkbox"
+                name="{{ setting }}.{{ sub_setting }}">
         </label>
     {% endcall %}
 {% endmacro %}
+
+{% macro settings_text_field(label, setting, sub_setting, field_name, default='') %}
+    {% call field_body(label) %}
+        <input
+            value="{{ instance.settings.get(setting, sub_setting, default) or '' }}"
+            class="input"
+            type="text"
+            name="{{ setting }}.{{ sub_setting }}">
+    {% endcall %}
+{% endmacro %}
+
 
 {% block content %}
 <form method="POST" action="{{ request.route_url("admin.instance", consumer_key=instance.consumer_key) }}">
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
-    {{ text_field("Consumer key", instance.consumer_key) }}
-    {{ text_field("LMS URL", instance.lms_url) }}
+    {{ read_only_field("Consumer key", instance.consumer_key) }}
+    {{ read_only_field("LMS URL", instance.lms_url) }}
 
-    {{ text_field("Tool consumer instance GUID", instance.tool_consumer_instance_guid) }}
-    {{ text_field("Tool consumer info product family code", instance.tool_consumer_info_product_family_code) }}
-    {{ text_field("Tool consumer instance description", instance.tool_consumer_instance_description) }}
-    {{ text_field("Tool consumer instance URL", instance.tool_consumer_instance_url) }}
-    {{ text_field("Tool consumer instance name", instance.tool_consumer_instance_name) }}
-    {{ text_field("Tool consumer instance contact email", instance.tool_consumer_instance_contact_email) }}
-    {{ text_field("Tool consumer info version", instance.tool_consumer_info_version) }}
+    {{ read_only_field("Tool consumer instance GUID", instance.tool_consumer_instance_guid) }}
+    {{ read_only_field("Tool consumer info product family code", instance.tool_consumer_info_product_family_code) }}
+    {{ read_only_field("Tool consumer instance description", instance.tool_consumer_instance_description) }}
+    {{ read_only_field("Tool consumer instance URL", instance.tool_consumer_instance_url) }}
+    {{ read_only_field("Tool consumer instance name", instance.tool_consumer_instance_name) }}
+    {{ read_only_field("Tool consumer instance contact email", instance.tool_consumer_instance_contact_email) }}
+    {{ read_only_field("Tool consumer info version", instance.tool_consumer_info_version) }}
 
-    {{ text_field("Custom Canvas API domain", instance.custom_canvas_api_domain) }}
+    {{ read_only_field("Custom Canvas API domain", instance.custom_canvas_api_domain) }}
 
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Canvas settings</legend>
-        {{ checkbox_field("Canvas sections enabled", "canvas", "sections_enabled") }}
-        {{ checkbox_field("Canvas groups enabled", "canvas", "groups_enabled") }}
+        {{ settings_checkbox("Canvas sections enabled", "canvas", "sections_enabled") }}
+        {{ settings_checkbox("Canvas groups enabled", "canvas", "groups_enabled") }}
     </fieldset>
 
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Blackboard settings</legend>
-        {{ checkbox_field("Blackboard groups enabled", "blackboard", "groups_enabled") }}
-        {{ checkbox_field("Blackboard files enabled", "blackboard", "files_enabled") }}
+        {{ settings_checkbox("Blackboard groups enabled", "blackboard", "groups_enabled") }}
+        {{ settings_checkbox("Blackboard files enabled", "blackboard", "files_enabled") }}
     </fieldset>
 
     <fieldset class="box mt-6">
-        <legend class="label has-text-centered">Other settings</legend>
-        {{ checkbox_field("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
-        {{ checkbox_field("VitalSource enabled", "vitalsource", "enabled") }}
-        {{ checkbox_field("JSTOR enabled", "jstor", "enabled") }}
+        <legend class="label has-text-centered">Content integrations</legend>
+        {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
+        {{ settings_checkbox("VitalSource enabled", "vitalsource", "enabled") }}
+        {{ settings_checkbox("JSTOR enabled", "jstor", "enabled") }}
+        {{ settings_text_field("JSTOR site code", "jstor", "site_code") }}
     </fieldset>
 
     {% call field_body(label="") %}

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -81,17 +81,24 @@ class AdminViews:
     def update_instance(self):
         ai = self._get_ai_or_404(self.request.matchdict["consumer_key"])
 
-        for setting, sub_setting in (
-            ("canvas", "sections_enabled"),
-            ("canvas", "groups_enabled"),
-            ("blackboard", "files_enabled"),
-            ("blackboard", "groups_enabled"),
-            ("microsoft_onedrive", "files_enabled"),
-            ("vitalsource", "enabled"),
-            ("jstor", "enabled"),
+        for setting, sub_setting, setting_type in (
+            ("canvas", "sections_enabled", bool),
+            ("canvas", "groups_enabled", bool),
+            ("blackboard", "files_enabled", bool),
+            ("blackboard", "groups_enabled", bool),
+            ("microsoft_onedrive", "files_enabled", bool),
+            ("vitalsource", "enabled", bool),
+            ("jstor", "enabled", bool),
+            ("jstor", "site_code", str),
         ):
-            enabled = self.request.params.get(f"{setting}.{sub_setting}") == "on"
-            ai.settings.set(setting, sub_setting, enabled)
+            value = self.request.params.get(f"{setting}.{sub_setting}")
+            if setting_type == bool:
+                value = value == "on"
+            else:
+                assert setting_type == str
+                value = value if value else None
+
+            ai.settings.set(setting, sub_setting, value)
 
         self.request.session.flash(
             f"Updated application instance {ai.consumer_key}", "messages"

--- a/tests/unit/lms/views/admin_test.py
+++ b/tests/unit/lms/views/admin_test.py
@@ -90,36 +90,40 @@ class TestAdminViews:
         )
 
     @pytest.mark.parametrize(
-        "setting,sub_setting",
+        "setting,sub_setting,value,expected",
         (
-            ("canvas", "groups_enabled"),
-            ("canvas", "sections_enabled"),
-            ("blackboard", "files_enabled"),
-            ("blackboard", "groups_enabled"),
-            ("microsoft_onedrive", "files_enabled"),
-            ("vitalsource", "enabled"),
-            ("jstor", "enabled"),
+            # Boolean fields
+            ("canvas", "groups_enabled", "on", True),
+            ("canvas", "sections_enabled", "", False),
+            ("blackboard", "files_enabled", "other", False),
+            ("blackboard", "groups_enabled", "off", False),
+            ("microsoft_onedrive", "files_enabled", "on", True),
+            ("vitalsource", "enabled", "on", True),
+            ("jstor", "enabled", "off", False),
+            # String fields
+            ("jstor", "site_code", "CODE", "CODE"),
+            ("jstor", "site_code", "", None),
+            ("jstor", "site_code", None, None),
         ),
     )
-    @pytest.mark.parametrize("enabled", (True, False))
     def test_update_instance_saves_ai_settings(
         self,
         pyramid_request,
         application_instance_service,
         setting,
         sub_setting,
-        enabled,
+        value,
+        expected,
     ):
         pyramid_request.matchdict["consumer_key"] = sentinel.consumer_key
-        if enabled:
-            pyramid_request.params[f"{setting}.{sub_setting}"] = "on"
+        pyramid_request.params[f"{setting}.{sub_setting}"] = value
 
         AdminViews(pyramid_request).update_instance()
 
         application_instance = (
             application_instance_service.get_by_consumer_key.return_value
         )
-        assert application_instance.settings.get(setting, sub_setting) == enabled
+        assert application_instance.settings.get(setting, sub_setting) == expected
 
     def test_update_instance_not_found(
         self, pyramid_request, application_instance_service


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3906

The names have changed a bit to reflect a read only field and a settings text field which you can change.

### Testing notes

 * Start _everything_
 * Go to http://localhost:8001/admin/
 * Enter `Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a`
 * Enable JSTOR and add a value to the site code and save
 * The values should be saved
 * Remove and clear the values and save
 * They should be removed
 * Add them back again
