### PR TITLE
Extend grouping plugin 

### DIFF
--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -91,7 +91,7 @@ class CanvasGroupingPlugin(GroupingPlugin):
 
         return course.settings.get("canvas", "sections_enabled")
 
-    def group_set_id(self, request, assignment):
+    def get_group_set_id(self, request, assignment):
         # For canvas we add parameter to the launch URL as we don't store the
         # assignment during deep linking.
         return request.params.get("group_set")

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -78,6 +78,24 @@ class CanvasGroupingPlugin(GroupingPlugin):
             self._custom_course_id(course), grading_student_id, group_set_id
         )
 
+    def sections_enabled(self, request, application_instance, course):
+        params = request.params
+        if "focused_user" in params and "learner_canvas_user_id" not in params:
+            # This is a legacy SpeedGrader URL, submitted to Canvas before our
+            # Canvas course sections feature was released.
+            return False
+
+        if not bool(application_instance.developer_key):
+            # We need a developer key to talk to the API
+            return False
+
+        return course.settings.get("canvas", "sections_enabled")
+
+    def group_set_id(self, request, assignment):
+        # For canvas we add parameter to the launch URL as we don't store the
+        # assignment during deep linking.
+        return request.params.get("group_set")
+
     def _custom_course_id(self, course):
         return course.extra["canvas"]["custom_canvas_course_id"]
 

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -70,7 +70,7 @@ class GroupingPlugin:
         """Check if sections are enabled for this LMS, instance and course."""
         return bool(self.sections_type)
 
-    def group_set_id(self, request, assignment):
+    def get_group_set_id(self, request, assignment):
         """
         Get the group set ID for group launches.
 

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -84,24 +84,6 @@ class GroupingPlugin:
 
         return assignment.extra.get("group_set_id") if assignment else None
 
-    def launch_grouping_type(
-        self, request, application_instance, course, assignment
-    ) -> Grouping.Type:
-        """
-        Return the type of grouping used in this launch.
-
-        Grouping types describe how the course members are divided.
-        If neither of the LMS grouping features are used "COURSE" is the default.
-        """
-        if bool(self.group_set_id(request, assignment)):
-            return Grouping.Type.GROUP
-
-        if self.sections_enabled(request, application_instance, course):
-            # Sections is the default when available. Groups must take precedence
-            return Grouping.Type.SECTION
-
-        return Grouping.Type.COURSE
-
 
 class GroupError(Exception):
     """Exceptions raised by plugins."""

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -68,7 +68,7 @@ class GroupingPlugin:
 
     def sections_enabled(self, request, application_instance, course) -> bool:
         """Check if sections are enabled for this LMS, instance and course."""
-        return False  # Disabled by default
+        return bool(self.sections_type)
 
     def group_set_id(self, request, assignment):
         """

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -524,7 +524,7 @@ class JSConfig:
                     "product": self._request.product.family,
                 },
                 "context_id": self._request.lti_params["context_id"],
