### PR TITLE
Return a redirect to automatically log users in to Vitalsource

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -68,11 +68,14 @@ class JSConfig:
                 ),
             }
         elif document_url.startswith("vitalsource://"):
-            vitalsource_svc = self._request.find_service(VitalSourceService)
+            svc = self._request.find_service(VitalSourceService)
 
             # nb. VitalSource doesn't use Via, but is otherwise handled exactly
             # the same way by the frontend.
-            self._config["viaUrl"] = vitalsource_svc.get_launch_url(document_url)
+            self._config["viaUrl"] = svc.get_launch_url(
+                user_reference=self._request.lti_params[svc.user_lti_param],
+                document_url=document_url,
+            )
         elif jstor_service.enabled and document_url.startswith("jstor://"):
             self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)
             self._config["contentBanner"] = {

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -68,14 +68,22 @@ class JSConfig:
                 ),
             }
         elif document_url.startswith("vitalsource://"):
-            svc = self._request.find_service(VitalSourceService)
+            svc: VitalSourceService = self._request.find_service(VitalSourceService)
 
-            # nb. VitalSource doesn't use Via, but is otherwise handled exactly
-            # the same way by the frontend.
-            self._config["viaUrl"] = svc.get_launch_url(
-                user_reference=self._request.lti_params[svc.user_lti_param],
-                document_url=document_url,
-            )
+            if svc.sso_enabled:
+                # nb. VitalSource doesn't use Via, but is otherwise handled
+                # exactly the same way by the frontend.
+                self._config["viaUrl"] = svc.get_sso_redirect(
+                    user_reference=self._request.lti_params[svc.user_lti_param],
+                    document_url=document_url,
+                )
+            else:
+                # This looks a bit silly, but pretty soon the above will
+                # be setting `api.viaURL` not `viaURL`
+                self._config["viaUrl"] = svc.get_book_reader_url(
+                    document_url=document_url
+                )
+
         elif jstor_service.enabled and document_url.startswith("jstor://"):
             self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)
             self._config["contentBanner"] = {

--- a/lms/services/vitalsource/exceptions.py
+++ b/lms/services/vitalsource/exceptions.py
@@ -1,0 +1,14 @@
+class VitalSourceError(Exception):
+    """Indicate a failure in the VitalSource service or client."""
+
+    def __init__(self, error_code, message=None):
+        """
+        Instantiate the error.
+
+        :param error_code: A string code used to present specific dialogs in
+            the front end. For details of the codes see:
+            lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+        :param message: A normal error message, mostly for debugging
+        """
+        self.error_code = error_code
+        super().__init__(message)

--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -4,9 +4,14 @@ from lms.services.vitalsource.service import VitalSourceService
 
 def service_factory(_context, request):
     settings = request.find_service(name="application_instance").get_current().settings
-    api_key = request.registry.settings["vitalsource_api_key"]
+
+    customer_key = settings.get("vitalsource", "api_key")
 
     return VitalSourceService(
-        client=VitalSourceClient(api_key) if api_key else None,
+        # It's important to pass None here if there's no key, so the service
+        # knows it's been disabled. The client will raise an error anyway if
+        # you try and create one with no API key.
+        client=VitalSourceClient(customer_key) if customer_key else None,
+        user_lti_param=settings.get("vitalsource", "user_lti_param"),
         enabled=settings.get("vitalsource", "enabled", False),
     )

--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -5,13 +5,15 @@ from lms.services.vitalsource.service import VitalSourceService
 def service_factory(_context, request):
     settings = request.find_service(name="application_instance").get_current().settings
 
+    global_key = request.registry.settings["vitalsource_api_key"]
     customer_key = settings.get("vitalsource", "api_key")
 
     return VitalSourceService(
         # It's important to pass None here if there's no key, so the service
         # knows it's been disabled. The client will raise an error anyway if
         # you try and create one with no API key.
-        client=VitalSourceClient(customer_key) if customer_key else None,
-        user_lti_param=settings.get("vitalsource", "user_lti_param"),
         enabled=settings.get("vitalsource", "enabled", False),
+        global_client=VitalSourceClient(global_key) if global_key else None,
+        customer_client=VitalSourceClient(customer_key) if customer_key else None,
+        user_lti_param=settings.get("vitalsource", "user_lti_param"),
     )

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -1,41 +1,60 @@
 from typing import List
 
 from lms.services.vitalsource._client import VitalSourceClient
+from lms.services.vitalsource.exceptions import VitalSourceError
 from lms.services.vitalsource.model import VSBookLocation
 
 
 class VitalSourceService:
     """A high-level interface for dealing with VitalSource."""
 
-    def __init__(self, client: VitalSourceClient, enabled):
+    user_lti_param = None
+    """The LTI parameter to use to work out the LTI user."""
+
+    def __init__(self, client: VitalSourceClient, enabled, user_lti_param):
+        """
+        Instantiate the service.
+
+        :param client: VitalSource client for connecting to the API
+        :param enabled: Are we enabled at all?
+        :param user_lti_param: Which LTI parameter to read to get the user
+            reference
+        """
+        self._client = client
         self._enabled = enabled
-        self.client = client
+        self.user_lti_param = user_lti_param
 
     @property
     def enabled(self) -> bool:
         """Check if the service has everything it needs to work."""
 
-        return bool(self._enabled and self.client)
+        return bool(self._enabled and self._client and self.user_lti_param)
 
     def get_book_info(self, book_id: str) -> dict:
         """Get details of a book."""
 
-        return self.client.get_book_info(book_id)
+        return self._client.get_book_info(book_id)
 
     def get_table_of_contents(self, book_id: str) -> List[dict]:
         """Get the table of contents for a book."""
 
-        return self.client.get_table_of_contents(book_id)
+        return self._client.get_table_of_contents(book_id)
 
-    def get_launch_url(self, document_url: str) -> str:
+    def get_launch_url(self, user_reference, document_url) -> str:
         """
         Get the public URL for VitalSource book viewer from our internal URL.
 
         That URL can be used to load VitalSource content in an iframe like we
         do with other types of content.
 
+        :param user_reference: The reference of the user
         :param document_url: `vitalsource://` type URL identifying the document
+        :raises VitalSourceError: If the user has no licences for the material
         """
         loc = VSBookLocation.from_document_url(document_url)
 
-        return f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
+        if not self._client.get_user_book_license(user_reference, loc.book_id):
+            raise VitalSourceError("vitalsource_no_book_license")
+
+        url = f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
+        return self._client.get_sso_redirect(user_reference, url)

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from lms.services.vitalsource._client import VitalSourceClient
 from lms.services.vitalsource.exceptions import VitalSourceError
@@ -11,36 +11,61 @@ class VitalSourceService:
     user_lti_param = None
     """The LTI parameter to use to work out the LTI user."""
 
-    def __init__(self, client: VitalSourceClient, enabled, user_lti_param):
+    def __init__(
+        self,
+        enabled: bool = False,
+        global_client: Optional[VitalSourceClient] = None,
+        customer_client: Optional[VitalSourceClient] = None,
+        user_lti_param: Optional[str] = None,
+    ):
         """
-        Instantiate the service.
+        Initialise the service.
 
-        :param client: VitalSource client for connecting to the API
-        :param enabled: Are we enabled at all?
-        :param user_lti_param: Which LTI parameter to read to get the user
-            reference
+        :param enabled: Is VitalSource enabled for the customer?
+        :param global_client: Client for making generic API calls
+        :param customer_client: Client for making customer specific API calls
+        :param user_lti_param: Field to lookup user details for SSO
         """
-        self._client = client
+
         self._enabled = enabled
+        self._metadata_client = customer_client or global_client
+        self._sso_client = customer_client
         self.user_lti_param = user_lti_param
 
     @property
     def enabled(self) -> bool:
-        """Check if the service has everything it needs to work."""
+        """Check if the service has the minimum it needs to work."""
 
-        return bool(self._enabled and self._client and self.user_lti_param)
+        return bool(self._enabled and self._metadata_client)
+
+    @property
+    def sso_enabled(self) -> bool:
+        """Check if the service can use single sign on."""
+
+        return bool(self.enabled and self._sso_client and self.user_lti_param)
 
     def get_book_info(self, book_id: str) -> dict:
         """Get details of a book."""
 
-        return self._client.get_book_info(book_id)
+        return self._metadata_client.get_book_info(book_id)
 
     def get_table_of_contents(self, book_id: str) -> List[dict]:
         """Get the table of contents for a book."""
 
-        return self._client.get_table_of_contents(book_id)
+        return self._metadata_client.get_table_of_contents(book_id)
 
-    def get_launch_url(self, user_reference, document_url) -> str:
+    @classmethod
+    def get_book_reader_url(cls, document_url) -> str:
+        """
+        Get the public URL for VitalSource book viewer.
+
+        :param document_url: `vitalsource://` type URL identifying the document
+        """
+        loc = VSBookLocation.from_document_url(document_url)
+
+        return f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
+
+    def get_sso_redirect(self, user_reference, document_url) -> str:
         """
         Get the public URL for VitalSource book viewer from our internal URL.
 
@@ -53,8 +78,9 @@ class VitalSourceService:
         """
         loc = VSBookLocation.from_document_url(document_url)
 
-        if not self._client.get_user_book_license(user_reference, loc.book_id):
+        if not self._sso_client.get_user_book_license(user_reference, loc.book_id):
             raise VitalSourceError("vitalsource_no_book_license")
 
-        url = f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
-        return self._client.get_sso_redirect(user_reference, url)
+        return self._sso_client.get_sso_redirect(
+            user_reference, self.get_book_reader_url(document_url)
+        )

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -28,7 +28,13 @@ class VitalSourceService:
         """
 
         self._enabled = enabled
+        # We can use either the customers API key (if they have one), or our
+        # generic fallback key. It's better to use the customer key as it
+        # ensures the books they can pick are available in their institution.
         self._metadata_client = customer_client or global_client
+        # For SSO we *must* use the customers API key as the user ids only make
+        # sense in the context of an institutional relationship between the uni
+        # and VitalSource.
         self._sso_client = customer_client
         self.user_lti_param = user_lti_param
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -121,12 +121,18 @@ class TestAddDocumentURL:
             "path": "/api/blackboard/courses/test_course_id/via_url?document_url=blackboard%3A%2F%2Fcontent-resource%2Fxyz123",
         }
 
-    def test_vitalsource_sets_config(self, js_config, vitalsource_service):
-        vitalsource_url = "vitalsource://book/bookID/book-id/cfi//abc"
+    def test_vitalsource_sets_config(
+        self, js_config, pyramid_request, vitalsource_service
+    ):
+        document_url = "vitalsource://book/bookID/book-id/cfi//abc"
+        vitalsource_service.user_lti_param = "user_id"
+        pyramid_request.lti_params["user_id"] = "USER_REF"
 
-        js_config.add_document_url(vitalsource_url)
+        js_config.add_document_url(document_url)
 
-        vitalsource_service.get_launch_url.assert_called_with(vitalsource_url)
+        vitalsource_service.get_launch_url.assert_called_with(
+            user_reference="USER_REF", document_url=document_url
+        )
         assert (
             js_config.asdict()["viaUrl"]
             == vitalsource_service.get_launch_url.return_value

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -6,11 +6,12 @@ from h_matchers import Any
 from lms.services.vitalsource.factory import service_factory
 
 
+@pytest.mark.usefixtures("application_instance_service")
 class TestServiceFactory:
     @pytest.mark.parametrize(
         "enabled,expected", ((sentinel.enabled, sentinel.enabled), (None, False))
     )
-    @pytest.mark.parametrize("api_key", (sentinel.api_key, None))
+    @pytest.mark.parametrize("customer_api_key", (sentinel.customer_api_key, None))
     def test_it(
         self,
         pyramid_request,
@@ -19,37 +20,52 @@ class TestServiceFactory:
         application_instance_service,
         enabled,
         expected,
-        api_key,
+        customer_api_key,
     ):
+        pyramid_request.registry.settings["vitalsource_api_key"] = None
         # This fixture is a bit odd and returns a real application instance
         ai = application_instance_service.get_current()
         ai.settings.set("vitalsource", "user_lti_param", sentinel.user_lti_param)
-        ai.settings.set("vitalsource", "api_key", api_key)
+        ai.settings.set("vitalsource", "api_key", customer_api_key)
         if enabled:
             ai.settings.set("vitalsource", "enabled", enabled)
 
         svc = service_factory(sentinel.context, pyramid_request)
 
-        if api_key:
-            VitalSourceClient.assert_called_once_with(api_key)
+        if customer_api_key:
+            VitalSourceClient.assert_called_once_with(customer_api_key)
+        else:
+            VitalSourceClient.assert_not_called()
 
         VitalSourceService.assert_called_once_with(
-            client=VitalSourceClient.return_value if api_key else None,
-            user_lti_param=sentinel.user_lti_param,
             enabled=expected,
+            global_client=None,
+            customer_client=VitalSourceClient.return_value
+            if customer_api_key
+            else None,
+            user_lti_param=sentinel.user_lti_param,
         )
         assert svc == VitalSourceService.return_value
 
-    @pytest.mark.usefixtures("application_instance_service")
-    def test_it_when_no_api_key(self, pyramid_request, VitalSourceService):
-        pyramid_request.registry.settings["vitalsource_api_key"] = None
+    @pytest.mark.parametrize("global_api_key", (sentinel.global_api_key, None))
+    def test_it_with_a_global_key(
+        self, pyramid_request, VitalSourceService, global_api_key, VitalSourceClient
+    ):
+        pyramid_request.registry.settings["vitalsource_api_key"] = global_api_key
 
-        svc = service_factory(sentinel.context, pyramid_request)
+        service_factory(sentinel.context, pyramid_request)
+
+        if global_api_key:
+            VitalSourceClient.assert_called_once_with(global_api_key)
+        else:
+            VitalSourceClient.assert_not_called()
 
         VitalSourceService.assert_called_once_with(
-            client=None, enabled=Any(), user_lti_param=Any()
+            enabled=Any(),
+            global_client=VitalSourceClient.return_value if global_api_key else None,
+            customer_client=Any(),
+            user_lti_param=Any(),
         )
-        assert svc == VitalSourceService.return_value
 
     @pytest.fixture
     def VitalSourceService(self, patch):

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -10,6 +10,7 @@ class TestServiceFactory:
     @pytest.mark.parametrize(
         "enabled,expected", ((sentinel.enabled, sentinel.enabled), (None, False))
     )
+    @pytest.mark.parametrize("api_key", (sentinel.api_key, None))
     def test_it(
         self,
         pyramid_request,
@@ -18,17 +19,24 @@ class TestServiceFactory:
         application_instance_service,
         enabled,
         expected,
+        api_key,
     ):
         # This fixture is a bit odd and returns a real application instance
         ai = application_instance_service.get_current()
+        ai.settings.set("vitalsource", "user_lti_param", sentinel.user_lti_param)
+        ai.settings.set("vitalsource", "api_key", api_key)
         if enabled:
             ai.settings.set("vitalsource", "enabled", enabled)
 
         svc = service_factory(sentinel.context, pyramid_request)
 
-        VitalSourceClient.assert_called_once_with(api_key="test_vs_api_key")
+        if api_key:
+            VitalSourceClient.assert_called_once_with(api_key)
+
         VitalSourceService.assert_called_once_with(
-            client=VitalSourceClient.return_value, enabled=expected
+            client=VitalSourceClient.return_value if api_key else None,
+            user_lti_param=sentinel.user_lti_param,
+            enabled=expected,
         )
         assert svc == VitalSourceService.return_value
 

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -38,7 +38,9 @@ class TestServiceFactory:
 
         svc = service_factory(sentinel.context, pyramid_request)
 
-        VitalSourceService.assert_called_once_with(client=None, enabled=Any())
+        VitalSourceService.assert_called_once_with(
+            client=None, enabled=Any(), user_lti_param=Any()
+        )
         assert svc == VitalSourceService.return_value
 
     @pytest.fixture

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -3,24 +3,46 @@ from unittest.mock import create_autospec, sentinel
 import pytest
 
 from lms.services.vitalsource._client import VitalSourceClient
+from lms.services.vitalsource.exceptions import VitalSourceError
 from lms.services.vitalsource.service import VitalSourceService
 
 
 class TestVitalSourceService:
     @pytest.mark.parametrize("client", (sentinel.client, None))
     @pytest.mark.parametrize("enabled", (sentinel.client, None))
-    def test_enabled(self, client, enabled):
-        svc = VitalSourceService(client=client, enabled=enabled)
-
-        assert svc.enabled == bool(client and enabled)
-
-    def test_get_launch_url(self, svc):
-        document_url = "vitalsource://book/bookID/book-id/cfi//abc"
-
-        assert (
-            svc.get_launch_url(document_url)
-            == "https://hypothesis.vitalsource.com/books/book-id/cfi//abc"
+    @pytest.mark.parametrize("user_lti_param", (sentinel.user_lti_param, None))
+    def test_enabled(self, client, enabled, user_lti_param):
+        svc = VitalSourceService(
+            client=client, enabled=enabled, user_lti_param=user_lti_param
         )
+
+        assert svc.enabled == bool(client and enabled and user_lti_param)
+
+    def test_get_launch_url(self, svc, client):
+        result = svc.get_launch_url(
+            sentinel.user_reference,
+            document_url="vitalsource://book/bookID/BOOK-ID/cfi/CFI",
+        )
+
+        client.get_user_book_license.assert_called_once_with(
+            sentinel.user_reference, "BOOK-ID"
+        )
+        client.get_sso_redirect.assert_called_once_with(
+            sentinel.user_reference,
+            "https://hypothesis.vitalsource.com/books/BOOK-ID/cfi/CFI",
+        )
+        assert result == client.get_sso_redirect.return_value
+
+    def test_get_launch_url_with_no_book_license(self, svc, client):
+        client.get_user_book_license.return_value = None
+
+        with pytest.raises(VitalSourceError) as exc:
+            svc.get_launch_url(
+                sentinel.user_reference,
+                document_url="vitalsource://book/bookID/BOOK-ID/cfi/CFI",
+            )
+
+        assert exc.value.error_code == "vitalsource_no_book_license"
 
     @pytest.mark.parametrize(
         "proxy_method,args",
@@ -42,4 +64,6 @@ class TestVitalSourceService:
 
     @pytest.fixture
     def svc(self, client):
-        return VitalSourceService(client=client, enabled=True)
+        return VitalSourceService(
+            client=client, enabled=True, user_lti_param=sentinel.user_lti_param
+        )


### PR DESCRIPTION
For:

 * https://github.com/orgs/hypothesis/projects/71/views/1

## What's changed?

Previous to this PR we would direct the user straight to the bookshelf on the correct book. This required the user to have independently signed into the bookshelf for this to work.

Now we:

 * Check if the user has a licences
    *  If not show an error
 * Generate a redirect link that signs the user in, and then redirects to the shelf

This means the user does not always need to log in

### What's not so great about this?

If the user does not have a licence then we show them an error instead of showing them the book viewer. However users can sometimes be automatically granted a licence by the book viewer. Unfortunately the redirect mechanism doesn't take this into account and fails.

This means we are deciding between our error page and the one generated by the redirect. It was decided that our error page could contain more helpful information about what had gone wrong than the default. At the moment there's no very good way to help the user to resolve the situation.

## ~Do not merge!~

~We can't deploy this until existing customers have settings added to their application instances.~

We've merged in this PR now which should make this safe to release:

 * https://github.com/hypothesis/lms/pull/4351

## Testing notes

Checking SSO:

 * Visit: https://bookshelf.vitalsource.com/ and ensure you are not logged in
 * Start all the things
 * Make sure you've run `make devdata` recently in LMS
 * Visit: https://hypothesis.instructure.com/courses/125/assignments/3153 as the teacher account
 * You should be redirected to the book eventually (it's a little slow for me)
 * Visit: https://bookshelf.vitalsource.com
 * You will see you are now logged in

When there's no licence:

 * Visit: https://bookshelf.vitalsource.com/ and ensure you are not logged in
 * Visit: https://hypothesis.instructure.com/courses/125/assignments/3127
 * You should see an unhandled error "Sorry, but something went wrong."

When there's no user (faking it):

 * Edit `lms.services.vitalsource._client.py:get_user_credentials()`
 * Comment out the if above the raised error
 * Visit: https://hypothesis.instructure.com/courses/125/assignments/3153
 * You should see an unhandled error "Sorry, but something went wrong."