### PR TITLE
Refactor lti_launch group properties

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -18,6 +18,11 @@ class Grouping(CreatedUpdatedMixin, BASE):
         CANVAS_GROUP = "canvas_group"
         BLACKBOARD_GROUP = "blackboard_group"
 
+        # These are the LMS agnostic versions of the ones avobe.
+        # They don't get stored in the DB but are meaningful in the codebase
+        SECTION = "section"
+        GROUP = "group"
+
     __tablename__ = "grouping"
     __mapper_args__ = {"polymorphic_on": "type"}
     __table_args__ = (

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -2,7 +2,7 @@ import functools
 from enum import Enum
 from typing import List, Optional
 
-from lms.models import GroupInfo, HUser, Product
+from lms.models import GroupInfo, Grouping, HUser, Product
 from lms.resources._js_config.file_picker_config import FilePickerConfig
 from lms.services import HAPIError, JSTORService
 from lms.validation.authentication import BearerTokenSchema
@@ -424,9 +424,12 @@ class JSConfig:
         }
 
     def _groups(self):
-        if self._context.canvas_sections_enabled or self._context.is_group_launch:
-            return "$rpc:requestGroups"
-        return [self._context.course.groupid(self._authority)]
+        if self._context.grouping_type == Grouping.Type.COURSE:
+            return [self._context.course.groupid(self._authority)]
+
+        # If not using the default COURSE grouping point the FE
+        # to the sync API to dynamically get the relevant groupings.
+        return "$rpc:requestGroups"
 
     def _canvas_sync_api(self):
         req = self._request
@@ -490,17 +493,13 @@ class JSConfig:
         }
 
     def _sync_api(self):
-        if self._context.is_canvas and (
-            self._context.canvas_sections_enabled
-            or self._context.canvas_is_group_launch
-        ):
+        if self._context.grouping_type == Grouping.Type.COURSE:
+            return None
+
+        if self._request.product.family == Product.Family.CANVAS:
             return self._canvas_sync_api()
 
-        if (
-            self._request.product.family == Product.Family.BLACKBOARD
-            and self._context.is_blackboard_group_launch
-        ):
-
+        if self._request.product.family == Product.Family.BLACKBOARD:
             return self._blackboard_sync_api()
 
         return None

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -8,7 +8,9 @@ class FilePickerConfig:
     def blackboard_config(cls, context, request, application_instance):
         """Get Blackboard files config."""
         files_enabled = application_instance.settings.get("blackboard", "files_enabled")
-        groups_enabled = context.blackboard_groups_enabled
+        groups_enabled = application_instance.settings.get(
+            "blackboard", "groups_enabled"
+        )
 
         auth_url = request.route_url("blackboard_api.oauth.authorize")
         course_id = context.lti_params.get("context_id")
@@ -43,7 +45,7 @@ class FilePickerConfig:
             "custom_canvas_course_id" in context.lti_params
             and application_instance.developer_key is not None
         )
-        groups_enabled = context.canvas_groups_enabled
+        groups_enabled = application_instance.settings.get("canvas", "groups_enabled")
 
         auth_url = request.route_url("canvas_api.oauth.authorize")
         course_id = context.lti_params.get("custom_canvas_course_id")

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -3,7 +3,7 @@
 import logging
 from functools import cached_property
 
-from lms.models import LTIParams, Product
+from lms.models import Grouping, LTIParams, Product
 from lms.resources._js_config import JSConfig
 from lms.services import ApplicationInstanceNotFound
 
@@ -25,11 +25,6 @@ class LTILaunchResource:
     def __init__(self, request):
         """Return the context resource for an LTI launch request."""
         self._request = request
-        self._authority = self._request.registry.settings["h_authority"]
-        self._application_instance_service = self._request.find_service(
-            name="application_instance"
-        )
-        self._assignment_service = request.find_service(name="assignment")
 
     @cached_property
     def course(self):
