### PR TITLE
Fix broken application instance routes after refactor

### DIFF
--- a/lms/templates/admin/instance.html.jinja2
+++ b/lms/templates/admin/instance.html.jinja2
@@ -43,7 +43,7 @@
 
 
 {% block content %}
-<form method="POST" action="{{ request.route_url("admin.instance.id", id_=instance.id) }}">
+<form method="POST" action="{{ request.route_url("admin.instance", id_=instance.id) }}">
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
     <fieldset class="box">

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -117,7 +117,7 @@
 
 {% macro instances_table(request,  instances) %}
 {{ object_list_table(
-    request, 'admin.instance.id', instances,
+    request, 'admin.instance', instances,
     ['Name', 'Consumer key', 'GUID', 'Deployment ID'],
     ['name', 'consumer_key', 'tool_consumer_instance_guid', 'deployment_id']
 ) }}

--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -49,7 +49,7 @@
 
         {% if org.application_instances %}
             {{ macros.object_list_table(
-                    request, 'admin.instance.id', org.application_instances,
+                    request, 'admin.instance', org.application_instances,
                     ['Consumer key', 'Deployment ID', 'Tool name', 'URL', "Email"],
                     ['consumer_key', 'deployment_id', 'tool_consumer_instance_name', 'lms_url', 'requesters_email']
                )


### PR DESCRIPTION
Caused by:

 * https://github.com/hypothesis/lms/pull/4967

The name of the route changed, but I missed some places where it was referenced as I was focussed on the page itself.

This effects places that use the standard macros to list application instances which are:

 * AI search page
 * Organization view
 * Registration view?

## Testing notes

The following should all fail on `main` but work on this branch:

AI search page:

 * Visit: http://localhost:8001/admin/instances
 * Press "Search"
 
Registration view:

 * http://localhost:8001/admin/registration/id/2/
 
Organization view:

 * You will need to have an org in your DB, so launch something if you don't
 * Look at an org
 
 