### PR TITLE
Add useFetch hook to make managing API fetches in components easier

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/fetch.js
+++ b/lms/static/scripts/frontend_apps/utils/fetch.js
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+/**
+ * @template T
+ * @typedef FetchResult
+ * @prop {T|null} data
+ * @prop {Error|null} error
+ * @prop {boolean} isLoading
+ */
+
+/**
+ * Function that fetches the data.
+ *
+ * `signal` should be passed to the underlying data fetcher (eg. {@link fetch})
+ * to support cancelation if possible.
+ *
+ * @template T
+ * @typedef {(signal: AbortSignal) => Promise<T>} Fetcher
+ */
+
+/**
+ * Hook that fetches data from the backend API or some other async data source.
+ *
+ * The API is intentionally very similar to SWR (https://swr.vercel.app), so
+ * we can easily migrate if we need its additional functionality in future.
+ *
+ * This hook handles:
+ *
+ *  - Tracking the state of the fetch (idle, fetching, fetched, error)
+ *  - Initiating a fetch when the data to be fetched changes
+ *  - Canceling in-flight requests when the query changes or the component is
+ *    unmounted
+ *
+ * @template [T=unknown]
+ * @param {string|null} key - Key identifying the data to be fetched. The data
+ *   will be re-fetched whenever this changes. If `null`, nothing will be fetched.
+ * @param {Fetcher<T>} [fetcher] - Callback that fetches the data.
+ * @return {FetchResult<T>}
+ */
+export function useFetch(key, fetcher) {
+  const [result, setResult] = useState(
+    /** @type {FetchResult<T>} */ ({
+      data: null,
+      error: null,
+      isLoading: key !== null,
+    })
+  );
+
+  const lastFetcher = useRef(fetcher);
+  lastFetcher.current = fetcher;
+
+  useEffect(() => {
+    setResult({ data: null, error: null, isLoading: key !== null });
+
+    if (!lastFetcher.current) {
+      throw new Error('Fetch key provided but no fetcher set');
+    }
+
+    const controller = new AbortController();
+    lastFetcher
+      .current(controller.signal)
+      .then(data => {
+        if (!controller.signal.aborted) {
+          setResult({ data, error: null, isLoading: false });
+        }
+      })
+      .catch(error => {
+        if (!controller.signal.aborted) {
+          setResult({ data: null, error, isLoading: false });
+        }
+      });
+
+    return () => {
+      // Cancel in-flight request if query changes or component is unmounted.
+      controller.abort();
+    };
+  }, [key]);
+
+  return result;
+}

