### PR TITLE
Begin to clarify which frontend config is available in different modes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,9 +31,23 @@
     //   exports is not enabled yet because that requires setting up type-aware
     //   linting.
     "@typescript-eslint/consistent-type-assertions": "error",
-    "@typescript-eslint/consistent-type-imports": "error"
+    "@typescript-eslint/consistent-type-imports": "error",
   },
   "overrides": [
+    // Additional rules that require type information, and thus can only
+    // run on a subset of the linted code.
+    {
+      "files": "lms/static/scripts/frontend_apps/**/*.{js,ts,tsx}",
+      "excludedFiles": ["**/test/*.js"],
+      "rules": {
+        "@typescript-eslint/no-unnecessary-condition": "error"
+      },
+      "parserOptions": {
+        "project": "lms/static/scripts/tsconfig.json"
+      }
+    },
+
+    // Code that runs in Node
     {
       "files": "*.mjs",
       "env": { "node": true },

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,8 +34,8 @@
     "@typescript-eslint/consistent-type-imports": "error",
   },
   "overrides": [
-    // Additional rules that require type information, and thus can only
-    // run on a subset of the linted code.
+    // Additional rules that require type information. These can only be run
+    // on files included in the TS project by tsconfig.json.
     {
       "files": "lms/static/scripts/frontend_apps/**/*.{js,ts,tsx}",
       "excludedFiles": ["**/test/*.js"],

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -228,7 +228,7 @@ export default function BasicLTILaunchApp() {
       // If a teacher launches an assignment or the LMS does not support reporting
       // outcomes or grading is not enabled for the assignment, then no submission
       // URL will be available.
-      if (!canvas.speedGrader || !canvas.speedGrader.submissionParams) {
+      if (!canvas.speedGrader) {
         return;
       }
 

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -174,7 +174,7 @@ export default function FilePickerApp({ onSubmit }) {
     if (
       shouldSubmit &&
       // We either are not using the deepLinkingAPI, or if we are, wait for deepLinkingFields to be available
-      (!deepLinkingAPI || (deepLinkingAPI && deepLinkingFields))
+      (!deepLinkingAPI || deepLinkingFields)
     ) {
       // Submit form using a hidden button rather than calling `form.submit()`
       // to facilitate observing the submission in tests and suppressing the

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -168,7 +168,7 @@ export default function GroupConfigSelector({
           path: listGroupSetsAPI.path,
         })
       );
-      if (groupSets && groupSets.length === 0) {
+      if (groupSets.length === 0) {
         setFetchError(new GroupListEmptyError());
       } else {
         setGroupSets(groupSets);

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.js
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.js
@@ -88,7 +88,7 @@ export default function JSTORPicker({ onCancel, onSelectURL }) {
    * @param {boolean} [confirmSelectedUrl=false]
    */
   const onURLChange = (confirmSelectedUrl = false) => {
-    const url = inputRef?.current?.value;
+    const url = inputRef.current.value;
     if (url && url === previousURL.current) {
       if (confirmSelectedUrl) {
         confirmSelection();

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -259,6 +259,8 @@ export default function LMSFilePicker({
           pathChanged = path !== folderPath;
           return path;
         });
+        // ESLint doesn't know that `setFolderPath` runs its callback synchronously.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (pathChanged) {
           return;
         }
@@ -287,7 +289,7 @@ export default function LMSFilePicker({
     }
     if (!file.type || file.type === 'File') {
       onSelectFile(file);
-    } else if (file.type === 'Folder') {
+    } else {
       onChangePath(file);
     }
   };

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -29,7 +29,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
     errorCode,
     errorDetails = '',
     canvasScopes = /** @type {string[]} */ ([]),
-  } = OAuth2RedirectError ?? {};
+  } = OAuth2RedirectError;
 
   const error = { errorCode, details: errorDetails };
 

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -461,18 +461,9 @@ describe('BasicLTILaunchApp', () => {
       assert.equal(errorDialog.prop('error'), error);
     });
 
-    it('does not report a submission if a teacher launches an assignment', async () => {
-      // When a teacher launches the assignment, there will typically be no
-      // `submissionParams` config provided by the backend.
-      fakeConfig.canvas.speedGrader.submissionParams = undefined;
-
-      renderLTILaunchApp();
-      await new Promise(resolve => setTimeout(resolve, 0));
-
-      assert.notCalled(fakeApiCall);
-    });
-
-    it('does not report a submission if `speedGrader` object is omitted', async () => {
+    it('does not report a submission if grading is not enabled for the current user', async () => {
+      // If the assignment is not gradable or the user is an instructor, the
+      // `speedGrader` config is omitted.
       fakeConfig.canvas.speedGrader = undefined;
 
       renderLTILaunchApp();

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -149,7 +149,7 @@ export type ClientConfig = {
    * grading submissions should only be submitted for a student after qualifying
    * annotation activity occurs (not immediately at launch).
    */
-  reportActivity: object;
+  reportActivity?: object;
 };
 
 /**
@@ -205,28 +205,40 @@ export type Product = {
  * the backend code.
  */
 export type ConfigObject = {
+  // Configuration present in all modes.
   mode: AppMode;
   api: {
     authToken: string;
-    sync: APICallInfo;
-    viaUrl: APICallInfo;
+
+    // Only present in "basic-lti-launch" mode.
+    sync?: APICallInfo;
+    viaUrl?: APICallInfo;
   };
+  dev: boolean;
+  debug?: DebugInfo;
+  product: Product;
+
+  // Only present in "basic-lti-launch" mode.
   canvas: {
-    speedGrader: SpeedGraderConfig;
+    // Only present in Canvas.
+    speedGrader?: SpeedGraderConfig;
   };
   contentBanner?: ContentBannerConfig;
-  dev: boolean;
-  filePicker: FilePickerConfig;
-  grading: GradingConfig;
+  grading?: GradingConfig; // Only present for instructors
   hypothesisClient: ClientConfig;
   rpcServer: {
     allowedOrigins: string[];
   };
   viaUrl: string;
-  OAuth2RedirectError: OAuthErrorConfig;
-  errorDialog: ErrorDialogConfig;
-  debug?: DebugInfo;
-  product: Product;
+
+  // Only present in "error-dialog" mode.
+  errorDialog?: ErrorDialogConfig;
+
+  // Only present in "content-item-selection" mode.
+  filePicker: FilePickerConfig;
+
+  // Only present in "oauth2-redirect-error" mode.
+  OAuth2RedirectError?: OAuthErrorConfig;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/services/content-info-fetcher.js
+++ b/lms/static/scripts/frontend_apps/services/content-info-fetcher.js
@@ -41,6 +41,8 @@ export class ContentInfoFetcher {
    * @param {ContentBannerConfig} contentId
    */
   async fetch(contentId) {
+    // This condition exists for when new content sources are added.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (contentId.source !== 'jstor') {
       throw new Error('Unknown content source');
     }

--- a/lms/static/scripts/frontend_apps/types.d.ts
+++ b/lms/static/scripts/frontend_apps/types.d.ts
@@ -2,7 +2,8 @@ export {};
 
 declare global {
   interface Window {
-    OneDrive: {
+    /** Global property set once OneDrive JS client is loaded. */
+    OneDrive?: {
       open: (options: Record<string, any>) => void;
     };
   }

--- a/lms/static/scripts/frontend_apps/utils/google-api-client.js
+++ b/lms/static/scripts/frontend_apps/utils/google-api-client.js
@@ -6,6 +6,10 @@
  * @return {Promise<typeof window.google.accounts>}
  */
 export async function loadIdentityServicesLibrary() {
+  // The third-party types assume `window.google` always exists, but it is only
+  // set once the library is loaded.
+  //
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (window.google?.accounts) {
     return window.google.accounts;
   }
@@ -27,6 +31,10 @@ export async function loadIdentityServicesLibrary() {
  * Load the Google API loader script (`window.gapi`), if not already loaded.
  */
 async function loadGAPI() {
+  // The third-party types assume `window.gapi` always exists, but it is only
+  // set once the library is loaded.
+  //
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (window.gapi) {
     return window.gapi;
   }

--- a/lms/static/scripts/frontend_apps/utils/jwt.js
+++ b/lms/static/scripts/frontend_apps/utils/jwt.js
@@ -75,7 +75,7 @@ export class JWT {
    * @param {string} type
    */
   _getField(field, type) {
-    if (!this._payload || typeof this._payload[field] !== type) {
+    if (typeof this._payload[field] !== type) {
       throw new Error(`Missing or invalid "${field}" field in JWT payload`);
     }
     return this._payload[field];


### PR DESCRIPTION
It was unclear which fields in the `ConfigObject` type are present in which apps, and the optional-ness of many fields did not match the code which used them. ie. We had code testing for the presence of fields that were marked non-optional in the type.

This commit begins to clean that up by:

 - Organizing fields in `ConfigObject` by the application modes they appear in

 - Enabling the [@typescript-eslint/no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition/) rule to check for conditionals that always evaluate to the truthy or falsey according to the types. This helps catch cases where a field is incorrectly marked as non-optional. [1]

 - Correcting the errors found by the above lint rule, which included incorrect optional-ness for several fields as well as some other unnecessary conditionals.

 - Correcting a Canvas SpeedGrader test whose expectations did not match the backend code

There are still some inconsistencies in the `ConfigObject` type. Some fields that are present only in certain modes are still marked as non-optional. However it is now at least consistent with the code that uses it. This will be further cleaned up in future.

[1] A downside of this change is that a "cold" lint run (when all files need re-linting) is a bit slower due to enabling type-aware linting. About ~5.1s on my machine compared with ~3.8s before. A no-op lint is about the same (~1.6s).