### PR TITLE
D2L api integration PoC

### DIFF
--- a/conf/development_https.ini
+++ b/conf/development_https.ini
@@ -1,0 +1,1 @@
+development.ini

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -9,6 +9,15 @@ stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
 
+[program:web-https]
+command=gunicorn --paste conf/development_https.ini --certfile=/home/marcos/localhost.crt --keyfile=/home/marcos/localhost.key  -b :48001
+
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal = KILL
+stopasgroup = true
+
+
 [program:worker]
 command=celery -A lms.tasks.celery:app worker --loglevel=INFO
 stdout_logfile=NONE

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -18,10 +18,10 @@ class Grouping(CreatedUpdatedMixin, BASE):
         CANVAS_GROUP = "canvas_group"
         BLACKBOARD_GROUP = "blackboard_group"
 
-        # These are the LMS agnostic versions of the ones avobe.
+        # These are the LMS agnostic versions of the ones above.
         # They don't get stored in the DB but are meaningful in the codebase
         SECTION = "section"
-        GROUP = "group"
+        GROUP = "group"  # 'small_group' ? lms_group?
 
     __tablename__ = "grouping"
     __mapper_args__ = {"polymorphic_on": "type"}
@@ -66,7 +66,7 @@ class Grouping(CreatedUpdatedMixin, BASE):
         ),
         # Only certain values are allowed in the `type` column.
         sa.CheckConstraint(
-            "type in ('course', 'canvas_section', 'canvas_group', 'blackboard_group')",
+            "type in ('course', 'canvas_section', 'canvas_group', 'blackboard_group', 'group')",
             name="grouping_type_must_be_a_valid_value",
         ),
     )
@@ -155,6 +155,10 @@ class CanvasGroup(Grouping):
 
 class BlackboardGroup(Grouping):
     __mapper_args__ = {"polymorphic_identity": Grouping.Type.BLACKBOARD_GROUP}
+
+
+class LMSGroup(Grouping):
+    __mapper_args__ = {"polymorphic_identity": Grouping.Type.GROUP}
 
 
 class Course(Grouping):

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -119,6 +119,7 @@ _V11_TO_V13 = (
         "resource_link_id",
         [f"{CLAIM_PREFIX}/lti1p1", "resource_link_id"],
     ),
+    ("lms_user_id", [f"{CLAIM_PREFIX}/custom", "User.id"]),
 )
 
 

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from typing import NamedTuple, Any
 
 from lms.models.h_user import HUser
 
@@ -23,6 +23,8 @@ class LTIUser(NamedTuple):
 
     email: str = ""
     """The user's email address."""
+
+    lms_user_id: Any = None
 
     @property
     def h_user(self):
@@ -56,6 +58,7 @@ class LTIUser(NamedTuple):
                 lti_core_schema["lis_person_name_full"],
             ),
             email=lti_core_schema["lis_person_contact_email_primary"],
+            lms_user_id=lti_core_schema["lms_user_id"],
         )
 
 

--- a/lms/product/__init__.py
+++ b/lms/product/__init__.py
@@ -9,8 +9,9 @@ def includeme(config):
     config.include("lms.product.plugin")
 
     # Give everyone a chance to register their plugins etc.
-    config.include("lms.product.canvas")
     config.include("lms.product.blackboard")
