### PR TITLE
Fix AI moving organization overriding all settings

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -123,6 +123,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.instances", "/admin/instances/")
     config.add_route("admin.instances.search", "/admin/instances/search")
     config.add_route("admin.instance.downgrade", "/admin/instance/id/{id_}/downgrade")
+    config.add_route("admin.instance.move_org", "/admin/instance/id/{id_}/move_org")
     config.add_route("admin.instance.consumer_key", "/admin/instance/{consumer_key}/")
     config.add_route("admin.instance.id", "/admin/instance/id/{id_}/")
     config.add_route(

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -136,7 +136,7 @@
 
 
     {% call macros.field_body(label="Move to organization") %}
-        <form method="POST" action="{{ request.route_url("admin.instance.id", id_=instance.id) }}">
+        <form method="POST" action="{{ request.route_url("admin.instance.move_org", id_=instance.id) }}">
           <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
           <input class="input" type="text" name="org_public_id">
           <input type="submit" class="button mb-2" value="Move">


### PR DESCRIPTION
Fixes https://github.com/hypothesis/product-backlog/issues/1398


# Testing notes

- Go over an AI in the admin pages http://localhost:8001/admin/instance/id/101/
- Make sure it has some settings set
- Move it to a an org 
- All the settings are preserved
- In `main`, repeat org moving operation.
- All settings are set to false/null