### PR TITLE
Add AssignmentService.get_copied_from_assignment

### DIFF
--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -16,6 +16,41 @@ class TestAssignmentService:
     def test_get_assignment_without_match(self, svc, non_matching_params):
         assert svc.get_assignment(**non_matching_params) is None
 
+    @pytest.mark.parametrize(
+        "param",
+        (
+            "resource_link_id_history",
+            "ext_d2l_resource_link_id_history",
+            "custom_ResourceLink.id.history",
+        ),
+    )
+    def test_get_copied_from_assignment(self, svc, param, assignment):
+        assert (
+            svc.get_copied_from_assignment(
+                {
+                    param: assignment.resource_link_id,
+                    "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
+                }
+            )
+            == assignment
+        )
+
+    def test_get_copied_from_assignment_not_found_bad_parameter(self, svc, assignment):
+        assert not svc.get_copied_from_assignment(
+            {
+                "unknown_param": assignment.resource_link_id,
+                "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
+            }
+        )
+
+    def test_get_copied_from_assignment_not_found(self, svc, assignment):
+        assert not svc.get_copied_from_assignment(
+            {
+                "resource_link_id_history": "Unknown_RESOURCE_LINK_ID",
+                "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
+            }
+        )
+
     upsert_kwargs = {
         "document_url": "new_document_url",
         "extra": {"new": "values"},


### PR DESCRIPTION
This makes the behavior of DocumentUrlService more explicit around course copy.

Ideally the final state of this would be to have each of the possible parameter locations be part of the individual product/product plugins instead of trying them in succession. Unfortunately the exact behaviour we rely on doesn't seem to be documented in D2L / Blackboard and we might be relying in it for other smaller LMS's even if it's not documented here.

Keeping the same behaviour for now in all LMS's while making the course copy aspect of it more apparent.


## Testing:

These all should point to the same document after:

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment cascade"```


```make devdata```



### Blackboard

- Original

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1


- Copy

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1367_1&course_id=_139_1


D2L 

- Original

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View

- Copy

https://aunltd.brightspacedemo.com/d2l/le/content/6855/viewContent/2409/View?ou=6855