### PR TITLE
Use pyramid services as the initialisation mechanism

### DIFF
--- a/lms/product/__init__.py
+++ b/lms/product/__init__.py
@@ -5,6 +5,14 @@ from lms.product.product import Product
 
 
 def includeme(config):
+    # Register the default plugins
+    config.include("lms.product.plugin")
+
+    # Give everyone a chance to register their plugins etc.
+    config.include("lms.product.canvas")
+    config.include("lms.product.blackboard")
+
+    # Add the `request.product` method
     config.add_request_method(
         get_product_from_request, name="product", property=True, reify=True
     )

--- a/lms/product/blackboard/__init__.py
+++ b/lms/product/blackboard/__init__.py
@@ -1,1 +1,10 @@
+from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
 from lms.product.blackboard.product import Blackboard
+
+
+def includeme(config):  # pragma: nocover
+    """Register all of our plugins."""
+
+    config.register_service_factory(
+        BlackboardGroupingPlugin.factory, iface=BlackboardGroupingPlugin
+    )

--- a/lms/product/blackboard/_plugin/grouping.py
+++ b/lms/product/blackboard/_plugin/grouping.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 from lms.models import Grouping
+from lms.product.plugin.grouping_service import GroupError, GroupingServicePlugin
 from lms.services.exceptions import ExternalRequestError
-from lms.services.grouping.plugin import GroupError, GroupingServicePlugin
 
 
 class ErrorCodes(str, Enum):
@@ -18,10 +18,6 @@ class BlackboardGroupingPlugin(GroupingServicePlugin):
 
     group_type = Grouping.Type.BLACKBOARD_GROUP
     sections_type = None  # We don't support sections in Blackboard
-
-    @classmethod
-    def from_request(cls, request):
-        return cls(request.find_service(name="blackboard_api_client"))
 
     def __init__(self, blackboard_api):
         self._blackboard_api = blackboard_api
@@ -56,3 +52,7 @@ class BlackboardGroupingPlugin(GroupingServicePlugin):
             raise GroupError(ErrorCodes.GROUP_SET_EMPTY, group_set=group_set_id)
 
         return groups
+
+    @classmethod
+    def factory(cls, _context, request):
+        return cls(request.find_service(name="blackboard_api_client"))

--- a/lms/product/canvas/__init__.py
+++ b/lms/product/canvas/__init__.py
@@ -1,1 +1,10 @@
+from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
 from lms.product.canvas.product import Canvas
+
+
+def includeme(config):  # pragma: nocover
+    """Register all of our plugins."""
+
+    config.register_service_factory(
+        CanvasGroupingPlugin.factory, iface=CanvasGroupingPlugin
+    )

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 from lms.models import Grouping
+from lms.product.plugin.grouping_service import GroupError, GroupingServicePlugin
 from lms.services.exceptions import CanvasAPIError
-from lms.services.grouping.plugin import GroupError, GroupingServicePlugin
 
 
 class ErrorCodes(str, Enum):
@@ -18,10 +18,6 @@ class CanvasGroupingPlugin(GroupingServicePlugin):
 
     group_type = Grouping.Type.CANVAS_GROUP
     sections_type = Grouping.Type.CANVAS_SECTION
-
-    @classmethod
-    def from_request(cls, request):
-        return cls(request.find_service(name="canvas_api_client"))
 
     def __init__(self, canvas_api):
         self._canvas_api = canvas_api
@@ -84,3 +80,7 @@ class CanvasGroupingPlugin(GroupingServicePlugin):
 
     def _custom_course_id(self, course):
         return course.extra["canvas"]["custom_canvas_course_id"]
+
+    @classmethod
+    def factory(cls, _context, request):
+        return cls(request.find_service(name="canvas_api_client"))

--- a/lms/product/plugin/__init__.py
+++ b/lms/product/plugin/__init__.py
@@ -1,0 +1,8 @@
+from lms.product.plugin.grouping_service import GroupingServicePlugin
+from lms.product.plugin.plugin import PluginConfig, Plugins
+
+
+def includeme(config):  # pragma: nocover
+    """Register all of our plugins."""
+
+    config.register_service(GroupingServicePlugin(), iface=GroupingServicePlugin)

--- a/lms/product/plugin/grouping_service.py
+++ b/lms/product/plugin/grouping_service.py
@@ -62,10 +62,6 @@ class GroupingServicePlugin:  # pragma: nocover
 
         return None
 
-    @classmethod
-    def from_request(cls, request):
-        return cls()
-
 
 class GroupError(Exception):
     """Exceptions raised by plugins."""

