### PR TITLE
Add RSAKeyService.rotate

### DIFF
--- a/tests/factories/rsa_key.py
+++ b/tests/factories/rsa_key.py
@@ -4,5 +4,5 @@ from factory.alchemy import SQLAlchemyModelFactory
 from lms import models
 
 RSAKey = make_factory(
-    models.RSAKey, FACTORY_CLASS=SQLAlchemyModelFactory, public_key="{}"
+    models.RSAKey, FACTORY_CLASS=SQLAlchemyModelFactory, public_key="{}", expired=False
 )

--- a/tests/unit/lms/services/rsa_key_service_test.py
+++ b/tests/unit/lms/services/rsa_key_service_test.py
@@ -1,8 +1,10 @@
+from datetime import datetime, timedelta
 from unittest.mock import sentinel
 
 import pytest
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+from freezegun import freeze_time
 from h_matchers import Any
 from jose import constants
 
@@ -12,6 +14,37 @@ from tests import factories
 
 
 class TestAESService:
+    @freeze_time("2022-1-15")
+    def test_rotate(self, svc, valid_keys, expired_keys, db_session):
+        # Keys created the 10th, max ages of 2 and 4 both expire valid and
+        # deleted expired on the 15th.
+        target_keys = 5
+
+        svc.rotate(
+            target_keys, max_age=timedelta(days=2), max_expired_age=timedelta(days=4)
+        )
+
+        assert all((key.expired for key in valid_keys))
+        assert not any((key in db_session for key in expired_keys))
+        assert db_session.query(RSAKey).filter_by(expired=False).count() == target_keys
+
+    @freeze_time("2022-1-11")
+    @pytest.mark.usefixtures("expired_keys")
+    def test_rotate_doesnt_expire_valid(self, svc, valid_keys):
+        # Keys created the 10th, max age of 2, doesn't expire the keys on the
+        # 11th.
+        svc.rotate(3, max_age=timedelta(days=2), max_expired_age=timedelta(days=5))
+
+        assert not any((key.expired for key in valid_keys))
+
+    @freeze_time("2022-1-11")
+    @pytest.mark.usefixtures("valid_keys")
+    def test_rotate_doesnt_delete_recent_expires(self, svc, expired_keys, db_session):
+        # Keys created the 10th, max expired age of 5, doesn't delete the keys
+        # on the 11th.
+        svc.rotate(3, max_age=timedelta(days=2), max_expired_age=timedelta(days=5))
+        assert all((key in db_session for key in expired_keys))
+
     def test_generate(self, svc, aes_service, rsa, jwk):
         jwk.RSAKey.return_value.to_dict.return_value = {}
 
@@ -45,7 +78,6 @@ class TestAESService:
             algorithm=constants.Algorithms.RS256,
             key=public_bytes.return_value.decode("utf-8"),
         )
-
         assert key.private_key == aes_service.encrypt.return_value
         assert key.aes_cipher_iv == aes_service.build_iv.return_value
 
@@ -57,11 +89,12 @@ class TestAESService:
         aes_service.decrypt.assert_called_once_with(sentinel.iv, sentinel.private_key)
         assert private_key == aes_service.decrypt.return_value
 
-    def test_get_all_public_jwks(self, svc, valid_keys):
+    def test_get_all_public_jwks(self, svc, valid_keys, expired_keys):
         keys = svc.get_all_public_jwks()
 
         expected_keys = [
-            {"use": "sig", "kid": key.kid, "key": "value"} for key in valid_keys
+            {"use": "sig", "kid": key.kid, "key": "value"}
+            for key in (valid_keys + expired_keys)
         ]
         assert keys == Any.list.containing(expected_keys).only()
 
@@ -72,10 +105,19 @@ class TestAESService:
 
     @pytest.fixture
     def valid_keys(self):
-        # Create some noise with some expired keys.
-        factories.RSAKey.create_batch(size=3, expired=True)
         return factories.RSAKey.create_batch(
-            size=3, expired=False, public_key='{"key": "value"}'
+            size=3,
+            public_key='{"key": "value"}',
+            created=datetime(2022, 1, 10),
+        )
+
+    @pytest.fixture
+    def expired_keys(self):
+        return factories.RSAKey.create_batch(
+            size=3,
+            expired=True,
+            public_key='{"key": "value"}',
+            created=datetime(2022, 1, 10),
         )
 
     @pytest.fixture

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -99,7 +99,12 @@ def application_instance_service(mock_service, application_instance):
 
 @pytest.fixture
 def aes_service(mock_service):
-    return mock_service(AESService)
+    aes_service = mock_service(AESService)
+    # Don't return MagicMock objects from these functions so the output can
+    # be tested against things which store them in the DB
+    aes_service.encrypt.return_value = b"fake_ciphertext"
+    aes_service.build_iv.return_value = b"fake_aes_iv"
+    return aes_service
 
 
 @pytest.fixture


### PR DESCRIPTION
For #3968 

Not yet executed in production as is meant to be called from a Celery task. 


## Testing

- Truncate rsa_key and `make devdata` before starting.

