### PR TITLE
Create new LTILaunchService and launch plug

### DIFF
--- a/lms/product/canvas/__init__.py
+++ b/lms/product/canvas/__init__.py
@@ -1,4 +1,5 @@
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
+from lms.product.canvas._plugin.launch import CanvasLaunchPlugin
 from lms.product.canvas.product import Canvas
 
 
@@ -8,3 +9,4 @@ def includeme(config):  # pragma: nocover
     config.register_service_factory(
         CanvasGroupingPlugin.factory, iface=CanvasGroupingPlugin
     )
+    config.register_service(CanvasLaunchPlugin(), iface=CanvasLaunchPlugin)

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -91,7 +91,7 @@ class CanvasGroupingPlugin(GroupingPlugin):
 
         return course.settings.get("canvas", "sections_enabled")
 
-    def group_set_id(self, request, assignment):
+    def get_group_set_id(self, request, assignment):
         # For canvas we add parameter to the launch URL as we don't store the
         # assignment during deep linking.
         return request.params.get("group_set")

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -78,6 +78,24 @@ class CanvasGroupingPlugin(GroupingPlugin):
             self._custom_course_id(course), grading_student_id, group_set_id
         )
 
+    def sections_enabled(self, request, application_instance, course):
+        params = request.params
+        if "focused_user" in params and "learner_canvas_user_id" not in params:
+            # This is a legacy SpeedGrader URL, submitted to Canvas before our
+            # Canvas course sections feature was released.
+            return False
+
+        if not bool(application_instance.developer_key):
+            # We need a developer key to talk to the API
+            return False
+
+        return course.settings.get("canvas", "sections_enabled")
+
+    def group_set_id(self, request, assignment):
+        # For canvas we add parameter to the launch URL as we don't store the
+        # assignment during deep linking.
+        return request.params.get("group_set")
+
     def _custom_course_id(self, course):
         return course.extra["canvas"]["custom_canvas_course_id"]
 

--- a/lms/product/canvas/_plugin/launch.py
+++ b/lms/product/canvas/_plugin/launch.py
@@ -1,0 +1,10 @@
+from lms.product.plugin.launch import LaunchPlugin
+
+
+class CanvasLaunchPlugin(LaunchPlugin):
+    def course_extra(self, lti_params):
+        return {
+            "canvas": {
+                "custom_canvas_course_id": lti_params.get("custom_canvas_course_id")
+            }
+        }

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
+from lms.product.canvas._plugin.launch import CanvasLaunchPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
 
@@ -16,7 +17,9 @@ class Canvas(Product):
         list_group_sets="canvas_api.courses.group_sets.list",
     )
 
-    plugin_config: PluginConfig = PluginConfig(grouping=CanvasGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(
+        grouping=CanvasGroupingPlugin, launch=CanvasLaunchPlugin
+    )
 
     settings_key = "canvas"
 

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -19,3 +19,6 @@ class Canvas(Product):
     plugin_config: PluginConfig = PluginConfig(grouping=CanvasGroupingPlugin)
 
     settings_key = "canvas"
+
+    use_grading_bar = False
+    """We integrate with SpeedGrader and don't need to use the grading bar"""

--- a/lms/product/plugin/__init__.py
+++ b/lms/product/plugin/__init__.py
@@ -1,4 +1,5 @@
 from lms.product.plugin.grouping import GroupingPlugin
+from lms.product.plugin.launch import LaunchPlugin
 from lms.product.plugin.plugin import PluginConfig, Plugins
 
 
@@ -6,3 +7,4 @@ def includeme(config):  # pragma: nocover
     """Register all of our plugins."""
 
     config.register_service(GroupingPlugin(), iface=GroupingPlugin)
+    config.register_service(LaunchPlugin(), iface=LaunchPlugin)

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -70,7 +70,7 @@ class GroupingPlugin:
         """Check if sections are enabled for this LMS, instance and course."""
         return bool(self.sections_type)
 
-    def group_set_id(self, request, assignment):
+    def get_group_set_id(self, request, assignment):
         """
         Get the group set ID for group launches.
 

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -84,24 +84,6 @@ class GroupingPlugin:
 
         return assignment.extra.get("group_set_id") if assignment else None
 
-    def launch_grouping_type(
-        self, request, application_instance, course, assignment
-    ) -> Grouping.Type:
-        """
-        Return the type of grouping used in this launch.
-
-        Grouping types describe how the course members are divided.
-        If neither of the LMS grouping features are used "COURSE" is the default.
-        """
-        if bool(self.group_set_id(request, assignment)):
-            return Grouping.Type.GROUP
-
-        if self.sections_enabled(request, application_instance, course):
-            # Sections is the default when available. Groups must take precedence
-            return Grouping.Type.SECTION
-
-        return Grouping.Type.COURSE
-
 
 class GroupError(Exception):
     """Exceptions raised by plugins."""

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -68,7 +68,7 @@ class GroupingPlugin:
 
     def sections_enabled(self, request, application_instance, course) -> bool:
         """Check if sections are enabled for this LMS, instance and course."""
-        return False  # Disabled by default
+        return bool(self.sections_type)
 
     def group_set_id(self, request, assignment):
         """

--- a/lms/product/plugin/launch.py
+++ b/lms/product/plugin/launch.py
@@ -1,0 +1,9 @@
+# pylint: disable=unused-argument
+class LaunchPlugin:
+    def is_assignment_gradable(self, lti_params):
+        """Check if the assignment of the current launch is gradable."""
+        return bool(lti_params.get("lis_outcome_service_url"))
+
+    def course_extra(self, lti_params):
+        """Extra information to store for courses."""
+        return {}

--- a/lms/product/plugin/plugin.py
+++ b/lms/product/plugin/plugin.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from lms.product.plugin.grouping import GroupingPlugin
+from lms.product.plugin.launch import LaunchPlugin
 
 
 @dataclass
@@ -9,6 +10,7 @@ class PluginConfig:
 
     # These also provide the default implementations
     grouping: type = GroupingPlugin
+    launch: type = LaunchPlugin
 
 
 class Plugins:
@@ -28,6 +30,7 @@ class Plugins:
             return plugin
 
     grouping: GroupingPlugin = _LazyPlugin()
+    launch: LaunchPlugin = _LazyPlugin()
 
     def __init__(self, request, plugin_config: PluginConfig):
         self._request = request

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -63,6 +63,9 @@ class Product:
     settings_key: Optional[str] = None
     """Key in the ai.settings dictionary that holds the product specific settings"""
 
+    use_grading_bar: bool = True
+    """Wether we use our own grading bar for this LMS (True) or integrate with the product provided alternative eg: Canvas Speedgrader (False)"""
+
     # Accessor for external consumption
     Family = Family
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -524,7 +524,7 @@ class JSConfig:
                     "product": self._request.product.family,
                 },
                 "context_id": self._request.lti_params["context_id"],
