### PR TITLE
Auto create D2L grade items

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 CLAIM_PREFIX = "https://purl.imsglobal.org/spec/lti/claim"
 
@@ -18,7 +18,7 @@ class LTIParams(dict):
     v11 and the object's dict interface.
     """
 
-    def __init__(self, v11: dict, v13: dict = None):
+    def __init__(self, v11: dict, v13: Optional[dict] = None):
         super().__init__(v11)
         self.v13 = v13
 
@@ -122,6 +122,10 @@ _V11_TO_V13 = (
     (
         "lis_outcome_service_url",
         ["https://purl.imsglobal.org/spec/lti-ags/claim/endpoint", "lineitem"],
+    ),
+    (
+        "lineitems",
+        ["https://purl.imsglobal.org/spec/lti-ags/claim/endpoint", "lineitems"],
     ),
     ("lis_result_sourcedid", ["sub"]),
     (

--- a/lms/product/d2l/__init__.py
+++ b/lms/product/d2l/__init__.py
@@ -1,7 +1,9 @@
 from lms.product.d2l._plugin.grouping import D2LGroupingPlugin
+from lms.product.d2l._plugin.misc import D2LMiscPlugin
 from lms.product.d2l.product import D2L
 
 
 def includeme(config):  # pragma: nocover
     """Register all of our plugins."""
     config.register_service_factory(D2LGroupingPlugin.factory, iface=D2LGroupingPlugin)
+    config.register_service_factory(D2LMiscPlugin.factory, iface=D2LMiscPlugin)

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -27,9 +27,9 @@ class D2LMiscPlugin(MiscPlugin):
         resource_link_id = lti_params.get("resource_link_id")
         resource_link_title = lti_params.get("resource_link_title")
 
-        if not lti_grading_service.read_lineitems(
-            lti_params.get("lineitems"), resource_link_id
-        ):
+        # If we already identified this assignment as gradable no need to
+        # create anything
+        if not super().is_assignment_gradable(lti_params):
             # If there are no existing lineitems, create one.
             lti_grading_service.create_lineitem(
                 lti_params.get("lineitems"),

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -3,8 +3,8 @@ from lms.services.lti_grading.interface import LTIGradingService
 
 
 class D2LMiscPlugin(MiscPlugin):
-    def __init__(self, settings: Settings):
-        self._settings = settings
+    def __init__(self, create_lineitem: bool):
+        self._create_lineitem = create_lineitem
 
     def post_configure_assignment(self, request):
         """
@@ -20,7 +20,7 @@ class D2LMiscPlugin(MiscPlugin):
         lti_params = request.lti_params
         lti_grading_service = request.find_service(LTIGradingService)
 
-        if not self._settings.create_lineitem:
+        if not self._create_lineitem:
             # No need to do anything if this option is off.
             return
 
@@ -54,4 +54,4 @@ class D2LMiscPlugin(MiscPlugin):
 
     @classmethod
     def factory(cls, _context, request):
-        return cls(request.product.settings)
+        return cls(request.product.settings.custom.get("create_lineitem", False))

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -3,24 +3,24 @@ from lms.services.lti_grading.interface import LTIGradingService
 
 
 class D2LMiscPlugin(MiscPlugin):
-    def __init__(self, create_lineitem: bool):
-        self._create_lineitem = create_lineitem
+    def __init__(self, create_line_item: bool):
+        self._create_line_item = create_line_item
 
     def post_configure_assignment(self, request):
         """
         Run any actions needed after configuring an assignment.
 
-        D2L doesn't create the container that holds grades (lineitems) LTI 1.3
+        D2L doesn't create the container that holds grades (line item) LTI 1.3
         assignments.
 
         As a work-around, as soon as we configure the assignment on our end
-        we'll use the LTIA grading API to create a new lineitem we can use
+        we'll use the LTIA grading API to create a new line item we can use
         later to record the grade.
         """
         lti_params = request.lti_params
         lti_grading_service = request.find_service(LTIGradingService)
 
-        if not self._create_lineitem:
+        if not self._create_line_item:
             # No need to do anything if this option is off.
             return
 
@@ -30,12 +30,7 @@ class D2LMiscPlugin(MiscPlugin):
         # If we already identified this assignment as gradable no need to
         # create anything
         if not super().is_assignment_gradable(lti_params):
-            # If there are no existing lineitems, create one.
-            lti_grading_service.create_lineitem(
-                lti_params.get("lineitems"),
-                resource_link_id,
-                resource_link_title,
-            )
+            lti_grading_service.create_line_item(resource_link_id, resource_link_title)
 
     def is_assignment_gradable(self, lti_params):
         """Check if the assignment of the current launch is gradable."""
@@ -54,4 +49,4 @@ class D2LMiscPlugin(MiscPlugin):
 
     @classmethod
     def factory(cls, _context, request):
