### PR TITLE
More complete log message on JWT decoding

### DIFF
--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -94,7 +94,7 @@ class JWTService:
                 id_token, key=signing_key.key, audience=aud, algorithms=["RS256"]
             )
         except PyJWTError as err:
-            LOG.debug("Invalid JWT. %s", str(err))
+            LOG.debug("Invalid JWT for: %s, %s. %s", iss, aud, str(err))
             return {}
 
     def encode_with_private_key(self, payload: dict):

--- a/tests/functional/lti_certification/v13/core/test_bad_payloads.py
+++ b/tests/functional/lti_certification/v13/core/test_bad_payloads.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from h_matchers import Any
 
 
 class TestBadPayloads:
@@ -29,7 +30,9 @@ class TestBadPayloads:
 
         do_lti_launch({"id_token": make_jwt(test_payload, jwt_headers)}, status=403)
         assert (
-            'Invalid JWT. Unable to find a signing key that matches: "imstester_66067"'
+            Any.string.matching(
+                "^Invalid JWT for:.* Unable to find a signing key that matches:.*$"
+            )
             in caplog.messages
         )
 


### PR DESCRIPTION
These are showing up in the logs but we can't identify where (which school) they are coming from.

Adding issuer and aud (client id) should help make the messages more useful.