### PR TITLE
Suppport for D2L files proxing using Via

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -7,6 +7,7 @@ from pyramid.httpexceptions import HTTPClientError
 from lms.models import Assignment, GroupInfo, Grouping, HUser
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
+from lms.product.d2l import D2L
 from lms.resources._js_config.file_picker_config import FilePickerConfig
 from lms.services import HAPIError, JSTORService, VitalSourceService
 from lms.validation.authentication import BearerTokenSchema
@@ -68,6 +69,16 @@ class JSConfig:
                     resource_link_id=self._request.lti_params["resource_link_id"],
                 ),
             }
+        elif document_url.startswith("d2l://"):
+            self._config["api"]["viaUrl"] = {
+                "authUrl": self._request.route_url(D2L.route.oauth2_authorize),
+                "path": self._request.route_path(
+                    "d2l_api.courses.files.via_url",
+                    course_id=self._request.lti_params["context_id"],
+                    _query={"document_url": document_url},
+                ),
+            }
+
         elif document_url.startswith("vitalsource://"):
             svc: VitalSourceService = self._request.find_service(VitalSourceService)
 

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -53,6 +53,9 @@ def includeme(config):  # pylint:disable=too-many-statements
         "d2l_api.courses.group_sets.list", "/api/d2l/courses/{course_id}/group_sets"
     )
     config.add_route("d2l_api.courses.files.list", "/api/d2l/courses/{course_id}/files")
