### PR TITLE
Track what roles users have within assignments

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -2,6 +2,7 @@ from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
 from lms.models.assignment import Assignment
+from lms.models.assignment_membership import AssignmentMembership
 from lms.models.course import LegacyCourse
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
 from lms.models.exceptions import ReusedConsumerKey

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -20,6 +20,7 @@ from lms.models.h_user import HUser
 from lms.models.lti_launches import LtiLaunches
 from lms.models.lti_params import CLAIM_PREFIX, LTIParams
 from lms.models.lti_registration import LTIRegistration
+from lms.models.lti_role import LTIRole
 from lms.models.lti_user import LTIUser, display_name
 from lms.models.oauth2_token import OAuth2Token
 from lms.models.rsa_key import RSAKey

--- a/lms/models/assignment_membership.py
+++ b/lms/models/assignment_membership.py
@@ -1,0 +1,30 @@
+import sqlalchemy as sa
+
+from lms.db import BASE
+from lms.models import CreatedUpdatedMixin
+
+
+class AssignmentMembership(CreatedUpdatedMixin, BASE):
+    """Model for users associations with assignments."""
+
+    __tablename__ = "assignment_membership"
+
+    assignment_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("assignment.id", ondelete="cascade"),
+        primary_key=True,
+    )
+    assignment = sa.orm.relationship("Assignment", foreign_keys=[assignment_id])
+    """The assignment the user is a member of."""
+
+    user_id = sa.Column(
+        sa.Integer(), sa.ForeignKey("user.id", ondelete="cascade"), primary_key=True
+    )
+    user = sa.orm.relationship("User", foreign_keys=[user_id])
+    """The user who is a member."""
+
+    lti_role_id = sa.Column(
+        sa.Integer(), sa.ForeignKey("lti_role.id", ondelete="cascade"), primary_key=True
+    )
+    lti_role = sa.orm.relationship("LTIRole", foreign_keys=[lti_role_id])
+    """What role the user plays in the assignment."""

