### PR TITLE
Rename the assignment service methods to have `assignment` in them

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -162,7 +162,7 @@ class LTILaunchResource:
         tool_consumer_instance_guid = self._request.parsed_params[
             "tool_consumer_instance_guid"
         ]
-        assignment = self._assignment_service.get(
+        assignment = self._assignment_service.get_assignment(
             tool_consumer_instance_guid, self.resource_link_id
         )
         return bool(assignment and assignment.extra.get("group_set_id"))

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -9,8 +9,8 @@ class AssignmentService:
     def __init__(self, db):
         self._db = db
 
-    def get(self, tool_consumer_instance_guid, resource_link_id):
-        """Get an assignment using by resource_link_id."""
+    def get_assignment(self, tool_consumer_instance_guid, resource_link_id):
+        """Get an assignment by resource_link_id."""
 
         return (
             self._db.query(Assignment)
@@ -22,10 +22,10 @@ class AssignmentService:
         )
 
     @lru_cache(maxsize=128)
-    def exists(self, tool_consumer_instance_guid, resource_link_id) -> bool:
-        return bool(self.get(tool_consumer_instance_guid, resource_link_id))
+    def assignment_exists(self, tool_consumer_instance_guid, resource_link_id) -> bool:
+        return bool(self.get_assignment(tool_consumer_instance_guid, resource_link_id))
 
-    def upsert(
+    def upsert_assignment(
         self, document_url, tool_consumer_instance_guid, resource_link_id, extra=None
     ):
         """
@@ -37,7 +37,7 @@ class AssignmentService:
 
         Any existing document_url for this assignment will be overwritten.
         """
-        assignment = self.get(tool_consumer_instance_guid, resource_link_id)
+        assignment = self.get_assignment(tool_consumer_instance_guid, resource_link_id)
         if not assignment:
             assignment = Assignment(
                 tool_consumer_instance_guid=tool_consumer_instance_guid,

--- a/lms/views/api/blackboard/sync.py
+++ b/lms/views/api/blackboard/sync.py
@@ -97,7 +97,7 @@ class Sync:
     def group_set(self):
         return (
             self.request.find_service(name="assignment")
-            .get(
+            .get_assignment(
                 self.tool_consumer_instance_guid,
                 self.request.parsed_params["assignment"]["resource_link_id"],
             )

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -42,7 +42,7 @@ class FilesAPIViews:
             name="application_instance"
         ).get_current()
 
-        assignment = self.request.find_service(name="assignment").get(
+        assignment = self.request.find_service(name="assignment").get_assignment(
             application_instance.tool_consumer_instance_guid,
             self.request.matchdict["resource_link_id"],
         )

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -77,7 +77,7 @@ class BasicLaunchViews:
 
         document_url = self.request.parsed_params["document_url"]
 
-        self.assignment_service.upsert(
+        self.assignment_service.upsert_assignment(
             document_url,
             self.context.lti_params["tool_consumer_instance_guid"],
             self.context.resource_link_id,
@@ -108,7 +108,7 @@ class BasicLaunchViews:
         # The ``db_configured=True`` view predicate ensures that this view
         # won't be called if there isn't a matching document_url in the DB. So
         # here we can safely assume that the document_url exists.
-        document_url = self.assignment_service.get(
+        document_url = self.assignment_service.get_assignment(
             self.context.lti_params["tool_consumer_instance_guid"],
             self.context.resource_link_id,
         ).document_url
@@ -234,7 +234,7 @@ class BasicLaunchViews:
         # module item configuration. As a result of this we can rely on this
         # being around in future code.
         document_url = f"canvas://file/course/{course_id}/file_id/{file_id}"
-        self.assignment_service.upsert(
+        self.assignment_service.upsert_assignment(
             document_url=document_url,
             tool_consumer_instance_guid=self.context.lti_params[
                 "tool_consumer_instance_guid"
@@ -273,9 +273,11 @@ class BasicLaunchViews:
             assignment that this assignment was copied from
         """
         guid = self.context.lti_params["tool_consumer_instance_guid"]
-        assignment = self.assignment_service.get(guid, original_resource_link_id)
+        assignment = self.assignment_service.get_assignment(
+            guid, original_resource_link_id
+        )
 
-        self.assignment_service.upsert(
+        self.assignment_service.upsert_assignment(
             assignment.document_url, guid, self.context.resource_link_id
         )
 

--- a/lms/views/predicates/_lti_launch.py
+++ b/lms/views/predicates/_lti_launch.py
@@ -31,14 +31,9 @@ class DBConfigured(Base):
     name = "db_configured"
 
     def __call__(self, context, request):
-        assignment_svc = request.find_service(name="assignment")
-        tool_consumer_instance_guid = context.lti_params.get(
-            "tool_consumer_instance_guid"
-        )
-
         return (
-            assignment_svc.exists(
-                tool_consumer_instance_guid,
+            request.find_service(name="assignment").assignment_exists(
+                context.lti_params.get("tool_consumer_instance_guid"),
                 context.resource_link_id,
             )
             == self.value
@@ -111,8 +106,9 @@ class _CourseCopied(Base, ABC):
             else:
                 # Look for the document URL of the previous assignment that
                 # this one was copied from.
-                assignment_service = request.find_service(name="assignment")
-                is_newly_copied = assignment_service.exists(
+                is_newly_copied = request.find_service(
+                    name="assignment"
+                ).assignment_exists(
                     tool_consumer_instance_guid, original_resource_link_id
                 )
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -317,19 +317,19 @@ class TestIsBlackboardGroupLaunch:
     def test_false_when_no_assignment(
         self, lti_launch_groups_enabled, assignment_service
     ):
-        assignment_service.get.return_value = None
+        assignment_service.get_assignment.return_value = None
 
         assert not lti_launch_groups_enabled.is_blackboard_group_launch
 
     def test_false_when_no_group_set(
         self, lti_launch_groups_enabled, assignment_service
     ):
-        assignment_service.get.return_value.extra = {}
+        assignment_service.get_assignment.return_value.extra = {}
 
         assert not lti_launch_groups_enabled.is_blackboard_group_launch
 
     def test_it(self, lti_launch_groups_enabled, assignment_service):
-        assignment_service.get.return_value.extra = {"group_set_id": "ID"}
+        assignment_service.get_assignment.return_value.extra = {"group_set_id": "ID"}
 
         assert lti_launch_groups_enabled.is_blackboard_group_launch
 

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -8,35 +8,39 @@ from tests import factories
 
 
 class TestAssignmentService:
-    def test_get(self, svc, assignment, matching_params):
-        assert svc.get(**matching_params) == assignment
+    def test_get_assignment(self, svc, assignment, matching_params):
+        assert svc.get_assignment(**matching_params) == assignment
 
-    def test_get_without_match(self, svc, non_matching_params):
-        assert svc.get(**non_matching_params) is None
+    def test_get_assignment_without_match(self, svc, non_matching_params):
+        assert svc.get_assignment(**non_matching_params) is None
 
     @pytest.mark.usefixtures("assignment")
-    def test_exists(self, svc, matching_params):
-        assert svc.exists(**matching_params)
+    def test_assignment_exists(self, svc, matching_params):
+        assert svc.assignment_exists(**matching_params)
 
-    def test_exists_without_match(self, svc, non_matching_params):
-        assert not svc.exists(**non_matching_params)
+    def test_assignment_exists_without_match(self, svc, non_matching_params):
+        assert not svc.assignment_exists(**non_matching_params)
 
-    def test_upsert_with_existing(self, svc, db_session, assignment, matching_params):
+    def test_upsert_assignment_with_existing(
+        self, svc, db_session, assignment, matching_params
+    ):
         updated_attrs = {"document_url": "new_document_url", "extra": {"new": "values"}}
 
-        result = svc.upsert(**matching_params, **updated_attrs)
+        result = svc.upsert_assignment(**matching_params, **updated_attrs)
 
         assert result == assignment
         db_session.flush()
         db_session.refresh(assignment)
         assert assignment == Any.object.with_attrs(updated_attrs)
 
-    def test_upsert_with_new(self, svc, db_session, assignment, non_matching_params):
+    def test_upsert_assignment_with_new(
+        self, svc, db_session, assignment, non_matching_params
+    ):
         non_matching_params.update(
             {"document_url": "new_document_url", "extra": {"new": "values"}}
         )
 
-        result = svc.upsert(**non_matching_params)
+        result = svc.upsert_assignment(**non_matching_params)
 
         assert result != assignment
         db_session.flush()

--- a/tests/unit/lms/views/api/blackboard/sync_test.py
+++ b/tests/unit/lms/views/api/blackboard/sync_test.py
@@ -116,7 +116,9 @@ def test_it_when_grading(
         course_service.get_by_context_id.return_value,
         "GRADING_STUDENT_ID",
         type_=Grouping.Type.BLACKBOARD_GROUP,
-        group_set_id=assignment_service.get.return_value.extra["group_set_id"],
+        group_set_id=assignment_service.get_assignment.return_value.extra[
+            "group_set_id"
+        ],
     )
     assert result == [
         group.groupid()
@@ -174,7 +176,9 @@ def request_json():
 
 @pytest.fixture(autouse=True)
 def assignment_service(assignment_service):
-    assignment_service.get.return_value.extra = {"group_set_id": "GROUP_SET_ID"}
+    assignment_service.get_assignment.return_value.extra = {
+        "group_set_id": "GROUP_SET_ID"
+    }
     return assignment_service
 
 

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -26,14 +26,14 @@ class TestFilesAPIViews:
     ):
         document_url = "canvas://file/course/COURSE_ID/file_id/FILE_ID"
         application_instance = application_instance_service.get_current.return_value
-        assignment = assignment_service.get.return_value
+        assignment = assignment_service.get_assignment.return_value
         assignment.document_url = document_url
         pyramid_request.matchdict = {
             "resource_link_id": "test_resource_link_id",
         }
         result = FilesAPIViews(pyramid_request).via_url()
 
-        assignment_service.get.assert_called_once_with(
+        assignment_service.get_assignment.assert_called_once_with(
             application_instance.tool_consumer_instance_guid,
             "test_resource_link_id",
         )

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -60,7 +60,7 @@ class TestBasicLaunchViews:
 
         svc.configure_assignment()
 
-        assignment_service.upsert.assert_called_once_with(
+        assignment_service.upsert_assignment.assert_called_once_with(
             pyramid_request.parsed_params["document_url"],
             pyramid_request.parsed_params["tool_consumer_instance_guid"],
             pyramid_request.parsed_params["resource_link_id"],
@@ -81,12 +81,12 @@ class TestBasicLaunchViews:
     def test_db_configured_launch(self, svc, assignment_service, context, _do_launch):
         svc.db_configured_launch()
 
-        assignment_service.get.assert_called_once_with(
+        assignment_service.get_assignment.assert_called_once_with(
             context.lti_params["tool_consumer_instance_guid"], context.resource_link_id
         )
 
         _do_launch.assert_called_once_with(
-            document_url=assignment_service.get.return_value.document_url
+            document_url=assignment_service.get_assignment.return_value.document_url
         )
 
     def test_url_configured_launch(self, svc, pyramid_request, _do_launch):
@@ -173,7 +173,7 @@ class TestBasicLaunchViews:
         file_id = pyramid_request.params["file_id"]
         document_url = f"canvas://file/course/{course_id}/file_id/{file_id}"
 
-        assignment_service.upsert.assert_called_once_with(
+        assignment_service.upsert_assignment.assert_called_once_with(
             document_url=document_url,
             tool_consumer_instance_guid=pyramid_request.params[
                 "tool_consumer_instance_guid"
@@ -209,19 +209,19 @@ class TestBasicLaunchViews:
         # pylint: disable=protected-access
         svc._course_copied_launch(sentinel.original_resource_link_id)
 
-        assignment_service.get.assert_called_once_with(
+        assignment_service.get_assignment.assert_called_once_with(
             pyramid_request.params["tool_consumer_instance_guid"],
             sentinel.original_resource_link_id,
         )
 
-        assignment_service.upsert.assert_called_once_with(
-            assignment_service.get.return_value.document_url,
+        assignment_service.upsert_assignment.assert_called_once_with(
+            assignment_service.get_assignment.return_value.document_url,
             context.lti_params["tool_consumer_instance_guid"],
             context.lti_params["resource_link_id"],
         )
 
         _do_launch.assert_called_once_with(
-            document_url=assignment_service.get.return_value.document_url
+            document_url=assignment_service.get_assignment.return_value.document_url
         )
 
     @pytest.mark.parametrize("grading_supported", (True, False))

--- a/tests/unit/lms/views/predicates/_lti_launch_test.py
+++ b/tests/unit/lms/views/predicates/_lti_launch_test.py
@@ -24,7 +24,7 @@ class TestDBConfigured:
     def test_when_theres_a_matching_assignment_config_in_the_db(
         self, pyramid_request, assignment_service, value, expected, context
     ):
-        assignment_service.exists.return_value = True
+        assignment_service.assignment_exists.return_value = True
 
         predicate = DBConfigured(value, mock.sentinel.config)
 
@@ -36,7 +36,7 @@ class TestDBConfigured:
     def test_when_theres_no_matching_assignment_config_in_the_db(
         self, assignment_service, pyramid_request, value, expected, context
     ):
-        assignment_service.exists.return_value = False
+        assignment_service.assignment_exists.return_value = False
 
         predicate = DBConfigured(value, mock.sentinel.config)
 
@@ -71,7 +71,7 @@ class TestFooCopied:
 
             return False
 
-        assignment_service.exists.side_effect = exists
+        assignment_service.assignment_exists.side_effect = exists
 
         # If there's no Assignment for resource_link_id in the DB
         # but there *is* a Assignment for resource_link_id_history
@@ -119,7 +119,7 @@ class TestCanvasFile:
     def test_when_assignment_is_not_canvas_file(
         self, value, expected, pyramid_request, assignment_service, context
     ):
-        assignment_service.exists.return_value = expected
+        assignment_service.assignment_exists.return_value = expected
 
         predicate = CanvasFile(value, mock.sentinel.config)
 
@@ -158,7 +158,7 @@ class TestURLConfigured:
     def test_when_assignment_is_not_url_configured(
         self, value, expected, context, pyramid_request, assignment_service
     ):
-        assignment_service.exists.return_value = expected
+        assignment_service.assignment_exists.return_value = expected
 
         predicate = URLConfigured(value, mock.sentinel.config)
 
@@ -188,7 +188,7 @@ class TestConfigured:
     def test_when_assignment_is_db_configured(
         self, pyramid_request, assignment_service, value, expected, context
     ):
-        assignment_service.exists.return_value = True
+        assignment_service.assignment_exists.return_value = True
 
         predicate = Configured(value, mock.sentinel.config)
 
@@ -207,7 +207,7 @@ class TestConfigured:
     def test_when_assignment_is_unconfigured(
         self, assignment_service, pyramid_request, value, expected, context
     ):
-        assignment_service.exists.return_value = False
+        assignment_service.assignment_exists.return_value = False
 
         predicate = Configured(value, mock.sentinel.config)
 
@@ -225,7 +225,7 @@ class TestConfigured:
     def assignment_service(self, assignment_service):
         # Make sure that the assignment is *not* DB-configured by default in
         # these tests.
-        assignment_service.exists.return_value = False
+        assignment_service.assignment_exists.return_value = False
         return assignment_service
 
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3990

This is to make it easier to find where they are used and to be sure when refactoring that we've got everything.

It's a bit ugly, but overall more maintainable I think. Which is a tradeoff probably worth making.