### PR TITLE
Return JSTOR titles and sub-titles with less interpretation

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -51,9 +51,13 @@
 /**
  * Response for an `/api/jstor/articles/{article_id}` call.
  *
+ * @typedef JSTORContentItemInfo
+ * @prop {string} title
+ * @prop {string} [subtitle]
+ *
  * @typedef JSTORMetadata
  * @prop {'available'|'no_content'|'no_access'} content_status
- * @prop {string} title
+ * @prop {JSTORContentItemInfo} item
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -211,7 +211,12 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
               {canConfirmSelection && (
                 <Icon name="check" classes="text-green-success" />
               )}
-              <div className="grow font-bold italic">{metadata.data.title}</div>
+              <div className="grow font-bold italic">
+                {metadata.data.item.title}
+                {metadata.data.item.subtitle && (
+                  <>: {metadata.data.item.subtitle}</>
+                )}
+              </div>
             </div>
           )}
 

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -29,7 +29,10 @@ describe('JSTORPicker', () => {
 
   function simulateMetadataFetch(wrapper, title, otherMetadata = {}) {
     simulateAPIFetch(wrapper, '/api/jstor/articles/1234', {
-      title,
+      item: {
+        title: title,
+        subtitle: 'The sequel',
+      },
       content_status: 'available',
       ...otherMetadata,
     });
@@ -232,7 +235,7 @@ describe('JSTORPicker', () => {
     simulateMetadataFetch(wrapper, 'Some interesting article');
     simulateThumbnailFetch(wrapper);
 
-    assert.include(wrapper.text(), 'Some interesting article');
+    assert.include(wrapper.text(), 'Some interesting article: The sequel');
     const thumbnail = wrapper.find('img');
     assert.equal(thumbnail.prop('src'), 'data:thumbnail-image-data');
   });

--- a/lms/static/scripts/frontend_apps/services/content-info-fetcher.js
+++ b/lms/static/scripts/frontend_apps/services/content-info-fetcher.js
@@ -54,7 +54,7 @@ export class ContentInfoFetcher {
         link: 'https://www.jstor.org',
       },
       item: {
-        title: metadata.title,
+        title: metadata.item.title,
 
         // TODO - Fill in this information from the API
         containerTitle: '',

--- a/lms/static/scripts/frontend_apps/services/test/content-info-fetcher-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/content-info-fetcher-test.js
@@ -6,7 +6,7 @@ describe('ContentInfoFetcher', () => {
   let fakeClientRPC;
 
   beforeEach(() => {
-    fakeAPICall = sinon.stub().resolves({ title: 'Test article' });
+    fakeAPICall = sinon.stub().resolves({ item: { title: 'Test article' } });
     fakeClientRPC = {
       showContentInfo: sinon.stub().resolves(),
     };


### PR DESCRIPTION
This changes the data structure we return from the JSTOR metadata proxy API from:

```json
{
    "title": "Title: Subtitle"
}
```

To be:

```json
{
    "item": {
        "title": "Title",
        "subtitle": "Subtitle"
    }
}
```


## Testing notes

 * Start LMS and friends
 * Visit: https://hypothesis.instructure.com/courses/125
 * Create a new assignment using the localhost LMS instance
 * Open the F12 dev tools to the network tab and filter by "jstor"
 * Select JSTOR and enter: https://www.jstor.org/stable/3314735
 * You should see the data correctly displayed
 * You should see the new details in the network output 

