### PR TITLE
Audit changes made to `organization.enabled`

### DIFF
--- a/lms/events/__init__.py
+++ b/lms/events/__init__.py
@@ -1,1 +1,1 @@
-from lms.events.event import BaseEvent, LTIEvent
+from lms.events.event import AuditTrailEvent, BaseEvent, LTIEvent

--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass, field, fields
 from typing import List, Optional
 
 from pyramid.request import Request
+from sqlalchemy import inspect
 
+from lms.db import BASE
 from lms.models import EventType
 from lms.services.lti_role_service import LTIRoleService
 
@@ -11,6 +13,9 @@ from lms.services.lti_role_service import LTIRoleService
 @dataclass
 class BaseEvent:  # pylint:disable=too-many-instance-attributes
     """Base class for generic events."""
+
+    Type = EventType.Type
+    """Expose the type here for the callers convenience"""
 
     request: Request
     """Reference to the current request"""
@@ -52,9 +57,6 @@ class LTIEvent(BaseEvent):
     """
 
     # pylint:disable=no-member
-
-    Type = EventType.Type
-    """Expose the type here for the callers convenience"""
 
     def _get_user_id(self):
         return self.request.user.id
@@ -101,3 +103,60 @@ class LTIEvent(BaseEvent):
             return assignment.id
 
         return None
+
+
+@dataclass
+class AuditTrailEvent(BaseEvent):
+    type: EventType.Type = EventType.Type.AUDIT_TRAIL
+
+    instance: BASE = None
+    """Object for which we are tracking changes"""
+
+    action: str = None
+    """What happen to the object: crated,updated,deleted..."""
+
+    source: str = None
+    """In which context the change happen"""
+
+    def _get_data(self):
+        """
+        Fill the event's data value.
+
+        This is called on BaseEvent.__post_init__
+        """
+        changes = {}
+        instance_details = inspect(self.instance)
+        for attr in instance_details.attrs:
+            history = instance_details.get_history(attr.key, True)
+
+            if not history.has_changes():
+                continue
+
+            changes[attr.key] = (
+                history.deleted[0] if history.deleted else None,
+                history.added[0] if history.added else None,
+            )
+
+        return {
+            "model": self.instance.__class__.__name__,
+            "id": self.instance.id,
+            "action": self.action,
+            "source": self.source,
+            # LTI users will have a FK to the User table.
+            # userid is useful for other authentication methods.
+            # For example this will be the user's email while using google oauth.
+            "userid": self.request.identity.userid,
+            "changes": changes,
+        }
+
+    @staticmethod
+    def notify(request: Request, instance: BASE, source="admin_pages"):
+        if request.db.is_modified(instance):
+            request.registry.notify(
+                AuditTrailEvent(
+                    request=request,
+                    instance=instance,
+                    action="update",
+                    source=source,
+                )
+            )

--- a/lms/models/event.py
+++ b/lms/models/event.py
@@ -13,6 +13,7 @@ class EventType(BASE):
     class Type(str, Enum):
         CONFIGURED_LAUNCH = "configured_launch"
         DEEP_LINKING = "deep_linking"
+        AUDIT_TRAIL = "audit"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     type = varchar_enum(Type)

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -3,6 +3,7 @@ from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from pyramid.view import view_config, view_defaults
 from webargs import fields
 
+from lms.events import AuditTrailEvent
 from lms.models import Organization
 from lms.security import Permissions
 from lms.services import OrganizationService
@@ -92,7 +93,9 @@ class AdminOrganizationViews:
             org, enabled=self.request.params.get("enabled", "") == "on"
         )
 
+        AuditTrailEvent.notify(self.request, org)
         self.request.session.flash("Updated organization", "messages")
+
         return {"org": org}
 
     @view_config(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,6 +11,7 @@ from lms.db import SESSION
 from lms.models import ApplicationSettings
 from lms.models.region import Regions
 from lms.product import Product
+from lms.security import Identity
 from tests import factories
 from tests.conftest import TEST_SETTINGS, get_test_database_url
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -149,7 +150,7 @@ def configure_jinja2_assets(config):
 
 
 @pytest.fixture
-def pyramid_config(pyramid_request):
+def pyramid_config(pyramid_request, lti_v11_params):
     """
     Return a test Pyramid config (Configurator) object.
 
@@ -159,6 +160,12 @@ def pyramid_config(pyramid_request):
     """
 
     with testing.testConfig(request=pyramid_request, settings=TEST_SETTINGS) as config:
+        # Align request.identity with request.lti_user
+        config.testing_securitypolicy(
+            userid=lti_v11_params["user_id"],
+            identity=Identity(lti_v11_params["user_id"], permissions=[]),
+        )
+
         config.include("pyramid_jinja2")
         config.include("pyramid_services")
         config.include("pyramid_tm")

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -66,7 +66,13 @@ class TestAdminOrganizationViews:
 
     @pytest.mark.parametrize("value,expected", [("", False), ("on", True)])
     def test_toggle_organization_enabled(
-        self, value, expected, pyramid_request, organization_service, views
+        self,
+        value,
+        expected,
+        pyramid_request,
+        organization_service,
+        views,
+        AuditTrailEvent,
     ):
         pyramid_request.matchdict["id_"] = sentinel.id_
         pyramid_request.params["enabled"] = value
@@ -77,6 +83,13 @@ class TestAdminOrganizationViews:
         organization_service.update_organization(
             organization_service.get_by_id.return_value, enabled=expected
         )
+        AuditTrailEvent.notify.assert_called_once_with(
+            pyramid_request, organization_service.get_by_id.return_value
+        )
+
+    @pytest.fixture
+    def AuditTrailEvent(self, patch):
+        return patch("lms.views.admin.organization.AuditTrailEvent")
 
     def test_search_by_public_id(self, pyramid_request, organization_service, views):
         pyramid_request.params["public_id"] = sentinel.public_id


### PR DESCRIPTION
The audit mechanism is more general than strictly needed for keeping changes for `enabled`.

My plan is to apply this to other type of objects in the admin pages. Ideally with one liner PRs after some testing.

## Testing

- Go over the admin pages, to one particular organization 
- Toggle the enabled status at the bottom
- Check the audit trail on the database with a query like:

```
select * from event 
join event_data on event.id = event_data.event_id 
join event_type on event.type_id = event_type.id
where type ='audit';
```
