### PR TITLE
Rename `content_item_selection` module to `deep_linking`

### DIFF
--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -59,7 +59,7 @@ from lms.validation._exceptions import LTIToolRedirect, ValidationError
 from lms.validation._lti_launch_params import (
     BasicLTILaunchSchema,
     ConfigureAssignmentSchema,
-    ContentItemSelectionLTILaunchSchema,
+    DeepLinkingLTILaunchSchema,
     LTIV11CoreSchema,
     URLConfiguredBasicLTILaunchSchema,
 )

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -174,8 +174,8 @@ class URLConfiguredBasicLTILaunchSchema(BasicLTILaunchSchema):
         return _data
 
 
-class ContentItemSelectionLTILaunchSchema(_CommonLTILaunchSchema):
-    """Schema for content item selection LTI launches."""
+class DeepLinkingLTILaunchSchema(_CommonLTILaunchSchema):
+    """Schema for deep linking LTI launches."""
 
     lti_message_type = fields.Str(
         validate=OneOf(["ContentItemSelectionRequest"]), required=True

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -3,7 +3,7 @@ Views for handling what the LTI spec calls "Basic LTI Launches".
 
 A Basic LTI Launch is the form submission POST request that an LMS sends us
 when it wants our app to launch an assignment, as opposed to other kinds of
-LTI launches such as the Content Item Selection launches that some LMS's
+LTI launches such as the deep linking launches that some LMS's
 send us while *creating* a new assignment.
 
 The spec requires Basic LTI Launch requests to have an ``lti_message_type``
@@ -147,8 +147,8 @@ class BasicLTILaunchViews:
 
         DB-configured assignment launch requests don't have any kind of file ID
         or document URL in the request. Instead the document URL is stored in
-        our own DB. This happens with LMS's that don't support LTI content item
-        selection/deep linking, so they don't support storing the document URL
+        our own DB. This happens with LMS's that don't support LTI deep linking,
+        so they don't support storing the document URL
         in the LMS and passing it back to us in each launch request. Instead we
         retrieve the document URL from the DB and pass it to Via.
         """
@@ -266,10 +266,9 @@ class BasicLTILaunchViews:
 
         URL-configured assignment launch requests have the document URL in the
         ``url`` request parameter. This happens in LMS's that support LTI
-        content item selection/deep linking: the document URL is chosen during
-        content item selection (during assignment creation) and saved in the
-        LMS, which passes it back to us in each launch request. All we have to
-        do is pass the URL to Via.
+        deep linking: the document URL is chosen during assignment creation
+        and saved in the LMS, which passes it back to us in each launch request.
+        All we have to do is pass the URL to Via.
         """
         return self.basic_lti_launch(self.request.parsed_params["url"])
 
@@ -284,10 +283,9 @@ class BasicLTILaunchViews:
 
         Unconfigured assignment launch requests don't contain any document URL
         or file ID because the assignment's document hasn't been chosen yet.
-        This happens in LMS's that don't support LTI content item
-        selection/deep linking. They go straight from assignment creation to
-        launching the assignment without the user having had a chance to choose
-        a document.
+        This happens in LMS's that don't support LTI deep linking.
+        They go straight from assignment creation to launching the assignment
+        without the user having had a chance to choose a document.
 
         When this happens we show the user our document-selection form instead
         of launching the assignment. The user will choose the document and

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -1,19 +1,19 @@
 """
-Views for handling content item selection launches.
+Views for handling deep linking launches.
 
-A content item selection request is an LTI launch request (so it's a form
+A deep linking request is an LTI launch request (so it's a form
 submission containing all the usual launch params, including the OAuth 1
 signature) that's used by LMS's during the assignment creation process.
 
 When an instructor creates a Hypothesis assignment in an LMS that supports
-content item selection the LMS launches our app in order for us to present an
+deep linking the LMS launches our app in order for us to present an
 interface for the user to select a "content item" (in our case: a document to
 be annotated) for use with the assignment.
 
-The spec requires that content item selection requests have an
-``lti_message_type`` parameter with the value ``ContentItemSelectionRequest``,
+The spec requires that deep linking requests have an ``lti_message_type``
+parameter with the value ``ContentItemSelectionRequest``,
 but we don't actually require the requests to have this parameter: instead we
-use a separate URL to distinguish content item selection launches.
+use a separate URL to distinguish deep linking launches.
 
 When the user selects a document we get the browser to POST the selection back
 to the LMS in a form submission with the ``lti_message_type`` parameter set to
@@ -37,7 +37,7 @@ https://canvas.instructure.com/doc/api/file.content_item.html
 from pyramid.view import view_config
 
 from lms.security import Permissions
-from lms.validation import ContentItemSelectionLTILaunchSchema
+from lms.validation import DeepLinkingLTILaunchSchema
 
 
 @view_config(
@@ -46,9 +46,9 @@ from lms.validation import ContentItemSelectionLTILaunchSchema
     renderer="lms:templates/file_picker.html.jinja2",
     request_method="POST",
     route_name="content_item_selection",
-    schema=ContentItemSelectionLTILaunchSchema,
+    schema=DeepLinkingLTILaunchSchema,
 )
-def content_item_selection(context, request):
+def deep_linking_launch(context, request):
     request.find_service(name="application_instance").get_current().update_lms_data(
         request.params
     )

--- a/lms/views/lti/oidc.py
+++ b/lms/views/lti/oidc.py
@@ -79,7 +79,7 @@ def oidc_view(request):
         # The value will be configured when registering the tool in the LMS and
         # will be different depending on the message type. For example, it will
         # be an lti_launch endpoint for launches and content_item_selection /
-        # deeplinking for LMSs that support it while creating or editing
+        # deep linking for LMSs that support it while creating or editing
         # assignments.
         "redirect_uri": params["target_link_uri"],
     }

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -21,9 +21,9 @@ class DBConfigured(Base):
     configuration (the URL of the document to be annotated for the assignment)
     is stored in our own DB.
 
-    This happens with LMS's that don't support LTI "content item selection"
-    (also known as "deep linking"), so they don't support storing the
-    assignment configuration (document URL) in the LMS.
+    This happens with LMS's that don't support LTI "Deep Linking"
+    so they don't support storing the assignment configuration
+    (document URL) in the LMS.
 
     Pass ``db_configured=True`` to a view's configuration to allow invoking the
     view only for requests whose assignment has its configuration stored in our

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -119,7 +119,7 @@ class TestIsCanvas:
             # `tool_consumer_info_product_family_code: canvas` and you can
             # detect Canvas that way.
             ({"tool_consumer_info_product_family_code": "canvas"}, True),
-            # Some Canvas launches, e.g. content item selection launches, do
+            # Some Canvas launches, e.g. deep linking, do
             # not have a tool_consumer_info_product_family_code param. In these
             # cases we can instead detect Canvas by the presence of its
             # custom_canvas_course_id param.

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -8,7 +8,7 @@ from pyramid import testing
 from lms.validation import (
     BasicLTILaunchSchema,
     ConfigureAssignmentSchema,
-    ContentItemSelectionLTILaunchSchema,
+    DeepLinkingLTILaunchSchema,
     LTIToolRedirect,
     LTIV11CoreSchema,
     URLConfiguredBasicLTILaunchSchema,
@@ -217,7 +217,7 @@ class TestURLConfiguredBasicLTILaunchSchema:
         return URLConfiguredBasicLTILaunchSchema(pyramid_request)
 
 
-class TestContentItemSelectionLTILaunchSchema:
+class TestDeepLinkingLTILaunchSchema:
     def test_it(self, schema, valid_params):
         parsed_params = schema.parse()
 
@@ -290,7 +290,7 @@ class TestContentItemSelectionLTILaunchSchema:
 
     @pytest.fixture
     def schema(self, pyramid_request):
-        return ContentItemSelectionLTILaunchSchema(pyramid_request)
+        return DeepLinkingLTILaunchSchema(pyramid_request)
 
 
 class TestConfigureAssignmentSchema:

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -4,16 +4,16 @@ import pytest
 
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
-from lms.views.content_item_selection import content_item_selection
+from lms.views.lti.deep_linking import deep_linking_launch
 
 pytestmark = pytest.mark.usefixtures(
     "application_instance_service", "course_service", "lti_h_service"
 )
 
 
-class TestContentItemSelection:
+class TestDeeplinkingLaunch:
     def test_it_enables_content_item_selection_mode(self, context, pyramid_request):
-        content_item_selection(context, pyramid_request)
+        deep_linking_launch(context, pyramid_request)
 
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="TEST_CONTENT_ITEM_RETURN_URL",
@@ -24,7 +24,7 @@ class TestContentItemSelection:
         )
 
     def test_it_records_the_course_in_the_DB(self, context, pyramid_request):
-        content_item_selection(context, pyramid_request)
+        deep_linking_launch(context, pyramid_request)
 
         context.get_or_create_course.assert_called_once_with()
 


### PR DESCRIPTION
In preparation for LTI1.3 / Deeplinking 2.0 using the same namespace.

We use deeplinking and content-item-selection as equivalent terms and deeplinking seems to be the preferred name in the spec in LTI1.0 and the only one in LTI1.3

https://www.imsglobal.org/specs/lticiv1p0
https://canvas.instructure.com/doc/api/file.content_item.html


# Testing 

Just as a sanity check try to configure/edit an assignment in Canvas.