### PR TITLE
Add non-recursive group counts for replies and shared annotations

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/04_activity_counts/01_group_activity/01_create_view.jinja2.sql
+++ b/lms/data_tasks/report/create_from_scratch/04_activity_counts/01_group_activity/01_create_view.jinja2.sql
@@ -3,15 +3,39 @@ DROP MATERIALIZED VIEW IF EXISTS report.group_activity CASCADE;
 -- A weekly count of groups with annotation activity
 
 CREATE MATERIALIZED VIEW report.group_activity AS (
+    WITH
+        launch_counts AS (
+            SELECT
+                DATE_TRUNC('week', timestamp)::DATE as timestamp_week,
+                group_id,
+                COUNT(1) AS launch_count
+            FROM report.group_map
+            -- Our rolled up events counts table is rolled by by org and user
+            -- which means we can't easily re-use if for groups. Not sure
+            -- that's avoidable really. It can't be rolled up with everything
+            -- without becoming the event table again. Regardless this is slow
+            JOIN event ON
+                event.course_id = group_map.lms_grouping_id
+                OR event.grouping_id = group_map.lms_grouping_id
+            JOIN event_type ON
+                event_type.id = event.type_id
+                AND event_type.type = 'configured_launch'
+            GROUP BY timestamp_week, group_id
+        )
+
     SELECT
-        created_week,
-        group_id,
-        count AS annotation_count,
-        shared AS annotation_shared_count,
-        replies AS annotation_replies_count
+        annotation_group_counts.created_week,
+        annotation_group_counts.group_id,
+        annotation_group_counts.count AS annotation_count,
+        annotation_group_counts.shared AS annotation_shared_count,
+        annotation_group_counts.replies AS annotation_replies_count,
+        COALESCE(launch_counts.launch_count, 0) AS launch_count
     FROM h.annotation_group_counts
     JOIN h.authorities ON
         annotation_group_counts.authority_id = authorities.id
         AND authorities.authority = '{{ region.authority }}'
         -- AND authorities.authority = 'lms.hypothes.is'
+    LEFT OUTER JOIN launch_counts ON
+        launch_counts.group_id = annotation_group_counts.group_id
+        AND launch_counts.timestamp_week = annotation_group_counts.created_week
 ) WITH NO DATA;

--- a/lms/data_tasks/report/create_from_scratch/04_activity_counts/01_group_activity/01_create_view.jinja2.sql
+++ b/lms/data_tasks/report/create_from_scratch/04_activity_counts/01_group_activity/01_create_view.jinja2.sql
@@ -6,7 +6,9 @@ CREATE MATERIALIZED VIEW report.group_activity AS (
     SELECT
         created_week,
         group_id,
-        count AS annotation_count
+        count AS annotation_count,
+        shared AS annotation_shared_count,
+        replies AS annotation_replies_count
     FROM h.annotation_group_counts
     JOIN h.authorities ON
         annotation_group_counts.authority_id = authorities.id


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/119

This adds the following metrics to the group counts table:

 * annotation_shared_count
 * annotation_replies_count
 * launch_count
 
This doesn't do anything on it's own, but will help with what we need to deliver.