--- a/lms/static/scripts/frontend_apps/utils/fetch.js
+++ b/lms/static/scripts/frontend_apps/utils/fetch.js
@@ -52,6 +52,10 @@ export function useFetch(key, fetcher) {
   useEffect(() => {
     setResult({ data: null, error: null, isLoading: key !== null });
 
+    if (!key) {
+      return undefined;
+    }
+
     if (!lastFetcher.current) {
       throw new Error('Fetch key provided but no fetcher set');
     }

--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -1,0 +1,127 @@
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import { useFetch } from '../fetch';
+import { delay } from '../../../test-util/wait';
+
+describe('useFetch', () => {
+  let wrappers;
+
+  function TestWidget({ fetchKey, fetcher }) {
+    const thing = useFetch(fetchKey, fetcher);
+
+    // This could be simplified to `isIdle = fetchKey === null`, but we want
+    // to check the `useFetch` result matches expectations in the idle case.
+    const isIdle = !thing.data && !thing.error && !thing.isLoading;
+
+    return (
+      <div>
+        {isIdle && 'Nothing to fetch'}
+        {thing.isLoading && 'Loading'}
+        {thing.error && `Error: ${thing.error.message}`}
+        {thing.data && `Data: ${thing.data}`}
+      </div>
+    );
+  }
+
+  function renderWidget(key, fetcher) {
+    const widget = mount(<TestWidget fetchKey={key} fetcher={fetcher} />);
+    wrappers.push(widget);
+    return widget;
+  }
+
+  async function waitForFetch(wrapper) {
+    await act(() => delay(0));
+    wrapper.update();
+  }
+
+  beforeEach(() => {
+    wrappers = [];
+  });
+
+  afterEach(() => {
+    wrappers.forEach(w => w.unmount());
+  });
+
+  it('returns loading state initially if loading', () => {
+    const wrapper = renderWidget('some-key', async () => 'Some data');
+    assert.equal(wrapper.text(), 'Loading');
+  });
+
+  it('returns idle state if not loading', () => {
+    const wrapper = renderWidget(null, async () => 'Some data');
+    assert.equal(wrapper.text(), 'Nothing to fetch');
+  });
+
+  it('fetches data and returns result', async () => {
+    const wrapper = renderWidget('some-key', async () => 'Some data');
+    await waitForFetch(wrapper);
+    assert.equal(wrapper.text(), 'Data: Some data');
+  });
+
+  it('cancels fetch if key changes', () => {
+    let signal;
+    const wrapper = renderWidget('some-key', async signal_ => {
+      signal = signal_;
+      return 'Some data';
+    });
+
+    wrapper.setProps({
+      key: 'other-key',
+      fetcher: async () => 'Different data',
+    });
+
+    assert.isTrue(signal.aborted);
+  });
+
+  it('returns error if fetch fails', async () => {
+    const wrapper = renderWidget('some-key', async () => {
+      throw new Error('Some error');
+    });
+    await waitForFetch(wrapper);
+    assert.equal(wrapper.text(), 'Error: Some error');
+  });
+
+  it('transitions to loading state if key changes', async () => {
+    const wrapper = renderWidget('some-key', async () => 'Some data');
+    await waitForFetch(wrapper);
+    assert.equal(wrapper.text(), 'Data: Some data');
+
+    wrapper.setProps({
+      fetchKey: 'other-key',
+      fetcher: async () => 'Different data',
+    });
+    assert.equal(wrapper.text(), 'Loading');
+
+    await waitForFetch(wrapper);
+    assert.equal(wrapper.text(), 'Data: Different data');
+  });
+
+  it('transitions to idle state if key is set to null', async () => {
+    const wrapper = renderWidget('some-key', async () => 'Some data');
+    await waitForFetch(wrapper);
+    assert.equal(wrapper.text(), 'Data: Some data');
+
+    wrapper.setProps({ fetchKey: null });
+
+    assert.equal(wrapper.text(), 'Nothing to fetch');
+  });
+
+  it('cancels fetch if component is unmounted', () => {
+    let signal;
+    const wrapper = renderWidget('some-key', async signal_ => {
+      signal = signal_;
+      return 'Some data';
+    });
+
+    wrapper.unmount();
+
+    assert.isTrue(signal.aborted);
+  });
+
+  it('throws if a key is set but a fetcher is not', () => {
+    assert.throws(() => {
+      renderWidget('some-key');
+    }, 'Fetch key provided but no fetcher set');
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -48,9 +48,11 @@ describe('useFetch', () => {
     assert.equal(wrapper.text(), 'Loading');
   });
 
-  it('returns idle state if not loading', () => {
-    const wrapper = renderWidget(null, async () => 'Some data');
-    assert.equal(wrapper.text(), 'Nothing to fetch');
+  [async () => 'Some data', undefined, null].forEach(fetcher => {
+    it('returns idle state if not loading', () => {
+      const wrapper = renderWidget(null, fetcher);
+      assert.equal(wrapper.text(), 'Nothing to fetch');
+    });
   });
 
   it('fetches data and returns result', async () => {


### PR DESCRIPTION
Whenever API data is fetched for display in a component, there are a common
set of states that we need to keep track of and side effects that need
to be performed:

 - The render function needs to know whether a fetch is happening, or
   succeeded, or failed
 - If the inputs to the fetch change or the component is unmounted, the
   previous fetch needs to be canceled

Add a hook to encapsulate this. The API is intentionally a very minimal subset of SWR's [1]. That has a bunch of additional
functionality and associated complexities that we don't yet need, but it would make a transition easy in future if we wanted to.

See the changes to JSTORPicker.js in https://github.com/hypothesis/lms/pull/4026 to see how this gets used in practice.

[1] https://swr.vercel.app