+    config.include("lms.product.canvas")
+    config.include("lms.product.d2l")
 
     # Add the `request.product` method
     config.add_request_method(

--- a/lms/product/d2l/__init__.py
+++ b/lms/product/d2l/__init__.py
@@ -1,0 +1,8 @@
+from lms.product.d2l._plugin.grouping import D2LGroupingPlugin
+from lms.product.d2l.product import D2L
+
+
+def includeme(config):  # pragma: nocover
+    """Register all of our plugins."""
+
+    config.register_service_factory(D2LGroupingPlugin.factory, iface=D2LGroupingPlugin)

--- a/lms/product/d2l/_plugin/grouping.py
+++ b/lms/product/d2l/_plugin/grouping.py
@@ -1,0 +1,62 @@
+from enum import Enum
+
+from lms.models import Grouping
+from lms.product.plugin.grouping_service import GroupError, GroupingServicePlugin
+from lms.services.exceptions import ExternalRequestError
+from lms.services import D2LAPIClient
+
+
+class ErrorCodes(str, Enum):
+    """Error codes that the FE is going to check for."""
+
+    GROUP_SET_NOT_FOUND = "d2l_group_set_not_found"
+    GROUP_SET_EMPTY = "d2l_group_set_empty"
+    STUDENT_NOT_IN_GROUP = "d2l_student_not_in_group"
+
+
+class D2LGroupingPlugin(GroupingServicePlugin):
+    """A plugin which implements D2L specific grouping functions."""
+
+    group_type = Grouping.Type.GROUP
+    sections_type = None  # We don't support sections in D2L
+
+    def __init__(self, d2l_api):
+        self._d2l_api = d2l_api
+
+    def get_groups_for_learner(self, _svc, course, group_set_id, d2l_user_id):
+        if learner_groups := self._d2l_api.group_set_groups(
+            course.lms_id, group_set_id, d2l_user_id
+        ):
+            return learner_groups
+
+        raise GroupError(ErrorCodes.STUDENT_NOT_IN_GROUP, group_set=group_set_id)
+
+    def get_groups_for_grading(
+        self, svc, course, group_set_id, grading_student_id=None
+    ):
+        return svc.get_course_groupings_for_user(
+            course,
+            grading_student_id,
+            type_=self.group_type,
+            group_set_id=int(group_set_id),
+        )
+
+    def get_groups_for_instructor(self, _svc, course, group_set_id):
+        try:
+            groups = self._d2l_api.group_set_groups(course.lms_id, group_set_id)
+        except ExternalRequestError as exc:
+            if exc.status_code == 404:
+                raise GroupError(
+                    ErrorCodes.GROUP_SET_NOT_FOUND, group_set=group_set_id
+                ) from exc
+
+            raise
+
+        if not groups:
+            raise GroupError(ErrorCodes.GROUP_SET_EMPTY, group_set=group_set_id)
+
+        return groups
+
+    @classmethod
+    def factory(cls, _context, request):
+        return cls(request.find_service(D2LAPIClient))

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from lms.product.product import PluginConfig, Product, Routes
+from lms.product.d2l._plugin.grouping import D2LGroupingPlugin
+
+
+@dataclass
+class D2L(Product):
+    """A product for D2L specific settings and tweaks."""
+
+    family: Product.Family = Product.Family.D2L
+
+    route: Routes = Routes(
+        oauth2_authorize="d2l_api.oauth.authorize",
+        oauth2_refresh="d2l_api.oauth.refresh",
+    )
+
+    plugin_config: PluginConfig = PluginConfig(grouping_service=D2LGroupingPlugin)

--- a/lms/product/factory.py
+++ b/lms/product/factory.py
@@ -1,9 +1,10 @@
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
+from lms.product.d2l import D2L
 from lms.product.product import Product
 from lms.services.application_instance import ApplicationInstanceNotFound
 
-_PRODUCT_MAP = {product.family: product for product in (Blackboard, Canvas)}
+_PRODUCT_MAP = {product.family: product for product in (Blackboard, Canvas, D2L)}
 
 
 def get_product_from_request(request) -> Product:

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -7,6 +7,7 @@ from pyramid.httpexceptions import HTTPClientError
 from lms.models import Assignment, GroupInfo, Grouping, HUser
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
+from lms.product.d2l import D2L
 from lms.resources._js_config.file_picker_config import FilePickerConfig
 from lms.services import HAPIError, JSTORService, VitalSourceService
 from lms.validation.authentication import BearerTokenSchema
@@ -68,6 +69,16 @@ class JSConfig:
                     resource_link_id=self._request.lti_params["resource_link_id"],
                 ),
             }
+        # elif document_url.startswith("d2l://"):
+        #    self._config["api"]["viaUrl"] = {
+        #        "authUrl": self._request.route_url(D2L.route.oauth2_authorize),
+        #        "path": self._request.route_path(
+        #            "d2l_api.files.via_url",
+        #            course_id=self._request.lti_params["context_id"],
+        #            _query={"document_url": document_url},
+        #        ),
+        #    }
+
         elif document_url.startswith("vitalsource://"):
             svc: VitalSourceService = self._request.find_service(VitalSourceService)
 
