### PR TITLE
Return assignment info in the gateway data

### DIFF
--- a/docs/gateway/schema.json
+++ b/docs/gateway/schema.json
@@ -9,7 +9,9 @@
                     "list_endpoints": {
                         "method": "GET",
                         "url": "https://h.example.com/api",
-                        "headers": {"Accept": "application/vnd.hypothesis.v2+json"}
+                        "headers": {
+                            "Accept": "application/vnd.hypothesis.v2+json"
+                        }
                     },
                     "exchange_grant_token": {
                         "method": "POST",
@@ -24,6 +26,20 @@
                         }
                     }
                 }
+            },
+            "data": {
+                "assignments": [
+                    {
+                        "lms": {
+                            "document_url": "https://example.com"
+                        },
+                        "lti": {
+                            "resource_link_id": "23987234",
+                            "resource_link_title": "Assignment name",
+                            "resource_link_description": "Assignment description"
+                        }
+                    }
+                ]
             }
         }
     ],
@@ -50,12 +66,52 @@
                 }
             },
             "required": ["h"]
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "assignments": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/assignment"}
+                }
+            },
+            "required": ["assignments"],
+            "additionalProperties": false
         }
     },
-    "required": ["api"],
+    "required": ["api", "data"],
     "additionalProperties": false,
 
     "$defs": {
+        "assignment": {
+            "type": "object",
+            "properties": {
+                "lms": {
+                    "type": "object",
+                    "properties": {
+                        "document_url": {"type":  "string"}
+                    },
+                    "additionalProperties": false,
+                    "required": ["document_url"]
+                },
+                "lti": {
+                    "type": "object",
+                    "properties": {
+                        "resource_link_id": {"type":  "string"},
+                        "resource_link_title": {"type":  "string"},
+                        "resource_link_description": {"type":  "string"}
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "resource_link_id",
+                        "resource_link_title",
+                        "resource_link_description"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": ["lms", "lti"]
+        },
         "api_call": {
             "title": "Pre-defined API call",
             "type": "object",

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -64,6 +64,16 @@ class Assignment(CreatedUpdatedMixin, BASE):
     description = sa.Column(sa.Unicode, nullable=True)
     """The resource link description from LTI params."""
 
+    assignment_groupings = sa.orm.relationship(
+        "AssignmentGrouping", back_populates="assignment"
+    )
+    groupings = sa.orm.relationship(
+        "Grouping",
+        secondary="assignment_grouping",
+        back_populates="assignments",
+        viewonly=True,
+    )
+
     def get_canvas_mapped_file_id(self, file_id):
         return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)
 

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -129,7 +129,19 @@ class Grouping(CreatedUpdatedMixin, BASE):
         nullable=False,
     )
 
+    # Related users relationships
     memberships = sa.orm.relationship("GroupingMembership", back_populates="grouping")
+
+    # All related assignments
+    assignment_groupings = sa.orm.relationship(
+        "AssignmentGrouping", back_populates="grouping"
+    )
+    assignments = sa.orm.relationship(
+        "Assignment",
+        secondary="assignment_grouping",
+        back_populates="groupings",
+        viewonly=True,
+    )
 
     @property
     def name(self):

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -20,7 +20,9 @@ class AssignmentService:
     def __init__(self, db: Session):
         self._db = db
 
-    def get_assignment(self, tool_consumer_instance_guid, resource_link_id):
+    def get_assignment(
+        self, tool_consumer_instance_guid, resource_link_id
+    ) -> Assignment:
         """Get an assignment by resource_link_id."""
 
         return (
@@ -30,6 +32,16 @@ class AssignmentService:
                 resource_link_id=resource_link_id,
             )
             .one_or_none()
+        )
+
+    def get_assignments_for_grouping(self, grouping_id) -> List[Assignment]:
+        """Get all assignments within a specified grouping."""
+
+        return (
+            self._db.query(Assignment)
+            .join(AssignmentGrouping)
+            .join(Grouping, Grouping.id == grouping_id)
+            .all()
         )
 
     # pylint: disable=too-many-arguments

--- a/lms/views/api/gateway.py
+++ b/lms/views/api/gateway.py
@@ -58,35 +58,37 @@ def h_lti(context, request):
     # anything until they launch an assignment and get put in a group.
     request.find_service(name="lti_h").sync([context.course], request.lti_params)
 
-    # Add API end-point details
-    h_api_url = request.registry.settings["h_api_url_public"]
-    return {
-        "api": {
-            "h": {
-                # These sections are arranged so you can use
-                # `requests.Request.request(**data)` and make the correct request
-                "list_endpoints": {
-                    # List the API end-points
-                    "method": "GET",
-                    "url": h_api_url,
-                    "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
+    return {"api": {"h": _GatewayService.render_h_connection_info(request)}}
+
+
+class _GatewayService:
+    @classmethod
+    def render_h_connection_info(cls, request):
+        h_api_url = request.registry.settings["h_api_url_public"]
+
+        return {
+            # These sections are arranged so you can use
+            # `requests.Request.request(**data)` and make the correct request
+            "list_endpoints": {
+                # List the API end-points
+                "method": "GET",
+                "url": h_api_url,
+                "headers": {"Accept": "application/vnd.hypothesis.v2+json"},
+            },
+            "exchange_grant_token": {
+                # Exchange our token for access and refresh tokens
+                "method": "POST",
+                "url": h_api_url + "token",
+                "headers": {
+                    "Accept": "application/vnd.hypothesis.v2+json",
+                    "Content-Type": "application/x-www-form-urlencoded",
                 },
-                "exchange_grant_token": {
-                    # Exchange our token for access and refresh tokens
-                    "method": "POST",
-                    "url": h_api_url + "token",
-                    "headers": {
-                        "Accept": "application/vnd.hypothesis.v2+json",
-                        "Content-Type": "application/x-www-form-urlencoded",
-                    },
-                    "data": {
-                        # Generate a short-lived login token for the Hypothesis client
-                        "assertion": request.find_service(
-                            name="grant_token"
-                        ).generate_token(request.lti_user.h_user),
-                        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-                    },
+                "data": {
+                    # Generate a short-lived login token for the Hypothesis client
+                    "assertion": request.find_service(
+                        name="grant_token"
+                    ).generate_token(request.lti_user.h_user),
+                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
                 },
-            }
+            },
         }
-    }

--- a/tests/functional/api/gateway_test.py
+++ b/tests/functional/api/gateway_test.py
@@ -35,7 +35,8 @@ class TestGatewayHLTI:
                         "url": TEST_SETTINGS["h_api_url_public"] + "token",
                     },
                 }
-            }
+            },
+            "data": {"assignments": Any.list()},
         }
 
     @pytest.mark.parametrize(

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -16,6 +16,17 @@ class TestAssignmentService:
     def test_get_assignment_without_match(self, svc, non_matching_params):
         assert svc.get_assignment(**non_matching_params) is None
 
+    def test_get_assignments_for_grouping(self, svc, db_session):
+        course = factories.Course()
+        assignments = factories.Assignment.create_batch(2)
+        for assignment in assignments:
+            factories.AssignmentGrouping(assignment=assignment, grouping=course)
+        db_session.flush()
+
+        results = svc.get_assignments_for_grouping(course.id)
+
+        assert results == assignments
+
     upsert_kwargs = {
         "document_url": "new_document_url",
         "extra": {"new": "values"},


### PR DESCRIPTION
For:

https://github.com/hypothesis/lms/issues/4197

This PR adds dumping of assignments alone. This isn't enough to use the API in all circumstances, but is the first meaningful piece which allows the user to test.

I'm planning to release this piece by piece, partially because that's how I'm working on it, but also because it reduces the size of each PR. I suspect we may find that certain features aren't needed immediately  / ever, so this should get something the customer can use to them quicker.

## Testing notes

 * Start `h` and `lms`
 * Ensure you have visited some assignments
 * Use `bin/gateway/oauth_call.py` to issue a request and view the results
    * If you are missing a config file for this please ask
 * You should see assignment data dumped in the output 