### PR TITLE
Return all groups in Canvas SpeedGrader if we can't find the right one

### DIFF
--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -71,12 +71,16 @@ class CanvasGroupingPlugin(GroupingPlugin):
         return all_course_groups
 
     def get_groups_for_grading(
-        self, _svc, course, group_set_id, grading_student_id=None
+        self, svc, course, group_set_id, grading_student_id=None
     ):
-        # SpeedGrader requests are made by the teacher, get the student we are grading
-        return self._canvas_api.user_groups(
+        # SpeedGrader requests are made by the teacher, get the groups for the student we are grading.
+        if grading_groups := self._canvas_api.user_groups(
             self._custom_course_id(course), grading_student_id, group_set_id
-        )
+        ):
+            return grading_groups
+
+        # If we can't find the groups for this particular student, get all of them.
+        return self.get_groups_for_instructor(svc, course, group_set_id)
 
     def sections_enabled(self, request, application_instance, course):
         params = request.params

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -370,7 +370,7 @@ class CanvasAPIClient:
             ):
                 continue
 
-            for user in group["users"]:
+            for user in group.get("users", []):
                 if user["id"] == int(user_id):
                     groups.append(group)
 

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -127,6 +127,25 @@ class TestCanvasGroupingPlugin:
         )
         assert canvas_api_client.user_groups.return_value == api_groups
 
+    def test_get_groups_for_grading_fallback_not_found(
+        self, canvas_api_client, grouping_service, plugin, course
+    ):
+        canvas_api_client.user_groups.return_value = []
+
+        all_groups = plugin.get_groups_for_grading(
+            grouping_service, course, sentinel.group_set_id, sentinel.grading_student_id
+        )
+
+        canvas_api_client.user_groups.assert_called_once_with(
+            sentinel.canvas_course_id,
+            sentinel.grading_student_id,
+            sentinel.group_set_id,
+        )
+        canvas_api_client.group_category_groups.assert_called_once_with(
+            sentinel.group_set_id
+        )
+        assert canvas_api_client.group_category_groups.return_value == all_groups
+
     def test_sections_enabled_speedgrader(self, plugin, pyramid_request):
         pyramid_request.params.update({"focused_user": sentinel.focused_user})
 

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -273,6 +273,15 @@ class TestCanvasAPIClientIntegrated:
         assert len(response) == 1
         assert user_id in [u["id"] for u in response[0]["users"]]
 
+    @pytest.mark.usefixtures("list_groups_response")
+    def test_user_groups_no_users_in_response(self, canvas_api_client):
+        user_id = course_id = 1
+        group_category_id = 2
+
+        response = canvas_api_client.user_groups(course_id, user_id, group_category_id)
+
+        assert not response
+
     @pytest.mark.parametrize("group_category_id", (2, "2"))
     @pytest.mark.parametrize("user_id", (1, "1"))
     @pytest.mark.usefixtures("list_groups_with_users_response")


### PR DESCRIPTION
The student will only appear in Speedgrader if he did a submissions so there must be annotations for the student in *some* group.

Different edge cases around the course roster, groups memberships, etc might prevent us from finding the right group, fallback to list all of them and let the teacher find the relevant annotations.


In addition to this we have seen at least one instance of canvas not returning the groups memberships when requested, this PR should solve that.

- https://sentry.io/organizations/hypothesis/issues/3885445215/?project=259908&query=&referrer=issue-stream&sort=freq&statsPeriod=14d
- https://github.com/hypothesis/product-backlog/issues/1415


## Testing

(when it comes to speed grader not sure how much of this could be skiped as is stored on canvas side, anyway giving the full process here)


- As eng+canvasstudent@hypothes.is launch *and* annotate https://hypothesis.instructure.com/courses/125/assignments/1833

Note that you'll be in the group "Group with student"

- As eng+canvasteacher@hypothes.is launch the assgiment in speedgrader:

https://hypothesis.instructure.com/courses/125/gradebook/speed_grader?assignment_id=1833&student_id=35 (make sure the same student is selected)

You'll see the annotation an the group selector will only show you the relevant group.


- Now remove the student from the group 
https://hypothesis.instructure.com/courses/125/groups#tab-121
 (no save button, just drag the student out of the group)


- Refresh the speedgrader window 

https://hypothesis.instructure.com/courses/125/gradebook/speed_grader?assignment_id=1833&student_id=35


Compare `main` where you'll get in a never fishing "loading" state with this branch, were you'll get all groups in the dropdown.


- **Return the student to the group** 
To leave things are they were before for future testing.



