### PR TITLE
Allow editing registration URLs in the admin

### DIFF
--- a/lms/templates/admin/macros.jinja
+++ b/lms/templates/admin/macros.jinja
@@ -44,15 +44,12 @@
 {% endmacro %}
 
 
-{% macro registrations_fields(request, lti_registration, view_button=False) %}
-<fieldset class="box">
-    <legend class="label has-text-centered">Registration</legend>
+{% macro registration_fields(request, lti_registration, view_button=False) %}
     {% if view_button %}
     <div class="block has-text-right">
         <a class="button" href="{{ request.route_url("admin.registration.id", id_=lti_registration.id) }}">View</a>
     </div>
     {% endif %}
-
     <div class="columns">
         <div class="column is-half">
             {{ disabled_text_field("Issuer", lti_registration.issuer) }}
@@ -61,16 +58,9 @@
             {{ disabled_text_field("Client ID", lti_registration.client_id) }}
         </div>
     </div>
-    <div class="columns">
-        <div class="column is-half">
-            {{ disabled_text_field("Auth login URL", lti_registration.auth_login_url) }}
-        </div>
-        <div class="column is-half">
-            {{ disabled_text_field("Key set URL", lti_registration.key_set_url) }}
-        </div>
-    </div>
-    {{ disabled_text_field("Token URL", lti_registration.token_url) }}
-</fieldset>
+    {{ form_text_field(request, "Auth login URL", "auth_login_url", lti_registration.auth_login_url) }}
+    {{ form_text_field(request, "Key set URL", "key_set_url", lti_registration.key_set_url) }}
+    {{ form_text_field(request, "Token URL", "token_url", lti_registration.token_url) }}
 {% endmacro %}
 
 {% macro instances_table(request, instances) %}

--- a/lms/templates/admin/registration.html.jinja2
+++ b/lms/templates/admin/registration.html.jinja2
@@ -6,7 +6,17 @@
 {% endblock %}
 
 {% block content %}
-    {{ macros.registrations_fields(request, registration) }}
+    <fieldset class="box">
+    <legend class="label has-text-centered">Registration</legend>
+    <form method="POST" action="{{ request.route_url("admin.registration.id", id_=registration.id) }}">
+        <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+        {{ macros.registration_fields(request, registration) }}
+
+        <div class="has-text-right mb-6">
+            <input type="submit" class="button is-primary" value="Save" />
+        </div>
+    </form>
+    </fieldset>
 
     <fieldset class="box">
     <legend class="label has-text-centered">Registration application instances</legend>

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -176,6 +176,34 @@ class TestAdminApplicationInstanceViews:
             response["registration"] == lti_registration_service.get_by_id.return_value
         )
 
+    @pytest.mark.usefixtures("with_form_submission")
+    def test_update_registration(
+        self, pyramid_request, lti_registration_service, views
+    ):
+        pyramid_request.matchdict["id_"] = sentinel.id_
+
+        response = views.update_registration()
+
+        lti_registration_service.get_by_id.assert_called_once_with(sentinel.id_)
+        assert (
+            response["registration"] == lti_registration_service.get_by_id.return_value
+        )
+        assert pyramid_request.session.peek_flash("messages")
+
+    @pytest.mark.usefixtures("with_form_submission")
+    def test_update_registration_failed_validation(
+        self, pyramid_request, lti_registration_service, views
+    ):
+        pyramid_request.matchdict["id_"] = sentinel.id_
+        del pyramid_request.POST["auth_login_url"]
+
+        response = views.update_registration()
+
+        assert (
+            response["registration"] == lti_registration_service.get_by_id.return_value
+        )
+        assert pyramid_request.session.peek_flash("validation")
+
     def test_registration_new_instance(
         self, pyramid_request, lti_registration_service, views
     ):


### PR DESCRIPTION
Allow editing URLs at the registration level (auth, token and JWKs). 

For #4304 

# Testing 

- Go over http://localhost:8001/admin/registration/id/1/
- Edit some URLs
- ????
- :tada: 
