### PR TITLE
WIP use the right D2L terminology

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -81,8 +81,7 @@ function GroupSelect({
 }
 
 /**
- *
- *  @typedef GroupSelectHeaderProps
+ * @typedef GroupSelectHeaderProps
  * @prop {string} htmlFor
  * @prop {string} productFamily
  *
@@ -97,8 +96,7 @@ function GroupSelectHeader({ htmlFor, productFamily }) {
 }
 
 /**
- *
- *  @typedef GroupSelectLoadingOptionProps
+ * @typedef GroupSelectLoadingOptionProps
  * @prop {string} productFamily
  *
  * @param {GroupSelectLoadingOptionProps} props
@@ -113,8 +111,7 @@ function GroupSelectLoadingOption({ productFamily }) {
 }
 
 /**
- *
- *  @typedef GroupSelectPromptOptionProps
+ * @typedef GroupSelectPromptOptionProps
  * @prop {string} productFamily
  * @prop {boolean} groupSelected
  *

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -142,7 +142,6 @@ export default function LaunchErrorDialog({
 
     case 'blackboard_group_set_not_found':
     case 'canvas_group_set_not_found':
-    case 'd2l_group_set_not_found':
       return (
         <ErrorModal
           busy={busy}
@@ -161,10 +160,28 @@ export default function LaunchErrorDialog({
           </p>
         </ErrorModal>
       );
+    case 'd2l_group_set_not_found':
+      return (
+        <ErrorModal
+          busy={busy}
+          error={error}
+          title="Assignment's group category no longer exists"
+        >
+          <p>
+            Hypothesis couldn&apos;t load this assignment because the
+            assignment&apos;s group category no longer exists.
+          </p>
+          <p>
+            <b>
+              To fix this problem, an instructor needs to edit the assignment
+              settings and select a new group category.
+            </b>
+          </p>
+        </ErrorModal>
+      );
 
     case 'blackboard_group_set_empty':
     case 'canvas_group_set_empty':
-    case 'd2l_group_set_empty':
       return (
         <ErrorModal
           busy={busy}
@@ -173,9 +190,22 @@ export default function LaunchErrorDialog({
         >
           <p>The group set for this Hypothesis assignment is empty. </p>
           <p>
+            <b>different group set for this assignment.</b>
+          </p>
+        </ErrorModal>
+      );
+    case 'd2l_group_set_empty':
+      return (
+        <ErrorModal
+          busy={busy}
+          error={error}
+          title="Assignment's group category is empty"
+        >
+          <p>The group category for this Hypothesis assignment is empty. </p>
+          <p>
             <b>
-              To fix this problem, add groups to the group set or use a
-              different group set for this assignment.
+              To fix this problem, add groups to the group category or use a
+              different group category for this assignment.
             </b>
           </p>
         </ErrorModal>
@@ -230,7 +260,8 @@ export default function LaunchErrorDialog({
         >
           <p>
             Hypothesis couldn&apos;t launch this assignment because you
-            aren&apos;t in any of the groups in the assignment&apos;s group set.
+            aren&apos;t in any of the groups in the assignment&apos;s group
+            category.
           </p>
           <p>
             <b>


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4678


This is a half done PR, the aim is to use the term "group category/ies" throughout the application when using D2L instead of "group set/s" nomenclature used in other LMS.

This is a very small thing to do but there's no existing examples of it on the code base so I'm struggling to find the right "design" so I'm happy to:

- Take some notes on the PR and continue to write a merge-able one
- Handing it over to you to finish it


Note that there's two commits here, the first one around error dialog, seems more obvious to me, we already have a mechanism there to display different message based on the error code. 

Is in the second one where strings appear in different ways in the  code and I'm not sure what the right approach is.

