### PR TITLE
Refactor groups config

### DIFF
--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -18,3 +18,4 @@ class Blackboard(Product):
     plugin_config: PluginConfig = PluginConfig(
         grouping_service=BlackboardGroupingPlugin
     )
+    settings_key = "blackboard"

--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -13,6 +13,7 @@ class Blackboard(Product):
     route: Routes = Routes(
         oauth2_authorize="blackboard_api.oauth.authorize",
         oauth2_refresh="blackboard_api.oauth.refresh",
+        list_group_sets="blackboard_api.courses.group_sets.list",
     )
 
     plugin_config: PluginConfig = PluginConfig(

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -13,6 +13,7 @@ class Canvas(Product):
     route: Routes = Routes(
         oauth2_authorize="canvas_api.oauth.authorize",
         oauth2_refresh="canvas_api.oauth.refresh",
+        list_group_sets="canvas_api.courses.group_sets.list",
     )
 
     plugin_config: PluginConfig = PluginConfig(grouping_service=CanvasGroupingPlugin)

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -16,3 +16,5 @@ class Canvas(Product):
     )
 
     plugin_config: PluginConfig = PluginConfig(grouping_service=CanvasGroupingPlugin)
+
+    settings_key = "canvas"

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -28,11 +28,14 @@ class Family(str, Enum):
 class Routes:
     """A collection of Pyramid route names for various functions."""
 
-    oauth2_authorize: str = None
+    oauth2_authorize: Optional[str] = None
     """Authorizing with OAuth 2."""
 
-    oauth2_refresh: str = None
+    oauth2_refresh: Optional[str] = None
     """Refreshing OAuth 2 tokens."""
+
+    list_group_sets: Optional[str] = None
+    """List available group sets. Takes a course_id parameter"""
 
 
 @dataclass

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -64,10 +64,9 @@ class Product:
     Family = Family
 
     @classmethod
-    def from_request(cls, request):
+    def from_request(cls, request, ai_settings: Dict):
         """Create a populated product object from the provided request."""
