### PR TITLE
Add API views to fetch JSTOR article metadata and thumbnails

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -98,6 +98,11 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("lti_api.result.read", "/api/lti/result", request_method="GET")
     config.add_route("lti_api.result.record", "/api/lti/result", request_method="POST")
 
+    config.add_route("jstor_api.articles.metadata", "/api/jstor/articles/{article_id}")
+    config.add_route(
+        "jstor_api.articles.thumbnail", "/api/jstor/articles/{article_id}/thumbnail"
+    )
+
     config.add_route("vitalsource_api.books.info", "/api/vitalsource/books/{book_id}")
     config.add_route(
         "vitalsource_api.books.toc", "/api/vitalsource/books/{book_id}/toc"

--- a/lms/views/api/jstor.py
+++ b/lms/views/api/jstor.py
@@ -1,0 +1,26 @@
+from pyramid.view import view_config, view_defaults
+
+from lms.security import Permissions
+from lms.services import JSTORService
+
+
+@view_defaults(renderer="json", permission=Permissions.API)
+class JSTORAPIViews:
+    def __init__(self, request):
+        self.request = request
+        self.jstor_service = request.find_service(iface=JSTORService)
+
+    @view_config(route_name="jstor_api.articles.metadata")
+    def article_metadata(self):
+        article_id = self.request.matchdict["article_id"]
+        article_info = self.jstor_service.metadata(article_id)
+        return {"title": article_info["title"]}
+
+    @view_config(route_name="jstor_api.articles.thumbnail")
+    def article_thumbnail(self):
+        article_id = self.request.matchdict["article_id"]
+        data_uri = self.jstor_service.thumbnail(article_id)
+
+        # The image is wrapped in an object to make API responses more uniform
+        # for consumers.
+        return {"image": data_uri}

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -1,12 +1,15 @@
 from datetime import timedelta
 from functools import partial
-from unittest.mock import MagicMock, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
 from lms.models import ApplicationSettings
 from lms.services import ExternalRequestError
 from lms.services.jstor import JSTORService, factory
+from tests import factories
+
+JSTOR_API_URL = "http://api.jstor.org"
 
 
 class TestJSTORService:
@@ -22,16 +25,14 @@ class TestJSTORService:
         [
             (
                 "jstor://ARTICLE_ID",
-                "http://jstor.example.com/pdf-url/10.2307/ARTICLE_ID",
+                f"{JSTOR_API_URL}/pdf-url/10.2307%2FARTICLE_ID",
             ),
-            ("jstor://PREFIX/SUFFIX", "http://jstor.example.com/pdf-url/PREFIX/SUFFIX"),
+            ("jstor://PREFIX/SUFFIX", f"{JSTOR_API_URL}/pdf-url/PREFIX%2FSUFFIX"),
         ],
     )
     def test_via_url(
         self, svc, pyramid_request, JWTService, http_service, via_url, url, expected
     ):
-        JWTService.encode_with_secret.return_value = "TOKEN"
-
         url = svc.via_url(pyramid_request, document_url=url)
 
         JWTService.encode_with_secret.assert_called_once_with(
@@ -40,15 +41,14 @@ class TestJSTORService:
             lifetime=timedelta(hours=1),
         )
 