-                "group_set_id": self._request.product.plugin.grouping.group_set_id(
+                "group_set_id": self._request.product.plugin.grouping.get_group_set_id(
                     self._request, assignment
                 ),
                 "group_info": {

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -524,7 +524,9 @@ class JSConfig:
                     "product": self._request.product.family,
                 },
                 "context_id": self._request.lti_params["context_id"],
-                "group_set_id": self._context.group_set_id,
+                "group_set_id": self._request.product.plugin.grouping.group_set_id(
+                    self._request, assignment
+                ),
                 "group_info": {
                     key: value
                     for key, value in self._request.lti_params.items()

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -56,8 +56,7 @@ class LTILaunchResource:
             self._request.lti_params["tool_consumer_instance_guid"],
             self._request.lti_params.get("resource_link_id"),
         )
-
-        return self._request.product.plugin.grouping_service.launch_grouping_type(
+        return self._request.find_service(name="grouping").get_launch_grouping_type(
             self._request, self.application_instance, self.course, assignment
         )
 

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -57,7 +57,7 @@ class LTILaunchResource:
             self._request.lti_params.get("resource_link_id"),
         )
         return self._request.find_service(name="grouping").get_launch_grouping_type(
-            self._request, self.application_instance, self.course, assignment
+            self._request, self.course, assignment
         )
 
     def _course_extra(self):

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -229,6 +229,24 @@ class GroupingService:
 
         return [course] + groupings
 
+    def get_launch_grouping_type(
+        self, request, application_instance, course, assignment
+    ) -> Grouping.Type:
+        """
+        Return the type of grouping used in the current LTI launch.
+
+        Grouping types describe how the course members are divided.
+        If neither of the LMS grouping features are used "COURSE" is the default.
+        """
+        if bool(self.plugin.group_set_id(request, assignment)):
+            return Grouping.Type.GROUP
+
+        if self.plugin.sections_enabled(request, application_instance, course):
+            # Sections is the default when available. Groups must take precedence
+            return Grouping.Type.SECTION
+
+        return Grouping.Type.COURSE
+
     def _to_groupings(self, user, groupings, course, type_):
         if groupings and not isinstance(groupings[0], Grouping):
             groupings = [

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -229,9 +229,7 @@ class GroupingService:
 
         return [course] + groupings
 
-    def get_launch_grouping_type(
-        self, request, application_instance, course, assignment
-    ) -> Grouping.Type:
+    def get_launch_grouping_type(self, request, course, assignment) -> Grouping.Type:
         """
         Return the type of grouping used in the current LTI launch.
 
@@ -241,7 +239,7 @@ class GroupingService:
         if bool(self.plugin.group_set_id(request, assignment)):
             return Grouping.Type.GROUP
 
-        if self.plugin.sections_enabled(request, application_instance, course):
+        if self.plugin.sections_enabled(request, self.application_instance, course):
             # Sections is the default when available. Groups must take precedence
             return Grouping.Type.SECTION
 

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -236,7 +236,7 @@ class GroupingService:
         Grouping types describe how the course members are divided.
         If neither of the LMS grouping features are used "COURSE" is the default.
         """
-        if bool(self.plugin.group_set_id(request, assignment)):
+        if bool(self.plugin.get_group_set_id(request, assignment)):
             return Grouping.Type.GROUP
 
         if self.plugin.sections_enabled(request, self.application_instance, course):

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -152,10 +152,10 @@ class TestCanvasGroupingPlugin:
             == enabled
         )
 
-    def test_group_set_id(self, pyramid_request, plugin):
+    def test_get_group_set_id(self, pyramid_request, plugin):
         pyramid_request.params.update({"group_set": 1})
 
-        assert plugin.group_set_id(pyramid_request, sentinel.assignment) == 1
+        assert plugin.get_group_set_id(pyramid_request, sentinel.assignment) == 1
 
     def test_factory(self, pyramid_request, canvas_api_client):
         plugin = CanvasGroupingPlugin.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/product/plugin/grouping_service_test.py
+++ b/tests/unit/lms/product/plugin/grouping_service_test.py
@@ -8,9 +8,17 @@ from tests import factories
 
 
 class TestGroupingServicePlugin:
-    def test_sections_enabled(self, plugin):
-        assert not plugin.sections_enabled(
-            sentinel.request, sentinel.application_instance, sentinel.course
+    @pytest.mark.parametrize(
+        "sections_type,expected", [(None, False), (Grouping.Type.CANVAS_SECTION, True)]
+    )
+    def test_sections_enabled(self, plugin, sections_type, expected):
+        plugin.sections_type = sections_type
+
+        assert (
+            plugin.sections_enabled(
+                sentinel.request, sentinel.application_instance, sentinel.course
+            )
+            == expected
         )
 
     def test_group_set_id_when_disabled(self, plugin):

--- a/tests/unit/lms/product/plugin/grouping_service_test.py
+++ b/tests/unit/lms/product/plugin/grouping_service_test.py
@@ -21,24 +21,25 @@ class TestGroupingServicePlugin:
             == expected
         )
 
-    def test_group_set_id_when_disabled(self, plugin):
+    def test_get_group_set_id_when_disabled(self, plugin):
         plugin.group_type = None
 
-        assert not plugin.group_set_id(sentinel.request, sentinel.assignment)
+        assert not plugin.get_group_set_id(sentinel.request, sentinel.assignment)
 
-    def test_group_set_id_when_no_assignment(self, plugin_with_groups):
-        assert not plugin_with_groups.group_set_id(sentinel.request, None)
+    def test_get_group_set_id_when_no_assignment(self, plugin_with_groups):
+        assert not plugin_with_groups.get_group_set_id(sentinel.request, None)
 
-    def test_group_set_id_when_no_group_set(self, plugin):
+    def test_get_group_set_id_when_no_group_set(self, plugin):
         assignment = factories.Assignment(extra={})
 
-        assert not plugin.group_set_id(sentinel.request, assignment)
+        assert not plugin.get_group_set_id(sentinel.request, assignment)
 
-    def test_group_set(self, plugin_with_groups):
+    def test_get_group_set_id(self, plugin_with_groups):
         assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
 
         assert (
-            plugin_with_groups.group_set_id(sentinel.request, assignment) == sentinel.id
+            plugin_with_groups.get_group_set_id(sentinel.request, assignment)
+            == sentinel.id
         )
 
     @pytest.fixture

--- a/tests/unit/lms/product/plugin/grouping_service_test.py
+++ b/tests/unit/lms/product/plugin/grouping_service_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
@@ -32,31 +32,6 @@ class TestGroupingServicePlugin:
         assert (
             plugin_with_groups.group_set_id(sentinel.request, assignment) == sentinel.id
         )
-
-    @pytest.mark.parametrize(
-        "sections_enabled,group_set_id,expected",
-        [
-            (True, 1, Grouping.Type.GROUP),
-            (True, None, Grouping.Type.SECTION),
-            (False, 1, Grouping.Type.GROUP),
-            (False, None, Grouping.Type.COURSE),
-        ],
-    )
-    def test_launch_grouping_type(
-        self, plugin, sections_enabled, group_set_id, expected
-    ):
-        with patch.object(
-            plugin, "sections_enabled", return_value=sections_enabled
-        ), patch.object(plugin, "group_set_id", return_value=group_set_id):
-            assert (
-                plugin.launch_grouping_type(
-                    sentinel.request,
-                    sentinel.application_instance,
-                    sentinel.course,
-                    sentinel.assignment,
-                )
-                == expected
-            )
 
     @pytest.fixture
     def plugin(self):

--- a/tests/unit/lms/product/plugin/grouping_service_test.py
+++ b/tests/unit/lms/product/plugin/grouping_service_test.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch, sentinel
+
+import pytest
+
+from lms.models import Grouping
+from lms.product.plugin.grouping import GroupingPlugin
+from tests import factories
+
+
+class TestGroupingServicePlugin:
+    def test_sections_enabled(self, plugin):
+        assert not plugin.sections_enabled(
+            sentinel.request, sentinel.application_instance, sentinel.course
+        )
+
+    def test_group_set_id_when_disabled(self, plugin):
+        plugin.group_type = None
+
+        assert not plugin.group_set_id(sentinel.request, sentinel.assignment)
+
+    def test_group_set_id_when_no_assignment(self, plugin_with_groups):
+        assert not plugin_with_groups.group_set_id(sentinel.request, None)
+
+    def test_group_set_id_when_no_group_set(self, plugin):
+        assignment = factories.Assignment(extra={})
+
+        assert not plugin.group_set_id(sentinel.request, assignment)
+
+    def test_group_set(self, plugin_with_groups):
+        assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
+
+        assert (
+            plugin_with_groups.group_set_id(sentinel.request, assignment) == sentinel.id
+        )
+
+    @pytest.mark.parametrize(
+        "sections_enabled,group_set_id,expected",
+        [
+            (True, 1, Grouping.Type.GROUP),
+            (True, None, Grouping.Type.SECTION),
+            (False, 1, Grouping.Type.GROUP),
+            (False, None, Grouping.Type.COURSE),
+        ],
+    )
+    def test_launch_grouping_type(
+        self, plugin, sections_enabled, group_set_id, expected
+    ):
+        with patch.object(
+            plugin, "sections_enabled", return_value=sections_enabled
+        ), patch.object(plugin, "group_set_id", return_value=group_set_id):
+            assert (
+                plugin.launch_grouping_type(
+                    sentinel.request,
+                    sentinel.application_instance,
+                    sentinel.course,
+                    sentinel.assignment,
+                )
+                == expected
+            )
+
+    @pytest.fixture
+    def plugin(self):
+        return GroupingPlugin()
+
+    @pytest.fixture
+    def plugin_with_groups(self, plugin):
+        plugin.group_type = Grouping.Type.BLACKBOARD_GROUP
+        return plugin

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -379,7 +379,7 @@ class TestJSConfigAPISync:
         pyramid_request.params["learner_canvas_user_id"] = "CANVAS_USER_ID"
         pyramid_request.product.route.oauth2_authorize = "welcome"
         context.grouping_type = grouping_type
-        grouping_plugin.group_set_id.return_value = "GROUP_SET_ID"
+        grouping_plugin.get_group_set_id.return_value = "GROUP_SET_ID"
 
         js_config.enable_lti_launch_mode(assignment)
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -371,13 +371,15 @@ class TestJSConfigAPISync:
     @pytest.mark.parametrize(
         "grouping_type", (Grouping.Type.GROUP, Grouping.Type.SECTION)
     )
-    def test_it(self, js_config, context, pyramid_request, grouping_type):
+    def test_it(
+        self, js_config, context, pyramid_request, grouping_type, grouping_plugin
+    ):
         assignment.id = 123456  # Ensure the assignment has an id
         pyramid_request.lti_params["context_id"] = "CONTEXT_ID"
         pyramid_request.params["learner_canvas_user_id"] = "CANVAS_USER_ID"
         pyramid_request.product.route.oauth2_authorize = "welcome"
         context.grouping_type = grouping_type
-        context.group_set_id = "GROUP_SET_ID"
+        grouping_plugin.group_set_id.return_value = "GROUP_SET_ID"
 
         js_config.enable_lti_launch_mode(assignment)
 
@@ -443,13 +445,13 @@ class TestJSConfigHypothesisClient:
             }
         ]
 
