### PR TITLE
Revert "Modify backfilling migration to work on batches."

### DIFF
--- a/lms/migrations/versions/396f46318023_events_backfill.py
+++ b/lms/migrations/versions/396f46318023_events_backfill.py
@@ -1,5 +1,5 @@
 """
-Backfill "events" from lti_launches rows (2020).
+Backfill "events" from lti_launches rows.
 
 Revision ID: 396f46318023
 Revises: 42b39684836f
@@ -13,18 +13,11 @@ from alembic import op
 revision = "396f46318023"
 down_revision = "42b39684836f"
 
-BATCH_START_DATE = "2000-08-17T13:00:08.241"
-BATCH_END_DATE = "2020-08-17T13:00:08.241"
-"""
-We'll do this in batches each bach between these two dates
-"""
 
 CUT_OFF_DATE = "2022-08-17T13:00:08.241"
 """
 Date when we started inserting launches directly on events.
 Rows in lti_launches would already have corresponding event after this date.
-
-While doing this in batches this will the END_DATE of the last batch.
 """
 
 
@@ -34,7 +27,9 @@ def get_configured_launch_type_pk(conn):
     ).fetchone()[0]
 
 
-def migrate_lti_launches(conn, start, end):
+def upgrade():
+    conn = op.get_bind()
+
     launch_event_type_id = get_configured_launch_type_pk(conn)
 
     result = conn.execute(
@@ -59,7 +54,7 @@ def migrate_lti_launches(conn, start, end):
                 AND grouping.application_instance_id = application_instances.id
                 AND grouping.type = 'course'
        -- Only backfill rows created before we also start tracking them directly on this table
-        WHERE lti_launches.created >= '{start}' AND lti_launches.created < '{end}'
+        WHERE lti_launches.created < '{CUT_OFF_DATE}'
         -- We need to group by to pick one (MAX grouping.id) above of the possible
         -- multiple courses on the grouping table
         GROUP BY lti_launches.id, lti_launches.created, application_instances.id
@@ -70,29 +65,17 @@ def migrate_lti_launches(conn, start, end):
     print("\tInserted lti_launches rows into events:", result.rowcount)
 
 
-def downgrade_lti_launches(conn, start, end):
+def downgrade():
+    conn = op.get_bind()
     launch_event_type_id = get_configured_launch_type_pk(conn)
 
-    result = conn.execute(
+    conn.execute(
         f"""
         DELETE FROM event
         WHERE type_id = {launch_event_type_id}
             -- All events inserted by the forward version of this migration
             -- will have empty assignments.
             AND assignment_id is null
-            AND timestamp >= '{start}' AND timestamp < '{end}'
+            AND timestamp < '{CUT_OFF_DATE}'
     """
     )
-    print("\tDeleted events rows:", result.rowcount)
-
-
-def upgrade():
-    conn = op.get_bind()
-
-    migrate_lti_launches(conn, BATCH_START_DATE, BATCH_END_DATE)
-
-
-def downgrade():
-    conn = op.get_bind()
-
-    downgrade_lti_launches(conn, BATCH_START_DATE, BATCH_END_DATE)


### PR DESCRIPTION
This reverts commit 1d2cf72657d2fdcb6ad6462362c782a402be5bda.

The migration that got applied in the US DB was the one before this
commit, without batches.

Reverting the commit to represent the migration history correctly.


## Testing

This migration has already run on production.