### PR TITLE
Rename `viaUrl` JS configuration / API to `contentUrl`

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -49,7 +49,7 @@ class JSConfig:
         jstor_service = self._request.find_service(iface=JSTORService)
 
         if document_url.startswith("blackboard://"):
-            self._config["api"]["viaUrl"] = {
+            self._config["api"]["contentUrl"] = {
                 "authUrl": self._request.route_url("blackboard_api.oauth.authorize"),
                 "path": self._request.route_path(
                     "blackboard_api.files.via_url",
@@ -58,7 +58,7 @@ class JSConfig:
                 ),
             }
         elif document_url.startswith("canvas://"):
-            self._config["api"]["viaUrl"] = {
+            self._config["api"]["contentUrl"] = {
                 "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
                 "path": self._request.route_path(
                     "canvas_api.files.via_url",
@@ -70,11 +70,13 @@ class JSConfig:
 
             # nb. VitalSource doesn't use Via, but is otherwise handled exactly
             # the same way by the frontend.
-            self._config["viaUrl"] = vitalsource_svc.get_launch_url(document_url)
+            self._config["contentUrl"] = vitalsource_svc.get_launch_url(document_url)
         elif jstor_service.enabled and document_url.startswith("jstor://"):
-            self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)
+            self._config["contentUrl"] = jstor_service.via_url(
+                self._request, document_url
+            )
         else:
-            self._config["viaUrl"] = via_url(self._request, document_url)
+            self._config["contentUrl"] = via_url(self._request, document_url)
 
     def asdict(self):
         """

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -49,7 +49,7 @@ export default function BasicLTILaunchApp() {
       // API callback to use to fetch the URL to show in the iframe. This is
       // needed if resolving the content URL involves potentially slow calls
       // to third party APIs (eg. the LMS's file storage).
-      viaUrl: viaAPICallInfo,
+      contentUrl: viaAPICallInfo,
       // Sync API callback and data to asynchronously load the section groups
       // to relay to the sidebar via RPC.
       sync: syncAPICallInfo,
@@ -57,7 +57,7 @@ export default function BasicLTILaunchApp() {
     grading,
     hypothesisClient: clientConfig,
     // Content URL to show in the iframe.
-    viaUrl: viaURL,
+    contentUrl: initialContentURL,
     canvas,
   } = useContext(Config);
 
@@ -80,7 +80,7 @@ export default function BasicLTILaunchApp() {
 
   // URL to display in the content iframe. This is either available immediately,
   // or otherwise we'll have to make an API call to fetch it.
-  const [contentURL, setContentURL] = useState(viaURL || null);
+  const [contentURL, setContentURL] = useState(initialContentURL || null);
 
   // Count of pending API requests which must complete before the assignment
   // content can be shown.

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -482,7 +482,6 @@ describe('BasicLTILaunchApp', () => {
     });
 
     it('does not report the submission when there is no `contentUrl` provided', async () => {
-      // When present, contentUrl becomes the contentUrl
       fakeConfig.contentUrl = null;
       renderLTILaunchApp();
       assert.isTrue(fakeApiCall.notCalled);

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -87,7 +87,7 @@ describe('BasicLTILaunchApp', () => {
 
   context('when a content URL is provided in the config', () => {
     beforeEach(() => {
-      fakeConfig.viaUrl = 'https://via.hypothes.is/123';
+      fakeConfig.contentUrl = 'https://via.hypothes.is/123';
     });
 
     it('displays the content URL in an iframe', () => {
@@ -141,7 +141,7 @@ describe('BasicLTILaunchApp', () => {
     const authUrl = 'https://lms.hypothes.is/authorize-lms';
 
     beforeEach(() => {
-      fakeConfig.api.viaUrl = {
+      fakeConfig.api.contentUrl = {
         authUrl,
         path: 'https://lms.hypothes.is/api/files/1234',
       };
@@ -421,7 +421,7 @@ describe('BasicLTILaunchApp', () => {
           lis_result_sourcedid: 'modelstudent-assignment1',
         },
       };
-      fakeConfig.viaUrl = 'https://via.hypothes.is/123';
+      fakeConfig.contentUrl = 'https://via.hypothes.is/123';
     });
 
     it('reports the submission when the content iframe starts loading', async () => {
@@ -481,9 +481,9 @@ describe('BasicLTILaunchApp', () => {
       assert.notCalled(fakeApiCall);
     });
 
-    it('does not report the submission when there is no `viaUrl` provided', async () => {
-      // When present, viaUrl becomes the contentUrl
-      fakeConfig.viaUrl = null;
+    it('does not report the submission when there is no `contentUrl` provided', async () => {
+      // When present, contentUrl becomes the contentUrl
+      fakeConfig.contentUrl = null;
       renderLTILaunchApp();
       assert.isTrue(fakeApiCall.notCalled);
     });
@@ -497,7 +497,7 @@ describe('BasicLTILaunchApp', () => {
               lis_result_sourcedid: 'modelstudent-assignment1',
             },
           };
-          fakeConfig.viaUrl = 'https://via.hypothes.is/123';
+          fakeConfig.contentUrl = 'https://via.hypothes.is/123';
           fakeConfig.hypothesisClient.reportActivity = {
             method: 'reportActivity',
             events: ['create', 'edit'],
@@ -665,7 +665,7 @@ describe('BasicLTILaunchApp', () => {
         enabled: true,
         students: [{ userid: 'user1' }, { userid: 'user2' }],
       };
-      fakeConfig.viaUrl = 'https://via.hypothes.is/123';
+      fakeConfig.contentUrl = 'https://via.hypothes.is/123';
     });
 
     it('renders the LMSGrader component', () => {
@@ -719,7 +719,7 @@ describe('BasicLTILaunchApp', () => {
       //  2. groups
       fakeConfig.api = {
         authToken: 'dummyAuthToken',
-        viaUrl: {
+        contentUrl: {
           authUrl: 'https://lms.hypothes.is/authorize-lms',
           path: 'https://lms.hypothes.is/api/files/1234',
         },
@@ -907,7 +907,7 @@ describe('BasicLTILaunchApp', () => {
         content: () => {
           fakeConfig = {
             ...fakeConfig,
-            viaUrl: 'https://via.hypothes.is/123',
+            contentUrl: 'https://via.hypothes.is/123',
           };
           return renderLTILaunchApp();
         },

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -156,7 +156,7 @@ import { createContext } from 'preact';
  * @prop {object} api
  *   @prop {string} api.authToken
  *   @prop {APICallInfo} api.sync
- *   @prop {APICallInfo} api.viaUrl
+ *   @prop {APICallInfo} api.contentUrl
  * @prop {object} canvas
  *   @prop {SpeedGraderConfig} canvas.speedGrader
  * @prop {boolean} dev
@@ -165,7 +165,7 @@ import { createContext } from 'preact';
  * @prop {ClientConfig} hypothesisClient
  * @prop {object} rpcServer
  *   @prop {string[]} rpcServer.allowedOrigins
- * @prop {string} viaUrl
+ * @prop {string} contentUrl
  * @prop {OAuthErrorConfig} OAuth2RedirectError
  * @prop {ErrorDialogConfig} errorDialog
  */

--- a/tests/functional/views/basic_lti_launch_test.py
+++ b/tests/functional/views/basic_lti_launch_test.py
@@ -40,7 +40,7 @@ class TestBasicLTILaunch:
 
         js_config = self.get_client_config(response)
         assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
-        assert urlencode({"url": assignment.document_url}) in js_config["viaUrl"]
+        assert urlencode({"url": assignment.document_url}) in js_config["contentUrl"]
 
     @pytest.mark.parametrize(
         "launch_params_fixture_name,existing_assignment_fixture_name",
@@ -86,7 +86,7 @@ class TestBasicLTILaunch:
         assert js_config["mode"] == JSConfig.Mode.BASIC_LTI_LAUNCH
         assert (
             urlencode({"url": "https://url-configured.com/document.pdf"})
-            in js_config["viaUrl"]
+            in js_config["contentUrl"]
         )
 
     @pytest.mark.parametrize(

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -106,16 +106,18 @@ class TestEnableLTILaunchMode:
 class TestAddDocumentURL:
     """Unit tests for JSConfig.add_document_url()."""
 
-    def test_it_adds_the_via_url(self, js_config, pyramid_request, via_url):
+    def test_it_adds_content_url(self, js_config, pyramid_request, via_url):
         js_config.add_document_url("example_document_url")
 
         via_url.assert_called_once_with(pyramid_request, "example_document_url")
-        assert js_config.asdict()["viaUrl"] == via_url.return_value
+        assert js_config.asdict()["contentUrl"] == via_url.return_value
 
-    def test_it_adds_the_viaUrl_api_config_for_Blackboard_documents(self, js_config):
+    def test_it_adds_the_contentUrl_api_config_for_Blackboard_documents(
+        self, js_config
+    ):
         js_config.add_document_url("blackboard://content-resource/xyz123")
 
-        assert js_config.asdict()["api"]["viaUrl"] == {
+        assert js_config.asdict()["api"]["contentUrl"] == {
             "authUrl": "http://example.com/api/blackboard/oauth/authorize",
             "path": "/api/blackboard/courses/test_course_id/via_url?document_url=blackboard%3A%2F%2Fcontent-resource%2Fxyz123",
         }
@@ -127,7 +129,7 @@ class TestAddDocumentURL:
 
         vitalsource_service.get_launch_url.assert_called_with(vitalsource_url)
         assert (
-            js_config.asdict()["viaUrl"]
+            js_config.asdict()["contentUrl"]
             == vitalsource_service.get_launch_url.return_value
         )
 
@@ -137,9 +139,9 @@ class TestAddDocumentURL:
         js_config.add_document_url(jstor_url)
 
         jstor_service.via_url.assert_called_with(pyramid_request, jstor_url)
-        assert js_config.asdict()["viaUrl"] == jstor_service.via_url.return_value
+        assert js_config.asdict()["contentUrl"] == jstor_service.via_url.return_value
 
-    def test_it_adds_the_viaUrl_api_config_for_Canvas_documents(
+    def test_it_adds_the_contentUrl_api_config_for_Canvas_documents(
         self, js_config, pyramid_request
     ):
         course_id, file_id = "125", "100"
@@ -150,7 +152,7 @@ class TestAddDocumentURL:
             f"canvas://file/course/{course_id}/file_id/{file_id}"
         )
 
-        assert js_config.asdict()["api"]["viaUrl"] == {
+        assert js_config.asdict()["api"]["contentUrl"] == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
             "path": "/api/canvas/assignments/TEST_RESOURCE_LINK_ID/via_url",
         }


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/lms/pull/4159**~~

This configuration refers to the URL of the assignment content iframe.
This used to always be Via, but that is no longer the case. VitalSource
uses it as well for example.

In this PR I kept to the existing naming convention for object properties in the JS config. We might want to revise that in future since it differs from both the `snek_case` of Python and our flavor of `camelCaseWithTLAs` in JS.