### PR TITLE
Separate checking for the application instance GUID and updating in the launch view

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -46,7 +46,9 @@ class BasicLaunchViews:
         self.application_instance = request.find_service(
             name="application_instance"
         ).get_current()
-        self.application_instance.update_lms_data(self.context.lti_params)
+        self.application_instance.check_guid_aligns(
+            self.context.lti_params.get("tool_consumer_instance_guid")
+        )
 
     # ----------------- #
     # Standard launches #
@@ -297,6 +299,8 @@ class BasicLaunchViews:
 
     def _store_lti_data(self):
         """Store LTI launch data in our LMS database."""
+
+        self.application_instance.update_lms_data(self.context.lti_params)
 
         lti_params = self.context.lti_params
 

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -127,6 +127,26 @@ class TestApplicationInstance:
         assert application_instance.tool_consumer_instance_guid == "EXISTING_GUID"
 
     @pytest.mark.parametrize(
+        "our_guid,new_guid,should_raise",
+        (
+            (None, None, False),
+            ("any", None, False),
+            (None, "any", False),
+            ("value", "different", True),
+        ),
+    )
+    def test_check_guid_aligns(
+        self, application_instance, our_guid, new_guid, should_raise
+    ):
+        application_instance.tool_consumer_instance_guid = our_guid
+
+        if should_raise:
+            with pytest.raises(ReusedConsumerKey):
+                application_instance.check_guid_aligns(new_guid)
+        else:
+            application_instance.check_guid_aligns(new_guid)
+
+    @pytest.mark.parametrize(
         "value,expected",
         [
             ("BlackboardLearn", ApplicationInstance.Product.BLACKBOARD),


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3990

This is mostly "for show" to allow us to see what's happening. This allows a clean division between things we need for the view  to work (checking the GUID) and data storage for our persisted model.

The code here is the same / a little worse, as it calls the check GUID twice effectively. But it makes the intent clearer.

This also avoids a potential problem where something crucial is happening as a side effect of updating the data, but it's not clear. So you could easily think you are doing something safe by moving the update, where you are actually creating a huge problem.