### PR TITLE
Handle OAuth2TokenError during course copy

### DIFF
--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional
 
 from lms.models import File
-from lms.services.exceptions import ExternalRequestError
+from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
 from lms.services.file import FileService
 
 
@@ -29,6 +29,10 @@ class CourseCopyFilesHelper:
         try:
             # Get the current (copied) courses files, that will have the side effect of storing files in the DB
             _ = store_new_course_files(new_course_id)
+        except OAuth2TokenError:
+            # If the issue while trying to talk to the API is OAuth related
+            # let that bubble up and be dealt with.
+            raise
         except ExternalRequestError:
             # We might not have access to use the API for that endpoint.
             # That will depend on our role and the course's permissions settings.


### PR DESCRIPTION
OAuth2TokenError is a ExternalRequestError and the more general except could in some cases shallow the need for a new token or refreshing the existing one before getting a relevant answer from the API.

Catch OAuth2TokenError independently and raise it to get a new token.


I'm struggling to reproduce the exact same issue but I reckon this makes sense in isolation.

If we look at:

https://github.com/hypothesis/lms/blob/d42e45267255cc0efdab30fd4b716038deaf120b/lms/views/api/blackboard/files.py#L77-L99

If self.request.lti_user.is_instructor is True
and `self.course_copy_plugin.is_file_in_course(course_id, file_id)` is False.

The first API request might be made inside `find_matching_file_in_course`.If that returns false will raise `BlackboardFileNotFoundInCourse`. If find_matching_file_in_course shallowed 
OAuth2TokenError we'll display the "we can't fin the file" modal instead of the "authorize" one.

With this change, if `find_matching_file_in_course` raises OAuth2TokenError that will make all the way to the top.


### Testing

I'm not able to reliably reproduce this, as a sanity check launch:

- The original course file assignment

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_39_1&course_id=_19_1

- The copied course file assignment

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1371_1&course_id=_139_1