--- a/lms/product/plugin/plugin.py
+++ b/lms/product/plugin/plugin.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+from lms.product.plugin.grouping_service import GroupingServicePlugin
+
+
+@dataclass
+class PluginConfig:
+    """A collection of plugin class definitions."""
+
+    # These also provide the default implementations
+    grouping_service: type = GroupingServicePlugin
+
+
+class Plugins:
+    """A collection of plugins used to separate LMS specific functionality."""
+
+    class _LazyPlugin:
+        # Lazy load plugins based on the plugin config from pyramid services
+        plugin_name = None
+
+        def __set_name__(self, owner, name):
+            self.plugin_name = name
+
+        def __get__(self, instance, owner):
+            plugin_class = getattr(instance._plugin_config, self.plugin_name)
+            plugin = instance._request.find_service(iface=plugin_class)
+            setattr(instance, self.plugin_name, plugin)  # Overwrite the attr
+            return plugin
+
+    grouping_service: GroupingServicePlugin = _LazyPlugin()
+
+    def __init__(self, request, plugin_config: PluginConfig):
+        self._request = request
+        self._plugin_config = plugin_config

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -1,9 +1,9 @@
 """Core models of the product."""
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from enum import Enum
 
-from lms.services.grouping.plugin import GroupingServicePlugin
+from lms.product.plugin import PluginConfig, Plugins
 
 
 class Family(str, Enum):
@@ -21,21 +21,6 @@ class Family(str, Enum):
     @classmethod
     def _missing_(cls, _value):
         return cls.UNKNOWN
-
-
-@dataclass
-class Plugins:
-    """A collection of plugins used to separate LMS specific functionality."""
-
-    grouping_service: GroupingServicePlugin
-
-
-@dataclass
-class PluginConfig:
-    """A collection of plugin class definitions."""
-
-    # These also provide the default implementations
-    grouping_service: type = GroupingServicePlugin
 
 
 @dataclass
@@ -65,9 +50,4 @@ class Product:
     def from_request(cls, request):
         """Create a populated product object from the provided request."""
 
-        plugins = {
-            name: plugin_class.from_request(request)
-            for name, plugin_class in asdict(cls.plugin_config).items()
-        }
-
-        return cls(plugin=Plugins(**plugins))
+        return cls(plugin=Plugins(request, cls.plugin_config))

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import aliased
 
 from lms.models import Course, Grouping, GroupingMembership, LTIUser, User
 from lms.models._hashed_id import hashed_id
-from lms.services.grouping.plugin import GroupingServicePlugin
+from lms.product.plugin.grouping_service import GroupingServicePlugin
 from lms.services.upsert import bulk_upsert
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from unittest import mock
 
 import httpretty
@@ -81,6 +82,14 @@ def lti_v13_params():
             "canvas_api_domain": "hypothesis.instructure.com",
         },
     }
+
+
+@pytest.fixture
+def with_plugins(pyramid_request, mock_service):
+    # Ensure that when plugins are read from the current product, all of its
+    # plugins are mocked and ready to be looked up
+    for plugin_class in asdict(pyramid_request.product.plugin_config).values():
+        mock_service(plugin_class)
 
 
 @pytest.fixture

--- a/tests/unit/lms/product/blackboard/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/grouping_test.py
@@ -4,8 +4,8 @@ import pytest
 
 from lms.models import Grouping
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin, ErrorCodes
+from lms.product.plugin.grouping_service import GroupError
 from lms.services.exceptions import ExternalRequestError
-from lms.services.grouping.plugin import GroupError
 from tests import factories
 
 
@@ -94,8 +94,8 @@ class TestBlackboardGroupingPlugin:
             )
         assert err.value.error_code == ErrorCodes.GROUP_SET_EMPTY
 
-    def test_from_request(self, pyramid_request, blackboard_api_client):
-        plugin = BlackboardGroupingPlugin.from_request(pyramid_request)
+    def test_factory(self, pyramid_request, blackboard_api_client):
+        plugin = BlackboardGroupingPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, BlackboardGroupingPlugin)
         # pylint: disable=protected-access
         assert plugin._blackboard_api == blackboard_api_client

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -3,8 +3,8 @@ from unittest.mock import sentinel
 import pytest
 
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin, ErrorCodes
+from lms.product.plugin.grouping_service import GroupError
 from lms.services import CanvasAPIError
-from lms.services.grouping.plugin import GroupError
 from tests import factories
 
 
@@ -126,8 +126,8 @@ class TestCanvasGroupingPlugin:
         )
         assert canvas_api_client.user_groups.return_value == api_groups
 
