### PR TITLE
Notes fields on application instances admin pages

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -32,7 +32,8 @@
 
 {% macro settings_textarea(label, setting, sub_setting, field_name, default='') %}
     {% call macros.field_body(label) %}
-        <textarea class="textarea" name="{{ setting }}.{{ sub_setting }}">{{ instance.settings.get(setting, sub_setting, default) or '' }}</textarea>
+        {% set text = instance.settings.get(setting, sub_setting, default) or ''  %}
+        <textarea class="textarea" name="{{ setting }}.{{ sub_setting }}">{{ text }}</textarea>
     {% endcall %}
 {% endmacro %}
 
@@ -51,6 +52,14 @@
 <form method="POST" action="{{ request.route_url("admin.instance.id", id_=instance.id) }}">
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
+    <fieldset class="box">
+        {{ settings_textarea("Notes", "hypothesis", "notes") }}
+        {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
+        {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
+        {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
+    </fieldset>
+
+
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Organization</legend>
         {{ macros.organization_preview(request, instance.organization) }}
@@ -59,12 +68,6 @@
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Registration</legend>
         {{ macros.registration_preview(request, instance.lti_registration) }}
-    </fieldset>
-
-    <fieldset class="box">
-        {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
-        {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
-        {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
     </fieldset>
 
     <fieldset class="box">
@@ -141,7 +144,6 @@
         {{ settings_text_field("JSTOR site code", "jstor", "site_code") }}
     </fieldset>
 
-    {{ settings_textarea("Notes", "hypothesis", "notes") }}
     {{ macros.created_updated_fields(instance) }}
 
     <div class="has-text-right mb-6">

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -30,6 +30,11 @@
     {% endcall %}
 {% endmacro %}
 
+{% macro settings_textarea(label, setting, sub_setting, field_name, default='') %}
+    {% call macros.field_body(label) %}
+        <textarea class="textarea" name="{{ setting }}.{{ sub_setting }}">{{ instance.settings.get(setting, sub_setting, default) or '' }}</textarea>
+    {% endcall %}
+{% endmacro %}
 
 {% macro settings_secret_field(label, setting, sub_setting, field_name, default='') %}
     {% call macros.field_body(label) %}
@@ -136,6 +141,7 @@
         {{ settings_text_field("JSTOR site code", "jstor", "site_code") }}
     </fieldset>
 
+    {{ settings_textarea("Notes", "hypothesis", "notes") }}
     {{ macros.created_updated_fields(instance) }}
 
     <div class="has-text-right mb-6">

--- a/lms/views/admin/__init__.py
+++ b/lms/views/admin/__init__.py
@@ -1,32 +1,9 @@
-from marshmallow import fields, missing
+from marshmallow import fields
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from pyramid.renderers import render_to_response
 from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 
 from lms.validation._exceptions import ValidationError
-
-
-class EmptyStringNoneMixin:
-    """
-    Allows empty string as "missing value".
-
-    Marshmallow doesn't have a clean solution yet to POSTed values
-    (that are always present in the request as empty strings)
-
-    Here we convert them explicitly to None
-
-    https://github.com/marshmallow-code/marshmallow/issues/713
-    """
-
-    def deserialize(self, value, attr, data, **kwargs):
-        # pylint:disable=compare-to-empty-string
-        if value == missing or value.strip() == "":
-            return None
-        return super().deserialize(value, attr, data, **kwargs)
-
-
-class EmptyStringInt(EmptyStringNoneMixin, fields.Int):
-    """Allow empty string as "missing value" instead of failing integer validation."""
 
 
 @forbidden_view_config(path_info="/admin/*")

--- a/lms/views/admin/_schemas.py
+++ b/lms/views/admin/_schemas.py
@@ -1,0 +1,25 @@
+"""Common marshmallow schemas for the admin pages."""
+from marshmallow import fields, missing
+
+
+class EmptyStringNoneMixin:
+    """
+    Allows empty string as "missing value".
+
+    Marshmallow doesn't have a clean solution yet to POSTed values
+    (that are always present in the request as empty strings)
+
+    Here we convert them explicitly to None
+
+    https://github.com/marshmallow-code/marshmallow/issues/713
+    """
+
+    def deserialize(self, value, attr, data, **kwargs):
+        # pylint:disable=compare-to-empty-string
+        if value == missing or value.strip() == "":
+            return None
+        return super().deserialize(value, attr, data, **kwargs)
+
+
+class EmptyStringInt(EmptyStringNoneMixin, fields.Int):
+    """Allow empty string as "missing value" instead of failing integer validation."""

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -10,7 +10,8 @@ from lms.security import Permissions
 from lms.services import ApplicationInstanceNotFound, LTIRegistrationService
 from lms.services.aes import AESService
 from lms.validation._base import PyramidRequestSchema, ValidationError
-from lms.views.admin import EmptyStringInt, error_render_to_response, flash_validation
+from lms.views.admin import error_render_to_response, flash_validation
+from lms.views.admin._schemas import EmptyStringInt
 
 
 class NewApplicationInstanceSchema(PyramidRequestSchema):
@@ -309,6 +310,7 @@ class AdminApplicationInstanceViews:
             ("vitalsource", "disable_licence_check", bool),
             ("jstor", "enabled", bool),
             ("jstor", "site_code", str),
+            ("hypothesis", "notes", str),
         ):
             value = self.request.params.get(f"{setting}.{sub_setting}")
             if setting_type == bool:

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -11,7 +11,8 @@ from lms.models import LTIRegistration
 from lms.security import Permissions
 from lms.services import LTIRegistrationService
 from lms.validation._base import PyramidRequestSchema
-from lms.views.admin import EmptyStringInt, flash_validation
+from lms.views.admin import flash_validation
+from lms.views.admin._schemas import EmptyStringInt
 
 
 class LTIRegistrationBaseSchema(PyramidRequestSchema):

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -9,7 +9,8 @@ from lms.models.public_id import InvalidPublicId
 from lms.security import Permissions
 from lms.services import OrganizationService
 from lms.validation._base import PyramidRequestSchema
-from lms.views.admin import EmptyStringInt, flash_validation
+from lms.views.admin import flash_validation
+from lms.views.admin._schemas import EmptyStringInt
 
 
 class SearchOrganizationSchema(PyramidRequestSchema):

--- a/tests/unit/lms/views/admin/__init___test.py
+++ b/tests/unit/lms/views/admin/__init___test.py
@@ -1,7 +1,4 @@
-import pytest
-
-from lms.validation._base import PyramidRequestSchema, ValidationError
-from lms.views.admin import EmptyStringInt, index, logged_out, notfound
+from lms.views.admin import index, logged_out, notfound
 from tests.matchers import temporary_redirect_to
 
 
@@ -29,27 +26,3 @@ def test_index(pyramid_request):
     assert response == temporary_redirect_to(
         pyramid_request.route_url("admin.instances")
     )
-
-
-class TestEmptyStringInt:
-    @pytest.mark.parametrize("value", ["1", "", "   "])
-    def test_valid(self, pyramid_request, value, TestSchema):
-        pyramid_request.POST["id"] = value
-
-        assert TestSchema(pyramid_request).parse()
-
-    @pytest.mark.parametrize("value", ["not a number"])
-    def test_invalid(self, pyramid_request, value, TestSchema):
-        pyramid_request.POST["id"] = value
-
-        with pytest.raises(ValidationError):
-            TestSchema(pyramid_request).parse()
-
-    @pytest.fixture
-    def TestSchema(self):
-        class _TestSchema(PyramidRequestSchema):
-            location = "form"
-
-            id = EmptyStringInt()
-
-        return _TestSchema

--- a/tests/unit/lms/views/admin/_schema_test.py
+++ b/tests/unit/lms/views/admin/_schema_test.py
@@ -1,0 +1,32 @@
+import pytest
+
+from lms.validation._base import PyramidRequestSchema, ValidationError
+from lms.views.admin._schemas import EmptyStringInt
+
+
+class TestEmptyStringInt:
+    @pytest.mark.parametrize("value", ["1", "", "   "])
+    def test_valid(self, pyramid_request, value, TestSchema):
+
+        pyramid_request.POST["id"] = value
+
+        assert TestSchema(pyramid_request).parse()
+
+    @pytest.mark.parametrize("value", ["not a number"])
+    def test_invalid(self, pyramid_request, value, TestSchema):
+
+        pyramid_request.POST["id"] = value
+
+        with pytest.raises(ValidationError):
+
+            TestSchema(pyramid_request).parse()
+
+    @pytest.fixture
+    def TestSchema(self):
+        class _TestSchema(PyramidRequestSchema):
+
+            location = "form"
+
+            id = EmptyStringInt()
+
+        return _TestSchema

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -357,6 +357,8 @@ class TestAdminApplicationInstanceViews:
             ("vitalsource", "api_key", "api_key", "api_key"),
             ("vitalsource", "user_lti_param", "user_id", "user_id"),
             ("vitalsource", "user_lti_pattern", "name_(.*)", "name_(.*)"),
+            ("hypothesis", "notes", "  NOTES ", "NOTES"),
+            ("hypothesis", "notes", "", None),
         ),
     )
     def test_update_instance_saves_ai_settings(


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4700


Add a note field in the admin pages for Application instances.

Also took the opportunity to move the admin schema to their own file in a separate commit


## Testing

- Go to http://localhost:8001/admin/instance/id/2/
- Write some (funny) note
- Save
- Refresh the page, it should appear again.
