### PR TITLE
Disable spell-checking for JSTOR and VitalSource input fields

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.js
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.js
@@ -170,6 +170,7 @@ export default function BookSelector({
             onChange={() => onUpdateURL(false /* confirmSelectedBook */)}
             onKeyDown={onKeyDown}
             placeholder="e.g. https://bookshelf.vitalsource.com/#/books/012345678..."
+            spellcheck={false}
           />
           <IconButton
             icon="arrowRight"

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -199,6 +199,7 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
               onInput={() => setArticleId(null)}
               onKeyDown={onKeyDown}
               placeholder="e.g. https://www.jstor.org/stable/1234"
+              spellcheck={false}
             />
             <IconButton
               icon="arrowRight"


### PR DESCRIPTION
These fields accept both URLs and item IDs. If the user enters a URL
then browsers can figure out not to apply spell checking. In case the
user enters a book/item ID however, we need to explicitly disable spell
checking.

**Testing:**

Enter an article ID like "10.7249/mg876rc.10" in the JSTOR picker. Previously you'd see a spelling error underline on part of the ID. With this change you shouldn't.