### PR TITLE
Store D2L files into the DB

### DIFF
--- a/lms/services/d2l_api/factory.py
+++ b/lms/services/d2l_api/factory.py
@@ -20,4 +20,5 @@ def d2l_api_client_factory(_context, request):
             oauth_http_service=request.find_service(name="oauth_http"),
         ),
         request=request,
+        file_service=request.find_service(name="file"),
     )

--- a/tests/unit/lms/services/d2l_api/client_test.py
+++ b/tests/unit/lms/services/d2l_api/client_test.py
@@ -53,7 +53,7 @@ class TestD2LAPIClient:
         ]
 
     @pytest.mark.parametrize(
-        "modules,files",
+        "modules,files,db_files",
         [
             (
                 {
@@ -125,15 +125,41 @@ class TestD2LAPIClient:
                         ],
                     },
                 ],
+                [
+                    {
+                        "type": "d2l_folder",
+                        "course_id": "COURSE_ID",
+                        "lms_id": 1,
+                        "name": "MODULE 1",
+                        "parent_lms_id": None,
+                    },
+                    {
+                        "type": "d2l_file",
+                        "course_id": "COURSE_ID",
+                        "lms_id": "d2l://file/course/COURSE_ID/file_id/FILE 1/",
+                        "name": "TITLE 1",
+                        "parent_lms_id": 1,
+                    },
+                    {
+                        "type": "d2l_folder",
+                        "course_id": "COURSE_ID",
+                        "lms_id": 2,
+                        "name": "MODULE 2",
+                        "parent_lms_id": 1,
+                    },
+                    {
+                        "type": "d2l_file",
+                        "course_id": "COURSE_ID",
+                        "lms_id": "d2l://file/course/COURSE_ID/file_id/FILE 2/",
+                        "name": "TITLE 2",
+                        "parent_lms_id": 2,
+                    },
+                ],
             ),
         ],
     )
     def test_list_files(
-        self,
-        svc,
-        basic_client,
-        modules,
-        files,
+        self, svc, basic_client, modules, files, db_files, file_service
     ):
         basic_client.request.return_value.json.return_value = modules
 
@@ -145,6 +171,8 @@ class TestD2LAPIClient:
         basic_client.request.assert_called_once_with(
             "GET", basic_client.api_url.return_value
         )
+
+        file_service.upsert.assert_called_with(db_files)
 
         assert files == returned_files
 
@@ -203,5 +231,5 @@ class TestD2LAPIClient:
         return create_autospec(BasicClient, instance=True, spec_set=True)
 
     @pytest.fixture
-    def svc(self, basic_client, pyramid_request):
-        return D2LAPIClient(basic_client, pyramid_request)
+    def svc(self, basic_client, pyramid_request, file_service):
+        return D2LAPIClient(basic_client, pyramid_request, file_service)

--- a/tests/unit/lms/services/d2l_api/factory_test.py
+++ b/tests/unit/lms/services/d2l_api/factory_test.py
@@ -14,6 +14,7 @@ def test_d2l_api_client_factory(
     pyramid_request,
     BasicClient,
     D2LAPIClient,
+    file_service,
 ):
     ai = create_autospec(ApplicationInstance)
     application_instance_service.get_current.return_value = ai
@@ -33,7 +34,7 @@ def test_d2l_api_client_factory(
         oauth_http_service=oauth_http_service,
     )
     D2LAPIClient.assert_called_once_with(
-        BasicClient.return_value, request=pyramid_request
+        BasicClient.return_value, request=pyramid_request, file_service=file_service
     )
     assert service == D2LAPIClient.return_value
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4771




## Testing


- `make sql` 
- `truncate "file";` to get a blank slate.
- Reconfigure https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2177/View
- Pick the D2L files option (no need to pick any),
- Check the new data on the DB with `select * from file;`
