### PR TITLE
Use a service method to decide if `VitalSource` is available

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -195,7 +195,7 @@ class JSConfig:
                     "canvas": FilePickerConfig.canvas_config(*args),
                     "google": FilePickerConfig.google_files_config(*args),
                     "microsoftOneDrive": FilePickerConfig.microsoft_onedrive(*args),
-                    "vitalSource": FilePickerConfig.vital_source_config(*args),
+                    "vitalSource": FilePickerConfig.vitalsource_config(*args),
                     "jstor": FilePickerConfig.jstor_config(*args),
                 },
             }

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -1,7 +1,7 @@
 from lms.product import Product
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
-from lms.services import JSTORService
+from lms.services import JSTORService, VitalSourceService
 
 
 class FilePickerConfig:
@@ -105,10 +105,10 @@ class FilePickerConfig:
         }
 
     @classmethod
-    def vital_source_config(cls, _request, application_instance):
-        """Get Vital Source config."""
-        enabled = application_instance.settings.get("vitalsource", "enabled", False)
-        return {"enabled": enabled}
+    def vitalsource_config(cls, request, _application_instance):
+        """Get VitalSource config."""
+
+        return {"enabled": request.find_service(VitalSourceService).enabled}
 
     @classmethod
     def jstor_config(cls, request, _application_instance):

--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -3,6 +3,11 @@ from lms.services.vitalsource.service import VitalSourceService
 
 
 def service_factory(_context, request):
+    settings = request.find_service(name="application_instance").get_current().settings
+
     return VitalSourceService(
-        VitalSourceClient(api_key=request.registry.settings["vitalsource_api_key"])
+        client=VitalSourceClient(
+            api_key=request.registry.settings["vitalsource_api_key"]
+        ),
+        enabled=settings.get("vitalsource", "enabled", False),
     )

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -7,8 +7,15 @@ from lms.services.vitalsource.model import VSBookLocation
 class VitalSourceService:
     """A high-level interface for dealing with VitalSource."""
 
-    def __init__(self, client: VitalSourceClient):
+    def __init__(self, client: VitalSourceClient, enabled):
+        self._enabled = enabled
         self.client = client
+
+    @property
+    def enabled(self) -> bool:
+        """Check if the service has everything it needs to work."""
+
+        return bool(self._enabled and self.client)
 
     def get_book_info(self, book_id: str) -> dict:
         """Get details of a book."""

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -44,7 +44,7 @@ class TestFilePickerMode:
             ("canvas_config", "canvas"),
             ("google_files_config", "google"),
             ("microsoft_onedrive", "microsoftOneDrive"),
-            ("vital_source_config", "vitalSource"),
+            ("vitalsource_config", "vitalSource"),
             ("jstor_config", "jstor"),
         ),
     )

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -139,15 +139,12 @@ class TestFilePickerConfig:
 
         assert config == expected
 
-    @pytest.mark.parametrize("enabled", (True, False))
-    def test_vital_source_config(self, pyramid_request, application_instance, enabled):
-        application_instance.settings.set("vitalsource", "enabled", enabled)
-
-        config = FilePickerConfig.vital_source_config(
-            pyramid_request, application_instance
+    def test_vitalsource_config(self, pyramid_request, vitalsource_service):
+        config = FilePickerConfig.vitalsource_config(
+            pyramid_request, sentinel.application_instance
         )
 
-        assert config == {"enabled": enabled}
+        assert config == {"enabled": vitalsource_service.enabled}
 
     @pytest.mark.parametrize("enabled", (True, False))
     def test_jstor_config(self, pyramid_request, jstor_service, enabled):

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -7,6 +7,13 @@ from lms.services.vitalsource.service import VitalSourceService
 
 
 class TestVitalSourceService:
+    @pytest.mark.parametrize("client", (sentinel.client, None))
+    @pytest.mark.parametrize("enabled", (sentinel.client, None))
+    def test_enabled(self, client, enabled):
+        svc = VitalSourceService(client=client, enabled=enabled)
+
+        assert svc.enabled == bool(client and enabled)
+
     def test_get_launch_url(self, svc):
         document_url = "vitalsource://book/bookID/book-id/cfi//abc"
 
@@ -35,4 +42,4 @@ class TestVitalSourceService:
 
     @pytest.fixture
     def svc(self, client):
-        return VitalSourceService(client)
+        return VitalSourceService(client=client, enabled=True)


### PR DESCRIPTION
Currently if LMS was misconfigured with:

 * Vitalsource enabled in the application instance settings
 * But the API key not setup

We would still present the VitalSource file picker, which would then fail.

This PR makes the responsibility of deciding whether the picker is available to the service. This has some follow up benefits for future PRs where the decision will become more complicated. This means we can change the service and nothing else should have to change.