### PR TITLE
Update UI related to acceptance of JSTOR terms

### DIFF
--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -2,7 +2,6 @@ import {
   Icon,
   IconButton,
   LabeledButton,
-  Checkbox,
   Link,
   Modal,
   Thumbnail,
@@ -55,9 +54,6 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
   // they have pasted/typed into the input field.
   const [articleId, setArticleId] = useState(/** @type {string|null} */ (null));
 
-  // Whether the T&Cs have been accepted by the user
-  const [acceptedTerms, setAcceptedTerms] = useState(false);
-
   /** @type {FetchResult<Metadata>} */
   const metadata = useAPIFetch(
     articleId ? urlPath`/api/jstor/articles/${articleId}` : null
@@ -86,10 +82,7 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
   const previousURL = useRef(/** @type {string|null} */ (null));
 
   const canConfirmSelection =
-    articleId &&
-    acceptedTerms &&
-    metadata.data !== null &&
-    !metadata.data.is_collection;
+    articleId && metadata.data !== null && !metadata.data.is_collection;
 
   const confirmSelection = () => {
     if (canConfirmSelection) {
@@ -156,7 +149,7 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
           onClick={confirmSelection}
           variant="primary"
         >
-          Submit
+          Accept and continue
         </LabeledButton>,
       ]}
     >
@@ -230,32 +223,17 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
           {metadata.data && (
             <>
               <div className="grow" />
-              <div className="flex space-x-2 items-center px-1">
+              <div className="self-stretch text-right px-1">
                 <label htmlFor="accept-jstor-terms" className="grow text-right">
-                  I accept the{' '}
+                  Your use of JSTOR indicates your acceptance of JSTOR&apos;s{' '}
                   <Link
                     href="https://about.jstor.org/terms/"
                     classes="underline hover:underline"
                     target="_blank"
                   >
-                    terms and conditions
-                  </Link>{' '}
-                  for JSTOR content use
+                    Terms and Conditions of Use.
+                  </Link>
                 </label>
-                <div className="text-lg">
-                  <Checkbox
-                    checked={acceptedTerms}
-                    data-testid="jstor-terms-checkbox"
-                    id="accept-jstor-terms"
-                    name="accept-terms"
-                    onInput={e =>
-                      setAcceptedTerms(
-                        /** @type {HTMLInputElement} */ (e.target).checked
-                      )
-                    }
-                    onKeyDown={onKeyDown}
-                  />
-                </div>
               </div>
             </>
           )}

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -41,16 +41,6 @@ describe('JSTORPicker', () => {
     });
   }
 
-  function toggleCheckbox(wrapper) {
-    interact(wrapper, () => {
-      const checkbox = wrapper.find(
-        'input[data-testid="jstor-terms-checkbox"]'
-      );
-      checkbox.getDOMNode().click();
-      checkbox.simulate('input');
-    });
-  }
-
   const renderJSTORPicker = (props = {}) => mount(<JSTORPicker {...props} />);
 
   beforeEach(() => {
@@ -190,11 +180,6 @@ describe('JSTORPicker', () => {
 
       simulateMetadataFetch(wrapper, 'test title');
 
-      // Second enter press won't do anything if the terms checkbox hasn't been checked
-      input.getDOMNode().dispatchEvent(keyEvent);
-
-      toggleCheckbox(wrapper);
-
       // Enter will submit if terms are checked and there is valid metadata fetched
       input.getDOMNode().dispatchEvent(keyEvent);
 
@@ -290,45 +275,21 @@ describe('JSTORPicker', () => {
     assert.isFalse(wrapper.exists('[data-testid="selected-book"]'));
   });
 
-  it('does not enable submit button if terms are not accepted', () => {
+  it('enables submit button when valid JSTOR metadata has been fetched', () => {
     const wrapper = renderJSTORPicker();
     const buttonSelector = 'LabeledButton[data-testid="select-button"]';
 
     assert.isTrue(wrapper.find(buttonSelector).props().disabled);
 
     updateURL(wrapper);
-
-    // Button remains disabled while metadata is being fetched.
-    assert.isTrue(wrapper.find(buttonSelector).props().disabled);
-
     simulateMetadataFetch(wrapper);
-
-    assert.isTrue(wrapper.find(buttonSelector).props().disabled);
-  });
-
-  it('enables submit button when valid JSTOR metadata has been fetched and terms accepted', () => {
-    const wrapper = renderJSTORPicker();
-    const buttonSelector = 'LabeledButton[data-testid="select-button"]';
-
-    updateURL(wrapper);
-    simulateMetadataFetch(wrapper);
-
-    assert.isTrue(wrapper.find(buttonSelector).props().disabled);
-
-    // Checking the T&Cs checkbox should enable the submit button
-    toggleCheckbox(wrapper);
 
     assert.isFalse(wrapper.find(buttonSelector).props().disabled);
-    assert.equal(wrapper.find(buttonSelector).text(), 'Submit');
+    assert.equal(wrapper.find(buttonSelector).text(), 'Accept and continue');
 
     // Since the chosen item is usable (eg. not a collection), no error should
     // be displayed.
     assert.isFalse(wrapper.exists('[data-testid="error-message"]'));
-
-    // Un-checking the T&Cs checkbox should re-disable the submit button
-    toggleCheckbox(wrapper);
-
-    assert.isTrue(wrapper.find(buttonSelector).props().disabled);
   });
 
   it('disables submit button and shows error if item is a collection', () => {


### PR DESCRIPTION
As discussed and agreed, this PR updates the wording and flow associated with accepting JSTOR terms in the assignment configuration content picker.

After these changes, the interface looks like so:

<img width="825" alt="image" src="https://user-images.githubusercontent.com/439947/176516718-5f206d7b-e383-4195-9f16-bd29d8d62e68.png">
