### PR TITLE
Insert new event types when first seen.

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -85,7 +85,7 @@ BASE = declarative_base(
 )
 
 
-def init(engine, drop=False, stamp=True, data=True):  # pragma: nocover
+def init(engine, drop=False, stamp=True):  # pragma: nocover
     """
     Create all the database tables if they don't already exist.
 
@@ -99,7 +99,6 @@ def init(engine, drop=False, stamp=True, data=True):  # pragma: nocover
     :param engine: the sqlalchemy Engine object
     :param drop: whether or not to delete existing tables
     :param stamp: whether or not to stamp alembic latest revision
-    :param data: whether or not to create any data needed by the application
     """
     try:
         engine.execute("select 1 from alembic_version")
@@ -110,25 +109,6 @@ def init(engine, drop=False, stamp=True, data=True):  # pragma: nocover
 
         if stamp:
             alembic.command.stamp(alembic.config.Config("conf/alembic.ini"), "head")
-
-        if data:
-            create_data(engine)
-
-
-def create_data(engine):
-    """
-    Create any data needed for the application.
-
-    This type of data is usually crated by migrations which are not executed
-    while using `init` above
-
-    Creating it here allows the data to available in the development environment and tests.
-    """
-    engine.execute(
-        """INSERT INTO event_type (type)
-        VALUES ('configured_launch'), ('deep_linking')
-        ON CONFLICT DO NOTHING"""
-    )
 
 
 def make_engine(settings):

--- a/lms/services/event.py
+++ b/lms/services/event.py
@@ -41,7 +41,13 @@ class EventService:
     @lru_cache(maxsize=10)
     def _get_type_pk(self, type_: EventType.Type) -> int:
         """Cache the PK of the event_type table to avoid an extra query while inserting events."""
-        return self._db.query(EventType).filter_by(type=type_).one().id
+        event_type = self._db.query(EventType).filter_by(type=type_).one_or_none()
+        if not event_type:
+            event_type = EventType(type=type_)
+            self._db.add(event_type)
+            self._db.flush()
+
+        return event_type.id
 
 
 def factory(_context, request):

--- a/tests/unit/lms/services/event_test.py
+++ b/tests/unit/lms/services/event_test.py
@@ -60,6 +60,27 @@ class TestEventService:
         )
         assert not db_session.query(EventData).one_or_none()
 
+    def test_insert_event_type(self, svc, db_session):
+        type_query = db_session.query(EventType).filter_by(
+            type=EventType.Type.CONFIGURED_LAUNCH
+        )
+
+        # Insert the event type for the first time
+        svc.insert_event(
+            BaseEvent(request=sentinel.request, type=EventType.Type.CONFIGURED_LAUNCH)
+        )
+
+        # It will create a new type
+        event_type = type_query.one()
+        # Clear the @lru_cache of the private method
+        svc._get_type_pk.cache_clear()  # pylint:disable=protected-access
+        # Insert the event type again
+        svc.insert_event(
+            BaseEvent(request=sentinel.request, type=EventType.Type.CONFIGURED_LAUNCH)
+        )
+        # The type is the same as the first insert
+        assert event_type == type_query.one()
+
     @pytest.fixture
     def svc(self, db_session):
         return EventService(db_session)


### PR DESCRIPTION
Instead of keeping them in sync with migrations and other methods for testing.