--- a/lms/models/lti_role.py
+++ b/lms/models/lti_role.py
@@ -1,0 +1,117 @@
+from enum import Enum, unique
+
+
+@unique
+class RoleType(str, Enum):
+    """Enum for the different types of role a user can have."""
+
+    INSTRUCTOR = "instructor"
+    LEARNER = "learner"
+    ADMIN = "admin"
+
+    @classmethod
+    def parse_lti_role(cls, role):
+        """Parse an LTI role string into one of our role types."""
+
+        # We have to do this work around because Enums can't have private
+        # attributes. They are just interpreted as extra values for the enum.
+        return _RoleParser.parse_role(role)
+
+
+class _RoleParser:
+    """Close collaborator class for parsing roles."""
+
+    @classmethod
+    def parse_role(cls, role) -> RoleType:
+        return (
+            cls._parse_v13_role(role) or cls._parse_v11_role(role) or RoleType.LEARNER
+        )
+
+    _V11_INSTRUCTOR_STRINGS = (
+        "instructor",
+        "teachingassistant",
+        "contentdeveloper",
+        "faculty",
+        "mentor",
+        "staff",
+    )
+
+    @classmethod
+    def _parse_v11_role(cls, role):
+        role = role.lower()
+
+        for string in cls._V11_INSTRUCTOR_STRINGS:
+            if string in role:
+                return RoleType.INSTRUCTOR
+
+        if "learner" in role:
+            return RoleType.LEARNER
+
+        if "admin" in role:
+            return RoleType.ADMIN
+
+        return None
+
+    _V13_PREFIX = "http://purl.imsglobal.org/vocab/lis/v2"
+    _V13_ROLE_MAPPINGS = {
+        # https://www.imsglobal.org/spec/lti/v1p3/#lis-vocabulary-for-context-roles
+        # A.2.1 LIS vocabulary for system roles
+        # Core system roles
+        f"{_V13_PREFIX}/system/person#Administrator": RoleType.ADMIN,
+        f"{_V13_PREFIX}/system/person#None": RoleType.LEARNER,
+        # Non‑core system roles
+        f"{_V13_PREFIX}/system/person#AccountAdmin": RoleType.ADMIN,
+        f"{_V13_PREFIX}/system/person#Creator": RoleType.INSTRUCTOR,
+        f"{_V13_PREFIX}/system/person#SysAdmin": RoleType.ADMIN,
+        f"{_V13_PREFIX}/system/person#SysSupport": RoleType.ADMIN,
+        f"{_V13_PREFIX}/system/person#User": RoleType.LEARNER,
+        # A.2.2 LIS vocabulary for institution roles
+        # Core institution roles
+        f"{_V13_PREFIX}/institution/person#Administrator": RoleType.ADMIN,
+        f"{_V13_PREFIX}/institution/person#Faculty": RoleType.INSTRUCTOR,
+        f"{_V13_PREFIX}/institution/person#Guest": RoleType.LEARNER,
+        f"{_V13_PREFIX}/institution/person#None": RoleType.LEARNER,
+        f"{_V13_PREFIX}/institution/person#Other": RoleType.LEARNER,
+        f"{_V13_PREFIX}/institution/person#Staff": RoleType.INSTRUCTOR,
+        f"{_V13_PREFIX}/institution/person#Student": RoleType.LEARNER,
+        # Non‑core institution roles
+        f"{_V13_PREFIX}/institution/person#Alumni": RoleType.LEARNER,
+        f"{_V13_PREFIX}/institution/person#Instructor": RoleType.INSTRUCTOR,
+        f"{_V13_PREFIX}/institution/person#Learner": RoleType.LEARNER,
+        f"{_V13_PREFIX}/institution/person#Member": RoleType.LEARNER,
+        f"{_V13_PREFIX}/institution/person#Mentor": RoleType.INSTRUCTOR,
+        f"{_V13_PREFIX}/institution/person#Observer": RoleType.LEARNER,
+        f"{_V13_PREFIX}/institution/person#ProspectiveStudent": RoleType.LEARNER,
+        # A.2.3 LIS vocabulary for context roles
+        # Core context roles
+        f"{_V13_PREFIX}/membership/Administrator": RoleType.ADMIN,
+        f"{_V13_PREFIX}/membership/ContentDeveloper": RoleType.INSTRUCTOR,
+        f"{_V13_PREFIX}/membership/Instructor": RoleType.INSTRUCTOR,
+        # Look out for this weirdo!
+        f"{_V13_PREFIX}/membership/Learner#Instructor": RoleType.INSTRUCTOR,
+        f"{_V13_PREFIX}/membership/Learner": RoleType.LEARNER,
+        f"{_V13_PREFIX}/membership/Mentor": RoleType.INSTRUCTOR,
+        # Non‑core context roles
+        f"{_V13_PREFIX}/membership/Manager": RoleType.INSTRUCTOR,
+        f"{_V13_PREFIX}/membership/Member": RoleType.LEARNER,
+        f"{_V13_PREFIX}/membership/Office": RoleType.INSTRUCTOR,
+    }
+
+    @classmethod
+    def _parse_v13_role(cls, role):
+        role = role.strip()
+
+        # Save some time if we aren't going to match
+        if not role.startswith(cls._V13_PREFIX):
+            return None
+
+        # Try a quick match
+        if type_ := cls._V13_ROLE_MAPPINGS.get(role):
+            return type_
+
+        # Do a thorough prefix match
+        for prefix, type_ in cls._V13_ROLE_MAPPINGS.items():
+            if role.startswith(prefix):
+                return type_
+
+        return None

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -21,6 +21,7 @@ from lms.services.launch_verifier import (
 )
 from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_registration import LTIRegistrationService
+from lms.services.lti_role_service import LTIRoleService
 from lms.services.ltia_http import LTIAHTTPService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
@@ -82,6 +83,9 @@ def includeme(config):
     config.register_service_factory("lms.services.jstor.factory", iface=JSTORService)
     config.register_service_factory(
         "lms.services.lti_registration.factory", iface=LTIRegistrationService
+    )
+    config.register_service_factory(
+        "lms.services.lti_role_service.service_factory", iface=LTIRoleService
     )
     config.register_service_factory("lms.services.aes.factory", iface=AESService)
     config.register_service_factory("lms.services.jwt.factory", iface=JWTService)

