### PR TITLE
Product service and model

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -91,6 +91,8 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.sentry")
     config.include("lms.session")
     config.include("lms.models")
+    config.include("lms.models.lti_params")
+    config.include("lms.models.product")
     config.include("lms.db")
     config.include("lms.routes")
     config.include("lms.assets")

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -22,6 +22,7 @@ from lms.models.lti_params import CLAIM_PREFIX, LTIParams
 from lms.models.lti_registration import LTIRegistration
 from lms.models.lti_user import LTIUser, display_name
 from lms.models.oauth2_token import OAuth2Token
+from lms.models.product import Product
 from lms.models.rsa_key import RSAKey
 from lms.models.user import User
 

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime
-from enum import Enum
 from urllib.parse import urlparse
 
 import sqlalchemy as sa
@@ -15,16 +14,6 @@ LOG = logging.getLogger(__name__)
 
 class ApplicationInstance(BASE):
     """Class to represent a single lms install."""
-
-    class Product(str, Enum):
-        BLACKBOARD = "BlackboardLearn"
-        CANVAS = "canvas"
-        MOODLE = "moodle"
-        D2L = "desire2learn"
-        BLACKBAUD = "BlackbaudK12"
-        SCHOOLOGY = "schoology"
-        SAKAI = "sakai"
-        UNKNOWN = "unknown"
 
     __tablename__ = "application_instances"
     __table_args__ = (
@@ -204,15 +193,6 @@ class ApplicationInstance(BASE):
                 existing_guid=self.tool_consumer_instance_guid,
                 new_guid=tool_consumer_instance_guid,
             )
-
-    @property
-    def product(self):
-        try:
-            product = self.Product(self.tool_consumer_info_product_family_code)
-        except ValueError:
-            product = self.Product.UNKNOWN
-
-        return product
 
     @property
     def lti_version(self) -> str:

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -123,3 +123,18 @@ def _get_key(data: dict, data_path: List[str]):
         value = value[path_item]
 
     return value
+
+
+def _get_lti_params(request):
+    if not request.lti_jwt:
+        # If we don't have a LTI1.3 JWT there's no params to map.
+        # Use the request original params.
+        return request.params
+
+    return LTIParams.from_v13(request.lti_jwt)
+
+
+def includeme(config):
+    config.add_request_method(
+        _get_lti_params, name="lti_params", property=True, reify=True
+    )

--- a/lms/models/product.py
+++ b/lms/models/product.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+@dataclass
+class Product:
+    class Family(str, Enum):
+        BLACKBAUD = "BlackbaudK12"
+        BLACKBOARD = "BlackboardLearn"
+        CANVAS = "canvas"
+        D2L = "desire2learn"
+        MOODLE = "moodle"
+        SAKAI = "sakai"
+        SCHOOLOGY = "schoology"
+        UNKNOWN = "unkown"
+
+        @classmethod
+        def _missing_(cls, _value):
+            return cls.UNKNOWN
+
+    family: Family
+
+    @classmethod
+    def from_request(cls, request):
+        return Product(family=cls._get_family(request))
+
+    @classmethod
+    def _get_family(cls, request):
+        # If we are in an API request, where we are forwarding the product type ourselves
+        if request.content_type == "application/json":
+            return cls.Family(request.json["lms"]["product"])
+
+        # In an LTI launch we'll use the parameters available to guess
+        if product_name := request.lti_params.get(
+            "tool_consumer_info_product_family_code"
+        ):
+            return cls.Family(product_name)
+
+        # If we don't get a hint from LTI check a canvas specific parameter
+        if "custom_canvas_course_id" in request.lti_params:
+            return cls.Family.CANVAS
+
+        return cls.Family.UNKNOWN
+
+
+def includeme(config):
+    config.add_request_method(
+        Product.from_request, name="product", property=True, reify=True
+    )

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -2,7 +2,7 @@ import functools
 from enum import Enum
 from typing import List, Optional
 
-from lms.models import ApplicationInstance, GroupInfo, HUser
+from lms.models import GroupInfo, HUser, Product
 from lms.resources._js_config.file_picker_config import FilePickerConfig
 from lms.services import HAPIError, JSTORService
 from lms.validation.authentication import BearerTokenSchema
