### PR TITLE
JWT better error handling

### DIFF
--- a/tests/functional/lti_certification/v13/core/test_bad_payloads.py
+++ b/tests/functional/lti_certification/v13/core/test_bad_payloads.py
@@ -19,7 +19,7 @@ class TestBadPayloads:
         """
         del jwt_headers["kid"]
 
-        do_lti_launch({"id_token": make_jwt(test_payload, jwt_headers)}, status=403)
+        do_lti_launch({"id_token": make_jwt(test_payload, jwt_headers)}, status=422)
 
         assert "Missing 'kid' value in JWT header" in caplog.messages
 
@@ -28,7 +28,7 @@ class TestBadPayloads:
     ):
         jwt_headers["kid"] = "imstester_66067"
 
-        do_lti_launch({"id_token": make_jwt(test_payload, jwt_headers)}, status=403)
+        do_lti_launch({"id_token": make_jwt(test_payload, jwt_headers)}, status=422)
         assert (
             Any.string.matching(
                 "^Invalid JWT for:.* Unable to find a signing key that matches:.*$"
@@ -58,9 +58,9 @@ class TestBadPayloads:
         """The provided JSON is NOT a 1.3 JWT launch"""
         payload = {"name": "badltilaunch"}
 
-        response = do_lti_launch({"id_token": make_jwt(payload)}, status=403)
+        response = do_lti_launch({"id_token": make_jwt(payload)}, status=422)
 
-        assert response.status_code == 403
+        assert response.status_code == 422
 
     def test_missing_lti_claims(self, test_payload, do_lti_launch, make_jwt):
         """The provided 1.3 JWT launch is missing one or more required claims"""
@@ -74,9 +74,9 @@ class TestBadPayloads:
         for missing_claim in missing_claims:
             del test_payload[missing_claim]
 
-        response = do_lti_launch({"id_token": make_jwt(test_payload)}, status=403)
+        response = do_lti_launch({"id_token": make_jwt(test_payload)}, status=422)
 
-        assert response.status_code == 403
+        assert response.status_code == 422
         assert response.html
 
     def test_timestamps_incorrect(self, test_payload, do_lti_launch, make_jwt):
@@ -84,7 +84,7 @@ class TestBadPayloads:
         test_payload["iat"] = 11111
         test_payload["exp"] = 22222
 
-        response = do_lti_launch({"id_token": make_jwt(test_payload)}, status=403)
+        response = do_lti_launch({"id_token": make_jwt(test_payload)}, status=422)
         assert response.html
 
     def test_message_type_claim_missing(self, test_payload, assert_missing_claim):

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -95,9 +95,10 @@ class TestLTIUserSecurityPolicy:
         get_lti_user_ = create_autospec(
             get_lti_user, side_effect=ValidationError(sentinel.messages)
         )
-        policy = LTIUserSecurityPolicy(get_lti_user_)
-        userid = policy.identity(pyramid_request)
 
+        policy = LTIUserSecurityPolicy(get_lti_user_)
+
+        userid = policy.identity(pyramid_request)
         assert userid == Identity(userid="", permissions=[])
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Current behavior of the JWT service is to fail silently and return an empty dictionary for invalid JWTs.

Raising `lms.ValidationError` instead which produces a meaningful error message.

## Testing 

- Simulate the three scenarios (not all at the same time):

```diff
--git a/lms/services/jwt.py b/lms/services/jwt.py
index 8beca8fb..a9f9e322 100644
--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -73,7 +73,7 @@ class JWTService:
         if not id_token:
             return {}
 
-        if not jwt.get_unverified_header(id_token).get("kid"):
+        if jwt.get_unverified_header(id_token).get("kid"):
             LOG.debug("Missing 'kid' value in JWT header")
             return {}
 
@@ -82,7 +82,7 @@ class JWTService:
 
         # Find the registration based on the token's claimed issuer & audience
         registration = self._registration_service.get(iss, aud)
-        if not registration:
+        if registration:
             LOG.debug("Unknown registration for lti_token. iss:%s aud:%s.", iss, aud)
             return {}
 
@@ -92,7 +92,7 @@ class JWTService:
             ).get_signing_key_from_jwt(id_token)
 
             return jwt.decode(
-                id_token, key=signing_key.key, audience=aud, algorithms=["RS256"]
+                "NOPE", key=signing_key.key, audience=aud, algorithms=["RS256"]
             )
         except PyJWTError as err:
             LOG.debug("Invalid JWT for: %s, %s. %s", iss, aud, str(err))
```


- On `main` this results in either a 

```You're not authorized to view this page```

in https://hypothesis.instructure.com/courses/319/assignments/3308

or a

```Sorry, but something went wrong. The issue has been reported and we'll try to fix it.```

on https://hypothesis.instructure.com/courses/319/assignments/3347 due to a ```KeyError: 'custom_canvas_course_id'``` on the logs. That was caused by the empty dictionary returned by the JWT service being interpreted as "This is an LTI1.1 launch".


- On this branch `jwt-error-handling` the same scenarios produce the following error messages in both assignment:



```
Hypothesis received an invalid request. There were problems with these request parameters:

jwt:
    Missing 'kid' value in JWT header
```

```
Hypothesis received an invalid request. There were problems with these request parameters:

jwt:
   Unknown registration for JWT. iss:https://canvas.instructure.com aud:93820000000000200.
```

```
Hypothesis received an invalid request. There were problems with these request parameters:

jwt:
    Invalid JWT for: https://canvas.instructure.com, 93820000000000200. Not enough segments
```








