### PR TITLE
Move `resource_link_id` to the `LTIParams`

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -45,16 +45,15 @@ class LTIParams(dict):
 def _apply_canvas_quirks(lti_params, request):
     # Canvas SpeedGrader launches LTI apps with the wrong resource_link_id,
     # see:
-    #
     # * https://github.com/instructure/canvas-lms/issues/1952
     # * https://github.com/hypothesis/lms/issues/3228
     #
     # We add the correct resource_link_id as a query param on the launch
     # URL that we submit to Canvas and use that instead of the incorrect
     # resource_link_id that Canvas puts in the request's body.
-    is_speedgrader = request.params.get("learner_canvas_user_id")
+    is_speedgrader = request.GET.get("learner_canvas_user_id")
 
-    if is_speedgrader and (resource_link_id := request.params.get("resource_link_id")):
+    if is_speedgrader and (resource_link_id := request.GET.get("resource_link_id")):
         lti_params["resource_link_id"] = resource_link_id
 
     for canvas_param_name in ["custom_canvas_course_id", "custom_canvas_user_id"]:

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -38,11 +38,6 @@ class LTILaunchResource:
         )
 
     @property
-    def resource_link_id(self):
-        # This should be replaced with direct calls
-        return self.lti_params.get("resource_link_id")
-
-    @property
     def is_canvas(self):
         """Return True if Canvas is the LMS that launched us."""
         return self._request.product.family == Product.Family.CANVAS
@@ -102,7 +97,7 @@ class LTILaunchResource:
                 "tool_consumer_instance_guid"
             ]
             assignment = self._request.find_service(name="assignment").get_assignment(
-                tool_consumer_instance_guid, self.resource_link_id
+                tool_consumer_instance_guid, self.lti_params.get("resource_link_id")
             )
             return assignment.extra.get("group_set_id") if assignment else None
 

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -38,25 +38,8 @@ class LTILaunchResource:
         )
 
     @property
-    def _is_speedgrader(self):
-        return bool(self._request.GET.get("learner_canvas_user_id"))
-
-    @property
     def resource_link_id(self):
-        # Canvas SpeedGrader launches LTI apps with the wrong resource_link_id,
-        # see:
-        #
-        # * https://github.com/instructure/canvas-lms/issues/1952
-        # * https://github.com/hypothesis/lms/issues/3228
-        #
-        # We add the correct resource_link_id as a query param on the launch
-        # URL that we submit to Canvas and use that instead of the incorrect
-        # resource_link_id that Canvas puts in the request's body.
-        if self._is_speedgrader and (
-            resource_link_id := self._request.GET.get("resource_link_id")
-        ):
-            return resource_link_id
-
+        # This should be replaced with direct calls
         return self.lti_params.get("resource_link_id")
 
     @property

--- a/lms/services/document_url.py
+++ b/lms/services/document_url.py
@@ -92,13 +92,7 @@ class DocumentURLService:
             "resource_link_id_history",  # A Blackboard course we can copy
             "ext_d2l_resource_link_id_history",  # Ditto for Brightspace
         ):
