### PR TITLE
Don't send the unnecessary nonce value in LTIA service

### DIFF
--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -18,7 +18,6 @@ class TestLTIAHTTPService:
                 "aud": application_instance.lti_registration.token_url,
                 "exp": datetime(2022, 4, 4, 1, 0),
                 "iat": datetime(2022, 4, 4, 0, 0),
-                "nonce": uuid.uuid4.return_value.hex,
                 "iss": application_instance.lti_registration.client_id,
                 "sub": application_instance.lti_registration.client_id,
                 "jti": uuid.uuid4.return_value.hex,


### PR DESCRIPTION
Fixing a couple of awkward spots here:

- LTIAHTTP service was using a set of defaults
- Those defaults were used in both the LTIHTTP own request method to sign token request and also using the `sign` method to sign any payload.
- Those defaults look very similar but are not actually the same.

Sending `nonce` on the token request was causing an error as D2L doesn't allow the unexpected parameters: https://sentry.io/organizations/hypothesis/issues/3394604678/?referrer=slack

The fix here is passing all the parameters in needed in both cases directly to JWTService and removing the public `sign` method on LTIA service.



# Testing

- Deep link an assignment: 

https://hypothesis.instructure.com/courses/125/assignments/2956/edit?name=Testing+grading+(marcos)&due_at=null&points_possible=10


- Submitting a submission:
 
make sure to `export FEATURE_FLAG_SUBMIT_ON_ANNOTATION=true` before `make dev`. 

Launch the same assignment as a student and make an annotation. Double check the submission checking the last submission date as a teacher in speed grader)