### PR TITLE
Hide lines marked as secret in SQL tasks

### DIFF
--- a/lms/sql_tasks/sql_query.py
+++ b/lms/sql_tasks/sql_query.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -49,7 +50,7 @@ class SQLQuery:
         :param indent: Optional indenting string prepended to each line.
         """
 
-        text = textwrap.indent(self.text, prefix=f"{self.index}=> ")
+        text = textwrap.indent(self._clean_query(self.text), prefix=f"{self.index}=> ")
         if self.rows:
             text += "\n" + tabulate(
                 tabular_data=[list(row) for row in self.rows],
@@ -58,3 +59,13 @@ class SQLQuery:
             )
         text += f"\n\nTime: {self.duration}"
         return textwrap.indent(text, indent)
+
+    @staticmethod
+    def _clean_query(query: str) -> str:
+        """Clean any of the query's lines marked as sensitive."""
+        return "\n".join(
+            [
+                re.sub(r"[^\s]", "*", line) if "secret" in line.lower() else line
+                for line in query.split("\n")
+            ]
+        )

--- a/tests/unit/lms/sql_tasks/sql_query_test.py
+++ b/tests/unit/lms/sql_tasks/sql_query_test.py
@@ -41,6 +41,13 @@ class TestSQLQuery:
 >>> +----------+"""
         )
 
+    def test_dump_cleans_secrets(self, query_with_secret):
+        assert query_with_secret.dump().startswith(
+            """0=> SELECT
+0=>             ********** ** **** ** ******
+0=>             'value' AS column"""
+        )
+
     def test_dump_works_with_no_rows(self, query_no_rows):
         assert query_no_rows.dump()
 
@@ -70,3 +77,12 @@ class TestSQLQuery:
     @fixture
     def query_no_rows(self):
         return SQLQuery(0, 'ANALYZE "user"')
+
+    @fixture
+    def query_with_secret(self):
+        return SQLQuery(
+            0,
+            """SELECT
+            'password` AS pass -- secret
+            'value' AS column""",
+        )


### PR DESCRIPTION
This is a pretty silly method but I'm convinced the real solution should be done at the variable level (which contains the secrets) rather then at the script/line level.


I added a note to revisit this for this project but with this I'm sure if we remember something is a secret will stick a `-- secret` to it without worrying to much about messing up the formatting.