### PR TITLE
Include LTIRoles in LTIUser

### DIFF
--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -7,7 +7,6 @@ from sqlalchemy import inspect
 
 from lms.db import BASE
 from lms.models import EventType
-from lms.services.lti_role_service import LTIRoleService
 
 
 @dataclass
@@ -64,12 +63,7 @@ class LTIEvent(BaseEvent):
     # These methods provide defaults for each field and are used in
     # `BaseEvent.__post_init__` above.
     def _get_role_ids(self):
-        return [
-            role.id
-            for role in self.request.find_service(LTIRoleService).get_roles(
-                self.request.lti_user.roles
-            )
-        ]
+        return [role.id for role in self.request.lti_user.lti_roles]
 
     def _get_application_instance_id(self):
         if application_instance := self.request.find_service(

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -48,48 +48,6 @@ class LTIUser:
         """Whether this user is a learner."""
         return "learner" in self.roles.lower()
 
-    @staticmethod
-    def from_auth_params(request, application_instance, lti_core_schema):
-        """Create an LTIUser from a LTIV11CoreSchema like dict."""
-
-        return LTIUser.unserialize(
-            request,
-            user_id=lti_core_schema["user_id"],
-            application_instance_id=application_instance.id,
-            roles=lti_core_schema["roles"],
-            tool_consumer_instance_guid=lti_core_schema["tool_consumer_instance_guid"],
-            display_name=display_name(
-                lti_core_schema["lis_person_name_given"],
-                lti_core_schema["lis_person_name_family"],
-                lti_core_schema["lis_person_name_full"],
-            ),
-            email=lti_core_schema["lis_person_contact_email_primary"],
-        )
-
-    @staticmethod
-    def unserialize(request, **kwargs: dict):
-        # pylint: disable= import-outside-toplevel
-        from lms.services.lti_role_service import LTIRoleService
-
-        lti_roles = request.find_service(LTIRoleService).get_roles(kwargs["roles"])
-
-        return LTIUser(lti_roles=lti_roles, **kwargs)
-
-    def serialize(self) -> dict:
-        """
-        Return a dict representing the LTIUser.
-
-        LTIUser is often serialized. We can pick here the exact representation.
-        """
-        return {
-            "user_id": self.user_id,
-            "roles": self.roles,
-            "tool_consumer_instance_guid": self.tool_consumer_instance_guid,
-            "display_name": self.display_name,
-            "application_instance_id": self.application_instance_id,
-            "email": self.email,
-        }
-
 
 def display_name(given_name, family_name, full_name):
     """

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -25,6 +25,7 @@ from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_names_roles import LTINamesRolesService
 from lms.services.lti_registration import LTIRegistrationService
 from lms.services.lti_role_service import LTIRoleService
+from lms.services.lti_user import LTIUserService
 from lms.services.ltia_http import LTIAHTTPService
 from lms.services.organization import OrganizationService
 from lms.services.rsa_key import RSAKeyService
@@ -115,7 +116,6 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.d2l_api.d2l_api_client_factory", iface=D2LAPIClient
     )
-
     # Plugins are not the same as top level services but we want to register them as pyramid services too
     # Importing them here to:
     # - Don't pollute the lms.services namespace
@@ -131,4 +131,7 @@ def includeme(config):
     )
     config.register_service_factory(
         CourseCopyGroupsHelper.factory, iface=CourseCopyGroupsHelper
+    )
+    config.register_service_factory(
+        "lms.services.lti_user.factory", iface=LTIUserService
     )

--- a/lms/services/lti_user.py
+++ b/lms/services/lti_user.py
@@ -1,0 +1,56 @@
+from lms.models.lti_user import LTIUser, display_name
+from lms.services import LTIRoleService
+
+
+class LTIUserService:
+    """
+    A service to handle LTIUser.
+
+    LTIUser is the center of many of our authentication schemas.
+    This service handles de/serialization of LTIUsers.
+    """
+
+    def __init__(self, lti_role_service):
+        self._lti_roles_service = lti_role_service
+
+    def from_auth_params(self, application_instance, lti_core_schema) -> LTIUser:
+        """Create an LTIUser from a LTIV11CoreSchema like dict."""
+
+        return self.deserialize(
+            user_id=lti_core_schema["user_id"],
+            application_instance_id=application_instance.id,
+            roles=lti_core_schema["roles"],
+            tool_consumer_instance_guid=lti_core_schema["tool_consumer_instance_guid"],
+            display_name=display_name(
+                lti_core_schema["lis_person_name_given"],
+                lti_core_schema["lis_person_name_family"],
+                lti_core_schema["lis_person_name_full"],
+            ),
+            email=lti_core_schema["lis_person_contact_email_primary"],
+        )
+
+    @staticmethod
+    def serialize(lti_user: LTIUser) -> dict:
+        """
+        Return a dict representing the LTIUser.
+
+        LTIUser is often serialized. We can pick here the exact representation.
+        """
+        return {
+            "user_id": lti_user.user_id,
+            "roles": lti_user.roles,
+            "tool_consumer_instance_guid": lti_user.tool_consumer_instance_guid,
+            "display_name": lti_user.display_name,
+            "application_instance_id": lti_user.application_instance_id,
+            "email": lti_user.email,
+        }
+
+    def deserialize(self, **kwargs: dict) -> LTIUser:
+        """Create an LTIUser based on kwargs."""
+        lti_roles = self._lti_roles_service.get_roles(kwargs["roles"])
+
+        return LTIUser(lti_roles=lti_roles, **kwargs)
+
+
+def factory(_context, request):
+    return LTIUserService(request.find_service(LTIRoleService))

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -101,7 +101,7 @@ class BearerTokenSchema(PyramidRequestSchema):
                 messages={"authorization": ["Invalid session token"]}
             ) from err
 
-        return LTIUser(**jwt_data)
+        return LTIUser.unserialize(self.context["request"], **jwt_data)
 
     @marshmallow.pre_load
     def _decode_authorization(self, data, **_kwargs):

--- a/lms/validation/authentication/_lti.py
+++ b/lms/validation/authentication/_lti.py
@@ -60,7 +60,9 @@ class LTI11AuthSchema(LTIV11CoreSchema):
                 {"consumer_key": ["Invalid OAuth 1 signature. Unknown consumer key."]}
             ) from err
 
-        return LTIUser.from_auth_params(application_instance, kwargs)
+        return LTIUser.from_auth_params(
+            self.context["request"], application_instance, kwargs
+        )
 
     @marshmallow.validates_schema
     def _verify_oauth_1(self, _data, **_kwargs):
@@ -124,4 +126,6 @@ class LTI13AuthSchema(LTIV11CoreSchema):
                 {"JWT": ["Invalid LTI1.3 params. Unknown application_instance."]}
             ) from err
 
-        return LTIUser.from_auth_params(application_instance, kwargs)
+        return LTIUser.from_auth_params(
+            self.context["request"], application_instance, kwargs
+        )

--- a/lms/validation/authentication/_oauth.py
+++ b/lms/validation/authentication/_oauth.py
@@ -112,7 +112,7 @@ class OAuthCallbackSchema(PyramidRequestSchema):
             raise MissingStateParamError() from err
 
         decoded_user = self._decode_state(state)["user"]
-        return LTIUser(**decoded_user)
+        return LTIUser.unserialize(self.context["request"], **decoded_user)
 
     @marshmallow.validates("state")
     def validate_state(self, state):

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -16,7 +16,7 @@ from pyramid.view import view_config, view_defaults
 
 from lms.events import LTIEvent
 from lms.security import Permissions
-from lms.services import DocumentURLService, LTIRoleService
+from lms.services import DocumentURLService
 from lms.services.assignment import AssignmentService
 from lms.services.grouping import GroupingService
 from lms.validation import BasicLTILaunchSchema, ConfigureAssignmentSchema
@@ -184,9 +184,7 @@ class BasicLaunchViews:
         self.assignment_service.upsert_assignment_membership(
             assignment=assignment,
             user=self.request.user,
-            lti_roles=self.request.find_service(LTIRoleService).get_roles(
-                self.request.lti_params["roles"]
-            ),
+            lti_roles=self.request.lti_user.lti_roles,
         )
         # Store the relationship between the assignment and the course
         self.assignment_service.upsert_assignment_groupings(

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -8,6 +8,7 @@ LTIUser = make_factory(
     user_id=USER_ID,
     application_instance_id=fuzzy.FuzzyInteger(1, 9999999999),
     roles=Faker("random_element", elements=["Learner", "Instructor"]),
+    lti_roles=[],
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     display_name=Faker("name"),
 )

--- a/tests/unit/lms/events/test_event.py
+++ b/tests/unit/lms/events/test_event.py
@@ -11,12 +11,12 @@ class TestLTIEvent:
     def test_lti_event(
         self,
         pyramid_request,
-        lti_role_service,
         application_instance_service,
         course_service,
         assignment_service,
+        lti_user,
     ):
-        lti_role_service.get_roles.return_value = [sentinel]
+        lti_user.lti_roles = [sentinel]
         event = LTIEvent(request=pyramid_request, type=sentinel.type)
 
         assert event.user_id == pyramid_request.user.id

--- a/tests/unit/lms/models/lti_user_test.py
+++ b/tests/unit/lms/models/lti_user_test.py
@@ -41,8 +41,10 @@ class TestLTIUser:
 
         assert lti_user.is_learner == is_learner
 
-    def test_from_auth_params(self, application_instance, auth_params):
-        lti_user = LTIUser.from_auth_params(application_instance, auth_params)
+    def test_from_auth_params(self, pyramid_request, application_instance, auth_params):
+        lti_user = LTIUser.from_auth_params(
+            pyramid_request, application_instance, auth_params
+        )
 
         assert lti_user.user_id == auth_params["user_id"]
         assert lti_user.roles == auth_params["roles"]

--- a/tests/unit/lms/models/lti_user_test.py
+++ b/tests/unit/lms/models/lti_user_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lms.models import LTIUser, display_name
+from lms.models import display_name
 from tests import factories
 
 
@@ -40,37 +40,6 @@ class TestLTIUser:
         lti_user = factories.LTIUser(roles=roles)
 
         assert lti_user.is_learner == is_learner
-
-    def test_from_auth_params(self, pyramid_request, application_instance, auth_params):
-        lti_user = LTIUser.from_auth_params(
-            pyramid_request, application_instance, auth_params
-        )
-
-        assert lti_user.user_id == auth_params["user_id"]
-        assert lti_user.roles == auth_params["roles"]
-        assert (
-            lti_user.tool_consumer_instance_guid
-            == auth_params["tool_consumer_instance_guid"]
-        )
-        assert lti_user.email == auth_params["lis_person_contact_email_primary"]
-        assert lti_user.display_name == display_name(
-            auth_params["lis_person_name_given"],
-            auth_params["lis_person_name_family"],
-            auth_params["lis_person_name_full"],
-        )
-        assert lti_user.application_instance_id == application_instance.id
-
-    @pytest.fixture
-    def auth_params(self):
-        return {
-            "user_id": "USER_ID",
-            "roles": "ROLES",
-            "tool_consumer_instance_guid": "TOOL_CONSUMER_INSTANCE_GUID",
-            "lis_person_name_given": "LIS_PERSON_NAME_GIVEN",
-            "lis_person_name_family": "LIS_PERSON_NAME_FAMILY",
-            "lis_person_name_full": "LIS_PERSON_NAME_FULL",
-            "lis_person_contact_email_primary": "LIS_PERSON_CONTACT_EMAIL_PRIMARY",
-        }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/lms/services/lti_user_test.py
+++ b/tests/unit/lms/services/lti_user_test.py
@@ -1,0 +1,64 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.lti_user import LTIUserService, factory
+
+
+class TestLTIUserService:
+    def test_from_auth_params(
+        self, application_instance, auth_params, svc, display_name
+    ):
+        lti_user = svc.from_auth_params(application_instance, auth_params)
+
+        assert lti_user.user_id == auth_params["user_id"]
+        assert lti_user.roles == auth_params["roles"]
+        assert (
+            lti_user.tool_consumer_instance_guid
+            == auth_params["tool_consumer_instance_guid"]
+        )
+        assert lti_user.email == auth_params["lis_person_contact_email_primary"]
+        assert lti_user.display_name == display_name(
+            auth_params["lis_person_name_given"],
+            auth_params["lis_person_name_family"],
+            auth_params["lis_person_name_full"],
+        )
+        assert lti_user.application_instance_id == application_instance.id
+
+    def test_serialize(self, svc, lti_user):
+        assert svc.serialize(lti_user) == {
+            "user_id": lti_user.user_id,
+            "roles": lti_user.roles,
+            "tool_consumer_instance_guid": lti_user.tool_consumer_instance_guid,
+            "display_name": lti_user.display_name,
+            "application_instance_id": lti_user.application_instance_id,
+            "email": lti_user.email,
+        }
+
+    @pytest.fixture
+    def auth_params(self):
+        return {
+            "user_id": "USER_ID",
+            "roles": "ROLES",
+            "tool_consumer_instance_guid": "TOOL_CONSUMER_INSTANCE_GUID",
+            "lis_person_name_given": "LIS_PERSON_NAME_GIVEN",
+            "lis_person_name_family": "LIS_PERSON_NAME_FAMILY",
+            "lis_person_name_full": "LIS_PERSON_NAME_FULL",
+            "lis_person_contact_email_primary": "LIS_PERSON_CONTACT_EMAIL_PRIMARY",
+        }
+
+    @pytest.fixture
+    def svc(self, lti_role_service):
+        return LTIUserService(lti_role_service)
+
+    @pytest.fixture
+    def display_name(self, patch):
+        return patch("lms.services.lti_user.display_name")
+
+
+class TestFactory:
+    @pytest.mark.usefixtures("lti_role_service")
+    def test_it(self, pyramid_request):
+        svc = factory(sentinel.context, pyramid_request)
+
+        assert isinstance(svc, LTIUserService)

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -184,8 +184,8 @@ class TestBasicLaunchViews:
         context,
         lti_h_service,
         assignment_service,
-        lti_role_service,
         misc_plugin,
+        lti_user,
     ):
         # pylint: disable=protected-access
         result = svc._show_document(
@@ -209,13 +209,10 @@ class TestBasicLaunchViews:
         )
         assignment = assignment_service.upsert_assignment.return_value
 
-        lti_role_service.get_roles.assert_called_once_with(
-            pyramid_request.lti_params["roles"]
-        )
         assignment_service.upsert_assignment_membership.assert_called_once_with(
             assignment=assignment,
             user=pyramid_request.user,
-            lti_roles=lti_role_service.get_roles.return_value,
+            lti_roles=lti_user.lti_roles,
         )
         assignment_service.upsert_assignment_groupings.assert_called_once_with(
             assignment_id=assignment.id, groupings=[context.course]

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -37,6 +37,7 @@ from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_h import LTIHService
 from lms.services.lti_registration import LTIRegistrationService
+from lms.services.lti_user import LTIUserService
 from lms.services.ltia_http import LTIAHTTPService
 from lms.services.oauth1 import OAuth1Service
 from lms.services.oauth2_token import OAuth2TokenService
@@ -75,6 +76,7 @@ __all__ = (
     "lti_h_service",
     "lti_registration_service",
     "lti_role_service",
+    "lti_user_service",
     "ltia_http_service",
     "oauth1_service",
     "oauth2_token_service",
@@ -303,6 +305,11 @@ def rsa_key_service(mock_service):
 @pytest.fixture
 def user_service(mock_service):
     return mock_service(UserService)
+
+
+@pytest.fixture
+def lti_user_service(mock_service):
+    return mock_service(LTIUserService)
 
 
 @pytest.fixture


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4749


Include LTIRoles in LTIUser.

The main motivation will be to later use this objects to determine the role of the current user, leveraging LTIRole instead of just matching strings:


https://github.com/hypothesis/lms/blob/668361e73615f9efc6b351bb2533433cc926d983/lms/models/lti_user.py#L39


That would centralize all role decision in LTIRole.


See a draft of that here:

- https://github.com/hypothesis/lms/pull/5123