-    @pytest.mark.usefixtures("with_sections_on")
+    @pytest.mark.usefixtures("with_sections_on", "grouping_plugin")
     def test_configures_the_client_to_fetch_the_groups_over_RPC_with_sections(
         self, config
     ):
         assert config["services"][0]["groups"] == "$rpc:requestGroups"
 
-    @pytest.mark.usefixtures("with_groups_on")
+    @pytest.mark.usefixtures("with_groups_on", "grouping_plugin")
     def test_it_configures_the_client_to_fetch_the_groups_over_RPC_with_groups(
         self, config
     ):
@@ -662,7 +664,6 @@ def context(application_instance):
         spec_set=True,
         instance=True,
         is_canvas=True,
-        sections_enabled=False,
         grouping_type=Grouping.Type.COURSE,
         course=create_autospec(Grouping, instance=True, spec_set=True),
         application_instance=application_instance,

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -59,7 +59,7 @@ class TestCourseExtra:
 class TestGroupingType:
     def test_it(
         self,
-        grouping_plugin,
+        grouping_service,
         lti_launch,
         course_service,
         assignment_service,
@@ -68,12 +68,12 @@ class TestGroupingType:
     ):
         assert (
             lti_launch.grouping_type
-            == grouping_plugin.launch_grouping_type.return_value
+            == grouping_service.get_launch_grouping_type.return_value
         )
         assignment_service.get_assignment.assert_called_once_with(
             mock.sentinel.tool_guid, mock.sentinel.resource_link_id
         )
