### PR TITLE
Fix route instantiation for Canvas and Blackboard

### DIFF
--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -1,15 +1,20 @@
+from dataclasses import dataclass
+
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
 
+@dataclass
 class Blackboard(Product):
     """A product for Blackboard specific settings and tweaks."""
 
-    family = Product.Family.BLACKBOARD
+    family: Product.Family = Product.Family.BLACKBOARD
 
-    route = Routes(
+    route: Routes = Routes(
         oauth2_authorize="blackboard_api.oauth.authorize",
         oauth2_refresh="blackboard_api.oauth.refresh",
     )
 
-    plugin_config = PluginConfig(grouping_service=BlackboardGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(
+        grouping_service=BlackboardGroupingPlugin
+    )

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -1,15 +1,18 @@
+from dataclasses import dataclass
+
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
 
+@dataclass
 class Canvas(Product):
     """A product for Canvas specific settings and tweaks."""
 
-    family = Product.Family.CANVAS
+    family: Product.Family = Product.Family.CANVAS
 
-    route = Routes(
+    route: Routes = Routes(
         oauth2_authorize="canvas_api.oauth.authorize",
         oauth2_refresh="canvas_api.oauth.refresh",
     )
 
-    plugin_config = PluginConfig(grouping_service=CanvasGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(grouping_service=CanvasGroupingPlugin)


### PR DESCRIPTION
For dataclasses class level variables will work as expected when accessing at a class level, but unless you declare them correctly, the dataclass generated init will ignore them and fill out the last correctly defined thing.

For safety it's best to fully declare them all.

To demonstrate this see:

```python
from dataclasses import dataclass


@dataclass
class Base:
    foo: str = None


@dataclass
class Both(Base):
    foo: str = "both"


@dataclass
class NoType(Base):
    foo = "no-type"


class NoDataClass(Base):
    foo: str = "no-data-class"


class Neither(Base):
    foo = "no-dataclass-no-type"


for class_ in (Both, NoType, NoDataClass, Neither):
    print(f"{class_.__name__}> cls={class_.foo}, instance={class_().foo}")
```

This results in:

```
Both> cls=both, instance=both
NoType> cls=no-type, instance=None
NoDataClass> cls=no-data-class, instance=None
Neither> cls=no-dataclass-no-type, instance=None
```