### PR TITLE
Return details of the current user in the Gateway data

### DIFF
--- a/docs/gateway/schema.json
+++ b/docs/gateway/schema.json
@@ -24,6 +24,15 @@
                         }
                     }
                 }
+            },
+            "data": {
+                "profile": {
+                    "userid": "acct:9238ae778956bcaff126@lms.hypothes.is",
+                    "display_name": "Mrs Example Name",
+                    "lti": {
+                        "user_id": "9782345"
+                    }
+                }
             }
         }
     ],
@@ -50,9 +59,20 @@
                 }
             },
             "required": ["h"]
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "profile": {
+                    "description": "Details of the current user",
+                    "$ref": "#/$defs/user"
+                }
+            },
+            "required": ["profile"],
+            "additionalProperties": false
         }
     },
-    "required": ["api"],
+    "required": ["api", "data"],
     "additionalProperties": false,
 
     "$defs": {
@@ -68,6 +88,26 @@
             },
             "additionalProperties": false,
             "required": ["method", "url"]
+        },
+
+        "user": {
+            "title": "A user",
+            "type": "object",
+
+            "properties": {
+                "userid": {"type": "string"},
+                "display_name": {"type": "string"},
+                "lti": {
+                    "type": "object",
+                    "properties": {
+                        "user_id": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "required": ["user_id"]
+                }
+            },
+            "additionalProperties": false,
+            "required": ["userid", "display_name", "lti"]
         }
     }
 }

--- a/lms/views/api/gateway.py
+++ b/lms/views/api/gateway.py
@@ -58,7 +58,10 @@ def h_lti(context, request):
     # anything until they launch an assignment and get put in a group.
     request.find_service(name="lti_h").sync([context.course], request.lti_params)
 
-    return {"api": {"h": _GatewayService.render_h_connection_info(request)}}
+    return {
+        "api": {"h": _GatewayService.render_h_connection_info(request)},
+        "data": _GatewayService.render_lti_context(request),
+    }
 
 
 class _GatewayService:
@@ -91,4 +94,20 @@ class _GatewayService:
                     "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
                 },
             },
+        }
+
+    @classmethod
+    def render_lti_context(cls, request):
+        h_user = request.lti_user.h_user
+        authority = request.registry.settings["h_authority"]
+
+        return {
+            # Details of the current user
+            "profile": {
+                "userid": h_user.userid(authority),
+                "display_name": h_user.display_name,
+                "lti": {
+                    "user_id": h_user.provider_unique_id,
+                },
+            }
         }

--- a/tests/functional/api/gateway_test.py
+++ b/tests/functional/api/gateway_test.py
@@ -34,8 +34,9 @@ class TestGatewayHLTI:
                         "method": "POST",
                         "url": TEST_SETTINGS["h_api_url_public"] + "token",
                     },
-                }
-            }
+                },
+            },
+            "data": Any.dict(),
         }
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4197

This has shares a commit for splitting up the body of the view from: https://github.com/hypothesis/lms/pull/4272

## Testing notes

 * Start `h` and `lms`
 * Ensure you have visited some assignments
 * Use `bin/gateway/oauth_call.py` to issue a request and view the results
    * If you are missing a config file for this please ask
 * You should see profile data dumped in the output 