### PR TITLE
Make a copy of the groups list before iterating over it.

### DIFF
--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -169,7 +169,9 @@ class BlackboardAPIClient:
             responses = self._request.find_service(name="async_oauth_http").request(
                 "GET", self_enrollment_check_urls
             )
-            for group, response in zip(self_enrollment_groups, responses):
+            # We are going to be modifying `self_enrollment_groups` within the loop
+            # Create a copy here to iterate over.
+            for group, response in zip(list(self_enrollment_groups), responses):
                 # If we are a member of any of the SelfEnrollment groups
                 # we'll get a 200 response from the endpoint
                 if response.status == 200:


### PR DESCRIPTION
The loop is going to modify that list, removing items from it, which can
cause the iteration to not reach all items.


I'm a bit puzzled by this one, I know this has worked before, specifically with the 50 groups group set as is the one we always tested this case (having to make lots of async requests) but I also can't see how this could have worked before :thinking:.


# Testing

- On `main` create a BB group assignment, pick the `Group set with 50 groups` group set.

- Launch it as a student. You'll get a long list of groups.

- Switch to this branch. Launch again as a student. You'll get 1 or two groups depending which student you picked.