### PR TITLE
Check for canvas values for canvas files

### DIFF
--- a/lms/services/document_url.py
+++ b/lms/services/document_url.py
@@ -60,10 +60,11 @@ class DocumentURLService:
         These values are ephemeral and can't be stored.
         """
 
-        if request.params.get("canvas_file"):
-            course_id = request.lti_params["custom_canvas_course_id"]
-            file_id = request.params["file_id"]
-
+        if (
+            request.params.get("canvas_file")
+            and (course_id := request.lti_params.get("custom_canvas_course_id"))
+            and (file_id := request.params["file_id"])
+        ):
             return f"canvas://file/course/{course_id}/file_id/{file_id}"
 
         return None


### PR DESCRIPTION
For: 
- https://github.com/hypothesis/lms/issues/4451

This is used from a predicate so it might be called for unrelated views while finding the appropriate one.

Take advantage of the existing path to return None when the conditions are not meet.

When the predicate fails in an unrelated view we get errors like

https://sentry.io/organizations/hypothesis/issues/3406054455/?referrer=github_integration


That add noise and hide the real issue (sometimes the real issue might be a legit 401 or 403)


## Testing

- Canvas files assignment keep working as expected: 

https://hypothesis.instructure.com/courses/125/assignments/875