-        return cls(request.product.settings.custom.get("create_lineitem", False))
+        return cls(request.product.settings.custom.get("create_line_item", False))

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -17,20 +17,16 @@ class D2LMiscPlugin(MiscPlugin):
         we'll use the LTIA grading API to create a new line item we can use
         later to record the grade.
         """
-        lti_params = request.lti_params
-        lti_grading_service = request.find_service(LTIGradingService)
-
-        if not self._create_line_item:
-            # No need to do anything if this option is off.
+        # Nothing to do if line item creation is off, or it's already there
+        if not self._create_line_item or super().is_assignment_gradable(
+            request.lti_params
+        ):
             return
 
-        resource_link_id = lti_params.get("resource_link_id")
-        resource_link_title = lti_params.get("resource_link_title")
-
-        # If we already identified this assignment as gradable no need to
-        # create anything
-        if not super().is_assignment_gradable(lti_params):
-            lti_grading_service.create_line_item(resource_link_id, resource_link_title)
+        request.find_service(LTIGradingService).create_line_item(
+            resource_link_id=request.lti_params.get("resource_link_id"),
+            label=request.lti_params.get("resource_link_title"),
+        )
 
     def is_assignment_gradable(self, lti_params):
         """Check if the assignment of the current launch is gradable."""

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -1,0 +1,57 @@
+from lms.product.plugin.misc import MiscPlugin
+from lms.services.lti_grading.interface import LTIGradingService
+
+
+class D2LMiscPlugin(MiscPlugin):
+    def __init__(self, settings: Settings):
+        self._settings = settings
+
+    def post_configure_assignment(self, request):
+        """
+        Run any actions needed after configuring an assignment.
+
+        D2L doesn't create the container that holds grades (lineitems) LTI 1.3
+        assignments.
+
+        As a work-around, as soon as we configure the assignment on our end
+        we'll use the LTIA grading API to create a new lineitem we can use
+        later to record the grade.
+        """
+        lti_params = request.lti_params
+        lti_grading_service = request.find_service(LTIGradingService)
+
+        if not self._settings.create_lineitem:
+            # No need to do anything if this option is off.
+            return
+
+        resource_link_id = lti_params.get("resource_link_id")
+        resource_link_title = lti_params.get("resource_link_title")
+
+        if not lti_grading_service.read_lineitems(
+            lti_params.get("lineitems"), resource_link_id
+        ):
+            # If there are no existing lineitems, create one.
+            lti_grading_service.create_lineitem(
+                lti_params.get("lineitems"),
+                resource_link_id,
+                resource_link_title,
+            )
+
+    def is_assignment_gradable(self, lti_params):
+        """Check if the assignment of the current launch is gradable."""
+        if self._create_line_item and lti_params["lti_version"] == "1.3.0":
+            # D2L doesn't automatically create a line item for assignments by
+            # default like it does for 1.1. If we are creating them
+            # automatically all assignments will be gradable.
+            return True
+
+        return super().is_assignment_gradable(lti_params)
+
+    def get_ltia_aud_claim(self, lti_registration):
+        # In D2L this value is always the same and different from
+        # `lti_registration.token_url` as in other LMS
+        return "https://api.brightspace.com/auth/token"
+
+    @classmethod
+    def factory(cls, _context, request):
+        return cls(request.product.settings)

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from lms.product.d2l._plugin.grouping import D2LGroupingPlugin
+from lms.product.d2l._plugin.misc import D2LMiscPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
 
@@ -10,7 +11,9 @@ class D2L(Product):
 
     family: Product.Family = Product.Family.D2L
 
-    plugin_config: PluginConfig = PluginConfig(grouping=D2LGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(
+        grouping=D2LGroupingPlugin, misc=D2LMiscPlugin
+    )
 
     route: Routes = Routes(
         oauth2_authorize="d2l_api.oauth.authorize",

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -47,12 +47,12 @@ class Settings:
     groups_enabled: bool = False
     """Is the course groups feature enabled"""
 
-    create_lineitem: bool = False
-    """Create lineitem on assignment configuration"""
+    custom: Optional[dict] = None
+    """Other non-standard settings."""
 
     def __post_init__(self, product_settings):
         self.groups_enabled = product_settings.get("groups_enabled", False)
-        self.create_lineitem = product_settings.get("create_lineitem", False)
+        self.custom = product_settings
 
 
 @dataclass

--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -47,8 +47,12 @@ class Settings:
     groups_enabled: bool = False
     """Is the course groups feature enabled"""
 
+    create_lineitem: bool = False
+    """Create lineitem on assignment configuration"""
+
     def __post_init__(self, product_settings):
         self.groups_enabled = product_settings.get("groups_enabled", False)
+        self.create_lineitem = product_settings.get("create_lineitem", False)
 
 
 @dataclass

--- a/lms/services/lti_grading/_v11.py
+++ b/lms/services/lti_grading/_v11.py
@@ -12,9 +12,9 @@ from lms.services.oauth1 import OAuth1Service
 class LTI11GradingService(LTIGradingService):
     #  See: LTI1.1 Outcomes https://www.imsglobal.org/specs/ltiomv1p0/specification
     def __init__(
-        self, grading_url, http_service: HTTPService, oauth1_service: OAuth1Service
+        self, line_item_url, http_service: HTTPService, oauth1_service: OAuth1Service
     ):
-        super().__init__(grading_url)
+        super().__init__(line_item_url, None)
         self.http_service = http_service
         self.oauth1_service = oauth1_service
 
@@ -62,7 +62,7 @@ class LTI11GradingService(LTIGradingService):
 
         try:
             response = self.http_service.post(
-                url=self.grading_url,
+                url=self.line_item_url,
                 data=xml_body,
                 headers={"Content-Type": "application/xml"},
                 auth=self.oauth1_service.get_client(),

--- a/lms/services/lti_grading/_v11.py
+++ b/lms/services/lti_grading/_v11.py
@@ -8,6 +8,7 @@ from lms.services.lti_grading.interface import LTIGradingService
 from lms.services.oauth1 import OAuth1Service
 
 
+# pylint:disable=abstract-method
 class LTI11GradingService(LTIGradingService):
     #  See: LTI1.1 Outcomes https://www.imsglobal.org/specs/ltiomv1p0/specification
     def __init__(

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -62,28 +62,6 @@ class LTI13GradingService(LTIGradingService):
             headers={"Content-Type": "application/vnd.ims.lis.v1.score+json"},
         )
 
-    def read_lineitems(self, lineitems_url, resource_link_id=None):
-        """
-        Read all the lineitem present in the `lineitems_url` container.
-
-        https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
-
-        :param lineitems_url: URL of the lineitems container
-        :param resource_link_id: Filter lineitems only relevant for this assignment id.
-        """
-        params = {}
-
-        if resource_link_id:
-            params["resource_link_id"] = resource_link_id
-
-        return self._ltia_service.request(
-            "GET",
-            lineitems_url,
-            scopes=self.LTIA_SCOPES,
-            params=params,
-            headers={"Accept": "application/vnd.ims.lis.v2.lineitemcontainer+json"},
-        ).json()
-
     def create_lineitem(
         self, lineitems_url, resource_link_id, label, score_maximum=100
     ):

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -15,15 +15,17 @@ class LTI13GradingService(LTIGradingService):
         "https://purl.imsglobal.org/spec/lti-ags/scope/score",
     ]
 
-    def __init__(self, grading_url, ltia_service: LTIAHTTPService):
-        super().__init__(grading_url)
+    def __init__(
+        self, line_item_url, line_item_container_url, ltia_service: LTIAHTTPService
+    ):
+        super().__init__(line_item_url, line_item_container_url)
         self._ltia_service = ltia_service
 
     def read_result(self, grading_id):
         try:
             response = self._ltia_service.request(
                 "GET",
-                self._service_url(self.grading_url, "/results"),
+                self._service_url(self.line_item_url, "/results"),
                 scopes=self.LTIA_SCOPES,
                 params={"user_id": grading_id},
                 headers={"Accept": "application/vnd.ims.lis.v2.resultcontainer+json"},
@@ -56,24 +58,21 @@ class LTI13GradingService(LTIGradingService):
 
         return self._ltia_service.request(
             "POST",
-            self._service_url(self.grading_url, "/scores"),
+            self._service_url(self.line_item_url, "/scores"),
             scopes=self.LTIA_SCOPES,
             json=payload,
             headers={"Content-Type": "application/vnd.ims.lis.v1.score+json"},
         )
 
-    def create_lineitem(
-        self, lineitems_url, resource_link_id, label, score_maximum=100
-    ):
+    def create_line_item(self, resource_link_id, label, score_maximum=100):
         """
