### PR TITLE
Refactor the LTI 1.3 func tests to not rely on JS config on the error page

### DIFF
--- a/tests/functional/lti_certification/v13/assertions.py
+++ b/tests/functional/lti_certification/v13/assertions.py
@@ -1,0 +1,25 @@
+"""Assertions for use in LTI 1.3 test."""
+
+import json
+
+from lms.resources._js_config import JSConfig
+
+
+def assert_launched_as_student(response):
+    assert response.status_code == 200
+
+    # This assumes an unconfigured launch giving us the error page
+    assert response.content_type == "text/html"
+    assert "assignment isn't configured" in response.text
+
+
+def assert_launched_as_teacher(response):
+    assert response.status_code == 200
+    assert response.html
+
+    js_config = json.loads(response.html.find("script", {"class": "js-config"}).string)
+
+    # This assumes an unconfigured launch, which causes the file picker to
+    # appear for teachers. We also double-check with the debug tag for role
+    assert "role:instructor" in js_config["debug"]["tags"]
+    assert js_config["mode"] == JSConfig.Mode.FILE_PICKER

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -5,8 +5,12 @@ import importlib_resources
 import jwt
 import pytest
 from httpretty import httpretty
+from pytest import register_assert_rewrite
 
 from tests import factories
+
+# Ensure that assertions get nice formatting from pytest
+register_assert_rewrite("tests.function.lti_certification.v13.assertions")
 
 keys_path = importlib_resources.files("tests.functional.lti_certification.v13")
 

--- a/tests/functional/lti_certification/v13/core/test_valid_student_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_student_launches.py
@@ -1,23 +1,23 @@
-import json
-
 import pytest
 
-from lms.resources._js_config import JSConfig
+from tests.functional.lti_certification.v13.assertions import assert_launched_as_student
 
 
 class TestValidStudentLaunches:
     """
-    Following the various valid instructor payload launches are valid Student/Learner payloads
+    Test valid instructor payload launches are valid Student/Learner payloads.
 
     http://www.imsproject.org/spec/lti/v1p3/cert/#valid-student-launches
     """
 
-    def test_message_as_student(self, student_payload, assert_launch_get_config):
+    def test_message_as_student(self, do_student_launch):
         """Launch LTI 1.3 Message as Student"""
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
 
-    def test_with_multiple_roles(self, student_payload, assert_launch_get_config):
+        response = do_student_launch()
+
+        assert_launched_as_student(response)
+
+    def test_with_multiple_roles(self, do_student_launch, student_payload):
         """Launch Student with Multiple Role Values"""
         student_payload["https://purl.imsglobal.org/spec/lti/claim/roles"] = [
             "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
@@ -25,51 +25,57 @@ class TestValidStudentLaunches:
             "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Mentor",
         ]
 
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_student_launch()
 
-    def test_with_short_role(self, student_payload, assert_launch_get_config):
+        assert_launched_as_student(response)
+
+    def test_with_short_role(self, do_student_launch, student_payload):
         """Launch Student with Short Role Value"""
         student_payload["https://purl.imsglobal.org/spec/lti/claim/roles"] = ["Learner"]
 
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_student_launch()
 
-    def test_with_unknown_role(self, student_payload, assert_launch_get_config):
+        assert_launched_as_student(response)
+
+    def test_with_unknown_role(self, do_student_launch, student_payload):
         """Launch Student with Unknown Role"""
         student_payload["https://purl.imsglobal.org/spec/lti/claim/roles"] = [
             "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
             "http://purl.imsglobal.org/vocab/lis/v2/uknownrole/unknown#Unknown",
         ]
 
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_student_launch()
 
-    def test_with_no_role(self, student_payload, assert_launch_get_config):
+        assert_launched_as_student(response)
+
+    def test_with_no_role(self, do_student_launch, student_payload):
         """Launch Student With No Role"""
         student_payload["https://purl.imsglobal.org/spec/lti/claim/roles"] = [""]
 
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_student_launch()
 
