### PR TITLE
New `list_all_files` method in BB API client

### DIFF
--- a/lms/services/file.py
+++ b/lms/services/file.py
@@ -21,6 +21,26 @@ class FileService:
             .one_or_none()
         )
 
+    def find_copied_file(self, new_course_id, original_file: File):
+        """Find an equivalent file to `original_file` in our DB."""
+        return (
+            self._db.query(File).filter(
+                # Both files should be in the same application instance
+                File.application_instance == original_file.application_instance,
+                # Looking for files in the new course only
+                File.course_id == new_course_id,
+                # Files of the same type
+                File.type == original_file.type,
+                # We don't want to find the same file we are looking for
+                File.lms_id != original_file.lms_id,
+                # And as a heuristic, we reckon same name, same size, probably the same file
+                File.name == original_file.name,
+                File.size == original_file.size,
+            )
+            # We might find more than one matching file, take any of them
+            .first()
+        )
+
     def upsert(self, file_dicts):
         """Insert or update a batch of files."""
         for value in file_dicts:

--- a/tests/unit/lms/services/file_test.py
+++ b/tests/unit/lms/services/file_test.py
@@ -7,18 +7,18 @@ from lms.services.file import FileService, factory
 from tests import factories
 
 
-class TestGet:
-    def test_it_returns_the_matching_file_if_there_is_one(
+class TestFileService:
+    def test_get_returns_the_matching_file_if_there_is_one(
         self, application_instance, svc
     ):
         file_ = factories.File(application_instance=application_instance)
 
         assert svc.get(file_.lms_id, file_.type) == file_
 
-    def test_it_returns_None_if_theres_no_matching_file(self, svc):
+    def test_get_returns_None_if_theres_no_matching_file(self, svc):
         assert not svc.get("unknown_file_id", "canvas_file")
 
-    def test_it_doesnt_return_matching_files_from_other_application_instances(
+    def test_get_doesnt_return_matching_files_from_other_application_instances(
         self, svc
     ):
         file_ = factories.File()


### PR DESCRIPTION
To populate the file picker in blackboard we make one API request per folder as the user navigates the tree. This is sensible as it keeps the API requests themselves small and fast.

Unfortunately for course copy we need the full tree of files to be able to:

- Find the current file that triggered the course copy process
- Guarantee that subsequent launches of other assignments in the course will also find their files without instructor intervention.

We'll use the new method only while doing course copy and keep the original `list_files` as the driver of the file picker.


## Testing 


We need this method for course copy but it's not used in the code base yet, one way to quickly check it is to apply a diff like:



```diff
diff --git a/lms/views/api/blackboard/files.py b/lms/views/api/blackboard/files.py
index cf6aa9f22..0a9df83ea 100644
--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -30,7 +30,7 @@ class BlackboardFilesAPIViews:
         course_id = self.request.matchdict["course_id"]
         folder_id = self.request.matchdict.get("folder_id")
 
-        results = self.blackboard_api_client.list_files(course_id, folder_id)
+        results = self.blackboard_api_client.list_all_files(course_id)
 
         response_results = []
```

and then head over the scratch assignment in blackboard and pick blackboard files. 


https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1380_1&course_id=_139_1


That will make the file picker behave strangely as it will list all the tree directly on the root level but it will exercise the new code path.
