### PR TITLE
Make application instance name mandatory on update

### DIFF
--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -40,6 +40,7 @@ class UpdateApplicationInstanceSchema(PyramidRequestSchema):
 
     location = "form"
 
+    name = fields.Str(required=True, validate=validate.Length(min=1))
     lms_url = fields.URL(required=False)
     deployment_id = fields.Str(required=False)
     developer_key = fields.Str(required=False)

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -35,6 +35,17 @@ class NewAppInstanceSchemaV13(NewAppInstanceSchema):
     lti_registration_id = fields.Str(required=True)
 
 
+class UpdateApplicationInstanceSchema(PyramidRequestSchema):
+    """Schema for updating an application instance."""
+
+    location = "form"
+
+    lms_url = fields.URL(required=False)
+    deployment_id = fields.Str(required=False)
+    developer_key = fields.Str(required=False)
+    developer_secret = fields.Str(required=False)
+
+
 class UpgradeApplicationInstanceSchema(PyramidRequestSchema):
     location = "form"
 
@@ -281,6 +292,10 @@ class AdminApplicationInstanceViews:
     @view_config(route_name="admin.instance", request_method="POST", require_csrf=True)
     def update_instance(self):
         ai = self._get_ai_or_404(self.request.matchdict["id_"])
+
+        if flash_validation(self.request, UpdateApplicationInstanceSchema):
+            # Looks like something went wrong!
+            return self._redirect("admin.instance", id_=ai.id)
 
         self.application_instance_service.update_application_instance(
             ai,

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -334,9 +334,9 @@ class TestAdminApplicationInstanceViews:
     def test_update_application_instance(
         self, views, pyramid_request, ai_from_matchdict, application_instance_service
     ):
-        pyramid_request.params = {
+        pyramid_request.params = pyramid_request.POST = {
             "name": "  NAME  ",
-            "lms_url": "   http://example.com    ",
+            "lms_url": "http://example.com",
             "deployment_id": " DEPLOYMENT_ID  ",
             "developer_key": "  DEVELOPER KEY  ",
             "developer_secret": " DEVELOPER SECRET  ",
@@ -353,7 +353,7 @@ class TestAdminApplicationInstanceViews:
             developer_secret="DEVELOPER SECRET",
         )
 
-    def test_update_application_instance_with_no_arguments(
+    def test_update_application_instance_with_minimal_arguments(
         self, views, ai_from_matchdict, application_instance_service
     ):
         views.update_instance()
@@ -366,6 +366,19 @@ class TestAdminApplicationInstanceViews:
             developer_key="",
             developer_secret="",
         )
+
+    @pytest.mark.usefixtures("ai_from_matchdict")
+    @pytest.mark.parametrize("param,bad_value", (("lms_url", "not_a_url"),))
+    def test_update_application_instance_with_invalid_arguments(
+        self, views, pyramid_request, application_instance_service, param, bad_value
+    ):
+        params = {}
+        params[param] = bad_value
+        pyramid_request.params = pyramid_request.POST = params
+
+        views.update_instance()
+
+        application_instance_service.update_application_instance.assert_not_called()
 
     @pytest.mark.parametrize(
         "setting,sub_setting,value,expected",


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4889

Requires:

 * https://github.com/hypothesis/lms/pull/4918

This makes application instance name mandatory when updating an existing application instance. The idea is to encourage better data quality over time.

## Testing notes

 * `make dev`
 * Visit: http://localhost:8001/admin/instance/id/5/
   * If that has a name search for one without
 * Try saving
 * You should get a name validation error
 * Fill out a name
 * It should save now