### PR TITLE
Nest in the H connection details to leave space for possible LMS ones in future

### DIFF
--- a/bin/gateway/config/h_calls_dev.json
+++ b/bin/gateway/config/h_calls_dev.json
@@ -1,10 +1,12 @@
 {
-    "h_api": {
-        "profile": {
-            "method": "GET",
-            "url": "http://localhost:5000/api/profile",
-            "headers": {
-                "Accept": "application/vnd.hypothesis.v2+json"
+    "api": {
+        "h": {
+            "profile": {
+                "method": "GET",
+                "url": "http://localhost:5000/api/profile",
+                "headers": {
+                    "Accept": "application/vnd.hypothesis.v2+json"
+                }
             }
         }
     }

--- a/bin/gateway/config/h_calls_prod.json
+++ b/bin/gateway/config/h_calls_prod.json
@@ -1,10 +1,12 @@
 {
-    "h_api": {
-        "profile": {
-            "method": "GET",
-            "url": "https://hypothes.is/api/profile",
-            "headers": {
-                "Accept": "application/vnd.hypothesis.v2+json"
+    "api": {
+        "h": {
+            "profile": {
+                "method": "GET",
+                "url": "https://hypothes.is/api/profile",
+                "headers": {
+                    "Accept": "application/vnd.hypothesis.v2+json"
+                }
             }
         }
     }

--- a/bin/gateway/config/h_calls_qa.json
+++ b/bin/gateway/config/h_calls_qa.json
@@ -1,10 +1,12 @@
 {
-    "h_api": {
-        "profile": {
-            "method": "GET",
-            "url": "https://qa.hypothes.is/api/profile",
-            "headers": {
-                "Accept": "application/vnd.hypothesis.v2+json"
+    "api": {
+        "h": {
+            "profile": {
+                "method": "GET",
+                "url": "https://qa.hypothes.is/api/profile",
+                "headers": {
+                    "Accept": "application/vnd.hypothesis.v2+json"
+                }
             }
         }
     }

--- a/bin/gateway/h_call.py
+++ b/bin/gateway/h_call.py
@@ -46,12 +46,12 @@ def main(args):
     # Read the spec file from the usual location if piped in from
     # `oauth_call.py`
     if args.stdin:
-        h_end_points.update(json.load(sys.stdin)["h_api"])
+        h_end_points.update(json.load(sys.stdin)["api"]["h"])
 
     # Also read from a JSON file for a manually curated set of calls
     if args.spec:
         with open(args.spec, encoding="utf-8") as handle:
-            h_end_points.update(json.load(handle)["h_api"])
+            h_end_points.update(json.load(handle)["api"]["h"])
 
     if not h_end_points:
         raise ValueError("No config loaded!")

--- a/docs/gateway/schema.json
+++ b/docs/gateway/schema.json
@@ -4,22 +4,24 @@
 
     "examples": [
         {
-            "h_api": {
-                "list_endpoints": {
-                    "method": "GET",
-                    "url": "https://h.example.com/api",
-                    "headers": {"Accept": "application/vnd.hypothesis.v2+json"}
-                },
-                "exchange_grant_token": {
-                    "method": "POST",
-                    "url": "https://h.example.com/api/token",
-                    "headers": {
-                        "Accept": "application/vnd.hypothesis.v2+json",
-                        "Content-Type": "application/x-www-form-urlencoded"
+            "api": {
+                "h": {
+                    "list_endpoints": {
+                        "method": "GET",
+                        "url": "https://h.example.com/api",
+                        "headers": {"Accept": "application/vnd.hypothesis.v2+json"}
                     },
-                    "data": {
-                        "assertion": "abcdef0123456789",
-                        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer"
+                    "exchange_grant_token": {
+                        "method": "POST",
+                        "url": "https://h.example.com/api/token",
+                        "headers": {
+                            "Accept": "application/vnd.hypothesis.v2+json",
+                            "Content-Type": "application/x-www-form-urlencoded"
+                        },
+                        "data": {
+                            "assertion": "abcdef0123456789",
+                            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer"
+                        }
                     }
                 }
             }
@@ -28,24 +30,29 @@
 
     "type": "object",
     "properties": {
-        "h_api": {
-            "description": "Pre-defined calls to H API end-points",
-            "type": "object",
+        "api": {
             "properties": {
-                "list_endpoints": {
-                    "description": "List all end-points in the H API",
-                    "$ref": "#/$defs/api_call"
-                },
-                "exchange_grant_token": {
-                    "description": "Exchange grant token for access and refresh tokens",
-                    "$ref": "#/$defs/api_call"
+                "h": {
+                    "description": "Pre-defined calls to H API end-points",
+                    "type": "object",
+                    "properties": {
+                        "list_endpoints": {
+                            "description": "List all end-points in the H API",
+                            "$ref": "#/$defs/api_call"
+                        },
+                        "exchange_grant_token": {
+                            "description": "Exchange grant token for access and refresh tokens",
+                            "$ref": "#/$defs/api_call"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": ["list_endpoints", "exchange_grant_token"]
                 }
             },
-            "additionalProperties": false,
-            "required": ["list_endpoints", "exchange_grant_token"]
+            "required": ["h"]
         }
     },
-    "required": ["h_api"],
+    "required": ["api"],
     "additionalProperties": false,
 
     "$defs": {

--- a/lms/views/api/gateway.py
+++ b/lms/views/api/gateway.py
@@ -53,30 +53,32 @@ def h_lti(context, request):
     # Add API end-point details
     h_api_url = request.registry.settings["h_api_url_public"]
     return {
-        "h_api": {
-            # These sections are arranged so you can use
-            # `requests.Request.request(**data)` and make the correct request
-            "list_endpoints": {
-                # List the API end-points
-                "method": "GET",
-                "url": h_api_url,
-                "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
-            },
-            "exchange_grant_token": {
-                # Exchange our token for access and refresh tokens
-                "method": "POST",
-                "url": h_api_url + "token",
-                "headers": {
-                    "Accept": "application/vnd.hypothesis.v2+json",
-                    "Content-Type": "application/x-www-form-urlencoded",
+        "api": {
+            "h": {
+                # These sections are arranged so you can use
+                # `requests.Request.request(**data)` and make the correct request
+                "list_endpoints": {
+                    # List the API end-points
+                    "method": "GET",
+                    "url": h_api_url,
+                    "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
                 },
-                "data": {
-                    # Generate a short-lived login token for the Hypothesis client
-                    "assertion": request.find_service(
-                        name="grant_token"
-                    ).generate_token(request.lti_user.h_user),
-                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "exchange_grant_token": {
+                    # Exchange our token for access and refresh tokens
+                    "method": "POST",
+                    "url": h_api_url + "token",
+                    "headers": {
+                        "Accept": "application/vnd.hypothesis.v2+json",
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                    "data": {
+                        # Generate a short-lived login token for the Hypothesis client
+                        "assertion": request.find_service(
+                            name="grant_token"
+                        ).generate_token(request.lti_user.h_user),
+                        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    },
                 },
-            },
+            }
         }
     }

--- a/tests/functional/api/gateway_test.py
+++ b/tests/functional/api/gateway_test.py
@@ -13,24 +13,26 @@ class TestGatewayHLTI:
 
         assert response.headers["Content-Type"] == "application/json"
         assert response.json == {
-            "h_api": {
-                "list_endpoints": {
-                    "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
-                    "method": "GET",
-                    "url": "https://example.com/api/",
-                },
-                "exchange_grant_token": {
-                    "data": {
-                        "assertion": Any.string(),
-                        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "api": {
+                "h": {
+                    "list_endpoints": {
+                        "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
+                        "method": "GET",
+                        "url": "https://example.com/api/",
                     },
-                    "headers": {
-                        "Accept": "application/vnd.hypothesis.v2+json",
-                        "Content-Type": "application/x-www-form-urlencoded",
+                    "exchange_grant_token": {
+                        "data": {
+                            "assertion": Any.string(),
+                            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                        },
+                        "headers": {
+                            "Accept": "application/vnd.hypothesis.v2+json",
+                            "Content-Type": "application/x-www-form-urlencoded",
+                        },
+                        "method": "POST",
+                        "url": "https://example.com/api/token",
                     },
-                    "method": "POST",
-                    "url": "https://example.com/api/token",
-                },
+                }
             }
         }
 

--- a/tests/unit/lms/views/api/gateway_test.py
+++ b/tests/unit/lms/views/api/gateway_test.py
@@ -20,7 +20,7 @@ class TestHLTI:
             pyramid_request.lti_user.h_user
         )
         h_api_url = pyramid_request.registry.settings["h_api_url_public"]
-        assert response["h_api"] == {
+        assert response["api"]["h"] == {
             "list_endpoints": {
                 "method": "GET",
                 "url": h_api_url,


### PR DESCRIPTION
This PR looks a lot bigger than it is. Before the layout was:

```json
{
    "h_api": ...
}
```

Now it's:

```json
{
    "api": {
        "h": ...
    }
}
```

This allows us to leave space for calls back to LMS (or something else?) in future without a cluttered root data structure.