### PR TITLE
Handle course copy across applications instance with the same GUID

### DIFF
--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -93,7 +93,11 @@ class CanvasFileFinder:
         Return None if no matching file is found.
         """
         for file_id in file_ids:
-            file = self._file_service.get(file_id, type_="canvas_file")
+            # Use both `get` (the most common scenario, files in th same application instance)
+            # and `get_with_guid` as a fallback for installs in the same LMS with multiple application instances.
+            file = self._file_service.get(
+                file_id, type_="canvas_file"
+            ) or self._file_service.get_with_guid(file_id, type_="canvas_file")
 
             if not file:
                 continue

--- a/lms/services/file.py
+++ b/lms/services/file.py
@@ -1,6 +1,6 @@
 from sqlalchemy import func
 
-from lms.models import File
+from lms.models import ApplicationInstance, File
 from lms.services.upsert import bulk_upsert
 
 
@@ -19,6 +19,31 @@ class FileService:
                 type=type_,
             )
             .one_or_none()
+        )
+
+    def get_with_guid(self, lms_id, type_):
+        """
+        Return with the given lms_id and type_ that belongs to the same GUID as the current ApplicationInstance.
+
+        Once we have "Organization" or a similar entity that groups together multiple
+        ApplicationInstance we should use that concept instead of GUID but for now
+        this allows us to find files across multiple installs in for example
+        migrations from course/account/global level install or in some LTI1.3 upgrade
+        scenarios.
+        """
+        return (
+            self._db.query(File)
+            .join(
+                ApplicationInstance,
+                ApplicationInstance.tool_consumer_instance_guid
+                == self._application_instance.tool_consumer_instance_guid,
+            )
+            .filter(
+                File.lms_id == lms_id,
+                File.type == type_,
+            )
+            .order_by(File.id.desc())
+            .first()
         )
 
     def upsert(self, file_dicts):

--- a/tests/factories/application_instance.py
+++ b/tests/factories/application_instance.py
@@ -1,4 +1,4 @@
-from factory import Faker, make_factory
+from factory import Faker, Sequence, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
@@ -12,4 +12,5 @@ ApplicationInstance = make_factory(
     lms_url=Faker("url", schemes=["https"]),
     requesters_email=Faker("email"),
     settings={},
+    tool_consumer_instance_guid=Sequence(lambda n: f"GUID-{n}"),
 )

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -103,6 +103,7 @@ class TestApplicationInstance:
         assert application_instance.decrypted_developer_secret(aes_service) is None
 
     def test_update_lms_data(self, application_instance, lms_data):
+        application_instance.tool_consumer_instance_guid = None
         lms_data["tool_consumer_instance_guid"] = "GUID"
         application_instance.update_lms_data(lms_data)
 
@@ -112,9 +113,10 @@ class TestApplicationInstance:
     def test_update_lms_data_no_guid_doesnt_change_values(
         self, application_instance, lms_data
     ):
+        existing_guid = application_instance.tool_consumer_instance_guid
         application_instance.update_lms_data(lms_data)
 
-        assert application_instance.tool_consumer_instance_guid is None
+        assert application_instance.tool_consumer_instance_guid == existing_guid
         assert application_instance.tool_consumer_info_product_family_code is None
 
     def test_update_lms_data_existing_guid(self, application_instance, lms_data):

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -213,6 +213,16 @@ class TestCanvasFileFinder:
         canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
         assert matching_file_id == str(sentinel.matching_file_id)
 
+    def test_fallback_to_guid_matching(self, finder, file_service):
+        file_service.get.return_value = None
+
+        finder.find_matching_file_in_course(sentinel.course_id, [sentinel.file_id])
+
+        file_service.get.assert_called_once_with(sentinel.file_id, type_="canvas_file")
+        file_service.get_with_guid.assert_called_once_with(
+            sentinel.file_id, type_="canvas_file"
+        )
+
     def test_find_matching_file_in_course_with_multiple_file_ids(
         self, finder, canvas_api_client, file_service
     ):
@@ -225,6 +235,9 @@ class TestCanvasFileFinder:
             # The third file_id *will* be found in the course.
             matching_file,
         ]
+        # The with GUID fallback doesn't returning anything else
+        file_service.get_with_guid.return_value = None
+
         canvas_api_client.list_files.return_value = [
             {
                 "id": sentinel.matching_file_id,

--- a/tests/unit/lms/services/file_test.py
+++ b/tests/unit/lms/services/file_test.py
@@ -8,22 +8,30 @@ from tests import factories
 
 
 class TestGet:
-    def test_it_returns_the_matching_file_if_there_is_one(
+    def test_get_returns_the_matching_file_if_there_is_one(
         self, application_instance, svc
     ):
         file_ = factories.File(application_instance=application_instance)
 
         assert svc.get(file_.lms_id, file_.type) == file_
 
-    def test_it_returns_None_if_theres_no_matching_file(self, svc):
+    def test_get_returns_None_if_theres_no_matching_file(self, svc):
         assert not svc.get("unknown_file_id", "canvas_file")
 
-    def test_it_doesnt_return_matching_files_from_other_application_instances(
+    def test_get_doesnt_return_matching_files_from_other_application_instances(
         self, svc
     ):
         file_ = factories.File()
 
         assert not svc.get(file_.lms_id, file_.type)
+
+    def test_get_with_guid(self, svc, application_instance):
+        file_ = factories.File(
+            application_instance=factories.ApplicationInstance(
+                tool_consumer_instance_guid=application_instance.tool_consumer_instance_guid
+            )
+        )
+        assert svc.get_with_guid(file_.lms_id, file_.type) == file_
 
     def test_upsert(self, db_session, svc, application_instance):
         existing_files_count = db_session.query(File).count()


### PR DESCRIPTION
## Requires

*  https://github.com/hypothesis/devdata/pull/62 needs to be merged


Course copy doesn't work across different application instances that belong to the same school (GUID now).

We look up in the DB for matching `File`s using the current application instance and won't find the original ones under a different AI.

This breaks course copy in the case of an Hypothesis install moving from course level to account level, some 1.1 -> 1.3 upgrades that create a new AI on our database, etc.


## Testing setup

The testing setup in canvas involves:

- An original course https://hypothesis.instructure.com/courses/319
which contains an Hypothesis course level install and a canvas file assignment.


- Copied course from 319 https://hypothesis.instructure.com/courses/376

In the course copy process the new course got a new assignment using the same canvas ID as the original but also a new LTI 1.3 install (with a new deployment ID) which is not configured a a new AI on `make devdata`.

The creation of the new LTI1.3 Canvas install (via course copy) is not the only way to replicate the issue, it would also happen in any scenario involving a new application instance (v1.1 or 1.3, moving to course level to instance/account level) / re-installing by the LMS admin...).

Using the LTI1.3 course level install duplication here because it's easier to setup and keep it isolated from other courses.


## Testing notes


* On `main`
* Launch the original assignment at least once as a teacher (to get the Files)
* https://hypothesis.instructure.com/courses/319/assignments/3347
* `make devdata`
* Launch https://hypothesis.instructure.com/courses/376/assignments/3357
    * Both as `eng+coursecopystudent` which doesn't have access to the original course's files 
    * ... and `Hypothesis 101 Teacher` who does.
* In both cases you see an error.


- Now switch to this branch `course-copy-across-ai`
- Relaunch as the student. Same error. This is normal as the student doesn't have access to the original file.
- Relaunch as the teacher. It works now.
- A file id mapping is now stored on the DB

```shell
tox -qe dockercompose -- exec postgres psql -U postgres -c "select extra from assignment order by id desc limit 1"
```

```
                   extra                    
--------------------------------------------
 {"canvas_file_mappings": {"1245": "1442"}}
(1 row)
```

- Relaunch as a student. It works now, using the mapping on the DB.