-        Create a new lineitem associated to one resource_link_id.
+        Create a new line item associated to one resource_link_id.
 
         https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
 
-        :param lineitems_url: URL of the lineitems container
-        :param resource_link_id: ID of the assignment this lineitem will belong to.
-        :param label: Name for the new lineitem.
-        :param score_maximum: Max score for the grades in the new lineitem.
+        :param resource_link_id: ID of the assignment this line item will belong to.
+        :param label: Name for the new line item.
+        :param score_maximum: Max score for the grades in the new line item.
         """
         payload = {
             "scoreMaximum": score_maximum,
@@ -82,7 +81,7 @@ class LTI13GradingService(LTIGradingService):
         }
         return self._ltia_service.request(
             "POST",
-            lineitems_url,
+            self.line_item_container_url,
             scopes=self.LTIA_SCOPES,
             json=payload,
             headers={"Content-Type": "application/vnd.ims.lis.v2.lineitem+json"},

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -62,6 +62,54 @@ class LTI13GradingService(LTIGradingService):
             headers={"Content-Type": "application/vnd.ims.lis.v1.score+json"},
         )
 
+    def read_lineitems(self, lineitems_url, resource_link_id=None):
+        """
+        Read all the lineitem present in the `lineitems_url` container.
+
+        https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
+
+        :param lineitems_url: URL of the lineitems container
+        :param resource_link_id: Filter lineitems only relevant for this assignment id.
+        """
+        params = {}
+
+        if resource_link_id:
+            params["resource_link_id"] = resource_link_id
+
+        return self._ltia_service.request(
+            "GET",
+            lineitems_url,
+            scopes=self.LTIA_SCOPES,
+            params=params,
+            headers={"Accept": "application/vnd.ims.lis.v2.lineitemcontainer+json"},
+        ).json()
+
+    def create_lineitem(
+        self, lineitems_url, resource_link_id, label, score_maximum=100
+    ):
+        """
+        Create a new lineitem associated to one resource_link_id.
+
+        https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
+
+        :param lineitems_url: URL of the lineitems container
+        :param resource_link_id: ID of the assignment this lineitem will belong to.
+        :param label: Name for the new lineitem.
+        :param score_maximum: Max score for the grades in the new lineitem.
+        """
+        payload = {
+            "scoreMaximum": score_maximum,
+            "label": label,
+            "resourceLinkId": resource_link_id,
+        }
+        return self._ltia_service.request(
+            "POST",
+            lineitems_url,
+            scopes=self.LTIA_SCOPES,
+            json=payload,
+            headers={"Content-Type": "application/vnd.ims.lis.v2.lineitem+json"},
+        ).json()
+
     @staticmethod
     def _service_url(base_url, endpoint):
         """

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -70,7 +70,8 @@ class LTI13GradingService(LTIGradingService):
 
         https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
 
