### PR TITLE
Fix registration macro to point to the right view

### DIFF
--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -106,8 +106,8 @@
 {% endmacro %}
 
 
-{% macro registrations_table(request,  instances) %}
-{{ object_list_table(request, 'admin.instance.id', instances, ['Issuer', 'Client ID'], ['issuer', 'client_id']) }}
+{% macro registrations_table(request,  registrations) %}
+{{ object_list_table(request, 'admin.registration.id', registrations, ['Issuer', 'Client ID'], ['issuer', 'client_id']) }}
 {% endmacro %}
 
 


### PR DESCRIPTION
Fix for https://github.com/hypothesis/product-backlog/issues/1401


## Testing 

- Head to http://localhost:8001/admin/registrations/
- Search for issuer `https://blackboard.com`
- The view button takes you to the right registration instead of a random AI.