@@ -44,21 +39,6 @@ class LTILaunchResource:
     @property
     def _is_speedgrader(self):
         return bool(self._request.GET.get("learner_canvas_user_id"))
-
-    @property
-    def is_legacy_speedgrader(self):
-        """
-        Return True if the current request is a legacy SpeedGrader launch.
-
-        To work around a Canvas bug we add the assignment's resource_link_id as
-        a query param on the LTI launch URLs that we submit to SpeedGrader (see
-        https://github.com/instructure/canvas-lms/issues/1952 and
-        https://github.com/hypothesis/lms/issues/3228).
-
-        "Legacy" SpeedGrader submissions are ones from before we implemented
-        this work-around, so they don't have the resource_link_id query param.
-        """
-        return self._is_speedgrader and not self._request.GET.get("resource_link_id")
 
     @property
     def resource_link_id(self):
@@ -87,9 +67,12 @@ class LTILaunchResource:
     def js_config(self):
         return JSConfig(self, self._request)
 
-    def canvas_sections_supported(self):
-        """Return True if Canvas sections is supported for this request."""
+    @property
+    def sections_enabled(self):
+        """Return if sections are enabled for this request."""
+
         if not self.is_canvas:
+            # Sections are only implemented in Canvas
             return False
 
         params = self._request.params
@@ -99,65 +82,64 @@ class LTILaunchResource:
             return False
 
         try:
-            application_instance = self._application_instance_service.get_current()
+            application_instance = self._request.find_service(
+                name="application_instance"
+            ).get_current()
         except ApplicationInstanceNotFound:
             return False
 
-        return bool(application_instance.developer_key)
-
-    @property
-    def canvas_sections_enabled(self):
-        """Return True if Canvas sections is enabled for this request."""
-
-        if not self.canvas_sections_supported():
+        if not bool(application_instance.developer_key):
+            # We need a developer key to talk to the API
             return False
 
         return self.course.settings.get("canvas", "sections_enabled")
 
     @property
-    def canvas_groups_enabled(self):
-        """Return True if Canvas groups are enabled at the school/installation level."""
-        try:
-            application_instance = self._application_instance_service.get_current()
-        except ApplicationInstanceNotFound:
-            return False
+    def group_set_id(self):
+        """
+        Get the group set ID for group launches.
 
-        return bool(application_instance.settings.get("canvas", "groups_enabled"))
+        A course can be divided in multiple "small groups" but it's possible to
+        have different sets of groups for the same course.
 
-    @property
-    def blackboard_groups_enabled(self):
-        """Return True if Blackboard groups are enabled at the school/installation level."""
-        try:
-            application_instance = self._application_instance_service.get_current()
-        except ApplicationInstanceNotFound:
-            return False
+        This ID identifies a collection of groups.
+        """
+        if self._request.product.family == Product.Family.CANVAS:
+            # For canvas we add parameter to the launch URL as we don't store the
+            # assignment during deep linking.
+            try:
+                return int(self._request.params.get("group_set"))
+            except (TypeError, ValueError):
+                return None
 
-        return bool(application_instance.settings.get("blackboard", "groups_enabled"))
+        elif self._request.product.family == Product.Family.BLACKBOARD:
+            # In blackboard we store the configuration details in the DB
+            tool_consumer_instance_guid = self._request.parsed_params[
+                "tool_consumer_instance_guid"
+            ]
+            assignment = self._request.find_service(name="assignment").get_assignment(
+                tool_consumer_instance_guid, self.resource_link_id
+            )
+            return assignment.extra.get("group_set_id") if assignment else None
 
