### PR TITLE
Allow editing canvas API details in the admin pages

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -79,7 +79,13 @@
     <fieldset class="box">
         <legend class="label has-text-centered">Canvas settings</legend>
         {{ macros.disabled_text_field("API domain", instance.custom_canvas_api_domain) }}
-        {{ macros.disabled_text_field("Developer key", instance.developer_key) }}
+        {{ macros.form_text_field(request, "Developer key", "developer_key", field_value=instance.developer_key) }}
+        {{ macros.form_text_field(
+            request,
+            "Developer secret",
+            "developer_secret",
+            placeholder="*" * 25 if instance.developer_secret else "")
+        }}
         {{ settings_checkbox("Sections enabled", "canvas", "sections_enabled") }}
         {{ settings_checkbox("Groups enabled", "canvas", "groups_enabled") }}
     </fieldset>

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -264,9 +264,13 @@ class AdminApplicationInstanceViews:
     def update_instance(self):
         ai = self._get_ai_or_404(**self.request.matchdict)
 
-        for ai_field in ["lms_url", "deployment_id"]:
-            if value := self.request.params.get(ai_field, "").strip():
-                setattr(ai, ai_field, value)
+        self.application_instance_service.update_application_instance(
+            ai,
+            lms_url=self.request.params.get("lms_url", "").strip(),
+            deployment_id=self.request.params.get("deployment_id", "").strip(),
+            developer_key=self.request.params.get("developer_key", "").strip(),
+            developer_secret=self.request.params.get("developer_secret", "").strip(),
+        )
 
         for setting, sub_setting, setting_type in (
             ("canvas", "sections_enabled", bool),


### PR DESCRIPTION
Allow editing AIs Canvas API details

Simpler alternative than https://github.com/hypothesis/lms/pull/4376

For #4304 

#  Testing

- Go over to http://localhost:8001/admin/instance/id/100/
- Enter any values for key/secret
- They are saved on the AI 

```tox -qe dockercompose -- exec postgres psql -U postgres -c "select developer_key, developer_secret, aes_cipher_iv from application_instances where id = 100"```