### PR TITLE
Sync view group set id refactor

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -444,7 +444,6 @@ class JSConfig:
                     "custom_canvas_course_id": self._context.lti_params[
                         "custom_canvas_course_id"
                     ],
-                    "group_set": req.params.get("group_set"),
                 },
                 "assignment": {
                     "resource_link_id": self._context.lti_params["resource_link_id"],
@@ -461,7 +460,6 @@ class JSConfig:
         if "learner_canvas_user_id" in req.params:
             sync_api_config["data"]["learner"] = {
                 "canvas_user_id": req.params["learner_canvas_user_id"],
-                "group_set": req.params.get("group_set"),
             }
 
         return sync_api_config

--- a/lms/views/api/blackboard/sync.py
+++ b/lms/views/api/blackboard/sync.py
@@ -9,10 +9,6 @@ class Sync:
         self.request = request
         self.grouping_service = self.request.find_service(name="grouping")
 
-        self.tool_consumer_instance_guid = self.request.parsed_params["lms"][
-            "tool_consumer_instance_guid"
-        ]
-
     @view_config(
         route_name="blackboard_api.sync",
         request_method="POST",
@@ -25,28 +21,15 @@ class Sync:
             self.request.user,
             self.request.lti_user,
             self.get_course(self.request.parsed_params["course"]["context_id"]),
-            self.group_set(),
+            self.request.parsed_params["assignment"]["group_set_id"],
             self.request.parsed_params.get("gradingStudentId"),
         )
 
-        self.sync_to_h(groups)
+        self.request.find_service(name="lti_h").sync(
+            groups, self.request.parsed_params["group_info"]
+        )
         authority = self.request.registry.settings["h_authority"]
         return [group.groupid(authority) for group in groups]
-
-    def group_set(self):
-        return (
-            self.request.find_service(name="assignment")
-            .get_assignment(
-                self.tool_consumer_instance_guid,
-                self.request.parsed_params["assignment"]["resource_link_id"],
-            )
-            .extra["group_set_id"]
-        )
-
-    def sync_to_h(self, groups):
-        lti_h_svc = self.request.find_service(name="lti_h")
-        group_info = self.request.parsed_params["group_info"]
-        lti_h_svc.sync(groups, group_info)
 
     def get_course(self, course_id):
         return self.request.find_service(name="course").get_by_context_id(course_id)

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -297,7 +297,6 @@ class TestJSConfigAPISync:
                 "course": {
                     "context_id": "test_context_id",
                     "custom_canvas_course_id": "test_custom_canvas_course_id",
-                    "group_set": None,
                 },
                 "assignment": {
                     "resource_link_id": "test_resource_link_id",
@@ -344,7 +343,6 @@ class TestJSConfigAPISync:
     def test_it_adds_learner_canvas_user_id_for_SpeedGrader_launches(self, sync):
         assert sync["data"]["learner"] == {
             "canvas_user_id": "test_learner_canvas_user_id",
-            "group_set": None,
         }
 
     def test_its_None_if_section_and_groups_arent_enabled(self, sync):

--- a/tests/unit/lms/views/api/blackboard/sync_test.py
+++ b/tests/unit/lms/views/api/blackboard/sync_test.py
@@ -10,13 +10,7 @@ from tests.conftest import TEST_SETTINGS
 @pytest.mark.usefixtures("application_instance_service", "lti_h_service")
 class TestSync:
     def test_sync(
-        self,
-        lti_h_service,
-        grouping_service,
-        lti_user,
-        course_service,
-        pyramid_request,
-        assignment_service,
+        self, lti_h_service, grouping_service, lti_user, course_service, pyramid_request
     ):
         groups = factories.BlackboardGroup.create_batch(5)
         grouping_service.get_groups.return_value = groups
@@ -24,15 +18,11 @@ class TestSync:
         groupids = Sync(pyramid_request).sync()
 
         course_service.get_by_context_id.assert_called_once_with(sentinel.context_id)
-        assignment_service.get_assignment.assert_called_once_with(
-            sentinel.guid,
-            sentinel.resource_link_id,
-        )
         grouping_service.get_groups.assert_called_once_with(
             sentinel.user,
             lti_user,
             course_service.get_by_context_id.return_value,
-            assignment_service.get_assignment.return_value.extra["group_set_id"],
+            sentinel.group_set_id,
             None,
         )
         lti_h_service.sync.assert_called_once_with(
@@ -56,6 +46,9 @@ class TestSync:
                 "custom_canvas_course_id": "test_custom_canvas_course_id",
             },
             "lms": {"tool_consumer_instance_guid": sentinel.guid},
-            "assignment": {"resource_link_id": sentinel.resource_link_id},
+            "assignment": {
+                "resource_link_id": sentinel.resource_link_id,
+                "group_set_id": sentinel.group_set_id,
+            },
             "group_info": sentinel.group_info,
         }

--- a/tests/unit/lms/views/api/canvas/sync_test.py
+++ b/tests/unit/lms/views/api/canvas/sync_test.py
@@ -62,7 +62,7 @@ class TestSync:
             sentinel.user,
             lti_user,
             course_service.get_by_context_id.return_value,
-            1,
+            sentinel.group_set_id,
             None,
         )
         lti_h_service.sync.assert_called_once_with(
@@ -86,7 +86,7 @@ class TestSync:
             sentinel.user,
             lti_user,
             course_service.get_by_context_id.return_value,
-            100,
+            sentinel.group_set_id,
             sentinel.canvas_user_id,
         )
 
@@ -99,7 +99,7 @@ class TestSync:
 
     @pytest.fixture
     def is_group_launch(self, application_instance_service, request_json):
-        request_json["course"]["group_set"] = 1
+        request_json["assignment"]["group_set_id"] = sentinel.group_set_id
         application_instance_service.get_current.return_value.settings = {
             "canvas": {"groups_enabled": True}
         }
@@ -107,10 +107,10 @@ class TestSync:
     @pytest.fixture
     def is_groups_and_speed_grader(self, application_instance_service, request_json):
         request_json["learner"] = {"canvas_user_id": sentinel.canvas_user_id}
+        request_json["assignment"]["group_set_id"] = sentinel.group_set_id
         application_instance_service.get_current.return_value.settings = {
             "canvas": {"groups_enabled": True}
         }
-        request_json["learner"]["group_set"] = 100
 
     @pytest.fixture
     def is_speedgrader(self, request_json):
@@ -126,5 +126,6 @@ class TestSync:
     def request_json(self):
         return {
             "course": {"context_id": sentinel.context_id},
+            "assignment": {"group_set_id": None},
             "group_info": sentinel.group_info,
         }


### PR DESCRIPTION
After #4133  been merged for a while it would be safer to switch to this approach.


It might not be evident in the diff but with this both sync APIs (canvas/bb) are mostly exactly the same code now. 

The next step is to merge them into one view.



# Testing


Sanity check with:

Canvas sections https://hypothesis.instructure.com/courses/125/assignments/873
Canvas groups https://hypothesis.instructure.com/courses/125/assignments/1833
Canvas course https://hypothesis.instructure.com/courses/122/assignments/856

BB course https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1
BB groups https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_398_1&course_id=_19_1