-                "group_set_id": self._request.product.plugin.grouping.group_set_id(
+                "group_set_id": self._request.product.plugin.grouping.get_group_set_id(
                     self._request, assignment
                 ),
                 "group_info": {

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -524,7 +524,9 @@ class JSConfig:
                     "product": self._request.product.family,
                 },
                 "context_id": self._request.lti_params["context_id"],
-                "group_set_id": self._context.group_set_id,
+                "group_set_id": self._request.product.plugin.grouping.group_set_id(
+                    self._request, assignment
+                ),
                 "group_info": {
                     key: value
                     for key, value in self._request.lti_params.items()

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -56,8 +56,7 @@ class LTILaunchResource:
             self._request.lti_params["tool_consumer_instance_guid"],
             self._request.lti_params.get("resource_link_id"),
         )
-
-        return self._request.product.plugin.grouping_service.launch_grouping_type(
+        return self._request.find_service(name="grouping").get_launch_grouping_type(
             self._request, self.application_instance, self.course, assignment
         )
 

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from lms.models import Grouping
 from lms.product import Product
 from lms.resources._js_config import JSConfig
+from lms.services.lti_launch import LTILaunchService
 
 LOG = logging.getLogger(__name__)
 
@@ -29,12 +30,7 @@ class LTILaunchResource:
     @cached_property
     def course(self):
         """Get the course this LTI launch based on the request's params."""
-
-        return self._request.find_service(name="course").upsert_course(
-            context_id=self._request.parsed_params["context_id"],
-            name=self._request.parsed_params["context_title"],
-            extra=self._course_extra(),
-        )
+        return self._request.find_service(LTILaunchService).record_course()
 
     @property
     def application_instance(self):
@@ -59,18 +55,3 @@ class LTILaunchResource:
         return self._request.find_service(name="grouping").get_launch_grouping_type(
             self._request, self.course, assignment
         )
-
-    def _course_extra(self):
-        """Extra information to store for courses."""
-        extra = {}
-
-        if self.is_canvas:
-            extra = {
-                "canvas": {
-                    "custom_canvas_course_id": self._request.parsed_params.get(
-                        "custom_canvas_course_id"
-                    )
-                }
-            }
-
-        return extra

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -57,7 +57,7 @@ class LTILaunchResource:
             self._request.lti_params.get("resource_link_id"),
         )
         return self._request.find_service(name="grouping").get_launch_grouping_type(
-            self._request, self.application_instance, self.course, assignment
+            self._request, self.course, assignment
         )
 
     def _course_extra(self):

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -24,6 +24,7 @@ from lms.services.launch_verifier import (
     LTIOAuthError,
 )
 from lms.services.lti_grading import LTIGradingService
+from lms.services.lti_launch import LTILaunchService
 from lms.services.lti_names_roles import LTINamesRolesService
 from lms.services.lti_registration import LTIRegistrationService
 from lms.services.lti_role_service import LTIRoleService
@@ -116,4 +117,7 @@ def includeme(config):
     )
     config.register_service_factory(
         "lms.services.d2l_api.d2l_api_client_factory", iface=D2LAPIClient
+    )
+    config.register_service_factory(
+        "lms.services.lti_launch.factory", iface=LTILaunchService
     )

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -229,6 +229,24 @@ class GroupingService:
 
         return [course] + groupings
 
