### PR TITLE
Add a work around to disable licence checking for VS SSO

### DIFF
--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -16,4 +16,7 @@ def service_factory(_context, request):
         global_client=VitalSourceClient(global_key) if global_key else None,
         customer_client=VitalSourceClient(customer_key) if customer_key else None,
         user_lti_param=settings.get("vitalsource", "user_lti_param"),
+        enable_licence_check=not bool(
+            settings.get("vitalsource", "disable_licence_check")
+        ),
     )

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -96,6 +96,7 @@
         {{ settings_checkbox("VitalSource enabled", "vitalsource", "enabled") }}
         {{ settings_text_field("VitalSource user ID param", "vitalsource", "user_lti_param") }}
         {{ settings_text_field("VitalSource API key", "vitalsource", "api_key") }}
+        {{ settings_checkbox("VitalSource disable licence check on SSO", "vitalsource", "disable_licence_check") }}
 
         {{ settings_checkbox("JSTOR enabled", "jstor", "enabled") }}
         {{ settings_text_field("JSTOR site code", "jstor", "site_code") }}

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -313,6 +313,7 @@ class AdminApplicationInstanceViews:
             ("vitalsource", "enabled", bool),
             ("vitalsource", "user_lti_param", str),
             ("vitalsource", "api_key", str),
+            ("vitalsource", "disable_licence_check", bool),
             ("jstor", "enabled", bool),
             ("jstor", "site_code", str),
         ):

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -12,6 +12,7 @@ class TestServiceFactory:
         "enabled,expected", ((sentinel.enabled, sentinel.enabled), (None, False))
     )
     @pytest.mark.parametrize("customer_api_key", (sentinel.customer_api_key, None))
+    @pytest.mark.parametrize("disable_licence_check", (None, True))
     def test_it(
         self,
         pyramid_request,
@@ -21,6 +22,7 @@ class TestServiceFactory:
         enabled,
         expected,
         customer_api_key,
+        disable_licence_check,
     ):
         pyramid_request.registry.settings["vitalsource_api_key"] = None
         # This fixture is a bit odd and returns a real application instance
@@ -29,6 +31,10 @@ class TestServiceFactory:
         ai.settings.set("vitalsource", "api_key", customer_api_key)
         if enabled:
             ai.settings.set("vitalsource", "enabled", enabled)
+        if disable_licence_check:
+            ai.settings.set(
+                "vitalsource", "disable_licence_check", disable_licence_check
+            )
 
         svc = service_factory(sentinel.context, pyramid_request)
 
@@ -44,6 +50,7 @@ class TestServiceFactory:
             if customer_api_key
             else None,
             user_lti_param=sentinel.user_lti_param,
+            enable_licence_check=not (disable_licence_check),
         )
         assert svc == VitalSourceService.return_value
 
@@ -65,6 +72,7 @@ class TestServiceFactory:
             global_client=VitalSourceClient.return_value if global_api_key else None,
             customer_client=Any(),
             user_lti_param=Any(),
+            enable_licence_check=Any(),
         )
 
     @pytest.fixture

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -63,6 +63,23 @@ class TestVitalSourceService:
 
         assert exc.value.error_code == "vitalsource_no_book_license"
 
+    def test_get_sso_redirect_with_no_book_licence_with_checking_disabled(
+        self, customer_client
+    ):
+        customer_client.get_user_book_license.return_value = None
+        svc = VitalSourceService(
+            customer_client=customer_client, enable_licence_check=False
+        )
+
+        result = svc.get_sso_redirect(
+            sentinel.user_reference,
+            document_url="vitalsource://book/bookID/BOOK-ID/cfi/CFI",
+        )
+
+        customer_client.get_user_book_license.assert_not_called()
+
+        assert result == customer_client.get_sso_redirect.return_value
+
     @pytest.mark.parametrize(
         "proxy_method,args",
         (
@@ -108,4 +125,5 @@ class TestVitalSourceService:
             global_client=global_client,
             customer_client=customer_client,
             user_lti_param=sentinel.user_lti_param,
+            enable_licence_check=True,
         )


### PR DESCRIPTION
This seems to unnecessarily cause problems for some customers. This is to provide an option to work around this while we work through the issue.