### PR TITLE
Store more metadata with assignments

### DIFF
--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -3,9 +3,10 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
 
 from lms.db import BASE
+from lms.models import CreatedUpdatedMixin
 
 
-class Assignment(BASE):
+class Assignment(CreatedUpdatedMixin, BASE):
     """
     An assignment configuration.
 
@@ -48,6 +49,20 @@ class Assignment(BASE):
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )
+
+    is_gradable = sa.Column(
+        sa.Boolean(),
+        default=False,
+        server_default=sa.sql.expression.false(),
+        nullable=False,
+    )
+    """Whether this assignment is gradable or not."""
+
+    title = sa.Column(sa.Unicode, nullable=True)
+    """The resource link title from LTI params."""
+
+    description = sa.Column(sa.Unicode, nullable=True)
+    """The resource link description from LTI params."""
 
     def get_canvas_mapped_file_id(self, file_id):
         return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -39,6 +39,8 @@ _V11_TO_V13 = (
     ("lti_version", [f"{CLAIM_PREFIX}/version"]),
     ("lti_message_type", [f"{CLAIM_PREFIX}/message_type"]),
     ("resource_link_id", [f"{CLAIM_PREFIX}/resource_link", "id"]),
+    ("resource_link_title", [f"{CLAIM_PREFIX}/resource_link", "title"]),
+    ("resource_link_description", [f"{CLAIM_PREFIX}/resource_link", "description"]),
     # tool_consumer_instance_guid is not sent by the LTI1.3 certification tool but we include
     # it as a custom parameter in the tool configuration
     ("tool_consumer_instance_guid", [f"{CLAIM_PREFIX}/custom", "certification_guid"]),

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -272,20 +272,22 @@ class BasicLaunchViews:
             [self.context.course], self.context.lti_params
         )
 
-        # Store assignment details
-        self.assignment_service.upsert_assignment(
-            document_url=document_url,
-            tool_consumer_instance_guid=self.context.lti_params[
-                "tool_consumer_instance_guid"
-            ],
-            resource_link_id=self.context.resource_link_id,
-            extra=assignment_extra,
-        )
-
         # An assignment has been configured in the LMS as "gradable" if it has
         # the `lis_outcome_service_url` param
         assignment_gradable = bool(
             self.context.lti_params.get("lis_outcome_service_url")
+        )
+
+        # Store assignment details
+        self.assignment_service.upsert_assignment(
+            tool_consumer_instance_guid=self.context.lti_params[
+                "tool_consumer_instance_guid"
+            ],
+            resource_link_id=self.context.resource_link_id,
+            document_url=document_url,
+            lti_params=self.context.lti_params,
+            extra=assignment_extra,
+            is_gradable=assignment_gradable,
         )
 
         # Set up the JS config for the front-end

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -50,6 +50,8 @@ def lti_v13_params():
         "https://purl.imsglobal.org/spec/lti/claim/version": "LTI_VERSION",
         "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
             "id": "RESOURCE_LINK_ID",
+            "title": "RESOURCE_LINK_TITLE",
+            "description": "RESOURCE_LINK_DESCRIPTION",
         },
         "iss": "ISSUER",
         "aud": "CLIENT_ID",

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -19,6 +19,8 @@ class TestLTI13Params:
             ("lti_version", "LTI_VERSION"),
             ("lti_message_type", "LTI_MESSAGE_TYPE"),
             ("resource_link_id", "RESOURCE_LINK_ID"),
+            ("resource_link_title", "RESOURCE_LINK_TITLE"),
+            ("resource_link_description", "RESOURCE_LINK_DESCRIPTION"),
         ],
     )
     def test_v13_mappings(self, lti_v13_params, lti_11_key, value):

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -239,11 +239,13 @@ class TestBasicLaunchViews:
         lti_h_service.sync.assert_called_once_with([context.course], context.lti_params)
 
         assignment_service.upsert_assignment.assert_called_once_with(
-            document_url=sentinel.document_url,
             tool_consumer_instance_guid=context.lti_params[
                 "tool_consumer_instance_guid"
             ],
             resource_link_id=context.lti_params["resource_link_id"],
+            document_url=sentinel.document_url,
+            lti_params=context.lti_params,
+            is_gradable=False,
             extra=sentinel.assignment_extra,
         )
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3991
 
Cannot be merged before:

 * https://github.com/hypothesis/lms/pull/4059

This adds storage of:

 * Created date
 * Updated date
 * Is gradable
 * Title
 * Description

## Implementation notes

The two fields we are reading from LTI params are title and description. It's hard to link to these in the spec for 1.1 ('cos the doc is broken):

 * https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-3 - 1.1
 
 > resource_link_title=My Weekly Wiki
A plain text[[1]](https://www.imsglobal.org/LTI/v1p1p1/ltiIMGv1p1p1.html#_ftn1) title for the resource. This is the clickable text that appears in the link. This parameter is recommended.
 >
> resource_link_description=…
A plain text description of the link’s destination, suitable for display alongside the link. Typically no more than a few lines long. This parameter is optional.

 * https://www.imsglobal.org/spec/lti/v1p3/#lti-resourcelink-variables
 
> ResourceLink.title | resource_link.title property
> ResourceLink.description | resource_link.description property

I've tried Canvas and Blackboard and neither seems to set the description, but :shrug: if anyone does, we'll catch it.

## Testing notes

 * `make db`
 * `make dev` on everything
 * Visit: https://hypothesis.instructure.com/courses/125/assignments/873
 ```shell
 tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from assignment where resource_link_id='f330509e8ee8e465a55c4c88a4fcc9ef1ee992bd'";
 ```
 * You should see values for the new fields (apart from description) with gradable true
 * Visit:https://hypothesis.instructure.com/courses/125/assignments/873 again
 ```shell
 tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from assignment where resource_link_id='f330509e8ee8e465a55c4c88a4fcc9ef1ee992bd'";
```
 * The updated date should have changed, and the created should not

### Testing graded / non-graded

 * Visit: https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_718_1&course_id=_19_1
 ```shell
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from assignment where resource_link_id='_718_1'";
```
 * The assignment should be marked graded
 * Visit: https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_717_1&course_id=_19_1
 ```shell
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from assignment where resource_link_id='_717_1'";
```
 * This should be marked as non graded

**Note:** I think it's logically impossible for us to be ungraded in Canvas as we are a submission type. If the assignment is not-graded, there is no submission, so there is no opportunity to configure us?
 
### Testing description

 * Visit: https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=110&forceview=1
```shell
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from assignment where resource_link_id='88'";
```
* You should see a description