### PR TITLE
Increase the timeout for LTIA requests

### DIFF
--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -44,7 +44,15 @@ class LTIAHTTPService:
         access_token = self._get_access_token(scopes)
         headers["Authorization"] = f"Bearer {access_token}"
 
-        return self._http.request(method, url, headers=headers, **kwargs)
+        return self._http.request(
+            method,
+            url,
+            headers=headers,
+            # This request could potentially involve the LMS calling us
+            # to the get JWK while we wait. Increase the timeout.
+            timeout=(28, 28),
+            **kwargs,
+        )
 
     def _get_access_token(self, scopes):
         """

--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -39,6 +39,7 @@ class TestLTIAHTTPService:
             headers={
                 "Authorization": f"Bearer {http_service.post.return_value.json.return_value['access_token']}"
             },
+            timeout=(28, 28),
         )
         assert response == http_service.request.return_value
 


### PR DESCRIPTION
These requests could involve the LMS doing a HTTP request back to us to
get corresponding JWK while we wait for it to finish.