### PR TITLE
Show error for copied Blackboard and D2L groups assignments.

### DIFF
--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -16,6 +16,41 @@ class TestAssignmentService:
     def test_get_assignment_without_match(self, svc, non_matching_params):
         assert svc.get_assignment(**non_matching_params) is None
 
+    @pytest.mark.parametrize(
+        "param",
+        (
+            "resource_link_id_history",
+            "ext_d2l_resource_link_id_history",
+            "custom_ResourceLink.id.history",
+        ),
+    )
+    def test_get_copied_from_assignment(self, svc, param, assignment):
+        assert (
+            svc.get_copied_from_assignment(
+                {
+                    param: assignment.resource_link_id,
+                    "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
+                }
+            )
+            == assignment
+        )
+
+    def test_get_copied_from_assignment_not_found_bad_parameter(self, svc, assignment):
+        assert not svc.get_copied_from_assignment(
+            {
+                "unknown_param": assignment.resource_link_id,
+                "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
+            }
+        )
+
+    def test_get_copied_from_assignment_not_found(self, svc, assignment):
+        assert not svc.get_copied_from_assignment(
+            {
+                "resource_link_id_history": "Unknown_RESOURCE_LINK_ID",
+                "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
+            }
+        )
+
     upsert_kwargs = {
         "document_url": "new_document_url",
         "extra": {"new": "values"},


### PR DESCRIPTION
upsert_assignment already takes lti_params as one of the mandatory parameters.

Use LTIParams in combination with the new get_copied_from_assignment to, in new assignments to copy some of the configuration of the old assignment over to he new one.

We only copy the value of `group_set_id` for now. As a result copied assignments will still be group ones after copy. They will point to an unavailable group set for now.

We don't look at document_url for now as that handled separately at the moment over in DocumentService.



####  Testing

- Reset assignment (once per branch):

 ```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment cascade"; make devdata```


- Now both in `main` and this branch (`course-copy-group-set`) try:


#### D2L

https://aunltd.brightspacedemo.com/d2l/le/content/6855/viewContent/2409/View?ou=6855


#### Blackboard 


https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1373_1&course_id=_139_1




On main, both will launch successfully but they'll become "course assignments", ie the group drop-down just shows the course group.

On this branch the "can't find group set" will appear.


(Canvas is not affected by this as the group set is part of the URL parameters sent by canvas itself)
