### PR TITLE
Fix product family for GET endpoints

### DIFF
--- a/lms/product/factory.py
+++ b/lms/product/factory.py
@@ -19,7 +19,7 @@ def _get_family(request):
     if request.matched_route.name.startswith("canvas_api."):
         return Product.Family.CANVAS
 
-    if request.matched_route.name.startswith("blackboard_api.."):
+    if request.matched_route.name.startswith("blackboard_api."):
         return Product.Family.BLACKBOARD
 
     # If we are in an API request, where we are forwarding the product type ourselves

--- a/lms/product/factory.py
+++ b/lms/product/factory.py
@@ -15,6 +15,13 @@ def get_product_from_request(request) -> Product:
 
 
 def _get_family(request):
+    # First, if we are in an LMS specific route, return that
+    if request.matched_route.name.startswith("canvas_api."):
+        return Product.Family.CANVAS
+
+    if request.matched_route.name.startswith("blackboard_api.."):
+        return Product.Family.BLACKBOARD
+
     # If we are in an API request, where we are forwarding the product type ourselves
     if request.content_type == "application/json":
         return Product.Family(request.json["lms"]["product"])

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -51,7 +51,6 @@ class JSConfig:
         if document_url.startswith("blackboard://"):
             self._config["api"]["viaUrl"] = {
                 "authUrl": self._request.route_url("blackboard_api.oauth.authorize"),
-                "product": self._request.product.family,
                 "path": self._request.route_path(
                     "blackboard_api.files.via_url",
                     course_id=self._context.lti_params["context_id"],
@@ -61,7 +60,6 @@ class JSConfig:
         elif document_url.startswith("canvas://"):
             self._config["api"]["viaUrl"] = {
                 "authUrl": self._request.route_url("canvas_api.oauth.authorize"),
-                "product": self._request.product.family,
                 "path": self._request.route_path(
                     "canvas_api.files.via_url",
                     resource_link_id=self._context.lti_params["resource_link_id"],
@@ -123,7 +121,6 @@ class JSConfig:
                 "mode": JSConfig.Mode.OAUTH2_REDIRECT_ERROR,
                 "OAuth2RedirectError": {
                     "authUrl": auth_url,
-                    "product": self._request.product.family,
                     "errorCode": error_code,
                     "canvasScopes": canvas_scopes or [],
                 },

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -112,9 +112,7 @@ class TestAddDocumentURL:
         via_url.assert_called_once_with(pyramid_request, "example_document_url")
         assert js_config.asdict()["viaUrl"] == via_url.return_value
 
-    def test_it_adds_the_viaUrl_api_config_for_Blackboard_documents(
-        self, js_config, pyramid_request
-    ):
+    def test_it_adds_the_viaUrl_api_config_for_Blackboard_documents(self, js_config):
         js_config.add_document_url("blackboard://content-resource/xyz123")
 
         assert js_config.asdict()["api"]["viaUrl"] == {

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -119,7 +119,6 @@ class TestAddDocumentURL:
 
         assert js_config.asdict()["api"]["viaUrl"] == {
             "authUrl": "http://example.com/api/blackboard/oauth/authorize",
-            "product": pyramid_request.product.family,
             "path": "/api/blackboard/courses/test_course_id/via_url?document_url=blackboard%3A%2F%2Fcontent-resource%2Fxyz123",
         }
 
@@ -154,7 +153,6 @@ class TestAddDocumentURL:
 
         assert js_config.asdict()["api"]["viaUrl"] == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
-            "product": pyramid_request.product.family,
             "path": "/api/canvas/assignments/TEST_RESOURCE_LINK_ID/via_url",
         }
 
@@ -440,7 +438,7 @@ class TestJSConfigRPCServer:
 
 
 class TestEnableOAuth2RedirectErrorMode:
-    def test_it(self, js_config, pyramid_request):
+    def test_it(self, js_config):
         js_config.enable_oauth2_redirect_error_mode(
             "auth_route",
             sentinel.error_code,
@@ -452,7 +450,6 @@ class TestEnableOAuth2RedirectErrorMode:
         assert config["mode"] == JSConfig.Mode.OAUTH2_REDIRECT_ERROR
         assert config["OAuth2RedirectError"] == {
             "authUrl": "http://example.com/auth?authorization=Bearer%3A+token_value",
-            "product": pyramid_request.product.family,
             "errorCode": sentinel.error_code,
             "errorDetails": sentinel.error_details,
             "canvasScopes": sentinel.canvas_scopes,

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, call, sentinel
+from unittest.mock import call, sentinel
 
 import pytest
 import requests
@@ -243,9 +243,6 @@ class TestErrorBody:
         # exception that was raised by the original view:
         # https://docs.pylonsproject.org/projects/pyramid/en/latest/api/request.html#pyramid.request.Request.exception
         pyramid_request.exception = ValueError()
-
-        pyramid_request.matched_route = Mock(spec_set=["name"])
-
         return pyramid_request
 
     @pytest.fixture


### PR DESCRIPTION
# Testing 

- Without this fix

```update oauth2_token set access_token = 'nope', refresh_token ='nope';```

and launch https://hypothesis.instructure.com/courses/125/assignments/875

There's this error message that flashes for a while.

That doesn't happen in this branch.