-    def test_from_request(self, pyramid_request, canvas_api_client):
-        plugin = CanvasGroupingPlugin.from_request(pyramid_request)
+    def test_factory(self, pyramid_request, canvas_api_client):
+        plugin = CanvasGroupingPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, CanvasGroupingPlugin)
         # pylint: disable=protected-access
         assert plugin._canvas_api == canvas_api_client

--- a/tests/unit/lms/product/plugin/test_plugin.py
+++ b/tests/unit/lms/product/plugin/test_plugin.py
@@ -1,0 +1,21 @@
+from dataclasses import asdict
+
+from h_matchers import Any
+
+from lms.product.plugin import PluginConfig, Plugins
+
+
+class TestPlugins:
+    def test_instantiation(self, pyramid_request, mock_service):
+        plugin_config = PluginConfig()
+        # We re-use pyramid services, so we can make use of our mock service
+        # fixture to register the services mentioned in the default
+        # `PluginConfig` object.
+        expected_attrs = {
+            plugin_name: mock_service(plugin_class)
+            for plugin_name, plugin_class in asdict(plugin_config).items()
+        }
+
+        plugins = Plugins(pyramid_request, plugin_config)
+
+        assert plugins == Any.instance_of(Plugins).with_attrs(expected_attrs)

--- a/tests/unit/lms/product/product_test.py
+++ b/tests/unit/lms/product/product_test.py
@@ -1,37 +1,18 @@
-from dataclasses import dataclass, fields
 from unittest.mock import sentinel
 
 import pytest
 
-from lms.product.product import PluginConfig, Product
-
-
-class FakePlugin:
-    request: None
-
-    @classmethod
-    def from_request(cls, request):
-        instance = cls()
-        instance.request = request
-        return instance
+from lms.product.product import Product
 
 
 class TestProduct:
-    def test_from_request(self, plugin_conf):
-        @dataclass
-        class MyProduct(Product):
-            plugin_config = plugin_conf
+    def test_from_request(self, Plugins):
+        product = Product.from_request(sentinel.request)
 
-        product = MyProduct.from_request(sentinel.request)
-
-        for field in fields(PluginConfig):
-            assert hasattr(product.plugin, field.name)
-            plugin = getattr(product.plugin, field.name)
-            assert isinstance(plugin, FakePlugin)
-            assert plugin.request == sentinel.request
+        assert isinstance(product, Product)
+        Plugins.assert_called_once_with(sentinel.request, Product.plugin_config)
+        assert product.plugin == Plugins.return_value
 
     @pytest.fixture
-    def plugin_conf(self):
-        return PluginConfig(
-            **{field.name: FakePlugin for field in fields(PluginConfig)}
-        )
+    def Plugins(self, patch):
+        return patch("lms.product.product.Plugins")

--- a/tests/unit/lms/services/grouping/factory_test.py
+++ b/tests/unit/lms/services/grouping/factory_test.py
@@ -5,7 +5,7 @@ import pytest
 from lms.services.grouping.factory import service_factory
 
 
-@pytest.mark.usefixtures("application_instance_service")
+@pytest.mark.usefixtures("application_instance_service", "with_plugins")
 class TestFactory:
     def test_it(self, pyramid_request, application_instance_service, GroupingService):
         svc = service_factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -5,8 +5,8 @@ import pytest
 from h_matchers import Any
 
 from lms.models import CanvasGroup, Course, Grouping, GroupingMembership
+from lms.product.plugin.grouping_service import GroupingServicePlugin
 from lms.services.grouping import GroupingService
-from lms.services.grouping.plugin import GroupingServicePlugin
 from tests import factories
 
 


### PR DESCRIPTION
I didn't want to go this way initially as I didn't want confusion between plugins and services. Here plugins are registered using the same mechanism as services but they aren't intended to be used stand alone like services, and are a different thing.

The plugins were starting to look quite service like, but attempting to solve up-coming problems was creating an awkward situation where we probably want access to the context sometimes. At that point the interface really is the same as services so :shrug: why not just embrace it?

### Let's just use pyramid services

This is a well understood mechanism. Which has some nice features:

* Naturally lazy loading and caching
* Plugins get full access to the request and context if required, meaning we should never have to pass it in to specific calls - as any plugin that needs it can keep it in the init.
* Plugins with no special requirements can be registered as global services and never re-created again

We are just putting a layer on top to get some features I think are useful:

* The plugin object has well defined fields and types
   * This allows very easy auto complete and documentation, making it hard to partially initialise one etc.
* Consuming a plugin is very easy and doesn't involve a service look up (that you are aware of)
* The configuration when specifying products is absolutely minimal with no duplication of defaults or instantiation
* The plugin object can easily be overriden by setting a value to anything you like, which is nice for testing (the default fixture setup might be a bit crap, but once that's done the usage should be ok).