-            # Horrible work around
-            if param == "resource_link_id":
-                resource_link_id = context.resource_link_id
-            else:
-                resource_link_id = context.lti_params.get(param)
-
-            if resource_link_id and (
+            if (resource_link_id := context.lti_params.get(param)) and (
                 assigment := self._assignment_service.get_assignment(
                     tool_consumer_instance_guid=context.lti_params.get(
                         "tool_consumer_instance_guid"

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -170,7 +170,7 @@ class BasicLaunchViews:
             tool_consumer_instance_guid=self.context.lti_params[
                 "tool_consumer_instance_guid"
             ],
-            resource_link_id=self.context.resource_link_id,
+            resource_link_id=self.context.lti_params.get("resource_link_id"),
             lti_params=self.context.lti_params,
             extra=extra,
             is_gradable=is_gradable,

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -85,6 +85,25 @@ class TestLTIParams:
         assert params[parameter_name] == "1"
 
 
+class TestCanvasQuirks:
+    @pytest.mark.parametrize(
+        "speedgrader,expected",
+        (("any_value", "canvas_value"), (None, "standard_value")),
+    )
+    def test_from_request_reads_resource_link_id(
+        self, pyramid_request, speedgrader, expected
+    ):
+        pyramid_request.lti_jwt = {
+            f"{CLAIM_PREFIX}/lti1p1": {"resource_link_id": "standard_value"}
+        }
+        pyramid_request.params["resource_link_id"] = "canvas_value"
+        pyramid_request.params["learner_canvas_user_id"] = speedgrader
+
+        lti_params = LTIParams.from_request(pyramid_request)
+
+        assert lti_params["resource_link_id"] == expected
+
+
 class TestIncludeMe:
     def test_it_sets_lti_jwt(self, configurator):
         includeme(configurator)

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -67,6 +67,26 @@ class TestLTIParams:
         assert params["user_id"] == "user_id-v11"
         assert params["resource_link_id"] == "resource_link_id-v11"
 
+
+class TestCanvasQuirks:
+    @pytest.mark.parametrize(
+        "speedgrader,expected",
+        (("any_value", "canvas_value"), (None, "standard_value")),
+    )
+    def test_from_request_reads_resource_link_id(
+        self, pyramid_request, speedgrader, expected
+    ):
+        pyramid_request.lti_jwt = {
+            f"{CLAIM_PREFIX}/lti1p1": {"resource_link_id": "standard_value"}
+        }
+        pyramid_request.POST["resource_link_id"] = "DECOY"
+        pyramid_request.GET["resource_link_id"] = "canvas_value"
+        pyramid_request.GET["learner_canvas_user_id"] = speedgrader
+
+        lti_params = LTIParams.from_request(pyramid_request)
+
+        assert lti_params["resource_link_id"] == expected
+
     @pytest.mark.parametrize(
         "parameter_name,claim_name",
         [
@@ -83,25 +103,6 @@ class TestLTIParams:
 
         assert isinstance(params[parameter_name], str)
         assert params[parameter_name] == "1"
-
-
-class TestCanvasQuirks:
-    @pytest.mark.parametrize(
-        "speedgrader,expected",
-        (("any_value", "canvas_value"), (None, "standard_value")),
-    )
-    def test_from_request_reads_resource_link_id(
-        self, pyramid_request, speedgrader, expected
-    ):
-        pyramid_request.lti_jwt = {
-            f"{CLAIM_PREFIX}/lti1p1": {"resource_link_id": "standard_value"}
-        }
-        pyramid_request.params["resource_link_id"] = "canvas_value"
-        pyramid_request.params["learner_canvas_user_id"] = speedgrader
-
-        lti_params = LTIParams.from_request(pyramid_request)
-
-        assert lti_params["resource_link_id"] == expected
 
 
 class TestIncludeMe:

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -1,12 +1,12 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import create_autospec
 
 import pytest
 from pyramid.config import Configurator
 
-from lms.models.lti_params import CLAIM_PREFIX, LTIParams, _get_lti_params, includeme
+from lms.models.lti_params import CLAIM_PREFIX, LTIParams, includeme
 
 
-class TestLTI13Params:
+class TestLTIParams:
     @pytest.mark.parametrize(
         "lti_11_key,value",
         [
@@ -26,43 +26,43 @@ class TestLTI13Params:
             ("resource_link_description", "RESOURCE_LINK_DESCRIPTION"),
         ],
     )
-    def test_v13_mappings(self, lti_v13_params, lti_11_key, value):
-        assert LTIParams.from_v13(lti_v13_params)[lti_11_key] == value
+    def test_v13_mappings(self, pyramid_request, lti_v13_params, lti_11_key, value):
+        pyramid_request.lti_jwt = lti_v13_params
 
-    def test_v13_non_existing(self):
-        assert not LTIParams.from_v13({}).v11
+        assert LTIParams.from_request(pyramid_request)[lti_11_key] == value
 
-    def test_v11(self):
-        sample_dict = {"test": "key"}
+    def test_v11(self, pyramid_request):
+        pyramid_request.params = {"test": "key"}
 
-        params = LTIParams(sample_dict)
-        assert params == params.v11 == sample_dict
+        params = LTIParams.from_request(pyramid_request)
 
-    def test_it_doesnt_set_partial_keys(self):
-        params = LTIParams.from_v13(
-            {
-                "https://purl.imsglobal.org/spec/lti/claim/custom": {
-                    "canvas_course_id": "SOME_ID"
-                }
+        assert params == params.v11 == pyramid_request.params
+
+    def test_it_doesnt_set_partial_keys(self, pyramid_request):
+        pyramid_request.lti_jwt = {
+            "https://purl.imsglobal.org/spec/lti/claim/custom": {
+                "canvas_course_id": "SOME_ID"
             }
-        )
+        }
+
+        params = LTIParams.from_request(pyramid_request)
 
         # The existent params get returned
         assert params["custom_canvas_course_id"] == "SOME_ID"
         # Nonexistent ones in the same "level" are not present
         assert "custom_canvas_api_domain" not in params
 
-    def test_prefers_lti1p1_ids(self):
-        params = LTIParams.from_v13(
-            {
-                "sub": "v13",
-                f"{CLAIM_PREFIX}/resource_link_id": {"id": "v13"},
-                f"{CLAIM_PREFIX}/lti1p1": {
-                    "user_id": "user_id-v11",
-                    "resource_link_id": "resource_link_id-v11",
-                },
-            }
-        )
+    def test_prefers_lti1p1_ids(self, pyramid_request):
+        pyramid_request.lti_jwt = {
+            "sub": "v13",
+            f"{CLAIM_PREFIX}/resource_link_id": {"id": "v13"},
+            f"{CLAIM_PREFIX}/lti1p1": {
+                "user_id": "user_id-v11",
+                "resource_link_id": "resource_link_id-v11",
+            },
+        }
+
+        params = LTIParams.from_request(pyramid_request)
 
         assert params["user_id"] == "user_id-v11"
         assert params["resource_link_id"] == "resource_link_id-v11"
@@ -74,31 +74,15 @@ class TestLTI13Params:
             ("custom_canvas_user_id", "canvas_user_id"),
         ],
     )
-    def test_integer_canvas_parameters(self, parameter_name, claim_name):
-        params = LTIParams.from_v13({f"{CLAIM_PREFIX}/custom": {claim_name: 1}})
+    def test_integer_canvas_parameters(
+        self, pyramid_request, parameter_name, claim_name
+    ):
+        pyramid_request.lti_jwt = {f"{CLAIM_PREFIX}/custom": {claim_name: 1}}
+
+        params = LTIParams.from_request(pyramid_request)
 
         assert isinstance(params[parameter_name], str)
         assert params[parameter_name] == "1"
-
-
-class TestGetLTIParams:
-    def test_with_lti_jwt(self, LTIParams, pyramid_request):
-        pyramid_request.lti_jwt = sentinel.lti_jwt
-
-        lti_params = _get_lti_params(pyramid_request)
-
-        LTIParams.from_v13.assert_called_once_with(sentinel.lti_jwt)
-        assert lti_params == LTIParams.from_v13.return_value
-
-    def test_without_lti_jwt(self, pyramid_request):
-        pyramid_request.lti_jwt = None
-        pyramid_request.params = sentinel.params
-
-        assert _get_lti_params(pyramid_request) == sentinel.params
-
-    @pytest.fixture
-    def LTIParams(self, patch):
-        return patch("lms.models.lti_params.LTIParams")
 
 
 class TestIncludeMe:
@@ -106,7 +90,7 @@ class TestIncludeMe:
         includeme(configurator)
 
         configurator.add_request_method.assert_called_once_with(
-            _get_lti_params, name="lti_params", property=True, reify=True
+            LTIParams.from_request, name="lti_params", property=True, reify=True
         )
 
     @pytest.fixture()

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -13,13 +13,6 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-class TestResourceLinkIdk:
-    def test_it(self, pyramid_request):
-        pyramid_request.lti_params['resource_link_id'] = "link_id"
-
-        assert LTILaunchResource(pyramid_request).resource_link_id == "link_id"
-
-
 class TestIsCanvas:
     @pytest.mark.parametrize(
         "product,expected",

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -14,23 +14,10 @@ pytestmark = pytest.mark.usefixtures(
 
 
 class TestResourceLinkIdk:
-    @pytest.mark.parametrize(
-        "learner_id,get_id,lti_id,expected",
-        [
-            param(None, None, "LTI_ID", "LTI_ID", id="regular"),
-            param("USER_ID", "GET_ID", "LTI_ID", "GET_ID", id="new_speedgrader"),
-            param("USER_ID", None, "LTI_ID", "LTI_ID", id="old_speedgrader"),
-        ],
-    )
-    def test_it(self, pyramid_request, learner_id, get_id, lti_id, expected):
-        pyramid_request.GET = {
-            "learner_canvas_user_id": learner_id,
-            "resource_link_id": get_id,
-        }
-        with mock.patch.object(
-            LTILaunchResource, "lti_params", {"resource_link_id": lti_id}
-        ):
-            assert LTILaunchResource(pyramid_request).resource_link_id == expected
+    def test_it(self, pyramid_request):
+        pyramid_request.lti_params['resource_link_id'] = "link_id"
+
+        assert LTILaunchResource(pyramid_request).resource_link_id == "link_id"
 
 
 class TestIsCanvas:

--- a/tests/unit/lms/services/document_url_test.py
+++ b/tests/unit/lms/services/document_url_test.py
@@ -93,11 +93,6 @@ class TestDocumentURLService:
             document_url=sentinel.document_url
         )
         context.lti_params[param] = sentinel.link_id
-        # Horrible work around
-        if param == "resource_link_id":
-            context.resource_link_id = sentinel.link_id
-        else:
-            context.resource_link_id = None
 
         result = svc.get_document_url(context, pyramid_request)
 

--- a/tests/unit/lms/validation/authentication/_lti_test.py
+++ b/tests/unit/lms/validation/authentication/_lti_test.py
@@ -143,7 +143,7 @@ class TestLTI13AuthSchema:
     def pyramid_request(self, pyramid_request, lti_v13_params):
         pyramid_request.params["id_token"] = sentinel.id_token
         pyramid_request.lti_jwt = lti_v13_params
-        pyramid_request.lti_params = LTIParams.from_v13(lti_v13_params)
+        pyramid_request.lti_params = LTIParams.from_request(pyramid_request)
 
         return pyramid_request
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -342,7 +342,6 @@ class TestBasicLaunchViews:
         context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
         context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
         context.is_canvas = False
-        context.resource_link_id = pyramid_request.params["resource_link_id"]
         context.lti_params = LTIParams(pyramid_request.params)
         return context
 


### PR DESCRIPTION
We had a quirk where you read all the params from `context.lti_params` except for `resource_link_id` which was read from the context. 

This fixes that weirdness. It also shows a likely place for another plugin to get all the Canvas behavior out of there.