### PR TITLE
Backfill user emails and names from group_info

### DIFF
--- a/lms/migrations/versions/0b7391f5b1e3_backfill_user_email.py
+++ b/lms/migrations/versions/0b7391f5b1e3_backfill_user_email.py
@@ -1,0 +1,86 @@
+"""
+Backfill email and name from group_info.
+
+Revision ID: 0b7391f5b1e3
+Revises: e32d2cf33591
+Create Date: 2022-12-19 10:42:00.577163
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0b7391f5b1e3"
+down_revision = "e32d2cf33591"
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Flatten group_info.info.instructors
+    conn.execute(
+        """CREATE TEMPORARY VIEW group_info_instructors AS (
+            SELECT
+                group_info.application_instance_id,
+                instructors.email,
+                instructors.display_name,
+                instructors.provider_unique_id,
+                -- Rank emails by latest group_info.id
+                row_number() over (partition by (instructors.provider_unique_id,  group_info.application_instance_id) order by group_info.id desc) as rank
+            FROM
+                group_info,
+                jsonb_to_recordset(group_info.info->'instructors') as instructors(email text, username text, display_name text,provider_unique_id text )
+        );"""
+    )
+
+    # Migrate emails
+    result_emails = conn.execute(
+        """
+        UPDATE "user"
+            SET email=group_info_emails.email
+            FROM (
+                SELECT "user".id, group_info_instructors.email
+                FROM group_info_instructors
+                LEFT OUTER JOIN "user" ON group_info_instructors.application_instance_id = "user".application_instance_id AND provider_unique_id = user_id
+                WHERE
+                    -- Only take the latest info from group_info for duplicates
+                    rank = 1
+                    -- Only take instructors that have an email in group_info
+                    AND group_info_instructors.email IS NOT NULL AND group_info_instructors.email <> ''
+                    --  And that we can match to a user in "user"
+                    AND "user".id IS NOT NULL
+                    -- Don't override any email we already had
+                    AND "user".display_name IS NULL
+            ) as group_info_emails
+        WHERE "user".id = group_info_emails.id
+    """
+    )
+
+    #  Migrate display_name
+    result_names = conn.execute(
+        """
+        UPDATE "user"
+            SET display_name=group_info_names.display_name
+            FROM (
+                SELECT "user".id, group_info_instructors.display_name
+                FROM group_info_instructors
+                LEFT OUTER JOIN "user" ON group_info_instructors.application_instance_id = "user".application_instance_id AND provider_unique_id = user_id
+                WHERE
+                    -- Only take the latest info from group_info for duplicates
+                    rank = 1
+                    -- Only take instructors that have a name in group_info
+                    AND group_info_instructors.display_name IS NOT NULL AND group_info_instructors.display_name <> ''
+                    --  And that we can match to a user in "user"
+                    AND "user".id IS NOT NULL
+                    -- Don't override any names we already had
+                    AND "user".display_name IS NULL
+            ) as group_info_names
+        WHERE "user".id = group_info_names.id
+    """
+    )
+    print("\tUpdated user rows with email from group_info:", result_emails.rowcount)
+    print("\tUpdated user rows with names from group_info:", result_names.rowcount)
+
+
+def downgrade():
+    pass

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -24,19 +24,45 @@ class TestUserService:
                 "user_id": lti_user.user_id,
                 "roles": lti_user.roles,
                 "h_userid": lti_user.h_user.userid("authority.example.com"),
+                "email": lti_user.email,
+                "display_name": lti_user.display_name,
             }
         )
         assert saved_user == user
 
-    def test_upsert_user_with_an_existing_user(
-        self, service, user, lti_user, db_session
+    def test_upsert_user_doesnt_save_personal_details_for_students(
+        self, service, lti_user, db_session
     ):
+        lti_user = lti_user._replace(roles="Student")
+
+        service.upsert_user(lti_user)
+
+        saved_user = db_session.query(User).order_by(User.id.desc()).first()
+        assert saved_user.roles == lti_user.roles
+        assert not saved_user.email
+        assert not saved_user.display_name
+
+    @pytest.mark.usefixtures("user")
+    def test_upsert_user_with_an_existing_user(self, service, lti_user, db_session):
         user = service.upsert_user(lti_user)
 
         saved_user = db_session.query(User).get(user.id)
         assert saved_user.id == user.id
         assert saved_user.roles == lti_user.roles
         assert user == saved_user
+
+    @pytest.mark.usefixtures("user")
+    def test_upsert_user_doesnt_save_personal_details_for_existing_students(
+        self, service, lti_user, db_session
+    ):
+        lti_user = lti_user._replace(roles="Student")
+
+        service.upsert_user(lti_user)
+
+        saved_user = db_session.query(User).order_by(User.id.desc()).first()
+        assert saved_user.roles == lti_user.roles
+        assert not saved_user.email
+        assert not saved_user.display_name
 
     def test_get(self, user, service):
         db_user = service.get(user.application_instance, user.user_id)


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4730


### Testing

- Launch https://hypothesis.instructure.com/courses/125/assignments/873 as different users to fill up `group_info`

- Clear the "user" table  ```update "user" set display_name=null, email=null;```

- Run the migration

```hdev alembic upgrade head```


- Check the data copied over to "user":

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select roles,email,display_name from \"user\""

   roles    |             email             |      display_name      
------------+-------------------------------+------------------------
 Learner    |                               | 
 Instructor | eng+canvasteacher@hypothes.is | Hypothesis 101 Teacher
(2 rows)
```