### PR TITLE
Remove the VitalSource API key env var as we no longer use it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,6 @@ will not work.
 | `GOOGLE_CLIENT_ID`                | Google Drive     | `abcdef012.apps.googleusercontent.com` | A client ID from an OAuth2 key from Google  |
 | `GOOGLE_DEVELOPER_KEY`            | Google Drive     | `01234567-89ab-cdef-0123-456789abcdef` | A developer key from Google                 |
 | `ONEDRIVE_CLIENT_ID`              | MS OneDrive      | `01234567-89ab-cdef-0123-456789abcdef` | Developer key from Microsoft OneDrive       |
-| `VITALSOURCE_API_KEY`             | VitalSource      | `0123456789ABCEDF`                     |                                             |
 
 ### Getting Blackboard credentials
 

--- a/lms/config.py
+++ b/lms/config.py
@@ -91,7 +91,6 @@ SETTINGS = (
     # like this:
     #     python3 -c 'import secrets; print(secrets.token_hex())'
     _Setting("oauth2_state_secret"),
-    _Setting("vitalsource_api_key"),
     _Setting("admin_auth_google_client_id"),
     _Setting("admin_auth_google_client_secret"),
     _Setting("blackboard_api_client_id"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ TEST_SETTINGS = {
     "via_secret": "not_a_secret",
     "blackboard_api_client_id": "test_blackboard_api_client_id",
     "blackboard_api_client_secret": "test_blackboard_api_client_secret",
-    "vitalsource_api_key": "test_vs_api_key",
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ passenv =
     dev: H_JWT_CLIENT_SECRET
     dev: LMS_SECRET
     dev: SENTRY_DSN
-    dev: VITALSOURCE_API_KEY
     dev: BLACKBOARD_API_CLIENT_ID
     dev: BLACKBOARD_API_CLIENT_SECRET
     dev: JSTOR_API_URL


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4218

This removes the global Vitalsource API key. This can only be deployed when the new customer specific key is in place