### PR TITLE
Add LTI1.3 config endpoint for canvas

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -12,6 +12,7 @@ def includeme(config):
     config.add_route("reports", "/reports")
 
     config.add_route("canvas.v11.config", "/config_xml")
+    config.add_route("canvas.v13.config", "/canvas/1.3/config")
     config.add_route(
         "configure_assignment",
         "/assignment",

--- a/lms/views/canvas/config.py
+++ b/lms/views/canvas/config.py
@@ -1,3 +1,9 @@
+"""
+Configuration views for Canvas.
+
+These views allow an admin user to paste in a URL and have Hypothesis automatically
+configured in Canvas.
+"""
 from pyramid.view import view_config
 
 
@@ -7,10 +13,74 @@ from pyramid.view import view_config
     request_method="GET",
 )
 def config_xml(request):
-    """Render the XML configuration."""
+    """
+    Render the configuration for LTI1.1 as an XML.
+
+    https://canvas.instructure.com/doc/api/file.tools_xml.html
+    """
     request.response.content_type = "text/xml"
 
     return {
         "launch_url": request.route_url("lti_launches"),
         "content_item_url": request.route_url("content_item_selection"),
+    }
+
+
+@view_config(
+    route_name="canvas.v13.config",
+    renderer="json",
+    request_method="GET",
+)
+def config_json(request):
+    """
+    Return tool configuration for Canvas installs as a json document.
+
+    https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#anatomy-of-a-json-configuration
+    """
+    return {
+        "title": "Hypothesis",
+        "description": "Hypothesis",
+        "oidc_initiation_url": request.route_url("lti.oidc"),
+        "target_link_uri": request.route_url("lti_launches"),
+        "extensions": [
+            {
+                "platform": "canvas.instructure.com",
+                "privacy_level": "public",
+                "settings": {
+                    "placements": [
+                        {
+                            "text": "Hypothesis",
+                            "enabled": True,
+                            "placement": "link_selection",
+                            "message_type": "LtiDeepLinkingRequest",
+                            "target_link_uri": request.route_url(
+                                "content_item_selection"
+                            ),
+                        },
+                        {
+                            "text": "Hypothesis",
+                            "enabled": True,
+                            "placement": "assignment_selection",
+                            "message_type": "LtiDeepLinkingRequest",
+                            "target_link_uri": request.route_url(
+                                "content_item_selection"
+                            ),
+                        },
+                    ],
+                },
+            }
+        ],
+        "public_jwk_url": request.route_url("lti.jwks"),
+        "custom_fields": {
+            "custom_canvas_course_id": "$Canvas.course.id",
+            "custom_canvas_api_domain": "$Canvas.api.domain",
+            "custom_canvas_user_id": "$Canvas.user.id",
+        },
+        "scopes": [
+            "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+            "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+            "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
+            "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
+            "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+        ],
     }

--- a/tests/unit/lms/views/canvas/config_test.py
+++ b/tests/unit/lms/views/canvas/config_test.py
@@ -1,7 +1,56 @@
-from lms.views.canvas.config import config_xml
+from lms.views.canvas.config import config_json, config_xml
 
 
 class TestConfigXml:
     def test_it_renders_the_config_xml(self, pyramid_request):
         response = config_xml(pyramid_request)
         assert response is not None
+
+
+class TestConfigJSON:
+    def test_it(self, pyramid_request):
+        config_dict = config_json(pyramid_request)
+
+        assert config_dict == {
+            "title": "Hypothesis",
+            "description": "Hypothesis",
+            "oidc_initiation_url": "http://example.com/lti/1.3/oidc",
+            "target_link_uri": "http://example.com/lti_launches",
+            "extensions": [
+                {
+                    "platform": "canvas.instructure.com",
+                    "privacy_level": "public",
+                    "settings": {
+                        "placements": [
+                            {
+                                "text": "Hypothesis",
+                                "enabled": True,
+                                "placement": "link_selection",
+                                "message_type": "LtiDeepLinkingRequest",
+                                "target_link_uri": "http://example.com/content_item_selection",
+                            },
+                            {
+                                "text": "Hypothesis",
+                                "enabled": True,
+                                "placement": "assignment_selection",
+                                "message_type": "LtiDeepLinkingRequest",
+                                "target_link_uri": "http://example.com/content_item_selection",
+                            },
+                        ],
+                    },
+                }
+            ],
+            "public_jwk_url": "http://example.com/lti/1.3/jwks",
+            "custom_fields": {
+                "custom_canvas_course_id": "$Canvas.course.id",
+                "custom_canvas_api_domain": "$Canvas.api.domain",
+                "custom_canvas_user_id": "$Canvas.user.id",
+            },
+            "scopes": [
+                "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+                "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+                "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
+                "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
+                "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+            ],
+        }


### PR DESCRIPTION
Add the same configuration endpoint concept for LTI1.3. 

In LTI1.3 the endpoint must return json instead of xml but the information is basically the same.


## Testing

Head to: http://localhost:8001/canvas/1.3/config


