### PR TITLE
Move decision part of `maybe_` JS config to the LTI view

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -229,7 +229,7 @@ class JSConfig:
         self._config.setdefault("filePicker", {})
         self._config["filePicker"]["deepLinkingAPI"] = config
 
-    def enable_grading(self):
+    def enable_grading_bar(self):
         """Enable our LMS app's built-in assignment grading UI."""
 
         # Get one student dict for each student who has launched the assignment

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -266,29 +266,8 @@ class JSConfig:
             "students": students,
         }
 
-    def maybe_set_focused_user(self):
-        """
-        Configure the Hypothesis client to focus on a particular user.
-
-        If there is a focused_user request param then add the necessary
-        Hypothesis client config to get the client to focus on the particular
-        user identified by the focused_user param, showing only that user's
-        annotations and not others.
-
-        In practice the focused_user param is only ever present in Canvas
-        SpeedGrader launches. We add a focused_user query param to the
-        SpeedGrader LTI launch URLs that we submit to Canvas for each student
-        when the student launches an assignment. Later, Canvas uses these URLs
-        to launch us when a teacher grades the assignment in SpeedGrader.
-
-        In theory, though, the focused_user param could work outside of Canvas
-        as well if we ever want it to.
-        """
-        focused_user = self._request.params.get("focused_user")
-
-        if not focused_user:
-            return
-
+    def set_focused_user(self, focused_user):
+        """Configure the client to only show one users' annotations."""
         self._hypothesis_client["focus"] = {"user": {"username": focused_user}}
 
         # Unfortunately we need to pass the user's current display name to the

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -301,7 +301,12 @@ class BasicLaunchViews:
         ):
             self.context.js_config.enable_grading()
 
-        self.context.js_config.maybe_set_focused_user()
+        # We add a `focused_user` query param to the SpeedGrader LTI launch
+        # URLs we submit to Canvas for each student when the student launches
+        # an assignment. Later, Canvas uses these URLs to launch us when a
+        # teacher grades the assignment in SpeedGrader.
+        if focused_user := self.request.params.get("focused_user"):
+            self.context.js_config.set_focused_user(focused_user)
 
         self.context.js_config.add_document_url(document_url)
         self.context.js_config.enable_lti_launch_mode()

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -301,7 +301,7 @@ class BasicLaunchViews:
             and self.request.lti_user.is_instructor
             and not self.context.is_canvas
         ):
-            self.context.js_config.enable_grading()
+            self.context.js_config.enable_grading_bar()
 
         # For students in Canvas with grades to submit we need to enable
         # Speedgrader settings for gradable assignments

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -206,11 +206,11 @@ class TestAddCanvasSpeedgraderSettings:
         }
 
 
-class TestEnableGrading:
+class TestEnableGradingBar:
     def test_it(
         self, js_config, context, grading_info_service, application_instance_service
     ):
-        js_config.enable_grading()
+        js_config.enable_grading_bar()
 
         grading_info_service.get_by_assignment.assert_called_once_with(
             context_id="test_course_id",

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -231,7 +231,7 @@ class TestBasicLaunchViews:
         )
 
         context.js_config.enable_lti_launch_mode.assert_called_once_with()
-        context.js_config.maybe_set_focused_user.assert_called_once_with()
+        context.js_config.set_focused_user.assert_not_called()
         context.js_config.add_document_url.assert_called_once_with(
             sentinel.document_url
         )
@@ -248,6 +248,15 @@ class TestBasicLaunchViews:
         )
 
         assert result == {}
+
+    def test__show_document_focuses_on_users(self, svc, pyramid_request, context):
+        pyramid_request.params["focused_user"] = sentinel.focused_user
+
+        svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
+
+        context.js_config.set_focused_user.assert_called_once_with(
+            sentinel.focused_user
+        )
 
     @pytest.mark.usefixtures("with_gradable_assignment", "user_is_instructor")
     def test__show_document_enables_grading(self, svc, context):

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -249,6 +249,7 @@ class TestBasicLaunchViews:
 
         assert result == {}
 
+    @pytest.mark.usefixtures("is_canvas")
     def test__show_document_focuses_on_users(self, svc, pyramid_request, context):
         pyramid_request.params["focused_user"] = sentinel.focused_user
 
@@ -257,6 +258,15 @@ class TestBasicLaunchViews:
         context.js_config.set_focused_user.assert_called_once_with(
             sentinel.focused_user
         )
+
+    def test__show_document_focuses_on_users_only_for_canvas(
+        self, svc, pyramid_request, context
+    ):
+        pyramid_request.params["focused_user"] = sentinel.focused_user
+
+        svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
+
+        context.js_config.set_focused_user.assert_not_called()
 
     @pytest.mark.usefixtures("with_gradable_assignment", "user_is_instructor")
     def test__show_document_enables_grading(self, svc, context):

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -262,13 +262,13 @@ class TestBasicLaunchViews:
     def test__show_document_enables_grading(self, svc, context):
         svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
 
-        context.js_config.enable_grading.assert_called()
+        context.js_config.enable_grading_bar.assert_called()
 
     @pytest.mark.usefixtures("with_gradable_assignment", "user_is_learner")
     def test__show_document_does_not_enable_grading_for_students(self, svc, context):
         svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
 
-        context.js_config.enable_grading.assert_not_called()
+        context.js_config.enable_grading_bar.assert_not_called()
 
     @pytest.mark.usefixtures("user_is_instructor")
     def test__show_document_does_not_enable_without_a_gradable_assignment(
@@ -276,7 +276,7 @@ class TestBasicLaunchViews:
     ):
         svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
 
-        context.js_config.enable_grading.assert_not_called()
+        context.js_config.enable_grading_bar.assert_not_called()
 
     @pytest.mark.usefixtures(
         "with_gradable_assignment", "user_is_instructor", "is_canvas"
@@ -284,7 +284,7 @@ class TestBasicLaunchViews:
     def test__show_document_does_not_enable_grading_for_canvas(self, svc, context):
         svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
 
-        context.js_config.enable_grading.assert_not_called()
+        context.js_config.enable_grading_bar.assert_not_called()
 
     @pytest.mark.usefixtures(
         "with_gradable_assignment", "is_canvas", "with_student_grading_id"


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3991

We had a number of methods in the JSConfig class which detected whether they should perform an action and then performed it. These were:

 * `maybe_enable_grading()`
* `maybe_set_focused_user()`
* `add_canvas_speedgrader_settings()`

This is bad for a number of reasons:

* When you call them you don't know if anything happened or not or why
* It's not clear from the caller whether you should be calling them (similar, but different)
* JSConfig is bloated with lots of decisions, rather than concentrating on doing

This resulted in a few things:

* The basic launch view was ignorant of whether something actually is graded
* Worse, the basic launch view had a spurious notion of `grading_enabled` which was basically irrelevant / wrong
* A lack of clarity around what happens and why when reading the code

This work moves the real "is_gradable" value into the view, and enables the work we want to do to store that value, and have it line up.

### Review notes

* No behavior should have changed
* Each method is tackled in turn in different commits for easy reviewing