### PR TITLE
Redirect users who visit us directly to help pages

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -1,7 +1,7 @@
 def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("index", "/")
+    config.add_route("welcome", "/welcome")  # Legacy view, points to "/" now
     config.add_route("feature_flags_test", "/flags/test")
-    config.add_route("welcome", "/welcome")
     config.add_route("assets", "/assets/*subpath")
     config.add_route("status", "/_status")
     config.add_route("favicon", "/favicon.ico")

--- a/lms/views/index.py
+++ b/lms/views/index.py
@@ -1,8 +1,12 @@
+from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
 
-@view_config(route_name="welcome", renderer="lms:templates/base.html.jinja2")
-@view_config(route_name="index", renderer="lms:templates/base.html.jinja2")
-def index(request):  # pylint: disable=unused-argument
-    """Render an empty page that contains a needed Google verification meta tag."""
-    return {}
+@view_config(route_name="welcome")
+@view_config(route_name="index")
+def index(_):
+    """Redirect curious users to some help."""
+
+    return HTTPFound(
+        location="https://web.hypothes.is/help/installing-the-hypothesis-lms-app/"
+    )

--- a/tests/functional/ui/landing_page_test.py
+++ b/tests/functional/ui/landing_page_test.py
@@ -1,5 +1,0 @@
-class TestLandingPage:
-    def test_we_can_get_the_page(self, app):
-        result = app.get("/", status=200)
-
-        assert "<html" in result

--- a/tests/unit/lms/views/index_test.py
+++ b/tests/unit/lms/views/index_test.py
@@ -1,8 +1,11 @@
+from h_matchers import Any
+from pyramid.httpexceptions import HTTPFound
+
 from lms.views.index import index
 
 
 class TestIndexView:
-    def test_it_does_nowt(self, pyramid_request):
-        template_params = index(pyramid_request)
+    def test_it(self, pyramid_request):
+        response = index(pyramid_request)
 
-        assert not template_params
+        assert response == Any.instance_of(HTTPFound)


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4864
 
Requires:

 * https://github.com/hypothesis/lms/pull/4876

We are removing the welcome page, but curious users might still visit. We help them better by redirecting them to some relevant help.

## Testing notes

 * Visit: http://localhost:8001/
 * Visit: http://localhost:8001/welcome
 * Both should redirect you to: https://web.hypothes.is/help/installing-the-hypothesis-lms-app/