### PR TITLE
VitalSource automatic sign-in prototype

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -68,9 +68,20 @@ class JSConfig:
                 ),
             }
         elif document_url.startswith("vitalsource://"):
+            lti_params = self._context.lti_params
             vitalsource_svc = self._request.find_service(name="vitalsource")
-            self._config["vitalSource"] = {
-                "launchUrl": vitalsource_svc.get_launch_url(document_url)
+            book_location = vitalsource_svc.parse_document_url(document_url)
+            self._config["api"]["viaUrl"] = {
+                "path": self._request.route_url(
+                    "vitalsource_api.launch_url",
+                    _query={
+                        "book_id": book_location["book_id"],
+                        "cfi": book_location["cfi"],
+                        "user_reference": vitalsource_svc.get_user_reference(
+                            lti_params
+                        ),
+                    },
+                )
             }
         elif jstor_service.enabled and document_url.startswith("jstor://"):
             self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -110,6 +110,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "vitalsource_api.books.toc", "/api/vitalsource/books/{book_id}/toc"
     )
+    config.add_route("vitalsource_api.launch_url", "/api/vitalsource/launch_url")
 
     config.add_route("admin.index", "/admin/")
     config.add_route("admin.instances", "/admin/instances/")

--- a/lms/services/vitalsource/client.py
+++ b/lms/services/vitalsource/client.py
@@ -1,6 +1,12 @@
 import re
+from typing import Optional, TypedDict, Union
 
+import requests
+import xmltodict
+
+from lms.models import LTIParams
 from lms.services.exceptions import ExternalRequestError
+from lms.services.http import HTTPService
 from lms.services.vitalsource._schemas import BookInfoSchema, BookTOCSchema
 
 #: A regex for parsing the BOOK_ID and CFI parts out of one of our custom
@@ -10,34 +16,59 @@ DOCUMENT_URL_REGEX = re.compile(
 )
 
 
+class BookLocation(TypedDict):
+    """Book ID and chapter extracted from a "vitalsource://..." document URL."""
+
+    book_id: str
+    cfi: str
+
+
+class VitalSourceUserNotFoundError(Exception):
+    """LTI user could not be matched to a VitalSource user."""
+
+    error_code = "vitalsource_user_not_found"
+
+
+class VitalSourceLicenseError(Exception):
+    """User does not have a license for the book."""
+
+    error_code = "vitalsource_no_book_license"
+
+
 class VitalSourceService:
+    """
+    Service for querying the VitalSource API.
+
+    See https://developer.vitalsource.com/hc/en-us for API reference.
+    """
+
     def __init__(
         self,
-        http_service,
-        api_key: str,
+        http_service: HTTPService,
+        metadata_api_key: str,
+        user_api_key: str,
+        lti_user_field: str,
     ):
         """
         Return a new VitalSourceService.
 
-        :param api_key: Key for VitalSource API
+        :param metadata_api_key: API key for book metadata requests. This key
+          is not specific to the LTI user's institution.
+        :param user_api_key: API key for requests to access user-specific
+          information. This will be a key that is specific to the LTI user's
+          institution.
+        :param lti_user_field: The field from the LTI launch request which
+          is used to identify the current user
         :raises ValueError: If credentials are invalid
         """
-        if not api_key:
-            raise ValueError("VitalSource credentials are missing")
-
         self._http_service = http_service
-        self._api_key = api_key
-
-    def get(self, endpoint):
-        url = f"https://api.vitalsource.com/v4/{endpoint}"
-
-        return self._http_service.get(
-            url, headers={"X-VitalSource-API-Key": self._api_key}
-        )
+        self._metadata_api_key = metadata_api_key
+        self._user_api_key = user_api_key
+        self._lti_user_field = lti_user_field
 
     def book_info(self, book_id: str):
         try:
-            response = self.get(f"products/{book_id}")
+            response = self._request(self._metadata_api_key, f"v4/products/{book_id}")
         except ExternalRequestError as err:
             if err.status_code == 404:
                 err.message = f"Book {book_id} not found"
@@ -48,7 +79,9 @@ class VitalSourceService:
 
     def book_toc(self, book_id: str):
         try:
-            response = self.get(f"products/{book_id}/toc")
+            response = self._request(
+                self._metadata_api_key, f"v4/products/{book_id}/toc"
+            )
         except ExternalRequestError as err:
             if err.status_code == 404:
                 err.message = f"Book {book_id} not found"
@@ -59,30 +92,160 @@ class VitalSourceService:
         schema.context["book_id"] = book_id
         return schema.parse()
 