-        grouping_plugin.launch_grouping_type.assert_called_once_with(
+        grouping_service.get_launch_grouping_type.assert_called_once_with(
             pyramid_request,
             application_instance,
             course_service.upsert_course.return_value,

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -1,14 +1,13 @@
 from unittest import mock
 
 import pytest
-from pytest import param
 
-from lms.models import ApplicationSettings, Grouping
 from lms.product import Product
 from lms.resources import LTILaunchResource
 
 pytestmark = pytest.mark.usefixtures(
-    "application_instance_service", "assignment_service"
+    "application_instance_service",
+    "assignment_service",
 )
 
 
@@ -37,62 +36,6 @@ class TestJSConfig:
         assert js_config == JSConfig.return_value
 
 
-@pytest.mark.usefixtures("has_course")
-class TestSectionsEnabled:
-    @pytest.mark.parametrize("is_canvas", [True, False])
-    def test_support_for_canvas(self, lti_launch, is_canvas):
-        with mock.patch.object(LTILaunchResource, "is_canvas", is_canvas):
-            assert lti_launch.sections_enabled == is_canvas
-
-    @pytest.mark.usefixtures("with_canvas")
-    @pytest.mark.parametrize(
-        "params,expected",
-        (
-            param(
-                {
-                    "focused_user": mock.sentinel.focused_user,
-                    "learner_canvas_user_id": mock.sentinel.learner_canvas_user_id,
-                },
-                True,
-                id="Speedgrader",
-            ),
-            param(
-                {"focused_user": mock.sentinel.focused_user},
-                False,
-                id="Legacy Speedgrader",
-            ),
-        ),
-    )
-    def test_its_support_for_speedgrader(
-        self, lti_launch, pyramid_request, params, expected
-    ):
-        pyramid_request.params.update(params)
-
-        assert lti_launch.sections_enabled is expected
-
-    @pytest.mark.usefixtures("with_canvas")
-    def test_it_depends_on_developer_key(
-        self, lti_launch, application_instance_service
-    ):
-        application_instance_service.get_current.return_value.developer_key = None
-        assert not lti_launch.sections_enabled
-
-    @pytest.mark.usefixtures("with_canvas")
-    @pytest.mark.parametrize("enabled", [True, False])
-    def test_it_depends_on_course_setting(self, lti_launch, course_settings, enabled):
-        course_settings.set("canvas", "sections_enabled", enabled)
-
-        assert lti_launch.sections_enabled == enabled
-
-    @pytest.fixture(autouse=True)
-    def course_settings(self, course_service):
-        settings = ApplicationSettings({"canvas": {"sections_enabled": True}})
-
-        course_service.upsert_course.return_value.settings = settings
-
-        return settings
-
-
 class TestCourseExtra:
     # pylint: disable=protected-access
     def test_empty_in_non_canvas(self, pyramid_request):
@@ -113,64 +56,29 @@ class TestCourseExtra:
         }
 
 
-class TestGroupSetId:
-    @pytest.mark.usefixtures("with_blackboard")
-    def test_blackboard_false_when_no_assignment(self, lti_launch, assignment_service):
-        assignment_service.get_assignment.return_value = None
-
-        assert not lti_launch.group_set_id
-
-    @pytest.mark.usefixtures("with_blackboard")
-    def test_blackboard_false_when_no_group_set(self, lti_launch, assignment_service):
-        assignment_service.get_assignment.return_value.extra = {}
-
-        assert not lti_launch.group_set_id
-
-    @pytest.mark.usefixtures("with_blackboard")
-    def test_blackboard(self, lti_launch, assignment_service):
-        assignment_service.get_assignment.return_value.extra = {
-            "group_set_id": mock.sentinel.id
-        }
-
-        assert lti_launch.group_set_id == mock.sentinel.id
-
-    @pytest.mark.usefixtures("with_canvas")
-    def test_canvas(self, pyramid_request):
-        pyramid_request.params.update({"group_set": 1})
-
-        assert LTILaunchResource(pyramid_request).group_set_id == 1
-
-    def test_other_lms(self, pyramid_request):
-        pyramid_request.product.family = Product.Family.UNKNOWN
-
-        assert not LTILaunchResource(pyramid_request).group_set_id
-
-    @pytest.fixture(autouse=True)
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.lti_params = {
-            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid"
-        }
-        return pyramid_request
-
-
 class TestGroupingType:
-    @pytest.mark.parametrize(
-        "sections_enabled,group_set_id,expected",
-        [
-            (True, 1, Grouping.Type.GROUP),
-            (True, None, Grouping.Type.SECTION),
-            (False, 1, Grouping.Type.GROUP),
-            (False, None, Grouping.Type.COURSE),
-        ],
-    )
-    def test_it(self, sections_enabled, group_set_id, expected, lti_launch):
-
-        with mock.patch.multiple(
-            LTILaunchResource,
-            sections_enabled=sections_enabled,
-            group_set_id=group_set_id,
-        ):
-            assert lti_launch.grouping_type == expected
+    def test_it(
+        self,
+        grouping_plugin,
+        lti_launch,
+        course_service,
+        assignment_service,
+        application_instance,
+        pyramid_request,
+    ):
+        assert (
+            lti_launch.grouping_type
+            == grouping_plugin.launch_grouping_type.return_value
+        )
+        assignment_service.get_assignment.assert_called_once_with(
+            mock.sentinel.tool_guid, mock.sentinel.resource_link_id
+        )
+        grouping_plugin.launch_grouping_type.assert_called_once_with(
+            pyramid_request,
+            application_instance,
+            course_service.upsert_course.return_value,
+            assignment_service.get_assignment.return_value,
+        )
 
 
 @pytest.fixture
@@ -184,25 +92,16 @@ def JSConfig(patch):
 
 
 @pytest.fixture
-def has_course(pyramid_request):
-    pyramid_request.parsed_params = {
-        "context_id": "test_context_id",
-        "context_title": "test_context_title",
-        "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
-    }
-
-
-@pytest.fixture
 def pyramid_request(pyramid_request):
-    pyramid_request.parsed_params = {}
+    pyramid_request.parsed_params = pyramid_request.lti_params = {
+        "tool_consumer_instance_guid": mock.sentinel.tool_guid,
+        "resource_link_id": mock.sentinel.resource_link_id,
+        "context_id": mock.sentinel.context_id,
+        "context_title": mock.sentinel.context_title,
+    }
     return pyramid_request
 
 
 @pytest.fixture
 def with_canvas(pyramid_request):
     pyramid_request.product.family = Product.Family.CANVAS
-
-
-@pytest.fixture
-def with_blackboard(pyramid_request):
-    pyramid_request.product.family = Product.Family.BLACKBOARD

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -11,6 +11,14 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
+class TestApplicationInstance:
+    def test_it(self, lti_launch, application_instance_service):
+        assert (
+            lti_launch.application_instance
+            == application_instance_service.get_current.return_value
+        )
+
+
 class TestIsCanvas:
     @pytest.mark.parametrize(
         "product,expected",
@@ -55,6 +63,10 @@ class TestCourseExtra:
             "canvas": {"custom_canvas_course_id": "ID"}
         }
 
+    @pytest.fixture
+    def with_canvas(self, pyramid_request):
+        pyramid_request.product.family = Product.Family.CANVAS
+
 
 class TestGroupingType:
     def test_it(
@@ -63,7 +75,6 @@ class TestGroupingType:
         lti_launch,
         course_service,
         assignment_service,
-        application_instance,
         pyramid_request,
     ):
         assert (
@@ -75,7 +86,6 @@ class TestGroupingType:
         )
         grouping_service.get_launch_grouping_type.assert_called_once_with(
             pyramid_request,
-            application_instance,
             course_service.upsert_course.return_value,
             assignment_service.get_assignment.return_value,
         )
@@ -100,8 +110,3 @@ def pyramid_request(pyramid_request):
         "context_title": mock.sentinel.context_title,
     }
     return pyramid_request
