### PR TITLE
Make organization a required field in admin pages application instance create

### DIFF
--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -229,6 +229,7 @@ class ApplicationInstanceService:
         email,
         developer_key,
         developer_secret,
+        organization_public_id=None,  # We want to make this mandatory
         settings=None,
         deployment_id=None,
         lti_registration_id=None,
@@ -257,6 +258,7 @@ class ApplicationInstanceService:
             application_instance,
             developer_key=developer_key,
             developer_secret=developer_secret,
+            organization_public_id=organization_public_id,
         )
         self._db.add(application_instance)
         self._db.flush()  # Force the returned AI to have an ID

--- a/lms/templates/admin/instance.new.html.jinja2
+++ b/lms/templates/admin/instance.new.html.jinja2
@@ -22,6 +22,7 @@ New application instance
 
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Create new Application instance</legend>
+        {{ macros.form_text_field(request, "Organization Public Id", "organization_public_id") }}
         {% if lti_registration %}
             {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
         {% endif %}

--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -41,6 +41,12 @@
 
     <fieldset class="box">
     <legend class="label has-text-centered">Application instances</legend>
+        <div class="block has-text-right">
+            <a class="button is-primary" href="{{ request.route_url("admin.instance.new", _query={"organization_public_id": org.public_id}) }}">
+                Add New LTI 1.1 instance
+            </a>
+        </div>
+
         {% if org.application_instances %}
             {{ macros.object_list_table(
                     request, 'admin.instance.id', org.application_instances,

--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -16,10 +16,10 @@ def create_application_instance(request):
     instance = request.find_service(
         name="application_instance"
     ).create_application_instance(
-        request.params["lms_url"],
-        request.params["email"],
-        developer_key,
-        developer_secret,
+        lms_url=request.params["lms_url"],
+        email=request.params["email"],
+        developer_key=developer_key,
+        developer_secret=developer_secret,
         settings={
             "canvas": {
                 "sections_enabled": False,

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -106,7 +106,6 @@ class TestApplicationInstanceService:
         developer_secret,
         aes_service,
     ):
-
         service.update_application_instance(
             application_instance,
             lms_url=lms_url,
@@ -177,11 +176,11 @@ class TestApplicationInstanceService:
             developer_key = developer_secret = None
 
         application_instance = service.create_application_instance(
-            "https://example.com/",
-            "example@example.com",
-            developer_key,
-            developer_secret,
-            {},
+            lms_url="https://example.com/",
+            email="example@example.com",
+            developer_key=developer_key,
+            developer_secret=developer_secret,
+            settings={},
         )
 
         assert application_instance.consumer_key

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -162,14 +162,21 @@ class TestApplicationInstanceService:
 
     @pytest.mark.parametrize("developer_key", ("key", None))
     @pytest.mark.parametrize("developer_secret", ("secret", None))
+    @pytest.mark.parametrize("organization_public_id", ("us.lms.org.ID", None))
     def test_create_application_instance(
-        self, service, update_application_instance, developer_key, developer_secret
+        self,
+        service,
+        update_application_instance,
+        developer_key,
+        developer_secret,
+        organization_public_id,
     ):
         application_instance = service.create_application_instance(
             lms_url="https://example.com/",
             email="example@example.com",
             developer_key=developer_key,
             developer_secret=developer_secret,
+            organization_public_id=organization_public_id,
             settings={},
         )
 
@@ -190,6 +197,7 @@ class TestApplicationInstanceService:
             application_instance,
             developer_key=developer_key,
             developer_secret=developer_secret,
+            organization_public_id=organization_public_id,
         )
 
     @pytest.mark.parametrize("field", ["issuer", "client_id"])


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4863

## Implementation notes

This PR:

 * Moves to kwargs for calls to `create_application_instance` to make it easier to change them
 * Fixes some oddities in the test for `create_application_instance`
 * Makes organization id mandatory on create
 * Adds a path to jump from org to the creation of a 1.1 application instance (but not 1.3)

## Testing notes

 * Visit an org: http://localhost:8001/admin/org/1
 * Press "Add New LTI 1.1 Instance"
 * Notice the organization id is passed through
 * Delete the id
 * Try to save
 * Notice you get an error about organization id
 * Fill out all the required fields, but put a mangled value in organization id
 * Try to save
 * Notice you get a malformed public id error
 * Add the original public id back again from  http://localhost:8001/admin/org/1
 * Save
 * It should work and redirect to the application instance page
 * Notice the linked organization is the correct one
