### PR TITLE
Accept more input formats in JSTOR article link entry field

### DIFF
--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -12,7 +12,7 @@ import { useRef, useState } from 'preact/hooks';
 
 import { formatErrorMessage } from '../errors';
 import { urlPath, useAPIFetch } from '../utils/api';
-import { articleIdFromURL, jstorURLFromArticleId } from '../utils/jstor';
+import { articleIdFromUserInput, jstorURLFromArticleId } from '../utils/jstor';
 
 /**
  * @template T
@@ -103,9 +103,9 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
       return;
     }
 
-    const articleId = articleIdFromURL(url);
+    const articleId = articleIdFromUserInput(url);
     if (!articleId) {
-      setError("That doesn't look like a JSTOR article link");
+      setError("That doesn't look like a JSTOR article link or ID");
       return;
     }
 

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -6,7 +6,7 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 import JSTORPicker, { $imports } from '../JSTORPicker';
 
 describe('JSTORPicker', () => {
-  let fakeArticleIdFromURL;
+  let fakeArticleIdFromUserInput;
 
   // Map of API path => fetch result state setter.
   let setAPIFetchResult;
@@ -40,7 +40,7 @@ describe('JSTORPicker', () => {
   const renderJSTORPicker = (props = {}) => mount(<JSTORPicker {...props} />);
 
   beforeEach(() => {
-    fakeArticleIdFromURL = sinon.stub().returns('1234');
+    fakeArticleIdFromUserInput = sinon.stub().returns('1234');
     setAPIFetchResult = {};
 
     function useAPIFetchFake(path) {
@@ -64,7 +64,7 @@ describe('JSTORPicker', () => {
         useAPIFetch: useAPIFetchFake,
       },
       '../utils/jstor': {
-        articleIdFromURL: fakeArticleIdFromURL,
+        articleIdFromUserInput: fakeArticleIdFromUserInput,
       },
     });
   });
@@ -121,22 +121,22 @@ describe('JSTORPicker', () => {
 
       updateURL(wrapper, 'foo');
 
-      assert.calledOnce(fakeArticleIdFromURL);
-      assert.calledWith(fakeArticleIdFromURL, 'foo');
+      assert.calledOnce(fakeArticleIdFromUserInput);
+      assert.calledWith(fakeArticleIdFromUserInput, 'foo');
 
       updateURL(wrapper, 'bar');
 
       assert.equal(
-        fakeArticleIdFromURL.callCount,
+        fakeArticleIdFromUserInput.callCount,
         2,
         're-validates if entered URL value changes'
       );
-      assert.calledWith(fakeArticleIdFromURL, 'bar');
+      assert.calledWith(fakeArticleIdFromUserInput, 'bar');
 
       updateURL(wrapper, 'bar');
 
       assert.equal(
-        fakeArticleIdFromURL.callCount,
+        fakeArticleIdFromUserInput.callCount,
         2,
         'Does not validate URL if it has not changed from previous value'
       );
@@ -152,9 +152,9 @@ describe('JSTORPicker', () => {
 
       input.getDOMNode().dispatchEvent(keyEvent);
 
-      assert.calledOnce(fakeArticleIdFromURL);
+      assert.calledOnce(fakeArticleIdFromUserInput);
       assert.calledWith(
-        fakeArticleIdFromURL,
+        fakeArticleIdFromUserInput,
         'https://www.jstor.org/stable/1234'
       );
     });
@@ -172,7 +172,7 @@ describe('JSTORPicker', () => {
       interact(wrapper, () => {
         input.getDOMNode().dispatchEvent(keyEvent);
       });
-      assert.calledOnce(fakeArticleIdFromURL);
+      assert.calledOnce(fakeArticleIdFromUserInput);
 
       // Second enter press, after metadata has been fetched, should "confirm"
       // the valid URL.
@@ -189,23 +189,23 @@ describe('JSTORPicker', () => {
 
       wrapper.find('IconButton button[title="Find article"]').simulate('click');
 
-      assert.calledOnce(fakeArticleIdFromURL);
-      assert.calledWith(fakeArticleIdFromURL, 'foo');
+      assert.calledOnce(fakeArticleIdFromUserInput);
+      assert.calledWith(fakeArticleIdFromUserInput, 'foo');
     });
 
     it('does not attempt to check the URL format if the field value is empty', () => {
       const wrapper = renderJSTORPicker();
       updateURL(wrapper, 'foo');
 
-      assert.calledOnce(fakeArticleIdFromURL);
+      assert.calledOnce(fakeArticleIdFromUserInput);
 
       updateURL(wrapper, '');
 
-      assert.calledOnce(fakeArticleIdFromURL);
+      assert.calledOnce(fakeArticleIdFromUserInput);
     });
 
     it('shows an error if entered URL format is invalid', () => {
-      fakeArticleIdFromURL.returns(null);
+      fakeArticleIdFromUserInput.returns(null);
 
       const wrapper = renderJSTORPicker();
       updateURL(wrapper, 'foo');
@@ -215,7 +215,7 @@ describe('JSTORPicker', () => {
       assert.isTrue(errorMessage.exists());
       assert.include(
         errorMessage.text(),
-        "That doesn't look like a JSTOR article link"
+        "That doesn't look like a JSTOR article link or ID"
       );
       assert.isTrue(errorMessage.find('Icon[name="cancel"]').exists());
     });

--- a/lms/static/scripts/frontend_apps/utils/jstor.js
+++ b/lms/static/scripts/frontend_apps/utils/jstor.js
@@ -1,27 +1,45 @@
 /**
- * Extract the JSTOR article ID from a URL.
+ * Test whether a value looks like a DOI.
  *
- * Accepts URLs of the form:
- * - http[s]://www.jstor.org/stable/<articleID> OR
- * - http[s]://www.jstor.org/stable/<doiPrefix>/<doiSuffix>
+ * See https://en.wikipedia.org/wiki/Digital_object_identifier#Nomenclature_and_syntax.
  *
- * (Query string is ignored on provided URLs)
+ * @param {string} value
+ */
+function isDOI(value) {
+  return /^10.([0-9]+\.?)+\/.*/.test(value);
+}
+
+/**
+ * Extract the JSTOR article ID or DOI from a form field value.
  *
- * and returns, respectively:
- * - <articleID> OR
- * - <doiPrefix>/<doiSuffix>
+ * Accepts input in various forms:
  *
- * Return `null` if provided string is not a URL or does not match one of the
- * accepted formats.
+ * - A numeric ID (1234)
+ * - A DOI (10.2307/1234)
+ * - A canonical URL for a JSTOR article (eg. http[s]://www.jstor.org/stable/<articleID>
+ *   OR http[s]://www.jstor.org/stable/<doiPrefix>/<doiSuffix>)
+ * - A URL for a JSTOR article that has being proxied through an institution's
+ *   EZProxy or similar service (eg. https://www-jstor-org.myuni.edu/stable/1234).
  *
- * @param {string} url
+ * Return `null` if the input does not match any of the recognized formats.
+ *
+ * @param {string} value
  * @returns {string|null}
  */
