### PR TITLE
Refactor admin pages to make the new vs upgraded instance actions more clear

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -135,6 +135,10 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "admin.registration.new.instance", "/admin/registration/id/{id_}/new/instance"
     )
+    config.add_route(
+        "admin.registration.upgrade.instance",
+        "/admin/registration/id/{id_}/upgrade/instance",
+    )
     config.add_route("admin.registration.new", "/admin/registration")
     config.add_route("admin.registration.suggest_urls", "/admin/registration/urls")
 

--- a/lms/templates/admin/instance.new.html.jinja2
+++ b/lms/templates/admin/instance.new.html.jinja2
@@ -19,18 +19,28 @@ New application instance
 
 
     <fieldset class="box mt-6">
-        <legend class="label has-text-centered">Application instance</legend>
-        {{ macros.form_text_field(request, "Consumer key", "consumer_key",
-            placeholder="Optional. Existing application instance's consumer key. It will be upgraded to LTI 1.3 using this registration") }}
+        <legend class="label has-text-centered">Create new Application instance</legend>
         {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
         {{ macros.form_text_field(request, "LMS URL", "lms_url") }}
         {{ macros.form_text_field(request, "Email", "email") }}
-
         {{ macros.form_text_field(request, "Canvas developer key", "developer_key") }}
         {{ macros.form_text_field(request, "Canvas developer secret", "developer_secret") }}
     </fieldset>
 
     <input type="submit" class="button is-info" value="New"/>
+</form>
+
+<form method="POST" action="{{ request.route_url("admin.registration.upgrade.instance", id_=lti_registration.id) }}">
+    <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+
+    <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Upgrade exsiting Application instance</legend>
+        {{ macros.form_text_field(request, "Consumer key", "consumer_key",
+            placeholder="Existing application instance's consumer key. It will be upgraded to LTI 1.3 using this registration") }}
+        {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
+    </fieldset>
+
+    <input type="submit" class="button is-info" value="Upgrade"/>
 </form>
 
 {% endblock %}

--- a/lms/templates/admin/registration.html.jinja2
+++ b/lms/templates/admin/registration.html.jinja2
@@ -11,7 +11,7 @@
     <fieldset class="box">
     <legend class="label has-text-centered">Registration application instances</legend>
         <div class="block has-text-right">
-            <a class="button is-primary" href="{{ request.route_url("admin.registration.new.instance", id_=registration.id) }}">New instance</a>
+            <a class="button is-primary" href="{{ request.route_url("admin.registration.new.instance", id_=registration.id) }}">Add instance</a>
         </div>
 
         {% if registration.application_instances %}

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -12,41 +12,6 @@ from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import error_render_to_response, flash_validation
 
 
-class EmptyStringNoneMixin:
-    """
-    Allows empty string as "missing value".
-
-    Marshmallow doesn't have a clean solution yet to POSTed values
-    (that are always present in the request as empty strings)
-
-    Here we convert them explicitly to None
-
-    https://github.com/marshmallow-code/marshmallow/issues/713
-    """
-
-    def deserialize(self, value, attr, data, **kwargs):
-        if not value:
-            return None
-        return super().deserialize(value, attr, data, **kwargs)
-
-
-class EmptyStringURL(EmptyStringNoneMixin, fields.URL):
-    ...
-
-
-class EmptyStringEmail(EmptyStringNoneMixin, fields.Email):
-    ...
-
-
-class ApplicationInstanceSchema(PyramidRequestSchema):
-    location = "form"
-
-    deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
-
-    developer_key = fields.Str(required=False, allow_none=True)
-    developer_secret = fields.Str(required=False, allow_none=True)
-
-
 class NewApplicationInstanceSchema(PyramidRequestSchema):
     location = "form"
 
@@ -59,11 +24,11 @@ class NewApplicationInstanceSchema(PyramidRequestSchema):
     email = fields.Email(required=True)
 
 
-class UpgradeApplicationInstanceSchema(ApplicationInstanceSchema):
+class UpgradeApplicationInstanceSchema(PyramidRequestSchema):
     location = "form"
 
-    lms_url = EmptyStringURL(required=False, allow_none=True)
-    email = EmptyStringEmail(required=False, allow_none=True)
+    consumer_key = fields.Str(required=True)
+    deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
 
 
 @view_defaults(request_method="GET", permission=Permissions.ADMIN)

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -94,7 +94,7 @@ class AdminApplicationInstanceViews:
         )
 
     @view_config(
-        route_name="admin.registration.new.instance",
+        route_name="admin.registration.upgrade.instance",
         request_method="POST",
         renderer="lms:templates/admin/instance.new.html.jinja2",
     )

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -124,7 +124,7 @@ class TestAdminApplicationInstanceViews:
         lti_registration_service.get_by_id.return_value = lti_registration
         assert not application_instance.lti_registration
 
-        response = views.new_instance()
+        response = views.upgrade_instance()
 
         application_instance_service.get_by_consumer_key.assert_called_once_with(
             application_instance.consumer_key
@@ -139,32 +139,10 @@ class TestAdminApplicationInstanceViews:
         )
 
     @pytest.mark.usefixtures("with_upgrade_form")
-    @pytest.mark.parametrize("parameter", ["lms_url", "email"])
-    def test_upgrade_instance_allows_empty(
-        self,
-        views,
-        pyramid_request,
-        parameter,
-        lti_registration_service,
-        application_instance,
-    ):
-        lti_registration_service.get_by_id.return_value = factories.LTIRegistration()
-
-        # Replicate real's pyramid_request behaviour
-        pyramid_request.POST[parameter] = ""
-        pyramid_request.params[parameter] = ""
-
-        response = views.new_instance()
-
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url("admin.instance.id", id_=application_instance.id)
-        )
-
-    @pytest.mark.usefixtures("with_upgrade_form")
     def test_upgrade_no_deployment_id(self, views, pyramid_request):
         del pyramid_request.POST["deployment_id"]
 
