### PR TITLE
Add user ID and browser ID info to JSTOR API requests

### DIFF
--- a/lms/services/jstor/factory.py
+++ b/lms/services/jstor/factory.py
@@ -8,10 +8,20 @@ def service_factory(_context, request):
 
     app_settings = request.registry.settings
 
+    # The h username is passed to JSTOR as a tracking ID because it is a
+    # conveniently available unique user ID in a standardized format and doesn't
+    # contain private info (email addresses etc.).
+    if request.lti_user:
+        tracking_user_id = request.lti_user.h_user.username
+    else:
+        tracking_user_id = None
+
     return JSTORService(
         api_url=app_settings.get("jstor_api_url"),
         secret=app_settings.get("jstor_api_secret"),
         enabled=ai_settings.get("jstor", "enabled"),
         site_code=ai_settings.get("jstor", "site_code"),
         http_service=request.find_service(name="http"),
+        tracking_user_agent=request.headers.get("User-Agent", None),
+        tracking_user_id=tracking_user_id,
     )

--- a/lms/services/jstor/factory.py
+++ b/lms/services/jstor/factory.py
@@ -8,20 +8,18 @@ def service_factory(_context, request):
 
     app_settings = request.registry.settings
 
-    # The h username is passed to JSTOR as a tracking ID because it is a
-    # conveniently available unique user ID in a standardized format and doesn't
-    # contain private info (email addresses etc.).
-    if request.lti_user:
-        tracking_user_id = request.lti_user.h_user.username
-    else:
-        tracking_user_id = None
-
     return JSTORService(
         api_url=app_settings.get("jstor_api_url"),
         secret=app_settings.get("jstor_api_secret"),
         enabled=ai_settings.get("jstor", "enabled"),
         site_code=ai_settings.get("jstor", "site_code"),
-        http_service=request.find_service(name="http"),
-        tracking_user_agent=request.headers.get("User-Agent", None),
-        tracking_user_id=tracking_user_id,
+        # The h username is passed to JSTOR as a tracking ID because it is a
+        # conveniently available unique user ID in a standardized format and
+        # doesn't contain private info (email addresses etc.).
+        headers={
+            "Tracking-User-ID": request.lti_user.h_user.username
+            if request.lti_user
+            else None,
+            "Tracking-User-Agent": request.headers.get("User-Agent", None),
+        },
     )

--- a/lms/services/jstor/service.py
+++ b/lms/services/jstor/service.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Optional
 from urllib.parse import quote
 
 import requests
@@ -22,7 +23,16 @@ class JSTORService:
     """Used when no DOI prefix can be found."""
 
     # pylint: disable=too-many-arguments
-    def __init__(self, api_url, secret, enabled, site_code, http_service: HTTPService):
+    def __init__(
+        self,
+        api_url,
+        secret,
+        enabled,
+        site_code,
+        http_service: HTTPService,
+        tracking_user_id: Optional[str],
+        tracking_user_agent: Optional[str],
+    ):
         """
         Initialise the JSTOR service.
 
@@ -31,6 +41,8 @@ class JSTORService:
         :param enabled: Whether JSTOR is enabled on this instance
         :param site_code: The site code to use to identify the organization
         :param http_service: HTTPService instance
+        :param tracking_user_id: Unique user ID, passed to JSTOR for analytics purposes
+        :param tracking_user_agent: User-Agent header from user's browser, passed to JSTOR for analytics purposes
         """
         self._api_url = api_url
         self._secret = secret
@@ -38,6 +50,8 @@ class JSTORService:
         self._site_code = site_code
 
         self._http = http_service
+        self._tracking_user_id = tracking_user_id
+        self._tracking_user_agent = tracking_user_agent
 
     @property
     def enabled(self) -> bool:
@@ -169,6 +183,15 @@ class JSTORService:
             secret=self._secret,
             lifetime=timedelta(hours=1),
         )
+        headers = {"Authorization": f"Bearer {token}"}
+
+        if self._tracking_user_id:
+            headers["Tracking-User-ID"] = self._tracking_user_id
+        if self._tracking_user_agent:
+            headers["Tracking-User-Agent"] = self._tracking_user_agent
+
         return self._http.get(
-            url=url, headers={"Authorization": f"Bearer {token}"}, params=params
+            url=url,
+            headers=headers,
+            params=params,
         )

--- a/lms/services/jstor/service.py
+++ b/lms/services/jstor/service.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import Optional
 from urllib.parse import quote
 
 import requests
@@ -23,16 +22,7 @@ class JSTORService:
     """Used when no DOI prefix can be found."""
 
     # pylint: disable=too-many-arguments