+    def get_launch_grouping_type(
+        self, request, application_instance, course, assignment
+    ) -> Grouping.Type:
+        """
+        Return the type of grouping used in the current LTI launch.
+
+        Grouping types describe how the course members are divided.
+        If neither of the LMS grouping features are used "COURSE" is the default.
+        """
+        if bool(self.plugin.group_set_id(request, assignment)):
+            return Grouping.Type.GROUP
+
+        if self.plugin.sections_enabled(request, application_instance, course):
+            # Sections is the default when available. Groups must take precedence
+            return Grouping.Type.SECTION
+
+        return Grouping.Type.COURSE
+
     def _to_groupings(self, user, groupings, course, type_):
         if groupings and not isinstance(groupings[0], Grouping):
             groupings = [

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -229,9 +229,7 @@ class GroupingService:
 
         return [course] + groupings
 
-    def get_launch_grouping_type(
-        self, request, application_instance, course, assignment
-    ) -> Grouping.Type:
+    def get_launch_grouping_type(self, request, course, assignment) -> Grouping.Type:
         """
         Return the type of grouping used in the current LTI launch.
 
@@ -241,7 +239,7 @@ class GroupingService:
         if bool(self.plugin.group_set_id(request, assignment)):
             return Grouping.Type.GROUP
 
-        if self.plugin.sections_enabled(request, application_instance, course):
+        if self.plugin.sections_enabled(request, self.application_instance, course):
             # Sections is the default when available. Groups must take precedence
             return Grouping.Type.SECTION
 

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -236,7 +236,7 @@ class GroupingService:
         Grouping types describe how the course members are divided.
         If neither of the LMS grouping features are used "COURSE" is the default.
         """
-        if bool(self.plugin.group_set_id(request, assignment)):
+        if bool(self.plugin.get_group_set_id(request, assignment)):
             return Grouping.Type.GROUP
 
         if self.plugin.sections_enabled(request, self.application_instance, course):

--- a/lms/services/lti_launch.py
+++ b/lms/services/lti_launch.py
@@ -1,0 +1,103 @@
+from lms.models import ApplicationInstance, LTIParams, LTIUser, User
+from lms.services.application_instance import ApplicationInstanceService
+from lms.services.assignment import AssignmentService
+from lms.services.grading_info import GradingInfoService
+from lms.services.grouping import GroupingService
+from lms.services.lti_role_service import LTIRoleService
+
+
+class LTILaunchService:
+    # pylint:disable=too-many-instance-attributes,too-many-arguments
+    def __init__(
+        self,
+        lti_params: LTIParams,
+        user: User,
+        lti_user: LTIUser,
+        course_service,
+        assignment_service: AssignmentService,
+        grouping_service: GroupingService,
+        lti_role_service: LTIRoleService,
+        application_instance_service: ApplicationInstanceService,
+        grading_info_service: GradingInfoService,
+        product,
+        plugin,
+    ):
+        self._lti_params = lti_params
+        self._user = user
+        self._application_instance: ApplicationInstance = user.application_instance
+        self.lti_user = lti_user
+        self._grouping_service = grouping_service
+        self._course_service = course_service
+        self._assignment_service = assignment_service
+        self._lti_role_service = lti_role_service
+        self._application_instance_service = application_instance_service
+        self._grading_info_service = grading_info_service
+        self._product = product
+        self._plugin = plugin
+
+    def validate_launch(self):
+        self._application_instance.check_guid_aligns(
+            self._lti_params.get("tool_consumer_instance_guid")
+        )
+
+    def record_course(self):
+        """Insert or update the course for the current launch."""
+        course = self._course_service.upsert_course(
+            context_id=self._lti_params["context_id"],
+            name=self._lti_params["context_title"],
+            extra=self._plugin.course_extra(self._lti_params),
+        )
+        self._grouping_service.upsert_grouping_memberships(
+            user=self._user, groups=[course]
+        )
+        return course
+
+    def record_assignment(self, course, document_url, extra):
+        """Store assignment details."""
+        assignment = self._assignment_service.upsert_assignment(
+            document_url=document_url,
+            tool_consumer_instance_guid=self._lti_params["tool_consumer_instance_guid"],
+            resource_link_id=self._lti_params.get("resource_link_id"),
+            lti_params=self._lti_params,
+            extra=extra,
+            is_gradable=self._plugin.is_assignment_gradable(self._lti_params),
+        )
+
+        # Store the relationship between the assignment and the course
+        self._assignment_service.upsert_assignment_membership(
+            assignment=assignment,
+            user=self._user,
+            lti_roles=self._lti_role_service.get_roles(self._lti_params["roles"]),
+        )
+        # Store the relationship between the assignment and the course
+        self._assignment_service.upsert_assignment_groupings(
+            assignment_id=assignment.id, groupings=[course]
+        )
+
+        return assignment
+
+    def record_launch(self, request):
+        """Persist launch type independent info to the DB."""
+        self._application_instance_service.update_from_lti_params(
+            self._application_instance, self._lti_params
+        )
+
+        if self._product.use_grading_bar and not self.lti_user.is_instructor:
+            # Create or update a record of LIS result data for a student launch
+            self._grading_info_service.upsert_from_request(request)
+
+
+def factory(_context, request):
+    return LTILaunchService(
+        lti_params=request.lti_params,
+        user=request.user,
+        lti_user=request.lti_user,
+        course_service=request.find_service(name="course"),
+        assignment_service=request.find_service(name="assignment"),
+        grouping_service=request.find_service(name="grouping"),
+        lti_role_service=request.find_service(LTIRoleService),
+        application_instance_service=request.find_service(name="application_instance"),
+        grading_info_service=request.find_service(name="grading_info"),
+        product=request.product,
+        plugin=request.product.plugin.launch,
+    )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,7 @@ from pyramid.request import apply_request_extensions
 
 from lms import models
 from lms.db import SESSION
-from lms.models import ApplicationSettings
+from lms.models import ApplicationSettings, LTIParams
 from lms.product import Product
 from lms.security import Identity
 from tests import factories
@@ -124,7 +124,7 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
     )
 
     pyramid_request.lti_jwt = {}
-    pyramid_request.lti_params = {}
+    pyramid_request.lti_params = LTIParams(lti_v11_params)
     pyramid_request.product = Product.from_request(
         pyramid_request, dict(application_instance.settings)
     )

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -152,10 +152,10 @@ class TestCanvasGroupingPlugin:
             == enabled
         )
 
-    def test_group_set_id(self, pyramid_request, plugin):
+    def test_get_group_set_id(self, pyramid_request, plugin):
         pyramid_request.params.update({"group_set": 1})
 
-        assert plugin.group_set_id(pyramid_request, sentinel.assignment) == 1
+        assert plugin.get_group_set_id(pyramid_request, sentinel.assignment) == 1
 
     def test_factory(self, pyramid_request, canvas_api_client):
         plugin = CanvasGroupingPlugin.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/product/canvas/_plugin/launch_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/launch_test.py
@@ -1,0 +1,14 @@
+import pytest
+
+from lms.product.canvas._plugin.launch import CanvasLaunchPlugin
+
+
+class TestCanvasLaunchPlugin:
+    def test_course_extra(self, plugin):
+        assert plugin.course_extra({"custom_canvas_course_id": "ID"}) == {
+            "canvas": {"custom_canvas_course_id": "ID"}
+        }
+
+    @pytest.fixture
+    def plugin(self):
+        return CanvasLaunchPlugin()

--- a/tests/unit/lms/product/factory_test.py
+++ b/tests/unit/lms/product/factory_test.py
@@ -86,6 +86,7 @@ class TestGetProductFromRequest:
     def test_from_application_instance(
         self, pyramid_request, application_instance, value, family, class_
     ):
+        del pyramid_request.lti_params["tool_consumer_info_product_family_code"]
         application_instance.tool_consumer_info_product_family_code = value
 
         product = get_product_from_request(pyramid_request)
@@ -99,6 +100,7 @@ class TestGetProductFromRequest:
     def test_from_application_instance_when_missing(
         self, pyramid_request, application_instance_service
     ):
+        del pyramid_request.lti_params["tool_consumer_info_product_family_code"]
         application_instance_service.get_current.side_effect = (
             ApplicationInstanceNotFound()
         )

