### PR TITLE
Track last launched date against application instances

### DIFF
--- a/lms/migrations/versions/64fd59a9f4b6_add_updated_last_launched_to_ai.py
+++ b/lms/migrations/versions/64fd59a9f4b6_add_updated_last_launched_to_ai.py
@@ -1,0 +1,62 @@
+"""
+Add updated and last_launched to application instances.
+
+Revision ID: 64fd59a9f4b6
+Revises: 53f9ad3b93a4
+Create Date: 2023-02-02 16:56:37.882370
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "64fd59a9f4b6"
+down_revision = "53f9ad3b93a4"
+
+
+def upgrade():
+    op.add_column(
+        "application_instances",
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+    )
+
+    op.add_column(
+        "application_instances",
+        sa.Column("last_launched", sa.DateTime(), nullable=True),
+    )
+
+    # Default the last launched date to the most recent deep linking or launch
+    op.execute(
+        """
+        WITH
+            last_update_times AS (
+                SELECT
+                    application_instance_id,
+                    MAX(timestamp) AS last_launched
+                FROM event
+                JOIN event_type ON
+                    event_type.id = event.type_id
+                WHERE
+                    event_type.type IN ('deep_linking', 'configured_launch')
+                    AND application_instance_id IS NOT NULL
+                GROUP BY application_instance_id
+            )
+
+        UPDATE application_instances
+        SET last_launched=last_update_times.last_launched
+        FROM last_update_times
+        WHERE id = last_update_times.application_instance_id
+    """
+    )
+
+    # Default the updated date to the existing created date / launched date
+    op.execute(
+        "UPDATE application_instances SET updated=COALESCE(last_launched, created)"
+    )
+
+
+def downgrade():
+    op.drop_column("application_instances", "last_launched")
+    op.drop_column("application_instances", "updated")

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,18 +1,18 @@
 import logging
-from datetime import datetime
 from urllib.parse import urlparse
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE
+from lms.models import CreatedUpdatedMixin
 from lms.models.application_settings import ApplicationSettings
 from lms.models.exceptions import ReusedConsumerKey
 
 LOG = logging.getLogger(__name__)
 
 
-class ApplicationInstance(BASE):
+class ApplicationInstance(CreatedUpdatedMixin, BASE):
     """Class to represent a single lms install."""
 
     __tablename__ = "application_instances"
@@ -48,7 +48,8 @@ class ApplicationInstance(BASE):
     lms_url = sa.Column(sa.Unicode(2048), nullable=False)
     requesters_email = sa.Column(sa.Unicode(2048), nullable=False)
 
-    created = sa.Column(sa.TIMESTAMP, default=datetime.utcnow(), nullable=False)
+    last_launched = sa.Column(sa.DateTime(), nullable=True)
+    """The last time this application instance was launched."""
 
     developer_key = sa.Column(sa.Unicode)
     developer_secret = sa.Column(sa.LargeBinary)

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -316,6 +316,10 @@ class ApplicationInstanceService:
         ]:
             setattr(application_instance, attr, params.get(attr))
 
+        # This is a potentially misleading, as we can get here from deep-linked
+        # "launches". Depending on whether you count that as a launch or not.
+        application_instance.last_launched = datetime.now()
+
 
 def factory(_context, request):
     return ApplicationInstanceService(

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
 from factory import Faker
+from freezegun import freeze_time
 from h_matchers import Any
 
 from lms.models import LTIParams, ReusedConsumerKey
@@ -226,10 +228,14 @@ class TestApplicationInstanceService:
             "custom_canvas_api_domain",
         ),
     )
+    @freeze_time("2022-04-04")
     def test_update_from_lti_params(
         self, service, organization_service, application_instance, field
     ):
-        lms_data = {field: field + "_value", "tool_consumer_instance_guid": "GUID"}
+        lms_data = {
+            field: field + "_value",
+            "tool_consumer_instance_guid": "GUID",
+        }
 
         service.update_from_lti_params(application_instance, LTIParams(lms_data))
 
@@ -237,6 +243,7 @@ class TestApplicationInstanceService:
             application_instance
         )
         assert application_instance == Any.object.with_attrs(lms_data)
+        assert application_instance.last_launched == datetime(year=2022, month=4, day=4)
 
     def test_update_from_lti_params_no_guid_doesnt_change_values(
         self, service, organization_service, application_instance


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4965

This PR adds tracking of last launch date to the application instance service. There is a slight fudge as we count a deep link as a launch because the follow the same code path.

This is probably technically wrong, practically right. People want to know the most recent and "in-play" application instances. Something you just created would meet this brief.

Requires:

 * https://github.com/hypothesis/lms/pull/4969

## Testing notes

 * Follow the notes in: https://github.com/hypothesis/lms/pull/4969
    * `make sql`
    * `SELECT created, updated, last_launched FROM application_instances WHERE id=8`
    * Keep the values on screen to compare
 * Relaunch: https://hypothesis.instructure.com/courses/125/assignments/873
    * `SELECT created, updated, last_launched FROM application_instances WHERE id=8`
    * The updated and last launched values should have changed
 * Visit: http://localhost:8001/admin/instance/8/
    * Press "Save"
    * `SELECT created, updated, last_launched FROM application_instances WHERE id=8`
   * The update date should change, but last launched should not