-        :param resource_link_id: ID of the assignment this line item will belong to.
+        :param resource_link_id: ID of the assignment this line item will
+            belong to.
         :param label: Name for the new line item.
         :param score_maximum: Max score for the grades in the new line item.
         """

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -10,12 +10,13 @@ def service_factory(_context, request):
 
     if application_instance.lti_version == "1.3.0":
         return LTI13GradingService(
-            grading_url=request.parsed_params.get("lis_outcome_service_url"),
+            line_item_url=request.parsed_params.get("lis_outcome_service_url"),
+            line_item_container_url=request.lti_params.get("lineitems"),
             ltia_service=request.find_service(LTIAHTTPService),
         )
 
     return LTI11GradingService(
-        grading_url=request.parsed_params.get("lis_outcome_service_url"),
+        line_item_url=request.parsed_params.get("lis_outcome_service_url"),
         http_service=request.find_service(name="http"),
         oauth1_service=request.find_service(name="oauth1"),
     )

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -10,12 +10,12 @@ def service_factory(_context, request):
 
     if application_instance.lti_version == "1.3.0":
         return LTI13GradingService(
-            grading_url=request.parsed_params["lis_outcome_service_url"],
+            grading_url=request.parsed_params.get("lis_outcome_service_url"),
             ltia_service=request.find_service(LTIAHTTPService),
         )
 
     return LTI11GradingService(
-        grading_url=request.parsed_params["lis_outcome_service_url"],
+        grading_url=request.parsed_params.get("lis_outcome_service_url"),
         http_service=request.find_service(name="http"),
         oauth1_service=request.find_service(name="oauth1"),
     )

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -32,14 +32,6 @@ class LTIGradingService:  # pragma: no cover
         """
         raise NotImplementedError()
 
-    def read_lineitems(self, lineitems_url, resource_link_id=None):
-        """
-        Read all the lineitem present in the `lineitems_url` container.
-
-        https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
-        """
-        raise NotImplementedError()
-
     def create_lineitem(self, lineitems_url, resource_link_id, label):
         """
         Create a new lineitem associated to one resource_link_id.

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -31,3 +31,19 @@ class LTIGradingService:  # pragma: no cover
         :raise TypeError: if the given pre_record_hook returns a non-dict
         """
         raise NotImplementedError()
+
+    def read_lineitems(self, lineitems_url, resource_link_id=None):
+        """
+        Read all the lineitem present in the `lineitems_url` container.
+
+        https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
+        """
+        raise NotImplementedError()
+
+    def create_lineitem(self, lineitems_url, resource_link_id, label):
+        """
+        Create a new lineitem associated to one resource_link_id.
+
+        https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
+        """
+        raise NotImplementedError()

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -2,36 +2,41 @@ class LTIGradingService:  # pragma: no cover
     """
     Service for sending grades back to the LMS.
 
-    From https://www.imsglobal.org/spec/lti-ags/v2p0#nomenclature:
+    Line item:
+        A line item is usually a column in the tool platform's gradebook; it is
+        able to hold the results associated with a specific activity
+        (assignment) for a set of users.
 
-    Line item
-        A line item is usually a column in the tool platform's gradebook; it is able to hold the results associated with a specific activity for a set of users.
+    Line item container:
+        A line item container has an array of line items (for a course).
 
-    Line item container
-        A line item container has an array of line items.
+    Result:
+        A result is usually a cell in the tool platform's gradebook; it is
+        unique for a specific line item and user.
 
-    Result
-        A result is usually a cell in the tool platform's gradebook; it is unique for a specific line item and user.
+    Score:
+        A score represents the last score obtained by the student for the
+        tool's activity. It also exposes the current status of the activity
+        (like completed or in progress), and status of the grade.
 
-    Score
-        A score represents the last score obtained by the student for the tool's activity. It also exposes the current status of the activity (like completed or in progress), and status of the grade.
-
-
-    These are the LTI1.3 concepts but with the exception of line item container they have a counter part in LTI 1.1:
+    These are the LTI1.3 concepts, but they have a counter-part in LTI 1.1
+    (except for the line item container):
 
     https://www.imsglobal.org/spec/lti-ags/v2p0#migrating-from-basic-outcomes-service
     """
 
     def __init__(self, line_item_url: str, line_item_container_url: str):
+        """
+        Initialize the service.
+
+        :param line_item_url: Identifies one line item to read/write grades
+            to. In LTI 1.1 this maps to the equivalent
+            `lis_outcome_service_url` parameter.
+        :param line_item_container_url: Identifies a container that might hold
+            many line items
+        """
         self.line_item_url = line_item_url
-        """
-        Identifies one line item to read/write grades to.
-
-        In LTI 1.1 this maps to the equivalent `lis_outcome_service_url` parameter.
-        """
-
         self.line_item_container_url = line_item_container_url
-        """Identifies a container that might hold many line items."""
 
     def read_result(self, grading_id):
         """

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -1,8 +1,37 @@
 class LTIGradingService:  # pragma: no cover
-    """Service for sending grades back to the LMS."""
+    """
+    Service for sending grades back to the LMS.
 
