### PR TITLE
CanvasPreRecordHook support for LTI1.3

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -70,6 +70,10 @@ _V11_TO_V13 = (
         "custom_canvas_api_domain",
         [f"{CLAIM_PREFIX}/custom", "canvas_api_domain"],
     ),
+    (
+        "custom_canvas_user_id",
+        [f"{CLAIM_PREFIX}/custom", "canvas_user_id"],
+    ),
 )
 
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -302,8 +302,10 @@ class JSConfig:
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
         """
-        lis_result_sourcedid = self._request.params.get("lis_result_sourcedid")
-        lis_outcome_service_url = self._request.params.get("lis_outcome_service_url")
+        lis_result_sourcedid = self._context.lti_params.get("lis_result_sourcedid")
+        lis_outcome_service_url = self._context.lti_params.get(
+            "lis_outcome_service_url"
+        )
 
         # Don't set the Canvas submission params in non-Canvas LMS's.
         if not self._context.is_canvas:
@@ -322,18 +324,23 @@ class JSConfig:
         if not lis_outcome_service_url:
             return
 
+        custom_canvas_user_id = self._context.lti_params["custom_canvas_user_id"]
+
         self._config["canvas"]["speedGrader"] = {
             "submissionParams": {
                 "h_username": self._h_user.username,
                 "lis_result_sourcedid": lis_result_sourcedid,
                 "lis_outcome_service_url": lis_outcome_service_url,
-                "learner_canvas_user_id": self._request.params["custom_canvas_user_id"],
+                # Canvas sends custom_canvas_user_id as in integer in LTI1.3 and as a string in LT1.1
+                "learner_canvas_user_id": str(custom_canvas_user_id)
+                if isinstance(custom_canvas_user_id, int)
+                else custom_canvas_user_id,
                 "group_set": self._request.params.get("group_set"),
                 # Canvas doesn't send the right value for this on speed grader launches
                 # sending instead the same value as for "context_id"
-                "resource_link_id": self._request.params.get("resource_link_id"),
+                "resource_link_id": self._context.lti_params.get("resource_link_id"),
                 # Canvas doesn't send this value at all on speed grader submissions
-                "ext_lti_assignment_id": self._request.params.get(
+                "ext_lti_assignment_id": self._context.lti_params.get(
                     "ext_lti_assignment_id"
                 ),
                 **kwargs,

--- a/lms/services/lti_grading/_v11.py
+++ b/lms/services/lti_grading/_v11.py
@@ -44,11 +44,6 @@ class LTI11GradingService(LTIGradingService):
         if pre_record_hook:
             request = pre_record_hook(score=score, request_body=request)
 
-            if not isinstance(request, dict):
-                raise TypeError(
-                    "The pre-record hook must return the request body as a dict"
-                )
-
         self._send_request({"replaceResultRequest": request})
 
     def _send_request(self, request_body) -> dict:

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -145,9 +145,10 @@ def common_payload():
             ],
             "lineitems": "https://ltiadvantagevalidator.imsglobal.org/ltitool/rest/assignmentsgrades/10843/lineitems",
         },
-        # Mirror the custom param we set in the LTI compliance testing tool
-        # This gets around the fact it doesn't send a GUID by default
         "https://purl.imsglobal.org/spec/lti/claim/custom": {
-            "certification_guid": "TEST_CONSUMER_INSTANCE_GUID"
+            "canvas_user_id": 1000,
+            # Mirror the custom param we set in the LTI compliance testing tool
+            # This gets around the fact it doesn't send a GUID by default
+            "certification_guid": "TEST_CONSUMER_INSTANCE_GUID",
         },
     }

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -171,17 +171,21 @@ class TestAddDocumentURL:
         assert submission_params()["document_url"] == "example_document_url"
 
     @pytest.mark.parametrize("submit_on_annotation_enabled", [True, False])
+    @pytest.mark.parametrize("custom_canvas_user_id", ["100", 100])
     def test_it_sets_the_canvas_submission_params(
         self,
         pyramid_request,
         js_config,
         submission_params,
+        context,
+        custom_canvas_user_id,
         submit_on_annotation_enabled,
     ):
         if submit_on_annotation_enabled:
             pyramid_request.feature.side_effect = (
                 lambda feature: feature == "submit_on_annotation"
             )
+        context.lti_params["custom_canvas_user_id"] = custom_canvas_user_id
 
         js_config.add_document_url("canvas://file/course_id/COURSE_ID/file_id/FILE_ID")
 
@@ -190,7 +194,7 @@ class TestAddDocumentURL:
                 "h_username": pyramid_request.lti_user.h_user.username,
                 "lis_outcome_service_url": "example_lis_outcome_service_url",
                 "lis_result_sourcedid": "example_lis_result_sourcedid",
-                "learner_canvas_user_id": "test_user_id",
+                "learner_canvas_user_id": "100",
                 "resource_link_id": pyramid_request.params["resource_link_id"],
                 "ext_lti_assignment_id": pyramid_request.params[
                     "ext_lti_assignment_id"
@@ -215,18 +219,18 @@ class TestAddDocumentURL:
         assert "speedGrader" not in js_config.asdict()["canvas"]
 
     def test_it_doesnt_set_the_speedGrader_settings_if_theres_no_lis_result_sourcedid(
-        self, js_config, pyramid_request
+        self, js_config, context
     ):
-        del pyramid_request.params["lis_result_sourcedid"]
+        del context.lti_params["lis_result_sourcedid"]
 
         js_config.add_document_url("canvas://file/course_id/COURSE_ID/file_id/FILE_ID")
 
         assert "speedGrader" not in js_config.asdict()["canvas"]
 
     def test_it_doesnt_set_the_speedGrader_settings_if_theres_no_lis_outcome_service_url(
-        self, js_config, pyramid_request
+        self, js_config, context
     ):
-        del pyramid_request.params["lis_outcome_service_url"]
+        del context.lti_params["lis_outcome_service_url"]
 
         js_config.add_document_url("canvas://file/course_id/COURSE_ID/file_id/FILE_ID")
 

--- a/tests/unit/lms/services/lti_grading/_v11_test.py
+++ b/tests/unit/lms/services/lti_grading/_v11_test.py
@@ -70,13 +70,6 @@ class TestLTI11GradingService:
             "replaceResultRequest": {"my_dict": "1"}
         }
 
-    @pytest.mark.parametrize("hook_result", [None, [], "foo"])
-    def test_record_result_requires_dict_result(self, svc, hook_result):
-        with pytest.raises(TypeError):
-            svc.record_result(
-                sentinel.grading_id, pre_record_hook=lambda *args, **kwargs: hook_result
-            )
-
     @pytest.mark.usefixtures("with_response")
     def test_methods_make_valid_post_requests(
         self, svc_method, http_service, oauth1_service


### PR DESCRIPTION
Canvas grading extensions for LTI1.3. 

Very similar to the LTI1.1 just on the JSON body instead of the XML one.

## Testing

Instructions mostly copied from https://github.com/hypothesis/lms/pull/3956.

Note that `submit_on_annotation` is not really necessary for this but it makes the testing much simpler IMO.


---


- Ensure that the `submit_on_annotation` feature flag is enabled on http://localhost:8001/flags
or start the server with `export FEATURE_FLAG_SUBMIT_ON_ANNOTATION=true`
- Launch a grade-able assignment as a student

LTI1.1 https://hypothesis.instructure.com/courses/125/assignments/2956
LTI1.3 https://hypothesis.instructure.com/courses/319/assignments/2988


- Add an annotation



- Log in as an instructor (incognito window / different browser) and launch the same assignment; go into Speed Grader
- You should  see a recent submission from the student who created the annotation.

