### PR TITLE
Remove `h_group` property from the context

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -488,7 +488,7 @@ class JSConfig:
     def _groups(self):
         if self._context.canvas_sections_enabled or self._context.is_group_launch:
             return "$rpc:requestGroups"
-        return [self._context.h_group.groupid(self._authority)]
+        return [self._context.get_or_create_course().groupid(self._authority)]
 
     def _canvas_sync_api(self):
         req = self._request

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -40,28 +40,6 @@ class LTILaunchResource:
         )
 
     @property
-    def h_group(self):
-        """
-        Return the h group for the current request.
-
-        The group's name is generated from the LTI course's title and is
-        usually a valid Hypothesis group name.  For example if the course's
-        title is too long for a Hypothesis group name it'll be truncated. But
-        this doesn't currently handle course titles that are *too short* to be
-        Hypothesis group names (shorter than 3 chars) - in that case if you try
-        to create a Hypothesis group using the generated name you'll get back
-        an unsuccessful response from the Hypothesis API.
-
-        The group's groupid and authority_provided_id are each deterministic
-        and unique to the LTI course. Calling this function again with params
-        representing the same LTI course will always return the same
-        groupid and authority_provided_id. Calling this function with
-        different params will always return a different groupid and
-        authority_provided_id.
-        """
-        return self.get_or_create_course()
-
-    @property
     def _is_speedgrader(self):
         return bool(self._request.GET.get("learner_canvas_user_id"))
 

--- a/lms/views/basic_lti_launch.py
+++ b/lms/views/basic_lti_launch.py
@@ -52,7 +52,6 @@ class BasicLTILaunchViews:
         """Do a basic LTI launch with the given document_url."""
         self.sync_lti_data_to_h()
         self.store_lti_data()
-        self.context.get_or_create_course()
 
         if grading_supported:
             self.context.js_config.maybe_enable_grading()
@@ -70,7 +69,7 @@ class BasicLTILaunchViews:
         """
 
         self.request.find_service(name="lti_h").sync(
-            [self.context.h_group], self.request.params
+            [self.context.get_or_create_course()], self.request.params
         )
 
     def store_lti_data(self):

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -65,9 +65,9 @@ def deep_linking_launch(context, request):
     ).get_current()
     application_instance.update_lms_data(context.lti_params)
 
-    context.get_or_create_course()
-
-    request.find_service(name="lti_h").sync([context.h_group], request.params)
+    request.find_service(name="lti_h").sync(
+        [context.get_or_create_course()], request.params
+    )
 
     context.js_config.enable_file_picker_mode(
         form_action=request.parsed_params["content_item_return_url"],

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -94,7 +94,9 @@ class TestEnableLTILaunchMode:
                         "authority": "TEST_AUTHORITY",
                         "enableShareLinks": False,
                         "grantToken": grant_token_service.generate_token.return_value,
-                        "groups": [context.h_group.groupid.return_value],
+                        "groups": [
+                            context.get_or_create_course.return_value.groupid.return_value
+                        ],
                     }
                 ]
             },
@@ -517,7 +519,9 @@ class TestJSConfigHypothesisClient:
                 "authority": "TEST_AUTHORITY",
                 "enableShareLinks": False,
                 "grantToken": grant_token_service.generate_token.return_value,
-                "groups": [context.h_group.groupid.return_value],
+                "groups": [
+                    context.get_or_create_course.return_value.groupid.return_value
+                ],
             }
         ]
 
@@ -722,11 +726,10 @@ def submission_params(config):
 
 @pytest.fixture
 def context(pyramid_request):
-    return create_autospec(
+    context = create_autospec(
         LTILaunchResource,
         spec_set=True,
         instance=True,
-        h_group=create_autospec(Grouping, instance=True, spec_set=True),
         is_canvas=True,
         canvas_sections_enabled=False,
         canvas_groups_enabled=False,
@@ -734,6 +737,12 @@ def context(pyramid_request):
         is_group_launch=False,
         lti_params=LTIParams(pyramid_request.params),
     )
+
+    context.get_or_create_course.return_value = create_autospec(
+        Grouping, instance=True, spec_set=True
+    )
+
+    return context
 
 
 @pytest.fixture

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -6,20 +6,10 @@ from pytest import param
 from lms.models import ApplicationSettings
 from lms.resources import LTILaunchResource
 from lms.services import ApplicationInstanceNotFound
-from tests import factories
 
 pytestmark = pytest.mark.usefixtures(
-    "application_instance_service", "course_service", "assignment_service"
+    "application_instance_service", "assignment_service"
 )
-
-
-class TestHGroup:
-    @pytest.mark.usefixtures("has_course")
-    def test_it(self, lti_launch, course_service):
-        course = factories.Course()
-        course_service.upsert_course.return_value = course
-
-        assert lti_launch.h_group == course
 
 
 class TestResourceLinkIdk:

--- a/tests/unit/lms/views/basic_lti_launch_test.py
+++ b/tests/unit/lms/views/basic_lti_launch_test.py
@@ -237,7 +237,7 @@ class TestCommon:
 
 
 class TestCourseRecording:
-    def test_it_records_the_course_in_the_DB(
+    def test_it_records_the_course_in_the_db(
         self, context, pyramid_request, view_caller
     ):
         view_caller(context, pyramid_request)

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -26,7 +26,7 @@ class TestDeepLinkingLaunch:
         )
         context.get_or_create_course.assert_called_once_with()
         lti_h_service.sync.assert_called_once_with(
-            [context.h_group], pyramid_request.params
+            [context.get_or_create_course.return_value], pyramid_request.params
         )
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="TEST_CONTENT_ITEM_RETURN_URL",


### PR DESCRIPTION
For: 

 * https://github.com/hypothesis/lms/issues/3990

This was just calling get or create course. This has also pointed out that we were clearly calling it more than once in lots of places.