### PR TITLE
Allow names to be null, so we don't have to make up silly ones

### DIFF
--- a/lms/migrations/versions/79eda94de79f_add_organizations_model.py
+++ b/lms/migrations/versions/79eda94de79f_add_organizations_model.py
@@ -25,7 +25,7 @@ def upgrade():
             "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
         ),
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("name", sa.UnicodeText(), nullable=False),
+        sa.Column("name", sa.UnicodeText(), nullable=True),
         sa.Column("enabled", sa.Boolean(), nullable=False),
         sa.Column("public_id", sa.UnicodeText(), nullable=False),
         sa.Column("parent_id", sa.Integer(), nullable=True),


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4200

Fix for:

 * https://github.com/hypothesis/lms/pull/4330

This allows names to be null. We often won't have one we can work out from the application instances, so there's no need to be forced to invent one.