### PR TITLE
Return details of the current user's groups in the Gateway data

### DIFF
--- a/docs/gateway/schema.json
+++ b/docs/gateway/schema.json
@@ -32,7 +32,27 @@
                     "lti": {
                         "user_id": "9782345"
                     }
-                }
+                },
+                "groups": [
+                    {
+                        "groupid": "group:b978234ff77e34a@lms.hypothes.is",
+                        "name": "My course name",
+                        "lms": {
+                            "id": "1234",
+                            "parentId": null,
+                            "type": "course"
+                        }
+                    },
+                    {
+                        "groupid": "group:f5b22dcb29f52e61@lms.hypothes.is",
+                        "name": "Section 1",
+                        "lms": {
+                            "id": "4321",
+                            "parentId": "1234",
+                            "type": "canvas_section"
+                        }
+                    }
+                ]
             }
         }
     ],
@@ -60,15 +80,21 @@
             },
             "required": ["h"]
         },
+
         "data": {
             "type": "object",
             "properties": {
                 "profile": {
                     "description": "Details of the current user",
                     "$ref": "#/$defs/user"
+                },
+                "groups": {
+                    "description": "A list of groups in the course which the user is a member of",
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/group"}
                 }
             },
-            "required": ["profile"],
+            "required": ["profile", "groups"],
             "additionalProperties": false
         }
     },
@@ -88,6 +114,28 @@
             },
             "additionalProperties": false,
             "required": ["method", "url"]
+        },
+
+        "group": {
+            "title": "A group the user is in",
+            "type": "object",
+
+            "properties": {
+                "groupid": {"type": "string"},
+                "name": {"type": ["string", "null"]},
+                "lms": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "parentId": {"type": ["string", "null"]},
+                        "type": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "required": ["id", "parentId", "type"]
+                }
+            },
+            "additionalProperties": false,
+            "required": ["groupid", "name", "lms"]
         },
 
         "user": {

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -205,10 +205,11 @@ class GroupingService:
 
     def get_known_groupings(self, user, course):
         """
-        Get the groupings we already know about for the provided user.
+        Get the groupings from the DB for the provided user.
 
         This will include the course, and any sections / groups we have seen
-        before. This does not attempt to retrieve the groups from the LMS.
+        before. This does not attempt to retrieve the groups from the tool
+        consumer using their API (for example by calling Canvas API).
 
         This only works for direct children of the course, not children of
         children.

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Union
 
 from sqlalchemy import func
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import aliased, subqueryload
 
 from lms.models import Course, Grouping, GroupingMembership, LTIUser, User
 from lms.models._hashed_id import hashed_id
@@ -202,6 +202,31 @@ class GroupingService:
             )
 
         return self._to_groupings(user, groupings, course, self.plugin.group_type)
+
+    def get_known_groupings(self, user, course):
+        """
+        Get the groupings we already know about for the provided user.
+
+        This will include the course, and any sections / groups we have seen
+        before. This does not attempt to retrieve the groups from the LMS.
+
+        This only works for direct children of the course, not children of
+        children.
+        """
+        parent_groups = aliased(Grouping)
+
+        groupings = (
+            # Get groupings which are children of the course
+            self._db.query(Grouping)
+            .filter_by(parent_id=course.id)
+            # Which the user is a part of
+            .join(GroupingMembership)
+            .filter(GroupingMembership.user == user)
+            # Eager load the parent groups
+            .options(subqueryload(parent_groups, Grouping.parent))
+        ).all()
+
+        return [course] + groupings
 
     def _to_groupings(self, user, groupings, course, type_):
         if groupings and not isinstance(groupings[0], Grouping):

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -22,6 +22,7 @@ from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo
 from tests.factories.group_info import GroupInfo
 from tests.factories.grouping import BlackboardGroup, CanvasGroup, CanvasSection, Course
+from tests.factories.grouping_membership import GroupingMembership
 from tests.factories.h_user import HUser
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole

--- a/tests/factories/grouping_membership.py
+++ b/tests/factories/grouping_membership.py
@@ -1,0 +1,8 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+GroupingMembership = make_factory(
+    models.GroupingMembership, FACTORY_CLASS=SQLAlchemyModelFactory
+)

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -446,6 +446,18 @@ class TestGetGroupings:
         upsert_groupings.assert_not_called()
         upsert_grouping_memberships.assert_called_once_with(sentinel.user, groupings)
 
+    def test_get_known_groupings(self, svc, db_session):
+        groupings = factories.CanvasGroup.create_batch(3)
+        course = factories.Course(children=groupings)
+        user = factories.User()
+        factories.GroupingMembership(grouping=groupings[1], user=user)
+        db_session.flush()
+
+        results = svc.get_known_groupings(user, course)
+
+        # We get the course no matter what + only the grouping we are in
+        assert results == Any.list.containing([course, groupings[1]])
+
     @pytest.fixture
     def assert_groups_returned(self, svc, assert_groupings_returned):
         return partial(assert_groupings_returned, grouping_type=svc.plugin.group_type)


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4197

This PR adds group return values for the gateway end-point. The groups returned are:

* Groups in the current course
* That the user is in as well

## Testing notes

 * Start `h` and `lms`
 * Ensure you have visited some assignments
 * Use `bin/gateway/oauth_call.py` to issue a request and view the results
    * If you are missing a config file for this please ask
 * You should see profile data dumped in the output 