### PR TITLE
Allow moving AI to different organizations

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -26,6 +26,7 @@ from lms.models.lti_role import LTIRole
 from lms.models.lti_user import LTIUser, display_name
 from lms.models.oauth2_token import OAuth2Token
 from lms.models.organization import Organization
+from lms.models.region import Region
 from lms.models.rsa_key import RSAKey
 from lms.models.user import User
 

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -170,6 +170,7 @@ class ApplicationInstanceService:
         deployment_id=None,
         developer_key=None,
         developer_secret=None,
+        organization_id=None,
     ):
         if lms_url:
             application_instance.lms_url = lms_url
@@ -185,6 +186,8 @@ class ApplicationInstanceService:
             encrypted_secret = self._aes_service.encrypt(aes_iv, developer_secret)
             application_instance.aes_cipher_iv = aes_iv
             application_instance.developer_secret = encrypted_secret
+
+        application_instance.organization_id = organization_id
 
     def create_application_instance(  # pylint:disable=too-many-arguments
         self,

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -4,8 +4,8 @@ from typing import List, Optional
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from lms.models import ApplicationInstance, GroupInfo, Organization
-from lms.validation import ValidationError
+from lms.models import ApplicationInstance, GroupInfo, Organization, Region
+from lms.services.public_id import get_by_public_id
 
 LOG = getLogger(__name__)
 
@@ -13,7 +13,7 @@ LOG = getLogger(__name__)
 class OrganizationService:
     """A service for dealing with organization actions."""
 
-    def __init__(self, db_session: Session, region):
+    def __init__(self, db_session: Session, region: Region):
         self._db_session = db_session
         self._region = region
 
@@ -41,39 +41,10 @@ class OrganizationService:
             .all()
         )
 
