### PR TITLE
Pin to tox<4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install tox
-      run: python -m pip install tox
+      run: python -m pip install 'tox<4'
 
     - name: Checkout git repo
       uses: actions/checkout@v2

--- a/bin/install-python
+++ b/bin/install-python
@@ -40,7 +40,7 @@ do
     # Install tox in this version of Python if it's not already installed.
     if ! "$(pyenv root)/versions/$python_version/bin/tox" --version > /dev/null 2>&1
     then
-        "$(pyenv root)/versions/$python_version/bin/pip" install --quiet --disable-pip-version-check tox > /dev/null
+        "$(pyenv root)/versions/$python_version/bin/pip" install --quiet --disable-pip-version-check 'tox<4' > /dev/null
         pyenv rehash
     fi
 done < .python-version

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = tests
 skipsdist = true
-minversion = 3.16.1
 requires =
+  tox>=3.25.0,<4
   tox-faster
   tox-pyenv
   tox-envfile


### PR DESCRIPTION
The release of tox 4.0.0 to PyPI has broken all our tox commands.

The reason for the breakage is that tox 3.x installs the new tox 4.0.0 in the `.tox/.tox` venv. Breaking changes in tox 4.0.0 then cause problems. In particular tox 4.0.0 breaks compatibility with all tox plugins. Fix this by telling it to install `tox<4`.