### PR TITLE
Admin pages tweaks

### DIFF
--- a/lms/templates/admin/instances.html.jinja2
+++ b/lms/templates/admin/instances.html.jinja2
@@ -11,6 +11,7 @@ Application instances
     <legend class="label has-text-centered">Find application instances</legend>
     <form method="POST" action="{{ request.route_url("admin.instances.search") }}">
         <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+        {{ macros.form_text_field(request, "ID", "id") }}
         {{ macros.form_text_field(request, "Consumer key", "consumer_key") }}
         {{ macros.form_text_field(request, "Issuer", "issuer") }}
         {{ macros.form_text_field(request, "Client ID", "client_id") }}

--- a/lms/templates/admin/registrations.html.jinja2
+++ b/lms/templates/admin/registrations.html.jinja2
@@ -20,6 +20,7 @@ Registrations
     <form method="POST" action="{{ request.route_url("admin.registrations.search") }}">
         <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
 
+        {{ macros.form_text_field(request, "ID", "id") }}
         {{ macros.form_text_field(request, "Issuer", "issuer") }}
         {{ macros.form_text_field(request, "Client ID", "client_id") }}
         {% call macros.field_body(label="") %}

--- a/lms/views/admin/__init__.py
+++ b/lms/views/admin/__init__.py
@@ -1,8 +1,32 @@
+from marshmallow import fields, missing
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from pyramid.renderers import render_to_response
 from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 
 from lms.validation._exceptions import ValidationError
+
+
+class EmptyStringNoneMixin:
+    """
+    Allows empty string as "missing value".
+
+    Marshmallow doesn't have a clean solution yet to POSTed values
+    (that are always present in the request as empty strings)
+
+    Here we convert them explicitly to None
+
+    https://github.com/marshmallow-code/marshmallow/issues/713
+    """
+
+    def deserialize(self, value, attr, data, **kwargs):
+        # pylint:disable=compare-to-empty-string
+        if value == missing or value.strip() == "":
+            return None
+        return super().deserialize(value, attr, data, **kwargs)
+
+
+class EmptyStringInt(EmptyStringNoneMixin, fields.Int):
+    """Allow empty string as "missing value" instead of failing integer validation."""
 
 
 @forbidden_view_config(path_info="/admin/*")

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -201,24 +201,8 @@ class AdminApplicationInstanceViews:
         renderer="lms:templates/admin/instances.html.jinja2",
     )
     def search(self):
-        if not any(
-            (
-                self.request.params.get(param)
-                for param in [
-                    "consumer_key",
-                    "issuer",
-                    "client_id",
-                    "deployment_id",
-                    "tool_consumer_instance_guid",
-                ]
-            )
-        ):
-            self.request.session.flash(
-                "Need to pass at least one search criteria", "errors"
-            )
-            return HTTPFound(location=self.request.route_url("admin.instances"))
-
         instances = self.application_instance_service.search(
+            id_=self.request.params.get("id"),
             consumer_key=self.request.params.get("consumer_key"),
             issuer=self.request.params.get("issuer"),
             client_id=self.request.params.get("client_id"),
@@ -227,10 +211,6 @@ class AdminApplicationInstanceViews:
                 "tool_consumer_instance_guid"
             ),
         )
-
-        if not instances:
-            self.request.session.flash("No instances found", "errors")
-            return HTTPFound(location=self.request.route_url("admin.instances"))
 
         if len(instances) == 1:
             return HTTPFound(

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -212,13 +212,6 @@ class AdminApplicationInstanceViews:
             ),
         )
 
-        if len(instances) == 1:
-            return HTTPFound(
-                location=self.request.route_url(
-                    "admin.instance.id", id_=instances[0].id
-                )
-            )
-
         return {"instances": instances}
 
     @view_config(

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -168,8 +168,8 @@ class AdminLTIRegistrationViews:
 
         registrations = self.lti_registration_service.search_registrations(
             id_=self.request.params.get("id"),
-            issuer=self.request.params.get("issuer"),
-            client_id=self.request.params.get("client_id"),
+            issuer=self.request.params.get("issuer", "").strip(),
+            client_id=self.request.params.get("client_id", "").strip(),
         )
 
         return {"registrations": registrations}

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -153,14 +153,6 @@ class AdminLTIRegistrationViews:
         renderer="lms:templates/admin/registrations.html.jinja2",
     )
     def search(self):
