### PR TITLE
Fixes for canvas files and canvas groups in LTI1.3

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -62,6 +62,14 @@ _V11_TO_V13 = (
         "deep_linking_settings",
         ["https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings"],
     ),
+    (
+        "custom_canvas_course_id",
+        [f"{CLAIM_PREFIX}/custom", "canvas_course_id"],
+    ),
+    (
+        "custom_canvas_api_domain",
+        [f"{CLAIM_PREFIX}/custom", "canvas_api_domain"],
+    ),
 )
 
 

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -85,6 +85,8 @@ def _to_lti_v11(v13_params):
             if path_item not in value:
                 break
             value = value[path_item]
+        else:
+            # We only found the key if we exhausted all of `v13_path`
             found = True
 
         # We don't want to add partial values along v13_path

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -66,7 +66,7 @@ class JSConfig:
                 "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
                 "path": self._request.route_path(
                     "canvas_api.files.via_url",
-                    resource_link_id=self._request.params["resource_link_id"],
+                    resource_link_id=self._context.lti_params["resource_link_id"],
                 ),
             }
         elif document_url.startswith("vitalsource://"):
@@ -490,18 +490,20 @@ class JSConfig:
             "path": req.route_path("canvas_api.sync"),
             "data": {
                 "lms": {
-                    "tool_consumer_instance_guid": req.params[
+                    "tool_consumer_instance_guid": self._context.lti_params[
                         "tool_consumer_instance_guid"
                     ],
                 },
                 "course": {
-                    "context_id": req.params["context_id"],
-                    "custom_canvas_course_id": req.params["custom_canvas_course_id"],
+                    "context_id": self._context.lti_params["context_id"],
+                    "custom_canvas_course_id": self._context.lti_params[
+                        "custom_canvas_course_id"
+                    ],
                     "group_set": req.params.get("group_set"),
                 },
                 "group_info": {
                     key: value
-                    for key, value in req.params.items()
+                    for key, value in self._context.lti_params.items()
                     if key in GroupInfo.columns()
                 },
             },

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -40,13 +40,13 @@ class FilePickerConfig:
     def canvas_config(cls, context, request, application_instance):
         """Get Canvas files config."""
         enabled = context.is_canvas and (
-            "custom_canvas_course_id" in request.params
+            "custom_canvas_course_id" in context.lti_params
             and application_instance.developer_key is not None
         )
         groups_enabled = context.canvas_groups_enabled
 
         auth_url = request.route_url("canvas_api.oauth.authorize")
-        course_id = request.params.get("custom_canvas_course_id")
+        course_id = context.lti_params.get("custom_canvas_course_id")
 
         config = {
             "enabled": enabled,

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -66,6 +66,22 @@ class _CommonLTILaunchSchema(LTIV11CoreSchema):
     launch_presentation_return_url = fields.Str()
     tool_consumer_info_product_family_code = fields.Str()
 
+    @pre_load
+    def _load_canvas_course_id(self, data, **_kwargs):  # pylint: disable=no-self-use
+        canvas_course_id = data.get("custom_canvas_course_id")
+        if canvas_course_id and isinstance(canvas_course_id, int):
+            # In LTI1.3 course_id is sent as an integer
+            # instead of as a string in LTI1.1.
+            # Coercing both version to integers could be handled
+            # with fields.Int(strict=False)
+            #
+            # Doing a manual conversion to str here instead so both versions
+            # behave the same as LMS is concern
+            # and to allow for future changes on canvas' side
+            data["custom_canvas_course_id"] = str(canvas_course_id)
+
+        return data
+
     @validates_schema
     def validate_consumer_key(self, data, **_kwargs):  # pylint: disable=no-self-use
         if (

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -46,7 +46,7 @@ class BasicLTILaunchViews:
         self.application_instance = request.find_service(
             name="application_instance"
         ).get_current()
-        self.application_instance.update_lms_data(self.request.params)
+        self.application_instance.update_lms_data(self.context.lti_params)
 
     def basic_lti_launch(self, document_url, grading_supported=True):
         """Do a basic LTI launch with the given document_url."""
@@ -123,7 +123,7 @@ class BasicLTILaunchViews:
         Note that this only apply to assignments configured but not yet launched
         after canvas assignments are also DB configured see: js_config._create_assignment_api
         """
-        course_id = self.request.params["custom_canvas_course_id"]
+        course_id = self.context.lti_params["custom_canvas_course_id"]
         file_id = self.request.params["file_id"]
 
         # Normally this would be done during `configure_assignment()` but

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -63,7 +63,7 @@ def deep_linking_launch(context, request):
     application_instance = request.find_service(
         name="application_instance"
     ).get_current()
-    application_instance.update_lms_data(request.params)
+    application_instance.update_lms_data(context.lti_params)
 
     context.get_or_create_course()
 

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -148,6 +148,6 @@ def common_payload():
         # Mirror the custom param we set in the LTI compliance testing tool
         # This gets around the fact it doesn't send a GUID by default
         "https://purl.imsglobal.org/spec/lti/claim/custom": {
-            "certification_guid": "GUID"
+            "certification_guid": "TEST_CONSUMER_INSTANCE_GUID"
         },
     }

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -32,3 +32,17 @@ class TestLTI13Params:
 
         params = LTIParams(sample_dict)
         assert params == params.v11 == sample_dict
+
+    def test_it_doesnt_set_partial_keys(self):
+        params = LTIParams.from_v13(
+            {
+                "https://purl.imsglobal.org/spec/lti/claim/custom": {
+                    "canvas_course_id": "SOME_ID"
+                }
+            }
+        )
+
+        # The existent params get returned
+        assert params["custom_canvas_course_id"] == "SOME_ID"
+        # Nonexistent ones in the same "level" are not present
+        assert "custom_canvas_api_domain" not in params

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -3,6 +3,7 @@ from unittest.mock import create_autospec, sentinel
 import pytest
 from h_matchers import Any
 
+from lms.models import LTIParams
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import FilePickerConfig
 
@@ -66,7 +67,7 @@ class TestFilePickerConfig:
     def test_canvas_config(
         self, context, pyramid_request, application_instance, groups_enabled
     ):
-        pyramid_request.params["custom_canvas_course_id"] = "COURSE_ID"
+        context.lti_params["custom_canvas_course_id"] = "COURSE_ID"
         context.canvas_groups_enabled = groups_enabled
 
         config = FilePickerConfig.canvas_config(
@@ -197,7 +198,7 @@ class TestFilePickerConfig:
         context.is_canvas = True
 
     @pytest.fixture
-    def context(self):
+    def context(self, pyramid_request):
         return create_autospec(
             LTILaunchResource,
             spec_set=True,
@@ -207,4 +208,5 @@ class TestFilePickerConfig:
             canvas_groups_enabled=False,
             custom_canvas_api_domain=None,
             blackboard_groups_enabled=False,
+            lti_params=LTIParams(pyramid_request.params),
         )

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -14,6 +14,7 @@ from lms.validation import (
     URLConfiguredBasicLTILaunchSchema,
     ValidationError,
 )
+from lms.validation._lti_launch_params import _CommonLTILaunchSchema
 
 
 class TestLTIV11CoreSchema:
@@ -40,6 +41,15 @@ class TestLTIV11CoreSchema:
         pyramid_request.params = {"extra": "value"}
         pyramid_request.lti_jwt = sentinel.lti_jwt
         return pyramid_request
+
+
+class TestCommonLTILaunchSchema:
+    def test_it_allows_int_custom_canvas_course_id(self, pyramid_request):
+        pyramid_request.params["custom_canvas_course_id"] = 1
+
+        params = _CommonLTILaunchSchema(pyramid_request).parse()
+
+        assert params["custom_canvas_course_id"] == str(1)
 
 
 class TestBasicLTILaunchSchema:
@@ -84,13 +94,6 @@ class TestBasicLTILaunchSchema:
                 "resource_link_id": ["Missing data for required field."],
             },
         }
-
-    def test_allows_int_custom_canvas_course_id(self, pyramid_request):
-        pyramid_request.params["custom_canvas_course_id"] = 1
-
-        params = BasicLTILaunchSchema(pyramid_request).parse()
-
-        assert params["custom_canvas_course_id"] == str(1)
 
     @pytest.mark.parametrize(
         "required_param",

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -85,6 +85,13 @@ class TestBasicLTILaunchSchema:
             },
         }
 
+    def test_allows_int_custom_canvas_course_id(self, pyramid_request):
+        pyramid_request.params["custom_canvas_course_id"] = 1
+
+        params = BasicLTILaunchSchema(pyramid_request).parse()
+
+        assert params["custom_canvas_course_id"] == str(1)
+
     @pytest.mark.parametrize(
         "required_param",
         ["oauth_consumer_key", "tool_consumer_instance_guid", "user_id"],

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -29,7 +29,7 @@ def legacy_canvas_file_basic_lti_launch_caller(context, pyramid_request):
     # The custom_canvas_course_id param is always present when
     # legacy_canvas_file_basic_lti_launch() is called: Canvas always includes this
     # param because we request it in our config.xml.
-    pyramid_request.params["custom_canvas_course_id"] = "TEST_COURSE_ID"
+    context.lti_params["custom_canvas_course_id"] = "TEST_COURSE_ID"
     # The file_id param is always present when legacy_canvas_file_basic_lti_launch()
     # is called. The canvas_file=True view predicate ensures this.
     pyramid_request.params["file_id"] = "TEST_FILE_ID"
@@ -292,7 +292,7 @@ class TestCanvasFileBasicLTILaunch:
     def test_it(self, context, pyramid_request, assignment_service):
         legacy_canvas_file_basic_lti_launch_caller(context, pyramid_request)
 
-        course_id = pyramid_request.params["custom_canvas_course_id"]
+        course_id = context.lti_params["custom_canvas_course_id"]
         file_id = pyramid_request.params["file_id"]
 
         assignment_service.upsert.assert_called_once_with(

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -22,7 +22,7 @@ class TestDeepLinkingLaunch:
         deep_linking_launch(context, pyramid_request)
 
         application_instance_service.get_current.return_value.update_lms_data.assert_called_once_with(
-            pyramid_request.params
+            context.lti_params
         )
         context.get_or_create_course.assert_called_once_with()
         lti_h_service.sync.assert_called_once_with(


### PR DESCRIPTION
Main thing is using `lti_params` instead of params. I rather do this feature by feature instead of a good old search and replace as is easier to test individually. 

When we are "done" I think it will be easier to review the ones that still use `request.params` one by one.


There was also a couple of things getting on the way of these features working on LTI1.3:

- A bug on LTIParams. Fixed and added a test for that.
- A difference between versions in one parameter canvas sends. `str` vs `int` depending on the version.



## Testing

(you can test a broken version of this in `master` first)

- `make devdata`

- Edit an LTI1.3 assignment https://hypothesis.instructure.com/courses/319/assignments/2781/edit?return_to=https%3A%2F%2Fhypothesis.instructure.com%2Fcourses%2F319%2Fassignments%2F2781

- Select Canvas files and pick the existing file. Also make it a groups assignment picking the existing group set. Save it.

- Launching the assignment will pick the right canvas PDF and the group selector will show on the sidebar.
