### PR TITLE
Remove remaining `.hyp-u-*` classes from `frontend-shared`

### DIFF
--- a/lms/static/scripts/browser_check/index.js
+++ b/lms/static/scripts/browser_check/index.js
@@ -8,7 +8,7 @@ if (!isBrowserSupported()) {
     <b>You may need to upgrade your browser to use Hypothesis.</b>
     See <a href="https://web.hypothes.is/help/which-browsers-are-supported-by-hypothesis/" target="_blank">this support article</a> for more information.
   </div>
-  <div class="hyp-u-stretch"></div>
+  <div class="grow"></div>
   <button class="Button">Dismiss</button>
 `;
 

--- a/lms/static/scripts/frontend_apps/components/ContentFrame.js
+++ b/lms/static/scripts/frontend_apps/components/ContentFrame.js
@@ -19,8 +19,7 @@ export default function ContentFrame({ url, iframeRef }) {
         // It's important that this content render full width and grow to fill
         // available flex space. n.b. It may be rendered together with grading
         // controls
-        'w-full grow',
-        'hyp-u-border'
+        'w-full grow border'
       )}
       src={url}
       title="Course content with Hypothesis annotation viewer"

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -45,7 +45,7 @@ function ErrorDetails({ error }) {
 
   return (
     <details
-      className="hyp-u-border"
+      className="border"
       onToggle={onDetailsToggle}
       data-testid="error-details"
     >

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -82,8 +82,8 @@ export default function StudentSelector({
             'appearance-none w-full h-touch-minimum',
             'pl-4 pr-8', // Make room on right for custom down-caret Icon
             'xl:w-80', // Fix the width at wider viewports
-            'hyp-u-outline-on-keyboard-focus--inset border',
-            'border-r-0 border-l-0' // left and right borders off
+            'u-outline-on-keyboard-focus--inset',
+            'border border-r-0 border-l-0' // left and right borders off
           )}
           onChange={e => {
             onSelectStudent(
@@ -132,7 +132,7 @@ export default function StudentSelector({
             // IconButton styling sets a border radius. Turn it off on the
             // right for better alignment with the select element
             'rounded-r-none',
-            'hyp-u-outline-on-keyboard-focus--inset'
+            'u-outline-on-keyboard-focus--inset'
           )}
           icon="arrowLeft"
           title="previous student"
@@ -146,7 +146,7 @@ export default function StudentSelector({
             'px-3',
             // Turn off border radius on left for better alignment with select
             'rounded-l-none',
-            'hyp-u-outline-on-keyboard-focus--inset'
+            'u-outline-on-keyboard-focus--inset'
           )}
           icon="arrowRight"
           title="next student"

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -82,7 +82,7 @@ export default function StudentSelector({
             'appearance-none w-full h-touch-minimum',
             'pl-4 pr-8', // Make room on right for custom down-caret Icon
             'xl:w-80', // Fix the width at wider viewports
-            'hyp-u-outline-on-keyboard-focus--inset hyp-u-border',
+            'hyp-u-outline-on-keyboard-focus--inset border',
             'border-r-0 border-l-0' // left and right borders off
           )}
           onChange={e => {

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -203,7 +203,7 @@ export default function SubmitGradeForm({ student }) {
               className={classnames(
                 'w-14 h-touch-minimum text-center',
                 'disabled:opacity-50',
-                'hyp-u-outline-on-keyboard-focus--inset hyp-u-border',
+                'hyp-u-outline-on-keyboard-focus--inset border',
                 'border-r-0',
                 {
                   'animate-gradeSubmitSuccess': gradeSaved,
@@ -225,9 +225,9 @@ export default function SubmitGradeForm({ student }) {
             icon="check"
             type="submit"
             classes={classnames(
-              'h-touch-minimum',
+              'h-touch-minimum border',
               'disabled:opacity-50 disabled:cursor-default',
-              'hyp-u-border hyp-u-outline-on-keyboard-focus--inset'
+              'hyp-u-outline-on-keyboard-focus--inset'
             )}
             disabled={disabled}
             onClick={onSubmitGrade}

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -218,7 +218,7 @@ export default function SubmitGradeForm({ student }) {
               defaultValue={grade}
               key={student ? student.LISResultSourcedId : null}
             />
-            {gradeLoading && <Spinner classes="hyp-u-absolute-centered" />}
+            {gradeLoading && <Spinner classes="u-absolute-centered" />}
           </span>
 
           <LabeledButton

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -203,8 +203,8 @@ export default function SubmitGradeForm({ student }) {
               className={classnames(
                 'w-14 h-touch-minimum text-center',
                 'disabled:opacity-50',
-                'hyp-u-outline-on-keyboard-focus--inset border',
-                'border-r-0',
+                'u-outline-on-keyboard-focus--inset',
+                'border border-r-0',
                 {
                   'animate-gradeSubmitSuccess': gradeSaved,
                 }
@@ -227,7 +227,7 @@ export default function SubmitGradeForm({ student }) {
             classes={classnames(
               'h-touch-minimum border',
               'disabled:opacity-50 disabled:cursor-default',
-              'hyp-u-outline-on-keyboard-focus--inset'
+              'u-outline-on-keyboard-focus--inset'
             )}
             disabled={disabled}
             onClick={onSubmitGrade}

--- a/lms/static/scripts/frontend_apps/components/URLPicker.js
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.js
@@ -61,7 +61,7 @@ export default function URLPicker({ onCancel, onSelectURL }) {
       ]}
       initialFocus={input}
     >
-      <div className="hyp-u-vertical-spacing">
+      <div className="space-y-4">
         <p>Enter the URL of any publicly available web page or PDF:</p>
         <form
           ref={form}

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -48,7 +48,7 @@ export default function ValidationMessage({
         'left-full',
         // Sm and larger breakpoints position the message to the left of the input
         'sm:left-0 sm:-translate-x-full',
-        'hyp-u-outline-on-keyboard-focus',
+        'u-outline-on-keyboard-focus',
         {
           'animate-validationMessageOpen': showError,
           'animate-validationMessageClose': !showError,

--- a/lms/static/styles/_utilities.scss
+++ b/lms/static/styles/_utilities.scss
@@ -1,6 +1,17 @@
 @use 'tailwindcss/utilities';
 
 @layer utilities {
+  // Reusable patterns for possible extraction
+
+  // Apply basic styling to a list
+  .u-list {
+    @apply px-4 list-disc;
+  }
+
+  // Apply ordered-style to a list, with numbers
+  .u-list--decimal {
+    @apply u-list list-decimal;
+  }
   .u-absolute-centered {
     @apply absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2;
   }

--- a/lms/static/styles/_utilities.scss
+++ b/lms/static/styles/_utilities.scss
@@ -1,8 +1,38 @@
-@use '@hypothesis/frontend-shared/styles/util';
 @use 'tailwindcss/utilities';
 
 @layer utilities {
   .u-absolute-centered {
     @apply absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2;
+  }
+
+  // Copied current implementation of `hyp-u-outline-on-keyboard-focus`
+  // classes from the `frontend-shared` package.
+  // TODO: This should be implemented as a TW plugin in `frontend-shared`
+  // and replaced
+  .u-outline-on-keyboard-focus:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px #59a7e8;
+  }
+  .js-focus-visible .u-outline-on-keyboard-focus:focus:not(.focus-visible) {
+    outline: none;
+    box-shadow: none;
+  }
+  .u-outline-on-keyboard-focus:focus:not(:focus-visible) {
+    outline: none;
+    box-shadow: none;
+  }
+
+  .u-outline-on-keyboard-focus--inset:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px #59a7e8 inset;
+  }
+  .js-focus-visible
+    .u-outline-on-keyboard-focus--inset:focus:not(.focus-visible) {
+    outline: none;
+    box-shadow: none;
+  }
+  .u-outline-on-keyboard-focus--inset:focus:not(:focus-visible) {
+    outline: none;
+    box-shadow: none;
   }
 }

--- a/lms/static/styles/_utilities.scss
+++ b/lms/static/styles/_utilities.scss
@@ -1,2 +1,8 @@
 @use '@hypothesis/frontend-shared/styles/util';
 @use 'tailwindcss/utilities';
+
+@layer utilities {
+  .u-absolute-centered {
+    @apply absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2;
+  }
+}

--- a/lms/static/styles/components/_index.scss
+++ b/lms/static/styles/components/_index.scss
@@ -13,16 +13,3 @@
 
 // HTML components
 @use 'browser-check-warning';
-
-// Reusable patterns for possible extraction
-@layer components {
-  // Apply basic styling to a list
-  .u-list {
-    @apply px-4 list-disc;
-  }
-
-  // Apply ordered-style to a list, with numbers
-  .u-list--decimal {
-    @apply u-list list-decimal;
-  }
-}


### PR DESCRIPTION
This is a cleanup PR to remove the last remaining `.hyp-u-` classes with their Tailwind equivalents or local implementations. This allows the removal of a bunch of unused shared utility classes.

There are no user-discernible changes from this.

Fixes https://github.com/hypothesis/lms/issues/3959