### PR TITLE
D2L details in the admin pages

### DIFF
--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -8,3 +8,5 @@ class D2L(Product):
     """A product for D2L specific settings and tweaks."""
 
     family: Product.Family = Product.Family.D2L
+
+    settings_key = "desire2learn"

--- a/lms/services/aes.py
+++ b/lms/services/aes.py
@@ -38,6 +38,9 @@ class AESService:
         # Using the cryptographic secure Cryptodome.Random instead of the stlib random package.
         return Random.new().read(AES.block_size)
 
+    class AESSecret:
+        """Dummy type to identify strings that must be encrypted."""
+
 
 def factory(_context, request):
     return AESService(secret=request.registry.settings["aes_secret"])

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -106,14 +106,9 @@
 
     <fieldset class="box">
         <legend class="label has-text-centered">D2L settings (EXPERIMENTAL)</legend>
-        {{ macros.form_text_field(request, "Developer key", "developer_key", field_value=instance.developer_key) }}
-        {{ macros.form_text_field(
-            request,
-            "Developer secret",
-            "developer_secret",
-            placeholder="*" * 25 if instance.developer_secret else "")
-        }}
-        {{ settings_checkbox("Groups enabled", "d2l", "groups_enabled") }}
+        {{ settings_text_field("API Client ID", "desire2learn", "client_id") }}
+        {{ settings_text_field("API Client secret", "desire2learn", "client_secret") }}
+        {{ settings_checkbox("Groups enabled", "desire2learn", "groups_enabled") }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -100,6 +100,19 @@
         {{ settings_checkbox("Groups enabled", "blackboard", "groups_enabled") }}
         {{ settings_checkbox("Files enabled", "blackboard", "files_enabled") }}
     </fieldset>
+
+    <fieldset class="box">
+        <legend class="label has-text-centered">D2L settings (EXPERIMENTAL)</legend>
+        {{ macros.form_text_field(request, "Developer key", "developer_key", field_value=instance.developer_key) }}
+        {{ macros.form_text_field(
+            request,
+            "Developer secret",
+            "developer_secret",
+            placeholder="*" * 25 if instance.developer_secret else "")
+        }}
+        {{ settings_checkbox("Groups enabled", "d2l", "groups_enabled") }}
+    </fieldset>
+
     <fieldset class="box">
         <legend class="label has-text-centered">Content integrations</legend>
         {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -31,6 +31,17 @@
 {% endmacro %}
 
 
+{% macro settings_secret_field(label, setting, sub_setting, field_name, default='') %}
+    {% call macros.field_body(label) %}
+        <input
+            value="{{ "*" * 25 if instance.settings.get(setting, sub_setting, default) else '' }}"
+            class="input"
+            type="text"
+            name="{{ setting }}.{{ sub_setting }}">
+    {% endcall %}
+{% endmacro %}
+
+
 {% block content %}
 <form method="POST" action="{{ request.route_url("admin.instance.id", id_=instance.id) }}">
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
@@ -107,7 +118,7 @@
     <fieldset class="box">
         <legend class="label has-text-centered">D2L settings (EXPERIMENTAL)</legend>
         {{ settings_text_field("API Client ID", "desire2learn", "client_id") }}
-        {{ settings_text_field("API Client secret", "desire2learn", "client_secret") }}
+        {{ settings_secret_field("API Client secret", "desire2learn", "client_secret") }}
         {{ settings_checkbox("Groups enabled", "desire2learn", "groups_enabled") }}
     </fieldset>
 

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -84,10 +84,13 @@
     <fieldset class="box">
         <legend class="label has-text-centered">Canvas settings</legend>
         {{ macros.disabled_text_field("API domain", instance.custom_canvas_api_domain) }}
-        {{ macros.form_text_field(request, "Developer key", "developer_key", field_value=instance.developer_key) }}
+        {# Note the mismatch betwween canvas nomenclature and ours #}
+        {# developer id -> developer key #}
+        {# developer key -> developer secret #}
+        {{ macros.form_text_field(request, "Developer ID", "developer_key", field_value=instance.developer_key) }}
         {{ macros.form_text_field(
             request,
-            "Developer secret",
+            "Developer key",
             "developer_secret",
             placeholder="*" * 25 if instance.developer_secret else "")
         }}

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -5,6 +5,7 @@ from pyramid.view import view_config, view_defaults
 from sqlalchemy.exc import IntegrityError
 from webargs import fields
 
+from lms.services.aes import AESService
 from lms.models import ApplicationInstance
 from lms.security import Permissions
 from lms.services import ApplicationInstanceNotFound, LTIRegistrationService
@@ -41,6 +42,7 @@ class AdminApplicationInstanceViews:
         self.lti_registration_service: LTIRegistrationService = request.find_service(
             LTIRegistrationService
         )
+        self._aes_service = request.find_service(AESService)
 
     @view_config(
         route_name="admin.instances",

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -296,8 +296,8 @@ class AdminApplicationInstanceViews:
             ai,
             lms_url=self.request.params.get("lms_url", "").strip(),
             deployment_id=self.request.params.get("deployment_id", "").strip(),
-            developer_key=self._getall_unique("developer_key", "").strip(),
-            developer_secret=self._getall_unique("developer_secret", "").strip(),
+            developer_key=self.request.params.get("developer_key", "").strip(),
+            developer_secret=self.request.params.get("developer_secret", "").strip(),
         )
 
         for setting, sub_setting, setting_type in (
@@ -305,7 +305,9 @@ class AdminApplicationInstanceViews:
             ("blackboard", "groups_enabled", bool),
             ("canvas", "sections_enabled", bool),
             ("canvas", "groups_enabled", bool),
-            ("d2l", "groups_enabled", bool),
+            ("desire2learn", "client_id", str),
+            ("desire2learn", "client_secret", AESService.AESSecret),
+            ("desire2learn", "groups_enabled", bool),
             ("microsoft_onedrive", "files_enabled", bool),
             ("vitalsource", "enabled", bool),
             ("vitalsource", "user_lti_param", str),
@@ -341,27 +343,3 @@ class AdminApplicationInstanceViews:
 
         except ApplicationInstanceNotFound as err:
             raise HTTPNotFound() from err
-
-    def _getall_unique(self, parameter, default=None):
-        """
-        Get an unique value from a MultiDict.
-
-        Raise if that value is not unique in all entries.
-
-        Useful for values that are duplicated in the form and we want to make sure
-        that don't get submitted with different values.
-        """
-        try:
-            values = {value for value in self.request.params.getall(parameter) if value}
-        except KeyError:
-            return default
-
-        if not values:
-            return default
-
-        if len(values) > 1:
-            raise ValidationError(
-                messages={parameter: [f"Received two different values. {values}"]}
-            )
-
-        return values.pop()

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -302,13 +302,16 @@ class AdminApplicationInstanceViews:
             developer_secret=self.request.params.get("developer_secret", "").strip(),
         )
 
+        # Helper to declare settings as secret
+        aes_secret = object()
+
         for setting, sub_setting, setting_type in (
             ("blackboard", "files_enabled", bool),
             ("blackboard", "groups_enabled", bool),
             ("canvas", "sections_enabled", bool),
             ("canvas", "groups_enabled", bool),
             ("desire2learn", "client_id", str),
-            ("desire2learn", "client_secret", AESService.AESSecret),
+            ("desire2learn", "client_secret", aes_secret),
             ("desire2learn", "groups_enabled", bool),
             ("microsoft_onedrive", "files_enabled", bool),
             ("vitalsource", "enabled", bool),
@@ -323,7 +326,7 @@ class AdminApplicationInstanceViews:
             if setting_type == bool:
                 value = value == "on"
                 ai.settings.set(setting, sub_setting, value)
-            elif setting_type == AESService.AESSecret:
+            elif setting_type == aes_secret:
                 value = value.strip() if value else None
                 if not value:
                     continue

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -1,4 +1,5 @@
 from unittest.mock import sentinel
+from multidict import MultiDict
 
 import pytest
 from pyramid.httpexceptions import HTTPNotFound
@@ -362,12 +363,14 @@ class TestAdminApplicationInstanceViews:
         lms_url,
         deployment_id,
     ):
-        pyramid_request.params = {
-            "developer_key": key,
-            "developer_secret": secret,
-            "lms_url": lms_url,
-            "deployment_id": deployment_id,
-        }
+        pyramid_request.params = MultiDict(
+            {
+                "developer_key": key,
+                "developer_secret": secret,
+                "lms_url": lms_url,
+                "deployment_id": deployment_id,
+            }
+        )
 
         views.update_instance()
 
@@ -432,7 +435,7 @@ class TestAdminApplicationInstanceViews:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = {}
+        pyramid_request.params = MultiDict()
         return pyramid_request
 
     @pytest.fixture

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -1,5 +1,4 @@
 from unittest.mock import sentinel
-from multidict import MultiDict
 
 import pytest
 from pyramid.httpexceptions import HTTPNotFound
@@ -363,14 +362,12 @@ class TestAdminApplicationInstanceViews:
         lms_url,
         deployment_id,
     ):
-        pyramid_request.params = MultiDict(
-            {
-                "developer_key": key,
-                "developer_secret": secret,
-                "lms_url": lms_url,
-                "deployment_id": deployment_id,
-            }
-        )
+        pyramid_request.params = {
+            "developer_key": key,
+            "developer_secret": secret,
+            "lms_url": lms_url,
+            "deployment_id": deployment_id,
+        }
 
         views.update_instance()
 
@@ -390,6 +387,8 @@ class TestAdminApplicationInstanceViews:
             ("canvas", "sections_enabled", "", False),
             ("blackboard", "files_enabled", "other", False),
             ("blackboard", "groups_enabled", "off", False),
+            ("desire2learn", "client_id", "client_id", "client_id"),
+            ("desire2learn", "groups_enabled", "off", False),
             ("microsoft_onedrive", "files_enabled", "on", True),
             ("vitalsource", "enabled", "on", True),
             ("jstor", "enabled", "off", False),
@@ -435,7 +434,7 @@ class TestAdminApplicationInstanceViews:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.params = MultiDict()
+        pyramid_request.params = {}
         return pyramid_request
 
     @pytest.fixture


### PR DESCRIPTION
Make room for D2L setting on the admin pages.

Took the opportunity I was around this code to tackle: https://github.com/hypothesis/product-backlog/issues/1399 


# Testing

(requires https://github.com/hypothesis/devdata/pull/65)


- Ahead to http://localhost:8001/admin/instance/id/106/
- Play with the settings for D2L