### PR TITLE
Handle course copy for Canvas groups

### DIFF
--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -56,10 +56,12 @@ class CanvasGroupingPlugin(GroupingPlugin):
 
         raise GroupError(ErrorCodes.STUDENT_NOT_IN_GROUP, group_set=group_set_id)
 
-    def get_groups_for_instructor(self, _svc, _course, group_set_id):
+    def get_groups_for_instructor(self, _svc, course, group_set_id):
         try:
             # If not grading return all the groups in the course so the teacher can toggle between them.
-            all_course_groups = self._canvas_api.group_category_groups(group_set_id)
+            all_course_groups = self._canvas_api.group_category_groups(
+                self._custom_course_id(course), group_set_id
+            )
         except CanvasAPIError as canvas_api_error:
             raise GroupError(
                 ErrorCodes.GROUP_SET_NOT_FOUND, group_set=group_set_id

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.js
@@ -140,8 +140,32 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
-    case 'blackboard_group_set_not_found':
     case 'canvas_group_set_not_found':
+      return (
+        <ErrorModal busy={busy} error={error} title="Group set not found">
+          <p>
+            Hypothesis couldn&apos;t find this assignment&apos;s group set. This
+            could be because:
+          </p>
+
+          <ul className="u-list">
+            <li>The group set has been deleted from Canvas.</li>
+            <li>
+              This course was created by copying another course (Canvas
+              doesn&apos;t copy the group sets over when you copy a course).
+            </li>
+          </ul>
+
+          <p>
+            <b>
+              To fix this problem, an instructor needs to edit the assignment
+              settings and select a new group set.
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
+    case 'blackboard_group_set_not_found':
       return (
         <ErrorModal
           busy={busy}

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -65,8 +65,8 @@ describe('LaunchErrorDialog', () => {
     {
       errorState: 'canvas_group_set_not_found',
       expectedText:
-        "Hypothesis couldn't load this assignment because the assignment's group set no longer exists.To fix this problem, an instructor needs to edit the assignment settings and select a new group set.",
-      expectedTitle: "Assignment's group set no longer exists",
+        "Hypothesis couldn't find this assignment's group set. This could be because:The group set has been deleted from Canvas.This course was created by copying another course (Canvas doesn't copy the group sets over when you copy a course).",
+      expectedTitle: 'Group set not found',
       hasRetry: false,
       withError: true,
     },

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -85,7 +85,7 @@ class TestCanvasGroupingPlugin:
         )
 
         canvas_api_client.group_category_groups.assert_called_once_with(
-            sentinel.group_set_id
+            sentinel.canvas_course_id, sentinel.group_set_id
         )
         assert canvas_api_client.group_category_groups.return_value == api_groups
 
@@ -142,7 +142,7 @@ class TestCanvasGroupingPlugin:
             sentinel.group_set_id,
         )
         canvas_api_client.group_category_groups.assert_called_once_with(
-            sentinel.group_set_id
+            sentinel.canvas_course_id, sentinel.group_set_id
         )
         assert canvas_api_client.group_category_groups.return_value == all_groups
 

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -176,12 +176,14 @@ class TestCanvasAPIClientIntegrated:
                 "name": "Group 1",
                 "description": "Group 1",
                 "group_category_id": 1,
+                "course_id": 1,
             },
             {
                 "id": 2,
                 "name": "Group 2",
                 "description": "Group 2",
                 "group_category_id": 1,
+                "course_id": 1,
             },
         ]
         http_session.send.return_value = factories.requests.Response(
@@ -295,8 +297,9 @@ class TestCanvasAPIClientIntegrated:
         assert response[0]["group_category_id"] == int(group_category_id)
 
     @pytest.mark.usefixtures("list_groups_response")
-    def test_group_category_groups(self, canvas_api_client, http_session):
-        response = canvas_api_client.group_category_groups("GROUP_CATEGORY")
+    @pytest.mark.parametrize("course_id", (1, "1"))
+    def test_group_category_groups(self, canvas_api_client, http_session, course_id):
+        response = canvas_api_client.group_category_groups(course_id, "GROUP_CATEGORY")
 
         assert len(response) == 2
         http_session.send.assert_called_once_with(
@@ -307,6 +310,17 @@ class TestCanvasAPIClientIntegrated:
                 ).with_query({"per_page": Any.string()}),
             ),
             timeout=Any(),
+        )
+
+    @pytest.mark.usefixtures("list_groups_response")
+    def test_group_category_groups_from_another_course(self, canvas_api_client):
+
+        with pytest.raises(CanvasAPIError) as exc_info:
+            canvas_api_client.group_category_groups(2, "GROUP_CATEGORY")
+
+        assert (
+            exc_info.value.message
+            == "Group set GROUP_CATEGORY doesn't belong to course 2"
         )
 
     def test_users_sections(self, canvas_api_client, http_session):
@@ -505,12 +519,14 @@ class TestCanvasAPIClientIntegrated:
                     "name": "Group 1",
                     "description": "Group 1",
                     "group_category_id": 1,
+                    "course_id": 1,
                 },
                 {
                     "id": 2,
                     "name": "Group 2",
                     "description": "Group 2",
                     "group_category_id": 2,
+                    "course_id": 1,
                 },
             ],
             status_code=200,
@@ -526,6 +542,7 @@ class TestCanvasAPIClientIntegrated:
                     "description": "Group 1",
                     "group_category_id": 1,
                     "users": [],
+                    "course_id": 1,
                 },
                 {
                     "id": 2,
@@ -533,6 +550,7 @@ class TestCanvasAPIClientIntegrated:
                     "description": "Group 2",
                     "group_category_id": 2,
                     "users": [{"id": 1}],
+                    "course_id": 1,
                 },
             ],
             status_code=200,


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4865



# Testing

- Launch in the original course as a teacher:

https://hypothesis.instructure.com/courses/125/assignments/1833

Evertying should work as before.


- Launch in the copied course 

https://hypothesis.instructure.com/courses/518/assignments/4211


You'll get the modified error modal.


- Compare to `main`
 
Checkout main and launch the copied assignment, everything would appear to work but you'll be pointing to the old course's groups.

https://hypothesis.instructure.com/courses/518/assignments/4211
