### PR TITLE
Name and Roles LTI1.3 API service

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -20,6 +20,7 @@ from lms.services.launch_verifier import (
     LTIOAuthError,
 )
 from lms.services.lti_grading import LTIGradingService
+from lms.services.lti_names_roles import LTINamesRolesService
 from lms.services.lti_registration import LTIRegistrationService
 from lms.services.lti_role_service import LTIRoleService
 from lms.services.ltia_http import LTIAHTTPService
@@ -81,6 +82,9 @@ def includeme(config):
     config.register_service_factory("lms.services.grouping.factory", name="grouping")
     config.register_service_factory("lms.services.file.factory", name="file")
     config.register_service_factory("lms.services.jstor.factory", iface=JSTORService)
+    config.register_service_factory(
+        "lms.services.lti_names_roles.factory", iface=LTINamesRolesService
+    )
     config.register_service_factory(
         "lms.services.lti_registration.factory", iface=LTIRegistrationService
     )

--- a/lms/services/lti_names_roles.py
+++ b/lms/services/lti_names_roles.py
@@ -1,0 +1,62 @@
+"""
+Service to talk to the Name and Roles LTIA API.
+
+We only implement this now as a way to obtain the LTI Advantage Complete
+certification and it's not used anywhere in the codebase yet.
+
+https://www.imsglobal.org/spec/lti-nrps/v2p0
+https://www.imsglobal.org/ltiadvantage
+"""
+from typing import List, Optional, TypedDict
+
+from lms.services.ltia_http import LTIAHTTPService
+
+
+class Member(TypedDict):
+    """Structure of the members returned by the name and roles LTI API."""
+
+    email: str
+    family_name: str
+    name: str
+    picture: str
+    roles: List[str]
+    status: str
+    user_id: str
+    lti11_legacy_user_id: Optional[str]
+
+
+class LTINamesRolesService:
+    LTIA_SCOPES = [
+        "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly"
+    ]
+
+    def __init__(self, service_url: str, ltia_http_service: LTIAHTTPService):
+        self._service_url = service_url
+        self._ltia_service = ltia_http_service
+
+    def get_context_memberships(self) -> List[Member]:
+        """
+        Get all the memberships of a context (a course).
+
+        The course is defined by the service URL which will obtain
+        from a LTI launch parameter and is always linked to an specific context.
+        """
+        response = self._ltia_service.request(
+            "GET",
+            self._service_url,
+            scopes=self.LTIA_SCOPES,
+            headers={
+                "Accept": "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"
+            },
+        )
+
+        return response.json()["members"]
+
+
+def factory(_context, request):
+    return LTINamesRolesService(
+        service_url=request.lti_jwt.get(
+            "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice", {}
+        ).get("context_memberships_url"),
+        ltia_http_service=request.find_service(LTIAHTTPService),
+    )

--- a/tests/unit/lms/services/lti_names_roles_test.py
+++ b/tests/unit/lms/services/lti_names_roles_test.py
@@ -1,0 +1,58 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.lti_names_roles import LTINamesRolesService, factory
+
+
+class TestLTINameRolesServices:
+    def test_get_context_memberships(self, svc, ltia_http_service):
+
+        memberships = svc.get_context_memberships()
+
+        ltia_http_service.request.assert_called_once_with(
+            "GET",
+            sentinel.service_url,
+            scopes=LTINamesRolesService.LTIA_SCOPES,
+            headers={
+                "Accept": "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"
+            },
+        )
+        assert (
+            memberships
+            == ltia_http_service.request.return_value.json.return_value["members"]
+        )
+
+    @pytest.fixture
+    def svc(self, ltia_http_service):
+        return LTINamesRolesService(
+            service_url=sentinel.service_url, ltia_http_service=ltia_http_service
+        )
+
+
+class TestFactory:
+    def test_it(
+        self,
+        pyramid_request,
+        LTINamesRolesService,
+        ltia_http_service,
+    ):
+        service = factory(sentinel.context, pyramid_request)
+
+        LTINamesRolesService.assert_called_once_with(
+            service_url=sentinel.service_url, ltia_http_service=ltia_http_service
+        )
+        assert service == LTINamesRolesService.return_value
+
+    @pytest.fixture
+    def LTINamesRolesService(self, patch):
+        return patch("lms.services.lti_names_roles.LTINamesRolesService")
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.lti_jwt = {
+            "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice": {
+                "context_memberships_url": sentinel.service_url
+            }
+        }
+        return pyramid_request


### PR DESCRIPTION
For #933 

Implement the only missing API required for the full LTIA certification. (Deep linking is fully implemented but we have to pair the certification with this one)

This PR just implements the service but it's not used yet in any production code. This is potentially very useful but the focus now is the certification.


# Testing

- Login in Canvas a teacher
- Apply a diff similar to 

```diff
diff --git a/lms/views/lti/basic_launch.py b/lms/views/lti/basic_launch.py
index 32d17c11..fe2bbf11 100644
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -352,6 +352,12 @@ class BasicLaunchViews:
 
         self.application_instance.update_lms_data(self.context.lti_params)
 
+        from lms.services import LTINamesRolesService
+
+        print(
+            self.request.find_service(LTINamesRolesService).get_context_memberships()
+        )
+
         # Report all LTI assignment launches to the /reports page.
         LtiLaunches.add(
             self.request.db,
```



- Launch https://hypothesis.instructure.com/courses/319/assignments/2781


- A list of members will be listed in the server output:
```
[
{'status': 'Active', 'name': 'Hypothesis 101 Student', 'picture': 'https://canvas.instructure.com/images/messages/avatar-50.png', 'given_name': 'Hypothesis 101', 'family_name': 'Student', 'email': 'eng+canvasstudent@hypothes.is', 'user_id': '2b04173b-1f12-42ea-aa87-5dd0b6ef2473', 'lti11_legacy_user_id': '2a8a99bc095a8438a594cd57c1f4f0341951e360', 'roles': ['http://purl.imsglobal.org/vocab/lis/v2/membership#Learner']}, 
{'status': 'Active', 'name': 'Hypothesis 101 Teacher', 'picture': 'https://canvas.instructure.com/images/messages/avatar-50.png', 'given_name': 'Hypothesis 101', 'family_name': 'Teacher', 'email': 'eng+canvasteacher@hypothes.is', 'user_id': '3f25366d-ab34-4307-be21-3ea444559e82', 'lti11_legacy_user_id': '969fc294ee26e3f1d0c9714af3351dc4eacfd6df', 'roles': ['http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor']}
]
```