### PR TITLE
Simplify `BearerTokenSchema`

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -1,9 +1,10 @@
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from lms.models.h_user import HUser
 
 
-class LTIUser(NamedTuple):
+@dataclass
+class LTIUser:
     """An LTI user."""
 
     user_id: str
@@ -57,6 +58,21 @@ class LTIUser(NamedTuple):
             ),
             email=lti_core_schema["lis_person_contact_email_primary"],
         )
+
+    def _asdict(self) -> dict:
+        """
+        Return a dict representing the LTIUser.
+
+        LTIUser is often serialized. We can pick here the exact representation.
+        """
+        return {
+            "user_id": self.user_id,
+            "roles": self.roles,
+            "tool_consumer_instance_guid": self.tool_consumer_instance_guid,
+            "display_name": self.display_name,
+            "application_instance_id": self.application_instance_id,
+            "email": self.email,
+        }
 
 
 def display_name(given_name, family_name, full_name):

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -59,7 +59,7 @@ class LTIUser:
             email=lti_core_schema["lis_person_contact_email_primary"],
         )
 
-    def _asdict(self) -> dict:
+    def serialize(self) -> dict:
         """
         Return a dict representing the LTIUser.
 

--- a/lms/validation/authentication/__init__.py
+++ b/lms/validation/authentication/__init__.py
@@ -1,10 +1,7 @@
 from lms.validation.authentication._bearer_token import BearerTokenSchema
 from lms.validation.authentication._exceptions import (
-    ExpiredSessionTokenError,
     ExpiredStateParamError,
-    InvalidSessionTokenError,
     InvalidStateParamError,
-    MissingSessionTokenError,
     MissingStateParamError,
 )
 from lms.validation.authentication._lti import LTI11AuthSchema, LTI13AuthSchema

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -70,7 +70,7 @@ class BearerTokenSchema(PyramidRequestSchema):
         self._jwt_service = request.find_service(iface=JWTService)
         self._secret = request.registry.settings["jwt_secret"]
 
-    def authorization_param(self, lti_user):
+    def authorization_param(self, lti_user: LTIUser):
         """
         Return ``lti_user`` serialized into an authorization param.
 
@@ -84,7 +84,7 @@ class BearerTokenSchema(PyramidRequestSchema):
         """
         return self.dump(lti_user)["authorization"]
 
-    def lti_user(self, location):
+    def lti_user(self, location) -> LTIUser:
         """
         Return an models.LTIUser from the request's authorization param.
 
@@ -109,8 +109,6 @@ class BearerTokenSchema(PyramidRequestSchema):
           ``"Bearer <ENCODED_JWT>"`` format.
         :raise ValidationError: if the JWT's payload is invalid, for example if
           it's missing a required parameter
