### PR TITLE
Show error in JSTOR picker if content is not available

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -52,7 +52,7 @@
  * Response for an `/api/jstor/articles/{article_id}` call.
  *
  * @typedef JSTORMetadata
- * @prop {boolean} is_collection
+ * @prop {'available'|'no_content'|'no_access'} content_status
  * @prop {string} title
  */
 

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -64,7 +64,7 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
     );
   } else if (metadata.data?.content_status === 'no_content') {
     renderedError =
-      'No content is available for this item. For collections, enter the link for a specific article or chapter.';
+      'There is no content available for this item. To select an item within a journal or book, enter a link to a specific article or chapter.';
   } else if (metadata.data?.content_status === 'no_access') {
     renderedError = 'Your institution does not have access to this item.';
   }

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -62,9 +62,11 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
       metadata.error,
       'Unable to fetch article details'
     );
-  } else if (metadata.data?.is_collection) {
+  } else if (metadata.data?.content_status === 'no_content') {
     renderedError =
-      'This work is a collection. Enter the link for a specific article in the collection.';
+      'No content is available for this item. For collections, enter the link for a specific article or chapter.';
+  } else if (metadata.data?.content_status === 'no_access') {
+    renderedError = 'Your institution does not have access to this item.';
   }
 
   const inputRef = /** @type {{ current: HTMLInputElement }} */ (useRef());
@@ -72,7 +74,9 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
   const previousURL = useRef(/** @type {string|null} */ (null));
 
   const canConfirmSelection =
-    articleId && metadata.data !== null && !metadata.data.is_collection;
+    articleId &&
+    metadata.data !== null &&
+    metadata.data.content_status === 'available';
 
   const confirmSelection = () => {
     if (canConfirmSelection) {
@@ -211,7 +215,7 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
             </div>
           )}
 
