### PR TITLE
Make sure newly created Organization have IDs

### DIFF
--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -65,10 +65,14 @@ class OrganizationService:
                     "Multiple organization matches found for application instance %s",
                     application_instance.id,
                 )
+
             org = orgs[0]
 
         else:
             org = Organization()
+            self._db_session.add(org)
+            # Ensure we have ids
+            self._db_session.flush()
 
         # Fill out missing names
         if not org.name and (name := application_instance.tool_consumer_instance_name):

--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -76,6 +76,9 @@ class TestOrganizationService:
         assert application_instance.organization == result
         if org:
             assert result == org
+        else:
+            # For the newly created org case, make sure we have an ID
+            assert result.id
 
         assert result == Any.instance_of(Organization).with_attrs({"name": name})
 


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/4448


Both PK and a `_public_id`. In some cases this might work as:

- The new org is added to the session implicitly on the AI relationship.

- Any query or the final commit will have the same effect as the flush.

but at least in the "unconfigured_launch" case an implicit flush doesn't happen before we try to use `public_id` on the organization.


# Testing

- Set un-org your application instances:

```update application_instances set organization_id = null;```

- On `main`, go to blackboard, create a new assignment and launch it, it will fail.

- Test again on this branch, it will succeed.