### PR TITLE
Get existing course instead of trying to recreate it

### DIFF
--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
@@ -13,15 +13,13 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-class TestApplicationInstance:
-    def test_it(self, lti_launch, application_instance_service):
+class TestLTILaunchResource:
+    def test_application_instance(self, lti_launch, application_instance_service):
         assert (
             lti_launch.application_instance
             == application_instance_service.get_current.return_value
         )
 
-
-class TestIsCanvas:
     @pytest.mark.parametrize(
         "product,expected",
         [
@@ -30,14 +28,12 @@ class TestIsCanvas:
             (Product.Family.UNKNOWN, False),
         ],
     )
-    def test_it(self, pyramid_request, product, expected):
+    def test_is_canvas(self, pyramid_request, product, expected):
         pyramid_request.product.family = product
 
         assert LTILaunchResource(pyramid_request).is_canvas == expected
 
-
-class TestJSConfig:
-    def test_it_returns_the_js_config(self, pyramid_request, JSConfig):
+    def test_js_config(self, pyramid_request, JSConfig):
         lti_launch = LTILaunchResource(pyramid_request)
 
         js_config = lti_launch.js_config
@@ -45,33 +41,7 @@ class TestJSConfig:
         JSConfig.assert_called_once_with(lti_launch, pyramid_request)
         assert js_config == JSConfig.return_value
 
-
-class TestNewCourseExtra:
-    # pylint: disable=protected-access
-    def test_empty_in_non_canvas(self, pyramid_request):
-        parsed_params = {}
-        pyramid_request.parsed_params = parsed_params
-
-        assert not LTILaunchResource(pyramid_request)._new_course_extra()
-
-    @pytest.mark.usefixtures("with_canvas")
-    def test_includes_course_id(self, pyramid_request):
-        parsed_params = {
-            "custom_canvas_course_id": "ID",
-        }
-        pyramid_request.parsed_params = parsed_params
-
-        assert LTILaunchResource(pyramid_request)._new_course_extra() == {
-            "canvas": {"custom_canvas_course_id": "ID"}
-        }
-
-    @pytest.fixture
-    def with_canvas(self, pyramid_request):
-        pyramid_request.product.family = Product.Family.CANVAS
-
-
-class TestCourse:
-    def test_it_when_existing(self, course_service, lti_launch):
+    def test_course_when_existing(self, course_service, lti_launch):
         course_service.get_by_context_id.return_value = factories.Course(
             extra={"existing": "extra"}
         )
@@ -88,7 +58,19 @@ class TestCourse:
         )
         assert course == course_service.upsert_course.return_value
 
-    def test_it_when_new(self, course_service, lti_launch, _new_course_extra):
+    def test_course_when_new(self, course_service, lti_launch):
+        course_service.get_by_context_id.return_value = None
+
+        course = lti_launch.course
+
+        course_service.get_by_context_id.assert_called_once_with(sentinel.context_id)
+        course_service.upsert_course.assert_called_once_with(
+            context_id=sentinel.context_id, name=sentinel.context_title, extra={}
+        )
+        assert course == course_service.upsert_course.return_value
+
+    @pytest.mark.usefixtures("with_canvas")
+    def test_course_when_new_and_canvas(self, course_service, lti_launch):
         course_service.get_by_context_id.return_value = None
 
         course = lti_launch.course
@@ -97,24 +79,12 @@ class TestCourse:
         course_service.upsert_course.assert_called_once_with(
             context_id=sentinel.context_id,
             name=sentinel.context_title,
-            extra=_new_course_extra.return_value,
+            extra={"canvas": {"custom_canvas_course_id": "ID"}},
         )
         assert course == course_service.upsert_course.return_value
 
-    @pytest.fixture
-    def _new_course_extra(self, lti_launch):
-        with patch.object(lti_launch, "_new_course_extra", autospec=True) as patched:
-            yield patched
-
-
-class TestGroupingType:
-    def test_it(
-        self,
-        grouping_service,
-        lti_launch,
-        assignment_service,
-        pyramid_request,
-        course,
+    def test_grouping_type(
+        self, grouping_service, lti_launch, assignment_service, pyramid_request
     ):
         assert (
             lti_launch.grouping_type
@@ -130,27 +100,24 @@ class TestGroupingType:
         )
 
     @pytest.fixture
-    def course(self, lti_launch):
-        with patch.object(lti_launch, "course", autospec=True) as patched:
-            yield patched
+    def with_canvas(self, pyramid_request):
+        pyramid_request.parsed_params["custom_canvas_course_id"] = "ID"
+        pyramid_request.product.family = Product.Family.CANVAS
 
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.parsed_params = pyramid_request.lti_params = {
+            "tool_consumer_instance_guid": sentinel.tool_guid,
+            "resource_link_id": sentinel.resource_link_id,
+            "context_id": sentinel.context_id,
+            "context_title": sentinel.context_title,
+        }
+        return pyramid_request
 
-@pytest.fixture
-def lti_launch(pyramid_request):
-    return LTILaunchResource(pyramid_request)
+    @pytest.fixture
+    def lti_launch(self, pyramid_request):
+        return LTILaunchResource(pyramid_request)
 
-
-@pytest.fixture(autouse=True)
-def JSConfig(patch):
-    return patch("lms.resources.lti_launch.JSConfig")
-
-
-@pytest.fixture
-def pyramid_request(pyramid_request):
-    pyramid_request.parsed_params = pyramid_request.lti_params = {
-        "tool_consumer_instance_guid": sentinel.tool_guid,
-        "resource_link_id": sentinel.resource_link_id,
-        "context_id": sentinel.context_id,
-        "context_title": sentinel.context_title,
-    }
-    return pyramid_request
+    @pytest.fixture(autouse=True)
+    def JSConfig(self, patch):
+        return patch("lms.resources.lti_launch.JSConfig")


### PR DESCRIPTION
While working on course copy I found that we never persist the extra portion of course other than the one we set on creation.

Arguably this is a bug that we are not yet hitting but worth fixing in preparation for course copy and not mixed with the rest of the changes.

# Testing


- Remove courses

`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping cascade;"`


- Launch https://hypothesis.instructure.com/courses/125/assignments/873


- Check the course's extra

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select extra from grouping where type = 'course'" 
                     extra                                                           
------------------------------------------------                                     
 {"canvas": {"custom_canvas_course_id": "125"}}                                      
(1 row)                   
```


- Update the course extra directly on the DB:

make sql
```
postgres=# update grouping set extra=jsonb_set(extra, '{other}', '"value"') where type = 'course';
UPDATE 1
postgres=# select extra from grouping where type = 'course';
                              extra                               
------------------------------------------------------------------
 {"other": "value", "canvas": {"custom_canvas_course_id": "125"}}
(1 row)
```


- Launch the assignment again

On `main` extra gets reset back to the original, in this branch the changes are preserved.

