### PR TITLE
Rollback failed transaction in admin pages

### DIFF
--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -177,9 +177,15 @@ class AdminApplicationInstanceViews:
             application_instance.lms_url = lms_url
 
         try:
-            # Flush here to find if we are making a duplicate in the process of upgrading
+            # Flush here to find if we are making a duplicate in the process of
+            # upgrading
             self.request.db.flush()
         except IntegrityError:
+            # Leave a clean transaction, otherwise  we get a:
+            #   "PendingRollbackError: This Session's transaction has been
+            #   rolled back due to a previous exception during flush."
+            self.request.db.rollback()
+
             return error_render_to_response(
                 self.request,
                 f"Application instance with deployment_id: {self.request.params['deployment_id']} already exists",


### PR DESCRIPTION
This is broken in `main` currently:

## Testing 

- Go to http://localhost:8001/admin/registration/id/2/new/instance
```
consumer key: Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b
deployment_id: 0f29b2ec-444d-462b-9c5b-fcc0803ab2d2
```

In main it will fail, it will hos a message in this branch.