### PR TITLE
Generalize access to the current LMS files

### DIFF
--- a/lms/product/blackboard/__init__.py
+++ b/lms/product/blackboard/__init__.py
@@ -1,3 +1,4 @@
+from lms.product.blackboard._plugin.files import BlackboardFilesPlugin
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
 from lms.product.blackboard.product import Blackboard
 
@@ -8,3 +9,4 @@ def includeme(config):  # pragma: nocover
     config.register_service_factory(
         BlackboardGroupingPlugin.factory, iface=BlackboardGroupingPlugin
     )
+    config.register_service(BlackboardFilesPlugin(), iface=BlackboardFilesPlugin)

--- a/lms/product/blackboard/_plugin/files.py
+++ b/lms/product/blackboard/_plugin/files.py
@@ -1,0 +1,5 @@
+from lms.product.plugin.files import FilesPlugin
+
+
+class BlackboardFilesPlugin(FilesPlugin):
+    missing_files_help_link = "https://web.hypothes.is/help/bb-files"

--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from lms.product.blackboard._plugin.files import BlackboardFilesPlugin
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
@@ -14,7 +15,12 @@ class Blackboard(Product):
         oauth2_authorize="blackboard_api.oauth.authorize",
         oauth2_refresh="blackboard_api.oauth.refresh",
         list_group_sets="blackboard_api.courses.group_sets.list",
+        list_course_files="blackboard_api.courses.files.list",
     )
 
-    plugin_config: PluginConfig = PluginConfig(grouping=BlackboardGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(
+        grouping=BlackboardGroupingPlugin,
+        files=BlackboardFilesPlugin,
+    )
+
     settings_key = "blackboard"

--- a/lms/product/canvas/__init__.py
+++ b/lms/product/canvas/__init__.py
@@ -1,3 +1,4 @@
+from lms.product.canvas._plugin.files import CanvasFilesPlugin
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
 from lms.product.canvas.product import Canvas
 
@@ -8,3 +9,4 @@ def includeme(config):  # pragma: nocover
     config.register_service_factory(
         CanvasGroupingPlugin.factory, iface=CanvasGroupingPlugin
     )
+    config.register_service(CanvasFilesPlugin(), iface=CanvasFilesPlugin)

--- a/lms/product/canvas/_plugin/files.py
+++ b/lms/product/canvas/_plugin/files.py
@@ -1,0 +1,20 @@
+from lms.product.plugin.files import FilesPlugin
+
+
+class CanvasFilesPlugin(FilesPlugin):
+    missing_files_help_link = "https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-upload-a-file-to-a-course/ta-p/618"
+
+    def enabled(self, request, application_instance) -> bool:
+        return (
+            "custom_canvas_course_id" in request.lti_params
+            and application_instance.developer_key is not None
+        )
+
+    def list_files_config(self, request) -> dict:
+        return {
+            "authUrl": request.route_url(request.product.route.oauth2_authorize),
+            "path": request.route_path(
+                request.product.route.list_course_files,
+                course_id=request.lti_params.get("custom_canvas_course_id"),
+            ),
+        }

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from lms.product.canvas._plugin.files import CanvasFilesPlugin
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
@@ -14,8 +15,11 @@ class Canvas(Product):
         oauth2_authorize="canvas_api.oauth.authorize",
         oauth2_refresh="canvas_api.oauth.refresh",
         list_group_sets="canvas_api.courses.group_sets.list",
+        list_course_files="canvas_api.courses.files.list",
     )
 
