### PR TITLE
Make the security policy/path relationship explicit

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -84,7 +84,7 @@ def get_policy(request):
     return UnAutheticatedSecurityPolicy()
 
 
-class UnAutheticatedSecurityPolicy:  # pragma: no cover
+class UnautheticatedSecurityPolicy:  # pragma: no cover
     """Security policy that always returns an unauthenticated user."""
 
     def authenticated_userid(self, _request):

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import create_autospec, patch, sentinel
 
 import pytest
 from pyramid.interfaces import ISecurityPolicy
@@ -16,7 +16,6 @@ from lms.security import (
     get_lti_user_from_bearer_token,
     get_lti_user_from_launch_params,
     get_lti_user_from_oauth_callback,
-    get_policy,
     includeme,
 )
 from lms.validation import ValidationError
@@ -188,50 +187,76 @@ class TestLTIUserSecurityPolicy:
         assert policy.authenticated_userid(pyramid_request) == expected_userid
 
 
-class TestGetPolicy:
+class TestSecurityPolicy:
+    def test_authenticated_userid(self, policy, get_policy, pyramid_request):
+        user_id = policy.authenticated_userid(pyramid_request)
+
+        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.return_value.authenticated_userid.assert_called_once_with(
+            pyramid_request
+        )
+        assert user_id == get_policy.return_value.authenticated_userid.return_value
+
+    def test_identity(self, policy, get_policy, pyramid_request):
+        user_id = policy.identity(pyramid_request)
+
+        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.return_value.identity.assert_called_once_with(pyramid_request)
+        assert user_id == get_policy.return_value.identity.return_value
+
+    def test_permits(self, policy, get_policy, pyramid_request):
+        user_id = policy.permits(pyramid_request, sentinel.context, sentinel.permission)
+
+        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.return_value.permits.assert_called_once_with(
+            pyramid_request, sentinel.context, sentinel.permission
+        )
+        assert user_id == get_policy.return_value.permits.return_value
+
+    def test_remember(self, policy, get_policy, pyramid_request):
+        user_id = policy.remember(
+            pyramid_request, sentinel.userid, kwarg=sentinel.kwargs
+        )
+
+        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.return_value.remember.assert_called_once_with(
+            pyramid_request, sentinel.userid, kwarg=sentinel.kwargs
+        )
+        assert user_id == get_policy.return_value.remember.return_value
+
+    def test_forgets(self, policy, pyramid_request, get_policy):
+        user_id = policy.forget(pyramid_request)
+
+        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.return_value.forget.assert_called_once_with(pyramid_request)
+        assert user_id == get_policy.return_value.forget.return_value
+
     @pytest.mark.parametrize(
-        "route",
+        "path",
         ["/admin", "/admin/instance", "/googleauth"],
     )
-    def test_picks_google_security_policy(
-        self, route, pyramid_request, LMSGoogleSecurityPolicy
-    ):
-        pyramid_request.path = route
-
-        policy = get_policy(pyramid_request)
+    def test_get_policy_google(self, path, LMSGoogleSecurityPolicy):
+        policy = SecurityPolicy.get_policy(path)
 
         assert policy == LMSGoogleSecurityPolicy.return_value
 
     @pytest.mark.parametrize(
-        "path",
-        ["/lti_launches", "/content_item_selection", "/api/gateway/h/lti"],
-    )
-    def test_picks_lti_launches_security_policy(
-        self, path, pyramid_request, LTIUserSecurityPolicy
-    ):
-        pyramid_request.path = path
-
-        policy = get_policy(pyramid_request)
-
-        LTIUserSecurityPolicy.assert_called_once_with(get_lti_user_from_launch_params)
-        assert policy == LTIUserSecurityPolicy.return_value
-
-    @pytest.mark.parametrize(
-        "path",
+        "path,lti_user_getter,",
         [
-            "/canvas_oauth_callback",
-            "/api/blackboard/oauth/callback",
-            "/api/d2l/oauth/callback",
+            ("/lti_launches", get_lti_user_from_launch_params),
+            ("/content_item_selection", get_lti_user_from_launch_params),
+            ("/api/gateway/h/lti", get_lti_user_from_launch_params),
+            ("/canvas_oauth_callback", get_lti_user_from_oauth_callback),
+            ("/api/blackboard/oauth/callback", get_lti_user_from_oauth_callback),
+            ("/api/d2l/oauth/callback", get_lti_user_from_oauth_callback),
         ],
     )
