### PR TITLE
Create grade items on assignment configuration in D2L

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -123,6 +123,10 @@ _V11_TO_V13 = (
         "lis_outcome_service_url",
         ["https://purl.imsglobal.org/spec/lti-ags/claim/endpoint", "lineitem"],
     ),
+    (
+        "lineitems",
+        ["https://purl.imsglobal.org/spec/lti-ags/claim/endpoint", "lineitems"],
+    ),
     ("lis_result_sourcedid", ["sub"]),
     (
         "content_item_return_url",

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 CLAIM_PREFIX = "https://purl.imsglobal.org/spec/lti/claim"
 
@@ -18,7 +18,7 @@ class LTIParams(dict):
     v11 and the object's dict interface.
     """
 
-    def __init__(self, v11: dict, v13: dict = None):
+    def __init__(self, v11: dict, v13: Optional[dict] = None):
         super().__init__(v11)
         self.v13 = v13
 

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -19,3 +19,11 @@ class D2L(Product):
     )
 
     settings_key = "desire2learn"
+
+    def is_gradable(self, lti_params):
+        if lti_params["lti_version"] != "1.3.0":
+            # D2L doesn't automatically create a line item for assignments by default like it does for 1.1.
+            # If we are creating them automatically in our end all of them will be gradable.
+            return True
+
+        return super().is_gradable(lti_params)

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -29,6 +29,10 @@ class D2L(Product):
 
         return super().is_gradable(lti_params)
 
+    def ltia_aud_claim(self, _lti_registration):
+        # In D2L this value is always the same
+        return "https://api.brightspace.com/auth/token"
+
     def configure_assignment(self, request):
         lti_params = request.lti_params
         resource_link_id = lti_params.get("resource_link_id")

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -22,10 +22,11 @@ class D2L(Product):
     settings_key = "desire2learn"
 
     def is_gradable(self, lti_params):
-        if lti_params["lti_version"] != "1.3.0":
-            # D2L doesn't automatically create a line item for assignments by default like it does for 1.1.
-            # If we are creating them automatically in our end all of them will be gradable.
-            return True
+        if not self.settings.auto_create_lineitem:
+            if lti_params["lti_version"] != "1.3.0":
+                # D2L doesn't automatically create a line item for assignments by default like it does for 1.1.
+                # If we are creating them automatically in our end all of them will be gradable.
+                return True
 
         return super().is_gradable(lti_params)
 
@@ -34,6 +35,9 @@ class D2L(Product):
         return "https://api.brightspace.com/auth/token"
 
     def configure_assignment(self, request):
+        if not self.settings.auto_create_lineitem:
+            return
+
         lti_params = request.lti_params
         resource_link_id = lti_params.get("resource_link_id")
         resource_link_title = lti_params.get("resource_link_title")

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -52,11 +52,9 @@ class D2L(Product):
                 resource_link_id,
                 resource_link_title,
             )
-
-            assert not lti_params.get(
-                "lis_outcome_service_url"
-            ), "We just created the lineitem, we expect it to be empty in the original request params"
-
-            # This is a bit nasty, mutating the "lti_params" to fake the existence of lis_outcome_service_url
-            # at the moment of the request as the rest of the code base assumes but so it's D2L behaviour.
-            lti_params["lis_outcome_service_url"] = lineitem["id"]
+            # We could now do something like:
+            #   lti_params["lis_outcome_service_url"] = lineitem["id"]
+            # to align the lti_params and the lineitem we just created.
+            # This is not necessary as we only creating the lineitem on assignment configuration,
+            # when we know we won't have any student submissions.
+            # The next launches will have the right value in `lis_outcome_service_url`

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -47,8 +47,12 @@ class Settings:
     groups_enabled: bool = False
     """Is the course groups feature enabled"""
 
+    auto_create_lineitem: bool = False
+    """Create lineitem on assignment configuration"""
+
     def __post_init__(self, product_settings):
         self.groups_enabled = product_settings.get("groups_enabled", False)
+        self.groups_enabled = product_settings.get("auto_create_lineitem", False)
 
 
 @dataclass

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -73,6 +73,10 @@ class Product:
     def configure_assigment(self):
         pass
 
+    def ltia_aud_claim(self, lti_registration):
+        """Return the value of the `aud` claim used in LTI advantage requests."""
+        return lti_registration.client_id
+
     @classmethod
     def from_request(cls, request, ai_settings: Dict):
         """Create a populated product object from the provided request."""

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -66,6 +66,10 @@ class Product:
     # Accessor for external consumption
     Family = Family
 
+    def is_gradable(self, lti_params):
+        """Check if the assignment of the current launch is gradable."""
+        return bool(lti_params.get("lis_outcome_service_url"))
+
     @classmethod
     def from_request(cls, request, ai_settings: Dict):
         """Create a populated product object from the provided request."""

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -70,6 +70,9 @@ class Product:
         """Check if the assignment of the current launch is gradable."""
         return bool(lti_params.get("lis_outcome_service_url"))
 
+    def configure_assigment(self):
+        pass
+
     @classmethod
     def from_request(cls, request, ai_settings: Dict):
         """Create a populated product object from the provided request."""

--- a/lms/services/lti_grading/_v11.py
+++ b/lms/services/lti_grading/_v11.py
@@ -46,6 +46,14 @@ class LTI11GradingService(LTIGradingService):
 
         self._send_request({"replaceResultRequest": request})
 
+    def read_lineitems(self, lineitems_url, resource_link_id=None):  # pragma: no cover
+        raise NotImplementedError("Not relevant in LTI 1.1")
+
+    def create_lineitem(
+        self, lineitems_url, resource_link_id, resource_title
+    ):  # pragma: no cover
+        raise NotImplementedError("Not relevant in LTI 1.1")
+
     def _send_request(self, request_body) -> dict:
         """
         Send a signed request to an LMS's Outcome Management Service endpoint.

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -62,6 +62,47 @@ class LTI13GradingService(LTIGradingService):
             headers={"Content-Type": "application/vnd.ims.lis.v1.score+json"},
         )
 
