### PR TITLE
DB migration to add name to the application instance

### DIFF
--- a/lms/migrations/versions/53f9ad3b93a4_add_a_name_to_application_instances.py
+++ b/lms/migrations/versions/53f9ad3b93a4_add_a_name_to_application_instances.py
@@ -1,0 +1,24 @@
+"""
+Add a name to application instances.
+
+Revision ID: 53f9ad3b93a4
+Revises: debaebd4a95c
+Create Date: 2023-01-24 17:48:15.688227
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "53f9ad3b93a4"
+down_revision = "debaebd4a95c"
+
+
+def upgrade():
+    op.add_column(
+        "application_instances", sa.Column("name", sa.UnicodeText(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("application_instances", "name")


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4889

## Testing notes

 * Reset your DB state:
```shell
git checkout main
make services args=down
make services db
``` 
* Run the update
```shell
git checkout ai-name-migration
hdev alembic upgrade head
make sql
```
* `\d+ application_instances;`
* You should see the new name column
* Run the downgrade:
```shell
hdev alembic downgrade -1
make sql
```
* `\d+ application_instances;`
* You should see the column gone