### PR TITLE
Make application instance part of the LTI context

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -35,11 +35,6 @@ class JSConfig:
     def _h_user(self):
         return self._lti_user.h_user
 
-    @property
-    def _application_instance(self):
-        """Return the current request's ApplicationInstance."""
-        return self._request.find_service(name="application_instance").get_current()
-
     def add_document_url(self, document_url):
         """
         Set the document to the document at the given document_url.
@@ -181,7 +176,7 @@ class JSConfig:
             HTML form that we submit
         """
 
-        args = self._context, self._request, self._application_instance
+        args = self._context, self._request, self._context.application_instance
 
         self._config.update(
             {
@@ -222,7 +217,7 @@ class JSConfig:
                 ],
             },
         }
-        if self._application_instance.lti_version == "1.3.0":
+        if self._context.application_instance.lti_version == "1.3.0":
             config["path"] = self._request.route_path(
                 "lti.v13.deep_linking.form_fields"
             )
@@ -241,7 +236,7 @@ class JSConfig:
         students = []
 
         grading_infos = self._grading_info_service.get_by_assignment(
-            application_instance=self._application_instance,
+            application_instance=self._context.application_instance,
             context_id=self._context.lti_params.get("context_id"),
             resource_link_id=self._context.lti_params.get("resource_link_id"),
         )
@@ -399,7 +394,7 @@ class JSConfig:
         # mutable. You can do self._hypothesis_client["foo"] = "bar" and the
         # mutation will be preserved.
 
-        if not self._application_instance.provisioning:
+        if not self._context.application_instance.provisioning:
             return {}
 
         api_url = self._request.registry.settings["h_api_url_public"]

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -6,7 +6,6 @@ from functools import cached_property
 from lms.models import Grouping, LTIParams
 from lms.product import Product
 from lms.resources._js_config import JSConfig
-from lms.services import ApplicationInstanceNotFound
 
 LOG = logging.getLogger(__name__)
 
@@ -38,6 +37,11 @@ class LTILaunchResource:
         )
 
     @property
+    def application_instance(self):
+        """Return the current request's ApplicationInstance."""
+        return self._request.find_service(name="application_instance").get_current()
+
+    @property
     def is_canvas(self):
         """Return True if Canvas is the LMS that launched us."""
         return self._request.product.family == Product.Family.CANVAS
@@ -60,14 +64,7 @@ class LTILaunchResource:
             # Canvas course sections feature was released.
             return False
 
-        try:
-            application_instance = self._request.find_service(
-                name="application_instance"
-            ).get_current()
-        except ApplicationInstanceNotFound:
-            return False
-
-        if not bool(application_instance.developer_key):
+        if not bool(self.application_instance.developer_key):
             # We need a developer key to talk to the API
             return False
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -47,10 +47,7 @@ class BasicLaunchViews:
             name="assignment"
         )
 
-        self.application_instance = request.find_service(
-            name="application_instance"
-        ).get_current()
-        self.application_instance.check_guid_aligns(
+        self.context.application_instance.check_guid_aligns(
             self.context.lti_params.get("tool_consumer_instance_guid")
         )
 
@@ -221,7 +218,7 @@ class BasicLaunchViews:
     def _record_launch(self):
         """Persist launch type independent info to the DB."""
 
-        self.application_instance.update_lms_data(self.context.lti_params)
+        self.context.application_instance.update_lms_data(self.context.lti_params)
 
         # Record all LTILaunches for future reporting
         LtiLaunches.add(

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -59,10 +59,7 @@ from lms.validation._base import JSONPyramidRequestSchema
 )
 def deep_linking_launch(context, request):
     """Handle deep linking launches."""
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
-    application_instance.update_lms_data(context.lti_params)
+    context.application_instance.update_lms_data(context.lti_params)
 
     request.find_service(name="lti_h").sync([context.course], request.params)
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -7,7 +7,7 @@ from lms.models import Grouping, LTIParams
 from lms.product import Product
 from lms.resources import LTILaunchResource, OAuth2RedirectResource
 from lms.resources._js_config import JSConfig
-from lms.services import ApplicationInstanceNotFound, HAPIError
+from lms.services import HAPIError
 from tests import factories
 
 pytestmark = pytest.mark.usefixtures(
@@ -19,7 +19,6 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-@pytest.mark.usefixtures("application_instance_service")
 class TestFilePickerMode:
     def test_it(self, js_config):
         js_config.enable_file_picker_mode(sentinel.form_action, sentinel.form_fields)
@@ -54,7 +53,6 @@ class TestFilePickerMode:
         context,
         pyramid_request,
         FilePickerConfig,
-        application_instance_service,
         config_function,
         key,
     ):
@@ -66,7 +64,7 @@ class TestFilePickerMode:
         config_provider.assert_called_once_with(
             context,
             pyramid_request,
-            application_instance_service.get_current.return_value,
+            context.application_instance,
         )
 
     @pytest.fixture(autouse=True)
@@ -74,7 +72,6 @@ class TestFilePickerMode:
         return patch("lms.resources._js_config.FilePickerConfig")
 
 
-@pytest.mark.usefixtures("application_instance_service")
 class TestEnableLTILaunchMode:
     def test_it(self, bearer_token_schema, context, grant_token_service, js_config):
         js_config.enable_lti_launch_mode()
@@ -104,18 +101,7 @@ class TestEnableLTILaunchMode:
             "rpcServer": {"allowedOrigins": ["http://localhost:5000"]},
         }
 
