### PR TITLE
Allow LTI1.3 upgrades from the admin pages

### DIFF
--- a/lms/templates/admin/instance.new.html.jinja2
+++ b/lms/templates/admin/instance.new.html.jinja2
@@ -17,8 +17,11 @@ New application instance
         {{ macros.registration_preview(request, lti_registration) }}
     </fieldset>
 
+
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Application instance</legend>
+        {{ macros.form_text_field(request, "Consumer key", "consumer_key",
+            placeholder="Optional. Existing application instance's consumer key. It will be upgraded to LTI 1.3 using this registration") }}
         {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
         {{ macros.form_text_field(request, "LMS URL", "lms_url") }}
         {{ macros.form_text_field(request, "Email", "email") }}

--- a/lms/templates/admin/macros.jinja
+++ b/lms/templates/admin/macros.jinja
@@ -31,14 +31,14 @@
     {% endcall %}
 {% endmacro %}
 
-{% macro form_text_field(request, label, field_name, field_value=None) %}
+{% macro form_text_field(request, label, field_name, field_value=None, placeholder="") %}
     {% call field_body(label) %}
         {% if field_value %}
             <input class="input" name="{{field_name}}" value="{{ field_value }}" type="text">
         {% elif request.params.get(field_name) %}
             <input class="input" name="{{field_name}}" value="{{ request.params.get(field_name) }}" type="text">
         {% else %}
-            <input class="input" name="{{field_name}}" type="text">
+            <input class="input" name="{{field_name}}" type="text" placeholder="{{placeholder}}">
         {% endif %}
     {% endcall %}
 {% endmacro %}

--- a/lms/views/admin/__init__.py
+++ b/lms/views/admin/__init__.py
@@ -1,4 +1,5 @@
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
+from pyramid.renderers import render_to_response
 from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 
 from lms.validation._exceptions import ValidationError
@@ -29,5 +30,13 @@ def flash_validation(request, schema):
     except ValidationError as err:
         request.session.flash(err.messages["form"], "validation")
         return True
-
     return False
+
+
+def error_render_to_response(
+    request, error_message, template, template_args, flash_type="errors"
+):
+    request.session.flash(error_message, flash_type)
+    response = render_to_response(template, template_args, request=request)
+    response.status = 400
+    return response

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -9,15 +9,61 @@ from lms.models import ApplicationInstance
 from lms.security import Permissions
 from lms.services import ApplicationInstanceNotFound, LTIRegistrationService
 from lms.validation._base import PyramidRequestSchema
-from lms.views.admin import flash_validation
+from lms.views.admin import error_render_to_response, flash_validation
+
+
+class EmptyStringNoneMixin:
+    """
+    Allows empty string as "missing value".
+
+    Marshmallow doesn't have a clean solution yet to POSTed values
+    (that are always present in the request as empty strings)
+
+    Here we convert them explicitly to None
+
+    https://github.com/marshmallow-code/marshmallow/issues/713
+    """
+
+    def deserialize(self, value, attr, data, **kwargs):
+        if not value:
+            return None
+        return super().deserialize(value, attr, data, **kwargs)
+
+
+class EmptyStringURL(EmptyStringNoneMixin, fields.URL):
+    ...
+
+
+class EmptyStringEmail(EmptyStringNoneMixin, fields.Email):
+    ...
 
 
 class ApplicationInstanceSchema(PyramidRequestSchema):
     location = "form"
 
     deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
+
+    developer_key = fields.Str(required=False, allow_none=True)
+    developer_secret = fields.Str(required=False, allow_none=True)
+
+
+class NewApplicationInstanceSchema(PyramidRequestSchema):
+    location = "form"
+
+    deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
+
+    developer_key = fields.Str(required=False, allow_none=True)
+    developer_secret = fields.Str(required=False, allow_none=True)
+
     lms_url = fields.URL(required=True)
     email = fields.Email(required=True)
+
+
+class UpdateApplicationInstanceSchema(ApplicationInstanceSchema):
+    location = "form"
+
+    lms_url = EmptyStringURL(required=False, allow_none=True)
+    email = EmptyStringEmail(required=False, allow_none=True)
 
 
 @view_defaults(request_method="GET", permission=Permissions.ADMIN)
@@ -49,7 +95,10 @@ class AdminApplicationInstanceViews:
             self.request.matchdict["id_"]
         )
 
