### PR TITLE
Migrate to Google Identity Services JS client library

### DIFF
--- a/docs/getting-google-credentials.md
+++ b/docs/getting-google-credentials.md
@@ -6,8 +6,7 @@ production environment then you'll need to set up the Google Drive integration
 manually.
 
 The outcome of this process will be a configured Google project and valid
-values for the `GOOGLE_APP_ID`, `GOOGLE_DEVELOPER_KEY` and `GOOGLE_CLIENT_ID`
-environment variables.
+values for the `GOOGLE_DEVELOPER_KEY` and `GOOGLE_CLIENT_ID` environment variables.
 
 ## For Google Drive
 

--- a/lms/config.py
+++ b/lms/config.py
@@ -53,7 +53,6 @@ SETTINGS = (
     _Setting("jwt_secret"),
     _Setting("google_client_id"),
     _Setting("google_developer_key"),
-    _Setting("google_app_id"),
     _Setting("onedrive_client_id"),
     _Setting("lms_secret"),
     # We need to use a randomly generated 16 byte array to encrypt secrets.

--- a/lms/static/scripts/frontend_apps/utils/google-api-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-api-client.js
@@ -1,4 +1,29 @@
 /**
+ * Load the Google Identity Services client library, if not already loaded.
+ *
+ * See https://developers.google.com/identity/oauth2/web/guides/load-3p-authorization-library.
+ *
+ * @return {Promise<typeof window.google.accounts>}
+ */
+export async function loadIdentityServicesLibrary() {
+  if (window.google?.accounts) {
+    return window.google.accounts;
+  }
+
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.onload = () => {
+      resolve(window.google.accounts);
+    };
+    script.onerror = () => {
+      reject(new Error('Failed to load Google Identity Services client'));
+    };
+    document.body.appendChild(script);
+  });
+}
+
+/**
  * Load the Google API loader script (`window.gapi`), if not already loaded.
  */
 async function loadGAPI() {

--- a/lms/static/scripts/frontend_apps/utils/test/google-api-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-api-client-test.js
@@ -1,6 +1,9 @@
-import { loadLibraries } from '../google-api-client';
+import {
+  loadLibraries,
+  loadIdentityServicesLibrary,
+} from '../google-api-client';
 
-describe('loadLibraries', () => {
+describe('google-api-client', () => {
   let dummyScript;
 
   beforeEach(() => {
@@ -14,65 +17,111 @@ describe('loadLibraries', () => {
   afterEach(() => {
     document.createElement.restore();
     dummyScript.remove();
+
+    // Unset globals that Google API scripts would create.
+    delete window.gapi;
+    delete window.google;
   });
 
-  it('loads API script', async () => {
-    // Call `loadLibraries` before `window.gapi` is set. This will cause
-    // it to load the API script first.
-    const libs = loadLibraries(['test']);
-    window.gapi = {
-      load: sinon.stub().callsFake((libs, { callback }) => {
-        callback();
-      }),
-    };
-    // Simulate API script load completing.
-    dummyScript.dispatchEvent(new Event('load'));
-    await libs;
+  describe('loadIdentityServicesLibrary', () => {
+    it('loads API script', async () => {
+      const libPromise = loadIdentityServicesLibrary();
+
+      // Simulate script load completing.
+      window.google = { accounts: {} };
+      dummyScript.dispatchEvent(new Event('load'));
+
+      const lib = await libPromise;
+
+      assert.equal(dummyScript.src, 'https://accounts.google.com/gsi/client');
+      assert.equal(lib, window.google.accounts);
+    });
+
+    it('does not load script if already loaded', async () => {
+      window.google = { accounts: {} };
+      const lib = await loadIdentityServicesLibrary();
+      assert.notCalled(document.createElement);
+      assert.equal(lib, window.google.accounts);
+    });
+
+    it('rejects if API script fails to load', async () => {
+      const lib = loadIdentityServicesLibrary();
+
+      // Simulate script failing to load.
+      dummyScript.onerror();
+
+      let err;
+      try {
+        await lib;
+      } catch (e) {
+        err = e;
+      }
+      assert.equal(
+        err.message,
+        'Failed to load Google Identity Services client'
+      );
+    });
   });
 
-  it('loads requested Google client libraries', async () => {
-    // Set `window.gapi` before calling `loadLibraries` as if API script had
-    // already been loaded.
-    window.gapi = {
-      load: sinon.stub().callsFake((libs, { callback }) => {
-        callback();
-      }),
-    };
-    await loadLibraries(['one', 'two']);
-    assert.calledWith(window.gapi.load, 'one:two');
-  });
-
-  it('rejects if API script fails to load', async () => {
-    const libs = loadLibraries(['one', 'two']);
-
-    // Simulate api.js failing to load.
-    dummyScript.onerror();
-
-    let err;
-    try {
+  describe('loadLibraries', () => {
+    it('loads API script', async () => {
+      // Call `loadLibraries` before `window.gapi` is set. This will cause
+      // it to load the API script first.
+      const libs = loadLibraries(['test']);
+      window.gapi = {
+        load: sinon.stub().callsFake((libs, { callback }) => {
+          callback();
+        }),
+      };
+      // Simulate API script load completing.
+      dummyScript.dispatchEvent(new Event('load'));
       await libs;
-    } catch (e) {
-      err = e;
-    }
-    assert.equal(err.message, 'Failed to load Google API client');
-  });
+    });
 
-  it('rejects if loading requested libraries fails', async () => {
-    window.gapi = {
-      load: sinon.stub().callsFake((libs, { onerror }) => {
-        onerror(new Error('Loading failed'));
-      }),
-    };
+    it('loads requested Google client libraries', async () => {
+      // Set `window.gapi` before calling `loadLibraries` as if API script had
+      // already been loaded.
+      window.gapi = {
+        load: sinon.stub().callsFake((libs, { callback }) => {
+          callback();
+        }),
+      };
+      await loadLibraries(['one', 'two']);
+      assert.calledWith(window.gapi.load, 'one:two');
+    });
 
-    const libs = loadLibraries(['one', 'two']);
-    dummyScript.dispatchEvent(new Event('load'));
-    let err;
-    try {
-      await libs;
-    } catch (e) {
-      err = e;
-    }
+    it('rejects if API script fails to load', async () => {
+      const libs = loadLibraries(['one', 'two']);
 
-    assert.equal(err.message, 'Loading failed');
+      // Simulate api.js failing to load.
+      dummyScript.onerror();
+
+      let err;
+      try {
+        await libs;
+      } catch (e) {
+        err = e;
+      }
+      assert.equal(err.message, 'Failed to load Google API client');
+    });
+
+    it('rejects if loading requested libraries fails', async () => {
+      window.gapi = {
+        load: sinon.stub().callsFake((libs, { onerror }) => {
+          onerror(new Error('Loading failed'));
+        }),
+      };
+
+      const libs = loadLibraries(['one', 'two']);
+      dummyScript.dispatchEvent(new Event('load'));
+      let err;
+      try {
+        await libs;
+      } catch (e) {
+        err = e;
+      }
+
+      assert.equal(err.message, 'Loading failed');
+    });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -155,12 +155,11 @@ describe('GooglePickerClient', () => {
     });
   });
 
-  describe('#showPicker', () => {
+  describe('#requestAuthorization', () => {
     it("requests the user's authorization to access their Google Drive files", async () => {
       const client = createClient();
-      client.showPicker();
 
-      await fakeGoogleLibs.pickerVisible;
+      await client.requestAuthorization();
 
       assert.ok(fakeTokenClient);
       assert.match(fakeTokenClient.config, {
@@ -168,6 +167,29 @@ describe('GooglePickerClient', () => {
         scope: GOOGLE_DRIVE_SCOPE,
       });
       assert.calledOnce(fakeTokenClient.requestAccessToken);
+    });
+
+    it('does nothing if called a second time', async () => {
+      const client = createClient();
+
+      await client.requestAuthorization();
+
+      const tokenClient = fakeTokenClient;
+      await client.requestAuthorization();
+      assert.equal(fakeTokenClient, tokenClient);
+
+      assert.calledOnce(fakeTokenClient.requestAccessToken);
+    });
+  });
+
+  describe('#showPicker', () => {
+    it('requests authorization and sets token used by picker', async () => {
+      const client = createClient();
+      client.showPicker();
+
+      await fakeGoogleLibs.pickerVisible;
+
+      assert.ok(fakeTokenClient);
       const builder = fakeGoogleLibs.picker.api.PickerBuilder();
       assert.calledWith(builder.setOAuthToken, 'the-access-token');
     });

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@types/gapi": "^0.0.43",
+    "@types/google.accounts": "^0.0.4",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.1",
     "axe-core": "^4.5.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ TEST_SETTINGS = {
     "jwt_secret": "test_secret",
     "google_client_id": "fake_client_id",
     "google_developer_key": "fake_developer_key",
-    "google_app_id": "fake_app_id",
     "lms_secret": "TEST_LMS_SECRET",
     "aes_secret": b"TSeQ7E3dzbHgu5ydX2xCrKJiXTmfJbOe",
     "jinja2.filters": {

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ passenv =
     {tests,functests}: PYTEST_ADDOPTS
     dev: DEBUG
     dev: FEATURE_FLAG_*
-    dev: GOOGLE_APP_ID
     dev: GOOGLE_CLIENT_ID
     dev: GOOGLE_DEVELOPER_KEY
     dev: ONEDRIVE_CLIENT_ID

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,6 +1356,11 @@
   resolved "https://registry.yarnpkg.com/@types/gapi/-/gapi-0.0.43.tgz#5291ae831006240e3484bdef3fff8dd69baf5947"
   integrity sha512-GbnoTC1psXR1XlBE76LW0eanE/a56iGUzbUOImEI8/xXHuppdbhhIKX9Z71mTut2XoFADh58PgfRg1cyD7TnTw==
 
+"@types/google.accounts@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@types/google.accounts/-/google.accounts-0.0.4.tgz#e72e7922bb658057e391b1c460fa88dfb292f625"
+  integrity sha512-X42obEgMx+Ptt3RZShgfRNLxGfm9PTLB/zdQkVBYtjnQnbQvTdbU02kZuS6pahp7LA9a5tUxB5vGBnD81SUhjg==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"


### PR DESCRIPTION
Migrate from the "gapi.auth2" module to the [Google Identity Services client library](https://developers.google.com/identity/oauth2/web/reference/js-reference) for getting an access token for use with Google Drive.

This migration fixes a browser console warning about use of deprecated libraries when clicking the "Select PDF from Google Drive" option in the assignment picker:

> Your client application uses libraries for user authentication or authorization that will soon be deprecated. See the [Migration Guide](https://developers.google.com/identity/gsi/web/guides/gis-migration) for more information.

This _may_ resolve https://github.com/hypothesis/lms/issues/4696. I was able to test in Firefox locally but testing the assignment picker in Safari locally is difficult due to mixed-content blocking. We need to do this migration anyway, so my plan is to test in Safari once this lands in QA.

See https://developers.google.com/identity/oauth2/web/guides/migration-to-gis.

**Testing:**

**Before testing this, run `make devdata` to get the latest Google API credentials. See https://github.com/hypothesis/devdata/pull/71.**

Happy path:

1. Create a new assignment and choose "Select PDF from Google Drive"
2. You should be able to authorize Google Drive access and choose a PDF from Google Drive
3. The "...will soon be deprecated" warning message mentioned above should not appear in the browser console.

Popup closure path:

1. Create a new assignment and choose "Select PDF from Google Drive"
2. Close the Google auth popup when it appears
3. The form should reset to its initial state and you should be able to click "Select PDF from Google Drive" again or a different option

I have tested this locally in Chrome and Firefox. Testing in Safari is a pain because Safari doesn't implement the "treat localhost as secure" behavior that Chrome does, and so the assignment creation form doesn't load. My plan is to test in Safari once this lands in QA.