### PR TITLE
Don't request unnecessary scopes for D2L

### DIFF
--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -17,18 +17,21 @@ FILES_SCOPES = ("content:toc:read", "content:topics:read")
     permission=Permissions.API,
 )
 def authorize(request):
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
-    state = OAuthCallbackSchema(request).state_param()
-
-    scopes = ["core:*:*"]
+    scopes = []
 
     if request.product.settings.files_enabled:
         scopes += FILES_SCOPES
 
     if request.product.settings.groups_enabled:
         scopes += GROUPS_SCOPES
+
+    if not scopes:
+        raise NotImplementedError("Trying to get a D2L without any scopes")
+
+    application_instance = request.find_service(
+        name="application_instance"
+    ).get_current()
+    state = OAuthCallbackSchema(request).state_param()
 
     return HTTPFound(
         location=urlunparse(

--- a/tests/unit/lms/views/api/d2l/authorize_test.py
+++ b/tests/unit/lms/views/api/d2l/authorize_test.py
@@ -19,14 +19,9 @@ class TestAuthorize:
     @pytest.mark.parametrize(
         "groups,files,scopes",
         [
-            (False, False, "core:*:*"),
-            (False, True, "core:*:* content:toc:read content:topics:read"),
-            (True, False, "core:*:* groups:group:read"),
-            (
-                True,
-                True,
-                "core:*:* content:toc:read content:topics:read groups:group:read",
-            ),
+            (False, True, "content:toc:read content:topics:read"),
+            (True, False, "groups:group:read"),
+            (True, True, "content:toc:read content:topics:read groups:group:read"),
         ],
     )
     def test_it(
@@ -64,6 +59,13 @@ class TestAuthorize:
                 },
             )
         )
+
+    def test_raises_with_no_scopes(self, pyramid_request):
+        pyramid_request.product.settings.groups_enabled = False
+        pyramid_request.product.settings.files_enabled = False
+
+        with pytest.raises(NotImplementedError):
+            authorize(pyramid_request)
 
 
 class TestOAuth2Redirect:


### PR DESCRIPTION
I added this initially as it was part of D2L examples in the documentation I thought it was a requirement but it's not needed at all.

---

`core:*` scopes don't seem to be a requirement for any of the endpoints we use.

See the full list at:

* https://docs.valence.desire2learn.com/http-scopestable.html

## Testing

- Remove existing tokens:
```shell
tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate oauth2_token"
```
- Remove assignments to allow re-configuring:
```shell
 tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment cascade"
```
- Configure: https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2177/View
with either files or groups or both. 
- It will succeed.