### PR TITLE
Move the call to get the SSO link to the front end as a call back

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import List, Optional
 
 from lms.models import Assignment, GroupInfo, Grouping, HUser
-from lms.product import Product
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
 from lms.resources._js_config.file_picker_config import FilePickerConfig
@@ -73,10 +72,17 @@ class JSConfig:
             if svc.sso_enabled:
                 # nb. VitalSource doesn't use Via, but is otherwise handled
                 # exactly the same way by the frontend.
-                self._config["viaUrl"] = svc.get_sso_redirect(
-                    user_reference=self._request.lti_params[svc.user_lti_param],
-                    document_url=document_url,
-                )
+                self._config["api"]["viaUrl"] = {
+                    "path": self._request.route_url(
+                        "vitalsource_api.launch_url",
+                        _query={
+                            "user_reference": self._request.lti_params[
+                                svc.user_lti_param
+                            ],
+                            "document_url": document_url,
+                        },
+                    )
+                }
             else:
                 # This looks a bit silly, but pretty soon the above will
                 # be setting `api.viaURL` not `viaURL`

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -117,6 +117,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "vitalsource_api.books.toc", "/api/vitalsource/books/{book_id}/toc"
     )
+    config.add_route("vitalsource_api.launch_url", "/api/vitalsource/launch_url")
 
     config.add_route("admin.index", "/admin/")
     config.add_route("admin.instances", "/admin/instances/")

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -16,7 +16,7 @@ class _BookSchema(PyramidRequestSchema):
 class VitalSourceAPIViews:
     def __init__(self, request):
         self.request = request
-        self.svc = request.find_service(VitalSourceService)
+        self.svc: VitalSourceService = request.find_service(VitalSourceService)
 
     @view_config(route_name="vitalsource_api.books.info", schema=_BookSchema)
     def book_info(self):
@@ -25,3 +25,15 @@ class VitalSourceAPIViews:
     @view_config(route_name="vitalsource_api.books.toc", schema=_BookSchema)
     def table_of_contents(self):
         return self.svc.get_table_of_contents(self.request.matchdict["book_id"])
+
+    @view_config(route_name="vitalsource_api.launch_url")
+    def launch_url(self):
+        # The URL is in a `via_url` property, so it can be used the same way
+        # as assignments that do use Via. We should rename this to something
+        # more generic.
+        return {
+            "via_url": self.svc.get_sso_redirect(
+                user_reference=self.request.params["user_reference"],
+                document_url=self.request.params["document_url"],
+            )
+        }

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -131,13 +131,10 @@ class TestAddDocumentURL:
 
         js_config.add_document_url(document_url)
 
-        vitalsource_service.get_sso_redirect.assert_called_with(
-            user_reference="USER_REF", document_url=document_url
-        )
-        assert (
-            js_config.asdict()["viaUrl"]
-            == vitalsource_service.get_sso_redirect.return_value
-        )
+        proxy_api_call = Any.url.matching(
+            "http://example.com/api/vitalsource/launch_url"
+        ).with_query({"user_reference": "USER_REF", "document_url": document_url})
+        assert js_config.asdict()["api"]["viaUrl"] == {"path": proxy_api_call}
 
     def test_vitalsource_sets_config_without_sso(self, js_config, vitalsource_service):
         document_url = "vitalsource://book/bookID/book-id/cfi//abc"

--- a/tests/unit/lms/views/api/vitalsource_test.py
+++ b/tests/unit/lms/views/api/vitalsource_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import sentinel
+
 import pytest
 
 from lms.views.api.vitalsource import VitalSourceAPIViews
@@ -5,18 +7,35 @@ from lms.views.api.vitalsource import VitalSourceAPIViews
 
 @pytest.mark.usefixtures("vitalsource_service")
 class TestVitalSourceAPIViews:
-    def test_book_info(self, pyramid_request, vitalsource_service):
+    def test_book_info(self, view, pyramid_request, vitalsource_service):
         pyramid_request.matchdict["book_id"] = "BOOK-ID"
 
-        response = VitalSourceAPIViews(pyramid_request).book_info()
+        response = view.book_info()
 
         vitalsource_service.get_book_info.assert_called_once_with("BOOK-ID")
         assert response == vitalsource_service.get_book_info.return_value
 
-    def test_table_of_contents(self, pyramid_request, vitalsource_service):
+    def test_table_of_contents(self, view, pyramid_request, vitalsource_service):
         pyramid_request.matchdict["book_id"] = "BOOK-ID"
 
-        response = VitalSourceAPIViews(pyramid_request).table_of_contents()
+        response = view.table_of_contents()
 
         vitalsource_service.get_table_of_contents.assert_called_once_with("BOOK-ID")
         assert response == vitalsource_service.get_table_of_contents.return_value
+
+    def test_launch_url(self, view, pyramid_request, vitalsource_service):
+        pyramid_request.params["user_reference"] = sentinel.user_reference
+        pyramid_request.params["document_url"] = sentinel.document_url
+
+        response = view.launch_url()
+
+        vitalsource_service.get_sso_redirect.assert_called_once_with(
+            user_reference=sentinel.user_reference, document_url=sentinel.document_url
+        )
+        assert response == {
+            "via_url": vitalsource_service.get_sso_redirect.return_value
+        }
+
+    @pytest.fixture
+    def view(self, pyramid_request):
+        return VitalSourceAPIViews(pyramid_request)


### PR DESCRIPTION
For:

 * https://github.com/orgs/hypothesis/projects/71/views/1

Requires:

 * https://github.com/hypothesis/lms/pull/4269

Put the front-end in charge of getting Vitalsource links to allow more parallelism. 

## Testing notes

Nothing should have changed from: https://github.com/hypothesis/lms/pull/4269.

You can follow the instructions there and should get the same outcome, except you should see the calls being made from the front end.
