### PR TITLE
Use permissions to tell if someone can edit an assignment

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -23,6 +23,7 @@ class Identity(NamedTuple):
 
 class Permissions(Enum):
     LTI_LAUNCH_ASSIGNMENT = "lti_launch_assignment"
+    LTI_CONFIGURE_ASSIGNMENT = "lti_configure_assignment"
     API = "api"
     ADMIN = "admin"
 
@@ -78,9 +79,15 @@ class LTISecurityPolicy:
         userid = self.authenticated_userid(request)
 
         if userid:
-            return Identity(
-                userid, [Permissions.LTI_LAUNCH_ASSIGNMENT, Permissions.API]
-            )
+            permissions = [Permissions.LTI_LAUNCH_ASSIGNMENT, Permissions.API]
+
+            if any(
+                role in request.lti_user.roles.lower()
+                for role in ["administrator", "instructor", "teachingassistant"]
+            ):
+                permissions.append(Permissions.LTI_CONFIGURE_ASSIGNMENT)
+
+            return Identity(userid, permissions)
 
         return Identity("", [])
 

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -51,8 +51,7 @@ from lms.validation._base import JSONPyramidRequestSchema
 
 
 @view_config(
-    authorized_to_configure_assignments=True,
-    permission=Permissions.LTI_LAUNCH_ASSIGNMENT,
+    permission=Permissions.LTI_CONFIGURE_ASSIGNMENT,
     renderer="lms:templates/file_picker.html.jinja2",
     request_method="POST",
     route_name="content_item_selection",

--- a/lms/views/predicates.py
+++ b/lms/views/predicates.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
-from lms.views.lti.basic_launch import LTI_LAUNCH_PREDICATES
+from lms.views.lti.basic_launch import has_document_url
 
 
 @dataclass
@@ -44,7 +44,9 @@ class Predicate:
 
 
 def includeme(config):
-    for name, comparison in LTI_LAUNCH_PREDICATES.items():
-        config.add_view_predicate(
-            name=name, factory=partial(Predicate, name=name, comparison=comparison)
-        )
+    config.add_view_predicate(
+        name="has_document_url",
+        factory=partial(
+            Predicate, name="has_document_url", comparison=has_document_url
+        ),
+    )

--- a/tests/unit/lms/views/predicates_test.py
+++ b/tests/unit/lms/views/predicates_test.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock, call, sentinel
 import pytest
 from h_matchers import Any
 
-from lms.views.predicates import LTI_LAUNCH_PREDICATES, Predicate, includeme
+from lms.views.lti.basic_launch import has_document_url
+from lms.views.predicates import Predicate, includeme
 
 
 class TestPredicate:
@@ -38,8 +39,7 @@ class TestPredicate:
         )
 
 
-@pytest.mark.parametrize("name,comparison", LTI_LAUNCH_PREDICATES.items())
-def test_includeme(name, comparison):
+def test_includeme():
     config = Mock(spec_set=["add_view_predicate"])
 
     includeme(config)
@@ -47,9 +47,9 @@ def test_includeme(name, comparison):
     predicate_partial = Any.object.of_type(partial).with_attrs(
         {
             "func": Predicate,
-            "keywords": {"name": name, "comparison": comparison},
+            "keywords": {"name": "has_document_url", "comparison": has_document_url},
         }
     )
     config.add_view_predicate.assert_has_calls(
-        [call(name=name, factory=predicate_partial)]
+        [call(name="has_document_url", factory=predicate_partial)]
     )


### PR DESCRIPTION
This PR swaps the `authorized_to_edit_assignment` for a permission as:

 * It's weird that it's a predicate when it sounds very like a security thing
 * This keeps all the logic for permissions in one place (`security.py`)
 * This untangles some sideways linkage between deep linking and LTI launch views

Although I'm not suggesting we do, this also shows how we could have a completely unified launch view without any predicates as well.