-    def get_by_public_id(self, public_id: str):
-        try:
-            region_code, app, type_, public_id = public_id.split(".")
-        except ValueError as err:
-            raise ValidationError(
-                messages={"public_id": [f"{public_id} doesn't have the right format"]}
-            ) from err
-
-        if region_code != self._region.code:
-            raise ValidationError(
-                messages={
-                    "public_id": [
-                        f"{region_code} doesn't match current region: {self._region.code}"
-                    ]
-                }
-            )
-
-        if app != "lms":
-            raise ValidationError(
-                messages={"public_id": [f"{app} doesn't match app region: lms"]}
-            )
-
-        if type_ != "org":
-            raise ValidationError(
-                messages={
-                    "public_id": [f"{type_} doesn't match organization type: 'org'"]
-                }
-            )
-
-        return (
-            self._db_session.query(Organization)
-            .filter_by(_public_id=public_id)
-            .one_or_none()
+    def get_by_public_id(self, public_id: str) -> Optional[List]:
+        """Get an organization by its public_id."""
+        return get_by_public_id(
+            self._db_session, Organization, public_id, region=self._region
         )
 
     def auto_assign_organization(

--- a/lms/services/public_id.py
+++ b/lms/services/public_id.py
@@ -1,0 +1,50 @@
+from typing import Optional, TypeVar
+
+from lms.models import Region
+from lms.validation import ValidationError
+
+Model = TypeVar("Model")
+
+
+def get_by_public_id(  # pylint:disable=too-many-arguments
+    db, model: Model, public_id: str, region: Region, app="lms", type_="org"
+) -> Optional[Model]:
+    """
+    Get a `model` by their public_id.
+
+    Public IDs have a format like:
+        region.app.type.id
+
+    eg:
+        us.lms.org.gkPHJPSRSHC7YWAYJ7s1LA
+
+    :raises ValidationError: If the given ID doesn't have the right format
+        or doesn't contain the expected constraints.
+    """
+    try:
+        id_region, id_app, id_type, id_public_id = public_id.split(".")
+    except ValueError as err:
+        raise ValidationError(
+            messages={"public_id": [f"{public_id} doesn't have the right format"]}
+        ) from err
+
+    if id_region != region.code:
+        raise ValidationError(
+            messages={
+                "public_id": [
+                    f"{id_region} doesn't match current region: {region.code}"
+                ]
+            }
+        )
+
+    if id_app != app:
+        raise ValidationError(
+            messages={"public_id": [f"{id_app} doesn't match app region: {app}"]}
+        )
+
+    if id_type != type_:
+        raise ValidationError(
+            messages={"public_id": [f"{id_type} doesn't match type: '{type_}'"]}
+        )
+
+    return db.query(model).filter_by(_public_id=id_public_id).one_or_none()

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -38,7 +38,6 @@
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Organization</legend>
         {{ macros.organization_preview(request, instance.organization) }}
-        {{ macros.form_text_field(request, "Move to organization ID", "org_public_id") }}
     </fieldset>
 
     <fieldset class="box mt-6">
@@ -120,19 +119,29 @@
     <div class="has-text-right mb-6">
         <input type="submit" class="button is-primary" value="Save" />
     </div>
+</form>
 
 
-    <fieldset class="box has-background-danger-light">
-        <legend class="label has-text-centered has-text-danger">Danger zone</legend>
+<fieldset class="box has-background-danger-light">
+    <legend class="label has-text-centered has-text-danger">Danger zone</legend>
 
-        {% call macros.field_body(label="Downgrade to LTI 1.1") %}
-            <input type="submit" class="button mb-2" formaction="{{ request.route_url("admin.instance.downgrade", id_=instance.id) }}" value="Downgrade">
+    {% call macros.field_body(label="Downgrade to LTI 1.1") %}
+        <form method="POST" action="{{ request.route_url("admin.instance.downgrade", id_=instance.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+            <input type="submit" class="button mb-2" value="Downgrade">
             <p>Downgrade this instance to LTI 1.1 removing its association with a registration and its deployment ID.</p>
             <p>This action will <b>break any existing LTI 1.3 assignments</b>. To undo it, upgrade it back again to LTI 1.3 using the same registration and deployment ID.</p>
-        {% endcall %}
+        </form>
+    {% endcall %}
 
-    </fieldset>
 
-
-</form>
+    {% call macros.field_body(label="Move to organization") %}
+        <form method="POST" action="{{ request.route_url("admin.instance.id", id_=instance.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+          <input class="input" type="text" name="org_public_id">
+          <input type="submit" class="button mb-2" value="Move">
+        </form>
+        <p>Moving this application instance might have destructive effects.</p>
+    {% endcall %}
+</fieldset>
 {% endblock %}

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -38,6 +38,7 @@
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Organization</legend>
         {{ macros.organization_preview(request, instance.organization) }}
+        {{ macros.form_text_field(request, "Move to organization ID", "org_public_id") }}
     </fieldset>
 
     <fieldset class="box mt-6">

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -12,7 +12,7 @@ from lms.services import (
     LTIRegistrationService,
     OrganizationService,
 )
-from lms.validation._base import PyramidRequestSchema, ValidationError
+from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import error_render_to_response, flash_validation
 
 
@@ -277,10 +277,9 @@ class AdminApplicationInstanceViews:
             deployment_id=self.request.params.get("deployment_id", "").strip(),
             developer_key=self.request.params.get("developer_key", "").strip(),
             developer_secret=self.request.params.get("developer_secret", "").strip(),
-            organization_public_id=(
-                self.request.params.get("org_public_id", "").strip()
-                or (
-                    # Keep the same org if no public_id is sent
+            organization_public_id=self.request.params.get("org_public_id", "").strip()
+            or (  # Keep the same org if no public_id is sent
+                (
                     ai.organization.public_id(self.request.region)
                     if ai.organization
                     else None

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -7,12 +7,8 @@ from webargs import fields
 
 from lms.models import ApplicationInstance
 from lms.security import Permissions
-from lms.services import (
-    ApplicationInstanceNotFound,
-    LTIRegistrationService,
-    OrganizationService,
-)
-from lms.validation._base import PyramidRequestSchema
+from lms.services import ApplicationInstanceNotFound, LTIRegistrationService
+from lms.validation._base import PyramidRequestSchema, ValidationError
 from lms.views.admin import error_render_to_response, flash_validation
 
 
@@ -44,9 +40,6 @@ class AdminApplicationInstanceViews:
         )
         self.lti_registration_service: LTIRegistrationService = request.find_service(
             LTIRegistrationService
-        )
-        self.organization_service: OrganizationService = request.find_service(
-            OrganizationService
         )
 
     @view_config(
@@ -271,21 +264,24 @@ class AdminApplicationInstanceViews:
     def update_instance(self):
         ai = self._get_ai_or_404(**self.request.matchdict)
 
-        self.application_instance_service.update_application_instance(
-            ai,
-            lms_url=self.request.params.get("lms_url", "").strip(),
-            deployment_id=self.request.params.get("deployment_id", "").strip(),
-            developer_key=self.request.params.get("developer_key", "").strip(),
-            developer_secret=self.request.params.get("developer_secret", "").strip(),
-            organization_public_id=self.request.params.get("org_public_id", "").strip()
-            or (  # Keep the same org if no public_id is sent
-                (
-                    ai.organization.public_id(self.request.region)
-                    if ai.organization
-                    else None
-                )
-            ),
-        )
+        try:
+            self.application_instance_service.update_application_instance(
+                ai,
+                lms_url=self.request.params.get("lms_url", "").strip(),
+                deployment_id=self.request.params.get("deployment_id", "").strip(),
+                developer_key=self.request.params.get("developer_key", "").strip(),
+                developer_secret=self.request.params.get(
+                    "developer_secret", ""
+                ).strip(),
+                organization_public_id=self.request.params.get(
+                    "org_public_id", ""
+                ).strip(),
+            )
+        except ValidationError as err:
+            self.request.session.flash(err.messages, "validation")
+            return HTTPFound(
+                location=self.request.route_url("admin.instance.id", id_=ai.id)
+            )
 
         for setting, sub_setting, setting_type in (
             ("canvas", "sections_enabled", bool),

--- a/tests/unit/lms/models/organization_test.py
+++ b/tests/unit/lms/models/organization_test.py
@@ -51,7 +51,6 @@ class TestOrganization:
     def test_public_id(self, organization, db_session):
         # Flush to ensure the default is applied
         db_session.flush()
-        print(organization.public_id(Regions.CA))
 
         assert organization.public_id(Regions.CA) == Any.string.matching(
             r"ca\.lms\.org\.[A-Za-z0-9-_]{22}"

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -11,8 +11,8 @@ from lms.services.application_instance import (
     ApplicationInstanceService,
     factory,
 )
-from tests import factories
 from lms.validation import ValidationError
+from tests import factories
 
 
 class TestApplicationInstanceService:

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -12,6 +12,7 @@ from lms.services.application_instance import (
     factory,
 )
 from tests import factories
+from lms.validation import ValidationError
 
 
 class TestApplicationInstanceService:
@@ -132,6 +133,35 @@ class TestApplicationInstanceService:
 
         if deployment_id:
             assert application_instance.deployment_id == deployment_id
+
+    def test_update_application_instance_with_invalid_org_id(
+        self, organization_service, application_instance, service
+    ):
+        organization_service.get_by_public_id.return_value = None
+
+        with pytest.raises(ValidationError):
+            service.update_application_instance(
+                application_instance, organization_public_id=mock.sentinel.org_id
+            )
+
+        organization_service.get_by_public_id.assert_called_once_with(
+            mock.sentinel.org_id
+        )
+
+    def test_update_application_instance_with_org_id(
+        self, organization_service, application_instance, service
+    ):
+        org = factories.Organization()
+        organization_service.get_by_public_id.return_value = org
+
+        service.update_application_instance(
+            application_instance, organization_public_id=mock.sentinel.org_id
+        )
+
+        organization_service.get_by_public_id.assert_called_once_with(
+            mock.sentinel.org_id
+        )
+        assert application_instance.organization == org
 
     @pytest.mark.parametrize("developer_key", ("key", None))
     @pytest.mark.parametrize("developer_secret", ("secret", None))

--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -51,13 +51,11 @@ class TestOrganizationService:
 
         assert not svc.get_by_linked_guid(None)
 
-    def test_get_by_public_id(self, svc, pyramid_request, db_session):
-        orgs = factories.Organization.create_batch(2)
-        # Set the _public_id in the models
-        db_session.flush()
+    def test_get_by_public_id(self, svc, pyramid_request, db_session, get_by_public_id):
+        svc.get_by_public_id(sentinel.public_id)
 
-        assert (
-            svc.get_by_public_id(orgs[0].public_id(pyramid_request.region)) == orgs[0]
+        get_by_public_id.assert_called_once_with(
+            db_session, Organization, sentinel.public_id, region=pyramid_request.region
         )
 
     @pytest.mark.parametrize(
@@ -132,6 +130,10 @@ class TestOrganizationService:
         return factories.ApplicationInstance(
             tool_consumer_instance_guid="guid", tool_consumer_instance_name="ai_name"
         )
+
+    @pytest.fixture
+    def get_by_public_id(self, patch):
+        return patch("lms.services.organization.get_by_public_id")
 
 
 class TestServiceFactory:

--- a/tests/unit/lms/services/public_id_test.py
+++ b/tests/unit/lms/services/public_id_test.py
@@ -1,0 +1,43 @@
+import pytest
+
+from tests import factories
+from lms.validation import ValidationError
+from lms.services.public_id import get_by_public_id
+from lms.models import Organization
+
+
+class TestGetByPublicId:
+    def test_get_by_public_id(self, pyramid_request, db_session):
+        orgs = factories.Organization.create_batch(2)
+        # Set the _public_id in the models
+        db_session.flush()
+
+        assert (
+            get_by_public_id(
+                db_session,
+                Organization,
+                orgs[0].public_id(pyramid_request.region),
+                region=pyramid_request.region,
+                app="lms",
+                type_="org",
+            )
+            == orgs[0]
+        )
+
+    @pytest.mark.parametrize(
+        "public_id",
+        ("ID", "es.lms.org.ID", "us.h.org.ID", "us.lms.user.ID"),
+        ids=["wrong format", "wrong region", "wrong app", "wrong type"],
+    )
+    def test_get_by_public_id_with_invalid(
+        self, public_id, db_session, pyramid_request
+    ):
+        with pytest.raises(ValidationError):
+            get_by_public_id(
+                db_session,
+                Organization,
+                public_id,
+                region=pyramid_request.region,
+                app="lms",
+                type_="org",
+            )

--- a/tests/unit/lms/services/public_id_test.py
+++ b/tests/unit/lms/services/public_id_test.py
@@ -1,9 +1,9 @@
 import pytest
 
-from tests import factories
-from lms.validation import ValidationError
-from lms.services.public_id import get_by_public_id
 from lms.models import Organization
+from lms.services.public_id import get_by_public_id
+from lms.validation import ValidationError
+from tests import factories
 
 
 class TestGetByPublicId:

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -314,6 +314,7 @@ class TestAdminApplicationInstanceViews:
     @pytest.mark.parametrize("secret", (" ", " secret "))
     @pytest.mark.parametrize("lms_url", (" ", "http://some-url.com    "))
     @pytest.mark.parametrize("deployment_id", (" ", " DEPLOYMENT_ID"))
+    @pytest.mark.parametrize("org_public_id", (" ", " ORG_ID"))
     def test_update_application_instance(
         self,
         pyramid_request,
@@ -323,12 +324,14 @@ class TestAdminApplicationInstanceViews:
         secret,
         lms_url,
         deployment_id,
+        org_public_id,
     ):
         pyramid_request.params = {
             "developer_key": key,
             "developer_secret": secret,
             "lms_url": lms_url,
             "deployment_id": deployment_id,
+            "org_public_id": org_public_id,
         }
 
         views.update_instance()
@@ -339,7 +342,7 @@ class TestAdminApplicationInstanceViews:
             deployment_id=deployment_id.strip() if deployment_id else "",
             developer_key=key.strip() if key else "",
             developer_secret=secret.strip() if secret else "",
-            organization_public_id=application_instance_service.get_by_id.return_value.organization.public_id.return_value,
+            organization_public_id=org_public_id.strip() if secret else "",
         )
 
     @pytest.mark.parametrize(
@@ -382,50 +385,18 @@ class TestAdminApplicationInstanceViews:
         )
         assert application_instance.settings.get(setting, sub_setting) == expected
 
-    def test_update_application_instance_organization_id(
+    def test_update_application_instance_invalid_organization_id(
         self, pyramid_request, application_instance_service, views
     ):
 
         pyramid_request.params["org_public_id"] = "PUBLIC_ID"
-
-        views.update_instance()
-
-        application_instance_service.update_application_instance.assert_called_once_with(
-            application_instance_service.get_by_id.return_value,
-            lms_url=Any(),
-            deployment_id=Any(),
-            developer_key=Any(),
-            developer_secret=Any(),
-            organization_public_id="PUBLIC_ID",
-        )
-
-    def test_update_application_instance_not_found_organization_id(
-        self, pyramid_request, application_instance_service, views, organization_service
-    ):
-
-        pyramid_request.params["org_public_id"] = "PUBLIC_ID"
-        organization_service.get_by_public_id.return_value = None
-
-        response = views.update_instance()
-
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url(
-                "admin.instance.id",
-                id_=application_instance_service.get_by_id.return_value.id,
-            )
-        )
-
-    def test_update_application_instance_invalid_organization_id(
-        self, pyramid_request, application_instance_service, views, organization_service
-    ):
-
-        pyramid_request.params["org_public_id"] = "PUBLIC_ID"
-        organization_service.get_by_public_id.side_effect = ValidationError(
-            messages=sentinel.messages
+        application_instance_service.update_application_instance.side_effect = (
+            ValidationError(messages=sentinel.messages)
         )
 
         response = views.update_instance()
 
+        assert pyramid_request.session.peek_flash("validation")
         assert response == temporary_redirect_to(
             pyramid_request.route_url(
                 "admin.instance.id",

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -329,7 +329,6 @@ class TestAdminApplicationInstanceViews:
             "developer_secret": secret,
             "lms_url": lms_url,
             "deployment_id": deployment_id,
-            "org_public_id": "",
         }
 
         views.update_instance()
@@ -340,7 +339,7 @@ class TestAdminApplicationInstanceViews:
             deployment_id=deployment_id.strip() if deployment_id else "",
             developer_key=key.strip() if key else "",
             developer_secret=secret.strip() if secret else "",
-            organization_id=application_instance_service.get_by_id.return_value.organization_id,
+            organization_public_id=application_instance_service.get_by_id.return_value.organization.public_id.return_value,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/4417

this doesn't yet tackle:

- Creating a new organisation from an application instance


# Testing 

- Go to an AI that has an organization
- Save without filling the new field with any value. Nothing will  update
- Save with an invalid/non existing ID. You'll get feedback on the error.
- Save with an existing valid ID. The organization wolud be updated.