### PR TITLE
Rename LMSGrader => GradingToolbar and convert to TS

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -16,7 +16,7 @@ import { apiCall } from '../utils/api';
 import AuthWindow from '../utils/AuthWindow';
 
 import ContentFrame from './ContentFrame';
-import LMSGrader from './LMSGrader';
+import GradingToolbar from './GradingToolbar';
 import LaunchErrorDialog from './LaunchErrorDialog';
 
 /**
@@ -330,14 +330,14 @@ export default function BasicLTILaunchApp() {
 
   if (grading && grading.enabled) {
     contentFrameWrapper = (
-      <LMSGrader
+      <GradingToolbar
         clientRPC={clientRPC}
         students={grading.students}
         courseName={grading.courseName}
         assignmentName={grading.assignmentName}
       >
         {contentFrame}
-      </LMSGrader>
+      </GradingToolbar>
     );
   } else {
     contentFrameWrapper = contentFrame;

--- a/lms/static/scripts/frontend_apps/components/GradingToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingToolbar.tsx
@@ -1,3 +1,5 @@
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
 import {
   useCallback,
   useContext,
@@ -8,38 +10,35 @@ import {
 
 import { apiCall } from '../utils/api';
 import { Config } from '../config';
-
+import type { StudentInfo } from '../config';
+import type { ClientRPC } from '../services/client-rpc';
 import StudentSelector from './StudentSelector';
 import SubmitGradeForm from './SubmitGradeForm';
-import classnames from 'classnames';
+
+export type GradingToolbarProps = {
+  /** Iframe element displaying assignment content. */
+  children: ComponentChildren;
+
+  /** Service for communicating with Hypothesis client. */
+  clientRPC: ClientRPC;
+  courseName: string;
+  assignmentName: string;
+
+  /** List of students to grade. */
+  students: StudentInfo[];
+};
 
 /**
- * @typedef {import('../config').StudentInfo} StudentInfo
- * @typedef {import('../services/client-rpc').ClientRPC} ClientRPC
+ * Toolbar which provides instructors with controls to list students who have
+ * annotated this document and view/submit grades.
  */
-
-/**
- * @typedef LMSGraderProps
- * @prop {object} children - The <iframe> element displaying the assignment
- * @prop {ClientRPC} clientRPC - Service for communicating with Hypothesis client
- * @prop {string} courseName
- * @prop {string} assignmentName
- * @prop {StudentInfo[]} students - List of students to grade
- */
-
-/**
- * The LMSGrader component is fixed at the top of the page. This toolbar shows which assignment is currently
- * active as well as a list of students to both view and submit grades for.
- *
- * @param {LMSGraderProps} props
- */
-export default function LMSGrader({
+export default function GradingToolbar({
   children,
   clientRPC,
   assignmentName,
   courseName,
   students: unorderedStudents,
-}) {
+}: GradingToolbarProps) {
   const {
     api: { authToken, sync: syncAPICallInfo },
   } = useContext(Config);
@@ -71,8 +70,7 @@ export default function LMSGrader({
    * Makes an RPC call to the sidebar to change to the focused user.
    */
   const changeFocusedUser = useCallback(
-    /** @param {StudentInfo|null} user - The user to focus on in the sidebar */
-    async user => {
+    async (user: StudentInfo | null) => {
       let groups = null;
       if (syncAPICallInfo && user?.lmsId) {
         // Request and set a list of groups specific to the student being graded
@@ -110,18 +108,10 @@ export default function LMSGrader({
     }
   }, [students, changeFocusedUser, currentStudentIndex]);
 
-  /**
-   * Callback to set the current selected student.
-   *
-   * @param {number} studentIndex
-   */
-  const onSelectStudent = studentIndex => {
+  const onSelectStudent = (studentIndex: number) => {
     setCurrentStudentIndex(studentIndex);
   };
 
-  /**
-   * Return the current student, or an empty object if there is none
-   */
   const getCurrentStudent = () => {
     return currentStudentIndex >= 0 ? students[currentStudentIndex] : null;
   };

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -668,10 +668,10 @@ describe('BasicLTILaunchApp', () => {
       fakeConfig.viaUrl = 'https://via.hypothes.is/123';
     });
 
-    it('renders the LMSGrader component', () => {
+    it('renders the GradingToolbar component', () => {
       const wrapper = renderLTILaunchApp();
-      const LMSGrader = wrapper.find('LMSGrader');
-      assert.isTrue(LMSGrader.exists());
+      const GradingToolbar = wrapper.find('GradingToolbar');
+      assert.isTrue(GradingToolbar.exists());
     });
   });
 

--- a/lms/static/scripts/frontend_apps/components/test/GradingToolbar-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GradingToolbar-test.js
@@ -3,12 +3,12 @@ import { act } from 'preact/test-utils';
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
-import LMSGrader, { $imports } from '../LMSGrader';
+import GradingToolbar, { $imports } from '../GradingToolbar';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { waitFor } from '../../../test-util/wait';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('LMSGrader', () => {
+describe('GradingToolbar', () => {
   let fakeApiCall;
   let fakeConfig;
   let fakeStudents;
@@ -73,7 +73,7 @@ describe('LMSGrader', () => {
   const renderGrader = (props = {}) => {
     return mount(
       <Config.Provider value={fakeConfig}>
-        <LMSGrader
+        <GradingToolbar
           onChangeSelectedUser={fakeOnChange}
           students={fakeStudents}
           courseName={'course name'}
@@ -82,7 +82,7 @@ describe('LMSGrader', () => {
           {...props}
         >
           <div title="The assignment content iframe" />
-        </LMSGrader>
+        </GradingToolbar>
       </Config.Provider>
     );
   };


### PR DESCRIPTION
The "LMS" part of the component name was redundant, and the "Toolbar" suffix makes it more obvious what kind of control this is.

This might not be the final name, as we're considering adding an "edit assignment" button to this toolbar in future and displaying it even when grading is not active.