-    plugin_config: PluginConfig = PluginConfig(grouping=CanvasGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(
+        grouping=CanvasGroupingPlugin, files=CanvasFilesPlugin
+    )
 
     settings_key = "canvas"

--- a/lms/product/plugin/files.py
+++ b/lms/product/plugin/files.py
@@ -1,0 +1,16 @@
+class FilesPlugin:
+    """Abstraction over the integration with the LMS provided file storage."""
+
+    missing_files_help_link = None
+
+    def enabled(self, request, _application_instance) -> bool:
+        return request.product.settings.files_enabled
+
+    def list_files_config(self, request) -> dict:
+        return {
+            "authUrl": request.route_url(request.product.route.oauth2_authorize),
+            "path": request.route_path(
+                request.product.route.list_course_files,
+                course_id=request.lti_params.get("context_id"),
+            ),
+        }

--- a/lms/product/plugin/plugin.py
+++ b/lms/product/plugin/plugin.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from lms.product.plugin.files import FilesPlugin
 from lms.product.plugin.grouping import GroupingPlugin
 
 
@@ -9,6 +10,7 @@ class PluginConfig:
 
     # These also provide the default implementations
     grouping: type = GroupingPlugin
+    files: type = FilesPlugin
 
 
 class Plugins:
@@ -28,6 +30,7 @@ class Plugins:
             return plugin
 
     grouping: GroupingPlugin = _LazyPlugin()
+    files: FilesPlugin = _LazyPlugin()
 
     def __init__(self, request, plugin_config: PluginConfig):
         self._request = request

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -37,6 +37,9 @@ class Routes:
     list_group_sets: Optional[str] = None
     """List available group sets. Takes a course_id parameter"""
 
+    list_course_files: Optional[str] = None
+    """List available files. Takes a course_id parameter"""
+
 
 @dataclass
 class Settings:
@@ -47,8 +50,12 @@ class Settings:
     groups_enabled: bool = False
     """Is the course groups feature enabled"""
 
+    files_enabled: bool = False
+    """Is the integrations with the LMS's files feature enabled"""
+
     def __post_init__(self, product_settings):
         self.groups_enabled = product_settings.get("groups_enabled", False)
+        self.files_enabled = product_settings.get("files_enabled", False)
 
 
 @dataclass

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -219,9 +219,9 @@ class JSConfig:
                     # construct these launch URLs our JavaScript code needs the
                     # base URL of our LTI launch endpoint.
                     "ltiLaunchUrl": self._request.route_url("lti_launches"),
-                    # Specific config for pickers
-                    "blackboard": FilePickerConfig.blackboard_config(*args),
-                    "canvas": FilePickerConfig.canvas_config(*args),
+                    # Current LMS files integration
+                    "lms": FilePickerConfig.lms_files_config(*args),
+                    # Specific config for third party pickers
                     "google": FilePickerConfig.google_files_config(*args),
                     "microsoftOneDrive": FilePickerConfig.microsoft_onedrive(*args),
                     "vitalSource": FilePickerConfig.vitalsource_config(*args),

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -18,7 +18,7 @@ import URLPicker from './URLPicker';
  *
  * @typedef {import('./FilePickerApp').ErrorInfo} ErrorInfo
  *
- * @typedef {'blackboardFile'|'canvasFile'|'jstor'|'url'|'vitalSourceBook'|null} DialogType
+ * @typedef {'lmsFile'|'jstor'|'url'|'vitalSourceBook'|null} DialogType
  *
  * @typedef {import('../utils/content-item').Content} Content
  */
@@ -42,12 +42,13 @@ export default function ContentSelector({
 }) {
   const {
     api: { authToken },
+    product: { family },
     filePicker: {
-      blackboard: {
-        enabled: blackboardFilesEnabled,
-        listFiles: blackboardListFilesApi,
+      lms: {
+        enabled: lmsFilesEnabled,
+        listFiles: listFilesApi,
+        missingFilesHelpLink: missingFilesHelpLink,
       },
-      canvas: { enabled: canvasFilesEnabled, listFiles: listFilesApi },
       google: {
         clientId: googleClientId,
         developerKey: googleDeveloperKey,
@@ -118,16 +119,15 @@ export default function ContentSelector({
   };
 
   /** @param {File} file */
-  const selectCanvasFile = file => {
+  const selectLMSFile = file => {
     cancelDialog();
-    onSelectContent({ type: 'file', file });
-  };
 
-  /** @param {File} file */
-  const selectBlackboardFile = file => {
-    cancelDialog();
-    // file.id shall be a url of the form blackboard://content-resource/{file_id}
-    onSelectContent({ type: 'url', url: file.id });
+    if (family === 'canvas') {
+      onSelectContent({ type: 'file', file });
+    } else {
+      // file.id shall be a url of the form blackboard://content-resource/{file_id}
+      onSelectContent({ type: 'url', url: file.id });
+    }
   };
 
   /**
@@ -147,28 +147,14 @@ export default function ContentSelector({
     case 'url':
       dialog = <URLPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
       break;
-    case 'canvasFile':
+    case 'lmsFile':
       dialog = (
         <LMSFilePicker
           authToken={authToken}
           listFilesApi={listFilesApi}
           onCancel={cancelDialog}
-          onSelectFile={selectCanvasFile}
-          missingFilesHelpLink="https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-upload-a-file-to-a-course/ta-p/618"
-        />
-      );
-      break;
-    case 'blackboardFile':
-      dialog = (
-        <LMSFilePicker
-          authToken={authToken}
-          listFilesApi={blackboardListFilesApi}
-          onCancel={cancelDialog}
-          onSelectFile={selectBlackboardFile}
-          // An alias we maintain that provides multiple external documentation links for
-          // different versions of Blackboard (Classic vs. Ultra)
-          missingFilesHelpLink={'https://web.hypothes.is/help/bb-files'}
-          withBreadcrumbs
+          onSelectFile={selectLMSFile}
+          missingFilesHelpLink={missingFilesHelpLink}
         />
       );
       break;
@@ -239,18 +225,18 @@ export default function ContentSelector({
           >
             Enter URL of web page or PDF
           </LabeledButton>
-          {canvasFilesEnabled && (
+          {lmsFilesEnabled && family === 'canvas' && (
             <LabeledButton
-              onClick={() => selectDialog('canvasFile')}
+              onClick={() => selectDialog('lmsFile')}
               variant="primary"
               data-testid="canvas-file-button"
             >
               Select PDF from Canvas
             </LabeledButton>
           )}
-          {blackboardFilesEnabled && (
+          {lmsFilesEnabled && family === 'BlackboardLearn' && (
             <LabeledButton
-              onClick={() => selectDialog('blackboardFile')}
+              onClick={() => selectDialog('lmsFile')}
               variant="primary"
               data-testid="blackboard-file-button"
             >

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -59,12 +59,10 @@ import { createContext } from 'preact';
  * @prop {Record<string,string>} formFields
  * @prop {APICallInfo} [deepLinkingAPI]
  * @prop {string} ltiLaunchUrl
- * @prop {object} blackboard
- *   @prop {boolean} blackboard.enabled
- *   @prop {APICallInfo} blackboard.listFiles
- * @prop {object} canvas
- *   @prop {boolean} canvas.enabled
- *   @prop {APICallInfo} canvas.listFiles
+ * @prop {object} lms
+ *   @prop {boolean} lms.enabled
+ *   @prop {APICallInfo} lms.listFiles
+ *   @prop {string} lms.missingFilesHelpLink
  * @prop {object} google
  *   @prop {string} google.clientId
  *   @prop {string} google.developerKey

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -41,8 +41,7 @@ class TestFilePickerMode:
     @pytest.mark.parametrize(
         "config_function,key",
         (
-            ("blackboard_config", "blackboard"),
-            ("canvas_config", "canvas"),
+            ("lms_files_config", "lms"),
             ("google_files_config", "google"),
             ("microsoft_onedrive", "microsoftOneDrive"),
             ("vitalsource_config", "vitalSource"),

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -1,22 +1,21 @@
+# pylint: disable=pointless-string-statement
 from unittest.mock import sentinel
 
 import pytest
-from h_matchers import Any
 
 from lms.product import Product
 from lms.resources._js_config import FilePickerConfig
 
 
 class TestFilePickerConfig:
-    @pytest.mark.parametrize("files_enabled", [False, True])
-    def test_blackboard_config(
+    def test_lms_files_config_disabled(
         self, pyramid_request, application_instance, files_enabled
     ):
 
         pyramid_request.lti_params["context_id"] = "COURSE_ID"
         application_instance.settings.set("blackboard", "files_enabled", files_enabled)
 
-        config = FilePickerConfig.blackboard_config(
+        config = FilePickerConfig.lms_files_config(
             pyramid_request, application_instance
         )
 


### PR DESCRIPTION
Refactor before D2L files

---


Create a new plugin to generalize the behaviour of "integrate with the LMS files".

This is similar across different LMS, canvas needing a few exceptions, the future D2L one being very similar to blackboard (not in this PR).

Close to this code we have third party file pickers (OneDrive, Google...) but those are a difference concept both on the backend and the effect in the UI, not tackled in this PR.