@@ -55,6 +55,7 @@ class JSConfig:
         if document_url.startswith("blackboard://"):
             self._config["api"]["viaUrl"] = {
                 "authUrl": self._request.route_url("blackboard_api.oauth.authorize"),
+                "product": self._request.product.family,
                 "path": self._request.route_path(
                     "blackboard_api.files.via_url",
                     course_id=self._context.lti_params["context_id"],
@@ -64,6 +65,7 @@ class JSConfig:
         elif document_url.startswith("canvas://"):
             self._config["api"]["viaUrl"] = {
                 "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
+                "product": self._request.product.family,
                 "path": self._request.route_path(
                     "canvas_api.files.via_url",
                     resource_link_id=self._context.lti_params["resource_link_id"],
@@ -125,6 +127,7 @@ class JSConfig:
                 "mode": JSConfig.Mode.OAUTH2_REDIRECT_ERROR,
                 "OAuth2RedirectError": {
                     "authUrl": auth_url,
+                    "product": self._request.product.family,
                     "errorCode": error_code,
                     "canvasScopes": canvas_scopes or [],
                 },
@@ -429,6 +432,7 @@ class JSConfig:
         req = self._request
         sync_api_config = {
             "authUrl": req.route_url("canvas_api.oauth.authorize"),
+            "product": self._request.product.family,
             "path": req.route_path("canvas_api.sync"),
             "data": {
                 "lms": {
@@ -463,6 +467,7 @@ class JSConfig:
         req = self._request
         return {
             "authUrl": req.route_url("blackboard_api.oauth.authorize"),
+            "product": self._request.product.family,
             "path": req.route_path("blackboard_api.sync"),
             "data": {
                 "lms": {
@@ -492,7 +497,7 @@ class JSConfig:
             return self._canvas_sync_api()
 
         if (
-            self._application_instance.product == ApplicationInstance.Product.BLACKBOARD
+            self._request.product.family == Product.Family.BLACKBOARD
             and self._context.is_blackboard_group_launch
         ):
 

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -3,7 +3,7 @@
 import logging
 from functools import cached_property
 
-from lms.models import LTIParams
+from lms.models import LTIParams, Product
 from lms.resources._js_config import JSConfig
 from lms.services import ApplicationInstanceNotFound
 
@@ -81,16 +81,7 @@ class LTILaunchResource:
     @property
     def is_canvas(self):
         """Return True if Canvas is the LMS that launched us."""
-        if (
-            self._request.parsed_params.get("tool_consumer_info_product_family_code")
-            == "canvas"
-        ):
-            return True
-
-        if "custom_canvas_course_id" in self._request.parsed_params:
-            return True
-
-        return False
+        return self._request.product.family == Product.Family.CANVAS
 
     @cached_property
     def js_config(self):
@@ -184,11 +175,7 @@ class LTILaunchResource:
     @property
     def lti_params(self) -> LTIParams:
         """Return the requests LTI parameters."""
-        return (
-            LTIParams.from_v13(self._request.lti_jwt)
-            if self._request.lti_jwt
-            else LTIParams(self._request.params)
-        )
+        return self._request.lti_params
 
     def _course_extra(self):
         """Extra information to store for courses."""

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -11,7 +11,6 @@ from marshmallow import (
 )
 from marshmallow.validate import OneOf
 
-from lms.models import LTIParams
 from lms.validation._base import PyramidRequestSchema
 from lms.validation._exceptions import LTIToolRedirect
 
@@ -41,7 +40,7 @@ class LTIV11CoreSchema(PyramidRequestSchema):
         if not self.context["request"].lti_jwt:
             return data
 
-        params = LTIParams.from_v13(self.context["request"].lti_jwt)
+        params = self.context["request"].lti_params
         # Make the rest of params also accessible to marshmallow in case any are not coming from the JWT
         # eg query parameters
         # This is to make it backwards compatible with schemas that mix LTI

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,7 @@ from pyramid import testing
 from pyramid.request import apply_request_extensions
 
 from lms.db import SESSION
-from lms.models import ApplicationSettings
+from lms.models import ApplicationSettings, Product
 from tests import factories
 from tests.conftest import TEST_SETTINGS, get_test_database_url
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -99,6 +99,8 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
         user_id=lti_v11_params["user_id"],
     )
     pyramid_request.lti_jwt = {}
+    pyramid_request.lti_params = {}
+    pyramid_request.product = Product(family=Product.Family.UNKNOWN)
 
     # The DummyRequest request lacks a content_type property which the real
     # request has

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -127,44 +127,6 @@ class TestApplicationInstance:
         assert application_instance.tool_consumer_instance_guid == "EXISTING_GUID"
 
     @pytest.mark.parametrize(
-        "our_guid,new_guid,should_raise",
-        (
-            (None, None, False),
-            ("any", None, False),
-            (None, "any", False),
-            ("value", "different", True),
-        ),
-    )
-    def test_check_guid_aligns(
-        self, application_instance, our_guid, new_guid, should_raise
-    ):
-        application_instance.tool_consumer_instance_guid = our_guid
-
-        if should_raise:
-            with pytest.raises(ReusedConsumerKey):
-                application_instance.check_guid_aligns(new_guid)
-        else:
-            application_instance.check_guid_aligns(new_guid)
-
-    @pytest.mark.parametrize(
-        "value,expected",
-        [
-            ("BlackboardLearn", ApplicationInstance.Product.BLACKBOARD),
-            ("canvas", ApplicationInstance.Product.CANVAS),
-            ("moodle", ApplicationInstance.Product.MOODLE),
-            ("desire2learn", ApplicationInstance.Product.D2L),
-            ("BlackbaudK12", ApplicationInstance.Product.BLACKBAUD),
-            ("schoology", ApplicationInstance.Product.SCHOOLOGY),
-            ("sakai", ApplicationInstance.Product.SAKAI),
-            ("wut", ApplicationInstance.Product.UNKNOWN),
-        ],
-    )
-    def test_product(self, value, expected, application_instance):
-        application_instance.tool_consumer_info_product_family_code = value
-
-        assert application_instance.product == expected
-
-    @pytest.mark.parametrize(
         "lti_registration_id,lti_version", [(None, "LTI-1p0"), (1, "1.3.0")]
     )
     def test_lti_version(self, lti_registration_id, lti_version, application_instance):

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -1,6 +1,9 @@
-import pytest
+from unittest.mock import create_autospec, sentinel
 
-from lms.models import CLAIM_PREFIX, LTIParams
+import pytest
+from pyramid.config import Configurator
+
+from lms.models.lti_params import CLAIM_PREFIX, LTIParams, _get_lti_params, includeme
 
 
 class TestLTI13Params:
@@ -74,3 +77,36 @@ class TestLTI13Params:
 
         assert isinstance(params[parameter_name], str)
         assert params[parameter_name] == "1"
+
+
+class TestGetLTIParams:
+    def test_with_lti_jwt(self, LTIParams, pyramid_request):
+        pyramid_request.lti_jwt = sentinel.lti_jwt
+
+        lti_params = _get_lti_params(pyramid_request)
+
+        LTIParams.from_v13.assert_called_once_with(sentinel.lti_jwt)
+        assert lti_params == LTIParams.from_v13.return_value
+
+    def test_without_lti_jwt(self, pyramid_request):
+        pyramid_request.lti_jwt = None
+        pyramid_request.params = sentinel.params
+
+        assert _get_lti_params(pyramid_request) == sentinel.params
+
+    @pytest.fixture
+    def LTIParams(self, patch):
+        return patch("lms.models.lti_params.LTIParams")
+
+
+class TestIncludeMe:
+    def test_it_sets_lti_jwt(self, configurator):
+        includeme(configurator)
+
+        configurator.add_request_method.assert_called_once_with(
+            _get_lti_params, name="lti_params", property=True, reify=True
+        )
+
+    @pytest.fixture()
+    def configurator(self):
+        return create_autospec(Configurator, spec_set=True, instance=True)

--- a/tests/unit/lms/models/product_test.py
+++ b/tests/unit/lms/models/product_test.py
@@ -1,0 +1,52 @@
+from unittest.mock import create_autospec
+
+import pytest
+from pyramid.config import Configurator
+
+from lms.models.product import Product, includeme
+
+PRODUCT_NAMES = [
+    ("BlackbaudK12", Product.Family.BLACKBAUD),
+    ("BlackboardLearn", Product.Family.BLACKBOARD),
+    ("canvas", Product.Family.CANVAS),
+    ("desire2learn", Product.Family.D2L),
+    ("moodle", Product.Family.MOODLE),
+    ("schoology", Product.Family.SCHOOLOGY),
+    ("sakai", Product.Family.SAKAI),
+    ("wut", Product.Family.UNKNOWN),
+    ("", Product.Family.UNKNOWN),
+    (None, Product.Family.UNKNOWN),
+]
+
+
+class TestProduct:
+    @pytest.mark.parametrize("value,expected", PRODUCT_NAMES)
+    def test_from_request_exact_match_lti(self, value, expected, pyramid_request):
+        pyramid_request.lti_params["tool_consumer_info_product_family_code"] = value
+
+        assert Product.from_request(pyramid_request).family == expected
+
+    @pytest.mark.parametrize("value,expected", PRODUCT_NAMES)
+    def test_from_request_api(self, value, expected, pyramid_request):
+        pyramid_request.content_type = "application/json"
+        pyramid_request.json = {"lms": {"product": value}}
+
+        assert Product.from_request(pyramid_request).family == expected
+
+    def test_from_request_canvas_custom(self, pyramid_request):
+        pyramid_request.lti_params = {"custom_canvas_course_id": "course_id"}
+
+        assert Product.from_request(pyramid_request).family == Product.Family.CANVAS
+
+
+class TestIncludeMe:
+    def test_it_sets_request_method(self, configurator):
+        includeme(configurator)
+
+        configurator.add_request_method.assert_called_once_with(
+            Product.from_request, name="product", property=True, reify=True
+        )
+
+    @pytest.fixture()
+    def configurator(self):
+        return create_autospec(Configurator, spec_set=True, instance=True)

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from pytest import param
 
-from lms.models import ApplicationSettings
+from lms.models import ApplicationSettings, Product
 from lms.resources import LTILaunchResource
 from lms.services import ApplicationInstanceNotFound
 
@@ -22,14 +22,14 @@ class TestResourceLinkIdk:
         ],
     )
     def test_it(self, pyramid_request, learner_id, get_id, lti_id, expected):
-        pyramid_request.params = {
-            "resource_link_id": lti_id,
-        }
         pyramid_request.GET = {
             "learner_canvas_user_id": learner_id,
             "resource_link_id": get_id,
         }
-        assert LTILaunchResource(pyramid_request).resource_link_id == expected
+        with mock.patch.object(
+            LTILaunchResource, "lti_params", {"resource_link_id": lti_id}
+        ):
+            assert LTILaunchResource(pyramid_request).resource_link_id == expected
 
 
 class TestIsLegacySpeedGrader:
@@ -84,30 +84,17 @@ class TestIsLegacySpeedGrader:
 
 class TestIsCanvas:
     @pytest.mark.parametrize(
-        "parsed_params,is_canvas",
+        "product,expected",
         [
-            # For *some* launches Canvas includes a
-            # `tool_consumer_info_product_family_code: canvas` and you can
-            # detect Canvas that way.
-            ({"tool_consumer_info_product_family_code": "canvas"}, True),
-            # Some Canvas launches, e.g. deep linking, do
-            # not have a tool_consumer_info_product_family_code param. In these
-            # cases we can instead detect Canvas by the presence of its
-            # custom_canvas_course_id param.
-            ({"custom_canvas_course_id": mock.sentinel.whatever}, True),
-            # Non-Canvas LMS's do also sometimes use
-            # tool_consumer_info_product_family_code but they don't set it to
-            # "canvas".
-            ({"tool_consumer_info_product_family_code": "whiteboard"}, False),
-            # If none of the recognized request params are present it should
-            # fall back on "not Canvas".
-            ({}, False),
+            (Product.Family.CANVAS, True),
+            (Product.Family.BLACKBOARD, False),
+            (Product.Family.UNKNOWN, False),
         ],
     )
-    def test_it(self, pyramid_request, parsed_params, is_canvas):
-        pyramid_request.parsed_params = parsed_params
+    def test_it(self, pyramid_request, product, expected):
+        pyramid_request.product.family = product
 
-        assert LTILaunchResource(pyramid_request).is_canvas == is_canvas
+        assert LTILaunchResource(pyramid_request).is_canvas == expected
 
 
 class TestCustomCanvasAPIDomain:
@@ -148,6 +135,7 @@ class TestCanvasSectionsSupported:
         with mock.patch.object(LTILaunchResource, "is_canvas", is_canvas):
             assert lti_launch.canvas_sections_supported() == is_canvas
 
+    @pytest.mark.usefixtures("with_canvas")
     @pytest.mark.parametrize(
         "params,expected",
         (
@@ -173,12 +161,14 @@ class TestCanvasSectionsSupported:
 
         assert lti_launch.canvas_sections_supported() is expected
 
+    @pytest.mark.usefixtures("with_canvas")
     def test_it_depends_on_application_instance_service(
         self, lti_launch, application_instance_service
     ):
         application_instance_service.get_current.return_value.developer_key = None
         assert not lti_launch.canvas_sections_supported()
 
+    @pytest.mark.usefixtures("with_canvas")
     def test_if_application_instance_service_raises(
         self, lti_launch, application_instance_service
     ):
@@ -241,9 +231,9 @@ class TestCourseExtra:
 
         assert not LTILaunchResource(pyramid_request)._course_extra()
 
+    @pytest.mark.usefixtures("with_canvas")
     def test_includes_course_id(self, pyramid_request):
         parsed_params = {
-            "tool_consumer_info_product_family_code": "canvas",
             "custom_canvas_course_id": "ID",
         }
         pyramid_request.parsed_params = parsed_params
@@ -368,31 +358,13 @@ class TestIsGroupLaunch:
 
 
 class TestLTIParams:
-    def test_it_when_lti_jwt(self, pyramid_request_with_jwt, LTIParams, lti_launch):
-        params = lti_launch.lti_params
-
-        LTIParams.from_v13.assert_called_once_with(pyramid_request_with_jwt.lti_jwt)
-        assert params == LTIParams.from_v13.return_value
-
-    def test_it_when_no_lti_jwt(self, pyramid_request, LTIParams, lti_launch):
-        params = lti_launch.lti_params
-
-        LTIParams.assert_called_once_with(pyramid_request.params)
-        assert params == LTIParams.return_value
+    def test_it_when_lti_jwt(self, lti_launch):
+        assert lti_launch.lti_params == mock.sentinel.lti_params
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.lti_jwt = {}
+        pyramid_request.lti_params = mock.sentinel.lti_params
         return pyramid_request
-
-    @pytest.fixture
-    def pyramid_request_with_jwt(self, pyramid_request):
-        pyramid_request.lti_jwt = {"KEY": "VALUE"}
-        return pyramid_request
-
-    @pytest.fixture
-    def LTIParams(self, patch):
-        return patch("lms.resources.lti_launch.LTIParams")
 
 
 @pytest.fixture
@@ -418,3 +390,8 @@ def has_course(pyramid_request):
 def pyramid_request(pyramid_request):
     pyramid_request.parsed_params = {}
     return pyramid_request
+
+
+@pytest.fixture
+def with_canvas(pyramid_request):
+    pyramid_request.product.family = Product.Family.CANVAS

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -17,22 +17,17 @@ from lms.validation import (
 
 
 class TestLTIV11CoreSchema:
-    def test_with_lti_jwt(self, pyramid_request, LTIParams, lti_v11_params):
+    def test_with_lti_jwt(self, pyramid_request, lti_v11_params):
         class ExampleSchema(LTIV11CoreSchema):
             location = "form"
             extra = marshmallow.fields.Str(required=False)
 
-        LTIParams.from_v13.return_value = lti_v11_params
+        pyramid_request.lti_params = lti_v11_params
 
         parsed_params = ExampleSchema(pyramid_request).parse()
 
-        LTIParams.from_v13.assert_called_once_with(pyramid_request.lti_jwt)
         # The resulting value contains both the key from the JWT and the extra one that comes originally from request.params
         assert parsed_params == Any.dict.containing({"extra": Any.string()})
-
-    @pytest.fixture
-    def LTIParams(self, patch):
-        return patch("lms.validation._lti_launch_params.LTIParams")
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/unit/lms/validation/authentication/_lti_test.py
+++ b/tests/unit/lms/validation/authentication/_lti_test.py
@@ -4,6 +4,7 @@ import marshmallow
 import pytest
 from pyramid.httpexceptions import HTTPUnprocessableEntity
 
+from lms.models import LTIParams
 from lms.services import ApplicationInstanceNotFound, LTILaunchVerificationError
 from lms.validation._exceptions import ValidationError
 from lms.validation.authentication import LTI11AuthSchema, LTI13AuthSchema
@@ -142,6 +143,7 @@ class TestLTI13AuthSchema:
     def pyramid_request(self, pyramid_request, lti_v13_params):
         pyramid_request.params["id_token"] = sentinel.id_token
         pyramid_request.lti_jwt = lti_v13_params
+        pyramid_request.lti_params = LTIParams.from_v13(lti_v13_params)
 
         return pyramid_request
 


### PR DESCRIPTION
Adds a `.product` property to the request object.

This doesn't look like much of an improvement over the current situation but enables many other refactors.