### PR TITLE
Migration to add email and name to User

### DIFF
--- a/lms/migrations/versions/e32d2cf33591_user_email.py
+++ b/lms/migrations/versions/e32d2cf33591_user_email.py
@@ -1,0 +1,24 @@
+"""
+Add "email" and "display_name" to the user table.
+
+Revision ID: e32d2cf33591
+Revises: f8b1ac3ca221
+Create Date: 2022-12-19 10:35:05.433945
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e32d2cf33591"
+down_revision = "c14193c4afb4"
+
+
+def upgrade():
+    op.add_column("user", sa.Column("email", sa.Unicode(), nullable=True))
+    op.add_column("user", sa.Column("display_name", sa.Unicode(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "email")
+    op.drop_column("user", "display_name")


### PR DESCRIPTION
### Testing

```
hdev alembic upgrade head
dev run-test-pre: PYTHONHASHSEED='3999552559'
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade c14193c4afb4 -> e32d2cf33591, Add "email" and "display_name" to the user table.


hdev alembic downgrade -1
dev run-test-pre: PYTHONHASHSEED='1549736742'
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini downgrade -1
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade e32d2cf33591 -> c14193c4afb4, Add "email" and "display_name" to the user table.
```