### PR TITLE
Add envvars for controlling which files to check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ test: backend-tests frontend-tests
 # we need to run them with different Docker images, but `make test` runs both.
 .PHONY: backend-tests
 backend-tests: python
+	@bin/create-db lms_test
 	@tox -qe tests
 
 .PHONY: coverage
@@ -97,6 +98,7 @@ functests: build/manifest.json functests-only
 
 .PHONY: functests-only
 functests-only: python
+	@bin/create-db lms_functests
 	@tox -qe functests
 
 .PHONY: docker
@@ -140,6 +142,7 @@ frontend-lint: node_modules/.uptodate
 
 .PHONY: bddtests
 bddtests: python
+	@bin/create-db lms_bddtests
 	@tox -qe bddtests
 
 .PHONY: sure

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ requires =
 tox_pyenv_fallback = false
 
 [testenv]
-parallel_show_output = true
 skip_install = true
 passenv =
     HOME
@@ -85,26 +84,25 @@ setenv =
     bddtests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:5433/lms_bddtests}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
     VIA_SECRET = not_a_secret
-whitelist_externals =
-    tests,functests,bddtests: sh
+    SRC_FILES = {env:SRC_FILES:lms bin}
+    UNIT_TEST_FILES = {env:UNIT_TEST_FILES:tests/unit}
+    FUNC_TEST_FILES = {env:FUNC_TEST_FILES:tests/functional}
+    ALL_FILES = {env:SRC_FILES} {env:UNIT_TEST_FILES} {env:FUNC_TEST_FILES}
 commands =
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
-    tests: sh bin/create-db lms_test
-    functests: sh bin/create-db lms_functests
-    bddtests: sh bin/create-db lms_bddtests
-    tests: coverage run -m pytest -v {posargs:tests/unit/}
+    tests: coverage run -m pytest {posargs:{env:UNIT_TEST_FILES}}
     coverage: -coverage combine
-    coverage: coverage report
-    functests: pytest {posargs:tests/functional/}
+    coverage: coverage report {env:COVERAGE_FILES:}
+    functests: pytest {posargs:{env:FUNC_TEST_FILES}}
     bddtests: behave {posargs:tests/bdd/}
-    lint: pylint lms bin
-    lint: pylint --rcfile=tests/.pylintrc tests
-    lint: pydocstyle lms tests bin
-    lint: pycodestyle lms tests bin
-    format: black lms tests bin
-    format: isort --quiet --atomic lms tests bin
-    checkformatting: black --check lms tests bin
-    checkformatting: isort --quiet --check-only lms tests bin
+    lint: pylint {env:SRC_FILES}
+    lint: pylint --rcfile=tests/.pylintrc {env:UNIT_TEST_FILES} {env:FUNC_TEST_FILES}
+    lint: pydocstyle {env:ALL_FILES}
+    lint: pycodestyle {env:ALL_FILES}
+    format: black {posargs:{env:ALL_FILES}}
+    format: isort --quiet --atomic {posargs:{env:ALL_FILES}}
+    checkformatting: black --check {posargs:{env:ALL_FILES}}
+    checkformatting: isort --quiet --check-only {posargs:{env:ALL_FILES}}
     dockercompose: docker-compose {posargs}
 sitepackages = {env:SITE_PACKAGES:false}
 


### PR DESCRIPTION
Add envvars for controlling which files to format, lint and test. This perhaps complicates `tox.ini` a little but it's arguably an improvement because it removes some duplication from the `commands` section.

Also move the `bin/create-db` calls from `tox.ini` into `Makefile` to speed up `tox` commands.

The motivation for this is to enable an improvement to Test Pilot:

# Problem

* Test Pilot breaks if your Python dependencies are out of date, [requires you to run `testpilot --tox` to update them](https://github.com/hypothesis/testpilot#test-pilot-bypasses-tox). Users [aren't going to remember this](https://hypothes-is.slack.com/archives/C1MA4E9B9/p1656065738695799) and will get confused and ask "Why isn't Test Pilot working?" Also, it complicates Test Pilot usage and code to have tox and no-tox modes

* Test Pilot will break if the tests depend on anything (other than the commands themselves) that's defined in `tox.ini`. For example environment variables. For example https://github.com/hypothesis/lms/pull/4162 moves the `TEST_DATABASE_URL` out of the code and into `tox.ini` and this completely breaks Test Pilot.

  (We've never noticed this before because none of the tests in any of our apps have depended on any envvars set in `tox.ini`.)

* Test Pilot has to duplicate all the format, lint, test, functest and coverage commands from each project's `tox.ini`

# Solution

What about having Test Pilot always run everything through tox, which would be slower, but then speed things up again by running `tox --parallel`?

This requires Test Pilot to be able to run `tox --parallel -e format,lint,test,coverage,functests` while also telling tox only to format, lint and test a subset of the files, but _the subset is different for each environment_ (we format and lint all the files, test only the unit test files, report coverage for the source and unit test files, functest only the functests files).

This requires a small change to each project's `tox.ini` file to add envvars to let the caller separately control which files are passed to each of the format, lint, unit test and functest commands.

This will also require a corresponding change in Test Pilot to remove the `--tox` option and the code for running commands directly (without tox) and instead have it always run `tox --parallel` commands like this:

```bash
SRC_FILES="lms/assets.py lms/services/grant_token.py lms/views/onedrive.py" UNIT_TEST_FILES="tests/unit/lms/assets_test.py tests/unit/lms/services/grant_token_test.py tests/unit/lms/views/onedrive_test.py" COVERAGE_FILES="lms/assets.py lms/services/grant_token.py lms/views/onedrive.py tests/unit/lms/assets_test.py tests/unit/lms/services/grant_token_test.py tests/unit/lms/views/onedrive_test.py" FUNC_TEST_FILES="tests/functional/views/basic_lti_launch_test.py" tox --quiet --parallel -e checkformatting,lint,tests,functests,coverage
```

(You can actually test out that command on this branch right now to see what it would do.)

This is easier to use (don't have to remember to run `testpilot --tox` whenever any of the requirements might have changed) and more reliable (won't break if the requirements have changed or if one project's tests depend on an envvar or something else in its `tox.ini`) and it's also actually _faster_ than Test Pilot currently. On a test branch with 3 src files, 3 unit test files and one functest files modified this runs in under 7s on my machine whereas Test Pilot currently takes over 13s. The reason is that this runs everything in parallel whereas Test Pilot currently runs everything in serial.

This might actually be even faster if we re-configured our `tox.ini` files to enable greater parallelism. Currently Black and isort have to be run in serial since they both share the `format` env, similarly the two PyLint commands (for linting the source code and tests) and the pydocstyle and pycodestyle commands all share the `lint` env. These could all be run in parallel if each command use a separate env. On the other hand that'd mean more envs on disk. It's probably fine as it is.

The output is also shorter because `tox --parallel` by default only prints the output of an env if that env failed, otherwise it just prints a summary of what succeeded:

```
✔ OK checkformatting in 0.461 seconds
✔ OK tests in 2.506 seconds
✔ OK coverage in 0.404 seconds
✔ OK lint in 5.34 seconds
✔ OK functests in 6.355 seconds
______________________________________________________________________________________________ summary _______________________________________________________________________________________________
  checkformatting: commands succeeded
  lint: commands succeeded
  tests: commands succeeded
  functests: commands succeeded
  coverage: commands succeeded
  congratulations :)
```

(I do wish it could also skip that summary report in the case when all envs passed, it just duplicates what was just printed above it. Might be possible to write a tox plugin to do that?)