### PR TITLE
Make application instance name mandatory on create

### DIFF
--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -243,7 +243,7 @@ class ApplicationInstanceService:
         developer_key,
         developer_secret,
         organization_public_id,
-        name=None,
+        name,
         deployment_id=None,
         lti_registration_id=None,
     ) -> ApplicationInstance:

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -22,7 +22,7 @@ class NewAppInstanceSchema(PyramidRequestSchema):
     developer_key = fields.Str(required=False, allow_none=True)
     developer_secret = fields.Str(required=False, allow_none=True)
 
-    name = fields.Str(required=False)
+    name = fields.Str(required=True, validate=validate.Length(min=1))
     lms_url = fields.URL(required=True)
     email = fields.Email(required=True)
     organization_public_id = fields.Str(required=True, validate=validate.Length(min=1))

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -101,6 +101,7 @@ class TestAdminApplicationInstanceViews:
         ("lms_url", "not a url"),
         ("email", "not an email"),
         ("organization_public_id", None),
+        ("name", None),
     ]
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4889

Requires:

  * https://github.com/hypothesis/lms/pull/4913
  * https://github.com/hypothesis/lms/pull/4876

This makes application instance name mandatory when creating a new one. The idea is to prevent patchy data collection in future.

## Testing notes

 * `make dev`
 * Visit: http://localhost:8001/admin/instance/new
 * Try and save without filling in a name
 * You should get a validation error