### PR TITLE
Accept assignment id instead of just assignment for `upsert_assignment_groupings`

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -20,11 +20,6 @@ class AssignmentService:
     def __init__(self, db: Session):
         self._db = db
 
-    def get_assignment_by_id(self, assignment_id) -> Assignment:
-        """Get an assignment by id."""
-
-        return self._db.query(Assignment).get(assignment_id)
-
     def get_assignment(self, tool_consumer_instance_guid, resource_link_id):
         """Get an assignment by resource_link_id."""
 
@@ -102,7 +97,7 @@ class AssignmentService:
         )
 
     def upsert_assignment_groupings(
-        self, assignment: Assignment, groupings: List[Grouping]
+        self, assignment_id, groupings: List[Grouping]
     ) -> List[AssignmentGrouping]:
         """Store details of any groups and courses an assignment is in."""
 
@@ -110,7 +105,7 @@ class AssignmentService:
         self._db.flush()
 
         values = [
-            {"assignment_id": assignment.id, "grouping_id": grouping.id}
+            {"assignment_id": assignment_id, "grouping_id": grouping.id}
             for grouping in groupings
         ]
 

--- a/lms/views/api/sync.py
+++ b/lms/views/api/sync.py
@@ -55,12 +55,8 @@ def sync(request):
     )
 
     # Store the relationship between the assignment and the groupings
-    assignment_service = request.find_service(name="assignment")
-    assignment_service.upsert_assignment_groupings(
-        assignment=assignment_service.get_assignment_by_id(
-            request.parsed_params["assignment_id"]
-        ),
-        groupings=groupings,
+    request.find_service(name="assignment").upsert_assignment_groupings(
+        assignment_id=request.parsed_params["assignment_id"], groupings=groupings
     )
 
     authority = request.registry.settings["h_authority"]

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -186,7 +186,7 @@ class BasicLaunchViews:
         )
         # Store the relationship between the assignment and the course
         self.assignment_service.upsert_assignment_groupings(
-            assignment=assignment, groupings=[self.context.course]
+            assignment_id=assignment.id, groupings=[self.context.course]
         )
 
         return assignment

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -10,15 +10,6 @@ from tests import factories
 
 
 class TestAssignmentService:
-    def test_get_assignment_by_id(self, svc, db_session, assignment):
-        db_session.add(assignment)
-        db_session.flush()
-
-        assert svc.get_assignment_by_id(assignment.id) == assignment
-
-    def test_get_assignment_by_id_without_match(self, svc):
-        assert not svc.get_assignment_by_id(123456789)
-
     def test_get_assignment(self, svc, assignment, matching_params):
         assert svc.get_assignment(**matching_params) == assignment
 
@@ -96,14 +87,15 @@ class TestAssignmentService:
             ).only()
         )
 
-    def test_upsert_assignment_grouping(self, svc, assignment):
+    def test_upsert_assignment_grouping(self, svc, assignment, db_session):
         groupings = factories.CanvasGroup.create_batch(3)
         # One existing row
         factories.AssignmentGrouping.create(
             assignment=assignment, grouping=groupings[0]
         )
+        db_session.flush()
 
-        refs = svc.upsert_assignment_groupings(assignment, groupings)
+        refs = svc.upsert_assignment_groupings(assignment.id, groupings)
 
         assert refs == Any.list.containing(
             [

--- a/tests/unit/lms/views/api/sync_test.py
+++ b/tests/unit/lms/views/api/sync_test.py
@@ -39,11 +39,8 @@ class TestSync:
         lti_h_service.sync.assert_called_once_with(
             grouping_method.return_value, sentinel.group_info
         )
-        assignment_service.get_assignment_by_id.assert_called_once_with(
-            sentinel.assignment_id
-        )
         assignment_service.upsert_assignment_groupings(
-            assignment=assignment_service.get_assignment_by_id.return_value,
+            assignment_id=sentinel.assignment_id,
             groupings=grouping_method.return_value,
         )
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -209,7 +209,7 @@ class TestBasicLaunchViews:
             lti_roles=lti_role_service.get_roles.return_value,
         )
         assignment_service.upsert_assignment_groupings.assert_called_once_with(
-            assignment=assignment, groupings=[context.course]
+            assignment_id=assignment.id, groupings=[context.course]
         )
 
         context.js_config.enable_lti_launch_mode.assert_called_once_with(assignment)


### PR DESCRIPTION
This allows us to skip looking up the assignment by id, only to then read the id from it.

This doesn't change other methods which could do the same thing.

Follow up to:

 * https://github.com/hypothesis/lms/pull/4158