-    def __init__(self, grading_url):
-        self.grading_url = grading_url
+    From https://www.imsglobal.org/spec/lti-ags/v2p0#nomenclature:
+
+    Line item
+        A line item is usually a column in the tool platform's gradebook; it is able to hold the results associated with a specific activity for a set of users.
+
+    Line item container
+        A line item container has an array of line items.
+
+    Result
+        A result is usually a cell in the tool platform's gradebook; it is unique for a specific line item and user.
+
+    Score
+        A score represents the last score obtained by the student for the tool's activity. It also exposes the current status of the activity (like completed or in progress), and status of the grade.
+
+
+    These are the LTI1.3 concepts but with the exception of line item container they have a counter part in LTI 1.1:
+
+    https://www.imsglobal.org/spec/lti-ags/v2p0#migrating-from-basic-outcomes-service
+    """
+
+    def __init__(self, line_item_url: str, line_item_container_url: str):
+        self.line_item_url = line_item_url
+        """
+        Identifies one line item to read/write grades to.
+
+        In LTI 1.1 this maps to the equivalent `lis_outcome_service_url` parameter.
+        """
+
+        self.line_item_container_url = line_item_container_url
+        """Identifies a container that might hold many line items."""
 
     def read_result(self, grading_id):
         """
@@ -32,9 +61,9 @@ class LTIGradingService:  # pragma: no cover
         """
         raise NotImplementedError()
 
-    def create_lineitem(self, lineitems_url, resource_link_id, label):
+    def create_line_item(self, resource_link_id, label):
         """
