### PR TITLE
Rename GroupingServicePluging to GroupingPlugin

### DIFF
--- a/lms/product/blackboard/_plugin/grouping.py
+++ b/lms/product/blackboard/_plugin/grouping.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from lms.models import Grouping
-from lms.product.plugin.grouping_service import GroupError, GroupingServicePlugin
+from lms.product.plugin.grouping import GroupError, GroupingPlugin
 from lms.services.exceptions import ExternalRequestError
 
 
@@ -13,7 +13,7 @@ class ErrorCodes(str, Enum):
     STUDENT_NOT_IN_GROUP = "blackboard_student_not_in_group"
 
 
-class BlackboardGroupingPlugin(GroupingServicePlugin):
+class BlackboardGroupingPlugin(GroupingPlugin):
     """A plugin which implements Blackboard specific grouping functions."""
 
     group_type = Grouping.Type.BLACKBOARD_GROUP

--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -16,7 +16,5 @@ class Blackboard(Product):
         list_group_sets="blackboard_api.courses.group_sets.list",
     )
 
-    plugin_config: PluginConfig = PluginConfig(
-        grouping_service=BlackboardGroupingPlugin
-    )
+    plugin_config: PluginConfig = PluginConfig(grouping=BlackboardGroupingPlugin)
     settings_key = "blackboard"

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from lms.models import Grouping
-from lms.product.plugin.grouping_service import GroupError, GroupingServicePlugin
+from lms.product.plugin.grouping import GroupError, GroupingPlugin
 from lms.services.exceptions import CanvasAPIError
 
 
@@ -13,7 +13,7 @@ class ErrorCodes(str, Enum):
     GROUP_SET_NOT_FOUND = "canvas_group_set_not_found"
 
 
-class CanvasGroupingPlugin(GroupingServicePlugin):
+class CanvasGroupingPlugin(GroupingPlugin):
     """A plugin which implements Canvas specific grouping functions."""
 
     group_type = Grouping.Type.CANVAS_GROUP

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -16,6 +16,6 @@ class Canvas(Product):
         list_group_sets="canvas_api.courses.group_sets.list",
     )
 
