### PR TITLE
Update handling of slashes in JSTOR API endpoint paths

### DIFF
--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -153,7 +153,7 @@ def format_uri(template: str, *params: str):
     This is like `template.format(*params)` except that the params are
     percent-encoded.
     """
-    encoded = [quote(param, safe="") for param in params]
+    encoded = [quote(param, safe="/") for param in params]
     return template.format(*encoded)
 
 

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -25,9 +25,9 @@ class TestJSTORService:
         [
             (
                 "jstor://ARTICLE_ID",
-                f"{JSTOR_API_URL}/pdf-url/10.2307%2FARTICLE_ID",
+                f"{JSTOR_API_URL}/pdf-url/10.2307/ARTICLE_ID",
             ),
-            ("jstor://PREFIX/SUFFIX", f"{JSTOR_API_URL}/pdf-url/PREFIX%2FSUFFIX"),
+            ("jstor://PREFIX/SUFFIX", f"{JSTOR_API_URL}/pdf-url/PREFIX/SUFFIX"),
         ],
     )
     def test_via_url(
@@ -70,21 +70,28 @@ class TestJSTORService:
             (
                 "12345",
                 {"title": ["test title"]},
-                f"{JSTOR_API_URL}/metadata/10.2307%2F12345",
+                f"{JSTOR_API_URL}/metadata/10.2307/12345",
+                {"title": "test title"},
+            ),
+            # Article ID that needs to be encoded
+            (
+                "123:45",
+                {"title": ["test title"]},
+                f"{JSTOR_API_URL}/metadata/10.2307/123%3A45",
                 {"title": "test title"},
             ),
             # Article with custom DOI prefix
             (
                 "10.123/12345",
                 {"title": ["test title"]},
-                f"{JSTOR_API_URL}/metadata/10.123%2F12345",
+                f"{JSTOR_API_URL}/metadata/10.123/12345",
                 {"title": "test title"},
             ),
             # No title
             (
                 "12345",
                 {"title": []},
-                f"{JSTOR_API_URL}/metadata/10.2307%2F12345",
+                f"{JSTOR_API_URL}/metadata/10.2307/12345",
                 {"title": None},
             ),
         ],
@@ -127,13 +134,19 @@ class TestJSTORService:
             (
                 "12345",
                 "data:image/jpeg;base64,ABCD",
-                f"{JSTOR_API_URL}/thumbnail/10.2307%2F12345",
+                f"{JSTOR_API_URL}/thumbnail/10.2307/12345",
+            ),
+            # Article ID that needs to be encoded
+            (
+                "123:45",
+                "data:image/jpeg;base64,ABCD",
+                f"{JSTOR_API_URL}/thumbnail/10.2307/123%3A45",
             ),
             # Article with custom DOI prefix
             (
                 "10.123/12345",
                 "data:image/jpeg;base64,ABCD",
-                f"{JSTOR_API_URL}/thumbnail/10.123%2F12345",
+                f"{JSTOR_API_URL}/thumbnail/10.123/12345",
             ),
         ],
     )


### PR DESCRIPTION
The JSTOR API endpoints are being moved to new infrastructure ([Related Slack thread](https://hypothes-is.slack.com/archives/C02T75RKBTK/p1655126049981469)). The old endpoints accepted DOIs with or without percent-encoding of the slash between the DOI prefix and suffix. The new endpoints require that the slash is not percent-encoded.

**Testing:**

Update the `JSTOR_API_URL` env var in your `.devdata.env` file to:

```
export JSTOR_API_URL="https://labs.jstor.org/api/anno"
```

And check that the metadata/thumbnail still load correctly when configuring a JSTOR assignment (eg. using this article link: https://www.jstor.org/stable/26158829)
