### PR TITLE
Allow editing of some AI settings in the admin pages

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -42,8 +42,8 @@
 
     <fieldset class="box">
         {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
-        {{ macros.disabled_text_field("Deployment ID", instance.deployment_id) }}
-        {{ macros.disabled_text_field("LMS URL", instance.lms_url) }}
+        {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
+        {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
     </fieldset>
 
     <fieldset class="box">
@@ -78,7 +78,7 @@
 
     <fieldset class="box">
         <legend class="label has-text-centered">Canvas settings</legend>
-        {{ macros.disabled_text_field("API domain", instance.custom_canvas_api_domain) }}
+        {{ macros.form_text_field(request, "API domain", "custom_canvas_api_domain", field_value=instance.custom_canvas_api_domain) }}
         {{ macros.disabled_text_field("Developer key", instance.developer_key) }}
         {{ settings_checkbox("Sections enabled", "canvas", "sections_enabled") }}
         {{ settings_checkbox("Groups enabled", "canvas", "groups_enabled") }}

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -78,7 +78,7 @@
 
     <fieldset class="box">
         <legend class="label has-text-centered">Canvas settings</legend>
-        {{ macros.form_text_field(request, "API domain", "custom_canvas_api_domain", field_value=instance.custom_canvas_api_domain) }}
+        {{ macros.disabled_text_field("API domain", instance.custom_canvas_api_domain) }}
         {{ macros.disabled_text_field("Developer key", instance.developer_key) }}
         {{ settings_checkbox("Sections enabled", "canvas", "sections_enabled") }}
         {{ settings_checkbox("Groups enabled", "canvas", "groups_enabled") }}

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -265,7 +265,7 @@ class AdminApplicationInstanceViews:
     def update_instance(self):
         ai = self._get_ai_or_404(**self.request.matchdict)
 
-        for ai_field in ["lms_url", "custom_canvas_api_domain", "deployment_id"]:
+        for ai_field in ["lms_url", "deployment_id"]:
             if value := self.request.params.get(ai_field, "").strip():
                 setattr(ai, ai_field, value)
 

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -266,8 +266,8 @@ class AdminApplicationInstanceViews:
         ai = self._get_ai_or_404(**self.request.matchdict)
 
         for ai_field in ["lms_url", "custom_canvas_api_domain", "deployment_id"]:
-            if value := self.request.params.get(ai_field):
-                setattr(ai, ai_field, value.strip())
+            if value := self.request.params.get(ai_field, "").strip():
+                setattr(ai, ai_field, value)
 
         for setting, sub_setting, setting_type in (
             ("canvas", "sections_enabled", bool),

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -59,7 +59,7 @@ class NewApplicationInstanceSchema(PyramidRequestSchema):
     email = fields.Email(required=True)
 
 
-class UpdateApplicationInstanceSchema(ApplicationInstanceSchema):
+class UpgradeApplicationInstanceSchema(ApplicationInstanceSchema):
     location = "form"
 
     lms_url = EmptyStringURL(required=False, allow_none=True)
@@ -132,7 +132,7 @@ class AdminApplicationInstanceViews:
         )
 
     def upgrade_instance(self, lti_registration, consumer_key):
-        if flash_validation(self.request, UpdateApplicationInstanceSchema):
+        if flash_validation(self.request, UpgradeApplicationInstanceSchema):
             response = render_to_response(
                 "lms:templates/admin/instance.new.html.jinja2",
                 {"lti_registration": lti_registration},

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -265,6 +265,10 @@ class AdminApplicationInstanceViews:
     def update_instance(self):
         ai = self._get_ai_or_404(**self.request.matchdict)
 
+        for ai_field in ["lms_url", "custom_canvas_api_domain", "deployment_id"]:
+            if value := self.request.params.get(ai_field):
+                setattr(ai, ai_field, value.strip())
+
         for setting, sub_setting, setting_type in (
             ("canvas", "sections_enabled", bool),
             ("canvas", "groups_enabled", bool),

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -278,23 +278,34 @@ class TestAdminApplicationInstanceViews:
         ),
     )
     def test_update_instance_save_ai_fields(
-        self,
-        setting,
-        value,
-        expected,
-        pyramid_request,
-        application_instance_service,
-        application_instance,
+        self, setting, value, expected, pyramid_request, application_instance
     ):
         pyramid_request.matchdict["consumer_key"] = sentinel.consumer_key
         pyramid_request.params[setting] = value
 
         AdminApplicationInstanceViews(pyramid_request).update_instance()
 
-        application_instance = (
-            application_instance_service.get_by_consumer_key.return_value
-        )
         assert getattr(application_instance, setting) == expected
+
+    @pytest.mark.parametrize(
+        "setting,value",
+        (
+            ("lms_url", ""),
+            ("custom_canvas_api_domain", ""),
+            ("deployment_id", "    "),
+        ),
+    )
+    def test_update_instance_save_ai_fields_keeps_existing(
+        self, setting, value, pyramid_request, application_instance
+    ):
+        pyramid_request.matchdict["consumer_key"] = sentinel.consumer_key
+        pyramid_request.params[setting] = value
+
+        existing_value = getattr(application_instance, setting)
+
+        AdminApplicationInstanceViews(pyramid_request).update_instance()
+
+        assert getattr(application_instance, setting) == existing_value
 
     @pytest.mark.parametrize(
         "setting,sub_setting,value,expected",

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -273,7 +273,6 @@ class TestAdminApplicationInstanceViews:
         "setting,value,expected",
         (
             ("lms_url", "http://some-url.com", "http://some-url.com"),
-            ("custom_canvas_api_domain", "some.domain.com", "some.domain.com"),
             ("deployment_id", "DEPLOYMENT_ID", "DEPLOYMENT_ID"),
         ),
     )
@@ -291,7 +290,6 @@ class TestAdminApplicationInstanceViews:
         "setting,value",
         (
             ("lms_url", ""),
-            ("custom_canvas_api_domain", ""),
             ("deployment_id", "    "),
         ),
     )

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -270,6 +270,33 @@ class TestAdminApplicationInstanceViews:
         )
 
     @pytest.mark.parametrize(
+        "setting,value,expected",
+        (
+            ("lms_url", "http://some-url.com", "http://some-url.com"),
+            ("custom_canvas_api_domain", "some.domain.com", "some.domain.com"),
+            ("deployment_id", "DEPLOYMENT_ID", "DEPLOYMENT_ID"),
+        ),
+    )
+    def test_update_instance_save_ai_fields(
+        self,
+        setting,
+        value,
+        expected,
+        pyramid_request,
+        application_instance_service,
+        application_instance,
+    ):
+        pyramid_request.matchdict["consumer_key"] = sentinel.consumer_key
+        pyramid_request.params[setting] = value
+
+        AdminApplicationInstanceViews(pyramid_request).update_instance()
+
+        application_instance = (
+            application_instance_service.get_by_consumer_key.return_value
+        )
+        assert getattr(application_instance, setting) == expected
+
+    @pytest.mark.parametrize(
         "setting,sub_setting,value,expected",
         (
             # Boolean fields
@@ -285,6 +312,8 @@ class TestAdminApplicationInstanceViews:
             ("jstor", "site_code", "  CODE  ", "CODE"),
             ("jstor", "site_code", "", None),
             ("jstor", "site_code", None, None),
+            ("vitalsource", "user_lti_param", "user_id", "user_id"),
+            ("vitalsource", "api_key", "api_key", "api_key"),
         ),
     )
     def test_update_instance_saves_ai_settings(


### PR DESCRIPTION
Mistakes while we input these couldn't be solved, allow editing them.

This is more relevant now with the LTI1.3 upgrade flow were these might need updating anyway.