### PR TITLE
Allow canvas API details editing in the admin pages

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -123,6 +123,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.instances", "/admin/instances/")
     config.add_route("admin.instances.search", "/admin/instances/search")
     config.add_route("admin.instance.downgrade", "/admin/instance/id/{id_}/downgrade")
+    config.add_route("admin.instance.canvas.api", "/admin/instance/id/{id_}/canvas/api")
     config.add_route("admin.instance.consumer_key", "/admin/instance/{consumer_key}/")
     config.add_route("admin.instance.id", "/admin/instance/id/{id_}/")
     config.add_route(

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -116,6 +116,19 @@ class ApplicationInstanceService:
 
         return query.all()
 
+    def set_canvas_api_details(
+        self, application_instance, developer_key, developer_secret
+    ):
+
+        # If either one of developer_key or developer_secret is missing, then we won't set either
+        if developer_secret and developer_key:
+            aes_iv = self._aes_service.build_iv()
+            encrypted_secret = self._aes_service.encrypt(aes_iv, developer_secret)
+
+            application_instance.developer_key = developer_key
+            application_instance.aes_cipher_iv = aes_iv
+            application_instance.developer_secret = encrypted_secret
+
     def create_application_instance(  # pylint:disable=too-many-arguments
         self,
         lms_url,
@@ -131,26 +144,18 @@ class ApplicationInstanceService:
             "Hypothesis" + secrets.token_hex(16) if not deployment_id else None
         )
 
-        if developer_secret and developer_key:
-            aes_iv = self._aes_service.build_iv()
-            encrypted_secret = self._aes_service.encrypt(aes_iv, developer_secret)
-        else:
-            # If either one of developer_key or developer_secret is missing, then we
-            # don't save the other one either.
-            developer_key = encrypted_secret = developer_secret = aes_iv = None
-
         application_instance = ApplicationInstance(
             consumer_key=consumer_key,
             shared_secret=secrets.token_hex(32),
             lms_url=lms_url,
             requesters_email=email,
-            developer_key=developer_key,
-            developer_secret=encrypted_secret,
-            aes_cipher_iv=aes_iv,
             created=datetime.utcnow(),
             settings=settings or {},
             deployment_id=deployment_id,
             lti_registration_id=lti_registration_id,
+        )
+        self.set_canvas_api_details(
+            application_instance, developer_key, developer_secret
         )
         self._db.add(application_instance)
         self._db.flush()  # Force the returned AI to have an ID

--- a/lms/templates/admin/instance.canvas_api_details.html.jinja2
+++ b/lms/templates/admin/instance.canvas_api_details.html.jinja2
@@ -1,0 +1,18 @@
+{% import "macros.jinja" as macros %}
+
+{% extends "lms:templates/admin/base.html.jinja2" %}
+
+{% block content %}
+<form method="POST" action="{{ request.route_url("admin.instance.canvas.api", id_=instance.id) }}">
+    <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+
+    <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Canvas API details</legend>
+
+        {{ macros.form_text_field(request, "API Key", "developer_key") }}
+        {{ macros.form_text_field(request, "API Secret", "developer_secret") }}
+    </fieldset>
+
+    <input type="submit" class="button is-info" value="Update"/>
+</form>
+{% endblock %}

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -79,7 +79,12 @@
     <fieldset class="box">
         <legend class="label has-text-centered">Canvas settings</legend>
         {{ macros.disabled_text_field("API domain", instance.custom_canvas_api_domain) }}
+
         {{ macros.disabled_text_field("Developer key", instance.developer_key) }}
+        <div class="has-text-right mb-6">
+            <a class="button is-primary" href="{{ request.route_url("admin.instance.canvas.api", id_=instance.id) }}">Update API details</a>
+        </div>
+
         {{ settings_checkbox("Sections enabled", "canvas", "sections_enabled") }}
         {{ settings_checkbox("Groups enabled", "canvas", "groups_enabled") }}
     </fieldset>

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -295,6 +295,42 @@ class AdminApplicationInstanceViews:
             location=self.request.route_url("admin.instance.id", id_=ai.id)
         )
 
+    @view_config(
+        route_name="admin.instance.canvas.api",
+        request_method="GET",
+        renderer="lms:templates/admin/instance.canvas_api_details.html.jinja2",
+    )
+    def update_canvas_api_details(self):
+        return {"instance": self._get_ai_or_404(**self.request.matchdict)}
+
+    @view_config(
+        route_name="admin.instance.canvas.api",
+        request_method="POST",
+        renderer="lms:templates/admin/instance.canvas_api_details.html.jinja2",
+    )
+    def update_canvas_api_details_callback(self):
+        ai = self._get_ai_or_404(**self.request.matchdict)
+        developer_key = self.request.params["developer_key"]
+        developer_secret = self.request.params["developer_secret"]
+
+        if not developer_key or not developer_secret:
+            self.request.session.flash(
+                "Both Developer key and secret are required", "errors"
+            )
+            self.request.response.status_code = 400
+            return {"instance": self._get_ai_or_404(**self.request.matchdict)}
+
+        self.application_instance_service.set_canvas_api_details(
+            ai,
+            self.request.params["developer_key"],
+            self.request.params["developer_secret"],
+        )
+
+        self.request.session.flash("Updated canvas API details", "messages")
+        return HTTPFound(
+            location=self.request.route_url("admin.instance.id", id_=ai.id)
+        )
+
     def _get_ai_or_404(self, consumer_key=None, id_=None) -> ApplicationInstance:
         try:
             if consumer_key:


### PR DESCRIPTION
Allow editing AIs Canvas API details


#  Testing

- Go over to http://localhost:8001/admin/instance/id/100/
- Click the new `Update API details` 
- Enter any values
- They are saved on the AI 

```tox -qe dockercompose -- exec postgres psql -U postgres -c "select developer_key, developer_secret, aes_cipher_iv from application_instances where id = 100"```