### PR TITLE
Move LTI authentication to LTIUserSecurityPolicy

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -101,8 +101,8 @@ class LTIUserSecurityPolicy:
 
         return Identity(self._get_userid(lti_user), permissions)
 
-    def permits(self, request, context, permission):
-        return _permits(self, request, context, permission)
+    def permits(self, request, _context, permission):
+        return _permits(self.identity(request), permission)
 
     def remember(self, request, userid, **kw):
         pass
@@ -120,12 +120,11 @@ class LMSGoogleSecurityPolicy(GoogleSecurityPolicy):
 
         return Identity("", [])
 
-    def permits(self, request, context, permission):
-        return _permits(self, request, context, permission)
+    def permits(self, request, _context, permission):
+        return _permits(self.identity(request), permission)
 
 
-def _permits(policy, request, _context, permission):
-    identity = policy.identity(request)
+def _permits(identity, permission):
     if identity and permission in identity.permissions:
         return Allowed("allowed")
 

--- a/lms/security.py
+++ b/lms/security.py
@@ -46,6 +46,9 @@ def get_policy(request):
     if path.startswith("/admin") or path.startswith("/googleauth"):
         return LMSGoogleSecurityPolicy()
 
+    if path in {"/lti_launches", "/content_item_selection", "/api/gateway/h/lti"}:
+        return LTIUserSecurityPolicy(_get_lti_user_from_lti_launch_params)
+
     return LTIUserSecurityPolicy(_get_lti_user)
 
 
@@ -151,6 +154,13 @@ def _permits(identity, permission):
         return Allowed("allowed")
 
     return Denied("denied")
+
+
+def _get_lti_user_from_lti_launch_params(request) -> LTIUser:
+    schema = LTI11AuthSchema(request).lti_user
+    if "id_token" in request.params:
+        schema = LTI13AuthSchema(request).lti_user
+    return schema()
 
 
 def _get_lti_user(request) -> LTIUser:

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -27,6 +27,13 @@ class ExceptionViews:
 
     @forbidden_view_config()
     def forbidden(self):
+        if validation_error := getattr(self.exception.result, "validation_error", None):
+            self.request.override_renderer = (
+                "lms:templates/validation_error.html.jinja2"
+            )
+            self.request.response.status_int = 403
+            return {"error": validation_error}
+
         return self.error_response(403, _("You're not authorized to view this page"))
 
     @exception_view_config(context=HTTPClientError)

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -59,6 +59,7 @@ def application_instance(lti_registration):
         tool_consumer_instance_guid="TEST_CONSUMER_INSTANCE_GUID",
         lti_registration=lti_registration,
         deployment_id="testdeploy",
+        organization=factories.Organization(),
     )
 
 

--- a/tests/functional/views/basic_lti_launch_test.py
+++ b/tests/functional/views/basic_lti_launch_test.py
@@ -178,7 +178,10 @@ class TestBasicLTILaunch:
 
     @pytest.fixture(autouse=True)
     def application_instance(self, db_session):  # pylint:disable=unused-argument
-        return factories.ApplicationInstance(tool_consumer_instance_guid="IMS Testing")
+        return factories.ApplicationInstance(
+            tool_consumer_instance_guid="IMS Testing",
+            organization=factories.Organization(),
+        )
 
     @pytest.fixture
     def assignment(self, db_session, application_instance, lti_params):

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -8,6 +8,7 @@ from lms.security import (
     Identity,
     LMSGoogleSecurityPolicy,
     LTIUserSecurityPolicy,
+    DeniedWithReason,
     Permissions,
     SecurityPolicy,
     _get_lti_user,
@@ -146,6 +147,14 @@ class TestLTIUserSecurityPolicy:
         is_allowed = policy.permits(pyramid_request, None, "some-permission")
 
         assert is_allowed == Denied("denied")
+
+    def test_permits_denied_with_validation_error(self, pyramid_request):
+        validation_error = ValidationError(sentinel.message)
+        policy = LTIUserSecurityPolicy(Mock(side_effect=validation_error))
+
+        is_allowed = policy.permits(pyramid_request, None, "some-permission")
+
+        assert is_allowed.validation_error == validation_error
 
     @pytest.mark.parametrize(
         "lti_user,expected_userid",


### PR DESCRIPTION
Use `LTIUserSecurityPolicy` introduced in https://github.com/hypothesis/lms/pull/4394 for LTIAuthentication and expose any validation error in them on `forbidden_view`.


# Testing

- Launch an assignment should work as before in this branch: https://hypothesis.instructure.com/courses/125/assignments/873

- Same for deep linking https://hypothesis.instructure.com/courses/125/assignments/3118/edit?name=Testing+upgrade+-+marcos&due_at=null&points_possible=10


- Switch to `main` a make change that would result in a validation error

```
diff 
--git a/lms/validation/_lti_launch_params.py b/lms/validation/_lti_launch_params.py
index 0ad79a84..e27a7cf8 100644
--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -25,7 +25,7 @@ class LTIV11CoreSchema(PyramidRequestSchema):
 
     user_id = fields.Str(required=True)
     roles = fields.Str(required=True)
-    tool_consumer_instance_guid = fields.Str(required=True)
+    tool_consumer_instance_guid = fields.Float(required=True)
     lis_person_name_given = fields.Str(load_default="")
     lis_person_name_family = fields.Str(load_default="")
     lis_person_name_full = fields.Str(load_default="")
~
```


- Launching  https://hypothesis.instructure.com/courses/125/assignments/873 fails with 

 
`You're not authorized to view this page`



- Switch to this branch, `security-refactor-launches`, re-launch and the error message will point to the offending field:

```
Hypothesis received an invalid request. There were problems with these request parameters:

form:
tool_consumer_instance_guid
````
