### PR TITLE
Add support for JSON-RPC 2.0 Notification requests

### DIFF
--- a/lms/static/scripts/postmessage_json_rpc/client.js
+++ b/lms/static/scripts/postmessage_json_rpc/client.js
@@ -87,4 +87,22 @@ async function call(
   }
 }
 
-export { call };
+/**
+ * Send a JSON-RPC 2.0 notification request to another frame via `postMessage`.
+ * No response is expected.
+ *
+ * @param {Window} frame - Frame to send call to
+ * @param {string} origin - Origin filter for `window.postMessage` call
+ * @param {string} method - Name of the JSON-RPC method
+ * @param {unknown[]} params - Parameters of the JSON-RPC method
+ */
+function notify(frame, origin, method, params = []) {
+  const request = {
+    jsonrpc: '2.0',
+    method,
+    params,
+  };
+  frame.postMessage(request, origin);
+}
+
+export { call, notify };

--- a/lms/static/scripts/postmessage_json_rpc/index.js
+++ b/lms/static/scripts/postmessage_json_rpc/index.js
@@ -1,2 +1,2 @@
-export { call } from './client';
+export { call, notify } from './client';
 export { Server } from './server';


### PR DESCRIPTION
This PR adds support for [JSON-RPC 2.0](https://www.jsonrpc.org/specification) notification requests — that is, requests that are notifications and do not need a response. This will allow the `client` to send annotation-activity notifications without us having to fuss with sending (empty) responses. I've tried to bolt this on with minimal fuss.

According to the spec, the non-presence of an `id` property in a request object defines it as a "notification" request and no response should be sent.

I've also added support here for the ability to _send_ such requests (`notify` vs. `call`), though this is mostly to have symmetry with what I intend to add to the client—it is currently unused.

Part of https://github.com/hypothesis/client/issues/4484