### PR TITLE
Fix result retrieval for cases for `None` values

### DIFF
--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -39,7 +39,7 @@ class LTI13GradingService(LTIGradingService):
 
         try:
             return results[-1]["resultScore"] / results[-1]["resultMaximum"]
-        except (ZeroDivisionError, KeyError, IndexError):
+        except (TypeError, ZeroDivisionError, KeyError, IndexError):
             return None
 
     def record_result(self, grading_id, score=None, pre_record_hook=None):

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, sentinel
 import pytest
 from freezegun import freeze_time
 from h_matchers import Any
+from pytest import param
 
 from lms.services.exceptions import ExternalRequestError
 from lms.services.lti_grading._v13 import LTI13GradingService
@@ -50,9 +51,10 @@ class TestLTI13GradingService:
     @pytest.mark.parametrize(
         "bad_response",
         (
-            [{"resultScore": 1, "resultMaximum": 0}],
-            [{"resultScore": 1}],
-            [{"resultMaximum": 10}],
+            param([{"resultScore": None, "resultMaximum": 100}], id="TypeError"),
+            param([{"resultScore": 1, "resultMaximum": 0}], id="ZeroDivisionError"),
+            param([{"resultScore": 1}], id="KeyError (max)"),
+            param([{"resultMaximum": 10}], id="KeyError (score)"),
         ),
     )
     def test_read_bad_response_lti_result(self, svc, ltia_http_service, bad_response):


### PR DESCRIPTION
For:  https://github.com/hypothesis/lms/issues/4443 
Fixes: https://sentry.io/organizations/hypothesis/issues/3486870164/?project=259908

Until now we only seen LMS not sending a value at all when there's no grade but some LMS seem to send a `None` value instead.


https://hypothes-is.slack.com/archives/C2BLQDKHA/p1663045160950229
