### PR TITLE
Replace `context.lti_params` with `request.lti_params`

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -55,7 +55,7 @@ class JSConfig:
                 "authUrl": self._request.route_url(Blackboard.route.oauth2_authorize),
                 "path": self._request.route_path(
                     "blackboard_api.files.via_url",
-                    course_id=self._context.lti_params["context_id"],
+                    course_id=self._request.lti_params["context_id"],
                     _query={"document_url": document_url},
                 ),
             }
@@ -64,7 +64,7 @@ class JSConfig:
                 "authUrl": self._request.route_url(Canvas.route.oauth2_authorize),
                 "path": self._request.route_path(
                     "canvas_api.files.via_url",
-                    resource_link_id=self._context.lti_params["resource_link_id"],
+                    resource_link_id=self._request.lti_params["resource_link_id"],
                 ),
             }
         elif document_url.startswith("vitalsource://"):
@@ -212,7 +212,7 @@ class JSConfig:
         config = {
             "path": self._request.route_path("lti.v11.deep_linking.form_fields"),
             "data": {
-                "content_item_return_url": self._context.lti_params[
+                "content_item_return_url": self._request.lti_params[
                     "content_item_return_url"
                 ],
             },
@@ -221,7 +221,7 @@ class JSConfig:
             config["path"] = self._request.route_path(
                 "lti.v13.deep_linking.form_fields"
             )
-            config["data"]["deep_linking_settings"] = self._context.lti_params.get(
+            config["data"]["deep_linking_settings"] = self._request.lti_params.get(
                 "deep_linking_settings"
             )
 
@@ -237,8 +237,8 @@ class JSConfig:
 
         grading_infos = self._grading_info_service.get_by_assignment(
             application_instance=self._context.application_instance,
-            context_id=self._context.lti_params.get("context_id"),
-            resource_link_id=self._context.lti_params.get("resource_link_id"),
+            context_id=self._request.lti_params.get("context_id"),
+            resource_link_id=self._request.lti_params.get("resource_link_id"),
         )
 
         for grading_info in grading_infos:
@@ -258,8 +258,8 @@ class JSConfig:
 
         self._config["grading"] = {
             "enabled": True,
-            "courseName": self._context.lti_params.get("context_title"),
-            "assignmentName": self._context.lti_params.get("resource_link_title"),
+            "courseName": self._request.lti_params.get("context_title"),
+            "assignmentName": self._request.lti_params.get("resource_link_title"),
             "students": students,
         }
 
@@ -291,7 +291,7 @@ class JSConfig:
         :raise HTTPBadRequest: if a request param needed to generate the config
             is missing
         """
-        lti_params = self._context.lti_params
+        lti_params = self._request.lti_params
 
         self._config["canvas"]["speedGrader"] = {
             "submissionParams": {
@@ -451,7 +451,7 @@ class JSConfig:
                 "group_set_id": self._context.group_set_id,
                 "group_info": {
                     key: value
-                    for key, value in self._context.lti_params.items()
+                    for key, value in self._request.lti_params.items()
                     if key in GroupInfo.columns()
                 },
                 # The student we are currently grading. In the case of Canvas

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -176,7 +176,7 @@ class JSConfig:
             HTML form that we submit
         """
 
-        args = self._context, self._request, self._context.application_instance
+        args = self._request, self._context.application_instance
 
         self._config.update(
             {

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -1,7 +1,6 @@
 from lms.product import Product
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
-from lms.product import Product
 from lms.services import JSTORService
 
 
@@ -9,7 +8,7 @@ class FilePickerConfig:
     """Config generation for specific file pickers."""
 
     @classmethod
-    def blackboard_config(cls, _context, request, application_instance):
+    def blackboard_config(cls, request, application_instance):
         """Get Blackboard files config."""
         files_enabled = application_instance.settings.get("blackboard", "files_enabled")
         groups_enabled = application_instance.settings.get(
@@ -43,7 +42,7 @@ class FilePickerConfig:
         return config
 
     @classmethod
-    def canvas_config(cls, _context, request, application_instance):
+    def canvas_config(cls, request, application_instance):
         """Get Canvas files config."""
 
         enabled = (request.product.family == Product.Family.CANVAS) and (
@@ -77,7 +76,7 @@ class FilePickerConfig:
         return config
 
     @classmethod
-    def google_files_config(cls, _context, request, application_instance):
+    def google_files_config(cls, request, application_instance):
         """Get Google file picker config."""
 
         return {
@@ -92,7 +91,7 @@ class FilePickerConfig:
         }
 
     @classmethod
-    def microsoft_onedrive(cls, _context, request, application_instance):
+    def microsoft_onedrive(cls, request, application_instance):
         enabled = application_instance.settings.get(
             "microsoft_onedrive", "files_enabled", default=True
         )
@@ -106,13 +105,13 @@ class FilePickerConfig:
         }
 
     @classmethod
-    def vital_source_config(cls, _context, _request, application_instance):
+    def vital_source_config(cls, _request, application_instance):
         """Get Vital Source config."""
         enabled = application_instance.settings.get("vitalsource", "enabled", False)
         return {"enabled": enabled}
 
     @classmethod
-    def jstor_config(cls, _context, request, _application_instance):
+    def jstor_config(cls, request, _application_instance):
         """Get JSTOR config."""
 
         return {"enabled": request.find_service(JSTORService).enabled}

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -1,5 +1,7 @@
+from lms.product import Product
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
+from lms.product import Product
 from lms.services import JSTORService
 
 
@@ -41,10 +43,10 @@ class FilePickerConfig:
         return config
 
     @classmethod
-    def canvas_config(cls, context, request, application_instance):
+    def canvas_config(cls, _context, request, application_instance):
         """Get Canvas files config."""
 
-        enabled = context.is_canvas and (
+        enabled = (request.product.family == Product.Family.CANVAS) and (
             "custom_canvas_course_id" in request.lti_params
             and application_instance.developer_key is not None
         )

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -7,7 +7,7 @@ class FilePickerConfig:
     """Config generation for specific file pickers."""
 
     @classmethod
-    def blackboard_config(cls, context, request, application_instance):
+    def blackboard_config(cls, _context, request, application_instance):
         """Get Blackboard files config."""
         files_enabled = application_instance.settings.get("blackboard", "files_enabled")
         groups_enabled = application_instance.settings.get(
@@ -15,7 +15,7 @@ class FilePickerConfig:
         )
 
         auth_url = request.route_url(Blackboard.route.oauth2_authorize)
-        course_id = context.lti_params.get("context_id")
+        course_id = request.lti_params.get("context_id")
 
         config = {
             "enabled": files_enabled,
@@ -43,14 +43,15 @@ class FilePickerConfig:
     @classmethod
     def canvas_config(cls, context, request, application_instance):
         """Get Canvas files config."""
+
         enabled = context.is_canvas and (
-            "custom_canvas_course_id" in context.lti_params
+            "custom_canvas_course_id" in request.lti_params
             and application_instance.developer_key is not None
         )
         groups_enabled = application_instance.settings.get("canvas", "groups_enabled")
 
         auth_url = request.route_url(Canvas.route.oauth2_authorize)
-        course_id = context.lti_params.get("custom_canvas_course_id")
+        course_id = request.lti_params.get("custom_canvas_course_id")
 
         config = {
             "enabled": enabled,
@@ -74,7 +75,7 @@ class FilePickerConfig:
         return config
 
     @classmethod
-    def google_files_config(cls, context, request, application_instance):
+    def google_files_config(cls, _context, request, application_instance):
         """Get Google file picker config."""
 
         return {
@@ -83,7 +84,7 @@ class FilePickerConfig:
             # Get the URL of the top-most page that the LMS app is running in.
             # The frontend has to pass this to Google Picker, otherwise Google
             # Picker refuses to launch in an iframe.
-            "origin": context.lti_params.get(
+            "origin": request.lti_params.get(
                 "custom_canvas_api_domain", application_instance.lms_url
             ),
         }

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -3,7 +3,7 @@
 import logging
 from functools import cached_property
 
-from lms.models import Grouping, LTIParams
+from lms.models import Grouping
 from lms.product import Product
 from lms.resources._js_config import JSConfig
 
@@ -87,11 +87,12 @@ class LTILaunchResource:
 
         if self._request.product.family == Product.Family.BLACKBOARD:
             # In blackboard we store the configuration details in the DB
-            tool_consumer_instance_guid = self._request.parsed_params[
+            tool_consumer_instance_guid = self._request.lti_params[
                 "tool_consumer_instance_guid"
             ]
             assignment = self._request.find_service(name="assignment").get_assignment(
-                tool_consumer_instance_guid, self.lti_params.get("resource_link_id")
+                tool_consumer_instance_guid,
+                self._request.lti_params.get("resource_link_id"),
             )
             return assignment.extra.get("group_set_id") if assignment else None
 
@@ -113,11 +114,6 @@ class LTILaunchResource:
             return Grouping.Type.SECTION
 
         return Grouping.Type.COURSE
-
-    @property
-    def lti_params(self) -> LTIParams:
-        """Return the requests LTI parameters."""
-        return self._request.lti_params
 
     def _course_extra(self):
         """Extra information to store for courses."""

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -23,16 +23,14 @@ from lms.validation import BasicLTILaunchSchema, ConfigureAssignmentSchema
 from lms.validation.authentication import BearerTokenSchema
 
 
-def has_document_url(context, request):
+def has_document_url(_context, request):
     """
     Get if the current launch has a resolvable document URL.
 
     This is imported into `lms.views.predicates` to provide the
     `has_document_url` predicate.
     """
-    return bool(
-        request.find_service(DocumentURLService).get_document_url(context, request)
-    )
+    return bool(request.find_service(DocumentURLService).get_document_url(request))
 
 
 @view_defaults(
@@ -65,7 +63,7 @@ class BasicLaunchViews:
 
         return self._show_document(
             document_url=self.request.find_service(DocumentURLService).get_document_url(
-                self.context, self.request
+                self.request
             )
         )
 

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -61,7 +61,7 @@ from lms.validation._base import JSONPyramidRequestSchema
 )
 def deep_linking_launch(context, request):
     """Handle deep linking launches."""
-    context.application_instance.update_lms_data(context.lti_params)
+    context.application_instance.update_lms_data(request.lti_params)
 
     request.find_service(name="lti_h").sync([context.course], request.params)
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -63,7 +63,6 @@ class TestFilePickerMode:
         config_provider = getattr(FilePickerConfig, config_function)
         assert config["filePicker"][key] == config_provider.return_value
         config_provider.assert_called_once_with(
-            context,
             pyramid_request,
             context.application_instance,
         )

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -19,22 +19,17 @@ class TestFilePickerConfig:
         ],
     )
     def test_blackboard_config(
-        self,
-        context,
-        pyramid_request,
-        application_instance,
-        files_enabled,
-        groups_enabled,
+        self, pyramid_request, application_instance, files_enabled, groups_enabled
     ):
 
-        context.lti_params["context_id"] = "COURSE_ID"
+        pyramid_request.lti_params["context_id"] = "COURSE_ID"
         application_instance.settings.set("blackboard", "files_enabled", files_enabled)
         application_instance.settings.set(
             "blackboard", "groups_enabled", groups_enabled
         )
 
         config = FilePickerConfig.blackboard_config(
-            context, pyramid_request, application_instance
+            sentinel.context, pyramid_request, application_instance
         )
 
         expected_config = {
@@ -67,7 +62,7 @@ class TestFilePickerConfig:
     def test_canvas_config(
         self, context, pyramid_request, application_instance, groups_enabled
     ):
-        context.lti_params["custom_canvas_course_id"] = "COURSE_ID"
+        pyramid_request.lti_params["custom_canvas_course_id"] = "COURSE_ID"
         application_instance.settings.set("canvas", "groups_enabled", groups_enabled)
 
         config = FilePickerConfig.canvas_config(
@@ -114,15 +109,15 @@ class TestFilePickerConfig:
         "origin_from", (None, "custom_canvas_api_domain", "lms_url")
     )
     def test_google_files_config(
-        self, context, pyramid_request, application_instance, origin_from
+        self, pyramid_request, application_instance, origin_from
     ):
         if origin_from == "custom_canvas_api_domain":
-            context.lti_params["custom_canvas_api_domain"] = sentinel.origin
+            pyramid_request.lti_params["custom_canvas_api_domain"] = sentinel.origin
         elif origin_from == "lms_url":
             application_instance.lms_url = sentinel.origin
 
         config = FilePickerConfig.google_files_config(
-            context, pyramid_request, application_instance
+            sentinel.context, pyramid_request, application_instance
         )
 
         assert config == {
@@ -132,16 +127,14 @@ class TestFilePickerConfig:
         }
 
     @pytest.mark.parametrize("enabled", (True, False))
-    def test_microsoft_onedrive(
-        self, context, pyramid_request, application_instance, enabled
-    ):
+    def test_microsoft_onedrive(self, pyramid_request, application_instance, enabled):
         pyramid_request.registry.settings["onedrive_client_id"] = sentinel.client_id
         application_instance.settings.set(
             "microsoft_onedrive", "files_enabled", enabled
         )
 
         config = FilePickerConfig.microsoft_onedrive(
-            context, pyramid_request, application_instance
+            sentinel.context, pyramid_request, application_instance
         )
 
         expected = {"enabled": enabled}
@@ -154,13 +147,11 @@ class TestFilePickerConfig:
         assert config == expected
 
     @pytest.mark.parametrize("enabled", (True, False))
-    def test_vital_source_config(
-        self, context, pyramid_request, application_instance, enabled
-    ):
+    def test_vital_source_config(self, pyramid_request, application_instance, enabled):
         application_instance.settings.set("vitalsource", "enabled", enabled)
 
         config = FilePickerConfig.vital_source_config(
-            context, pyramid_request, application_instance
+            sentinel.context, pyramid_request, application_instance
         )
 
         assert config == {"enabled": enabled}

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -1,11 +1,9 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
 
-from lms.models import LTIParams
 from lms.product import Product
-from lms.resources import LTILaunchResource
 from lms.resources._js_config import FilePickerConfig
 
 
@@ -30,7 +28,7 @@ class TestFilePickerConfig:
         )
 
         config = FilePickerConfig.blackboard_config(
-            sentinel.context, pyramid_request, application_instance
+            pyramid_request, application_instance
         )
 
         expected_config = {
@@ -64,9 +62,7 @@ class TestFilePickerConfig:
         pyramid_request.lti_params["custom_canvas_course_id"] = "COURSE_ID"
         application_instance.settings.set("canvas", "groups_enabled", groups_enabled)
 
-        config = FilePickerConfig.canvas_config(
-            sentinel.context, pyramid_request, application_instance
-        )
+        config = FilePickerConfig.canvas_config(pyramid_request, application_instance)
 
         expected_config = {
             "enabled": Any(),
@@ -98,9 +94,7 @@ class TestFilePickerConfig:
         elif missing_value == "developer_key":
             application_instance.developer_key = None
 
-        config = FilePickerConfig.canvas_config(
-            sentinel.context, pyramid_request, application_instance
-        )
+        config = FilePickerConfig.canvas_config(pyramid_request, application_instance)
 
         assert config["enabled"] != missing_value
 
@@ -116,7 +110,7 @@ class TestFilePickerConfig:
             application_instance.lms_url = sentinel.origin
 
         config = FilePickerConfig.google_files_config(
-            sentinel.context, pyramid_request, application_instance
+            pyramid_request, application_instance
         )
 
         assert config == {
@@ -133,7 +127,7 @@ class TestFilePickerConfig:
         )
 
         config = FilePickerConfig.microsoft_onedrive(
-            sentinel.context, pyramid_request, application_instance
+            pyramid_request, application_instance
         )
 
         expected = {"enabled": enabled}
@@ -150,7 +144,7 @@ class TestFilePickerConfig:
         application_instance.settings.set("vitalsource", "enabled", enabled)
 
         config = FilePickerConfig.vital_source_config(
-            sentinel.context, pyramid_request, application_instance
+            pyramid_request, application_instance
         )
 
         assert config == {"enabled": enabled}
@@ -160,7 +154,7 @@ class TestFilePickerConfig:
         jstor_service.enabled = enabled
 
         config = FilePickerConfig.jstor_config(
-            sentinel.context, pyramid_request, sentinel.application_instance
+            pyramid_request, sentinel.application_instance
         )
 
         assert config == {"enabled": enabled}
@@ -168,7 +162,6 @@ class TestFilePickerConfig:
     @pytest.fixture
     @pytest.mark.usefixtures("with_is_canvas")
     def canvas_files_enabled(self, pyramid_request, application_instance):
-
         pyramid_request.params["custom_canvas_course_id"] = sentinel.course_id
         application_instance.developer_key = sentinel.developer_key
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -147,7 +147,7 @@ class TestGroupSetId:
 
     @pytest.fixture(autouse=True)
     def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = {
+        pyramid_request.lti_params = {
             "tool_consumer_instance_guid": "test_tool_consumer_instance_guid"
         }
         return pyramid_request
@@ -171,16 +171,6 @@ class TestGroupingType:
             group_set_id=group_set_id,
         ):
             assert lti_launch.grouping_type == expected
-
-
-class TestLTIParams:
-    def test_it_when_lti_jwt(self, lti_launch):
-        assert lti_launch.lti_params == mock.sentinel.lti_params
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.lti_params = mock.sentinel.lti_params
-        return pyramid_request
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -18,9 +18,7 @@ class TestHasDocumentURL:
 
         result = has_document_url(sentinel.context, pyramid_request)
 
-        document_url_service.get_document_url.assert_called_once_with(
-            sentinel.context, pyramid_request
-        )
+        document_url_service.get_document_url.assert_called_once_with(pyramid_request)
         assert result == bool(document_url)
 
 
@@ -112,13 +110,11 @@ class TestBasicLaunchViews:
         )
 
     def test_configured_launch(
-        self, svc, document_url_service, context, pyramid_request, _show_document
+        self, svc, document_url_service, pyramid_request, _show_document
     ):
         svc.configured_launch()
 
-        document_url_service.get_document_url.assert_called_once_with(
-            context, pyramid_request
-        )
+        document_url_service.get_document_url.assert_called_once_with(pyramid_request)
 
         _show_document.assert_called_once_with(
             document_url=document_url_service.get_document_url.return_value

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -344,7 +344,7 @@ class TestBasicLaunchViews:
         return pyramid_request
 
     @pytest.fixture
-    def context(self, pyramid_request):
+    def context(self):
         context = mock.create_autospec(LTILaunchResource, spec_set=True, instance=True)
         context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
         context.is_canvas = False

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -25,7 +25,7 @@ class TestDeepLinkingLaunch:
         deep_linking_launch(context, pyramid_request)
 
         context.application_instance.update_lms_data.assert_called_once_with(
-            context.lti_params
+            pyramid_request.lti_params
         )
         lti_h_service.sync.assert_called_once_with(
             [context.course], pyramid_request.params


### PR DESCRIPTION
The LTI launch context `lti_params` method was just a proxy for the request method of the same name:

```python
    @property
    def lti_params(self) -> LTIParams:
        """Return the requests LTI parameters."""
        return self._request.lti_params
```

This replaces all uses of `context.lti_params` and removes it. In some cases this also removes the need for the context object completely.