### PR TITLE
Clean up the VitalSource api view

### DIFF
--- a/lms/services/vitalsource/_client.py
+++ b/lms/services/vitalsource/_client.py
@@ -47,7 +47,7 @@ class VitalSourceClient:
 
         return _BookInfoSchema(response).parse()
 
-    def get_book_toc(self, book_id: str):
+    def get_table_of_contents(self, book_id: str):
         """
         Get the table of contents for a book.
 
@@ -64,8 +64,8 @@ class VitalSourceClient:
 
             raise
 
-        toc = _BookTOCSchema(response).parse()
-        for chapter in toc["table_of_contents"]:
+        toc = _BookTOCSchema(response).parse()["table_of_contents"]
+        for chapter in toc:
             chapter["url"] = VSBookLocation(book_id, chapter["cfi"]).document_url
 
         return toc

--- a/lms/services/vitalsource/_client.py
+++ b/lms/services/vitalsource/_client.py
@@ -45,7 +45,13 @@ class VitalSourceClient:
 
             raise
 
-        return _BookInfoSchema(response).parse()
+        book_info = _BookInfoSchema(response).parse()
+
+        return {
+            "id": book_info["vbid"],
+            "title": book_info["title"],
+            "cover_image": book_info["resource_links"]["cover_image"],
+        }
 
     def get_table_of_contents(self, book_id: str):
         """

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -13,10 +13,10 @@ class VitalSourceService:
 
         return self.client.get_book_info(book_id)
 
-    def get_book_toc(self, book_id: str):
+    def get_table_of_contents(self, book_id: str):
         """Get the table of contents for a book."""
 
