### PR TITLE
Consider admin role regardless of their scope

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -169,6 +169,11 @@ def _to_lti_v11(v13_params):
     if "roles" in v11_params:
         context_roles = []
         for role in v11_params["roles"]:
+            # Consider administrator regardless of their scope
+            if role.endswith("Administrator"):
+                context_roles.append(role)
+                continue
+
             # From: https://www.imsglobal.org/spec/lti/v1p3#role-vocabularies
             #
             # Conforming implementations MAY recognize the simple

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -90,6 +90,8 @@ class TestLTIParams:
                 # We should accept either of these formats
                 "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
                 "Mentor",
+                # But we make an exception for admins, we consider them regarless of the scope
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator",
             ],
         }
 
@@ -97,7 +99,7 @@ class TestLTIParams:
 
         assert (
             params["roles"]
-            == "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner,Mentor"
+            == "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner,Mentor,http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"
         )
 
 


### PR DESCRIPTION
We want consider admins to be teacher for authorization purposes, ie we allow them to create/edit assignments.

Currently we exclude non-context scoped roles to avoid mixing roles from other courses in the current one but we make an exception here for admin.


This is a much simpler approach than:
- https://github.com/hypothesis/lms/pull/4641

and directly fixes:
- https://github.com/hypothesis/product-backlog/issues/1394


but it doesn't fix any of the refactor aspects of that PR, doesn't unify the roles handling or exposes the scope of the role to the rest of the app.


## Testing

- In `main`

- Log in as `Canvas Admin` in canvas and head try to edit (use the `Hypothesis LTI1.3 (localhost)` LTI app) 

https://hypothesis.instructure.com/courses/319/assignments/2988/edit?name=No+grade+LTI1.3&due_at=null&points_possible=10

You'll get a authorization error


- Switch to `admin-role` and try again, you'll be able to edit the assignment.