### PR TITLE
Process all custom 1.3 parameters instead of a few Canvas ones

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -106,18 +106,6 @@ _V11_TO_V13 = (
         "deep_linking_settings",
         ["https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings"],
     ),
-    (
-        "custom_canvas_course_id",
-        [f"{CLAIM_PREFIX}/custom", "canvas_course_id"],
-    ),
-    (
-        "custom_canvas_api_domain",
-        [f"{CLAIM_PREFIX}/custom", "canvas_api_domain"],
-    ),
-    (
-        "custom_canvas_user_id",
-        [f"{CLAIM_PREFIX}/custom", "canvas_user_id"],
-    ),
     # Some LMSs provide a https://purl.imsglobal.org/spec/lti/claim/lti1p1 claim
     # with the LTI1.1 version value of some IDs that are different in LTI1.3.
     # To make upgrades seamless we prefer the LTI1.1 version when available
@@ -143,6 +131,11 @@ def _to_lti_v11(v13_params):
         except KeyError:
             # We don't want to add partial values along v13_path
             continue
+
+    # Deal with the custom params. See:
+    # https://www.imsglobal.org/spec/lti/v1p3/#custom-properties-and-variable-substitution
+    if custom := v13_params.get(f"{CLAIM_PREFIX}/custom"):
+        v11_params.update({f"custom_{key}": value for key, value in custom.items()})
 
     if "roles" in v11_params:
         # We need to squish together the roles for v1.1

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -31,6 +31,13 @@ class TestLTIParams:
 
         assert LTIParams.from_request(pyramid_request)[lti_11_key] == value
 
+    def test_v13_custom_fields(self, pyramid_request):
+        pyramid_request.lti_jwt = {
+            "https://purl.imsglobal.org/spec/lti/claim/custom": {"name": "value"}
+        }
+
+        assert LTIParams.from_request(pyramid_request)["custom_name"] == "value"
+
     def test_v11(self, pyramid_request):
         pyramid_request.params = {"test": "key"}
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4325

This processes all custom LTI parameters into 1.1 ones with a `custom_` prefix. I'm not sure why we didn't do this before.

This might also untie the knot around using LTI params to determine the product type?

## Testing notes

None really. There is no user facing change, but it allows us to process all custom params instead of just some.