### PR TITLE
Use a single name for searching for instances which matches the pattern

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -129,8 +129,8 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("vitalsource_api.launch_url", "/api/vitalsource/launch_url")
 
     config.add_route("admin.index", "/admin/")
-    config.add_route("admin.instances", "/admin/instances/")
-    config.add_route("admin.instances.search", "/admin/instances/search")
+
+    config.add_route("admin.instance.search", "/admin/instances/")
     config.add_route("admin.instance.new", "/admin/instance/new")
     config.add_route("admin.instance.upgrade", "/admin/instance/upgrade")
     config.add_route("admin.instance", "/admin/instance/{id_}/")

--- a/lms/templates/admin/base.html.jinja2
+++ b/lms/templates/admin/base.html.jinja2
@@ -18,7 +18,7 @@
 
   <div class="navbar-menu is-active">
     <div class="navbar-start" style="flex-grow: 1; justify-content: center;">
-      <a class="navbar-item" href="{{ request.route_url("admin.instances") }}" >
+      <a class="navbar-item" href="{{ request.route_url("admin.instance.search") }}" >
         Application Instances
       </a>
       <a class="navbar-item" href="{{ request.route_url("admin.registrations") }}" >

--- a/lms/templates/admin/instance.search.html.jinja2
+++ b/lms/templates/admin/instance.search.html.jinja2
@@ -15,7 +15,7 @@ Application instances
 
 <fieldset class="box mt-6">
     <legend class="label has-text-centered">Find application instances</legend>
-    <form method="POST" action="{{ request.route_url("admin.instances.search") }}">
+    <form method="POST" action="{{ request.route_url("admin.instance.search") }}">
         <input type="hidden" name="csrf_token" value="{{get_csrf_token()}}">
         {{ macros.form_text_field(request, "ID", "id") }}
         {{ macros.form_text_field(request, "Name", "name") }}

--- a/lms/views/admin/__init__.py
+++ b/lms/views/admin/__init__.py
@@ -20,7 +20,7 @@ def notfound(_request):
 
 @view_config(route_name="admin.index")
 def index(request):
-    return HTTPFound(location=request.route_url("admin.instances"))
+    return HTTPFound(location=request.route_url("admin.instance.search"))
 
 
 def flash_validation(request, schema):

--- a/lms/views/admin/application_instance.py
+++ b/lms/views/admin/application_instance.py
@@ -80,13 +80,6 @@ class AdminApplicationInstanceViews:
         self._aes_service = request.find_service(AESService)
 
     @view_config(
-        route_name="admin.instances",
-        renderer="lms:templates/admin/instances.html.jinja2",
-    )
-    def instances(self):
-        return {}
-
-    @view_config(
         route_name="admin.instance.new",
         renderer="lms:templates/admin/instance.new.html.jinja2",
     )
@@ -236,12 +229,19 @@ class AdminApplicationInstanceViews:
         return self._redirect("admin.instance", id_=ai.id)
 
     @view_config(
-        route_name="admin.instances.search",
+        route_name="admin.instance.search",
+        renderer="lms:templates/admin/instance.search.html.jinja2",
+    )
+    def search_start(self):
+        return {}
+
+    @view_config(
+        route_name="admin.instance.search",
         request_method="POST",
         require_csrf=True,
-        renderer="lms:templates/admin/instances.html.jinja2",
+        renderer="lms:templates/admin/instance.search.html.jinja2",
     )
-    def search(self):
+    def search_callback(self):
         if flash_validation(self.request, SearchApplicationInstanceSchema):
             return {}
 

--- a/tests/unit/lms/views/admin/__init___test.py
+++ b/tests/unit/lms/views/admin/__init___test.py
@@ -24,5 +24,5 @@ def test_index(pyramid_request):
     response = index(pyramid_request)
 
     assert response == temporary_redirect_to(
-        pyramid_request.route_url("admin.instances")
+        pyramid_request.route_url("admin.instance.search")
     )

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -28,9 +28,6 @@ REDIRECT_TO_UPGRADE_AI = Any.instance_of(HTTPFound).with_attrs(
     "aes_service",
 )
 class TestAdminApplicationInstanceViews:
-    def test_instances(self, views):
-        assert views.instances() == {}
-
     @pytest.mark.parametrize("lti_registration_id", ("123", "  123   "))
     def test_new_instance_start_v13(
         self, views, pyramid_request, lti_registration_service, lti_registration_id
@@ -279,6 +276,9 @@ class TestAdminApplicationInstanceViews:
 
         assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
 
+    def test_search_start(self, views):
+        assert not views.search_start()
+
     def test_search(self, pyramid_request, application_instance_service, views):
         pyramid_request.params = pyramid_request.POST = {
             "id": "1",
@@ -290,7 +290,7 @@ class TestAdminApplicationInstanceViews:
             "tool_consumer_instance_guid": "TOOL_CONSUMER_INSTANCE_GUID",
         }
 
-        response = views.search()
+        response = views.search_callback()
 
         application_instance_service.search.assert_called_once_with(
             id_="1",
@@ -305,10 +305,10 @@ class TestAdminApplicationInstanceViews:
             "instances": application_instance_service.search.return_value
         }
 
-    def test_search_invalid(self, views, pyramid_request):
+    def test_search_callback_invalid(self, views, pyramid_request):
         pyramid_request.POST = {"id": "not a number"}
 
-        assert not views.search()
+        assert not views.search_callback()
         assert pyramid_request.session.peek_flash
 
     def test_show_instance_id(self, views, ai_from_matchdict):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4998

Previously we had `GET:admin.instances` to start the search and `POST:admin.instances.search` for the callback. In all other cases we have the same route and distinguish by HTTP method. This keeps the two halves of the search more obviously intertwined. I've also named them similarly and put them next to each other.

We have `admin.instance.blah` for pretty much everything else, so I've made this `admin.instance.search` and renamed the template accordingly.