### PR TITLE
Allow searching for organizations by primary key

### DIFF
--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -15,9 +15,6 @@ class OrganizationService:
     def __init__(self, db_session: Session):
         self._db_session = db_session
 
-    def get_by_id(self, id_) -> Optional[Organization]:
-        return self._db_session.query(Organization).filter_by(id=id_).one_or_none()
-
     def get_by_linked_guid(self, guid) -> List[Organization]:
         """Get organizations which match the provided GUID."""
 
@@ -39,29 +36,40 @@ class OrganizationService:
             .all()
         )
 
+    def get_by_id(self, id_) -> Optional[Organization]:
+        """Get an organization by its private primary key."""
+
+        return self._organization_search_query(id_=id_).one_or_none()
+
     def get_by_public_id(self, public_id: str) -> Optional[List]:
         """Get an organization by its public_id."""
 
         return self._organization_search_query(public_id=public_id).one_or_none()
 
-    def search(self, public_id=None, name=None, limit=100) -> List[Organization]:
+    def search(
+        self, id_=None, public_id=None, name=None, limit=100
+    ) -> List[Organization]:
         """
         Search for organizations.
 
         The results are returned as an OR of the specified filters.
 
+        :param id_: Match on primary key
         :param public_id: Match on public id
         :param name: Match organization by name. Case-insensitive.
         :param limit: Limit the number of results
         """
         return (
-            self._organization_search_query(public_id=public_id, name=name)
+            self._organization_search_query(id_=id_, public_id=public_id, name=name)
             .limit(limit)
             .all()
         )
 
-    def _organization_search_query(self, public_id=None, name=None):
+    def _organization_search_query(self, id_=None, public_id=None, name=None):
         clauses = []
+
+        if id_:
+            clauses.append(Organization.id == id_)
 
         if public_id:
             clauses.append(Organization.public_id == public_id)

--- a/lms/templates/admin/organizations.html.jinja2
+++ b/lms/templates/admin/organizations.html.jinja2
@@ -19,6 +19,7 @@ Organizations
         <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
 
         {{ macros.form_text_field(request, "Public ID", "public_id") }}
+        {{ macros.form_text_field(request, "ID", "id") }}
         {{ macros.form_text_field(request, "Name", "name") }}
         {% call macros.field_body(label="") %}
             <input type="submit" class="button is-info" value="Search" />
@@ -35,6 +36,7 @@ Organizations
           <thead>
             <tr>
               <th></th>
+              <th>Public ID</th>
               <th>ID</th>
               <th>Name</th>
             </tr>
@@ -46,6 +48,7 @@ Organizations
                     <a class="button" href="{{ request.route_url('admin.organization', id_=org.id) }}">View</a>
                   </td>
                   <td>{{org.public_id}}</td>
+                  <td>{{org.id}}</td>
                   <td>{{org.name}}</td>
                </tr>
             {% endfor %}

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -108,6 +108,7 @@ class AdminOrganizationViews:
         try:
             orgs = self.organization_service.search(
                 name=self.request.params.get("name"),
+                id_=self.request.params.get("id"),
                 public_id=self.request.params.get("public_id"),
             )
         except InvalidPublicId as err:

--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -61,7 +61,7 @@ class TestOrganizationService:
 
     @pytest.mark.usefixtures("with_matching_noise")
     @pytest.mark.parametrize(
-        "param,field", (("name", "name"), ("public_id", "public_id"))
+        "param,field", (("name", "name"), ("public_id", "public_id"), ("id_", "id"))
     )
     def test_search(self, svc, param, field, db_session):
         org = factories.Organization(name="NAME")

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -95,11 +95,12 @@ class TestAdminOrganizationViews:
     def test_search(self, pyramid_request, organization_service, views):
         pyramid_request.params["public_id"] = sentinel.public_id
         pyramid_request.params["name"] = sentinel.name
+        pyramid_request.params["id"] = sentinel.id
 
         result = views.search()
 
         organization_service.search.assert_called_once_with(
-            name=sentinel.name, public_id=sentinel.public_id
+            name=sentinel.name, public_id=sentinel.public_id, id_=sentinel.id
         )
         assert result == {"organizations": organization_service.search.return_value}
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4480

Depends on:

 * https://github.com/hypothesis/lms/issues/4480

Now we have a unified search, it's quite easy to add more variations to it. This PR:

 * Inlines searching by primary key into the unified search
 * Exposes this on the organization search page