### PR TITLE
Add DB migration updated and last_launched dates for application instances

### DIFF
--- a/lms/migrations/versions/64fd59a9f4b6_add_updated_last_launched_to_ai.py
+++ b/lms/migrations/versions/64fd59a9f4b6_add_updated_last_launched_to_ai.py
@@ -1,0 +1,62 @@
+"""
+Add updated and last_launched to application instances.
+
+Revision ID: 64fd59a9f4b6
+Revises: 53f9ad3b93a4
+Create Date: 2023-02-02 16:56:37.882370
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "64fd59a9f4b6"
+down_revision = "53f9ad3b93a4"
+
+
+def upgrade():
+    op.add_column(
+        "application_instances",
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+    )
+
+    op.add_column(
+        "application_instances",
+        sa.Column("last_launched", sa.DateTime(), nullable=True),
+    )
+
+    # Default the last launched date to the most recent deep linking or launch
+    op.execute(
+        """
+        WITH
+            last_update_times AS (
+                SELECT
+                    application_instance_id,
+                    MAX(timestamp) AS last_launched
+                FROM event
+                JOIN event_type ON
+                    event_type.id = event.type_id
+                WHERE
+                    event_type.type IN ('deep_linking', 'configured_launch')
+                    AND application_instance_id IS NOT NULL
+                GROUP BY application_instance_id
+            )
+
+        UPDATE application_instances
+        SET last_launched=last_update_times.last_launched
+        FROM last_update_times
+        WHERE id = last_update_times.application_instance_id
+    """
+    )
+
+    # Default the updated date to the existing created date / launched date
+    op.execute(
+        "UPDATE application_instances SET updated=COALESCE(last_launched, created)"
+    )
+
+
+def downgrade():
+    op.drop_column("application_instances", "last_launched")
+    op.drop_column("application_instances", "updated")


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4965

This PR:

 * Adds a new `last_launched` column and defaults it to the last launched in the events table
 * Adds a bog standard `updated` column and sets it to the max of the last launched / created

## Testing notes

 * Reset the DB
```shell
git checkout main
make services args=down
make services db devdata
```
* To test this you will need to have launched some assignments.
* Visit: https://hypothesis.instructure.com/courses/125/assignments/873
* Perform the update:
```shell
git checkout ai-last-launched-migration
hdev alembic upgrade head
make sql
```
* Run:
```sql
select id, created, updated, last_launched FROM application_instances;
```
* You should see `updated` and `last_launched` columns
* Row 8 should have a more recent updated / last_launched date
* The rest of the updated should match the created