### PR TITLE
Track assignment course relationships

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -2,6 +2,7 @@ from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.application_instance import ApplicationInstance
 from lms.models.application_settings import ApplicationSettings
 from lms.models.assignment import Assignment
+from lms.models.assignment_grouping import AssignmentGrouping
 from lms.models.assignment_membership import AssignmentMembership
 from lms.models.course import LegacyCourse
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH

--- a/lms/models/assignment_grouping.py
+++ b/lms/models/assignment_grouping.py
@@ -1,0 +1,24 @@
+import sqlalchemy as sa
+
+from lms.db import BASE
+from lms.models import CreatedUpdatedMixin
+
+
+class AssignmentGrouping(CreatedUpdatedMixin, BASE):
+    """Model for associations between assignments and groupings."""
+
+    __tablename__ = "assignment_grouping"
+
+    assignment_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("assignment.id", ondelete="cascade"),
+        primary_key=True,
+    )
+    assignment = sa.orm.relationship("Assignment", foreign_keys=[assignment_id])
+    """The assignment."""
+
+    grouping_id = sa.Column(
+        sa.Integer(), sa.ForeignKey("grouping.id", ondelete="cascade"), primary_key=True
+    )
+    grouping = sa.orm.relationship("Grouping", foreign_keys=[grouping_id])
+    """The grouping the assignment is a part of."""

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -5,6 +5,7 @@ from factory.alchemy import SQLAlchemyModelFactory
 from tests.factories import requests_ as requests
 from tests.factories.application_instance import ApplicationInstance
 from tests.factories.assignment import Assignment
+from tests.factories.assignment_grouping import AssignmentGrouping
 from tests.factories.assignment_membership import AssignmentMembership
 from tests.factories.attributes import (
     ACCESS_TOKEN,

--- a/tests/factories/assignment_grouping.py
+++ b/tests/factories/assignment_grouping.py
@@ -1,0 +1,8 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+AssignmentGrouping = make_factory(
+    models.AssignmentGrouping, FACTORY_CLASS=SQLAlchemyModelFactory
+)

--- a/tests/unit/lms/models/assignment_grouping_test.py
+++ b/tests/unit/lms/models/assignment_grouping_test.py
@@ -1,0 +1,35 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from lms.models.assignment_grouping import AssignmentGrouping
+from tests import factories
+
+
+class TestAssignmentGrouping:
+    def test_it(self, db_session, assignment, grouping):
+        db_session.commit()  # Ensure our objects have ids
+
+        rel = AssignmentGrouping(assignment=assignment, grouping=grouping)
+        db_session.add(rel)
+
+        db_session.flush()
+        assert rel.assignment == assignment
+        assert rel.assignment_id == assignment.id
+        assert rel.grouping == grouping
+        assert rel.grouping_id == grouping.id
+
+    def test_it_does_not_allow_duplicates(self, db_session, assignment, grouping):
+        db_session.add(AssignmentGrouping(assignment=assignment, grouping=grouping))
+        db_session.commit()
+
+        with pytest.raises(IntegrityError):
+            db_session.add(AssignmentGrouping(assignment=assignment, grouping=grouping))
+            db_session.commit()
+
+    @pytest.fixture
+    def assignment(self):
+        return factories.Assignment.create()
+
+    @pytest.fixture
+    def grouping(self):
+        return factories.CanvasGroup.create()

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -4,7 +4,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from lms.models import AssignmentMembership, LTIParams
+from lms.models import AssignmentGrouping, AssignmentMembership, LTIParams
 from lms.services.assignment import AssignmentService, factory
 from tests import factories
 
@@ -82,7 +82,6 @@ class TestAssignmentService:
         membership = svc.upsert_assignment_membership(
             assignment=assignment, user=user, lti_roles=lti_roles
         )
-
         assert (
             membership
             == Any.list.containing(
@@ -93,6 +92,24 @@ class TestAssignmentService:
                     for lti_role in lti_roles
                 ]
             ).only()
+        )
+
+    def test_upsert_assignment_grouping(self, svc, assignment):
+        groupings = factories.CanvasGroup.create_batch(3)
+        # One existing row
+        factories.AssignmentGrouping.create(
+            assignment=assignment, grouping=groupings[0]
+        )
+
+        refs = svc.upsert_assignment_groupings(assignment, groupings)
+
+        assert refs == Any.list.containing(
+            [
+                Any.instance_of(AssignmentGrouping).with_attrs(
+                    {"assignment": assignment, "grouping": grouping}
+                )
+                for grouping in groupings
+            ]
         )
 
     @pytest.fixture

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -265,6 +265,10 @@ class TestBasicLaunchViews:
             user=pyramid_request.user,
             lti_roles=lti_role_service.get_roles.return_value,
         )
+        assignment_service.upsert_assignment_groupings.assert_called_once_with(
+            assignment=assignment_service.upsert_assignment.return_value,
+            groupings=[context.course],
+        )
 
         assert result == {}
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3992

Requires:

 * https://github.com/hypothesis/lms/pull/4067

We want to know all the other relations between an assignment and sections and groups etc, but it's more complicated as these values aren't available at launch.

## Testing notes

 * Nuke your DB
 * Start everything in the world and the visit a lot of assignments as different users
 * Observe `assignment_grouping` filling up