### PR TITLE
Automatically assign application instance to organizations

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -1,5 +1,4 @@
 import logging
-from functools import cached_property
 
 import alembic.command
 import alembic.config
@@ -7,7 +6,7 @@ import sqlalchemy
 import zope.sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.properties import ColumnProperty
 
 from lms.db._columns import varchar_enum
@@ -24,6 +23,7 @@ class BaseClass:
     @classmethod
     def columns(cls):
         """Return a list of all declared SQLAlchemy column names."""
+
         return [
             property.key
             for property in inspect(cls).iterate_properties
@@ -59,13 +59,10 @@ class BaseClass:
                 setattr(self, key, data[key])
 
     def __repr__(self):
-        return "{class_}({kwargs})".format(  # pylint: disable=consider-using-f-string
-            class_=self.__class__.__name__,
-            kwargs=", ".join(
-                f"{kwarg}={repr(getattr(self, kwarg))}"
-                for kwarg in self.__table__.columns.keys()  # pylint:disable=no-member
-            ),
+        kwargs = ", ".join(
+            f"{column}={repr(getattr(self, column))}" for column in self.columns()
         )
+        return f"{self.__class__.__name__}({kwargs})"
 
 
 BASE = declarative_base(

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -153,37 +153,6 @@ class ApplicationInstance(BASE):
 
         return lms_host
 
-    def update_lms_data(self, params: dict):
-        """
-        Update all the LMS-related attributes present in `params`.
-
-        If the current instance already has a `tool_consumer_instance_guid`
-        report it on logging and don't update any of the columns.
-        """
-
-        tool_consumer_instance_guid = params.get("tool_consumer_instance_guid")
-        if not tool_consumer_instance_guid:
-            # guid identifies the rest of the LMS data, if not there skip any updates
-            return
-
-        self.check_guid_aligns(tool_consumer_instance_guid)
-
-        # This looks a bit weird after the statement above, but our GUID might
-        # be null and still pass the check above
-        self.tool_consumer_instance_guid = tool_consumer_instance_guid
-
-        for attr in [
-            "tool_consumer_info_product_family_code",
-            "tool_consumer_instance_description",
-            "tool_consumer_instance_url",
-            "tool_consumer_instance_name",
-            "tool_consumer_instance_contact_email",
-            "tool_consumer_info_version",
-            "custom_canvas_api_domain",
-        ]:
-
-            setattr(self, attr, params.get(attr))
-
     def check_guid_aligns(self, tool_consumer_instance_guid):
         """
         Check there is no conflict between the provided GUID and ours.

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -27,6 +27,7 @@ from lms.services.lti_names_roles import LTINamesRolesService
 from lms.services.lti_registration import LTIRegistrationService
 from lms.services.lti_role_service import LTIRoleService
 from lms.services.ltia_http import LTIAHTTPService
+from lms.services.organization import OrganizationService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.vitalsource import VitalSourceService
@@ -109,3 +110,6 @@ def includeme(config):
         "lms.services.document_url.factory", iface=DocumentURLService
     )
     config.register_service_factory("lms.services.event.factory", iface=EventService)
+    config.register_service_factory(
+        "lms.services.organization.service_factory", iface=OrganizationService
+    )

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import NoResultFound
 
 from lms.models import ApplicationInstance, LTIParams, LTIRegistration
 from lms.services.aes import AESService
+from lms.services.organization import OrganizationService
 
 
 class ApplicationInstanceNotFound(Exception):
@@ -14,10 +15,17 @@ class ApplicationInstanceNotFound(Exception):
 
 
 class ApplicationInstanceService:
-    def __init__(self, db, request, aes_service):
+    def __init__(
+        self,
+        db,
+        request,
+        aes_service: AESService,
+        organization_service: OrganizationService,
+    ):
         self._db = db
         self._request = request
         self._aes_service = aes_service
+        self._organization_service = organization_service
 
     @lru_cache(maxsize=1)
     def get_current(self) -> ApplicationInstance:
@@ -173,6 +181,9 @@ class ApplicationInstanceService:
 
         application_instance.check_guid_aligns(tool_consumer_instance_guid)
 
+        # Make sure this application instance is associated with an org.
+        self._organization_service.auto_assign_organization(application_instance)
+
         for attr in [
             "tool_consumer_info_product_family_code",
             "tool_consumer_instance_description",
@@ -188,7 +199,8 @@ class ApplicationInstanceService:
 
 def factory(_context, request):
     return ApplicationInstanceService(
-        request.db,
-        request,
-        request.find_service(AESService),
+        db=request.db,
+        request=request,
+        aes_service=request.find_service(AESService),
+        organization_service=request.find_service(OrganizationService),
     )

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -1,0 +1,78 @@
+from logging import getLogger
+from typing import List, Optional
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from lms.models import ApplicationInstance, GroupInfo, Organization
+
+LOG = getLogger(__name__)
+
+
+class OrganizationService:
+    """A service for dealing with organization actions."""
+
+    def __init__(self, db_session: Session):
+        self._db_session = db_session
+
+    def get_by_linked_guid(self, guid) -> List[Organization]:
+        """Get organizations which match the provided GUID."""
+
+        # There are huge numbers of null GUIDs, don't match on them
+        if not guid:
+            return []
+
+        return (
+            self._db_session.query(Organization)
+            .join(ApplicationInstance)
+            .outerjoin(GroupInfo)
+            .filter(
+                sa.or_(
+                    ApplicationInstance.tool_consumer_instance_guid == guid,
+                    GroupInfo.tool_consumer_instance_guid == guid,
+                )
+            )
+            .all()
+        )
+
+    def auto_assign_organization(
+        self, application_instance: ApplicationInstance
+    ) -> Optional[Organization]:
+        """
+        Automatically associate an application instance with an org by GUID.
+
+        If there is no GUID matching is skipped, and we return `None`. If no
+        match can be found, then a new organization is created.
+        """
+
+        # We can't match by GUID if there isn't one
+        guid = application_instance.tool_consumer_instance_guid
+        if not guid:
+            return None
+
+        if application_instance.organization:
+            org = application_instance.organization
+
+        elif orgs := self.get_by_linked_guid(guid):
+            if len(orgs) > 1:
+                LOG.warning(
+                    "Multiple organization matches found for application instance %s",
+                    application_instance.id,
+                )
+            org = orgs[0]
+
+        else:
+            org = Organization()
+
+        # Fill out missing names
+        if not org.name and (name := application_instance.tool_consumer_instance_name):
+            org.name = name
+
+        application_instance.organization = org
+        return org
+
+
+def service_factory(_context, request) -> OrganizationService:
+    """Get a new instance of OrganizationService."""
+
+    return OrganizationService(db_session=request.db)

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -32,6 +32,7 @@ class OrganizationService:
                     GroupInfo.tool_consumer_instance_guid == guid,
                 )
             )
+            .order_by(Organization.updated.desc())
             .all()
         )
 
@@ -43,6 +44,8 @@ class OrganizationService:
 
         If there is no GUID matching is skipped, and we return `None`. If no
         match can be found, then a new organization is created.
+
+        When more than one organization is found, the most recent will be used.
         """
 
         # We can't match by GUID if there isn't one

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -236,7 +236,9 @@ class BasicLaunchViews:
     def _record_launch(self):
         """Persist launch type independent info to the DB."""
 
-        self.context.application_instance.update_lms_data(self.request.lti_params)
+        self.request.find_service(name="application_instance").update_from_lti_params(
+            self.context.application_instance, self.request.lti_params
+        )
 
         if not self.request.lti_user.is_instructor and not self.context.is_canvas:
             # Create or update a record of LIS result data for a student launch

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -62,8 +62,10 @@ from lms.validation._base import JSONPyramidRequestSchema
 )
 def deep_linking_launch(context, request):
     """Handle deep linking launches."""
-    context.application_instance.update_lms_data(request.lti_params)
 
+    request.find_service(name="application_instance").update_from_lti_params(
+        context.application_instance, request.lti_params
+    )
     request.find_service(name="lti_h").sync([context.course], request.params)
 
     context.js_config.enable_file_picker_mode(

--- a/tests/factories/group_info.py
+++ b/tests/factories/group_info.py
@@ -1,4 +1,4 @@
-from factory import SubFactory, make_factory
+from factory import Faker, SubFactory, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
@@ -7,5 +7,6 @@ from tests.factories.application_instance import ApplicationInstance
 GroupInfo = make_factory(
     models.GroupInfo,
     FACTORY_CLASS=SQLAlchemyModelFactory,
+    authority_provided_id=Faker("hexify", text="^" * 40),
     application_instance=SubFactory(ApplicationInstance),
 )

--- a/tests/unit/lms/db/__init___test.py
+++ b/tests/unit/lms/db/__init___test.py
@@ -11,6 +11,7 @@ class Child(BASE):
 
 class ModelClass(BASE):
     __tablename__ = "model_class"
+    _aliased_column = sa.Column("aliased_column", sa.Integer)
     id = sa.Column(sa.Integer, primary_key=True)
     column = sa.Column(sa.Integer, sa.ForeignKey("child.id"))
     relationship = sa.orm.relationship("Child")
@@ -19,6 +20,7 @@ class ModelClass(BASE):
 class TestBase:
     def test_we_can_get_columns(self):
         assert sorted(ModelClass.columns()) == [
+            "_aliased_column",
             "column",
             "id",
         ]
@@ -49,9 +51,9 @@ class TestBase:
             ModelClass().update_from_dict({}, skip_keys=["a"])
 
     def test_repr(self):
-        model = ModelClass(id=23, column=46)
+        model = ModelClass(_aliased_column=77, id=23, column=46)
 
-        assert repr(model) == "ModelClass(id=23, column=46)"
+        assert repr(model) == "ModelClass(_aliased_column=77, id=23, column=46)"
 
     def test_repr_is_valid_python(self):
         model = ModelClass(id=23, column=46)

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from lms.models import ApplicationInstance, ApplicationSettings, ReusedConsumerKey
+from lms.models import ApplicationInstance, ApplicationSettings
 from tests import factories
 
 
@@ -102,30 +102,6 @@ class TestApplicationInstance:
 
         assert application_instance.decrypted_developer_secret(aes_service) is None
 
-    def test_update_lms_data(self, application_instance, lms_data):
-        lms_data["tool_consumer_instance_guid"] = "GUID"
-        application_instance.update_lms_data(lms_data)
-
-        for k, v in lms_data.items():
-            assert getattr(application_instance, k) == v
-
-    def test_update_lms_data_no_guid_doesnt_change_values(
-        self, application_instance, lms_data
-    ):
-        application_instance.update_lms_data(lms_data)
-
-        assert application_instance.tool_consumer_instance_guid is None
-        assert application_instance.tool_consumer_info_product_family_code is None
-
-    def test_update_lms_data_existing_guid(self, application_instance, lms_data):
-        application_instance.tool_consumer_instance_guid = "EXISTING_GUID"
-        lms_data["tool_consumer_instance_guid"] = "NEW GUID"
-
-        with pytest.raises(ReusedConsumerKey):
-            application_instance.update_lms_data(lms_data)
-
-        assert application_instance.tool_consumer_instance_guid == "EXISTING_GUID"
-
     @pytest.mark.parametrize(
         "lti_registration_id,deployment_id,lti_version",
         [
@@ -147,15 +123,6 @@ class TestApplicationInstance:
     def application_instance(self):
         """Return an ApplicationInstance with minimal required attributes."""
         return factories.ApplicationInstance()
-
-    @pytest.fixture
-    def lms_data(self):
-        return {
-            "tool_consumer_info_product_family_code": "FAMILY",
-            "tool_consumer_instance_description": "DESCRIPTION",
-            "tool_consumer_instance_url": "URL",
-            "tool_consumer_instance_name": "NAME",
-        }
 
 
 class TestApplicationSettings:

--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -1,0 +1,120 @@
+from unittest.mock import sentinel
+
+import pytest
+from h_matchers import Any
+
+from lms.models import Organization
+from lms.services.organization import OrganizationService, service_factory
+from tests import factories
+
+
+class TestOrganizationService:
+    @pytest.mark.usefixtures("with_matching_noise")
+    def test_get_by_linked_guid_matches_from_ai(self, svc):
+        orgs = factories.Organization.create_batch(2)
+        for org in orgs:
+            factories.ApplicationInstance(
+                tool_consumer_instance_guid="guid", organization=org
+            )
+
+        matches = svc.get_by_linked_guid("guid")
+
+        assert matches == Any.list.containing(orgs).only()
+
+    @pytest.mark.usefixtures("with_matching_noise")
+    def test_get_by_linked_guid_matches_from_group_info(self, svc):
+        orgs = factories.Organization.create_batch(2)
+        for org in orgs:
+            factories.GroupInfo(
+                application_instance=factories.ApplicationInstance(
+                    tool_consumer_instance_guid="guid", organization=org
+                ),
+                tool_consumer_instance_guid="guid",
+            )
+
+        matches = svc.get_by_linked_guid("guid")
+
+        assert matches == Any.list.containing(orgs).only()
+
+    def test_get_by_linked_guid_with_no_guid(self, svc):
+        factories.ApplicationInstance(
+            tool_consumer_instance_guid=None, organization=factories.Organization()
+        )
+
+        assert not svc.get_by_linked_guid(None)
+
+    def test_auto_assign_organization_with_no_guid(self, svc, application_instance):
+        application_instance.tool_consumer_instance_guid = None
+
+        assert svc.auto_assign_organization(application_instance) is None
+
+    @pytest.mark.parametrize(
+        "org_params,name",
+        (
+            (None, "ai_name"),
+            ({"name": None}, "ai_name"),
+            ({"name": "existing"}, "existing"),
+        ),
+    )
+    def test_auto_assign_organization_defaults_the_name(
+        self, svc, application_instance, org_params, name
+    ):
+        # This is also a cheeky test that if there's no matching org, we
+        # create a new one
+        org = factories.Organization(**org_params) if org_params else None
+        application_instance.organization = org
+
+        result = svc.auto_assign_organization(application_instance)
+
+        assert application_instance.organization == result
+        if org:
+            assert result == org
+
+        assert result == Any.instance_of(Organization).with_attrs({"name": name})
+
+    @pytest.mark.usefixtures("with_matching_noise")
+    @pytest.mark.parametrize("matching_ais", (1, 2))
+    def test_auto_assign_organization_matches(
+        self, svc, application_instance, matching_ais
+    ):
+        # We've tested get_by_linked_guid above, so we won't retread
+        orgs = factories.Organization.create_batch(matching_ais)
+        for org in orgs:
+            factories.ApplicationInstance(
+                tool_consumer_instance_guid=application_instance.tool_consumer_instance_guid,
+                organization=org,
+            )
+
+        result = svc.auto_assign_organization(application_instance)
+
+        assert result in orgs  # You'll get one, but we don't say which
+        assert application_instance.organization == result
+
+    @pytest.fixture
+    def with_matching_noise(self):
+        factories.ApplicationInstance(
+            tool_consumer_instance_guid="NO MATCH",
+            organization=factories.Organization(),
+        )
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return OrganizationService(db_session=db_session)
+
+    @pytest.fixture
+    def application_instance(self):
+        return factories.ApplicationInstance(
+            tool_consumer_instance_guid="guid", tool_consumer_instance_name="ai_name"
+        )
+
+
+class TestServiceFactory:
+    def test_it(self, pyramid_request, OrganizationService):
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        OrganizationService.assert_called_once_with(db_session=pyramid_request.db)
+        assert svc == OrganizationService.return_value
+
+    @pytest.fixture
+    def OrganizationService(self, patch):
+        return patch("lms.services.organization.OrganizationService")

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -24,6 +24,7 @@ class TestHasDocumentURL:
 
 @pytest.mark.usefixtures(
     "assignment_service",
+    "application_instance_service",
     "grading_info_service",
     "lti_h_service",
     "lti_role_service",
@@ -43,11 +44,12 @@ class TestBasicLaunchViews:
         context,
         pyramid_request,
         grading_info_service,
+        application_instance_service,
     ):
         BasicLaunchViews(context, pyramid_request)
 
-        context.application_instance.update_lms_data.assert_called_once_with(
-            pyramid_request.lti_params
+        application_instance_service.update_from_lti_params.assert_called_once_with(
+            context.application_instance, pyramid_request.lti_params
         )
 
         grading_info_service.upsert_from_request.assert_called_once_with(

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -6,7 +6,6 @@ import pytest
 from freezegun import freeze_time
 from h_matchers import Any
 
-from lms.models import ApplicationInstance
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
 from lms.views.lti.deep_linking import DeepLinkingFieldsViews, deep_linking_launch
@@ -18,15 +17,12 @@ class TestDeepLinkingLaunch:
     def test_it(
         self, context, pyramid_request, lti_h_service, application_instance_service
     ):
-        application_instance_service.get_current.return_value = create_autospec(
-            ApplicationInstance, spec_set=True, instance=True
-        )
-
         deep_linking_launch(context, pyramid_request)
 
-        context.application_instance.update_lms_data.assert_called_once_with(
-            pyramid_request.lti_params
+        application_instance_service.update_from_lti_params.assert_called_once_with(
+            context.application_instance, pyramid_request.lti_params
         )
+
         lti_h_service.sync.assert_called_once_with(
             [context.course], pyramid_request.params
         )

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,7 +2,12 @@ from unittest import mock
 
 import pytest
 
-from lms.services import CanvasService, DocumentURLService, LTIRoleService
+from lms.services import (
+    CanvasService,
+    DocumentURLService,
+    LTIRoleService,
+    OrganizationService,
+)
 from lms.services.aes import AESService
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.assignment import AssignmentService
@@ -65,6 +70,7 @@ __all__ = (
     "oauth1_service",
     "oauth2_token_service",
     "oauth_http_service",
+    "organization_service",
     "rsa_key_service",
     "user_service",
     "vitalsource_service",
@@ -219,6 +225,11 @@ def async_oauth_http_service(mock_service):
         AsyncOAuthHTTPService, service_name="async_oauth_http"
     )
     return async_oauth_http_service
+
+
+@pytest.fixture
+def organization_service(mock_service):
+    return mock_service(OrganizationService)
 
 
 @pytest.fixture


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4202

This looks at the status of the application instances org and attempts to match it with the following behavior:

 * If there is no org
    * Search for matching orgs by guid either from the application instances or group info table
    * If one or more matches are found, use the first
    * If no matches are found, create a new org
    * Set the org to the application instance
  * If the org has no name, and the application instance `tool_consumer_instance_name` is present, set the name from it

## Review notes

This includes a refactor to move the updating of application instances into the service because:

 * That's where I expected to find it and I got confused
 * We are not expanding it beyond what's ok to have on a model

This could be a separate PR if you'd prefer it

## Testing notes

Mostly just noodle about in LMS and watch the table fill up
