### PR TITLE
Handle catalog errors and group our error handling

### DIFF
--- a/lms/services/vitalsource/_client.py
+++ b/lms/services/vitalsource/_client.py
@@ -163,6 +163,10 @@ class VitalSourceClient:
     @classmethod
     def _handle_book_errors(cls, book_id: str, err: ExternalRequestError):
         if json_errors := cls._get_json_errors(err):
+            # This isn't something we can do anything about, but we can check
+            # for it. If the catalog is not initialized we get this error and
+            # VS need to do "something" to configure it. This shouldn't happen
+            # at random, only when onboarding new customers.
             if "Catalog not found" in json_errors:
                 raise VitalSourceConfigurationError(
                     "The catalog has not been initialized"

--- a/tests/unit/lms/services/vitalsource/_client_test.py
+++ b/tests/unit/lms/services/vitalsource/_client_test.py
@@ -8,6 +8,7 @@ from lms.services.exceptions import ExternalRequestError
 from lms.services.vitalsource._client import (
     BookNotFound,
     VitalSourceClient,
+    VitalSourceConfigurationError,
     _VSUserAuth,
 )
 from lms.services.vitalsource.exceptions import VitalSourceError
@@ -53,29 +54,6 @@ class TestVitalSourceClient:
             "cover_image": "COVER_IMAGE",
         }
 
-    def test_get_book_info_not_found(self, client, http_service):
-        http_service.request.side_effect = ExternalRequestError(
-            response=factories.requests.Response(
-                status_code=404,
-                headers={"Content-Type": "application/json; charset=utf-8"},
-                json_data={"errors": ["Product BOOK_ID not fonud"]},
-            )
-        )
-
-        with pytest.raises(BookNotFound):
-            client.get_book_info("BOOK_ID")
-
-    @pytest.mark.parametrize("status_code", (404, 500))
-    def test_get_book_info_error(self, client, http_service, status_code):
-        http_service.request.side_effect = ExternalRequestError(
-            response=factories.requests.Response(
-                status_code=status_code, headers={"Content-Type": "application/json"}
-            )
-        )
-
-        with pytest.raises(ExternalRequestError):
-            client.get_book_info("BOOK_ID")
-
     def test_get_table_of_contents(self, client, http_service):
         http_service.request.return_value = factories.requests.Response(
             json_data={
@@ -100,28 +78,71 @@ class TestVitalSourceClient:
             }
         ]
 
-    def test_get_table_of_contents_not_found(self, client, http_service):
-        http_service.request.side_effect = ExternalRequestError(
-            response=factories.requests.Response(
-                status_code=404,
-                headers={"Content-Type": "application/json; charset=utf-8"},
-                json_data={"errors": ["Book not found"]},
-            )
-        )
+    @pytest.mark.parametrize(
+        "response,exception_class",
+        (
+            (
+                factories.requests.Response(
+                    status_code=404,
+                    headers={"Content-Type": "application/json"},
+                    json_data={"errors": ["Book not found"]},
+                ),
+                BookNotFound,
+            ),
+            (
+                factories.requests.Response(
+                    status_code=404,
+                    headers={"Content-Type": "application/json"},
+                    json_data={"errors": ["Product BOOK_ID not found"]},
+                ),
+                BookNotFound,
+            ),
+            (
+                factories.requests.Response(
+                    # We don't actually know the error code, because we didn't
+                    # capture it at the time
+                    status_code=500,
+                    headers={"Content-Type": "application/json; charset=utf-8"},
+                    json_data={"errors": ["Catalog not found"]},
+                ),
+                VitalSourceConfigurationError,
+            ),
+            (
+                factories.requests.Response(
+                    status_code=500,
+                    headers={"Content-Type": "application/json"},
+                    json_data={"errors": ["Any valid string"]},
+                ),
+                ExternalRequestError,
+            ),
+            (
+                factories.requests.Response(
+                    status_code=404,
+                    headers={"Content-Type": "application/json"},
+                    json_data="Not the expected dict",
+                ),
+                ExternalRequestError,
+            ),
+            (
+                factories.requests.Response(
+                    status_code=404,
+                    headers={"Content-Type": "application/json"},
+                    raw=b"[not valid json...",
+                ),
+                ExternalRequestError,
+            ),
+            (factories.requests.Response(status_code=400), ExternalRequestError),
+            (factories.requests.Response(status_code=500), ExternalRequestError),
+        ),
+    )
+    @pytest.mark.parametrize("method", ("get_table_of_contents", "get_book_info"))
+    def test_book_method_errors(
+        self, client, http_service, response, exception_class, method
+    ):
+        http_service.request.side_effect = ExternalRequestError(response=response)
 
-        with pytest.raises(BookNotFound):
-            client.get_table_of_contents("BOOK_ID")
-
-    @pytest.mark.parametrize("status_code", (404, 500))
-    def test_get_table_of_contents_error(self, client, http_service, status_code):
-        http_service.request.side_effect = ExternalRequestError(
-            response=factories.requests.Response(
-                status_code=status_code, headers={"Content-Type": "application/json"}
-            )
-        )
-
-        with pytest.raises(ExternalRequestError):
-            client.get_table_of_contents("BOOK_ID")
+        with pytest.raises(exception_class):
+            getattr(client, method)("BOOK_ID")
 
     @pytest.mark.parametrize(
         "response_xml",


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4462

This pulls all the error handling for the two book methods into a single chain of methods and unifies the testing.

## Testing notes (or lack thereof)

There's not much we can do to test this really, as it requires a situation on VitalSource's side. If you want to see the exception you can hack the code to raise the exception.

 * Hack `lms.services.vitalsource._client` to add `raise VitalSourceConfigurationError("test")` in `get_book_info()`
 * Start all the things
 * Visit: http://localhost:8001/admin/instance/id/8/
 * Enable Vitalsource
 * Visit: https://hypothesis.instructure.com/courses/125/
 * Create your own localhost assignment with VitalSource
 * Paste in any book, e.g. https://bookshelf.vitalsource.com/reader/books/9781786894700
 * You should see a message indicating VitalSource is misconfigured

