### PR TITLE
Remove check constraint in Grouping.type

### DIFF
--- a/lms/migrations/versions/debaebd4a95c_remove_enum_constraint.py
+++ b/lms/migrations/versions/debaebd4a95c_remove_enum_constraint.py
@@ -1,0 +1,29 @@
+"""
+Remove enum DB constraint.
+
+Revision ID: debaebd4a95c
+Revises: 0b7391f5b1e3
+Create Date: 2022-12-27 14:19:35.278944
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "debaebd4a95c"
+down_revision = "0b7391f5b1e3"
+
+constraint_name = "grouping_type_must_be_a_valid_value"
+table_name = "grouping"
+
+
+def upgrade():
+    op.drop_constraint(constraint_name, table_name=table_name, type_="check")
+
+
+def downgrade():
+    op.create_check_constraint(
+        constraint_name,
+        table_name=table_name,
+        condition="type in ('course', 'canvas_section', 'canvas_group', 'blackboard_group', 'd2l_group')",
+    )

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
 
-from lms.db import BASE
+from lms.db import BASE, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.application_settings import ApplicationSettings
 
@@ -114,7 +114,7 @@ class Grouping(CreatedUpdatedMixin, BASE):
     #: Full name given on the LMS (e.g. "A course name 101")
     lms_name = sa.Column(sa.UnicodeText(), nullable=False)
 
-    type = sa.Column(sa.Unicode(), nullable=False)
+    type = varchar_enum(Type, nullable=False)
 
     settings = sa.Column(
         "settings",

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -65,11 +65,6 @@ class Grouping(CreatedUpdatedMixin, BASE):
             "(type='course' AND parent_id IS NULL) OR (type!='course' AND parent_id IS NOT NULL)",
             name="courses_must_NOT_have_parents_and_other_groupings_MUST_have_parents",
         ),
-        # Only certain values are allowed in the `type` column.
-        sa.CheckConstraint(
-            "type in ('course', 'canvas_section', 'canvas_group', 'blackboard_group', 'd2l_group')",
-            name="grouping_type_must_be_a_valid_value",
-        ),
     )
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4773

## Testing for the migration

```
hdev alembic upgrade head
dev run-test-pre: PYTHONHASHSEED='551793646'
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 0b7391f5b1e3 -> debaebd4a95c, Remove enum DB constraint.
```


```
dev alembic downgrade -1
dev run-test-pre: PYTHONHASHSEED='3452916469'
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini downgrade -1
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade debaebd4a95c -> 0b7391f5b1e3, Remove enum DB constraint.
```