-    plugin_config: PluginConfig = PluginConfig(grouping_service=CanvasGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(grouping=CanvasGroupingPlugin)
 
     settings_key = "canvas"

--- a/lms/product/d2l/_plugin/grouping.py
+++ b/lms/product/d2l/_plugin/grouping.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from lms.models import Grouping
-from lms.product.plugin.grouping_service import GroupError, GroupingServicePlugin
+from lms.product.plugin.grouping import GroupError, GroupingPlugin
 from lms.services import D2LAPIClient
 from lms.services.exceptions import ExternalRequestError
 
@@ -14,7 +14,7 @@ class ErrorCodes(str, Enum):
     STUDENT_NOT_IN_GROUP = "d2l_student_not_in_group"
 
 
-class D2LGroupingPlugin(GroupingServicePlugin):
+class D2LGroupingPlugin(GroupingPlugin):
     """A plugin which implements D2L specific grouping functions."""
 
     group_type = Grouping.Type.D2L_GROUP

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -10,7 +10,7 @@ class D2L(Product):
 
     family: Product.Family = Product.Family.D2L
 
-    plugin_config: PluginConfig = PluginConfig(grouping_service=D2LGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(grouping=D2LGroupingPlugin)
 
     route: Routes = Routes(
         oauth2_authorize="d2l_api.oauth.authorize",

--- a/lms/product/plugin/__init__.py
+++ b/lms/product/plugin/__init__.py
@@ -1,8 +1,8 @@
-from lms.product.plugin.grouping_service import GroupingServicePlugin
+from lms.product.plugin.grouping import GroupingPlugin
 from lms.product.plugin.plugin import PluginConfig, Plugins
 
 
 def includeme(config):  # pragma: nocover
     """Register all of our plugins."""
 
-    config.register_service(GroupingServicePlugin(), iface=GroupingServicePlugin)
+    config.register_service(GroupingPlugin(), iface=GroupingPlugin)

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -5,9 +5,9 @@ from lms.models import Course, Grouping
 
 
 # pylint: disable=unused-argument
-class GroupingServicePlugin:  # pragma: nocover
+class GroupingPlugin:  # pragma: nocover
     """
-    An interface between the grouping service and a specific LMS.
+    An abstraction between a specific LMS API and different grouping types.
 
     This is intended to give a place for product specific actions to take
     place. For example if you are creating a Canvas plugin, it will be implicit

--- a/lms/product/plugin/plugin.py
+++ b/lms/product/plugin/plugin.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from lms.product.plugin.grouping_service import GroupingServicePlugin
+from lms.product.plugin.grouping import GroupingPlugin
 
 
 @dataclass
@@ -8,7 +8,7 @@ class PluginConfig:
     """A collection of plugin class definitions."""
 
     # These also provide the default implementations
-    grouping_service: type = GroupingServicePlugin
+    grouping: type = GroupingPlugin
 
 
 class Plugins:
@@ -27,7 +27,7 @@ class Plugins:
             setattr(instance, self.plugin_name, plugin)  # Overwrite the attr
             return plugin
 
-    grouping_service: GroupingServicePlugin = _LazyPlugin()
+    grouping: GroupingPlugin = _LazyPlugin()
 
     def __init__(self, request, plugin_config: PluginConfig):
         self._request = request

--- a/lms/services/grouping/factory.py
+++ b/lms/services/grouping/factory.py
@@ -7,5 +7,5 @@ def service_factory(_context, request):
         application_instance=request.find_service(
             name="application_instance"
         ).get_current(),
-        plugin=request.product.plugin.grouping_service,
+        plugin=request.product.plugin.grouping,
     )

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -5,12 +5,12 @@ from sqlalchemy.orm import aliased, subqueryload
 
 from lms.models import Course, Grouping, GroupingMembership, LTIUser, User
 from lms.models._hashed_id import hashed_id
-from lms.product.plugin.grouping_service import GroupingServicePlugin
+from lms.product.plugin.grouping import GroupingPlugin
 from lms.services.upsert import bulk_upsert
 
 
 class GroupingService:
-    def __init__(self, db, application_instance, plugin: GroupingServicePlugin):
+    def __init__(self, db, application_instance, plugin: GroupingPlugin):
         self._db = db
         self.application_instance = application_instance
         self.plugin = plugin

--- a/tests/unit/lms/product/blackboard/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/grouping_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from lms.models import Grouping
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin, ErrorCodes
-from lms.product.plugin.grouping_service import GroupError
+from lms.product.plugin.grouping import GroupError
 from lms.services.exceptions import ExternalRequestError
 from tests import factories
 

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 import pytest
 
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin, ErrorCodes
-from lms.product.plugin.grouping_service import GroupError
+from lms.product.plugin.grouping import GroupError
 from lms.services import CanvasAPIError
 from tests import factories
 

--- a/tests/unit/lms/product/d2l/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/grouping_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from lms.models import Grouping
 from lms.product.d2l._plugin.grouping import D2LGroupingPlugin, ErrorCodes
-from lms.product.plugin.grouping_service import GroupError
+from lms.product.plugin.grouping import GroupError
 from lms.services.exceptions import ExternalRequestError
 from tests import factories
 

--- a/tests/unit/lms/services/grouping/factory_test.py
+++ b/tests/unit/lms/services/grouping/factory_test.py
@@ -15,7 +15,7 @@ class TestFactory:
         GroupingService.assert_called_once_with(
             db=pyramid_request.db,
             application_instance=application_instance_service.get_current.return_value,
-            plugin=pyramid_request.product.plugin.grouping_service,
+            plugin=pyramid_request.product.plugin.grouping,
         )
 
         assert svc == GroupingService.return_value

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -5,7 +5,7 @@ import pytest
 from h_matchers import Any
 
 from lms.models import CanvasGroup, Course, Grouping, GroupingMembership
-from lms.product.plugin.grouping_service import GroupingServicePlugin
+from lms.product.plugin.grouping import GroupingPlugin
 from lms.services.grouping import GroupingService
 from tests import factories
 
@@ -513,5 +513,5 @@ def svc(db_session, application_instance):
     return GroupingService(
         db_session,
         application_instance,
-        plugin=create_autospec(GroupingServicePlugin, spec_set=True, instance=True),
+        plugin=create_autospec(GroupingPlugin, spec_set=True, instance=True),
     )


### PR DESCRIPTION
The old name was confusing as we already have a grouping_service.

The main focus of the pluging is not to abstract the existing service (although it might use it) but to abstract the API of the different LMS, for example the canvas plugin doesn't use the service.