### PR TITLE
Allow disabling key rotation task with a new setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ LMS. Each of these is mandatory to get the service working correctly.
 | `ADMIN_AUTH_GOOGLE_CLIENT_ID`     | `abcdef012.apps.googleusercontent.com` | An OAuth2 pair from Google for `/admin` pages   |
 | `ADMIN_AUTH_GOOGLE_CLIENT_SECRET` | `01234567-89ab-cdef-0123-456789abcdef` | The matching secret from the above              |
 | `DATABASE_URL`                    | `postgresql://user:pw@host/lms`        | Postgres DSN of this service main DB            | 
+| `DISABLE_KEY_ROTATION`            | `0`                                    | Disable key rotation. Useful in QA              |
 | `H_FDW_DATABASE_URL`              | `postgresql://user:pw@host/h`          | Postgres DSN pointing to H's DB                 | 
 | `H_API_URL_PRIVATE`               | `https://cloud.hosting.url/api`        | URL for service to service communication        |
 | `H_API_URL_PUBLIC`                | `https://fr.hypothes.is/api`           | URL for client to service communication         |

--- a/lms/config.py
+++ b/lms/config.py
@@ -100,6 +100,7 @@ SETTINGS = (
     _Setting("blackboard_api_client_secret"),
     _Setting("jstor_api_url"),
     _Setting("jstor_api_secret"),
+    _Setting("disable_key_rotation", value_mapper=asbool),
 )
 
 

--- a/lms/tasks/rsa_key.py
+++ b/lms/tasks/rsa_key.py
@@ -1,5 +1,9 @@
+import logging
+
 from lms.services import RSAKeyService
 from lms.tasks.celery import app
+
+LOG = logging.getLogger(__name__)
 
 TARGET_KEYS = 5
 
@@ -9,6 +13,10 @@ def rotate_keys():
     """Periodically (based on h-periodic) rotate RSA keys."""
 
     with app.request_context() as request:  # pylint: disable=no-member
+        if request.registry.settings["disable_key_rotation"]:
+            LOG.info("RSA Key rotation is disabled")
+            return
+
         with request.tm:
             # Using a hardcoded value for target keys
             # and relying on the service's defaults for max_age and max_expired_age

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ TEST_SETTINGS = {
     "blackboard_api_client_id": "test_blackboard_api_client_id",
     "blackboard_api_client_secret": "test_blackboard_api_client_secret",
     "vitalsource_api_key": "test_vs_api_key",
+    "disable_key_rotation": False,
 }
 
 

--- a/tests/unit/lms/tasks/rsa_key_test.py
+++ b/tests/unit/lms/tasks/rsa_key_test.py
@@ -18,6 +18,14 @@ def test_rotate_keys(pyramid_request, rsa_key_service):
     rsa_key_service.rotate.assert_called_once_with(TARGET_KEYS)
 
 
+def test_rotate_keys_disabled(pyramid_request, rsa_key_service):
+    pyramid_request.registry.settings["disable_key_rotation"] = True
+
+    rotate_keys()
+
+    rsa_key_service.rotate.assert_not_called()
+
+
 @pytest.fixture(autouse=True)
 def app(patch, pyramid_request):
     app = patch("lms.tasks.rsa_key.app")

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ passenv =
     dev: BLACKBOARD_API_CLIENT_SECRET
     dev: JSTOR_API_URL
     dev: JSTOR_API_SECRET
+    dev: DISABLE_KEY_ROTATION
 deps =
     -r requirements/{env:TOX_ENV_NAME}.txt
 depends =


### PR DESCRIPTION
For 
- #3916 


---

`DISABLE_KEY_ROTATION` allows disabling RSA key rotation in one environment.

This is useful in QA, where we could disable key rotation and point external servers to the QA environment and share the same keys in the local environments.

The alternative to this is using tunneling but that can be cumbersome as:

- Tunnels can't be shared, two developers can't use the same tunnel at the same time.
- Using different tunnels would require the LMS config to have multiple registrations/application instances. This are time consuming to create and then assignment are linked to one of them. Testing the same thing by different developer will require duplicating the assignments.


## Testing

- Start `make dev`
- Start a new shell with `make shell` and run

```
from lms.tasks.rsa_key import rotate_keys
rotate_keys.apply_async()
```

you see logging in the `make dev` window handling the task.

- Stop `make dev` and start it with `DISABLE_KEY_ROTATION=1 make dev` 
- Send the task again, you can `rotate_keys.apply_async()` again from the existing shell
- Now the logging includes the message about the task being disabled.