### PR TITLE
Add a passing test to the SQL runner functests

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -104,6 +104,10 @@ def init(engine, drop=False, stamp=True):  # pragma: nocover
         engine.execute("select 1 from alembic_version")
     except sqlalchemy.exc.ProgrammingError:
         if drop:
+            # SQLAlchemy doesnt' know about the report schema, and will end up
+            # trying to drop tables without cascade that have dependent tables
+            # in the report schema and failing. Clear it out first.
+            engine.execute("DROP SCHEMA IF EXISTS report CASCADE")
             BASE.metadata.drop_all(engine)
         BASE.metadata.create_all(engine)
 

--- a/tests/functional/bin/run_sql_task_test.py
+++ b/tests/functional/bin/run_sql_task_test.py
@@ -10,33 +10,39 @@ from tests.functional.conftest import TEST_ENVIRONMENT
 
 
 class TestRunSQLTask:
+    def test_sanity(self, environ):
+        self.run_task(environ, "hello_world")
+
     # We use "db_engine" here to ensure the schema is created
     @pytest.mark.usefixtures("db_engine")
     # If you want to run these tests, you first need to start services in H
     # and run the `report/create_from_scratch` task there.
     @pytest.mark.xfail(reason="Requires reporting tasks to be run in H")
     def test_reporting_tasks(self, environ):
-        for report_path in (
+        for task_name in (
             "report/create_from_scratch",
             "report/refresh",
             "report/create_from_scratch",
         ):
-            result = check_output(
-                [
-                    sys.executable,
-                    "bin/run_sql_task.py",
-                    "--config-file",
-                    "conf/development.ini",
-                    "--task",
-                    report_path,
-                ],
-                env=environ,
-            )
+            self.run_task(environ, task_name)
 
-            assert result
+    def run_task(self, environ, task_name):
+        result = check_output(
+            [
+                sys.executable,
+                "bin/run_sql_task.py",
+                "--config-file",
+                "conf/development.ini",
+                "--task",
+                task_name,
+            ],
+            env=environ,
+        )
 
-            print(f"Task {report_path} OK!")
-            print(result.decode("utf-8"))
+        assert result
+
+        print(f"Task {task_name} OK!")
+        print(result.decode("utf-8"))
 
     @fixture
     def environ(self):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/84

This expands the number of failures the tests can catch (like missing environment variables).

This also fixes a bug where the report schema can prevent the functests from running. I think this can only happen in dev where you have successfully run the script against `h`. In CI it should never run and create the schema.