### PR TITLE
Prefer lti_params over raw params for blackboard APIs

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -57,7 +57,7 @@ class JSConfig:
                 "authUrl": self._request.route_url("blackboard_api.oauth.authorize"),
                 "path": self._request.route_path(
                     "blackboard_api.files.via_url",
-                    course_id=self._request.params["context_id"],
+                    course_id=self._context.lti_params["context_id"],
                     _query={"document_url": document_url},
                 ),
             }
@@ -524,19 +524,19 @@ class JSConfig:
             "path": req.route_path("blackboard_api.sync"),
             "data": {
                 "lms": {
-                    "tool_consumer_instance_guid": req.params[
+                    "tool_consumer_instance_guid": self._context.lti_params[
                         "tool_consumer_instance_guid"
                     ],
                 },
                 "course": {
-                    "context_id": req.params["context_id"],
+                    "context_id": self._context.lti_params["context_id"],
                 },
                 "assignment": {
-                    "resource_link_id": req.params["resource_link_id"],
+                    "resource_link_id": self._context.lti_params["resource_link_id"],
                 },
                 "group_info": {
                     key: value
-                    for key, value in req.params.items()
+                    for key, value in self._context.lti_params.items()
                     if key in GroupInfo.columns()
                 },
             },

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -11,7 +11,7 @@ class FilePickerConfig:
         groups_enabled = context.blackboard_groups_enabled
 
         auth_url = request.route_url("blackboard_api.oauth.authorize")
-        course_id = request.params.get("context_id")
+        course_id = context.lti_params.get("context_id")
 
         config = {
             "enabled": files_enabled,

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -27,7 +27,7 @@ class TestFilePickerConfig:
         groups_enabled,
     ):
 
-        pyramid_request.params["context_id"] = "COURSE_ID"
+        context.lti_params["context_id"] = "COURSE_ID"
         blackboard_application_instance.settings.set(
             "blackboard", "files_enabled", files_enabled
         )


### PR DESCRIPTION
Just some `params` -> `lti_params` replacements.


# Testing

- `loophole http 8001 --hostname blackboard-jon` (This is needed until a better workflow comes of #3916)

- https://github.com/hypothesis/devdata/pull/56 review and self-server merge

- `make devdata`

- Login into blackboard as `blackboardteacher` https://aunltd-test.blackboard.com/?new_loc=%2Fultra%2Fstream

- Create a new assignment (Build Content -> Hypothesis LTI1.3) use both canvas files and groups.

- Launch the assignment.