### PR TITLE
Move @babel/preset-typescript from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/core": "^7.19.0",
     "@babel/preset-env": "^7.18.10",
     "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.18.6",
     "@hypothesis/frontend-build": "1.2.0",
     "@hypothesis/frontend-shared": "5.4.2",
     "@rollup/plugin-babel": "^5.3.1",
@@ -55,7 +56,6 @@
     "tiny-emitter": "^2.1.0"
   },
   "devDependencies": {
-    "@babel/preset-typescript": "^7.18.6",
     "@types/gapi": "^0.0.42",
     "@typescript-eslint/eslint-plugin": "^5.35.1",
     "@typescript-eslint/parser": "^5.35.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,6 +3413,11 @@ function.prototype.name@^1.1.5:
     es-abstract "^1.19.0"
     functions-have-names "^1.2.2"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+
 functions-have-names@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.1.tgz#a981ac397fa0c9964551402cdc5533d7a4d52f91"


### PR DESCRIPTION
This package is needed during the Docker build, and packages listed in
devDependencies are not installed in that context.
