### PR TITLE
Fix handling of JSTOR metadata/thumbnail requests that include a DOI prefix

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -98,9 +98,16 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("lti_api.result.read", "/api/lti/result", request_method="GET")
     config.add_route("lti_api.result.record", "/api/lti/result", request_method="POST")
 
-    config.add_route("jstor_api.articles.metadata", "/api/jstor/articles/{article_id}")
+    # JSTOR article IDs need a custom pattern because they may contain a slash,
+    # after URL-decoding of the path.
+    jstor_article_id_pat = r"(10\.[0-9]+/)?[^/]+"
     config.add_route(
-        "jstor_api.articles.thumbnail", "/api/jstor/articles/{article_id}/thumbnail"
+        "jstor_api.articles.metadata",
+        f"/api/jstor/articles/{{article_id:{jstor_article_id_pat}}}",
+    )
+    config.add_route(
+        "jstor_api.articles.thumbnail",
+        f"/api/jstor/articles/{{article_id:{jstor_article_id_pat}}}/thumbnail",
     )
 
     config.add_route("vitalsource_api.books.info", "/api/vitalsource/books/{book_id}")

--- a/tests/unit/lms/routes_test.py
+++ b/tests/unit/lms/routes_test.py
@@ -1,0 +1,48 @@
+import pytest
+from pyramid.interfaces import IRoutesMapper
+from pyramid.testing import DummyRequest
+
+
+# This test does not cover all routes, only cases that have non-trivial route
+# patterns.
+#
+# Note that the `path` test param is the path _after_ URL decoding.
+# See https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/urldispatch.html#route-pattern-syntax
+@pytest.mark.parametrize(
+    "path,expected_route,expected_match",
+    [
+        (
+            "/api/jstor/articles/1234",
+            "jstor_api.articles.metadata",
+            {"article_id": "1234"},
+        ),
+        (
+            "/api/jstor/articles/10.123/456",
+            "jstor_api.articles.metadata",
+            {"article_id": "10.123/456"},
+        ),
+        ("/api/jstor/articles/10/456", None, None),
+        (
+            "/api/jstor/articles/1234/thumbnail",
+            "jstor_api.articles.thumbnail",
+            {"article_id": "1234"},
+        ),
+        (
+            "/api/jstor/articles/10.123/456/thumbnail",
+            "jstor_api.articles.thumbnail",
+            {"article_id": "10.123/456"},
+        ),
+        ("/api/jstor/articles/10/456/thumbnail", None, None),
+    ],
+)
+def test_request_matches_expected_route(
+    pyramid_config, path, expected_route, expected_match
+):
+    route_mapper = pyramid_config.registry.queryUtility(IRoutesMapper)
+    request = DummyRequest(path=path)
+
+    route = route_mapper(request)
+    route_name = route["route"].name if route["route"] else None
+
+    assert route_name == expected_route
+    assert route["match"] == expected_match


### PR DESCRIPTION
Metadata/thumbnail requests for JSTOR article IDs with a DOI prefix (eg. 10.5325/jafrideve.18.2.0019) did not match the expected route. It seems this is because the path is URL-decoded before being matched against the route's path pattern [1], and the default regex for path parameters is `[^/]+`. Fix this by specifying a custom pattern for the path parameter.

**Testing:**

1. Configure an assignment and choose JSTOR as the content type
2. Enter https://www.jstor.org/stable/10.5325/jafrideve.18.2.0019 as the article link.
3. Press Enter and the metadata/thumbnail should be fetched correctly

----

[1] Per https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/urldispatch.html#route-pattern-syntax: "Literal strings in the path segment should represent the decoded value of the PATH_INFO provided to Pyramid"