--- a/tests/unit/lms/product/plugin/grouping_service_test.py
+++ b/tests/unit/lms/product/plugin/grouping_service_test.py
@@ -8,9 +8,17 @@ from tests import factories
 
 
 class TestGroupingServicePlugin:
-    def test_sections_enabled(self, plugin):
-        assert not plugin.sections_enabled(
-            sentinel.request, sentinel.application_instance, sentinel.course
+    @pytest.mark.parametrize(
+        "sections_type,expected", [(None, False), (Grouping.Type.CANVAS_SECTION, True)]
+    )
+    def test_sections_enabled(self, plugin, sections_type, expected):
+        plugin.sections_type = sections_type
+
+        assert (
+            plugin.sections_enabled(
+                sentinel.request, sentinel.application_instance, sentinel.course
+            )
+            == expected
         )
 
     def test_group_set_id_when_disabled(self, plugin):

--- a/tests/unit/lms/product/plugin/grouping_service_test.py
+++ b/tests/unit/lms/product/plugin/grouping_service_test.py
@@ -21,24 +21,25 @@ class TestGroupingServicePlugin:
             == expected
         )
 
-    def test_group_set_id_when_disabled(self, plugin):
+    def test_get_group_set_id_when_disabled(self, plugin):
         plugin.group_type = None
 
-        assert not plugin.group_set_id(sentinel.request, sentinel.assignment)
+        assert not plugin.get_group_set_id(sentinel.request, sentinel.assignment)
 
-    def test_group_set_id_when_no_assignment(self, plugin_with_groups):
-        assert not plugin_with_groups.group_set_id(sentinel.request, None)
+    def test_get_group_set_id_when_no_assignment(self, plugin_with_groups):
+        assert not plugin_with_groups.get_group_set_id(sentinel.request, None)
 
-    def test_group_set_id_when_no_group_set(self, plugin):
+    def test_get_group_set_id_when_no_group_set(self, plugin):
         assignment = factories.Assignment(extra={})
 
-        assert not plugin.group_set_id(sentinel.request, assignment)
+        assert not plugin.get_group_set_id(sentinel.request, assignment)
 
-    def test_group_set(self, plugin_with_groups):
+    def test_get_group_set_id(self, plugin_with_groups):
         assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
 
         assert (
-            plugin_with_groups.group_set_id(sentinel.request, assignment) == sentinel.id
+            plugin_with_groups.get_group_set_id(sentinel.request, assignment)
+            == sentinel.id
         )
 
     @pytest.fixture

--- a/tests/unit/lms/product/plugin/grouping_service_test.py
+++ b/tests/unit/lms/product/plugin/grouping_service_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
@@ -32,31 +32,6 @@ class TestGroupingServicePlugin:
         assert (
             plugin_with_groups.group_set_id(sentinel.request, assignment) == sentinel.id
         )
-
-    @pytest.mark.parametrize(
-        "sections_enabled,group_set_id,expected",
-        [
-            (True, 1, Grouping.Type.GROUP),
-            (True, None, Grouping.Type.SECTION),
-            (False, 1, Grouping.Type.GROUP),
-            (False, None, Grouping.Type.COURSE),
-        ],
-    )
-    def test_launch_grouping_type(
-        self, plugin, sections_enabled, group_set_id, expected
-    ):
-        with patch.object(
-            plugin, "sections_enabled", return_value=sections_enabled
-        ), patch.object(plugin, "group_set_id", return_value=group_set_id):
-            assert (
-                plugin.launch_grouping_type(
-                    sentinel.request,
-                    sentinel.application_instance,
-                    sentinel.course,
-                    sentinel.assignment,
-                )
-                == expected
-            )
 
     @pytest.fixture
     def plugin(self):

--- a/tests/unit/lms/product/plugin/grouping_service_test.py
+++ b/tests/unit/lms/product/plugin/grouping_service_test.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch, sentinel
+
+import pytest
+
+from lms.models import Grouping
+from lms.product.plugin.grouping import GroupingPlugin
+from tests import factories
+
+
+class TestGroupingServicePlugin:
+    def test_sections_enabled(self, plugin):
+        assert not plugin.sections_enabled(
+            sentinel.request, sentinel.application_instance, sentinel.course
+        )
+
+    def test_group_set_id_when_disabled(self, plugin):
+        plugin.group_type = None
+
+        assert not plugin.group_set_id(sentinel.request, sentinel.assignment)
+
+    def test_group_set_id_when_no_assignment(self, plugin_with_groups):
+        assert not plugin_with_groups.group_set_id(sentinel.request, None)
+
+    def test_group_set_id_when_no_group_set(self, plugin):
+        assignment = factories.Assignment(extra={})
+
+        assert not plugin.group_set_id(sentinel.request, assignment)
+
+    def test_group_set(self, plugin_with_groups):
+        assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
+
+        assert (
+            plugin_with_groups.group_set_id(sentinel.request, assignment) == sentinel.id
+        )
+
+    @pytest.mark.parametrize(
+        "sections_enabled,group_set_id,expected",
+        [
+            (True, 1, Grouping.Type.GROUP),
+            (True, None, Grouping.Type.SECTION),
+            (False, 1, Grouping.Type.GROUP),
+            (False, None, Grouping.Type.COURSE),
+        ],
+    )
+    def test_launch_grouping_type(
+        self, plugin, sections_enabled, group_set_id, expected
+    ):
+        with patch.object(
+            plugin, "sections_enabled", return_value=sections_enabled
+        ), patch.object(plugin, "group_set_id", return_value=group_set_id):
+            assert (
+                plugin.launch_grouping_type(
+                    sentinel.request,
+                    sentinel.application_instance,
+                    sentinel.course,
+                    sentinel.assignment,
+                )
+                == expected
+            )
+
+    @pytest.fixture
+    def plugin(self):
+        return GroupingPlugin()
+
+    @pytest.fixture
+    def plugin_with_groups(self, plugin):
+        plugin.group_type = Grouping.Type.BLACKBOARD_GROUP
+        return plugin

