### PR TITLE
Don't stamp the dev DB in the BDD tests

### DIFF
--- a/tests/bdd/steps/lms_db.py
+++ b/tests/bdd/steps/lms_db.py
@@ -20,7 +20,7 @@ class LMSDBContext(StepContext):
         super().__init__(**kwargs)
         self.engine = sqlalchemy.create_engine(TEST_DATABASE_URL)
         self.session_maker = sessionmaker(bind=self.engine.connect())
-        db.init(self.engine)
+        db.init(self.engine, stamp=False)
 
         self.session = None
         self.modified_tables = None


### PR DESCRIPTION
The unit tests and functests both pass `stamp=False`:

https://github.com/hypothesis/lms/blob/b87d3b8f307e868efbc73156d69d66fd5ecf6352/tests/conftest.py#L54
https://github.com/hypothesis/lms/blob/b87d3b8f307e868efbc73156d69d66fd5ecf6352/tests/functional/conftest.py#L49

The BDD tests need to do the same. Currently the BDD tests are actually stamping the dev DB! Using the hard-coded SQLAlchemy URL in `conf/alembic.ini`. (They're not stamping the BDD tests DB.)