### PR TITLE
Search for application instances in the admin pages

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -104,7 +104,10 @@ def includeme(config):
 
     config.add_route("admin.index", "/admin/")
     config.add_route("admin.instances", "/admin/instances/")
-    config.add_route("admin.instance", "/admin/instance/{consumer_key}/")
+    config.add_route("admin.instances.consumer_key", "/admin/instances/consumer_key/")
+    config.add_route("admin.instances.search", "/admin/instances/search")
+    config.add_route("admin.instance.consumer_key", "/admin/instance/{consumer_key}/")
+    config.add_route("admin.instance.id", "/admin/instance/id/{id_}/")
 
     config.add_route("lti.oidc", "/lti/1.3/oidc")
     config.add_route("lti.jwks", "/lti/1.3/jwks")

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -1,6 +1,6 @@
 {% extends "lms:templates/admin/base.html.jinja2" %}
 {% block header %}
-    Application instance {{instance.consumer_key}}
+    Application instance {{instance.id}}
 {% endblock %}
 
 {% macro field_body(label) %}
@@ -47,10 +47,13 @@
 
 
 {% block content %}
-<form method="POST" action="{{ request.route_url("admin.instance", consumer_key=instance.consumer_key) }}">
+<form method="POST" action="{{ request.route_url("admin.instance.id", id_=instance.id) }}">
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
     {{ read_only_field("Consumer key", instance.consumer_key) }}
+    {{ read_only_field("Issuer", instance.lti_registration.issuer) }}
+    {{ read_only_field("Client ID", instance.lti_registration.client_id) }}
+    {{ read_only_field("Deployment ID", instance.deployment_id) }}
     {{ read_only_field("LMS URL", instance.lms_url) }}
 
     {{ read_only_field("Tool consumer instance GUID", instance.tool_consumer_instance_guid) }}

--- a/lms/templates/admin/instances.html.jinja2
+++ b/lms/templates/admin/instances.html.jinja2
@@ -4,15 +4,41 @@ Application instances
 {% endblock %}
 
 {% block content %}
-    <form method="POST" action="{{ request.route_url("admin.instances") }}">
+
+<fieldset class="box mt-6">
+    <legend class="label has-text-centered">Find by consumer_key</legend>
+    <form method="POST" action="{{ request.route_url("admin.instances.consumer_key") }}">
         <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
         <div class="field has-addons">
            <div class="control">
-                <input class="input" name="query" type="text" placeholder="Consumer_key">
+                <input class="input" name="consumer_key" type="text" placeholder="Consumer_key">
             </div>
             <div class="control">
                 <input type="submit" class="button is-info" value="Find"/>
             </div>
         </div>
     </form>
+</fieldset>
+
+<fieldset class="box mt-6">
+    <legend class="label has-text-centered">Search</legend>
+    <form method="POST" action="{{ request.route_url("admin.instances.search") }}">
+        <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+        <div class="field has-addons">
+           <div class="control">
+                <input class="input" name="issuer" type="text" placeholder="Issuer">
+                <input class="input" name="client_id" type="text" placeholder="Client ID">
+                <input class="input" name="deployment_id" type="text" placeholder="Deployment ID">
+                <input class="input" name="guid" type="text" placeholder="GUID">
+            </div>
+        </div>
+        <div class="field is-grouped">
+          <div class="control">
+            <input type="submit" class="button is-info" value="Search"/>
+          </div>
+      </div>
+</div>
+    </form>
+</fieldset>
+
 {% endblock %}

--- a/lms/templates/admin/instances.results.html.jinja2
+++ b/lms/templates/admin/instances.results.html.jinja2
@@ -1,0 +1,32 @@
+{% extends "lms:templates/admin/base.html.jinja2" %}
+{% block header %}
+Application instances
+{% endblock %}
+
+{% block content %}
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Consumer Key</th>
+      <th>GUID</th>
+      <th>Issuer</th>
+      <th>Deployment ID</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+{% for instance in instances %}
+    <tr>
+      <td>{{instance.id}}</td>
+      <td>{{instance.consumer_key}}</th>
+      <td>{{instance.tool_consumer_instance_guid}}</td>
+      <td>{{instance.lti_registration.issuer}}</td>
+      <td>{{instance.deployment_id}}</td>
+      <td><a href="{{ request.route_url("admin.instance.id", id_=instance.id) }}">View</a></td>
+    </tr>
+{% endfor %}
+
+
+{% endblock %}

--- a/lms/views/admin.py
+++ b/lms/views/admin.py
@@ -6,6 +6,7 @@ from pyramid.view import (
     view_defaults,
 )
 
+from lms.models import ApplicationInstance
 from lms.security import Permissions
 from lms.services import ApplicationInstanceNotFound
 
@@ -34,19 +35,20 @@ class AdminViews:
 
     @view_config(
         route_name="admin.instances",
+        request_method="GET",
         renderer="lms:templates/admin/instances.html.jinja2",
     )
     def instances(self):  # pylint: disable=no-self-use
         return {}
 
     @view_config(
-        route_name="admin.instances",
+        route_name="admin.instances.consumer_key",
         request_method="POST",
         require_csrf=True,
     )
-    def find_instance(self):
+    def find_by_consumer_key(self):
         try:
-            consumer_key = self.request.params["query"]
+            consumer_key = self.request.params["consumer_key"]
         except KeyError as err:
             raise HTTPBadRequest() from err
 
@@ -54,32 +56,86 @@ class AdminViews:
             ai = self.application_instance_service.get_by_consumer_key(consumer_key)
         except ApplicationInstanceNotFound:
             self.request.session.flash(
-                f'No application instance found for {self.request.params["query"]}',
+                f'No application instance found for {self.request.params["consumer_key"]}',
                 "errors",
             )
             return HTTPFound(location=self.request.route_url("admin.instances"))
 
         return HTTPFound(
             location=self.request.route_url(
-                "admin.instance", consumer_key=ai.consumer_key
+                "admin.instance.consumer_key", consumer_key=ai.consumer_key
             ),
         )
 
     @view_config(
-        route_name="admin.instance",
+        route_name="admin.instances.search",
+        request_method="POST",
+        require_csrf=True,
+        renderer="lms:templates/admin/instances.results.html.jinja2",
+    )
+    def search(self):
+        if not any(
+            (
+                self.request.params.get(param)
+                for param in [
+                    "issuer",
+                    "client_id",
+                    "deployment_id",
+                    "tool_consumer_instance_guid",
+                ]
+            )
+        ):
+            self.request.session.flash(
+                "Need to pass at least one search criteria", "errors"
+            )
+            return HTTPFound(location=self.request.route_url("admin.instances"))
+
+        instances = self.application_instance_service.search(
+            issuer=self.request.params.get("issuer"),
+            client_id=self.request.params.get("client_id"),
+            deployment_id=self.request.params.get("deployment_id"),
+            tool_consumer_instance_guid=self.request.params.get(
+                "tool_consumer_instance_guid"
+            ),
+        )
+
+        if not instances:
+            self.request.session.flash("No instances found", "errors")
+            return HTTPFound(location=self.request.route_url("admin.instances"))
+
+        if len(instances) == 1:
+            return HTTPFound(
+                location=self.request.route_url(
+                    "admin.instance.id", id_=instances[0].id
+                )
+            )
+
+        return {"instances": instances}
+
+    @view_config(
+        route_name="admin.instance.id",
+        renderer="lms:templates/admin/instance.html.jinja2",
+    )
+    @view_config(
+        route_name="admin.instance.consumer_key",
         renderer="lms:templates/admin/instance.html.jinja2",
     )
     def show_instance(self):
-        ai = self._get_ai_or_404(self.request.matchdict["consumer_key"])
+        ai = self._get_ai_or_404(**self.request.matchdict)
         return {"instance": ai}
 
     @view_config(
-        route_name="admin.instance",
+        route_name="admin.instance.id",
+        request_method="POST",
+        require_csrf=True,
+    )
+    @view_config(
+        route_name="admin.instance.consumer_key",
         request_method="POST",
         require_csrf=True,
     )
     def update_instance(self):
-        ai = self._get_ai_or_404(self.request.matchdict["consumer_key"])
+        ai = self._get_ai_or_404(**self.request.matchdict)
 
         for setting, sub_setting, setting_type in (
             ("canvas", "sections_enabled", bool),
@@ -100,18 +156,20 @@ class AdminViews:
 
             ai.settings.set(setting, sub_setting, value)
 
-        self.request.session.flash(
-            f"Updated application instance {ai.consumer_key}", "messages"
-        )
+        self.request.session.flash(f"Updated application instance {ai.id}", "messages")
 
         return HTTPFound(
-            location=self.request.route_url(
-                "admin.instance", consumer_key=ai.consumer_key
-            )
+            location=self.request.route_url("admin.instance.id", id_=ai.id)
         )
 
-    def _get_ai_or_404(self, consumer_key):
+    def _get_ai_or_404(self, consumer_key=None, id_=None) -> ApplicationInstance:
         try:
-            return self.application_instance_service.get_by_consumer_key(consumer_key)
+            if consumer_key:
+                return self.application_instance_service.get_by_consumer_key(
+                    consumer_key
+                )
+
+            return self.application_instance_service.get_by_id(id_=id_)
+
         except ApplicationInstanceNotFound as err:
             raise HTTPNotFound() from err


### PR DESCRIPTION
- Added the new fields identifying AI to the detail page
- Add a new form to search by a few fields.

Main motivation here is to make the admin pages useful in development while wokring on LTI1.3. This PR doesn't try to tackle https://github.com/hypothesis/lms/issues/3690 (ie how to get new registration/application instances) into the DB.

In LTI1.3 install are identified by three fields: issuer, client_id and deployment ID. Typing all of them would be cumbersome so opted for a search form instead.

Added GUID to the search fields as it might be useful. 


## Testing

- Go to http://localhost:8001/admin/instances/
- Test find by consumer key still works
- Test editing an application instance works as expected.
- Test the search funtiallity, some test data to make some queries

```
Consumer key: Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b
Issuer: https://blackboard.com
Client ID: 4aa65f52-1d75-48d2-8a32-42b5e4ae995e
Deployment ID: 609:6ed5aff92b5257ab607ec9c629844ea8586fde68
GUID: 041c05b262b54282a0d9b61c42413ec0
```
