### PR TITLE
Refine check for whether a sharing URL refers to SharePoint

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
+++ b/lms/static/scripts/frontend_apps/utils/onedrive-picker-client.js
@@ -121,7 +121,7 @@ export class OneDrivePickerClient {
    */
   static downloadURL(sharingURL) {
     const url = new URL(sharingURL);
-    if (url.hostname.endsWith('sharepoint.com')) {
+    if (url.hostname.endsWith('.sharepoint.com')) {
       url.search = 'download=1';
       return url.href;
     } else {


### PR DESCRIPTION
Make sure we check the top-level domain as a whole. The check should match hostnames like "companyname.sharepoint.com" but not "notsharepoint.com". As far as I know, the hostname should always have a subdomain (ie. will never be just "sharepoint.com").

This issue was found by CodeQL. See https://github.com/hypothesis/lms/issues/4507