### PR TITLE
Fix product guessing for json request

### DIFF
--- a/lms/product/factory.py
+++ b/lms/product/factory.py
@@ -35,7 +35,7 @@ def _get_family(
         return Product.Family.BLACKBOARD
 
     # If we are in an API request, where we are forwarding the product type ourselves
-    if request.content_type == "application/json":
+    if request.content_type == "application/json" and "lms" in request.json:
         return Product.Family(request.json["lms"]["product"])
 
     # In an LTI launch we'll use the parameters available to guess

--- a/tests/unit/lms/product/factory_test.py
+++ b/tests/unit/lms/product/factory_test.py
@@ -69,6 +69,15 @@ class TestGetProductFromRequest:
         assert product == class_.from_request.return_value
         assert product.family == family
 
+    @pytest.mark.parametrize("value", Product.Family)
+    def test_from_request_api_with_no_key(self, pyramid_request, value):
+        pyramid_request.content_type = "application/json"
+        pyramid_request.json = {"OTHERKEY": {"product": value}}
+
+        assert (
+            get_product_from_request(pyramid_request).family == Product.Family.UNKNOWN
+        )
+
     def test_from_request_canvas_custom(self, pyramid_request, application_instance):
         pyramid_request.lti_params = {"custom_canvas_course_id": "course_id"}
 


### PR DESCRIPTION
Not all JSON request include the product hint we rely on. If not present use the next fallback methods.


This is not a problem in production right now but as we include more product/plugins (eg D2L in follow up PRs) we'll reach for the value of `product.family` in more contexts which might not currently send the hint.

This allows using the next fallback method in the chain. Ideally we'll settle just in one or two methods but that would be bigger PR/refactor.