### PR TITLE
Ignore leading and trailing space in JSTOR input field

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/jstor.js
+++ b/lms/static/scripts/frontend_apps/utils/jstor.js
@@ -27,6 +27,8 @@ function isDOI(value) {
  * @returns {string|null}
  */
 export function articleIdFromUserInput(value) {
+  value = value.trim();
+
   // Plain JSTOR article ID
   if (/^[0-9a-z.]+$/.test(value)) {
     return value;

--- a/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
@@ -21,6 +21,12 @@ describe('utils/jstor', () => {
       ['https://www.jstor.org/stable/1234/', '1234'],
       ['https://www.jstor.org/stable/1234//', '1234'],
 
+      // Leading and trailing whitespace ignored
+      ['10.2307/1234  ', '10.2307/1234'],
+      ['  10.2307/1234  ', '10.2307/1234'],
+      [' https://www.jstor.org/stable/1234 ', '1234'],
+      [' 1234  ', '1234'],
+
       // http protocol OK
       ['http://www.jstor.org/stable/1234', '1234'],
 


### PR DESCRIPTION
This avoids an error if the article ID was copied and pasted from a selection
that had some extra spaces.