### PR TITLE
Handle duplicated `deployment_id` while updating application instances

### DIFF
--- a/lms/templates/admin/base.html.jinja2
+++ b/lms/templates/admin/base.html.jinja2
@@ -53,7 +53,7 @@
     </div>
     <div class="message-body">
     {% for error in request.session.pop_flash("errors") %}
-        <ul>{{ error }}</ul>
+        <ul>{{ error|safe }}</ul>
     {% endfor %}
     </div>
     </article>

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -300,7 +300,7 @@ class AdminApplicationInstanceViews:
         if deployment_id := self.request.params.get("deployment_id", "").strip():
             if ai.lti_version == "1.3.0":
                 try:
-                    duplicated_ai = (
+                    existing_ai = (
                         self.application_instance_service.get_by_deployment_id(
                             issuer=ai.lti_registration.issuer,
                             client_id=ai.lti_registration.client_id,
@@ -311,9 +311,9 @@ class AdminApplicationInstanceViews:
                     # No duplicated AI, we can update the current one.
                     pass
                 else:
-                    if duplicated_ai.id != ai.id:
+                    if existing_ai.id != ai.id:
                         self.request.session.flash(
-                            f"Can't set deployment_id to '{deployment_id}'. Already in use on: {self._get_ai_link(duplicated_ai)}",
+                            f"Can't set deployment_id to '{deployment_id}'. Already in use on: {self._get_ai_link(existing_ai)}",
                             "errors",
                         )
 


### PR DESCRIPTION
Something that came up in the review where editing of `deployment_id` was added.

## Testing

- Go to http://localhost:8001/admin/registration/id/1/
- New instance, with any "deployment_id" value
- In the newly created instance try updating deployment_id to any other value. That should update.
- Now try to update it to "1f5a3b8f-1c11-4837-9ea2-f3a1596382f2" which should trigger the new code.