### PR TITLE
Add a `.tox/requirements` venv to simplify `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,16 +144,12 @@ bddtests: python
 # `touch` is used to pre-create an empty requirements/%.txt file if none
 # exists, otherwise tox crashes.
 #
-# $(subst) is used because in the special case of making requirements.txt we
-# actually need to touch dev.txt not requirements.txt and we need to run
-# `tox -e dev ...` not `tox -e requirements ...`
-#
 # $(basename $(notdir $@))) gets just the environment name from the
 # requirements/%.txt filename, for example requirements/foo.txt -> foo.
 requirements/%.txt: requirements/%.in
-	@touch -a $(subst requirements.txt,dev.txt,$@)
-	@tox -qe $(subst requirements,dev,$(basename $(notdir $@))) --run-command 'pip --quiet --disable-pip-version-check install pip-tools'
-	@tox -qe $(subst requirements,dev,$(basename $(notdir $@))) --run-command 'pip-compile --allow-unsafe --quiet $(args) $<'
+	@touch -a $@
+	@tox -qe $(basename $(notdir $@)) --run-command 'pip --quiet --disable-pip-version-check install pip-tools'
+	@tox -qe $(basename $(notdir $@)) --run-command 'pip-compile --allow-unsafe --quiet $(args) $<'
 
 # Inform make of the dependencies between our requirements files so that it
 # knows what order to re-compile them in and knows to re-compile a file if a

--- a/tox.ini
+++ b/tox.ini
@@ -97,3 +97,5 @@ sitepackages = {env:SITE_PACKAGES:false}
 suicide_timeout = 60.0
 interrupt_timeout = 60.0
 terminate_timeout = 60.0
+
+[testenv:requirements]


### PR DESCRIPTION
I wonder if we should have a `.tox/prod` virtualenv for compiling the `requirements/prod.txt` file in (currently this is named `requirements/requirements.txt` but in the cookiecutter I've renamed it to `prod.txt` which I think is a better name).

For all our other requirements files the names all line up nicely: `make dev` runs `tox -e dev` which creates the `.tox/dev` virtualenv and installs `requirements/dev.txt` into it, which is compiled from `requirements/dev.in`. The command to compile `dev.txt` is `tox -e dev --run-command 'pip-compile requirements/dev.in'`.

`requirements/prod.{in,txt}` is the one exception: since there's no `prod` virtualenv it's compiled using the `dev` one: `tox -e dev --run-command 'pip-compile requirements/prod.in'`. This actually leads to quite a lot of complexity in the Makefile: all that `$(subst prod,dev)` stuff.

The problem is that we don't have any other use for a `.tox/prod` virtualenv other than for compiling `prod.{in,txt}` so it's maybe a bit weird.