### PR TITLE
Add a new field for VitalSource user field regexes

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -78,9 +78,9 @@ class JSConfig:
                     "path": self._request.route_url(
                         "vitalsource_api.launch_url",
                         _query={
-                            "user_reference": self._request.lti_params[
-                                svc.user_lti_param
-                            ],
+                            "user_reference": svc.get_user_reference(
+                                self._request.lti_params
+                            ),
                             "document_url": document_url,
                         },
                     )

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -2,6 +2,8 @@ import functools
 from enum import Enum
 from typing import List, Optional
 
+from pyramid.httpexceptions import HTTPClientError
+
 from lms.models import Assignment, GroupInfo, Grouping, HUser
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
@@ -154,7 +156,7 @@ class JSConfig:
         if error_details:
             self._config["OAuth2RedirectError"]["errorDetails"] = error_details
 
-    def enable_error_dialog_mode(self, error_code, error_details=None):
+    def enable_error_dialog_mode(self, error_code, error_details=None, message=None):
         self._config.update(
             {
                 "mode": JSConfig.Mode.ERROR_DIALOG,
@@ -164,6 +166,9 @@ class JSConfig:
 
         if error_details:
             self._config["errorDialog"]["errorDetails"] = error_details
+
+        if message:
+            self._config["errorDialog"]["errorMessage"] = message
 
     def enable_lti_launch_mode(self, assignment: Assignment):
         """

--- a/lms/services/vitalsource/__init__.py
+++ b/lms/services/vitalsource/__init__.py
@@ -1,3 +1,4 @@
+from lms.services.vitalsource.exceptions import VitalSourceError
 from lms.services.vitalsource.factory import service_factory
 from lms.services.vitalsource.model import VSBookLocation
 from lms.services.vitalsource.service import VitalSourceService

--- a/lms/services/vitalsource/_client.py
+++ b/lms/services/vitalsource/_client.py
@@ -159,7 +159,7 @@ class VitalSourceClient:
         if credentials := result["credentials"].get("credential"):
             return self._to_camel_case(self._pick_first(credentials))
 
-        raise VitalSourceError("vitalsource_user_not_found")
+        raise VitalSourceError(error_code="vitalsource_user_not_found")
 
     @staticmethod
     def _is_resource_not_found(err: ExternalRequestError) -> bool:

--- a/lms/services/vitalsource/exceptions.py
+++ b/lms/services/vitalsource/exceptions.py
@@ -1,14 +1,16 @@
-class VitalSourceError(Exception):
+from lms.services.exceptions import SerializableError
+
+
+class VitalSourceError(SerializableError):
     """Indicate a failure in the VitalSource service or client."""
 
-    def __init__(self, error_code, message=None):
-        """
-        Instantiate the error.
 
-        :param error_code: A string code used to present specific dialogs in
-            the front end. For details of the codes see:
-            lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
-        :param message: A normal error message, mostly for debugging
-        """
-        self.error_code = error_code
-        super().__init__(message)
+class VitalSourceMalformedRegex(VitalSourceError):
+    """An issue with the user regex."""
+
+    def __init__(self, description, pattern):
+        super().__init__(
+            error_code="bad_user_lti_pattern",
+            message="There is a problem with the configured VitalSource configuration",
+            details={"error": description, "pattern": pattern},
+        )

--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -16,6 +16,7 @@ def service_factory(_context, request):
         global_client=VitalSourceClient(global_key) if global_key else None,
         customer_client=VitalSourceClient(customer_key) if customer_key else None,
         user_lti_param=settings.get("vitalsource", "user_lti_param"),
+        user_lti_pattern=settings.get("vitalsource", "user_lti_pattern"),
         enable_licence_check=not bool(
             settings.get("vitalsource", "disable_licence_check")
         ),

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -19,6 +19,7 @@ export default function ErrorDialogApp() {
   const error = {
     errorCode: errorDialog?.errorCode,
     details: errorDialog?.errorDetails ?? '',
+    message: errorDialog?.errorMessage ?? '',
   };
 
   let description;

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -93,6 +93,7 @@ import { createContext } from 'preact';
  * @typedef ConfigErrorBase
  * @prop {AppLaunchServerErrorCode|OAuthServerErrorCode} [errorCode]
  * @prop {object|string} [errorDetails]
+ * @prop {string} [errorMessage]
  */
 
 /**

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -94,8 +94,9 @@
         {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
 
         {{ settings_checkbox("VitalSource enabled", "vitalsource", "enabled") }}
-        {{ settings_text_field("VitalSource user ID param", "vitalsource", "user_lti_param") }}
         {{ settings_text_field("VitalSource API key", "vitalsource", "api_key") }}
+        {{ settings_text_field("VitalSource SSO user ID field", "vitalsource", "user_lti_param") }}
+        {{ settings_text_field("VitalSource SSO user ID regex", "vitalsource", "user_lti_pattern") }}
         {{ settings_checkbox("VitalSource disable licence check on SSO", "vitalsource", "disable_licence_check") }}
 
         {{ settings_checkbox("JSTOR enabled", "jstor", "enabled") }}

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -312,6 +312,7 @@ class AdminApplicationInstanceViews:
             ("microsoft_onedrive", "files_enabled", bool),
             ("vitalsource", "enabled", bool),
             ("vitalsource", "user_lti_param", str),
+            ("vitalsource", "user_lti_pattern", str),
             ("vitalsource", "api_key", str),
             ("vitalsource", "disable_licence_check", bool),
             ("jstor", "enabled", bool),

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -9,7 +9,7 @@ from pyramid.view import (
 )
 
 from lms.models import ReusedConsumerKey
-from lms.services import HAPIError
+from lms.services import HAPIError, SerializableError
 from lms.validation import ValidationError
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -56,6 +56,20 @@ class ExceptionViews:
                 "existing_tool_consumer_instance_guid": self.exception.existing_guid,
                 "new_tool_consumer_instance_guid": self.exception.new_guid,
             },
+        )
+
+        return {}
+
+    @exception_view_config(
+        context=SerializableError, renderer="lms:templates/error_dialog.html.jinja2"
+    )
+    def serializable_error(self):
+        self.request.response.status_int = 400
+
+        self.request.context.js_config.enable_error_dialog_mode(
+            error_code=self.exception.error_code,
+            message=self.exception.message,
+            error_details=self.exception.details,
         )
 
         return {}

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -551,13 +551,18 @@ class TestAddDeepLinkingAPI:
 
 class TestEnableErrorDialogMode:
     def test_it(self, js_config):
-        js_config.enable_error_dialog_mode(sentinel.error_code, sentinel.error_details)
+        js_config.enable_error_dialog_mode(
+            error_code=sentinel.error_code,
+            error_details=sentinel.error_details,
+            message=sentinel.message,
+        )
         config = js_config.asdict()
 
         assert config["mode"] == JSConfig.Mode.ERROR_DIALOG
         assert config["errorDialog"] == {
             "errorCode": sentinel.error_code,
             "errorDetails": sentinel.error_details,
+            "errorMessage": sentinel.message,
         }
 
     def test_it_omits_errorDetails_if_no_error_details_argument_is_given(

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -125,15 +125,23 @@ class TestAddDocumentURL:
         self, js_config, pyramid_request, vitalsource_service
     ):
         document_url = "vitalsource://book/bookID/book-id/cfi//abc"
-        vitalsource_service.user_lti_param = "user_id"
         vitalsource_service.sso_enabled = True
-        pyramid_request.lti_params["user_id"] = "USER_REF"
+        vitalsource_service.get_user_reference.return_value = "a_string"
 
         js_config.add_document_url(document_url)
 
+        vitalsource_service.get_user_reference.assert_called_once_with(
+            pyramid_request.lti_params
+        )
+
         proxy_api_call = Any.url.matching(
             "http://example.com/api/vitalsource/launch_url"
-        ).with_query({"user_reference": "USER_REF", "document_url": document_url})
+        ).with_query(
+            {
+                "user_reference": vitalsource_service.get_user_reference.return_value,
+                "document_url": document_url,
+            }
+        )
         assert js_config.asdict()["api"]["viaUrl"] == {"path": proxy_api_call}
 
     def test_vitalsource_sets_config_without_sso(self, js_config, vitalsource_service):

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -28,6 +28,7 @@ class TestServiceFactory:
         # This fixture is a bit odd and returns a real application instance
         ai = application_instance_service.get_current()
         ai.settings.set("vitalsource", "user_lti_param", sentinel.user_lti_param)
+        ai.settings.set("vitalsource", "user_lti_pattern", sentinel.user_lti_pattern)
         ai.settings.set("vitalsource", "api_key", customer_api_key)
         if enabled:
             ai.settings.set("vitalsource", "enabled", enabled)
@@ -50,6 +51,7 @@ class TestServiceFactory:
             if customer_api_key
             else None,
             user_lti_param=sentinel.user_lti_param,
+            user_lti_pattern=sentinel.user_lti_pattern,
             enable_licence_check=not (disable_licence_check),
         )
         assert svc == VitalSourceService.return_value
@@ -72,6 +74,7 @@ class TestServiceFactory:
             global_client=VitalSourceClient.return_value if global_api_key else None,
             customer_client=Any(),
             user_lti_param=Any(),
+            user_lti_pattern=Any(),
             enable_licence_check=Any(),
         )
 

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -380,8 +380,9 @@ class TestAdminApplicationInstanceViews:
             ("jstor", "site_code", "  CODE  ", "CODE"),
             ("jstor", "site_code", "", None),
             ("jstor", "site_code", None, None),
-            ("vitalsource", "user_lti_param", "user_id", "user_id"),
             ("vitalsource", "api_key", "api_key", "api_key"),
+            ("vitalsource", "user_lti_param", "user_id", "user_id"),
+            ("vitalsource", "user_lti_pattern", "name_(.*)", "name_(.*)"),
         ),
     )
     def test_update_instance_saves_ai_settings(

--- a/tests/unit/lms/views/exceptions_test.py
+++ b/tests/unit/lms/views/exceptions_test.py
@@ -6,82 +6,86 @@ from pyramid import httpexceptions
 from lms.models import ReusedConsumerKey
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
-from lms.services import HAPIError
+from lms.services import HAPIError, SerializableError
 from lms.validation import ValidationError
 from lms.views.exceptions import ExceptionViews
 
 
 class TestExceptionViews:
-    def test_notfound(self, assert_response, pyramid_request):
+    def test_notfound(self, pyramid_request):
         exception = httpexceptions.HTTPNotFound()
 
         template_data = ExceptionViews(exception, pyramid_request).notfound()
 
-        assert_response(template_data, 404, message="Page not found")
+        assert pyramid_request.response.status_int == 404
+        assert template_data == {"message": "Page not found"}
 
-    def test_forbidden(self, assert_response, pyramid_request):
+    def test_forbidden(self, pyramid_request):
         exception = httpexceptions.HTTPForbidden()
 
         template_data = ExceptionViews(exception, pyramid_request).forbidden()
 
-        assert_response(
-            template_data, 403, message="You're not authorized to view this page"
-        )
+        assert pyramid_request.response.status_int == 403
+        assert template_data == {"message": "You're not authorized to view this page"}
 
-    def test_http_client_error(self, assert_response, pyramid_request):
-        exception = httpexceptions.HTTPBadRequest("http_client_error_test_message")
+    def test_http_client_error(self, pyramid_request):
+        exception = httpexceptions.HTTPBadRequest(sentinel.message)
 
         template_data = ExceptionViews(exception, pyramid_request).http_client_error()
 
-        assert_response(
-            template_data,
-            status=exception.status_int,
-            message="http_client_error_test_message",
-        )
+        assert pyramid_request.response.status_int == exception.status_int
+        assert template_data == {"message": "sentinel.message"}
 
-    def test_hapi_error(self, assert_response, pyramid_request):
-        exception = HAPIError("hapi_error_test_message")
+    def test_hapi_error(self, pyramid_request):
+        exception = HAPIError(sentinel.message)
 
         template_data = ExceptionViews(exception, pyramid_request).hapi_error()
 
-        assert_response(template_data, 500, message="hapi_error_test_message")
+        assert pyramid_request.response.status_int == 500
+        assert template_data == {"message": sentinel.message}
 
-    def test_validation_error(self, assert_response, pyramid_request):
+    def test_validation_error(self, pyramid_request):
         exception = ValidationError(sentinel.messages)
 
         template_data = ExceptionViews(exception, pyramid_request).validation_error()
 
-        assert_response(template_data, status=exception.status_int, error=exception)
+        assert pyramid_request.response.status_int == exception.status_int
+        assert template_data == {"error": exception}
 
-    def test_error(self, assert_response, pyramid_request):
+    @pytest.mark.usefixtures("js_config")
+    def test_serializable_error(self, pyramid_request):
+        exception = SerializableError(
+            error_code=sentinel.error_code,
+            message=sentinel.message,
+            details=sentinel.details,
+        )
+
+        template_data = ExceptionViews(exception, pyramid_request).serializable_error()
+
+        pyramid_request.context.js_config.enable_error_dialog_mode.assert_called_with(
+            error_code=exception.error_code,
+            error_details=exception.details,
+            message=exception.message,
+        )
+        assert not template_data
+        assert pyramid_request.response.status_int == 400
+
+    def test_error(self, pyramid_request):
         exception = RuntimeError()
 
         template_data = ExceptionViews(exception, pyramid_request).error()
 
-        assert_response(
-            template_data,
-            500,
-            message="Sorry, but something went wrong. The issue has been "
-            "reported and we'll try to fix it.",
-        )
+        assert pyramid_request.response.status_int == 500
+        assert template_data == {
+            "message": "Sorry, but something went wrong. The issue has been reported and we'll try to fix it."
+        }
 
-    def test_reused_consumer_key(self, assert_response, pyramid_request):
-        pyramid_request.context = create_autospec(
-            LTILaunchResource,
-            instance=True,
-            spec_set=True,
-            js_config=create_autospec(
-                JSConfig,
-                instance=True,
-                spec_set=True,
-                ErrorCode=JSConfig.ErrorCode,
-            ),
-        )
+    @pytest.mark.usefixtures("js_config")
+    def test_reused_consumer_key(self, pyramid_request):
         exception = ReusedConsumerKey(sentinel.existing_guid, sentinel.new_guid)
 
         template_data = ExceptionViews(exception, pyramid_request).reused_consumer_key()
 
-        assert_response(template_data, 400)
         pyramid_request.context.js_config.enable_error_dialog_mode.assert_called_with(
             error_code=JSConfig.ErrorCode.REUSED_CONSUMER_KEY,
             error_details={
@@ -89,19 +93,21 @@ class TestExceptionViews:
                 "new_tool_consumer_instance_guid": sentinel.new_guid,
             },
         )
+        assert not template_data
+        assert pyramid_request.response.status_int == 400
 
     @pytest.fixture
-    def assert_response(self, pyramid_request):
-        def assert_response(template_data, status, message=None, error=None):
-            assert pyramid_request.response.status_int == status
+    def js_config(self, pyramid_request):
+        js_config = create_autospec(
+            JSConfig,
+            instance=True,
+            spec_set=True,
+            ErrorCode=JSConfig.ErrorCode,
+        )
 
-            if message:
-                assert template_data == {"message": message}
+        context = create_autospec(
+            LTILaunchResource, instance=True, spec_set=True, js_config=js_config
+        )
+        pyramid_request.context = context
 
-            elif error:
-                assert template_data == {"error": error}
-
-            else:
-                assert template_data == {}
-
-        return assert_response
+        return js_config


### PR DESCRIPTION
Also change the names a bit to make it clear the user is about SSO.

## Review notes

This PR is a bit longer than it really should have to have been as we didn't have a way of raising a new exception without:

 * Writing a custom handler for it in the `views.exceptions.py`
 * Writing a custom entry in the Javscript for it

This builds on the `SerializableError` work for the API's which introduced an exception you can raise and expect sensible behavior from the front end.

This really shouldn't be in the location it is in `services.exceptions`, but we don't have a generic `exceptions.py` and I don't want to get into that right now.

## Testing notes

 * `make devdata` and start everything
 * Visit a VS assignment (e.g. https://hypothesis.instructure.com/courses/125/assignments/3158)
 * This should work as normal

Error case: too many or too few capture groups

 * Visit: http://localhost:8001/admin/instance/id/8/
 * Edit the regex to contain "no_group_here" or "too (many) capture (groups)"
 * Refresh the assignment
 * You should see an error about the regex

Error case: malformed regex

 * As above with `[` as the regex

With a valid regex:

 * Open the dev tools in the assignment
 * Edit the regex to contain `^(.{4})`
 * Refresh the assignment
 * It should fail saying the user is not found
 * Filter the network tab by `user_reference`
 * You should see a call with a user reference only 4 chars long

