### PR TITLE
Newer Canvas instances will now return a nice error for unavailable files

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -210,7 +210,7 @@ class CanvasAPIError(ExternalRequestError):
         ):
             raise OAuth2TokenError(**kwargs) from cause
 
-        if status_code == 401:
+        if status_code in (401, 403):
             raise CanvasAPIPermissionError(**kwargs) from cause
 
         raise CanvasAPIServerError(**kwargs) from cause

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -208,7 +208,20 @@ class TestCanvasAPIError:
                 OAuth2TokenError,
             ),
             # A permissions error from Canvas, because the Canvas user doesn't
-            # have permission to make the API call.
+            # have permission to make the API call. Updated Canvas instances
+            # will send 403, rather than 401.
+            (
+                403,
+                json.dumps(
+                    {
+                        "status": "unauthorized",
+                        "errors": [
+                            {"message": "user not authorized to perform that action"}
+                        ],
+                    }
+                ),
+                CanvasAPIPermissionError,
+            ),
             (
                 401,
                 json.dumps(
@@ -223,11 +236,7 @@ class TestCanvasAPIError:
             ),
             # A 400 Bad Request response from Canvas, because we sent an invalid
             # parameter or something.
-            (
-                400,
-                json.dumps({"test": "body"}),
-                CanvasAPIServerError,
-            ),
+            (400, json.dumps({"test": "body"}), CanvasAPIServerError),
             # An unexpected error response from Canvas.
             (500, "test_body", CanvasAPIServerError),
         ],


### PR DESCRIPTION
For: 

 * https://github.com/hypothesis/product-backlog/issues/1368

It seems Canvas have changed the output we get from a 401 to a 403 when the user is not authorized. As there are many different Canvas deploys in the wild we now catch both.

## Testing notes

 * Login to Canvas as a student
 * Visit: https://hypothesis.instructure.com/courses/125/assignments/1371
 * On main you see a generic error
 * On this branch you should see "Couldn't get the file from Canvas"