### PR TITLE
Add per-instance VitalSource API keys and user ID field settings

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -89,11 +89,14 @@
         {{ settings_checkbox("Groups enabled", "blackboard", "groups_enabled") }}
         {{ settings_checkbox("Files enabled", "blackboard", "files_enabled") }}
     </fieldset>
-
     <fieldset class="box">
         <legend class="label has-text-centered">Content integrations</legend>
         {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
+
         {{ settings_checkbox("VitalSource enabled", "vitalsource", "enabled") }}
+        {{ settings_text_field("VitalSource user ID param", "vitalsource", "user_lti_param") }}
+        {{ settings_text_field("VitalSource API key", "vitalsource", "api_key") }}
+
         {{ settings_checkbox("JSTOR enabled", "jstor", "enabled") }}
         {{ settings_text_field("JSTOR site code", "jstor", "site_code") }}
     </fieldset>

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -272,6 +272,8 @@ class AdminApplicationInstanceViews:
             ("blackboard", "groups_enabled", bool),
             ("microsoft_onedrive", "files_enabled", bool),
             ("vitalsource", "enabled", bool),
+            ("vitalsource", "user_lti_param", str),
+            ("vitalsource", "api_key", str),
             ("jstor", "enabled", bool),
             ("jstor", "site_code", str),
         ):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4218

 - The per-instance VitalSource API key needs to be used to query for
   information about users or courses associated with a particular
   institution.
 - The user ID field identifies which field from the LTI launch request
   should be passed to VitalSource's `POST /v3/credentials.xml` API in
   order to obtain a token for use in subsequent user-specific requests
   (eg. to list the books a user has access to)

We need this information to be in place before we can deploy the new work, otherwise existing customers will break.