### PR TITLE
VitalSource  automatic sign-in proof of concept

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -68,11 +68,14 @@ class JSConfig:
                 ),
             }
         elif document_url.startswith("vitalsource://"):
-            vitalsource_svc = self._request.find_service(VitalSourceService)
+            svc = self._request.find_service(VitalSourceService)
 
             # nb. VitalSource doesn't use Via, but is otherwise handled exactly
             # the same way by the frontend.
-            self._config["viaUrl"] = vitalsource_svc.get_launch_url(document_url)
+            self._config["viaUrl"] = svc.get_launch_url(
+                user_reference=self._request.lti_params[svc.user_lti_param],
+                document_url=document_url,
+            )
         elif jstor_service.enabled and document_url.startswith("jstor://"):
             self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)
         else:

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -70,12 +70,15 @@ class JSConfig:
         elif document_url.startswith("vitalsource://"):
             svc = self._request.find_service(VitalSourceService)
 
-            # nb. VitalSource doesn't use Via, but is otherwise handled exactly
-            # the same way by the frontend.
-            self._config["viaUrl"] = svc.get_launch_url(
-                user_reference=self._request.lti_params[svc.user_lti_param],
-                document_url=document_url,
-            )
+            self._config["api"]["viaUrl"] = {
+                "path": self._request.route_url(
+                    "vitalsource_api.launch_url",
+                    _query={
+                        "user_reference": self._request.lti_params[svc.user_lti_param],
+                        "document_url": document_url,
+                    },
+                )
+            }
         elif jstor_service.enabled and document_url.startswith("jstor://"):
             self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)
         else:

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -117,6 +117,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "vitalsource_api.books.toc", "/api/vitalsource/books/{book_id}/toc"
     )
+    config.add_route("vitalsource_api.launch_url", "/api/vitalsource/launch_url")
 
     config.add_route("admin.index", "/admin/")
     config.add_route("admin.instances", "/admin/instances/")

--- a/lms/services/vitalsource/exceptions.py
+++ b/lms/services/vitalsource/exceptions.py
@@ -1,0 +1,14 @@
+class VitalSourceError(Exception):
+    """Indicate a failure in the VitalSource service or client."""
+
+    def __init__(self, error_code, message=None):
+        """
+        Instantiate the error.
+
+        :param error_code: A string code used to present specific dialogs in
+            the front end. For details of the codes see:
+            lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+        :param message: A normal error message, mostly for debugging
+        """
+        self.error_code = error_code
+        super().__init__(message)

--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -5,9 +5,13 @@ from lms.services.vitalsource.service import VitalSourceService
 def service_factory(_context, request):
     settings = request.find_service(name="application_instance").get_current().settings
 
+    customer_key = settings.get("vitalsource", "api_key")
+
     return VitalSourceService(
-        client=VitalSourceClient(
-            api_key=request.registry.settings["vitalsource_api_key"]
-        ),
+        # It's important to pass None here if there's no key, so the service
+        # knows it's been disabled. The client will raise an error anyway if
+        # you try and create one with no API key.
+        client=VitalSourceClient(customer_key) if customer_key else None,
+        user_lti_param=settings.get("vitalsource", "user_lti_param"),
         enabled=settings.get("vitalsource", "enabled", False),
     )

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -1,41 +1,60 @@
 from typing import List
 
 from lms.services.vitalsource._client import VitalSourceClient
+from lms.services.vitalsource.exceptions import VitalSourceError
 from lms.services.vitalsource.model import VSBookLocation
 
 
 class VitalSourceService:
     """A high-level interface for dealing with VitalSource."""
 
-    def __init__(self, client: VitalSourceClient, enabled):
+    user_lti_param = None
+    """The LTI parameter to use to work out the LTI user."""
+
+    def __init__(self, client: VitalSourceClient, enabled, user_lti_param):
+        """
+        Instantiate the service.
+
+        :param client: VitalSource client for connecting to the API
+        :param enabled: Are we enabled at all?
+        :param user_lti_param: Which LTI parameter to read to get the user
+            reference
+        """
+        self._client = client
         self._enabled = enabled