-        return self.client.get_book_toc(book_id)
+        return self.client.get_table_of_contents(book_id)
 
     def get_launch_url(self, document_url: str) -> str:
         """

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -15,13 +15,7 @@ class VitalSourceAPIViews:
 
     @view_config(route_name="vitalsource_api.books.info")
     def book_info(self):
-        book_info = self.svc.get_book_info(self._book_id)
-
-        return {
-            "id": book_info["vbid"],
-            "title": book_info["title"],
-            "cover_image": book_info["resource_links"]["cover_image"],
-        }
+        return self.svc.get_book_info(self._book_id)
 
     @view_config(route_name="vitalsource_api.books.toc")
     def table_of_contents(self):

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -25,8 +25,7 @@ class VitalSourceAPIViews:
 
     @view_config(route_name="vitalsource_api.books.toc")
     def table_of_contents(self):
-        book_toc = self.svc.get_book_toc(self._book_id)
-        return book_toc["table_of_contents"]
+        return self.svc.get_table_of_contents(self._book_id)
 
     _VALID_BOOK_ID = re.compile(r"^[\dA-Z-]+$")
 

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -1,10 +1,15 @@
-import re
-
-from pyramid.httpexceptions import HTTPBadRequest
+from marshmallow import fields, validate
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
 from lms.services import VitalSourceService
+from lms.validation import PyramidRequestSchema
+
+
+class _BookSchema(PyramidRequestSchema):
+    location = "matchdict"
+
+    book_id = fields.Str(required=True, validate=validate.Regexp(r"^[\dA-Z-]+$"))
 
 
 @view_defaults(renderer="json", permission=Permissions.API)
@@ -13,21 +18,10 @@ class VitalSourceAPIViews:
         self.request = request
         self.svc = request.find_service(VitalSourceService)
 
-    @view_config(route_name="vitalsource_api.books.info")
+    @view_config(route_name="vitalsource_api.books.info", schema=_BookSchema)
     def book_info(self):
-        return self.svc.get_book_info(self._book_id)
+        return self.svc.get_book_info(self.request.matchdict["book_id"])
 
-    @view_config(route_name="vitalsource_api.books.toc")
+    @view_config(route_name="vitalsource_api.books.toc", schema=_BookSchema)
     def table_of_contents(self):
-        return self.svc.get_table_of_contents(self._book_id)
-
-    _VALID_BOOK_ID = re.compile(r"^[\dA-Z-]+$")
-
-    @property
-    def _book_id(self):
-        book_id = self.request.matchdict["book_id"]
-
-        if not self._VALID_BOOK_ID.match(book_id):
-            raise HTTPBadRequest("Invalid `book_id`. It must only contain [0-9A-Z-].")
-
-        return book_id
+        return self.svc.get_table_of_contents(self.request.matchdict["book_id"])

--- a/tests/unit/lms/services/vitalsource/_client_test.py
+++ b/tests/unit/lms/services/vitalsource/_client_test.py
@@ -21,13 +21,12 @@ class TestVitalSourceClient:
             VitalSourceClient(api_key=None)
 
     def test_get_book_info(self, client, http_service):
-        json_data = {
-            "vbid": "VBID",
-            "title": "TITLE",
-            "resource_links": {"cover_image": "COVER_IMAGE"},
-        }
         http_service.request.return_value = factories.requests.Response(
-            json_data=json_data
+            json_data={
+                "vbid": "VBID",
+                "title": "TITLE",
+                "resource_links": {"cover_image": "COVER_IMAGE"},
+            }
         )
 
         book_info = client.get_book_info("BOOK_ID")
@@ -37,7 +36,11 @@ class TestVitalSourceClient:
             "https://api.vitalsource.com/v4/products/BOOK_ID",
             headers={"Accept": "application/json"},
         )
-        assert book_info == json_data
+        assert book_info == {
+            "id": "VBID",
+            "title": "TITLE",
+            "cover_image": "COVER_IMAGE",
+        }
 
     def test_get_book_info_not_found(self, client, http_service):
         http_service.request.side_effect = ExternalRequestError(

--- a/tests/unit/lms/services/vitalsource/_client_test.py
+++ b/tests/unit/lms/services/vitalsource/_client_test.py
@@ -57,14 +57,14 @@ class TestVitalSourceClient:
         with pytest.raises(ExternalRequestError):
             client.get_book_info("BOOK_ID")
 
-    def test_get_book_toc(self, client, http_service):
+    def test_get_table_of_contents(self, client, http_service):
         http_service.request.return_value = factories.requests.Response(
             json_data={
                 "table_of_contents": [{"title": "TITLE", "cfi": "CFI", "page": "PAGE"}]
             }
         )
 
-        book_toc = client.get_book_toc("BOOK_ID")
+        book_toc = client.get_table_of_contents("BOOK_ID")
 
         http_service.request.assert_called_once_with(
             "GET",
@@ -72,34 +72,32 @@ class TestVitalSourceClient:
             headers={"Accept": "application/json"},
         )
 
-        assert book_toc == {
-            "table_of_contents": [
-                {
-                    "title": "TITLE",
-                    "cfi": "CFI",
-                    "page": "PAGE",
-                    "url": "vitalsource://book/bookID/BOOK_ID/cfi/CFI",
-                }
-            ]
-        }
+        assert book_toc == [
+            {
+                "title": "TITLE",
+                "cfi": "CFI",
+                "page": "PAGE",
+                "url": "vitalsource://book/bookID/BOOK_ID/cfi/CFI",
+            }
+        ]
 
-    def test_get_book_toc_not_found(self, client, http_service):
+    def test_get_table_of_contents_not_found(self, client, http_service):
         http_service.request.side_effect = ExternalRequestError(
             response=factories.requests.Response(status_code=404)
         )
 
         with pytest.raises(ExternalRequestError) as exc_info:
-            client.get_book_toc("BOOK_ID")
+            client.get_table_of_contents("BOOK_ID")
 
         assert exc_info.value.message == "Book BOOK_ID not found"
 
-    def test_get_book_toc_error(self, client, http_service):
+    def test_get_table_of_contents_error(self, client, http_service):
         http_service.request.side_effect = ExternalRequestError(
             response=factories.requests.Response(status_code=500)
         )
 
         with pytest.raises(ExternalRequestError):
-            client.get_book_toc("BOOK_ID")
+            client.get_table_of_contents("BOOK_ID")
 
     @pytest.fixture
     def client(self):

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -18,8 +18,8 @@ class TestVitalSourceService:
     @pytest.mark.parametrize(
         "proxy_method,args",
         (
-            ("get_book_toc", [sentinel.book_id]),
             ("get_book_info", [sentinel.book_id]),
+            ("get_table_of_contents", [sentinel.book_id]),
         ),
     )
     def test_proxied_methods(self, svc, client, proxy_method, args):

--- a/tests/unit/lms/views/api/vitalsource_test.py
+++ b/tests/unit/lms/views/api/vitalsource_test.py
@@ -6,31 +6,21 @@ from lms.views.api.vitalsource import VitalSourceAPIViews
 
 @pytest.mark.usefixtures("vitalsource_service")
 class TestVitalSourceAPIViews:
-    def test_book_info_returns_metadata(self, pyramid_request, vitalsource_service):
-        api_book_info = {
-            "vbid": "VBID",
-            "title": "BOOK  TITLE",
-            "resource_links": {"cover_image": "http://cover_image/url"},
-        }
+    def test_book_info(self, pyramid_request, vitalsource_service):
+        pyramid_request.matchdict["book_id"] = "BOOK-ID"
 
-        vitalsource_service.get_book_info.return_value = api_book_info
+        response = VitalSourceAPIViews(pyramid_request).book_info()
 
-        pyramid_request.matchdict["book_id"] = "BOOKSHELF-TUTORIAL"
-
-        metadata = VitalSourceAPIViews(pyramid_request).book_info()
-
-        assert metadata == {
-            "id": api_book_info["vbid"],
-            "title": api_book_info["title"],
-            "cover_image": api_book_info["resource_links"]["cover_image"],
-        }
+        vitalsource_service.get_book_info.assert_called_once_with("BOOK-ID")
+        assert response == vitalsource_service.get_book_info.return_value
 
     def test_table_of_contents(self, pyramid_request, vitalsource_service):
-        pyramid_request.matchdict["book_id"] = "BOOKSHELF-TUTORIAL"
+        pyramid_request.matchdict["book_id"] = "BOOK-ID"
 
-        toc = VitalSourceAPIViews(pyramid_request).table_of_contents()
+        response = VitalSourceAPIViews(pyramid_request).table_of_contents()
 
-        assert toc == vitalsource_service.get_table_of_contents.return_value
+        vitalsource_service.get_table_of_contents.assert_called_once_with("BOOK-ID")
+        assert response == vitalsource_service.get_table_of_contents.return_value
 
     @pytest.mark.parametrize("method", ("book_info", "table_of_contents"))
     @pytest.mark.parametrize("invalid_book_id", ["", "lowercase", "OTHER#CHARS-OTHER"])

--- a/tests/unit/lms/views/api/vitalsource_test.py
+++ b/tests/unit/lms/views/api/vitalsource_test.py
@@ -1,5 +1,4 @@
 import pytest
-from pyramid.httpexceptions import HTTPBadRequest
 
 from lms.views.api.vitalsource import VitalSourceAPIViews
 
@@ -21,13 +20,3 @@ class TestVitalSourceAPIViews:
 
         vitalsource_service.get_table_of_contents.assert_called_once_with("BOOK-ID")
         assert response == vitalsource_service.get_table_of_contents.return_value
-
-    @pytest.mark.parametrize("method", ("book_info", "table_of_contents"))
-    @pytest.mark.parametrize("invalid_book_id", ["", "lowercase", "OTHER#CHARS-OTHER"])
-    def test_we_check_book_id_validity(self, pyramid_request, method, invalid_book_id):
-        view = VitalSourceAPIViews(pyramid_request)
-
-        pyramid_request.matchdict["book_id"] = invalid_book_id
-
-        with pytest.raises(HTTPBadRequest):
-            getattr(view, method)()

--- a/tests/unit/lms/views/api/vitalsource_test.py
+++ b/tests/unit/lms/views/api/vitalsource_test.py
@@ -6,9 +6,13 @@ from lms.views.api.vitalsource import VitalSourceAPIViews
 
 @pytest.mark.usefixtures("vitalsource_service")
 class TestVitalSourceAPIViews:
-    def test_book_info_returns_metadata(
-        self, pyramid_request, vitalsource_service, api_book_info
-    ):
+    def test_book_info_returns_metadata(self, pyramid_request, vitalsource_service):
+        api_book_info = {
+            "vbid": "VBID",
+            "title": "BOOK  TITLE",
+            "resource_links": {"cover_image": "http://cover_image/url"},
+        }
+
         vitalsource_service.get_book_info.return_value = api_book_info
 
         pyramid_request.matchdict["book_id"] = "BOOKSHELF-TUTORIAL"
@@ -22,13 +26,18 @@ class TestVitalSourceAPIViews:
         }
 
     def test_table_of_contents_returns_chapter_data(
-        self, pyramid_request, vitalsource_service, api_book_table_of_contents
+        self, pyramid_request, vitalsource_service
     ):
-        vitalsource_service.get_book_toc.return_value = api_book_table_of_contents
+        vitalsource_service.get_book_toc.return_value = {
+            "table_of_contents": [
+                {"title": "chapter 1", "cfi": "XXXX", "page": "1"},
+                ...,
+            ]
+        }
 
         pyramid_request.matchdict["book_id"] = "BOOKSHELF-TUTORIAL"
         toc = VitalSourceAPIViews(pyramid_request).table_of_contents()
-        assert toc == api_book_table_of_contents["table_of_contents"]
+        assert toc == vitalsource_service.get_book_toc.return_value["table_of_contents"]
 
     @pytest.mark.parametrize("method", ("book_info", "table_of_contents"))
     @pytest.mark.parametrize("invalid_book_id", ["", "lowercase", "OTHER#CHARS-OTHER"])
@@ -39,24 +48,3 @@ class TestVitalSourceAPIViews:
 
         with pytest.raises(HTTPBadRequest):
             getattr(view, method)()
-
-    @pytest.fixture
-    def api_book_table_of_contents(self):
-        return {
-            "table_of_contents": [
-                {"title": "chapter 1", "cfi": "XXXX", "page": "1"},
-                {"title": "chapter 2", "cfi": "XXXX", "page": "2"},
-                {"title": "chapter 3", "cfi": "XXXX", "page": "3"},
-                {"title": "chapter 4", "cfi": "XXXX", "page": "4"},
-            ]
-        }
-
-    @pytest.fixture
-    def api_book_info(self):
-        return {
-            "vbid": "VBID",
-            "title": "BOOK  TITLE",
-            "resource_links": {
-                "cover_image": "http://cover_image/url",
-            },
-        }

--- a/tests/unit/lms/views/api/vitalsource_test.py
+++ b/tests/unit/lms/views/api/vitalsource_test.py
@@ -25,19 +25,12 @@ class TestVitalSourceAPIViews:
             "cover_image": api_book_info["resource_links"]["cover_image"],
         }
 
-    def test_table_of_contents_returns_chapter_data(
-        self, pyramid_request, vitalsource_service
-    ):
-        vitalsource_service.get_book_toc.return_value = {
-            "table_of_contents": [
-                {"title": "chapter 1", "cfi": "XXXX", "page": "1"},
-                ...,
-            ]
-        }
-
+    def test_table_of_contents(self, pyramid_request, vitalsource_service):
         pyramid_request.matchdict["book_id"] = "BOOKSHELF-TUTORIAL"
+
         toc = VitalSourceAPIViews(pyramid_request).table_of_contents()
-        assert toc == vitalsource_service.get_book_toc.return_value["table_of_contents"]
+
+        assert toc == vitalsource_service.get_table_of_contents.return_value
 
     @pytest.mark.parametrize("method", ("book_info", "table_of_contents"))
     @pytest.mark.parametrize("invalid_book_id", ["", "lowercase", "OTHER#CHARS-OTHER"])


### PR DESCRIPTION
We were previously returning data verbatim from VitalSource and then manipulating it to be the format we want. We might as well do that all in the client directly as our abstraction over the real API.

There are some other small refactors here as well.