-        http_service.request.assert_called_once_with(
-            method="GET",
+        http_service.get.assert_called_once_with(
             url=expected,
             headers={"Authorization": "Bearer TOKEN"},
         )
 
         via_url.assert_called_once_with(
             pyramid_request,
-            http_service.request.return_value.text,
+            http_service.get.return_value.text,
             content_type="pdf",
             options={"via.client.contentPartner": "jstor"},
         )
@@ -58,14 +58,112 @@ class TestJSTORService:
     def test_via_url_with_bad_return_value_from_s3(
         self, svc, http_service, pyramid_request
     ):
-        http_service.request.return_value.text = "NOT A URL"
+        http_service.get.return_value = factories.requests.Response(raw="NOT A URL")
 
         with pytest.raises(ExternalRequestError):
             svc.via_url(pyramid_request, document_url="jstor://ANY")
 
+    @pytest.mark.parametrize(
+        "article_id, api_response, expected_api_url, expected_metadata",
+        [
+            # Typical JSTOR article, with no DOI prefix given
+            (
+                "12345",
+                {"title": ["test title"]},
+                f"{JSTOR_API_URL}/metadata/10.2307%2F12345",
+                {"title": "test title"},
+            ),
+            # Article with custom DOI prefix
+            (
+                "10.123/12345",
+                {"title": ["test title"]},
+                f"{JSTOR_API_URL}/metadata/10.123%2F12345",
+                {"title": "test title"},
+            ),
+            # No title
+            (
+                "12345",
+                {"title": []},
+                f"{JSTOR_API_URL}/metadata/10.2307%2F12345",
+                {"title": None},
+            ),
+        ],
+    )
+    def test_metadata(
+        self,
+        svc,
+        http_service,
+        api_response,
+        article_id,
+        expected_api_url,
+        expected_metadata,
+    ):
+        http_service.get.return_value = factories.requests.Response(
+            json_data=api_response
+        )
+
+        metadata = svc.metadata(article_id)
+
+        http_service.get.assert_called_with(
+            url=expected_api_url, headers={"Authorization": "Bearer TOKEN"}
+        )
+        assert metadata == expected_metadata
+
+    def test_metadata_raises_if_schema_mismatch(self, svc, http_service):
+        invalid_api_response = {"title": "This should be a list"}
+        http_service.get.return_value = factories.requests.Response(
+            json_data=invalid_api_response
+        )
+
+        with pytest.raises(ExternalRequestError) as exc:
+            svc.metadata("1234")
+
+        assert exc.value.validation_errors is not None
+
+    @pytest.mark.parametrize(
+        "article_id, api_response, expected_api_url",
+        [
+            # Typical JSTOR article, with no DOI prefix given
+            (
+                "12345",
+                "data:image/jpeg;base64,ABCD",
+                f"{JSTOR_API_URL}/thumbnail/10.2307%2F12345",
+            ),
+            # Article with custom DOI prefix
+            (
+                "10.123/12345",
+                "data:image/jpeg;base64,ABCD",
+                f"{JSTOR_API_URL}/thumbnail/10.123%2F12345",
+            ),
+        ],
+    )
+    def test_thumbnail(
+        self, svc, http_service, article_id, api_response, expected_api_url
+    ):
+        http_service.get.return_value = factories.requests.Response(raw=api_response)
+
+        data_uri = svc.thumbnail(article_id)
+
+        http_service.get.assert_called_with(
+            url=expected_api_url, headers={"Authorization": "Bearer TOKEN"}
+        )
+        assert data_uri == api_response
+
+    def test_thumbnail_raises_if_response_not_image(self, svc, http_service):
+        http_service.get.return_value = factories.requests.Response(
+            raw="not-a-data-uri"
+        )
+
+        with pytest.raises(ExternalRequestError) as exc_info:
+            svc.thumbnail("1234")
+
+        assert exc_info.value.message.startswith("Expected to get data URI")
+
     @pytest.fixture
     def http_service(self, http_service):
-        http_service.request.return_value = MagicMock(text="https://s3.example.com/pdf")
+        http_service.get.return_value = factories.requests.Response(
+            raw="https://s3.example.com/pdf"
+        )
 
         return http_service
 
@@ -77,7 +175,7 @@ class TestJSTORService:
     def get_service(self, http_service):
         return partial(
             JSTORService,
-            api_url="http://jstor.example.com",
+            api_url=JSTOR_API_URL,
             secret=sentinel.secret,
             enabled=True,
             site_code=sentinel.site_code,
@@ -90,7 +188,9 @@ class TestJSTORService:
 
     @pytest.fixture(autouse=True)
     def JWTService(self, patch):
-        return patch("lms.services.jstor.JWTService")
+        svc = patch("lms.services.jstor.JWTService")
+        svc.encode_with_secret.return_value = "TOKEN"
+        return svc
 
 
 class TestFactory:

--- a/tests/unit/lms/views/api/jstor_test.py
+++ b/tests/unit/lms/views/api/jstor_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from lms.views.api.jstor import JSTORAPIViews
+
+
+@pytest.mark.usefixtures("jstor_service")
+class TestJSTORAPIViews:
+    def test_article_metadata(self, jstor_service, pyramid_request):
+        views = JSTORAPIViews(pyramid_request)
+        pyramid_request.matchdict["article_id"] = "test-article"
+
+        metadata = views.article_metadata()
+
+        jstor_service.metadata.assert_called_once_with("test-article")
+        assert metadata == {"title": jstor_service.metadata.return_value["title"]}
+
+    def test_article_thumbnail(self, jstor_service, pyramid_request):
+        views = JSTORAPIViews(pyramid_request)
+        pyramid_request.matchdict["article_id"] = "test-article"
+
+        thumbnail = views.article_thumbnail()
+
+        jstor_service.thumbnail.assert_called_once_with("test-article")
+        assert thumbnail == {"image": jstor_service.thumbnail.return_value}


### PR DESCRIPTION
These will be used by the frontend when configuring a JSTOR assignment, to help the user check they are using the right content. To see how these views get used, see https://github.com/hypothesis/lms/pull/4026.

 - Add `/api/jstor/articles/{article_id}` route which returns article
   metadata
 - Add `/api/jstor/articles/{article_id}/thumbnail` route which returns
   the article image as a `data:image...` URI
 - Ensure that DOIs are escaped when generating API URLs. The JSTOR API
   accepts DOIs with or without encoding "/", but since these article
   IDs come from user input they could include other characters that
   ought to be encoded.
