### PR TITLE
Track assignment group / section relationships

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -2,7 +2,7 @@ import functools
 from enum import Enum
 from typing import List, Optional
 
-from lms.models import GroupInfo, Grouping, HUser
+from lms.models import Assignment, GroupInfo, Grouping, HUser
 from lms.product import Product
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
@@ -144,7 +144,7 @@ class JSConfig:
         if error_details:
             self._config["errorDialog"]["errorDetails"] = error_details
 
-    def enable_lti_launch_mode(self):
+    def enable_lti_launch_mode(self, assignment: Assignment):
         """
         Put the JavaScript code into "LTI launch" mode.
 
@@ -152,7 +152,7 @@ class JSConfig:
         """
         self._config["mode"] = JSConfig.Mode.BASIC_LTI_LAUNCH
 
-        self._config["api"]["sync"] = self._sync_api()
+        self._config["api"]["sync"] = self._sync_api(assignment)
 
         # The config object for the Hypothesis client.
         # Our JSON-RPC server passes this to the Hypothesis client over
@@ -427,7 +427,7 @@ class JSConfig:
         # to the sync API to dynamically get the relevant groupings.
         return "$rpc:requestGroups"
 
-    def _sync_api(self):
+    def _sync_api(self, assignment):
         """Add configuration the front-end will use to get groupings."""
 
         if self._context.grouping_type == Grouping.Type.COURSE:
@@ -443,6 +443,7 @@ class JSConfig:
             # description. Anything we add here should be echoed back by the
             # frontend.
             "data": {
+                "assignment_id": assignment.id,
                 "lms": {
                     "product": self._request.product.family,
                 },

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -20,6 +20,11 @@ class AssignmentService:
     def __init__(self, db: Session):
         self._db = db
 
+    def get_assignment_by_id(self, assignment_id) -> Assignment:
+        """Get an assignment by id."""
+
+        return self._db.query(Assignment).get(assignment_id)
+
     def get_assignment(self, tool_consumer_instance_guid, resource_link_id):
         """Get an assignment by resource_link_id."""
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -154,12 +154,14 @@ class BasicLaunchViews:
 
         # Store lots of info
         self._record_course()
-        self._record_assignment(
+        assignment = self._record_assignment(
             document_url, extra=assignment_extra, is_gradable=assignment_gradable
         )
 
         # Set up the JS config for the front-end
-        self._configure_js_to_show_document(document_url, assignment_gradable)
+        self._configure_js_to_show_document(
+            document_url, assignment, assignment_gradable
+        )
 
         return {}
 
@@ -189,6 +191,8 @@ class BasicLaunchViews:
             assignment=assignment, groupings=[self.context.course]
         )
 
+        return assignment
+
     def _record_course(self):
         # It's not completely clear but accessing a course in this way actually
         # is an upsert. So this stores the course as well
@@ -196,7 +200,9 @@ class BasicLaunchViews:
             user=self.request.user, groups=[self.context.course]
         )
 
-    def _configure_js_to_show_document(self, document_url, assignment_gradable):
+    def _configure_js_to_show_document(
+        self, document_url, assignment, assignment_gradable
+    ):
         if self.context.is_canvas:
             # For students in Canvas with grades to submit we need to enable
             # Speedgrader settings for gradable assignments
@@ -223,7 +229,7 @@ class BasicLaunchViews:
             self.context.js_config.enable_grading_bar()
 
         self.context.js_config.add_document_url(document_url)
-        self.context.js_config.enable_lti_launch_mode()
+        self.context.js_config.enable_lti_launch_mode(assignment)
 
     def _record_launch(self):
         """Persist launch type independent info to the DB."""

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -10,6 +10,15 @@ from tests import factories
 
 
 class TestAssignmentService:
+    def test_get_assignment_by_id(self, svc, db_session, assignment):
+        db_session.add(assignment)
+        db_session.flush()
+
+        assert svc.get_assignment_by_id(assignment.id) == assignment
+
+    def test_get_assignment_by_id_without_match(self, svc):
+        assert not svc.get_assignment_by_id(123456789)
+
     def test_get_assignment(self, svc, assignment, matching_params):
         assert svc.get_assignment(**matching_params) == assignment
 

--- a/tests/unit/lms/views/api/sync_test.py
+++ b/tests/unit/lms/views/api/sync_test.py
@@ -17,6 +17,7 @@ class TestSync:
         self,
         pyramid_request,
         grouping_service,
+        assignment_service,
         course_service,
         lti_h_service,
         grouping_method,
@@ -38,6 +39,14 @@ class TestSync:
         lti_h_service.sync.assert_called_once_with(
             grouping_method.return_value, sentinel.group_info
         )
+        assignment_service.get_assignment_by_id.assert_called_once_with(
+            sentinel.assignment_id
+        )
+        assignment_service.upsert_assignment_groupings(
+            assignment=assignment_service.get_assignment_by_id.return_value,
+            groupings=grouping_method.return_value,
+        )
+
         assert returned_ids == [
             group.groupid(TEST_SETTINGS["h_authority"])
             for group in grouping_method.return_value
@@ -56,6 +65,7 @@ class TestSync:
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.parsed_params = {
+            "assignment_id": sentinel.assignment_id,
             "lms": {"tool_consumer_instance_guid": sentinel.guid},
             "context_id": sentinel.context_id,
             "gradingStudentId": sentinel.grading_student_id,

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -182,12 +182,6 @@ class TestBasicLaunchViews:
             sentinel.document_url, assignment_extra=sentinel.assignment_extra
         )
 
-        context.js_config.enable_lti_launch_mode.assert_called_once_with()
-        context.js_config.set_focused_user.assert_not_called()
-        context.js_config.add_document_url.assert_called_once_with(
-            sentinel.document_url
-        )
-
         lti_h_service.sync.assert_called_once_with([context.course], context.lti_params)
 
         # `_record_course()`
@@ -206,16 +200,22 @@ class TestBasicLaunchViews:
             is_gradable=False,
             extra=sentinel.assignment_extra,
         )
+        assignment = assignment_service.upsert_assignment.return_value
 
         lti_role_service.get_roles.assert_called_once_with(context.lti_params["roles"])
         assignment_service.upsert_assignment_membership.assert_called_once_with(
-            assignment=assignment_service.upsert_assignment.return_value,
+            assignment=assignment,
             user=pyramid_request.user,
             lti_roles=lti_role_service.get_roles.return_value,
         )
         assignment_service.upsert_assignment_groupings.assert_called_once_with(
-            assignment=assignment_service.upsert_assignment.return_value,
-            groupings=[context.course],
+            assignment=assignment, groupings=[context.course]
+        )
+
+        context.js_config.enable_lti_launch_mode.assert_called_once_with(assignment)
+        context.js_config.set_focused_user.assert_not_called()
+        context.js_config.add_document_url.assert_called_once_with(
+            sentinel.document_url
         )
 
         assert result == {}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4080

Based on:

 * https://github.com/hypothesis/lms/pull/4148

We were already tracking the association between assignments and courses, and this adds tracking between assignments and other types of grouping.

### Review notes

The PR is in two commits. The first adds the required data and the second consumes it. If we want to we can split this into two PRs and merge the first one only to allow clients in the wild to get the new config before it's required.

### Testing notes

 * Start everything
 * Visit: https://hypothesis.instructure.com/courses/125/assignments/873
 * Look for assignment grouping relations which aren't to do with course:
```sql
SELECT assignment_id, grouping.type
FROM assignment_grouping
JOIN grouping ON grouping.id = grouping_id
WHERE type != 'course'
```
* In `main` you shouldn't find any, and in this PR you should