### PR TITLE
Include events which don't have user records

### DIFF
--- a/lms/sql_tasks/tasks/report/create_from_scratch/02_entities/05_events/01_create_view.sql
+++ b/lms/sql_tasks/tasks/report/create_from_scratch/02_entities/05_events/01_create_view.sql
@@ -1,7 +1,7 @@
 DROP TYPE IF EXISTS report.event_type CASCADE;
 
 CREATE TYPE report.event_type AS ENUM (
-    'configured_launch', 'deep_linking'
+    'configured_launch', 'deep_linking', 'audit'
 );
 
 DROP MATERIALIZED VIEW IF EXISTS report.events CASCADE;
@@ -10,6 +10,11 @@ DROP MATERIALIZED VIEW IF EXISTS report.events CASCADE;
 
 CREATE MATERIALIZED VIEW report.events AS (
     WITH
+        -- Unique event user relations without considering role
+        unique_event_users AS (
+            SELECT DISTINCT event_id, user_id FROM event_user
+        ),
+
         translated_events AS (
             SELECT
                 DATE_TRUNC('week', timestamp)::date AS timestamp_week,
@@ -17,25 +22,20 @@ CREATE MATERIALIZED VIEW report.events AS (
                 event_type.type::report.event_type AS event_type,
                 user_map.user_id
             FROM event
-            JOIN event_user ON
-                event_user.event_id = event.id
             JOIN event_type ON
                 event.type_id = event_type.id
-            JOIN report.user_map ON
-                event_user.user_id = user_map.lms_user_id
-            GROUP BY
-                timestamp, event_id, event_type.type, user_map.user_id, user_map.organization_id
+            -- Lots of events don't have users
+            LEFT OUTER JOIN unique_event_users ON
+                unique_event_users.event_id = event.id
+            LEFT OUTER JOIN report.user_map ON
+                unique_event_users.user_id = user_map.lms_user_id
         )
 
     SELECT
-        timestamp_week,
-        organization_id,
-        event_type,
-        user_id,
+        translated_events.*,
         COUNT(1) AS event_count
     FROM translated_events
-    GROUP BY
-        timestamp_week, organization_id, event_type, user_id
+    GROUP BY timestamp_week, organization_id, event_type, user_id
     ORDER BY timestamp_week, organization_id, event_type, user_id
 ) WITH NO DATA;
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/92

We didn't need this before (as we were only interested in organizations), but without rows which have no user, we miss a massive number of launches from the before times.