### PR TITLE
Don't allow `/` on issuer

### DIFF
--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlparse
 
-from marshmallow import validate
+from marshmallow import ValidationError, validate, validates
 from pyramid.httpexceptions import HTTPFound
 from pyramid.renderers import render_to_response
 from pyramid.view import view_config, view_defaults
@@ -18,6 +18,12 @@ class LTIRegistrationBaseSchema(PyramidRequestSchema):
 
     issuer = fields.URL(required=True)
     client_id = fields.Str(required=True, validate=validate.Length(min=1))
+
+    @validates("issuer")
+    def validate_issuer(self, value):
+        if value.endswith("/"):
+            # Prevent confusion with application instance LMS URL.
+            raise ValidationError("Issuer can't end with '/'")
 
 
 class LTIRegistrationSchema(LTIRegistrationBaseSchema):

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -122,6 +122,14 @@ class TestAdminApplicationInstanceViews:
 
         assert response.status_code == 400
 
+    @pytest.mark.usefixtures("with_form_submission")
+    def test_new_registration_bad_issuer(self, pyramid_request, views):
+        pyramid_request.POST["issuer"] = "https://issuer.com/"
+
+        response = views.new_registration_callback()
+
+        assert response.status_code == 400
+
     def test_search_not_query(self, pyramid_request):
         response = AdminLTIRegistrationViews(pyramid_request).search()
 


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/4304


This is a common error while pasting the values for a new registration as we have this value (the issuer) but also the "LMS URL" which might look very similar depending of the LMS.

We could just remove the slash if present but I reckon this just makes it more explicit and might be a good prompt to double check things.


# Testing

- Go over http://localhost:8001/admin/registration try an new issuer ending with `/`

