### PR TITLE
Add organisation and application instance info to the launch debug data

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -92,6 +92,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include("lms.session")
     config.include("lms.models")
     config.include("lms.models.lti_params")
+    config.include("lms.models.region")
     config.include("lms.product")
     config.include("lms.db")
     config.include("lms.routes")

--- a/lms/models/region.py
+++ b/lms/models/region.py
@@ -28,7 +28,7 @@ class Regions:
     _AUTHORITY_MAP = {region.authority: region for region in ALL}
 
     @classmethod
-    def from_authority(cls, request: Request) -> Region:
+    def from_request(cls, request: Request) -> Region:
         """
         Get a region object based on a request.
 
@@ -42,3 +42,9 @@ class Regions:
             raise ValueError(
                 f"Cannot find a region for the authority '{authority}'"
             ) from err
+
+
+def includeme(config):
+    config.add_request_method(
+        Regions.from_request, name="region", property=True, reify=True
+    )

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -188,7 +188,7 @@ class JSConfig:
         self._config["rpcServer"] = {
             "allowedOrigins": self._request.registry.settings["rpc_allowed_origins"]
         }
-        self._config["debug"]["values"] = self._set_lti_launch_debug_values()
+        self._config["debug"]["values"] = self._get_lti_launch_debug_values()
 
     def enable_file_picker_mode(self, form_action, form_fields):
         """
@@ -227,7 +227,7 @@ class JSConfig:
                 },
             }
         )
-        self._config["debug"]["values"] = self._set_lti_launch_debug_values()
+        self._config["debug"]["values"] = self._get_lti_launch_debug_values()
 
     def add_deep_linking_api(self):
         """
@@ -505,7 +505,14 @@ class JSConfig:
             },
         }
 
-    def _set_lti_launch_debug_values(self):
+    def _get_lti_launch_debug_values(self):
         """Debug values common to different types of LTI launches."""
         ai = self._context.application_instance
-        return {"LTI version": ai.lti_version}
+
+        return {
+            "Organization ID": ai.organization.public_id(self._request.region)
+            if ai.organization
+            else None,
+            "Application Instance ID": ai.id,
+            "LTI version": ai.lti_version,
+        }

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -188,9 +188,7 @@ class JSConfig:
         self._config["rpcServer"] = {
             "allowedOrigins": self._request.registry.settings["rpc_allowed_origins"]
         }
-
-        ai = self._context.application_instance
-        self._config["debug"]["values"]["LTI version"] = ai.lti_version
+        self._config["debug"]["values"] = self._set_lti_launch_debug_values()
 
     def enable_file_picker_mode(self, form_action, form_fields):
         """
@@ -229,6 +227,7 @@ class JSConfig:
                 },
             }
         )
