### PR TITLE
Fix crashes in the organization hierarchy view caused by null names

### DIFF
--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -11,7 +11,7 @@
 
         {% if node.children %}
             <ul>
-            {% for child in node.children | sort(attribute='name') %}
+            {% for child in sort_by_name(node.children) %}
                 {{ org_hierarchy(child, focus_org) }}
             {% endfor %}
             </ul>

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -82,6 +82,9 @@ class AdminOrganizationViews:
         return {
             "org": self._get_org_or_404(org_id),
             "hierarchy_root": self.organization_service.get_hierarchy_root(org_id),
+            "sort_by_name": lambda items: sorted(
+                items, key=lambda value: value.name or ""
+            ),
         }
 
     @view_config(route_name="admin.organization", request_method="POST")

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -42,7 +42,21 @@ class TestAdminOrganizationViews:
         assert response == {
             "org": organization_service.get_by_id.return_value,
             "hierarchy_root": organization_service.get_hierarchy_root.return_value,
+            "sort_by_name": Any.callable(),
         }
+
+    def test_show_organization_sort_by_name(self, views, pyramid_request):
+        pyramid_request.matchdict["id_"] = sentinel.id_
+        response = views.show_organization()
+        sort_by_name = response["sort_by_name"]
+
+        org_a = factories.Organization(name="a")
+        org_b = factories.Organization(name="b")
+        org_none = factories.Organization(name=None)
+
+        results = sort_by_name([org_a, org_none, org_b])
+
+        assert list(results) == [org_none, org_a, org_b]
 
     def test_show_organization_not_found(
         self, pyramid_request, organization_service, views


### PR DESCRIPTION
In Python 3 None has no natural sort, so the built in sort operation in Jinja2 isn't very useful over objects with attributes which can be None. To fix that we inject our own sorting method here.

## The issue

In order to trigger this issue you need two organizations at the same level, where one has a string name and another has a null name. You cannot set a null name through the interface (it interprets an empty string as "don't set a name").

You can see a failing example in live here:

  * https://lms.hypothes.is/admin/org/378

## Testing notes

To set this up:

 * Pick an organization to be the parent and copy the public id
 * Pick two other orgs and set them to be children of that org
 * Pick the id of one of the child orgs
 * `UPDATE organization SET name = NULL where id=<ID>`
 * On `main`: This should fail with an exception like:
```python
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```
* In this branch it should sort ahead of other items in the list