### PR TITLE
Support HTTPS in `make dev`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,14 @@ yarn-error.log
 include/
 .pytest_cache
 
-# Devloper Specific Files
+# Developer Specific Files
 secret_env.sh
 .autoenv
 docker.sh
+
+# Files created by make devdata
 .devdata.env
+.certificates
 
 # yalc related files
 yalc.lock

--- a/bin/update_dev_data.py
+++ b/bin/update_dev_data.py
@@ -143,6 +143,13 @@ def devdata():
                 os.path.join(pathlib.Path(lms.__file__).parent.parent, ".devdata.env"),
             )
 
+            # Copy any certificates
+            shutil.copytree(
+                os.path.join(git_dir, "lms", "certificates"),
+                os.path.join(pathlib.Path(lms.__file__).parent.parent, ".certificates"),
+                dirs_exist_ok=True,
+            )
+
             with open(
                 os.path.join(git_dir, "lms", "devdata.json"), encoding="utf-8"
             ) as handle:

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -9,6 +9,13 @@ stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
 
+[program:web-https]
+command=gunicorn --paste conf/development.ini --certfile=.certificates/localhost/localhost.crt --keyfile=.certificates/localhost/localhost.key -b :48001
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal = KILL
+stopasgroup = true
+
 [program:worker]
 command=celery -A lms.tasks.celery:app worker --loglevel=INFO
 stdout_logfile=NONE


### PR DESCRIPTION
This is not a solution for #3690  but it will help in some cases.

The main motivation for this is D2L requirement that oauth2 callbacks are in https domains. They allow https://localhost so this is a much simpler solution that anything involving tunnels.

To test this requirement head over https://aunltd.brightspacedemo.com/d2l/lp/extensibility/oauth2

(credentials in 1Password) and try to edit the existing key to use http.

---

Using certificates stored in devdata server the main application at '48001' using gunicorn builtin HTTPS support.


- Using '4' + '8001' as the HTTPS port I think this could be an easy to remember convention if we exteneed this to other projects.


- Running the HTTPS server in the main `make dev` command. This will fail if some of the HTTPS setup is wrong but will avoid the HTTPS support to bit rot over time.


## Testing 


- Checkout this branch of devdata https://github.com/hypothesis/devdata/pull/63


- Make a diff similar too:

```diff
diff --git a/bin/update_dev_data.py b/bin/update_dev_data.py
index 49bed167..dff10eac 100644
--- a/bin/update_dev_data.py
+++ b/bin/update_dev_data.py
@@ -134,7 +134,8 @@ def devdata():
             git_dir = os.path.join(tmpdirname, "devdata")
 
             subprocess.check_call(
-                ["git", "clone", "https://github.com/hypothesis/devdata.git", git_dir]
+                # ["git", "clone", "https://github.com/hypothesis/devdata.git", git_dir]
+                ["git", "clone", "/home/marcos/hypo/devdata", git_dir]
             )
 
             # Copy devdata env file into place.

```

to point LMS's devdata command to your local copy.



- `make devdata`


- `make dev`

You'll see loggin indicating that gunicorn is now running twice, one for http and one for https:


```
web (stderr)         | [2022-10-24 12:00:31 +0200] [1639546] [INFO] Starting gunicorn 20.1.0
web (stderr)         | [2022-10-24 12:00:31 +0200] [1639546] [INFO] Listening at: http://0.0.0.0:8001 (1639546)
web (stderr)         | [2022-10-24 12:00:31 +0200] [1639546] [INFO] Using worker: sync
web (stderr)         | [2022-10-24 12:00:31 +0200] [1639576] [INFO] Booting worker with pid: 1639576
web-https (stderr)   | [2022-10-24 12:00:31 +0200] [1639547] [INFO] Starting gunicorn 20.1.0
web-https (stderr)   | [2022-10-24 12:00:31 +0200] [1639547] [INFO] Listening at: https://0.0.0.0:48001 (1639547)
web-https (stderr)   | [2022-10-24 12:00:31 +0200] [1639547] [INFO] Using worker: sync
web-https (stderr)   | [2022-10-24 12:00:31 +0200] [1639578] [INFO] Booting worker with pid: 1639578
web-https (stderr)   | [2022-10-24 12:00:31 +0200] [1639583] [INFO] Booting worker with pid: 1639583
web (stderr)         | [2022-10-24 12:00:31 +0200] [1639584] [INFO] Booting worker with pid: 1639584
```

head over:

- http://localhost:8001/welcome (works as expected)
- https://localhost:48001/welcome
You'll get a (in chrome) `Your connection is not private` warning that you can dismiss with `Proceed to localhost (unsafe)`.

We don't need to trust this certificate in our browser for the D2L testing.






