### PR TITLE
Store events for configured launches.

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -14,6 +14,7 @@ doesn't actually require basic launch requests to have this parameter.
 
 from pyramid.view import view_config, view_defaults
 
+from lms.events import LTIEvent
 from lms.models import LtiLaunches
 from lms.security import Permissions
 from lms.services import DocumentURLService, LTIRoleService
@@ -61,11 +62,15 @@ class BasicLaunchViews:
     def configured_launch(self):
         """Display a document if we can resolve one to show."""
 
-        return self._show_document(
+        self._show_document(
             document_url=self.request.find_service(DocumentURLService).get_document_url(
                 self.request
             )
         )
+        self.request.registry.notify(
+            LTIEvent(request=self.request, type=LTIEvent.Type.CONFIGURED_LAUNCH)
+        )
+        return {}
 
     @view_config(
         route_name="lti_launches",

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -110,7 +110,7 @@ class TestBasicLaunchViews:
         )
 
     def test_configured_launch(
-        self, svc, document_url_service, pyramid_request, _show_document
+        self, svc, document_url_service, pyramid_request, _show_document, LTIEvent
     ):
         svc.configured_launch()
 
@@ -119,6 +119,11 @@ class TestBasicLaunchViews:
         _show_document.assert_called_once_with(
             document_url=document_url_service.get_document_url.return_value
         )
+        LTIEvent.assert_called_once_with(
+            request=pyramid_request,
+            type=LTIEvent.Type.CONFIGURED_LAUNCH,
+        )
+        pyramid_request.registry.notify.has_call_with(LTIEvent.return_value)
 
     def test_unconfigured_launch(
         self, svc, BearerTokenSchema, context, pyramid_request
@@ -357,3 +362,7 @@ class TestBasicLaunchViews:
     @pytest.fixture(autouse=True)
     def BearerTokenSchema(self, patch):
         return patch("lms.views.lti.basic_launch.BearerTokenSchema")
+
+    @pytest.fixture
+    def LTIEvent(self, patch):
+        return patch("lms.views.lti.basic_launch.LTIEvent")


### PR DESCRIPTION
For now we'll allow duplicate records of the same launch in both `Events` and `LtiLaunches`. This will simplify the next step of the migration to eventually just having them in Events.

# Testing

- Start with no events

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate event,lti_launches cascade"
```


- Launch a couple of assignment

https://hypothesis.instructure.com/courses/125/assignments/873
https://hypothesis.instructure.com/courses/125/assignments/1513



- Check the inserted data


```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from event"

 id |         timestamp          | type_id | application_instance_id | course_id | assignment_id | grouping_id 
----+----------------------------+---------+-------------------------+-----------+---------------+-------------
  8 | 2022-08-17 09:07:41.732288 |       1 |                       8 |         7 |            26 |            
  9 | 2022-08-17 09:07:46.213168 |       1 |                       8 |         7 |            28 |            
(2 rows)


tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from lti_launches"

 id |          created           |                context_id                |                  lti_key                   
----+----------------------------+------------------------------------------+--------------------------------------------
 15 | 2022-08-17 09:07:41.739215 | f3cd019017839c4630358662a05540f2f6ec5f93 | Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
 16 | 2022-08-17 09:07:46.222109 | f3cd019017839c4630358662a05540f2f6ec5f93 | Hypothesisb3be0b33d0b5e4b1cf3aaf04e0e1819a
(2 rows)
```
