### PR TITLE
Remove duplicate `TEST_DATABASE_URL` default values

### DIFF
--- a/tests/bdd/steps/lms_db.py
+++ b/tests/bdd/steps/lms_db.py
@@ -8,9 +8,7 @@ from lms import db, models
 from tests.bdd.step_context import StepContext
 from tests.conftest import get_test_database_url
 
-TEST_DATABASE_URL = get_test_database_url(
-    default="postgresql://postgres@localhost:5433/lms_bddtests"
-)
+TEST_DATABASE_URL = get_test_database_url()
 
 
 class LMSDBContext(StepContext):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,8 @@ import sqlalchemy
 from lms import db
 
 
-def get_test_database_url(default):
-    return os.environ.get("TEST_DATABASE_URL", default)
+def get_test_database_url():
+    return os.environ["TEST_DATABASE_URL"]
 
 
 TEST_SETTINGS = {

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -14,9 +14,7 @@ from lms.db import SESSION
 from tests import factories
 from tests.conftest import TEST_SETTINGS, get_test_database_url
 
-TEST_SETTINGS["database_url"] = get_test_database_url(
-    default="postgresql://postgres@localhost:5433/lms_functests"
-)
+TEST_SETTINGS["database_url"] = get_test_database_url()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,9 +13,7 @@ from tests import factories
 from tests.conftest import TEST_SETTINGS, get_test_database_url
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
-TEST_SETTINGS["database_url"] = get_test_database_url(
-    default="postgresql://postgres@localhost:5433/lms_test"
-)
+TEST_SETTINGS["database_url"] = get_test_database_url()
 
 
 @pytest.fixture


### PR DESCRIPTION
`TEST_DATABASE_URL` is always set in `tox.ini` so there's no need to have default values for it in the Python code as well.