### PR TITLE
Improve extraction of titles from JSTOR API responses

### DIFF
--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -14,10 +14,7 @@ from lms.views.helpers import via_url
 
 
 class JSTORMetadataSchema(RequestsResponseSchema):
-    """Incomplete response schema for `/metadata/{doi}` endpoint in the JSTOR API."""
-
-    class ReviewedWorks(Schema):
-        title = fields.Str()
+    """Response schema for `/metadata/{doi}` endpoint in the JSTOR API."""
 
     # Title fields for "regular" articles.
     title = fields.List(fields.Str())
@@ -29,6 +26,10 @@ class JSTORMetadataSchema(RequestsResponseSchema):
     tbsub = fields.Str(allow_none=True)
 
     # Fields for articles which are reviews of other works.
+
+    class ReviewedWorks(Schema):
+        title = fields.Str()
+
     reviewed_works = fields.List(fields.Nested(ReviewedWorks, unknown=EXCLUDE))
 
 

--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -215,22 +215,16 @@ def _format_uri(template: str, *params: str):
 
 def _strip_html_tags(html: str) -> str:
     """Extract plain text from a string which may contain HTML formatting tags."""
-    text = ""
 
     # Extract text nodes using HTMLParser. We rely on it being tolerant of
     # invalid markup.
-    #
-    # See https://bugs.python.org/issue31844 for abstract-method issue.
-    class Parser(HTMLParser):  # pylint:disable=abstract-method
-        def handle_data(self, data: str):
-            nonlocal text
-            text += data
-
-    parser = Parser()
+    chunks = []
+    parser = HTMLParser()
+    parser.handle_data = chunks.append
     parser.feed(html)
     parser.close()
 
-    return text
+    return "".join(chunks)
 
 
 def _normalize_whitespace(val: str) -> str:

--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -111,7 +111,6 @@ class JSTORService:
         # Articles which are reviews of other works may not have a title of
         # their own, but we can generate one from the title of the reviewed work.
         if not title and metadata.get("reviewed_works"):
-            # TBD: Can reviewed works be collections or have subtitles?
             reviewed_title = metadata["reviewed_works"][0]["title"]
             title = f"Review: {reviewed_title}"
 

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -124,6 +124,9 @@ class TestJSTORService:
                 },
                 "Review: Some other work",
             ),
+            # Primary source content (various kinds of item listed under
+            # "Primary source content" in JSTOR search results)
+            ({"item_title": "Some primary source"}, "Some primary source"),
             # Titles with extra whitespace or new lines. These should be cleaned up.
             (
                 {"title": ["   Too\n many\n lines \t and spaces "]},

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -102,15 +102,11 @@ class TestJSTORService:
         [
             # Simple title
             ({"title": ["Some title"]}, {"title": "Some title"}),
-            # No titles.
+            # Empty or missing "title" field, and no other title
             (
                 {"title": []},
                 {"title": None},
             ),
-            # No title field.
-            #
-            # This can happen if the work is a container publication (eg.
-            # a book). See https://github.com/hypothesis/lms/issues/4082.
             (
                 {},
                 {"title": None},


### PR DESCRIPTION
Handle various issues found when extracting article titles from JSTOR API responses. This fixes various cases in which the JSTOR picker form showed incomplete or missing titles.

We could ask JSTOR to do some of this normalization on their side, but doing it on our end gives us more flexibility and the ability to change it when needed. Also some of these differences are due to different item types (articles vs collections of articles vs reviews of other articles) that we will need to treat differently on our end in other ways too.

 1. Append subtitle to title, if present. The title often doesn't make sense
    without the subtitle part (see https://github.com/hypothesis/lms/issues/4088)
 2. Handle container publications, which use a different field for the title
    ("tb") and subtitle ("tbsub") (see https://github.com/hypothesis/lms/issues/4082)
 3. Handle articles which are reviews of other works. These don't have a title
    themselves, but we can generate one from the title of the reviewed work (see https://github.com/hypothesis/lms/issues/4049)
 4. Strip HTML-like tags from the title (see https://github.com/hypothesis/lms/issues/4087)
 5. Normalize whitespace to replace new lines and remove leading/trailing space
    which occurs in some titles (part of https://github.com/hypothesis/lms/issues/4087)

Fixes https://github.com/hypothesis/lms/issues/4087
Fixes https://github.com/hypothesis/lms/issues/4088
Fixes https://github.com/hypothesis/lms/issues/4049
Part of https://github.com/hypothesis/lms/issues/4082

A known issue with this PR is that entering a syntactically valid but non-existent JSTOR article ID or link will show a checkmark with an empty response:

<img width="715" alt="JSTOR empty result" src="https://user-images.githubusercontent.com/2458/174585670-7d9ea9dd-a961-4dc2-a35d-a588ed774066.png">

Resolving this is currently blocked on some changes to how JSTOR handles invalid IDs in their `/metadata/{doi}` and `/thumbnail/{doi}` endpoints. See https://hypothes-is.slack.com/archives/C02T75RKBTK/p1655378603511759.

---

**Testing:**

In the JSTOR article picker form:

1. Enter "https://www.jstor.org/stable/10.1525/as.2003.43.3.423". The title should be displayed as "Racing from The Bottom in South Korea?: The Nexus Between Civil Society and Transnational Migrants" with no HTML tags.
2. Enter "https://www.jstor.org/stable/10.3138/j.ctt1whm96v.10". The title should be displayed as "Talking about History: The Encomium Emmae reginae and the Court of Harthacnut"
3. Enter "https://www.jstor.org/stable/331473". The title should be displayed as "Review: Homenaje ofrecido a Menéndez Pidal. Miscelánea de estudios lingüísticos, literarios e históricos".
4. Enter "https://www.jstor.org/stable/resrep19567". The title should be displayed as "NUMBERS MATTER: THE 2020 CENSUS AND CONFLICT IN PAPUA". This article is a collection, so cannot be used directly. Indicating this will happen in a follow-up PR. It is expected that no thumbnail will appear for this link.
