### PR TITLE
Add a gateway end-point which provides H API connection details

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -29,6 +29,15 @@ def includeme(config):  # pylint:disable=too-many-statements
 
     config.add_route("api.assignments.create", "/api/assignment", request_method="POST")
 
+    # The gateway end-point is a bit of an oddball as it uses LTI launch as the
+    # authentication method, and so requires the LTILaunch resource
+    config.add_route(
+        "api.gateway.h.lti",
+        "/api/gateway/h/lti",
+        request_method="POST",
+        factory="lms.resources.LTILaunchResource",
+    )
+
     config.add_route(
         "blackboard_api.oauth.authorize",
         "/api/blackboard/oauth/authorize",

--- a/lms/views/api/gateway.py
+++ b/lms/views/api/gateway.py
@@ -1,0 +1,48 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+
+
+@view_config(
+    request_method="POST",
+    permission=Permissions.API,
+    renderer="json",
+    route_name="api.gateway.h.lti"
+)
+def h_lti(request):
+    """
+    Provide tokens and information to allow customers to query H.
+
+    We expect the user to authenticate with us using an LTI launch.
+    """
+
+    # Add API end-point details
+    h_api_url = request.registry.settings["h_api_url_public"]
+    return {
+        "h_api": {
+            # These sections are arranged so you can use
+            # `requests.Request.request(**data)` and make the correct request
+            "list_endpoints": {
+                # List the API end-points
+                "method": "GET",
+                "url": h_api_url,
+                "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
+            },
+            "exchange_grant_token": {
+                # Exchange our token for access and refresh tokens
+                "method": "POST",
+                "url": h_api_url + "token",
+                "headers": {
+                    "Accept": "application/vnd.hypothesis.v2+json",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                "data": {
+                    # Generate a short-lived login token for the Hypothesis client
+                    "assertion": request.find_service(
+                        name="grant_token"
+                    ).generate_token(request.lti_user.h_user),
+                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                },
+            },
+        }
+    }

--- a/tests/functional/api/gateway_test.py
+++ b/tests/functional/api/gateway_test.py
@@ -1,0 +1,78 @@
+from functools import partial
+
+import pytest
+from h_matchers import Any
+
+# pylint: disable=wildcard-import,unused-wildcard-import
+from tests.functional.oauth1 import *
+
+
+class TestGatewayHLTI:
+    def test_minimum_viable_login(self, gateway_launch, required_params):
+        response = gateway_launch(required_params)
+
+        assert response.headers["Content-Type"] == "application/json"
+        assert response.json == {
+            "h_api": {
+                "list_endpoints": {
+                    "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
+                    "method": "GET",
+                    "url": "https://example.com/api/",
+                },
+                "exchange_grant_token": {
+                    "data": {
+                        "assertion": Any.string(),
+                        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    },
+                    "headers": {
+                        "Accept": "application/vnd.hypothesis.v2+json",
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                    "method": "POST",
+                    "url": "https://example.com/api/token",
+                },
+            }
+        }
+
+    @pytest.mark.parametrize(
+        "param,status",
+        (
+            # Required for auth
+            ("tool_consumer_instance_guid", 403),
+            ("user_id", 403),
+            ("roles", 403),
+        ),
+    )
+    def test_each_param_is_required(
+        self, gateway_launch, required_params, param, status
+    ):
+        required_params.pop(param)
+
+        gateway_launch(required_params, status=status)
+
+    @pytest.mark.parametrize("auth_field", ("consumer_key", "shared_secret"))
+    def test_signature_must_be_valid(
+        self, gateway_launch, required_params, oauth1_credentials, auth_field
+    ):
+        oauth1_credentials[auth_field] = "WRONG"
+
+        gateway_launch(required_params, status=403)
+
+    @pytest.fixture
+    def required_params(self, application_instance):
+        return {
+            "tool_consumer_instance_guid": application_instance.tool_consumer_instance_guid,
+            "user_id": "123",
+            "roles": "Instructor",
+            "context_id": "321",
+            "lti_version": "LTI-1p0",
+            "lti_message_type": "basic-lti-launch-request",
+        }
+
+    @pytest.fixture
+    def gateway_launch(self, do_lti_launch):
+        return partial(
+            do_lti_launch,
+            "http://localhost/api/gateway/h/lti",
+            headers={"Accept": "application/json"},
+        )

--- a/tests/functional/api/gateway_test.py
+++ b/tests/functional/api/gateway_test.py
@@ -41,6 +41,12 @@ class TestGatewayHLTI:
             ("tool_consumer_instance_guid", 403),
             ("user_id", 403),
             ("roles", 403),
+            # Required for us to work
+            ("context_id", 422),
+            # Us being picky, but useful for checking it's a well-formed
+            # LTI launch
+            ("lti_version", 422),
+            ("lti_message_type", 422),
         ),
     )
     def test_each_param_is_required(

--- a/tests/functional/api/gateway_test.py
+++ b/tests/functional/api/gateway_test.py
@@ -56,6 +56,11 @@ class TestGatewayHLTI:
 
         gateway_launch(required_params, status=status)
 
+    def test_guid_must_match(self, gateway_launch, required_params):
+        required_params["tool_consumer_instance_guid"] = "NOT MATCHING"
+
+        gateway_launch(required_params, status=403)
+
     @pytest.mark.parametrize("auth_field", ("consumer_key", "shared_secret"))
     def test_signature_must_be_valid(
         self, gateway_launch, required_params, oauth1_credentials, auth_field

--- a/tests/functional/oauth1.py
+++ b/tests/functional/oauth1.py
@@ -1,0 +1,82 @@
+"""A collection of fixtures for making signed launches."""
+
+import random
+import time
+
+import oauthlib.common
+import oauthlib.oauth1
+import pytest
+
+from tests import factories
+
+__all__ = (
+    "do_lti_launch",
+    "oauth1_credentials",
+    "application_instance",
+    "oauth1_sign_data",
+)
+
+
+@pytest.fixture
+def do_lti_launch(app, oauth1_sign_data):
+    def do_lti_launch(url, form_data, sign=True, headers=None, **kwargs):
+        if not headers:
+            headers = {}
+
+        if sign:
+            form_data = oauth1_sign_data(url, form_data)
+
+        return app.post(
+            url,
+            params=form_data,
+            headers=dict(
+                {
+                    "Accept": "text/html",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                **headers,
+            ),
+            **kwargs,
+        )
+
+    return do_lti_launch
+
+
+@pytest.fixture
+def oauth1_credentials(application_instance):
+    return {
+        "consumer_key": application_instance.consumer_key,
+        "shared_secret": application_instance.shared_secret,
+    }
+
+
+@pytest.fixture
+def application_instance(db_session):  # pylint:disable=unused-argument
+    return factories.ApplicationInstance(tool_consumer_instance_guid="GUID")
+
+
+@pytest.fixture
+def oauth1_sign_data(oauth1_credentials):
+    def oauth1_sign_data(url, data):
+        oauth_client = oauthlib.oauth1.Client(
+            oauth1_credentials["consumer_key"], oauth1_credentials["shared_secret"]
+        )
+
+        data.update(
+            {
+                "oauth_consumer_key": oauth1_credentials["consumer_key"],
+                "oauth_callback": "about:blank",
+                "oauth_nonce": "".join(random.choices("0123456789abcdef", k=64)),
+                "oauth_signature_method": "HMAC-SHA1",
+                "oauth_timestamp": str(int(time.time())),
+                "oauth_version": "1.0",
+            }
+        )
+
+        data["oauth_signature"] = oauth_client.get_oauth_signature(
+            oauthlib.common.Request(url, "POST", body=data)
+        )
+
+        return data
+
+    return oauth1_sign_data

--- a/tests/unit/lms/views/api/gateway_test.py
+++ b/tests/unit/lms/views/api/gateway_test.py
@@ -1,0 +1,41 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.views.api.gateway import h_lti
+
+
+@pytest.mark.usefixtures("grant_token_service")
+class TestHLTI:
+    def test_it_adds_h_api_details(self, pyramid_request, grant_token_service):
+        response = h_lti(pyramid_request)
+
+        grant_token_service.generate_token.assert_called_once_with(
+            pyramid_request.lti_user.h_user
+        )
+        h_api_url = pyramid_request.registry.settings["h_api_url_public"]
+        assert response["h_api"] == {
+            "list_endpoints": {
+                "method": "GET",
+                "url": h_api_url,
+                "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
+            },
+            "exchange_grant_token": {
+                "method": "POST",
+                "url": h_api_url + "token",
+                "headers": {
+                    "Accept": "application/vnd.hypothesis.v2+json",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                "data": {
+                    "assertion": grant_token_service.generate_token.return_value,
+                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                },
+            },
+        }
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.lti_params["tool_consumer_instance_guid"] = sentinel.guid
+
+        return pyramid_request


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4197

This adds a version of the gateway end-point which only provides information sufficient for connecting to H.

This version enforces that the GUID provided matches the credentials we expect for the application instance. I think this really should happen in our security layer but due to the way we try policies in order this might be a little tricky.

### Testing notes

 * Check out and try the tools in: https://github.com/hypothesis/lms/pull/4224