### PR TITLE
Store and update email and name in "User"

### DIFF
--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -24,19 +24,45 @@ class TestUserService:
                 "user_id": lti_user.user_id,
                 "roles": lti_user.roles,
                 "h_userid": lti_user.h_user.userid("authority.example.com"),
+                "email": lti_user.email,
+                "display_name": lti_user.display_name,
             }
         )
         assert saved_user == user
 
-    def test_upsert_user_with_an_existing_user(
-        self, service, user, lti_user, db_session
+    def test_upsert_user_doesnt_save_personal_details_for_students(
+        self, service, lti_user, db_session
     ):
+        lti_user = lti_user._replace(roles="Student")
+
+        service.upsert_user(lti_user)
+
+        saved_user = db_session.query(User).order_by(User.id.desc()).first()
+        assert saved_user.roles == lti_user.roles
+        assert not saved_user.email
+        assert not saved_user.display_name
+
+    @pytest.mark.usefixtures("user")
+    def test_upsert_user_with_an_existing_user(self, service, lti_user, db_session):
         user = service.upsert_user(lti_user)
 
         saved_user = db_session.query(User).get(user.id)
         assert saved_user.id == user.id
         assert saved_user.roles == lti_user.roles
         assert user == saved_user
+
+    @pytest.mark.usefixtures("user")
+    def test_upsert_user_doesnt_save_personal_details_for_existing_students(
+        self, service, lti_user, db_session
+    ):
+        lti_user = lti_user._replace(roles="Student")
+
+        service.upsert_user(lti_user)
+
+        saved_user = db_session.query(User).order_by(User.id.desc()).first()
+        assert saved_user.roles == lti_user.roles
+        assert not saved_user.email
+        assert not saved_user.display_name
 
     def test_get(self, user, service):
         db_user = service.get(user.application_instance, user.user_id)


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4730


### Testing


- Remove any that from other testing:

```tox -qe dockercompose -- exec postgres psql -U postgres -c "update \"user\" set display_name=null, email=null;"```


- Launch https://hypothesis.instructure.com/courses/125/assignments/873 both as an student and instructor.

- Check what's store for each user

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select roles,email,display_name from \"user\""

   roles    |             email             |      display_name      
------------+-------------------------------+------------------------
 Instructor | eng+canvasteacher@hypothes.is | Hypothesis 101 Teacher
 Learner    |                               | 
(2 rows)
```

