### PR TITLE
Enable the new frontend refresh feature

### DIFF
--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -16,7 +16,7 @@ def blackboard_api_client_factory(_context, request):
             redirect_uri=request.route_url("blackboard_api.oauth.callback"),
             http_service=request.find_service(name="http"),
             oauth_http_service=request.find_service(name="oauth_http"),
-            refresh_enabled=True,
+            refresh_enabled=False,
         ),
         request=request,
         file_service=request.find_service(name="file"),

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -27,7 +27,7 @@ def canvas_api_client_factory(_context, request):
         client_id=application_instance.developer_key,
         client_secret=developer_secret,
         redirect_uri=request.route_url("canvas_api.oauth.callback"),
-        refresh_enabled=True,
+        refresh_enabled=False,
     )
 
     return CanvasAPIClient(

--- a/tests/unit/lms/services/blackboard_api/factory_test.py
+++ b/tests/unit/lms/services/blackboard_api/factory_test.py
@@ -26,7 +26,7 @@ def test_blackboard_api_client_factory(
         redirect_uri=pyramid_request.route_url("blackboard_api.oauth.callback"),
         http_service=http_service,
         oauth_http_service=oauth_http_service,
-        refresh_enabled=True,
+        refresh_enabled=False,
     )
     BlackboardAPIClient.assert_called_once_with(
         BasicClient.return_value, pyramid_request, file_service

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -50,7 +50,7 @@ class TestCanvasAPIClientFactory:
                 aes_service
             ),
             redirect_uri=pyramid_request.route_url("canvas_api.oauth.callback"),
-            refresh_enabled=True,
+            refresh_enabled=False,
         )
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Slack thread: https://hypothes-is.slack.com/archives/C1MA4E9B9/p1652200138759249

I've also got a draft PR to actually remove the will-no-longer-be-used backend refresh code: https://github.com/hypothesis/lms/pull/3943, but I guess we should deploy this PR to disable backend refresh/enable frontend refresh and let it run for a while first.

When we [removed the `frontend_refresh` feature flag](https://github.com/hypothesis/lms/pull/3806) we removed it and _disabled_ the feature rather than enabling it: the new frontend-based OAuth 2 refresh code is currently *not* being used on master or on production. The old backend-based refresh is in use instead. To verify this:

Canvas
------

On master:

1. Launch [localhost (make devdata) Canvas Files Assignment](https://hypothesis.instructure.com/courses/125/assignments/875) so that you get a Canvas access token in your DB

2. Invalidate the access token in your DB: `tox -qe dockercompose -- exec postgres psql -U postgres -c "UPDATE oauth2_token SET access_token = 'foo';"`

3. Open the dev tools _Network_ tab and launch [localhost (make devdata) Canvas Files Assignment](https://hypothesis.instructure.com/courses/125/assignments/875) again.

   The assignment should launch successfully _without_ showing you an authorization dialog and if you look in the dev tools you will _not_ see a request to the new `/api/canvas/oauth/refresh` API: the access token was refreshed by the backend without frontend involvement.

If you repeat the same test on _this_ branch the same thing will happen but you will see a request to the refresh API in dev tools.

Blackboard
----------

On master:

1. Go to [Developer Test Course with Original Course View](https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline) and launch **localhost (make devdata) Blackboard Files Assignment** so that you get an access token in your DB.

2. Invalidate the access token in your DB: `tox -qe dockercompose -- exec postgres psql -U postgres -c "UPDATE oauth2_token SET access_token = 'foo';"`

3. Open the dev tools _Network_ tab and launch the same assignment again.

   As in Canvas the assignment should launch successfully _without_ showing you an authorization dialog and if you look in the dev tools you will _not_ see a request to the new `/api/blackboard/oauth/refresh` API: the access token was refreshed by the backend without frontend involvement.

Also as in Canvas if you repeat the same test on _this_ branch the same thing will happen but you will see a request to the refresh API in dev tools.