- `tox -qe dockercompose -- exec postgres psql -U postgres -c "select created, kid, expired from  rsa_key;"`


```
         created          |               kid                | expired 
---------------------------+----------------------------------+---------
 2022-06-21 07:41:31.52763 | f1a394d0268e4fd8b45391ce4c1ee901 | f
(1 row)
```

(this one comes from devdata)



- Rotate the keys, on `make shell`


```
from datetime import timedelta
from lms.services import RSAKeyService
rsa_service = request.find_service(RSAKeyService)
rsa_service.rotate(5, timedelta(days=1), timedelta(days=1))
tm.commit()
```



- `tox -qe dockercompose -- exec postgres psql -U postgres -c "select kid, expired from  rsa_key;"`

```          created           |               kid                | expired 
 2022-06-24 15:29:51.547215 | f1a394d0268e4fd8b45391ce4c1ee901 | f
 2022-06-24 15:30:33.958874 | 53f1be3f52b44672b377b87c01ef1124 | f
 2022-06-24 15:30:33.958874 | 0ccd632409554b328b313aabf5d3b9a9 | f
 2022-06-24 15:30:33.958874 | 9859b8e1ce8b4457b7f74d5f9dda98be | f
 2022-06-24 15:30:33.958874 | f8081ab08fa84bf1ba9f9373f22d92d4 | f
(5 rows)
```

Nothing got expired, but 4 new keys were created to match the target


- Rotate again


```
from datetime import timedelta
from lms.services import RSAKeyService
rsa_service = request.find_service(RSAKeyService)
rsa_service.rotate(5, timedelta(days=1), timedelta(days=1))
tm.commit()
```


```
          created           |               kid                | expired 
----------------------------+----------------------------------+---------
 2022-06-24 15:29:51.547215 | f1a394d0268e4fd8b45391ce4c1ee901 | f
 2022-06-24 15:30:33.958874 | 53f1be3f52b44672b377b87c01ef1124 | f
 2022-06-24 15:30:33.958874 | 0ccd632409554b328b313aabf5d3b9a9 | f
 2022-06-24 15:30:33.958874 | 9859b8e1ce8b4457b7f74d5f9dda98be | f
 2022-06-24 15:30:33.958874 | f8081ab08fa84bf1ba9f9373f22d92d4 | f
(5 rows)

```

Nothing has been expired or deleted

- Now with short ages:

```
rsa_service.rotate(5, timedelta(minutes=1), timedelta(minutes=1))
```

```
          created           |               kid                | expired 
----------------------------+----------------------------------+---------
 2022-06-24 15:29:51.547215 | f1a394d0268e4fd8b45391ce4c1ee901 | t
 2022-06-24 15:30:33.958874 | 53f1be3f52b44672b377b87c01ef1124 | t
 2022-06-24 15:30:33.958874 | 0ccd632409554b328b313aabf5d3b9a9 | t
 2022-06-24 15:30:33.958874 | 9859b8e1ce8b4457b7f74d5f9dda98be | t
 2022-06-24 15:30:33.958874 | f8081ab08fa84bf1ba9f9373f22d92d4 | t
 2022-06-24 15:31:16.356098 | a0d03c0de65e455985bace53da618d18 | f
 2022-06-24 15:31:16.356098 | 72b2cd9d226b4d5dab161994fa858117 | f
 2022-06-24 15:31:16.356098 | 4ac434c089f14463beceb6b54c154db3 | f
 2022-06-24 15:31:16.356098 | 4fe21a6daf1f45279fb14742ae8aec1e | f
 2022-06-24 15:31:16.356098 | 828fa4dd2cdb462bb6fc20934c64e5fe | f
(10 rows)

```

existing keys got expired.

- Running it again 

```
rsa_service.rotate(5, timedelta(minutes=1), timedelta(minutes=1))
```

```
          created           |               kid                | expired 
----------------------------+----------------------------------+---------
 2022-06-24 15:31:16.356098 | a0d03c0de65e455985bace53da618d18 | t
 2022-06-24 15:31:16.356098 | 72b2cd9d226b4d5dab161994fa858117 | t
 2022-06-24 15:31:16.356098 | 4ac434c089f14463beceb6b54c154db3 | t
 2022-06-24 15:31:16.356098 | 4fe21a6daf1f45279fb14742ae8aec1e | t
 2022-06-24 15:31:16.356098 | 828fa4dd2cdb462bb6fc20934c64e5fe | t
 2022-06-24 15:37:03.85588  | 62ffe00dabed42a2adbc7a674872df3b | f
 2022-06-24 15:37:03.85588  | 096ab3ef6c0944598be714e1b54e61a5 | f
 2022-06-24 15:37:03.85588  | f0b3455bf7b94115bd168f7b688aea1a | f
 2022-06-24 15:37:03.85588  | 5e7c31c2814f49a3ba7be411bb7d18a0 | f
 2022-06-24 15:37:03.85588  | 569572d2c6e540e7934f01c35cdaec53 | f
(10 rows)
```

Expired ones got deleted, active ones got expired and new ones got created.




