### PR TITLE
Add `useConfig` hook to read frontend configuration from UI components

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.js
@@ -1,15 +1,9 @@
 import { FullScreenSpinner } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'preact/hooks';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
-import { Config } from '../config';
+import { useConfig } from '../config';
 import { isAuthorizationError, isLTILaunchServerError } from '../errors';
 import { ClientRPC, useService } from '../services';
 import { apiCall } from '../utils/api';
@@ -59,7 +53,7 @@ export default function BasicLTILaunchApp() {
     // Content URL to show in the iframe.
     viaUrl: viaURL,
     canvas,
-  } = useContext(Config);
+  } = useConfig();
 
   const clientRPC = useService(ClientRPC);
 

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.js
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.js
@@ -1,7 +1,7 @@
 import { FullScreenSpinner, LabeledButton } from '@hypothesis/frontend-shared';
-import { useContext, useMemo, useState } from 'preact/hooks';
+import { useMemo, useState } from 'preact/hooks';
 
-import { Config } from '../config';
+import { useConfig } from '../config';
 import { PickerCanceledError } from '../errors';
 import { GooglePickerClient } from '../utils/google-picker-client';
 import { OneDrivePickerClient } from '../utils/onedrive-picker-client';
@@ -62,7 +62,7 @@ export default function ContentSelector({
       },
       vitalSource: { enabled: vitalSourceEnabled },
     },
-  } = useContext(Config);
+  } = useConfig(['filePicker']);
 
   const [isLoadingIndicatorVisible, setLoadingIndicatorVisible] =
     useState(false);

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.js
@@ -1,8 +1,6 @@
 import { Link } from '@hypothesis/frontend-shared';
-import { useContext } from 'preact/hooks';
 
-import { Config } from '../config';
-
+import { useConfig } from '../config';
 import ErrorModal from './ErrorModal';
 
 /**
@@ -14,12 +12,12 @@ import ErrorModal from './ErrorModal';
  * (e.g. OAuth2RedirectErrorApp, LaunchErrorDialog).
  */
 export default function ErrorDialogApp() {
-  const { errorDialog } = useContext(Config);
+  const { errorDialog } = useConfig(['errorDialog']);
 
   const error = {
-    errorCode: errorDialog?.errorCode,
-    details: errorDialog?.errorDetails ?? '',
-    message: errorDialog?.errorMessage ?? '',
+    errorCode: errorDialog.errorCode,
+    details: errorDialog.errorDetails ?? '',
+    message: errorDialog.errorMessage ?? '',
   };
 
   let description;

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.js
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.js
@@ -1,13 +1,7 @@
 import { FullScreenSpinner, LabeledButton } from '@hypothesis/frontend-shared';
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'preact/hooks';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
-import { Config } from '../config';
+import { useConfig } from '../config';
 import { apiCall } from '../utils/api';
 import { truncateURL } from '../utils/format';
 
@@ -97,7 +91,7 @@ export default function FilePickerApp({ onSubmit }) {
       settings: { groupsEnabled: enableGroupConfig },
     },
     filePicker: { deepLinkingAPI, formAction, formFields },
-  } = useContext(Config);
+  } = useConfig(['filePicker']);
 
   const [content, setContent] = useState(/** @type {Content|null} */ (null));
 

--- a/lms/static/scripts/frontend_apps/components/GradingToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingToolbar.tsx
@@ -1,15 +1,9 @@
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
 import { apiCall } from '../utils/api';
-import { Config } from '../config';
+import { useConfig } from '../config';
 import type { StudentInfo } from '../config';
 import type { ClientRPC } from '../services/client-rpc';
 import StudentSelector from './StudentSelector';
@@ -41,7 +35,7 @@ export default function GradingToolbar({
 }: GradingToolbarProps) {
   const {
     api: { authToken, sync: syncAPICallInfo },
-  } = useContext(Config);
+  } = useConfig();
 
   // No initial current student selected
   const [currentStudentIndex, setCurrentStudentIndex] = useState(-1);

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.js
@@ -1,7 +1,7 @@
 import { LabeledCheckbox, Link } from '@hypothesis/frontend-shared';
-import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 
-import { Config } from '../config';
+import { useConfig } from '../config';
 import { isAuthorizationError, GroupListEmptyError } from '../errors';
 import { apiCall } from '../utils/api';
 import { useUniqueId } from '../utils/hooks';
@@ -145,7 +145,7 @@ export default function GroupConfigSelector({
     product: {
       api: { listGroupSets: listGroupSetsAPI },
     },
-  } = useContext(Config);
+  } = useConfig();
 
   const useGroupSet = groupConfig.useGroupSet;
   const groupSet = useGroupSet ? groupConfig.groupSet : null;

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.js
@@ -1,8 +1,6 @@
 import { Link } from '@hypothesis/frontend-shared';
