### PR TITLE
D2L files: Authorization and API endpoints

### DIFF
--- a/lms/product/product.py
+++ b/lms/product/product.py
@@ -47,11 +47,15 @@ class Settings:
     groups_enabled: bool = False
     """Is the course groups feature enabled"""
 
+    files_enabled: bool = False
+    """Is this product files feature enabled"""
+
     custom: Optional[dict] = None
     """Other non-standard settings."""
 
     def __post_init__(self, product_settings):
         self.groups_enabled = product_settings.get("groups_enabled", False)
+        self.files_enabled = product_settings.get("files_enabled", False)
         self.custom = product_settings
 
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -221,6 +221,7 @@ class JSConfig:
                     "ltiLaunchUrl": self._request.route_url("lti_launches"),
                     # Specific config for pickers
                     "blackboard": FilePickerConfig.blackboard_config(*args),
+                    "d2l": FilePickerConfig.d2l_config(*args),
                     "canvas": FilePickerConfig.canvas_config(*args),
                     "google": FilePickerConfig.google_files_config(*args),
                     "microsoftOneDrive": FilePickerConfig.microsoft_onedrive(*args),

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -1,11 +1,29 @@
 from lms.product import Product
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
+from lms.product.d2l import D2L
 from lms.services import JSTORService, VitalSourceService
 
 
 class FilePickerConfig:
     """Config generation for specific file pickers."""
+
+    @classmethod
+    def d2l_config(cls, request, _application_instance):
+        """Get D2L files config."""
+        files_enabled = request.product.settings.files_enabled
+
+        config = {"enabled": files_enabled}
+        if files_enabled:
+            config["listFiles"] = {
+                "authUrl": request.route_url(D2L.route.oauth2_authorize),
+                "path": request.route_path(
+                    "d2l_api.courses.files.list",
+                    course_id=request.lti_params.get("context_id"),
+                ),
+            }
+
+        return config
 
     @classmethod
     def blackboard_config(cls, request, application_instance):

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -52,6 +52,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "d2l_api.courses.group_sets.list", "/api/d2l/courses/{course_id}/group_sets"
     )
