### PR TITLE
Fix org backfill migration that caused each AI to get it's own org

### DIFF
--- a/lms/migrations/versions/52755322151e_db_migration_to_back_fill_organizations.sql
+++ b/lms/migrations/versions/52755322151e_db_migration_to_back_fill_organizations.sql
@@ -59,5 +59,5 @@ SELECT
     ids_and_guids_right.application_instance_id AS right_id
 FROM ids_and_guids AS ids_and_guids_left
 JOIN ids_and_guids AS ids_and_guids_right
-    ON ids_and_guids_left.application_instance_id = ids_and_guids_right.application_instance_id
+    ON ids_and_guids_left.guid = ids_and_guids_right.guid
 GROUP BY left_id, right_id


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4201

The problem was a silly mistake joining on application instance id, rather than guid. Meaning every application instance was only paired with itself, rather than with other application instances with matching GUIDs.

## Review notes

If you want more detailed debugging, then I suggest printing out the edges and grouped items to understand what's going on.

## Testing notes

 * Start everything
 * Ensure you have a clean DB state
```shell
make services args=down
make services db devdata
hdev alembic upgrade head
hdev alembic downgrade -1
```
* Visit different application instance assignments with the same GUID:
  * https://hypothesis.instructure.com/courses/319/assignments/3308
  * https://hypothesis.instructure.com/courses/125/assignments/873
* Observe that the two application instances are auto assigned to the same new org (bonus testing!)
* `hdev alembic upgrade head`
* The output should mention creating an org for two instances:
> Creating new organizations...
>	Creating 'University of Hypothesis' for 2 application instance(s)
> Created 1 organization(s). Done