### PR TITLE
Add extra configuration to blackboard and canvas sync API.

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -450,6 +450,10 @@ class JSConfig:
                     ],
                     "group_set": req.params.get("group_set"),
                 },
+                "assignment": {
+                    "resource_link_id": self._context.lti_params["resource_link_id"],
+                    "group_set_id": self._context.group_set_id,
+                },
                 "group_info": {
                     key: value
                     for key, value in self._context.lti_params.items()
@@ -483,6 +487,7 @@ class JSConfig:
                 },
                 "assignment": {
                     "resource_link_id": self._context.lti_params["resource_link_id"],
+                    "group_set_id": self._context.group_set_id,
                 },
                 "group_info": {
                     key: value

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -93,6 +93,7 @@ class APIBlackboardSyncSchema(PyramidRequestSchema):
 
     class Assignment(Schema):
         resource_link_id = fields.Str(required=True)
+        group_set_id = fields.Str(required=False, allow_none=True)
 
     class GroupInfo(Schema):
         class Meta:

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -307,7 +307,7 @@ class TestJSConfigAPISync:
     """Unit tests for the api.sync sub-dict of JSConfig."""
 
     @pytest.mark.usefixtures("with_sections_on")
-    def test_when_is_canvas(self, sync, pyramid_request, GroupInfo):
+    def test_when_is_canvas(self, sync, pyramid_request, GroupInfo, context):
         assert sync == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
             "path": "/api/canvas/sync",
@@ -316,6 +316,10 @@ class TestJSConfigAPISync:
                     "context_id": "test_context_id",
                     "custom_canvas_course_id": "test_custom_canvas_course_id",
                     "group_set": None,
+                },
+                "assignment": {
+                    "resource_link_id": "test_resource_link_id",
+                    "group_set_id": context.group_set_id,
                 },
                 "lms": {
                     "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
@@ -330,7 +334,7 @@ class TestJSConfigAPISync:
         }
 
     @pytest.mark.usefixtures("blackboard_group_launch")
-    def test_when_is_blackboard(self, sync, pyramid_request, GroupInfo):
+    def test_when_is_blackboard(self, sync, pyramid_request, GroupInfo, context):
         assert sync == {
             "authUrl": "http://example.com/api/blackboard/oauth/authorize",
             "path": "/api/blackboard/sync",
@@ -340,6 +344,7 @@ class TestJSConfigAPISync:
                 },
                 "assignment": {
                     "resource_link_id": "test_resource_link_id",
+                    "group_set_id": context.group_set_id,
                 },
                 "lms": {
                     "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",


### PR DESCRIPTION
Adding this ahead of any changes on the API to populate the client's
config and avoid backwards incompatible changes in the next steps.