### PR TITLE
Add documentation and tools for using Gateway return values

### DIFF
--- a/bin/gateway/config/gateway_qa_example.json
+++ b/bin/gateway/config/gateway_qa_example.json
@@ -4,7 +4,7 @@
         "shared_secret": "__SHARED_SECRET__"
     },
     "request": {
-        "url": "https://qa.hypothes.is/lti_launches",
+        "url": "https://qa.hypothes.is/api/gateway/h/lti",
         "headers": {
             "Accept": "application/vnd.hypothesis.v2+json",
             "Content-Type": "application/x-www-form-urlencoded"
@@ -13,7 +13,6 @@
             "tool_consumer_instance_guid": "GUID",
 
             "context_id": "__COURSE_ID__",
-            "context_title": "Course name",
             "resource_link_id": "__ASSIGNMENT_ID__",
 
             "user_id":  "__USER_ID__",

--- a/bin/gateway/config/h_calls_dev.json
+++ b/bin/gateway/config/h_calls_dev.json
@@ -1,0 +1,11 @@
+{
+    "h_api": {
+        "profile": {
+            "method": "GET",
+            "url": "http://localhost:5000/api/profile",
+            "headers": {
+                "Accept": "application/vnd.hypothesis.v2+json"
+            }
+        }
+    }
+}

--- a/bin/gateway/config/h_calls_prod.json
+++ b/bin/gateway/config/h_calls_prod.json
@@ -1,0 +1,11 @@
+{
+    "h_api": {
+        "profile": {
+            "method": "GET",
+            "url": "https://hypothes.is/api/profile",
+            "headers": {
+                "Accept": "application/vnd.hypothesis.v2+json"
+            }
+        }
+    }
+}

--- a/bin/gateway/config/h_calls_qa.json
+++ b/bin/gateway/config/h_calls_qa.json
@@ -1,0 +1,11 @@
+{
+    "h_api": {
+        "profile": {
+            "method": "GET",
+            "url": "https://qa.hypothes.is/api/profile",
+            "headers": {
+                "Accept": "application/vnd.hypothesis.v2+json"
+            }
+        }
+    }
+}

--- a/bin/gateway/h_call.py
+++ b/bin/gateway/h_call.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+"""
+Read Gateway format JSON and make calls to H.
+
+See `docs/gateway/03_testing_tools.md` for more details.
+"""
+
+import json
+import sys
+from argparse import ArgumentParser
+
+from requests import Session
+
+parser = ArgumentParser()
+parser.add_argument("--spec", "-s", help="Load call definitions from JSON file")
+parser.add_argument(
+    "--stdin", "-i", action="store_const", const=True, help="Load from STDIN"
+)
+parser.add_argument("--call", "-c", help="The end-point to call")
+parser.add_argument(
+    "--authenticate",
+    "-a",
+    action="store_const",
+    const=True,
+    help="Authenticate with a bearer token using `exchange_grant_token` before"
+    " making the call",
+)
+
+
+def dump_response(response):
+    # Print to stderr, so you can the pipe main output to a file easily
+    print("Response:", response, file=sys.stderr)
+    print("Headers:", response.headers, file=sys.stderr)
+
+    if "json" in response.headers["Content-Type"]:
+        print(json.dumps(response.json(), indent=4))
+    else:
+        print(response.text)
+
+    response.raise_for_status()
+
+
+def main(args):
+    h_end_points = {}
+
+    # Read the spec file from the usual location if piped in from
+    # `oauth_call.py`
+    if args.stdin:
+        h_end_points.update(json.load(sys.stdin)["h_api"])
+
+    # Also read from a JSON file for a manually curated set of calls
+    if args.spec:
+        with open(args.spec, encoding="utf-8") as handle:
+            h_end_points.update(json.load(handle)["h_api"])
+
+    if not h_end_points:
+        raise ValueError("No config loaded!")
+
+    session = Session()
+
+    if args.authenticate:
+        # Perform `exchange_grant_token` with `h` to get access tokens
+
+        response = session.request(**h_end_points["exchange_grant_token"])
+        response.raise_for_status()
+        access_token = response.json()["access_token"]
+        session.headers.update({"Authorization": f"Bearer {access_token}"})
+
+    if args.call:
+        # Run a named call
+        response = session.request(**h_end_points[args.call])
+        dump_response(response)
+
+    else:
+        # List all the commands we know about from the loaded specs
+        print("Available end-points:")
+        for key in h_end_points:
+            print(f"\t * {key}")
+
+
+if __name__ == "__main__":
+    main(parser.parse_args())

--- a/bin/gateway/oauth_call.py
+++ b/bin/gateway/oauth_call.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
-"""Call an LTI style OAuth1 end-point using a JSON definition file."""
+"""
+Call an LTI style OAuth1 end-point using a JSON definition file.
+
+See `docs/gateway/03_testing_tools.md` for more details.
+"""
 
 import json
 import random

--- a/docs/gateway/01_overview.md
+++ b/docs/gateway/01_overview.md
@@ -1,10 +1,5 @@
 # LMS Gateway
 
-_See also:_
-
- * [Hypothesis API Specfication](https://h.readthedocs.io/en/latest/api-reference/) - 
- * [Gateway API Specification](02_api_spec.md) - Details of the Gateway end-points used to gain access
- * [Testing tools](03_testing_tools.md) - Testing tools and reference implementation
 
 ## Overview
 
@@ -38,97 +33,19 @@ You should then have everything you need to make any calls to the `h` API **as
 the user you passed to us**. This means you will see what they can see, and can
 act on behalf of that user.
 
-## Authentication
-
-Authentication happens in two steps:
-
- * In the first step you will perform the signed OAuth1 request to the Gateway
- * In the second step you will use tokens to authenticate with the `h` API
-
-### Getting started
+## Getting started
 
 The Gateway is only available to certain partners. If you are interested in 
 using the Gateway, please contact [Hypothesis support](https://web.hypothes.is/help/)
 who can discuss your use case, and enable it for you.
 
-In order to authenticate with the Gateway you will need:
+We also provide a set of [testing tools](04_testing_tools.md) which should 
+allow you to experiment with the API without having to write any code. A Python
+environment and some setup is required to use these tools.
 
- * The tool consumer instance GUID of the LMS instance
- * The client key created when Hypothesis was installed
- * The shared secret created when Hypothesis was installed
+## See also
 
-If you do not know any of these values you can work with 
-[Hypothesis support](https://web.hypothes.is/help/) to get the correct values.
-
-### Calling the Gateway
-
-_Note: [See the `oauth_call.py` tool](03_testing_tools.md) for a demonstration 
-this process._
-
-You will need to make an OAuth1 signed post request. This involves adding 
-certain extra OAuth specific fields to the form data, cryptographically signing
-those parameters with the client secret and then making a conventional POST
-request to the [Gateway end-point](02_api_spec.md).
-
-The process is described in the [LTI 1.1 Implementation Guide](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-4)
-
-We also provide some [testing tools / reference implementation](03_testing_tools.md)
-in Python. These tools are intended to get you started quickly after which you 
-can adapt the implementation.
-
-**Note:** There is a terminology difference  between OAuth1 and the LTI spec:
-
-| This document     | LTI                     | OAuth1          | 
-|-------------------|-------------------------|-----------------|
-| `consumer_key`    | `oauth_consumer_key`    | `client_key`    |
-| `consumer_secret` | `oauth_consumer_secret` | `client_secret` |
-
-### Swapping the grant token for an access token
-
-_Note: [See the `h_call.py` tool](03_testing_tools.md) for a demonstration 
-this process._
-
-If you successfully call the Gateway end-point then the response you receive
-will include a section called `h_api` which will list a number of pre-prepared
-requests you can make.
-
-One of these requests is called `grant_token_exchange` and provies the call you
-need to make to get access tokens for the `h` API.
-
-These are formatted so you can pass them directly to Python's 
-[`requests` library](https://requests.readthedocs.io/en/latest/), (but the same
-details can be used with any HTTP library). For example:
-
-```python
-from requests import Session
- 
-gateway_response = ...  # The response data from the Gateway end-point 
-response = Session().request(**gateway_response['h_api']['grant_token_exchange'])
-print(response.json())
-```
-This will return you a set of OAuth2 credentials you can use with the `h` API.
-
-```json
-{
-    "access_token": "5218-fV8jIXVx3aprt-PyL3H456456456645AcJGbWiJJs",
-    "expires_in": 3600.0,
-    "token_type": "Bearer",
-    "refresh_token": "4344-k2RMSX234534563478YBBMDHj4UYk8nsBvKP4"
-}
-```
-
-### Using the OAuth 2 access
-
-You can then use the access token in future requests to the `h` API by 
-including a header like this (using the value you received):
-
-```
-Authorization: Bearer 5218-fV8jIXVx3aprt-PyL3H456456456645AcJGbWiJJs
-```
-
-You can also perform OAuth2 token refreshes to keep access tokens alive, and 
-prevent you from having to perform this step each time.
-
-By combining this token, URL and header details provided and the 
-[Hypothesis API Specification](https://h.readthedocs.io/en/latest/api-reference/) 
-you should be able to make any calls you need to the `h` API.
+ * [Hypothesis API Specification](https://h.readthedocs.io/en/latest/api-reference/) - Details of the main `h` API
+ * [Gateway API Specification](02_api_spec.md) - Details of the Gateway end-points used to gain access to the `h` API
+ * [Authentication](03_authentication.md) - How to authenticate with the Gateway and `h` API
+ * [Testing tools](04_testing_tools.md) - Testing tools and reference implementation

--- a/docs/gateway/01_overview.md
+++ b/docs/gateway/01_overview.md
@@ -2,7 +2,8 @@
 
 _See also:_
 
- * [API Specification](02_api_spec.md) - Details of the end-points
+ * [Hypothesis API Specfication](https://h.readthedocs.io/en/latest/api-reference/) - 
+ * [Gateway API Specification](02_api_spec.md) - Details of the Gateway end-points used to gain access
  * [Testing tools](03_testing_tools.md) - Testing tools and reference implementation
 
 ## Overview
@@ -59,7 +60,10 @@ In order to authenticate with the Gateway you will need:
 If you do not know any of these values you can work with 
 [Hypothesis support](https://web.hypothes.is/help/) to get the correct values.
 
-### Calling the gateway
+### Calling the Gateway
+
+_Note: [See the `oauth_call.py` tool](03_testing_tools.md) for a demonstration 
+this process._
 
 You will need to make an OAuth1 signed post request. This involves adding 
 certain extra OAuth specific fields to the form data, cryptographically signing
@@ -78,3 +82,53 @@ can adapt the implementation.
 |-------------------|-------------------------|-----------------|
 | `consumer_key`    | `oauth_consumer_key`    | `client_key`    |
 | `consumer_secret` | `oauth_consumer_secret` | `client_secret` |
+
+### Swapping the grant token for an access token
+
+_Note: [See the `h_call.py` tool](03_testing_tools.md) for a demonstration 
+this process._
+
+If you successfully call the Gateway end-point then the response you receive
+will include a section called `h_api` which will list a number of pre-prepared
+requests you can make.
+
+One of these requests is called `grant_token_exchange` and provies the call you
+need to make to get access tokens for the `h` API.
+
+These are formatted so you can pass them directly to Python's 
+[`requests` library](https://requests.readthedocs.io/en/latest/), (but the same
+details can be used with any HTTP library). For example:
+
+```python
+from requests import Session
+ 
+gateway_response = ...  # The response data from the Gateway end-point 
+response = Session().request(**gateway_response['h_api']['grant_token_exchange'])
+print(response.json())
+```
+This will return you a set of OAuth2 credentials you can use with the `h` API.
+
+```json
+{
+    "access_token": "5218-fV8jIXVx3aprt-PyL3H456456456645AcJGbWiJJs",
+    "expires_in": 3600.0,
+    "token_type": "Bearer",
+    "refresh_token": "4344-k2RMSX234534563478YBBMDHj4UYk8nsBvKP4"
+}
+```
+
+### Using the OAuth 2 access
+
+You can then use the access token in future requests to the `h` API by 
+including a header like this (using the value you received):
+
+```
+Authorization: Bearer 5218-fV8jIXVx3aprt-PyL3H456456456645AcJGbWiJJs
+```
+
+You can also perform OAuth2 token refreshes to keep access tokens alive, and 
+prevent you from having to perform this step each time.
+
+By combining this token, URL and header details provided and the 
+[Hypothesis API Specification](https://h.readthedocs.io/en/latest/api-reference/) 
+you should be able to make any calls you need to the `h` API.

--- a/docs/gateway/02_api_spec.md
+++ b/docs/gateway/02_api_spec.md
@@ -13,21 +13,16 @@ All end-points here are specified with reference to these base URLs:
 Unless you are familiar with Hypothesis development, we recommend you start 
 with the public QA test environment.
 
-## POST `/lti_launches`*
+## POST `/api/gateway/h/lti`
 
-_* Note: This is the main HTML launch URL, a new URL will be provided for
-the gateway soon._
-
-This end-point will allow you to test the authentication mechanism while the 
-final end-point is being written.
+Returns connection details and contextual information about the current user,
+course and optionally assignment.
 
 ### Headers
 ```
-Accept: text/html
+Accept: application/json
 Content-Type: application/x-www-form-urlencoded
 ```
-
-_Note: The final end-point will return `application/json` not HTML_
 
 ### Post body fields
 
@@ -48,15 +43,16 @@ optional.
 | `user_id`                     | `2978763`                  | The user id we should act on behalf of                                  |
 | `roles`                       | `Instructor`               | The role that user has (used in permission generation)                  |
 | `context_id`                  | `454`                      | Specify the course you want to access                                   |
-| `context_title`               | `My course name`           | _Note: This is only a required field for now_                           |
 | `resource_link_id`            | `22`                       | _(optional)_ Narrow the scope to a single assignment                    |
 
 ### Responses
 
 **200 - OK**
 
-Everything worked correctly. At the moment this will return HTML, but in the 
-end you should receive JSON.
+Everything worked correctly. You should receive a JSON payload which matches 
+[this schema](schema.json) (in [JSON Schema](http://json-schema.org/) format).
+
+This schema file also includes an example of the output you can expect.
 
 **403 - Not authorized**
 

--- a/docs/gateway/02_api_spec.md
+++ b/docs/gateway/02_api_spec.md
@@ -24,6 +24,11 @@ Accept: application/json
 Content-Type: application/x-www-form-urlencoded
 ```
 
+### Authentication
+
+You will need to OAuth1 sign the parameters in order to pass authentication.
+For details of how to do this see [Authentication](03_authentication.md).
+
 ### Post body fields
 
 We accept any and all LTI 1.1 parameters.
@@ -34,6 +39,8 @@ It is recommended for stability and the best performance that you pass all LTI
 parameters received onto this end-point. This will ensure compatibility as the
 more features may be added in future which require fields which were previously
 optional.
+
+
 
 | Field                         | Example                    | Notes                                                                   |
 |-------------------------------|----------------------------|-------------------------------------------------------------------------|

--- a/docs/gateway/03_authentication.md
+++ b/docs/gateway/03_authentication.md
@@ -1,0 +1,91 @@
+# Authentication
+
+Authentication happens in two steps:
+
+ * In the first step you will perform the signed OAuth1 request to the Gateway
+ * In the second step you will use tokens to authenticate with the `h` API
+
+## Getting started
+
+In order to authenticate with the Gateway you will need:
+
+ * The tool consumer instance GUID of the LMS instance
+ * The client key created when Hypothesis was installed
+ * The shared secret created when Hypothesis was installed
+
+If you do not know any of these values you can work with 
+[Hypothesis support](https://web.hypothes.is/help/) to get the correct values.
+
+## Calling the Gateway
+
+> _Note: [See the `oauth_call.py` tool](04_testing_tools.md) for a demonstration 
+this process._
+
+You will need to make an OAuth1 signed post request. This involves adding 
+certain extra OAuth specific fields to the form data, cryptographically signing
+those parameters with the client secret and then making a conventional POST
+request to the [Gateway end-point](02_api_spec.md).
+
+The process is described in the [LTI 1.1 Implementation Guide](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-4).
+
+We also provide some [testing tools / reference implementation](04_testing_tools.md)
+in Python. These tools are intended to get you started quickly after which you 
+can adapt the implementation.
+
+**Note:** There is a terminology difference  between OAuth1 and the LTI spec:
+
+| This document     | LTI                     | OAuth1          | 
+|-------------------|-------------------------|-----------------|
+| `consumer_key`    | `oauth_consumer_key`    | `client_key`    |
+| `consumer_secret` | `oauth_consumer_secret` | `client_secret` |
+
+## Swapping the grant token for an access token
+
+> _Note: [See the `h_call.py` tool](04_testing_tools.md) for a demonstration 
+this process._
+
+If you successfully call the Gateway end-point then the response you receive
+will include a section called `h_api` which will list a number of pre-prepared
+requests you can make.
+
+One of these requests is called `grant_token_exchange` and provies the call you
+need to make to get access tokens for the `h` API.
+
+These are formatted so you can pass them directly to Python's 
+[`requests` library](https://requests.readthedocs.io/en/latest/), (but the same
+details can be used with any HTTP library). For example:
+
+```python
+from requests import Session
+ 
+gateway_response = ...  # The response data from the Gateway end-point 
+response = Session().request(**gateway_response['h_api']['grant_token_exchange'])
+print(response.json())
+```
+This will return you a set of OAuth2 credentials you can use with the `h` API. 
+e.g.
+
+```json
+{
+    "access_token": "5218-fV8jIXVx3-NOT-A-REAL-TOKEN-6645AcJGbWiJJss",
+    "expires_in": 3600.0,
+    "token_type": "Bearer",
+    "refresh_token": "4344-k2RMSX23-NOT-A-REAL-TOKEN-DHj4UYk8nsBvKP4"
+}
+```
+
+## Using the OAuth 2 access
+
+You can then use the access token in future requests to the `h` API by 
+including a header like this (using the value you received):
+
+```
+Authorization: Bearer 5218-fV8jIXVx3-NOT-A-REAL-TOKEN-6645AcJGbWiJJss
+```
+
+You can also perform OAuth2 token refreshes to keep access tokens alive, and 
+prevent you from having to perform this step each time.
+
+By combining this token, URL and header details provided and the 
+[Hypothesis API Specification](https://h.readthedocs.io/en/latest/api-reference/) 
+you should be able to make any calls you need to the `h` API.

--- a/docs/gateway/03_testing_tools.md
+++ b/docs/gateway/03_testing_tools.md
@@ -35,7 +35,7 @@ You should then be able to run the commands:
 python oauth_call.py
 ```
 
-## Calling the gateway with `oauth_call.py`
+## `oauth_call.py` - Calling the Gateway 
 
 [The `oauth_call.py` script](../../bin/gateway/oauth_call.py) can be used to
 make an OAuth1 signed POST request to an end-point such as the Gateway.
@@ -68,3 +68,59 @@ STDOUT, which allows you to view each separately:
 ```shell
 ./oauth_call.py --spec gateway.json 1>response.txt 2>errors.txt
 ```
+
+## `h_call.py` - Calling the `h` API using Gateway data 
+
+[The `oauth_call.py` script](../../bin/gateway/h_call.py) can make calls to the 
+`h` API using the format returned by the Gateway end-point.
+
+It can read those values from a JSON file, or directly from `oauth_call.py`. 
+You can use this to make authenticated calls using an exchanged token and to
+store a list of tests calls in a file.
+
+### Examples
+
+By default `h_call.py` just lists the calls that are available, but doesn't 
+call any of them. Here we use an example file to provide a call.
+
+```shell
+./h_call.py --spec config/h_calls_qa.json
+```
+```shell
+Available end-points:
+	 * profile
+```
+We can use the name of these end-points to make a call:
+
+```shell
+./h_call.py --spec config/h_calls_qa.json --call profile
+```
+
+As we are not authenticated we will get default anonymous user info back.
+
+### Examples combining with `oauth_call.py`
+
+We can read the spec details directly from the `oauth_call.py` script instead 
+of using JSON:
+
+```shell
+./oauth_call.py --quiet --spec gateway.json | ./h_call.py --stdin --call list_endpoints
+```
+
+We can combine this with automatic token exchange, and our predefined JSON 
+calls to call the profile end-point again, but as the user we specified in 
+our `gateway.json` config:
+
+```shell
+./oauth_call.py --quiet --spec gateway.json | ./h_call.py --stdin --spec config/h_calls_qa.json --authenticate --call profile
+```
+
+You should now see user specific details. As this is a bit long winded, short
+codes are provided for each command. This is the same command as above:
+
+```shell
+./oauth_call.py -qs gateway.json | ./h_call.py -ais config/h_calls_qa.json -c profile
+```
+
+Using this method you can keep a list of pre-prepared calls to the `h` API in
+a file and conveniently call them with the correct authentication for testing.

--- a/docs/gateway/04_testing_tools.md
+++ b/docs/gateway/04_testing_tools.md
@@ -71,12 +71,12 @@ STDOUT, which allows you to view each separately:
 
 ## `h_call.py` - Calling the `h` API using Gateway data 
 
-[The `oauth_call.py` script](../../bin/gateway/h_call.py) can make calls to the 
+[The `h_call.py` script](../../bin/gateway/h_call.py) can make calls to the 
 `h` API using the format returned by the Gateway end-point.
 
 It can read those values from a JSON file, or directly from `oauth_call.py`. 
-You can use this to make authenticated calls using an exchanged token and to
-store a list of tests calls in a file.
+You can use this to make authenticated calls (using an exchanged token) against
+a stored list of API calls you define.
 
 ### Examples
 

--- a/docs/gateway/schema.json
+++ b/docs/gateway/schema.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "LMS Gateway to H return schema",
+
+    "examples": [
+        {
+            "h_api": {
+                "list_endpoints": {
+                    "method": "GET",
+                    "url": "https://h.example.com/api",
+                    "headers": {"Accept": "application/vnd.hypothesis.v2+json"}
+                },
+                "exchange_grant_token": {
+                    "method": "POST",
+                    "url": "https://h.example.com/api/token",
+                    "headers": {
+                        "Accept": "application/vnd.hypothesis.v2+json",
+                        "Content-Type": "application/x-www-form-urlencoded"
+                    },
+                    "data": {
+                        "assertion": "abcdef0123456789",
+                        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer"
+                    }
+                }
+            }
+        }
+    ],
+
+    "type": "object",
+    "properties": {
+        "h_api": {
+            "description": "Pre-defined calls to H API end-points",
+            "type": "object",
+            "properties": {
+                "list_endpoints": {
+                    "description": "List all end-points in the H API",
+                    "$ref": "#/$defs/api_call"
+                },
+                "exchange_grant_token": {
+                    "description": "Exchange grant token for access and refresh tokens",
+                    "$ref": "#/$defs/api_call"
+                }
+            },
+            "additionalProperties": false,
+            "required": ["list_endpoints", "exchange_grant_token"]
+        }
+    },
+    "required": ["h_api"],
+    "additionalProperties": false,
+
+    "$defs": {
+        "api_call": {
+            "title": "Pre-defined API call",
+            "type": "object",
+
+            "properties": {
+                "method": {"type": "string", "enum": ["GET", "POST"]},
+                "url": {"type":  "string", "format": "uri"},
+                "headers": {"type":  "object"},
+                "data": {"type":  "object"}
+            },
+            "additionalProperties": false,
+            "required": ["method", "url"]
+        }
+    }
+}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4197

This adds testing tools to accompany the return of actual data from the new gateway end-point and also documentation which is intended for user consumption. This documents the output from:

 * https://github.com/hypothesis/lms/pull/4222

### Testing notes

 * This adds a new tool `h_call.py`
 * [The documentation](https://github.com/hypothesis/lms/blob/gateway-tools/docs/gateway/01_overview.md) should describe how to use it, and basically form the testing instructions.