### PR TITLE
Show error in JSTOR article picker if item is a collection

### DIFF
--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -23,6 +23,7 @@ import { articleIdFromUserInput, jstorURLFromArticleId } from '../utils/jstor';
  * Response for an `/api/jstor/articles/{article_id}` call.
  *
  * @typedef Metadata
+ * @prop {boolean} is_collection
  * @prop {string} title
  */
 
@@ -70,13 +71,18 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
       metadata.error,
       'Unable to fetch article details'
     );
+  } else if (metadata.data?.is_collection) {
+    renderedError =
+      'This work is a collection. Enter the link for a specific article in the collection.';
   }
 
   const inputRef = /** @type {{ current: HTMLInputElement }} */ (useRef());
   // The last confirmed value of the URL-entry text input
   const previousURL = useRef(/** @type {string|null} */ (null));
 
-  const canConfirmSelection = articleId && metadata.data !== null;
+  const canConfirmSelection =
+    articleId && metadata.data && !metadata.data.is_collection;
+
   const confirmSelection = () => {
     if (canConfirmSelection) {
       onSelectURL(jstorURLFromArticleId(articleId));
@@ -206,7 +212,9 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
               className="flex flex-row space-x-2"
               data-testid="selected-book"
             >
-              <Icon name="check" classes="text-green-success" />
+              {canConfirmSelection && (
+                <Icon name="check" classes="text-green-success" />
+              )}
               <div className="grow font-bold italic">{metadata.data.title}</div>
             </div>
           )}

--- a/lms/views/api/jstor.py
+++ b/lms/views/api/jstor.py
@@ -14,7 +14,10 @@ class JSTORAPIViews:
     def article_metadata(self):
         article_id = self.request.matchdict["article_id"]
         article_info = self.jstor_service.metadata(article_id)
-        return {"title": article_info["title"]}
+
+        is_collection = False  # Placeholder
+
+        return {"title": article_info["title"], "is_collection": is_collection}
 
     @view_config(route_name="jstor_api.articles.thumbnail")
     def article_thumbnail(self):

--- a/tests/unit/lms/views/api/jstor_test.py
+++ b/tests/unit/lms/views/api/jstor_test.py
@@ -12,7 +12,10 @@ class TestJSTORAPIViews:
         metadata = views.article_metadata()
 
         jstor_service.metadata.assert_called_once_with("test-article")
-        assert metadata == {"title": jstor_service.metadata.return_value["title"]}
+        assert metadata == {
+            "title": jstor_service.metadata.return_value["title"],
+            "is_collection": False,
+        }
 
     def test_article_thumbnail(self, jstor_service, pyramid_request):
         views = JSTORAPIViews(pyramid_request)


### PR DESCRIPTION
_This PR contains the frontend part of https://github.com/hypothesis/lms/pull/4118._

PDFs are not available for collections, only specific articles in a
collection. For this reason, disable the Submit button in the JSTOR
article picker if the item is a collection and present an error to
explain why and how to resolve the issue.

The `is_collection` property of the article metadata API response is
just a placeholder for the moment, while some schema changes are worked
out on JSTOR's side.

---

**Testing:**

1. Enter an article ID in the JSTOR picker, eg. 123456. The title should appear and the Submit button should be available.2. 
2. Apply the following diff below, then close and re-open the picker and enter the same ID. The title should appear but this time the Submit button will be disabled and an error will appear below the title.

```diff
diff --git a/lms/views/api/jstor.py b/lms/views/api/jstor.py
index b5ef948d..c2a9d8a0 100644
--- a/lms/views/api/jstor.py
+++ b/lms/views/api/jstor.py
@@ -15,7 +15,7 @@ class JSTORAPIViews:
         article_id = self.request.matchdict["article_id"]
         article_info = self.jstor_service.metadata(article_id)
 
-        is_collection = False  # Placeholder
+        is_collection = True  # Placeholder
 
         return {"title": article_info["title"], "is_collection": is_collection}
```
