### PR TITLE
Make sure the network `dbs` exists for `make services`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 .PHONY: services
 services: args?=up -d
 services: python
+	@tox -qe dockercompose --run-command 'sh -c "docker network create dbs 2>/dev/null || true"'
 	@tox -qe dockercompose -- $(args)
 
 .PHONY: db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
         interval: 1s
-
     networks:
       - dbs
 
@@ -18,5 +17,8 @@ services:
      - '127.0.0.1:15674:15672'
 
 networks:
+  # This external network allows FDW connections between H, LMS and report DBs.
+  # To avoid having unnecessary dependencies between the projects
+  # the network is created with `docker network crate dbs` in each project's Makefile (make services)
   dbs:
     external: true

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
     VIA_SECRET = not_a_secret
 whitelist_externals =
-    tests,functests,bddtests: sh
+    tests,functests,bddtests,dockercompose: sh
 commands =
     pip-sync-faster requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}


### PR DESCRIPTION
(Needs to be tested together with the equivalent in H https://github.com/hypothesis/h/pull/7673)

The `dbs` network is used by multiple projects is available without needing to synchronize which project creates it first.


## Testing

- `docker-compose down` in both H and LMS
- `docker network rm dbs` (if you have created it manually)
- `make services` in both H and LMS, in any other.