### PR TITLE
Roles scope parsing

### DIFF
--- a/lms/models/lti_role.py
+++ b/lms/models/lti_role.py
@@ -54,8 +54,11 @@ class LTIRole(BASE):
     @value.setter
     def value(self, value):
         self._value = value
-        # pylint: disable=protected-access
-        self.scope, self.type = _RoleParser._parse_role(value)
+        self.update_from_value()
+
+    def update_from_value(self):
+        """Set scope and type based on `_value`."""
+        self.scope, self.type = _RoleParser.parse_role(self._value)
 
 
 class _RoleParser:
@@ -126,7 +129,7 @@ class _RoleParser:
     }
 
     @classmethod
-    def _parse_role(cls, role) -> Tuple[RoleScope, RoleType]:
+    def parse_role(cls, role) -> Tuple[RoleScope, RoleType]:
         """Parse roles according to the expected values from the specs."""
         role_parts = {}
         for regex in cls._ROLE_REGEXP:

--- a/lms/models/lti_role.py
+++ b/lms/models/lti_role.py
@@ -99,98 +99,61 @@ class _RoleParser:
 
     @classmethod
     def parse_role(cls, role) -> RoleType:
-        if role := cls._parse_v13_role(role) or cls._parse_v11_role(role):
+        if role := cls._parse_v13_role(role):
             return role
 
         # If we can't match any, pick the most restrictive
         LOG.debug("Can't find role type for %s", role)
         return RoleType.LEARNER
 
