### PR TITLE
Remove duplicate envvars from `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,38 +17,25 @@ passenv =
     EXTRA_DEPS
     {tests,functests,bddtests}: TEST_DATABASE_URL
     {tests,functests}: PYTEST_ADDOPTS
-    dev: SESSION_COOKIE_SECRET
-    dev: DATABASE_URL
     dev: DEBUG
     dev: FEATURE_FLAG_*
-    dev: FEATURE_FLAGS_ALLOWED_IN_COOKIE
-    dev: FEATURE_FLAGS_COOKIE_SECRET
     dev: GOOGLE_APP_ID
     dev: GOOGLE_CLIENT_ID
     dev: GOOGLE_DEVELOPER_KEY
     dev: ONEDRIVE_CLIENT_ID
     dev: ADMIN_AUTH_GOOGLE_CLIENT_ID
     dev: ADMIN_AUTH_GOOGLE_CLIENT_SECRET
-    dev: H_AUTHORITY
-    dev: H_API_URL_PRIVATE
-    dev: H_API_URL_PUBLIC
     dev: H_CLIENT_ID
     dev: H_CLIENT_SECRET
     dev: H_JWT_CLIENT_ID
     dev: H_JWT_CLIENT_SECRET
-    dev: JWT_SECRET
     dev: LMS_SECRET
-    dev: OAUTH2_STATE_SECRET
-    dev: RPC_ALLOWED_ORIGINS
     dev: SENTRY_DSN
-    dev: SENTRY_ENVIRONMENT
-    dev: VIA_URL
     dev: VITALSOURCE_API_KEY
     dev: BLACKBOARD_API_CLIENT_ID
     dev: BLACKBOARD_API_CLIENT_SECRET
     dev: JSTOR_API_URL
     dev: JSTOR_API_SECRET
-    dev: BROKER_URL
 deps =
     dev: -r requirements/dev.txt
     {format,checkformatting}: -r requirements/format.txt


### PR DESCRIPTION
These envvars are now read from the environment by the `setenv` section of `tox.ini` with lines like this:

```ini
dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:5433/postgres}
```

This means it's no longer necessary to list these envvars in the `passenv` section.