-        response = views.new_instance()
+        response = views.upgrade_instance()
 
         assert response.status_code == 400
 
@@ -173,7 +151,7 @@ class TestAdminApplicationInstanceViews:
         application_instance.lti_registration_id = 100
         application_instance.deployment_id = "ID"
 
-        response = views.new_instance()
+        response = views.upgrade_instance()
 
         assert response.status_code == 400
 
@@ -185,7 +163,7 @@ class TestAdminApplicationInstanceViews:
             lti_registration=lti_registration, deployment_id="DEPLOYMENT_ID"
         )
 
-        response = views.new_instance()
+        response = views.upgrade_instance()
 
         assert response.status_code == 400
 
@@ -200,7 +178,7 @@ class TestAdminApplicationInstanceViews:
             ApplicationInstanceNotFound
         )
 
-        response = views.new_instance()
+        response = views.upgrade_instance()
 
         assert response.status_code == 400
 
@@ -446,7 +424,9 @@ class TestAdminApplicationInstanceViews:
 
     @pytest.fixture
     def with_upgrade_form(self, with_form_submission, application_instance):
-        with_form_submission.params["consumer_key"] = application_instance.consumer_key
+        with_form_submission.params["consumer_key"] = with_form_submission.POST[
+            "consumer_key"
+        ] = application_instance.consumer_key
         return with_form_submission
 
     @pytest.fixture


### PR DESCRIPTION
Refactor the views/forms for new registrations.

The current form is not very clear on the intent as is using the same form/view two do two different things:

- Add a new AI to a registration
- Upgrade an existing AI while adding it to the registration.

This PR makes the split more explicit. 

There's a behavior change, in the version in `main` you can edit `lms url` and `email` (but not canvas key/secret) while upgrading an existing AI. Removing that option here, if you want to change those while upgrading you'll have to first upgrade and then update them on the AI details page.


### Old version
![Screenshot from 2022-08-29 11-11-34](https://user-images.githubusercontent.com/1433832/187168731-8d73d37d-a8f6-4bb2-98e9-cabbe1115c77.png)


### New version
![Screenshot from 2022-08-29 11-14-07](https://user-images.githubusercontent.com/1433832/187168753-bd8bc304-6e15-4c91-859c-6c78382c5ebb.png)


# Testing 

### New AI
- Go to http://localhost:8001/admin/registration/id/1/
- Click "Add instance"
- Complete the first form, the one labeled "Create new Application instance"
- You'll be taken to newly created AI.

### Update AI

- Check http://localhost:8001/admin/instance/Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b/. It should be marked as 1.1 at the top.
- Go back to http://localhost:8001/admin/registration/id/1/new/instance
- Use the second form with the consumer of the existing AI, `Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b` and any deployment_id
- You are taken the the same AI, now marked as 1.3