### PR TITLE
Using a global singleton instead of a request method for region

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -3,6 +3,7 @@ import pyramid_tm
 from sqlalchemy.exc import IntegrityError
 
 from lms.config import configure
+from lms.models.region import Regions
 
 
 def configure_jinja2_assets(config):
@@ -13,6 +14,10 @@ def configure_jinja2_assets(config):
 
 def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config = configure(settings=settings)
+
+    # Set the singleton region, so it's accesible globally without going
+    # through the request object etc.
+    Regions.set_region(config.registry.settings["h_authority"])
 
     # Make sure that pyramid_exclog's tween runs under pyramid_tm's tween so
     # that pyramid_exclog doesn't re-open the DB session after pyramid_tm has

--- a/tests/unit/lms/app_test.py
+++ b/tests/unit/lms/app_test.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import sentinel
 
 import pytest
 
@@ -26,10 +27,29 @@ class TestConfigureJinja2Assets:
 
 
 class TestCreateApp:
-    def test_it_doesnt_crash(self, pyramid_config):
-        create_app(pyramid_config)
+    def test_it(self, configure, Regions):
+        settings = {"key": "value"}
 
+        create_app(sentinel.pyramid_config, **settings)
 
-@pytest.fixture(autouse=True)
-def configure(patch):
-    return patch("lms.app.configure")
+        configure.assert_called_once_with(settings=settings)
+        Regions.set_region.assert_called_once_with(sentinel.h_authority)
+
+    @pytest.fixture(autouse=True)
+    def registry(self, configure):
+        registry = configure.return_value.registry
+        registry.settings = {
+            "h_authority": sentinel.h_authority,
+            "lms_secret": sentinel.lms_secret,
+            "admin_auth_google_client_id": sentinel.admin_auth_google_client_id,
+            "admin_auth_google_client_secret": sentinel.admin_auth_google_client_secret,
+        }
+        return registry
+
+    @pytest.fixture(autouse=True)
+    def Regions(self, patch):
+        return patch("lms.app.Regions")
+
+    @pytest.fixture(autouse=True)
+    def configure(self, patch):
+        return patch("lms.app.configure")

--- a/tests/unit/lms/models/region_test.py
+++ b/tests/unit/lms/models/region_test.py
@@ -1,20 +1,24 @@
-from unittest.mock import create_autospec
+from unittest import mock
+from unittest.mock import create_autospec, sentinel
 
 import pytest
+from h_matchers import Any
 from pyramid.config import Configurator
 
 from lms.models.region import Regions, includeme
 
 
 class TestRegions:
-    @pytest.mark.parametrize(
-        "authority,region",
-        (("lms.hypothes.is", Regions.US), ("lms.ca.hypothes.is", Regions.CA)),
-    )
-    def test_from_request(self, pyramid_request, authority, region):
-        pyramid_request.registry.settings["h_authority"] = authority
+    def test_get_region(self, current_region):
+        current_region.return_value = Regions.CA
 
-        assert Regions.from_request(pyramid_request) == region
+        assert Regions.get_region() == Regions.CA
+
+    def test_get_region_with_no_region(self, current_region):
+        current_region.return_value = None
+
+        with pytest.raises(ValueError):
+            Regions.get_region()
 
     @pytest.mark.parametrize("bad_authority", (None, "UNRECOGNIZED"))
     def test_from_request_raises_ValueError_for_bad_authorities(
@@ -23,17 +27,34 @@ class TestRegions:
         pyramid_request.registry.settings["h_authority"] = bad_authority
 
         with pytest.raises(ValueError):
-            Regions.from_request(pyramid_request)
+            Regions.set_region(pyramid_request)
+
+    @pytest.fixture
+    def current_region(self):
+        with mock.patch.object(Regions, "_current_region") as _current_region:
+            _current_region.__get__ = mock.Mock(return_value=None)
+            yield _current_region.__get__
 
 
 class TestIncludeMe:
-    def test_it(self, configurator):
+    def test_it(self, configurator, Regions):
         includeme(configurator)
 
+        any_callable = Any.callable()
+
         configurator.add_request_method.assert_called_once_with(
-            Regions.from_request, name="region", property=True, reify=True
+            any_callable, name="region", property=True, reify=True
         )
 
-    @pytest.fixture()
+        # You can use h-matchers as spies to capture what they last matched
+        response = any_callable.last_matched()(sentinel.request)
+        Regions.get_region.assert_called_once_with()
+        assert response == Regions.get_region.return_value
+
+    @pytest.fixture
     def configurator(self):
         return create_autospec(Configurator, spec_set=True, instance=True)
+
+    @pytest.fixture
+    def Regions(self, patch):
+        return patch("lms.models.region.Regions")


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4500

This keeps the request method for now, but makes it optional. This is just to demonstrate the way of setting this up.