### PR TITLE
Modify backfilling migration to work on batches.

### DIFF
--- a/lms/migrations/versions/396f46318023_events_backfill.py
+++ b/lms/migrations/versions/396f46318023_events_backfill.py
@@ -1,5 +1,5 @@
 """
-Backfill "events" from lti_launches rows.
+Backfill "events" from lti_launches rows (2020).
 
 Revision ID: 396f46318023
 Revises: 42b39684836f
@@ -13,11 +13,18 @@ from alembic import op
 revision = "396f46318023"
 down_revision = "42b39684836f"
 
+BATCH_START_DATE = "2000-08-17T13:00:08.241"
+BATCH_END_DATE = "2020-08-17T13:00:08.241"
+"""
+We'll do this in batches each bach between these two dates
+"""
 
 CUT_OFF_DATE = "2022-08-17T13:00:08.241"
 """
 Date when we started inserting launches directly on events.
 Rows in lti_launches would already have corresponding event after this date.
+
+While doing this in batches this will the END_DATE of the last batch.
 """
 
 
@@ -27,9 +34,7 @@ def get_configured_launch_type_pk(conn):
     ).fetchone()[0]
 
 
-def upgrade():
-    conn = op.get_bind()
-
+def migrate_lti_launches(conn, start, end):
     launch_event_type_id = get_configured_launch_type_pk(conn)
 
     result = conn.execute(
@@ -54,7 +59,7 @@ def upgrade():
                 AND grouping.application_instance_id = application_instances.id
                 AND grouping.type = 'course'
        -- Only backfill rows created before we also start tracking them directly on this table
-        WHERE lti_launches.created < '{CUT_OFF_DATE}'
+        WHERE lti_launches.created >= '{start}' AND lti_launches.created < '{end}'
         -- We need to group by to pick one (MAX grouping.id) above of the possible
         -- multiple courses on the grouping table
         GROUP BY lti_launches.id, lti_launches.created, application_instances.id
@@ -65,17 +70,29 @@ def upgrade():
     print("\tInserted lti_launches rows into events:", result.rowcount)
 
 
-def downgrade():
-    conn = op.get_bind()
+def downgrade_lti_launches(conn, start, end):
     launch_event_type_id = get_configured_launch_type_pk(conn)
 
-    conn.execute(
+    result = conn.execute(
         f"""
         DELETE FROM event
         WHERE type_id = {launch_event_type_id}
             -- All events inserted by the forward version of this migration
             -- will have empty assignments.
             AND assignment_id is null
-            AND timestamp < '{CUT_OFF_DATE}'
+            AND timestamp >= '{start}' AND timestamp < '{end}'
     """
     )
+    print("\tDeleted events rows:", result.rowcount)
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    migrate_lti_launches(conn, BATCH_START_DATE, BATCH_END_DATE)
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    downgrade_lti_launches(conn, BATCH_START_DATE, BATCH_END_DATE)


### PR DESCRIPTION
Original migration timed out on production:

https://jenkins.hypothes.is/job/lms-tasks/174/console

Running the query side on metabase seem to finish in a reasonable time so the problem might be on inserting side. 


This, the whole table query, finish in metabase:

```
        SELECT
                lti_launches.created,
                1,
                application_instances.id,
                MAX(grouping.id)
        FROM lti_launches
        LEFT OUTER JOIN application_instances
            ON lti_launches.lti_key = application_instances.consumer_key
        LEFT OUTER JOIN grouping
            ON context_id = grouping.lms_id
                AND grouping.application_instance_id = application_instances.id
                AND grouping.type = 'course'
       -- Only backfill rows created before we also start tracking them directly on this table
        WHERE lti_launches.created < '2022-08-17T13:00:08.241'
        -- We need to group by to pick one (MAX grouping.id) above of the possible
        -- multiple courses on the grouping table
        GROUP BY lti_launches.id, lti_launches.created, application_instances.id
        -- Ordering will keep new rows physically sorted on disk which should later help while querying
        ORDER BY lti_launches.created ASC
```



The  batch on this PR covers 1,123,235 rows (out of 13M) 




# Testing

(You might have to `hdev alembic downgrade -1` first depending on the state of your DB)


- Start with empty tables

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate event,lti_launches cascade"
```


- Insert some test rows (2 in the range of the batch, one outside)

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "insert into lti_launches (created, context_id, lti_key) values ('2001-08-17T13:00:08.241', 'CONTEXT', 'LTI'), ('2017-08-17T13:00:08.241', 'CONTEXT', 'LTI'), ('2021-08-17T13:00:08.241', 'CONTEXT', 'LTI');"
```

- Run the migration

`hdev alembic upgrade head`


Two rows are inserted


- Run it backwards `hdev alembic downgrade -1`


Two rows are deleted