--- a/lms/services/lti_role_service.py
+++ b/lms/services/lti_role_service.py
@@ -1,0 +1,38 @@
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from lms.models import LTIRole
+
+
+class LTIRoleService:
+    """A service for dealing with LTIRole objects."""
+
+    def __init__(self, db_session: Session):
+        self._db = db_session
+
+    def get_roles(self, role_description: str) -> List[LTIRole]:
+        """
+        Get a list of role objects for the provided strings.
+
+        :param role_description: A comma delimited set of role strings
+        """
+        role_strings = [role.strip() for role in role_description.split(",")]
+
+        # pylint: disable=no-member
+        # Pylint is confused about the `in_` for some reason
+        roles = self._db.query(LTIRole).filter(LTIRole.value.in_(role_strings)).all()
+
+        if missing := (set(role_strings) - set(role.value for role in roles)):
+            new_roles = [LTIRole(value=value) for value in missing]
+            self._db.add_all(new_roles)
+
+            roles.extend(new_roles)
+
+        return roles
+
+
+def service_factory(_context, request) -> LTIRoleService:
+    """Create an LTIRoleService object."""
+
+    return LTIRoleService(db_session=request.db)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -5,6 +5,7 @@ from factory.alchemy import SQLAlchemyModelFactory
 from tests.factories import requests_ as requests
 from tests.factories.application_instance import ApplicationInstance
 from tests.factories.assignment import Assignment
