### PR TITLE
Sync the user before we issue credentials in the Gateway

### DIFF
--- a/bin/gateway/config/gateway_qa_example.json
+++ b/bin/gateway/config/gateway_qa_example.json
@@ -13,6 +13,7 @@
             "tool_consumer_instance_guid": "GUID",
 
             "context_id": "__COURSE_ID__",
+            "context_title": "__COURSE_NAME__",
             "resource_link_id": "__ASSIGNMENT_ID__",
 
             "user_id":  "__USER_ID__",

--- a/docs/gateway/02_api_spec.md
+++ b/docs/gateway/02_api_spec.md
@@ -40,8 +40,6 @@ parameters received onto this end-point. This will ensure compatibility as the
 more features may be added in future which require fields which were previously
 optional.
 
-
-
 | Field                         | Example                    | Notes                                                                   |
 |-------------------------------|----------------------------|-------------------------------------------------------------------------|
 | `lti_version`                 | `LTI-1p0`                  | Specify LTI version (only 1.1 supported at present)                     |
@@ -50,6 +48,7 @@ optional.
 | `user_id`                     | `2978763`                  | The user id we should act on behalf of                                  |
 | `roles`                       | `Instructor`               | The role that user has (used in permission generation)                  |
 | `context_id`                  | `454`                      | Specify the course you want to access                                   |
+| `context_title`               | `Course name`              | Specify the course name (used to update records)                        |
 | `resource_link_id`            | `22`                       | _(optional)_ Narrow the scope to a single assignment                    |
 
 ### Responses

--- a/tests/functional/api/gateway_test.py
+++ b/tests/functional/api/gateway_test.py
@@ -9,6 +9,7 @@ from tests.functional.oauth1 import *
 
 
 class TestGatewayHLTI:
+    @pytest.mark.usefixtures("intercept_http_calls_to_h")
     def test_minimum_viable_login(self, gateway_launch, required_params):
         response = gateway_launch(required_params)
 
@@ -46,6 +47,7 @@ class TestGatewayHLTI:
             ("roles", 403),
             # Required for us to work
             ("context_id", 422),
+            ("context_title", 422),
             # Us being picky, but useful for checking it's a well-formed
             # LTI launch
             ("lti_version", 422),
@@ -79,6 +81,7 @@ class TestGatewayHLTI:
             "user_id": "123",
             "roles": "Instructor",
             "context_id": "321",
+            "context_title": "Course name",
             "lti_version": "LTI-1p0",
             "lti_message_type": "basic-lti-launch-request",
         }

--- a/tests/unit/lms/views/api/gateway_test.py
+++ b/tests/unit/lms/views/api/gateway_test.py
@@ -11,7 +11,7 @@ from lms.resources import LTILaunchResource
 from lms.views.api.gateway import h_lti
 
 
-@pytest.mark.usefixtures("grant_token_service")
+@pytest.mark.usefixtures("grant_token_service", "lti_h_service")
 class TestHLTI:
     def test_it_adds_h_api_details(self, context, pyramid_request, grant_token_service):
         response = h_lti(context, pyramid_request)
@@ -48,8 +48,15 @@ class TestHLTI:
         with pytest.raises(HTTPForbidden):
             h_lti(context, pyramid_request)
 
+    def test_syncs_the_user_to_h(self, context, pyramid_request, lti_h_service):
+        h_lti(context, pyramid_request)
 
-@pytest.mark.usefixtures("grant_token_service")
+        lti_h_service.sync.assert_called_once_with(
+            [context.course], pyramid_request.lti_params
+        )
+
+
+@pytest.mark.usefixtures("grant_token_service", "lti_h_service")
 class TestHLTIConsumer:
     # These tests are "consumer tests" and ensure we meet the spec we have
     # provided to our users in our documentation


### PR DESCRIPTION
It's possible for a client to launch our gateway view before a user has ever launched us. This will result in the credentials we issue belonging to a user which is not yet in H and so not valid. To get around this we insert the user.

A secondary problem is that the user will have no anntations to look at. We can get some of the way around this by allocating them to the course group. For course grouped assignments, this is actually all you will need.

For groups / sections, the user will still see nothing and will need to launch some assignments.

## What goes wrong the for customer

In all of these cases assume the call is being made for a user which has never interacted with our products.

Assuming we don't sync a user:

 * The customer calls the gateway
* **When they try to exchange our token for an OAuth token they are told the `sub` (user) is invalid**

Assuming we sync the user only:

 * The customer calls the gateway
 * The user successfully exchanges a token 
 * **The customer cannot retrieve any annotations, because the user is in no groups**

Assuming we sync the user and course (this is the solution in this ticket):


 * The customer calls the gateway
 * The user successfully exchanges a token 
 * The customer retrieves annotations in the course group
 * **The customer does not see any annotations from groups or sections**

## Review notes

This is exactly what we do for a regular LTI launch, so doesn't seem risky.

## Change in behavior

This means it's not possible for us to know that a user is "missing" in any way as we will create it from the settings given. This also means we can't use mock values as they will get updated.

As long as the caller issues the same LTI params as they got from the LMS this should work fine.