### PR TITLE
Make JSTOR article thumbnail show first page instead of last page.

### DIFF
--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -42,8 +42,7 @@ class TestJSTORService:
         )
 
         http_service.get.assert_called_once_with(
-            url=expected,
-            headers={"Authorization": "Bearer TOKEN"},
+            url=expected, headers={"Authorization": "Bearer TOKEN"}, params=None
         )
 
         via_url.assert_called_once_with(
@@ -105,7 +104,7 @@ class TestJSTORService:
         metadata = svc.metadata(article_id)
 
         http_service.get.assert_called_with(
-            url=expected_api_url, headers={"Authorization": "Bearer TOKEN"}
+            url=expected_api_url, headers={"Authorization": "Bearer TOKEN"}, params=None
         )
         assert metadata == expected_metadata
 
@@ -145,7 +144,12 @@ class TestJSTORService:
         data_uri = svc.thumbnail(article_id)
 
         http_service.get.assert_called_with(
-            url=expected_api_url, headers={"Authorization": "Bearer TOKEN"}
+            url=expected_api_url,
+            headers={"Authorization": "Bearer TOKEN"},
+            params={
+                "offset": 1,
+                "width": 280,
+            },
         )
         assert data_uri == api_response
 


### PR DESCRIPTION
Fix an issue where the JSTOR article picker would show a thumbnail of the last page of the article instead of the first page.

The resolution of the image has also been increased to make it sharper. The size of the UI in the thumbnail is still too small to really make it possible to check if it is the correct thumbnail, but fixing this requires layout changes in a separate PR.

Fixes https://github.com/hypothesis/lms/issues/4061