-    def test_picks_lti_launches_with_oauth_callback(
-        self, path, pyramid_request, LTIUserSecurityPolicy
+    def test_get_policy_lti_user(
+        self, path, lti_user_getter, policy, LTIUserSecurityPolicy
     ):
-        pyramid_request.path = path
+        policy = policy.get_policy(path)
 
-        policy = get_policy(pyramid_request)
-
-        LTIUserSecurityPolicy.assert_called_once_with(get_lti_user_from_oauth_callback)
+        LTIUserSecurityPolicy.assert_called_once_with(lti_user_getter)
         assert policy == LTIUserSecurityPolicy.return_value
 
     @pytest.mark.parametrize(
@@ -245,11 +270,9 @@ class TestGetPolicy:
         ],
     )
     def test_picks_lti_launches_with_bearer_token(
-        self, path, location, pyramid_request, LTIUserSecurityPolicy
+        self, path, location, LTIUserSecurityPolicy, policy
     ):
-        pyramid_request.path = path
-
-        policy = get_policy(pyramid_request)
+        policy = policy.get_policy(path)
 
         LTIUserSecurityPolicy.assert_called_once()
         # Can't compare functions directly, discussion: https://bugs.python.org/issue3564
@@ -258,76 +281,28 @@ class TestGetPolicy:
         assert call_args[0].func.__name__ == "get_lti_user_from_bearer_token"
         assert policy == LTIUserSecurityPolicy.return_value
 
-    def test_unauthorized_policy(self, pyramid_request, UnAutheticatedSecurityPolicy):
-        pyramid_request.path = "/unknown"
+    def test_unauthorized_policy(self, UnautheticatedSecurityPolicy, policy):
+        policy = policy.get_policy("/unknown")
 
-        policy = get_policy(pyramid_request)
-
-        UnAutheticatedSecurityPolicy.assert_called_once()
-        assert policy == UnAutheticatedSecurityPolicy.return_value
-
-    @pytest.fixture(autouse=True)
-    def LMSGoogleSecurityPolicy(self, patch):
-        return patch("lms.security.LMSGoogleSecurityPolicy")
+        UnautheticatedSecurityPolicy.assert_called_once()
+        assert policy == UnautheticatedSecurityPolicy.return_value
 
     @pytest.fixture(autouse=True)
     def LTIUserSecurityPolicy(self, patch):
         return patch("lms.security.LTIUserSecurityPolicy")
 
     @pytest.fixture(autouse=True)
-    def UnAutheticatedSecurityPolicy(self, patch):
-        return patch("lms.security.UnAutheticatedSecurityPolicy")
+    def LMSGoogleSecurityPolicy(self, patch):
+        return patch("lms.security.LMSGoogleSecurityPolicy")
 
-
-class TestSecurityPolicy:
-    def test_authenticated_userid(self, policy, get_policy):
-        user_id = policy.authenticated_userid(sentinel.request)
-
-        get_policy.assert_called_once_with(sentinel.request)
-        get_policy.return_value.authenticated_userid.assert_called_once_with(
-            sentinel.request
-        )
-        assert user_id == get_policy.return_value.authenticated_userid.return_value
-
-    def test_identity(self, policy, get_policy):
-        user_id = policy.identity(sentinel.request)
-
-        get_policy.assert_called_once_with(sentinel.request)
-        get_policy.return_value.identity.assert_called_once_with(sentinel.request)
-        assert user_id == get_policy.return_value.identity.return_value
-
-    def test_permits(self, policy, get_policy):
-        user_id = policy.permits(
-            sentinel.request, sentinel.context, sentinel.permission
-        )
-
-        get_policy.assert_called_once_with(sentinel.request)
-        get_policy.return_value.permits.assert_called_once_with(
-            sentinel.request, sentinel.context, sentinel.permission
-        )
-        assert user_id == get_policy.return_value.permits.return_value
-
-    def test_remember(self, policy, get_policy):
-        user_id = policy.remember(
-            sentinel.request, sentinel.userid, kwarg=sentinel.kwargs
-        )
-
-        get_policy.assert_called_once_with(sentinel.request)
-        get_policy.return_value.remember.assert_called_once_with(
-            sentinel.request, sentinel.userid, kwarg=sentinel.kwargs
-        )
-        assert user_id == get_policy.return_value.remember.return_value
-
-    def test_forgets(self, policy, pyramid_request, get_policy):
-        user_id = policy.forget(pyramid_request)
-
-        get_policy.assert_called_once_with(pyramid_request)
-        get_policy.return_value.forget.assert_called_once_with(pyramid_request)
-        assert user_id == get_policy.return_value.forget.return_value
+    @pytest.fixture(autouse=True)
+    def UnautheticatedSecurityPolicy(self, patch):
+        return patch("lms.security.UnautheticatedSecurityPolicy")
 
     @pytest.fixture