-    def test_with_only_email(self, student_payload, assert_launch_get_config):
+        assert_launched_as_student(response)
+
+    def test_with_only_email(self, do_student_launch, student_payload):
         """Launch Student Only Email"""
         del student_payload["name"]
         del student_payload["given_name"]
         del student_payload["family_name"]
         del student_payload["middle_name"]
 
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_student_launch()
 
-    def test_with_only_names(self, student_payload, assert_launch_get_config):
+        assert_launched_as_student(response)
+
+    def test_with_only_names(self, do_student_launch, student_payload):
         """Launch Student Only Names"""
         del student_payload["email"]
 
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_student_launch()
 
-    def test_without_pii(self, student_payload, assert_launch_get_config):
+        assert_launched_as_student(response)
+
+    def test_without_pii(self, do_student_launch, student_payload):
         """Launch Student No PII"""
         del student_payload["name"]
         del student_payload["email"]
@@ -77,29 +83,25 @@ class TestValidStudentLaunches:
         del student_payload["family_name"]
         del student_payload["middle_name"]
 
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_student_launch()
+
+        assert_launched_as_student(response)
 
     @pytest.mark.xfail(
         reason="Pending. Context is required in our schemas", strict=True
     )
-    def test_with_email_no_context(self, student_payload, assert_launch_get_config):
+    def test_with_email_no_context(self, do_student_launch, student_payload):
         """Launch Student With Email No Context"""
 
         del student_payload["https://purl.imsglobal.org/spec/lti/claim/context"]
 
-        js_config = assert_launch_get_config(student_payload)
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_student_launch()
+
+        assert_launched_as_student(response)
 
     @pytest.fixture
-    def assert_launch_get_config(self, do_lti_launch, make_jwt):
-        def _assert_launch(payload):
-            response = do_lti_launch({"id_token": make_jwt(payload)}, status=200)
+    def do_student_launch(self, do_lti_launch, make_jwt, student_payload):
+        def do_student_launch():
+            return do_lti_launch({"id_token": make_jwt(student_payload)})
 
-            assert response.status_code == 200
-            assert response.html
-            return json.loads(
-                response.html.find("script", {"class": "js-config"}).string
-            )
-
-        return _assert_launch
+        return do_student_launch

--- a/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
+++ b/tests/functional/lti_certification/v13/core/test_valid_teacher_launches.py
@@ -1,8 +1,9 @@
-import json
-
 import pytest
 
-from lms.resources._js_config import JSConfig
+from tests.functional.lti_certification.v13.assertions import (
+    assert_launched_as_student,
+    assert_launched_as_teacher,
+)
 
 
 @pytest.mark.usefixtures("intercept_http_calls_to_h")