+        self._config["debug"]["values"] = self._set_lti_launch_debug_values()
 
     def add_deep_linking_api(self):
         """
@@ -505,3 +504,8 @@ class JSConfig:
                 "gradingStudentId": req.params.get("learner_canvas_user_id"),
             },
         }
+
+    def _set_lti_launch_debug_values(self):
+        """Debug values common to different types of LTI launches."""
+        ai = self._context.application_instance
+        return {"LTI version": ai.lti_version}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ TEST_SETTINGS = {
     "h_client_secret": "TEST_CLIENT_SECRET",
     "h_jwt_client_id": "TEST_JWT_CLIENT_ID",
     "h_jwt_client_secret": "TEST_JWT_CLIENT_SECRET",
-    "h_authority": "TEST_AUTHORITY",
+    "h_authority": "lms.hypothes.is",
     "h_api_url_public": "https://h.example.com/api/",
     "h_api_url_private": "https://h.example.com/private/api/",
     "rpc_allowed_origins": ["http://localhost:5000"],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,6 +9,7 @@ from pyramid.request import apply_request_extensions
 
 from lms.db import SESSION
 from lms.models import ApplicationSettings
+from lms.models.region import Regions
 from lms.product import Product
 from tests import factories
 from tests.conftest import TEST_SETTINGS, get_test_database_url
@@ -119,6 +120,7 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
     pyramid_request.lti_jwt = {}
     pyramid_request.lti_params = {}
     pyramid_request.product = Product.from_request(pyramid_request)
+    pyramid_request.region = Regions.US
 
     # The DummyRequest request lacks a content_type property which the real
     # request has

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -74,8 +74,19 @@ class TestFilePickerMode:
 
 class TestEnableLTILaunchMode:
     def test_it(
-        self, bearer_token_schema, context, grant_token_service, js_config, assignment
+        self,
+        bearer_token_schema,
+        context,
+        grant_token_service,
+        js_config,
+        assignment,
+        db_session,
     ):
+        context.application_instance.organization = factories.Organization(
+            _public_id="PUBLIC_ID"
+        )
+        db_session.flush()
+
         js_config.enable_lti_launch_mode(assignment)
 
         assert js_config.asdict() == {
@@ -86,7 +97,11 @@ class TestEnableLTILaunchMode:
             "canvas": {},
             "debug": {
                 "tags": [Any.string.matching("^role:.*")],
-                "values": {"LTI version": "LTI-1p0"},
+                "values": {
+                    "Organization ID": "us.lms.org.PUBLIC_ID",
+                    "Application Instance ID": context.application_instance.id,
+                    "LTI version": "LTI-1p0",
+                },
             },
             "dev": False,
             "hypothesisClient": {

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -263,7 +263,7 @@ class TestEnableGradingBar:
             "assignmentName": pyramid_request.lti_params["resource_link_title"],
             "students": [
                 {
-                    "userid": f"acct:{grading_info.h_username}@TEST_AUTHORITY",
+                    "userid": f"acct:{grading_info.h_username}@lms.hypothes.is",
                     "displayName": grading_info.h_display_name,
                     "lmsId": grading_info.user_id,
                     "LISResultSourcedId": grading_info.lis_result_sourcedid,

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -27,7 +27,7 @@ class TestHAPI:
                     {
                         "body": Any.object.with_attrs(
                             {
-                                "effective_user": "acct:lms@TEST_AUTHORITY",
+                                "effective_user": "acct:lms@lms.hypothes.is",
                                 "total_instructions": 3,
                             }
                         )
@@ -58,7 +58,7 @@ class TestHAPI:
         user = h_api.get_user("username")
 
         _api_request.assert_called_once_with(
-            "GET", path="users/acct:username@TEST_AUTHORITY"
+            "GET", path="users/acct:username@lms.hypothes.is"
         )
 
         assert user == HUser(username="username", display_name=sentinel.display_name)

--- a/tests/unit/lms/views/api/gateway_test.py
+++ b/tests/unit/lms/views/api/gateway_test.py
@@ -88,7 +88,7 @@ class Test_GatewayService:
         assert data["profile"] == {
             "display_name": sentinel.display_name,
             "lti": {"user_id": sentinel.user_id},
-            "userid": Any.string.matching("^acct:.*@TEST_AUTHORITY$"),
+            "userid": Any.string.matching("^acct:.*@lms.hypothes.is$"),
         }
 
     def test_tender_lti_context_renders_groups(
@@ -105,7 +105,7 @@ class Test_GatewayService:
 
         assert data["groups"] == [
             {
-                "groupid": "group:course_authority_provided_id@TEST_AUTHORITY",
+                "groupid": "group:course_authority_provided_id@lms.hypothes.is",
                 "name": "course_lms_name",
                 "lms": {
                     "id": course.lms_id,
@@ -114,7 +114,7 @@ class Test_GatewayService:
                 },
             },
             {
-                "groupid": "group:grouping_authority_provided_id@TEST_AUTHORITY",
+                "groupid": "group:grouping_authority_provided_id@lms.hypothes.is",
                 "name": "grouping_lms_name",
                 "lms": {
                     "id": grouping.lms_id,


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4204

This adds dumping a few extra values into the console, including the org id.

## Testing notes

 * Start everything
 * Checkout `orgs-auto-assign` - https://github.com/hypothesis/lms/issues/4202
 * Look at https://hypothesis.instructure.com/courses/125/assignments/873
 * This will create an org
 * Checkout this branch
 * Look at https://hypothesis.instructure.com/courses/125/assignments/873
 * Open the debug F12 menu and checkout the logs