### PR TITLE
Fix secret field value in application instance settings

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -34,7 +34,7 @@
 {% macro settings_secret_field(label, setting, sub_setting, field_name, default='') %}
     {% call macros.field_body(label) %}
         <input
-            value="{{ "*" * 25 if instance.settings.get(setting, sub_setting, default) else '' }}"
+            placeholder="{{ "*" * 25 if instance.settings.get(setting, sub_setting, default) else '' }}"
             class="input"
             type="text"
             name="{{ setting }}.{{ sub_setting }}">


### PR DESCRIPTION
Setting the value would override the setting in the DB.

Using placeholder as a hint of the presence of the value.



