### PR TITLE
Handle all JSTOR work on the LMS side

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,9 @@ LMS. Each of these is mandatory to get the service working correctly.
 | `H_CLIENT_SECRET`                 | `0123456789abcdefghijklmnopqrABCDEFGH` | A `client_credentials` OAuth2 pair from `h`     |
 | `H_JWT_CLIENT_ID`                 | `fedcba98-7654-3210-fedc-ba9876543210` | A `jwt_bearer` OAuth2 pair from `h`             |
 | `H_JWT_CLIENT_SECRET`             | `0123456789abcdefghijklmnopqrABCDEFGH` | A `jwt_bearer` OAuth2 pair from `h`             |
-| `JWT_SECRET`                      | `random-string-12345`                  | An arbitrary secret value                       |                                
+| `JWT_SECRET`                      | `random-string-12345`                  | An arbitrary secret value                       |
+| `JSTOR_API_SECRET`                | `random-string-12345`                  | JWT secret for authenticating with JSTOR        |
+| `JSTOR_API_URL`                   | `http://example.com/api`               | URL of JSTOR API base url.                      |
 | `LMS_SECRET`                      | `random-string-12345`                  | An arbitrary secret value                       |
 | `OAUTH2_STATE_SECRET`             | `random-string-12345`                  | An arbitrary secret value                       |
 | `RPC_ALLOWED_ORIGINS`             | `https://fr.hypothes.is`               | `h` instances clients can be connecting from    |

--- a/lms/config/__init__.py
+++ b/lms/config/__init__.py
@@ -72,6 +72,8 @@ def configure(settings):
         "admin_auth_google_client_secret": sg.get("ADMIN_AUTH_GOOGLE_CLIENT_SECRET"),
         "blackboard_api_client_id": sg.get("BLACKBOARD_API_CLIENT_ID"),
         "blackboard_api_client_secret": sg.get("BLACKBOARD_API_CLIENT_SECRET"),
+        "jstor_api_url": sg.get("JSTOR_API_URL"),
+        "jstor_api_secret": sg.get("JSTOR_API_SECRET"),
     }
 
     env_settings["dev"] = asbool(env_settings["dev"])

--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -46,7 +46,11 @@ class JSTORService:
         """
 
         return via_url(
-            request, document_url=self._get_public_url(document_url), content_type="pdf"
+            request,
+            document_url=self._get_public_url(document_url),
+            content_type="pdf",
+            # Show content partner banner in client for JSTOR.
+            options={"via.client.contentPartner": "jstor"},
         )
 
     def _get_public_url(self, url):

--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -1,22 +1,41 @@
+from datetime import datetime, timedelta
+
+from jose import jwt
+
+from lms.services import ExternalRequestError
+from lms.services.http import HTTPService
 from lms.views.helpers import via_url
 
 
 class JSTORService:
-    def __init__(self, enabled, site_code):
+    """An interface for dealing with JSTOR documents."""
+
+    DEFAULT_DOI_PREFIX = "10.2307"
+    """Used when no DOI prefix can be found."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, api_url, secret, enabled, site_code, http_service: HTTPService):
         """
         Initialise the JSTOR service.
 
+        :param api_url: JSTOR API url
+        :param secret: Secret for authenticating with JSTOR
         :param enabled: Whether JSTOR is enabled on this instance
         :param site_code: The site code to use to identify the organization
+        :param http_service: HTTPService instance
         """
+        self._api_url = api_url
+        self._secret = secret
         self._enabled = enabled
         self._site_code = site_code
+
+        self._http = http_service
 
     @property
     def enabled(self) -> bool:
         """Get whether this instance is configured for JSTOR."""
 
