### PR TITLE
Fix the definition of billable to include at least one annotation in the group

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/04_activity_counts/03_organization_activity/01_create_view.sql
+++ b/lms/data_tasks/report/create_from_scratch/04_activity_counts/03_organization_activity/01_create_view.sql
@@ -110,6 +110,8 @@ CREATE MATERIALIZED VIEW report.organization_activity AS (
                 facets.period, facets.timescale, facets.role, events.organization_id
         ),
 
+        -- A billable user is defined as any user who is in a group which has
+        -- at least one annotation in the period in question.
         billable AS (
             SELECT
                 facets.period,
@@ -120,6 +122,7 @@ CREATE MATERIALIZED VIEW report.organization_activity AS (
             FROM facets
             JOIN report.group_activity ON
                 group_activity.created_week = facets.timestamp_week
+                AND group_activity.annotation_count > 0
             JOIN report.group_map ON
                 group_activity.group_id = group_map.group_id
             JOIN report.user_groups ON


### PR DESCRIPTION
It appears we inadvertently changed the definition of billable users during the creation of report by missing out the requirement that a billable user be in a group with at least one annotation.

For more details see:

 * https://github.com/hypothesis/report/pull/167

This leads to a larger amount of users being counted as billable as a teacher can end up including users into other periods of time simply by visiting groups.