-          {metadata.data && (
+          {metadata.data && canConfirmSelection && (
             <>
               <div className="grow" />
               <div className="self-stretch text-right px-1">

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -300,7 +300,7 @@ describe('JSTORPicker', () => {
     {
       contentStatus: 'no_content',
       expectedError:
-        'No content is available for this item. For collections, enter the link for a specific article or chapter.',
+        'There is no content available for this item. To select an item within a journal or book, enter a link to a specific article or chapter.',
     },
   ].forEach(({ contentStatus, expectedError }) => {
     it('disables submit button and shows error if content is not available', () => {

--- a/lms/views/api/jstor.py
+++ b/lms/views/api/jstor.py
@@ -12,20 +12,16 @@ class JSTORAPIViews:
 
     @view_config(route_name="jstor_api.articles.metadata")
     def article_metadata(self):
-        article_id = self.request.matchdict["article_id"]
-        article_info = self.jstor_service.metadata(article_id)
-        content_status = article_info["content_status"]
-
-        return {
-            "title": article_info["title"],
-            "content_status": content_status.name.lower(),
-        }
+        return self.jstor_service.get_article_metadata(
+            article_id=self.request.matchdict["article_id"]
+        )
 
     @view_config(route_name="jstor_api.articles.thumbnail")
     def article_thumbnail(self):
-        article_id = self.request.matchdict["article_id"]
-        data_uri = self.jstor_service.thumbnail(article_id)
-
         # The image is wrapped in an object to make API responses more uniform
         # for consumers.
-        return {"image": data_uri}
+        return {
+            "image": self.jstor_service.thumbnail(
+                article_id=self.request.matchdict["article_id"]
+            )
+        }

--- a/lms/views/api/jstor.py
+++ b/lms/views/api/jstor.py
@@ -8,16 +8,18 @@ from lms.services import JSTORService
 class JSTORAPIViews:
     def __init__(self, request):
         self.request = request
-        self.jstor_service = request.find_service(iface=JSTORService)
+        self.jstor_service: JSTORService = request.find_service(iface=JSTORService)
 
     @view_config(route_name="jstor_api.articles.metadata")
     def article_metadata(self):
         article_id = self.request.matchdict["article_id"]
         article_info = self.jstor_service.metadata(article_id)
+        content_status = article_info["content_status"]
 
-        is_collection = False  # Placeholder
-
-        return {"title": article_info["title"], "is_collection": is_collection}
+        return {
+            "title": article_info["title"],
+            "content_status": content_status.name.lower(),
+        }
 
     @view_config(route_name="jstor_api.articles.thumbnail")
     def article_thumbnail(self):

--- a/tests/unit/lms/views/api/jstor_test.py
+++ b/tests/unit/lms/views/api/jstor_test.py
@@ -14,7 +14,9 @@ class TestJSTORAPIViews:
         jstor_service.metadata.assert_called_once_with("test-article")
         assert metadata == {
             "title": jstor_service.metadata.return_value["title"],
-            "is_collection": False,
+            "content_status": jstor_service.metadata.return_value[
+                "content_status"
+            ].name.lower(),
         }
 
     def test_article_thumbnail(self, jstor_service, pyramid_request):

--- a/tests/unit/lms/views/api/jstor_test.py
+++ b/tests/unit/lms/views/api/jstor_test.py
@@ -5,25 +5,22 @@ from lms.views.api.jstor import JSTORAPIViews
 
 @pytest.mark.usefixtures("jstor_service")
 class TestJSTORAPIViews:
-    def test_article_metadata(self, jstor_service, pyramid_request):
-        views = JSTORAPIViews(pyramid_request)
+    def test_article_metadata(self, views, jstor_service, pyramid_request):
         pyramid_request.matchdict["article_id"] = "test-article"
 
         metadata = views.article_metadata()
 
-        jstor_service.metadata.assert_called_once_with("test-article")
-        assert metadata == {
-            "title": jstor_service.metadata.return_value["title"],
-            "content_status": jstor_service.metadata.return_value[
-                "content_status"
-            ].name.lower(),
-        }
+        jstor_service.get_article_metadata.assert_called_once_with("test-article")
+        assert metadata == jstor_service.get_article_metadata.return_value
 
-    def test_article_thumbnail(self, jstor_service, pyramid_request):
-        views = JSTORAPIViews(pyramid_request)
+    def test_article_thumbnail(self, views, jstor_service, pyramid_request):
         pyramid_request.matchdict["article_id"] = "test-article"
 
         thumbnail = views.article_thumbnail()
 
         jstor_service.thumbnail.assert_called_once_with("test-article")
         assert thumbnail == {"image": jstor_service.thumbnail.return_value}
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return JSTORAPIViews(pyramid_request)


### PR DESCRIPTION
Show an error and disable the "Continue" button in the JSTOR assignment picker dialog, if the item does not have an associated PDF (eg. because it is a collection) or the PDF is not accessible to the institution that the current user is associated with.

Fixes https://github.com/hypothesis/lms/issues/4082.

## Screenshots

These show what the user will see in each of the three situations.

**Content available:**

(Example link: https://www.jstor.org/stable/3314737)

<img width="712" alt="JSTOR content available" src="https://user-images.githubusercontent.com/2458/180221002-e549197a-083c-4754-a302-884720547ae7.png">

**Item has no content:**

(Example link: https://www.jstor.org/stable/i274509)

<img width="719" alt="JSTOR no content v2" src="https://user-images.githubusercontent.com/2458/180240075-6b9ea4b1-ddfc-4a10-8cce-c5d7ed23c84b.png">

**Item has content, but user's institution does not have access:**

(Example link, when using our "hypothes.is" site code: 10.2307/community.30528851. The availability of this particular item might change pending a discussion with JSTOR).

<img width="714" alt="JSTOR no access" src="https://user-images.githubusercontent.com/2458/180221112-dc91263d-503c-4d8e-843c-9a058e7fca59.png">

