### PR TITLE
Add article metadata and thumbnail to JSTOR picker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -10,7 +10,28 @@ import {
 import classnames from 'classnames';
 import { useRef, useState } from 'preact/hooks';
 
-import { toJSTORUrl } from '../utils/jstor';
+import { formatErrorMessage } from '../errors';
+import { urlPath, useAPIFetch } from '../utils/api';
+import { articleIdFromURL, jstorURLFromArticleId } from '../utils/jstor';
+
+/**
+ * @template T
+ * @typedef {import('../utils/fetch').FetchResult<T>} FetchResult
+ */
+
+/**
+ * Response for an `/api/jstor/articles/{article_id}` call.
+ *
+ * @typedef Metadata
+ * @prop {string} title
+ */
+
+/**
+ * Response for an `/api/jstor/articles/{article_id}/thumbnail` call.
+ *
+ * @typedef Thumbnail
+ * @prop {string} image
+ */
 
 /**
  * @typedef JSTORPickerProps
@@ -26,24 +47,46 @@ import { toJSTORUrl } from '../utils/jstor';
  */
 export default function JSTORPicker({ onCancel, onSelectURL }) {
   const [error, setError] = useState(/** @type {string|null} */ (null));
-  const [selectedURL, setSelectedURL] = useState(
-    /** @type {string|null} */ (null)
+
+  // Selected JSTOR article ID or DOI, updated when the user confirms what
+  // they have pasted/typed into the input field.
+  const [articleId, setArticleId] = useState(/** @type {string|null} */ (null));
+
+  /** @type {FetchResult<Metadata>} */
+  const metadata = useAPIFetch(
+    articleId ? urlPath`/api/jstor/articles/${articleId}` : null
   );
 
+  /** @type {FetchResult<Thumbnail>} */
+  const thumbnail = useAPIFetch(
+    articleId ? urlPath`/api/jstor/articles/${articleId}/thumbnail` : null
+  );
+
+  let renderedError;
+  if (error) {
+    renderedError = error;
+  } else if (metadata.error) {
+    renderedError = formatErrorMessage(
+      metadata.error,
+      'Unable to fetch article details'
+    );
+  }
+
   const inputRef = /** @type {{ current: HTMLInputElement }} */ (useRef());
-  // The last value of the URL-entry text input
+  // The last confirmed value of the URL-entry text input
   const previousURL = useRef(/** @type {string|null} */ (null));
 
+  const canConfirmSelection = articleId && metadata.data !== null;
   const confirmSelection = () => {
-    if (selectedURL) {
-      onSelectURL(selectedURL);
+    if (canConfirmSelection) {
+      onSelectURL(jstorURLFromArticleId(articleId));
     }
   };
 
   /**
    * @param {boolean} [confirmSelectedUrl=false]
    */
-  const onUpdateURL = (confirmSelectedUrl = false) => {
+  const onURLChange = (confirmSelectedUrl = false) => {
     const url = inputRef?.current?.value;
     if (url && url === previousURL.current) {
       if (confirmSelectedUrl) {
@@ -53,21 +96,21 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
     }
 
     previousURL.current = url;
-    setSelectedURL(null);
+    setArticleId(null);
 
     if (!url) {
       // If the field is empty, there's nothing to do
       return;
     }
 
-    const jstorUrl = toJSTORUrl(url);
-
-    if (jstorUrl) {
-      setError(null);
-      setSelectedURL(jstorUrl);
-    } else {
+    const articleId = articleIdFromURL(url);
+    if (!articleId) {
       setError("That doesn't look like a JSTOR article link");
+      return;
     }
+
+    setError(null);
+    setArticleId(articleId);
   };
 
   /**
@@ -77,11 +120,13 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
    */
   const onKeyDown = event => {
     if (event.key === 'Enter') {
-      onUpdateURL(true /* confirmSelectedUrl */);
       event.preventDefault();
       event.stopPropagation();
+      onURLChange(true /* confirmSelection */);
     }
   };
+
+  const isLoading = thumbnail.isLoading || metadata.isLoading;
 
   return (
     <Modal
@@ -92,7 +137,7 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
       buttons={[
         <LabeledButton
           data-testid="select-button"
-          disabled={!selectedURL}
+          disabled={!canConfirmSelection}
           key="submit"
           onClick={confirmSelection}
           variant="primary"
@@ -102,7 +147,11 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
       ]}
     >
       <div className="flex flex-row space-x-3">
-        <Thumbnail classes="w-32 h-40" />
+        <Thumbnail classes="w-32 h-40" isLoading={isLoading}>
+          {thumbnail.data && (
+            <img alt="article thumbnail" src={thumbnail.data.image} />
+          )}
+        </Thumbnail>
         <div className="space-y-2 grow">
           <p>Paste a link to the JSTOR article you&apos;d like to use:</p>
 
@@ -110,35 +159,36 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
             <TextInput
               inputRef={inputRef}
               name="jstorURL"
-              onChange={() => onUpdateURL(false /* confirmSelectedUrl */)}
+              onChange={() => onURLChange()}
+              onInput={() => setArticleId(null)}
               onKeyDown={onKeyDown}
               placeholder="e.g. https://www.jstor.org/stable/1234"
             />
             <IconButton
               icon="arrowRight"
-              onClick={() => onUpdateURL(false /* confirmSelectedUrl */)}
+              onClick={() => onURLChange()}
               variant="dark"
               title="Find article"
             />
           </TextInputWithButton>
 
-          {selectedURL && (
+          {metadata.data && (
             <div
               className="flex flex-row items-center space-x-2"
               data-testid="selected-book"
             >
               <Icon name="check" classes="text-green-success" />
-              <div className="grow font-bold italic">JSTOR article</div>
+              <div className="grow font-bold italic">{metadata.data.title}</div>
             </div>
           )}
 
-          {error && (
+          {renderedError && (
             <div
               className="flex flex-row items-center space-x-2 text-red-error"
               data-testid="error-message"
             >
               <Icon name="cancel" />
-              <div className="grow">{error}</div>
+              <div className="grow">{renderedError}</div>
             </div>
           )}
         </div>

--- a/lms/static/scripts/frontend_apps/utils/jstor.js
+++ b/lms/static/scripts/frontend_apps/utils/jstor.js
@@ -1,16 +1,15 @@
 /**
- * Transform a provided URL to a via-recognizable identifier pointing
- * to a JSTOR article.
+ * Extract the JSTOR article ID from a URL.
  *
- * Accepts URLS of the form:
+ * Accepts URLs of the form:
  * - http[s]://www.jstor.org/stable/<articleID> OR
  * - http[s]://www.jstor.org/stable/<doiPrefix>/<doiSuffix>
  *
  * (Query string is ignored on provided URLs)
  *
  * and returns, respectively:
- * - jstor://<articleID> OR
- * - jstor://<doiPrefix>/<doiSuffix>
+ * - <articleID> OR
+ * - <doiPrefix>/<doiSuffix>
  *
  * Return `null` if provided string is not a URL or does not match one of the
  * accepted formats.
@@ -18,7 +17,7 @@
  * @param {string} url
  * @returns {string|null}
  */
-export function toJSTORUrl(url) {
+export function articleIdFromURL(url) {
   let testURL;
 
   try {
@@ -36,14 +35,14 @@ export function toJSTORUrl(url) {
       case 1:
         // Supplied URL is of the format
         // http[s]://www.jstor.org/stable/<articleID>
-        return `jstor://${pathSegments[0]}`;
+        return pathSegments[0];
       case 2:
         // Supplied URL is of the format
         // http[s]://www.jstor.org/stable/<doiPrefix>/<doiSuffix>
         // Ensure <doiPrefix> starts with `10.` and contains only digits or
         // periods
         if (pathSegments[0].match(/10\.[\d.]*$/)) {
-          return `jstor://${pathSegments[0]}/${pathSegments[1]}`;
+          return `${pathSegments[0]}/${pathSegments[1]}`;
         }
         break;
       default:
@@ -52,4 +51,11 @@ export function toJSTORUrl(url) {
   }
 
   return null;
+}
+
+/**
+ * @param {string} articleId
+ */
+export function jstorURLFromArticleId(articleId) {
+  return `jstor://${articleId}`;
 }

--- a/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
@@ -1,23 +1,23 @@
-import { toJSTORUrl } from '../jstor';
+import { articleIdFromURL } from '../jstor';
 
 describe('utils/jstor', () => {
-  describe('toJSTORUrl', () => {
+  describe('articleIdFromURL', () => {
     [
       // GOOD URLS
       // URL with article ID
-      ['https://www.jstor.org/stable/1234', 'jstor://1234'],
+      ['https://www.jstor.org/stable/1234', '1234'],
       // Querystring ignored
-      ['https://www.jstor.org/stable/1234?q=bananas&bar=baz', 'jstor://1234'],
+      ['https://www.jstor.org/stable/1234?q=bananas&bar=baz', '1234'],
       // Trailing slash(es) ignored
-      ['https://www.jstor.org/stable/1234/', 'jstor://1234'],
-      ['https://www.jstor.org/stable/1234//', 'jstor://1234'],
+      ['https://www.jstor.org/stable/1234/', '1234'],
+      ['https://www.jstor.org/stable/1234//', '1234'],
       // http protocol OK
-      ['http://www.jstor.org/stable/1234', 'jstor://1234'],
+      ['http://www.jstor.org/stable/1234', '1234'],
       // DOI Prefx and DOI suffix
-      ['https://www.jstor.org/stable/10.1086/508573', 'jstor://10.1086/508573'],
+      ['https://www.jstor.org/stable/10.1086/508573', '10.1086/508573'],
       [
         'https://www.jstor.org/stable/10.1086.3333.9/508573',
-        'jstor://10.1086.3333.9/508573',
+        '10.1086.3333.9/508573',
       ],
 
       // BAD URLS
@@ -33,7 +33,9 @@ describe('utils/jstor', () => {
       // Too many path segments
       ['https://www.jstor.org/stable/10.1086/508573/34434', null],
     ].forEach(([input, expected]) => {
-      assert.equal(toJSTORUrl(input), expected);
+      it('returns expected ID', () => {
+        assert.equal(articleIdFromURL(input), expected);
+      });
     });
   });
 });


### PR DESCRIPTION
**Depends on ~~https://github.com/hypothesis/lms/pull/4025~~, ~~https://github.com/hypothesis/lms/pull/4027~~, https://github.com/hypothesis/lms/pull/4028, ~~https://github.com/hypothesis/lms/pull/4039~~**

This PR adds article metadata and thumbnails to the JSTOR article picker form:

<img width="834" alt="JSTOR assignment picker" src="https://user-images.githubusercontent.com/2458/171664600-5e02a1a5-72fb-4410-a44e-07c558d92f77.png">

The thumbnail we currently display is of the article itself. There is ongoing discussion [here](https://hypothes-is.slack.com/archives/C07NXBDNW/p1654182208320269) of whether we want to use something else (eg. the issue/book cover) instead, as that may look better.

The current implementation does not check whether the user has access to the content, the plan is to add that in future we'd show some appropriate indication.

The content of this dialog overlaps somewhat with the form used for picking VitalSource books. It isn't completely clear what a useful abstraction might be that could be used for both (eg. would it be just the layout or also some of the interaction/data fetching logic?) so that has been left for subsequent work.