### PR TITLE
Include jstor in Speedgrader URL bug workaround

### DIFF
--- a/lms/services/document_url.py
+++ b/lms/services/document_url.py
@@ -32,7 +32,7 @@ class DocumentURLService:
 
         return None
 
-    _ENCODED_URL = re.compile("^(?:https?|canvas|vitalsource)%3a", re.IGNORECASE)
+    _ENCODED_URL = re.compile("^(?:https?|canvas|vitalsource|jstor)%3a", re.IGNORECASE)
 
     @classmethod
     def _from_deep_linking_provided_url(cls, request):

--- a/tests/unit/lms/services/document_url_test.py
+++ b/tests/unit/lms/services/document_url_test.py
@@ -33,6 +33,10 @@ class TestDocumentURLService:
                 "canvas%3A%2F%2Ffile%2Fcourse_id%2FCOURSE_ID%2Ffile_if%2FFILE_ID",
                 "canvas://file/course_id/COURSE_ID/file_if/FILE_ID",
             ),
+            (
+                "jstor%3A%2F%2FDOI",
+                "jstor://DOI",
+            ),
             # Non-URL encoded paths
             (
                 "https://example.com/path?param=value",


### PR DESCRIPTION
For 

- https://github.com/hypothesis/product-backlog/issues/1408


Speedgrader double quotes chars in the URL. We need to unquote those to correctly identify the schema.

Add `jstor://` to the whitelisted schemas.


## Ideas for a more general fix

This PR addresses the bug without making any bigger changes, we could potentially:


- Make the regexp more general, if it starts with some chars followed by `%3a` just unquote it. (See https://github.com/hypothesis/lms/pull/4711)


- Report unparseable URLs in (lms) via to sentry. We might get a few false positives there (typos) but it might worth a try. We could start with a regular (papertrail) log to see how much volume it generates.




## Testing

- Launch https://hypothesis.instructure.com/courses/125/assignments/3849 in Speedgrader (you might need to first make an annotation to get the document to show)

- In main via will error. It should work in this branch


