### PR TITLE
Limit the scopes for groups to the minimum necessary

### DIFF
--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -7,7 +7,7 @@ from lms.security import Permissions
 from lms.services.d2l_api import D2LAPIClient
 from lms.validation.authentication import OAuthCallbackSchema
 
-GROUPS_SCOPES = ("groups:*:*",)
+GROUPS_SCOPES = ("groups:group:read",)
 FILES_SCOPES = ("content:toc:read", "content:topics:read")
 
 

--- a/tests/unit/lms/views/api/d2l/authorize_test.py
+++ b/tests/unit/lms/views/api/d2l/authorize_test.py
@@ -21,8 +21,12 @@ class TestAuthorize:
         [
             (False, False, "core:*:*"),
             (False, True, "core:*:* content:toc:read content:topics:read"),
-            (True, False, "core:*:* groups:*:*"),
-            (True, True, "core:*:* content:toc:read content:topics:read groups:*:*"),
+            (True, False, "core:*:* groups:group:read"),
+            (
+                True,
+                True,
+                "core:*:* content:toc:read content:topics:read groups:group:read",
+            ),
         ],
     )
     def test_it(


### PR DESCRIPTION
No need to require more than we need.


The two endpoints we use:


https://docs.valence.desire2learn.com/res/groups.html#get--d2l-api-lp-(version)-(orgUnitId)-groupcategories-

https://docs.valence.desire2learn.com/res/groups.html#get--d2l-api-lp-(version)-(orgUnitId)-groupcategories-(groupCategoryId)-groups-

need the same scope.


We might be able to also remove the `core:*` one but I'll do more testing and a separate PR

## Testing

Test the assignment in https://aunltd.brightspacedemo.com/d2l/le/content/6782/Home?itemIdentifier=D2L.LE.Content.ContentObject.ModuleCO-2122
