### PR TITLE
Remove the `ext_lti_assignment_id` column from the model

### DIFF
--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -24,23 +24,11 @@ class Assignment(BASE):
     __tablename__ = "assignment"
     __table_args__ = (
         sa.UniqueConstraint("resource_link_id", "tool_consumer_instance_guid"),
-        sa.UniqueConstraint("tool_consumer_instance_guid", "ext_lti_assignment_id"),
-        sa.CheckConstraint(
-            "NOT(resource_link_id IS NULL AND ext_lti_assignment_id IS NULL)",
-            name="nullable_resource_link_id_ext_lti_assignment_id",
-        ),
     )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 
-    ext_lti_assignment_id = sa.Column(sa.UnicodeText, nullable=True)
-    """
-    ID given for the assignment by Canvas.
-
-    Null for non canvas assignments and older Canvas ones.
-    """
-
-    resource_link_id = sa.Column(sa.Unicode, nullable=True)
+    resource_link_id = sa.Column(sa.Unicode, nullable=False)
     """The resource_link_id launch param of the assignment."""
 
     tool_consumer_instance_guid = sa.Column(sa.Unicode, nullable=False)


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3990


Remove the code first, migration will follow on https://github.com/hypothesis/lms/pull/4037.

The order is reversed from other DB changes as here we are deleting a column, we want to the code to stop using it before we delete it for real in the DB.


#  Testing 

Launch a few canvas assignments as a sanity check:

- https://hypothesis.instructure.com/courses/125/assignments/873 
- https://hypothesis.instructure.com/courses/125/assignments/875
- Also SpeedGrading https://hypothesis.instructure.com/courses/125/gradebook/speed_grader?assignment_id=873&student_id=35