+    def get_user_reference(self, lti_params: LTIParams) -> str:
+        """
+        Extract the VitalSource user reference from the LTI launch parameters.
+
+        The user reference is a string which can subsequently be passed to
+        `get_user_access_token` to make VitalSource API calls on behalf of
+        the current LTI user. Which field of the LTI launch parameters is
+        used as a reference depends on how VitalSource is configured at an
+        institution.
+        """
+        return lti_params[self._lti_user_field]
+
+    def get_user_access_token(self, user_reference: str) -> str:
+        """
+        Get an access token for the current LTI user.
+
+        This generates an access token that can be used with user-specific
+        queries such as `user_has_book_license` and `book_reader_url`.
+
+        One of the LTI launch request properties from `lti_params` will be
+        passed to VitalSource to identify the current user. Which one depends
+        on the LMS installation.
+
+        :param user_reference: String identifying the current user. This must
+          be extracted from the LTI launch parameters during the initial
+          assignment launch, using `get_user_reference`.
+        """
+
+        data = {
+            "credentials": {
+                "credential": {"@reference": user_reference},
+            }
+        }
+        result = self._xml_request(self._user_api_key, "v3/credentials.xml", data=data)
+
+        credentials = result["credentials"].get("credential")
+        if not credentials:
+            raise VitalSourceUserNotFoundError()
+
+        if isinstance(credentials, list):
+            credentials = credentials[0]
+        return credentials["@access-token"]
+
+    def user_has_book_license(self, access_token: str, book_id: str) -> bool:
+        """
+        Check whether a user has a license to access a book.
+
+        :param access_token: Token previously obtained via `get_user_access_token`
+        """
+        result = self._xml_request(
+            self._user_api_key,
+            "v3/licenses.xml",
+            params={"sku": book_id},
+            access_token=access_token,
+        )
+
+        # The result is a list of active licenses that match the given book ID/SKU.
+        # Check that we have at least one.
+        return result["licenses"] and "license" in result["licenses"]
+
+    def get_launch_url(self, book_id: str, cfi: str, user_reference: str) -> str:
+        """
+        Return a temporary URL to load the VitalSource book viewer.
+
+        The returned URL will automatically log the user into the VitalSource
+        book reader with the account that corresponds to the current LMS user.
+
+        :param book_id: The book to open
+        :param cfi: The location to navigate to within the book
+        :param user_reference: User identifier extracted from LTI launch
+          parameters using `get_user_reference`.
+        """
+        access_token = self.get_user_access_token(user_reference)
+        if not self.user_has_book_license(access_token, book_id):
+            raise VitalSourceLicenseError()
+
+        # TBD: Do we want to support a mode where SSO is not used? In this case
+        # we should just return this URL directly.
+        destination = f"https://hypothesis.vitalsource.com/books/{book_id}/cfi/{cfi}"
+
+        data = {"redirect": {"destination": destination}}
+        result = self._xml_request(
+            self._user_api_key, "v3/redirects.xml", data=data, access_token=access_token
+        )
+        return result["redirect"]["@auto-signin"]
+
+    def _xml_request(
+        self,
+        api_key: str,
+        endpoint: str,
+        params: Optional[dict] = None,
+        data: Optional[dict] = None,
+        access_token: Optional[str] = None,
+    ) -> dict:
+        """
+        Make a request to a VitalSource endpoint that accepts/returns XML.
+
+        The VitalSource API endpoints prefixed with "v3/" use XML. The
+        endpoints prefixed with "v4/" use JSON instead.
+        """
+
+        xml_data = xmltodict.unparse(data) if data else None
+        response = self._request(api_key, endpoint, params, xml_data, access_token)
+        return xmltodict.parse(response.text)
+
+    def _request(
+        self,
+        api_key: str,
+        endpoint: str,
+        params: Optional[dict] = None,
+        data: Union[str, Optional[dict]] = None,
+        access_token: Optional[str] = None,
+    ) -> requests.Response:
+        """
+        Make a request to the VitalSource API.
+
+        :param params: Query parameters
+        :param data: Request body to send. This can either be a dict which will
+          be sent as JSON, or a string of XML for v3 APIs.
+        :param access_token: Access token to identify and authenticate the
+          current user. Only needed for user-specific endpoints.
+        """
+
+        method = "POST" if data else "GET"
+        url = f"https://api.vitalsource.com/{endpoint}"
+
+        headers = {"X-VitalSource-API-Key": api_key}
+        if access_token:
+            headers["X-VitalSource-Access-Token"] = access_token
+
+        response = self._http_service.request(
+            method=method, url=url, params=params, headers=headers, data=data
+        )
+        response.raise_for_status()
+
+        return response
+
     @staticmethod
