### PR TITLE
Adapt to new JSTOR metadata API schema

### DIFF
--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -16,7 +16,7 @@ class JSTORMetadataSchema(RequestsResponseSchema):
     """
     Response schema for `/metadata/{doi}` endpoint in the JSTOR API.
 
-    See https://hypothes-is.slack.com/archives/C02T75RKBTK/p1655930468948019.
+    See https://labs.jstor.org/api/anno/docs
     """
 
     title = fields.Str()

--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -1,10 +1,9 @@
 from datetime import timedelta
 from html.parser import HTMLParser
-from typing import Optional
 from urllib.parse import quote
 
 import requests
-from marshmallow import EXCLUDE, Schema, fields
+from marshmallow import fields
 
 from lms.services.exceptions import ExternalRequestError
 from lms.services.http import HTTPService
@@ -17,28 +16,14 @@ class JSTORMetadataSchema(RequestsResponseSchema):
     """
     Response schema for `/metadata/{doi}` endpoint in the JSTOR API.
 
-    The schema varies according to the type of item and whether it is
-    "Academic content" or "Primary source content" (see JSTOR search results
-    page).
+    See https://hypothes-is.slack.com/archives/C02T75RKBTK/p1655930468948019.
     """
 
-    # Fields for Journal articles, book chapters and research reports
-    title = fields.List(fields.Str())
-    subtitle = fields.List(fields.Str())
+    title = fields.Str()
+    subtitle = fields.Str()
 
-    # Fields for collections (books, multi-part research reports)
-    # These may be present but set to `null` for other types of article.
-    tb = fields.Str(allow_none=True)
-    tbsub = fields.Str(allow_none=True)
-
-    # Fields for articles which are reviews of other works.
-    class ReviewedWorks(Schema):
-        title = fields.Str()
-
-    reviewed_works = fields.List(fields.Nested(ReviewedWorks, unknown=EXCLUDE))
-
-    # Fields for Primary source content
-    item_title = fields.Str()
+    # List of titles of works that this item is a review of.
+    reviewed_works = fields.List(fields.Str())
 
 
 class JSTORService:
@@ -107,7 +92,7 @@ class JSTORService:
         :param article_id: A JSTOR article ID or DOI
         """
 
-        response = self._api_request("/metadata/{doi}", doi=article_id)
+        response = self._api_request("/metadata-new/{doi}", doi=article_id)
         metadata = JSTORMetadataSchema(response).parse()
 
         return {"title": self._get_title_from_metadata(metadata)}
@@ -168,38 +153,26 @@ class JSTORService:
         )
 
     @classmethod
-    def _get_title_from_metadata(cls, metadata: dict) -> Optional[str]:
-        subtitle = None
+    def _get_title_from_metadata(cls, metadata: dict) -> str:
+        # Reviews of other works may not have a title of their own, but we can
+        # generate one from the reviewed work's metadata.
+        if reviewed_works := metadata.get("reviewed_works"):
+            title = f"Review: {reviewed_works[0]}"
 
         # Journal articles, book chapters and research reports have a title
         # field with a single entry.
-        if titles := metadata.get("title"):
-            title = titles[0]
+        elif title := metadata.get("title"):
 
             # Some articles have a subtitle which needs to be appended for the
             # title to make sense.
-            if subtitles := metadata.get("subtitle"):
-                subtitle = subtitles[0]
+            if subtitle := metadata.get("subtitle"):
+                # Some titles include a delimiter, some do not.
+                if title.endswith(":"):
+                    title = title[:-1]
+                title = f"{title}: {subtitle}"
 
-        # Collections (eg. books, multi-part research reports) have their title
-        # in a separate field.
-        elif collection_title := metadata.get("tb"):
-            title = collection_title
-            subtitle = metadata.get("tbsub")
-
-        # Reviews of other works may not have a title of their own, but we can
-        # generate one from the reviewed work's metadata.
-        elif reviewed_works := metadata.get("reviewed_works"):
-            title = f'Review: {reviewed_works[0]["title"]}'
-
-        # "Primary source" items use a different field.
-        elif item_title := metadata.get("item_title"):
-            title = item_title
         else:
-            return None
-
-        if subtitle:
-            title = f"{title} {subtitle}"
+            title = "[Unknown title]"
 
         # Some titles contain HTML formatting tags, new lines or unwanted
         # extra spaces. Strip these to simplify downstream processing.

--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -166,10 +166,8 @@ class JSTORService:
             # Some articles have a subtitle which needs to be appended for the
             # title to make sense.
             if subtitle := metadata.get("subtitle"):
-                # Some titles include a delimiter, some do not.
-                if title.endswith(":"):
-                    title = title[:-1]
-                title = f"{title}: {subtitle}"
+                # Some titles include a trailing ':' delimiter, some do not.
+                title = f"{title.rstrip(':')}: {subtitle}"
 
         else:
             title = "[Unknown title]"


### PR DESCRIPTION
Adapt to the new JSTOR metadata API schema, as described in https://hypothes-is.slack.com/archives/C02T75RKBTK/p1655930468948019 and in the OpenAPI docs at https://labs.jstor.org/api/anno/docs#/default/get_metadata_new_metadata_new__doi__get.

 - Expect "title" and "subtitle" fields to be strings rather than
   single-item lists
 - Expect "reviewed_works" field to be an array of titles rather than
   items
 - Expect the "title" and "subtitle" fields to be used for more item
   types, reducing the need for us to check different fields depending
   on the item type.

The new API has been temporarily exposed under the `/metadata-new`
endpoint. It will be exposed under the original `/metadata` endpoint in
future.

A set of test cases have been collated from existing issues into a list at
https://gist.github.com/robertknight/a2b045b717d6c7dda18879df91c16e90.
Some of these could not be tested because the API server is returning
5xx responses. I assume these responses will be similar to the items
that do work.

**Testing:**

Try entering the article IDs from the list of test cases, you should see a sensible title displayed. If there is a thumbnail (not always available), and the title is clearly visible in it, the two should match.

* Research article: `10.2307/26202019`
* Primary source image: `10.2307/community.22669911`
* Item with subtitle: `10.3138/j.ctt1whm96v.10` (see https://github.com/hypothesis/lms/issues/4088). 
   * Displayed title should be `{title}: {subtitle}`
* Item with HTML tags in title: `10.1525/as.2003.43.3.423` (see https://github.com/hypothesis/lms/issues/4087). 
   * Displayed title should not include HTML tags.
* Review of another work: `10.2307/331473` (see https://github.com/hypothesis/lms/issues/4049). 
   * Displayed title should be Review: {title of original work}

In the case of book chapters, you will see the chapter title rather than the book title. These chapter titles can sometimes be somewhat generic ("Intro", "Appendix"). We might want to include some details from the containing book in this case. That's outside the scope of this PR.

* Book chapter: `10.7249/mg876rc.10`
* Book: `10.7249/mg876rc`
* Primary source book: `10.2307/community.30528851`