### PR TITLE
Ensure `course_groups()` returns users when we ask for them

### DIFF
--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -176,6 +176,7 @@ class TestCanvasAPIClientIntegrated:
                 "name": "Group 1",
                 "description": "Group 1",
                 "group_category_id": 1,
+                "users": [{"id": 1}],
             },
             {
                 "id": 2,
@@ -184,6 +185,7 @@ class TestCanvasAPIClientIntegrated:
                 "group_category_id": 1,
             },
         ]
+
         http_session.send.return_value = factories.requests.Response(
             status_code=200, json_data=groups
         )
@@ -191,6 +193,9 @@ class TestCanvasAPIClientIntegrated:
         response = canvas_api_client.course_groups(
             "COURSE_ID", only_own_groups=only_own_groups, include_users=include_users
         )
+
+        if include_users:
+            groups[1]["users"] = []
 
         assert response == groups
 


### PR DESCRIPTION
No matter what Canvas chooses to do. 

For:

 * https://sentry.io/organizations/hypothesis/issues/3604779293/?project=259908&referrer=slack

It seems that despite asking for users, Canvas sometimes doesn't send them. We will tack in empty lists so callers don't crash when trying to access the key.