### PR TITLE
Add `retry` callback to `useFetch` result

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -184,8 +184,6 @@ describe('useFetch', () => {
 
       await waitForFetch(wrapper);
       assert.equal(getResult(wrapper), 'Data: OK');
-
-      wrapper.unmount();
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -15,12 +15,17 @@ describe('useFetch', () => {
     const isIdle = !thing.data && !thing.error && !thing.isLoading;
 
     return (
-      <div>
-        {isIdle && 'Nothing to fetch'}
-        {thing.isLoading && 'Loading'}
-        {thing.error && `Error: ${thing.error.message}`}
-        {thing.data && `Data: ${thing.data}`}
-      </div>
+      <>
+        <div data-testid="result">
+          {isIdle && 'Nothing to fetch'}
+          {thing.isLoading && 'Loading'}
+          {thing.error && `Error: ${thing.error.message}`}
+          {thing.data && `Data: ${thing.data}`}
+        </div>
+        <button data-testid="retry" onClick={thing.retry}>
+          Retry
+        </button>
+      </>
     );
   }
 
@@ -35,6 +40,14 @@ describe('useFetch', () => {
     wrapper.update();
   }
 
+  function getResult(wrapper) {
+    return wrapper.find('[data-testid="result"]').text();
+  }
+
+  function retry(wrapper) {
+    return wrapper.find('[data-testid="retry"]').simulate('click');
+  }
+
   beforeEach(() => {
     wrappers = [];
   });
@@ -45,20 +58,20 @@ describe('useFetch', () => {
 
   it('returns loading state initially if loading', () => {
     const wrapper = renderWidget('some-key', async () => 'Some data');
-    assert.equal(wrapper.text(), 'Loading');
+    assert.equal(getResult(wrapper), 'Loading');
   });
 
   [async () => 'Some data', undefined, null].forEach(fetcher => {
     it('returns idle state if not loading', () => {
       const wrapper = renderWidget(null, fetcher);
-      assert.equal(wrapper.text(), 'Nothing to fetch');
+      assert.equal(getResult(wrapper), 'Nothing to fetch');
     });
   });
 
   it('fetches data and returns result', async () => {
     const wrapper = renderWidget('some-key', async () => 'Some data');
     await waitForFetch(wrapper);
-    assert.equal(wrapper.text(), 'Data: Some data');
+    assert.equal(getResult(wrapper), 'Data: Some data');
   });
 
   it('cancels fetch if key changes', () => {
@@ -81,32 +94,32 @@ describe('useFetch', () => {
       throw new Error('Some error');
     });
     await waitForFetch(wrapper);
-    assert.equal(wrapper.text(), 'Error: Some error');
+    assert.equal(getResult(wrapper), 'Error: Some error');
   });
 
   it('transitions to loading state if key changes', async () => {
     const wrapper = renderWidget('some-key', async () => 'Some data');
     await waitForFetch(wrapper);
-    assert.equal(wrapper.text(), 'Data: Some data');
+    assert.equal(getResult(wrapper), 'Data: Some data');
 
     wrapper.setProps({
       fetchKey: 'other-key',
       fetcher: async () => 'Different data',
     });
-    assert.equal(wrapper.text(), 'Loading');
+    assert.equal(getResult(wrapper), 'Loading');
 
     await waitForFetch(wrapper);
-    assert.equal(wrapper.text(), 'Data: Different data');
+    assert.equal(getResult(wrapper), 'Data: Different data');
   });
 
   it('transitions to idle state if key is set to null', async () => {
     const wrapper = renderWidget('some-key', async () => 'Some data');
     await waitForFetch(wrapper);
-    assert.equal(wrapper.text(), 'Data: Some data');
+    assert.equal(getResult(wrapper), 'Data: Some data');
 
     wrapper.setProps({ fetchKey: null });
 
-    assert.equal(wrapper.text(), 'Nothing to fetch');
+    assert.equal(getResult(wrapper), 'Nothing to fetch');
   });
 
   it('cancels fetch if component is unmounted', () => {
@@ -125,5 +138,54 @@ describe('useFetch', () => {
     assert.throws(() => {
       renderWidget('some-key');
     }, 'Fetch key provided but no fetcher set');
+  });
+
+  describe('`retry` callback', () => {
+    it('does nothing if there is nothing to fetch', () => {
+      const fetcher = sinon.stub();
+      const wrapper = renderWidget(null, fetcher);
+      assert.equal(getResult(wrapper), 'Nothing to fetch');
+
+      retry(wrapper);
+
+      assert.equal(getResult(wrapper), 'Nothing to fetch');
+      assert.notCalled(fetcher);
+    });
+
+    it('does nothing if data is being fetched', async () => {
+      const fetcher = sinon.stub().resolves('OK');
+      const wrapper = renderWidget('test-key', fetcher);
+      assert.equal(getResult(wrapper), 'Loading');
+
+      retry(wrapper);
+
+      assert.equal(getResult(wrapper), 'Loading');
+      assert.calledOnce(fetcher);
+
+      await waitForFetch(wrapper);
+      assert.equal(getResult(wrapper), 'Data: OK');
+    });
+
+    it('re-runs the last fetch', async () => {
+      let fail = true;
+      const fetcher = async () => {
+        if (fail) {
+          throw new Error('Fetch failed');
+        }
+        return 'OK';
+      };
+
+      const wrapper = renderWidget('some-key', fetcher);
+      await waitForFetch(wrapper);
+      assert.equal(getResult(wrapper), 'Error: Fetch failed');
+
+      fail = false;
+      retry(wrapper);
+
+      await waitForFetch(wrapper);
+      assert.equal(getResult(wrapper), 'Data: OK');
+
+      wrapper.unmount();
+    });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -40,7 +40,7 @@ describe('useFetch', () => {
     wrapper.update();
   }
 
-  function getResult(wrapper) {
+  function getResultText(wrapper) {
     return wrapper.find('[data-testid="result"]').text();
   }
 
@@ -58,20 +58,20 @@ describe('useFetch', () => {
 
   it('returns loading state initially if loading', () => {
     const wrapper = renderWidget('some-key', async () => 'Some data');
-    assert.equal(getResult(wrapper), 'Loading');
+    assert.equal(getResultText(wrapper), 'Loading');
   });
 
   [async () => 'Some data', undefined, null].forEach(fetcher => {
     it('returns idle state if not loading', () => {
       const wrapper = renderWidget(null, fetcher);
-      assert.equal(getResult(wrapper), 'Nothing to fetch');
+      assert.equal(getResultText(wrapper), 'Nothing to fetch');
     });
   });
 
   it('fetches data and returns result', async () => {
     const wrapper = renderWidget('some-key', async () => 'Some data');
     await waitForFetch(wrapper);
-    assert.equal(getResult(wrapper), 'Data: Some data');
+    assert.equal(getResultText(wrapper), 'Data: Some data');
   });
 
   it('cancels fetch if key changes', () => {
@@ -94,32 +94,32 @@ describe('useFetch', () => {
       throw new Error('Some error');
     });
     await waitForFetch(wrapper);
-    assert.equal(getResult(wrapper), 'Error: Some error');
+    assert.equal(getResultText(wrapper), 'Error: Some error');
   });
 
   it('transitions to loading state if key changes', async () => {
     const wrapper = renderWidget('some-key', async () => 'Some data');
     await waitForFetch(wrapper);
-    assert.equal(getResult(wrapper), 'Data: Some data');
+    assert.equal(getResultText(wrapper), 'Data: Some data');
 
     wrapper.setProps({
       fetchKey: 'other-key',
       fetcher: async () => 'Different data',
     });
-    assert.equal(getResult(wrapper), 'Loading');
+    assert.equal(getResultText(wrapper), 'Loading');
 
     await waitForFetch(wrapper);
-    assert.equal(getResult(wrapper), 'Data: Different data');
+    assert.equal(getResultText(wrapper), 'Data: Different data');
   });
 
   it('transitions to idle state if key is set to null', async () => {
     const wrapper = renderWidget('some-key', async () => 'Some data');
     await waitForFetch(wrapper);
-    assert.equal(getResult(wrapper), 'Data: Some data');
+    assert.equal(getResultText(wrapper), 'Data: Some data');
 
     wrapper.setProps({ fetchKey: null });
 
-    assert.equal(getResult(wrapper), 'Nothing to fetch');
+    assert.equal(getResultText(wrapper), 'Nothing to fetch');
   });
 
   it('cancels fetch if component is unmounted', () => {
@@ -144,26 +144,26 @@ describe('useFetch', () => {
     it('does nothing if there is nothing to fetch', () => {
       const fetcher = sinon.stub();
       const wrapper = renderWidget(null, fetcher);
-      assert.equal(getResult(wrapper), 'Nothing to fetch');
+      assert.equal(getResultText(wrapper), 'Nothing to fetch');
 
       retry(wrapper);
 
-      assert.equal(getResult(wrapper), 'Nothing to fetch');
+      assert.equal(getResultText(wrapper), 'Nothing to fetch');
       assert.notCalled(fetcher);
     });
 
     it('does nothing if data is being fetched', async () => {
       const fetcher = sinon.stub().resolves('OK');
       const wrapper = renderWidget('test-key', fetcher);
-      assert.equal(getResult(wrapper), 'Loading');
+      assert.equal(getResultText(wrapper), 'Loading');
 
       retry(wrapper);
 
-      assert.equal(getResult(wrapper), 'Loading');
+      assert.equal(getResultText(wrapper), 'Loading');
       assert.calledOnce(fetcher);
 
       await waitForFetch(wrapper);
-      assert.equal(getResult(wrapper), 'Data: OK');
+      assert.equal(getResultText(wrapper), 'Data: OK');
     });
 
     it('re-runs the last fetch', async () => {
@@ -177,13 +177,13 @@ describe('useFetch', () => {
 
       const wrapper = renderWidget('some-key', fetcher);
       await waitForFetch(wrapper);
-      assert.equal(getResult(wrapper), 'Error: Fetch failed');
+      assert.equal(getResultText(wrapper), 'Error: Fetch failed');
 
       fail = false;
       retry(wrapper);
 
       await waitForFetch(wrapper);
-      assert.equal(getResult(wrapper), 'Data: OK');
+      assert.equal(getResultText(wrapper), 'Data: OK');
     });
   });
 });


### PR DESCRIPTION
We have various places in our app where an API fetch gets retried after
re-authorization or when manually triggered by the user. Add a `retry` callback
to the `useFetch` hook's result to enable converting some of these fetches to use
`useFetch`/`useAPIFetch`.