### PR TITLE
Exclude counts which don't have an org associated with them

### DIFF
--- a/lms/sql_tasks/tasks/report/create_from_scratch/04_activity_counts/03_organization_activity/01_create_view.sql
+++ b/lms/sql_tasks/tasks/report/create_from_scratch/04_activity_counts/03_organization_activity/01_create_view.sql
@@ -179,6 +179,7 @@ CREATE MATERIALIZED VIEW report.organization_activity AS (
         COALESCE(MAX(active), 0) AS active,
         COALESCE(MAX(billable), 0) AS billable
     FROM unioned_metrics
+    WHERE organization_id IS NOT NULL
     GROUP BY period, timescale, role, organization_id
     ORDER BY period, timescale, role, organization_id
 ) WITH NO DATA;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4663

There are some inactive application instances which don't have organization ids, but do have some old activity associated with them. We should exclude them from this report.