### PR TITLE
Add accessible label to student selector

### DIFF
--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -78,6 +78,7 @@ export default function StudentSelector({
         */}
         {/* eslint-disable-next-line jsx-a11y/no-onchange*/}
         <select
+          aria-label="Select student"
           className={classnames(
             'appearance-none w-full h-touch-minimum',
             'pl-4 pr-8', // Make room on right for custom down-caret Icon

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -89,10 +89,8 @@ describe('StudentSelector', () => {
     assert.isTrue(wrapper.find('button').last().prop('disabled'));
   });
 
-  it.skip(
+  it(
     'should pass a11y checks',
-    checkAccessibility({
-      content: () => renderSelector(),
-    })
+    checkAccessibility({ content: () => renderSelector() })
   );
 });


### PR DESCRIPTION
Visually the purpose of this widget seems obvious and the form is
space-constrained, so I added an aria-label attribute rather than a visible
`<label>` widget.

Part of https://github.com/hypothesis/lms/issues/2957