### PR TITLE
Fix course copy assignment URL for BB and D2L in 1.3

### DIFF
--- a/lms/services/document_url.py
+++ b/lms/services/document_url.py
@@ -93,17 +93,18 @@ class DocumentURLService:
         for param in (
             "resource_link_id",  # A normal LTI (non-deep linked) launch
             "resource_link_id_history",  # A Blackboard course we can copy
-            "ext_d2l_resource_link_id_history",  # Ditto for Brightspace
+            "ext_d2l_resource_link_id_history",  # Ditto for D2L
+            "custom_ResourceLink.id.history",  # LTI 1.3 location for D2L and blackboard
         ):
             if (resource_link_id := request.lti_params.get(param)) and (
-                assigment := self._assignment_service.get_assignment(
+                assignment := self._assignment_service.get_assignment(
                     tool_consumer_instance_guid=request.lti_params.get(
                         "tool_consumer_instance_guid"
                     ),
                     resource_link_id=resource_link_id,
                 )
             ):
-                return assigment.document_url
+                return assignment.document_url
 
         return None
 

--- a/tests/unit/lms/services/document_url_test.py
+++ b/tests/unit/lms/services/document_url_test.py
@@ -108,6 +108,7 @@ class TestDocumentURLService:
             "resource_link_id",
             "ext_d2l_resource_link_id_history",
             "resource_link_id_history",
+            "custom_ResourceLink.id.history",
         ),
     )
     def test_get_document_url_with_assignment_in_db(


### PR DESCRIPTION
In blackboard and D2L we rely on a parameter to point to the old id of an assignment and get its URL from the old one in the DB.

For LTI1.3 this parameter is in a different location.


# Testing


- Configure the original assignment 

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2177/View?ou=6782

for with example with: https://buildmedia.readthedocs.org/media/pdf/docs/latest/docs.pdf


You'll need something like 

`make sql` 
`truncate assignment cascade;`

if you already configured it before.


- Launch the equivalent assignment in the copied course. 

https://aunltd.brightspacedemo.com/d2l/le/content/6845/viewContent/2310/View
 
 
In `main` it will show the `configure assignment` selector.

In `course-copy-1.3` it will point already to the same PDF as the orignial.