### PR TITLE
Fix deeplinking requests missing `deep_linking_settings`

### DIFF
--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -136,7 +136,8 @@ class DeepLinkingFieldsViews:
         #
         # This claim is required if present in the `LtiDeepLinkingRequest`
         # message.
-        if data := self.request.parsed_params["deep_linking_settings"].get("data"):
+        settings = self.request.parsed_params["deep_linking_settings"] or {}
+        if data := settings.get("data"):
             message["https://purl.imsglobal.org/spec/lti-dl/claim/data"] = data
 
         self.request.registry.notify(

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -94,10 +94,11 @@ class TestDeepLinkingFieldsView:
         assert fields["JWT"] == jwt_service.encode_with_private_key.return_value
 
     @pytest.mark.usefixtures("LTIEvent")
+    @pytest.mark.parametrize("settings", [None, {}, {"data": None}])
     def test_it_for_v13_missing_deep_linking_settings_data(
-        self, jwt_service, views, pyramid_request
+        self, jwt_service, views, pyramid_request, settings
     ):
-        del pyramid_request.parsed_params["deep_linking_settings"]["data"]
+        pyramid_request.parsed_params["deep_linking_settings"] = settings
 
         views.file_picker_to_form_fields_v13()
 


### PR DESCRIPTION
For https://github.com/hypothesis/lms/issues/4438

It looks like most LMS don't send a `data` field but there at least a few instances where the whole `deep_linking_settings` is not present.