--- a/tests/unit/lms/product/plugin/launch_test.py
+++ b/tests/unit/lms/product/plugin/launch_test.py
@@ -1,0 +1,21 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.product.plugin.launch import LaunchPlugin
+
+
+class TestCanvasLaunchPlugin:
+    @pytest.mark.parametrize("value,expected", [(None, False), (sentinel.url, True)])
+    def test_is_assignment_gradable(self, plugin, value, expected):
+        assert (
+            plugin.is_assignment_gradable({"lis_outcome_service_url": value})
+            == expected
+        )
+
+    def test_course_extra(self, plugin, pyramid_request):
+        assert not plugin.course_extra(pyramid_request)
+
+    @pytest.fixture
+    def plugin(self):
+        return LaunchPlugin()

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -379,7 +379,7 @@ class TestJSConfigAPISync:
         pyramid_request.params["learner_canvas_user_id"] = "CANVAS_USER_ID"
         pyramid_request.product.route.oauth2_authorize = "welcome"
         context.grouping_type = grouping_type
-        grouping_plugin.group_set_id.return_value = "GROUP_SET_ID"
+        grouping_plugin.get_group_set_id.return_value = "GROUP_SET_ID"
 
         js_config.enable_lti_launch_mode(assignment)
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -371,13 +371,15 @@ class TestJSConfigAPISync:
     @pytest.mark.parametrize(
         "grouping_type", (Grouping.Type.GROUP, Grouping.Type.SECTION)
     )
-    def test_it(self, js_config, context, pyramid_request, grouping_type):
+    def test_it(
+        self, js_config, context, pyramid_request, grouping_type, grouping_plugin
+    ):
         assignment.id = 123456  # Ensure the assignment has an id
         pyramid_request.lti_params["context_id"] = "CONTEXT_ID"
         pyramid_request.params["learner_canvas_user_id"] = "CANVAS_USER_ID"
         pyramid_request.product.route.oauth2_authorize = "welcome"
         context.grouping_type = grouping_type
-        context.group_set_id = "GROUP_SET_ID"
+        grouping_plugin.group_set_id.return_value = "GROUP_SET_ID"
 
         js_config.enable_lti_launch_mode(assignment)
 
@@ -443,13 +445,13 @@ class TestJSConfigHypothesisClient:
             }
         ]
 
-    @pytest.mark.usefixtures("with_sections_on")
+    @pytest.mark.usefixtures("with_sections_on", "grouping_plugin")
     def test_configures_the_client_to_fetch_the_groups_over_RPC_with_sections(
         self, config
     ):
         assert config["services"][0]["groups"] == "$rpc:requestGroups"
 
-    @pytest.mark.usefixtures("with_groups_on")
+    @pytest.mark.usefixtures("with_groups_on", "grouping_plugin")
     def test_it_configures_the_client_to_fetch_the_groups_over_RPC_with_groups(
         self, config
     ):
@@ -662,7 +664,6 @@ def context(application_instance):
         spec_set=True,
         instance=True,
         is_canvas=True,
-        sections_enabled=False,
         grouping_type=Grouping.Type.COURSE,
         course=create_autospec(Grouping, instance=True, spec_set=True),
         application_instance=application_instance,

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -59,7 +59,7 @@ class TestCourseExtra:
 class TestGroupingType:
     def test_it(
         self,
-        grouping_plugin,
+        grouping_service,
         lti_launch,
         course_service,
         assignment_service,
@@ -68,12 +68,12 @@ class TestGroupingType:
     ):
         assert (
             lti_launch.grouping_type
-            == grouping_plugin.launch_grouping_type.return_value
+            == grouping_service.get_launch_grouping_type.return_value
         )
         assignment_service.get_assignment.assert_called_once_with(
             mock.sentinel.tool_guid, mock.sentinel.resource_link_id
         )