-        if not any(
-            (self.request.params.get(param) for param in ["issuer", "client_id"])
-        ):
-            self.request.session.flash(
-                "Need to pass at least one search criteria", "errors"
-            )
-            return HTTPFound(location=self.request.route_url("admin.registrations"))
-
         registrations = self.lti_registration_service.search_registrations(
             id_=self.request.params.get("id"),
             issuer=self.request.params.get("issuer"),

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -162,6 +162,7 @@ class AdminLTIRegistrationViews:
             return HTTPFound(location=self.request.route_url("admin.registrations"))
 
         registrations = self.lti_registration_service.search_registrations(
+            id_=self.request.params.get("id"),
             issuer=self.request.params.get("issuer"),
             client_id=self.request.params.get("client_id"),
         )

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -166,13 +166,6 @@ class AdminLTIRegistrationViews:
             client_id=self.request.params.get("client_id"),
         )
 
-        if registrations and len(registrations) == 1:
-            return HTTPFound(
-                location=self.request.route_url(
-                    "admin.registration.id", id_=registrations[0].id
-                )
-            )
-
         return {"registrations": registrations}
 
     @view_config(

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -9,7 +9,17 @@ from lms.models.public_id import InvalidPublicId
 from lms.security import Permissions
 from lms.services import OrganizationService
 from lms.validation._base import PyramidRequestSchema
-from lms.views.admin import flash_validation
+from lms.views.admin import EmptyStringInt, flash_validation
+
+
+class SearchOrganizationSchema(PyramidRequestSchema):
+    location = "form"
+
+    # Max value for postgres `integer` type
+    id = EmptyStringInt(required=False, validate=validate.Range(max=2147483647))
+    name = fields.Str(required=False)
+    public_id = fields.Str(required=False)
+    guid = fields.Str(required=False)
 
 
 class NewOrganizationSchema(PyramidRequestSchema):
@@ -105,6 +115,9 @@ class AdminOrganizationViews:
         renderer="lms:templates/admin/organizations.html.jinja2",
     )
     def search(self):