+    config.add_route(
+        "d2l_api.courses.files.via_url", "/api/d2l/courses/{course_id}/via_url"
+    )
 
     config.add_route(
         "blackboard_api.oauth.authorize",

--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -8,7 +8,7 @@ from lms.services.d2l_api import D2LAPIClient
 from lms.validation.authentication import OAuthCallbackSchema
 
 GROUPS_SCOPES = ("groups:*:*",)
-FILES_SCOPES = ("content:toc:read",)
+FILES_SCOPES = ("content:toc:read", "content:topics:read")
 
 
 @view_config(

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -11,17 +11,6 @@ DOCUMENT_URL_REGEX = re.compile(
 )
 
 
-def _find_files(modules):
-    """Recursively find files in modules."""
-    for module in modules:
-        for topic in module.get("topics", []):
-            if topic.get("type") == "File":
-                yield topic
-
-        # Find submodules
-        yield from _find_files(module.get("modules", []))
-
-
 @view_config(
     request_method="GET",
     route_name="d2l_api.courses.files.list",
@@ -30,13 +19,7 @@ def _find_files(modules):
 )
 def list_files(_context, request):
     """Return the list of files in the given course."""
-    course_id = request.matchdict["course_id"]
-    results = request.find_service(D2LAPIClient).list_files(course_id)
-
-    for result in results:
-        result["id"] = f"d2l://file/course/{course_id}/file_id/{result['id']}/"
-
-    return results
+    return request.find_service(D2LAPIClient).list_files(request.matchdict["course_id"])
 
 
 @view_config(

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -1,10 +1,10 @@
 import re
+
 from pyramid.view import view_config
-from lms.views import helpers
 
 from lms.security import Permissions
 from lms.services.d2l_api import D2LAPIClient
-
+from lms.views import helpers
 
 DOCUMENT_URL_REGEX = re.compile(
     r"d2l:\/\/file\/course\/(?P<course_id>[^\/]*)\/file_id\/(?P<file_id>[^\/]*)\/"
@@ -38,5 +38,8 @@ def via_url(_context, request):
     access_token = request.find_service(name="oauth2_token").get().access_token
     headers = {"Authorization": f"Bearer {access_token}"}
 
-    via_url = helpers.via_url(request, public_url, content_type="pdf", headers=headers)
-    return {"via_url": via_url}
+    return {
+        "via_url": helpers.via_url(
+            request, public_url, content_type="pdf", headers=headers
+        )
+    }

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -1,7 +1,25 @@
+import re
 from pyramid.view import view_config
+from lms.views import helpers
 
 from lms.security import Permissions
 from lms.services.d2l_api import D2LAPIClient
+
+
+DOCUMENT_URL_REGEX = re.compile(
+    r"d2l:\/\/file\/course\/(?P<course_id>[^\/]*)\/file_id\/(?P<file_id>[^\/]*)\/"
+)
+
+
+def _find_files(modules):
+    """Recursively find files in modules."""
+    for module in modules:
+        for topic in module.get("topics", []):
+            if topic.get("type") == "File":
+                yield topic
+
+        # Find submodules
+        yield from _find_files(module.get("modules", []))
 
 
 @view_config(
@@ -12,6 +30,30 @@ from lms.services.d2l_api import D2LAPIClient
 )
 def list_files(_context, request):
     """Return the list of files in the given course."""
-    return request.find_service(D2LAPIClient).list_files(
-        org_unit=request.matchdict["course_id"]
-    )
+    course_id = request.matchdict["course_id"]
+    results = request.find_service(D2LAPIClient).list_files(course_id)
+
+    for result in results:
+        result["id"] = f"d2l://file/course/{course_id}/file_id/{result['id']}/"
+
+    return results
+
+
+@view_config(
+    request_method="GET",
+    route_name="d2l_api.courses.files.via_url",
+    renderer="json",
+    permission=Permissions.API,
+)
+def via_url(_context, request):
+    course_id = request.matchdict["course_id"]
+    document_url = request.params["document_url"]
+    file_id = DOCUMENT_URL_REGEX.search(document_url)["file_id"]
+
+    public_url = request.find_service(D2LAPIClient).public_url(course_id, file_id)
+
+    access_token = request.find_service(name="oauth2_token").get().access_token
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    via_url = helpers.via_url(request, public_url, content_type="pdf", headers=headers)
+    return {"via_url": via_url}

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -4,7 +4,7 @@ from h_vialib import ViaClient
 __all__ = ["via_url"]
 
 
-def via_url(request, document_url, content_type=None, options=None):
+def via_url(request, document_url, content_type=None, options=None, headers=None):
     """
     Return the Via URL for annotating the given ``document_url``.
 
@@ -17,6 +17,7 @@ def via_url(request, document_url, content_type=None, options=None):
     :param document_url: Document URL to present in Via
     :param content_type: Either "pdf" or "html" if known, None if not
     :param options: Any extra options for the url
+    :param headers: Headers for the request to `document_url`
     :return: A URL string
     """
     if not options:
@@ -37,4 +38,5 @@ def via_url(request, document_url, content_type=None, options=None):
         content_type,
         blocked_for="lms",
         options=options,
+        headers=headers,
     )

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -166,6 +166,30 @@ class TestAddDocumentURL:
             "path": "/api/blackboard/courses/test_course_id/via_url?document_url=blackboard%3A%2F%2Fcontent-resource%2Fxyz123",
         }
 
+    def test_it_adds_the_viaUrl_api_config_for_Canvas_documents(
+        self, js_config, pyramid_request
+    ):
+        course_id, file_id = "125", "100"
+        pyramid_request.params["custom_canvas_course_id"] = course_id
+        pyramid_request.params["file_id"] = file_id
+
+        js_config.add_document_url(
+            f"canvas://file/course/{course_id}/file_id/{file_id}"
+        )
+
+        assert js_config.asdict()["api"]["viaUrl"] == {
+            "authUrl": "http://example.com/api/canvas/oauth/authorize",
+            "path": "/api/canvas/assignments/TEST_RESOURCE_LINK_ID/via_url",
+        }
+
+    def test_it_adds_the_viaUrl_api_config_for_D2L_documents(self, js_config):
+        js_config.add_document_url("d2l://file/course/125/file_id/100")
+
+        assert js_config.asdict()["api"]["viaUrl"] == {
+            "authUrl": "http://example.com/api/d2l/oauth/authorize",
+            "path": "/api/d2l/courses/test_course_id/via_url?document_url=d2l%3A%2F%2Ffile%2Fcourse%2F125%2Ffile_id%2F100",
+        }
+
     def test_vitalsource_sets_config_with_sso(
         self, js_config, pyramid_request, vitalsource_service
     ):
@@ -214,22 +238,6 @@ class TestAddDocumentURL:
             "itemId": "DOI",
         }
         assert js_config.asdict()["viaUrl"] == jstor_service.via_url.return_value
-
-    def test_it_adds_the_viaUrl_api_config_for_Canvas_documents(
-        self, js_config, pyramid_request
-    ):
-        course_id, file_id = "125", "100"
-        pyramid_request.params["custom_canvas_course_id"] = course_id
-        pyramid_request.params["file_id"] = file_id
-
-        js_config.add_document_url(
-            f"canvas://file/course/{course_id}/file_id/{file_id}"
-        )
-
-        assert js_config.asdict()["api"]["viaUrl"] == {
-            "authUrl": "http://example.com/api/canvas/oauth/authorize",
-            "path": "/api/canvas/assignments/TEST_RESOURCE_LINK_ID/via_url",
-        }
 
 
 class TestAddCanvasSpeedgraderSettings:

--- a/tests/unit/lms/services/d2l_api/client_test.py
+++ b/tests/unit/lms/services/d2l_api/client_test.py
@@ -104,7 +104,7 @@ class TestD2LAPIClient:
                         "children": [
                             {
                                 "display_name": "TITLE 1",
-                                "id": "FILE 1",
+                                "id": "d2l://file/course/COURSE_ID/file_id/FILE 1/",
                                 "type": "File",
                                 "updated_at": "DATE 1",
                             },
@@ -116,7 +116,7 @@ class TestD2LAPIClient:
                                 "children": [
                                     {
                                         "display_name": "TITLE 2",
-                                        "id": "FILE 2",
+                                        "id": "d2l://file/course/COURSE_ID/file_id/FILE 2/",
                                         "type": "File",
                                         "updated_at": "DATE 2",
                                     },
@@ -147,6 +147,22 @@ class TestD2LAPIClient:
         )
 
         assert files == returned_files
+
+    def test_public_url(self, svc, basic_client):
+        public_url = svc.public_url("COURSE_ID", "FILE_ID")
+
+        basic_client.api_url.assert_any_call(
+            "/COURSE_ID/content/topics/FILE_ID", product="le"
+        )
+        basic_client.request.assert_called_once_with(
+            "GET", basic_client.api_url.return_value
+        )
+
+        basic_client.api_url.assert_called_with(
+            "/COURSE_ID/content/topics/FILE_ID/file?stream=1", product="le"
+        )
+
+        assert public_url == basic_client.api_url.return_value
 
     @pytest.mark.parametrize(
         "user_id,api_user_id",

--- a/tests/unit/lms/views/api/d2l/authorize_test.py
+++ b/tests/unit/lms/views/api/d2l/authorize_test.py
@@ -20,9 +20,9 @@ class TestAuthorize:
         "groups,files,scopes",
         [
             (False, False, "core:*:*"),
-            (False, True, "core:*:* content:toc:read"),
+            (False, True, "core:*:* content:toc:read content:topics:read"),
             (True, False, "core:*:* groups:*:*"),
-            (True, True, "core:*:* content:toc:read groups:*:*"),
+            (True, True, "core:*:* content:toc:read content:topics:read groups:*:*"),
         ],
     )
     def test_it(

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -1,6 +1,8 @@
 from unittest.mock import sentinel
 
-from lms.views.api.d2l.files import list_files
+import pytest
+
+from lms.views.api.d2l.files import list_files, via_url
 
 
 def test_course_group_sets(pyramid_request, d2l_api_client):
@@ -10,3 +12,26 @@ def test_course_group_sets(pyramid_request, d2l_api_client):
 
     d2l_api_client.list_files.assert_called_once_with("test_course_id")
     assert result == d2l_api_client.list_files.return_value
+
+
+def test_via_url(helpers, pyramid_request, d2l_api_client, oauth2_token_service):
+    pyramid_request.matchdict = {"course_id": "COURSE_ID"}
+    pyramid_request.params[
+        "document_url"
+    ] = "d2l://file/course/COURSE_ID/file_id/FILE_ID/"
+
+    response = via_url(sentinel.context, pyramid_request)
+
+    d2l_api_client.public_url.assert_called_once_with("COURSE_ID", "FILE_ID")
+    helpers.via_url.assert_called_once_with(
+        pyramid_request,
+        d2l_api_client.public_url.return_value,
+        content_type="pdf",
+        headers={"Authorization": f"Bearer {oauth2_token_service.get().access_token}"},
+    )
+    assert response == {"via_url": helpers.via_url.return_value}
+
+
+@pytest.fixture
+def helpers(patch):
+    return patch("lms.views.api.d2l.files.helpers")


### PR DESCRIPTION
#### Needs

- https://github.com/hypothesis/h-vialib/pull/42 
- https://github.com/hypothesis/via/pull/845


### Testing

- Checkout https://github.com/hypothesis/h-vialib/pull/42  h_vialib
- Checkout https://github.com/hypothesis/via/pull/845 in Via
- Install the local version of h-vialib in both Via and LMS

I've been using 

```.tox/dev/bin/pip install -e /home/marcos/hypo/h-vialib``` for this.

- Enable D2L files in http://localhost:8001/admin/instance/id/106/
- Launch a D2L assignment as a teacher and configure it as D2L assignment:


https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2184/View

- You should be able to see the contents of the file a follow the trip of URL
  - via_url request to LMS to get the file which contains the `via.secret.headers`
  - Via request to get the pdf, again with the header