-    def get_policy(self, patch):
-        return patch("lms.security.get_policy")
+    def get_policy(self, policy):
+        with patch.object(policy, "get_policy") as get_policy:
+            yield get_policy
 
     @pytest.fixture
     def policy(self):

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, create_autospec, sentinel
+from unittest.mock import create_autospec, sentinel
 
 import pytest
 from pyramid.interfaces import ISecurityPolicy
@@ -13,7 +13,9 @@ from lms.security import (
     SecurityPolicy,
     _get_user,
     get_lti_user,
+    get_lti_user_from_bearer_token,
     get_lti_user_from_launch_params,
+    get_lti_user_from_oauth_callback,
     get_policy,
     includeme,
 )
@@ -214,16 +216,55 @@ class TestGetPolicy:
         LTIUserSecurityPolicy.assert_called_once_with(get_lti_user_from_launch_params)
         assert policy == LTIUserSecurityPolicy.return_value
 
-    @pytest.mark.parametrize("path", ["/", "/api/canvas"])
-    def test_picks_default_lti_user_security_policy(
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/canvas_oauth_callback",
+            "/api/blackboard/oauth/callback",
+            "/api/d2l/oauth/callback",
+        ],
+    )
+    def test_picks_lti_launches_with_oauth_callback(
         self, path, pyramid_request, LTIUserSecurityPolicy
     ):
         pyramid_request.path = path
 
         policy = get_policy(pyramid_request)
 
-        LTIUserSecurityPolicy.assert_called_once_with(get_lti_user)
+        LTIUserSecurityPolicy.assert_called_once_with(get_lti_user_from_oauth_callback)
         assert policy == LTIUserSecurityPolicy.return_value
+
+    @pytest.mark.parametrize(
+        "path,location",
+        [
+            ("/api/canvas/authorize", "querystring"),
+            ("/api/d2l/authorize", "querystring"),
+            ("/api/canvas/files", "headers"),
+            ("/api/blackboard/groups", "headers"),
+            ("/assignment", "form"),
+        ],
+    )
+    def test_picks_lti_launches_with_bearer_token(
+        self, path, location, pyramid_request, LTIUserSecurityPolicy
+    ):
+        pyramid_request.path = path
+
+        policy = get_policy(pyramid_request)
+
+        LTIUserSecurityPolicy.assert_called_once()
+        # Can't compare functions directly, discussion: https://bugs.python.org/issue3564
+        call_args = LTIUserSecurityPolicy.call_args_list[0].args
+        assert call_args[0].keywords == {"location": location}
+        assert call_args[0].func.__name__ == "get_lti_user_from_bearer_token"
+        assert policy == LTIUserSecurityPolicy.return_value
+
+    def test_unauthorized_policy(self, pyramid_request, UnAutheticatedSecurityPolicy):
+        pyramid_request.path = "/unknown"
+
+        policy = get_policy(pyramid_request)
+
+        UnAutheticatedSecurityPolicy.assert_called_once()
+        assert policy == UnAutheticatedSecurityPolicy.return_value
 
     @pytest.fixture(autouse=True)
     def LMSGoogleSecurityPolicy(self, patch):
@@ -232,6 +273,10 @@ class TestGetPolicy:
     @pytest.fixture(autouse=True)
     def LTIUserSecurityPolicy(self, patch):
         return patch("lms.security.LTIUserSecurityPolicy")
+
+    @pytest.fixture(autouse=True)
+    def UnAutheticatedSecurityPolicy(self, patch):
+        return patch("lms.security.UnAutheticatedSecurityPolicy")
 
 
 class TestSecurityPolicy:
@@ -290,7 +335,7 @@ class TestSecurityPolicy:
 
 
 @pytest.mark.usefixtures("user_service")
-class TestGetLaunchesLTIUser:
+class TestGetLTIUserFromLaunchParams:
     def test_it_with_lti11(self, LTI11AuthSchema, lti11_auth_schema, pyramid_request):
         lti_user = get_lti_user_from_launch_params(pyramid_request)
 
@@ -322,104 +367,13 @@ class TestGetLaunchesLTIUser:
 
 
 @pytest.mark.usefixtures("user_service")
