### PR TITLE
D2L API authentication

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -63,6 +63,8 @@ good-names=
 
     # ApplicationInstance
     ai,
+    # Organization unit (D2L)
+    ou,
 
 [REPORTS]
 output-format=colorized

--- a/.pylintrc
+++ b/.pylintrc
@@ -63,8 +63,6 @@ good-names=
 
     # ApplicationInstance
     ai,
-    # Organization unit (D2L)
-    ou,
 
 [REPORTS]
 output-format=colorized

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -12,6 +12,7 @@ class D2L(Product):
     route: Routes = Routes(
         oauth2_authorize="d2l_api.oauth.authorize",
         oauth2_refresh="d2l_api.oauth.refresh",
+        list_group_sets="d2l_api.courses.group_sets.list",
     )
 
     settings_key = "desire2learn"

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from lms.product.product import Product
+from lms.product.product import Product, Routes
 
 
 @dataclass
@@ -8,5 +8,10 @@ class D2L(Product):
     """A product for D2L specific settings and tweaks."""
 
     family: Product.Family = Product.Family.D2L
+
+    route: Routes = Routes(
+        oauth2_authorize="d2l_api.oauth.authorize",
+        oauth2_refresh="d2l_api.oauth.refresh",
+    )
 
     settings_key = "desire2learn"

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -39,6 +39,18 @@ def includeme(config):  # pylint:disable=too-many-statements
     )
 
     config.add_route(
+        "d2l_api.oauth.authorize",
+        "/api/d2l/oauth/authorize",
+        factory="lms.resources.OAuth2RedirectResource",
+    )
+    config.add_route(
+        "d2l_api.oauth.callback",
+        "/api/d2l/oauth/callback",
+        factory="lms.resources.OAuth2RedirectResource",
+    )
+    config.add_route("d2l_api.oauth.refresh", "/api/d2l/oauth/refresh")
+
+    config.add_route(
         "blackboard_api.oauth.authorize",
         "/api/blackboard/oauth/authorize",
         factory="lms.resources.OAuth2RedirectResource",

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -49,6 +49,9 @@ def includeme(config):  # pylint:disable=too-many-statements
         factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route("d2l_api.oauth.refresh", "/api/d2l/oauth/refresh")
+    config.add_route(
+        "d2l_api.courses.group_sets.list", "/api/d2l/courses/{course_id}/group_sets"
+    )
 
     config.add_route(
         "blackboard_api.oauth.authorize",

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,6 +1,7 @@
 from lms.services.aes import AESService
 from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.canvas import CanvasService
+from lms.services.d2l_api.client import D2LAPIClient
 from lms.services.document_url import DocumentURLService
 from lms.services.event import EventService
 from lms.services.exceptions import (
@@ -112,4 +113,7 @@ def includeme(config):
     config.register_service_factory("lms.services.event.factory", iface=EventService)
     config.register_service_factory(
         "lms.services.organization.service_factory", iface=OrganizationService
+    )
+    config.register_service_factory(
+        "lms.services.d2l_api.d2l_api_client_factory", iface=D2LAPIClient
     )

--- a/lms/services/d2l_api/__init__.py
+++ b/lms/services/d2l_api/__init__.py
@@ -1,0 +1,2 @@
+from lms.services.d2l_api.client import D2LAPIClient
+from lms.services.d2l_api.factory import d2l_api_client_factory

--- a/lms/services/d2l_api/_basic.py
+++ b/lms/services/d2l_api/_basic.py
@@ -1,0 +1,78 @@
+from lms.services.exceptions import ExternalRequestError
+
+TOKEN_URL = "https://auth.brightspace.com/core/connect/token"
+"""This is constant for all D2L instances"""
+
+
+API_VERSION = "1.31"
+"""Minimum, non deprecated version we can use for all needed endpoints"""
+
+
+class BasicClient:
+    """A low-level D2L API client."""
+
+    def __init__(
+        self,
+        client_id,
+        client_secret,
+        lms_host,
+        redirect_uri,
+        http_service,
+        oauth_http_service,
+    ):  # pylint:disable=too-many-arguments
+        self.lms_host = lms_host
+
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+
+        self._http_service = http_service
+        self._oauth_http_service = oauth_http_service
+
+    def get_token(self, authorization_code):
+        """Get an oauth2 token and store it in the DB."""
+        self._oauth_http_service.get_access_token(
+            token_url=TOKEN_URL,
+            redirect_uri=self.redirect_uri,
+            auth=(self.client_id, self.client_secret),
+            authorization_code=authorization_code,
+        )
+
+    def refresh_access_token(self):
+        """Refresh and existing oauth2 token."""
+        self._oauth_http_service.refresh_access_token(
+            TOKEN_URL,
+            self.redirect_uri,
+            auth=(self.client_id, self.client_secret),
+        )
+
+    def request(self, method, path, **kwargs):
+        """
+        Make an API http request.
+
+        :param method: HTTP method
+        :param path: path of the endpoint.
+            Relative paths are expanded by `BasicClient.api_url`. Absolute URLs are used verbatim.
+        :param kwargs: extra arguments for the requests
+
+        :raises ExternalRequestError: For any request based failure
+        """
+        if path.startswith("/"):
+            path = self.api_url(path)
+
+        try:
+            return self._oauth_http_service.request(method, path, **kwargs)
+        except ExternalRequestError as err:
+            err.refreshable = getattr(err.response, "status_code", None) == 401
+            raise
+
+    def api_url(self, path, product="lp"):
+        """
+        Get the full API.
+
+        :param path: relative path of the endpoint.
+        :param product: product within the D2L api
+
+            https://docs.valence.desire2learn.com/basic/conventions.html#term-D2LPRODUCT
+        """
+        return f"https://{self.lms_host}/d2l/api/{product}/{API_VERSION}{path}"

--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -36,11 +36,11 @@ class D2LAPIClient:
         """
         self._api.refresh_access_token()
 
-    def course_group_sets(self, ou):
+    def course_group_sets(self, org_unit):
         """
-        Get the group categories of an org unit (OU).
+        Get the group categories of an org unit.
 
         https://docs.valence.desire2learn.com/res/groups.html#get--d2l-api-lp-(version)-(orgUnitId)-groupcategories-
         """
-        response = self._api.request("GET", f"/{ou}/groupcategories/")
+        response = self._api.request("GET", f"/{org_unit}/groupcategories/")
         return D2LGroupSetsSchema(response).parse()

--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -1,0 +1,46 @@
+from marshmallow import EXCLUDE, fields
+
+from lms.validation._base import RequestsResponseSchema
+
+
+class D2LGroupSetsSchema(RequestsResponseSchema):
+    many = True
+
+    class Meta:
+        unknown = EXCLUDE
+
+    id = fields.Int(required=True, data_key="GroupCategoryId")
+    name = fields.Str(required=True, data_key="Name")
+
+
+class D2LAPIClient:
+    def __init__(self, basic_client, request):
+        self._api = basic_client
+        self._request = request
+
+    def get_token(self, authorization_code):
+        """
+        Save a new access token for the current user to the DB.
+
+        :raise services.ExternalRequestError: if something goes wrong with the
+            access token request
+        """
+        self._api.get_token(authorization_code)
+
+    def refresh_access_token(self):
+        """
+        Refresh the current user's access token in the DB.
+
+        :raise services.ExternalRequestError: if something goes wrong with the
+            refresh token request
+        """
+        self._api.refresh_access_token()
+
+    def course_group_sets(self, ou):
+        """
+        Get the group categories of an org unit (OU).
+
+        https://docs.valence.desire2learn.com/res/groups.html#get--d2l-api-lp-(version)-(orgUnitId)-groupcategories-
+        """
+        response = self._api.request("GET", f"/{ou}/groupcategories/")
+        return D2LGroupSetsSchema(response).parse()

--- a/lms/services/d2l_api/factory.py
+++ b/lms/services/d2l_api/factory.py
@@ -1,0 +1,23 @@
+from lms.services.aes import AESService
+from lms.services.d2l_api._basic import BasicClient
+from lms.services.d2l_api.client import D2LAPIClient
+
+
+def d2l_api_client_factory(_context, request):
+    application_instance = request.find_service(
+        name="application_instance"
+    ).get_current()
+
+    return D2LAPIClient(
+        BasicClient(
+            lms_host=application_instance.lms_host(),
+            client_id=application_instance.settings.get("desire2learn", "client_id"),
+            client_secret=application_instance.settings.get_secret(
+                request.find_service(AESService), "desire2learn", "client_secret"
+            ),
+            redirect_uri=request.route_url("d2l_api.oauth.callback"),
+            http_service=request.find_service(name="http"),
+            oauth_http_service=request.find_service(name="oauth_http"),
+        ),
+        request=request,
+    )

--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -1,0 +1,78 @@
+from urllib.parse import urlencode, urlunparse
+
+from pyramid.httpexceptions import HTTPFound
+from pyramid.view import exception_view_config, view_config
+
+from lms.security import Permissions
+from lms.services.d2l_api import D2LAPIClient
+from lms.validation.authentication import OAuthCallbackSchema
+
+
+@view_config(
+    request_method="GET",
+    route_name="d2l_api.oauth.authorize",
+    permission=Permissions.API,
+)
+def authorize(request):
+    application_instance = request.find_service(
+        name="application_instance"
+    ).get_current()
+    state = OAuthCallbackSchema(request).state_param()
+
+    return HTTPFound(
+        location=urlunparse(
+            (
+                "https",
+                "auth.brightspace.com",
+                "oauth2/auth",
+                "",
+                urlencode(
+                    {
+                        "client_id": application_instance.settings.get(
+                            "desire2learn", "client_id"
+                        ),
+                        "response_type": "code",
+                        "redirect_uri": request.route_url("d2l_api.oauth.callback"),
+                        "state": state,
+                        "scope": " ".join(
+                            [
+                                "core:*:*",
+                                "groups:*:*",
+                            ]
+                        ),
+                    }
+                ),
+                "",
+            )
+        )
+    )
+
+
+@view_config(
+    request_method="GET",
+    route_name="d2l_api.oauth.callback",
+    permission=Permissions.API,
+    renderer="lms:templates/api/oauth2/redirect.html.jinja2",
+    schema=OAuthCallbackSchema,
+)
+def oauth2_redirect(request):
+    request.find_service(D2LAPIClient).get_token(request.params["code"])
+    return {}
+
+
+@exception_view_config(
+    request_method="GET",
+    route_name="d2l_api.oauth.callback",
+    renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
+)
+@exception_view_config(
+    request_method="GET",
+    route_name="d2l_api.oauth.authorize",
+    renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
+)
+def oauth2_redirect_error(request):
+    request.context.js_config.enable_oauth2_redirect_error_mode(
+        auth_route="d2l_api.oauth.authorize"
+    )
+
+    return {}

--- a/lms/views/api/d2l/groups.py
+++ b/lms/views/api/d2l/groups.py
@@ -1,0 +1,16 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+from lms.services.d2l_api import D2LAPIClient
+
+
+@view_config(
+    request_method="GET",
+    permission=Permissions.API,
+    renderer="json",
+    route_name="d2l_api.courses.group_sets.list",
+)
+def course_group_sets(_context, request):
+    return request.find_service(D2LAPIClient).course_group_sets(
+        request.matchdict["course_id"]
+    )

--- a/lms/views/api/d2l/groups.py
+++ b/lms/views/api/d2l/groups.py
@@ -12,5 +12,5 @@ from lms.services.d2l_api import D2LAPIClient
 )
 def course_group_sets(_context, request):
     return request.find_service(D2LAPIClient).course_group_sets(
-        request.matchdict["course_id"]
+        org_unit=request.matchdict["course_id"]
     )

--- a/lms/views/api/refresh.py
+++ b/lms/views/api/refresh.py
@@ -1,6 +1,7 @@
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
+from lms.services.d2l_api import D2LAPIClient
 
 
 @view_defaults(request_method="POST", permission=Permissions.API, renderer="json")
@@ -23,3 +24,7 @@ class RefreshViews:
     def get_refreshed_token_from_blackboard(self):
         blackboard_api_client = self.request.find_service(name="blackboard_api_client")
         blackboard_api_client.refresh_access_token()
+
+    @view_config(route_name="d2l_api.oauth.refresh")
+    def get_refreshed_token_from_d2l(self):
+        self.request.find_service(D2LAPIClient).refresh_access_token()

--- a/tests/unit/lms/services/d2l_api/_basic_test.py
+++ b/tests/unit/lms/services/d2l_api/_basic_test.py
@@ -1,0 +1,63 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.d2l_api._basic import API_VERSION, TOKEN_URL, BasicClient
+from lms.services.exceptions import ExternalRequestError
+
+
+class TestBasicClient:
+    def test_get_token(self, basic_client, oauth_http_service):
+        basic_client.get_token(sentinel.authorization_code)
+
+        oauth_http_service.get_access_token.assert_called_once_with(
+            token_url=TOKEN_URL,
+            redirect_uri=sentinel.redirect_uri,
+            auth=(sentinel.client_id, sentinel.client_secret),
+            authorization_code=sentinel.authorization_code,
+        )
+
+    def test_refresh_access_token(self, basic_client, oauth_http_service):
+        basic_client.refresh_access_token()
+
+        oauth_http_service.refresh_access_token.assert_called_once_with(
+            TOKEN_URL,
+            sentinel.redirect_uri,
+            auth=(sentinel.client_id, sentinel.client_secret),
+        )
+
+    @pytest.mark.parametrize(
+        "path,expected_url",
+        [
+            ("/foo/bar", f"https://d2l.example.com/d2l/api/lp/{API_VERSION}/foo/bar"),
+            ("https://full.d2l.url.com/foo", "https://full.d2l.url.com/foo"),
+        ],
+    )
+    def test_request_sends_the_request_and_returns_the_response(
+        self, basic_client, oauth_http_service, path, expected_url
+    ):
+        response = basic_client.request("GET", path)
+
+        oauth_http_service.request.assert_called_once_with("GET", expected_url)
+        assert response == oauth_http_service.request.return_value
+
+    def test_request_raises_ExternalRequestError_if_the_request_fails(
+        self, basic_client, oauth_http_service
+    ):
+        oauth_http_service.request.side_effect = ExternalRequestError
+
+        with pytest.raises(ExternalRequestError) as exc_info:
+            basic_client.request("GET", "/foo")
+
+        assert not exc_info.value.refreshable
+
+    @pytest.fixture
+    def basic_client(self, http_service, oauth_http_service):
+        return BasicClient(
+            lms_host="d2l.example.com",
+            client_id=sentinel.client_id,
+            client_secret=sentinel.client_secret,
+            redirect_uri=sentinel.redirect_uri,
+            http_service=http_service,
+            oauth_http_service=oauth_http_service,
+        )

--- a/tests/unit/lms/services/d2l_api/client_test.py
+++ b/tests/unit/lms/services/d2l_api/client_test.py
@@ -1,0 +1,26 @@
+from unittest.mock import create_autospec, sentinel
+
+import pytest
+
+from lms.services.d2l_api._basic import BasicClient
+from lms.services.d2l_api.client import D2LAPIClient
+
+
+class TestD2LAPIClient:
+    def test_get_token(self, svc, basic_client):
+        svc.get_token(sentinel.authorization_code)
+
+        basic_client.get_token.assert_called_once_with(sentinel.authorization_code)
+
+    def test_refresh_access_token(self, svc, basic_client):
+        svc.refresh_access_token()
+
+        basic_client.refresh_access_token.assert_called_once_with()
+
+    @pytest.fixture
+    def basic_client(self):
+        return create_autospec(BasicClient, instance=True, spec_set=True)
+
+    @pytest.fixture
+    def svc(self, basic_client, pyramid_request):
+        return D2LAPIClient(basic_client, pyramid_request)

--- a/tests/unit/lms/services/d2l_api/client_test.py
+++ b/tests/unit/lms/services/d2l_api/client_test.py
@@ -17,6 +17,25 @@ class TestD2LAPIClient:
 
         basic_client.refresh_access_token.assert_called_once_with()
 
+    def test_course_group_sets(
+        self, svc, basic_client, D2LGroupSetsSchema, d2l_group_sets_schema
+    ):
+        group_sets = svc.course_group_sets("COURSE_ID")
+
+        basic_client.request.assert_called_once_with(
+            "GET", "/COURSE_ID/groupcategories/"
+        )
+        D2LGroupSetsSchema.assert_called_once_with(basic_client.request.return_value)
+        assert group_sets == d2l_group_sets_schema.parse.return_value
+
+    @pytest.fixture(autouse=True)
+    def D2LGroupSetsSchema(self, patch):
+        return patch("lms.services.d2l_api.client.D2LGroupSetsSchema")
+
+    @pytest.fixture
+    def d2l_group_sets_schema(self, D2LGroupSetsSchema):
+        return D2LGroupSetsSchema.return_value
+
     @pytest.fixture
     def basic_client(self):
         return create_autospec(BasicClient, instance=True, spec_set=True)

--- a/tests/unit/lms/services/d2l_api/factory_test.py
+++ b/tests/unit/lms/services/d2l_api/factory_test.py
@@ -1,0 +1,48 @@
+from unittest.mock import create_autospec, sentinel
+
+import pytest
+
+from lms.models import ApplicationInstance
+from lms.services.d2l_api.factory import d2l_api_client_factory
+
+
+def test_d2l_api_client_factory(
+    application_instance_service,
+    http_service,
+    oauth_http_service,
+    aes_service,
+    pyramid_request,
+    BasicClient,
+    D2LAPIClient,
+):
+    ai = create_autospec(ApplicationInstance)
+    application_instance_service.get_current.return_value = ai
+
+    service = d2l_api_client_factory(sentinel.context, pyramid_request)
+
+    ai.settings.get.assert_called_once_with("desire2learn", "client_id")
+    ai.settings.get_secret.assert_called_once_with(
+        aes_service, "desire2learn", "client_secret"
+    )
+    BasicClient.assert_called_once_with(
+        lms_host=ai.lms_host.return_value,
+        client_id=ai.settings.get.return_value,
+        client_secret=ai.settings.get_secret.return_value,
+        redirect_uri=pyramid_request.route_url("d2l_api.oauth.callback"),
+        http_service=http_service,
+        oauth_http_service=oauth_http_service,
+    )
+    D2LAPIClient.assert_called_once_with(
+        BasicClient.return_value, request=pyramid_request
+    )
+    assert service == D2LAPIClient.return_value
+
+
+@pytest.fixture(autouse=True)
+def BasicClient(patch):
+    return patch("lms.services.d2l_api.factory.BasicClient")
+
+
+@pytest.fixture(autouse=True)
+def D2LAPIClient(patch):
+    return patch("lms.services.d2l_api.factory.D2LAPIClient")

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -82,7 +82,6 @@ class TestOAuth2RedirectError:
         return pyramid_request
 
 
-@pytest.mark.usefixtures("blackboard_api_client")
 class TestOAuth2Redirect:
     def test_it_gets_a_new_access_token_for_the_user(
         self, pyramid_request, blackboard_api_client

--- a/tests/unit/lms/views/api/d2l/authorize_test.py
+++ b/tests/unit/lms/views/api/d2l/authorize_test.py
@@ -1,0 +1,90 @@
+from unittest.mock import create_autospec
+
+import pytest
+from h_matchers import Any
+
+from lms.models import ApplicationInstance
+from lms.resources._js_config import JSConfig
+from lms.resources.oauth2_redirect import OAuth2RedirectResource
+from lms.views.api.d2l.authorize import (
+    authorize,
+    oauth2_redirect,
+    oauth2_redirect_error,
+)
+from tests.matchers import temporary_redirect_to
+
+
+@pytest.mark.usefixtures("application_instance_service")
+class TestAuthorize:
+    def test_it(
+        self,
+        application_instance_service,
+        OAuthCallbackSchema,
+        oauth_callback_schema,
+        pyramid_request,
+    ):
+        ai = create_autospec(ApplicationInstance)
+        application_instance_service.get_current.return_value = ai
+        ai.settings.get.return_value = "CLIENT_ID"
+        oauth_callback_schema.state_param.return_value = "STATE"
+
+        response = authorize(pyramid_request)
+
+        OAuthCallbackSchema.assert_called_once_with(pyramid_request)
+        ai.settings.get.assert_called_once_with("desire2learn", "client_id")
+        assert response == temporary_redirect_to(
+            Any.url(
+                scheme="https",
+                host="auth.brightspace.com",
+                path="oauth2/auth",
+                query={
+                    "client_id": "CLIENT_ID",
+                    "response_type": "code",
+                    "redirect_uri": pyramid_request.route_url("d2l_api.oauth.callback"),
+                    "state": "STATE",
+                    "scope": "core:*:* groups:*:*",
+                },
+            )
+        )
+
+
+class TestOAuth2Redirect:
+    def test_it(self, pyramid_request, d2l_api_client):
+        pyramid_request.params["code"] = "test_code"
+
+        result = oauth2_redirect(pyramid_request)
+
+        d2l_api_client.get_token.assert_called_once_with("test_code")
+        assert not result
+
+
+class TestOAuth2RedirectError:
+    def test_it(self, pyramid_request):
+        template_variables = oauth2_redirect_error(pyramid_request)
+
+        pyramid_request.context.js_config.enable_oauth2_redirect_error_mode.assert_called_once_with(
+            auth_route="d2l_api.oauth.authorize"
+        )
+        assert not template_variables
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        js_config = create_autospec(JSConfig, spec_set=True, instance=True)
+        js_config.ErrorCode = JSConfig.ErrorCode
+        pyramid_request.context = create_autospec(
+            OAuth2RedirectResource,
+            instance=True,
+            js_config=js_config,
+        )
+        return pyramid_request
+
+
+@pytest.fixture(autouse=True)
+def OAuthCallbackSchema(patch):
+    OAuthCallbackSchema = patch("lms.views.api.d2l.authorize.OAuthCallbackSchema")
+    return OAuthCallbackSchema
+
+
+@pytest.fixture
+def oauth_callback_schema(OAuthCallbackSchema):
+    return OAuthCallbackSchema.return_value

--- a/tests/unit/lms/views/api/d2l/groups_test.py
+++ b/tests/unit/lms/views/api/d2l/groups_test.py
@@ -1,0 +1,12 @@
+from unittest.mock import sentinel
+
+from lms.views.api.d2l.groups import course_group_sets
+
+
+def test_course_group_sets(pyramid_request, d2l_api_client):
+    pyramid_request.matchdict = {"course_id": "test_course_id"}
+
+    result = course_group_sets(sentinel.context, pyramid_request)
+
+    assert result == d2l_api_client.course_group_sets.return_value
+    d2l_api_client.course_group_sets.assert_called_once_with("test_course_id")

--- a/tests/unit/lms/views/api/refresh_test.py
+++ b/tests/unit/lms/views/api/refresh_test.py
@@ -20,6 +20,11 @@ class TestRefreshViews:
 
         blackboard_api_client.refresh_access_token.assert_called_once_with()
 
+    def test_get_refreshed_token_from_d2l(self, d2l_api_client, views):
+        views.get_refreshed_token_from_d2l()
+
+        d2l_api_client.refresh_access_token.assert_called_once_with()
+
     @pytest.fixture
     def views(self, pyramid_request):
         return RefreshViews(sentinel.context, pyramid_request)

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -15,6 +15,7 @@ from lms.services.async_oauth_http import AsyncOAuthHTTPService
 from lms.services.blackboard_api.client import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
+from lms.services.d2l_api import D2LAPIClient
 from lms.services.event import EventService
 from lms.services.file import FileService
 from lms.services.grading_info import GradingInfoService
@@ -50,6 +51,7 @@ __all__ = (
     "canvas_api_client",
     "canvas_service",
     "course_service",
+    "d2l_api_client",
     "document_url_service",
     "event_service",
     "file_service",
@@ -149,6 +151,11 @@ def canvas_service(mock_service, canvas_api_client):
 @pytest.fixture
 def course_service(mock_service):
     return mock_service(CourseService, service_name="course")
+
+
+@pytest.fixture
+def d2l_api_client(mock_service):
+    return mock_service(D2LAPIClient)
 
 
 @pytest.fixture


### PR DESCRIPTION
Adds the required service and views for D2L oauth2 authentication.

On top of that adds a method and view to get the list of group categories so we can test the whole oauth2 process using the UI.


## Testing 

- `make devdata` to start with.
- Go to https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2120/View as a teacher
- Select any type of document and check the group assignment
- When prompted to authorize, deny the request (to test https://github.com/hypothesis/lms/pull/4639/files#diff-acd99c9193ec519d3248994780ce552fef977e8915329f06f5d300e18aee5a5eR73)
- Try again and authorize the request this time
- You'll get a group category in the drop down coming from the D2L API.