-    def test_it_raises_if_theres_no_ApplicationInstance(
-        self, application_instance_service, js_config
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound
-        )
 
-        with pytest.raises(ApplicationInstanceNotFound):
-            js_config.enable_lti_launch_mode()
-
-
-@pytest.mark.usefixtures("application_instance_service")
 class TestAddDocumentURL:
     """Unit tests for JSConfig.add_document_url()."""
 
@@ -193,7 +179,6 @@ class TestAddCanvasSpeedgraderSettings:
         }
         assert not config.get("hypothesisClient")
 
-    @pytest.mark.usefixtures("application_instance_service")
     def test_it_adds_report_activity_if_submit_on_annotation_enabled(
         self, js_config, pyramid_request
     ):
@@ -212,14 +197,12 @@ class TestAddCanvasSpeedgraderSettings:
 
 
 class TestEnableGradingBar:
-    def test_it(
-        self, js_config, context, grading_info_service, application_instance_service
-    ):
+    def test_it(self, js_config, context, grading_info_service):
         js_config.enable_grading_bar()
 
         grading_info_service.get_by_assignment.assert_called_once_with(
             context_id="test_course_id",
-            application_instance=application_instance_service.get_current.return_value,
+            application_instance=context.application_instance,
             resource_link_id="TEST_RESOURCE_LINK_ID",
         )
 
@@ -253,7 +236,6 @@ class TestEnableGradingBar:
         return pyramid_request
 
 
