### PR TITLE
Set the refresh job to happen 30 minutes after `h`

### DIFF
--- a/.github/workflows/report_refresh.yml
+++ b/.github/workflows/report_refresh.yml
@@ -3,8 +3,8 @@
 name: Report refresh
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: '0 14 * * *'
+  schedule:
+    - cron: '30 15 * * *'
 
 jobs:
   refresh:


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/4

Trigger the refresh job to happen 30 minutes after the `h` one. We can tweak the time eventually, but it's intended to run during times we will be around to see it fail (rather than waking someone up).

This will make it less reliable as people will probably disrupt it with deploys, but we can fix that later.