### PR TITLE
Add growth metrics and expose the timestamp column

### DIFF
--- a/lms/sql_tasks/tasks/report/create_from_scratch/01_functions/02_comparison_functions.sql
+++ b/lms/sql_tasks/tasks/report/create_from_scratch/01_functions/02_comparison_functions.sql
@@ -1,0 +1,16 @@
+-- Calculate the ratio of increase (or decrease) between two numbers taking
+-- care not to trip over divide by zero issues.
+-- For example:
+--    Moving from 100 to 200 will give a ratio of +1.0
+--    Moving from 200 to 100 will give a ratio of -0.5
+
+CREATE OR REPLACE FUNCTION report.growth_ratio(previous BIGINT, current BIGINT)
+RETURNS FLOAT4
+IMMUTABLE
+AS $$
+    SELECT CASE
+       WHEN previous != 0 THEN
+        ((current - previous) / previous::FLOAT)::FLOAT4
+    END
+$$
+LANGUAGE SQL;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/4

We also expose the underlying timestamp column for easier limiting to dates as our "period" field is a string.

## Testing notes

 * In `h`:
   * `make services`
   * tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development-app.ini --task report/create_from_scratch"
* In `lms`:
  * `make services`
  * `tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development.ini --task report/create_from_scratch"`
 * `make db`
 * `select * from report.organization_activity;`
 * You should see some stuff
 * `tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development.ini --task report/refresh"`
 * It shouldn't crash

You can also comment out the `xfail` in the functional tests in: `tests/functional/bin/run_sql_task_test.py`