-        ai = request.find_service(name="application_instance").get_current()
-        product_settings = ai.settings.get(cls.settings_key, {})
+        product_settings = ai_settings.get(cls.settings_key, {})
 
         return cls(
             plugin=Plugins(request, cls.plugin_config),

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -40,7 +40,10 @@ class Routes:
 
 @dataclass
 class Settings:
+    """Product specific settings."""
+
     groups_enabled: bool = False
+    """Is the course groups feature enabled"""
 
     product_settings: InitVar[Dict] = field(default_factory=dict)
 

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -42,10 +42,10 @@ class Routes:
 class Settings:
     """Product specific settings."""
 
+    product_settings: InitVar[Dict]
+
     groups_enabled: bool = False
     """Is the course groups feature enabled"""
-
-    product_settings: InitVar[Dict] = field(default_factory=dict)
 
     def __post_init__(self, product_settings):
         self.groups_enabled = product_settings.get("groups_enabled", False)

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -208,6 +208,7 @@ class JSConfig:
         self._config.update(
             {
                 "mode": JSConfig.Mode.FILE_PICKER,
+                # Info about the product we are currently running in
                 "product": self._get_product_info(),
                 "filePicker": {
                     "formAction": form_action,
@@ -420,13 +421,16 @@ class JSConfig:
         return config
 
     def _get_product_info(self):
+        """Return product (Canvas, BB, D2L..) configuration."""
         product = self._request.product
 
         product_info = {
             "family": product.family,
-            "features": {
-                "groups": self._request.product.settings.groups_enabled,
+            "settings": {
+                # Is the small groups feature enabled
+                "groupsEnabled": self._request.product.settings.groups_enabled,
             },
+            # List of API endpoints we proxy for this product
             "api": {},
         }
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -409,6 +409,12 @@ class JSConfig:
             # launches its BasicLtiLaunchApp, whereas in
             # "content-item-selection" mode it launches its FilePickerApp.
             "mode": None,
+            "product": {
+                "family": self._request.product.family,
+                "features": {
+                    "groups": self._request.product.settings.groups_enabled,
+                },
+            },
         }
 
         if self._lti_user:

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -414,6 +414,7 @@ class JSConfig:
                 "features": {
                     "groups": self._request.product.settings.groups_enabled,
                 },
+                "api": self._product_api_config(),
             },
         }
 
@@ -423,6 +424,27 @@ class JSConfig:
             )
 
         return config
+
+    def _product_api_config(self):
+        product = self._request.product
+        # This should be abstracted as "lms_course_id" or similar in either
+        # LTIParams or as part of product.
+        api_course_id = self._request.lti_params.get(
+            "custom_canvas_course_id"
+        ) or self._request.lti_params.get("context_id")
+
+        api_config = {}
+
+        if product.route.list_group_sets:
+            api_config["listGroupSets"] = {
+                "authUrl": self._request.route_url(product.route.oauth2_authorize),
+                "path": self._request.route_path(
+                    product.route.list_group_sets,
+                    course_id=api_course_id,
+                ),
+            }
+
+        return api_config
 
     @property
     @functools.lru_cache()

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -208,6 +208,7 @@ class JSConfig:
         self._config.update(
             {
                 "mode": JSConfig.Mode.FILE_PICKER,
+                "product": self._get_product_info(),
                 "filePicker": {
                     "formAction": form_action,
                     "formFields": form_fields,
@@ -409,13 +410,6 @@ class JSConfig:
             # launches its BasicLtiLaunchApp, whereas in
             # "content-item-selection" mode it launches its FilePickerApp.
             "mode": None,
-            "product": {
-                "family": self._request.product.family,
-                "features": {
-                    "groups": self._request.product.settings.groups_enabled,
-                },
-                "api": self._product_api_config(),
-            },
         }
 
         if self._lti_user:
@@ -425,18 +419,25 @@ class JSConfig:
 
         return config
 
-    def _product_api_config(self):
+    def _get_product_info(self):
         product = self._request.product
-        # This should be abstracted as "lms_course_id" or similar in either
-        # LTIParams or as part of product.
-        api_course_id = self._request.lti_params.get(
-            "custom_canvas_course_id"
-        ) or self._request.lti_params.get("context_id")
 
-        api_config = {}
+        product_info = {
+            "family": product.family,
+            "features": {
+                "groups": self._request.product.settings.groups_enabled,
+            },
+            "api": {},
+        }
 
         if product.route.list_group_sets:
-            api_config["listGroupSets"] = {
+            # This should be abstracted as "lms_course_id" or similar in either
+            # LTIParams or as part of product.
+            api_course_id = self._request.lti_params.get(
+                "custom_canvas_course_id"
+            ) or self._request.lti_params.get("context_id")
+
+            product_info["api"]["listGroupSets"] = {
                 "authUrl": self._request.route_url(product.route.oauth2_authorize),
                 "path": self._request.route_path(
                     product.route.list_group_sets,
@@ -444,7 +445,7 @@ class JSConfig:
                 ),
             }
 
-        return api_config
+        return product_info
 
     @property
     @functools.lru_cache()

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -11,31 +11,17 @@ class FilePickerConfig:
     def blackboard_config(cls, request, application_instance):
         """Get Blackboard files config."""
         files_enabled = application_instance.settings.get("blackboard", "files_enabled")
-        groups_enabled = application_instance.settings.get(
-            "blackboard", "groups_enabled"
-        )
 
         auth_url = request.route_url(Blackboard.route.oauth2_authorize)
         course_id = request.lti_params.get("context_id")
 
-        config = {
-            "enabled": files_enabled,
-            "groupsEnabled": groups_enabled,
-        }
+        config = {"enabled": files_enabled}
 
         if files_enabled:
             config["listFiles"] = {
                 "authUrl": auth_url,
                 "path": request.route_path(
                     "blackboard_api.courses.files.list", course_id=course_id
-                ),
-            }
-
-        if groups_enabled:
-            config["listGroupSets"] = {
-                "authUrl": auth_url,
-                "path": request.route_path(
-                    "blackboard_api.courses.group_sets.list", course_id=course_id
                 ),
             }
 
@@ -49,14 +35,12 @@ class FilePickerConfig:
             "custom_canvas_course_id" in request.lti_params
             and application_instance.developer_key is not None
         )
-        groups_enabled = application_instance.settings.get("canvas", "groups_enabled")
 
         auth_url = request.route_url(Canvas.route.oauth2_authorize)
         course_id = request.lti_params.get("custom_canvas_course_id")
 
         config = {
             "enabled": enabled,
-            "groupsEnabled": groups_enabled,
             "listFiles": {
                 "authUrl": auth_url,
                 "path": request.route_path(
@@ -64,14 +48,6 @@ class FilePickerConfig:
                 ),
             },
         }
-
-        if groups_enabled:
-            config["listGroupSets"] = {
-                "authUrl": auth_url,
-                "path": request.route_path(
-                    "canvas_api.courses.group_sets.list", course_id=course_id
-                ),
-            }
 
         return config
 

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -90,13 +90,13 @@ export default function FilePickerApp({ onSubmit }) {
   const submitButton = /** @type {{ current: HTMLInputElement }} */ (useRef());
   const {
     api: { authToken },
-    product: { settings },
+    product: {
+      settings: { groupsEnabled: enableGroupConfig },
+    },
     filePicker: { deepLinkingAPI, formAction, formFields },
   } = useContext(Config);
 
   const [content, setContent] = useState(/** @type {Content|null} */ (null));
-
-  const enableGroupConfig = settings.groupsEnabled;
 
   const [groupConfig, setGroupConfig] = useState(
     /** @type {GroupConfig} */ ({

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -90,13 +90,13 @@ export default function FilePickerApp({ onSubmit }) {
   const submitButton = /** @type {{ current: HTMLInputElement }} */ (useRef());
   const {
     api: { authToken },
-    product: { features },
+    product: { settings },
     filePicker: { deepLinkingAPI, formAction, formFields },
   } = useContext(Config);
 
   const [content, setContent] = useState(/** @type {Content|null} */ (null));
 
-  const enableGroupConfig = features.groups;
+  const enableGroupConfig = settings.groupsEnabled;
 
   const [groupConfig, setGroupConfig] = useState(
     /** @type {GroupConfig} */ ({

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -90,12 +90,13 @@ export default function FilePickerApp({ onSubmit }) {
   const submitButton = /** @type {{ current: HTMLInputElement }} */ (useRef());
   const {
     api: { authToken },
-    filePicker: { deepLinkingAPI, formAction, formFields, blackboard, canvas },
+    product: { features },
+    filePicker: { deepLinkingAPI, formAction, formFields },
   } = useContext(Config);
 
   const [content, setContent] = useState(/** @type {Content|null} */ (null));
 
-  const enableGroupConfig = blackboard?.groupsEnabled || canvas?.groupsEnabled;
+  const enableGroupConfig = features.groups;
 
   const [groupConfig, setGroupConfig] = useState(
     /** @type {GroupConfig} */ ({

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -142,12 +142,13 @@ export default function GroupConfigSelector({
 
   const {
     api: { authToken },
-    product: { api },
+    product: {
+      api: { listGroupSets: listGroupSetsAPI },
+    },
   } = useContext(Config);
 
   const useGroupSet = groupConfig.useGroupSet;
   const groupSet = useGroupSet ? groupConfig.groupSet : null;
-  const listGroupSetsAPI = api.listGroupSets;
 
   const fetchingGroupSets = !groupSets && !fetchError && useGroupSet;
 

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -142,12 +142,12 @@ export default function GroupConfigSelector({
 
   const {
     api: { authToken },
-    filePicker: { blackboard, canvas },
+    product: { api },
   } = useContext(Config);
 
   const useGroupSet = groupConfig.useGroupSet;
   const groupSet = useGroupSet ? groupConfig.groupSet : null;
-  const listGroupSetsAPI = canvas?.listGroupSets ?? blackboard?.listGroupSets;
+  const listGroupSetsAPI = api.listGroupSets;
 
   const fetchingGroupSets = !groupSets && !fetchError && useGroupSet;
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -34,8 +34,8 @@ describe('FilePickerApp', () => {
     fakeConfig = {
       api: { authToken: 'DUMMY_AUTH_TOKEN' },
       product: {
-        features: {
-          groups: false,
+        settings: {
+          groupsEnabled: false,
         },
       },
       filePicker: {
@@ -215,7 +215,7 @@ describe('FilePickerApp', () => {
 
   context('when group configuration is enabled', () => {
     beforeEach(() => {
-      fakeConfig.product.features.groups = true;
+      fakeConfig.product.settings.groupsEnabled = true;
     });
 
     it('does not submit form when content is selected', () => {

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -34,8 +34,8 @@ describe('GroupConfigSelector', () => {
     fakeAPICall.withArgs(groupSetsAPIRequest).resolves(fakeGroupSets);
     fakeConfig = {
       api: { authToken: groupSetsAPIRequest.authToken },
-      filePicker: {
-        canvas: {
+      product: {
+        api: {
           listGroupSets: {
             authUrl: authURL,
             path: groupSetsAPIRequest.path,
@@ -255,36 +255,6 @@ describe('GroupConfigSelector', () => {
     assert.calledWith(onChangeGroupConfig, {
       useGroupSet: false,
       groupSet: null,
-    });
-  });
-
-  context('Blackboard groups', () => {
-    // Component functionality should be identical for either canvas or
-    // blackboard groups; this exercises the blackboard path specifically
-    it('fetches blackboard groups if activated in config', async () => {
-      fakeConfig.filePicker = {
-        blackboard: {
-          listGroupSets: {
-            authUrl: authURL,
-            path: groupSetsAPIRequest.path,
-          },
-        },
-      };
-      const wrapper = createComponent({
-        groupConfig: { useGroupSet: true, groupConfig: null },
-      });
-
-      // Once group sets are fetched, they should be rendered as `<option>`s.
-      const options = await waitForElement(
-        wrapper,
-        'option[data-testid="groupset-option"]'
-      );
-      assert.equal(options.length, fakeGroupSets.length);
-
-      fakeGroupSets.forEach((gs, i) => {
-        assert.equal(options.at(i).text(), gs.name);
-        assert.equal(options.at(i).prop('value'), gs.id);
-      });
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -161,12 +161,6 @@ import { createContext } from 'preact';
  */
 
 /**
- * Each product type known
- * @typedef {'BlackbaudK12'|'BlackboardLearn'|'canvas'|'desire2learn'|'moodle'|'sakai'| 'schoology' | 'unknown'} ProductFamily
- *
- */
-
-/**
  * Features enabled for the current product
  *
  * @typedef ProductFeatures
@@ -184,7 +178,7 @@ import { createContext } from 'preact';
  * Information for the current product
  *
  * @typedef Product
- * @prop {ProductFamily} family
+ * @prop {string} family
  * @prop {ProductFeatures} features
  * @prop {ProductAPI} api
  */

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -161,7 +161,7 @@ import { createContext } from 'preact';
  */
 
 /**
- * Settings or the current product
+ * Settings of the current product
  *
  * @typedef ProductSettings
  * @prop {boolean} groupsEnabled
@@ -175,7 +175,7 @@ import { createContext } from 'preact';
  */
 
 /**
- * Information for the current product
+ * Information about the current product
  *
  * @typedef Product
  * @prop {string} family

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -165,6 +165,27 @@ import { createContext } from 'preact';
  */
 
 /**
+ * Each product type known
+ * @typedef {'BlackbaudK12'|'BlackboardLearn'|'canvas'|'desire2learn'|'moodle'|'sakai'| 'schoology' | 'unknown'} ProductFamily
+ *
+ */
+
+/**
+ * Features enabled for the current product
+ *
+ * @typedef ProductFeatures
+ * @prop {boolean} groups
+ */
+
+/**
+ * Information for the current productr
+ *
+ * @typedef Product
+ * @prop {ProductFamily} family
+ * @prop {ProductFeatures} features
+ */
+
+/**
  * Data/configuration needed for frontend applications in the LMS app.
  * The `mode` property specifies which frontend application should load and
  * the available configuration/data depends on the mode and LTI user role.
@@ -191,6 +212,7 @@ import { createContext } from 'preact';
  * @prop {OAuthErrorConfig} OAuth2RedirectError
  * @prop {ErrorDialogConfig} errorDialog
  * @prop {DebugInfo} [debug]
+ * @prop {Product} product
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -161,10 +161,10 @@ import { createContext } from 'preact';
  */
 
 /**
- * Features enabled for the current product
+ * Settings or the current product
  *
- * @typedef ProductFeatures
- * @prop {boolean} groups
+ * @typedef ProductSettings
+ * @prop {boolean} groupsEnabled
  */
 
 /**
@@ -179,7 +179,7 @@ import { createContext } from 'preact';
  *
  * @typedef Product
  * @prop {string} family
- * @prop {ProductFeatures} features
+ * @prop {ProductSettings} settings
  * @prop {ProductAPI} api
  */
 

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -178,11 +178,19 @@ import { createContext } from 'preact';
  */
 
 /**
- * Information for the current productr
+ * API endpoints for the product
+ *
+ * @typedef ProductAPI
+ * @prop {APICallInfo} listGroupSets
+ */
+
+/**
+ * Information for the current product
  *
  * @typedef Product
  * @prop {ProductFamily} family
  * @prop {ProductFeatures} features
+ * @prop {ProductAPI} api
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -61,14 +61,10 @@ import { createContext } from 'preact';
  * @prop {string} ltiLaunchUrl
  * @prop {object} blackboard
  *   @prop {boolean} blackboard.enabled
- *   @prop {boolean} blackboard.groupsEnabled
  *   @prop {APICallInfo} blackboard.listFiles
- *   @prop {APICallInfo} blackboard.listGroupSets
  * @prop {object} canvas
  *   @prop {boolean} canvas.enabled
- *   @prop {boolean} canvas.groupsEnabled
  *   @prop {APICallInfo} canvas.listFiles
- *   @prop {APICallInfo} canvas.listGroupSets
  * @prop {object} google
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -120,7 +120,9 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
 
     pyramid_request.lti_jwt = {}
     pyramid_request.lti_params = {}
-    pyramid_request.product = Product.from_request(pyramid_request)
+    pyramid_request.product = Product.from_request(
+        pyramid_request, dict(application_instance.settings)
+    )
 
     # The DummyRequest request lacks a content_type property which the real
     # request has

--- a/tests/unit/lms/product/factory_test.py
+++ b/tests/unit/lms/product/factory_test.py
@@ -30,12 +30,16 @@ class TestGetProductFromRequest:
     ]
 
     @pytest.mark.parametrize("value,family,class_", PRODUCT_MAP)
-    def test_from_request_exact_match_lti(self, pyramid_request, value, family, class_):
+    def test_from_request_exact_match_lti(
+        self, pyramid_request, value, family, class_, application_instance
+    ):
         pyramid_request.lti_params["tool_consumer_info_product_family_code"] = value
 
         product = get_product_from_request(pyramid_request)
 
-        class_.from_request.assert_called_once_with(pyramid_request)
+        class_.from_request.assert_called_once_with(
+            pyramid_request, application_instance.settings
+        )
         assert product == class_.from_request.return_value
         assert product.family == family
 
@@ -51,24 +55,30 @@ class TestGetProductFromRequest:
         assert get_product_from_request(pyramid_request).family == family
 
     @pytest.mark.parametrize("value,family,class_", PRODUCT_MAP)
-    def test_from_request_api(self, pyramid_request, value, family, class_):
+    def test_from_request_api(
+        self, pyramid_request, value, family, class_, application_instance
+    ):
         pyramid_request.content_type = "application/json"
         pyramid_request.json = {"lms": {"product": value}}
 
         product = get_product_from_request(pyramid_request)
 
-        class_.from_request.assert_called_once_with(pyramid_request)
+        class_.from_request.assert_called_once_with(
+            pyramid_request, application_instance.settings
+        )
         assert product == class_.from_request.return_value
         assert product.family == family
 
-    def test_from_request_canvas_custom(self, pyramid_request):
+    def test_from_request_canvas_custom(self, pyramid_request, application_instance):
         pyramid_request.lti_params = {"custom_canvas_course_id": "course_id"}
 
         product = get_product_from_request(pyramid_request)
 
         # Pylint doesn't know we patched this
         # pylint: disable=no-member
-        Canvas.from_request.assert_called_once_with(pyramid_request)
+        Canvas.from_request.assert_called_once_with(
+            pyramid_request, application_instance.settings
+        )
         assert product == Canvas.from_request.return_value
         assert product.family == Product.Family.CANVAS
 
@@ -80,7 +90,9 @@ class TestGetProductFromRequest:
 
         product = get_product_from_request(pyramid_request)
 
-        class_.from_request.assert_called_once_with(pyramid_request)
+        class_.from_request.assert_called_once_with(
+            pyramid_request, application_instance.settings
+        )
         assert product == class_.from_request.return_value
         assert product.family == family
 

--- a/tests/unit/lms/product/product_test.py
+++ b/tests/unit/lms/product/product_test.py
@@ -7,7 +7,7 @@ from lms.product.product import Product
 
 class TestProduct:
     def test_from_request(self, Plugins):
-        product = Product.from_request(sentinel.request)
+        product = Product.from_request(sentinel.request, sentinel.ai_settings)
 
         assert isinstance(product, Product)
         Plugins.assert_called_once_with(sentinel.request, Product.plugin_config)

--- a/tests/unit/lms/product/product_test.py
+++ b/tests/unit/lms/product/product_test.py
@@ -7,7 +7,7 @@ from lms.product.product import Product
 
 class TestProduct:
     def test_from_request(self, Plugins):
-        product = Product.from_request(sentinel.request, sentinel.ai_settings)
+        product = Product.from_request(sentinel.request, {})
 
         assert isinstance(product, Product)
         Plugins.assert_called_once_with(sentinel.request, Product.plugin_config)

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -94,6 +94,11 @@ class TestEnableLTILaunchMode:
                 "authToken": bearer_token_schema.authorization_param.return_value,
                 "sync": None,
             },
+            "product": {
+                "api": {},
+                "family": Product.Family.UNKNOWN,
+                "features": {"groups": False},
+            },
             "canvas": {},
             "debug": {
                 "tags": [Any.string.matching("^role:.*")],
@@ -602,6 +607,21 @@ class TestEnableErrorDialogMode:
     @pytest.fixture
     def context(self):
         return create_autospec(OAuth2RedirectResource, spec_set=True, instance=True)
+
+
+class TestProductAPIConfig:
+    def test_empty(self, js_config):
+        assert js_config.asdict()["product"]["api"] == {}
+
+    def test_with_list_group_sets(self, js_config, pyramid_request):
+        pyramid_request.product.route.list_group_sets = "welcome"
+
+        assert js_config.asdict()["product"]["api"] == {
+            "listGroupSets": {
+                "authUrl": "http://example.com/welcome",
+                "path": "/welcome",
+            }
+        }
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -73,7 +73,7 @@ class TestFilePickerMode:
         assert js_config.asdict()["product"] == {
             "api": {},
             "family": "unknown",
-            "features": {"groups": False},
+            "settings": {"groupsEnabled": False},
         }
 
     def test_product_with_list_group_sets(self, js_config, pyramid_request):
@@ -91,7 +91,7 @@ class TestFilePickerMode:
                     "path": "/welcome",
                 }
             },
-            "features": {"groups": True},
+            "settings": {"groupsEnabled": True},
         }
 
     @pytest.fixture(autouse=True)

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -8,33 +8,19 @@ from lms.resources._js_config import FilePickerConfig
 
 
 class TestFilePickerConfig:
-    @pytest.mark.parametrize(
-        "files_enabled,groups_enabled",
-        [
-            (False, False),
-            (True, False),
-            (False, True),
-            (True, True),
-        ],
-    )
+    @pytest.mark.parametrize("files_enabled", [False, True])
     def test_blackboard_config(
-        self, pyramid_request, application_instance, files_enabled, groups_enabled
+        self, pyramid_request, application_instance, files_enabled
     ):
 
         pyramid_request.lti_params["context_id"] = "COURSE_ID"
         application_instance.settings.set("blackboard", "files_enabled", files_enabled)
-        application_instance.settings.set(
-            "blackboard", "groups_enabled", groups_enabled
-        )
 
         config = FilePickerConfig.blackboard_config(
             pyramid_request, application_instance
         )
 
-        expected_config = {
-            "enabled": files_enabled,
-            "groupsEnabled": groups_enabled,
-        }
+        expected_config = {"enabled": files_enabled}
 
         if files_enabled:
             expected_config["listFiles"] = {
@@ -42,42 +28,21 @@ class TestFilePickerConfig:
                 "path": "/api/blackboard/courses/COURSE_ID/files",
             }
 
-        if groups_enabled:
-            expected_config["listGroupSets"] = {
-                "authUrl": "http://example.com/api/blackboard/oauth/authorize",
-                "path": "/api/blackboard/courses/COURSE_ID/group_sets",
-            }
-
         assert config == expected_config
 
     @pytest.mark.usefixtures("with_is_canvas")
-    @pytest.mark.parametrize(
-        "groups_enabled",
-        [
-            False,
-            True,
-        ],
-    )
-    def test_canvas_config(self, pyramid_request, application_instance, groups_enabled):
+    def test_canvas_config(self, pyramid_request, application_instance):
         pyramid_request.lti_params["custom_canvas_course_id"] = "COURSE_ID"
-        application_instance.settings.set("canvas", "groups_enabled", groups_enabled)
 
         config = FilePickerConfig.canvas_config(pyramid_request, application_instance)
 
         expected_config = {
             "enabled": Any(),
-            "groupsEnabled": groups_enabled,
             "listFiles": {
                 "authUrl": "http://example.com/api/canvas/oauth/authorize",
                 "path": "/api/canvas/courses/COURSE_ID/files",
             },
         }
-
-        if groups_enabled:
-            expected_config["listGroupSets"] = {
-                "authUrl": "http://example.com/api/canvas/oauth/authorize",
-                "path": "/api/canvas/courses/COURSE_ID/group_sets",
-            }
 
         assert config == expected_config
 


### PR DESCRIPTION
While doing the D2L groups PoC there was lots of repetition around the config (is the feature enabled? what are the endpoint details?)

This aims to reduce the duplication exposing the details once, not once per product.



## Testing 

To check nothing's been broken in the process:


### Canvas


- Reconfigure https://hypothesis.instructure.com/courses/125/assignments/3118/edit?name=Testing+upgrade+-+marcos&due_at=null&points_possible=10

Set it to any document source and pick groups and a groupset. Launch it.



### Blackboard

- Same testing with https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1