### PR TITLE
Include group info data when mapping groups to ensure we include old values

### DIFF
--- a/lms/sql_tasks/tasks/report/create_from_scratch/02_entities/04_group_map/01_create_view.sql
+++ b/lms/sql_tasks/tasks/report/create_from_scratch/02_entities/04_group_map/01_create_view.sql
@@ -1,16 +1,37 @@
 DROP MATERIALIZED VIEW IF EXISTS report.group_map CASCADE;
 
--- Map LMS groupings to reporting groups
+-- Map LMS groupings and organizations to reporting groups
 
 CREATE MATERIALIZED VIEW report.group_map AS (
+    WITH
+        all_groups AS (
+            SELECT
+                grouping.id AS lms_grouping_id,
+                -- Coalesce the ids in case the left or right side is missing
+                COALESCE(
+                    grouping.authority_provided_id,
+                    group_info.authority_provided_id
+                ) AS authority_provided_id,
+                COALESCE(
+                    grouping.application_instance_id,
+                    group_info.application_instance_id
+                ) AS application_instance_id
+            FROM grouping
+            -- Do a full outer join here so a result from either side will
+            -- result in a record
+            FULL OUTER JOIN group_info ON
+                group_info.authority_provided_id = grouping.authority_provided_id
+                AND group_info.application_instance_id = grouping.application_instance_id
+        )
+
     SELECT
-        grouping.id AS lms_grouping_id,
+        lms_grouping_id,
         groups.id AS group_id,
         application_instances.organization_id
-    FROM grouping
+    FROM all_groups
     JOIN report.groups ON
-        grouping.authority_provided_id = groups.authority_provided_id
+        all_groups.authority_provided_id = groups.authority_provided_id
     JOIN application_instances ON
-        grouping.application_instance_id = application_instances.id
+        all_groups.application_instance_id = application_instances.id
     ORDER BY lms_grouping_id, group_id
 ) WITH NO DATA;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/4

Previously we were missing anything which joined onto this table and didn't have a `grouping` entry, which would be a lot of older stuff.


## Testing notes

 * In `h`:
   * `make services`
   * tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development-app.ini --task report/create_from_scratch"
* In `lms`:
  * `make services`
  * `tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development.ini --task report/create_from_scratch"`
 * `make db`
 * `select * from report.organization_activity;`
 * You should see some stuff
 * `tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development.ini --task report/refresh"`
 * It shouldn't crash

You can also comment out the `xfail` in the functional tests in: `tests/functional/bin/run_sql_task_test.py`