-
-
-@pytest.fixture
-def with_canvas(pyramid_request):
-    pyramid_request.product.family = Product.Family.CANVAS

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -475,7 +475,6 @@ class TestGetGroupings:
         assert (
             svc.get_launch_grouping_type(
                 sentinel.request,
-                sentinel.application_instance,
                 sentinel.course,
                 sentinel.assignment,
             )

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -1,11 +1,10 @@
 from functools import partial
-from unittest.mock import create_autospec, patch, sentinel
+from unittest.mock import patch, sentinel
 
 import pytest
 from h_matchers import Any
 
 from lms.models import CanvasGroup, Course, Grouping, GroupingMembership
-from lms.product.plugin.grouping import GroupingPlugin
 from lms.services.grouping import GroupingService
 from tests import factories
 
@@ -509,9 +508,5 @@ def user():
 
 
 @pytest.fixture
-def svc(db_session, application_instance):
-    return GroupingService(
-        db_session,
-        application_instance,
-        plugin=create_autospec(GroupingPlugin, spec_set=True, instance=True),
-    )
+def svc(db_session, application_instance, grouping_plugin):
+    return GroupingService(db_session, application_instance, plugin=grouping_plugin)

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -457,6 +457,31 @@ class TestGetGroupings:
         # We get the course no matter what + only the grouping we are in
         assert results == Any.list.containing([course, groupings[1]])
 
+    @pytest.mark.parametrize(
+        "sections_enabled,group_set_id,expected",
+        [
+            (True, 1, Grouping.Type.GROUP),
+            (True, None, Grouping.Type.SECTION),
+            (False, 1, Grouping.Type.GROUP),
+            (False, None, Grouping.Type.COURSE),
+        ],
+    )
+    def test_launch_grouping_type(
+        self, svc, grouping_plugin, sections_enabled, group_set_id, expected
+    ):
+        grouping_plugin.sections_enabled.return_value = sections_enabled
+        grouping_plugin.group_set_id.return_value = group_set_id
+
+        assert (
+            svc.get_launch_grouping_type(
+                sentinel.request,
+                sentinel.application_instance,
+                sentinel.course,
+                sentinel.assignment,
+            )
+            == expected
+        )
+
     @pytest.fixture
     def assert_groups_returned(self, svc, assert_groupings_returned):
         return partial(assert_groupings_returned, grouping_type=svc.plugin.group_type)

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -470,7 +470,7 @@ class TestGetGroupings:
         self, svc, grouping_plugin, sections_enabled, group_set_id, expected
     ):
         grouping_plugin.sections_enabled.return_value = sections_enabled
