### PR TITLE
Use `lti_params` for 1.3 compatibility in the LTI launches

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -298,19 +298,21 @@ class BasicLaunchViews:
     def _store_lti_data(self):
         """Store LTI launch data in our LMS database."""
 
-        request = self.request
+        lti_params = self.context.lti_params
 
         # Before any LTI assignments launch, create or update the Hypothesis
         # user and group corresponding to the LTI user and course.
-        request.find_service(name="lti_h").sync([self.context.course], request.params)
+        self.request.find_service(name="lti_h").sync([self.context.course], lti_params)
 
         # Report all LTI assignment launches to the /reports page.
         LtiLaunches.add(
-            request.db,
-            request.params.get("context_id"),
-            request.params.get("oauth_consumer_key"),
+            self.request.db,
+            lti_params.get("context_id"),
+            lti_params.get("oauth_consumer_key"),
         )
 
-        if not request.lti_user.is_instructor and not self.context.is_canvas:
+        if not self.request.lti_user.is_instructor and not self.context.is_canvas:
             # Create or update a record of LIS result data for a student launch
-            request.find_service(name="grading_info").upsert_from_request(request)
+            self.request.find_service(name="grading_info").upsert_from_request(
+                self.request
+            )

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -255,14 +255,12 @@ class TestBasicLaunchViews:
     ):
         svc._store_lti_data()  # pylint: disable=protected-access
 
-        lti_h_service.sync.assert_called_once_with(
-            [context.course], pyramid_request.params
-        )
+        lti_h_service.sync.assert_called_once_with([context.course], context.lti_params)
 
         LtiLaunches.add.assert_called_once_with(
             pyramid_request.db,
-            pyramid_request.params["context_id"],
-            pyramid_request.params["oauth_consumer_key"],
+            context.lti_params["context_id"],
+            context.lti_params["oauth_consumer_key"],
         )
 
         grading_info_service.upsert_from_request.assert_called_once_with(


### PR DESCRIPTION
There were quite a few places where we didn't use the 1.1 -> 1.3 compat
layer. I think this might mean these were not working correctly for those
situations?