### PR TITLE
Bump `frontend-shared` and use `focus-visible-ring`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.js
@@ -53,7 +53,7 @@ function ErrorDetails({ error }) {
         className={classnames(
           'sticky top-0',
           'bg-grey-1 p-2 cursor-pointer',
-          'yp-u-outline-on-keyboard-focus--inset'
+          'focus-visible-ring ring-inset'
         )}
       >
         Error Details

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.js
@@ -82,7 +82,7 @@ export default function StudentSelector({
             'appearance-none w-full h-touch-minimum',
             'pl-4 pr-8', // Make room on right for custom down-caret Icon
             'xl:w-80', // Fix the width at wider viewports
-            'u-outline-on-keyboard-focus--inset',
+            'focus-visible-ring ring-inset',
             'border border-r-0 border-l-0' // left and right borders off
           )}
           onChange={e => {
@@ -132,7 +132,7 @@ export default function StudentSelector({
             // IconButton styling sets a border radius. Turn it off on the
             // right for better alignment with the select element
             'rounded-r-none',
-            'u-outline-on-keyboard-focus--inset'
+            'focus-visible-ring ring-inset'
           )}
           icon="arrowLeft"
           title="previous student"
@@ -146,7 +146,7 @@ export default function StudentSelector({
             'px-3',
             // Turn off border radius on left for better alignment with select
             'rounded-l-none',
-            'u-outline-on-keyboard-focus--inset'
+            'focus-visible-ring ring-inset'
           )}
           icon="arrowRight"
           title="next student"

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.js
@@ -203,7 +203,7 @@ export default function SubmitGradeForm({ student }) {
               className={classnames(
                 'w-14 h-touch-minimum text-center',
                 'disabled:opacity-50',
-                'u-outline-on-keyboard-focus--inset',
+                'focus-visible-ring ring-inset',
                 'border border-r-0',
                 {
                   'animate-gradeSubmitSuccess': gradeSaved,
@@ -227,7 +227,7 @@ export default function SubmitGradeForm({ student }) {
             classes={classnames(
               'h-touch-minimum border',
               'disabled:opacity-50 disabled:cursor-default',
-              'u-outline-on-keyboard-focus--inset'
+              'focus-visible-ring ring-inset'
             )}
             disabled={disabled}
             onClick={onSubmitGrade}

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -48,7 +48,7 @@ export default function ValidationMessage({
         'left-full',
         // Sm and larger breakpoints position the message to the left of the input
         'sm:left-0 sm:-translate-x-full',
-        'u-outline-on-keyboard-focus',
+        'focus-visible-ring',
         {
           'animate-validationMessageOpen': showError,
           'animate-validationMessageClose': !showError,

--- a/lms/static/styles/_utilities.scss
+++ b/lms/static/styles/_utilities.scss
@@ -15,35 +15,4 @@
   .u-absolute-centered {
     @apply absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2;
   }
-
-  // Copied current implementation of `hyp-u-outline-on-keyboard-focus`
-  // classes from the `frontend-shared` package.
-  // TODO: This should be implemented as a TW plugin in `frontend-shared`
-  // and replaced
-  .u-outline-on-keyboard-focus:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px #59a7e8;
-  }
-  .js-focus-visible .u-outline-on-keyboard-focus:focus:not(.focus-visible) {
-    outline: none;
-    box-shadow: none;
-  }
-  .u-outline-on-keyboard-focus:focus:not(:focus-visible) {
-    outline: none;
-    box-shadow: none;
-  }
-
-  .u-outline-on-keyboard-focus--inset:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px #59a7e8 inset;
-  }
-  .js-focus-visible
-    .u-outline-on-keyboard-focus--inset:focus:not(.focus-visible) {
-    outline: none;
-    box-shadow: none;
-  }
-  .u-outline-on-keyboard-focus--inset:focus:not(:focus-visible) {
-    outline: none;
-    box-shadow: none;
-  }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-react": "^7.17.12",
     "@hypothesis/frontend-build": "1.2.0",
-    "@hypothesis/frontend-shared": "4.5.2",
+    "@hypothesis/frontend-shared": "4.6.0",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,10 +1057,10 @@
     fancy-log "^1.3.3"
     glob "^7.2.0"
 
-"@hypothesis/frontend-shared@4.5.2":
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-4.5.2.tgz#841d7197a99aeec9b66b579acceb8e91a4a16fd7"
-  integrity sha512-9ckLkzmKmwGnzVuT7dJEAA8d5Yd3/YXjbUyXx0IAlq9YPrNzdNKPa4SX1hBqCfc0Q5IrVFsnEzH1YqeAgiOyrg==
+"@hypothesis/frontend-shared@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-4.6.0.tgz#2a45697b205662b0437e03167df4b615337fccef"
+  integrity sha512-AuQMwT6ggWCvSGxs8ERSfdQ4YSLcAk4XBKb92UqOu4wrhJ6PsKLCyv6HIrX3o4tnamZ0EiotTmrUsCi7XxM07Q==
   dependencies:
     normalize.css "^8.0.1"
 


### PR DESCRIPTION
This PR bumps `@hypothesis/frontend-shared` to `v4.6.0` to get the added `.focus-ring-visible` utility class and updates components to use it.