### PR TITLE
Add consumer tests to prove we meet our own schema

### DIFF
--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -137,13 +137,14 @@ importlib-resources==5.9.0
     #   -r requirements/requirements.txt
     #   alembic
     #   h-api
+    #   jsonschema
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
     # via
     #   -r requirements/requirements.txt
     #   pyramid-jinja2
-jsonschema==3.2.0
+jsonschema==4.7.2
     # via
     #   -r requirements/requirements.txt
     #   h-api
@@ -302,7 +303,6 @@ six==1.15.0
     #   click-repl
     #   ecdsa
     #   google-auth
-    #   jsonschema
     #   parse-type
     #   python-dateutil
 soupsieve==2.2.1
@@ -405,7 +405,6 @@ setuptools==62.6.0
     #   -r requirements/requirements.txt
     #   google-auth
     #   gunicorn
-    #   jsonschema
     #   pip-tools
     #   plaster
     #   pyramid

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -136,6 +136,7 @@ importlib-resources==5.9.0
     #   -r requirements/requirements.txt
     #   alembic
     #   h-api
+    #   jsonschema
 ipython==8.4.0
     # via pyramid-ipython
 jedi==0.18.1
@@ -144,7 +145,7 @@ jinja2==2.11.3
     # via
     #   -r requirements/requirements.txt
     #   pyramid-jinja2
-jsonschema==3.2.0
+jsonschema==4.7.2
     # via
     #   -r requirements/requirements.txt
     #   h-api
@@ -307,7 +308,6 @@ six==1.15.0
     #   click-repl
     #   ecdsa
     #   google-auth
-    #   jsonschema
     #   python-dateutil
 sqlalchemy==1.4.39
     # via
@@ -408,7 +408,6 @@ setuptools==62.6.0
     #   google-auth
     #   gunicorn
     #   ipython
-    #   jsonschema
     #   pip-tools
     #   plaster
     #   pyramid

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -135,13 +135,14 @@ importlib-resources==5.9.0
     #   -r requirements/requirements.txt
     #   alembic
     #   h-api
+    #   jsonschema
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
     # via
     #   -r requirements/requirements.txt
     #   pyramid-jinja2
-jsonschema==3.2.0
+jsonschema==4.7.2
     # via
     #   -r requirements/requirements.txt
     #   h-api
@@ -293,7 +294,6 @@ six==1.15.0
     #   click-repl
     #   ecdsa
     #   google-auth
-    #   jsonschema
     #   python-dateutil
 soupsieve==2.2.1
     # via beautifulsoup4
@@ -395,7 +395,6 @@ setuptools==62.6.0
     #   -r requirements/requirements.txt
     #   google-auth
     #   gunicorn
-    #   jsonschema
     #   pip-tools
     #   plaster
     #   pyramid

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -238,6 +238,7 @@ importlib-resources==5.9.0
     #   -r requirements/tests.txt
     #   alembic
     #   h-api
+    #   jsonschema
 iniconfig==1.1.1
     # via
     #   -r requirements/bddtests.txt
@@ -252,7 +253,7 @@ jinja2==2.11.3
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pyramid-jinja2
-jsonschema==3.2.0
+jsonschema==4.7.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -530,7 +531,6 @@ six==1.15.0
     #   click-repl
     #   ecdsa
     #   google-auth
-    #   jsonschema
     #   parse-type
     #   python-dateutil
 snowballstemmer==2.1.0
@@ -705,7 +705,6 @@ setuptools==62.6.0
     #   astroid
     #   google-auth
     #   gunicorn
-    #   jsonschema
     #   pip-tools
     #   plaster
     #   pyramid

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -83,9 +83,10 @@ importlib-resources==5.9.0
     #   -r requirements/requirements.in
     #   alembic
     #   h-api
+    #   jsonschema
 jinja2==2.11.3
     # via pyramid-jinja2
-jsonschema==3.2.0
+jsonschema==4.7.2
     # via h-api
 kombu==5.2.4
     # via celery
@@ -192,7 +193,6 @@ six==1.15.0
     #   click-repl
     #   ecdsa
     #   google-auth
-    #   jsonschema
 sqlalchemy==1.4.39
     # via
     #   -r requirements/requirements.in
@@ -255,7 +255,6 @@ setuptools==62.6.0
     # via
     #   google-auth
     #   gunicorn
-    #   jsonschema
     #   plaster
     #   pyramid
     #   zope-deprecation

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -141,13 +141,14 @@ importlib-resources==5.9.0
     #   -r requirements/requirements.txt
     #   alembic
     #   h-api
+    #   jsonschema
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
     # via
     #   -r requirements/requirements.txt
     #   pyramid-jinja2
-jsonschema==3.2.0
+jsonschema==4.7.2
     # via
     #   -r requirements/requirements.txt
     #   h-api
@@ -301,7 +302,6 @@ six==1.15.0
     #   click-repl
     #   ecdsa
     #   google-auth
-    #   jsonschema
     #   python-dateutil
 sqlalchemy==1.4.39
     # via
@@ -396,7 +396,6 @@ setuptools==62.6.0
     #   -r requirements/requirements.txt
     #   google-auth
     #   gunicorn
-    #   jsonschema
     #   pip-tools
     #   plaster
     #   pyramid


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4197

This PR includes consumer testing, which is something we don't do by name, which is to run tests which check the agreement you make with 3rd parties.

If we change our API in a way such that the documentation isn't valid any more (at least as far as the schema goes) this should result in a test failure.

This keeps us honest with the schema we provide to customers and will alert us of any changes.