### PR TITLE
Support API call cancelation via AbortSignal

### DIFF
--- a/lms/static/scripts/frontend_apps/services/vitalsource.js
+++ b/lms/static/scripts/frontend_apps/services/vitalsource.js
@@ -3,7 +3,7 @@
  * @typedef {import('../api-types').Chapter} Chapter
  */
 
-import { apiCall } from '../utils/api';
+import { apiCall, urlPath } from '../utils/api';
 
 /**
  * Service for fetching information about available VitalSoure books and the
@@ -28,7 +28,7 @@ export class VitalSourceService {
     // Path parameter encoding is currently handled by the `apiCall` caller,
     // but this should be done by `apiCall` in future.
     return apiCall({
-      path: `/api/vitalsource/books/${encodeURIComponent(bookID)}`,
+      path: urlPath`/api/vitalsource/books/${bookID}`,
       authToken: this._authToken,
     });
   }
@@ -42,7 +42,7 @@ export class VitalSourceService {
    */
   async fetchChapters(bookID) {
     return apiCall({
-      path: `/api/vitalsource/books/${encodeURIComponent(bookID)}/toc`,
+      path: urlPath`/api/vitalsource/books/${bookID}/toc`,
       authToken: this._authToken,
     });
   }

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -42,7 +42,8 @@ const activeRefreshCalls = new Map();
  *
  * @param {object} options
  *   @param {string} options.authToken - Session authorization token
- *   @param {string} options.path - The `/api/...` path of the endpoint to call
+ *   @param {string} options.path - The `/api/...` path of the endpoint to call.
+ *     If this path contains parameters, use {@link urlPath} to generate this.
  *   @param {boolean} [options.allowRefresh] - If the request fails due to
  *     an expired access token for an external API, this flag specifies whether
  *     to attempt to refresh the token.
@@ -129,4 +130,24 @@ export async function apiCall(options) {
   }
 
   return resultJSON;
+}
+
+/**
+ * Template tag that formats a URL path, ensuring interpolated strings are
+ * percent-encoded.
+ *
+ * @example
+ *   // Assume `widgetId` is "foo/bar"
+ *   urlPath`/api/widgets/${widgetId}` => `/api/widgets/foo%2Fbar`
+ *
+ * @param {TemplateStringsArray} strings
+ * @param {string[]} params
+ */
+export function urlPath(strings, ...params) {
+  let result = '';
+  for (const [i, param] of params.entries()) {
+    result += strings[i];
+    result += encodeURIComponent(param);
+  }
+  return result + strings[strings.length - 1];
 }

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -133,8 +133,8 @@ export async function apiCall(options) {
 }
 
 /**
- * Template tag that formats a URL path, ensuring interpolated strings are
- * percent-encoded.
+ * Template tag function that formats a URL path, ensuring interpolated strings
+ * are percent-encoded.
  *
  * @example
  *   // Assume `widgetId` is "foo/bar"

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -49,6 +49,7 @@ const activeRefreshCalls = new Map();
  *   @param {object} [options.data] - JSON-serializable body of the request
  *   @param {string} [options.method] - Custom HTTP method for call. Defaults
  *     to GET, or POST if `data` is set.
+ *   @param {AbortSignal} [options.signal]
  *   @param {Record<string, string>} [options.params] - Query parameters
  * @return {Promise<any>} - Parsed JSON response. TODO: Convert this to `Promise<unknown>`
  */
@@ -62,6 +63,7 @@ export async function apiCall(options) {
     data,
     method,
     params,
+    signal,
   } = options;
 
   let body;
@@ -90,6 +92,7 @@ export async function apiCall(options) {
     method: method ?? defaultMethod,
     body,
     headers,
+    signal,
   });
   const resultJSON = await result.json();
 
@@ -108,6 +111,7 @@ export async function apiCall(options) {
           method,
           path,
           allowRefresh: false,
+          signal,
         });
         activeRefreshCalls.set(path, refreshDone);
         try {

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -292,7 +292,7 @@ describe('api', () => {
     assert.deepEqual(secondCallResult, await fakeResponse.json());
   });
 
-  it('aborts if fetch is canceled', async () => {
+  it('passes abort signal to fetch', async () => {
     const controller = new AbortController();
     window.fetch.rejects(new DOMException('Request canceled', 'AbortError'));
 
@@ -309,7 +309,7 @@ describe('api', () => {
     );
 
     // Simulate request being canceled, as `fetch` would do if we called
-    // `controller.abort()`.
+    // `controller.abort()`, and check that the AbortError is re-thrown.
     let error;
     try {
       await result;

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -1,5 +1,5 @@
 import { APIError } from '../../errors';
-import { apiCall } from '../api';
+import { apiCall, urlPath } from '../api';
 
 function createResponse(status, body) {
   return {
@@ -319,5 +319,25 @@ describe('api', () => {
 
     assert.instanceOf(error, Error);
     assert.equal(error.name, 'AbortError');
+  });
+});
+
+describe('urlPath', () => {
+  it('escapes path parameters', () => {
+    const thingId = 'abc/123:456%789';
+    const encodedThingId = encodeURIComponent(thingId);
+    const subThingId = '<foo>';
+    const encodedSubThingId = encodeURIComponent(subThingId);
+
+    const path = urlPath`/api/things/${thingId}/sub-things/${subThingId}`;
+
+    assert.equal(
+      path,
+      `/api/things/${encodedThingId}/sub-things/${encodedSubThingId}`
+    );
+  });
+
+  it('returns path with no parameters unchanged', () => {
+    assert.equal(urlPath`/api/foo/bar`, '/api/foo/bar');
   });
 });


### PR DESCRIPTION
This PR adds some general functionality for LMS frontend -> backend API calls which will be used by the JSTOR picker.

1. A `signal` argument to `apiCall`, which can be used to pass an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to fetch, to enable later cancelation of the request
2. A `urlPath` helper for safely generating API URL Paths that include parameters