### PR TITLE
Escape "." in DOI regex

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/jstor.js
+++ b/lms/static/scripts/frontend_apps/utils/jstor.js
@@ -6,7 +6,7 @@
  * @param {string} value
  */
 function isDOI(value) {
-  return /^10.([0-9]+\.?)+\/.*/.test(value);
+  return /^10\.([0-9]+\.?)+\/.*/.test(value);
 }
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/jstor-test.js
@@ -61,6 +61,9 @@ describe('utils/jstor', () => {
       // Not a URL or ID
       'foo-bar',
 
+      // DOI-like, but doesn't start with "10."
+      '10a2407/1234',
+
       // Missing "/stable/"
       'http://www.jstor.org/1234',
       'https://www.jstor.org/10.1086/508573',


### PR DESCRIPTION
This fixes a mistake found by CodeQL. See https://github.com/hypothesis/lms/issues/4507.