-        grouping_plugin.launch_grouping_type.assert_called_once_with(
+        grouping_service.get_launch_grouping_type.assert_called_once_with(
             pyramid_request,
             application_instance,
             course_service.upsert_course.return_value,

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -1,14 +1,13 @@
 from unittest import mock
 
 import pytest
-from pytest import param
 
-from lms.models import ApplicationSettings, Grouping
 from lms.product import Product
 from lms.resources import LTILaunchResource
 
 pytestmark = pytest.mark.usefixtures(
-    "application_instance_service", "assignment_service"
+    "application_instance_service",
+    "assignment_service",
 )
 
 
@@ -37,62 +36,6 @@ class TestJSConfig:
         assert js_config == JSConfig.return_value
 
 
-@pytest.mark.usefixtures("has_course")
-class TestSectionsEnabled:
-    @pytest.mark.parametrize("is_canvas", [True, False])
-    def test_support_for_canvas(self, lti_launch, is_canvas):
-        with mock.patch.object(LTILaunchResource, "is_canvas", is_canvas):
-            assert lti_launch.sections_enabled == is_canvas
-
-    @pytest.mark.usefixtures("with_canvas")
-    @pytest.mark.parametrize(
-        "params,expected",
-        (
-            param(
-                {
-                    "focused_user": mock.sentinel.focused_user,
-                    "learner_canvas_user_id": mock.sentinel.learner_canvas_user_id,
-                },
-                True,
-                id="Speedgrader",
-            ),
-            param(
-                {"focused_user": mock.sentinel.focused_user},
-                False,
-                id="Legacy Speedgrader",
-            ),
-        ),
-    )
-    def test_its_support_for_speedgrader(
-        self, lti_launch, pyramid_request, params, expected
-    ):
-        pyramid_request.params.update(params)
-
-        assert lti_launch.sections_enabled is expected
-
-    @pytest.mark.usefixtures("with_canvas")
-    def test_it_depends_on_developer_key(
-        self, lti_launch, application_instance_service
-    ):
-        application_instance_service.get_current.return_value.developer_key = None
-        assert not lti_launch.sections_enabled
-
-    @pytest.mark.usefixtures("with_canvas")
-    @pytest.mark.parametrize("enabled", [True, False])
-    def test_it_depends_on_course_setting(self, lti_launch, course_settings, enabled):
-        course_settings.set("canvas", "sections_enabled", enabled)
-
-        assert lti_launch.sections_enabled == enabled
-
-    @pytest.fixture(autouse=True)
-    def course_settings(self, course_service):
-        settings = ApplicationSettings({"canvas": {"sections_enabled": True}})
-
-        course_service.upsert_course.return_value.settings = settings
-
-        return settings
-
-
 class TestCourseExtra:
     # pylint: disable=protected-access
     def test_empty_in_non_canvas(self, pyramid_request):
@@ -113,64 +56,29 @@ class TestCourseExtra:
         }
 
 
-class TestGroupSetId:
-    @pytest.mark.usefixtures("with_blackboard")
-    def test_blackboard_false_when_no_assignment(self, lti_launch, assignment_service):
-        assignment_service.get_assignment.return_value = None
-
-        assert not lti_launch.group_set_id
-
-    @pytest.mark.usefixtures("with_blackboard")
-    def test_blackboard_false_when_no_group_set(self, lti_launch, assignment_service):
-        assignment_service.get_assignment.return_value.extra = {}
-
-        assert not lti_launch.group_set_id
-
-    @pytest.mark.usefixtures("with_blackboard")
-    def test_blackboard(self, lti_launch, assignment_service):
-        assignment_service.get_assignment.return_value.extra = {
-            "group_set_id": mock.sentinel.id
-        }
-
-        assert lti_launch.group_set_id == mock.sentinel.id
-
-    @pytest.mark.usefixtures("with_canvas")
-    def test_canvas(self, pyramid_request):
-        pyramid_request.params.update({"group_set": 1})
-
-        assert LTILaunchResource(pyramid_request).group_set_id == 1
-
-    def test_other_lms(self, pyramid_request):
-        pyramid_request.product.family = Product.Family.UNKNOWN
-
-        assert not LTILaunchResource(pyramid_request).group_set_id
-
-    @pytest.fixture(autouse=True)
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.lti_params = {
-            "tool_consumer_instance_guid": "test_tool_consumer_instance_guid"
-        }
-        return pyramid_request
-
-
 class TestGroupingType:
-    @pytest.mark.parametrize(
-        "sections_enabled,group_set_id,expected",
-        [
-            (True, 1, Grouping.Type.GROUP),
-            (True, None, Grouping.Type.SECTION),
-            (False, 1, Grouping.Type.GROUP),
-            (False, None, Grouping.Type.COURSE),
-        ],
-    )
-    def test_it(self, sections_enabled, group_set_id, expected, lti_launch):
-
-        with mock.patch.multiple(
-            LTILaunchResource,
-            sections_enabled=sections_enabled,
-            group_set_id=group_set_id,
-        ):
-            assert lti_launch.grouping_type == expected
+    def test_it(
+        self,
+        grouping_plugin,
+        lti_launch,
+        course_service,
+        assignment_service,
+        application_instance,
+        pyramid_request,
+    ):
+        assert (
+            lti_launch.grouping_type
+            == grouping_plugin.launch_grouping_type.return_value
+        )
+        assignment_service.get_assignment.assert_called_once_with(
+            mock.sentinel.tool_guid, mock.sentinel.resource_link_id
+        )
+        grouping_plugin.launch_grouping_type.assert_called_once_with(
+            pyramid_request,
+            application_instance,
+            course_service.upsert_course.return_value,
+            assignment_service.get_assignment.return_value,
+        )
 
 
 @pytest.fixture
@@ -184,25 +92,16 @@ def JSConfig(patch):
 
 
 @pytest.fixture
-def has_course(pyramid_request):
-    pyramid_request.parsed_params = {
-        "context_id": "test_context_id",
-        "context_title": "test_context_title",
-        "tool_consumer_instance_guid": "test_tool_consumer_instance_guid",
-    }
-
-
-@pytest.fixture
 def pyramid_request(pyramid_request):
-    pyramid_request.parsed_params = {}
+    pyramid_request.parsed_params = pyramid_request.lti_params = {
+        "tool_consumer_instance_guid": mock.sentinel.tool_guid,
+        "resource_link_id": mock.sentinel.resource_link_id,
+        "context_id": mock.sentinel.context_id,
+        "context_title": mock.sentinel.context_title,
+    }
     return pyramid_request
 
 
 @pytest.fixture
 def with_canvas(pyramid_request):
     pyramid_request.product.family = Product.Family.CANVAS
-
-
-@pytest.fixture
-def with_blackboard(pyramid_request):
-    pyramid_request.product.family = Product.Family.BLACKBOARD

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -44,36 +44,12 @@ class TestJSConfig:
         assert js_config == JSConfig.return_value
 
 
-class TestCourseExtra:
-    # pylint: disable=protected-access
-    def test_empty_in_non_canvas(self, pyramid_request):
-        parsed_params = {}
-        pyramid_request.parsed_params = parsed_params
-
-        assert not LTILaunchResource(pyramid_request)._course_extra()
-
-    @pytest.mark.usefixtures("with_canvas")
-    def test_includes_course_id(self, pyramid_request):
-        parsed_params = {
-            "custom_canvas_course_id": "ID",
-        }
-        pyramid_request.parsed_params = parsed_params
-
-        assert LTILaunchResource(pyramid_request)._course_extra() == {
-            "canvas": {"custom_canvas_course_id": "ID"}
-        }
-
-    @pytest.fixture
-    def with_canvas(self, pyramid_request):
-        pyramid_request.product.family = Product.Family.CANVAS
-
-
 class TestGroupingType:
     def test_it(
         self,
         grouping_service,
         lti_launch,
-        course_service,
+        lti_launch_service,
         assignment_service,
         pyramid_request,
     ):
@@ -86,7 +62,7 @@ class TestGroupingType:
         )
         grouping_service.get_launch_grouping_type.assert_called_once_with(
             pyramid_request,
-            course_service.upsert_course.return_value,
+            lti_launch_service.record_course.return_value,
             assignment_service.get_assignment.return_value,
         )
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -11,6 +11,14 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
+class TestApplicationInstance:
+    def test_it(self, lti_launch, application_instance_service):
+        assert (
+            lti_launch.application_instance
+            == application_instance_service.get_current.return_value
+        )
+
+
 class TestIsCanvas:
     @pytest.mark.parametrize(
         "product,expected",
@@ -55,6 +63,10 @@ class TestCourseExtra:
             "canvas": {"custom_canvas_course_id": "ID"}
         }
 
