### PR TITLE
Add support to load nested children in the file picker if we already have them

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -19,7 +19,8 @@
  *   content. Only present if `type` is 'Folder'.
  * @prop {string|null} [parent_id] - Only present if `type` is 'Folder'. A
  *   folder may have a parent folder.
- * @prop {File[]} [children] - List of children of the current Folder
+ * @prop {File[]} [children] - Applies only when `type` is `Folder`. A folder
+ *   may contain children (files and folders).
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/api-types.js
+++ b/lms/static/scripts/frontend_apps/api-types.js
@@ -19,6 +19,7 @@
  *   content. Only present if `type` is 'Folder'.
  * @prop {string|null} [parent_id] - Only present if `type` is 'Folder'. A
  *   folder may have a parent folder.
+ * @prop {File[]} [children] - List of children of the current Folder
  */
 
 /**

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -192,10 +192,16 @@ export default function LMSFilePicker({
       };
       try {
         setDialogState({ state: 'fetching', isReload });
-        const files: File[] = await apiCall({
-          authToken,
-          path: getNextAPICallInfo().path,
-        });
+
+        // If the last element in current folderPath contains children, we use them without calling the API
+        // Otherwise, we fetch files from the API
+        const files: File[] =
+          folderPath[folderPath.length - 1]?.children ??
+          (await apiCall({
+            authToken,
+            path: getNextAPICallInfo().path,
+          }));
+
         // Handle the case in which a subsequent fetch request for a
         // different path's files was dispatched before this request resolved.
         // Give preference to the later request: If the path has changed

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -158,6 +158,8 @@ export default function LMSFilePicker({
   // An array of File objects representing the "path" to the current
   // list of files being displayed. This always starts at the root. The last
   // element represents the current directory path.
+  // Every item can potentially have `children`. In that case we'll retrieve
+  // those without querying the API when the folder becomes active.
   const [folderPath, setFolderPath] = useState<File[]>([
     {
       display_name: 'Files',
@@ -169,7 +171,7 @@ export default function LMSFilePicker({
 
   /**
    * Change to a new folder path. This will update the breadcrumb path history
-   * and cause a new fetch to be initiated to retrieve files in that folder path.
+   * and cause displayed files to be re-computed for that folder path.
    */
   const onChangePath = (folder: File) => {
     setSelectedFile(null);
@@ -184,23 +186,69 @@ export default function LMSFilePicker({
     }
   };
 
-  // Fetches files or shows a prompt to authorize access.
-  const fetchFiles = useCallback(
+  const loadFilesToDisplay = useCallback(
+    /**
+     * Retrieve the files for the active directory, either by returning an
+     * appropriate subset of previously-loaded files, or by fetching a file
+     * listing from the API.
+     *
+     * @param isReload - When true, force a fetch of file listings from the API,
+     *   even if files were previously loaded.
+     */
     async (isReload = false) => {
-      const getNextAPICallInfo = () => {
-        return folderPath[folderPath.length - 1]?.contents || listFilesApi;
-      };
+      const getNextAPICallInfo = () =>
+        folderPath[folderPath.length - 1]?.contents || listFilesApi;
+      const loadFilesFromAPI = (): Promise<File[]> =>
+        apiCall({
+          authToken,
+          path: getNextAPICallInfo().path,
+        });
+
+      const children = folderPath[folderPath.length - 1]?.children;
+      if (!isReload && children) {
+        // The files in this directory were loaded by an earlier fetch
+        return children;
+      }
+
+      const loadedFiles = await loadFilesFromAPI();
+      const [, ...activePathWithoutRoot] = folderPath;
+      let filesForFolder = loadedFiles;
+
+      // Ensure we only return the files for the active directory.
+      //
+      // Depending on the LMS API being used, the loaded files could be either:
+      // 1. A flat list of files and folders for the active directory only, or
+      // 2. A full tree of all files and folders
+      //
+      // In the first case (flat list), we can return the `loadedFiles`
+      // directly. To handle the second case (tree), we need to search the tree
+      // for just those files and folders that are within the currently-active
+      // directory.
+      for (const folder of activePathWithoutRoot) {
+        const folderFound = filesForFolder.find(
+          fileOrFolder => fileOrFolder.id === folder.id
+        );
+        if (folderFound?.children) {
+          filesForFolder = folderFound.children;
+        }
+      }
+
+      return filesForFolder;
+    },
+    [authToken, folderPath, listFilesApi]
+  );
+
+  const computeFilesToDisplay = useCallback(
+    /**
+     * Compute the correct list of files to display in the picker. Handle error
+     * states if they arise.
+     *
+     * @param isReload - When true, request a fresh fetch of files from the API
+     */
+    async (isReload = false) => {
       try {
         setDialogState({ state: 'fetching', isReload });
-
-        // If the last element in current folderPath contains children, we use them without calling the API
-        // Otherwise, we fetch files from the API
-        const files: File[] =
-          folderPath[folderPath.length - 1]?.children ??
-          (await apiCall({
-            authToken,
-            path: getNextAPICallInfo().path,
-          }));
+        const files = await loadFilesToDisplay(isReload);
 
         // Handle the case in which a subsequent fetch request for a
         // different path's files was dispatched before this request resolved.
@@ -224,12 +272,12 @@ export default function LMSFilePicker({
       }
       setInitialFetch(false);
     },
-    [authToken, folderPath, listFilesApi]
+    [folderPath, loadFilesToDisplay]
   );
 
-  // Update the file list any time the path changes
+  // Re-compute the file list any time the path changes
   useEffect(() => {
-    fetchFiles();
+    computeFilesToDisplay();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [folderPath]);
 
@@ -290,7 +338,7 @@ export default function LMSFilePicker({
           authURL={listFilesApi.authUrl!}
           authToken={authToken}
           label={continueAction.label}
-          onAuthComplete={() => fetchFiles(true /* reload */)}
+          onAuthComplete={() => computeFilesToDisplay(true /* reload */)}
         />
       );
       break;
@@ -298,7 +346,7 @@ export default function LMSFilePicker({
       continueButton = (
         <LabeledButton
           variant="primary"
-          onClick={() => fetchFiles(true /* reload */)}
+          onClick={() => computeFilesToDisplay(true /* reload */)}
           data-testid="reload"
         >
           Reload

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -139,7 +139,7 @@ describe('LMSFilePicker', () => {
     });
   });
 
-  it('does not fetch files in indicated sub-folder if already available from first load', async () => {
+  it('does not fetch files for a folder if files were previously loaded', async () => {
     const folderWithChildren = {
       type: 'Folder',
       display_name: 'A folder with children',
@@ -314,8 +314,6 @@ describe('LMSFilePicker', () => {
 
     // After first render, the component will kick off the first file API fetch
     const wrapper = renderFilePicker();
-
-    // The file list is empty. The continue button should have a "Reload" label.
     const reloadButton = await waitForElement(
       wrapper,
       'LabeledButton[data-testid="reload"]'
@@ -363,6 +361,41 @@ describe('LMSFilePicker', () => {
     );
     assert.equal(finalReloadButton.text(), 'Reload');
     assert.isNotOk(finalReloadButton.prop('disabled'));
+  });
+
+  it('loads the set of files for the active directory when user clicks "Reload"', async () => {
+    fakeApiCall.resolves([]);
+
+    const wrapper = renderFilePicker({ withBreadcrumbs: true });
+
+    // Set the active directory to a sub-directory in folderPath
+    await waitForElement(wrapper, 'Breadcrumbs');
+    changePath(wrapper, fakeFolders[0]);
+
+    // Make next call resolve to a full tree of files and folders.
+    const expectedFiles = [fakeFiles[0]];
+    fakeApiCall.resolves([
+      {
+        ...fakeFolders[0],
+        children: expectedFiles,
+      },
+      fakeFolders[1],
+    ]);
+
+    // The file list is empty. The continue button should have a "Reload" label.
+    const reloadButton = await waitForElement(
+      wrapper,
+      'LabeledButton[data-testid="reload"]'
+    );
+    assert.equal(reloadButton.text(), 'Reload');
+
+    await act(() => reloadButton.prop('onClick')());
+
+    const fileList = await waitForElement(wrapper, 'FileList');
+
+    // It should set the file list to the files for the active directory,
+    // not the root directory
+    assert.equal(fileList.props().files, expectedFiles);
   });
 
   it('shows a "Select" button when the request return a list with one or more files', async () => {

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -139,6 +139,23 @@ describe('LMSFilePicker', () => {
     });
   });
 
+  it('does not fetch files in indicated sub-folder if already available from first load', async () => {
+    const folderWithChildren = {
+      type: 'Folder',
+      display_name: 'A folder with children',
+      children: fakeFiles,
+    };
+
+    const wrapper = renderFilePicker({ withBreadcrumbs: true });
+    const breadcrumbs = await waitForElement(wrapper, 'Breadcrumbs');
+    fakeApiCall.resetHistory();
+
+    // Simulate changing the folder path, as if a user clicked on a "crumb"
+    act(() => breadcrumbs.props().onSelectItem(folderWithChildren));
+
+    assert.notCalled(fakeApiCall);
+  });
+
   it('updates Breadcrumbs when folder path changes', async () => {
     const wrapper = renderFilePicker({ withBreadcrumbs: true });
     await waitForElement(wrapper, 'Breadcrumbs');


### PR DESCRIPTION
This PR enhances the `LMSFilePicker` so that it can transparently load children of the last folder in the active folderPath, without re-fetching the API.

It is done primarily to support D2L, where the full multi-dimensional file tree is returned in one go, but it opens the door to:

* Add support for other LMSs which behave like D2L, without having to change the client
* Start "caching" already loaded paths client-side, for LMSs which require querying the API for every folder, so that once the folder is opened, if the user comes back to it, we don't have to re-fetch the API (this has other considerations, of course, but would be possible with some extra changes if we wish to).
* If at some point we want file management for Canvas/Blackbopard/Others to behave consistently and make our server return a tree instead of a list, this change would also work with them.

### TODO

- [x] Properly handle reload
- [x] Cover new behavior with tests
- [x] Merge https://github.com/hypothesis/lms/pull/4850 first, and edit this PR to point to `main`.

### Testing

In order to test this works, follow the instructions from @marcospri's original PR https://github.com/hypothesis/lms/pull/4795

Ideally, it should be verified that Canvas and Blockboard keep working as before.