### PR TITLE
Allow searching for organizations by GUID

### DIFF
--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -69,7 +69,7 @@ class OrganizationService:
             )
 
         if guid:
-            query = query.join(ApplicationInstance).outerjoin(GroupInfo)
+            query = query.outerjoin(ApplicationInstance).outerjoin(GroupInfo)
 
             clauses.extend(
                 sa.or_(

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -15,19 +15,6 @@ class OrganizationService:
     def __init__(self, db_session: Session):
         self._db_session = db_session
 
-    def get_by_linked_guid(self, guid) -> List[Organization]:
-        """Get organizations which match the provided GUID."""
-
-        # There are huge numbers of null GUIDs, don't match on them
-        if not guid:
-            return []
-
-        return (
-            self._organization_search_query(guid=guid)
-            .order_by(Organization.updated.desc())
-            .all()
-        )
-
     def get_by_id(self, id_) -> Optional[Organization]:
         """Get an organization by its private primary key."""
 
@@ -116,7 +103,11 @@ class OrganizationService:
         if application_instance.organization:
             org = application_instance.organization
 
-        elif orgs := self.get_by_linked_guid(guid):
+        elif (
+            orgs := self._organization_search_query(guid=guid)
+            .order_by(Organization.updated.desc())
+            .all()
+        ):
             if len(orgs) > 1:
                 LOG.warning(
                     "Multiple organization matches found for application instance %s",

--- a/lms/templates/admin/organizations.html.jinja2
+++ b/lms/templates/admin/organizations.html.jinja2
@@ -21,6 +21,7 @@ Organizations
         {{ macros.form_text_field(request, "Public ID", "public_id") }}
         {{ macros.form_text_field(request, "ID", "id") }}
         {{ macros.form_text_field(request, "Name", "name") }}
+        {{ macros.form_text_field(request, "Linked GUID", "guid") }}
         {% call macros.field_body(label="") %}
             <input type="submit" class="button is-info" value="Search" />
         {% endcall %}

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -110,6 +110,7 @@ class AdminOrganizationViews:
                 name=self.request.params.get("name"),
                 id_=self.request.params.get("id"),
                 public_id=self.request.params.get("public_id"),
+                guid=self.request.params.get("guid"),
             )
         except InvalidPublicId as err:
             self.request.session.flash(str(err), "errors")

--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -10,40 +10,6 @@ from tests import factories
 
 class TestOrganizationService:
     @pytest.mark.usefixtures("with_matching_noise")
-    def test_get_by_linked_guid_matches_from_ai(self, svc):
-        orgs = factories.Organization.create_batch(2)
-        for org in orgs:
-            factories.ApplicationInstance(
-                tool_consumer_instance_guid="guid", organization=org
-            )
-
-        matches = svc.get_by_linked_guid("guid")
-
-        assert matches == Any.list.containing(orgs).only()
-
-    @pytest.mark.usefixtures("with_matching_noise")
-    def test_get_by_linked_guid_matches_from_group_info(self, svc):
-        orgs = factories.Organization.create_batch(2)
-        for org in orgs:
-            factories.GroupInfo(
-                application_instance=factories.ApplicationInstance(
-                    tool_consumer_instance_guid="guid", organization=org
-                ),
-                tool_consumer_instance_guid="guid",
-            )
-
-        matches = svc.get_by_linked_guid("guid")
-
-        assert matches == Any.list.containing(orgs).only()
-
-    def test_get_by_linked_guid_with_no_guid(self, svc):
-        factories.ApplicationInstance(
-            tool_consumer_instance_guid=None, organization=factories.Organization()
-        )
-
-        assert not svc.get_by_linked_guid(None)
-
-    @pytest.mark.usefixtures("with_matching_noise")
     def test_get_by_id(self, svc, db_session):
         org = factories.Organization()
         db_session.flush()
@@ -91,6 +57,33 @@ class TestOrganizationService:
             == Any.list.containing(orgs).only()
         )
 
+    @pytest.mark.usefixtures("with_matching_noise")
+    def test_search_with_guid_matches_from_ai(self, svc):
+        orgs = factories.Organization.create_batch(2)
+        for org in orgs:
+            factories.ApplicationInstance(
+                tool_consumer_instance_guid="guid", organization=org
+            )
+
+        matches = svc.search(guid="guid")
+
+        assert matches == Any.list.containing(orgs).only()
+
+    @pytest.mark.usefixtures("with_matching_noise")
+    def test_search_with_guid_matches_from_group_info(self, svc):
+        orgs = factories.Organization.create_batch(2)
+        for org in orgs:
+            factories.GroupInfo(
+                application_instance=factories.ApplicationInstance(
+                    tool_consumer_instance_guid="guid", organization=org
+                ),
+                tool_consumer_instance_guid="guid",
+            )
+
+        matches = svc.search(guid="guid")
+
+        assert matches == Any.list.containing(orgs).only()
+
     def test_auto_assign_organization_with_no_guid(self, svc, application_instance):
         application_instance.tool_consumer_instance_guid = None
 
@@ -128,7 +121,7 @@ class TestOrganizationService:
     def test_auto_assign_organization_matches(
         self, svc, application_instance, matching_ais
     ):
-        # We've tested get_by_linked_guid above, so we won't retread
+        # We separately test searching by GUID, so we won't retread
         orgs = factories.Organization.create_batch(matching_ais)
         for org in orgs:
             factories.ApplicationInstance(

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -96,11 +96,15 @@ class TestAdminOrganizationViews:
         pyramid_request.params["public_id"] = sentinel.public_id
         pyramid_request.params["name"] = sentinel.name
         pyramid_request.params["id"] = sentinel.id
+        pyramid_request.params["guid"] = sentinel.guid
 
         result = views.search()
 
         organization_service.search.assert_called_once_with(
-            name=sentinel.name, public_id=sentinel.public_id, id_=sentinel.id
+            name=sentinel.name,
+            public_id=sentinel.public_id,
+            id_=sentinel.id,
+            guid=sentinel.guid,
         )
         assert result == {"organizations": organization_service.search.return_value}
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4480

Depends on:

 * https://github.com/hypothesis/lms/issues/4480
 * https://github.com/hypothesis/lms/pull/4478

Now we have a unified search, it's quite easy to add more variations to it. This PR:

 * Inlines the GUID search into the unified search function
 * Adds it to the admin pages
 * Removes the old function which is completely superseded by search now