### PR TITLE
Simplify `make requirements` by not using `tox`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,20 +140,9 @@ bddtests: python
 	@tox -qe bddtests
 
 # Tell make how to compile requirements/*.txt files.
-#
-# `touch` is used to pre-create an empty requirements/%.txt file if none
-# exists, otherwise tox crashes.
-#
-# $(subst) is used because in the special case of making requirements.txt we
-# actually need to touch dev.txt not requirements.txt and we need to run
-# `tox -e dev ...` not `tox -e requirements ...`
-#
-# $(basename $(notdir $@))) gets just the environment name from the
-# requirements/%.txt filename, for example requirements/foo.txt -> foo.
 requirements/%.txt: requirements/%.in
-	@touch -a $(subst requirements.txt,dev.txt,$@)
-	@tox -qe $(subst requirements,dev,$(basename $(notdir $@))) --run-command 'pip --quiet --disable-pip-version-check install pip-tools'
-	@tox -qe $(subst requirements,dev,$(basename $(notdir $@))) --run-command 'pip-compile --allow-unsafe --quiet $(args) $<'
+	pyenv exec pip --quiet --disable-pip-version-check install --upgrade pip-tools
+	pyenv exec pip-compile --allow-unsafe --quiet $(args) $<
 
 # Inform make of the dependencies between our requirements files so that it
 # knows what order to re-compile them in and knows to re-compile a file if a


### PR DESCRIPTION
`pip-compile` only needs to be run with the right version of Python, it doesn't actually need to be run in the same virtualenv that the requirements file is (or will be) installed in.

IIRC the only reason why I did use `tox` to run `pip-compile` in the first place was that we might have a project that uses different Python versions for different virtualenvs. For example we did this in the past with legacy Via: Via itself only supported Python 2 so virtualenvs like dev, tests, functests, etc used Python 2. But the Black code formatter could only be run in Python 3 (even though it could format Python 2 code) so we used Python 3 for the format virtualenv. Generally speaking the ability to have different tox environments using different Python versions enables us to adopt a tool like a formatter or linter without that tool necessarily having to be run with the same version of Python that the app runs in.

But:

1. We don't currently have any apps that use multiple Python versions in this way.

2. As far as I know using multiple Python versions with `pip-compile`'d requirements files isn't compatible with Dependabot: Dependabot will use the first Python version from your `.python-version` to compile *all* your `requirements.txt` files so it'll break any `requirements.txt` files that use a different Python version.

   I don't understand the Dependabot Ruby source code well enough to verify whether this is still the case without actually trying it but [last time I tested](https://github.com/seanh/python-multiversion-dependency-management-demo#dependabot-) it was and there are still multiple open issues about this on Dependabot's GitHub issues, for example https://github.com/dependabot/dependabot-core/issues/4216 and https://github.com/dependabot/dependabot-core/issues/4607

   I think it may be possible to get Dependabot to use the right Python version if you put different requirements files in different subdirs and give each subdir its own `.python-version` file. But I haven't tested this and I don't think we want to do it.

   I'm not sure how we got away with this when legacy Via used multiple Python versions. I suspect maybe it wasn't using Dependabot?

I think we should consider leaning in to the fact that while our Python _packages_ can support multiple Python versions because they don't use `pip-compile` and don't have pinned requirements files, our _apps_ can only support one version of Python at a time (one version shared by all their tox envs).

If we're willing to make that assumption we can simplify the implementation of `make requirements`, which is what this commit does.