### PR TITLE
Update JSTOR metadata and PDF endpoints

### DIFF
--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -69,7 +69,7 @@ class JSTORService:
 
         # Get a signed S3 URL for the given JSTOR URL.
         s3_url = self._api_request(
-            "/pdf-url/{doi}", doi=document_url.replace("jstor://", "")
+            "/pdf/{doi}", doi=document_url.replace("jstor://", "")
         ).text
 
         if not s3_url.startswith("https://"):

--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -92,7 +92,7 @@ class JSTORService:
         :param article_id: A JSTOR article ID or DOI
         """
 
-        response = self._api_request("/metadata-new/{doi}", doi=article_id)
+        response = self._api_request("/metadata/{doi}", doi=article_id)
         metadata = JSTORMetadataSchema(response).parse()
 
         return {"title": self._get_title_from_metadata(metadata)}

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -25,9 +25,9 @@ class TestJSTORService:
         [
             (
                 "jstor://ARTICLE_ID",
-                f"{JSTOR_API_URL}/pdf-url/10.2307/ARTICLE_ID",
+                f"{JSTOR_API_URL}/pdf/10.2307/ARTICLE_ID",
             ),
-            ("jstor://PREFIX/SUFFIX", f"{JSTOR_API_URL}/pdf-url/PREFIX/SUFFIX"),
+            ("jstor://PREFIX/SUFFIX", f"{JSTOR_API_URL}/pdf/PREFIX/SUFFIX"),
         ],
     )
     def test_via_url(

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -66,11 +66,11 @@ class TestJSTORService:
         "article_id, expected_api_url",
         [
             # Typical JSTOR article, with no DOI prefix given
-            ("12345", f"{JSTOR_API_URL}/metadata-new/10.2307/12345"),
+            ("12345", f"{JSTOR_API_URL}/metadata/10.2307/12345"),
             # Article ID that needs to be encoded
-            ("123:45", f"{JSTOR_API_URL}/metadata-new/10.2307/123%3A45"),
+            ("123:45", f"{JSTOR_API_URL}/metadata/10.2307/123%3A45"),
             # Article with custom DOI prefix
-            ("10.123/12345", f"{JSTOR_API_URL}/metadata-new/10.123/12345"),
+            ("10.123/12345", f"{JSTOR_API_URL}/metadata/10.123/12345"),
         ],
     )
     def test_metadata_calls_jstor_api(


### PR DESCRIPTION
Change temporary `/metadata-new/{doi}` endpoint back to `/metadata/{doi}` and update `/pdf-url/{doi}` to `/pdf/{doi}`. See [note from Ron](https://hypothes-is.slack.com/archives/C02T75RKBTK/p1656344325914429?thread_ts=1656076613.726979&cid=C02T75RKBTK).

I tested all the article IDs from https://gist.github.com/robertknight/a2b045b717d6c7dda18879df91c16e90 in the JSTOR file picker using the updated endpoint, and they all return some reasonable title. Note that not all of these items have thumbnails, so it is expected that the thumbnail is blank for some of them.

If you're trying to launch an assignment, you'll find that our test account that has access to "everything" doesn't in fact appear to have PDF access to all of these test articles. If you look in the metadata responses you'll see `"requestor_access": "preview_access"` instead of `"requestor_access": "full_access"` for some of them. I'm clarifying the situation there, but article IDs from that set that do work include 10.2307/26202019, 10.2307/resrep09983, 10.2307/60236024 and 10.2307/resrep31045.8. Also note that the UI doesn't indicate whether a PDF is available or not, that will happen in a separate PR.