-    def __init__(
-        self,
-        api_url,
-        secret,
-        enabled,
-        site_code,
-        http_service: HTTPService,
-        tracking_user_id: Optional[str],
-        tracking_user_agent: Optional[str],
-    ):
+    def __init__(self, api_url, secret, enabled, site_code, headers=None):
         """
         Initialise the JSTOR service.
 
@@ -40,18 +30,16 @@ class JSTORService:
         :param secret: Secret for authenticating with JSTOR
         :param enabled: Whether JSTOR is enabled on this instance
         :param site_code: The site code to use to identify the organization
-        :param http_service: HTTPService instance
-        :param tracking_user_id: Unique user ID, passed to JSTOR for analytics purposes
-        :param tracking_user_agent: User-Agent header from user's browser, passed to JSTOR for analytics purposes
+        :param headers: Additional headers to pass onto JSTOR when making
+            requests
         """
         self._api_url = api_url
         self._secret = secret
         self._enabled = enabled
         self._site_code = site_code
 
-        self._http = http_service
-        self._tracking_user_id = tracking_user_id
-        self._tracking_user_agent = tracking_user_agent
+        self._http = HTTPService()
+        self._http.session.headers = headers
 
     @property
     def enabled(self) -> bool:
@@ -183,15 +171,6 @@ class JSTORService:
             secret=self._secret,
             lifetime=timedelta(hours=1),
         )
-        headers = {"Authorization": f"Bearer {token}"}
-
-        if self._tracking_user_id:
-            headers["Tracking-User-ID"] = self._tracking_user_id
-        if self._tracking_user_agent:
-            headers["Tracking-User-Agent"] = self._tracking_user_agent
-
         return self._http.get(
-            url=url,
-            headers=headers,
-            params=params,
+            url=url, headers={"Authorization": f"Bearer {token}"}, params=params
         )

--- a/tests/unit/lms/services/jstor/factory_test.py
+++ b/tests/unit/lms/services/jstor/factory_test.py
@@ -7,9 +7,44 @@ from lms.services.jstor.factory import service_factory
 
 
 class TestServiceFactory:
