### PR TITLE
Display organization hierarchy in the admin pages

### DIFF
--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -1,5 +1,24 @@
 {% import "macros.html.jinja2" as macros %}
 
+{% macro org_hierarchy(node, focus_org) %}
+    <li>
+        {% if node.id == focus_org.id %}
+            <b>(You are here)</b> {{ node.name }} - <code>{{ node.public_id }}</code>
+        {% else %}
+            <a href="{{ request.route_url('admin.organization', id_=node.id) }}">{{ node.name }}</a>
+            - <code>{{ node.public_id }}</code>
+        {% endif %}
+
+        {% if node.children %}
+            <ul>
+            {% for child in node.children | sort(attribute='name') %}
+                {{ org_hierarchy(child, focus_org) }}
+            {% endfor %}
+            </ul>
+        {% endif %}
+    </li>
+{% endmacro %}
+
 {% extends "lms:templates/admin/base.html.jinja2" %}
 {% block header %}
     Organization {{org.id}}
@@ -34,6 +53,12 @@
         {% endif %}
     </fieldset>
 
+    <div class="box">
+        <legend class="label has-text-centered">Hierarchy</legend>
+        <div class="content">
+            <ul>{{ org_hierarchy(hierarchy_root, org) }}</ul>
+        </div>
+    </div>
     <fieldset class="box has-background-danger-light">
         <legend class="label has-text-centered has-text-danger">Danger zone</legend>
 

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -77,8 +77,12 @@ class AdminOrganizationViews:
         renderer="lms:templates/admin/organization.html.jinja2",
     )
     def show_organization(self):
-        org = self._get_org_or_404(self.request.matchdict["id_"])
-        return {"org": org}
+        org_id = self.request.matchdict["id_"]
+
+        return {
+            "org": self._get_org_or_404(org_id),
+            "hierarchy_root": self.organization_service.get_hierarchy_root(org_id),
+        }
 
     @view_config(route_name="admin.organization", request_method="POST")
     def update_organization(self):

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -80,11 +80,7 @@ class AdminOrganizationViews:
         org = self._get_org_or_404(self.request.matchdict["id_"])
         return {"org": org}
 
-    @view_config(
-        route_name="admin.organization",
-        request_method="POST",
-        renderer="lms:templates/admin/organization.html.jinja2",
-    )
+    @view_config(route_name="admin.organization", request_method="POST")
     def update_organization(self):
         org = self._get_org_or_404(self.request.matchdict["id_"])
 
@@ -95,13 +91,11 @@ class AdminOrganizationViews:
         )
         self.request.session.flash("Updated organization", "messages")
 
-        return {"org": org}
+        return HTTPFound(
+            location=self.request.route_url("admin.organization", id_=org.id)
+        )
 
-    @view_config(
-        route_name="admin.organization.move_org",
-        request_method="POST",
-        renderer="lms:templates/admin/organization.html.jinja2",
-    )
+    @view_config(route_name="admin.organization.move_org", request_method="POST")
     def move_organization(self):
         org = self._get_org_or_404(self.request.matchdict["id_"])
 
@@ -116,17 +110,12 @@ class AdminOrganizationViews:
             self.request.session.flash(
                 f"Could not move organization id: {err}", "errors"
             )
-            return HTTPFound(
-                location=self.request.route_url("admin.organization", id_=org.id)
-            )
 
-        return {"org": org}
+        return HTTPFound(
+            location=self.request.route_url("admin.organization", id_=org.id)
+        )
 
-    @view_config(
-        route_name="admin.organization.toggle",
-        request_method="POST",
-        renderer="lms:templates/admin/organization.html.jinja2",
-    )
+    @view_config(route_name="admin.organization.toggle", request_method="POST")
     def toggle_organization_enabled(self):
         org = self._get_org_or_404(self.request.matchdict["id_"])
 
@@ -137,7 +126,9 @@ class AdminOrganizationViews:
         AuditTrailEvent.notify(self.request, org)
         self.request.session.flash("Updated organization", "messages")
 
-        return {"org": org}
+        return HTTPFound(
+            location=self.request.route_url("admin.organization", id_=org.id)
+        )
 
     @view_config(
         route_name="admin.organizations",

--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -29,6 +29,11 @@ class TestOrganizationService:
 
         assert result == orgs[1]
 
+    def test_get_hierarchy_root(self, svc, org_with_parent):
+        root = svc.get_hierarchy_root(org_with_parent.id)
+
+        assert root == org_with_parent.parent
+
     @pytest.mark.usefixtures("with_matching_noise")
     @pytest.mark.parametrize(
         "param,field", (("name", "name"), ("public_id", "public_id"), ("id_", "id"))

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -37,7 +37,12 @@ class TestAdminOrganizationViews:
         response = views.show_organization()
 
         organization_service.get_by_id.assert_called_once_with(sentinel.id_)
-        assert response["org"] == organization_service.get_by_id.return_value
+        organization_service.get_hierarchy_root.assert_called_once_with(sentinel.id_)
+
+        assert response == {
+            "org": organization_service.get_by_id.return_value,
+            "hierarchy_root": organization_service.get_hierarchy_root.return_value,
+        }
 
     def test_show_organization_not_found(
         self, pyramid_request, organization_service, views

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -67,8 +67,8 @@ class TestAdminOrganizationViews:
             name=name.strip() if name else "",
             notes=notes.strip() if notes else "",
         )
-        org = response["org"]
-        assert org == organization_service.get_by_id.return_value
+
+        assert response == Any.instance_of(HTTPFound)
 
     @pytest.mark.parametrize(
         "parent_public_id_param,expected",
@@ -94,12 +94,11 @@ class TestAdminOrganizationViews:
         response = views.move_organization()
 
         organization_service.get_by_id.assert_called_once_with(sentinel.id_)
-        org = organization_service.get_by_id.return_value
         organization_service.update_organization.assert_called_once_with(
-            org, parent_public_id=expected
+            organization_service.get_by_id.return_value, parent_public_id=expected
         )
 
-        assert response == {"org": org}
+        assert response == Any.instance_of(HTTPFound)
 
     @pytest.mark.parametrize("exception", (InvalidPublicId, InvalidOrganizationParent))
     def test_move_organization_errors(


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4861
 
Requires: 

 * https://github.com/hypothesis/lms/pull/4866

## Testing notes

 * Create a hierarchy of orgs
 * Look at them
 * You should be able to navigate between and view the full hierarchy
 * The organization you are on is not navigable and should be highlighted