+    config.add_route("d2l_api.courses.files.list", "/api/d2l/courses/{course_id}/files")
 
     config.add_route(
         "blackboard_api.oauth.authorize",

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -18,7 +18,7 @@ import URLPicker from './URLPicker';
  *
  * @typedef {import('./FilePickerApp').ErrorInfo} ErrorInfo
  *
- * @typedef {'blackboardFile'|'canvasFile'|'jstor'|'url'|'vitalSourceBook'|null} DialogType
+ * @typedef {'blackboardFile'|'canvasFile'|'d2lFile'|'jstor'|'url'|'vitalSourceBook'|null} DialogType
  *
  * @typedef {import('../utils/content-item').Content} Content
  */
@@ -47,6 +47,7 @@ export default function ContentSelector({
         enabled: blackboardFilesEnabled,
         listFiles: blackboardListFilesApi,
       },
+      d2l: { enabled: d2lFilesEnabled, listFiles: d2lListFilesApi },
       canvas: { enabled: canvasFilesEnabled, listFiles: listFilesApi },
       google: {
         clientId: googleClientId,
@@ -130,6 +131,13 @@ export default function ContentSelector({
     onSelectContent({ type: 'url', url: file.id });
   };
 
+  /** @param {File} file */
+  const selectD2LFile = file => {
+    cancelDialog();
+    // file.id shall be a url of the form d2l://content-resource/{file_id}
+    onSelectContent({ type: 'url', url: file.id });
+  };
+
   /**
    * @param {Book} book
    * @param {Chapter} chapter
@@ -172,6 +180,19 @@ export default function ContentSelector({
         />
       );
       break;
+    case 'd2lFile':
+      dialog = (
+        <LMSFilePicker
+          authToken={authToken}
+          listFilesApi={d2lListFilesApi}
+          onCancel={cancelDialog}
+          onSelectFile={selectD2LFile}
+          missingFilesHelpLink={'https://web.hypothes.is/help-categories/d2l/'}
+          withBreadcrumbs
+        />
+      );
+      break;
+
     case 'jstor':
       dialog = <JSTORPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
       break;
@@ -255,6 +276,15 @@ export default function ContentSelector({
               data-testid="blackboard-file-button"
             >
               Select PDF from Blackboard
+            </LabeledButton>
+          )}
+          {d2lFilesEnabled && (
+            <LabeledButton
+              onClick={() => selectDialog('d2lFile')}
+              variant="primary"
+              data-testid="d2l-file-button"
+            >
+              Select PDF from D2L
             </LabeledButton>
           )}
           {googlePicker && (

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -56,6 +56,9 @@ function formatContentURL(content) {
   if (content.url.startsWith('blackboard://')) {
     return 'PDF file in Blackboard';
   }
+  if (content.url.startsWith('d2l://')) {
+    return 'PDF file in D2L';
+  }
   if (content.url.startsWith('vitalsource://')) {
     return 'Book from VitalSource';
   }

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -47,6 +47,13 @@ describe('ContentSelector', () => {
             path: 'https://lms.anno.co/api/canvas/files',
           },
         },
+        d2l: {
+          enabled: true,
+          listFiles: {
+            authUrl: 'https://lms.anno.co/d2l/authorize',
+            path: 'https://lms.anno.co/api/d2l/files',
+          },
+        },
         google: {},
         jstor: {
           enabled: false,
@@ -115,6 +122,7 @@ describe('ContentSelector', () => {
         'url-button',
         'canvas-file-button',
         'blackboard-file-button',
+        'd2l-file-button',
         'onedrive-button',
       ]
     );
@@ -169,6 +177,11 @@ describe('ContentSelector', () => {
         buttonTestId: 'blackboard-file-button',
         files: () => fakeConfig.filePicker.blackboard.listFiles,
       },
+      {
+        name: 'D2L',
+        buttonTestId: 'd2l-file-button',
+        files: () => fakeConfig.filePicker.d2l.listFiles,
+      },
     ].forEach(test => {
       it(`shows LMS file dialog when "Select PDF from ${test.name}" is clicked`, () => {
         const wrapper = renderContentSelector();
@@ -213,6 +226,16 @@ describe('ContentSelector', () => {
           url: 'blackboard://content-resource/123',
         },
         missingFilesHelpLink: 'https://web.hypothes.is/help/bb-files',
+      },
+      {
+        name: 'd2l',
+        dialogName: 'd2lFile',
+        file: { id: 'd2l://content-resource/123' },
+        result: {
+          type: 'url',
+          url: 'd2l://content-resource/123',
+        },
+        missingFilesHelpLink: 'https://web.hypothes.is/help-categories/d2l/',
       },
     ].forEach(test => {
       it(`supports selecting a file from the ${test.name} file dialog`, () => {

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -248,6 +248,14 @@ describe('FilePickerApp', () => {
         summary: 'PDF file in Blackboard',
       },
       {
+        content: {
+          type: 'url',
+          url: 'd2l://content-resource/1/',
+        },
+        summary: 'PDF file in D2L',
+      },
+
+      {
         content: { type: 'file', id: 'abcd' },
         summary: 'PDF file in Canvas',
       },

--- a/lms/static/scripts/frontend_apps/config.js
+++ b/lms/static/scripts/frontend_apps/config.js
@@ -62,6 +62,9 @@ import { createContext } from 'preact';
  * @prop {object} blackboard
  *   @prop {boolean} blackboard.enabled
  *   @prop {APICallInfo} blackboard.listFiles
+ * @prop {object} d2l
+ *   @prop {boolean} d2l.enabled
+ *   @prop {APICallInfo} d2l.listFiles
  * @prop {object} canvas
  *   @prop {boolean} canvas.enabled
  *   @prop {APICallInfo} canvas.listFiles

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -121,6 +121,7 @@
         {{ settings_text_field("API Client ID", "desire2learn", "client_id") }}
         {{ settings_secret_field("API Client secret", "desire2learn", "client_secret") }}
         {{ settings_checkbox("Groups enabled", "desire2learn", "groups_enabled") }}
+        {{ settings_checkbox("Files enabled (EXPERIMENTAL)", "desire2learn", "files_enabled") }}
         {{ settings_checkbox("Create grade items", "desire2learn", "create_line_item") }}
     </fieldset>
 

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -302,6 +302,7 @@ class AdminApplicationInstanceViews:
             ("desire2learn", "client_id", str),
             ("desire2learn", "client_secret", aes_secret),
             ("desire2learn", "groups_enabled", bool),
+            ("desire2learn", "files_enabled", bool),
             ("desire2learn", "create_line_item", bool),
             ("microsoft_onedrive", "files_enabled", bool),
             ("vitalsource", "enabled", bool),

--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -7,6 +7,9 @@ from lms.security import Permissions
 from lms.services.d2l_api import D2LAPIClient
 from lms.validation.authentication import OAuthCallbackSchema
 
+GROUPS_SCOPES = ("groups:*:*",)
+FILES_SCOPES = ("content:toc:read",)
+
 
 @view_config(
     request_method="GET",
@@ -18,6 +21,14 @@ def authorize(request):
         name="application_instance"
     ).get_current()
     state = OAuthCallbackSchema(request).state_param()
+
+    scopes = ["core:*:*"]
+
+    if request.product.settings.files_enabled:
+        scopes += FILES_SCOPES
+
+    if request.product.settings.groups_enabled:
+        scopes += GROUPS_SCOPES
 
     return HTTPFound(
         location=urlunparse(
@@ -34,12 +45,7 @@ def authorize(request):
                         "response_type": "code",
                         "redirect_uri": request.route_url("d2l_api.oauth.callback"),
                         "state": state,
-                        "scope": " ".join(
-                            [
-                                "core:*:*",
-                                "groups:*:*",
-                            ]
-                        ),
+                        "scope": " ".join(scopes),
                     }
                 ),
                 "",

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -1,0 +1,37 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+from lms.services.d2l_api import D2LAPIClient
+
+
+def _find_files(modules):
+    """Recursively find files in modules."""
+    for module in modules:
+        for topic in module.get("topics", []):
+            if topic.get("type") == "File":
+                yield topic
+
+        # Find submodules
+        yield from _find_files(module.get("modules", []))
+
+
+@view_config(
+    request_method="GET",
+    route_name="d2l_api.courses.files.list",
+    renderer="json",
+    permission=Permissions.API,
+)
+def list_files(_context, request):
+    """Return the list of files in the given course."""
+    modules = request.find_service(D2LAPIClient).course_table_of_contents(
+        org_unit=request.matchdict["course_id"]
+    )
+    return [
+        {
+            "id": f"d2l://content-resource/{file['id']}/",
+            "display_name": file["name"],
+            "updated_at": file["updated_at"],
+            "type": "File",
+        }
+        for file in _find_files(modules)
+    ]

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -30,6 +30,26 @@ class TestFilePickerConfig:
 
         assert config == expected_config
 
+    @pytest.mark.parametrize("files_enabled", [False, True])
+    def test_d2l_config(self, pyramid_request, files_enabled):
+
+        pyramid_request.lti_params["context_id"] = "COURSE_ID"
+        pyramid_request.product.settings.files_enabled = files_enabled
+
+        config = FilePickerConfig.d2l_config(
+            pyramid_request, sentinel.application_instance
+        )
+
+        expected_config = {"enabled": files_enabled}
+
+        if files_enabled:
+            expected_config["listFiles"] = {
+                "authUrl": "http://example.com/api/d2l/oauth/authorize",
+                "path": "/api/d2l/courses/COURSE_ID/files",
+            }
+
+        assert config == expected_config
+
     @pytest.mark.usefixtures("with_is_canvas")
     def test_canvas_config(self, pyramid_request, application_instance):
         pyramid_request.lti_params["custom_canvas_course_id"] = "COURSE_ID"

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -1,0 +1,85 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.views.api.d2l.files import list_files
+
+
+@pytest.mark.parametrize(
+    "toc,files",
+    [
+        (
+            [
+                {
+                    "topics": [
+                        {
+                            "id": sentinel.id,
+                            "type": "File",
+                            "name": sentinel.name,
+                            "updated_at": sentinel.updated_at,
+                        },
+                        {
+                            "type": "NOT A FILE",
+                        },
+                    ]
+                }
+            ],
+            [
+                {
+                    "id": "d2l://content-resource/sentinel.id/",
+                    "display_name": sentinel.name,
+                    "updated_at": sentinel.updated_at,
+                    "type": "File",
+                }
+            ],
+        ),
+        (
+            [
+                {
+                    "topics": [
+                        {
+                            "id": sentinel.id,
+                            "type": "File",
+                            "name": sentinel.name,
+                            "updated_at": sentinel.updated_at,
+                        }
+                    ],
+                    "modules": [
+                        {
+                            "topics": [
+                                {
+                                    "id": sentinel.nested_id,
+                                    "type": "File",
+                                    "name": sentinel.nested_name,
+                                    "updated_at": sentinel.nested_updated_at,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            [
+                {
+                    "id": "d2l://content-resource/sentinel.id/",
+                    "display_name": sentinel.name,
+                    "updated_at": sentinel.updated_at,
+                    "type": "File",
+                },
+                {
+                    "id": "d2l://content-resource/sentinel.nested_id/",
+                    "display_name": sentinel.nested_name,
+                    "updated_at": sentinel.nested_updated_at,
+                    "type": "File",
+                },
+            ],
+        ),
+    ],
+)
+def test_course_group_sets(pyramid_request, d2l_api_client, toc, files):
+    pyramid_request.matchdict = {"course_id": "test_course_id"}
+    d2l_api_client.course_table_of_contents.return_value = toc
+
+    result = list_files(sentinel.context, pyramid_request)
+
+    assert result == files
+    d2l_api_client.course_table_of_contents.assert_called_once_with("test_course_id")


### PR DESCRIPTION
This PRs add some of the bolilerplate needed for authorization, basic fetching of the list of file from D2L and the bits needed on the frontend to be able to test it all together.

This PR doesn't however support:

- https://github.com/hypothesis/lms/issues/4769
- https://github.com/hypothesis/lms/issues/4768
- https://github.com/hypothesis/lms/issues/4771

It also doesn't try to find a better abstraction for files/file pickers. We can tackle that  once this lands and we have canvas, blackboard and D2L examples to build that abstraction.


## Testing

- Lunch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2184/View

There should not be a D2L files button.

- Enable the files setting on http://localhost:8001/admin/instance/id/106/

Now you'll get a D2L files button.


- Click the "D2L files button. After you authorize you'll should see files in the dialog.


- You can try updating new files at the top level menu:


![Screenshot from 2022-12-19 15-24-20](https://user-images.githubusercontent.com/1433832/208447378-2b4277dd-88a8-41e6-9524-efbaab38e85a.png)



- Configuring and launching that file will fail.