### PR TITLE
Display the last launched dates on application instances admin pages

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -53,6 +53,7 @@
         {{ macros.disabled_text_field("Shared secret", instance.shared_secret) }}
         {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
         {{ macros.form_text_field(request, "LMS URL", "lms_url", field_value=instance.lms_url) }}
+        {{ macros.disabled_text_field("Last Launched", instance.last_launched) }}
     </fieldset>
 
     <fieldset class="box mt-6">

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -79,6 +79,7 @@
     {% endif %}
 {% endmacro %}
 
+
 {% macro object_list_table(request, route, objects, fields) %}
 <div class="container">
     <div class="table-container">
@@ -120,10 +121,11 @@
     request, 'admin.instance', instances,
     fields=[
         {"label": "Name", "name": "name"},
-        {"label": "Consumer key", "name": "consumer_key"},
-        {"label": "GUID", "name": "tool_consumer_instance_guid"},
-        {"label": "Deployment ID", "name": "deployment_id"},
+        {"label": "Created", "name": "created"},
         {"label": "Last Launched", "name": "last_launched"},
+        {"label": "Product Family", "name": "tool_consumer_info_product_family_code"},
+        {"label": "Email", "name": "requesters_email"},
+        {"label": "LMS URL", "name": "lms_url"},
     ]
 ) }}
 {% endmacro %}

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -118,8 +118,8 @@
 {% macro instances_table(request,  instances) %}
 {{ object_list_table(
     request, 'admin.instance', instances,
-    ['Name', 'Consumer key', 'GUID', 'Deployment ID'],
-    ['name', 'consumer_key', 'tool_consumer_instance_guid', 'deployment_id']
+    ['Name', 'Consumer key', 'GUID', 'Deployment ID', 'Last Launched'],
+    ['name', 'consumer_key', 'tool_consumer_instance_guid', 'deployment_id', 'last_launched']
 ) }}
 {% endmacro %}
 

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -79,15 +79,15 @@
     {% endif %}
 {% endmacro %}
 
-{% macro object_list_table(request, route, objects, headers, fields) %}
+{% macro object_list_table(request, route, objects, fields) %}
 <div class="container">
     <div class="table-container">
         <table class="table is-fullwidth">
           <thead>
             <tr>
               <th></th>
-              {% for heading in headers %}
-              <th>{{heading}}</th>
+              {% for field in fields %}
+              <th>{{field.label}}</th>
               {% endfor %}
             </tr>
           </thead>
@@ -99,10 +99,10 @@
                   </td>
                   {% for field in fields %}
                   <td>
-                    {% if object[field] is none %}
+                    {% if object[field.name] is none %}
                         <span style="color:#aaa">-</span>
                     {% else %}
-                        {{ object[field] }}
+                        {{ object[field.name] }}
                     {% endif %}
                   </td>
                   {% endfor %}
@@ -115,17 +115,28 @@
 {% endmacro %}
 
 
-{% macro instances_table(request,  instances) %}
+{% macro instances_table(request, instances) %}
 {{ object_list_table(
     request, 'admin.instance', instances,
-    ['Name', 'Consumer key', 'GUID', 'Deployment ID', 'Last Launched'],
-    ['name', 'consumer_key', 'tool_consumer_instance_guid', 'deployment_id', 'last_launched']
+    fields=[
+        {"label": "Name", "name": "name"},
+        {"label": "Consumer key", "name": "consumer_key"},
+        {"label": "GUID", "name": "tool_consumer_instance_guid"},
+        {"label": "Deployment ID", "name": "deployment_id"},
+        {"label": "Last Launched", "name": "last_launched"},
+    ]
 ) }}
 {% endmacro %}
 
 
-{% macro registrations_table(request,  registrations) %}
-{{ object_list_table(request, 'admin.registration.id', registrations, ['Issuer', 'Client ID'], ['issuer', 'client_id']) }}
+{% macro registrations_table(request, registrations) %}
+{{ object_list_table(
+    request, 'admin.registration.id', registrations,
+    fields=[
+        {"label": "Client ID", "name": "client_id"},
+        {"label": "Issuer ID", "name": "issuer"},
+    ]
+) }}
 {% endmacro %}
 
 

--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -48,12 +48,7 @@
         </div>
 
         {% if org.application_instances %}
-            {{ macros.object_list_table(
-                    request, 'admin.instance', org.application_instances,
-                    ['Consumer key', 'Deployment ID', 'Tool name', 'URL', "Email"],
-                    ['consumer_key', 'deployment_id', 'tool_consumer_instance_name', 'lms_url', 'requesters_email']
-               )
-            }}
+            {{ macros.instances_table(request, org.application_instances) }}
         {% else %}
             <div class="is-size-5 has-text-centered">No application instances</div>
         {% endif %}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4965

Requires:

 * https://github.com/hypothesis/lms/pull/4968
 * https://github.com/hypothesis/lms/pull/4969

## Implementation notes

There are some big rough edges on this one. 

The first is date formatting. We haven't tried harder anywhere else by we are showing dates to the micro-second, which is long and unhelpful.

~The second is that we are triggering horizontal scrolling in the application instance tables. I've asked support if we can drop / re-order / truncate any of the fields (https://hypothes-is.slack.com/archives/C2BLQDKHA/p1675706515773809)~. There are some extensive notes at the bottom about new more useful (and compact) columns.

![image](https://user-images.githubusercontent.com/7131143/217560025-16d884ce-c5fd-41b4-8df7-600ed455ccac.png)

These new columns have more likely break points for inserting softbreaks, so they tend to wrap and don't trigger horizontal scroll. A very long URL could probably still do it, but I've put it as the last column.

## Testing notes

 * Follow the steps in: https://github.com/hypothesis/lms/pull/4968
     * Visit: http://localhost:8001/admin/instance/8/
     * The last launch date should be visible
  * Visit: http://localhost:8001/admin/instances/
     * Press "Search"
     * You should see the last launch dates
     * You may have to horizontally scroll to see them

## Feedback on useful columns

The columns we show at the moment aren't very useful for telling application instances apart. They tend to fall into two (overlapping) categores:

 * Long inscrutable strings
 * The thing you searched for, and so don't need to be told

Current practice in the support team is to search in Metabase to find the correct record using other fields, and then locate it in the admin pages. Ideally we'd present the most relevant details in the admin pages so this wasn't required.

### Column summary

* LMS URL - useful to see
* Requesters email - useful to see 
* Last launched - useful
* Created - useful
* Name - useful some day
* Settings - useful to see (but huge!)
* GUID - not so useful
* Consumer key - not so useful
* Deployment ID - not useful?

### Current columns

The current columns heavily cluster around not-useful settings:

 * Name 
 * Consumer key
 * GUID
 * Deployment ID 

### Proposed columns

* Name 
* LMS URL
* Requesters Email
* Created - As `YYYY-MM-DD HH:MM`
* Last Launched - As `YYYY-MM-DD HH:MM`
* `tool_consumer_info_product_family_code` - Family

