### PR TITLE
Support nested folders/files in the files response

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -19,6 +19,7 @@
  *   content. Only present if `type` is 'Folder'.
  * @prop {string|null} [parent_id] - Only present if `type` is 'Folder'. A
  *   folder may have a parent folder.
+ * @prop {File[]} children - List of children of the current Folder
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -189,6 +189,7 @@ export default function ContentSelector({
           onSelectFile={selectD2LFile}
           missingFilesHelpLink={'https://web.hypothes.is/help-categories/d2l/'}
           withBreadcrumbs
+          apiSendsChildren
         />
       );
       break;

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -146,8 +146,13 @@ export default function LMSFilePicker({
    * @param {File} folder
    */
   const onChangePath = folder => {
-    setSelectedFile(null);
+    console.log("CHANGE PATH");
+    console.log("FILES", folder);
     const currentIndex = folderPath.findIndex(file => file.id === folder.id);
+    if ('children' in folder) {
+      const files = folder.children;
+      setDialogState({ state: 'fetched', files });
+    }
     if (currentIndex >= 0) {
       // If the selected folder is already in the path, remove any entries
       // below (after) it to make it the last entry
@@ -199,7 +204,9 @@ export default function LMSFilePicker({
 
   // Update the file list any time the path changes
   useEffect(() => {
-    fetchFiles();
+    if (selectedFile == null || !('children' in selectedFile)) {
+      fetchFiles();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [folderPath]);
 

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.js
@@ -195,7 +195,21 @@ export default function LMSFilePicker({
           // append these to the top level `__root___` folder.
           folderPath[0].children = files;
         }
-        setDialogState({ state: 'fetched', files });
+
+        if (apiSendsChildren && isReload) {
+          let reloaded_files = files;
+          // Iterate over the paths skipping the first `__root__` elmement
+          for (let i = 1; i < folderPath.length; i++) {
+            const path = folderPath[i];
+            // Find this level's path in the files returned
+            const foundPath = reloaded_files.find(file => file.id === path.id);
+            reloaded_files = foundPath ? foundPath.children : [];
+          }
+          // Set the files at the correct path
+          setDialogState({ state: 'fetched', files: reloaded_files });
+        } else {
+          setDialogState({ state: 'fetched', files });
+        }
       } catch (error) {
         if (isAuthorizationError(error)) {
           setDialogState({ state: 'authorizing', isRetry: isReload });


### PR DESCRIPTION
For:

- #4769 


D2L sends the whole tree structure in one API call so it wouldn't make sense to make extra requests from the frontend every time we change folders. This tries to support both methods in the file picker.

## Testing
- Accessing with a self signed certificate in https://localhost:48001/ should be allowed. Depending on the browser this can be done once (and it's remembered for a while) or be made permanent. In chrome it can be permanent with the flag `chrome://flags/#allow-insecure-localhost`

- Make sure D2L files are enabled in http://localhost:8001/admin/instance/id/106/ (this is now part of (`make devdata`)


- https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2184/View
Pick D2L files and play with the file picker.

- Note that actually picking a file and proxing it doesn't work #4792 