### PR TITLE
Support json() for async responses

### DIFF
--- a/lms/services/async_oauth_http.py
+++ b/lms/services/async_oauth_http.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from typing import List
 
 import aiohttp
@@ -44,6 +45,8 @@ async def _async_request(aio_session, method, url, **kwargs):
         # We assign it to another response attribute for it to be
         # available in a sync context without needing to start coroutine.
         response.sync_text = await response.text()
+        # For json we want to emulate the behavour of the sync version, calling json might raise if text is not valid json
+        response.json = lambda: json.loads(response.sync_text)
         return response
 
 

--- a/tests/unit/lms/services/async_oauth_http_test.py
+++ b/tests/unit/lms/services/async_oauth_http_test.py
@@ -17,6 +17,8 @@ class TestAsyncOAuthHTTPService:
         for url, response in zip(urls, responses):
             assert response.status == 200
             assert response.headers["url"] == url
+            assert response.sync_text == '["ASYNC RESPONSE"]'
+            assert response.json() == ["ASYNC RESPONSE"]
 
         for request in with_successful_responses.requests.values():
             request_kwargs = request[0].kwargs
@@ -36,7 +38,7 @@ class TestAsyncOAuthHTTPService:
     def with_successful_responses(self, urls):
         with aioresponses() as m:
             for url in urls:
-                m.get(url, headers=dict(url=url))
+                m.get(url, headers=dict(url=url), body='["ASYNC RESPONSE"]')
 
             yield m
 


### PR DESCRIPTION
Emulate the behavior or `requests.Response.json()` in our async wrapper for aiohttp.


### Testing 

There's probably a better way to exercise this but with this diff I reckon I can prove that what I'm trying to accomplish works, the client code using responses from either `ouath_http` or `async_oauth_http` is agnostic to where the `json()` comes from.

We don't plan to a whole replacement like this.


```diff
diff --git a/lms/services/async_oauth_http.py b/lms/services/async_oauth_http.py
index b1dc06aa0..f5e5c39b2 100644
--- a/lms/services/async_oauth_http.py
+++ b/lms/services/async_oauth_http.py
@@ -45,7 +45,9 @@ async def _async_request(aio_session, method, url, **kwargs):
         # We assign it to another response attribute for it to be
         # available in a sync context without needing to start coroutine.
         response.sync_text = await response.text()
-        # For json we want to emulate the behavour of the sync version, calling json might raise if text is not valid json
+        # For json we want to emulate the behaviour of the sync version:
+        # calling json might raise if text is not valid json
+        print("async response", len(response.sync_text))
         response.json = lambda: json.loads(response.sync_text)
         return response
 
diff --git a/lms/services/blackboard_api/_basic.py b/lms/services/blackboard_api/_basic.py
index 25a732bd3..6ccd2193e 100644
--- a/lms/services/blackboard_api/_basic.py
+++ b/lms/services/blackboard_api/_basic.py
@@ -53,6 +53,7 @@ class BasicClient:
         redirect_uri,
         http_service,
         oauth_http_service,
+        async_oauth_http_service,
     ):  # pylint:disable=too-many-arguments
         self.blackboard_host = blackboard_host
         self.client_id = client_id
@@ -61,6 +62,7 @@ class BasicClient:
 
         self._http_service = http_service
         self._oauth_http_service = oauth_http_service
+        self._async_oauth_http_service = async_oauth_http_service
 
     def get_token(self, authorization_code):
         self._oauth_http_service.get_access_token(
@@ -90,6 +92,22 @@ class BasicClient:
 
             raise
 
+    def async_request(self, method, path):
+        try:
+            # return self._oauth_http_service.request(method, self._api_url(path))
+            return self._async_oauth_http_service.request(
+                method, [self._api_url(path)]
+            )[0]
+        except ExternalRequestError as err:
+            err.refreshable = getattr(err.response, "status_code", None) == 401
+
+            error_dict = BlackboardErrorResponseSchema(err.response).parse()
+
+            if error_dict.get("message") == "Bearer token is invalid":
+                raise OAuth2TokenError(refreshable=err.refreshable) from err
+
+            raise
+
     @property
     def token_url(self):
         return self._api_url("oauth2/token")
diff --git a/lms/services/blackboard_api/client.py b/lms/services/blackboard_api/client.py
index 1407e4cec..2b239c8ea 100644
--- a/lms/services/blackboard_api/client.py
+++ b/lms/services/blackboard_api/client.py
@@ -70,7 +70,7 @@ class BlackboardAPIClient:
         results = []
 
         for _ in range(PAGINATION_MAX_REQUESTS):
-            response = self._api.request("GET", path)
+            response = self._api.async_request("GET", path)
             results.extend(BlackboardListFilesSchema(response).parse())
             path = response.json().get("paging", {}).get("nextPage")
             if not path:
diff --git a/lms/services/blackboard_api/factory.py b/lms/services/blackboard_api/factory.py
index cc3ac9c40..b7c606279 100644
--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -16,6 +16,7 @@ def blackboard_api_client_factory(_context, request):
             redirect_uri=request.route_url("blackboard_api.oauth.callback"),
             http_service=request.find_service(name="http"),
             oauth_http_service=request.find_service(name="oauth_http"),
+            async_oauth_http_service=request.find_service(name="async_oauth_http"),
         ),
         request=request,
         file_service=request.find_service(name="file"),
```


with that change, head to blackboard (use `blackboardteacher` login) and configure the scratch assignment to use files. You'll see logging on the console indicating that the request are being made asynchronously. 


https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1380_1&course_id=_139_1
 