-class TestGetLTIUser:
-    def test_it_returns_LTIUsers_from_authorization_headers(
-        self, BearerTokenSchema, bearer_token_schema, pyramid_request
-    ):
-        lti_user = get_lti_user(pyramid_request)
+class TestGetLTIUserFromBearerToken:
+    def test_it(self, BearerTokenSchema, bearer_token_schema, pyramid_request):
+        lti_user = get_lti_user_from_bearer_token(pyramid_request, sentinel.location)
 
         BearerTokenSchema.assert_called_once_with(pyramid_request)
-        bearer_token_schema.lti_user.assert_called_once_with(location="headers")
+        bearer_token_schema.lti_user.assert_called_once_with(location=sentinel.location)
         assert lti_user == bearer_token_schema.lti_user.return_value
-
-    def test_it_returns_LTIUsers_from_authorization_query_string_params(
-        self, bearer_token_schema, pyramid_request
-    ):
-        lti_user = factories.LTIUser()
-        bearer_token_schema.lti_user.side_effect = [
-            ValidationError(["TEST_ERROR_MESSAGE"]),
-            lti_user,
-            ValidationError(["TEST_ERROR_MESSAGE"]),
-        ]
-
-        returned_lti_user = get_lti_user(pyramid_request)
-
-        assert bearer_token_schema.lti_user.call_args_list == [
-            call(location="headers"),
-            call(location="querystring"),
-        ]
-        assert returned_lti_user == lti_user
-
-    def test_it_returns_LTIUsers_from_authorization_form_fields(
-        self, bearer_token_schema, pyramid_request
-    ):
-        lti_user = factories.LTIUser()
-        bearer_token_schema.lti_user.side_effect = [
-            ValidationError(["TEST_ERROR_MESSAGE"]),
-            ValidationError(["TEST_ERROR_MESSAGE"]),
-            lti_user,
-        ]
-
-        returned_lti_user = get_lti_user(pyramid_request)
-
-        assert bearer_token_schema.lti_user.call_args_list == [
-            call(location="headers"),
-            call(location="querystring"),
-            call(location="form"),
-        ]
-        assert returned_lti_user == lti_user
-
-    def test_it_returns_LTIUsers_from_OAuth2_state_params(
-        self,
-        bearer_token_schema,
-        OAuthCallbackSchema,
-        oauth_callback_schema,
-        pyramid_request,
-    ):
-        bearer_token_schema.lti_user.side_effect = ValidationError(
-            ["TEST_ERROR_MESSAGE"]
-        )
-
-        lti_user = get_lti_user(pyramid_request)
-
-        OAuthCallbackSchema.assert_called_once_with(pyramid_request)
-        oauth_callback_schema.lti_user.assert_called_once_with()
-        assert lti_user == oauth_callback_schema.lti_user.return_value
-
-    def test_it_returns_None_if_all_schemas_fail(
-        self, bearer_token_schema, oauth_callback_schema, pyramid_request
-    ):
-        bearer_token_schema.lti_user.side_effect = ValidationError(
-            ["TEST_ERROR_MESSAGE"]
-        )
-        oauth_callback_schema.lti_user.side_effect = ValidationError(
-            ["TEST_ERROR_MESSAGE"]
-        )
-
-        assert get_lti_user(pyramid_request) is None
-
-    def test_it_stores_the_user(
-        self, pyramid_request, user_service, bearer_token_schema
-    ):
-        get_lti_user(pyramid_request)
-
-        user_service.upsert_user.assert_called_once_with(
-            bearer_token_schema.lti_user.return_value
-        )
-
-    @pytest.mark.usefixtures("pyramid_request_with_identity")
-    def test_it_picks_lit_user_from_identity(self, pyramid_request):
-        lti_user = get_lti_user(pyramid_request, from_identity=True)
-
-        assert lti_user == sentinel.lti_user
-
-    @pytest.fixture
-    def pyramid_request_with_identity(self, pyramid_config, pyramid_request):
-        pyramid_config.testing_securitypolicy(
-            userid=sentinel.userid,
-            identity=Identity(sentinel.userid, sentinel.permissions, sentinel.lti_user),
-        )
-        return pyramid_request
 
     @pytest.fixture(autouse=True)
     def BearerTokenSchema(self, patch):
@@ -429,6 +383,15 @@ class TestGetLTIUser:
     def bearer_token_schema(self, BearerTokenSchema):
         return BearerTokenSchema.return_value
 