-        return bool(self._enabled and self._site_code)
+        return bool(self._enabled and self._api_url and self._site_code)
 
     def via_url(self, request, document_url):
         """
@@ -28,17 +47,58 @@ class JSTORService:
         """
 
         return via_url(
-            request,
-            document_url,
-            content_type="pdf",
-            options={"via.jstor.site_code": self._site_code},
+            request, document_url=self._get_public_url(document_url), content_type="pdf"
+        )
+
+    def _get_public_url(self, url):
+        """
+        Get a signed S3 URL for the given JSTOR URL.
+
+        :param url: The URL to stream
+        :return: A public URL
+        :raises ExternalRequestError: If we get bad data back from the service
+        """
+
+        doi = url.replace("jstor://", "")
+        if "/" not in doi:
+            doi = f"{self.DEFAULT_DOI_PREFIX}/{doi}"
+
+        token = self._get_access_token(self._site_code)
+        s3_url = self._http.request(
+            method="GET",
+            url=f"{self._api_url}/pdf-url/{doi}",
+            headers={"Authorization": f"Bearer {token}"},
+        ).text
+
+        if not s3_url.startswith("https://"):
+            raise ExternalRequestError(
+                f"Expected to get an S3 URL but got: '{s3_url}' instead"
+            )
+
+        return s3_url
+
+    def _get_access_token(self, site_code):
+        return jwt.encode(
+            {
+                "exp": int((datetime.now() + timedelta(hours=1)).timestamp()),
+                "site_code": site_code,
+            },
+            self._secret,
+            algorithm="HS256",
         )
 
 
 def factory(_context, request):
-    settings = request.find_service(name="application_instance").get_current().settings
+    ai_settings = (
+        request.find_service(name="application_instance").get_current().settings
+    )
+
+    app_settings = request.registry.settings
 
     return JSTORService(
-        enabled=settings.get("jstor", "enabled"),
-        site_code=settings.get("jstor", "site_code"),
+        api_url=app_settings.get("jstor_api_url"),
+        secret=app_settings.get("jstor_api_secret"),
+        enabled=ai_settings.get("jstor", "enabled"),
+        site_code=ai_settings.get("jstor", "site_code"),
+        http_service=request.find_service(name="http"),
     )

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -47,7 +47,10 @@ class TestJSTORService:
         )
 
         via_url.assert_called_once_with(
-            pyramid_request, http_service.request.return_value.text, content_type="pdf"
+            pyramid_request,
+            http_service.request.return_value.text,
+            content_type="pdf",
+            options={"via.client.contentPartner": "jstor"},
         )
 
         assert url == via_url.return_value

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -1,40 +1,100 @@
-from unittest.mock import sentinel
+from functools import partial
+from unittest.mock import MagicMock, sentinel
 
 import pytest
+from freezegun import freeze_time
 
 from lms.models import ApplicationSettings
+from lms.services import ExternalRequestError
 from lms.services.jstor import JSTORService, factory
 
 
 class TestJSTORService:
     @pytest.mark.parametrize("enabled", (True, False, None))
     @pytest.mark.parametrize("site_code", ("code", None, ""))
-    def test_enabled(self, enabled, site_code):
-        svc = JSTORService(enabled=enabled, site_code=site_code)
+    def test_enabled(self, get_service, enabled, site_code):
+        svc = get_service(enabled=enabled, site_code=site_code)
 
         assert svc.enabled == bool(enabled and site_code)
 
-    def test_via_url(self, pyramid_request, via_url):
-        svc = JSTORService(enabled=True, site_code=sentinel.site_code)
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            (
+                "jstor://ARTICLE_ID",
+                "http://jstor.example.com/pdf-url/10.2307/ARTICLE_ID",
+            ),
+            ("jstor://PREFIX/SUFFIX", "http://jstor.example.com/pdf-url/PREFIX/SUFFIX"),
+        ],
+    )
+    @freeze_time("2022-01-14")
+    def test_via_url(
+        self, svc, pyramid_request, jwt, http_service, via_url, url, expected
+    ):
+        jwt.encode.return_value = "TOKEN"
 