-    @property
-    def is_blackboard_group_launch(self):
-        """Return True if the current assignment uses Blackboard groups."""
-        tool_consumer_instance_guid = self._request.parsed_params[
-            "tool_consumer_instance_guid"
-        ]
-        assignment = self._assignment_service.get_assignment(
-            tool_consumer_instance_guid, self.resource_link_id
-        )
-        return bool(assignment and assignment.extra.get("group_set_id"))
-
-    @property
-    def canvas_is_group_launch(self):
-        """Return True if the current assignment uses canvas groups."""
-        try:
-            int(self._request.params["group_set"])
-        except (KeyError, ValueError, TypeError):
-            return False
-        else:
-            return True
+        return None
 
     @property
-    def is_group_launch(self):
-        return self.canvas_is_group_launch or self.is_blackboard_group_launch
+    def grouping_type(self) -> Grouping.Type:
+        """
+        Return the type of grouping used in this launch.
+
+        Grouping types describe how the course members are divided.
+        If neither of the LMS grouping features are used "COURSE" is the default.
+        """
+        if bool(self.group_set_id):
+            return Grouping.Type.GROUP
+
+        if self.sections_enabled:
+            # Sections is the default when available. Groups must take precedence
+            return Grouping.Type.SECTION
+
+        return Grouping.Type.COURSE
 
     @property
     def lti_params(self) -> LTIParams:

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -22,19 +22,19 @@ class TestFilePickerConfig:
         self,
         context,
         pyramid_request,
-        blackboard_application_instance,
+        application_instance,
         files_enabled,
         groups_enabled,
     ):
 
         context.lti_params["context_id"] = "COURSE_ID"
