### PR TITLE
Make Thumbnail in JSTOR picker wider, "crop" vertically

### DIFF
--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -147,9 +147,38 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
       ]}
     >
       <div className="flex flex-row space-x-3">
-        <Thumbnail classes="w-32 h-40" isLoading={isLoading}>
+        <Thumbnail
+          classes={classnames(
+            // Customize Thumbnail to:
+            //  - Make more use of available vertical space within the Modal
+            //  - "Crop" thumbnail image vertically to allow it to be wider
+            //
+            // TODO: Remove this customization after shared `Thumbnail`/related
+            // shared component refactors.
+            //
+            // Negative vertical margins allow thumbnail to use up more vertical
+            // space in the containing Modal
+            '-mb-12 -mt-2',
+            // Narrower grey border/background
+            '!p-2',
+            // Set up object containment such that the child is always a
+            // specific width, with a suggested but variable height
+            'w-[200px] min-w-[200px] h-52'
+          )}
+          isLoading={isLoading}
+        >
           {thumbnail.data && (
-            <img alt="article thumbnail" src={thumbnail.data.image} />
+            <img
+              className={classnames(
+                // Set up object positioning to "top". Bottom of thumbnail
+                // image is "cropped" as necesary to fit container.
+                // Need `!` to override `Thumbnail` styling's object-position
+                // rules
+                '!object-cover object-top'
+              )}
+              alt="article thumbnail"
+              src={thumbnail.data.image}
+            />
           )}
         </Thumbnail>
         <div className="space-y-2 grow">

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -203,7 +203,7 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
 
           {metadata.data && (
             <div
-              className="flex flex-row items-center space-x-2"
+              className="flex flex-row space-x-2"
               data-testid="selected-book"
             >
               <Icon name="check" classes="text-green-success" />


### PR DESCRIPTION
This PR provides an in-situ customization and override of `Thumbnail` styling to allow the JSTOR article-picker thumbnail to be usable in size.

Before:
<img width="694" alt="Screen Shot 2022-06-15 at 9 50 34 AM" src="https://user-images.githubusercontent.com/439947/173844035-a4f85e88-de2a-4b2c-8919-6561ae2bd4c6.png">

After:
<img width="697" alt="Screen Shot 2022-06-15 at 9 49 57 AM" src="https://user-images.githubusercontent.com/439947/173844057-0ff129a3-0711-4d5d-bc10-719837304b38.png">

This PR also makes a small fix to vertical alignment of the "checkmark" icon to better accommodate long, wrapping titles:

Before:
<img width="704" alt="Screen Shot 2022-06-15 at 10 02 54 AM" src="https://user-images.githubusercontent.com/439947/173847287-db21e68a-f6dc-4b3c-8472-8978b0693481.png">

After:
<img width="695" alt="Screen Shot 2022-06-15 at 10 04 36 AM" src="https://user-images.githubusercontent.com/439947/173847321-2e1cec65-8508-4c7d-85ef-b09e6d5a16ae.png">

This quick styling-override fix is considered interim until some known larger-picture items can be addressed. I looked at jumping into a broader fix this morning but it's larger in scope than this specific need warrants. We need to, as part of ongoing UI toolkit improvements:

- [refactor and break down the `Thumbnail` shared component](https://github.com/hypothesis/frontend-shared/issues/134)
- Consider the addition of an `AspectRatio` or similar shared component (this is a common component in various UI component libraries).
- Decompose `Modal` such that we have more direct control over things like "where the buttons show up" (workaround here uses negative vertical margins to account for lack of control in this area)

Fixes #4083