### PR TITLE
Fix roles reported for LTI1.3 launches

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -138,8 +138,29 @@ def _to_lti_v11(v13_params):
         v11_params.update({f"custom_{key}": value for key, value in custom.items()})
 
     if "roles" in v11_params:
-        # We need to squish together the roles for v1.1
-        v11_params["roles"] = ",".join(v11_params["roles"])
+        context_roles = []
+        for role in v11_params["roles"]:
+            # From: https://www.imsglobal.org/spec/lti/v1p3#role-vocabularies
+            #
+            # Conforming implementations MAY recognize the simple
+            # names for context roles; thus, for example, vendors can use
+            # the following roles interchangeably:
+            #   http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor
+            #   Instructor
+            if "http://purl.imsglobal.org/vocab/lis/v2" not in role:
+                # If using the simple name, we'll take it
+                context_roles.append(role)
+
+            if role.startswith("http://purl.imsglobal.org/vocab/lis/v2/membership"):
+                # For roles that have the whole LIS 2.0 name, take only the one
+                # relevant for the current context. We'd need to expose the
+                # rest of the roles somewhere else if they become necessary /
+                # interesting, but for LTI 1.1 compatibility we only expose the
+                # roles of the current context (course) here.
+                context_roles.append(role)
+
+        # We need to squish together the roles for v1.1 compatibility
+        v11_params["roles"] = ",".join(context_roles)
 
     return v11_params
 

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -74,6 +74,26 @@ class TestLTIParams:
         assert params["user_id"] == "user_id-v11"
         assert params["resource_link_id"] == "resource_link_id-v11"
 
+    def test_ignores_non_context_roles(self, pyramid_request):
+        pyramid_request.lti_jwt = {
+            f"{CLAIM_PREFIX}/roles": [
+                # These roles do not relate to the current context (course) and
+                # should be ignored
+                "http://purl.imsglobal.org/vocab/lis/v2/system/person#User",
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+                # We should accept either of these formats
+                "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+                "Mentor",
+            ],
+        }
+
+        params = LTIParams.from_request(pyramid_request)
+
+        assert (
+            params["roles"]
+            == "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner,Mentor"
+        )
+
 
 class TestCanvasQuirks:
     @pytest.mark.parametrize(


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/4369


LTI1.3 reports the roles for the context (same as LTI1.1, the roles for
the current launch) but also any other roles across the institution in
different namespaces.

For the  current layer of compatibility with LTI1.1 we'll take only the
relevant roles for the current course.

https://www.imsglobal.org/spec/lti/v1p3#role-vocabularies


# Testing 

## Role changes

- Clear event_user 

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate event_user"```

- Switch  to this branch an launch  

https://hypothesis.instructure.com/courses/319/assignments/3308

as `Hypothesis 101 Teacher`

check the JWT coming from canvas, it contains:

```
"https://purl.imsglobal.org/spec/lti/claim/roles": [
    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
    "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
    "http://purl.imsglobal.org/vocab/lis/v2/system/person#User"
]
```

note the different namespaces here, `institution`, `system`, `membership`.


- Check the roles reported on the DB

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from  event_user join lti_role on lti_role_id = lti_role.id"

 id | event_id | user_id | lti_role_id | id |                            value                             |    type    
----+----------+---------+-------------+----+--------------------------------------------------------------+------------
 95 |       44 |       2 |           4 |  4 | http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor | instructor
(1 row)
```



## Effects on course copy

This has been the cause of most of the issues we've seen around course copy I'm going to focus the testing on that here


### On `main`

To get the course copy setup working

- Launch https://hypothesis.instructure.com/courses/319/assignments/3347 once as `Hypothesis 101 Teacher` (the orignal course)

- Launch https://hypothesis.instructure.com/courses/376/assignments/3357 with the same teacher user. (the copied course)

- Now, as a `eng+coursecopystudent@hypothes.is`

launch again https://hypothesis.instructure.com/courses/376/assignments/3357


You'll get  the course copy error dialog.

`eng+coursecopystudent@hypothes.is` is now a teacher in another course but only student in this one. When the course copy logic kicks in we pick up the teacher role and try to fetch the files, but as a student in the current course we don't have access and fail.

### On branch `fix-lti13-roles`

- Relaunch https://hypothesis.instructure.com/courses/376/assignments/3357 as `eng+coursecopystudent@hypothes.is` it now should work. We correctly identify the student role only and go grab the file without trying to list all the files first.

