### PR TITLE
Handle tokens with not all the required scopes

### DIFF
--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -17,18 +17,21 @@ FILES_SCOPES = ("content:toc:read", "content:topics:read")
     permission=Permissions.API,
 )
 def authorize(request):
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
-    state = OAuthCallbackSchema(request).state_param()
-
-    scopes = ["core:*:*"]
+    scopes = []
 
     if request.product.settings.files_enabled:
         scopes += FILES_SCOPES
 
     if request.product.settings.groups_enabled:
         scopes += GROUPS_SCOPES
+
+    if not scopes:
+        raise NotImplementedError("Trying to get a D2L without any scopes")
+
+    application_instance = request.find_service(
+        name="application_instance"
+    ).get_current()
+    state = OAuthCallbackSchema(request).state_param()
 
     return HTTPFound(
         location=urlunparse(

--- a/tests/unit/lms/views/api/d2l/authorize_test.py
+++ b/tests/unit/lms/views/api/d2l/authorize_test.py
@@ -19,14 +19,9 @@ class TestAuthorize:
     @pytest.mark.parametrize(
         "groups,files,scopes",
         [
-            (False, False, "core:*:*"),
-            (False, True, "core:*:* content:toc:read content:topics:read"),
-            (True, False, "core:*:* groups:group:read"),
-            (
-                True,
-                True,
-                "core:*:* content:toc:read content:topics:read groups:group:read",
-            ),
+            (False, True, "content:toc:read content:topics:read"),
+            (True, False, "groups:group:read"),
+            (True, True, "content:toc:read content:topics:read groups:group:read"),
         ],
     )
     def test_it(
@@ -64,6 +59,13 @@ class TestAuthorize:
                 },
             )
         )
+
+    def test_raises_with_no_scopes(self, pyramid_request):
+        pyramid_request.product.settings.groups_enabled = False
+        pyramid_request.product.settings.files_enabled = False
+
+        with pytest.raises(NotImplementedError):
+            authorize(pyramid_request)
 
 
 class TestOAuth2Redirect:


### PR DESCRIPTION
For:

- #4856 

Raise OAuth2TokenError to force a new token generation with the necessary tokens.

From the PoV of the user this just changes the name of the button where they have to click ("Try again" vs "Authorize"). It's a slightly better experience but it's also more explicit in the code around what's going on in this case. It's not a lot of code to manage it in any case.

## Testing 

While on `main`:

- Remove existing tokens
`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token"`
- Disable files for http://localhost:8001/admin/instance/id/106/
- Configure https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2177/View?ou=6782 to use groups
This will get a token with only the scopes needed for groups.
- Re-enable files: http://localhost:8001/admin/instance/id/106/
- Reset the assignment 
`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment cascade"`
- Configure it again, now try to use D2L files, you'll get an error:
```
lms.services.exceptions.ExternalRequestError: ExternalRequestError(message=None, request=Request(method='GET', url='https://aunltd.brightspacedemo.com/d2l/api/le/1.31/6782/content/toc', body=None), response=Response(status_code=403, reason='Forbidden', body='{ Errors: [ {Message: "Insufficient scope to call API.Required: content:toc:read"} ] }'), validation_errors=None)
```
- Don't click "Try again"
- Now, switch to this branch, refresh the assignment and repeat the process. You'll see the authorize screen instead of the error one this time.