-        grouping_plugin.group_set_id.return_value = group_set_id
+        grouping_plugin.get_group_set_id.return_value = group_set_id
 
         assert (
             svc.get_launch_grouping_type(

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from lms.product.plugin.grouping import GroupingPlugin
 from lms.services import (
     CanvasService,
     DocumentURLService,
@@ -76,6 +77,8 @@ __all__ = (
     "rsa_key_service",
     "user_service",
     "vitalsource_service",
+    # Product plugins
+    "grouping_plugin",
 )
 
 
@@ -295,3 +298,8 @@ def user_service(mock_service):
 @pytest.fixture
 def vitalsource_service(mock_service):
     return mock_service(VitalSourceService)
+
+
+@pytest.fixture
+def grouping_plugin(mock_service):
+    return mock_service(GroupingPlugin)


### PR DESCRIPTION
Extend the existing grouping plugin to include a few grouping related methods from the LTIResource.

We can remove a couple of `is_canvas` and put all grouping related functionality together.


### Testing 

Launching these should bring the right group select in the client.

#### Canvas

- Groups https://hypothesis.instructure.com/courses/125/assignments/1833
- Sections https://hypothesis.instructure.com/courses/125/assignments/873
- Course https://hypothesis.instructure.com/courses/124/assignments/868 

#### Blackboard

- Course https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1
- Groups https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_398_1&course_id=_19_1