+    @pytest.fixture
+    def with_canvas(self, pyramid_request):
+        pyramid_request.product.family = Product.Family.CANVAS
+
 
 class TestGroupingType:
     def test_it(
@@ -63,7 +75,6 @@ class TestGroupingType:
         lti_launch,
         course_service,
         assignment_service,
-        application_instance,
         pyramid_request,
     ):
         assert (
@@ -75,7 +86,6 @@ class TestGroupingType:
         )
         grouping_service.get_launch_grouping_type.assert_called_once_with(
             pyramid_request,
-            application_instance,
             course_service.upsert_course.return_value,
             assignment_service.get_assignment.return_value,
         )
@@ -100,8 +110,3 @@ def pyramid_request(pyramid_request):
         "context_title": mock.sentinel.context_title,
     }
     return pyramid_request
-
-
-@pytest.fixture
-def with_canvas(pyramid_request):
-    pyramid_request.product.family = Product.Family.CANVAS

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -475,7 +475,6 @@ class TestGetGroupings:
         assert (
             svc.get_launch_grouping_type(
                 sentinel.request,
-                sentinel.application_instance,
                 sentinel.course,
                 sentinel.assignment,
             )

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -1,11 +1,10 @@
 from functools import partial
-from unittest.mock import create_autospec, patch, sentinel
+from unittest.mock import patch, sentinel
 
 import pytest
 from h_matchers import Any
 
 from lms.models import CanvasGroup, Course, Grouping, GroupingMembership
-from lms.product.plugin.grouping import GroupingPlugin
 from lms.services.grouping import GroupingService
 from tests import factories
 
@@ -509,9 +508,5 @@ def user():
 
 
 @pytest.fixture
-def svc(db_session, application_instance):
-    return GroupingService(
-        db_session,
-        application_instance,
-        plugin=create_autospec(GroupingPlugin, spec_set=True, instance=True),
-    )
+def svc(db_session, application_instance, grouping_plugin):
+    return GroupingService(db_session, application_instance, plugin=grouping_plugin)

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -457,6 +457,31 @@ class TestGetGroupings:
         # We get the course no matter what + only the grouping we are in
         assert results == Any.list.containing([course, groupings[1]])
 
+    @pytest.mark.parametrize(
+        "sections_enabled,group_set_id,expected",
+        [
+            (True, 1, Grouping.Type.GROUP),
+            (True, None, Grouping.Type.SECTION),
+            (False, 1, Grouping.Type.GROUP),
+            (False, None, Grouping.Type.COURSE),
+        ],
+    )
+    def test_launch_grouping_type(
+        self, svc, grouping_plugin, sections_enabled, group_set_id, expected
+    ):
+        grouping_plugin.sections_enabled.return_value = sections_enabled
+        grouping_plugin.group_set_id.return_value = group_set_id
+
+        assert (
+            svc.get_launch_grouping_type(
+                sentinel.request,
+                sentinel.application_instance,
+                sentinel.course,
+                sentinel.assignment,
+            )
+            == expected
+        )
+
     @pytest.fixture
     def assert_groups_returned(self, svc, assert_groupings_returned):
         return partial(assert_groupings_returned, grouping_type=svc.plugin.group_type)

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -470,7 +470,7 @@ class TestGetGroupings:
         self, svc, grouping_plugin, sections_enabled, group_set_id, expected
     ):
         grouping_plugin.sections_enabled.return_value = sections_enabled