-
-        :rtype: LTIUser
         """
         try:
             return self.parse(location=location)
@@ -172,6 +170,6 @@ class BearerTokenSchema(PyramidRequestSchema):
             ) from err
 
     @marshmallow.post_load
-    def _make_user(self, data, **_kwargs):
+    def _make_user(self, data, **_kwargs) -> LTIUser:
         # See https://marshmallow.readthedocs.io/en/2.x-line/quickstart.html#deserializing-to-objects
         return LTIUser(**data)

--- a/lms/validation/authentication/_exceptions.py
+++ b/lms/validation/authentication/_exceptions.py
@@ -4,25 +4,10 @@ from lms.validation._exceptions import ValidationError
 # ValidationError has a large hierarchy, but we need to inherit from it
 
 __all__ = [
-    "ExpiredSessionTokenError",
-    "MissingSessionTokenError",
-    "InvalidSessionTokenError",
     "MissingStateParamError",
     "ExpiredStateParamError",
     "InvalidStateParamError",
 ]
-
-
-class ExpiredSessionTokenError(ValidationError):
-    """Raised when the request has an expired session token."""
-
-
-class MissingSessionTokenError(ValidationError):
-    """Raised when the request has no session token."""
-
-
-class InvalidSessionTokenError(ValidationError):
-    """Raised when the request has an invalid session token."""
 
 
 class MissingStateParamError(ValidationError):

--- a/lms/validation/authentication/_oauth.py
+++ b/lms/validation/authentication/_oauth.py
@@ -79,7 +79,7 @@ class OAuthCallbackSchema(PyramidRequestSchema):
 
         csrf = secrets.token_hex()
 
-        data = {"user": request.lti_user._asdict(), "csrf": csrf}
+        data = {"user": request.lti_user.serialize(), "csrf": csrf}
 
         jwt_str = self._jwt_service.encode_with_secret(
             data, self._secret, lifetime=timedelta(hours=1)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -138,12 +138,12 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
 
 @pytest.fixture
 def user_is_learner(pyramid_request):
-    pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Learner")
+    pyramid_request.lti_user.roles = "Learner"
 
 
 @pytest.fixture
 def user_is_instructor(pyramid_request):
-    pyramid_request.lti_user = pyramid_request.lti_user._replace(roles="Instructor")
+    pyramid_request.lti_user.roles = "Instructor"
 
 
 def configure_jinja2_assets(config):

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -114,11 +114,10 @@ class TestLTIUserSecurityPolicy:
     def test_identity_when_theres_an_lti_user(
         self, pyramid_request, roles, extra_permissions
     ):
+
+        pyramid_request.lti_user.roles = roles
         policy = LTIUserSecurityPolicy(
-            create_autospec(
-                get_lti_user,
-                return_value=pyramid_request.lti_user._replace(roles=roles),
-            )
+            create_autospec(get_lti_user, return_value=pyramid_request.lti_user)
         )
 
         identity = policy.identity(pyramid_request)

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -32,9 +32,7 @@ class TestApplicationInstanceService:
             service.get_current()
 
     def test_get_current_raises_for_non_existing_id(self, service, pyramid_request):
-        pyramid_request.lti_user = pyramid_request.lti_user._replace(
-            application_instance_id=1000
-        )
+        pyramid_request.lti_user.application_instance_id = 1000
 
         with pytest.raises(ApplicationInstanceNotFound):
             service.get_current()

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -111,9 +111,7 @@ class TestUpsertFromRequest:
             context_id=pyramid_request.params["context_id"],
             resource_link_id=pyramid_request.params["resource_link_id"],
         )
-        pyramid_request.lti_user = pyramid_request.lti_user._replace(
-            display_name="updated_display_name"
-        )
+        pyramid_request.lti_user.display_name = "updated_display_name"
 
         svc.upsert_from_request(pyramid_request)
 

--- a/tests/unit/lms/services/group_info_test.py
+++ b/tests/unit/lms/services/group_info_test.py
@@ -138,5 +138,5 @@ class TestGroupInfoService:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.lti_user = pyramid_request.lti_user._replace(email="test_email")
+        pyramid_request.lti_user.email = "test_email"
         return pyramid_request

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -33,7 +33,7 @@ class TestUserService:
     def test_upsert_user_doesnt_save_personal_details_for_students(
         self, service, lti_user, db_session
     ):
-        lti_user = lti_user._replace(roles="Student")
+        lti_user.roles = "Student"
 
         service.upsert_user(lti_user)
 
@@ -55,7 +55,7 @@ class TestUserService:
     def test_upsert_user_doesnt_save_personal_details_for_existing_students(
         self, service, lti_user, db_session
     ):
-        lti_user = lti_user._replace(roles="Student")
+        lti_user.roles = "Student"
 
         service.upsert_user(lti_user)
 

--- a/tests/unit/lms/validation/authentication/_bearer_token_test.py
+++ b/tests/unit/lms/validation/authentication/_bearer_token_test.py
@@ -19,7 +19,7 @@ class TestBearerTokenSchema:
         authorization_param_value = schema.authorization_param(lti_user)
 
         jwt_service.encode_with_secret.assert_called_once_with(
-            lti_user._asdict(), "test_secret", lifetime=datetime.timedelta(hours=24)
+            lti_user.serialize(), "test_secret", lifetime=datetime.timedelta(hours=24)
         )
         assert (
             authorization_param_value
@@ -101,7 +101,7 @@ class TestBearerTokenSchema:
 
     @pytest.fixture(autouse=True)
     def jwt_service(self, jwt_service, lti_user):
-        jwt_service.decode_with_secret.return_value = lti_user._asdict()
+        jwt_service.decode_with_secret.return_value = lti_user.serialize()
         jwt_service.encode_with_secret.return_value = "ENCODED_JWT"
 
         return jwt_service

--- a/tests/unit/lms/validation/authentication/_oauth_test.py
+++ b/tests/unit/lms/validation/authentication/_oauth_test.py
@@ -25,7 +25,7 @@ class TestOauthCallbackSchema:
 
         secrets.token_hex.assert_called_once_with()
         jwt_service.encode_with_secret.assert_called_once_with(
-            {"user": lti_user._asdict(), "csrf": secrets.token_hex.return_value},
+            {"user": lti_user.serialize(), "csrf": secrets.token_hex.return_value},
             "test_oauth2_state_secret",
             lifetime=datetime.timedelta(hours=1),
         )
@@ -256,6 +256,6 @@ def secrets(patch):
 def jwt_service(jwt_service, lti_user):
     jwt_service.decode_with_secret.return_value = {
         "csrf": "test_csrf",
-        "user": lti_user._asdict(),
+        "user": lti_user.serialize(),
     }
     return jwt_service

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -52,7 +52,7 @@ class TestFilesAPIViews:
 
     @pytest.fixture(params=("instructor", "learner"))
     def with_teacher_or_student(self, request, pyramid_request):
-        pyramid_request.lti_user._replace(roles=request.param)
+        pyramid_request.lti_user.roles = request.param
 
     @pytest.fixture
     def helpers(self, patch):


### PR DESCRIPTION
LTIUser, security policies and marshmallow schemas are all part of various authentication schemes which are all interconnected in sometimes, surprisingly ways.

This PR tries to untangle one of the pieces and simplify one of the marshmallow schemas to be more explicit about the data flow around LTIUser.

LTIUser is now in charge of it's own serialization in both BearerTokenSchema  and OAuthCallbackSchema.


## Testing 

There's no new behavior in this branch but to sanity check the changes make any launch that will use the sync API (which needs to get LTIUser using BearerTokenSchema)


- Launch https://hypothesis.instructure.com/courses/125/assignments/1833 successfully 