-        url = svc.via_url(pyramid_request, "jstor://doi")
+        url = svc.via_url(pyramid_request, document_url=url)
+
+        jwt.encode.assert_called_once_with(
+            {"exp": 1642122000, "site_code": sentinel.site_code},
+            sentinel.secret,
+            algorithm="HS256",
+        )
+
+        http_service.request.assert_called_once_with(
+            method="GET",
+            url=expected,
+            headers={"Authorization": "Bearer TOKEN"},
+        )
 
         via_url.assert_called_once_with(
-            pyramid_request,
-            "jstor://doi",
-            content_type="pdf",
-            options={"via.jstor.site_code": sentinel.site_code},
+            pyramid_request, http_service.request.return_value.text, content_type="pdf"
         )
 
         assert url == via_url.return_value
+
+    def test_via_url_with_bad_return_value_from_s3(
+        self, svc, http_service, pyramid_request
+    ):
+        http_service.request.return_value.text = "NOT A URL"
+
+        with pytest.raises(ExternalRequestError):
+            svc.via_url(pyramid_request, document_url="jstor://ANY")
+
+    @pytest.fixture
+    def http_service(self, http_service):
+        http_service.request.return_value = MagicMock(text="https://s3.example.com/pdf")
+
+        return http_service
 
     @pytest.fixture
     def via_url(self, patch):
         return patch("lms.services.jstor.via_url")
 
+    @pytest.fixture
+    def get_service(self, http_service):
+        return partial(
+            JSTORService,
+            api_url="http://jstor.example.com",
+            secret=sentinel.secret,
+            enabled=True,
+            site_code=sentinel.site_code,
+            http_service=http_service,
+        )
+
+    @pytest.fixture
+    def svc(self, get_service):
+        return get_service()
+
+    @pytest.fixture(autouse=True)
+    def jwt(self, patch):
+        return patch("lms.services.jstor.jwt")
+
 
 class TestFactory:
-    def test_it(self, pyramid_request, application_instance_service, JSTORService):
+    def test_it(
+        self, pyramid_request, application_instance_service, http_service, JSTORService
+    ):
         application_instance_service.get_current.return_value.settings = (
             ApplicationSettings(
                 {
@@ -45,11 +105,21 @@ class TestFactory:
                 }
             )
         )
+        pyramid_request.registry.settings.update(
+            {
+                "jstor_api_url": sentinel.jstor_api_url,
+                "jstor_api_secret": sentinel.jstor_api_secret,
+            }
+        )
 
         svc = factory(sentinel.context, pyramid_request)
 
         JSTORService.assert_called_once_with(
-            enabled=sentinel.jstor_enabled, site_code=sentinel.jstor_site_code
+            api_url=sentinel.jstor_api_url,
+            secret=sentinel.jstor_api_secret,
+            enabled=sentinel.jstor_enabled,
+            site_code=sentinel.jstor_site_code,
+            http_service=http_service,
         )
         assert svc == JSTORService.return_value
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,8 @@ passenv =
     dev: VITALSOURCE_API_KEY
     dev: BLACKBOARD_API_CLIENT_ID
     dev: BLACKBOARD_API_CLIENT_SECRET
+    dev: JSTOR_API_URL
+    dev: JSTOR_API_SECRET
 deps =
     dev: -r requirements/dev.txt
     {format,checkformatting}: -r requirements/format.txt


### PR DESCRIPTION
For: 

 * https://github.com/hypothesis/private-issues/issues/110

Requires:

 * https://github.com/hypothesis/h-vialib/pull/35
 * An update in Via to add the above

This completely removes the need to have any JSTOR specific code in Via.

## Testing notes

 * Get the devdata as of (https://github.com/hypothesis/devdata/pull/53)
 * Start all the services
 * Open the dev tools with caching disabled
 * Visit https://hypothesis.instructure.com/courses/125/assignments/2968
 * You should see a request go to Via with a normal URL in it
 * You should see the JSTOR content banner in Via