### PR TITLE
Migration for renaming `module_item_configurations` to `assignment`

### DIFF
--- a/lms/migrations/versions/bdfe1c72813f_rename_module_item_configurations_to_assignment.py
+++ b/lms/migrations/versions/bdfe1c72813f_rename_module_item_configurations_to_assignment.py
@@ -1,0 +1,71 @@
+"""
+Rename module_item_configurations to assignment.
+
+Revision ID: bdfe1c72813f
+Revises: 911d1f7da759
+Create Date: 2022-05-26 14:45:34.578511
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bdfe1c72813f"
+down_revision = "911d1f7da759"
+
+
+ITEMS = (
+    ("INDEX", "pk__module_item_configurations", "pk__assignment"),
+    (
+        "INDEX",
+        "uq__module_item_configurations__resource_link_id",
+        "uq__assignment__resource_link_id",
+    ),
+    (
+        "INDEX",
+        "uq__module_item_configurations__tool_consumer_instance_guid",
+        "uq__assignment__tool_consumer_instance_guid",
+    ),
+    ("SEQUENCE", "module_item_configurations_id_seq", "assignment_id_seq"),
+)
+
+
+def upgrade():
+    # I don't think you can rename constraints, so we have to drop and recreate
+    # them. When removing constraints we must use the full generated name
+    op.drop_constraint(
+        "ck__module_item_configurations__nullable_resource_link__081b",
+        "module_item_configurations",
+    )
+    op.rename_table("module_item_configurations", "assignment")
+
+    # Re-create the constraint after the table renaming to get the correct auto
+    # generated name
+    op.create_check_constraint(
+        "nullable_resource_link_id_ext_lti_assignment_id",
+        table_name="assignment",
+        condition="NOT(resource_link_id IS NULL AND ext_lti_assignment_id IS NULL)",
+    )
+
+    for item_type, old_name, new_name in ITEMS:
+        op.execute(f"ALTER {item_type} {old_name} RENAME TO {new_name}")
+
+    op.execute("CREATE VIEW module_item_configurations AS (SELECT * FROM assignment)")
+
+
+def downgrade():
+    op.execute("DROP VIEW module_item_configurations")
+
+    op.drop_constraint(
+        "ck__assignment__nullable_resource_link_id_ext_lti_assignment_id", "assignment"
+    )
+    op.rename_table("assignment", "module_item_configurations")
+
+    for item_type, old_name, new_name in ITEMS:
+        op.execute(f"ALTER {item_type} {new_name} RENAME TO {old_name}")
+
+    op.create_check_constraint(
+        "nullable_resource_link_id_ext_lti_assignment_id",
+        table_name="module_item_configurations",
+        condition="NOT(resource_link_id IS NULL AND ext_lti_assignment_id IS NULL)",
+    )


### PR DESCRIPTION
For: 

 * https://github.com/hypothesis/lms/issues/3990

## Testing notes

I'm sure there's a better way, but this certainly forces it to happen:

### Start with a clean slate:
```shell
git checkout master
make services args=down
make services
make db

git checkout rename-assignments-table
```

### Upgrading

 * In `make sql` - `\d+ module_item_configurations` you should see:
```sql
           Column            |       Type        | Collation | Nullable |                        Default                         | Storage  | Stats target | Description 
-----------------------------+-------------------+-----------+----------+--------------------------------------------------------+----------+--------------+-------------
 id                          | integer           |           | not null | nextval('module_item_configurations_id_seq'::regclass) | plain    |              | 
 ext_lti_assignment_id       | text              |           |          |                                                        | extended |              | 
 resource_link_id            | character varying |           |          |                                                        | extended |              | 
 tool_consumer_instance_guid | character varying |           | not null |                                                        | extended |              | 
 document_url                | character varying |           | not null |                                                        | extended |              | 
 extra                       | jsonb             |           | not null | '{}'::jsonb                                            | extended |              | 
Indexes:
    "pk__module_item_configurations" PRIMARY KEY, btree (id)
    "uq__module_item_configurations__resource_link_id" UNIQUE CONSTRAINT, btree (resource_link_id, tool_consumer_instance_guid)
    "uq__module_item_configurations__tool_consumer_instance_guid" UNIQUE CONSTRAINT, btree (tool_consumer_instance_guid, ext_lti_assignment_id)
Check constraints:
    "ck__module_item_configurations__nullable_resource_link__081b" CHECK (NOT (resource_link_id IS NULL AND ext_lti_assignment_id IS NULL))

```
 * `hdev alembic upgrade head`
 * In `make sql` - `\d+ assignment` you should see:
```sql
           Column            |       Type        | Collation | Nullable |                Default                 | Storage  | Stats target | Description 
-----------------------------+-------------------+-----------+----------+----------------------------------------+----------+--------------+-------------
 id                          | integer           |           | not null | nextval('assignment_id_seq'::regclass) | plain    |              | 
 ext_lti_assignment_id       | text              |           |          |                                        | extended |              | 
 resource_link_id            | character varying |           |          |                                        | extended |              | 
 tool_consumer_instance_guid | character varying |           | not null |                                        | extended |              | 
 document_url                | character varying |           | not null |                                        | extended |              | 
 extra                       | jsonb             |           | not null | '{}'::jsonb                            | extended |              | 
Indexes:
    "pk__assignment" PRIMARY KEY, btree (id)
    "uq__assignment__resource_link_id" UNIQUE CONSTRAINT, btree (resource_link_id, tool_consumer_instance_guid)
    "uq__assignment__tool_consumer_instance_guid" UNIQUE CONSTRAINT, btree (tool_consumer_instance_guid, ext_lti_assignment_id)
Check constraints:
    "ck__assignment__nullable_resource_link_id_ext_lti_assignment_id" CHECK (NOT (resource_link_id IS NULL AND ext_lti_assignment_id IS NULL))
```
 * Note that all the check, sequences etc are all assignment named
 * In `make sql` - `\d+ module_item_configuration`:
```sql
          Column            |       Type        | Collation | Nullable | Default | Storage  | Description 
-----------------------------+-------------------+-----------+----------+---------+----------+-------------
 id                          | integer           |           |          |         | plain    | 
 ext_lti_assignment_id       | text              |           |          |         | extended | 
 resource_link_id            | character varying |           |          |         | extended | 
 tool_consumer_instance_guid | character varying |           |          |         | extended | 
 document_url                | character varying |           |          |         | extended | 
 extra                       | jsonb             |           |          |         | extended | 
View definition:
 SELECT assignment.id,
    assignment.ext_lti_assignment_id,
    assignment.resource_link_id,
    assignment.tool_consumer_instance_guid,
    assignment.document_url,
    assignment.extra
   FROM assignment;
```
 * `make sure` 
    * **NOTE:** This _isn't_ the same as running CI, which will create the DB from the SQLAlchemy code (and so not be a view)
    * For as long as this is deployed and the code isn't changed, the tests aren't 100% accurate

### Downgrading

 * `hdev alembic downgrade -1`
 *  In `make sql` - `\d+ module_item_configuration` you should get the same as before
 * The view should be gone