### PR TITLE
Simplify grade fetching using `useFetch` hook

### DIFF
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -40,19 +40,21 @@ export default function SubmitGradeForm({ student }) {
   const [fetchGradeErrorDismissed, setFetchGradeErrorDismissed] =
     useState(false);
   const gradingService = useService(GradingService);
+
+  /** @param {StudentInfo} student */
+  const fetchGrade = async student => {
+    setFetchGradeErrorDismissed(false);
+    const { currentScore = null } = await gradingService.fetchGrade({
+      student,
+    });
+    return currentScore === null
+      ? ''
+      : `${scaleGrade(currentScore, GRADE_MULTIPLIER)}`;
+  };
+
   const grade = useFetch(
     student ? `grade:${student.userid}` : null,
-    student
-      ? async () => {
-          setFetchGradeErrorDismissed(false);
-          const { currentScore = null } = await gradingService.fetchGrade({
-            student,
-          });
-          return currentScore === null
-            ? ''
-            : `${scaleGrade(currentScore, GRADE_MULTIPLIER)}`;
-        }
-      : undefined
+    student ? () => fetchGrade(student) : undefined
   );
 
   // The following is state for saving the grade

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -261,14 +261,15 @@ describe('SubmitGradeForm', () => {
       assert.strictEqual(wrapper.find(inputSelector).prop('defaultValue'), '');
     });
 
-    it('shows the error dialog when the grade request throws an error', () => {
+    it('shows the error dialog when the grade request throws an error', async () => {
       const error = {
         serverMessage: 'message',
         details: 'details',
       };
-      fakeGradingService.fetchGrade.throws(error);
+      fakeGradingService.fetchGrade.rejects(error);
       const wrapper = renderForm();
-      wrapper.find('button[type="submit"]').simulate('click');
+
+      await waitForGradeFetch(wrapper);
 
       assert.isTrue(wrapper.find('ErrorModal').exists());
       // Ensure the error object passed to ErrorDialog is the same as the one thrown


### PR DESCRIPTION
Use the `useFetch` hook to simplify fetching the grade for a student in
the SubmitGradeForm component. In particular `useFetch` handles ignoring
the results of fetches when the input query changes, avoiding the need
for the component to do it.

There was an error in a test where an async function was faked with a
stub that threw synchronously. This has been corrected to be async like
the real implementation.

---

**Testing:**

Aside from the unit tests, I also did a manual test of the grading bar using the assignment at https://hypothesisuniversity.moodlecloud.com/course/view.php?id=11.

To test error handling I applied this diff to force grade fetches to fail:

```diff
diff --git a/lms/views/api/lti.py b/lms/views/api/lti.py
index f71e233f..baf04b1e 100644
--- a/lms/views/api/lti.py
+++ b/lms/views/api/lti.py
@@ -43,7 +43,7 @@ class LTIOutcomesViews:
         """Proxy request for current result (grade/score) to LTI Outcomes Result API."""
 
         current_score = self.lti_grading_service.read_result(
-            self.parsed_params["lis_result_sourcedid"]
+            self.parsed_params["lis_result_sourcedid"] + "FOO"
         )
 
         return {"currentScore": current_score}
```