### PR TITLE
Remove vitalsource_anon_launch feature flag

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -71,19 +71,9 @@ class JSConfig:
             }
         elif document_url.startswith("vitalsource://"):
             vitalsource_svc = self._request.find_service(name="vitalsource")
-            if self._request.feature("vitalsource_anon_launch"):
-                self._config["vitalSource"] = {
-                    "launchUrl": vitalsource_svc.get_launch_url(document_url)
-                }
-
-            else:
-                launch_url, launch_params = vitalsource_svc.get_launch_params(
-                    document_url, self._request.lti_user
-                )
-                self._config["vitalSource"] = {
-                    "launchUrl": launch_url,
-                    "launchParams": launch_params,
-                }
+            self._config["vitalSource"] = {
+                "launchUrl": vitalsource_svc.get_launch_url(document_url)
+            }
         elif jstor_service.enabled and document_url.startswith("jstor://"):
             self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)
         else:

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -131,31 +131,7 @@ class TestAddDocumentURL:
             "path": "/api/blackboard/courses/test_course_id/via_url?document_url=blackboard%3A%2F%2Fcontent-resource%2Fxyz123",
         }
 
-    def test_vitalsource_sets_config_with_launch_params(
-        self, js_config, vitalsource_service, pyramid_request
-    ):
-        vitalsource_url = "vitalsource://book/bookID/book-id/cfi//abc"
-        vitalsource_service.get_launch_params.return_value = (
-            sentinel.launch_url,
-            sentinel.launch_params,
-        )
-
-        js_config.add_document_url(vitalsource_url)
-
-        vitalsource_service.get_launch_params.assert_called_with(
-            vitalsource_url, pyramid_request.lti_user
-        )
-        assert js_config.asdict()["vitalSource"] == {
-            "launchUrl": sentinel.launch_url,
-            "launchParams": sentinel.launch_params,
-        }
-
-    def test_vitalsource_sets_config_with_anon_launch(
-        self, js_config, vitalsource_service, pyramid_request
-    ):
-        pyramid_request.feature.side_effect = (
-            lambda feature: feature == "vitalsource_anon_launch"
-        )
+    def test_vitalsource_sets_config(self, js_config, vitalsource_service):
         vitalsource_url = "vitalsource://book/bookID/book-id/cfi//abc"
 
         js_config.add_document_url(vitalsource_url)


### PR DESCRIPTION
Enable anonymous (non LTI-authenticated) launches of VitalSource
assignments by default, and remove the feature flag that was needed to
enable it before.

The code that supports LTI-authenticated launches still exists and will
be removed in a follow-up.

Fixes https://github.com/hypothesis/private-issues/issues/102