### PR TITLE
Add basic test for LMS frontend entry point

### DIFF
--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -19,7 +19,7 @@ import { registerIcons } from '@hypothesis/frontend-shared';
 import iconSet from './icons';
 registerIcons(iconSet);
 
-function init() {
+export function init() {
   // Read configuration embedded into page by backend.
   const config = readConfig();
 
@@ -69,9 +69,11 @@ function init() {
 
   // Render frontend application.
   const rootEl = document.querySelector('#app');
+  /* istanbul ignore next */
   if (!rootEl) {
     throw new Error('#app container for LMS frontend is missing');
   }
+
   render(
     <Config.Provider value={config}>
       <Services.Provider value={services}>{app}</Services.Provider>
@@ -80,4 +82,8 @@ function init() {
   );
 }
 
-init();
+/* istanbul ignore next */
+// @ts-expect-error - Ignore LMS_FRONTEND_TESTS global set by Rollup
+if (typeof LMS_FRONTEND_TESTS === 'undefined') {
+  init();
+}

--- a/lms/static/scripts/frontend_apps/test/index-test.js
+++ b/lms/static/scripts/frontend_apps/test/index-test.js
@@ -1,0 +1,86 @@
+import { Config } from '../config';
+import { init, $imports } from '../index';
+import { Services } from '../services';
+
+// Minimal version of the configuration that the backend renders into the page.
+const minimalConfig = {
+  api: {
+    authToken: '1234',
+  },
+  rpcServer: {
+    allowedOrigins: ['https://example.com'],
+  },
+  mode: 'basic-lti-launch',
+};
+
+describe('LMS frontend entry', () => {
+  let container;
+  let fakeReadConfig;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.id = 'app';
+    document.body.append(container);
+
+    fakeReadConfig = sinon.stub().returns(minimalConfig);
+
+    $imports.$mock({
+      './config': { readConfig: fakeReadConfig, Config },
+
+      // Since `init` calls `render` directly, mock these components in a way
+      // that allows us to tell what was rendered by inspecting the DOM,
+      // as opposed to querying an Enzyme wrapper.
+      './components/BasicLTILaunchApp': () => (
+        <div data-component="BasicLTILaunchApp" />
+      ),
+      './components/OAuth2RedirectErrorApp': () => (
+        <div data-component="OAuth2RedirectErrorApp" />
+      ),
+      './components/ErrorDialogApp': () => (
+        <div data-component="ErrorDialogApp" />
+      ),
+      './components/FilePickerApp': () => (
+        <div data-component="FilePickerApp" />
+      ),
+
+      './services': {
+        ClientRPC: sinon.stub(),
+        GradingService: sinon.stub(),
+        Services,
+        VitalSourceService: sinon.stub(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    container.remove();
+    $imports.$restore();
+  });
+
+  [
+    {
+      config: { mode: 'basic-lti-launch' },
+      appComponent: 'BasicLTILaunchApp',
+    },
+    {
+      config: { mode: 'content-item-selection' },
+      appComponent: 'FilePickerApp',
+    },
+    {
+      config: { mode: 'error-dialog' },
+      appComponent: 'ErrorDialogApp',
+    },
+    {
+      config: { mode: 'oauth2-redirect-error' },
+      appComponent: 'OAuth2RedirectErrorApp',
+    },
+  ].forEach(({ config, appComponent }) => {
+    it('launches correct app for "mode" config', () => {
+      fakeReadConfig.returns({ ...minimalConfig, ...config });
+
+      init();
+
+      assert.ok(container.querySelector(`[data-component=${appComponent}`));
+    });
+  });
+});

--- a/rollup-tests.config.mjs
+++ b/rollup-tests.config.mjs
@@ -30,6 +30,7 @@ export default {
       preventAssignment: true,
       values: {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'LMS_FRONTEND_TESTS': 'true',
       },
     }),
     nodeResolve({


### PR DESCRIPTION
Add some minimal tests for the LMS app entry point, to check it runs the right
app depending on the config.

To allow the entry point to only run when explicitly called in the test
environment, define an `LMS_FRONTEND_TESTS` global in the Rollup bundle, which
code can check for.