### PR TITLE
LTIParams changes

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -106,6 +106,13 @@ def _to_lti_v11(v13_params):
         # We need to squish together the roles for v1.1
         v11_params["roles"] = ",".join(v11_params["roles"])
 
+    for canvas_param_name in ["custom_canvas_course_id", "custom_canvas_user_id"]:
+        # In LTI1.3 some custom canvas parameters are sent as integers
+        # and as a string in LTI1.1.
+        canvas_param_value = v11_params.get(canvas_param_name)
+        if isinstance(canvas_param_value, int):
+            v11_params[canvas_param_name] = str(canvas_param_value)
+
     return v11_params
 
 

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -1,3 +1,5 @@
+from typing import List
+
 CLAIM_PREFIX = "https://purl.imsglobal.org/spec/lti/claim"
 
 
@@ -94,24 +96,23 @@ def _to_lti_v11(v13_params):
     v11_params = {}
 
     for v11_key, v13_path in _V11_TO_V13:
-        # Descend into the object for each item in the path
-        found = False
-        value = v13_params
-
-        for path_item in v13_path:
-            if path_item not in value:
-                break
-            value = value[path_item]
-        else:
-            # We only found the key if we exhausted all of `v13_path`
-            found = True
-
-        # We don't want to add partial values along v13_path
-        if found:
-            v11_params[v11_key] = value
+        try:
+            v11_params[v11_key] = _get_key(v13_params, v13_path)
+        except KeyError:
+            # We don't want to add partial values along v13_path
+            continue
 
     if "roles" in v11_params:
         # We need to squish together the roles for v1.1
         v11_params["roles"] = ",".join(v11_params["roles"])
 
     return v11_params
+
+
+def _get_key(data: dict, data_path: List[str]):
+    # Descend into the object for each item in the path
+    value = data
+    for path_item in data_path:
+        value = value[path_item]
+
+    return value

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -324,17 +324,14 @@ class JSConfig:
         if not lis_outcome_service_url:
             return
 
-        custom_canvas_user_id = self._context.lti_params["custom_canvas_user_id"]
-
         self._config["canvas"]["speedGrader"] = {
             "submissionParams": {
                 "h_username": self._h_user.username,
                 "lis_result_sourcedid": lis_result_sourcedid,
                 "lis_outcome_service_url": lis_outcome_service_url,
-                # Canvas sends custom_canvas_user_id as in integer in LTI1.3 and as a string in LT1.1
-                "learner_canvas_user_id": str(custom_canvas_user_id)
-                if isinstance(custom_canvas_user_id, int)
-                else custom_canvas_user_id,
+                "learner_canvas_user_id": self._context.lti_params[
+                    "custom_canvas_user_id"
+                ],
                 "group_set": self._request.params.get("group_set"),
                 # Canvas doesn't send the right value for this on speed grader launches
                 # sending instead the same value as for "context_id"

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -66,22 +66,6 @@ class _CommonLTILaunchSchema(LTIV11CoreSchema):
     launch_presentation_return_url = fields.Str()
     tool_consumer_info_product_family_code = fields.Str()
 
-    @pre_load
-    def _load_canvas_course_id(self, data, **_kwargs):  # pylint: disable=no-self-use
-        canvas_course_id = data.get("custom_canvas_course_id")
-        if canvas_course_id and isinstance(canvas_course_id, int):
-            # In LTI1.3 course_id is sent as an integer
-            # instead of as a string in LTI1.1.
-            # Coercing both version to integers could be handled
-            # with fields.Int(strict=False)
-            #
-            # Doing a manual conversion to str here instead so both versions
-            # behave the same as LMS is concern
-            # and to allow for future changes on canvas' side
-            data["custom_canvas_course_id"] = str(canvas_course_id)
-
-        return data
-
     @validates_schema
     def validate_consumer_key(self, data, **_kwargs):  # pylint: disable=no-self-use
         if (

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -61,3 +61,16 @@ class TestLTI13Params:
 
         assert params["user_id"] == "user_id-v11"
         assert params["resource_link_id"] == "resource_link_id-v11"
+
+    @pytest.mark.parametrize(
+        "parameter_name,claim_name",
+        [
+            ("custom_canvas_course_id", "canvas_course_id"),
+            ("custom_canvas_user_id", "canvas_user_id"),
+        ],
+    )
+    def test_integer_canvas_parameters(self, parameter_name, claim_name):
+        params = LTIParams.from_v13({f"{CLAIM_PREFIX}/custom": {claim_name: 1}})
+
+        assert isinstance(params[parameter_name], str)
+        assert params[parameter_name] == "1"

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -171,21 +171,17 @@ class TestAddDocumentURL:
         assert submission_params()["document_url"] == "example_document_url"
 
     @pytest.mark.parametrize("submit_on_annotation_enabled", [True, False])
-    @pytest.mark.parametrize("custom_canvas_user_id", ["100", 100])
     def test_it_sets_the_canvas_submission_params(
         self,
         pyramid_request,
         js_config,
         submission_params,
-        context,
-        custom_canvas_user_id,
         submit_on_annotation_enabled,
     ):
         if submit_on_annotation_enabled:
             pyramid_request.feature.side_effect = (
                 lambda feature: feature == "submit_on_annotation"
             )
-        context.lti_params["custom_canvas_user_id"] = custom_canvas_user_id
 
         js_config.add_document_url("canvas://file/course_id/COURSE_ID/file_id/FILE_ID")
 
@@ -194,7 +190,7 @@ class TestAddDocumentURL:
                 "h_username": pyramid_request.lti_user.h_user.username,
                 "lis_outcome_service_url": "example_lis_outcome_service_url",
                 "lis_result_sourcedid": "example_lis_result_sourcedid",
-                "learner_canvas_user_id": "100",
+                "learner_canvas_user_id": "test_user_id",
                 "resource_link_id": pyramid_request.params["resource_link_id"],
             }
         )

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -14,7 +14,6 @@ from lms.validation import (
     URLConfiguredBasicLTILaunchSchema,
     ValidationError,
 )
-from lms.validation._lti_launch_params import _CommonLTILaunchSchema
 
 
 class TestLTIV11CoreSchema:
@@ -41,15 +40,6 @@ class TestLTIV11CoreSchema:
         pyramid_request.params = {"extra": "value"}
         pyramid_request.lti_jwt = sentinel.lti_jwt
         return pyramid_request
-
-
-class TestCommonLTILaunchSchema:
-    def test_it_allows_int_custom_canvas_course_id(self, pyramid_request):
-        pyramid_request.params["custom_canvas_course_id"] = 1
-
-        params = _CommonLTILaunchSchema(pyramid_request).parse()
-
-        assert params["custom_canvas_course_id"] == str(1)
 
 
 class TestBasicLTILaunchSchema:


### PR DESCRIPTION
- Refactor the `_to_lti_v11`. Stop using `for...else` and use a more explicit `KeyError` except block.

- Move handling of int -> str conversion for custom canvas parameters to LTIParams .