### PR TITLE
Move grouping sync config to the plugin

### DIFF
--- a/lms/product/blackboard/_plugin/grouping.py
+++ b/lms/product/blackboard/_plugin/grouping.py
@@ -18,6 +18,8 @@ class BlackboardGroupingPlugin(GroupingServicePlugin):
 
     group_type = Grouping.Type.BLACKBOARD_GROUP
     sections_type = None  # We don't support sections in Blackboard
+    auth_route = "blackboard_api.oauth.authorize"
+    sync_route = "blackboard_api.sync"
 
     @classmethod
     def from_request(cls, request):

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -18,6 +18,8 @@ class CanvasGroupingPlugin(GroupingServicePlugin):
 
     group_type = Grouping.Type.CANVAS_GROUP
     sections_type = Grouping.Type.CANVAS_SECTION
+    auth_route = "canvas_api.oauth.authorize"
+    sync_route = "canvas_api.sync"
 
     @classmethod
     def from_request(cls, request):
@@ -25,6 +27,18 @@ class CanvasGroupingPlugin(GroupingServicePlugin):
 
     def __init__(self, canvas_api):
         self._canvas_api = canvas_api
+
+    def get_grouping_sync_config(self, request, data):
+        data["course"].update(
+            {"custom_canvas_course_id": request.lti_params["custom_canvas_course_id"]}
+        )
+
+        if "learner_canvas_user_id" in request.params:
+            data["learner"] = {
+                "canvas_user_id": request.params["learner_canvas_user_id"],
+            }
+
+        return data
 
     def get_sections_for_learner(self, _svc, course):
         return self._canvas_api.authenticated_users_sections(

--- a/lms/services/grouping/plugin.py
+++ b/lms/services/grouping/plugin.py
@@ -24,6 +24,22 @@ class GroupingServicePlugin:  # pragma: nocover
     sections_type: Grouping.Type = None
     """The type of sections this plugin supports. `None` disables support."""
 
+    sync_route = None
+    """The route to use for syncing grouping info with the client."""
+
+    auth_route = None
+    """If syncing is enable which route to authorize the client."""
+
+    def get_grouping_sync_config(self, request, data) -> dict:
+        """
+        Get the config for grouping syncing used in `lms.resources._js_config`.
+
+        :param request: Pyramid request
+        :param data: Default sync configuration
+        """
+
+        return data
+
     def get_sections_for_learner(self, svc, course) -> Optional[List]:
         """Get the sections from context when launched by a normal learner."""
 

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -9,6 +9,25 @@ from tests import factories
 
 
 class TestCanvasGroupingPlugin:
+    def test_get_grouping_sync_config(self, plugin, pyramid_request):
+        pyramid_request.lti_params["custom_canvas_course_id"] = sentinel.course_id
+        pyramid_request.params["learner_canvas_user_id"] = sentinel.learner_id
+
+        data = plugin.get_grouping_sync_config(pyramid_request, {"course": {}})
+
+        assert data == {
+            "course": {"custom_canvas_course_id": sentinel.course_id},
+            "learner": {"canvas_user_id": sentinel.learner_id},
+        }
+
+    def test_get_grouping_sync_config_with_no_learner_id(self, plugin, pyramid_request):
+        pyramid_request.lti_params["custom_canvas_course_id"] = sentinel.course_id
+        pyramid_request.params.pop("learner_canvas_user_id", None)
+
+        data = plugin.get_grouping_sync_config(pyramid_request, {"course": {}})
+
+        assert "learner" not in data
+
     def test_get_sections_for_learner(
         self, canvas_api_client, course, grouping_service, plugin
     ):


### PR DESCRIPTION
This moves the Canvas and Blackboard specific parts of grouping config to the grouping service plugin.

I think at this point there's a genuine question about whether this is just the "GroupingPlugin" and should maybe move into the product dir? With this it's no longer exclusively used by the service, and instead is becoming the one stop shop for everything you need to implement to setup grouping.