### PR TITLE
Move install instructions from `README.md` to `HACKING.md`

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,3 +1,84 @@
+# Setting up Your LMS Development Environment
+
+First you'll need to install:
+
+* [Git](https://git-scm.com/).
+  On Ubuntu: `sudo apt install git`, on macOS: `brew install git`.
+* [pyenv](https://github.com/pyenv/pyenv).
+  See [pyenv's README](https://github.com/pyenv/pyenv#readme) for install instructions.
+  First you need to [install the Python build dependencies](https://github.com/pyenv/pyenv/wiki#suggested-build-environment)
+  then on macOS use the **Homebrew** installation method,
+  on Ubuntu use the **Basic GitHub Checkout** method.
+  You _don't_ need to set up pyenv's shell integration ("shims"), you can
+  [use pyenv without shims](https://github.com/pyenv/pyenv#using-pyenv-without-shims).
+* [GNU Make](https://www.gnu.org/software/make/).
+  This is probably already installed or will have been installed while installing pyenv, run `make --version` to check.
+* [Docker](https://docs.docker.com/install/).
+  Follow the [instructions on the Docker website](https://docs.docker.com/install/)
+  to install it.  
+  You **don't** need to install Docker Compose, the development environment
+  will install it automatically for you in tox.  
+  You **do** need to set up the `docker` command to work without `sudo`,
+  on Linux this means following Docker's [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
+* [Node](https://nodejs.org/) and npm.
+  On Ubuntu: `sudo snap install --classic node`.
+  On macOS: `brew install node`.
+* [Yarn](https://yarnpkg.com/): `sudo npm install -g yarn`.
+* `pg_config`. On Ubuntu: `sudo apt install libpq-dev`. On macOS: `brew install postgresql`.
+
+* The LMS app integrates h, the Hypothesis client and Via, so you will need to
+  set up development environments for each of those before you can develop the
+  LMS app:
+
+  * https://h.readthedocs.io/en/latest/developing/install/
+  * https://h.readthedocs.io/projects/client/en/latest/developers/developing/
+  * https://github.com/hypothesis/via
+
+Then to set up your development environment:
+
+```terminal
+git clone https://github.com/hypothesis/lms.git
+cd lms
+make services
+make devdata
+make help
+```
+
+Bypassing the browser's "unsafe scripts" (mixed content) blocking
+-----------------------------------------------------------------
+
+If you use our hosted Canvas instance at <https://hypothesis.instructure.com/>
+to test your local dev instance of the app you'll get "unsafe scripts" or "mixed content"
+warnings from your browser. This is because hypothesis.instructure.com uses https but your
+local dev app, which is running in an iframe in hypothesis.instructure.com, only uses http.
+
+You'll see a blank iframe in Canvas where the app should be, along with a warning about
+"trying to launch insecure content" like this:
+
+!["Trying to launch insecure content" error](docs/images/trying-to-launch-insecure-content.png "'Trying to launch insecure content' error")
+
+If you open the browser's developer console you should see an error message like:
+
+    Mixed Content: The page at 'https://hypothesis.instructure.com/...' was loaded over HTTPS,
+    but requested an insecure form action 'http://localhost:8001/...'. This request has been
+    blocked; the content must be served over HTTPS.
+
+Fortunately you can easily bypass this mixed content blocking by your browser.
+You should also see an "Insecure content blocked" icon in the top right of the location bar:
+
+!["Insecure content blocked" dialog](docs/images/insecure-content-blocked.png "'Insecure content blocked' dialog")
+
+Click on the <samp>Load unsafe scripts</samp> link and the app should load successfully.
+
+Overview and code design
+------------------------
+
+There are three presentations for developers that describe what the Hypothesis LMS app is and how it works. The **speaker notes** in these presentations also contain additional notes and links:
+
+1. [LMS App Demo & Architecture](https://docs.google.com/presentation/d/1eRMjS5B8Yja6Aupp8oKi-UztIJ9_8KRViSc6OMDLfMY/)
+2. [LMS App Code Design Patterns](https://docs.google.com/presentation/d/1AWcDoHaV9aAvInefR54SJepZiNM08Zou9jxNssccw3c/)
+3. [Speed Grader Workshop](https://docs.google.com/presentation/d/1TJF9SXRMbtHCPnkD9sy-TXe_u55--zYt6veVW0M6leA/) (about the design of the first version of our Canvas Speed Grader support)
+
 Changing the Project's Python Dependencies
 ------------------------------------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -4,134 +4,15 @@
 
 # Hypothesis LMS App
 
-See also:
+An LTI app that integrates Hypothesis with Learning Management Systems.
 
-  * [Configuration](docs/configuration.md) - Details of environment variables and setup
-  * [Setting up a region](docs/setting-up-a-region.md) - How to setup a new geographic region
+Hacking
+-------
 
-## Installing the Hypothesis LMS app in a development environment
+For how to set up the LMS development environment see
+[HACKING.md](https://github.com/hypothesis/lms/blob/main/HACKING.md).
 
-### You will need
+Docs
+----
 
-* The LMS app integrates h, the Hypothesis client and Via, so you will need to
-  set up development environments for each of those before you can develop the
-  LMS app:
-
-  * https://h.readthedocs.io/en/latest/developing/install/
-  * https://h.readthedocs.io/projects/client/en/latest/developers/developing/
-  * https://github.com/hypothesis/via
-
-* [Git](https://git-scm.com/)
-
-* [Node](https://nodejs.org/) and npm.
-  On Linux you should follow
-  [nodejs.org's instructions for installing node](https://nodejs.org/en/download/package-manager/)
-  because the version of node in the standard Ubuntu package repositories is
-  too old.
-  On macOS you should use [Homebrew](https://brew.sh/) to install node.
-
-* [Docker](https://docs.docker.com/install/).
-  Follow the [instructions on the Docker website](https://docs.docker.com/install/)
-  to install "Docker Engine - Community".
-
-* [pyenv](https://github.com/pyenv/pyenv)
-  Follow the instructions in the pyenv README to install it.
-  The Homebrew method works best on macOS.
-
-* [Yarn](https://yarnpkg.com/)
-
-* `pg_config`. On Ubuntu: `sudo apt install libpq-dev`. On macOS: `brew install postgresql`.
-
-### Clone the Git repo
-
-    git clone https://github.com/hypothesis/lms.git
-
-This will download the code into an `lms` directory in your current working
-directory. You need to be in the `lms` directory from the remainder of the
-installation process:
-
-    cd lms
-
-### Run the services with Docker Compose
-
-Start the services that the LMS app requires using Docker Compose:
-
-    make services
-
-### Create the development data and settings
-
-Create the database contents and environment variable settings needed to get lms
-working nicely with your local development instances of the rest of the
-Hypothesis apps, and with our test LMS sites (Canvas, Blackboard, ...):
-
-    make devdata
-
-<details> <summary>Creating data and settings manually instead</summary>
-
-`make devdata` requires you to have a git SSH key set up that has access to the
-private https://github.com/hypothesis/devdata repo. Otherwise it'll crash. If
-you aren't a Hypothesis team member and don't have access to the devdata repo,
-or if you're installing the app in a production environment, you can follow
-these instructions to create the necessary data and settings manually:
-
-[Creating the development data and settings manually](docs/getting-h-credentials.md)
-</details>
-
-### Start the development server
-
-    make dev
-
-The first time you run `make dev` it might take a while to start because it'll
-need to install the application dependencies and build the client assets.
-
-This will start the server on port 8001 (http://localhost:8001), reload the
-application whenever changes are made to the source code, and restart it should
-it crash for some reason.
-
-**That's it!** You’ve finished setting up your lms development environment. Run
-`make help` to see all the commands that're available for running the tests,
-linting, code formatting, Python and SQL shells, etc.
-
-### Run the tests
-
-You should now be able to run the tests successfully by typing:
-
-    make test
-
-See [`HACKING.md`](HACKING.md) for documentation of common development tasks.
-
-### Bypassing the browser's "unsafe scripts" (mixed content) blocking
-
-If you use our hosted Canvas instance at <https://hypothesis.instructure.com/>
-to test your local dev instance of the app you'll get "unsafe scripts" or "mixed content"
-warnings from your browser. This is because hypothesis.instructure.com uses https but your
-local dev app, which is running in an iframe in hypothesis.instructure.com, only uses http.
-
-You'll see a blank iframe in Canvas where the app should be, along with a warning about
-"trying to launch insecure content" like this:
-
-!["Trying to launch insecure content" error](docs/images/trying-to-launch-insecure-content.png "'Trying to launch insecure content' error")
-
-If you open the browser's developer console you should see an error message like:
-
-    Mixed Content: The page at 'https://hypothesis.instructure.com/...' was loaded over HTTPS,
-    but requested an insecure form action 'http://localhost:8001/...'. This request has been
-    blocked; the content must be served over HTTPS.
-
-Fortunately you can easily bypass this mixed content blocking by your browser.
-You should also see an "Insecure content blocked" icon in the top right of the location bar:
-
-!["Insecure content blocked" dialog](docs/images/insecure-content-blocked.png "'Insecure content blocked' dialog")
-
-Click on the <samp>Load unsafe scripts</samp> link and the app should load successfully.
-
-## Overview and code design
-
-There are three presentations for developers that describe what the Hypothesis LMS app is and how it works. The **speaker notes** in these presentations also contain additional notes and links:
-
-1. [LMS App Demo & Architecture](https://docs.google.com/presentation/d/1eRMjS5B8Yja6Aupp8oKi-UztIJ9_8KRViSc6OMDLfMY/)
-2. [LMS App Code Design Patterns](https://docs.google.com/presentation/d/1AWcDoHaV9aAvInefR54SJepZiNM08Zou9jxNssccw3c/)
-3. [Speed Grader Workshop](https://docs.google.com/presentation/d/1TJF9SXRMbtHCPnkD9sy-TXe_u55--zYt6veVW0M6leA/) (about the design of the first version of our Canvas Speed Grader support)
-
-
-
+For other documentation see the [docs folder](https://github.com/hypothesis/lms/tree/main/docs).


### PR DESCRIPTION
The [new cookiecutters](https://github.com/hypothesis/cookiecutters) for Pyramid apps and Python packages put each project's development environment setup instructions in `HACKING.md`. I want the [new version of our development environment setup docs](https://github.com/hypothesis/onboarding/pull/13) to reference `HACKING.md` as the place to find these instructions in any Hypothesis project. For that reason I need to move the instructions from `README.md` to `HACKING.md` now (since it may be a while before we get the new cookiecutter applied to this project).