### PR TITLE
Replace uses of `any` type with `void` or `unknown`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FileList.js
+++ b/lms/static/scripts/frontend_apps/components/FileList.js
@@ -10,9 +10,9 @@ import { Icon, Table } from '@hypothesis/frontend-shared';
  * @prop {File[]} files - List of file objects returned by the API
  * @prop {boolean} [isLoading] - Whether to show a loading indicator
  * @prop {File|null} selectedFile - The file within `files` which is currently selected
- * @prop {(f: File) => any} onSelectFile -
+ * @prop {(f: File) => void} onSelectFile -
  *   Callback invoked when the user clicks on a file
- * @prop {(f: File) => any} onUseFile -
+ * @prop {(f: File) => void} onUseFile -
  *   Callback invoked when the user double-clicks a file to indicate that they want to use it
  * @prop {Children} [noFilesMessage] - component displayed when no files are available
  */

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -26,7 +26,7 @@ import GroupConfigSelector from './GroupConfigSelector';
  * @typedef FilePickerAppProps
  * @prop {DialogType} [defaultActiveDialog] -
  *   The dialog that should be shown when the app is first opened.
- * @prop {() => any} [onSubmit] - Callback invoked when the form is submitted.
+ * @prop {() => void} [onSubmit] - Callback invoked when the form is submitted.
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -51,7 +51,7 @@ function NoFilesMessage({ href, inSubfolder }) {
  * @prop {APICallInfo} listFilesApi -
  *   Config for the API call to list available files
  * @prop {() => any} onCancel - Callback invoked if the user cancels file selection
- * @prop {(f: File) => any} onSelectFile -
+ * @prop {(f: File) => void} onSelectFile -
  *   Callback invoked with the metadata of the selected file if the user makes a selection
  * @prop {string} missingFilesHelpLink - A helpful URL to documentation that explains
  *   how to upload files to an LMS such as Canvas or Blackboard. This link is only shown

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 
 /**
  * @typedef StudentSelectorProps
- * @prop {(index: number) => any} onSelectStudent -
+ * @prop {(index: number) => void} onSelectStudent -
  *   Callback invoked when the selected student changes
  * @prop {number} selectedStudentIndex -
  *   Index of selected student in `students` or -1 if no student is selected

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -9,8 +9,8 @@ import { useRef, useState } from 'preact/hooks';
 
 /**
  * @typedef URLPickerProps
- * @prop {() => any} onCancel
- * @prop {(url: string) => any} onSelectURL -
+ * @prop {() => void} onCancel
+ * @prop {(url: string) => void} onSelectURL -
  *   Callback invoked with the entered URL when the user accepts the dialog
  */
 

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
  * @typedef ValidationMessageProps
  * @prop {string} message - Error message text
  * @prop {boolean} [open] - Should this be open or closed
- * @prop {() => any} [onClose] - Optional callback when the error message is closed
+ * @prop {() => void} [onClose] - Optional callback when the error message is closed
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -56,7 +56,7 @@ export class APIError extends Error {
    * @param {object} data - Parsed JSON body from the API response
    *   @param {string} [data.message]
    *   @param {string} [data.error_code]
-   *   @param {any} [data.details]
+   *   @param {unknown} [data.details]
    */
   constructor(status, data) {
     super('API call failed');

--- a/lms/static/scripts/postmessage_json_rpc/client.js
+++ b/lms/static/scripts/postmessage_json_rpc/client.js
@@ -18,7 +18,7 @@ function createTimeout(delay, message) {
  * @param {Window} frame - Frame to send call to
  * @param {string} origin - Origin filter for `window.postMessage` call
  * @param {string} method - Name of the JSON-RPC method
- * @param {any[]} params - Parameters of the JSON-RPC method
+ * @param {unknown[]} params - Parameters of the JSON-RPC method
  * @param {number} [timeout] - Maximum time to wait in ms
  * @param {Window} [window_] - Test seam.
  * @param {string} [id] - Test seam.

--- a/lms/static/scripts/postmessage_json_rpc/server.js
+++ b/lms/static/scripts/postmessage_json_rpc/server.js
@@ -4,7 +4,7 @@
  * @typedef JsonRpcRequest
  * @prop {'2.0'} jsonrpc
  * @prop {string} method
- * @prop {any[]} params
+ * @prop {unknown[]} params
  * @prop {string|null} id
  */
 


### PR DESCRIPTION
Replace various uses of the `any` type with the either `void`, for callbacks whose result is unused or `unknown` for values where the type should be checked or asserted before use. No changes to the calling code were required.