### PR TITLE
Migration for new D2L grouping type

### DIFF
--- a/lms/migrations/versions/6eb9de301ac3_d2l_group_grouping.py
+++ b/lms/migrations/versions/6eb9de301ac3_d2l_group_grouping.py
@@ -1,0 +1,35 @@
+"""
+New d2l_group type for groupings.
+
+Revision ID: 6eb9de301ac3
+Revises: 52755322151e
+Create Date: 2022-11-17 11:28:55.747286
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6eb9de301ac3"
+down_revision = "52755322151e"
+
+constraint_name = "grouping_type_must_be_a_valid_value"
+table_name = "grouping"
+
+
+def upgrade():
+    op.drop_constraint(constraint_name, table_name=table_name, type_="check")
+    op.create_check_constraint(
+        constraint_name,
+        table_name=table_name,
+        condition="type in ('course', 'canvas_section', 'canvas_group', 'blackboard_group', 'd2l_group')",
+    )
+
+
+def downgrade():
+    op.drop_constraint(constraint_name, table_name=table_name, type_="check")
+    op.create_check_constraint(
+        constraint_name,
+        table_name=table_name,
+        condition="type in ('course', 'canvas_section', 'canvas_group', 'blackboard_group')",
+    )


### PR DESCRIPTION
Based on the changes on 

https://github.com/hypothesis/lms/pull/4659/files#diff-1247685c2ce802726b483f8d3f351f5ff88a47bd45305ba5cb00c0376a6b77e9R70


The migration is not autogenerated, as the constraint already exists, both the upgrade and downgrade paths first delete it and then re-create with the right shape.


## Testing

`hdev alembic upgrade head`

```
dev run-test-pre: PYTHONHASHSEED='3981211424'
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 52755322151e -> 6eb9de301ac3, New d2l_group type for groupings.
```

- Check the constraint

```
ox -qe dockercompose -- exec postgres psql -U postgres -c "\d grouping"           

                                               Table "public.grouping"
         Column          |            Type             | Collation | Nullable |               Default                
-------------------------+-----------------------------+-----------+----------+--------------------------------------
 created                 | timestamp without time zone |           | not null | now()
 updated                 | timestamp without time zone |           | not null | now()
 id                      | integer                     |           | not null | nextval('grouping_id_seq'::regclass)
 application_instance_id | integer                     |           | not null | 
 authority_provided_id   | text                        |           | not null | 
 parent_id               | integer                     |           |          | 
 lms_id                  | character varying           |           | not null | 
 lms_name                | text                        |           | not null | 
 type                    | character varying           |           | not null | 
 settings                | jsonb                       |           | not null | '{}'::jsonb
 extra                   | jsonb                       |           | not null | '{}'::jsonb
Indexes:
    "pk__grouping" PRIMARY KEY, btree (id)
    "uq__grouping__application_instance_id" UNIQUE CONSTRAINT, btree (application_instance_id, authority_provided_id)
    "uq__grouping__id" UNIQUE CONSTRAINT, btree (id, application_instance_id)
    "uq__grouping__lms_id" UNIQUE CONSTRAINT, btree (lms_id, application_instance_id, parent_id, type)
Check constraints:
    "ck__grouping__courses_must_NOT_have_parents_and_other_g_65d1" CHECK (type::text = 'course'::text AND parent_id IS NULL OR type::text <> 'course'::text AND parent_id IS NOT NULL)
    "ck__grouping__grouping_type_must_be_a_valid_value" CHECK (type::text = ANY (ARRAY['course'::character varying, 'canvas_section'::character varying, 'canvas_group'::character varying, 'blackboard_group'::character varying, 'd2l_group'::character varying]::text[]))
```