-    _V11_INSTRUCTOR_STRINGS = (
-        "instructor",
-        "teachingassistant",
-        "contentdeveloper",
-        "faculty",
-        "mentor",
-        "staff",
-    )
-
-    @classmethod
-    def _parse_v11_role(cls, role) -> RoleType:
-        role = role.lower()
-
-        for string in cls._V11_INSTRUCTOR_STRINGS:
-            if string in role:
-                return RoleType.INSTRUCTOR
-
-        if "learner" in role:
-            return RoleType.LEARNER
-
-        if "admin" in role:
-            return RoleType.ADMIN
-
-        return None
-
-    _V13_PREFIX = "http://purl.imsglobal.org/vocab/lis/v2"
     _V13_ROLE_MAPPINGS = {
-        # https://www.imsglobal.org/spec/lti/v1p3/#lis-vocabulary-for-context-roles
-        # A.2.1 LIS vocabulary for system roles
-        # Core system roles
-        f"{_V13_PREFIX}/system/person#Administrator": RoleType.ADMIN,
-        f"{_V13_PREFIX}/system/person#None": RoleType.LEARNER,
-        # Non‑core system roles
-        f"{_V13_PREFIX}/system/person#AccountAdmin": RoleType.ADMIN,
-        f"{_V13_PREFIX}/system/person#Creator": RoleType.INSTRUCTOR,
-        f"{_V13_PREFIX}/system/person#SysAdmin": RoleType.ADMIN,
-        f"{_V13_PREFIX}/system/person#SysSupport": RoleType.ADMIN,
-        f"{_V13_PREFIX}/system/person#User": RoleType.LEARNER,
-        # A.2.2 LIS vocabulary for institution roles
-        # Core institution roles
-        f"{_V13_PREFIX}/institution/person#Administrator": RoleType.ADMIN,
-        f"{_V13_PREFIX}/institution/person#Faculty": RoleType.INSTRUCTOR,
-        f"{_V13_PREFIX}/institution/person#Guest": RoleType.LEARNER,
-        f"{_V13_PREFIX}/institution/person#None": RoleType.LEARNER,
-        f"{_V13_PREFIX}/institution/person#Other": RoleType.LEARNER,
-        f"{_V13_PREFIX}/institution/person#Staff": RoleType.INSTRUCTOR,
-        f"{_V13_PREFIX}/institution/person#Student": RoleType.LEARNER,
-        # Non‑core institution roles
-        f"{_V13_PREFIX}/institution/person#Alumni": RoleType.LEARNER,
-        f"{_V13_PREFIX}/institution/person#Instructor": RoleType.INSTRUCTOR,
-        f"{_V13_PREFIX}/institution/person#Learner": RoleType.LEARNER,
-        f"{_V13_PREFIX}/institution/person#Member": RoleType.LEARNER,
-        f"{_V13_PREFIX}/institution/person#Mentor": RoleType.INSTRUCTOR,
-        f"{_V13_PREFIX}/institution/person#Observer": RoleType.LEARNER,
-        f"{_V13_PREFIX}/institution/person#ProspectiveStudent": RoleType.LEARNER,
-        # A.2.3 LIS vocabulary for context roles
-        # Core context roles
-        f"{_V13_PREFIX}/membership/Administrator": RoleType.ADMIN,
-        f"{_V13_PREFIX}/membership/ContentDeveloper": RoleType.INSTRUCTOR,
-        f"{_V13_PREFIX}/membership/Instructor": RoleType.INSTRUCTOR,
+        "Administrator": RoleType.ADMIN,
+        "ContentDeveloper": RoleType.INSTRUCTOR,
+        "Instructor": RoleType.INSTRUCTOR,
+        "Learner": RoleType.LEARNER,
         # Look out for this weirdo!
-        f"{_V13_PREFIX}/membership/Learner#Instructor": RoleType.INSTRUCTOR,
-        f"{_V13_PREFIX}/membership/Learner": RoleType.LEARNER,
-        f"{_V13_PREFIX}/membership/Mentor": RoleType.INSTRUCTOR,
-        # Non‑core context roles
-        f"{_V13_PREFIX}/membership/Manager": RoleType.INSTRUCTOR,
-        f"{_V13_PREFIX}/membership/Member": RoleType.LEARNER,
-        f"{_V13_PREFIX}/membership/Office": RoleType.INSTRUCTOR,
+        "Learner#Instructor": RoleType.INSTRUCTOR,
+        "Manager": RoleType.INSTRUCTOR,
+        "Member": RoleType.LEARNER,
+        "Mentor": RoleType.INSTRUCTOR,
+        "Office": RoleType.INSTRUCTOR,
+        "Grader": RoleType.INSTRUCTOR,
+        "Staff": RoleType.INSTRUCTOR,
+        "Faculty": RoleType.INSTRUCTOR,
+        "SysAdmin": RoleType.ADMIN,
+        "TeachingAssistant": RoleType.INSTRUCTOR,
+        "person#AccountAdmin": RoleType.ADMIN,
+        "person#Administrator": RoleType.ADMIN,
+        "person#Alumni": RoleType.LEARNER,
+        "person#Creator": RoleType.INSTRUCTOR,
+        "person#Faculty": RoleType.INSTRUCTOR,
+        "person#Guest": RoleType.LEARNER,
+        "person#Instructor": RoleType.INSTRUCTOR,
+        "person#Learner": RoleType.LEARNER,
+        "person#Member": RoleType.LEARNER,
+        "person#Mentor": RoleType.INSTRUCTOR,
+        "person#None": RoleType.LEARNER,
+        "person#Observer": RoleType.LEARNER,
+        "person#Other": RoleType.LEARNER,
+        "person#ProspectiveStudent": RoleType.LEARNER,
+        "person#Staff": RoleType.INSTRUCTOR,
+        "person#Student": RoleType.LEARNER,
+        "person#SysAdmin": RoleType.ADMIN,
+        "person#SysSupport": RoleType.ADMIN,
+        "person#User": RoleType.LEARNER,
     }
 
     @classmethod
     def _parse_v13_role(cls, role):
         role = role.strip()
+        role_mapping = dict(
+            sorted(
+                cls._V13_ROLE_MAPPINGS.items(), key=lambda x: len(x[0]), reverse=True
+            )
+        )
 
