### PR TITLE
Don't run the functests on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,20 +25,6 @@ node {
         img = buildApp(name: "hypothesis/lms")
     }
 
-    stage("Backend tests") {
-        // Run the Postgres test DB in a Docker container.
-        postgresContainer = docker.image("postgres:11.5").run("-P -e POSTGRES_DB=lmstest")
-
-        try {
-            testApp(image: img, runArgs: "${runArgs} -e TEST_DATABASE_URL=${databaseUrl(postgresContainer)}") {
-                installDeps()
-                run("make functests-only")
-            }
-        } finally {
-            postgresContainer.stop()
-        }
-    }
-
     onlyOnMain {
         stage("release") {
             releaseApp(image: img)
@@ -70,27 +56,4 @@ onlyOnMain {
             }
         )
     }
-}
-
-/** Return the URL of the test database in the Postgres container. */
-def databaseUrl(postgresContainer) {
-    hostIp = sh(script: "facter ipaddress_eth0", returnStdout: true).trim()
-    containerPort = sh(script: "docker port ${postgresContainer.id} 5432 | cut -d: -f2", returnStdout: true).trim()
-    return "postgresql://postgres@${hostIp}:${containerPort}/lmstest"
-}
-
-/**
- * Install some common system dependencies.
- *
- * These are test dependencies that're need to run most of the stages above
- * (tests, lint, ...) but that aren't installed in the production Docker image.
- */
-def installDeps() {
-    sh "apk add build-base postgresql-dev python3-dev"
-    sh "pip3 install -q tox>=3.8.0"
-}
-
-/** Run the given command. */
-def run(command) {
-    sh "cd /var/lib/lms && ${command}"
 }

--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,7 @@ else
 endif
 
 .PHONY: functests
-functests: build/manifest.json functests-only
-
-.PHONY: functests-only
-functests-only: python
+functests: build/manifest.json
 	@tox -qe functests
 
 .PHONY: docker


### PR DESCRIPTION
This is a pain because it apparently requires there to be a separate `make functests-only` target (although is that really necessary?)

But anyway: I don't think there's any benefit to running the functests on Jenkins after we've already run them on GitHub Actions. It's just more code to maintain and more waiting around for Jenkins to finish. The idea originally was that Jenkins runs the tests actually inside the Docker container so it's more similar to production than GitHub Actions which doesn't run the tests in Docker. But I don't think there's ever been a case of the tests passing on GitHub Actions and then Jenkins catching a problem with its second run of the tests. So in practice I think this is silly.

I think there are better steps that we could take to control CI-versus-prod differences if we wanted to do that:

- Use the same OS in production as we use on CI. We could change CI to Alpine. But I'd recommend changing production to Ubuntu instead then we'd have Ubuntu on prod, CI and dev. And people recommend Ubuntu over Alpine anyway: https://pythonspeed.com/articles/base-image-python-docker-images/, https://pythonspeed.com/articles/alpine-docker-python/

- Install the app into a virtualenv within the production Docker container so that it's isolated from the container's OS's Python packages. This is a generally recommended best practice. Yes, even in Docker containers. Even if you're running in Docker, it's still not okay to have any old random Python packages that might ship with Alpine or be installed by `apk add` commands mixing in with your app's packages in the same Python environment.

In practice neither of the above have bitten us yet