### PR TITLE
Store group membership data for courses

### DIFF
--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -25,7 +25,11 @@ class TestHasDocumentURL:
 
 
 @pytest.mark.usefixtures(
-    "assignment_service", "grading_info_service", "lti_h_service", "lti_role_service"
+    "assignment_service",
+    "grading_info_service",
+    "lti_h_service",
+    "lti_role_service",
+    "grouping_service",
 )
 class TestBasicLaunchViews:
     def test___init___(self, context, pyramid_request):
@@ -171,6 +175,7 @@ class TestBasicLaunchViews:
         lti_h_service,
         assignment_service,
         lti_role_service,
+        grouping_service,
     ):
         # pylint: disable=protected-access
         result = svc._show_document(
@@ -185,6 +190,12 @@ class TestBasicLaunchViews:
 
         lti_h_service.sync.assert_called_once_with([context.course], context.lti_params)
 
+        # `_record_course()`
+        grouping_service.upsert_grouping_memberships.assert_called_once_with(
+            user=pyramid_request.user, groups=[context.course]
+        )
+
+        # `_record_assignment()`
         assignment_service.upsert_assignment.assert_called_once_with(
             tool_consumer_instance_guid=context.lti_params[
                 "tool_consumer_instance_guid"


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/3994

Previously this was only done for groups and sections etc.

### Testing notes

 * Start all the things
 * Run `make sql` and keep a terminal open to type in queries
 * Clear existing records:
 ```sql
TRUNCATE grouping_membership;
```
 * Visit any assignment, e.g. https://hypothesis.instructure.com/courses/125/assignments/873
 * Select rows from the table:
```sql
SELECT
    "user".h_userid,
    grouping.lms_name,
    grouping.type
FROM "user"
JOIN grouping_membership 
    ON grouping_membership.user_id = "user".id
JOIN grouping 
    ON grouping_membership.grouping_id = grouping.id;
```
* In `main` you should only see rows for sections
* In this branch you should see the course too