-        # Save some time if we aren't going to match
-        if not role.startswith(cls._V13_PREFIX):
-            return None
-
-        # Try a quick match
-        if type_ := cls._V13_ROLE_MAPPINGS.get(role):
-            return type_
-
-        # Do a thorough prefix match
-        for prefix, type_ in cls._V13_ROLE_MAPPINGS.items():
-            if role.startswith(prefix):
+        for suffix, type_ in role_mapping.items():
+            if role.endswith(suffix):
                 return type_
 
         return None

--- a/lms/services/lti_role_service.py
+++ b/lms/services/lti_role_service.py
@@ -23,6 +23,13 @@ class LTIRoleService:
         # Pylint is confused about the `in_` for some reason
         roles = self._db.query(LTIRole).filter(LTIRole.value.in_(role_strings)).all()
 
+        for role in roles:
+            # Update scope and type.
+            # This is useful when the logic for those fields change, updating
+            # the values in the DB and also exposing the right values in the
+            # rest to the application.
+            role.update_from_value()
+
         if missing := (set(role_strings) - set(role.value for role in roles)):
             new_roles = [LTIRole(value=value) for value in missing]
             self._db.add_all(new_roles)

--- a/tests/unit/lms/models/lti_role_test.py
+++ b/tests/unit/lms/models/lti_role_test.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlalchemy.exc import StatementError
 
-from lms.models.lti_role import LTIRole, RoleType, _RoleParser
+from lms.models.lti_role import LTIRole, RoleType, _RoleParser, RoleScope
 
 
 class TestRoleType:
@@ -50,17 +50,17 @@ class TestRoleType:
             ("urn:lti:sysrole:ims/lis/SysAdmin", RoleType.ADMIN),
         ),
     )
-    def test_parse_lti_role_v11(self, value, role_type):
-        assert RoleType.parse_lti_role(value) == role_type
+    def test_parse_lti_role_type_v11(self, value, role_type):
+        assert RoleType.parse(value) == role_type
+
+    _V13_PREFIX = "http://purl.imsglobal.org/vocab/lis/v2/"
 
     # pylint: disable=protected-access
     @pytest.mark.parametrize(
         "value,role_type", tuple(_RoleParser._V13_ROLE_MAPPINGS.items())
     )
     def test_parse_lti_role_v13_exact_matches(self, value, role_type):
