### PR TITLE
Parameterize auth urls

### DIFF
--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -1,9 +1,15 @@
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
-from lms.product.product import PluginConfig, Product
+from lms.product.product import PluginConfig, Product, Routes
 
 
 class Blackboard(Product):
     """A product for Blackboard specific settings and tweaks."""
 
     family = Product.Family.BLACKBOARD
+
+    route = Routes(
+        oauth2_authorize="blackboard_api.oauth.authorize",
+        oauth2_refresh="blackboard_api.oauth.refresh",
+    )
+
     plugin_config = PluginConfig(grouping_service=BlackboardGroupingPlugin)

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -1,9 +1,15 @@
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
-from lms.product.product import PluginConfig, Product
+from lms.product.product import PluginConfig, Product, Routes
 
 
 class Canvas(Product):
     """A product for Canvas specific settings and tweaks."""
 
     family = Product.Family.CANVAS
+
+    route = Routes(
+        oauth2_authorize="canvas_api.oauth.authorize",
+        oauth2_refresh="canvas_api.oauth.refresh",
+    )
+
     plugin_config = PluginConfig(grouping_service=CanvasGroupingPlugin)

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -39,11 +39,23 @@ class PluginConfig:
 
 
 @dataclass
+class Routes:
+    """A collection of Pyramid route names for various functions."""
+
+    oauth2_authorize: str = None
+    """Authorizing with OAuth 2."""
+
+    oauth2_refresh: str = None
+    """Refreshing OAuth 2 tokens."""
+
+
+@dataclass
 class Product:
     """The main product object which is passed around the app."""
 
     plugin: Plugins
     plugin_config: PluginConfig = PluginConfig()
+    route: Routes = Routes()
     family: Family = Family.UNKNOWN
 
     # Accessor for external consumption

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 
 from lms.models import GroupInfo, Grouping, HUser
 from lms.product import Product
+from lms.product.blackboard import Blackboard
+from lms.product.canvas import Canvas
 from lms.resources._js_config.file_picker_config import FilePickerConfig
 from lms.services import HAPIError, JSTORService
 from lms.validation.authentication import BearerTokenSchema
