### PR TITLE
Allow editing and viewing the application instance name

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -37,6 +37,9 @@ class ApplicationInstance(BASE):
     organization = sa.orm.relationship("Organization")
     """The organization this application instance belongs to."""
 
+    name = sa.Column(sa.UnicodeText(), nullable=True)
+    """Human readable name for the application instance."""
+
     consumer_key = sa.Column(sa.Unicode, unique=True, nullable=True)
     shared_secret = sa.Column(sa.Unicode, nullable=False)
     lms_url = sa.Column(sa.Unicode(2048), nullable=False)

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -189,12 +189,16 @@ class ApplicationInstanceService:
     def update_application_instance(  # pylint:disable=too-many-arguments
         self,
         application_instance,
+        name=None,
         lms_url=None,
         deployment_id=None,
         developer_key=None,
         developer_secret=None,
         organization_public_id=None,
     ):
+        if name:
+            application_instance.name = name
+
         if lms_url:
             application_instance.lms_url = lms_url
 
@@ -229,6 +233,7 @@ class ApplicationInstanceService:
         email,
         developer_key,
         developer_secret,
+        name=None,
         organization_public_id=None,  # We want to make this mandatory
         deployment_id=None,
         lti_registration_id=None,
@@ -239,6 +244,7 @@ class ApplicationInstanceService:
         )
 
         application_instance = ApplicationInstance(
+            name=name,
             consumer_key=consumer_key,
             shared_secret=secrets.token_hex(32),
             lms_url=lms_url,

--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -47,6 +47,7 @@
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
     <fieldset class="box">
+        {{ macros.form_text_field(request, "Name", "name", field_value=instance.name) }}
         {{ macros.settings_textarea(instance, "Notes", "hypothesis", "notes") }}
         {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
         {{ macros.disabled_text_field("Shared secret", instance.shared_secret) }}

--- a/lms/templates/admin/instance.new.html.jinja2
+++ b/lms/templates/admin/instance.new.html.jinja2
@@ -22,6 +22,7 @@ New application instance
 
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Create new Application instance</legend>
+        {{ macros.form_text_field(request, "Name", "name") }}
         {{ macros.form_text_field(request, "Organization Public Id", "organization_public_id") }}
         {% if lti_registration %}
             {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -22,6 +22,7 @@ class NewAppInstanceSchema(PyramidRequestSchema):
     developer_key = fields.Str(required=False, allow_none=True)
     developer_secret = fields.Str(required=False, allow_none=True)
 
+    name = fields.Str(required=False)
     lms_url = fields.URL(required=True)
     email = fields.Email(required=True)
     organization_public_id = fields.Str(required=True, validate=validate.Length(min=1))
@@ -103,6 +104,7 @@ class AdminApplicationInstanceViews:
 
         try:
             ai = self.application_instance_service.create_application_instance(
+                name=self.request.params["name"].strip(),
                 lms_url=self.request.params["lms_url"].strip(),
                 email=self.request.params["email"].strip(),
                 deployment_id=self.request.params.get("deployment_id", "").strip(),
@@ -278,6 +280,7 @@ class AdminApplicationInstanceViews:
 
         self.application_instance_service.update_application_instance(
             ai,
+            name=self.request.params.get("name", "").strip(),
             lms_url=self.request.params.get("lms_url", "").strip(),
             deployment_id=self.request.params.get("deployment_id", "").strip(),
             developer_key=self.request.params.get("developer_key", "").strip(),

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -100,6 +100,7 @@ class TestApplicationInstanceService:
 
         service.update_application_instance(
             application_instance,
+            name="NAME",
             lms_url="http://example.com",
             deployment_id="DEPLOYMENT_ID",
             developer_key="DEVELOPER_KEY",
@@ -107,6 +108,7 @@ class TestApplicationInstanceService:
             organization_public_id=mock.sentinel.org_id,
         )
 
+        assert application_instance.name == "NAME"
         assert application_instance.lms_url == "http://example.com"
         assert application_instance.deployment_id == "DEPLOYMENT_ID"
         assert application_instance.developer_key == "DEVELOPER_KEY"
@@ -152,6 +154,7 @@ class TestApplicationInstanceService:
         organization_public_id,
     ):
         application_instance = service.create_application_instance(
+            name="NAME",
             lms_url="https://example.com/",
             email="example@example.com",
             developer_key=developer_key,
@@ -160,6 +163,7 @@ class TestApplicationInstanceService:
         )
 
         # Things we set ourselves
+        assert application_instance.name == "NAME"
         assert application_instance.shared_secret == Any.string.matching("[0-9a-f]{32}")
         assert application_instance.consumer_key == Any.string.matching(
             "Hypothesis[0-9a-f]{16}"

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -60,6 +60,7 @@ class TestAdminApplicationInstanceViews:
         response = views.new_instance_callback()
 
         application_instance_service.create_application_instance.assert_called_once_with(
+            name="NAME",
             lms_url="http://example.com",
             email="test@example.com",
             deployment_id="22222",
@@ -353,6 +354,7 @@ class TestAdminApplicationInstanceViews:
         self, pyramid_request, application_instance_service, views
     ):
         pyramid_request.params = {
+            "name": "  NAME  ",
             "lms_url": "   http://example.com    ",
             "deployment_id": " DEPLOYMENT_ID  ",
             "developer_key": "  DEVELOPER KEY  ",
@@ -363,6 +365,7 @@ class TestAdminApplicationInstanceViews:
 
         application_instance_service.update_application_instance.assert_called_once_with(
             application_instance_service.get_by_id.return_value,
+            name="NAME",
             lms_url="http://example.com",
             deployment_id="DEPLOYMENT_ID",
             developer_key="DEVELOPER KEY",
@@ -376,6 +379,7 @@ class TestAdminApplicationInstanceViews:
 
         application_instance_service.update_application_instance.assert_called_once_with(
             application_instance_service.get_by_id.return_value,
+            name="",
             lms_url="",
             deployment_id="",
             developer_key="",
@@ -471,6 +475,7 @@ class TestAdminApplicationInstanceViews:
     @pytest.fixture
     def ai_new_params_v11(self, pyramid_request):
         params = {
+            "name": "  NAME  ",
             "lms_url": "http://example.com",
             "email": "test@example.com",
             "developer_key": "DEVELOPER_KEY",
@@ -493,6 +498,7 @@ class TestAdminApplicationInstanceViews:
     @pytest.fixture
     def with_upgrade_form(self, pyramid_request, application_instance):
         pyramid_request.POST = pyramid_request.params = {
+            "name": "NAME",
             "lms_url": "http://lms-url.com",
             "email": "test@email.com",
             "deployment_id": "DEPLOYMENT_ID",


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4889

Depends on:

 * https://github.com/hypothesis/lms/pull/4912
 * https://github.com/hypothesis/lms/pull/4914

## Testing notes

### Checking viewing application instances

 * `make devdata dev`
 * Visit: http://localhost:8001/admin/instance/id/1/
 * Name should be empty
 * Save
 * Name is still empty (not "None" etc)
 * Fill out a name and save
 * Refresh the page
 * The name should remain

### Checking creating application instances

 * Visit: http://localhost:8001/admin/instance/new
 * Name field should be visible
 * Press "New"
 * Note name is not required
 * Fill out a name and all required fields
 * The name should persist