-        blackboard_application_instance.settings.set(
-            "blackboard", "files_enabled", files_enabled
+        application_instance.settings.set("blackboard", "files_enabled", files_enabled)
+        application_instance.settings.set(
+            "blackboard", "groups_enabled", groups_enabled
         )
-        context.blackboard_groups_enabled = groups_enabled
 
         config = FilePickerConfig.blackboard_config(
-            context, pyramid_request, blackboard_application_instance
+            context, pyramid_request, application_instance
         )
 
         expected_config = {
@@ -68,7 +68,7 @@ class TestFilePickerConfig:
         self, context, pyramid_request, application_instance, groups_enabled
     ):
         context.lti_params["custom_canvas_course_id"] = "COURSE_ID"
-        context.canvas_groups_enabled = groups_enabled
+        application_instance.settings.set("canvas", "groups_enabled", groups_enabled)
 
         config = FilePickerConfig.canvas_config(
             context, pyramid_request, application_instance
@@ -188,12 +188,6 @@ class TestFilePickerConfig:
         return application_instance
 
     @pytest.fixture
-    def blackboard_application_instance(self, application_instance):
-        application_instance.tool_consumer_info_product_family_code = "BlackboardLearn"
-
-        return application_instance
-
-    @pytest.fixture
     def with_is_canvas(self, context):
         context.is_canvas = True
 
@@ -204,8 +198,5 @@ class TestFilePickerConfig:
             spec_set=True,
             instance=True,
             is_canvas=False,
-            canvas_sections_enabled=False,
-            canvas_groups_enabled=False,
-            blackboard_groups_enabled=False,
             lti_params=LTIParams(pyramid_request.params),
         )

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from pytest import param
 
-from lms.models import ApplicationSettings, Product
+from lms.models import ApplicationSettings, Grouping, Product
 from lms.resources import LTILaunchResource
 from lms.services import ApplicationInstanceNotFound
 
@@ -32,56 +32,6 @@ class TestResourceLinkIdk:
             assert LTILaunchResource(pyramid_request).resource_link_id == expected
 
 
-class TestIsLegacySpeedGrader:
-    @pytest.mark.parametrize(
-        "learner_id,get_resource_id,post_resource_id,context_id,expected",
-        [
-            param(
-                None,
-                "GET_ID",
-                "POST_ID",
-                "CONTEXT_ID",
-                False,
-                id="not speed grading",
-            ),
-            param(
-                "USER_ID",
-                "GET_ID",
-                "WRONG_RESOURCE_LINK_ID",
-                "WRONG_RESOURCE_LINK_ID",
-                False,
-                id="fixed speed grader",
-            ),
-            param(
-                "USER_ID",
-                None,
-                "WRONG_RESOURCE_LINK_ID",
-                "WRONG_RESOURCE_LINK_ID",
-                True,
-                id="legacy speed grader",
-            ),
-        ],
-    )
-    def test_it(
-        self,
-        pyramid_request,
-        learner_id,
-        get_resource_id,
-        post_resource_id,
-        context_id,
-        expected,
-    ):
-        pyramid_request.POST = {
-            "resource_link_id": post_resource_id,
-            "context_id": context_id,
-        }
-        pyramid_request.GET = {
-            "learner_canvas_user_id": learner_id,
-            "resource_link_id": get_resource_id,
-        }
-        assert LTILaunchResource(pyramid_request).is_legacy_speedgrader == expected
-
-
 class TestIsCanvas:
     @pytest.mark.parametrize(
         "product,expected",
@@ -107,11 +57,12 @@ class TestJSConfig:
         assert js_config == JSConfig.return_value
 
 
-class TestCanvasSectionsSupported:
+@pytest.mark.usefixtures("has_course")
+class TestSectionsEnabled:
     @pytest.mark.parametrize("is_canvas", [True, False])
     def test_support_for_canvas(self, lti_launch, is_canvas):
         with mock.patch.object(LTILaunchResource, "is_canvas", is_canvas):
-            assert lti_launch.canvas_sections_supported() == is_canvas
+            assert lti_launch.sections_enabled == is_canvas
 
     @pytest.mark.usefixtures("with_canvas")
     @pytest.mark.parametrize(
@@ -137,14 +88,7 @@ class TestCanvasSectionsSupported:
     ):
         pyramid_request.params.update(params)
 
-        assert lti_launch.canvas_sections_supported() is expected
-
-    @pytest.mark.usefixtures("with_canvas")
-    def test_it_depends_on_application_instance_service(
-        self, lti_launch, application_instance_service
-    ):
-        application_instance_service.get_current.return_value.developer_key = None
-        assert not lti_launch.canvas_sections_supported()
+        assert lti_launch.sections_enabled is expected
 
     @pytest.mark.usefixtures("with_canvas")
     def test_if_application_instance_service_raises(
@@ -153,36 +97,21 @@ class TestCanvasSectionsSupported:
         application_instance_service.get_current.side_effect = (
             ApplicationInstanceNotFound
         )
-        assert not lti_launch.canvas_sections_supported()
+        assert not lti_launch.sections_enabled
 
-    @pytest.fixture(autouse=True)
-    def sections_supported(self, pyramid_request):
-        # We are in canvas
-        pyramid_request.parsed_params[
-            "tool_consumer_info_product_family_code"
-        ] = "canvas"
-
-
-@pytest.mark.usefixtures("has_course")
-class TestCanvasSectionsEnabled:
-    def test_its_enabled_when_everything_is_right(self, lti_launch, course_service):
-        assert lti_launch.canvas_sections_enabled
-
-        course_service.upsert_course.assert_called_with(
-            "test_context_id", "test_context_title", {}
-        )
-
-    def test_its_disabled_if_sections_are_not_supported(
-        self, lti_launch, canvas_sections_supported
+    @pytest.mark.usefixtures("with_canvas")
+    def test_it_depends_on_developer_key(
+        self, lti_launch, application_instance_service
     ):
-        canvas_sections_supported.return_value = False
-        assert not lti_launch.canvas_sections_enabled
+        application_instance_service.get_current.return_value.developer_key = None
+        assert not lti_launch.sections_enabled
 
-    def test_its_disabled_if_the_course_settings_is_False(
-        self, lti_launch, course_settings
-    ):
-        course_settings.set("canvas", "sections_enabled", False)
-        assert not lti_launch.canvas_sections_enabled
+    @pytest.mark.usefixtures("with_canvas")
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_it_depends_on_course_setting(self, lti_launch, course_settings, enabled):
+        course_settings.set("canvas", "sections_enabled", enabled)
+
+        assert lti_launch.sections_enabled == enabled
 
     @pytest.fixture(autouse=True)
     def course_settings(self, course_service):
@@ -191,14 +120,6 @@ class TestCanvasSectionsEnabled:
         course_service.upsert_course.return_value.settings = settings
 
         return settings
-
-    @pytest.fixture(autouse=True)
-    def canvas_sections_supported(self):
-        with mock.patch.object(
-            LTILaunchResource, "canvas_sections_supported"
-        ) as canvas_sections_supported:
-            canvas_sections_supported.return_value = True
-            yield canvas_sections_supported
 
 
 class TestCourseExtra:
@@ -221,118 +142,71 @@ class TestCourseExtra:
         }
 
 
-@pytest.mark.usefixtures("has_course")
-class TestBlackboardGroupsEnabled:
-    def test_it_returns_False_if_theres_no_ApplicationInstance(
-        self, application_instance_service, lti_launch
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound
-        )
-
-        assert not lti_launch.blackboard_groups_enabled
-
-    @pytest.mark.parametrize(
-        "setting_value,expected",
-        [(True, True), (False, False), (None, False)],
-    )
-    def test_it_returns_the_setting_from_the_ApplicationInstance(
-        self, setting_value, expected, application_instance_service, lti_launch
-    ):
-        settings = ApplicationSettings(
-            {"blackboard": {"groups_enabled": setting_value}}
-        )
-        application_instance_service.get_current.return_value.settings = settings
-
-        assert lti_launch.blackboard_groups_enabled == expected
-
-
-@pytest.mark.usefixtures("has_course")
-class TestCanvasGroupsEnabled:
-    def test_false_when_no_application_instance(
-        self, application_instance_service, lti_launch
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound
-        )
-
-        assert not lti_launch.canvas_groups_enabled
-
-    @pytest.mark.parametrize("settings_value", [True, False])
-    def test_returns_settings_value(
-        self, settings_value, application_instance_service, lti_launch
-    ):
-        settings = ApplicationSettings({"canvas": {"groups_enabled": settings_value}})
-        application_instance_service.get_current.return_value.settings = settings
-
-        assert lti_launch.canvas_groups_enabled == settings_value
-
-
-class TestCanvasIsGroupLaunch:
-    @pytest.mark.parametrize("group_set", ["", "not a number", None])
-    def test_false_invalid_group_set_param(self, pyramid_request, group_set):
-        pyramid_request.params.update({"group_set": group_set})
-
-        assert not LTILaunchResource(pyramid_request).canvas_is_group_launch
-
-    def test_it(self, pyramid_request):
-        pyramid_request.params.update({"group_set": 1})
-
-        assert LTILaunchResource(pyramid_request).canvas_is_group_launch
-
-
-class TestIsBlackboardGroupLaunch:
-    def test_false_when_no_assignment(
-        self, lti_launch_groups_enabled, assignment_service
-    ):
+class TestGroupSetId:
+    @pytest.mark.usefixtures("with_blackboard")
+    def test_blackboard_false_when_no_assignment(self, lti_launch, assignment_service):
         assignment_service.get_assignment.return_value = None
 
-        assert not lti_launch_groups_enabled.is_blackboard_group_launch
+        assert not lti_launch.group_set_id
 
-    def test_false_when_no_group_set(
-        self, lti_launch_groups_enabled, assignment_service
-    ):
+    @pytest.mark.usefixtures("with_blackboard")
+    def test_blackboard_false_when_no_group_set(self, lti_launch, assignment_service):
         assignment_service.get_assignment.return_value.extra = {}
 
-        assert not lti_launch_groups_enabled.is_blackboard_group_launch
+        assert not lti_launch.group_set_id
 
-    def test_it(self, lti_launch_groups_enabled, assignment_service):
-        assignment_service.get_assignment.return_value.extra = {"group_set_id": "ID"}
+    @pytest.mark.usefixtures("with_blackboard")
+    def test_blackboard(self, lti_launch, assignment_service):
+        assignment_service.get_assignment.return_value.extra = {
+            "group_set_id": mock.sentinel.id
+        }
 
-        assert lti_launch_groups_enabled.is_blackboard_group_launch
+        assert lti_launch.group_set_id == mock.sentinel.id
 
-    @pytest.fixture
-    def lti_launch_groups_enabled(self, pyramid_request):
-        class TestableLTILaunchResource(LTILaunchResource):
-            blackboard_groups_enabled = True
+    @pytest.mark.usefixtures("with_canvas")
+    @pytest.mark.parametrize("group_set", ["", "not a number", None])
+    def test_canvas_false_invalid_group_set_param(self, pyramid_request, group_set):
+        pyramid_request.params.update({"group_set": group_set})
 
-        return TestableLTILaunchResource(pyramid_request)
+        assert not LTILaunchResource(pyramid_request).group_set_id
+
+    @pytest.mark.usefixtures("with_canvas")
+    def test_canvas(self, pyramid_request):
+        pyramid_request.params.update({"group_set": 1})
+
+        assert LTILaunchResource(pyramid_request).group_set_id == 1
+
+    def test_other_lms(self, pyramid_request):
+        pyramid_request.product.family = Product.Family.UNKNOWN
+
+        assert not LTILaunchResource(pyramid_request).group_set_id
 
     @pytest.fixture(autouse=True)
     def pyramid_request(self, pyramid_request):
         pyramid_request.parsed_params = {
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid"
         }
-        pyramid_request.lti_params = {}
         return pyramid_request
 
 
-class TestIsGroupLaunch:
+class TestGroupingType:
     @pytest.mark.parametrize(
-        "canvas,blackboard,expected",
+        "sections_enabled,group_set_id,expected",
         [
-            (True, True, True),
-            (True, False, True),
-            (False, True, True),
-            (False, False, False),
+            (True, 1, Grouping.Type.GROUP),
+            (True, None, Grouping.Type.SECTION),
+            (False, 1, Grouping.Type.GROUP),
+            (False, None, Grouping.Type.COURSE),
         ],
     )
-    def test_it(self, canvas, blackboard, expected, pyramid_request):
-        class TestableLTILaunchResource(LTILaunchResource):
-            canvas_is_group_launch = canvas
-            is_blackboard_group_launch = blackboard
+    def test_it(self, sections_enabled, group_set_id, expected, lti_launch):
 
-        assert TestableLTILaunchResource(pyramid_request).is_group_launch == expected
+        with mock.patch.multiple(
+            LTILaunchResource,
+            sections_enabled=sections_enabled,
+            group_set_id=group_set_id,
+        ):
+            assert lti_launch.grouping_type == expected
 
 
 class TestLTIParams:
@@ -373,3 +247,8 @@ def pyramid_request(pyramid_request):
 @pytest.fixture
 def with_canvas(pyramid_request):
     pyramid_request.product.family = Product.Family.CANVAS
+
+
+@pytest.fixture
+def with_blackboard(pyramid_request):
+    pyramid_request.product.family = Product.Family.BLACKBOARD


### PR DESCRIPTION
Use request.product in the methods themselves to provide a more
concise API instead of having methods per LMS.

Again, not a massive improvement but having the same "API" in the LTIResource class allow for further refactors.


- canvas_sections_supported -> sections_enabled

It doesn't have any practical implications but it makes for a cleaner API

-  canvas_sections_supported inlined in sections_enabled

We only used the supported concept in `sections_enabled`. It could make sense as a separate concept if it was used elsewhere.

- canvas_groups_enabled and blackboard_groups_enabled moved/inlined in the filepicker.