@@ -13,12 +14,13 @@ class TestValidTeacherPayloads:
     http://www.imsproject.org/spec/lti/v1p3/cert/#valid-teacher-launches
     """
 
-    def test_message_as_instructor(self, teacher_payload, assert_launch_get_config):
+    def test_message_as_instructor(self, do_teacher_launch):
         """Launch LTI 1.3 Message as Instructor"""
-        js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
+        response = do_teacher_launch()
 
-    def test_with_multiple_roles(self, teacher_payload, assert_launch_get_config):
+        assert_launched_as_teacher(response)
+
+    def test_with_multiple_roles(self, do_teacher_launch, teacher_payload):
         """Launch Instructor with Multiple Role Values"""
         teacher_payload["https://purl.imsglobal.org/spec/lti/claim/roles"] = [
             "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
@@ -26,54 +28,62 @@ class TestValidTeacherPayloads:
             "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Other",
         ]
 
-        js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
+        response = do_teacher_launch()
 
-    def test_with_short_role(self, teacher_payload, assert_launch_get_config):
+        assert_launched_as_teacher(response)
+
+    def test_with_short_role(self, do_teacher_launch, teacher_payload):
         """Launch Instructor with Short Role Value"""
         teacher_payload["https://purl.imsglobal.org/spec/lti/claim/roles"] = [
             "Instructor"
         ]
 
-        js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
+        response = do_teacher_launch()
 
-    def test_with_unknown_role(self, teacher_payload, assert_launch_get_config):
+        assert_launched_as_teacher(response)
+
+    def test_with_unknown_role(self, do_teacher_launch, teacher_payload):
         """Launch Instructor with Unknown Role"""
         teacher_payload["https://purl.imsglobal.org/spec/lti/claim/roles"] = [
             "http://purl.imsglobal.org/vocab/lis/v2/unknown/unknown#Helper"
         ]
 
-        js_config = assert_launch_get_config(teacher_payload)
-        # With non instructor we are not identified as a teacher and not allowed to configure
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_teacher_launch()
 
-    def test_with_no_role(self, teacher_payload, assert_launch_get_config):
+        # With non instructor roles we are not identified as a teacher and not
+        # allowed to configure
+        assert_launched_as_student(response)
+
+    def test_with_no_role(self, do_teacher_launch, teacher_payload):
         """Launch Instructor With No Role"""
         teacher_payload["https://purl.imsglobal.org/spec/lti/claim/roles"] = [""]
 
-        js_config = assert_launch_get_config(teacher_payload)
-        # With non instructor we are not identified as a teacher and not allowed to configure
-        assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
+        response = do_teacher_launch()
 
-    def test_with_only_email(self, teacher_payload, assert_launch_get_config):
+        # With non instructor roles we are not identified as a teacher and not
+        # allowed to configure
+        assert_launched_as_student(response)
+
+    def test_with_only_email(self, do_teacher_launch, teacher_payload):
         """Launch Instructor Only Email"""
         del teacher_payload["name"]
         del teacher_payload["given_name"]
         del teacher_payload["family_name"]
         del teacher_payload["middle_name"]
 
-        js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
+        response = do_teacher_launch()
 
-    def test_with_only_names(self, teacher_payload, assert_launch_get_config):
+        assert_launched_as_teacher(response)
+
+    def test_with_only_names(self, do_teacher_launch, teacher_payload):
         """Launch Instructor Only Names"""
         del teacher_payload["email"]
 
-        js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
+        response = do_teacher_launch()
 
-    def test_without_pii(self, teacher_payload, assert_launch_get_config):
+        assert_launched_as_teacher(response)
+
+    def test_without_pii(self, do_teacher_launch, teacher_payload):
         """Launch Instructor No PII"""
         del teacher_payload["name"]
         del teacher_payload["email"]
@@ -81,27 +91,23 @@ class TestValidTeacherPayloads:
         del teacher_payload["family_name"]
         del teacher_payload["middle_name"]
 
-        js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
+        response = do_teacher_launch()
+
+        assert_launched_as_teacher(response)
 
     @pytest.mark.xfail(reason="Pending. Context is required in our schemas")
-    def test_with_email_no_context(self, teacher_payload, assert_launch_get_config):
+    def test_with_email_no_context(self, do_teacher_launch, teacher_payload):
         """Launch Instructor With Email No Context"""
 
         del teacher_payload["https://purl.imsglobal.org/spec/lti/claim/context"]
 
-        js_config = assert_launch_get_config(teacher_payload)
-        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
+        response = do_teacher_launch()
+
+        assert_launched_as_teacher(response)
 
     @pytest.fixture
-    def assert_launch_get_config(self, do_lti_launch, make_jwt):
-        def _assert_launch(payload):
-            response = do_lti_launch({"id_token": make_jwt(payload)}, status=200)
+    def do_teacher_launch(self, do_lti_launch, make_jwt, teacher_payload):
+        def do_teacher_launch():
+            return do_lti_launch({"id_token": make_jwt(teacher_payload)})
 
-            assert response.status_code == 200
-            assert response.html
-            return json.loads(
-                response.html.find("script", {"class": "js-config"}).string
-            )
-
-        return _assert_launch
+        return do_teacher_launch


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3995

Currently we assume the error page has JS config, but it doesn't need any,  so the tests being this way prevent us from changing that.

We still want to use the error page as an indicator of whether you are a student or a teacher, but this can be accomplished by some text matching.