### PR TITLE
Populate `is_collection` field in JSTOR article metadata response

### DIFF
--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -100,7 +100,11 @@ class JSTORService:
 
         title = self._get_title_from_metadata(metadata)
 
-        return {"title": title}
+        # Collections (eg. books) have a different schema than regular articles.
+        # Test for a field that only appears in collections.
+        is_collection = "tb" in metadata
+
+        return {"title": title, "is_collection": is_collection}
 
     def thumbnail(self, article_id: str):
         """

--- a/lms/views/api/jstor.py
+++ b/lms/views/api/jstor.py
@@ -13,11 +13,7 @@ class JSTORAPIViews:
     @view_config(route_name="jstor_api.articles.metadata")
     def article_metadata(self):
         article_id = self.request.matchdict["article_id"]
-        article_info = self.jstor_service.metadata(article_id)
-
-        is_collection = False  # Placeholder
-
-        return {"title": article_info["title"], "is_collection": is_collection}
+        return self.jstor_service.metadata(article_id)
 
     @view_config(route_name="jstor_api.articles.thumbnail")
     def article_thumbnail(self):

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -153,6 +153,23 @@ class TestJSTORService:
         metadata = svc.metadata("12345")
         assert metadata["title"] == expected_title
 
+    @pytest.mark.parametrize(
+        "api_response, is_collection",
+        [
+            ({"title": ["Foo bar"]}, False),
+            ({"reviewed_works": [{"title": "Some article"}]}, False),
+            ({"tb": "Some book"}, True),
+        ],
+    )
+    def test_metadata_is_collection_field(
+        self, svc, http_service, api_response, is_collection
+    ):
+        http_service.get.return_value = factories.requests.Response(
+            json_data=api_response
+        )
+        metadata = svc.metadata("12345")
+        assert metadata["is_collection"] is is_collection
+
     def test_metadata_raises_if_schema_mismatch(self, svc, http_service):
         invalid_api_response = {"title": "This should be a list"}
         http_service.get.return_value = factories.requests.Response(

--- a/tests/unit/lms/views/api/jstor_test.py
+++ b/tests/unit/lms/views/api/jstor_test.py
@@ -12,10 +12,7 @@ class TestJSTORAPIViews:
         metadata = views.article_metadata()
 
         jstor_service.metadata.assert_called_once_with("test-article")
-        assert metadata == {
-            "title": jstor_service.metadata.return_value["title"],
-            "is_collection": False,
-        }
+        assert metadata == jstor_service.metadata.return_value
 
     def test_article_thumbnail(self, jstor_service, pyramid_request):
         views = JSTORAPIViews(pyramid_request)


### PR DESCRIPTION
Populate the `is_collection` field of the JSTOR metadata API response, so that the frontend can show a notice to the user informing them that they must instead pick a specific article within the collection.

This PR previously contained the frontend changes to use this field. That aspect has since been extracted into a separate PR: https://github.com/hypothesis/lms/pull/4124

**TODO:**

- The current code in this PR was written before I'd tested all the different article types. It needs to either be updated so that it passes all  the cases in [this comment](https://github.com/hypothesis/lms/pull/4118#issuecomment-1164325952) or equivalent logic will be needed on JSTOR's side

**Testing:**

In the JSTOR assignment picker:

1. Enter one of the article IDs from the "Collection IDs" list in [this comment](https://github.com/hypothesis/lms/pull/4118#issuecomment-1164325952) and press Enter. You should see an error message indicating that the item is from a collection, and the submit button should be disabled even if the T&Cs checkbox is checked.
2. Enter one of the article IDs from the "Non-collection IDs" list in the same comment and press Enter. You should not see the error message and the submit button should become enabled once the T&Cs checkbox is checked.

Fixes https://github.com/hypothesis/lms/issues/4082