### PR TITLE
Filter out non-PDFs for D2L files

### DIFF
--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -37,6 +37,8 @@ class _D2LTopic(Schema):
     display_name = fields.Str(required=True, data_key="Title")
     updated_at = fields.Str(required=True, data_key="LastModifiedDate")
     type = fields.Str(required=True, data_key="TypeIdentifier")
+    url = fields.Str(required=True, data_key="Url")
+    """Url contains the full filename, useful to get the extension of the file"""
 
 
 class _D2LModuleSchema(Schema):
@@ -186,6 +188,10 @@ class D2LAPIClient:
                 }
                 for topic in module.get("topics", [])
                 if topic.get("type") == "File"
+                # Filter out non-pdfs using the file's name.
+                # Other LMS offer the content type of the file at this level
+                # but will have to rely on the extension for D2L.
+                and topic["url"].lower().endswith(".pdf")
             ]
 
             module_children = self._find_files(course_id, module.get("modules", []))

--- a/tests/unit/lms/services/d2l_api/client_test.py
+++ b/tests/unit/lms/services/d2l_api/client_test.py
@@ -68,6 +68,7 @@ class TestD2LAPIClient:
                                     "TypeIdentifier": "File",
                                     "Title": "TITLE 1",
                                     "LastModifiedDate": "DATE 1",
+                                    "Url": "TITLE 1.pdf",
                                 },
                                 # Check we don't include non-files
                                 {
@@ -75,6 +76,15 @@ class TestD2LAPIClient:
                                     "TypeIdentifier": "NOT A FILE",
                                     "Title": "NAME 2",
                                     "LastModifiedDate": "DATE 2",
+                                    "Url": "NAME 2.pdf",
+                                },
+                                # Check we don't include non-pdfs
+                                {
+                                    "Identifier": "ID 2",
+                                    "TypeIdentifier": "NOT A PDF",
+                                    "Title": "NOT PDF",
+                                    "LastModifiedDate": "DATE 2",
+                                    "Url": "NOT PDF.png",
                                 },
                             ],
                             "Modules": [
@@ -88,6 +98,7 @@ class TestD2LAPIClient:
                                             "TypeIdentifier": "File",
                                             "Title": "TITLE 2",
                                             "LastModifiedDate": "DATE 2",
+                                            "Url": "FILE 2.pdf",
                                         }
                                     ],
                                 }


### PR DESCRIPTION
~~This needs #4769 before it can be tested without messing around with different branches.~~

We need to filter out non-PDF files as those are the only ones we can proxy / annotate.


In other LMS's this is done by either the API exposing a content-type query parameter (the LMS does the filtering for us) or a content type field we can filter ourselves by.

D2L offers neither of those we we'll have to rely on the extension of the file.


## Testing

- Compare the files in `Scratch area" while configuring: https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2177/View?ou=6782 and selecting D2L files

In main you'll get a `this_is_not_fine` file (which is an image).
In this branch you'll only get the PDF.