### PR TITLE
Add the postgres container to an external network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,15 @@ services:
         test: ["CMD", "pg_isready", "-U", "postgres"]
         interval: 1s
 
+    networks:
+      - dbs
+
   rabbit:
    image: rabbitmq:3.6-management-alpine
    ports:
      - '127.0.0.1:5674:5672'
      - '127.0.0.1:15674:15672'
+
+networks:
+  dbs:
+    external: true


### PR DESCRIPTION
This allows containers in other projects to talk directly to H's DB.

With this change we can mimic the foreign data wrapper setup we have in production locally.