### PR TITLE
Specify a worker-temp-dir in production

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:web]
-command=newrelic-admin run-program gunicorn --paste conf/production.ini --bind 0.0.0.0:8001
+command=newrelic-admin run-program gunicorn --paste conf/production.ini --bind 0.0.0.0:8001 --worker-tmp-dir /dev/shm
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
Based on https://docs.gunicorn.org/en/stable/faq.html#how-do-i-avoid-gunicorn-excessively-blocking-in-os-fchmod

in AWS an EBS root instance volume may sometimes hang for half a minute
and during this time Gunicorn workers may completely block in os.fchmod.
os.fchmod may introduce extra delays if the disk gets full.

As a work around we use the tmpfs mounted on /dev/shm