### PR TITLE
Canvas: Only submit for grading if annotation is shared

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -281,12 +281,16 @@ export default function BasicLTILaunchApp() {
       clientRPC.off('annotationActivity', onAnnotationActivity);
 
     /**
-     * @param {string} eventType
-     * @param {object} data
-     *   @param {string} data.date
+     * @param {import('../services/client-rpc').AnnotationEventType} eventType
+     * @param {import('../services/client-rpc').AnnotationEventData} data
      */
     function onAnnotationActivity(eventType, data) {
-      reportSubmission(data.date).then(unsubscribe);
+      if (
+        ['create', 'update'].includes(eventType) &&
+        data.annotation.isShared
+      ) {
+        reportSubmission(data.date).then(unsubscribe);
+      }
     }
 
     clientRPC.on('annotationActivity', onAnnotationActivity);

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -11,6 +11,16 @@ import { JWT } from '../utils/jwt';
  */
 
 /**
+ * @typedef {'create'|'update'|'flag'|'delete'} AnnotationEventType
+ *
+ * @typedef AnnotationEventData
+ * @prop {string} date
+ * @prop {object} annotation
+ *  @prop {string} annotation.id
+ *  @prop {boolean} annotation.isShared
+ */
+
+/**
  * @typedef {import('../config').ClientConfig} ClientConfig
  */
 
@@ -72,13 +82,16 @@ export class ClientRPC extends TinyEmitter {
       return clientConfig;
     });
 
-    this._server.register('reportActivity', (event, data) => {
-      this.emit('annotationActivity', event, data);
-      // The client requires a response, or its Promise will reject
-      // TODO: Change this expectation in the client so that we don't have
-      // to return a meaningless return value
-      return true;
-    });
+    this._server.register(
+      'reportActivity',
+      /**
+       * @param {AnnotationEventType} eventType
+       * @param {AnnotationEventData} data
+       */
+      (eventType, data) => {
+        this.emit('annotationActivity', eventType, data);
+      }
+    );
 
     const groups = new Promise(resolve => {
       this._resolveGroups = resolve;

--- a/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
@@ -177,9 +177,8 @@ describe('ClientRPC', () => {
       );
       clientRPC.on('annotationActivity', callback);
 
-      const result = serverMethod('create', 'foo');
+      serverMethod('create', 'foo');
 
-      assert.isTrue(result);
       assert.calledWith(callback, 'create', 'foo');
     });
   });


### PR DESCRIPTION
Update grading submission such that an automated empty grading submission is only made if annotation activity pertains to a shared annotation.

### Testing

Running this branch, try these things or a combination of:

1. Ensure that the `submit_on_annotation` feature flag is enabled on http://localhost:8001/flags
2. Launch a grade-able assignment as a student
3. Add a new _highlight_ or private (only me) annotation.
4. Log out
5. Log in as an instructor and launch the same assignment; go into Speed Grader
6. You should not see a recent submission from the student who created the highlight
7. Log out; log in as student
8. Launch assignment. Create or edit a shared annotation.
9. Log out; log in as instructor; launch assignment; go into Speed Grader
10. You should see a recent submission from the student user who created the shared annotation

If so inclined, you could also disable the feature flag and verify that a submission is created on launch with the old dummy date (i.e. things work as expected when this feature is not enabled).

Fixes https://github.com/hypothesis/product-backlog/issues/1352
Fixes https://github.com/hypothesis/client/issues/4484