+        if flash_validation(self.request, SearchOrganizationSchema):
+            return {}
+
         try:
             orgs = self.organization_service.search(
                 name=self.request.params.get("name", "").strip(),

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -63,7 +63,7 @@ class TestApplicationInstanceService:
 
     def test_get_by_not_found(self, service):
         with pytest.raises(ApplicationInstanceNotFound):
-            service.get_by_id(0)
+            service.get_by_id(100_000_000)
 
     def test_get_by_deployment_id(
         self,

--- a/tests/unit/lms/services/lti_registration_test.py
+++ b/tests/unit/lms/services/lti_registration_test.py
@@ -11,6 +11,10 @@ class TestLTIRegistrationService:
     def test_get(self, svc, registration):
         assert svc.get(registration.issuer, registration.client_id) == registration
 
+    @pytest.mark.usefixtures("registration")
+    def test_get_none_issuer(self, svc):
+        assert not svc.get(None)
+
     def test_get_without_client_id(self, svc, registration):
         assert svc.get(registration.issuer) == registration
 
@@ -57,6 +61,7 @@ class TestLTIRegistrationService:
 
     @pytest.fixture
     def registration(self):
+        factories.LTIRegistration.create_batch(4)
         return factories.LTIRegistration()
 
     @pytest.fixture

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -226,28 +226,34 @@ class TestAdminApplicationInstanceViews:
         assert response.status_code == 400
 
     def test_search(self, pyramid_request, application_instance_service, views):
-        pyramid_request.params = {
-            "id": sentinel.id,
-            "consumer_key": sentinel.consumer_key,
-            "issuer": sentinel.issuer,
-            "client_id": sentinel.client_id,
-            "deployment_id": sentinel.deployment_id,
-            "tool_consumer_instance_guid": sentinel.tool_consumer_instance_guid,
-        }
+        pyramid_request.params = pyramid_request.POST = dict(
+            id="1",
+            consumer_key="CONSUMER_KEY",
+            issuer="ISSUER",
+            client_id="CLIENT_ID",
+            deployment_id="DEPLOYMENT_ID",
+            tool_consumer_instance_guid="TOOL_CONSUMER_INSTANCE_GUID",
+        )
 
         response = views.search()
 
         application_instance_service.search.assert_called_once_with(
-            id_=sentinel.id,
-            consumer_key=sentinel.consumer_key,
-            issuer=sentinel.issuer,
-            client_id=sentinel.client_id,
-            deployment_id=sentinel.deployment_id,
-            tool_consumer_instance_guid=sentinel.tool_consumer_instance_guid,
+            id_="1",
+            consumer_key="CONSUMER_KEY",
+            issuer="ISSUER",
+            client_id="CLIENT_ID",
+            deployment_id="DEPLOYMENT_ID",
+            tool_consumer_instance_guid="TOOL_CONSUMER_INSTANCE_GUID",
         )
         assert response == {
             "instances": application_instance_service.search.return_value
         }
+
+    def test_search_invalid(self, pyramid_request, views):
+        pyramid_request.POST = {"id": "not a number"}
+
+        assert not views.search()
+        assert pyramid_request.session.peek_flash
 
     def test_show_instance_consumer_key(
         self, pyramid_request, application_instance_service

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -225,32 +225,7 @@ class TestAdminApplicationInstanceViews:
 
         assert response.status_code == 400
 
-    def test_search_single_result(
-        self, pyramid_request, application_instance_service, application_instance, views
-    ):
-        application_instance_service.search.return_value = [application_instance]
-        pyramid_request.params["issuer"] = sentinel.issuer
-
-        response = views.search()
-
-        application_instance_service.search.assert_called_once_with(
-            id_=None,
-            consumer_key=None,
-            issuer=sentinel.issuer,
-            client_id=None,
-            deployment_id=None,
-            tool_consumer_instance_guid=None,
-        )
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url(
-                "admin.instance.id",
-                id_=application_instance_service.search.return_value[0].id,
-            )
-        )
-
-    def test_search_multiple_results(
-        self, pyramid_request, application_instance_service, views
-    ):
+    def test_search(self, pyramid_request, application_instance_service, views):
         pyramid_request.params = {
             "id": sentinel.id,
             "consumer_key": sentinel.consumer_key,

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -225,34 +225,6 @@ class TestAdminApplicationInstanceViews:
 
         assert response.status_code == 400
 
-    def test_search_not_query(self, pyramid_request, views):
-        response = views.search()
-
-        assert pyramid_request.session.peek_flash("errors")
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url("admin.instances")
-        )
-
-    def test_search_no_results(
-        self, pyramid_request, application_instance_service, views
-    ):
-        application_instance_service.search.return_value = None
-        pyramid_request.params["issuer"] = sentinel.issuer
-
-        response = views.search()
-
-        application_instance_service.search.assert_called_once_with(
-            consumer_key=None,
-            issuer=sentinel.issuer,
-            client_id=None,
-            deployment_id=None,
-            tool_consumer_instance_guid=None,
-        )
-        assert pyramid_request.session.peek_flash("errors")
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url("admin.instances")
-        )
-
     def test_search_single_result(
         self, pyramid_request, application_instance_service, application_instance, views
     ):
@@ -262,6 +234,7 @@ class TestAdminApplicationInstanceViews:
         response = views.search()
 
         application_instance_service.search.assert_called_once_with(
+            id_=None,
             consumer_key=None,
             issuer=sentinel.issuer,
             client_id=None,
@@ -279,6 +252,7 @@ class TestAdminApplicationInstanceViews:
         self, pyramid_request, application_instance_service, views
     ):
         pyramid_request.params = {
+            "id": sentinel.id,
             "consumer_key": sentinel.consumer_key,
             "issuer": sentinel.issuer,
             "client_id": sentinel.client_id,
@@ -289,6 +263,7 @@ class TestAdminApplicationInstanceViews:
         response = views.search()
 
         application_instance_service.search.assert_called_once_with(
+            id_=sentinel.id,
             consumer_key=sentinel.consumer_key,
             issuer=sentinel.issuer,
             client_id=sentinel.client_id,

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -138,24 +138,6 @@ class TestAdminApplicationInstanceViews:
             pyramid_request.route_url("admin.registrations")
         )
 
-    def test_search_single_result(
-        self, pyramid_request, lti_registration_service, lti_registration, views
-    ):
-        lti_registration_service.search_registrations.return_value = [lti_registration]
-        pyramid_request.params["issuer"] = sentinel.issuer
-
-        response = views.search()
-
-        lti_registration_service.search_registrations.assert_called_once_with(
-            issuer=sentinel.issuer, client_id=None
-        )
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url(
-                "admin.registration.id",
-                id_=lti_registration_service.search_registrations.return_value[0].id,
-            )
-        )
-
     def test_search_multiple_results(
         self, pyramid_request, lti_registration_service, views
     ):

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import sentinel
 
 import pytest
+from pyramid.httpexceptions import HTTPNotFound
 from sqlalchemy.exc import IntegrityError
 
 from lms.views.admin.lti_registration import AdminLTIRegistrationViews
@@ -155,6 +156,15 @@ class TestAdminApplicationInstanceViews:
         assert (
             response["registration"] == lti_registration_service.get_by_id.return_value
         )
+
+    def test_show_registration_404(
+        self, pyramid_request, lti_registration_service, views
+    ):
+        pyramid_request.matchdict["id_"] = sentinel.id_
+        lti_registration_service.get_by_id.return_value = None
+
+        with pytest.raises(HTTPNotFound):
+            views.show_registration()
 
     @pytest.mark.usefixtures("with_form_submission")
     def test_update_registration(

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -131,21 +131,27 @@ class TestAdminApplicationInstanceViews:
         assert response.status_code == 400
 
     def test_search(self, pyramid_request, lti_registration_service, views):
-        pyramid_request.params = {
-            "id": sentinel.id,
-            "issuer": sentinel.issuer,
-            "client_id": sentinel.client_id,
+        pyramid_request.POST = pyramid_request.params = {
+            "id": "1",
+            "issuer": "ISSUER",
+            "client_id": "CLIENT_ID",
         }
 
         response = views.search()
 
         lti_registration_service.search_registrations.assert_called_once_with(
-            id_=sentinel.id, issuer=sentinel.issuer, client_id=sentinel.client_id
+            id_="1", issuer="ISSUER", client_id="CLIENT_ID"
         )
 
         assert response == {
             "registrations": lti_registration_service.search_registrations.return_value
         }
+
+    def test_search_invalid(self, pyramid_request, views):
+        pyramid_request.POST["id"] = "not a number"
+
+        assert not views.search()
+        assert pyramid_request.session.peek_flash
 
     def test_show_registration(self, pyramid_request, lti_registration_service, views):
         pyramid_request.matchdict["id_"] = sentinel.id_

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -4,7 +4,6 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from lms.views.admin.lti_registration import AdminLTIRegistrationViews
-from tests import factories
 from tests.matchers import Any, temporary_redirect_to
 
 
@@ -130,17 +129,7 @@ class TestAdminApplicationInstanceViews:
 
         assert response.status_code == 400
 
-    def test_search_not_query(self, pyramid_request):
-        response = AdminLTIRegistrationViews(pyramid_request).search()
-
-        assert pyramid_request.session.peek_flash("errors")
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url("admin.registrations")
-        )
-
-    def test_search_multiple_results(
-        self, pyramid_request, lti_registration_service, views
-    ):
+    def test_search(self, pyramid_request, lti_registration_service, views):
         pyramid_request.params = {
             "id": sentinel.id,
             "issuer": sentinel.issuer,
@@ -233,7 +222,3 @@ class TestAdminApplicationInstanceViews:
     @pytest.fixture
     def views(self, pyramid_request):
         return AdminLTIRegistrationViews(pyramid_request)
-
-    @pytest.fixture
-    def lti_registration(self):
-        return factories.LTIRegistration()

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -142,6 +142,7 @@ class TestAdminApplicationInstanceViews:
         self, pyramid_request, lti_registration_service, views
     ):
         pyramid_request.params = {
+            "id": sentinel.id,
             "issuer": sentinel.issuer,
             "client_id": sentinel.client_id,
         }
@@ -149,7 +150,7 @@ class TestAdminApplicationInstanceViews:
         response = views.search()
 
         lti_registration_service.search_registrations.assert_called_once_with(
-            issuer=sentinel.issuer, client_id=sentinel.client_id
+            id_=sentinel.id, issuer=sentinel.issuer, client_id=sentinel.client_id
         )
 
         assert response == {

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -95,15 +95,21 @@ class TestAdminOrganizationViews:
     def test_search(self, pyramid_request, organization_service, views):
         pyramid_request.params["public_id"] = " PUBLIC_ID "
         pyramid_request.params["name"] = " NAME "
-        pyramid_request.params["id"] = " ID "
+        pyramid_request.params["id"] = " 100 "
         pyramid_request.params["guid"] = " GUID  "
 
         result = views.search()
 
         organization_service.search.assert_called_once_with(
-            name="NAME", public_id="PUBLIC_ID", id_="ID", guid="GUID"
+            name="NAME", public_id="PUBLIC_ID", id_="100", guid="GUID"
         )
         assert result == {"organizations": organization_service.search.return_value}
+
+    def test_search_invalid(self, pyramid_request, views):
+        pyramid_request.params["id"] = "not a number"
+
+        assert not views.search()
+        assert pyramid_request.session.peek_flash
 
     def test_blank_search(self, views, organization_service):
         views.search()


### PR DESCRIPTION
For both registrations and application instances:

- Search by ID.
- Searching with no criteria returns some results.
- Don't redirect to the result when there only one. It's a bit confusing, you just might want to copy something from the results table for example.
- Correctly 404 when registration doesn't exist.


## Testing

- http://localhost:8001/admin/registrations/

  - Search directly there, you'll get results
  - Search using ID `1`
  - http://localhost:8001/admin/registration/id/78789789/ is a 404 not an empty page


- http://localhost:8001/admin/instances/

  - Search directly there, you'll get results
  - Search using ID `100`
