### PR TITLE
Move settings defaults for application instances into the service

### DIFF
--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -230,7 +230,6 @@ class ApplicationInstanceService:
         developer_key,
         developer_secret,
         organization_public_id=None,  # We want to make this mandatory
-        settings=None,
         deployment_id=None,
         lti_registration_id=None,
     ):
@@ -245,7 +244,13 @@ class ApplicationInstanceService:
             lms_url=lms_url,
             requesters_email=email,
             created=datetime.utcnow(),
-            settings=settings or {},
+            # Some helpful defaults for settings
+            settings={
+                "canvas": {
+                    "sections_enabled": False,
+                    "groups_enabled": bool(developer_key),
+                }
+            },
             deployment_id=deployment_id,
             lti_registration_id=lti_registration_id,
         )

--- a/lms/views/application_instances.py
+++ b/lms/views/application_instances.py
@@ -10,22 +10,14 @@ from pyramid.view import view_config
 )
 def create_application_instance(request):
     """Create application instance in the database and respond with key and secret."""
-    developer_key = request.params["developer_key"].strip()
-    developer_secret = request.params["developer_secret"].strip()
 
     instance = request.find_service(
         name="application_instance"
     ).create_application_instance(
         lms_url=request.params["lms_url"],
         email=request.params["email"],
-        developer_key=developer_key,
-        developer_secret=developer_secret,
-        settings={
-            "canvas": {
-                "sections_enabled": False,
-                "groups_enabled": bool(developer_key),
-            }
-        },
+        developer_key=request.params["developer_key"].strip(),
+        developer_secret=request.params["developer_secret"].strip(),
     )
 
     return {

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -177,7 +177,6 @@ class TestApplicationInstanceService:
             developer_key=developer_key,
             developer_secret=developer_secret,
             organization_public_id=organization_public_id,
-            settings={},
         )
 
         # Things we set ourselves
@@ -187,7 +186,12 @@ class TestApplicationInstanceService:
         )
         assert application_instance.lms_url == "https://example.com/"
         assert application_instance.requesters_email == "example@example.com"
-        assert application_instance.settings == {}
+        assert application_instance.settings == {
+            "canvas": {
+                "sections_enabled": False,
+                "groups_enabled": bool(developer_key),
+            }
+        }
 
         # Things we delegate to `update_application_instance`
         if not all([developer_secret, developer_key]):

--- a/tests/unit/lms/views/application_instance_test.py
+++ b/tests/unit/lms/views/application_instance_test.py
@@ -1,5 +1,4 @@
 import pytest
-from h_matchers import Any
 
 from lms.views.application_instances import (
     create_application_instance,
@@ -8,36 +7,17 @@ from lms.views.application_instances import (
 
 
 class TestCreateApplicationInstance:
-    @pytest.mark.parametrize(
-        "developer_key,canvas_sections_enabled, canvas_groups_enabled",
-        [("test_developer_key", False, True), ("", False, False)],
-    )
-    def test_it(
-        self,
-        pyramid_request,
-        application_instance_service,
-        developer_key,
-        canvas_sections_enabled,
-        canvas_groups_enabled,
-    ):
-        pyramid_request.params["developer_key"] = developer_key
-        pyramid_request.params["developer_secret"] = "test_developer_secret"
+    def test_it(self, pyramid_request, application_instance_service):
+        pyramid_request.params["developer_key"] = "  DEVELOPER_KEY  "
+        pyramid_request.params["developer_secret"] = " DEVELOPER_SECRET "
 
         result = create_application_instance(pyramid_request)
 
         application_instance_service.create_application_instance.assert_called_once_with(
-            "canvas.example.com",
-            "email@example.com",
-            developer_key,
-            "test_developer_secret",
-            settings=Any.dict.containing(
-                {
-                    "canvas": {
-                        "sections_enabled": canvas_sections_enabled,
-                        "groups_enabled": canvas_groups_enabled,
-                    }
-                }
-            ),
+            lms_url="canvas.example.com",
+            email="email@example.com",
+            developer_key="DEVELOPER_KEY",
+            developer_secret="DEVELOPER_SECRET",
         )
         created_ai = (
             application_instance_service.create_application_instance.return_value


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4863

Requires:

  * https://github.com/hypothesis/lms/pull/4886

Our internal and external application instance creation pages apply different settings as defaults. This moves those settings inside the service and ensures both will set the same value.