### PR TITLE
Notes field on the admin pages

### DIFF
--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -135,13 +135,16 @@ class OrganizationService:
 
         return org
 
-    def update_organization(self, organization, name=None, enabled=None):
+    def update_organization(self, organization, name=None, enabled=None, notes=None):
         """Update an existing organization."""
         if name:
             organization.name = name
 
         if enabled is not None:
             organization.enabled = enabled
+
+        if notes is not None:
+            organization.settings.set("hypothesis", "notes", notes)
 
         return organization
 

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -46,6 +46,13 @@
 <form method="POST" action="{{ request.route_url("admin.instance.id", id_=instance.id) }}">
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
+    <fieldset class="box">
+        {{ macros.settings_textarea(instance, "Notes", "hypothesis", "notes") }}
+        {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
+        {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
+        {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
+    </fieldset>
+
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Organization</legend>
         {{ macros.organization_preview(request, instance.organization) }}
@@ -54,12 +61,6 @@
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Registration</legend>
         {{ macros.registration_preview(request, instance.lti_registration) }}
-    </fieldset>
-
-    <fieldset class="box">
-        {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
-        {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
-        {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -44,6 +44,14 @@
 {% endmacro %}
 
 
+{% macro settings_textarea(object, label, setting, sub_setting, field_name, default='') %}
+    {% call field_body(label) %}
+        {% set text = object.settings.get(setting, sub_setting, default) or ''  %}
+        <textarea class="textarea" name="{{ setting }}.{{ sub_setting }}">{{ text }}</textarea>
+    {% endcall %}
+{% endmacro %}
+
+
 {% macro registration_fields(request, lti_registration, view_button=False) %}
     {% if view_button %}
     <div class="block has-text-right">

--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -11,6 +11,7 @@
     <form method="POST" action="{{ request.route_url("admin.organization", id_=org.id) }}">
         <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
         {{ macros.disabled_text_field("ID", org.public_id) }}
+        {{ macros.settings_textarea(org, "Notes", "hypothesis", "notes") }}
         {{ macros.form_text_field(request, "Name", "name", org.name) }}
         {{ macros.created_updated_fields(org) }}
         <div class="has-text-right mb-6">

--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -11,8 +11,8 @@
     <form method="POST" action="{{ request.route_url("admin.organization", id_=org.id) }}">
         <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
         {{ macros.disabled_text_field("ID", org.public_id) }}
-        {{ macros.settings_textarea(org, "Notes", "hypothesis", "notes") }}
         {{ macros.form_text_field(request, "Name", "name", org.name) }}
+        {{ macros.settings_textarea(org, "Notes", "hypothesis", "notes") }}
         {{ macros.created_updated_fields(org) }}
         <div class="has-text-right mb-6">
             <input type="submit" class="button is-primary" value="Save" />

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -92,6 +92,7 @@ class AdminOrganizationViews:
             name=self.request.params.get("name", "").strip(),
             notes=self.request.params.get("hypothesis.notes", "").strip(),
         )
+        self.request.session.flash("Updated organization", "messages")
 
         return {"org": org}
 

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -88,7 +88,9 @@ class AdminOrganizationViews:
         org = self._get_org_or_404(self.request.matchdict["id_"])
 
         self.organization_service.update_organization(
-            org, name=self.request.params.get("name", "").strip()
+            org,
+            name=self.request.params.get("name", "").strip(),
+            notes=self.request.params.get("hypothesis.notes", "").strip(),
         )
 
         return {"org": org}

--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -141,13 +141,17 @@ class TestOrganizationService:
 
     @pytest.mark.parametrize("name", (None, "NAME"))
     @pytest.mark.parametrize("enabled", (None, True, False))
-    def test_update_organization(self, svc, name, enabled):
+    @pytest.mark.parametrize("notes", (None, "Some notes"))
+    def test_update_organization(self, svc, name, enabled, notes):
         org = svc.update_organization(
-            factories.Organization(), name=name, enabled=enabled
+            factories.Organization(), name=name, enabled=enabled, notes=notes
         )
 
         if name:
             assert org.name == name
+
+        if notes:
+            assert org.settings.get("hypothesis", "notes") == notes
 
         if enabled is not None:
             assert org.enabled == enabled

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -49,11 +49,13 @@ class TestAdminOrganizationViews:
         organization_service.get_by_id.assert_called_once_with(sentinel.id_)
 
     @pytest.mark.parametrize("name", ["  ", " name"])
+    @pytest.mark.parametrize("notes", ["  ", " name"])
     def test_update_organization_name(
-        self, pyramid_request, organization_service, views, name
+        self, pyramid_request, organization_service, views, name, notes
     ):
         pyramid_request.matchdict["id_"] = sentinel.id_
         pyramid_request.params["name"] = name
+        pyramid_request.params["hypothesis.notes"] = notes
         organization_service.get_by_id.return_value = factories.Organization()
 
         response = views.update_organization()
@@ -61,6 +63,7 @@ class TestAdminOrganizationViews:
         organization_service.update_organization.assert_called_once_with(
             organization_service.get_by_id.return_value,
             name=name.strip() if name else "",
+            notes=notes.strip() if notes else "",
         )
         org = response["org"]
         assert org == organization_service.get_by_id.return_value


### PR DESCRIPTION
Removed by mistake in instances, added also to organizations.


## Testing:


Play with the notes in orgs and AIs:

- http://localhost:8001/admin/org/1
- http://localhost:8001/admin/instance/id/4/

 