+from tests.factories.assignment_membership import AssignmentMembership
 from tests.factories.attributes import (
     ACCESS_TOKEN,
     H_DISPLAY_NAME,

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -22,6 +22,7 @@ from tests.factories.group_info import GroupInfo
 from tests.factories.grouping import BlackboardGroup, CanvasGroup, CanvasSection, Course
 from tests.factories.h_user import HUser
 from tests.factories.lti_registration import LTIRegistration
+from tests.factories.lti_role import LTIRole
 from tests.factories.lti_user import LTIUser
 from tests.factories.oauth2_token import OAuth2Token
 from tests.factories.rsa_key import RSAKey

--- a/tests/factories/assignment_membership.py
+++ b/tests/factories/assignment_membership.py
@@ -1,0 +1,8 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+AssignmentMembership = make_factory(
+    models.AssignmentMembership, FACTORY_CLASS=SQLAlchemyModelFactory
+)

--- a/tests/factories/lti_role.py
+++ b/tests/factories/lti_role.py
@@ -1,0 +1,28 @@
+import factory
+from factory import Faker, Sequence
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+
+class LTIRole(SQLAlchemyModelFactory):
+    class Meta:
+        model = models.LTIRole
+
+        exclude = ("primary_role", "sub_role")
+
+    primary_role = Faker(
+        "random_element",
+        elements=[
+            "http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator",
+            "http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper",
+            "http://purl.imsglobal.org/vocab/lis/v2/membership/Learner",
+            "http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor",
+            "http://purl.imsglobal.org/vocab/lis/v2/membership/Manager",
+            "http://purl.imsglobal.org/vocab/lis/v2/membership/Office",
+        ],
+    )
+    sub_role = Sequence(lambda n: f"SubRole{n}")
+
+    # We want the value to be random, but it must also be guaranteed unique
+    value = factory.LazyAttribute(lambda o: f"{o.primary_role}#{o.sub_role}")

--- a/tests/unit/lms/models/assignment_membership_test.py
+++ b/tests/unit/lms/models/assignment_membership_test.py
@@ -1,0 +1,49 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from lms.models import AssignmentMembership
+from tests import factories
+
+
+class TestAssignmentMembership:
+    def test_it(self, db_session, user, assignment, lti_role):
+        db_session.commit()  # Ensure our objects have ids
+
+        membership = AssignmentMembership(
+            user=user, assignment=assignment, lti_role=lti_role
+        )
+        db_session.add(membership)
+
+        db_session.flush()
+        assert membership.user == user
+        assert membership.user_id == user.id
+        assert membership.assignment == assignment
+        assert membership.assignment_id == assignment.id
+        assert membership.lti_role == lti_role
+        assert membership.lti_role_id == lti_role.id
+
+    def test_it_does_not_allow_duplicates(self, db_session, user, assignment, lti_role):
+        db_session.add(
+            AssignmentMembership(user=user, assignment=assignment, lti_role=lti_role)
+        )
+        db_session.commit()
+
+        with pytest.raises(IntegrityError):
+            db_session.add(
+                AssignmentMembership(
+                    user=user, assignment=assignment, lti_role=lti_role
+                )
+            )
+            db_session.commit()
+
+    @pytest.fixture
+    def user(self):
+        return factories.User.create()
+
+    @pytest.fixture
+    def assignment(self):
+        return factories.Assignment.create()
+
+    @pytest.fixture
+    def lti_role(self):
+        return factories.LTIRole.create()

--- a/tests/unit/lms/models/lti_role_test.py
+++ b/tests/unit/lms/models/lti_role_test.py
@@ -1,0 +1,85 @@
+import pytest
+
+from lms.models.lti_role import RoleType, _RoleParser
+
+
+class TestRoleType:
+    # At the time of writing, this is every role string we've seen from an
+    # LTI 1.1 LMS
+    @pytest.mark.parametrize(
+        "value,role_type",
+        (
+            ("Administrator", RoleType.ADMIN),
+            ("Alumni", RoleType.LEARNER),
+            ("ContentDeveloper", RoleType.INSTRUCTOR),
+            ("Faculty", RoleType.INSTRUCTOR),
+            ("Guest", RoleType.LEARNER),
+            ("Instructor", RoleType.INSTRUCTOR),
+            ("Learner", RoleType.LEARNER),
+            ("Member", RoleType.LEARNER),
+            ("Mentor", RoleType.INSTRUCTOR),
+            ("None", RoleType.LEARNER),
+            ("Observer", RoleType.LEARNER),
+            ("Other", RoleType.LEARNER),
+            ("ProspectiveStudent", RoleType.LEARNER),
+            ("Staff", RoleType.INSTRUCTOR),
+            ("Student", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/Administrator", RoleType.ADMIN),
+            ("urn:lti:instrole:ims/lis/Alumni", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/Faculty", RoleType.INSTRUCTOR),
+            ("urn:lti:instrole:ims/lis/Guest", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/Instructor", RoleType.INSTRUCTOR),
+            ("urn:lti:instrole:ims/lis/Learner", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/Member", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/Mentor", RoleType.INSTRUCTOR),
+            ("urn:lti:instrole:ims/lis/None", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/Observer", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/Other", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/ProspectiveStudent", RoleType.LEARNER),
+            ("urn:lti:instrole:ims/lis/Staff", RoleType.INSTRUCTOR),
+            ("urn:lti:instrole:ims/lis/Student", RoleType.LEARNER),
+            ("urn:lti:role:ims/lis/ContentDeveloper", RoleType.INSTRUCTOR),
+            ("urn:lti:role:ims/lis/Instructor", RoleType.INSTRUCTOR),
+            ("urn:lti:role:ims/lis/Learner", RoleType.LEARNER),
+            ("urn:lti:role:ims/lis/Mentor", RoleType.INSTRUCTOR),
+            ("urn:lti:role:ims/lis/TeachingAssistant", RoleType.INSTRUCTOR),
+            ("urn:lti:role:ims/lis/TeachingAssistant/Grader", RoleType.INSTRUCTOR),
+            ("urn:lti:sysrole:ims/lis/Administrator", RoleType.ADMIN),
+            ("urn:lti:sysrole:ims/lis/None", RoleType.LEARNER),
+            ("urn:lti:sysrole:ims/lis/SysAdmin", RoleType.ADMIN),
+        ),
+    )
+    def test_parse_lti_role_v11(self, value, role_type):
+        assert RoleType.parse_lti_role(value) == role_type
+
+    # pylint: disable=protected-access
+    @pytest.mark.parametrize(
+        "value,role_type", tuple(_RoleParser._V13_ROLE_MAPPINGS.items())
+    )
+    def test_parse_lti_role_v13_exact_matches(self, value, role_type):
+        assert RoleType.parse_lti_role(value) == role_type
+
+    _V13_PREFIX = "http://purl.imsglobal.org/vocab/lis/v2/"
+
+    @pytest.mark.parametrize(
+        "value,role_type",
+        (
+            (
+                f"{_V13_PREFIX}membership/Learner#GuestLearner",
+                RoleType.LEARNER,
+            ),
+            (
+                f"{_V13_PREFIX}membership/Learner#Instructor",
+                RoleType.INSTRUCTOR,
+            ),
+            (
+                f"{_V13_PREFIX}membership/Instructor#Lecturer",
+                RoleType.INSTRUCTOR,
+            ),
+            (f"{_V13_PREFIX}membership/WRONG", RoleType.LEARNER),
+        ),
+    )
+    def test_parse_lti_role_v13_prefix_matches(self, value, role_type):
+        # "Context roles" can have sub-roles appended to the end. Check we can
+        # match these correctly
+        assert RoleType.parse_lti_role(value) == role_type

--- a/tests/unit/lms/services/lti_role_service_test.py
+++ b/tests/unit/lms/services/lti_role_service_test.py
@@ -1,0 +1,56 @@
+from unittest.mock import sentinel
+
+import pytest
+from h_matchers import Any
+
+from lms.models import LTIRole
+from lms.services.lti_role_service import LTIRoleService, service_factory
+from tests import factories
+
+
+class TestLTIRoleService:
+    def test_get_roles(self, svc, existing_roles):
+        existing_role_strings = [role.value for role in existing_roles]
+        new_roles = [
+            "http://purl.imsglobal.org/vocab/lis/v2/system/person#SysSupport",
+            "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner",
+        ]
+
+        role_descriptions = list(existing_role_strings)
+        # Add one duplicate
+        role_descriptions.append(existing_roles[0].value)
+        role_descriptions.extend(new_roles)
+
+        roles = svc.get_roles(", ".join(role_descriptions))
+
+        expected_new_roles = [
+            Any.instance_of(LTIRole).with_attrs({"value": value}) for value in new_roles
+        ]
+        assert roles == Any.list.containing(existing_roles + expected_new_roles).only()
+
+    def test_get_roles_with_existing_only(self, svc, existing_roles):
+        # This is to get some coverage over the branch where we don't create
+        # any new rows
+        roles = svc.get_roles(", ".join([role.value for role in existing_roles]))
+
+        assert roles == existing_roles
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return LTIRoleService(db_session=db_session)
+
+    @pytest.fixture
+    def existing_roles(self):
+        return factories.LTIRole.create_batch(3)
+
+
+class TestServiceFactory:
+    def test_it(self, pyramid_request, LTIRoleService):
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        LTIRoleService.assert_called_once_with(db_session=pyramid_request.db)
+        assert svc == LTIRoleService.return_value
+
+    @pytest.fixture
+    def LTIRoleService(self, patch):
+        return patch("lms.services.lti_role_service.LTIRoleService")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from lms.services import CanvasService
+from lms.services import CanvasService, LTIRoleService
 from lms.services.aes import AESService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
@@ -57,6 +57,7 @@ __all__ = (
     "lti_grading_service",
     "lti_h_service",
     "lti_registration_service",
+    "lti_role_service",
     "ltia_http_service",
     "oauth1_service",
     "oauth2_token_service",
@@ -220,6 +221,11 @@ def lti_h_service(mock_service):
 @pytest.fixture
 def lti_registration_service(mock_service):
     return mock_service(LTIRegistrationService)
+
+
+@pytest.fixture
+def lti_role_service(mock_service):
+    return mock_service(LTIRoleService)
 
 
 @pytest.fixture


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3993

Needs:

 * https://github.com/hypothesis/lms/pull/4063

## Testing notes

 * Nuke your DB
 * Start everything in the world and the visit a lot of assignments as different users
 * Observe `lti_role` and `assignment_membership` filling up