### PR TITLE
Make organization id a required param on application instance creation

### DIFF
--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -242,12 +242,12 @@ class ApplicationInstanceService:
         email,
         developer_key,
         developer_secret,
+        organization_public_id,
         name=None,
-        organization_public_id=None,  # We want to make this mandatory
         deployment_id=None,
         lti_registration_id=None,
-    ):
-        """Create an ApplicationInstance."""
+    ) -> ApplicationInstance:
+        """Create an application instance."""
         consumer_key = (
             "Hypothesis" + secrets.token_hex(16) if not deployment_id else None
         )

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -144,14 +144,12 @@ class TestApplicationInstanceService:
 
     @pytest.mark.parametrize("developer_key", ("key", None))
     @pytest.mark.parametrize("developer_secret", ("secret", None))
-    @pytest.mark.parametrize("organization_public_id", ("us.lms.org.ID", None))
     def test_create_application_instance(
         self,
         service,
         update_application_instance,
         developer_key,
         developer_secret,
-        organization_public_id,
     ):
         application_instance = service.create_application_instance(
             name="NAME",
@@ -159,7 +157,7 @@ class TestApplicationInstanceService:
             email="example@example.com",
             developer_key=developer_key,
             developer_secret=developer_secret,
-            organization_public_id=organization_public_id,
+            organization_public_id="us.lms.org.ID",
         )
 
         # Things we set ourselves
@@ -185,7 +183,7 @@ class TestApplicationInstanceService:
             application_instance,
             developer_key=developer_key,
             developer_secret=developer_secret,
-            organization_public_id=organization_public_id,
+            organization_public_id="us.lms.org.ID",
         )
 
     @pytest.mark.parametrize("field", ["issuer", "client_id"])


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4864

Requires:

 * https://github.com/hypothesis/lms/pull/4886
 * https://github.com/hypothesis/lms/pull/4887
 * https://github.com/hypothesis/lms/pull/4876

## Review notes

This has a pile of merging and cherry picking and will need rebasing when the other PRs are all merged through. The only relevant commit to review is the last one.