-        grouping_plugin.group_set_id.return_value = group_set_id
+        grouping_plugin.get_group_set_id.return_value = group_set_id
 
         assert (
             svc.get_launch_grouping_type(

--- a/tests/unit/lms/services/lti_launch_test.py
+++ b/tests/unit/lms/services/lti_launch_test.py
@@ -1,0 +1,156 @@
+from unittest.mock import patch, sentinel
+
+import pytest
+
+from lms.services.lti_launch import LTILaunchService, factory
+
+
+class TestLTILaunchService:
+    def test_validate_launch(self, svc, pyramid_request):
+        with patch.object(svc, "_application_instance", autospec=True) as ai:
+            svc.validate_launch()
+
+            ai.check_guid_aligns.assert_called_once_with(
+                pyramid_request.lti_params["tool_consumer_instance_guid"]
+            )
+
+    def test_record_course(
+        self, svc, launch_plugin, pyramid_request, grouping_service, course_service
+    ):
+        svc.record_course()
+
+        course_service.upsert_course.assert_called_once_with(
+            context_id=pyramid_request.lti_params["context_id"],
+            name=pyramid_request.lti_params["context_title"],
+            extra=launch_plugin.course_extra.return_value,
+        )
+        grouping_service.upsert_grouping_memberships.assert_called_once_with(
+            user=pyramid_request.user,
+            groups=[course_service.upsert_course.return_value],
+        )
+
+    def test_record_assignment(
+        self, svc, assignment_service, pyramid_request, lti_role_service, launch_plugin
+    ):
+
+        svc.record_assignment(sentinel.course, sentinel.document_url, sentinel.extra)
+        assignment_service.upsert_assignment.assert_called_once_with(
+            document_url=sentinel.document_url,
+            tool_consumer_instance_guid=pyramid_request.lti_params[
+                "tool_consumer_instance_guid"
+            ],
+            resource_link_id=pyramid_request.lti_params["resource_link_id"],
+            lti_params=pyramid_request.lti_params,
+            extra=sentinel.extra,
+            is_gradable=launch_plugin.is_assignment_gradable.return_value,
+        )
+        assignment = assignment_service.upsert_assignment.return_value
+
+        lti_role_service.get_roles.assert_called_once_with(
+            pyramid_request.lti_params["roles"]
+        )
+        assignment_service.upsert_assignment_membership.assert_called_once_with(
+            assignment=assignment,
+            user=pyramid_request.user,
+            lti_roles=lti_role_service.get_roles.return_value,
+        )
+        assignment_service.upsert_assignment_groupings.assert_called_once_with(
+            assignment_id=assignment.id, groupings=[sentinel.course]
+        )
+
+    @pytest.mark.parametrize(
+        "grading_bar,is_instructor,record_grading",
+        [
+            (True, True, False),
+            (True, False, True),
+            (False, True, False),
+            (False, False, False),
+        ],
+    )
+    def test_record_launch(
+        self,
+        svc,
+        application_instance_service,
+        application_instance,
+        pyramid_request,
+        grading_info_service,
+        grading_bar,
+        is_instructor,
+        record_grading,
+    ):
+        pyramid_request.product.use_grading_bar = grading_bar
+        svc.lti_user = pyramid_request.lti_user._replace(
+            roles="Instructor" if is_instructor else "Learner"
+        )
+
+        svc.record_launch(pyramid_request)
+
+        application_instance_service.update_from_lti_params(
+            application_instance, pyramid_request.lti_params
+        )
+
+        if record_grading:
+            grading_info_service.upsert_from_request.assert_called_once_with(
+                pyramid_request
+            )
+
+    @pytest.fixture
+    def svc(
+        self,
+        pyramid_request,
+        course_service,
+        assignment_service,
+        grouping_service,
+        lti_role_service,
+        application_instance_service,
+        grading_info_service,
+        launch_plugin,
+    ):
+        return LTILaunchService(
+            lti_params=pyramid_request.lti_params,
+            user=pyramid_request.user,
+            lti_user=pyramid_request.lti_user,
+            course_service=course_service,
+            assignment_service=assignment_service,
+            grouping_service=grouping_service,
+            lti_role_service=lti_role_service,
+            application_instance_service=application_instance_service,
+            grading_info_service=grading_info_service,
+            product=pyramid_request.product,
+            plugin=launch_plugin,
+        )
+
+
+class TestFactory:
+    def test_it(
+        self,
+        pyramid_request,
+        LTILaunchService,
+        course_service,
+        assignment_service,
+        grouping_service,
+        lti_role_service,
+        application_instance_service,
+        grading_info_service,
+        launch_plugin,
+    ):
+        service = factory(sentinel.context, pyramid_request)
+
+        LTILaunchService.assert_called_once_with(
+            lti_params=pyramid_request.lti_params,
+            user=pyramid_request.user,
+            lti_user=pyramid_request.lti_user,
+            course_service=course_service,
+            assignment_service=assignment_service,
+            grouping_service=grouping_service,
+            lti_role_service=lti_role_service,
+            application_instance_service=application_instance_service,
+            grading_info_service=grading_info_service,
+            product=pyramid_request.product,
+            plugin=launch_plugin,
+        )
+        assert service == LTILaunchService.return_value
+
+    @pytest.fixture
+    def LTILaunchService(self, patch):
+        return patch("lms.services.lti_launch.LTILaunchService")

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -14,17 +14,12 @@ from tests import factories
 
 @pytest.mark.usefixtures("application_instance_service", "lti_h_service")
 class TestDeepLinkingLaunch:
-    def test_it(
-        self, context, pyramid_request, lti_h_service, application_instance_service
-    ):
+    def test_it(self, context, pyramid_request, lti_h_service, lti_launch_service):
         deep_linking_launch(context, pyramid_request)
 
-        application_instance_service.update_from_lti_params.assert_called_once_with(
-            context.application_instance, pyramid_request.lti_params
-        )
-
+        lti_launch_service.record_course.assert_called_once()
         lti_h_service.sync.assert_called_once_with(
-            [context.course], pyramid_request.params
+            [lti_launch_service.record_course.return_value], pyramid_request.params
         )
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="TEST_CONTENT_ITEM_RETURN_URL",

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from lms.product.plugin.grouping import GroupingPlugin
 from lms.services import (
     CanvasService,
     DocumentURLService,
@@ -76,6 +77,8 @@ __all__ = (
     "rsa_key_service",
     "user_service",
     "vitalsource_service",
+    # Product plugins
+    "grouping_plugin",
 )
 
 
@@ -295,3 +298,8 @@ def user_service(mock_service):
 @pytest.fixture
 def vitalsource_service(mock_service):
     return mock_service(VitalSourceService)
+
+
+@pytest.fixture
+def grouping_plugin(mock_service):
+    return mock_service(GroupingPlugin)

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from lms.product.plugin.grouping import GroupingPlugin
+from lms.product.plugin.launch import LaunchPlugin
 from lms.services import (
     CanvasService,
     DocumentURLService,
@@ -30,6 +31,7 @@ from lms.services.jwt import JWTService
 from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_h import LTIHService
+from lms.services.lti_launch import LTILaunchService
 from lms.services.lti_registration import LTIRegistrationService
 from lms.services.ltia_http import LTIAHTTPService
 from lms.services.oauth1 import OAuth1Service
@@ -67,6 +69,7 @@ __all__ = (
     "launch_verifier",
     "lti_grading_service",
     "lti_h_service",
+    "lti_launch_service",
     "lti_registration_service",
     "lti_role_service",
     "ltia_http_service",
@@ -79,6 +82,7 @@ __all__ = (
     "vitalsource_service",
     # Product plugins
     "grouping_plugin",
+    "launch_plugin",
 )
 
 
@@ -303,3 +307,13 @@ def vitalsource_service(mock_service):
 @pytest.fixture
 def grouping_plugin(mock_service):
     return mock_service(GroupingPlugin)
+
+
+@pytest.fixture
+def launch_plugin(mock_service):
+    return mock_service(LaunchPlugin)
+
+
+@pytest.fixture
+def lti_launch_service(mock_service):
+    return mock_service(LTILaunchService)


### PR DESCRIPTION
Moves bits of the views into a new service. 

With the extra boilerplate of the new service and plugin this looks bigger than the original for not much benefit.

This PR doesn't:

- Make any changes around JSConfig (which could belong to the new service). That would be its own separate refactor.
- Change the behavior of the moved code, except for the bits moved the plugin. Again that would make the size of this PR much bigger.

That being said this PR allows to move some product specific behavior into plugins, allows re-use of some of the launch logic and moves us close to remove the last `is_canvas` in the codebase.

## Testing

Sanity check with some launches:

- https://hypothesis.instructure.com/courses/125/assignments/873
- https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_398_1&course_id=_19_1
- And re-configure:  https://hypothesis.instructure.com/courses/125/assignments/3118/edit?return_to=https%3A%2F%2Fhypothesis.instructure.com%2Fcourses%2F125%2Fassignments%2F3118