@@ -50,7 +52,7 @@ class JSConfig:
 
         if document_url.startswith("blackboard://"):
             self._config["api"]["viaUrl"] = {
-                "authUrl": self._request.route_url("blackboard_api.oauth.authorize"),
+                "authUrl": self._request.route_url(Blackboard.route.oauth2_authorize),
                 "path": self._request.route_path(
                     "blackboard_api.files.via_url",
                     course_id=self._context.lti_params["context_id"],
@@ -59,7 +61,7 @@ class JSConfig:
             }
         elif document_url.startswith("canvas://"):
             self._config["api"]["viaUrl"] = {
-                "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
+                "authUrl": self._request.route_url(Canvas.route.oauth2_authorize),
                 "path": self._request.route_path(
                     "canvas_api.files.via_url",
                     resource_link_id=self._context.lti_params["resource_link_id"],
@@ -432,13 +434,8 @@ class JSConfig:
 
         req = self._request
 
-        auth_url = {
-            Product.Family.CANVAS: req.route_url("canvas_api.oauth.authorize"),
-            Product.Family.BLACKBOARD: req.route_url("blackboard_api.oauth.authorize"),
-        }.get(self._request.product.family)
-
         return {
-            "authUrl": auth_url,
+            "authUrl": req.route_url(req.product.route.oauth2_authorize),
             "path": req.route_path("api.sync"),
             # This data is consumed by the view in `lms.views.api.sync` which
             # defines the arguments it expects. We need to match that

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -1,3 +1,5 @@
+from lms.product.blackboard import Blackboard
+from lms.product.canvas import Canvas
 from lms.services import JSTORService
 
 
@@ -12,7 +14,7 @@ class FilePickerConfig:
             "blackboard", "groups_enabled"
         )
 
-        auth_url = request.route_url("blackboard_api.oauth.authorize")
+        auth_url = request.route_url(Blackboard.route.oauth2_authorize)
         course_id = context.lti_params.get("context_id")
 
         config = {
@@ -47,7 +49,7 @@ class FilePickerConfig:
         )
         groups_enabled = application_instance.settings.get("canvas", "groups_enabled")
 
-        auth_url = request.route_url("canvas_api.oauth.authorize")
+        auth_url = request.route_url(Canvas.route.oauth2_authorize)
         course_id = context.lti_params.get("custom_canvas_course_id")
 
         config = {

--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -3,6 +3,7 @@ import re
 
 from pyramid.view import view_config, view_defaults
 
+from lms.product.blackboard import Blackboard
 from lms.security import Permissions
 from lms.views import helpers
 
@@ -33,7 +34,7 @@ class BlackboardFilesAPIViews:
 
         response_results = []
 
-        auth_url = self.request.route_url("blackboard_api.oauth.authorize")
+        auth_url = self.request.route_url(Blackboard.route.oauth2_authorize)
 
         for result in results:
             response_result = {

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -13,7 +13,6 @@ from pyramid.view import (
     view_defaults,
 )
 
-from lms.product import Product
 from lms.services import (
     CanvasAPIPermissionError,
     ExternalAsyncRequestError,
@@ -39,19 +38,19 @@ class APIExceptionViews:
        relevant to the particular error code. For example if "error_code" is
        "canvas_api_permission_error" the frontend should show a
        "You don't have permission" error dialog. The error dialog should
-       include a [Try again] button that opens the "canvas_api.oauth.authorize"
+       include a [Try again] button that opens the OAuth 2 authorize
        route.
 
     2. "message": An error message for the frontend to show to the user.
 
        If "message" is present the frontend will show an error dialog that
        indicates that something went wrong and has a [Try again] button that
-       opens the "canvas_api.oauth.authorize" route. The "message" string
+       opens the OAuth 2 authorize route. The "message" string
        should be rendered by the frontend somewhere in the error dialog.
 
     If no "error_code" or "message" is present the frontend will show a
     standard authorization dialog (not an error dialog) and the button that
-    opens "canvas_api.oauth.authorize" route will be labelled [Authorize].
+    opens the OAuth 2 authorize route will be labelled [Authorize].
 
     3. "details": Optional further error details to show to the user in the
        error dialog, for debugging and support.
@@ -247,12 +246,12 @@ class ErrorBody:
                 # If we don't have an access token we can't refresh it.
                 pass
             else:
-                if request.product.family == Product.Family.CANVAS:
-                    path = request.route_path("canvas_api.oauth.refresh")
-                elif request.product.family == Product.Family.BLACKBOARD:
-                    path = request.route_path("blackboard_api.oauth.refresh")
+                if refresh_route := request.product.route.oauth2_refresh:
+                    path = request.route_path(refresh_route)
                 else:
-                    raise ValueError(f"No API for {request.product.family}")
+                    raise ValueError(
+                        f"No OAuth 2 refresh API for {request.product.family}"
+                    )
 
                 body["refresh"] = {"method": "POST", "path": path}
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -271,13 +271,3 @@ def oauth_token(lti_user, application_instance):
         user_id=lti_user.user_id,
         application_instance=application_instance,
     )
-
-
-@pytest.fixture
-def with_canvas(pyramid_request):
-    pyramid_request.product.family = Product.Family.CANVAS
-
-
-@pytest.fixture
-def with_blackboard(pyramid_request):
-    pyramid_request.product.family = Product.Family.BLACKBOARD

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -286,31 +286,12 @@ class TestJSConfigAPISync:
     """Unit tests for the api.sync sub-dict of JSConfig."""
 
     @pytest.mark.parametrize(
-        "product_family,auth_url",
-        (
-            (Product.Family.CANVAS, "http://example.com/api/canvas/oauth/authorize"),
-            (
-                Product.Family.BLACKBOARD,
-                "http://example.com/api/blackboard/oauth/authorize",
-            ),
-        ),
-    )
-    @pytest.mark.parametrize(
         "grouping_type", (Grouping.Type.GROUP, Grouping.Type.SECTION)
     )
-    def test_it(
-        self,
-        js_config,
-        context,
-        pyramid_request,
-        product_family,
-        auth_url,
-        grouping_type,
-    ):
+    def test_it(self, js_config, context, pyramid_request, grouping_type):
         pyramid_request.lti_params["context_id"] = "CONTEXT_ID"
-        pyramid_request.params.clear()
         pyramid_request.params["learner_canvas_user_id"] = "CANVAS_USER_ID"
-        pyramid_request.product.family = product_family
+        pyramid_request.product.route.oauth2_authorize = "welcome"
         context.grouping_type = grouping_type
         context.group_set_id = "GROUP_SET_ID"
 
@@ -318,10 +299,10 @@ class TestJSConfigAPISync:
 
         sync_config = js_config.asdict()["api"]["sync"]
         assert sync_config == {
-            "authUrl": auth_url,
+            "authUrl": "http://example.com/welcome",
             "path": "/api/sync",
             "data": {
-                "lms": {"product": product_family},
+                "lms": {"product": pyramid_request.product.family},
                 "context_id": "CONTEXT_ID",
                 "group_set_id": "GROUP_SET_ID",
                 "group_info": {

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -206,3 +206,13 @@ def has_course(pyramid_request):
 def pyramid_request(pyramid_request):
     pyramid_request.parsed_params = {}
     return pyramid_request
+
+
+@pytest.fixture
+def with_canvas(pyramid_request):
+    pyramid_request.product.family = Product.Family.CANVAS
+
+
+@pytest.fixture
+def with_blackboard(pyramid_request):
+    pyramid_request.product.family = Product.Family.BLACKBOARD

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -200,30 +200,23 @@ class TestErrorBody:
     def test_json(self, pyramid_request, error_body, expected):
         assert error_body.__json__(pyramid_request) == expected
 
-    @pytest.mark.usefixtures("with_refreshable_exception", "with_canvas")
+    @pytest.mark.usefixtures("with_refreshable_exception")
     def test_json_includes_refresh_info_if_the_exception_is_refreshable(
         self, pyramid_request
     ):
+        pyramid_request.product.route.oauth2_refresh = "welcome"
+
         body = ErrorBody().__json__(pyramid_request)
 
         assert body["refresh"] == {
             "method": "POST",
-            "path": pyramid_request.route_path("canvas_api.oauth.refresh"),
-        }
-
-    @pytest.mark.usefixtures("with_refreshable_exception", "with_blackboard")
-    def test_json_includes_Blackboard_refresh_info_for_Blackboard_APIs(
-        self, pyramid_request
-    ):
-        body = ErrorBody().__json__(pyramid_request)
-
-        assert body["refresh"] == {
-            "method": "POST",
-            "path": pyramid_request.route_path("blackboard_api.oauth.refresh"),
+            "path": pyramid_request.route_path("welcome"),
         }
 
     @pytest.mark.usefixtures("with_refreshable_exception")
-    def test_json_raises_if_unknown_product(self, pyramid_request):
+    def test_json_raises_if_no_refresh_route(self, pyramid_request):
+        pyramid_request.product.route.oauth2_refresh = None
+
         with pytest.raises(ValueError):
             ErrorBody().__json__(pyramid_request)
 


### PR DESCRIPTION
This is a small change to parameterize the authentication URLs we use in various places.

This doesn't go as far as replacing it in the views and routes definitions, but it does:

 * Remove some conditionality around products
 * Means that if we need to add this in future none of the code will need to change to accommodate it