-    def parse_document_url(document_url):
+    def parse_document_url(document_url: str) -> BookLocation:
+        """Extract the book ID and location from a `vitalsource://` URL."""
         return DOCUMENT_URL_REGEX.search(document_url).groupdict()
 
     @staticmethod
     def generate_document_url(book_id, cfi):
         return f"vitalsource://book/bookID/{book_id}/cfi/{cfi}"
 
-    def get_launch_url(self, document_url: str) -> str:
-        """
-        Return a URL to load the VitalSource book viewer at a particular book and location.
-
-        That URL can be used to load VitalSource content in an iframe like we do with other types of content.
-
-        Note that this method is an alternative to `get_launch_params` below.
-
-        :param document_url: `vitalsource://` type URL identifying the document
-        """
-        url_params = self.parse_document_url(document_url)
-        return f"https://hypothesis.vitalsource.com/books/{url_params['book_id']}/cfi/{url_params['cfi']}"
-
 
 def factory(_context, request):
+    ai_settings = (
+        request.find_service(name="application_instance").get_current().settings
+    )
     return VitalSourceService(
-        request.find_service(name="http"),
-        request.registry.settings["vitalsource_api_key"],
+        http_service=request.find_service(name="http"),
+        metadata_api_key=request.registry.settings["vitalsource_api_key"],
+        user_api_key=ai_settings.get("vitalsource", "api_key"),
+        lti_user_field=ai_settings.get("vitalsource", "lti_user_field"),
     )

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -20,6 +20,15 @@ import ErrorModal from './ErrorModal';
  */
 
 /**
+ * URL that opens the VitalSource bookshelf reader in the current LMS.
+ *
+ * TODO: This should be replaced with an installation-specific link that opens
+ * VitalSource inside the current LMS. This allows an association between the
+ * LTI user and VitalSource account to be established.
+ */
+const vitalsourceBookshelfURL = 'https://bookshelf.vitalsource.com';
+
+/**
  * Render an error that prevents an LTI launch from completing successfully.
  *
  * This is rendered in a non-cancelable modal.
@@ -210,6 +219,45 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
+    case 'vitalsource_user_not_found':
+      return (
+        <ErrorModal
+          busy={busy}
+          error={error}
+          title="VitalSource account not found"
+        >
+          <p>Hypothesis could not find your VitalSource user account.</p>
+          <p>
+            This account is set up the first time that you open the VitalSource
+            book reader.{' '}
+            <b>
+              To fix the problem, please open the{' '}
+              <Link target="_blank" href={vitalsourceBookshelfURL}>
+                VitalSource book reader
+              </Link>
+              .
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
+    case 'vitalsource_no_book_license':
+      return (
+        // TODO: Add some details of _which_ book is not available.
+        <ErrorModal busy={busy} error={error} title="Book not available">
+          <p>Your VitalSource library does not have this book in it.</p>
+          <p>
+            <b>
+              To fix the problem, open the{' '}
+              <Link target="_blank" href={vitalsourceBookshelfURL}>
+                VitalSource book reader
+              </Link>{' '}
+              and add the book to your library.
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
     case 'error-fetching':
       // Do not display canned text if there is a back-end-provided message
       // to show here, as it's redundant and not useful
@@ -225,6 +273,7 @@ export default function LaunchErrorDialog({
           )}
         </ErrorModal>
       );
+
     case 'error-reporting-submission':
       // nb. There is no retry action here as we just suggest reloading the entire
       // page.

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -11,7 +11,9 @@
  *           'canvas_file_not_found_in_course'|
  *           'canvas_group_set_not_found'|
  *           'canvas_group_set_empty'|
- *           'canvas_student_not_in_group'} LTILaunchServerErrorCode
+ *           'canvas_student_not_in_group'|
+ *           'vitalsource_user_not_found'|
+ *           'vitalsource_no_book_license'} LTILaunchServerErrorCode
  */
 
 /**
@@ -131,6 +133,8 @@ export function isLTILaunchServerError(error) {
       'canvas_group_set_not_found',
       'canvas_group_set_empty',
       'canvas_student_not_in_group',
+      'vitalsource_user_not_found',
+      'vitalsource_no_book_license',
     ].includes(error.errorCode)
   );
 }

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -89,7 +89,11 @@
     <fieldset class="box">
         <legend class="label has-text-centered">Content integrations</legend>
         {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
+
         {{ settings_checkbox("VitalSource enabled", "vitalsource", "enabled") }}
+        {{ settings_text_field("VitalSource user ID field", "vitalsource", "lti_user_field") }}
+        {{ settings_text_field("VitalSource API key", "vitalsource", "api_key") }}
+
         {{ settings_checkbox("JSTOR enabled", "jstor", "enabled") }}
         {{ settings_text_field("JSTOR site code", "jstor", "site_code") }}
     </fieldset>

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -155,6 +155,8 @@ class AdminApplicationInstanceViews:
             ("blackboard", "groups_enabled", bool),
             ("microsoft_onedrive", "files_enabled", bool),
             ("vitalsource", "enabled", bool),
+            ("vitalsource", "lti_user_field", str),
+            ("vitalsource", "api_key", str),
             ("jstor", "enabled", bool),
             ("jstor", "site_code", str),
         ):

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -30,6 +30,21 @@ class VitalSourceAPIViews:
         book_toc = self.vitalsource_service.book_toc(book_id)
         return book_toc["table_of_contents"]
 
+    @view_config(route_name="vitalsource_api.launch_url")
+    def launch_url(self):
+        book_id = self.request.params["book_id"]
+        cfi = self.request.params["cfi"]
+        user_reference = self.request.params["user_reference"]
+
+        # The URL is in a `via_url` property so it can be used the same way
+        # as assignments that do use Via. We should rename this to something
+        # more generic.
+        return {
+            "via_url": self.vitalsource_service.get_launch_url(
+                book_id, cfi, user_reference
+            )
+        }
+
     def _get_book_id(self):
         book_id = self.request.matchdict["book_id"]
         if not self._is_valid_book_id(book_id):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4214

This is a prototype/spike of a set of changes that enables users to be automatically logged in to VitalSource based on their LTI identity.

Currently, before users launch a VitalSource assignment, they are required to first create their own VitalSource account, and then add the books used in the assignment to their account. When they launch the assignment, they then need to enter their VS credentials before they get taken to the book. This is undesirable friction:

<img width="500" alt="VitalSource login screen" src="https://user-images.githubusercontent.com/2458/176678983-15e14c86-cd98-4001-b9b1-a287e4c3fa6b.png">


This PR changes the process so that we use user identity information from the LTI launch to make API calls to VitalSource to test whether the current user has access to the book, and then generate a temporary URL that will automatically log them in. If no corresponding user account could be found, or it does not have access to the book, we show an error.

**Summary of changes:**

- Add two new VitalSource-related settings per LMS installation: an API key and the name of a user ID field from an LTI launch request, which is passed to VitalSource to identify the LTI user. Which ID field is used depends on the institution. I believe we'll need to add a third new setting in future, for a link which opens VitalSource's own book reader in the LMS. This is needed for certain error handling scenarios.
- Add methods to `VitalSourceService` to get a user ID from the LTI launch parameters and generate a temporary URL that can be used to launch the VitalSource book reader. This temporary URL will automatically log the user in and put them in the correct book/chapter. Before generating a launch URL we check if the VS user has access to the book, and present an error if not.
- Change how VitalSource launches work, such that the launch URL is fetched by the LMS frontend via an API call, instead of being generated by the initial LMS launch. This is needed because VS assignment launches now involve calls to a third-party API which may take time, and may also result in errors that we need to translate into an appropriate error screen in the frontend. This follows the pattern of how various Canvas and Blackboard files launches work.
- Handle errors that can occur when launching VitalSource assignments in `LaunchErrorDialog`. These will in future need to include an installation-specific link to VitalSource's own book reader.

**Setting up credentials:**

1. In your local LMS admin pages (http://localhost:8001/admin) find the LMS install that you want to test with ( `Hypothesis6b31df6897cac5c46efdca29cb086eeb` is "Localhost (devdata) with Sections Enabled", which I used)
2. For the `vitalsource.api_key` setting, enter the value from the "API key" field of the "VitalSource Test School" entry in 1PW.
3. For the `vitalsource.user_reference` setting, enter the value `user_id`

**Error shown if there is no VitalSource account that corresponds to the current LTI user:**

<img width="711" alt="VitalSource SSO - Account not found" src="https://user-images.githubusercontent.com/2458/176676633-dc69e948-de01-4b6c-adbb-8b137fecbbf6.png">

**Error shown if the VitalSource account does not have a license to the book:**

<img width="661" alt="VitalSource SSO - Book not available" src="https://user-images.githubusercontent.com/2458/176676752-f9478bce-c59c-4a41-8977-b5818038b015.png">