-        if flash_validation(self.request, ApplicationInstanceSchema):
+        if consumer_key := self.request.params.get("consumer_key", "").strip():
+            return self.upgrade_instance(lti_registration, consumer_key)
+
+        if flash_validation(self.request, NewApplicationInstanceSchema):
             response = render_to_response(
                 "lms:templates/admin/instance.new.html.jinja2",
                 {"lti_registration": lti_registration},
@@ -71,20 +120,77 @@ class AdminApplicationInstanceViews:
             )
 
         except IntegrityError:
-            self.request.session.flash(
+            return error_render_to_response(
+                self.request,
                 f"Application instance with deployment_id: {self.request.params['deployment_id']} already exists",
-                "errors",
-            )
-            response = render_to_response(
                 "lms:templates/admin/instance.new.html.jinja2",
                 {"lti_registration": lti_registration.id},
+            )
+
+        return HTTPFound(
+            location=self.request.route_url("admin.instance.id", id_=ai.id)
+        )
+
+    def upgrade_instance(self, lti_registration, consumer_key):
+        if flash_validation(self.request, UpdateApplicationInstanceSchema):
+            response = render_to_response(
+                "lms:templates/admin/instance.new.html.jinja2",
+                {"lti_registration": lti_registration},
                 request=self.request,
             )
             response.status = 400
             return response
 
+        # Find the Application instance we are upgrading
+        try:
+            application_instance = (
+                self.application_instance_service.get_by_consumer_key(consumer_key)
+            )
+        except ApplicationInstanceNotFound:
+            return error_render_to_response(
+                self.request,
+                f"Can't find application instance: '{consumer_key}' for upgrade.",
+                "lms:templates/admin/instance.new.html.jinja2",
+                {"lti_registration": lti_registration},
+            )
+
+        # Don't allow to change instances that already on 1.3
+        if application_instance.lti_version == "1.3.0":
+            return error_render_to_response(
+                self.request,
+                f"Application instance: '{consumer_key}' is already on LTI 1.3.",
+                "lms:templates/admin/instance.new.html.jinja2",
+                {"lti_registration": lti_registration},
+            )
+
+        # Set the LTI1.3 values
+        application_instance.lti_registration = lti_registration
+        application_instance.deployment_id = self.request.params[
+            "deployment_id"
+        ].strip()
+
+        # And upgrade any other values present in the request
+        if email := self.request.params["email"].strip():
+            application_instance.requesters_email = email
+
+        if lms_url := self.request.params["lms_url"].strip():
+            application_instance.lms_url = lms_url
+
+        try:
+            # Flush here to find if we are making a duplicate in the process of upgrading
+            self.request.db.flush()
+        except IntegrityError:
+            return error_render_to_response(
+                self.request,
+                f"Application instance with deployment_id: {self.request.params['deployment_id']} already exists",
+                "lms:templates/admin/instance.new.html.jinja2",
+                {"lti_registration": lti_registration.id},
+            )
+
         return HTTPFound(
-            location=self.request.route_url("admin.instance.id", id_=ai.id)
+            location=self.request.route_url(
+                "admin.instance.id", id_=application_instance.id
+            )
         )
 
     @view_config(


### PR DESCRIPTION
Add a path to upgrade existing instances to LTI 1.3


I went through different options to do this with @chrisshaw and settled on the one implemented here, unifying the creation/upgrading flows into one. In any case we can revisit it once it get enough use.



# Testing 


- Search for issuer `https://blackboard.com` at http://localhost:8001/admin/registrations/

- Pick any of the results and click `New instance`

- Use the consumer key `Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b`

- Save, you are taken to the application instance details, which new include the registration and a deployment id.