### PR TITLE
Add a downgrade to LTI 1.1 option in the admin pages

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -121,6 +121,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.index", "/admin/")
     config.add_route("admin.instances", "/admin/instances/")
     config.add_route("admin.instances.search", "/admin/instances/search")
+    config.add_route("admin.instance.downgrade", "/admin/instance/id/{id_}/downgrade")
     config.add_route("admin.instance.consumer_key", "/admin/instance/{consumer_key}/")
     config.add_route("admin.instance.id", "/admin/instance/id/{id_}/")
     config.add_route(

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -101,8 +101,22 @@
         {{ settings_text_field("JSTOR site code", "jstor", "site_code") }}
     </fieldset>
 
-    {% call macros.field_body(label="") %}
+    <div class="has-text-right mb-6">
         <input type="submit" class="button is-primary" value="Save" />
-    {% endcall %}
+    </div>
+
+
+    <fieldset class="box has-background-danger-light">
+        <legend class="label has-text-centered has-text-danger">Danger zone</legend>
+
+        {% call macros.field_body(label="Downgrade to LTI 1.1") %}
+            <input type="submit" class="button mb-2" formaction="{{ request.route_url("admin.instance.downgrade", id_=instance.id) }}" value="Downgrade">
+            <p>Downgrade this instance to LTI 1.1 removing its association with a registration and its deployment ID.</p>
+            <p>This action will <b>break any existing LTI 1.3 assignments</b>. To undo it, upgrade it back again to LTI 1.3 using the same registration and deployment ID.</p>
+        {% endcall %}
+
+    </fieldset>
+
+
 </form>
 {% endblock %}

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -193,6 +193,35 @@ class AdminApplicationInstanceViews:
             )
         )
 
+    @view_config(route_name="admin.instance.downgrade", request_method="POST")
+    def downgrade_instance(self):
+        ai = self._get_ai_or_404(**self.request.matchdict)
+
+        if ai.lti_version != "1.3.0":
+            self.request.session.flash(
+                f"Application instance: '{ai.id}' is not on LTI 1.3.", "errors"
+            )
+            return HTTPFound(
+                location=self.request.route_url("admin.instance.id", id_=ai.id)
+            )
+
+        if not ai.consumer_key:
+            self.request.session.flash(
+                f"Application instance: '{ai.id}' doesn't have a consumer key to fallback to.",
+                "errors",
+            )
+            return HTTPFound(
+                location=self.request.route_url("admin.instance.id", id_=ai.id)
+            )
+
+        ai.lti_registration_id = None
+        ai.deployment_id = None
+
+        self.request.session.flash("Downgraded LTI 1.1 successful", "messages")
+        return HTTPFound(
+            location=self.request.route_url("admin.instance.id", id_=ai.id)
+        )
+
     @view_config(
         route_name="admin.instances.search",
         request_method="POST",

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -60,22 +60,21 @@ class TestAdminApplicationInstanceViews:
         self,
         views,
         pyramid_request,
-        application_instance,
-        db_session,
+        application_instance_lti_13,
         application_instance_service,
     ):
-        lti_registration = factories.LTIRegistration()
-        db_session.flush()
-        application_instance.lti_registration_id = lti_registration.id
-        application_instance.deployment_id = "ID"
-        application_instance_service.get_by_id.return_value = application_instance
+        application_instance_service.get_by_id.return_value = (
+            application_instance_lti_13
+        )
 
         response = views.downgrade_instance()
 
-        assert not application_instance.lti_registration_id
-        assert not application_instance.deployment_id
+        assert not application_instance_lti_13.lti_registration_id
+        assert not application_instance_lti_13.deployment_id
         assert response == temporary_redirect_to(
-            pyramid_request.route_url("admin.instance.id", id_=application_instance.id)
+            pyramid_request.route_url(
+                "admin.instance.id", id_=application_instance_lti_13.id
+            )
         )
 
     def test_downgrade_instance_no_lti13(
@@ -95,18 +94,17 @@ class TestAdminApplicationInstanceViews:
         self,
         views,
         pyramid_request,
-        application_instance,
         application_instance_service,
-        db_session,
+        application_instance_lti_13,
     ):
-        lti_registration = factories.LTIRegistration()
-        db_session.flush()
-        application_instance.lti_registration_id = lti_registration.id
-        application_instance.deployment_id = "ID"
-        application_instance.consumer_key = None
-        application_instance_service.get_by_id.return_value = application_instance
+        application_instance_lti_13.consumer_key = None
+        application_instance_service.get_by_id.return_value = (
+            application_instance_lti_13
+        )
 
-        application_instance_service.get_by_id.return_value = application_instance
+        application_instance_service.get_by_id.return_value = (
+            application_instance_lti_13
+        )
 
         views.downgrade_instance()
 
@@ -414,6 +412,16 @@ class TestAdminApplicationInstanceViews:
     def pyramid_request(self, pyramid_request):
         pyramid_request.params = {}
         return pyramid_request
+
+    @pytest.fixture
+    def application_instance_lti_13(self, application_instance, db_session):
+        lti_registration = factories.LTIRegistration()
+        # Get an valid ID for the registration
+        db_session.flush()
+        application_instance.lti_registration_id = lti_registration.id
+        application_instance.deployment_id = "ID"
+
+        return application_instance
 
     @pytest.fixture
     def with_form_submission(self, pyramid_request):


### PR DESCRIPTION
This is something that *in theory* shouldn't be necessary. In practice we have found the need for it 3 times already over the last few days as we are finding bugs, strange behaviors from the LMS, etc.



### Testing


- Go to http://localhost:8001/admin/registration/id/1/
- Click new instance

```
Consumer key: Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b
Deployment id: DEPLOYMENT_ID
```

Leave the rest blank

- Check that the AI now has a registration and deployment IDs attached

- Scroll to the bottom of the application instance, click downgrade.
- The application instance now longer has the LTI 1.3 fields.