-export function articleIdFromURL(url) {
-  let testURL;
+export function articleIdFromUserInput(value) {
+  // Plain JSTOR article ID
+  if (/^[0-9a-z.]+$/.test(value)) {
+    return value;
+  }
 
+  if (isDOI(value)) {
+    return value;
+  }
+
+  // Try matching input as a URL containing a JSTOR article ID or DOI
+  let testURL;
   try {
-    testURL = new URL(url);
+    testURL = new URL(value);
   } catch (e) {
     return null;
   }
@@ -29,24 +47,35 @@ export function articleIdFromURL(url) {
   // Split path and remove any empty entries representing leading or trailing slashes
   const pathSegments = testURL.pathname.split('/').filter(segment => !!segment);
 
-  if (testURL.hostname === 'www.jstor.org' && pathSegments[0] === 'stable') {
-    pathSegments.shift();
-    switch (pathSegments.length) {
-      case 1:
-        // Supplied URL is of the format
-        // http[s]://www.jstor.org/stable/<articleID>
-        return pathSegments[0];
-      case 2:
-        // Supplied URL is of the format
-        // http[s]://www.jstor.org/stable/<doiPrefix>/<doiSuffix>
-        // Ensure <doiPrefix> starts with `10.` and contains only digits or
-        // periods
-        if (pathSegments[0].match(/10\.[\d.]*$/)) {
-          return `${pathSegments[0]}/${pathSegments[1]}`;
-        }
-        break;
-      default:
-        return null;
+  // Test if this looks like the main JSTOR site (www.jstor.org) or the main
+  // JSTOR site accessed via a proxy (eg. www-jstor-org.library.someuni.edu).
+  //
+  // See https://gist.github.com/robertknight/5110065b0ad536093f466a60aed0ae23
+  // for more examples of real proxied URLs.
+  const isJSTORHost = /\bwww\Wjstor\Worg\b/.test(testURL.hostname);
+
+  if (isJSTORHost && pathSegments[0] === 'stable') {
+    // The path is expected to be in one of these formats:
+    //
+    // /stable/{article_id}
+    // /stable/{doi_prefix}/{doi_suffix}
+    // /stable/pdf/{article_id}.pdf
+    // /stable/pdf/{doi_prefix}/{doi_suffix}.pdf
+    //
+    const idSegments =
+      pathSegments[1] === 'pdf'
+        ? pathSegments.slice(2).map(s => s.replace(/\.pdf$/, ''))
+        : pathSegments.slice(1);
+
+    if (idSegments.length === 1) {
+      return idSegments[0];
+    } else if (idSegments.length === 2) {
+      const doi = idSegments.join('/');
+      if (isDOI(doi)) {
+        return doi;
+      }
+    } else {
+      return null;
     }
   }
 

--- a/lms/static/scripts/frontend_apps/utils/jstor.js
+++ b/lms/static/scripts/frontend_apps/utils/jstor.js
@@ -14,8 +14,8 @@ function isDOI(value) {
  *
  * Accepts input in various forms:
  *
- * - A numeric ID (1234)
- * - A DOI (10.2307/1234)
+ * - A JSTOR ID (eg. 1234 or abc123.456)
+ * - A DOI (eg. 10.2307/1234)
  * - A canonical URL for a JSTOR article (eg. http[s]://www.jstor.org/stable/<articleID>
  *   OR http[s]://www.jstor.org/stable/<doiPrefix>/<doiSuffix>)
  * - A URL for a JSTOR article that has being proxied through an institution's

--- a/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
@@ -1,18 +1,29 @@
-import { articleIdFromURL } from '../jstor';
+import { articleIdFromUserInput } from '../jstor';
 
 describe('utils/jstor', () => {
-  describe('articleIdFromURL', () => {
+  describe('articleIdFromUserInput', () => {
     [
-      // GOOD URLS
+      // Plain article ID
+      ['1234', '1234'],
+      ['j.ctv125jfg.3.6', 'j.ctv125jfg.3.6'],
+
+      // DOI
+      ['10.2307/1234', '10.2307/1234'],
+      ['10.7591/j.ctt5hh13f.4', '10.7591/j.ctt5hh13f.4'],
+
       // URL with article ID
       ['https://www.jstor.org/stable/1234', '1234'],
+
       // Querystring ignored
       ['https://www.jstor.org/stable/1234?q=bananas&bar=baz', '1234'],
+
       // Trailing slash(es) ignored
       ['https://www.jstor.org/stable/1234/', '1234'],
       ['https://www.jstor.org/stable/1234//', '1234'],
+
       // http protocol OK
       ['http://www.jstor.org/stable/1234', '1234'],
+
       // DOI Prefx and DOI suffix
       ['https://www.jstor.org/stable/10.1086/508573', '10.1086/508573'],
       [
@@ -20,21 +31,43 @@ describe('utils/jstor', () => {
         '10.1086.3333.9/508573',
       ],
 
-      // BAD URLS
-      // Not a URL
-      ['foo', null],
-      // Missing "/stable/"
-      ['http://www.jstor.org/1234', null],
-      ['https://www.jstor.org/10.1086/508573', null],
-      // Bad DOI Prefix format
-      ['https://www.jstor.org/stable/10.1086k/508573', null],
-      // Bad hostname
-      ['https://jstor.org/stable/1234', null],
-      // Too many path segments
-      ['https://www.jstor.org/stable/10.1086/508573/34434', null],
+      // PDF URLs
+      ['https://www.jstor.org/stable/pdf/4101611.pdf', '4101611'],
+      [
+        'https://www.jstor.org/stable/pdf/10.7591/j.ctt5hh13f.4.pdf',
+        '10.7591/j.ctt5hh13f.4',
+      ],
+
+      // Proxied JSTOR URLs
+      ['https://www-jstor-org.someuni.edu/stable/1234', '1234'],
+      ['https://www.jstor.org.someproxy.usc.edu/stable/1234', '1234'],
     ].forEach(([input, expected]) => {
-      it('returns expected ID', () => {
-        assert.equal(articleIdFromURL(input), expected);
+      it('returns article ID if input format is supported', () => {
+        assert.equal(articleIdFromUserInput(input), expected);
+      });
+    });
+
+    [
+      // Not a URL
+      'foo-bar',
+
+      // Missing "/stable/"
+      'http://www.jstor.org/1234',
+      'https://www.jstor.org/10.1086/508573',
+
+      // Bad DOI Prefix format
+      'https://www.jstor.org/stable/10.1086k/508573',
+
+      // Bad hostname
+      'https://othersite.org/stable/1234',
+      'https://daily.jstor.org/stable/1234',
+      'https://not-jstor.com.someproxy.edu/stable/1234',
+
+      // Too many path segments
+      'https://www.jstor.org/stable/10.1086/508573/34434',
+    ].forEach(input => {
+      it('returns null if article ID cannot be extracted', () => {
+        assert.isNull(articleIdFromUserInput(input));
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
@@ -41,6 +41,10 @@ describe('utils/jstor', () => {
       // Proxied JSTOR URLs
       ['https://www-jstor-org.someuni.edu/stable/1234', '1234'],
       ['https://www.jstor.org.someproxy.usc.edu/stable/1234', '1234'],
+      [
+        'https://www.jstor.org.someproxy.usc.edu/stable/pdf/abc.def.pdf',
+        'abc.def',
+      ],
     ].forEach(([input, expected]) => {
       it('returns article ID if input format is supported', () => {
         assert.equal(articleIdFromUserInput(input), expected);
@@ -48,7 +52,7 @@ describe('utils/jstor', () => {
     });
 
     [
-      // Not a URL
+      // Not a URL or ID
       'foo-bar',
 
       // Missing "/stable/"


### PR DESCRIPTION
In addition to a JSTOR canonical article URL, also allow the user to enter:

 - A plain article ID or DOI
 - A JSTOR article URL that is being proxied via EZProxy or a similar service. Such services are one of the most common ways that off-campus access to JSTOR is handled.
 - A JSTOR PDF URL or proxied PDF URL

Since we can extract the article ID / DOI from each of these inputs, it makes sense to accept them.

The parsing was informed by looking at [URLs from existing annotations which contain "jstor"](https://gist.github.com/robertknight/5110065b0ad536093f466a60aed0ae23). Note that we don't want to support all of the URLs in that list, as not all of them are JSTOR PDFs that can be chosen in the JSTOR article picker, and a very small proportion of the proxied URLs use unusual formats which are not handled.