### PR TITLE
Present a message on the organization search instead of a blank table when there are no results

### DIFF
--- a/lms/templates/admin/organizations.html.jinja2
+++ b/lms/templates/admin/organizations.html.jinja2
@@ -30,33 +30,39 @@ Organizations
 
 {% if organizations is defined %}
 <fieldset class="box mt-6">
-<legend class="label has-text-centered">Results</legend>
-<div class="container">
-    <div class="table-container">
-        <table class="table is-fullwidth">
-          <thead>
-            <tr>
-              <th></th>
-              <th>Public ID</th>
-              <th>ID</th>
-              <th>Name</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for org in organizations %}
-                <tr>
-                  <td>
-                    <a class="button" href="{{ request.route_url('admin.organization', id_=org.id) }}">View</a>
-                  </td>
-                  <td>{{org.public_id}}</td>
-                  <td>{{org.id}}</td>
-                  <td>{{org.name}}</td>
-               </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-    </div>
-</div>
+    {% if organizations %}
+        <legend class="label has-text-centered">Results</legend>
+        <div class="container">
+            <div class="table-container">
+                <table class="table is-fullwidth">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th>Public ID</th>
+                      <th>ID</th>
+                      <th>Name</th>
+                    </tr>
+                  </thead>
+
+                  <tbody>
+                    {% for org in organizations %}
+                        <tr>
+                          <td>
+                            <a class="button" href="{{ request.route_url('admin.organization', id_=org.id) }}">View</a>
+                          </td>
+                          <td>{{org.public_id}}</td>
+                          <td>{{org.id}}</td>
+                          <td>{{org.name}}</td>
+                       </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+            </div>
+        </div>
+    {% else %}
+        <legend class="label has-text-centered">No results found</legend>
+        <div class="container has-text-centered">😿</div>
+    {% endif %}
 </fieldset>
 {% endif %}
 


### PR DESCRIPTION
Just a small quality of life improvement. The page looks kind of goofy with an empty table.