### PR TITLE
Refactor SecurityPolicy to map routes to policies

### DIFF
--- a/tests/functional/views/admin_test.py
+++ b/tests/functional/views/admin_test.py
@@ -1,0 +1,5 @@
+def test_admin_authentication_redirects_to_google(app):
+    response = app.get("/admin/instances/")
+
+    assert response.status_code == 302
+    assert response.location.startswith("http://localhost/googleauth/login")


### PR DESCRIPTION
Instead of trying policies until one of them works explicitly declare
the policy to be used based on the current URL.


This only tackles the "map routes to policies" issue and only applies it to the admin pages which use Google's Oauth. 

## Testing

- Head over http://localhost:8001/admin login, logout.
- Launch an assignment as a sanity check for the rest of the auth methods: https://hypothesis.instructure.com/courses/125/assignments/875
