### PR TITLE
Rename `get_or_create_course()` to `course` as a property

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -488,7 +488,7 @@ class JSConfig:
     def _groups(self):
         if self._context.canvas_sections_enabled or self._context.is_group_launch:
             return "$rpc:requestGroups"
-        return [self._context.get_or_create_course().groupid(self._authority)]
+        return [self._context.course.groupid(self._authority)]
 
     def _canvas_sync_api(self):
         req = self._request

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -1,6 +1,7 @@
 """Traversal resources for LTI launch views."""
-import functools
+
 import logging
+from functools import cached_property
 
 from lms.models import LTIParams
 from lms.resources._js_config import JSConfig
@@ -30,7 +31,8 @@ class LTILaunchResource:
         )
         self._assignment_service = request.find_service(name="assignment")
 
-    def get_or_create_course(self):
+    @cached_property
+    def course(self):
         """Get the course this LTI launch based on the request's params."""
 
         return self._request.find_service(name="course").upsert_course(
@@ -101,8 +103,7 @@ class LTILaunchResource:
 
         return False
 
-    @property
-    @functools.lru_cache()
+    @cached_property
     def js_config(self):
         return JSConfig(self, self._request)
 
@@ -144,9 +145,7 @@ class LTILaunchResource:
         if not self.canvas_sections_supported():
             return False
 
-        course = self.get_or_create_course()
-
-        return course.settings.get("canvas", "sections_enabled")
+        return self.course.settings.get("canvas", "sections_enabled")
 
     @property
     def canvas_groups_enabled(self):

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -297,9 +297,7 @@ class BasicLaunchViews:
 
         # Before any LTI assignments launch, create or update the Hypothesis
         # user and group corresponding to the LTI user and course.
-        request.find_service(name="lti_h").sync(
-            [self.context.get_or_create_course()], request.params
-        )
+        request.find_service(name="lti_h").sync([self.context.course], request.params)
 
         # Report all LTI assignment launches to the /reports page.
         LtiLaunches.add(

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -65,9 +65,7 @@ def deep_linking_launch(context, request):
     ).get_current()
     application_instance.update_lms_data(context.lti_params)
 
-    request.find_service(name="lti_h").sync(
-        [context.get_or_create_course()], request.params
-    )
+    request.find_service(name="lti_h").sync([context.course], request.params)
 
     context.js_config.enable_file_picker_mode(
         form_action=request.parsed_params["content_item_return_url"],

--- a/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
@@ -5,6 +5,7 @@ import pytest
 from lms.resources._js_config import JSConfig
 
 
+@pytest.mark.usefixtures("intercept_http_calls_to_h")
 class TestValidTeacherPayloads:
     """
     Following the known "bad" payload launches are valid Teacher payloads.

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -94,9 +94,7 @@ class TestEnableLTILaunchMode:
                         "authority": "TEST_AUTHORITY",
                         "enableShareLinks": False,
                         "grantToken": grant_token_service.generate_token.return_value,
-                        "groups": [
-                            context.get_or_create_course.return_value.groupid.return_value
-                        ],
+                        "groups": [context.course.groupid.return_value],
                     }
                 ]
             },
@@ -519,9 +517,7 @@ class TestJSConfigHypothesisClient:
                 "authority": "TEST_AUTHORITY",
                 "enableShareLinks": False,
                 "grantToken": grant_token_service.generate_token.return_value,
-                "groups": [
-                    context.get_or_create_course.return_value.groupid.return_value
-                ],
+                "groups": [context.course.groupid.return_value],
             }
         ]
 
@@ -726,7 +722,7 @@ def submission_params(config):
 
 @pytest.fixture
 def context(pyramid_request):
-    context = create_autospec(
+    return create_autospec(
         LTILaunchResource,
         spec_set=True,
         instance=True,
@@ -734,15 +730,10 @@ def context(pyramid_request):
         canvas_sections_enabled=False,
         canvas_groups_enabled=False,
         canvas_is_group_launch=False,
+        course=create_autospec(Grouping, instance=True, spec_set=True),
         is_group_launch=False,
         lti_params=LTIParams(pyramid_request.params),
     )
-
-    context.get_or_create_course.return_value = create_autospec(
-        Grouping, instance=True, spec_set=True
-    )
-
-    return context
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -236,13 +236,22 @@ class TestCommon:
         return request.param
 
 
-class TestCourseRecording:
-    def test_it_records_the_course_in_the_db(
-        self, context, pyramid_request, view_caller
+class TestDataRecording:
+    def test_it_calls__store_lti_data(
+        self,
+        context,
+        pyramid_request,
+        view_caller,
+        lti_h_service,
     ):
         view_caller(context, pyramid_request)
 
-        context.get_or_create_course.assert_called_once_with()
+        lti_h_service.sync.assert_called_once_with(
+            [context.course], pyramid_request.params
+        )
+
+        # There's lots more in the _store_lti_data() that we aren't testing
+        # because... answer pending
 
     @pytest.fixture(
         params=[

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -24,9 +24,8 @@ class TestDeepLinkingLaunch:
         application_instance_service.get_current.return_value.update_lms_data.assert_called_once_with(
             context.lti_params
         )
-        context.get_or_create_course.assert_called_once_with()
         lti_h_service.sync.assert_called_once_with(
-            [context.get_or_create_course.return_value], pyramid_request.params
+            [context.course], pyramid_request.params
         )
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="TEST_CONTENT_ITEM_RETURN_URL",


### PR DESCRIPTION
For: 

 * https://github.com/hypothesis/lms/issues/3990

This PR involves two changes:

 * Calling the sync data methods from `unconfigured_launch()`
 * Rename the method and make it a property

The change to calling data sync means we will be capturing launches when teachers are configuring records, which they would not have been before.