### PR TITLE
Record courses in the DB on configuration

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -50,7 +50,7 @@ class BasicLaunchViews:
         self.context.application_instance.check_guid_aligns(
             self.request.lti_params.get("tool_consumer_instance_guid")
         )
-
+        self._record_course()
         self._record_launch()
 
     @view_config(
@@ -108,7 +108,6 @@ class BasicLaunchViews:
             form_action=self.request.route_url("configure_assignment"),
             form_fields=form_fields,
         )
-
         return {}
 
     @view_config(
@@ -159,7 +158,6 @@ class BasicLaunchViews:
         )
 
         # Store lots of info
-        self._record_course()
         assignment = self._record_assignment(
             document_url, extra=assignment_extra, is_gradable=assignment_gradable
         )

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -32,9 +32,15 @@ class TestHasDocumentURL:
     "misc_plugin",
 )
 class TestBasicLaunchViews:
-    def test___init___(self, context, pyramid_request):
+    def test___init___(self, context, pyramid_request, grouping_service):
         BasicLaunchViews(context, pyramid_request)
 
+        # `_record_course()`
+        grouping_service.upsert_grouping_memberships.assert_called_once_with(
+            user=pyramid_request.user, groups=[context.course]
+        )
+
+        # `_record_launch()`
         context.application_instance.check_guid_aligns.assert_called_once_with(
             pyramid_request.lti_params["tool_consumer_instance_guid"]
         )
@@ -179,7 +185,6 @@ class TestBasicLaunchViews:
         lti_h_service,
         assignment_service,
         lti_role_service,
-        grouping_service,
         misc_plugin,
     ):
         # pylint: disable=protected-access
@@ -189,11 +194,6 @@ class TestBasicLaunchViews:
 
         lti_h_service.sync.assert_called_once_with(
             [context.course], pyramid_request.lti_params
-        )
-
-        # `_record_course()`
-        grouping_service.upsert_grouping_memberships.assert_called_once_with(
-            user=pyramid_request.user, groups=[context.course]
         )
 
         # `_record_assignment()`


### PR DESCRIPTION
Create a course in the DB as soon as we start configuring an assignment in it.

This brings the behavior in line with the deeplinking counterpart where this was already the case, the deeplinking request creates the course.

The new behavior allows APIs that are called during configuration (files, groups) to rely on the presence of the course.



### Testing 

- On `main`, reset the DB state:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment,grouping cascade"; make devdata
```

- Launch https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1

do not configure it.


- Check the DB for groupings:

```
select * from grouping;
(0 rows)
```


- Repeat the process in this branch `store-course`

```
select * from grouping;
-[ RECORD 1 ]-----------+----------------------------------------------------------------
created                 | 2023-02-07 13:44:05.447744
updated                 | 2023-02-07 13:44:05.447744
id                      | 426
application_instance_id | 110
authority_provided_id   | 026ffd48cdfbe1c6f32a4f434390cbc12c8b4292
parent_id               | 
lms_id                  | c494dc384def49bfb66b9dd356010a63
lms_name                | COPIED Test Course with Original Course View
type                    | course
settings                | {"blackboard": {"files_enabled": true, "groups_enabled": true}}
extra                   | {}
```

now the course is created.


