### PR TITLE
Make the `GroupInfoService` grouping centric

### DIFF
--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -1,8 +1,6 @@
 """A service for managing `GroupInfo` records."""
 
-from lms.models import ApplicationInstance, GroupInfo, Grouping
-
-__all__ = ["GroupInfoService"]
+from lms.models import GroupInfo, Grouping
 
 
 class GroupInfoService:
@@ -19,17 +17,11 @@ class GroupInfoService:
         "blackboard_group": "blackboard_group_group",
     }
 
-    def upsert_group_info(
-        self,
-        grouping: Grouping,
-        application_instance: ApplicationInstance,
-        params: dict,
-    ):
+    def upsert_group_info(self, grouping: Grouping, params: dict):
         """
         Upsert a row into the `group_info` DB table.
 
         :param grouping: grouping to upsert based on
-        :param application_instance: ApplicationInstance this group belongs to
         :param params: columns to set on the row ("authority_provided_id",
             "id", "info" and any non-matching items will be ignored)
         """
@@ -42,12 +34,11 @@ class GroupInfoService:
         if not group_info:
             group_info = GroupInfo(
                 authority_provided_id=grouping.authority_provided_id,
-                application_instance=application_instance,
+                application_instance=grouping.application_instance,
             )
             self._db.add(group_info)
 
         group_info.type = self._GROUPING_TYPES[grouping.type]
-        group_info.application_instance_id = application_instance.id
         group_info.update_from_dict(
             params, skip_keys={"authority_provided_id", "id", "info"}
         )

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -38,6 +38,12 @@ class GroupInfoService:
             )
             self._db.add(group_info)
 
+        # This is very strange. The DB layout is wrong here. You can "steal" a
+        # group info row from another application instance by updating it with
+        # a grouping from another AI. This is wrong in because grouping to
+        # AI should be many:many, and we reflect that wrongness here.
+        group_info.application_instance = grouping.application_instance
+
         group_info.type = self._GROUPING_TYPES[grouping.type]
         group_info.update_from_dict(
             params, skip_keys={"authority_provided_id", "id", "info"}

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -6,14 +6,7 @@ __all__ = ["GroupInfoService"]
 
 
 class GroupInfoService:
-    """
-    A service that upserts :class:`~lms.models.GroupInfo` records.
-
-    Usage::
-
-        group_info = request.find_service(name="group_info")
-        group_info.upsert(h_group, application_instance, request.params)
-    """
+    """A service that upserts :class:`~lms.models.GroupInfo` records."""
 
     GROUPING_TYPES = {
         "course": "course_group",
@@ -26,7 +19,7 @@ class GroupInfoService:
         self._db = request.db
         self._lti_user = request.lti_user
 
-    def upsert(self, h_group, application_instance, params: dict):
+    def upsert_group_info(self, h_group, application_instance, params: dict):
         """
         Upsert a row into the `group_info` DB table.
 

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -49,9 +49,7 @@ class LTIHService:
         # Keep a note of the groups locally for reporting purposes.
         for h_group in h_groups:
             self._group_info_service.upsert_group_info(
-                grouping=h_group,
-                application_instance=application_instance,
-                params=group_info_params,
+                grouping=h_group, params=group_info_params
             )
 
     def _yield_commands(self, h_groups):

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -49,7 +49,7 @@ class LTIHService:
         # Keep a note of the groups locally for reporting purposes.
         for h_group in h_groups:
             self._group_info_service.upsert_group_info(
-                h_group=h_group,
+                grouping=h_group,
                 application_instance=application_instance,
                 params=group_info_params,
             )

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -48,7 +48,7 @@ class LTIHService:
 
         # Keep a note of the groups locally for reporting purposes.
         for h_group in h_groups:
-            self._group_info_service.upsert(
+            self._group_info_service.upsert_group_info(
                 h_group=h_group,
                 application_instance=application_instance,
                 params=group_info_params,

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -86,14 +86,12 @@ class TestSync:
 
 class TestGroupInfoUpdating:
     def test_sync_upserts_the_GroupInfo_into_the_db(
-        self, group_info_service, lti_h_svc, grouping, application_instance_service
+        self, group_info_service, lti_h_svc, grouping
     ):
         lti_h_svc.sync([grouping], sentinel.params)
 
         group_info_service.upsert_group_info.assert_called_once_with(
-            grouping=grouping,
-            application_instance=application_instance_service.get_current.return_value,
-            params=sentinel.params,
+            grouping=grouping, params=sentinel.params
         )
 
     @pytest.fixture

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -91,7 +91,7 @@ class TestGroupInfoUpdating:
         lti_h_svc.sync([grouping], sentinel.params)
 
         group_info_service.upsert_group_info.assert_called_once_with(
-            h_group=grouping,
+            grouping=grouping,
             application_instance=application_instance_service.get_current.return_value,
             params=sentinel.params,
         )

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -90,7 +90,7 @@ class TestGroupInfoUpdating:
     ):
         lti_h_svc.sync([grouping], sentinel.params)
 
-        group_info_service.upsert.assert_called_once_with(
+        group_info_service.upsert_group_info.assert_called_once_with(
             h_group=grouping,
             application_instance=application_instance_service.get_current.return_value,
             params=sentinel.params,


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3990

Some time ago we move from `HGroup` domain model objects to `Grouping` DB model objects, but never updated the code. 

This makes it clear that we are using grouping objects and also makes use of the embedded link to application instance instead of requiring it be passed in.