### PR TITLE
Inject None as a client to the VS service when the api key is missing

### DIFF
--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -4,10 +4,9 @@ from lms.services.vitalsource.service import VitalSourceService
 
 def service_factory(_context, request):
     settings = request.find_service(name="application_instance").get_current().settings
+    api_key = request.registry.settings["vitalsource_api_key"]
 
     return VitalSourceService(
-        client=VitalSourceClient(
-            api_key=request.registry.settings["vitalsource_api_key"]
-        ),
+        client=VitalSourceClient(api_key) if api_key else None,
         enabled=settings.get("vitalsource", "enabled", False),
     )

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import sentinel
 
 import pytest
+from h_matchers import Any
 
 from lms.services.vitalsource.factory import service_factory
 
@@ -29,6 +30,15 @@ class TestServiceFactory:
         VitalSourceService.assert_called_once_with(
             client=VitalSourceClient.return_value, enabled=expected
         )
+        assert svc == VitalSourceService.return_value
+
+    @pytest.mark.usefixtures("application_instance_service")
+    def test_it_when_no_api_key(self, pyramid_request, VitalSourceService):
+        pyramid_request.registry.settings["vitalsource_api_key"] = None
+
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        VitalSourceService.assert_called_once_with(client=None, enabled=Any())
         assert svc == VitalSourceService.return_value
 
     @pytest.fixture


### PR DESCRIPTION
This fixes an issue were the api key is required (ValueError is thrown)
for a VitalSourceSerivce.enabled check.


Not sure if this is the right approach, the enable check in the service does check for the presence of the client so this works.

https://github.com/hypothesis/lms/blob/907c512c3929add67987f703d50985f18d068c1b/lms/services/vitalsource/service.py#L18


## Testing

- On `main` remove `VITALSOURCE_API_KEY` from `.devdata.env` (and restart the server is running)

- Try to configure an assignment, you'll get an error page.

- Same thing on this branch should work.