-        self.client = client
+        self.user_lti_param = user_lti_param
 
     @property
     def enabled(self) -> bool:
         """Check if the service has everything it needs to work."""
 
-        return bool(self._enabled and self.client)
+        return bool(self._enabled and self._client and self.user_lti_param)
 
     def get_book_info(self, book_id: str) -> dict:
         """Get details of a book."""
 
-        return self.client.get_book_info(book_id)
+        return self._client.get_book_info(book_id)
 
     def get_table_of_contents(self, book_id: str) -> List[dict]:
         """Get the table of contents for a book."""
 
-        return self.client.get_table_of_contents(book_id)
+        return self._client.get_table_of_contents(book_id)
 
-    def get_launch_url(self, document_url: str) -> str:
+    def get_launch_url(self, user_reference, document_url) -> str:
         """
         Get the public URL for VitalSource book viewer from our internal URL.
 
         That URL can be used to load VitalSource content in an iframe like we
         do with other types of content.
 
+        :param user_reference: The reference of the user
         :param document_url: `vitalsource://` type URL identifying the document
+        :raises VitalSourceError: If the user has no licences for the material
         """
         loc = VSBookLocation.from_document_url(document_url)
 
-        return f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
+        if not self._client.get_user_book_license(user_reference, loc.book_id):
+            raise VitalSourceError("vitalsource_no_book_license")
+
+        url = f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
+        return self._client.get_sso_redirect(user_reference, url)

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -20,6 +20,15 @@ import ErrorModal from './ErrorModal';
  */
 
 /**
+ * URL that opens the VitalSource bookshelf reader in the current LMS.
+ *
+ * TODO: This should be replaced with an installation-specific link that opens
+ * VitalSource inside the current LMS. This allows an association between the
+ * LTI user and VitalSource account to be established.
+ */
+const vitalsourceBookshelfURL = 'https://bookshelf.vitalsource.com';
+
+/**
  * Render an error that prevents an LTI launch from completing successfully.
  *
  * This is rendered in a non-cancelable modal.
@@ -210,6 +219,45 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
+    case 'vitalsource_user_not_found':
+      return (
+        <ErrorModal
+          busy={busy}
+          error={error}
+          title="VitalSource account not found"
+        >
+          <p>Hypothesis could not find your VitalSource user account.</p>
+          <p>
+            This account is set up the first time that you open the VitalSource
+            book reader.{' '}
+            <b>
+              To fix the problem, please open the{' '}
+              <Link target="_blank" href={vitalsourceBookshelfURL}>
+                VitalSource book reader
+              </Link>
+              .
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
+    case 'vitalsource_no_book_license':
+      return (
+        // TODO: Add some details of _which_ book is not available.
+        <ErrorModal busy={busy} error={error} title="Book not available">
+          <p>Your VitalSource library does not have this book in it.</p>
+          <p>
+            <b>
+              To fix the problem, open the{' '}
+              <Link target="_blank" href={vitalsourceBookshelfURL}>
+                VitalSource book reader
+              </Link>{' '}
+              and add the book to your library.
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
     case 'error-fetching':
       // Do not display canned text if there is a back-end-provided message
       // to show here, as it's redundant and not useful
@@ -225,6 +273,7 @@ export default function LaunchErrorDialog({
           )}
         </ErrorModal>
       );
+
     case 'error-reporting-submission':
       // nb. There is no retry action here as we just suggest reloading the entire
       // page.

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -109,6 +109,20 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
+      errorState: 'vitalsource_user_not_found',
+      expectedText: 'Hypothesis could not find your VitalSource user account',
+      expectedTitle: 'VitalSource account not found',
+      hasRetry: false,
+      withError: true,
+    },
+    {
+      errorState: 'vitalsource_no_book_license',
+      expectedText: 'Your VitalSource library does not have this book in it',
+      expectedTitle: 'Book not available',
+      hasRetry: false,
+      withError: true,
+    },
+    {
       errorState: 'error-fetching',
       expectedText: 'There was a problem fetching this Hypothesis assignment',
       expectedTitle: 'Something went wrong',

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -11,7 +11,9 @@
  *           'canvas_file_not_found_in_course'|
  *           'canvas_group_set_not_found'|
  *           'canvas_group_set_empty'|
- *           'canvas_student_not_in_group'} LTILaunchServerErrorCode
+ *           'canvas_student_not_in_group'|
+ *           'vitalsource_user_not_found'|
+ *           'vitalsource_no_book_license'} LTILaunchServerErrorCode
  */
 
 /**
@@ -131,6 +133,8 @@ export function isLTILaunchServerError(error) {
       'canvas_group_set_not_found',
       'canvas_group_set_empty',
       'canvas_student_not_in_group',
+      'vitalsource_user_not_found',
+      'vitalsource_no_book_license',
     ].includes(error.errorCode)
   );
 }

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -25,3 +25,15 @@ class VitalSourceAPIViews:
     @view_config(route_name="vitalsource_api.books.toc", schema=_BookSchema)
     def table_of_contents(self):
         return self.svc.get_table_of_contents(self.request.matchdict["book_id"])
+
+    @view_config(route_name="vitalsource_api.launch_url")
+    def launch_url(self):
+        # The URL is in a `via_url` property, so it can be used the same way
+        # as assignments that do use Via. We should rename this to something
+        # more generic.
+        return {
+            "via_url": self.svc.get_launch_url(
+                user_reference=self.request.params["user_reference"],
+                document_url=self.request.params["document_url"],
+            )
+        }

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -9,6 +9,7 @@ class TestServiceFactory:
     @pytest.mark.parametrize(
         "enabled,expected", ((sentinel.enabled, sentinel.enabled), (None, False))
     )
+    @pytest.mark.parametrize("api_key", (sentinel.api_key, None))
     def test_it(
         self,
         pyramid_request,
@@ -17,17 +18,24 @@ class TestServiceFactory:
         application_instance_service,
         enabled,
         expected,
+        api_key,
     ):
         # This fixture is a bit odd and returns a real application instance
         ai = application_instance_service.get_current()
+        ai.settings.set("vitalsource", "user_lti_param", sentinel.user_lti_param)
+        ai.settings.set("vitalsource", "api_key", api_key)
         if enabled:
             ai.settings.set("vitalsource", "enabled", enabled)
 
         svc = service_factory(sentinel.context, pyramid_request)
 
-        VitalSourceClient.assert_called_once_with(api_key="test_vs_api_key")
+        if api_key:
+            VitalSourceClient.assert_called_once_with(api_key)
+
         VitalSourceService.assert_called_once_with(
-            client=VitalSourceClient.return_value, enabled=expected
+            client=VitalSourceClient.return_value if api_key else None,
+            user_lti_param=sentinel.user_lti_param,
+            enabled=expected,
         )
         assert svc == VitalSourceService.return_value
 

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -3,24 +3,46 @@ from unittest.mock import create_autospec, sentinel
 import pytest
 
 from lms.services.vitalsource._client import VitalSourceClient
+from lms.services.vitalsource.exceptions import VitalSourceError
 from lms.services.vitalsource.service import VitalSourceService
 
 
 class TestVitalSourceService:
     @pytest.mark.parametrize("client", (sentinel.client, None))
     @pytest.mark.parametrize("enabled", (sentinel.client, None))
-    def test_enabled(self, client, enabled):
-        svc = VitalSourceService(client=client, enabled=enabled)
-
-        assert svc.enabled == bool(client and enabled)
-
-    def test_get_launch_url(self, svc):
-        document_url = "vitalsource://book/bookID/book-id/cfi//abc"
-
-        assert (
-            svc.get_launch_url(document_url)
-            == "https://hypothesis.vitalsource.com/books/book-id/cfi//abc"
+    @pytest.mark.parametrize("user_lti_param", (sentinel.user_lti_param, None))
+    def test_enabled(self, client, enabled, user_lti_param):
+        svc = VitalSourceService(
+            client=client, enabled=enabled, user_lti_param=user_lti_param
         )
+
+        assert svc.enabled == bool(client and enabled and user_lti_param)
+
+    def test_get_launch_url(self, svc, client):
+        result = svc.get_launch_url(
+            sentinel.user_reference,
+            document_url="vitalsource://book/bookID/BOOK-ID/cfi/CFI",
+        )
+
+        client.get_user_book_license.assert_called_once_with(
+            sentinel.user_reference, "BOOK-ID"
+        )
+        client.get_sso_redirect.assert_called_once_with(
+            sentinel.user_reference,
+            "https://hypothesis.vitalsource.com/books/BOOK-ID/cfi/CFI",
+        )
+        assert result == client.get_sso_redirect.return_value
+
+    def test_get_launch_url_with_no_book_license(self, svc, client):
+        client.get_user_book_license.return_value = None
+
+        with pytest.raises(VitalSourceError) as exc:
+            svc.get_launch_url(
+                sentinel.user_reference,
+                document_url="vitalsource://book/bookID/BOOK-ID/cfi/CFI",
+            )
+
+        assert exc.value.error_code == "vitalsource_no_book_license"
 
     @pytest.mark.parametrize(
         "proxy_method,args",
@@ -42,4 +64,6 @@ class TestVitalSourceService:
 
     @pytest.fixture
     def svc(self, client):
-        return VitalSourceService(client=client, enabled=True)
+        return VitalSourceService(
+            client=client, enabled=True, user_lti_param=sentinel.user_lti_param
+        )

--- a/tests/unit/lms/views/api/vitalsource_test.py
+++ b/tests/unit/lms/views/api/vitalsource_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import sentinel
+
 import pytest
 
 from lms.views.api.vitalsource import VitalSourceAPIViews
@@ -5,18 +7,33 @@ from lms.views.api.vitalsource import VitalSourceAPIViews
 
 @pytest.mark.usefixtures("vitalsource_service")
 class TestVitalSourceAPIViews:
-    def test_book_info(self, pyramid_request, vitalsource_service):
+    def test_book_info(self, view, pyramid_request, vitalsource_service):
         pyramid_request.matchdict["book_id"] = "BOOK-ID"
 
-        response = VitalSourceAPIViews(pyramid_request).book_info()
+        response = view.book_info()
 
         vitalsource_service.get_book_info.assert_called_once_with("BOOK-ID")
         assert response == vitalsource_service.get_book_info.return_value
 
-    def test_table_of_contents(self, pyramid_request, vitalsource_service):
+    def test_table_of_contents(self, view, pyramid_request, vitalsource_service):
         pyramid_request.matchdict["book_id"] = "BOOK-ID"
 
-        response = VitalSourceAPIViews(pyramid_request).table_of_contents()
+        response = view.table_of_contents()
 
         vitalsource_service.get_table_of_contents.assert_called_once_with("BOOK-ID")
         assert response == vitalsource_service.get_table_of_contents.return_value
+
+    def test_launch_url(self, view, pyramid_request, vitalsource_service):
+        pyramid_request.params["user_reference"] = sentinel.user_reference
+        pyramid_request.params["document_url"] = sentinel.document_url
+
+        response = view.launch_url()
+
+        vitalsource_service.get_launch_url.assert_called_once_with(
+            user_reference=sentinel.user_reference, document_url=sentinel.document_url
+        )
+        assert response == {"via_url": vitalsource_service.get_launch_url.return_value}
+
+    @pytest.fixture
+    def view(self, pyramid_request):
+        return VitalSourceAPIViews(pyramid_request)


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4215
 
This builds on the work in:

 * https://github.com/hypothesis/lms/pull/4151

And other refactoring work to try and make this more real. There are a couple of bigger changes to the approach taken by the previous approach, along with lots of smaller refactors:

 * There is now a division between service and client
 * The client methods all wrap a single call to the API
 * The client now handles authentication transparently (caller isn't involved)
 * ~Instead of one client with two API keys, we have the same client twice with different API keys~
    * I'm making a gamble here that we only need the one client now - All in separate PRs
 * Instead of parsing the document URL (and passing ids) when calling our own proxy API view, we now pass the whole URL and parse it inside the service