-    def test_it(
-        self, pyramid_request, application_instance_service, http_service, JSTORService
+    def test_it(self, pyramid_request, http_service, JSTORService):
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        JSTORService.assert_called_once_with(
+            api_url=sentinel.jstor_api_url,
+            secret=sentinel.jstor_api_secret,
+            enabled=sentinel.jstor_enabled,
+            site_code=sentinel.jstor_site_code,
+            http_service=http_service,
+            tracking_user_agent="Chrome 100",
+            tracking_user_id=pyramid_request.lti_user.h_user.username,
+        )
+        assert svc == JSTORService.return_value
+
+    def test_it_omits_tracking_info_if_not_available(
+        self, pyramid_request, http_service, JSTORService
     ):
+        del pyramid_request.headers["User-Agent"]
+        pyramid_request.lti_user = None
+
+        service_factory(sentinel.context, pyramid_request)
+
+        JSTORService.assert_called_once_with(
+            api_url=sentinel.jstor_api_url,
+            secret=sentinel.jstor_api_secret,
+            enabled=sentinel.jstor_enabled,
+            site_code=sentinel.jstor_site_code,
+            http_service=http_service,
+            tracking_user_agent=None,
+            tracking_user_id=None,
+        )
+
+    @pytest.fixture
+    def JSTORService(self, patch):
+        return patch("lms.services.jstor.factory.JSTORService")
+
+    @pytest.fixture(autouse=True)
+    def application_instance_service(self, application_instance_service):
         application_instance_service.get_current.return_value.settings = (
             ApplicationSettings(
                 {
@@ -20,24 +55,19 @@ class TestServiceFactory:
                 }
             )
         )
-        pyramid_request.registry.settings.update(
+        return application_instance_service
+
+    @pytest.fixture(autouse=True)
+    def pyramid_config(self, pyramid_config):
+        pyramid_config.registry.settings.update(
             {
                 "jstor_api_url": sentinel.jstor_api_url,
                 "jstor_api_secret": sentinel.jstor_api_secret,
             }
         )
+        return pyramid_config
 
-        svc = service_factory(sentinel.context, pyramid_request)
-
-        JSTORService.assert_called_once_with(
-            api_url=sentinel.jstor_api_url,
-            secret=sentinel.jstor_api_secret,
-            enabled=sentinel.jstor_enabled,
-            site_code=sentinel.jstor_site_code,
-            http_service=http_service,
-        )
-        assert svc == JSTORService.return_value
-
-    @pytest.fixture
-    def JSTORService(self, patch):
-        return patch("lms.services.jstor.factory.JSTORService")
+    @pytest.fixture(autouse=True)
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.headers["User-Agent"] = "Chrome 100"
+        return pyramid_request

--- a/tests/unit/lms/services/jstor/factory_test.py
+++ b/tests/unit/lms/services/jstor/factory_test.py
@@ -2,7 +2,6 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.models import ApplicationSettings
 from lms.services.jstor.factory import service_factory
 
 
@@ -17,22 +16,13 @@ class TestServiceFactory:
         user_agent,
         with_user,
     ):
-        application_instance_service.get_current.return_value.settings = (
-            ApplicationSettings(
-                {
-                    "jstor": {
-                        "enabled": sentinel.jstor_enabled,
-                        "site_code": sentinel.jstor_site_code,
-                    }
-                }
-            )
-        )
-        pyramid_request.registry.settings.update(
-            {
-                "jstor_api_url": sentinel.jstor_api_url,
-                "jstor_api_secret": sentinel.jstor_api_secret,
-            }
-        )
+        ai_settings = application_instance_service.get_current.return_value.settings
+        ai_settings.set("jstor", "enabled", sentinel.jstor_enabled)
+        ai_settings.set("jstor", "site_code", sentinel.jstor_site_code)
+
+        reg_settings = pyramid_request.registry.settings
+        reg_settings["jstor_api_url"] = sentinel.jstor_api_url
+        reg_settings["jstor_api_secret"] = sentinel.jstor_api_secret
 
         if user_agent:
             pyramid_request.headers["User-Agent"] = user_agent

--- a/tests/unit/lms/services/jstor/factory_test.py
+++ b/tests/unit/lms/services/jstor/factory_test.py
@@ -7,44 +7,16 @@ from lms.services.jstor.factory import service_factory
 
 
 class TestServiceFactory:
-    def test_it(self, pyramid_request, http_service, JSTORService):
-        svc = service_factory(sentinel.context, pyramid_request)
-
-        JSTORService.assert_called_once_with(
-            api_url=sentinel.jstor_api_url,
-            secret=sentinel.jstor_api_secret,
-            enabled=sentinel.jstor_enabled,
-            site_code=sentinel.jstor_site_code,
-            http_service=http_service,
-            tracking_user_agent="Chrome 100",
-            tracking_user_id=pyramid_request.lti_user.h_user.username,
-        )
-        assert svc == JSTORService.return_value
-
-    def test_it_omits_tracking_info_if_not_available(
-        self, pyramid_request, http_service, JSTORService
+    @pytest.mark.parametrize("user_agent", ("Example UA", None))
+    @pytest.mark.parametrize("with_user", (True, False))
+    def test_it(
+        self,
+        pyramid_request,
+        application_instance_service,
+        JSTORService,
+        user_agent,
+        with_user,
     ):
-        del pyramid_request.headers["User-Agent"]
-        pyramid_request.lti_user = None
-
-        service_factory(sentinel.context, pyramid_request)
-
-        JSTORService.assert_called_once_with(
-            api_url=sentinel.jstor_api_url,
-            secret=sentinel.jstor_api_secret,
-            enabled=sentinel.jstor_enabled,
-            site_code=sentinel.jstor_site_code,
-            http_service=http_service,
-            tracking_user_agent=None,
-            tracking_user_id=None,
-        )
-
-    @pytest.fixture
-    def JSTORService(self, patch):
-        return patch("lms.services.jstor.factory.JSTORService")
-
-    @pytest.fixture(autouse=True)
-    def application_instance_service(self, application_instance_service):
         application_instance_service.get_current.return_value.settings = (
             ApplicationSettings(
                 {
@@ -55,19 +27,34 @@ class TestServiceFactory:
                 }
             )
         )
-        return application_instance_service
-
-    @pytest.fixture(autouse=True)
-    def pyramid_config(self, pyramid_config):
-        pyramid_config.registry.settings.update(
+        pyramid_request.registry.settings.update(
             {
                 "jstor_api_url": sentinel.jstor_api_url,
                 "jstor_api_secret": sentinel.jstor_api_secret,
             }
         )
-        return pyramid_config
 
-    @pytest.fixture(autouse=True)
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.headers["User-Agent"] = "Chrome 100"
-        return pyramid_request
+        if user_agent:
+            pyramid_request.headers["User-Agent"] = user_agent
+        if not with_user:
+            pyramid_request.lti_user = None
+
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        JSTORService.assert_called_once_with(
+            api_url=sentinel.jstor_api_url,
+            secret=sentinel.jstor_api_secret,
+            enabled=sentinel.jstor_enabled,
+            site_code=sentinel.jstor_site_code,
+            headers={
+                "Tracking-User-ID": pyramid_request.lti_user.h_user.username
+                if with_user
+                else None,
+                "Tracking-User-Agent": user_agent,
+            },
+        )
+        assert svc == JSTORService.return_value
+
+    @pytest.fixture
+    def JSTORService(self, patch):
+        return patch("lms.services.jstor.factory.JSTORService")


### PR DESCRIPTION
Add a unique user ID and user agent (browser) information to JSTOR API requests as `Tracking-User-ID` and `Tracking-User-Agent` headers respectively. These are needed by JSTOR for usage counting purposes. See https://github.com/hypothesis/lms/issues/4340 for background.

Example of the headers that are now sent with each API request:

```py
{'Authorization': 'Bearer ...', 'Tracking-User-ID': '3a022b6c146dfd9df4ea8662178eac', 'Tracking-User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36'
```

Fixes https://github.com/hypothesis/lms/issues/4340