### PR TITLE
Update JSTOR PDF endpoint

### DIFF
--- a/lms/services/jstor.py
+++ b/lms/services/jstor.py
@@ -69,7 +69,7 @@ class JSTORService:
 
         # Get a signed S3 URL for the given JSTOR URL.
         s3_url = self._api_request(
-            "/pdf-url/{doi}", doi=document_url.replace("jstor://", "")
+            "/pdf/{doi}", doi=document_url.replace("jstor://", "")
         ).text
 
         if not s3_url.startswith("https://"):

--- a/tests/unit/lms/services/jstor_test.py
+++ b/tests/unit/lms/services/jstor_test.py
@@ -25,9 +25,9 @@ class TestJSTORService:
         [
             (
                 "jstor://ARTICLE_ID",
-                f"{JSTOR_API_URL}/pdf-url/10.2307/ARTICLE_ID",
+                f"{JSTOR_API_URL}/pdf/10.2307/ARTICLE_ID",
             ),
-            ("jstor://PREFIX/SUFFIX", f"{JSTOR_API_URL}/pdf-url/PREFIX/SUFFIX"),
+            ("jstor://PREFIX/SUFFIX", f"{JSTOR_API_URL}/pdf/PREFIX/SUFFIX"),
         ],
     )
     def test_via_url(


### PR DESCRIPTION
Update PDF URL endpoint from `/pdf-url/{doi}` => `/pdf/{doi}`.

See https://hypothes-is.slack.com/archives/C02T75RKBTK/p1656344325914429?thread_ts=1656076613.726979&cid=C02T75RKBTK

Marked as a draft because authentication is not currently working and the endpoint is returning a 403. I'm investigating this.