### PR TITLE
Removed unused view to handle canvas assignment launches

### DIFF
--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -109,7 +109,7 @@ class BasicLTILaunchViews:
         return self.basic_lti_launch(document_url=document_url, grading_supported=True)
 
     @view_config(canvas_file=True)
-    def legacy_canvas_file_basic_lti_launch(self):
+    def canvas_file_basic_lti_launch(self):
         """
         Respond to a Canvas file assignment launch which is not db_configured.
 
@@ -119,9 +119,6 @@ class BasicLTILaunchViews:
         for the file from the Canvas API. We then pass that download URL to
         Via. We have to re-do this file-ID-for-download-URL exchange on every
         single launch because Canvas's download URLs are temporary.
-
-        Note that this only apply to assignments configured but not yet launched
-        after canvas assignments are also DB configured see: js_config._create_assignment_api
         """
         course_id = self.context.lti_params["custom_canvas_course_id"]
         file_id = self.request.params["file_id"]
@@ -160,54 +157,6 @@ class BasicLTILaunchViews:
             self.context.resource_link_id,
         ).document_url
         return self.basic_lti_launch(document_url)
-
-    @view_config(
-        db_configured=True,
-        canvas_file=False,
-        request_param="ext_lti_assignment_id",
-        url_configured=False,
-    )
-    def canvas_db_configured_basic_lti_launch(self):
-        """Respond to a Canvas DB-configured assignment launch."""
-        resource_link_id = self.context.resource_link_id
-        ext_lti_assignment_id = self.context.ext_lti_assignment_id
-
-        assignments = self.assignment_service.get_for_canvas_launch(
-            self.context.lti_params["tool_consumer_instance_guid"],
-            resource_link_id,
-            ext_lti_assignment_id,
-        )
-
-        if len(assignments) == 2:
-            # We found two assignments: one with the matching resource_link_id and no ext_lti_assignment_id
-            # and one with the matching ext_lti_assignment_id and no resource_link_id.
-            #
-            # This happens because legacy code used to store Canvas assignments in the DB with a
-            # resource_link_id and no ext_lti_assignment_id, see https://github.com/hypothesis/lms/pull/2780
-            #
-            # Whereas current code stores Canvas assignments during content-item-selection with an
-            # ext_lti_assignment_id and no resource_link_id.
-            #
-            # We need to merge the two assignments into one.
-            old_assignment, new_assignment = assignments
-
-            assert not old_assignment.ext_lti_assignment_id
-            assert not new_assignment.resource_link_id
-
-            assignment = self.assignment_service.merge_canvas_assignments(
-                old_assignment, new_assignment
-            )
-        else:
-            assignment = assignments[0]
-
-        if not assignment.resource_link_id:
-            # We found an assignment with an ext_lti_assignment_id but no resource_link_id.
-            # This happens the first time a new Canvas assignment is launched: the assignment got created
-            # during content-item-selection with an ext_lti_assignment_id but no resource_link_id,
-            # and then the first time the assignment is launched we add the resource_link_id.
-            assignment.resource_link_id = resource_link_id
-
-        return self.basic_lti_launch(assignment.document_url)
 
     @view_config(blackboard_copied=True)
     def blackboard_copied_basic_lti_launch(self):

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-def legacy_canvas_file_basic_lti_launch_caller(context, pyramid_request):
+def canvas_file_basic_lti_launch_caller(context, pyramid_request):
     """
     Call BasicLTILaunchViews.legacy_canvas_file_basic_lti_launch().
 
@@ -36,28 +36,7 @@ def legacy_canvas_file_basic_lti_launch_caller(context, pyramid_request):
 
     views = BasicLTILaunchViews(context, pyramid_request)
 
-    return views.legacy_canvas_file_basic_lti_launch()
-
-
-def canvas_db_configured_basic_lti_launch_caller(context, pyramid_request):
-    """
-    Call BasicLTILaunchViews.db_configured_basic_lti_launch().
-
-    Set up the appropriate conditions and then call
-    BasicLTILaunchViews.canvas_db_configured_basic_lti_launch(), and return whatever
-    BasicLTILaunchViews.canvas_db_configured_basic_lti_launch() returns.
-    """
-    # The custom_canvas_course_id param is always present when
-    # canvas_file_basic_lti_launch() is called: Canvas always includes this
-    # param because we request it in our config.xml.
-    pyramid_request.params["custom_canvas_course_id"] = "TEST_COURSE_ID"
-    # The ext_lti_assignment_id param is always present for canvas launches.
-    # The `request_param="ext_lti_assignment_id"` on the view ensures this.
-    pyramid_request.params["ext_lti_assignment_id"] = "TEXT_EXT_LTI_ASSIGNMENT_ID"
-
-    views = BasicLTILaunchViews(context, pyramid_request)
-
-    return views.canvas_db_configured_basic_lti_launch()
+    return views.canvas_file_basic_lti_launch()
 
 
 def db_configured_basic_lti_launch_caller(context, pyramid_request):
@@ -237,7 +216,7 @@ class TestCommon:
 
     @pytest.fixture(
         params=[
-            legacy_canvas_file_basic_lti_launch_caller,
+            canvas_file_basic_lti_launch_caller,
             db_configured_basic_lti_launch_caller,
             blackboard_copied_basic_lti_launch_caller,
             brightspace_copied_basic_lti_launch_caller,
@@ -267,7 +246,7 @@ class TestCourseRecording:
 
     @pytest.fixture(
         params=[
-            legacy_canvas_file_basic_lti_launch_caller,
+            canvas_file_basic_lti_launch_caller,
             db_configured_basic_lti_launch_caller,
             blackboard_copied_basic_lti_launch_caller,
             brightspace_copied_basic_lti_launch_caller,
@@ -290,7 +269,7 @@ class TestCourseRecording:
 @pytest.mark.usefixtures("is_canvas")
 class TestCanvasFileBasicLTILaunch:
     def test_it(self, context, pyramid_request, assignment_service):
-        legacy_canvas_file_basic_lti_launch_caller(context, pyramid_request)
+        canvas_file_basic_lti_launch_caller(context, pyramid_request)
 
         course_id = context.lti_params["custom_canvas_course_id"]
         file_id = pyramid_request.params["file_id"]
@@ -301,31 +280,6 @@ class TestCanvasFileBasicLTILaunch:
                 "tool_consumer_instance_guid"
             ],
             resource_link_id=pyramid_request.params["resource_link_id"],
-        )
-
-
-@pytest.mark.usefixtures("is_canvas")
-class TestCanvasDBConfiguredBasicLTILaunch:
-    def test_it_sets_resource_id(self, context, pyramid_request, assignment_service):
-        assignment = factories.Assignment(resource_link_id=None)
-        assignment_service.get_for_canvas_launch.return_value = [assignment]
-
-        canvas_db_configured_basic_lti_launch_caller(context, pyramid_request)
-
-        assert assignment.resource_link_id == pyramid_request.params["resource_link_id"]
-
-    def test_it_merges_duplicates(self, context, pyramid_request, assignment_service):
-        old_assignment = factories.Assignment(ext_lti_assignment_id=None)
-        new_assignment = factories.Assignment(resource_link_id=None)
-        assignment_service.get_for_canvas_launch.return_value = [
-            old_assignment,
-            new_assignment,
-        ]
-
-        canvas_db_configured_basic_lti_launch_caller(context, pyramid_request)
-
-        assignment_service.merge_canvas_assignments.assert_called_once_with(
-            old_assignment, new_assignment
         )
 
 


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/3990


This view was part of an effort to store all canvas assignments on the
DB. Due to some bugs/particularities of Canvas that effort failed but the
code dealing with it was never deleted.


The view is not used as `url_configured=False` (the launch URL contains a `url` parameter) and `db_configured` (there's a record of the assignment on our DB) are never true at the same-time; We continue to include the `url` parameter in canvas and we don't store the assignments (other than Canvas files ones, which are excluded by `canvas_file=False`)