### PR TITLE
Catch 404's from JSTOR and try and distinguish between no item and wrong URL

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -11,6 +11,7 @@ from lms.services.exceptions import (
     ExternalAsyncRequestError,
     ExternalRequestError,
     OAuth2TokenError,
+    SerializableError,
 )
 from lms.services.h_api import HAPIError
 from lms.services.jstor import JSTORService

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -258,6 +258,29 @@ class BlackboardFileNotFoundInCourse(Exception):
         super().__init__(self.details)
 
 
+class SerializableError(Exception):
+    """An exception compatible with our default error handling for APIs."""
+
+    def __init__(
+        self,
+        message: str = None,
+        error_code: Optional[str] = None,
+        details: Optional[dict] = None,
+    ):
+        """
+        Initialise the error.
+
+        :param message: Message to display to the user (if any)
+        :param error_code: Error code to allow client side code to detect
+            this error
+        :param details: A JSON serializable payload of extra info
+        """
+        super().__init__(message)
+        self.error_code = error_code
+        self.message = message
+        self.details = details
+
+
 def _repr_external_request_exception(exception):
     # Include the details of the request and response for debugging. This
     # appears in the logs and in tools like Sentry and Papertrail.

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -19,6 +19,7 @@ from lms.services import (
     ExternalRequestError,
     OAuth2TokenError,
 )
+from lms.services.exceptions import SerializableError
 from lms.validation import ValidationError
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -170,6 +171,7 @@ class APIExceptionViews:
         context=CanvasAPIPermissionError
     )
     @exception_view_config(context=Exception)
+    @exception_view_config(context=SerializableError)
     def api_error(self):
         """
         General fallback error handler for API requests.
@@ -178,16 +180,15 @@ class APIExceptionViews:
 
         1. The `error_code` attribute will be used as the "error_code" field in
            the response's JSON body
-
         2. The response's HTTP status will be 400
-
         3. If the exception also has a `details` attribute this will be used as
            "details" field in the response's body
 
+        You can use `SerializableError` or a child if you'd like to trigger
+        this conveniently.
+
         If the exception does not have an `error_code` attribute then:
-
         1. The response's HTTP status will be 500
-
         2. A fixed string (see below) will be used as the "message" field in
            the response's JSON body
         """
@@ -195,6 +196,7 @@ class APIExceptionViews:
         if hasattr(self.context, "error_code"):
             return ErrorBody(
                 error_code=self.context.error_code,
+                message=getattr(self.context, "message", None),
                 details=getattr(self.context, "details", None),
             )
 

--- a/tests/factories/requests_.py
+++ b/tests/factories/requests_.py
@@ -3,10 +3,10 @@ from io import BytesIO
 
 import requests
 from factory import Factory, Faker, post_generation
+from requests.structures import CaseInsensitiveDict
+
 
 # pylint:disable=no-self-argument,method-hidden
-
-
 class Response(Factory):
     class Meta:
         model = requests.Response
@@ -20,7 +20,9 @@ class Response(Factory):
     def headers(response, _create, headers, **_kwargs):
         """Lower-case all header names. Requests requires this."""
         if headers:
-            response.headers = {key.lower(): value for key, value in headers.items()}
+            response.headers = CaseInsensitiveDict(
+                {key.lower(): value for key, value in headers.items()}
+            )
 
     @post_generation
     def json_data(response, _create, json_data, **_kwargs):


### PR DESCRIPTION
The JSTOR API raises 404s when:

 * You have a completely broken URL
 * You have the right URL but the particular thing you are looking for doesn't exist

There's quite a lot of variation, but by experimenting with various calls I managed to get a set of indicators that narrowed down which type of 404 we have.

## Replicating my findings

Correctly formatted by missing items:

 * https://labs.jstor.org/api/anno/metadata/10.2307/9999999999
    * `Content-Type: application/json;charset=UTF-8`
    * Content: `null`
 * https://labs.jstor.org/api/anno/thumbnail/10.2307/999999999?offset=1&width=280
   * `Content-Type: text/plain;charset=UTF-8`

Broken URLs:

 * https://labs.jstor.org/api/anno/BROKEN
    * `Content-Type: application/json;charset=UTF-8`
    * Content: `{	"detail": "Not Found"}`
 * https://labs.jstor.org/api/BROKEN
    * `Content-Type: text/html;charset=UTF-8`
    * Content: A big HTML page

## Testing notes

 * Start everything
 * Create a new assignment in https://hypothesis.instructure.com/courses/125
 * Open the JSTOR option in the file picker
 * Try very long numbers
 * You should see "Book 345345345 not found" or something similar
 * In the network tab you should see errors with 400 statuses for the metadata and thumbnail