### PR TITLE
Remove unused columns

### DIFF
--- a/lms/migrations/versions/a9990b0efb3f_remove_consumer_key.py
+++ b/lms/migrations/versions/a9990b0efb3f_remove_consumer_key.py
@@ -1,0 +1,35 @@
+"""
+Remove unused consumer_key columns.
+
+Revision ID: a9990b0efb3f
+Revises: 1e146996cca6
+Create Date: 2022-07-11 12:28:13.684023
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a9990b0efb3f"
+down_revision = "1e146996cca6"
+
+
+def upgrade():
+    op.drop_column("group_info", "consumer_key")
+    op.drop_column("lis_result_sourcedid", "oauth_consumer_key")
+    op.drop_column("oauth2_token", "consumer_key")
+
+
+def downgrade():
+    op.add_column(
+        "oauth2_token",
+        sa.Column("consumer_key", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "lis_result_sourcedid",
+        sa.Column("oauth_consumer_key", sa.TEXT(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "group_info",
+        sa.Column("consumer_key", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )

--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -47,7 +47,6 @@ class GradingInfo(CreatedUpdatedMixin, BASE):
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
     lis_result_sourcedid = sa.Column(sa.UnicodeText(), nullable=False)
     lis_outcome_service_url = sa.Column(sa.UnicodeText(), nullable=False)
-    oauth_consumer_key = sa.Column(sa.UnicodeText(), nullable=True)
 
     #: The ApplicationInstance FK that this grading info belongs to
     application_instance_id = sa.Column(

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -32,10 +32,6 @@ class GroupInfo(BASE):
     #: DB.
     authority_provided_id = sa.Column(sa.UnicodeText(), nullable=False, unique=True)
 
-    #: The LTI consumer_key (oauth_consumer_key) of the application instance
-    #: that this access token belongs to.
-    consumer_key = sa.Column(sa.Unicode(), nullable=True)
-
     #: The ApplicationInstance that this group belongs to foreign key
     application_instance_id = sa.Column(
         sa.Integer(),

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -25,10 +25,6 @@ class OAuth2Token(BASE):
     #: The LTI user_id of the LMS user who this access token belongs to.
     user_id = sa.Column(sa.UnicodeText(), nullable=False)
 
-    #: The LTI consumer_key (oauth_consumer_key) of the application instance
-    #: that this access token belongs to.
-    consumer_key = sa.Column(sa.Unicode(), nullable=True)
-
     #: The ApplicationInstance that this token belongs to foreign key
     application_instance_id = sa.Column(
         sa.Integer(),


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/3923


After the relationship with application_instance was added back we can now remove the leftover columns.


For group_info we added code in the loading part of anaylics that would regenerate this column: https://github.com/hypothesis/analytics/blob/main/refresh/load.sh#L46