### PR TITLE
Migrate LMSFilePicker to TS

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-this-alias": "off",
 
     // Enforce consistency in cases where TypeScript supports old and new

--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -13,7 +13,7 @@
  * @typedef File
  * @prop {string} id - Identifier for the resource within the LMS's file storage
  * @prop {string} display_name - Name of the resource to present in the file picker
- * @prop {string} updated_at - An ISO 8601 date string
+ * @prop {string} [updated_at] - An ISO 8601 date string
  * @prop {'File'|'Folder'} [type]
  * @prop {APICallInfo} [contents] - APICallInfo for fetching a folders's
  *   content. Only present if `type` is 'Folder'.


### PR DESCRIPTION
While working on #4769, I took the opportunity to migrate the `LMSFilePicker` component to TS, as the majority of changes are happening there and it's more convenient to not have to deal with JSDocs.