### PR TITLE
PyLint: fail on useless-suppression

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,6 +12,11 @@ load-plugins=pylint.extensions.bad_builtin,
              pylint.extensions.overlapping_exceptions,
              pylint.extensions.redefined_variable_type,
 
+# Fail if there are *any* messages from PyLint.
+# The letters refer to PyLint's message categories, see
+# https://pylint.pycqa.org/en/latest/messages/messages_introduction.html
+fail-on=C,E,F,I,R,W
+
 [MESSAGES CONTROL]
 enable=
     bad-inline-option,

--- a/lms/validation/authentication/_lti.py
+++ b/lms/validation/authentication/_lti.py
@@ -90,7 +90,7 @@ class LTI13AuthSchema(LTIV11CoreSchema):
     deployment_id = marshmallow.fields.Str(required=True)
 
     @marshmallow.pre_load
-    def _lti_v13_fields(self, data, **_kwargs):  # pylint:disable=no-self-use
+    def _lti_v13_fields(self, data, **_kwargs):
         if not self.context["request"].lti_jwt:
             return data
 

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -11,6 +11,11 @@ load-plugins=pylint.extensions.bad_builtin,
              pylint.extensions.overlapping_exceptions,
              pylint.extensions.redefined_variable_type,
 
+# Fail if there are *any* messages from PyLint.
+# The letters refer to PyLint's message categories, see
+# https://pylint.pycqa.org/en/latest/messages/messages_introduction.html
+fail-on=C,E,F,I,R,W
+
 [MESSAGES CONTROL]
 enable=
     bad-inline-option,


### PR DESCRIPTION
I'm not sure exactly which messages do and don't cause PyLint to fail (non-zero exit status) by default but apparently `useless-suppression` doesn't (maybe no "informational" category messages do).

Fix our pylintrc files so that any messages from PyLint will cause it to fail.

Unfortunately the only way I can find to do this is to list all six of PyLint's message categories individually, and to list them using cryptic single-letter identifiers. I can't find any way to say `fail-on=*` or `fail-on=all` (`all` does work with some PyLint settings but doesn't seem to work with `fail-on`).

New versions of PyLint frequently add new messages but hopefully they rarely add new message _categories_ so this shouldn't need to be updated often.