### PR TITLE
Re-instate the non-SSO VitalSource path as a fallback

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -68,14 +68,22 @@ class JSConfig:
                 ),
             }
         elif document_url.startswith("vitalsource://"):
-            svc = self._request.find_service(VitalSourceService)
+            svc: VitalSourceService = self._request.find_service(VitalSourceService)
 
-            # nb. VitalSource doesn't use Via, but is otherwise handled exactly
-            # the same way by the frontend.
-            self._config["viaUrl"] = svc.get_launch_url(
-                user_reference=self._request.lti_params[svc.user_lti_param],
-                document_url=document_url,
-            )
+            if svc.sso_enabled:
+                # nb. VitalSource doesn't use Via, but is otherwise handled
+                # exactly the same way by the frontend.
+                self._config["viaUrl"] = svc.get_sso_redirect(
+                    user_reference=self._request.lti_params[svc.user_lti_param],
+                    document_url=document_url,
+                )
+            else:
+                # This looks a bit silly, but pretty soon the above will
+                # be setting `api.viaURL` not `viaURL`
+                self._config["viaUrl"] = svc.get_book_reader_url(
+                    document_url=document_url
+                )
+
         elif jstor_service.enabled and document_url.startswith("jstor://"):
             self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)
             self._config["contentBanner"] = {

--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -5,13 +5,15 @@ from lms.services.vitalsource.service import VitalSourceService
 def service_factory(_context, request):
     settings = request.find_service(name="application_instance").get_current().settings
 
+    global_key = request.registry.settings["vitalsource_api_key"]
     customer_key = settings.get("vitalsource", "api_key")
 
     return VitalSourceService(
         # It's important to pass None here if there's no key, so the service
         # knows it's been disabled. The client will raise an error anyway if
         # you try and create one with no API key.
-        client=VitalSourceClient(customer_key) if customer_key else None,
-        user_lti_param=settings.get("vitalsource", "user_lti_param"),
         enabled=settings.get("vitalsource", "enabled", False),
+        global_client=VitalSourceClient(global_key) if global_key else None,
+        customer_client=VitalSourceClient(customer_key) if customer_key else None,
+        user_lti_param=settings.get("vitalsource", "user_lti_param"),
     )

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from lms.services.vitalsource._client import VitalSourceClient
 from lms.services.vitalsource.exceptions import VitalSourceError
@@ -11,36 +11,61 @@ class VitalSourceService:
     user_lti_param = None
     """The LTI parameter to use to work out the LTI user."""
 
-    def __init__(self, client: VitalSourceClient, enabled, user_lti_param):
+    def __init__(
+        self,
+        enabled: bool = False,
+        global_client: Optional[VitalSourceClient] = None,
+        customer_client: Optional[VitalSourceClient] = None,
+        user_lti_param: Optional[str] = None,
+    ):
         """
-        Instantiate the service.
+        Initialise the service.
 
-        :param client: VitalSource client for connecting to the API
-        :param enabled: Are we enabled at all?
-        :param user_lti_param: Which LTI parameter to read to get the user
-            reference
+        :param enabled: Is VitalSource enabled for the customer?
+        :param global_client: Client for making generic API calls
+        :param customer_client: Client for making customer specific API calls
+        :param user_lti_param: Field to lookup user details for SSO
         """
-        self._client = client
+
         self._enabled = enabled
+        self._metadata_client = customer_client or global_client
+        self._sso_client = customer_client
         self.user_lti_param = user_lti_param
 
     @property
     def enabled(self) -> bool:
-        """Check if the service has everything it needs to work."""
+        """Check if the service has the minimum it needs to work."""
 
-        return bool(self._enabled and self._client and self.user_lti_param)
+        return bool(self._enabled and self._metadata_client)
+
+    @property
+    def sso_enabled(self) -> bool:
+        """Check if the service can use single sign on."""
+
+        return bool(self.enabled and self._sso_client and self.user_lti_param)
 
     def get_book_info(self, book_id: str) -> dict:
         """Get details of a book."""
 
-        return self._client.get_book_info(book_id)
+        return self._metadata_client.get_book_info(book_id)
 
     def get_table_of_contents(self, book_id: str) -> List[dict]:
         """Get the table of contents for a book."""
 
-        return self._client.get_table_of_contents(book_id)
+        return self._metadata_client.get_table_of_contents(book_id)
 
-    def get_launch_url(self, user_reference, document_url) -> str:
+    @classmethod
+    def get_book_reader_url(cls, document_url) -> str:
+        """
+        Get the public URL for VitalSource book viewer.
+
+        :param document_url: `vitalsource://` type URL identifying the document
+        """
+        loc = VSBookLocation.from_document_url(document_url)
+
+        return f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
+
+    def get_sso_redirect(self, user_reference, document_url) -> str:
         """
         Get the public URL for VitalSource book viewer from our internal URL.
 
@@ -53,8 +78,9 @@ class VitalSourceService:
         """
         loc = VSBookLocation.from_document_url(document_url)
 
-        if not self._client.get_user_book_license(user_reference, loc.book_id):
+        if not self._sso_client.get_user_book_license(user_reference, loc.book_id):
             raise VitalSourceError("vitalsource_no_book_license")
 
-        url = f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
-        return self._client.get_sso_redirect(user_reference, url)
+        return self._sso_client.get_sso_redirect(
+            user_reference, self.get_book_reader_url(document_url)
+        )

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -28,7 +28,13 @@ class VitalSourceService:
         """
 
         self._enabled = enabled
+        # We can use either the customers API key (if they have one), or our
+        # generic fallback key. It's better to use the customer key as it
+        # ensures the books they can pick are available in their institution.
         self._metadata_client = customer_client or global_client
+        # For SSO we *must* use the customers API key as the user ids only make
+        # sense in the context of an institutional relationship between the uni
+        # and VitalSource.
         self._sso_client = customer_client
         self.user_lti_param = user_lti_param
 

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -6,11 +6,12 @@ from h_matchers import Any
 from lms.services.vitalsource.factory import service_factory
 
 
+@pytest.mark.usefixtures("application_instance_service")
 class TestServiceFactory:
     @pytest.mark.parametrize(
         "enabled,expected", ((sentinel.enabled, sentinel.enabled), (None, False))
     )
-    @pytest.mark.parametrize("api_key", (sentinel.api_key, None))
+    @pytest.mark.parametrize("customer_api_key", (sentinel.customer_api_key, None))
     def test_it(
         self,
         pyramid_request,
@@ -19,37 +20,52 @@ class TestServiceFactory:
         application_instance_service,
         enabled,
         expected,
-        api_key,
+        customer_api_key,
     ):
+        pyramid_request.registry.settings["vitalsource_api_key"] = None
         # This fixture is a bit odd and returns a real application instance
         ai = application_instance_service.get_current()
         ai.settings.set("vitalsource", "user_lti_param", sentinel.user_lti_param)
-        ai.settings.set("vitalsource", "api_key", api_key)
+        ai.settings.set("vitalsource", "api_key", customer_api_key)
         if enabled:
             ai.settings.set("vitalsource", "enabled", enabled)
 
         svc = service_factory(sentinel.context, pyramid_request)
 
-        if api_key:
-            VitalSourceClient.assert_called_once_with(api_key)
+        if customer_api_key:
+            VitalSourceClient.assert_called_once_with(customer_api_key)
+        else:
+            VitalSourceClient.assert_not_called()
 
         VitalSourceService.assert_called_once_with(
-            client=VitalSourceClient.return_value if api_key else None,
-            user_lti_param=sentinel.user_lti_param,
             enabled=expected,
+            global_client=None,
+            customer_client=VitalSourceClient.return_value
+            if customer_api_key
+            else None,
+            user_lti_param=sentinel.user_lti_param,
         )
         assert svc == VitalSourceService.return_value
 
-    @pytest.mark.usefixtures("application_instance_service")
-    def test_it_when_no_api_key(self, pyramid_request, VitalSourceService):
-        pyramid_request.registry.settings["vitalsource_api_key"] = None
+    @pytest.mark.parametrize("global_api_key", (sentinel.global_api_key, None))
+    def test_it_with_a_global_key(
+        self, pyramid_request, VitalSourceService, global_api_key, VitalSourceClient
+    ):
+        pyramid_request.registry.settings["vitalsource_api_key"] = global_api_key
 
-        svc = service_factory(sentinel.context, pyramid_request)
+        service_factory(sentinel.context, pyramid_request)
+
+        if global_api_key:
+            VitalSourceClient.assert_called_once_with(global_api_key)
+        else:
+            VitalSourceClient.assert_not_called()
 
         VitalSourceService.assert_called_once_with(
-            client=None, enabled=Any(), user_lti_param=Any()
+            enabled=Any(),
+            global_client=VitalSourceClient.return_value if global_api_key else None,
+            customer_client=Any(),
+            user_lti_param=Any(),
         )
-        assert svc == VitalSourceService.return_value
 
     @pytest.fixture
     def VitalSourceService(self, patch):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4349

This allows the original, non SSO, non institutional key solution for VitalSource to continue to work. This will allow us to release this to our customers who have their own API keys without disrupting those that don't.

### Behavior

 * If we have a customer key we will use it in preference to the global key for metadata lookup
 * If we have a customer key **and** a user id field, we will enable SSO

This leads to a few different modes of operation:

 * Global key lookup, no SSO
 * User key lookup, no SSO
 * User key lookup + SSO

## Merging notes

This needs to be merged into `vs-sso` not `main` to enable `vs-sso` to be safe to release without having all the customer details updated.

## Review notes

You may wish to review this as a [diff against `main`](https://github.com/hypothesis/lms/compare/main...vs-sso-fallback) instead of `vs-sso` as this is what we will be merging in the end.


## Testing notes

We are going to setup the three modes described above. In each case picking files should be the same, although a different key is in operation. It's not really currently present to tell the difference between whether the global key is working or the built in one as they are both the same key. So to prove this we are going to break the local one.

#### Proving the SSO flow

 * `make devdata`
 * Edit: `.devdata.env` and write nonsense in the `VITALSOURCE_API_KEY` field
 * Start all the services
 * Visit: https://bookshelf.vitalsource.com/#/ and logout
 * Visit: https://hypothesis.instructure.com/courses/125/assignments/3154 and re-configure it
 * Pick the localhost optional and add a Vitalsource documemt
 * Enter URL: https://bookshelf.vitalsource.com/reader/books/L-999-70867/pages/recent
 * Save and proceed to the assignment
 * It should work
 * Visit: https://bookshelf.vitalsource.com/#/, you should be logged back in

#### Proving the global key, no SSO

 * http://localhost:8001/admin/instance/id/102/
 * Check that Vitalsource is enabled by the key is blank
 * Visit: https://bookshelf.vitalsource.com/#/ and logout
 * Visit: https://hypothesis.instructure.com/courses/319/assignments/3310 and re-configure it
 * Pick the localhost optional and add a Vitalsource documemt
 * Enter URL: https://bookshelf.vitalsource.com/reader/books/L-999-70867/pages/recent
 * You should see "External request failed"
    * This is because we broke the key
 * `make devdata` and restart `make dev`
 * Try this again
 * Picking should now work, but viewing the assignment should show you a login screen
    * This proves SSO is disabled

#### Proving a local key with no SSO

 * Visit: http://localhost:8001/admin/instance/id/102/
 * Add the `VITALSOURCE_API_KEY` from `.devdata.env` as an API key
 * Edit: `.devdata.env` and write nonsense in the `VITALSOURCE_API_KEY` field
 * Follow the instructions for "Proving the global key, no SSO"
 * Everything should be the same, except the initial failure should not happen because we will use the customer API key