### PR TITLE
Change to HTTPS for the devdata clone URL

### DIFF
--- a/bin/update_dev_data.py
+++ b/bin/update_dev_data.py
@@ -134,7 +134,7 @@ def devdata():
             git_dir = os.path.join(tmpdirname, "devdata")
 
             subprocess.check_call(
-                ["git", "clone", "git@github.com:hypothesis/devdata.git", git_dir]
+                ["git", "clone", "https://github.com/hypothesis/devdata.git", git_dir]
             )
 
             # Copy devdata env file into place.


### PR DESCRIPTION
The easiest way to set up Git->GitHub.com authentication nowadays is by
installing [GitHub CLI](https://cli.github.com/), running
[gh auth login](https://cli.github.com/manual/gh_auth_login), and
answering "Yes" (the default) when it asks "Authenticate Git with your
GitHub credentials?". By default this will set up authentication for
HTTPS git clone URLs but not SSH ones so `make devdata` will fail with
an authentication error because it tries to clone the private devdata
repo using the SSH clone URL.

Fix this by changing the devdata clone URL to the HTTPS one.