+    def read_lineitems(self, lineitems_url, resource_link_id=None):
+        """
+        Read all the lineitem present in the `lineitems_url` container.
+
+        https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
+        """
+        params = {}
+
+        if resource_link_id:
+            params["resource_link_id"] = resource_link_id
+
+        return self._ltia_service.request(
+            "GET",
+            lineitems_url,
+            scopes=self.LTIA_SCOPES,
+            params=params,
+            headers={"Accept": "application/vnd.ims.lis.v2.lineitemcontainer+json"},
+        ).json()
+
+    def create_lineitem(
+        self, lineitems_url, resource_link_id, resource_title, score_maximum=100
+    ):
+        """
+        Create a new lineitem associated to one resource_link_id.
+
+        https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
+        """
+
+        payload = {
+            "scoreMaximum": score_maximum,
+            "label": resource_title,
+            "resourceLinkId": resource_link_id,
+        }
+        return self._ltia_service.request(
+            "POST",
+            lineitems_url,
+            scopes=self.LTIA_SCOPES,
+            json=payload,
+            headers={"Content-Type": "application/vnd.ims.lis.v2.lineitem+json"},
+        ).json()
+
     @staticmethod
     def _service_url(base_url, endpoint):
         """

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -10,12 +10,12 @@ def service_factory(_context, request):
 
     if application_instance.lti_version == "1.3.0":
         return LTI13GradingService(
-            grading_url=request.parsed_params["lis_outcome_service_url"],
+            grading_url=request.parsed_params.get("lis_outcome_service_url"),
             ltia_service=request.find_service(LTIAHTTPService),
         )
 
     return LTI11GradingService(
-        grading_url=request.parsed_params["lis_outcome_service_url"],
+        grading_url=request.parsed_params.get("lis_outcome_service_url"),
         http_service=request.find_service(name="http"),
         oauth1_service=request.find_service(name="oauth1"),
     )

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -31,3 +31,9 @@ class LTIGradingService:  # pragma: no cover
         :raise TypeError: if the given pre_record_hook returns a non-dict
         """
         raise NotImplementedError()
+
+    def read_lineitems(self, lineitems_url, resource_link_id=None):
+        raise NotImplementedError()
+
+    def create_lineitem(self, lineitems_url, resource_link_id, resource_title):
+        raise NotImplementedError()

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -9,11 +9,16 @@ class LTIAHTTPService:
     """Send LTI Advantage requests and return the responses."""
 
     def __init__(
-        self, lti_registration: LTIRegistration, jwt_service: JWTService, http
+        self,
+        lti_registration: LTIRegistration,
+        aud_claim: str,
+        jwt_service: JWTService,
+        http,
     ):
         self._lti_registration = lti_registration
         self._jwt_service = jwt_service
         self._http = http
