### PR TITLE
Flag auto assigned application instances

### DIFF
--- a/tests/unit/lms/services/organization_service_test.py
+++ b/tests/unit/lms/services/organization_service_test.py
@@ -119,9 +119,17 @@ class TestOrganizationService:
         assert application_instance.organization == result
         if org:
             assert result == org
+            assert not result.settings.get("hypothesis", "auto_created")
+            assert not application_instance.settings.get(
+                "hypothesis", "auto_assigned_to_org"
+            )
         else:
             # For the newly created org case, make sure we have an ID
             assert result.id
+            assert result.settings.get("hypothesis", "auto_created")
+            assert application_instance.settings.get(
+                "hypothesis", "auto_assigned_to_org"
+            )
 
         assert result == Any.instance_of(Organization).with_attrs({"name": name})
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4864

This does two things:

 * Point out when an application instance was automatically added to an organization
 * Point out when an organization was created for this process

This allows us to vet them at a later date if we want to. Currently it has no effect, but if we capture the information we can chose to act on it.