@@ -225,6 +236,8 @@ class JSConfig:
                     # Also this is displayed and  relevant by the "file picker"
                     # but it shouldn't be owned by it
                     "d2l": {
+                        # Enabled at this level to mean "files enabled" is a bit weird but that's how we do it for other LMSs
+                        "enabled": True,
                         "groupsEnabled": True,
                         "listGroupSets": {
                             "authUrl": self._request.route_url(
@@ -232,6 +245,15 @@ class JSConfig:
                             ),
                             "path": self._request.route_path(
                                 "d2l_api.courses.group_sets.list",
+                                course_id=self._request.lti_params.get("context_id"),
+                            ),
+                        },
+                        "listFiles": {
+                            "authUrl": self._request.route_url(
+                                "d2l_api.oauth.authorize"
+                            ),
+                            "path": self._request.route_path(
+                                "d2l_api.courses.files.list",
                                 course_id=self._request.lti_params.get("context_id"),
                             ),
                         },

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -220,6 +220,22 @@ class JSConfig:
                     # Specific config for pickers
                     "blackboard": FilePickerConfig.blackboard_config(*args),
                     "canvas": FilePickerConfig.canvas_config(*args),
+                    # TODO we don't need to check canvas/blackbaord/d2l -> groups_enabled
+                    # we should just provide "groups_enabled"
+                    # Also this is displayed and  relevant by the "file picker"
+                    # but it shouldn't be owned by it
+                    "d2l": {
+                        "groupsEnabled": True,
+                        "listGroupSets": {
+                            "authUrl": self._request.route_url(
+                                "d2l_api.oauth.authorize"
+                            ),
+                            "path": self._request.route_path(
+                                "d2l_api.courses.group_sets.list",
+                                course_id=self._request.lti_params.get("context_id"),
+                            ),
+                        },
+                    },
                     "google": FilePickerConfig.google_files_config(*args),
                     "microsoftOneDrive": FilePickerConfig.microsoft_onedrive(*args),
                     "vitalSource": FilePickerConfig.vitalsource_config(*args),

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -85,7 +85,10 @@ class LTILaunchResource:
             # assignment during deep linking.
             return self._request.params.get("group_set")
 
-        if self._request.product.family == Product.Family.BLACKBOARD:
+        if self._request.product.family in [
+            Product.Family.BLACKBOARD,
+            Product.Family.D2L,
+        ]:
             # In blackboard we store the configuration details in the DB
             tool_consumer_instance_guid = self._request.lti_params[
                 "tool_consumer_instance_guid"

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -52,6 +52,8 @@ def includeme(config):  # pylint:disable=too-many-statements
         "d2l_api.courses.group_sets.list",
         "/api/d2l/courses/{course_id}/group_sets",
     )
+    config.add_route("d2l_api.courses.files.list", "/api/d2l/courses/{course_id}/files")
+    config.add_route("d2l_api.files.via_url", "/api/d2l/courses/{course_id}/via_url")
 
     config.add_route(
         "blackboard_api.oauth.authorize",

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -39,6 +39,21 @@ def includeme(config):  # pylint:disable=too-many-statements
     )
 
     config.add_route(
+        "d2l_api.oauth.authorize",
+        "/api/d2l/oauth/authorize",
+        factory="lms.resources.OAuth2RedirectResource",
+    )
+    config.add_route(
+        "d2l_api.oauth.callback",
+        "/api/d2l/oauth/callback",
+        factory="lms.resources.OAuth2RedirectResource",
+    )
+    config.add_route(
+        "d2l_api.courses.group_sets.list",
+        "/api/d2l/courses/{course_id}/group_sets",
+    )
+
+    config.add_route(
         "blackboard_api.oauth.authorize",
         "/api/blackboard/oauth/authorize",
         factory="lms.resources.OAuth2RedirectResource",

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -32,6 +32,8 @@ from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.vitalsource import VitalSourceService
 
+from lms.services.d2l_api import D2LAPIClient
+
 
 def includeme(config):
     config.register_service_factory("lms.services.http.factory", name="http")
@@ -113,3 +115,4 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.organization.service_factory", iface=OrganizationService
     )
+    config.register_service_factory("lms.services.d2l_api.factory", iface=D2LAPIClient)

--- a/lms/services/d2l_api/__init__.py
+++ b/lms/services/d2l_api/__init__.py
@@ -52,6 +52,7 @@ class BasicClient:
         try:
             return self._oauth_http_service.request(method, path, **kwargs)
         except ExternalRequestError as err:
+            err.refreshable = getattr(err.response, "status_code", None) == 401
             raise
 
     def api_url(self, path, product="lp"):
@@ -154,6 +155,7 @@ class D2LAPIClient:
         #    allow_redirects=False,  # No luck, no redirect
         # )
         # print(response)
+        # Maybe try: https://docs.valence.desire2learn.com/res/content.html#get--d2l-api-le-(version)-(orgUnitId)-content-topics-(topicId)-file
         return self._api.api_url(f"/{ou}/managefiles/file?path={file_path}")
 
 

--- a/lms/services/d2l_api/__init__.py
+++ b/lms/services/d2l_api/__init__.py
@@ -1,0 +1,158 @@
+from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
+from lms.services.aes import AESService
+
+
+class BasicClient:
+    def __init__(
+        self,
+        oauth_http_service,
+        http_service,
+        lms_host,
+        client_id,
+        client_secret,
+        redirect_uri,
+    ):
+        self._http_service = http_service
+        self._oauth_http_service = oauth_http_service
+
+        self.lms_host = "aunltd.brightspacedemo.com"
+        self.token_url = "https://auth.brightspace.com/core/connect/token"
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+        self.redirect_uri = "https://localhost:48001/api/d2l/oauth/callback"
+
+        # https://docs.valence.desire2learn.com/basic/oauth2.html
+
+        # Authorization endpoint: https://auth.brightspace.com/oauth2/auth
+        # Token endpoint: https://auth.brightspace.com/core/connect/token
+
+        self.api_version = "1.31"
+
+    def get_token(self, authorization_code):
+        self._oauth_http_service.get_access_token(
+            token_url=self.token_url,
+            redirect_uri=self.redirect_uri,
+            auth=(self.client_id, self.client_secret),
+            authorization_code=authorization_code,
+        )
+
+    def refresh_access_token(self):
+        self._oauth_http_service.refresh_access_token(
+            self.token_url,
+            self.redirect_uri,
+            auth=(self.client_id, self.client_secret),
+        )
+
+    def request(self, method, path):
+        try:
+            return self._oauth_http_service.request(method, self._api_url(path))
+        except ExternalRequestError as err:
+            raise
+
+    def _api_url(self, path):
+        return f"https://{self.lms_host}/d2l/api/lp/{self.api_version}{path}"
+
+
+from marshmallow import EXCLUDE, Schema, fields, post_load
+
+from lms.validation._base import RequestsResponseSchema
+
+
+class GroupSetSchema(RequestsResponseSchema):
+    """
+    [{"GroupCategoryId":22,"EnrollmentStyle":"PeoplePerGroupAutoEnrollment","EnrollmentQuantity":2,"AutoEnroll":false,"RandomizeEnrollments":true,"Name":"Group Category testing","Description":{"Text":"","Html":""},"Groups":[6793],"MaxUsersPerGroup":2,"RestrictedByOrgUnitId":null}]
+    """
+
+    many = True
+
+    class Meta:
+        unknown = EXCLUDE
+
+    id = fields.Int(required=True, data_key="GroupCategoryId")
+    name = fields.Str(required=True, data_key="Name")
+
+
+class GroupSchema(RequestsResponseSchema):
+    """
+    [{"GroupId":6793,"Name":"Test Group 1","Code":"Test Group_6782_1","Description":{"Text":"","Html":""},"Enrollments":[355]}]
+    """
+
+    many = True
+
+    class Meta:
+        unknown = EXCLUDE
+
+    id = fields.Int(required=True, data_key="GroupId")
+    name = fields.Str(required=True, data_key="Name")
+    group_set_id = fields.Int(required=False)
+    enrollments = fields.List(fields.Int(), required=True, data_key="Enrollments")
+
+
+class D2LAPIClient:
+    def __init__(self, basic_client, request):
+        self._api = basic_client
+        self._request = request
+
+    def get_token(self, authorization_code):
+        """
+        Save a new Blackboard access token for the current user to the DB.
+
+        :raise services.ExternalRequestError: if something goes wrong with the
+            access token request to Blackboard
+        """
+        self._api.get_token(authorization_code)
+
+    def refresh_access_token(self):
+        """
+        Refresh the current user's access token in the DB.
+
+        :raise services.ExternalRequestError: if something goes wrong with the
+            refresh token request to Blackboard
+        """
+        self._api.refresh_access_token()
+
+    def course_group_sets(self, ou):
+        response = self._api.request(
+            "GET",
+            f"/{ou}/groupcategories/",
+        )
+
+        return GroupSetSchema(response).parse()
+
+    def group_set_groups(self, ou, group_category_id, user_id=None):
+        response = self._api.request(
+            "GET",
+            f"/{ou}/groupcategories/{group_category_id}/groups/",
+        )
+        groups = GroupSchema(response).parse()
+        # D2L doesn't return the group_set_id of the listed groups as other LMS
+        # but we know which one it is because we queried for it, inject it:
+        groups = [dict(group, group_set_id=group_category_id) for group in groups]
+
+        if user_id:
+            groups = [group for group in groups if int(user_id) in group["enrollments"]]
+
+        return groups
+
+
+def factory(_context, request):
+    application_instance = request.find_service(
+        name="application_instance"
+    ).get_current()
+
+    client_secret = application_instance.decrypted_developer_secret(
+        request.find_service(AESService)
+    )
+
+    return D2LAPIClient(
+        BasicClient(
+            lms_host=application_instance.lms_host(),
+            client_id=application_instance.developer_key,
+            client_secret=client_secret,
+            redirect_uri=request.route_url("d2l_api.oauth.callback"),
+            http_service=request.find_service(name="http"),
+            oauth_http_service=request.find_service(name="oauth_http"),
+        ),
+        request=request,
+    )

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -15,6 +15,7 @@ class GroupInfoService:
         "canvas_section": "section_group",
         "canvas_group": "canvas_group_group",
         "blackboard_group": "blackboard_group_group",
+        "group": "group_group",
     }
 
     def upsert_group_info(self, grouping: Grouping, params: dict):

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -189,7 +189,9 @@ class GroupingService:
             return None
 
         if lti_user.is_learner:
-            groupings = self.plugin.get_groups_for_learner(self, course, group_set_id)
+            groupings = self.plugin.get_groups_for_learner(
+                self, course, group_set_id, lti_user.lms_user_id
+            )
 
         elif grading_student_id:
             groupings = self.plugin.get_groups_for_grading(

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -18,7 +18,7 @@ import URLPicker from './URLPicker';
  *
  * @typedef {import('./FilePickerApp').ErrorInfo} ErrorInfo
  *
- * @typedef {'blackboardFile'|'canvasFile'|'jstor'|'url'|'vitalSourceBook'|null} DialogType
+ * @typedef {'blackboardFile'|'canvasFile'|'d2lFile'|'jstor'|'url'|'vitalSourceBook'|null} DialogType
  *
  * @typedef {import('../utils/content-item').Content} Content
  */
@@ -48,6 +48,7 @@ export default function ContentSelector({
         listFiles: blackboardListFilesApi,
       },
       canvas: { enabled: canvasFilesEnabled, listFiles: listFilesApi },
+      d2l: { enabled: d2lFilesEnabled, listFiles: d2lListFilesApi },
       google: {
         clientId: googleClientId,
         developerKey: googleDeveloperKey,
@@ -124,7 +125,7 @@ export default function ContentSelector({
   };
 
   /** @param {File} file */
-  const selectBlackboardFile = file => {
+  const selectLMSFile = file => {
     cancelDialog();
     // file.id shall be a url of the form blackboard://content-resource/{file_id}
     onSelectContent({ type: 'url', url: file.id });
@@ -164,7 +165,7 @@ export default function ContentSelector({
           authToken={authToken}
           listFilesApi={blackboardListFilesApi}
           onCancel={cancelDialog}
-          onSelectFile={selectBlackboardFile}
+          onSelectFile={selectLMSFile}
           // An alias we maintain that provides multiple external documentation links for
           // different versions of Blackboard (Classic vs. Ultra)
           missingFilesHelpLink={'https://web.hypothes.is/help/bb-files'}
@@ -172,6 +173,21 @@ export default function ContentSelector({
         />
       );
       break;
+    case 'd2lFile':
+      dialog = (
+        <LMSFilePicker
+          authToken={authToken}
+          listFilesApi={d2lListFilesApi}
+          onCancel={cancelDialog}
+          onSelectFile={selectLMSFile}
+          // An alias we maintain that provides multiple external documentation links for
+          // different versions of Blackboard (Classic vs. Ultra)
+          missingFilesHelpLink={'https://web.hypothes.is/help/bb-files'}
+          withBreadcrumbs
+        />
+      );
+      break;
+
     case 'jstor':
       dialog = <JSTORPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
       break;
@@ -257,6 +273,16 @@ export default function ContentSelector({
               Select PDF from Blackboard
             </LabeledButton>
           )}
+          {d2lFilesEnabled && (
+            <LabeledButton
+              onClick={() => selectDialog('d2lFile')}
+              variant="primary"
+              data-testid="blackboard-file-button"
+            >
+              Select PDF from D2L
+            </LabeledButton>
+          )}
+
           {googlePicker && (
             <LabeledButton
               onClick={showGooglePicker}

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -56,6 +56,9 @@ function formatContentURL(content) {
   if (content.url.startsWith('blackboard://')) {
     return 'PDF file in Blackboard';
   }
+  if (content.url.startsWith('d2l://')) {
+    return 'PDF file in D2L';
+  }
   if (content.url.startsWith('vitalsource://')) {
     return 'Book from VitalSource';
   }
@@ -90,13 +93,21 @@ export default function FilePickerApp({ onSubmit }) {
   const submitButton = /** @type {{ current: HTMLInputElement }} */ (useRef());
   const {
     api: { authToken },
-    filePicker: { deepLinkingAPI, formAction, formFields, blackboard, canvas, d2l },
+    filePicker: {
+      deepLinkingAPI,
+      formAction,
+      formFields,
+      blackboard,
+      canvas,
+      d2l,
+    },
   } = useContext(Config);
 
   const [content, setContent] = useState(/** @type {Content|null} */ (null));
 
   // TODO we don't need to pick this from each product, just expose one groupsEnabled and pick that up
-  const enableGroupConfig = blackboard?.groupsEnabled || canvas?.groupsEnabled || d2l?.groupsEnabled;
+  const enableGroupConfig =
+    blackboard?.groupsEnabled || canvas?.groupsEnabled || d2l?.groupsEnabled;
 
   const [groupConfig, setGroupConfig] = useState(
     /** @type {GroupConfig} */ ({

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -90,12 +90,13 @@ export default function FilePickerApp({ onSubmit }) {
   const submitButton = /** @type {{ current: HTMLInputElement }} */ (useRef());
   const {
     api: { authToken },
-    filePicker: { deepLinkingAPI, formAction, formFields, blackboard, canvas },
+    filePicker: { deepLinkingAPI, formAction, formFields, blackboard, canvas, d2l },
   } = useContext(Config);
 
   const [content, setContent] = useState(/** @type {Content|null} */ (null));
 
-  const enableGroupConfig = blackboard?.groupsEnabled || canvas?.groupsEnabled;
+  // TODO we don't need to pick this from each product, just expose one groupsEnabled and pick that up
+  const enableGroupConfig = blackboard?.groupsEnabled || canvas?.groupsEnabled || d2l?.groupsEnabled;
 
   const [groupConfig, setGroupConfig] = useState(
     /** @type {GroupConfig} */ ({

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -147,7 +147,8 @@ export default function GroupConfigSelector({
 
   const useGroupSet = groupConfig.useGroupSet;
   const groupSet = useGroupSet ? groupConfig.groupSet : null;
-  const listGroupSetsAPI = canvas?.listGroupSets ?? blackboard?.listGroupSets ?? d2l?.listGroupSets;
+  const listGroupSetsAPI =
+    canvas?.listGroupSets ?? blackboard?.listGroupSets ?? d2l?.listGroupSets;
 
   const fetchingGroupSets = !groupSets && !fetchError && useGroupSet;
 

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -142,12 +142,12 @@ export default function GroupConfigSelector({
 
   const {
     api: { authToken },
-    filePicker: { blackboard, canvas },
+    filePicker: { blackboard, canvas, d2l },
   } = useContext(Config);
 
   const useGroupSet = groupConfig.useGroupSet;
   const groupSet = useGroupSet ? groupConfig.groupSet : null;
-  const listGroupSetsAPI = canvas?.listGroupSets ?? blackboard?.listGroupSets;
+  const listGroupSetsAPI = canvas?.listGroupSets ?? blackboard?.listGroupSets ?? d2l?.listGroupSets;
 
   const fetchingGroupSets = !groupSets && !fetchError && useGroupSet;
 

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -65,8 +65,10 @@ import { createContext } from 'preact';
  *   @prop {APICallInfo} blackboard.listFiles
  *   @prop {APICallInfo} blackboard.listGroupSets
  * @prop {object} d2l
- *   @prop {boolean} canvas.groupsEnabled
- *   @prop {APICallInfo} canvas.listGroupSets
+ *   @prop {boolean} d2l.enabled
+ *   @prop {boolean} d2l.groupsEnabled
+ *   @prop {APICallInfo} d2l.listGroupSets
+ *   @prop {APICallInfo} d2l.listFiles
  * @prop {object} canvas
  *   @prop {boolean} canvas.enabled
  *   @prop {boolean} canvas.groupsEnabled

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -64,6 +64,9 @@ import { createContext } from 'preact';
  *   @prop {boolean} blackboard.groupsEnabled
  *   @prop {APICallInfo} blackboard.listFiles
  *   @prop {APICallInfo} blackboard.listGroupSets
+ * @prop {object} d2l
+ *   @prop {boolean} canvas.groupsEnabled
+ *   @prop {APICallInfo} canvas.listGroupSets
  * @prop {object} canvas
  *   @prop {boolean} canvas.enabled
  *   @prop {boolean} canvas.groupsEnabled

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -31,6 +31,8 @@ class LTIV11CoreSchema(PyramidRequestSchema):
     lis_person_name_full = fields.Str(load_default="")
     lis_person_contact_email_primary = fields.Str(load_default="")
 
+    lms_user_id = fields.Str(required=True)
+
     @pre_load
     def _decode_jwt(self, data, **_kwargs):
         """Use the values encoded in the `id_token` JWT if present."""

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -64,6 +64,7 @@ class BearerTokenSchema(PyramidRequestSchema):
     tool_consumer_instance_guid = marshmallow.fields.Str(required=True)
     display_name = marshmallow.fields.Str(required=True)
     email = marshmallow.fields.Str()
+    lms_user_id = marshmallow.fields.Str()
 
     def __init__(self, request):
         super().__init__(request)

--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -1,0 +1,53 @@
+from urllib.parse import urlencode, urlunparse
+
+from pyramid.httpexceptions import HTTPFound
+from pyramid.view import exception_view_config, view_config
+
+from lms.security import Permissions
+from lms.validation.authentication import OAuthCallbackSchema
+from lms.services.d2l_api import D2LAPIClient
+
+
+@view_config(
+    request_method="GET",
+    route_name="d2l_api.oauth.authorize",
+    permission=Permissions.API,
+)
+def authorize(request):
+    application_instance = request.find_service(
+        name="application_instance"
+    ).get_current()
+    state = OAuthCallbackSchema(request).state_param()
+
+    return HTTPFound(
+        location=urlunparse(
+            (
+                "https",
+                "auth.brightspace.com",
+                "oauth2/auth",
+                "",
+                urlencode(
+                    {
+                        "client_id": application_instance.developer_key,
+                        "response_type": "code",
+                        "redirect_uri": request.route_url("d2l_api.oauth.callback"),
+                        "state": state,
+                        "scope": "core:*:* groups:*:*",
+                    }
+                ),
+                "",
+            )
+        )
+    )
+
+
+@view_config(
+    request_method="GET",
+    route_name="d2l_api.oauth.callback",
+    permission=Permissions.API,
+    renderer="lms:templates/api/oauth2/redirect.html.jinja2",
+    schema=OAuthCallbackSchema,
+)
+def oauth2_redirect(request):
+    request.find_service(D2LAPIClient).get_token(request.params["code"])
+    return {}

--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -32,7 +32,7 @@ def authorize(request):
                         "response_type": "code",
                         "redirect_uri": request.route_url("d2l_api.oauth.callback"),
                         "state": state,
-                        "scope": "core:*:* groups:*:*",
+                        "scope": "core:*:* groups:*:* content:toc:read managefiles:files:read",
                     }
                 ),
                 "",

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -1,0 +1,87 @@
+"""Proxy API views for files-related D2L API endpoints."""
+import re
+
+from pyramid.view import view_config, view_defaults
+
+from lms.product.d2l import D2L
+from lms.security import Permissions
+from lms.views import helpers
+from lms.services import D2LAPIClient
+
+#: A regex for parsing just the file_id part out of one of our custom
+#: d2l://content-resource/<file_id>/ URLs.
+DOCUMENT_URL_REGEX = re.compile(r"d2l:\/\/content-resource\/(?P<file_path>.*)")
+
+
+@view_defaults(permission=Permissions.API, renderer="json")
+class D2LFilesAPIViews:
+    def __init__(self, request):
+        self.request = request
+        self.d2l_api_client = request.find_service(D2LAPIClient)
+
+    @view_config(request_method="GET", route_name="d2l_api.courses.files.list")
+    def list_files(self):
+        """Return the list of files in the given course or folder."""
+
+        course_id = self.request.matchdict["course_id"]
+        folder_id = self.request.matchdict.get("folder_id")
+
+        results = self.d2l_api_client.course_table_of_contents(course_id).json()
+
+        response_results = []
+        for module in results["Modules"]:
+            # Does the FE support returning the whole folder structure in one go?
+            response_results.append(
+                {
+                    "display_name": module["Title"],
+                    "updated_at": module["LastModifiedDate"],
+                    "type": "Folder",
+                    "id": module["ModuleId"],
+                    "parent_id": None,
+                }
+            )
+
+            for topic in module["Topics"]:
+                if topic["TypeIdentifier"] != "File":
+                    continue
+                response_results.append(
+                    {
+                        "display_name": topic["Title"],
+                        "updated_at": topic["LastModifiedDate"],
+                        "type": "File",
+                        # If want the complete folder structure we'd need itkj
+                        # we need to take it from here
+                        # we also need to remove /content/enforced/6782-DTC101/
+                        "id": f"d2l://content-resource/{topic['Url']}",
+                        "parent_id": module["ModuleId"],
+                    }
+                )
+
+        return response_results
+
+    @view_config(request_method="GET", route_name="d2l_api.files.via_url")
+    def via_url(self):
+        """Return the Via URL for annotating the given D2L file."""
+
+        course_id = self.request.matchdict["course_id"]
+        document_url = self.request.params["document_url"]
+        print(document_url)
+        file_path = DOCUMENT_URL_REGEX.search(document_url)["file_path"]
+
+        file_path = file_path.replace("/content/enforced/6782-DTC101/", "")
+
+        public_url = self.d2l_api_client.public_url(course_id, file_path)
+
+        via_url = helpers.via_url(self.request, public_url, content_type="pdf")
+
+        #
+        # NO via pdf gets downloaded
+        # return {"via_url": public_url}
+        return {"via_url": via_url}
+
+
+"""
+/d2l/api/le/(version)/(orgUnitId)/content/toc
+
+https://docs.valence.desire2learn.com/res/course.html#get--d2l-api-lp-(version)-(orgUnitId)-managefiles-filekjhttps://docs.valence.desire2learn.com/res/content.html#get--d2l-api-le-(version)-(orgUnitId)-content-toc
+"""

--- a/lms/views/api/d2l/groups.py
+++ b/lms/views/api/d2l/groups.py
@@ -1,0 +1,16 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+from lms.services.d2l_api import D2LAPIClient
+
+
+@view_config(
+    request_method="GET",
+    permission=Permissions.API,
+    renderer="json",
+    route_name="d2l_api.courses.group_sets.list",
+)
+def course_group_sets(_context, request):
+    return request.find_service(D2LAPIClient).course_group_sets(
+        request.matchdict["course_id"]
+    )


### PR DESCRIPTION
## General API

- We need to use https endpoints to use the API. The approach taken here is enough.
- The authentication (OAuth2) is similar to other LMSs


## Groups 

- Groups match pretty much 1 to 1 with other implementations


## Files

- The API around files seems a bit incomplete.
- The last endpoint, to get the file contents, return the PDF bytes directly and needs to be authenticated. This is not how it usually works with via (not 100% sure, maybe we can reuse some other source's existing flow)

- "public files"

Not linked to a course. No API integration with those.

- There seems to be a dropbox integration accessible from the API :thinking: 

https://docs.valence.desire2learn.com/res/dropbox.html


- Files can be added directly to the course here 
https://aunltd.brightspacedemo.com/d2l/lp/manageFiles/main.d2l?ou=6782

I can't find a way to list those through the API

- Or added directly as "topics" (the same as assignment)

This also end up in "Manage files" but they can be accessed. This is what the PR works on but it seems and odd choice to organize files.


## Product questions

- Are there multiple UI flavors like in blackboard we don't know about?

- Could we offer this as an LTI1.3 only feature. It does not need LTI1.3 in particular but we could avoid some extra compatibility work.

- Can we confirm how schools use groups. The assumption here is "like in canvas or blackboard".

- Can we confirm how schools use files. Is not very clear if they'd use them like I assume here.
- If we phased this in 1/ groups and 2/files. Would adding extra scopes for files later on be a problem.
- Should we tackle "course copy for groups" attached to this.
