### PR TITLE
Explicitly check for the user roles to send canvas submissions

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -298,9 +298,11 @@ class BasicLaunchViews:
             # For students in Canvas with grades to submit we need to enable
             # Speedgrader settings for gradable assignments
             # `lis_result_sourcedid` associates a specific user with an
-            # assignment. This is evidence that a student is launching us
-            if assignment_gradable and self.context.lti_params.get(
-                "lis_result_sourcedid"
+            # assignment.
+            if (
+                assignment_gradable
+                and self.request.lti_user.is_learner
+                and self.context.lti_params.get("lis_result_sourcedid")
             ):
                 self.context.js_config.add_canvas_speedgrader_settings(document_url)
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -297,15 +297,31 @@ class TestBasicLaunchViews:
         context.js_config.enable_grading_bar.assert_not_called()
 
     @pytest.mark.usefixtures(
-        "with_gradable_assignment", "is_canvas", "with_student_grading_id"
+        "with_gradable_assignment",
+        "is_canvas",
+        "with_student_grading_id",
+        "user_is_learner",
     )
     def test__show_document_enables_speedgrader_settings(self, svc, context):
         svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
 
-        context.js_config.add_canvas_speedgrader_settings(sentinel.document_url)
+        context.js_config.add_canvas_speedgrader_settings.assert_called_once_with(
+            sentinel.document_url
+        )
 
     @pytest.mark.usefixtures("with_gradable_assignment", "with_student_grading_id")
     def test__show_document_no_speedgrader_without_canvas(self, svc, context):
+        svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
+
+        context.js_config.add_canvas_speedgrader_settings.assert_not_called()
+
+    @pytest.mark.usefixtures(
+        "is_canvas",
+        "with_gradable_assignment",
+        "with_student_grading_id",
+        "user_is_instructor",
+    )
+    def test__show_document_no_speedgrader_with_instructor(self, svc, context):
         svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
 
         context.js_config.add_canvas_speedgrader_settings.assert_not_called()


### PR DESCRIPTION
In LTI1.1 we used the presence of `lis_result_sourcedid` as proxy for
being a student but that's not true in LTI1.3.

We'll check for the role in both LTI versions and also still require
`lis_result_sourcedid` to be present as is mandatory to talk to the
grading API.


## Testing

- On `master` launch https://hypothesis.instructure.com/courses/319/assignments/2988

Get an error ( the error being `User not found in course or is not a student`)

- Switch to `submision-teacher`, launch again, no error.