+
+@pytest.mark.usefixtures("user_service")
+class TestGetLTIUserFromOauthCallback:
+    def test_it(self, OAuthCallbackSchema, oauth_callback_schema, pyramid_request):
+        lti_user = get_lti_user_from_oauth_callback(pyramid_request)
+
+        OAuthCallbackSchema.assert_called_once_with(pyramid_request)
+        assert lti_user == oauth_callback_schema.lti_user.return_value
+
     @pytest.fixture(autouse=True)
     def OAuthCallbackSchema(self, patch):
         return patch("lms.security.OAuthCallbackSchema")
@@ -436,6 +399,29 @@ class TestGetLTIUser:
     @pytest.fixture
     def oauth_callback_schema(self, OAuthCallbackSchema):
         return OAuthCallbackSchema.return_value
+
+
+@pytest.mark.usefixtures("user_service")
+class TestGetLTIUser:
+    @pytest.mark.usefixtures("pyramid_request_with_identity")
+    def test_it(self, pyramid_request, user_service):
+        lti_user = get_lti_user(pyramid_request)
+
+        assert lti_user == sentinel.lti_user
+        user_service.upsert_user.assert_called_once_with(sentinel.lti_user)
+
+    def test_it_when_no_lti_user(self, pyramid_request):
+        lti_user = get_lti_user(pyramid_request)
+
+        assert not lti_user
+
+    @pytest.fixture
+    def pyramid_request_with_identity(self, pyramid_config, pyramid_request):
+        pyramid_config.testing_securitypolicy(
+            userid=sentinel.userid,
+            identity=Identity(sentinel.userid, sentinel.permissions, sentinel.lti_user),
+        )
+        return pyramid_request
 
 
 class TestGetUser:


### PR DESCRIPTION
Instead of trying different locations in succession explicitly have a one to one relationship between security policy and the current path.


## Testing

#### path.startswith("/googleauth") LMSGoogleSecurityPolicy 

Google oauth routes

Go to http://localhost:8001/admin and logout (or follow the auth flow if not already logged in)


#### path.startswith("/admin") LMSGoogleSecurityPolicy 

Auth in all the admin pages

Navigate around http://localhost:8001/admin

#### /content_item_selection LTIUserSecurityPolicy(get_lti_user_from_launch_params) 

Display the configure assignment screen in non-deeplinking LMS's. 

Reconfigure https://hypothesis.instructure.com/courses/125/assignments/3930


#### /lti_launches LTIUserSecurityPolicy(get_lti_user_from_launch_params) 

Regular launch in all LMS's

Launch https://hypothesis.instructure.com/courses/125/assignments/3930

#### /api/*/authorize LTIUserSecurityPolicy ("querystring")
#### /canvas_oauth_callback LTIUserSecurityPolicy(get_lti_user_from_oauth_callback)

Oauth flow in canvas

`make sql` and then `truncate oauth2_token ;`

then re-launch Launch https://hypothesis.instructure.com/courses/125/assignments/3930
 and complete the oauth flow.


#### /api/*/authorize LTIUserSecurityPolicy ("querystring")
#### /api/blackboard/oauth/callback LTIUserSecurityPolicy(get_lti_user_from_oauth_callback)

Oauth flow in blackboard

Launch 
https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1

and pick "Blackboard files", complete the oauth flow.

#### /api/*/authorize LTIUserSecurityPolicy ("querystring")
#### /api/d2l/oauth/callback  LTIUserSecurityPolicy(get_lti_user_from_oauth_callback)

Oauth flow in D2L

Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2177/View

pick D2L files and complete the oauth flow.


#### /api/* LTIUserSecurityPolicy ("headers")

Auth between the LMS backend and frontend for our internal API

Launch https://hypothesis.instructure.com/courses/125/assignments/873

The /api/sync request contains the auth header.

#### /lti/1.3/deep_linking/form_fields LTIUserSecurityPolicy ("headers")

Finishing configuration in deep linking LMS's (1.3)

Reconfigure https://hypothesis.instructure.com/courses/319/assignments/2988/edit?name=No+grade+LTI1.3&due_at=null&points_possible=10

#### /lti/1.1/deep_linking/form_fields LTIUserSecurityPolicy ("headers")

Finishing configuration in deep linking LMS's (1.1)

Reconfigure https://hypothesis.instructure.com/courses/125/assignments/3930/edit?name=Marcos+Assignment&due_at=null&points_possible=0


#### /assignment LTIUserSecurityPolicy ("form")

Configuration in non-deeplinking LMS's

Reconfigure https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1
