### PR TITLE
Fix D2L file enable toggle

### DIFF
--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -11,8 +11,10 @@ class FilePickerConfig:
     @classmethod
     def d2l_config(cls, request, _application_instance):
         """Get D2L files config."""
-        files_enabled = request.product.settings.files_enabled
-
+        files_enabled = (
+            request.product.family == D2L.family
+            and request.product.settings.files_enabled
+        )
         config = {"enabled": files_enabled}
         if files_enabled:
             config["listFiles"] = {

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -30,19 +30,27 @@ class TestFilePickerConfig:
 
         assert config == expected_config
 
-    @pytest.mark.parametrize("files_enabled", [False, True])
-    def test_d2l_config(self, pyramid_request, files_enabled):
-
+    @pytest.mark.parametrize(
+        "family,enabled,expected",
+        [
+            (Product.Family.BLACKBOARD, False, False),
+            (Product.Family.BLACKBOARD, True, False),
+            (Product.Family.D2L, False, False),
+            (Product.Family.D2L, True, True),
+        ],
+    )
+    def test_d2l_config(self, pyramid_request, family, enabled, expected):
         pyramid_request.lti_params["context_id"] = "COURSE_ID"
-        pyramid_request.product.settings.files_enabled = files_enabled
+        pyramid_request.product.family = family
+        pyramid_request.product.settings.files_enabled = enabled
 
         config = FilePickerConfig.d2l_config(
             pyramid_request, sentinel.application_instance
         )
 
-        expected_config = {"enabled": files_enabled}
+        expected_config = {"enabled": expected}
 
-        if files_enabled:
+        if expected:
             expected_config["listFiles"] = {
                 "authUrl": "http://example.com/api/d2l/oauth/authorize",
                 "path": "/api/d2l/courses/COURSE_ID/files",


### PR DESCRIPTION
Just checking "files_enabled" will be true in both d2l and blackboard at the same time.

Added a family check.


## Testing 

### In main

Launch as teacher:

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1


You'll see the D2L button in the file picker.

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2128/View?ou=6782
(with the toggle enabled at http://localhost:8001/admin/instance/id/107/)

the D2L files button will appear.


### Switch to `fix-d2l-files-toggle`


https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1


doesn't show the toggle

While in D2L https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2128/View?ou=6782

it does appaear.


