### PR TITLE
Rename `content_item_selection` mode to `file_picker`

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -15,7 +15,7 @@ class JSConfig:
     class Mode(str, Enum):
         OAUTH2_REDIRECT_ERROR = "oauth2-redirect-error"
         BASIC_LTI_LAUNCH = "basic-lti-launch"
-        CONTENT_ITEM_SELECTION = "content-item-selection"
+        FILE_PICKER = "content-item-selection"
         ERROR_DIALOG = "error-dialog"
 
     class ErrorCode(str, Enum):
@@ -176,9 +176,9 @@ class JSConfig:
             "allowedOrigins": self._request.registry.settings["rpc_allowed_origins"]
         }
 
-    def enable_content_item_selection_mode(self, form_action, form_fields):
+    def enable_file_picker_mode(self, form_action, form_fields):
         """
-        Put the JavaScript code into "content item selection" mode.
+        Put the JavaScript code into "file picker" mode.
 
         This mode shows teachers an assignment configuration UI where they can
         choose the document to be annotated for the assignment.
@@ -193,7 +193,7 @@ class JSConfig:
 
         self._config.update(
             {
-                "mode": JSConfig.Mode.CONTENT_ITEM_SELECTION,
+                "mode": JSConfig.Mode.FILE_PICKER,
                 "filePicker": {
                     "formAction": form_action,
                     "formFields": form_fields,

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -308,7 +308,7 @@ class BasicLTILaunchViews:
             self.request
         ).authorization_param(self.request.lti_user)
 
-        self.context.js_config.enable_content_item_selection_mode(
+        self.context.js_config.enable_file_picker_mode(
             form_action=self.request.route_url("configure_assignment"),
             form_fields=form_fields,
         )

--- a/lms/views/content_item_selection.py
+++ b/lms/views/content_item_selection.py
@@ -57,7 +57,7 @@ def content_item_selection(context, request):
 
     request.find_service(name="lti_h").sync([context.h_group], request.params)
 
-    context.js_config.enable_content_item_selection_mode(
+    context.js_config.enable_file_picker_mode(
         form_action=request.params["content_item_return_url"],
         form_fields={
             "lti_message_type": "ContentItemSelection",

--- a/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
@@ -15,7 +15,7 @@ class TestValidTeacherPayloads:
     def test_message_as_instructor(self, teacher_payload, assert_launch_get_config):
         """Launch LTI 1.3 Message as Instructor"""
         js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.CONTENT_ITEM_SELECTION
+        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
 
     def test_with_multiple_roles(self, teacher_payload, assert_launch_get_config):
         """Launch Instructor with Multiple Role Values"""
@@ -26,7 +26,7 @@ class TestValidTeacherPayloads:
         ]
 
         js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.CONTENT_ITEM_SELECTION
+        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
 
     def test_with_short_role(self, teacher_payload, assert_launch_get_config):
         """Launch Instructor with Short Role Value"""
@@ -35,7 +35,7 @@ class TestValidTeacherPayloads:
         ]
 
         js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.CONTENT_ITEM_SELECTION
+        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
 
     def test_with_unknown_role(self, teacher_payload, assert_launch_get_config):
         """Launch Instructor with Unknown Role"""
@@ -63,14 +63,14 @@ class TestValidTeacherPayloads:
         del teacher_payload["middle_name"]
 
         js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.CONTENT_ITEM_SELECTION
+        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
 
     def test_with_only_names(self, teacher_payload, assert_launch_get_config):
         """Launch Instructor Only Names"""
         del teacher_payload["email"]
 
         js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.CONTENT_ITEM_SELECTION
+        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
 
     def test_without_pii(self, teacher_payload, assert_launch_get_config):
         """Launch Instructor No PII"""
@@ -81,7 +81,7 @@ class TestValidTeacherPayloads:
         del teacher_payload["middle_name"]
 
         js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.CONTENT_ITEM_SELECTION
+        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
 
     @pytest.mark.xfail(reason="Pending. Context is required in our schemas")
     def test_with_email_no_context(self, teacher_payload, assert_launch_get_config):
@@ -90,7 +90,7 @@ class TestValidTeacherPayloads:
         del teacher_payload["https://purl.imsglobal.org/spec/lti/claim/context"]
 
         js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.CONTENT_ITEM_SELECTION
+        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
 
     @pytest.fixture
     def assert_launch_get_config(self, do_lti_launch, make_jwt):

--- a/tests/functional/views/basic_lti_launch_test.py
+++ b/tests/functional/views/basic_lti_launch_test.py
@@ -32,10 +32,7 @@ class TestBasicLTILaunch:
             status=200,
         )
 
-        assert (
-            self.get_client_config(response)["mode"]
-            == JSConfig.Mode.CONTENT_ITEM_SELECTION
-        )
+        assert self.get_client_config(response)["mode"] == JSConfig.Mode.FILE_PICKER
 
     def test_db_configured_basic_lti_launch(
         self, lti_params, assignment, do_lti_launch

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.usefixtures(
 @pytest.mark.usefixtures("application_instance_service")
 class TestEnableContentItemSelectionMode:
     def test_it(self, js_config):
-        js_config.enable_content_item_selection_mode(
+        js_config.enable_file_picker_mode(
             mock.sentinel.form_action, mock.sentinel.form_fields
         )
         config = js_config.asdict()
@@ -58,7 +58,7 @@ class TestEnableContentItemSelectionMode:
         config_function,
         key,
     ):
-        js_config.enable_content_item_selection_mode(
+        js_config.enable_file_picker_mode(
             mock.sentinel.form_action, mock.sentinel.form_fields
         )
         config = js_config.asdict()

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -461,7 +461,7 @@ class TestUnconfiguredBasicLTILaunch:
         bearer_token_schema.authorization_param.assert_called_once_with(
             pyramid_request.lti_user
         )
-        context.js_config.enable_content_item_selection_mode.assert_called_once_with(
+        context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="http://example.com/assignment",
             form_fields=dict(
                 {

--- a/tests/unit/lms/views/content_item_selection_test.py
+++ b/tests/unit/lms/views/content_item_selection_test.py
@@ -15,7 +15,7 @@ class TestContentItemSelection:
     def test_it_enables_content_item_selection_mode(self, context, pyramid_request):
         content_item_selection(context, pyramid_request)
 
-        context.js_config.enable_content_item_selection_mode.assert_called_once_with(
+        context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="TEST_CONTENT_ITEM_RETURN_URL",
             form_fields={
                 "lti_message_type": "ContentItemSelection",


### PR DESCRIPTION
Naming was confusing as it was mixing to different concepts:

- Our app displaying the filepicker
- Enabling or not the use of LTI's content_item_selection / deeplinking
API to communicate the selected document to the LMS.