### PR TITLE
Pass on additional JSTOR item metadata to the client for banner

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -55,9 +55,15 @@
  * @prop {string} title
  * @prop {string} [subtitle]
  *
+ * @typedef JSTORRelatedItemsInfo
+ * @prop {string} [next_id]
+ * @prop {string} [previous_id]
+ *
  * @typedef JSTORMetadata
  * @prop {'available'|'no_content'|'no_access'} content_status
  * @prop {JSTORContentItemInfo} item
+ * @prop {JSTORContentItemInfo} container
+ * @prop {JSTORRelatedItemsInfo} related_items
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -38,8 +38,9 @@ import { JWT } from '../utils/jwt';
  *
  * @typedef ContentInfoItem
  * @prop {string} title - Title of the current article, chapter etc.
- * @prop {string} containerTitle - Title of the journal issue, book etc. which
- *   contains the current work
+ * @prop {string} [subtitle]
+ * @prop {string} [containerTitle] - Title of the journal issue, book etc. which
+ *   contains the current work. DEPRECATED
  */
 
 /**
@@ -48,6 +49,7 @@ import { JWT } from '../utils/jwt';
  * @typedef ContentInfoLinks
  * @prop {string} [previousItem] - Previous item in the book, journal etc.
  * @prop {string} [nextItem] - Next item in the book, journal etc.
+ * @prop {string} currentItem
  */
 
 /**
@@ -58,6 +60,7 @@ import { JWT } from '../utils/jwt';
  * @typedef {object} ContentInfoConfig
  * @prop {ContentInfoLogo} logo - Logo of the content provider
  * @prop {ContentInfoItem} item
+ * @prop {ContentInfoItem} container
  * @prop {ContentInfoLinks} links
  */
 

--- a/lms/static/scripts/frontend_apps/services/test/content-info-fetcher-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/content-info-fetcher-test.js
@@ -6,7 +6,20 @@ describe('ContentInfoFetcher', () => {
   let fakeClientRPC;
 
   beforeEach(() => {
-    fakeAPICall = sinon.stub().resolves({ item: { title: 'Test article' } });
+    fakeAPICall = sinon.stub().resolves({
+      container: {
+        title: 'Test container',
+        subtitle: 'Test container subtitle',
+      },
+      item: {
+        title: 'Test article',
+        subtitle: 'Test article subtitle',
+      },
+      related_items: {
+        previous_id: '111111',
+        next_id: '333333',
+      },
+    });
     fakeClientRPC = {
       showContentInfo: sinon.stub().resolves(),
     };
@@ -42,12 +55,21 @@ describe('ContentInfoFetcher', () => {
           title: 'JSTOR homepage',
           link: 'https://www.jstor.org',
         },
+        container: {
+          title: 'Test container',
+          subtitle: 'Test container subtitle',
+        },
         item: {
           title: 'Test article',
-          containerTitle: '',
+          subtitle: 'Test article subtitle',
+          containerTitle: 'Test container',
         },
 
-        links: {},
+        links: {
+          currentItem: 'https://www.jstor.org/stable/123456',
+          nextItem: 'https://www.jstor.org/stable/333333',
+          previousItem: 'https://www.jstor.org/stable/111111',
+        },
       });
     });
 


### PR DESCRIPTION
This PR shuttles some of the additional fields recently added to the proxy API for JSTOR item metadata on over to the client for use in the banner. As a result, the client banner is now able to display:

* The title of the container
* Next and/or previous links, when available

A few tweaks are necessary on the client side before we can show the following, but the metadata supporting them are part of these changes:

* Link to the current item
* Subtitle of the current item

### Try it out

* Configure a Canvas localhost assignment in https://hypothesis.instructure.com/courses/125 to use JSTOR content
* In the JSTOR content picker, enter the ID `26893773` (this item has a subtitle, as well as next/previous links)
* Launch the assignment. **Click the button to open the assignment in a new window**. This is important because the container title is not displayed in the iframed assignment because there's not enough room. 

You should see:

* The "container" title, which in this case is "Journal of Architectural and Planning Research" (if you don't see it, make sure your browser window is reasonably wide)
* Next and previous links: these should each open in a new tab and go to adjacent sections/articles in this journal

You will not see an item subtitle yet. That is expected.

Fixes #4294