### PR TITLE
Split out upgrading application instances as a separate activity

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -146,6 +146,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.instance.consumer_key", "/admin/instance/{consumer_key}/")
     config.add_route("admin.instance.id", "/admin/instance/id/{id_}/")
     config.add_route("admin.instance.new", "/admin/instance/new")
+    config.add_route("admin.instance.upgrade", "/admin/instance/upgrade")
 
     config.add_route("admin.organization", "/admin/org/{id_}")
     config.add_route("admin.organization.toggle", "/admin/org/{id_}/toggle")
@@ -158,10 +159,6 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.registration.id", "/admin/registration/id/{id_}/")
     config.add_route(
         "admin.registration.new.instance", "/admin/registration/id/{id_}/new/instance"
-    )
-    config.add_route(
-        "admin.registration.upgrade.instance",
-        "/admin/registration/id/{id_}/upgrade/instance",
     )
     config.add_route("admin.registration.new", "/admin/registration")
     config.add_route("admin.registration.suggest_urls", "/admin/registration/urls")

--- a/lms/templates/admin/instance.new.html.jinja2
+++ b/lms/templates/admin/instance.new.html.jinja2
@@ -21,7 +21,7 @@ New application instance
     <input type="hidden" name="lti_registration_id" value="{{ lti_registration.id }}">
 
     <fieldset class="box mt-6">
-        <legend class="label has-text-centered">Create new Application instance</legend>
+        <legend class="label has-text-centered">Create new application instance</legend>
         {{ macros.form_text_field(request, "Name", "name") }}
         {{ macros.form_text_field(request, "Organization Public Id", "organization_public_id") }}
         {% if lti_registration %}
@@ -35,20 +35,5 @@ New application instance
 
     <input type="submit" class="button is-info" value="New"/>
 </form>
-
-{% if lti_registration %}
-    <form method="POST" action="{{ request.route_url("admin.registration.upgrade.instance", id_=lti_registration.id) }}">
-        <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
-
-        <fieldset class="box mt-6">
-            <legend class="label has-text-centered">Upgrade existing Application instance</legend>
-            {{ macros.form_text_field(request, "Consumer key", "consumer_key",
-                placeholder="Existing application instance's consumer key. It will be upgraded to LTI 1.3 using this registration") }}
-            {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
-        </fieldset>
-
-        <input type="submit" class="button is-info" value="Upgrade"/>
-    </form>
-{% endif %}
 
 {% endblock %}

--- a/lms/templates/admin/instance.upgrade.html.jinja2
+++ b/lms/templates/admin/instance.upgrade.html.jinja2
@@ -1,0 +1,31 @@
+{% import "macros.html.jinja2" as macros %}
+
+{% extends "lms:templates/admin/base.html.jinja2" %}
+
+{% block header %}
+Upgrade application instance to LTI 1.3
+{% endblock %}
+
+{% block content %}
+
+<fieldset class="box mt-6">
+    <legend class="label has-text-centered">Registration</legend>
+
+    {{ macros.registration_preview(request, lti_registration) }}
+</fieldset>
+
+<form method="POST" action="{{ request.route_url("admin.instance.upgrade") }}">
+    <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
+    <input type="hidden" name="lti_registration_id" value="{{ lti_registration.id }}">
+
+    <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Upgrade existing application instance</legend>
+        {{ macros.form_text_field(request, "Consumer key", "consumer_key",
+            placeholder="Existing application instance's consumer key. It will be upgraded to LTI 1.3 using this registration") }}
+        {{ macros.form_text_field(request, "Deployment ID", "deployment_id") }}
+    </fieldset>
+
+    <input type="submit" class="button is-info" value="Upgrade"/>
+</form>
+
+{% endblock %}

--- a/lms/templates/admin/registration.html.jinja2
+++ b/lms/templates/admin/registration.html.jinja2
@@ -20,8 +20,10 @@
 
     <fieldset class="box">
     <legend class="label has-text-centered">Registration application instances</legend>
-        <div class="block has-text-right">
-            <a class="button is-primary" href="{{ request.route_url("admin.instance.new", _query={"lti_registration_id": registration.id}) }}">Add instance</a>
+         <div class="block has-text-right">
+            <a class="button is-primary" href="{{ request.route_url("admin.instance.upgrade", _query={"lti_registration_id": registration.id}) }}">Upgrade LTI 1.1 instance</a>
+
+            <a class="button is-primary" href="{{ request.route_url("admin.instance.new", _query={"lti_registration_id": registration.id}) }}">Add LTI 1.3 instance</a>
         </div>
 
         {% if registration.application_instances %}


### PR DESCRIPTION
This PR splits up the journey for application instance upgrade and new 1.3 instance so they have different starting and templates. 

This makes each journey and template simpler for the user and in the code, at the cost of making the overall size bigger.

## Testing notes

Testing new

 * `make dev`
 * Visit: http://localhost:8001/admin/registration/id/2/
 * Click "Add LTI 1.3 instance"
 * The registration you started with should appear
 * The section at the bottom of the page for upgrading should not appear
 * Everything here should work as normal

Testing upgrade

 * Visit: http://localhost:8001/admin/registration/id/2/
 * Click "Upgrade LTI 1.3 instance"
 * The registration you started with should appear
 * The regular "new" fields should not appear
 * Press "Save"
 * You should get validation errors for both "deployment_id" and "consumer_key"
 * Fill out "consumer_key": `Hypothesis4685565a4f5cf3c9cc3b199b0bd9abf4`
 * Fill out "deployment_id": `98477234`
 * Press "Save"
 * You should end up on an application instance now linked to this registration