### PR TITLE
Allow organizations search in the admin pages

### DIFF
--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -47,6 +47,24 @@ class OrganizationService:
             self._db_session, Organization, public_id, region=self._region
         )
 
+    def search(self, name, limit=100):
+        """
+        Search organizations.
+
+        :param name: Match organization by name. Case insensitive.
+        :param limit: Limit the number of results
+        """
+        return (
+            self._db_session.query(Organization)
+            .filter(
+                sa.func.to_tsvector("english", Organization.name).op("@@")(
+                    sa.func.websearch_to_tsquery(name, postgresql_regconfig="english")
+                )
+            )
+            .limit(limit)
+            .all()
+        )
+
     def auto_assign_organization(
         self, application_instance: ApplicationInstance
     ) -> Optional[Organization]:

--- a/lms/templates/admin/organizations.html.jinja2
+++ b/lms/templates/admin/organizations.html.jinja2
@@ -6,13 +6,54 @@ Organizations
 {% endblock %}
 
 {% block content %}
+<div class="block has-text-right">
+    <a class="button is-primary" 
+        href="{{ request.route_url("admin.organization.new") }}">
+        New organization
+    </a>
+</div>
 
 <fieldset class="box mt-6">
-    <div class="block has-text-right">
-        <a class="button is-primary" 
-            href="{{ request.route_url("admin.organization.new") }}">
-            New organization
-        </a>
-    </div>
+   <legend class="label has-text-centered">Find organization</legend>
+    <form method="POST" action="{{ request.route_url("admin.organizations") }}">
+        <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+
+        {{ macros.form_text_field(request, "Public ID", "public_id") }}
+        {{ macros.form_text_field(request, "Name", "name") }}
+        {% call macros.field_body(label="") %}
+            <input type="submit" class="button is-info" value="Search" />
+        {% endcall %}
+    </form>
 </fieldset>
+
+{% if organizations is defined %} 
+<fieldset class="box mt-6">
+<legend class="label has-text-centered">Results</legend>
+<div class="container">
+    <div class="table-container">
+        <table class="table is-fullwidth">
+          <thead>
+            <tr>
+              <th></th>
+              <th>ID</th>
+              <th>Name</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for org in organizations %}
+                <tr>
+                  <td>
+                    <a class="button" href="{{ request.route_url('admin.organization', id_=org.id) }}">View</a>
+                  </td>
+                  <td>{{org.public_id(request.region)}}</td>
+                  <td>{{org.name}}</td>
+               </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+    </div>
+</div>
+</fieldset>
+{% endif %}
+
 {% endblock %}

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -78,7 +78,6 @@ class AdminOrganizationViews:
             org, name=self.request.params.get("name", "").strip()
         )
 
-        self.request.session.flash("Updated organization", "messages")
         return {"org": org}
 
     @view_config(
@@ -95,6 +94,21 @@ class AdminOrganizationViews:
 
         self.request.session.flash("Updated organization", "messages")
         return {"org": org}
+
+    @view_config(
+        route_name="admin.organizations",
+        request_method="POST",
+        renderer="lms:templates/admin/organizations.html.jinja2",
+    )
+    def search(self):
+        if public_id := self.request.params.get("public_id"):
+            orgs = [self.organization_service.get_by_public_id(public_id)]
+        else:
+            orgs = self.organization_service.search(
+                name=self.request.params.get("name", "").strip()
+            )
+
+        return {"organizations": orgs}
 
     def _get_org_or_404(self, id_) -> Organization:
         if org := self.organization_service.get_by_id(id_):

--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -135,6 +135,12 @@ class TestOrganizationService:
         if enabled is not None:
             assert org.enabled == enabled
 
+    @pytest.mark.usefixtures("with_matching_noise")
+    def test_search_by_name(self, svc):
+        org = factories.Organization(name="NAME")
+
+        assert svc.search(name="NAME") == [org]
+
     @pytest.fixture
     def with_matching_noise(self):
         factories.ApplicationInstance(


### PR DESCRIPTION
Search organizations by name or public id.

# Testing 

- Go over http://localhost:8001/admin/orgs
- Search by public id
- Search by name

