### PR TITLE
Refactor the new application instance to allow the creation of LTI 1.1

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -145,9 +145,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.instance.move_org", "/admin/instance/id/{id_}/move_org")
     config.add_route("admin.instance.consumer_key", "/admin/instance/{consumer_key}/")
     config.add_route("admin.instance.id", "/admin/instance/id/{id_}/")
-    config.add_route(
-        "admin.instance.new.registration", "/admin/instance/new/registration"
-    )
+    config.add_route("admin.instance.new", "/admin/instance/new")
 
     config.add_route("admin.organization", "/admin/org/{id_}")
     config.add_route("admin.organization.toggle", "/admin/org/{id_}/toggle")

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -49,6 +49,7 @@
     <fieldset class="box">
         {{ macros.settings_textarea(instance, "Notes", "hypothesis", "notes") }}
         {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
+        {{ macros.disabled_text_field("Shared secret", instance.shared_secret) }}
         {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
         {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
     </fieldset>

--- a/lms/templates/admin/instance.new.html.jinja2
+++ b/lms/templates/admin/instance.new.html.jinja2
@@ -2,25 +2,29 @@
 
 {% extends "lms:templates/admin/base.html.jinja2" %}
 
-
 {% block header %}
 New application instance
 {% endblock %}
 
 {% block content %}
 
-<form method="POST" action="{{ request.route_url("admin.registration.new.instance", id_=lti_registration.id) }}">
-    <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+{% if lti_registration %}
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Registration</legend>
 
         {{ macros.registration_preview(request, lti_registration) }}
     </fieldset>
+{% endif %}
 
+<form method="POST" action="{{ request.route_url("admin.instance.new") }}">
+    <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+    <input type="hidden" name="lti_registration_id" value="{{ lti_registration.id }}">
 
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Create new Application instance</legend>
-        {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
+        {% if lti_registration %}
+            {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
+        {% endif %}
         {{ macros.form_text_field(request, "LMS URL", "lms_url") }}
         {{ macros.form_text_field(request, "Email", "email") }}
         {{ macros.form_text_field(request, "Canvas developer key", "developer_key") }}
@@ -30,17 +34,19 @@ New application instance
     <input type="submit" class="button is-info" value="New"/>
 </form>
 
-<form method="POST" action="{{ request.route_url("admin.registration.upgrade.instance", id_=lti_registration.id) }}">
-    <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+{% if lti_registration %}
+    <form method="POST" action="{{ request.route_url("admin.registration.upgrade.instance", id_=lti_registration.id) }}">
+        <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
 
-    <fieldset class="box mt-6">
-        <legend class="label has-text-centered">Upgrade exsiting Application instance</legend>
-        {{ macros.form_text_field(request, "Consumer key", "consumer_key",
-            placeholder="Existing application instance's consumer key. It will be upgraded to LTI 1.3 using this registration") }}
-        {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
-    </fieldset>
+        <fieldset class="box mt-6">
+            <legend class="label has-text-centered">Upgrade existing Application instance</legend>
+            {{ macros.form_text_field(request, "Consumer key", "consumer_key",
+                placeholder="Existing application instance's consumer key. It will be upgraded to LTI 1.3 using this registration") }}
+            {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
+        </fieldset>
 
-    <input type="submit" class="button is-info" value="Upgrade"/>
-</form>
+        <input type="submit" class="button is-info" value="Upgrade"/>
+    </form>
+{% endif %}
 
 {% endblock %}

--- a/lms/templates/admin/instances.html.jinja2
+++ b/lms/templates/admin/instances.html.jinja2
@@ -7,6 +7,12 @@ Application instances
 
 {% block content %}
 
+<div class="block has-text-right">
+    <a class="button is-primary" href="{{request.route_url("admin.instance.new")}}">
+        New LTI 1.1 application instance
+    </a>
+</div>
+
 <fieldset class="box mt-6">
     <legend class="label has-text-centered">Find application instances</legend>
     <form method="POST" action="{{ request.route_url("admin.instances.search") }}">
@@ -25,7 +31,7 @@ Application instances
 </fieldset>
 
 
-{% if instances is defined %} 
+{% if instances is defined %}
 <fieldset class="box mt-6">
 <legend class="label has-text-centered">Results</legend>
 {{ macros.instances_table(request, instances) }}

--- a/lms/templates/admin/registration.html.jinja2
+++ b/lms/templates/admin/registration.html.jinja2
@@ -21,7 +21,7 @@
     <fieldset class="box">
     <legend class="label has-text-centered">Registration application instances</legend>
         <div class="block has-text-right">
-            <a class="button is-primary" href="{{ request.route_url("admin.registration.new.instance", id_=registration.id) }}">Add instance</a>
+            <a class="button is-primary" href="{{ request.route_url("admin.instance.new", _query={"lti_registration_id": registration.id}) }}">Add instance</a>
         </div>
 
         {% if registration.application_instances %}

--- a/lms/views/admin/__init__.py
+++ b/lms/views/admin/__init__.py
@@ -1,6 +1,4 @@
-from marshmallow import fields
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
-from pyramid.renderers import render_to_response
 from pyramid.view import forbidden_view_config, notfound_view_config, view_config
 
 from lms.validation._exceptions import ValidationError
@@ -32,12 +30,3 @@ def flash_validation(request, schema):
         request.session.flash(err.messages["form"], "validation")
         return True
     return False
-
-
-def error_render_to_response(
-    request, error_message, template, template_args, flash_type="errors"
-):
-    request.session.flash(error_message, flash_type)
-    response = render_to_response(template, template_args, request=request)
-    response.status = 400
-    return response

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -1,6 +1,5 @@
 from marshmallow import validate
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
-from pyramid.renderers import render_to_response
 from pyramid.view import view_config, view_defaults
 from sqlalchemy.exc import IntegrityError
 from webargs import fields
@@ -10,20 +9,27 @@ from lms.security import Permissions
 from lms.services import ApplicationInstanceNotFound, LTIRegistrationService
 from lms.services.aes import AESService
 from lms.validation._base import PyramidRequestSchema, ValidationError
-from lms.views.admin import error_render_to_response, flash_validation
+from lms.views.admin import flash_validation
 from lms.views.admin._schemas import EmptyStringInt
 
 
-class NewApplicationInstanceSchema(PyramidRequestSchema):
-    location = "form"
+class NewAppInstanceSchema(PyramidRequestSchema):
+    """Schema for creating a new application instance."""
 
-    deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
+    location = "form"
 
     developer_key = fields.Str(required=False, allow_none=True)
     developer_secret = fields.Str(required=False, allow_none=True)
 
     lms_url = fields.URL(required=True)
     email = fields.Email(required=True)
+
+
+class NewAppInstanceSchemaV13(NewAppInstanceSchema):
+    """Schema for creating a new LTI 1.3 application instance."""
+
+    deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
+    lti_registration_id = fields.Str(required=True)
 
 
 class UpgradeApplicationInstanceSchema(PyramidRequestSchema):
@@ -59,71 +65,68 @@ class AdminApplicationInstanceViews:
 
     @view_config(
         route_name="admin.instances",
-        request_method="GET",
         renderer="lms:templates/admin/instances.html.jinja2",
     )
     def instances(self):
         return {}
 
     @view_config(
-        route_name="admin.registration.new.instance",
-        request_method="POST",
+        route_name="admin.instance.new",
         renderer="lms:templates/admin/instance.new.html.jinja2",
     )
-    def new_instance(self):
-        lti_registration = self.lti_registration_service.get_by_id(
-            self.request.matchdict["id_"]
-        )
+    def new_instance_start(self):
+        """Show the page to kick off creating a new application instance."""
 
-        if flash_validation(self.request, NewApplicationInstanceSchema):
-            response = render_to_response(
-                "lms:templates/admin/instance.new.html.jinja2",
-                {"lti_registration": lti_registration},
-                request=self.request,
+        lti_registration = None
+        if lti_registration_id := self.request.params.get("lti_registration_id"):
+            lti_registration = self.lti_registration_service.get_by_id(
+                lti_registration_id.strip()
             )
-            response.status = 400
-            return response
+
+        return dict(self.request.params, lti_registration=lti_registration)
+
+    @view_config(route_name="admin.instance.new", request_method="POST")
+    def new_instance_callback(self):
+        """Create an application instance (callback from the new AI page)."""
+
+        lti_registration_id = self.request.params.get("lti_registration_id", "").strip()
+        lti_registration_id = int(lti_registration_id) if lti_registration_id else None
+
+        if flash_validation(
+            self.request,
+            NewAppInstanceSchemaV13 if lti_registration_id else NewAppInstanceSchema,
+        ):
+            # Looks like something went wrong!
+            return self._redirect("admin.instance.new", _query=self.request.params)
 
         try:
             ai = self.application_instance_service.create_application_instance(
                 lms_url=self.request.params["lms_url"].strip(),
                 email=self.request.params["email"].strip(),
-                deployment_id=self.request.params["deployment_id"].strip(),
+                deployment_id=self.request.params.get("deployment_id", "").strip(),
                 developer_key=self.request.params.get("developer_key", "").strip(),
                 developer_secret=self.request.params.get(
                     "developer_secret", ""
                 ).strip(),
-                lti_registration_id=self.request.matchdict["id_"],
+                lti_registration_id=lti_registration_id,
             )
 
         except IntegrityError:
-            return error_render_to_response(
-                self.request,
+            self.request.session.flash(
                 f"Application instance with deployment_id: {self.request.params['deployment_id']} already exists",
-                "lms:templates/admin/instance.new.html.jinja2",
-                {"lti_registration": lti_registration.id},
+                "errors",
             )
+
+            return self._redirect("admin.instance.new", _query=self.request.params)
 
         return self._redirect("admin.instance.id", id_=ai.id)
 
     @view_config(
-        route_name="admin.registration.upgrade.instance",
-        request_method="POST",
-        renderer="lms:templates/admin/instance.new.html.jinja2",
+        route_name="admin.registration.upgrade.instance", request_method="POST"
     )
     def upgrade_instance(self):
-        lti_registration = self.lti_registration_service.get_by_id(
-            self.request.matchdict["id_"]
-        )
-
         if flash_validation(self.request, UpgradeApplicationInstanceSchema):
-            response = render_to_response(
-                "lms:templates/admin/instance.new.html.jinja2",
-                {"lti_registration": lti_registration},
-                request=self.request,
-            )
-            response.status = 400
-            return response
+            return self._redirect("admin.instance.new", _query=self.request.params)
 
         consumer_key = self.request.params["consumer_key"].strip()
         deployment_id = self.request.params["deployment_id"].strip()
@@ -134,24 +137,25 @@ class AdminApplicationInstanceViews:
                 self.application_instance_service.get_by_consumer_key(consumer_key)
             )
         except ApplicationInstanceNotFound:
-            return error_render_to_response(
-                self.request,
+            self.request.session.flash(
                 f"Can't find application instance: '{consumer_key}' for upgrade.",
-                "lms:templates/admin/instance.new.html.jinja2",
-                {"lti_registration": lti_registration},
+                "errors",
             )
+
+            return self._redirect("admin.instance.new", _query=self.request.params)
 
         # Don't allow to change instances that already on 1.3
         if application_instance.lti_version == "1.3.0":
-            return error_render_to_response(
-                self.request,
+            self.request.session.flash(
                 f"Application instance: '{consumer_key}' is already on LTI 1.3.",
-                "lms:templates/admin/instance.new.html.jinja2",
-                {"lti_registration": lti_registration},
+                "errors",
             )
 
+            return self._redirect("admin.instance.new", _query=self.request.params)
         # Set the LTI1.3 values
-        application_instance.lti_registration = lti_registration
+        application_instance.lti_registration = self.lti_registration_service.get_by_id(
+            self.request.params.get("lti_registration_id", "").strip()
+        )
         application_instance.deployment_id = deployment_id
         try:
             # Flush here to find if we are making a duplicate in the process of
@@ -163,12 +167,12 @@ class AdminApplicationInstanceViews:
             #   rolled back due to a previous exception during flush."
             self.request.db.rollback()
 
-            return error_render_to_response(
-                self.request,
+            self.request.session.flash(
                 f"Application instance with deployment_id: {self.request.params['deployment_id']} already exists",
-                "lms:templates/admin/instance.new.html.jinja2",
-                {"lti_registration": lti_registration.id},
+                "errors",
             )
+
+            return self._redirect("admin.instance.new", _query=self.request.params)
 
         return self._redirect("admin.instance.id", id_=application_instance.id)
 
@@ -252,9 +256,7 @@ class AdminApplicationInstanceViews:
         return self._redirect("admin.instance.id", id_=ai.id)
 
     @view_config(
-        route_name="admin.instance.id",
-        request_method="POST",
-        require_csrf=True,
+        route_name="admin.instance.id", request_method="POST", require_csrf=True
     )
     @view_config(
         route_name="admin.instance.consumer_key",

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -180,19 +180,17 @@ class AdminApplicationInstanceViews:
             self.request.session.flash(
                 f"Application instance: '{ai.id}' is not on LTI 1.3.", "errors"
             )
-            return self._redirect("admin.instance.id", id_=ai.id)
-
-        if not ai.consumer_key:
+        elif not ai.consumer_key:
             self.request.session.flash(
                 f"Application instance: '{ai.id}' doesn't have a consumer key to fallback to.",
                 "errors",
             )
-            return self._redirect("admin.instance.id", id_=ai.id)
+        else:
+            ai.lti_registration_id = None
+            ai.deployment_id = None
 
-        ai.lti_registration_id = None
-        ai.deployment_id = None
+            self.request.session.flash("Downgraded LTI 1.1 successful", "messages")
 
-        self.request.session.flash("Downgraded LTI 1.1 successful", "messages")
         return self._redirect("admin.instance.id", id_=ai.id)
 
     @view_config(

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -104,9 +104,7 @@ class AdminApplicationInstanceViews:
                 {"lti_registration": lti_registration.id},
             )
 
-        return HTTPFound(
-            location=self.request.route_url("admin.instance.id", id_=ai.id)
-        )
+        return self._redirect("admin.instance.id", id_=ai.id)
 
     @view_config(
         route_name="admin.registration.upgrade.instance",
@@ -172,11 +170,7 @@ class AdminApplicationInstanceViews:
                 {"lti_registration": lti_registration.id},
             )
 
-        return HTTPFound(
-            location=self.request.route_url(
-                "admin.instance.id", id_=application_instance.id
-            )
-        )
+        return self._redirect("admin.instance.id", id_=application_instance.id)
 
     @view_config(route_name="admin.instance.downgrade", request_method="POST")
     def downgrade_instance(self):
@@ -186,26 +180,20 @@ class AdminApplicationInstanceViews:
             self.request.session.flash(
                 f"Application instance: '{ai.id}' is not on LTI 1.3.", "errors"
             )
-            return HTTPFound(
-                location=self.request.route_url("admin.instance.id", id_=ai.id)
-            )
+            return self._redirect("admin.instance.id", id_=ai.id)
 
         if not ai.consumer_key:
             self.request.session.flash(
                 f"Application instance: '{ai.id}' doesn't have a consumer key to fallback to.",
                 "errors",
             )
-            return HTTPFound(
-                location=self.request.route_url("admin.instance.id", id_=ai.id)
-            )
+            return self._redirect("admin.instance.id", id_=ai.id)
 
         ai.lti_registration_id = None
         ai.deployment_id = None
 
         self.request.session.flash("Downgraded LTI 1.1 successful", "messages")
-        return HTTPFound(
-            location=self.request.route_url("admin.instance.id", id_=ai.id)
-        )
+        return self._redirect("admin.instance.id", id_=ai.id)
 
     @view_config(
         route_name="admin.instances.search",
@@ -262,13 +250,8 @@ class AdminApplicationInstanceViews:
             )
         except ValidationError as err:
             self.request.session.flash(err.messages, "validation")
-            return HTTPFound(
-                location=self.request.route_url("admin.instance.id", id_=ai.id)
-            )
 
-        return HTTPFound(
-            location=self.request.route_url("admin.instance.id", id_=ai.id)
-        )
+        return self._redirect("admin.instance.id", id_=ai.id)
 
     @view_config(
         route_name="admin.instance.id",
@@ -332,9 +315,10 @@ class AdminApplicationInstanceViews:
 
         self.request.session.flash(f"Updated application instance {ai.id}", "messages")
 
-        return HTTPFound(
-            location=self.request.route_url("admin.instance.id", id_=ai.id)
-        )
+        return self._redirect("admin.instance.id", id_=ai.id)
+
+    def _redirect(self, route_name, **kwargs):
+        return HTTPFound(location=self.request.route_url(route_name, **kwargs))
 
     def _get_ai_or_404(self, consumer_key=None, id_=None) -> ApplicationInstance:
         try:

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -204,18 +204,6 @@ class AdminLTIRegistrationViews:
         self.request.session.flash("Updated registration", "messages")
         return {"registration": lti_registration}
 
-    @view_config(
-        route_name="admin.registration.new.instance",
-        request_method="GET",
-        renderer="lms:templates/admin/instance.new.html.jinja2",
-    )
-    def registration_new_instance(self):
-        return {
-            "lti_registration": self._get_registration_or_404(
-                self.request.matchdict["id_"]
-            )
-        }
-
     @staticmethod
     def _get_url_suggestions(issuer, client_id):
         """

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -200,19 +200,6 @@ class TestAdminApplicationInstanceViews:
         )
         assert pyramid_request.session.peek_flash("validation")
 
-    def test_registration_new_instance(
-        self, pyramid_request, lti_registration_service, views
-    ):
-        pyramid_request.matchdict["id_"] = sentinel.id_
-
-        response = views.registration_new_instance()
-
-        lti_registration_service.get_by_id.assert_called_once_with(sentinel.id_)
-        assert (
-            response["lti_registration"]
-            == lti_registration_service.get_by_id.return_value
-        )
-
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.params = {}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4863

This also disentangles the registration from the application instance and makes it optional.

## Implementation notes

 * `/admin/instance/new/registration` has become `/admin/instance/new`
    * Some of the methods have moved over to the application instance view as a result
 * We now read all of the values from params instead of any path params
 * This makes is possible to optionally accept a registration id (which enables 1.3 mode)
 * If it's missing we use a different schema and only expect 1.1 values
 * As the `POST` methods all return redirects we don't need `error_render_to_response` any more

This mixes in a refactor for a `_redirect()` which is probably better as a separate PR / commit.

## Testing notes

The LTI 1.3 path should not be effected and should keep working:

 * Visit: http://localhost:8001/admin/registration/id/2/
 * Click "Add instance"
 * This page should work as before, specifically check that:
   * Deployment ID is required
   * You can save a filled out application instance
   * You can upgrade an exising LTI1.1 (try "Hypothesis37c8a8ac186ad5d7e6da83c060c3b18b")

The new LTI 1.1 path should also work:

 * Visit: http://localhost:8001/admin/instances/
 * Click: "New LTI 1.1 application instance"
 * Notice the following are not visible:
   * Upgrade an instnace
   * Deployment Id
   * Should we hide the "No LTI registration"?
 * Try saving without filling anything out, notice that "Deployment id" is not required
 * Try filling out the required fields, it should work and redirect you to view the application instance