### PR TITLE
Add searching for application instance by name to the admin pages

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.properties import ColumnProperty
 
 from lms.db._columns import varchar_enum
+from lms.db._text_search import full_text_match
 
 __all__ = ("BASE", "init", "varchar_enum")
 

--- a/lms/db/_text_search.py
+++ b/lms/db/_text_search.py
@@ -1,0 +1,14 @@
+import sqlalchemy as sa
+
+
+def full_text_match(column, value):
+    """
+    Get an SQL comparator for full text matching.
+
+    This uses a slightly janky kind of full text searching, but is more
+    flexible than a direct comparison.
+    """
+
+    return sa.func.to_tsvector("english", column).op("@@")(
+        sa.func.websearch_to_tsquery("english", value)
+    )

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -6,6 +6,7 @@ from typing import List
 
 from sqlalchemy.exc import NoResultFound
 
+from lms.db import full_text_match
 from lms.models import ApplicationInstance, LTIParams, LTIRegistration
 from lms.services.aes import AESService
 from lms.services.exceptions import SerializableError
@@ -131,6 +132,7 @@ class ApplicationInstanceService:
         self,
         *,
         id_=None,
+        name=None,
         consumer_key=None,
         issuer=None,
         client_id=None,
@@ -142,6 +144,7 @@ class ApplicationInstanceService:
         return (
             self._ai_search_query(
                 id_=id_,
+                name=name,
                 consumer_key=consumer_key,
                 issuer=issuer,
                 client_id=client_id,
@@ -156,6 +159,7 @@ class ApplicationInstanceService:
         self,
         *,
         id_=None,
+        name=None,
         consumer_key=None,
         issuer=None,
         client_id=None,
@@ -163,9 +167,14 @@ class ApplicationInstanceService:
         tool_consumer_instance_guid=None,
     ):
         """Return a query with the passed parameters applied as filters."""
+
         query = self._db.query(ApplicationInstance).outerjoin(LTIRegistration)
         if id_:
             query = query.filter(ApplicationInstance.id == id_)
+
+        if name:
+            query = query.filter(full_text_match(ApplicationInstance.name, name))
+
         if consumer_key:
             query = query.filter(ApplicationInstance.consumer_key == consumer_key)
 

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
+from lms.db import full_text_match
 from lms.models import ApplicationInstance, GroupInfo, Organization
 
 LOG = getLogger(__name__)
@@ -96,11 +97,7 @@ class OrganizationService:
             clauses.append(Organization.public_id == public_id)
 
         if name:
-            clauses.append(
-                sa.func.to_tsvector("english", Organization.name).op("@@")(
-                    sa.func.websearch_to_tsquery("english", name)
-                )
-            )
+            clauses.append(full_text_match(Organization.name, name))
 
         if guid:
             query = query.outerjoin(ApplicationInstance).outerjoin(GroupInfo)

--- a/lms/templates/admin/instances.html.jinja2
+++ b/lms/templates/admin/instances.html.jinja2
@@ -18,6 +18,7 @@ Application instances
     <form method="POST" action="{{ request.route_url("admin.instances.search") }}">
         <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
         {{ macros.form_text_field(request, "ID", "id") }}
+        {{ macros.form_text_field(request, "Name", "name") }}
         {{ macros.form_text_field(request, "Consumer key", "consumer_key") }}
         {{ macros.form_text_field(request, "Issuer", "issuer") }}
         {{ macros.form_text_field(request, "Client ID", "client_id") }}
@@ -33,8 +34,8 @@ Application instances
 
 {% if instances is defined %}
 <fieldset class="box mt-6">
-<legend class="label has-text-centered">Results</legend>
-{{ macros.instances_table(request, instances) }}
+    <legend class="label has-text-centered">Results</legend>
+    {{ macros.instances_table(request, instances) }}
 </fieldset>
 {% endif %}
 

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -98,7 +98,13 @@
                     <a class="button" href="{{ request.route_url(route, id_=object.id) }}">View</a>
                   </td>
                   {% for field in fields %}
-                  <td>{{object[field]}}</th>
+                  <td>
+                    {% if object[field] is none %}
+                        <span style="color:#aaa">-</span>
+                    {% else %}
+                        {{ object[field] }}
+                    {% endif %}
+                  </td>
                   {% endfor %}
                </tr>
             {% endfor %}
@@ -110,7 +116,11 @@
 
 
 {% macro instances_table(request,  instances) %}
-{{ object_list_table(request, 'admin.instance.id', instances, ['Consumer key', 'GUID', 'Deployment ID'], ['consumer_key', 'tool_consumer_instance_guid', 'deployment_id']) }}
+{{ object_list_table(
+    request, 'admin.instance.id', instances,
+    ['Name', 'Consumer key', 'GUID', 'Deployment ID'],
+    ['name', 'consumer_key', 'tool_consumer_instance_guid', 'deployment_id']
+) }}
 {% endmacro %}
 
 

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -47,6 +47,7 @@ class SearchApplicationInstanceSchema(PyramidRequestSchema):
 
     # Max value for postgres `integer` type
     id = EmptyStringInt(required=False, validate=validate.Range(max=2147483647))
+    name = fields.Str(required=False)
     consumer_key = fields.Str(required=False)
     issuer = fields.Str(required=False)
     client_id = fields.Str(required=False)
@@ -221,6 +222,7 @@ class AdminApplicationInstanceViews:
 
         instances = self.application_instance_service.search(
             id_=self.request.params.get("id"),
+            name=self.request.params.get("name"),
             consumer_key=self.request.params.get("consumer_key"),
             issuer=self.request.params.get("issuer"),
             client_id=self.request.params.get("client_id"),

--- a/tests/factories/application_instance.py
+++ b/tests/factories/application_instance.py
@@ -7,6 +7,7 @@ from tests.factories.attributes import OAUTH_CONSUMER_KEY, SHARED_SECRET
 ApplicationInstance = make_factory(
     models.ApplicationInstance,
     FACTORY_CLASS=SQLAlchemyModelFactory,
+    name=Faker("company"),
     consumer_key=OAUTH_CONSUMER_KEY,
     shared_secret=SHARED_SECRET,
     lms_url=Faker("url", schemes=["https"]),

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -203,7 +203,8 @@ class TestApplicationInstanceService:
             }
 
     @pytest.mark.parametrize(
-        "field", ["consumer_key", "deployment_id", "tool_consumer_instance_guid"]
+        "field",
+        ["name", "consumer_key", "deployment_id", "tool_consumer_instance_guid"],
     )
     def test_search_by_instance_fields(
         self, field, service, with_application_instances_for_search

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -273,6 +273,7 @@ class TestAdminApplicationInstanceViews:
     def test_search(self, pyramid_request, application_instance_service, views):
         pyramid_request.params = pyramid_request.POST = dict(
             id="1",
+            name="NAME",
             consumer_key="CONSUMER_KEY",
             issuer="ISSUER",
             client_id="CLIENT_ID",
@@ -284,6 +285,7 @@ class TestAdminApplicationInstanceViews:
 
         application_instance_service.search.assert_called_once_with(
             id_="1",
+            name="NAME",
             consumer_key="CONSUMER_KEY",
             issuer="ISSUER",
             client_id="CLIENT_ID",


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4889
 
Depends on:

 * https://github.com/hypothesis/lms/pull/4913

## Testing notes

 * Visit: http://localhost:8001/admin/instances/search
 * Add a name like "Name one" to one application instance and "Name two" to another
 * Try searching for name "one OR two" - You should see both
 * Try searching for "NAME" - You should see both
 * Try searching for "name one"  - You should only see one