-import { useContext } from 'preact/hooks';
 
-import { Config } from '../config';
-
+import { useConfig } from '../config';
 import ErrorModal from './ErrorModal';
 
 /** @typedef {import('../config').OAuthErrorConfig} OAuthErrorConfig */
@@ -21,15 +19,14 @@ import ErrorModal from './ErrorModal';
  * @param {OAuth2RedirectErrorAppProps} props
  */
 export default function OAuth2RedirectErrorApp({ location = window.location }) {
-  const { OAuth2RedirectError = /** @type {OAuthErrorConfig} */ ({}) } =
-    useContext(Config);
-
   const {
-    authUrl = null,
-    errorCode,
-    errorDetails = '',
-    canvasScopes = /** @type {string[]} */ ([]),
-  } = OAuth2RedirectError;
+    OAuth2RedirectError: {
+      authUrl = null,
+      errorCode,
+      errorDetails = '',
+      canvasScopes = /** @type {string[]} */ ([]),
+    },
+  } = useConfig(['OAuth2RedirectError']);
 
   const error = { errorCode, details: errorDetails };
 

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -236,7 +236,7 @@ export type ConfigObject = {
   errorDialog?: ErrorDialogConfig;
 
   // Only present in "content-item-selection" mode.
-  filePicker: FilePickerConfig;
+  filePicker?: FilePickerConfig;
 
   // Only present in "oauth2-redirect-error" mode.
   OAuth2RedirectError?: OAuthErrorConfig;

--- a/lms/static/scripts/frontend_apps/test/config-test.js
+++ b/lms/static/scripts/frontend_apps/test/config-test.js
@@ -1,4 +1,6 @@
-import { readConfig } from '../config';
+import { render } from 'preact';
+
+import { Config, readConfig, useConfig } from '../config';
 
 describe('readConfig', () => {
   let expectedConfig;
@@ -36,5 +38,42 @@ describe('readConfig', () => {
   it('should return the parsed configuration', () => {
     const config = readConfig();
     assert.deepEqual(config, expectedConfig);
+  });
+});
+
+describe('useConfig', () => {
+  const config = {
+    someApp: { setting: true },
+  };
+
+  it('should return current config', () => {
+    let result;
+    function Widget() {
+      result = useConfig();
+    }
+
+    render(
+      <Config.Provider value={config}>
+        <Widget />
+      </Config.Provider>,
+      document.createElement('div')
+    );
+
+    assert.deepEqual(result, config);
+  });
+
+  it('should throw if required keys are not set', () => {
+    function Widget() {
+      useConfig(['otherApp']);
+    }
+
+    assert.throws(() => {
+      render(
+        <Config.Provider value={config}>
+          <Widget />
+        </Config.Provider>,
+        document.createElement('div')
+      );
+    }, 'Required configuration key "otherApp" not set');
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/api.js
+++ b/lms/static/scripts/frontend_apps/utils/api.js
@@ -1,6 +1,4 @@
-import { useContext } from 'preact/hooks';
-
-import { Config } from '../config';
+import { useConfig } from '../config';
 import { APIError } from '../errors';
 import { useFetch } from './fetch';
 
@@ -167,7 +165,7 @@ export function urlPath(strings, ...params) {
 export function useAPIFetch(path, params) {
   const {
     api: { authToken },
-  } = useContext(Config);
+  } = useConfig();
 
   /** @type {import('./fetch').Fetcher<T>|undefined} */
   const fetcher = path

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -358,11 +358,11 @@ describe('useAPIFetch', () => {
     fakeFetchResult = { data: {}, error: null, isLoading: false };
     fakeUseFetch = sinon.stub().returns(fakeFetchResult);
 
-    const fakeUseContext = sinon.stub();
-    fakeUseContext.withArgs(Config).returns(fakeConfig);
+    const fakeUseConfig = sinon.stub();
+    fakeUseConfig.returns(fakeConfig);
 
     $imports.$mock({
-      'preact/hooks': { useContext: fakeUseContext },
+      '../config': { useConfig: fakeUseConfig },
       './fetch': { useFetch: fakeUseFetch },
     });
 


### PR DESCRIPTION
This PR adds a `useConfig` hook to simplify reading configuration embedded into the page by the backend, from within UI components. It is a simple wrapper around the previous `useContext(Config)` pattern, which checks that certain app/route-specific keys are provided and throws a sensible error if missing.

I have converted the existing uses of `useContext(Config)` to use this new hook.