### PR TITLE
Remove unused `containerTitle` field

### DIFF
--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -39,8 +39,6 @@ import { JWT } from '../utils/jwt';
  * @typedef ContentInfoItem
  * @prop {string} title - Title of the current article, chapter etc.
  * @prop {string} [subtitle]
- * @prop {string} [containerTitle] - Title of the journal issue, book etc. which
- *   contains the current work. DEPRECATED
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/services/content-info-fetcher.js
+++ b/lms/static/scripts/frontend_apps/services/content-info-fetcher.js
@@ -76,9 +76,6 @@ export class ContentInfoFetcher {
       item: {
         title: metadata.item.title,
         subtitle: metadata.item.subtitle,
-        // TODO Remove once client updated to look this up in the
-        // `container` object
-        containerTitle: metadata.container.title,
       },
       container: {
         title: metadata.container.title,

--- a/lms/static/scripts/frontend_apps/services/test/content-info-fetcher-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/content-info-fetcher-test.js
@@ -62,7 +62,6 @@ describe('ContentInfoFetcher', () => {
         item: {
           title: 'Test article',
           subtitle: 'Test article subtitle',
-          containerTitle: 'Test container',
         },
 
         links: {


### PR DESCRIPTION
This is a trivial cleanup PR to remove the now-unused `containerTitle` field from the JSTOR content-info payload sent to the `client` to show the content-info banner. 

This is possible now that https://github.com/hypothesis/client/pull/4684 has landed and the `client` no longer references this field.