### PR TITLE
Handle D2L group related error codes

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -142,6 +142,7 @@ export default function LaunchErrorDialog({
 
     case 'blackboard_group_set_not_found':
     case 'canvas_group_set_not_found':
+    case 'd2l_group_set_not_found':
       return (
         <ErrorModal
           busy={busy}
@@ -163,6 +164,7 @@ export default function LaunchErrorDialog({
 
     case 'blackboard_group_set_empty':
     case 'canvas_group_set_empty':
+    case 'd2l_group_set_empty':
       return (
         <ErrorModal
           busy={busy}
@@ -213,6 +215,26 @@ export default function LaunchErrorDialog({
           <p>
             <b>
               To fix the problem, an instructor needs to add your Canvas user
+              account to one of this assignment&apos;s groups.
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
+    case 'd2l_student_not_in_group':
+      return (
+        <ErrorModal
+          busy={busy}
+          error={error}
+          title="You're not in any of this assignment's groups"
+        >
+          <p>
+            Hypothesis couldn&apos;t launch this assignment because you
+            aren&apos;t in any of the groups in the assignment&apos;s group set.
+          </p>
+          <p>
+            <b>
+              To fix the problem, an instructor needs to add your D2L user
               account to one of this assignment&apos;s groups.
             </b>
           </p>

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -78,7 +78,14 @@ describe('LaunchErrorDialog', () => {
       hasRetry: false,
       withError: true,
     },
-
+    {
+      errorState: 'd2l_group_set_not_found',
+      expectedText:
+        "Hypothesis couldn't load this assignment because the assignment's group set no longer exists.To fix this problem, an instructor needs to edit the assignment settings and select a new group set.",
+      expectedTitle: "Assignment's group set no longer exists",
+      hasRetry: false,
+      withError: true,
+    },
     {
       errorState: 'blackboard_group_set_empty',
       expectedText: 'The group set for this Hypothesis assignment is empty',
@@ -94,6 +101,13 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
+      errorState: 'd2l_group_set_empty',
+      expectedText: 'The group set for this Hypothesis assignment is empty',
+      expectedTitle: "Assignment's group set is empty",
+      hasRetry: false,
+      withError: true,
+    },
+    {
       errorState: 'blackboard_student_not_in_group',
       expectedText: 'an instructor needs to add your Blackboard user',
       expectedTitle: "You're not in any of this assignment's groups",
@@ -102,6 +116,14 @@ describe('LaunchErrorDialog', () => {
     },
     {
       errorState: 'canvas_student_not_in_group',
+      expectedText:
+        "you aren't in any of the groups in the assignment's group set",
+      expectedTitle: "You're not in any of this assignment's groups",
+      hasRetry: false,
+      withError: true,
+    },
+    {
+      errorState: 'd2l_student_not_in_group',
       expectedText:
         "you aren't in any of the groups in the assignment's group set",
       expectedTitle: "You're not in any of this assignment's groups",

--- a/lms/static/scripts/frontend_apps/errors.js
+++ b/lms/static/scripts/frontend_apps/errors.js
@@ -7,6 +7,9 @@
  *           'blackboard_group_set_empty' |
  *           'blackboard_group_set_not_found' |
  *           'blackboard_student_not_in_group' |
+ *           'd2l_group_set_not_found' |
+ *           'd2l_group_set_empty' |
+ *           'd2l_student_not_in_group' |
  *           'canvas_api_permission_error'|
  *           'canvas_file_not_found_in_course'|
  *           'canvas_group_set_not_found'|
@@ -128,6 +131,9 @@ export function isLTILaunchServerError(error) {
       'blackboard_group_set_empty',
       'blackboard_group_set_not_found',
       'blackboard_student_not_in_group',
+      'd2l_group_set_not_found',
+      'd2l_group_set_empty',
+      'd2l_student_not_in_group',
       'canvas_api_permission_error',
       'canvas_file_not_found_in_course',
       'canvas_group_set_not_found',


### PR DESCRIPTION
Use the same dialog as for other products except for "user not in group" where we want to make explicit that the user missing is the one in D2L, not hypothesis (or at least I reckon that the rationale for the existing Canvas/Blackboard ones).


The dialogs look like:

![Screenshot from 2022-11-18 15-56-43](https://user-images.githubusercontent.com/1433832/202733846-0fe85508-02dd-4596-afbb-8820ab86bd8b.png)

![Screenshot from 2022-11-18 15-55-39](https://user-images.githubusercontent.com/1433832/202733867-50bf1e85-343d-48d2-90e0-7b59fc785598.png)
![Screenshot from 2022-11-18 15-54-51](https://user-images.githubusercontent.com/1433832/202733880-6d0a11bd-33cc-436d-8277-d99b0c51b672.png)


### Testing 

- (You'll need the latest commits in H to test this locally)
- `make devdata`
- Testing this locally relies on a self signed HTTPS certificate, in chrome you might need to either:
  - Visit https://localhost:48001/lti/1.3/oidc and approve a the certificate
  - Or enable the toggle in chrome://flags/#allow-insecure-localhost

- Head over https://aunltd.brightspacedemo.com/d2l/le/content/6782/Home?itemIdentifier=TOC
(credentials in 1Pass)

and launch the assignments (no LTI1.1 vs 1.3 differences here are relevant)

As teacher 
- https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2133/View
- https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2134/View

As an student 

- https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2134/View

you should see specific dialog  as opposed to generic ones in `main`.

