### PR TITLE
Renamed default branch to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,14 +39,14 @@ node {
         }
     }
 
-    onlyOnMaster {
+    onlyOnMain {
         stage("release") {
             releaseApp(image: img)
         }
     }
 }
 
-onlyOnMaster {
+onlyOnMain {
     milestone()
     stage("qa deploy") {
         deployApp(image: img, app: "lms", env: "qa", region: "us-west-1")

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/hypothesis/lms.svg?branch=master)](https://travis-ci.org/hypothesis/lms)
+[![Build Status](https://travis-ci.org/hypothesis/lms.svg?branch=main)](https://travis-ci.org/hypothesis/lms)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![Coverage: 100%](https://img.shields.io/badge/Coverage-100%25-brightgreen)](https://github.com/hypothesis/lms/blob/master/.coveragerc#L18)
+[![Coverage: 100%](https://img.shields.io/badge/Coverage-100%25-brightgreen)](https://github.com/hypothesis/lms/blob/main/.coveragerc#L18)
 
 # Hypothesis LMS App
 


### PR DESCRIPTION
1. Replaced the onlyOnMaster function with onlyOnMain in the Jenkinsfile
2. Replaced references to master with main in README.markdown
3. ~~Replaced section targeting MASTER branch with MAIN in tests/.pylintrc~~

The update to `tests/.pylintrc` was removed. Move info can be found here: https://hypothes-is.slack.com/archives/C1MA4E9B9/p1654675409844899