### PR TITLE
Switch type-checking from opt-in to opt-out

### DIFF
--- a/lms/static/scripts/browser_check/.babelrc
+++ b/lms/static/scripts/browser_check/.babelrc
@@ -4,6 +4,7 @@
 // This baseline here is based on browsers that support `<script type="module">`.
 {
   "presets": [
+    "@babel/preset-typescript",
     ["@babel/preset-env", {
        "targets": {
          "chrome": "61",

--- a/lms/static/scripts/browser_check/index.ts
+++ b/lms/static/scripts/browser_check/index.ts
@@ -12,7 +12,7 @@ if (!isBrowserSupported()) {
   <button class="Button">Dismiss</button>
 `;
 
-  const dismissButton = browserWarning.querySelector('button');
+  const dismissButton = browserWarning.querySelector('button')!;
   dismissButton.onclick = () => {
     browserWarning.style.display = 'none';
   };

--- a/lms/static/scripts/tsconfig.json
+++ b/lms/static/scripts/tsconfig.json
@@ -12,6 +12,15 @@
     "target": "ES2020",
     "useUnknownInCatchVariables": false
   },
-  "include": ["frontend_apps/**/*.js", "frontend_apps/**/*d.ts"],
-  "exclude": ["frontend_apps/**/test/*.js"]
+  "include": ["**/*.js", "**/*.ts", "**/*.tsx"],
+  "exclude": [
+    "new-application-instance.js",
+    "ui-playground/**/*.js",
+
+    // Tests and test infrastructure
+    "**/test/*.js",
+    "bootstrap.js",
+    "karma.config.js",
+    "test-util/*.js"
+  ]
 }


### PR DESCRIPTION
This will catch mistakes where code is unintentionally omitted from checking. It also makes the lms TS setup more similar to the client's.