### PR TITLE
A more powerful unified search function for the organization service

### DIFF
--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -44,14 +44,17 @@ class OrganizationService:
 
         return self._search_query(public_id=public_id).one_or_none()
 
-    def search(self, name, limit=100):
+    def search(self, public_id=None, name=None, limit=100) -> List[Organization]:
         """
-        Search organizations.
+        Search for organizations.
 
+        The results are returned as an OR of the specified filters.
+
+        :param public_id: Match on public id
         :param name: Match organization by name. Case-insensitive.
         :param limit: Limit the number of results
         """
-        return self._search_query(name=name).limit(limit).all()
+        return self._search_query(public_id=public_id, name=name).limit(limit).all()
 
     def _search_query(self, public_id=None, name=None):
         clauses = []

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -42,7 +42,7 @@ class OrganizationService:
     def get_by_public_id(self, public_id: str) -> Optional[List]:
         """Get an organization by its public_id."""
 
-        return self._search_query(public_id=public_id).one_or_none()
+        return self._organization_search_query(public_id=public_id).one_or_none()
 
     def search(self, public_id=None, name=None, limit=100) -> List[Organization]:
         """
@@ -54,9 +54,13 @@ class OrganizationService:
         :param name: Match organization by name. Case-insensitive.
         :param limit: Limit the number of results
         """
-        return self._search_query(public_id=public_id, name=name).limit(limit).all()
+        return (
+            self._organization_search_query(public_id=public_id, name=name)
+            .limit(limit)
+            .all()
+        )
 
-    def _search_query(self, public_id=None, name=None):
+    def _organization_search_query(self, public_id=None, name=None):
         clauses = []
 
         if public_id:

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -69,7 +69,7 @@ class OrganizationService:
         if name:
             clauses.append(
                 sa.func.to_tsvector("english", Organization.name).op("@@")(
-                    sa.func.websearch_to_tsquery(name, postgresql_regconfig="english")
+                    sa.func.websearch_to_tsquery("english", name)
                 )
             )
 

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -105,17 +105,14 @@ class AdminOrganizationViews:
         renderer="lms:templates/admin/organizations.html.jinja2",
     )
     def search(self):
-        if public_id := self.request.params.get("public_id"):
-            try:
-                orgs = [self.organization_service.get_by_public_id(public_id)]
-            except InvalidPublicId as err:
-                self.request.session.flash(str(err), "errors")
-                orgs = []
-
-        else:
+        try:
             orgs = self.organization_service.search(
-                name=self.request.params.get("name", "").strip()
+                name=self.request.params.get("name"),
+                public_id=self.request.params.get("public_id"),
             )
+        except InvalidPublicId as err:
+            self.request.session.flash(str(err), "errors")
+            orgs = []
 
         return {"organizations": orgs}
 

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -92,36 +92,27 @@ class TestAdminOrganizationViews:
     def AuditTrailEvent(self, patch):
         return patch("lms.views.admin.organization.AuditTrailEvent")
 
-    def test_search_by_public_id(self, pyramid_request, organization_service, views):
+    def test_search(self, pyramid_request, organization_service, views):
         pyramid_request.params["public_id"] = sentinel.public_id
+        pyramid_request.params["name"] = sentinel.name
 
         result = views.search()
 
-        organization_service.get_by_public_id.assert_called_once_with(
-            sentinel.public_id
+        organization_service.search.assert_called_once_with(
+            name=sentinel.name, public_id=sentinel.public_id
         )
-        assert result == {
-            "organizations": [organization_service.get_by_public_id.return_value]
-        }
+        assert result == {"organizations": organization_service.search.return_value}
 
     def test_search_handles_invalid_public_id(
         self, pyramid_request, organization_service, views
     ):
-        organization_service.get_by_public_id.side_effect = InvalidPublicId
+        organization_service.search.side_effect = InvalidPublicId
         pyramid_request.params["public_id"] = "NOT A VALID PUBLIC ID"
 
         result = views.search()
 
         assert pyramid_request.session.peek_flash("errors")
         assert result == {"organizations": []}
-
-    def test_search_by_name(self, pyramid_request, organization_service, views):
-        pyramid_request.params["name"] = "   NAME "
-
-        result = views.search()
-
-        organization_service.search.assert_called_once_with(name="NAME")
-        assert result == {"organizations": organization_service.search.return_value}
 
     @pytest.fixture
     def views(self, pyramid_request):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4480

This merges public id and name searching into one function under the hood. This allows a few improvements:

 * This allows an OR search across both
 * You can also hit search with no values and get a list of orgs. This could be handy for devs

## Notes

This also fixes text searching (hopefully) in QA and Live