-        Create a new lineitem associated to one resource_link_id.
+        Create a new line item associated to one resource_link_id.
 
         https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters
         """

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -120,7 +120,7 @@
         {{ settings_text_field("API Client ID", "desire2learn", "client_id") }}
         {{ settings_secret_field("API Client secret", "desire2learn", "client_secret") }}
         {{ settings_checkbox("Groups enabled", "desire2learn", "groups_enabled") }}
-        {{ settings_checkbox("Create grade items", "desire2learn", "create_lineitem") }}
+        {{ settings_checkbox("Create grade items", "desire2learn", "create_line_item") }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -30,12 +30,6 @@
     {% endcall %}
 {% endmacro %}
 
-{% macro settings_textarea(label, setting, sub_setting, field_name, default='') %}
-    {% call macros.field_body(label) %}
-        {% set text = instance.settings.get(setting, sub_setting, default) or ''  %}
-        <textarea class="textarea" name="{{ setting }}.{{ sub_setting }}">{{ text }}</textarea>
-    {% endcall %}
-{% endmacro %}
 
 {% macro settings_secret_field(label, setting, sub_setting, field_name, default='') %}
     {% call macros.field_body(label) %}
@@ -52,14 +46,6 @@
 <form method="POST" action="{{ request.route_url("admin.instance.id", id_=instance.id) }}">
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
-    <fieldset class="box">
-        {{ settings_textarea("Notes", "hypothesis", "notes") }}
-        {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
-        {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
-        {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
-    </fieldset>
-
-
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Organization</legend>
         {{ macros.organization_preview(request, instance.organization) }}
@@ -68,6 +54,12 @@
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Registration</legend>
         {{ macros.registration_preview(request, instance.lti_registration) }}
+    </fieldset>
+
+    <fieldset class="box">
+        {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
+        {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
+        {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
     </fieldset>
 
     <fieldset class="box">
@@ -124,10 +116,11 @@
     </fieldset>
 
     <fieldset class="box">
-        <legend class="label has-text-centered">D2L settings (EXPERIMENTAL)</legend>
+        <legend class="label has-text-centered">D2L settings</legend>
         {{ settings_text_field("API Client ID", "desire2learn", "client_id") }}
         {{ settings_secret_field("API Client secret", "desire2learn", "client_secret") }}
         {{ settings_checkbox("Groups enabled", "desire2learn", "groups_enabled") }}
+        {{ settings_checkbox("Create grade items", "desire2learn", "create_lineitem") }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -302,7 +302,7 @@ class AdminApplicationInstanceViews:
             ("desire2learn", "client_id", str),
             ("desire2learn", "client_secret", aes_secret),
             ("desire2learn", "groups_enabled", bool),
-            ("desire2learn", "create_lineitem", bool),
+            ("desire2learn", "create_line_item", bool),
             ("microsoft_onedrive", "files_enabled", bool),
             ("vitalsource", "enabled", bool),
             ("vitalsource", "user_lti_param", str),

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -302,6 +302,7 @@ class AdminApplicationInstanceViews:
             ("desire2learn", "client_id", str),
             ("desire2learn", "client_secret", aes_secret),
             ("desire2learn", "groups_enabled", bool),
+            ("desire2learn", "create_lineitem", bool),
             ("microsoft_onedrive", "files_enabled", bool),
             ("vitalsource", "enabled", bool),
             ("vitalsource", "user_lti_param", str),

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -66,9 +66,6 @@ class BasicLaunchViews:
                 self.request
             )
         )
-        # Make any product-specific actions after configuring the assignment
-        self.request.product.plugin.misc.post_configure_assignment()
-
         self.request.registry.notify(
             LTIEvent(request=self.request, type=LTIEvent.Type.CONFIGURED_LAUNCH)
         )

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -66,6 +66,9 @@ class BasicLaunchViews:
                 self.request
             )
         )
+        # Make any product-specific actions after configuring the assignment
+        self.request.product.plugin.misc.post_configure_assignment()
+
         self.request.registry.notify(
             LTIEvent(request=self.request, type=LTIEvent.Type.CONFIGURED_LAUNCH)
         )

--- a/tests/unit/lms/product/d2l/_plugin/misc_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/misc_test.py
@@ -1,0 +1,88 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.product.d2l._plugin.misc import D2LMiscPlugin
+from lms.product.product import Settings
+
+
+class TestD2LMiscPlugin:
+    def test_post_configure_assignment(
+        self, plugin, lti_grading_service, pyramid_request
+    ):
+        pyramid_request.lti_params = {
+            "lineitems": sentinel.lineitems,
+            "resource_link_id": sentinel.resource_link_id,
+            "resource_link_title": sentinel.resource_link_title,
+        }
+        # pylint:disable=protected-access
+        plugin._settings.create_lineitem = True
+        lti_grading_service.read_lineitems.return_value = []
+
+        plugin.post_configure_assignment(pyramid_request)
+
+        lti_grading_service.read_lineitems.assert_called_once_with(
+            sentinel.lineitems,
+            sentinel.resource_link_id,
+        )
+        lti_grading_service.create_lineitem.assert_called_once_with(
+            sentinel.lineitems,
+            sentinel.resource_link_id,
+            sentinel.resource_link_title,
+        )
+
+    def test_post_configure_assignment_existing_lineitem(
+        self, plugin, lti_grading_service, pyramid_request
+    ):
+        pyramid_request.lti_params = {
+            "lineitems": sentinel.lineitems,
+            "resource_link_id": sentinel.resource_link_id,
+            "resource_link_title": sentinel.resource_link_title,
+        }
+        # pylint:disable=protected-access
+        plugin._settings.create_lineitem = True
+        lti_grading_service.read_lineitems.return_value = sentinel.lineitem
+
+        plugin.post_configure_assignment(pyramid_request)
+
+        lti_grading_service.read_lineitems.assert_called_once_with(
+            sentinel.lineitems,
+            sentinel.resource_link_id,
+        )
+        lti_grading_service.create_lineitem.assert_not_called()
+
+    def test_post_configure_assignment_create_lineitem_disabled(
+        self, plugin, lti_grading_service, pyramid_request
+    ):
+        plugin.post_configure_assignment(pyramid_request)
+
+        lti_grading_service.read_lineitems.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "create_lineitem,version,expected",
+        [
+            (False, "1.1", False),
+            (False, "1.3.0", False),
+            (True, "1.1", False),
+            (True, "1.3.0", True),
+        ],
+    )
+    def test_is_assignment_gradable(self, plugin, create_lineitem, version, expected):
+        # pylint:disable=protected-access
+        plugin._settings.create_lineitem = create_lineitem
+
+        assert plugin.is_assignment_gradable({"lti_version": version}) == expected
+
+    def test_get_ltia_aud_claim(self, plugin):
+        assert (
+            plugin.get_ltia_aud_claim(sentinel.registration)
+            == "https://api.brightspace.com/auth/token"
+        )
+
+    def test_factory(self, pyramid_request):
+        plugin = D2LMiscPlugin.factory(sentinel.context, pyramid_request)
+        assert isinstance(plugin, D2LMiscPlugin)
+
+    @pytest.fixture
+    def plugin(self):
+        return D2LMiscPlugin(Settings({}))

--- a/tests/unit/lms/product/d2l/_plugin/misc_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/misc_test.py
@@ -15,17 +15,15 @@ class TestD2LMiscPlugin:
             "resource_link_title": sentinel.resource_link_title,
         }
         # pylint:disable=protected-access
-        plugin._create_lineitem = True
+        plugin._create_line_item = True
 
         plugin.post_configure_assignment(pyramid_request)
 
-        lti_grading_service.create_lineitem.assert_called_once_with(
-            sentinel.lineitems,
-            sentinel.resource_link_id,
-            sentinel.resource_link_title,
+        lti_grading_service.create_line_item.assert_called_once_with(
+            sentinel.resource_link_id, sentinel.resource_link_title
         )
 
-    def test_post_configure_assignment_existing_lineitem(
+    def test_post_configure_assignment_gradable_assignment(
         self, plugin, lti_grading_service, pyramid_request
     ):
         pyramid_request.lti_params = {
@@ -35,21 +33,21 @@ class TestD2LMiscPlugin:
             "lis_outcome_service_url": sentinel.lis_outcome_service_url,
         }
         # pylint:disable=protected-access
-        plugin._create_lineitem = True
+        plugin._create_line_item = True
 
         plugin.post_configure_assignment(pyramid_request)
 
-        lti_grading_service.create_lineitem.assert_not_called()
+        lti_grading_service.create_line_item.assert_not_called()
 
-    def test_post_configure_assignment_create_lineitem_disabled(
+    def test_post_configure_assignment_create_line_item_disabled(
         self, plugin, lti_grading_service, pyramid_request
     ):
         plugin.post_configure_assignment(pyramid_request)
 
-        lti_grading_service.create_lineitem.assert_not_called()
+        lti_grading_service.create_line_item.assert_not_called()
 
     @pytest.mark.parametrize(
-        "create_lineitem,version,expected",
+        "create_line_item,version,expected",
         [
             (False, "1.1", False),
             (False, "1.3.0", False),
@@ -57,9 +55,9 @@ class TestD2LMiscPlugin:
             (True, "1.3.0", True),
         ],
     )
-    def test_is_assignment_gradable(self, plugin, create_lineitem, version, expected):
+    def test_is_assignment_gradable(self, plugin, create_line_item, version, expected):
         # pylint:disable=protected-access
-        plugin._create_lineitem = create_lineitem
+        plugin._create_line_item = create_line_item
 
         assert plugin.is_assignment_gradable({"lti_version": version}) == expected
 
@@ -75,4 +73,4 @@ class TestD2LMiscPlugin:
 
     @pytest.fixture
     def plugin(self):
-        return D2LMiscPlugin(create_lineitem=False)
+        return D2LMiscPlugin(create_line_item=False)

--- a/tests/unit/lms/product/d2l/_plugin/misc_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/misc_test.py
@@ -3,7 +3,6 @@ from unittest.mock import sentinel
 import pytest
 
 from lms.product.d2l._plugin.misc import D2LMiscPlugin
-from lms.product.product import Settings
 
 
 class TestD2LMiscPlugin:
@@ -16,15 +15,10 @@ class TestD2LMiscPlugin:
             "resource_link_title": sentinel.resource_link_title,
         }
         # pylint:disable=protected-access
-        plugin._settings.create_lineitem = True
-        lti_grading_service.read_lineitems.return_value = []
+        plugin._create_lineitem = True
 
         plugin.post_configure_assignment(pyramid_request)
 
-        lti_grading_service.read_lineitems.assert_called_once_with(
-            sentinel.lineitems,
-            sentinel.resource_link_id,
-        )
         lti_grading_service.create_lineitem.assert_called_once_with(
             sentinel.lineitems,
             sentinel.resource_link_id,
@@ -38,17 +32,13 @@ class TestD2LMiscPlugin:
             "lineitems": sentinel.lineitems,
             "resource_link_id": sentinel.resource_link_id,
             "resource_link_title": sentinel.resource_link_title,
+            "lis_outcome_service_url": sentinel.lis_outcome_service_url,
         }
         # pylint:disable=protected-access
-        plugin._settings.create_lineitem = True
-        lti_grading_service.read_lineitems.return_value = sentinel.lineitem
+        plugin._create_lineitem = True
 
         plugin.post_configure_assignment(pyramid_request)
 
-        lti_grading_service.read_lineitems.assert_called_once_with(
-            sentinel.lineitems,
-            sentinel.resource_link_id,
-        )
         lti_grading_service.create_lineitem.assert_not_called()
 
     def test_post_configure_assignment_create_lineitem_disabled(
@@ -56,7 +46,7 @@ class TestD2LMiscPlugin:
     ):
         plugin.post_configure_assignment(pyramid_request)
 
-        lti_grading_service.read_lineitems.assert_not_called()
+        lti_grading_service.create_lineitem.assert_not_called()
 
     @pytest.mark.parametrize(
         "create_lineitem,version,expected",
@@ -69,7 +59,7 @@ class TestD2LMiscPlugin:
     )
     def test_is_assignment_gradable(self, plugin, create_lineitem, version, expected):
         # pylint:disable=protected-access
-        plugin._settings.create_lineitem = create_lineitem
+        plugin._create_lineitem = create_lineitem
 
         assert plugin.is_assignment_gradable({"lti_version": version}) == expected
 
@@ -85,4 +75,4 @@ class TestD2LMiscPlugin:
 
     @pytest.fixture
     def plugin(self):
-        return D2LMiscPlugin(Settings({}))
+        return D2LMiscPlugin(create_lineitem=False)

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -84,28 +84,6 @@ class TestLTI13GradingService:
         )
         assert response == ltia_http_service.request.return_value
 
-    @pytest.mark.parametrize(
-        "resource_link_id,params",
-        [
-            (None, {}),
-            (
-                sentinel.resource_link_id,
-                {"resource_link_id": sentinel.resource_link_id},
-            ),
-        ],
-    )
-    def test_read_lineitems(self, svc, ltia_http_service, resource_link_id, params):
-        response = svc.read_lineitems(sentinel.lineitems_url, resource_link_id)
-
-        ltia_http_service.request.assert_called_once_with(
-            "GET",
-            sentinel.lineitems_url,
-            scopes=svc.LTIA_SCOPES,
-            params=params,
-            headers={"Accept": "application/vnd.ims.lis.v2.lineitemcontainer+json"},
-        )
-        assert response == ltia_http_service.request.return_value.json.return_value
-
     def test_create_lineitem(self, svc, ltia_http_service):
         response = svc.create_lineitem(
             sentinel.lineitems_url,

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -84,6 +84,49 @@ class TestLTI13GradingService:
         )
         assert response == ltia_http_service.request.return_value
 
+    @pytest.mark.parametrize(
+        "resource_link_id,params",
+        [
+            (None, {}),
+            (
+                sentinel.resource_link_id,
+                {"resource_link_id": sentinel.resource_link_id},
+            ),
+        ],
+    )
+    def test_read_lineitems(self, svc, ltia_http_service, resource_link_id, params):
+        response = svc.read_lineitems(sentinel.lineitems_url, resource_link_id)
+
+        ltia_http_service.request.assert_called_once_with(
+            "GET",
+            sentinel.lineitems_url,
+            scopes=svc.LTIA_SCOPES,
+            params=params,
+            headers={"Accept": "application/vnd.ims.lis.v2.lineitemcontainer+json"},
+        )
+        assert response == ltia_http_service.request.return_value.json.return_value
+
+    def test_create_lineitem(self, svc, ltia_http_service):
+        response = svc.create_lineitem(
+            sentinel.lineitems_url,
+            sentinel.resource_link_id,
+            sentinel.label,
+            sentinel.score_maximum,
+        )
+
+        ltia_http_service.request.assert_called_once_with(
+            "POST",
+            sentinel.lineitems_url,
+            scopes=svc.LTIA_SCOPES,
+            json={
+                "scoreMaximum": sentinel.score_maximum,
+                "label": sentinel.label,
+                "resourceLinkId": sentinel.resource_link_id,
+            },
+            headers={"Content-Type": "application/vnd.ims.lis.v2.lineitem+json"},
+        )
+        assert response == ltia_http_service.request.return_value.json.return_value
+
     def test_record_result_calls_hook(self, svc, ltia_http_service):
         my_hook = Mock(return_value={"my_dict": 1})
 

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -13,7 +13,7 @@ class TestLTI13GradingService:
     @freeze_time("2022-04-04")
     def test_read_lti_result(self, svc, response, ltia_http_service):
         ltia_http_service.request.return_value.json.return_value = response
-        svc.grading_url = "https://lms.com/lineitems?param=1"
+        svc.line_item_url = "https://lms.com/lineitems?param=1"
 
         score = svc.read_result(sentinel.user_id)
 
@@ -64,7 +64,7 @@ class TestLTI13GradingService:
 
     @freeze_time("2022-04-04")
     def test_record_result(self, svc, ltia_http_service):
-        svc.grading_url = "https://lms.com/lineitems?param=1"
+        svc.line_item_url = "https://lms.com/lineitems?param=1"
 
         response = svc.record_result(sentinel.user_id, sentinel.score)
 
@@ -84,9 +84,8 @@ class TestLTI13GradingService:
         )
         assert response == ltia_http_service.request.return_value
 
-    def test_create_lineitem(self, svc, ltia_http_service):
-        response = svc.create_lineitem(
-            sentinel.lineitems_url,
+    def test_create_line_item(self, svc, ltia_http_service):
+        response = svc.create_line_item(
             sentinel.resource_link_id,
             sentinel.label,
             sentinel.score_maximum,
@@ -94,7 +93,7 @@ class TestLTI13GradingService:
 
         ltia_http_service.request.assert_called_once_with(
             "POST",
-            sentinel.lineitems_url,
+            svc.line_item_container_url,
             scopes=svc.LTIA_SCOPES,
             json={
                 "scoreMaximum": sentinel.score_maximum,
@@ -113,7 +112,7 @@ class TestLTI13GradingService:
         my_hook.assert_called_once_with(request_body=Any.dict(), score=1.5)
         ltia_http_service.request.assert_called_once_with(
             "POST",
-            "http://example.com/service_url/scores",
+            "http://example.com/lineitem/scores",
             scopes=svc.LTIA_SCOPES,
             json={"my_dict": 1},
             headers={"Content-Type": "application/vnd.ims.lis.v1.score+json"},
@@ -134,4 +133,8 @@ class TestLTI13GradingService:
 
     @pytest.fixture
     def svc(self, ltia_http_service):
-        return LTI13GradingService("http://example.com/service_url", ltia_http_service)
+        return LTI13GradingService(
+            "http://example.com/lineitem",
+            "http://example.com/linesitems",
+            ltia_http_service,
+        )

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -37,7 +37,7 @@ class TestFactory:
         svc = service_factory(sentinel.context, pyramid_request)
 
         LTI13GradingService.assert_called_once_with(
-            sentinel.grading_url, ltia_http_service
+            sentinel.grading_url, sentinel.lineitems, ltia_http_service
         )
         assert svc == LTI13GradingService.return_value
 
@@ -46,6 +46,8 @@ class TestFactory:
         pyramid_request.parsed_params = {
             "lis_outcome_service_url": sentinel.grading_url
         }
+        pyramid_request.lti_params = {"lineitems": sentinel.lineitems}
+
         return pyramid_request
 
     @pytest.fixture

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -122,7 +122,6 @@ class TestBasicLaunchViews:
         _show_document.assert_called_once_with(
             document_url=document_url_service.get_document_url.return_value
         )
-
         LTIEvent.assert_called_once_with(
             request=pyramid_request,
             type=LTIEvent.Type.CONFIGURED_LAUNCH,


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4699


Workaround for  a behavior difference in D2L in LTI 1.1 vs 1.3.

In LTI 1.1 creating an assignment also creates the "container" to hold grades for it. In LTI1.3 the container is not created.

The fix is to create it from our end as soon as the assignment is configured. We use a setting/feature flag to control the roll out of the fix and in case D2L changes the behavior again.



## Testing


## LTI 1.1 behavior

- Create a new assignment in https://aunltd.brightspacedemo.com/d2l/le/content/6782/Home
- "Existing activites" -> "External Learning Tools" -> "Create new LTI link " at the bottom 

Use http://localhost:8001/lti_launches for LTI1.1

Finish the setup and launch the assignment. Note the grading bar at the top.

## LTI1.3 (without enabling the new setting)

- Same as in LTI1.1 but use `https://localhost:48001/lti_launches` as the LTI URL and make sure `Hypothesis (https localhost)` is picked as "Tool"
- Open https://localhost:48001/lti/1.3/oidc in a new window and ok the security exception
- Pick a pdf for easier testing https://h.readthedocs.io/_/downloads/client/en/latest/pdf/
- Note that there's no grading bar here.

Now we'll check the manual work around we asked schools to do:

 * Click "Add a grade item..." at the bottom
 * Pick something?
 * Reload the assignment, now you get the grading bar.

## LTI1.3 (with the new setting)

- Enable the new setting (`Create grade items`) over http://localhost:8001/admin/instance/id/106/
- Repeat the assignment creation for LTI1.3 , now the grading bar will show without creating a grade item manually.
- The grade item will show up in the "Assessment" section after a refresh.
