### PR TITLE
Migration for lti_role.scope

### DIFF
--- a/lms/migrations/versions/c14193c4afb4_role_scope.py
+++ b/lms/migrations/versions/c14193c4afb4_role_scope.py
@@ -1,0 +1,36 @@
+"""
+Add the scope column to "lti_role".
+
+Revision ID: c14193c4afb4
+Revises: 6eb9de301ac3
+Create Date: 2022-12-08 15:33:11.055578
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c14193c4afb4"
+down_revision = "6eb9de301ac3"
+
+
+def upgrade():
+    op.add_column(
+        "lti_role",
+        sa.Column(
+            "scope",
+            sa.Enum(
+                "course",
+                "institution",
+                "system",
+                name="rolescope",
+                native_enum=False,
+                length=64,
+            ),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("lti_role", "scope")


### PR DESCRIPTION
For:
- https://github.com/hypothesis/lms/issues/4749

Based on the model changes in https://github.com/hypothesis/lms/pull/4738

And split from https://github.com/hypothesis/lms/pull/4641

Adds a new, nullable, column to hold the scope of each role.