### PR TITLE
Add some warning notes in locations related to users about report implications

### DIFF
--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -55,6 +55,11 @@ class LTIHService:
             )
 
     def _yield_commands(self, groupings):
+        # Note! - Syncing a user to `h` currently has an implication for
+        # reporting and so billing and will as long as our billing metric is
+        # tied to users in groups. Should we start to sync users who have not
+        # launched us, we could inflate our numbers or change their meaning.
+
         yield self._user_upsert(self._h_user)
 
         for i, grouping in enumerate(groupings):

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -23,6 +23,12 @@ class UserService:
 
     def upsert_user(self, lti_user: LTIUser) -> User:
         """Store a record of having seen a particular user."""
+
+        # Note! - Storing a user in our DB currently has an implication for
+        # reporting and so billing and will as long as our billing metric is
+        # tied to users in groups. Should we start to store users who have not
+        # launched us, we could inflate our numbers or change their meaning.
+
         user = User(
             application_instance_id=lti_user.application_instance_id,
             user_id=lti_user.user_id,


### PR DESCRIPTION
For:

* https://github.com/hypothesis/report/issues/168

This might hopefully steer us clear from storing users for some operational reason in the future without considering the effect it might have on reporting related things.