+        self._aud_claim = aud_claim
 
     def request(self, method, url, scopes, headers=None, **kwargs):
         headers = headers or {}
@@ -39,7 +44,7 @@ class LTIAHTTPService:
                 "iat": now,
                 "iss": self._lti_registration.client_id,
                 "sub": self._lti_registration.client_id,
-                "aud": self._lti_registration.token_url,
+                "aud": self._aud_claim,
                 "jti": uuid.uuid4().hex,
             }
         )
@@ -58,10 +63,13 @@ class LTIAHTTPService:
 
 
 def factory(_context, request):
+    lti_registration = (
+        request.find_service(name="application_instance").get_current().lti_registration
+    )
+
     return LTIAHTTPService(
-        request.find_service(name="application_instance")
-        .get_current()
-        .lti_registration,
+        lti_registration,
+        request.product.lti_aud_claim(lti_registration),
         request.find_service(JWTService),
         request.find_service(name="http"),
     )

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -116,10 +116,11 @@
     </fieldset>
 
     <fieldset class="box">
-        <legend class="label has-text-centered">D2L settings (EXPERIMENTAL)</legend>
+        <legend class="label has-text-centered">D2L settings</legend>
         {{ settings_text_field("API Client ID", "desire2learn", "client_id") }}
         {{ settings_secret_field("API Client secret", "desire2learn", "client_secret") }}
         {{ settings_checkbox("Groups enabled", "desire2learn", "groups_enabled") }}
+        {{ settings_checkbox("Create grade items", "desire2learn", "auto_create_lineitem") }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -128,6 +128,9 @@ class BasicLaunchViews:
         if group_set := self.request.parsed_params.get("group_set"):
             extra["group_set_id"] = group_set
 
+        # Do any product specific tasks to configure the assignment
+        self.request.product.configure_assignment(self.request)
+
         return self._show_document(
             document_url=self.request.parsed_params["document_url"],
             assignment_extra=extra,

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -150,9 +150,7 @@ class BasicLaunchViews:
 
         # An assignment has been configured in the LMS as "gradable" if it has
         # the `lis_outcome_service_url` param
-        assignment_gradable = bool(
-            self.request.lti_params.get("lis_outcome_service_url")
-        )
+        assignment_gradable = self.request.product.is_gradable(self.request.lti_params)
 
         # Store lots of info
         self._record_course()

--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -44,7 +44,10 @@ class TestLTIAHTTPService:
     @pytest.fixture
     def svc(self, application_instance, jwt_service, http_service):
         return LTIAHTTPService(
-            application_instance.lti_registration, jwt_service, http_service
+            application_instance.lti_registration,
+            application_instance.lti_registration.client_id,
+            jwt_service,
+            http_service,
         )
 
     @pytest.fixture
@@ -65,7 +68,10 @@ class TestFactory:
         ltia_http_service = factory(sentinel.context, pyramid_request)
 
         LTIAHTTPService.assert_called_once_with(
-            application_instance.lti_registration, jwt_service, http_service
+            application_instance.lti_registration,
+            pyramid_request.product.lti_aud_claim.return_value,
+            jwt_service,
+            http_service,
         )
         assert ltia_http_service == LTIAHTTPService.return_value
 


### PR DESCRIPTION
For 

- https://github.com/hypothesis/lms/issues/4699


In summary:

- In other LMS the moment you create a gradable assignment in the LMS the container to hold the grades it's also created by the LMS itself.
- We get a reference (a URL) to that container on launch and we decide if the assignment is gradable based on its presence.
- This is also true in D2L for LTI 1.1
- In D2L 1.3 we found that the behavior cahnged and the container is not created. 
- As a work around the container (lineitem in 1.3 speak, grade item in D2Ls UI) can be created directly in the UI. This add an extra step to use hypothesis.
- A new version of D2L doesn't allow  creating this in the UI.


The proposed solution is to mimic  the LTI 1.1 behavior creating the lineitem on assignment configuration using LTIA.

We'll use a AI setting as a feature flag to make it easier to roll-out (and reverting) and just in case some schools prefer using the UI.