### PR TITLE
Add a DB migration for the organization work

### DIFF
--- a/lms/migrations/versions/79eda94de79f_add_organizations_model.py
+++ b/lms/migrations/versions/79eda94de79f_add_organizations_model.py
@@ -1,0 +1,69 @@
+"""
+Add Organizations model.
+
+Revision ID: 79eda94de79f
+Revises: 396f46318023
+Create Date: 2022-09-07 16:57:14.077132
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "79eda94de79f"
+down_revision = "9bb2beba95bc"
+
+
+def upgrade():
+    op.create_table(
+        "organization",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.UnicodeText(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("public_id", sa.UnicodeText(), nullable=False),
+        sa.Column("parent_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "settings",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["parent_id"],
+            ["organization.id"],
+            name=op.f("fk__organization__parent_id__organization"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__organization")),
+        sa.UniqueConstraint("public_id", name=op.f("uq__organization__public_id")),
+    )
+
+    op.add_column(
+        "application_instances",
+        sa.Column("organization_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        op.f("fk__application_instances__organization_id__organization"),
+        "application_instances",
+        "organization",
+        ["organization_id"],
+        ["id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk__application_instances__organization_id__organization"),
+        "application_instances",
+        type_="foreignkey",
+    )
+    op.drop_column("application_instances", "organization_id")
+
+    op.drop_table("organization")


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4200

Adds a migration for the model in:

 * https://github.com/hypothesis/lms/pull/4329

## Testing notes

Reset your DB and run the upgrade:

```shell
git checkout main
make services args=down
make services db devdata
git checkout orgs-db-migration
hdev alembic upgrade head
make sql
```
Check the results

```sql
\d+ organization;
```
```sql
\d+ application_instances;
```

Note the `organization_id` column and `fk__application_instances__organization_id__organization`.

Downgrade the DB and check the results:

```shell
hdev alembic downgrade -1
make sql
```

```sql
\d+ organization;
```
Gone!

```sql
\d+ application_instances;
```

The org column and relation is gone