-@pytest.mark.usefixtures("application_instance_service")
 class TestSetFocusedUser:
     def test_it_sets_the_focused_user_if_theres_a_focused_user_param(
         self, h_api, js_config
@@ -303,7 +285,6 @@ class TestJSConfigAuthToken:
         return config["api"]["authToken"]
 
 
-@pytest.mark.usefixtures("application_instance_service")
 class TestJSConfigAPISync:
     """Unit tests for the api.sync sub-dict of JSConfig."""
 
@@ -408,7 +389,6 @@ class TestJSConfigDebug:
         return config["debug"]
 
 
-@pytest.mark.usefixtures("application_instance_service")
 class TestJSConfigHypothesisClient:
     """Unit tests for the "hypothesisClient" sub-dict of JSConfig."""
 
@@ -459,7 +439,6 @@ class TestJSConfigHypothesisClient:
         return config["hypothesisClient"]
 
 
-@pytest.mark.usefixtures("application_instance_service")
 class TestJSConfigRPCServer:
     """Unit tests for the "rpcServer" sub-dict of JSConfig."""
 
@@ -524,7 +503,6 @@ class TestEnableOAuth2RedirectErrorMode:
         pyramid_config.add_route("auth_route", "/auth")
 
 
-@pytest.mark.usefixtures("application_instance_service")
 class TestAddDeepLinkingAPI:
     def test_it_adds_deep_linking_v11(self, js_config, context):
         context.lti_params = {
@@ -560,9 +538,9 @@ class TestAddDeepLinkingAPI:
         }
 
     @pytest.fixture
-    def with_lti_13(self, application_instance):
+    def with_lti_13(self, context):
         # Make the application instance `lti_version` return "1.3.0"
-        application_instance.lti_registration_id = 100
+        context.application_instance.lti_registration_id = 100
 
 
 class TestEnableErrorDialogMode:
@@ -614,7 +592,7 @@ def config(js_config):
 
 
 @pytest.fixture
-def context(pyramid_request):
+def context(pyramid_request, application_instance):
     return create_autospec(
         LTILaunchResource,
         spec_set=True,
@@ -624,6 +602,7 @@ def context(pyramid_request):
         grouping_type=Grouping.Type.COURSE,
         course=create_autospec(Grouping, instance=True, spec_set=True),
         lti_params=LTIParams(pyramid_request.params),
+        application_instance=application_instance,
     )
 
 
@@ -644,8 +623,8 @@ def with_no_user(pyramid_request):
 
 
 @pytest.fixture
-def with_provisioning_disabled(application_instance_service):
-    application_instance_service.get_current.return_value.provisioning = False
+def with_provisioning_disabled(context):
+    context.application_instance.provisioning = False
 
 
 @pytest.fixture

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -6,7 +6,6 @@ from pytest import param
 from lms.models import ApplicationSettings, Grouping
 from lms.product import Product
 from lms.resources import LTILaunchResource
-from lms.services import ApplicationInstanceNotFound
 
 pytestmark = pytest.mark.usefixtures(
     "application_instance_service", "assignment_service"
@@ -70,15 +69,6 @@ class TestSectionsEnabled:
         pyramid_request.params.update(params)
 
         assert lti_launch.sections_enabled is expected
-
-    @pytest.mark.usefixtures("with_canvas")
-    def test_if_application_instance_service_raises(
-        self, lti_launch, application_instance_service
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound
-        )
-        assert not lti_launch.sections_enabled
 
     @pytest.mark.usefixtures("with_canvas")
     def test_it_depends_on_developer_key(

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -1,9 +1,9 @@
 from unittest import mock
-from unittest.mock import create_autospec, patch, sentinel
+from unittest.mock import patch, sentinel
 
 import pytest
 
-from lms.models import ApplicationInstance, LTIParams
+from lms.models import LTIParams
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
 from lms.security import Permissions
@@ -25,19 +25,13 @@ class TestHasDocumentURL:
 
 
 @pytest.mark.usefixtures(
-    "application_instance_service",
-    "assignment_service",
-    "grading_info_service",
-    "lti_h_service",
-    "lti_role_service",
+    "assignment_service", "grading_info_service", "lti_h_service", "lti_role_service"
 )
 class TestBasicLaunchViews:
-    def test___init___(self, context, pyramid_request, application_instance_service):
+    def test___init___(self, context, pyramid_request):
         BasicLaunchViews(context, pyramid_request)
 
-        application_instance_service.get_current.assert_called_once_with()
-        application_instance = application_instance_service.get_current.return_value
-        application_instance.check_guid_aligns.assert_called_once_with(
+        context.application_instance.check_guid_aligns.assert_called_once_with(
             context.lti_params["tool_consumer_instance_guid"]
         )
 
@@ -49,9 +43,9 @@ class TestBasicLaunchViews:
         LtiLaunches,
         grading_info_service,
     ):
-        svc = BasicLaunchViews(context, pyramid_request)
+        BasicLaunchViews(context, pyramid_request)
 
-        svc.application_instance.update_lms_data.assert_called_once_with(
+        context.application_instance.update_lms_data.assert_called_once_with(
             context.lti_params
         )
 
@@ -344,16 +338,6 @@ class TestBasicLaunchViews:
         context.is_canvas = False
         context.lti_params = LTIParams(pyramid_request.params)
         return context
-
-    @pytest.fixture
-    def application_instance_service(self, application_instance_service):
-        # Override the "helpful" base behavior or the application instance
-        # service mock so we can assert things about the value returned
-        application_instance_service.get_current.return_value = create_autospec(
-            ApplicationInstance, spec_set=True, instance=True
-        )
-
-        return application_instance_service
 
     @pytest.fixture
     def LtiLaunches(self, patch):

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -21,7 +21,7 @@ class TestDeepLinkingLaunch:
 
         deep_linking_launch(context, pyramid_request)
 
-        application_instance_service.get_current.return_value.update_lms_data.assert_called_once_with(
+        context.application_instance.update_lms_data.assert_called_once_with(
             context.lti_params
         )
         lti_h_service.sync.assert_called_once_with(


### PR DESCRIPTION
I reckon we are aiming to reduce the size of `LTILaunchResource` removing LMS specific bits from it.

application_instance is a fundamental part of a launch and fits better here than in JSConfig. 

Removed some, IMO, superfluous exception handling. The application instance is suppose to be there by the time we are handling the launch, if it's not there we rather let any exceptions bubble up to sentry instead of hiding it. We do the same thing for user/lti_user.