-        assert RoleType.parse_lti_role(value) == role_type
-
-    _V13_PREFIX = "http://purl.imsglobal.org/vocab/lis/v2/"
+        assert RoleType.parse(value) == role_type
 
     @pytest.mark.parametrize(
         "value,role_type",
@@ -83,18 +83,209 @@ class TestRoleType:
     def test_parse_lti_role_v13_prefix_matches(self, value, role_type):
         # "Context roles" can have sub-roles appended to the end. Check we can
         # match these correctly
-        assert RoleType.parse_lti_role(value) == role_type
+        assert RoleType.parse(value) == role_type
 
 
 class TestLTIRole:
     @pytest.mark.parametrize(
-        "value,role_type",
-        (("Learner", RoleType.LEARNER), ("Instructor", RoleType.INSTRUCTOR)),
+        "value,role_type,role_scope",
+        # At the time of writing, this is every role string we've seen
+        [
+            (
+                "urn:lti:instrole:ims/lis/Administrator",
+                RoleType.ADMIN,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "urn:lti:instrole:ims/lis/Alumni",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "urn:lti:instrole:ims/lis/Faculty",
+                RoleType.INSTRUCTOR,
+                RoleScope.INSTITUTION,
+            ),
+            ("urn:lti:instrole:ims/lis/Guest", RoleType.LEARNER, RoleScope.INSTITUTION),
+            (
+                "urn:lti:instrole:ims/lis/Instructor",
+                RoleType.INSTRUCTOR,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "urn:lti:instrole:ims/lis/Learner",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "urn:lti:instrole:ims/lis/Member",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "urn:lti:instrole:ims/lis/Mentor",
+                RoleType.INSTRUCTOR,
+                RoleScope.INSTITUTION,
+            ),
+            ("urn:lti:instrole:ims/lis/None", RoleType.LEARNER, RoleScope.INSTITUTION),
+            (
+                "urn:lti:instrole:ims/lis/Observer",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            ("urn:lti:instrole:ims/lis/Other", RoleType.LEARNER, RoleScope.INSTITUTION),
+            (
+                "urn:lti:instrole:ims/lis/ProspectiveStudent",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "urn:lti:instrole:ims/lis/Staff",
+                RoleType.INSTRUCTOR,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "urn:lti:instrole:ims/lis/Student",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            ("urn:lti:role:ims/lis/Administrator", RoleType.ADMIN, RoleScope.COURSE),
+            (
+                "urn:lti:role:ims/lis/ContentDeveloper",
+                RoleType.INSTRUCTOR,
+                RoleScope.COURSE,
+            ),
+            ("urn:lti:role:ims/lis/Instructor", RoleType.INSTRUCTOR, RoleScope.COURSE),
+            ("urn:lti:role:ims/lis/Learner", RoleType.LEARNER, RoleScope.COURSE),
+            (
+                "urn:lti:role:ims/lis/Learner/GuestLearner",
+                RoleType.LEARNER,
+                RoleScope.COURSE,
+            ),
+            ("urn:lti:role:ims/lis/Mentor", RoleType.INSTRUCTOR, RoleScope.COURSE),
+            (
+                "urn:lti:role:ims/lis/TeachingAssistant",
+                RoleType.INSTRUCTOR,
+                RoleScope.COURSE,
+            ),
+            (
+                "urn:lti:role:ims/lis/TeachingAssistant/Grader",
+                RoleType.INSTRUCTOR,
+                RoleScope.COURSE,
+            ),
+            (
+                "urn:lti:sysrole:ims/lis/Administrator",
+                RoleType.ADMIN,
+                RoleScope.SYSTEM,
+            ),
+            ("urn:lti:sysrole:ims/lis/None", RoleType.LEARNER, RoleScope.SYSTEM),
+            ("urn:lti:sysrole:ims/lis/SysAdmin", RoleType.ADMIN, RoleScope.SYSTEM),
+            ("Administrator", RoleType.ADMIN, RoleScope.COURSE),
+            ("Alumni", RoleType.LEARNER, RoleScope.COURSE),
+            ("ContentDeveloper", RoleType.INSTRUCTOR, RoleScope.COURSE),
+            ("Faculty", RoleType.INSTRUCTOR, RoleScope.COURSE),
+            ("Guest", RoleType.LEARNER, RoleScope.COURSE),
+            ("Instructor", RoleType.INSTRUCTOR, RoleScope.COURSE),
+            ("Learner", RoleType.LEARNER, RoleScope.COURSE),
+            ("Member", RoleType.LEARNER, RoleScope.COURSE),
+            ("Mentor", RoleType.INSTRUCTOR, RoleScope.COURSE),
+            ("Observer", RoleType.LEARNER, RoleScope.COURSE),
+            ("Other", RoleType.LEARNER, RoleScope.COURSE),
+            ("ProspectiveStudent", RoleType.LEARNER, RoleScope.COURSE),
+            ("Staff", RoleType.INSTRUCTOR, RoleScope.COURSE),
+            ("Student", RoleType.LEARNER, RoleScope.COURSE),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator",
+                RoleType.ADMIN,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Alumni",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Faculty",
+                RoleType.INSTRUCTOR,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+                RoleType.INSTRUCTOR,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Staff",
+                RoleType.INSTRUCTOR,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
+                RoleType.LEARNER,
+                RoleScope.INSTITUTION,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator",
+                RoleType.ADMIN,
+                RoleScope.COURSE,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper",
+                RoleType.INSTRUCTOR,
+                RoleScope.COURSE,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+                RoleType.INSTRUCTOR,
+                RoleScope.COURSE,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+                RoleType.LEARNER,
+                RoleScope.COURSE,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/membership#Member",
+                RoleType.LEARNER,
+                RoleScope.COURSE,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor",
+                RoleType.INSTRUCTOR,
+                RoleScope.COURSE,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant",
+                RoleType.INSTRUCTOR,
+                RoleScope.COURSE,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator",
+                RoleType.ADMIN,
+                RoleScope.SYSTEM,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lis/v2/system/person#User",
+                RoleType.LEARNER,
+                RoleScope.SYSTEM,
+            ),
+            (
+                "http://purl.imsglobal.org/vocab/lti/system/person#TestUser",
+                RoleType.LEARNER,
+                RoleScope.SYSTEM,
+            ),
+        ],
     )
-    def test_it_sets_the_type_from_the_value(self, value, role_type):
+    def test_it(self, value, role_type, role_scope):
         lti_role = LTIRole(value=value)
 
         assert lti_role.type == role_type
+        assert lti_role.scope == role_scope
 
     def test_it_converts_type_to_an_enum(self):
         lti_role = LTIRole(type="admin")

--- a/tests/unit/lms/models/lti_role_test.py
+++ b/tests/unit/lms/models/lti_role_test.py
@@ -1,92 +1,12 @@
 import pytest
 from sqlalchemy.exc import StatementError
 
-from lms.models.lti_role import LTIRole, RoleType, _RoleParser, RoleScope
-
-
-class TestRoleType:
-    # At the time of writing, this is every role string we've seen from an
-    # LTI 1.1 LMS
-    @pytest.mark.parametrize(
-        "value,role_type",
-        (
-            ("Administrator", RoleType.ADMIN),
-            ("Alumni", RoleType.LEARNER),
-            ("ContentDeveloper", RoleType.INSTRUCTOR),
-            ("Faculty", RoleType.INSTRUCTOR),
-            ("Guest", RoleType.LEARNER),
-            ("Instructor", RoleType.INSTRUCTOR),
-            ("Learner", RoleType.LEARNER),
-            ("Member", RoleType.LEARNER),
-            ("Mentor", RoleType.INSTRUCTOR),
-            ("None", RoleType.LEARNER),
-            ("Observer", RoleType.LEARNER),
-            ("Other", RoleType.LEARNER),
-            ("ProspectiveStudent", RoleType.LEARNER),
-            ("Staff", RoleType.INSTRUCTOR),
-            ("Student", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/Administrator", RoleType.ADMIN),
-            ("urn:lti:instrole:ims/lis/Alumni", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/Faculty", RoleType.INSTRUCTOR),
-            ("urn:lti:instrole:ims/lis/Guest", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/Instructor", RoleType.INSTRUCTOR),
-            ("urn:lti:instrole:ims/lis/Learner", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/Member", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/Mentor", RoleType.INSTRUCTOR),
-            ("urn:lti:instrole:ims/lis/None", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/Observer", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/Other", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/ProspectiveStudent", RoleType.LEARNER),
-            ("urn:lti:instrole:ims/lis/Staff", RoleType.INSTRUCTOR),
-            ("urn:lti:instrole:ims/lis/Student", RoleType.LEARNER),
-            ("urn:lti:role:ims/lis/ContentDeveloper", RoleType.INSTRUCTOR),
-            ("urn:lti:role:ims/lis/Instructor", RoleType.INSTRUCTOR),
-            ("urn:lti:role:ims/lis/Learner", RoleType.LEARNER),
-            ("urn:lti:role:ims/lis/Mentor", RoleType.INSTRUCTOR),
-            ("urn:lti:role:ims/lis/TeachingAssistant", RoleType.INSTRUCTOR),
-            ("urn:lti:role:ims/lis/TeachingAssistant/Grader", RoleType.INSTRUCTOR),
-            ("urn:lti:sysrole:ims/lis/Administrator", RoleType.ADMIN),
-            ("urn:lti:sysrole:ims/lis/None", RoleType.LEARNER),
-            ("urn:lti:sysrole:ims/lis/SysAdmin", RoleType.ADMIN),
-        ),
-    )
-    def test_parse_lti_role_type_v11(self, value, role_type):
-        assert RoleType.parse(value) == role_type
-
-    _V13_PREFIX = "http://purl.imsglobal.org/vocab/lis/v2/"
-
-    # pylint: disable=protected-access
-    @pytest.mark.parametrize(
-        "value,role_type", tuple(_RoleParser._V13_ROLE_MAPPINGS.items())
-    )
-    def test_parse_lti_role_v13_exact_matches(self, value, role_type):
-        assert RoleType.parse(value) == role_type
-
-    @pytest.mark.parametrize(
-        "value,role_type",
-        (
-            (
-                f"{_V13_PREFIX}membership/Learner#GuestLearner",
-                RoleType.LEARNER,
-            ),
-            (
-                f"{_V13_PREFIX}membership/Learner#Instructor",
-                RoleType.INSTRUCTOR,
-            ),
-            (
-                f"{_V13_PREFIX}membership/Instructor#Lecturer",
-                RoleType.INSTRUCTOR,
-            ),
-            (f"{_V13_PREFIX}membership/WRONG", RoleType.LEARNER),
-        ),
-    )
-    def test_parse_lti_role_v13_prefix_matches(self, value, role_type):
-        # "Context roles" can have sub-roles appended to the end. Check we can
-        # match these correctly
-        assert RoleType.parse(value) == role_type
+from lms.models.lti_role import LTIRole, RoleScope, RoleType
 
 
 class TestLTIRole:
+    _V13_PREFIX = "http://purl.imsglobal.org/vocab/lis/v2/"
+
     @pytest.mark.parametrize(
         "value,role_type,role_scope",
         # At the time of writing, this is every role string we've seen
@@ -195,85 +115,69 @@ class TestLTIRole:
             ("Staff", RoleType.INSTRUCTOR, RoleScope.COURSE),
             ("Student", RoleType.LEARNER, RoleScope.COURSE),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator",
+                f"{_V13_PREFIX}institution/person#Administrator",
                 RoleType.ADMIN,
                 RoleScope.INSTITUTION,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Alumni",
+                f"{_V13_PREFIX}institution/person#Alumni",
                 RoleType.LEARNER,
                 RoleScope.INSTITUTION,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Faculty",
+                f"{_V13_PREFIX}institution/person#Faculty",
                 RoleType.INSTRUCTOR,
                 RoleScope.INSTITUTION,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+                f"{_V13_PREFIX}institution/person#Instructor",
                 RoleType.INSTRUCTOR,
                 RoleScope.INSTITUTION,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner",
+                f"{_V13_PREFIX}institution/person#Learner",
                 RoleType.LEARNER,
                 RoleScope.INSTITUTION,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Staff",
+                f"{_V13_PREFIX}institution/person#Staff",
                 RoleType.INSTRUCTOR,
                 RoleScope.INSTITUTION,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
+                f"{_V13_PREFIX}institution/person#Student",
                 RoleType.LEARNER,
                 RoleScope.INSTITUTION,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator",
+                f"{_V13_PREFIX}membership#Administrator",
                 RoleType.ADMIN,
                 RoleScope.COURSE,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper",
+                f"{_V13_PREFIX}membership#ContentDeveloper",
                 RoleType.INSTRUCTOR,
                 RoleScope.COURSE,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+                f"{_V13_PREFIX}membership#Instructor",
+                RoleType.INSTRUCTOR,
+                RoleScope.COURSE,
+            ),
+            (f"{_V13_PREFIX}membership#Learner", RoleType.LEARNER, RoleScope.COURSE),
+            (f"{_V13_PREFIX}membership#Member", RoleType.LEARNER, RoleScope.COURSE),
+            (f"{_V13_PREFIX}membership#Mentor", RoleType.INSTRUCTOR, RoleScope.COURSE),
+            (
+                f"{_V13_PREFIX}membership/Instructor#TeachingAssistant",
                 RoleType.INSTRUCTOR,
                 RoleScope.COURSE,
             ),
             (
-                "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
-                RoleType.LEARNER,
-                RoleScope.COURSE,
-            ),
-            (
-                "http://purl.imsglobal.org/vocab/lis/v2/membership#Member",
-                RoleType.LEARNER,
-                RoleScope.COURSE,
-            ),
-            (
-                "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor",
-                RoleType.INSTRUCTOR,
-                RoleScope.COURSE,
-            ),
-            (
-                "http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant",
-                RoleType.INSTRUCTOR,
-                RoleScope.COURSE,
-            ),
-            (
-                "http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator",
+                f"{_V13_PREFIX}system/person#Administrator",
                 RoleType.ADMIN,
                 RoleScope.SYSTEM,
             ),
-            (
-                "http://purl.imsglobal.org/vocab/lis/v2/system/person#User",
-                RoleType.LEARNER,
-                RoleScope.SYSTEM,
-            ),
+            (f"{_V13_PREFIX}system/person#User", RoleType.LEARNER, RoleScope.SYSTEM),
             (
                 "http://purl.imsglobal.org/vocab/lti/system/person#TestUser",
                 RoleType.LEARNER,
@@ -286,6 +190,23 @@ class TestLTIRole:
 
         assert lti_role.type == role_type
         assert lti_role.scope == role_scope
+
+    @pytest.mark.parametrize(
+        "value,role_type",
+        (
+            (f"{_V13_PREFIX}membership/Learner#GuestLearner", RoleType.LEARNER),
+            (f"{_V13_PREFIX}membership/Learner#Instructor", RoleType.LEARNER),
+            (f"{_V13_PREFIX}membership/Instructor#Lecturer", RoleType.INSTRUCTOR),
+            (f"{_V13_PREFIX}membership/WRONG", RoleType.LEARNER),
+        ),
+    )
+    def test_parse_lti_role_v13_prefix_matches(self, value, role_type):
+        # We are ignoring the subtype, the spec says:
+
+        # LTI does not classify any of the sub-roles as a core role. Whenever a
+        # platform specifies a sub-role, by best practice it should also
+        # include the associated principal role.
+        assert LTIRole(value=value).type == role_type
 
     def test_it_converts_type_to_an_enum(self):
         lti_role = LTIRole(type="admin")

--- a/tests/unit/lms/services/lti_role_service_test.py
+++ b/tests/unit/lms/services/lti_role_service_test.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from h_matchers import Any
 
-from lms.models import LTIRole
+from lms.models.lti_role import LTIRole, RoleScope, RoleType
 from lms.services.lti_role_service import LTIRoleService, service_factory
 from tests import factories
 
@@ -34,6 +34,18 @@ class TestLTIRoleService:
         roles = svc.get_roles(", ".join([role.value for role in existing_roles]))
 
         assert roles == existing_roles
+
+    def test_get_roles_updates_value(self, svc):
+        # Create a role where the type and scope don't match the value
+        factories.LTIRole(
+            _value="Instructor", type=RoleType.ADMIN, scope=RoleScope.SYSTEM
+        )
+
+        roles = svc.get_roles("Instructor")
+
+        assert len(roles) == 1
+        assert roles[0].type == RoleType.INSTRUCTOR
+        assert roles[0].scope == RoleScope.COURSE
 
     @pytest.fixture
     def svc(self, db_session):


### PR DESCRIPTION
For:
- https://github.com/hypothesis/lms/issues/4749



Introduces the `scope` concept in the LTIRole table and simplifies the parsing.

Note that we don't yet based any authorization decisions on this table but having this here will make that possible.

The plan is to, after we have this out for a little bit,  connect LTIUser with LTIRole and have only one role parsing/checking location in the code base.



## Testing

- Launch any assignment, maybe with both a student and teacher:

https://hypothesis.instructure.com/courses/125/assignments/873


- Check scopes are now in the DB

```tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from lti_role where scope is not null"```

```
 id |   value    |    type    | scope  
----+------------+------------+--------
  7 | Learner    | learner    | course
  4 | Instructor | instructor | course
(2 rows)

```
