### PR TITLE
Refactor the `AssignmentService` tests to use fixtures

### DIFF
--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -1,141 +1,89 @@
 from unittest.mock import sentinel
 
 import pytest
+from h_matchers import Any
 
-from lms.models import Assignment
 from lms.services.assignment import AssignmentService, factory
 from tests import factories
 
-MATCHING_TOOL_CONSUMER_INSTANCE_GUID = "matching_tool_consumer_instance_guid"
-MATCHING_RESOURCE_LINK_ID = "matching_resource_link_id"
 
+class TestAssignmentService:
+    def test_get(self, svc, assignment, matching_params):
+        assert svc.get(**matching_params) == assignment
 
-class TestGet:
-    def test_it(self, svc):
-        matching_assignment = factories.Assignment(
-            tool_consumer_instance_guid=MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            resource_link_id=MATCHING_RESOURCE_LINK_ID,
+    def test_get_without_match(self, svc, non_matching_params):
+        assert svc.get(**non_matching_params) is None
+
+    @pytest.mark.usefixtures("assignment")
+    def test_exists(self, svc, matching_params):
+        assert svc.exists(**matching_params)
+
+    def test_exists_without_match(self, svc, non_matching_params):
+        assert not svc.exists(**non_matching_params)
+
+    def test_upsert_with_existing(self, svc, db_session, assignment, matching_params):
+        updated_attrs = {"document_url": "new_document_url", "extra": {"new": "values"}}
+
+        result = svc.upsert(**matching_params, **updated_attrs)
+
+        assert result == assignment
+        db_session.flush()
+        db_session.refresh(assignment)
+        assert assignment == Any.object.with_attrs(updated_attrs)
+
+    def test_upsert_with_new(self, svc, db_session, assignment, non_matching_params):
+        non_matching_params.update(
+            {"document_url": "new_document_url", "extra": {"new": "values"}}
         )
 
-        returned_assignment = svc.get(
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            MATCHING_RESOURCE_LINK_ID,
-        )
+        result = svc.upsert(**non_matching_params)
 
-        assert returned_assignment == matching_assignment
-
-    def test_no_matching_assignment(self, svc):
-        returned_assignment = svc.get(
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            MATCHING_RESOURCE_LINK_ID,
-        )
-
-        assert returned_assignment is None
-
-    def test_assignment_has_different_tool_consumer_instance_guid(self, svc):
-        factories.Assignment(
-            tool_consumer_instance_guid="different",
-            resource_link_id=MATCHING_RESOURCE_LINK_ID,
-        )
-
-        returned_assignment = svc.get(
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID, MATCHING_RESOURCE_LINK_ID
-        )
-
-        assert returned_assignment is None
-
-
-class TestExists:
-    def test_existing(self, svc):
-        factories.Assignment(
-            tool_consumer_instance_guid=MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            resource_link_id=MATCHING_RESOURCE_LINK_ID,
-        )
-
-        result = svc.exists(
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID, MATCHING_RESOURCE_LINK_ID
-        )
-
-        assert result is True
-
-    def test_non_existing(self, svc):
-        result = svc.exists(
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID, MATCHING_RESOURCE_LINK_ID
-        )
-
-        assert not result
-
-
-class TestUpsertDocumentURL:
-    def test_if_theres_no_matching_assignment_it_creates_one(
-        self, svc, assert_document_url
-    ):
-        svc.upsert(
-            "new_document_url",
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            MATCHING_RESOURCE_LINK_ID,
-        )
-
-        assert_document_url(
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            MATCHING_RESOURCE_LINK_ID,
-            "new_document_url",
-        )
-
-    def test_if_theres_a_matching_assignment_it_updates_it(
-        self, svc, assert_document_url
-    ):
-        factories.Assignment(
-            tool_consumer_instance_guid=MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            resource_link_id=MATCHING_RESOURCE_LINK_ID,
-            document_url="old_document_url",
-        )
-
-        svc.upsert(
-            "new_document_url",
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            MATCHING_RESOURCE_LINK_ID,
-        )
-
-        assert_document_url(
-            MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-            MATCHING_RESOURCE_LINK_ID,
-            "new_document_url",
-        )
+        assert result != assignment
+        db_session.flush()
+        db_session.refresh(result)
+        assert result == Any.object.with_attrs(non_matching_params)
 
     @pytest.fixture
-    def assert_document_url(self, db_session):
-        def _assert_document_url(guid, resource_link_id, document_url):
-            assert (
-                db_session.query(Assignment)
-                .filter_by(
-                    tool_consumer_instance_guid=guid, resource_link_id=resource_link_id
-                )
-                .one()
-            ).document_url == document_url
+    def svc(self, db_session):
+        return AssignmentService(db_session)
 
-        return _assert_document_url
+    @pytest.fixture(autouse=True)
+    def assignment(self):
+        return factories.Assignment()
+
+    @pytest.fixture
+    def matching_params(self, assignment):
+        return {
+            "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
+            "resource_link_id": assignment.resource_link_id,
+        }
+
+    @pytest.fixture(params=["tool_consumer_instance_guid", "resource_link_id"])
+    def non_matching_params(self, request, matching_params):
+        non_matching_params = dict(matching_params)
+        non_matching_params[request.param] = "NOT_MATCHING"
+
+        return non_matching_params
+
+    @pytest.fixture(autouse=True)
+    def with_assignment_noise(self, assignment):
+        factories.Assignment(
+            tool_consumer_instance_guid=assignment.tool_consumer_instance_guid,
+            resource_link_id="noise_resource_link_id",
+        )
+        factories.Assignment(
+            tool_consumer_instance_guid="noise_tool_consumer_instance_guid",
+            resource_link_id=assignment.resource_link_id,
+        )
 
 
 class TestFactory:
-    def test_it(self, pyramid_request):
-        assignment_service = factory(sentinel.context, pyramid_request)
+    def test_it(self, pyramid_request, AssignmentService):
+        svc = factory(sentinel.context, pyramid_request)
 
-        assert isinstance(assignment_service, AssignmentService)
+        AssignmentService.assert_called_once_with(db=pyramid_request.db)
+        assert svc == AssignmentService.return_value
 
-
-@pytest.fixture(autouse=True)
-def noise():
-    factories.Assignment(
-        tool_consumer_instance_guid=MATCHING_TOOL_CONSUMER_INSTANCE_GUID,
-        resource_link_id="noise_resource_link_id",
-    )
-    factories.Assignment(
-        tool_consumer_instance_guid="noise_tool_consumer_instance_guid",
-        resource_link_id=MATCHING_RESOURCE_LINK_ID,
-    )
-
-
-@pytest.fixture
-def svc(db_session):
-    return AssignmentService(db_session)
+    @pytest.fixture
+    def AssignmentService(self, patch):
+        return patch("lms.services.assignment.AssignmentService")


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3990
 
Use a more involved fixturing setup to simplify the tests. This also removes a strange backwardness in the tests where two constants "MATCHING_*" seemed to be used in many places where we didn't want a match.

It's a bit more explicit now.

### Review notes

You probably want to side by side the two versions yourself. The diff isn't helpful as I completely rewrote it.