### PR TITLE
Update ESLint config and simplify project config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,13 +4,6 @@
     "prefer-arrow-callback": "error",
     "prefer-const": ["error", { "destructuring": "all" }],
 
-    // Handled by Prettier.
-    "comma-dangle": "off",
-
-    // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
-    "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off",
-
     // Prop validation is performed by TypeScript + JSDoc.
     "react/prop-types": "off"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-preact-pure": "^4.0.1",
     "eslint": "^8.20.0",
-    "eslint-config-hypothesis": "^2.5.0",
+    "eslint-config-hypothesis": "^2.6.0",
     "eslint-plugin-jsx-a11y": "^6.6.0",
     "karma": "^6.4.0",
     "karma-chai": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2716,10 +2716,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-hypothesis@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.5.0.tgz#bc9c281b07923666696c5df1c1f96f3cbace266b"
-  integrity sha512-3KiknU/zX117ggOhDetdbnqn+RupdIsp4XXl9kn8NICc/1ObVY3dt802L01A//ajCGHgiYu5/vR2afsuChlnhw==
+eslint-config-hypothesis@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.6.0.tgz#627a3f0478c6d732ea776d813be6a70ac2f2d9dd"
+  integrity sha512-CMQSym4Oz2RVKwAAD+cftYPoSRzj3CUBfkytf0UG41wBsKh7eHGCAer8AcibYP8G2JelKoB6K6CzOYviCiBi/A==
 
 eslint-plugin-jsx-a11y@^6.6.0:
   version "6.6.0"


### PR DESCRIPTION
Update eslint-config-hypothesis and remove local overrides that are no
longer required.

See also notes in https://github.com/hypothesis/client/pull/4657.