### PR TITLE
Prep the `StudentSelector`, `GradingToolbar` components for UI enhancements

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GradingToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingToolbar.tsx
@@ -124,11 +124,17 @@ export default function GradingToolbar({
           'lg:grid-cols-3 lg:gap-x-4 lg:px-3'
         )}
       >
-        <div>
-          <h1 className="text-lg font-bold" data-testid="assignment-name">
+        <div className="space-y-1">
+          <h1
+            className="text-lg font-semibold leading-none"
+            data-testid="assignment-name"
+          >
             {assignmentName}
           </h1>
-          <h2 className="text-base font-medium" data-testid="course-name">
+          <h2
+            className="text-sm font-normal text-color-text-light leading-none"
+            data-testid="course-name"
+          >
             {courseName}
           </h2>
         </div>

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
@@ -1,7 +1,13 @@
-import { Icon, IconButton } from '@hypothesis/frontend-shared';
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  IconButton,
+  InputGroup,
+  Select,
+} from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
-type Student = {
+export type Student = {
   displayName: string;
 };
 
@@ -15,7 +21,7 @@ export type StudentSelectorProps = {
 };
 
 /**
- * A student navigation tool which shows a student selection list and a previous and next button.
+ * A drop-down control that allows selecting a student from a list of students.
  */
 export default function StudentSelector({
   onSelectStudent,
@@ -29,72 +35,12 @@ export default function StudentSelector({
   // indicating the "All Students" choice is selected.
   const hasPrevView = selectedStudentIndex >= 0;
 
-  /**
-   * Select the next student index in the list.
-   */
   const onNextView = () => {
     onSelectStudent(selectedStudentIndex + 1);
   };
-  /**
-   * Select the previous student index in the list. The 0 index
-   * represents "All Students."
-   */
+
   const onPrevView = () => {
     onSelectStudent(selectedStudentIndex - 1);
-  };
-
-  /**
-   * Build the <select> list from the current array of students.
-   */
-  const buildStudentList = () => {
-    const options = students.map((student, i) => (
-      <option
-        key={`student-${i}`}
-        selected={selectedStudentIndex === i}
-        value={i}
-      >
-        {student.displayName}
-      </option>
-    ));
-    options.unshift(
-      <option
-        key={'all-students'}
-        selected={selectedStudentIndex === -1}
-        value={-1}
-      >
-        All Students
-      </option>
-    );
-
-    return (
-      <span className="relative">
-        {/*
-        This lint issue may have arisen from browser inconsistency issues with
-        `onChange` which have since been fixed. See browser compatibility note here:
-        https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event#annotations:xeC6ClQsEequhUdih2lXzw
-        */}
-        {/* eslint-disable-next-line jsx-a11y/no-onchange*/}
-        <select
-          aria-label="Select student"
-          className={classnames(
-            'appearance-none w-full h-touch-minimum',
-            'pl-4 pr-8', // Make room on right for custom down-caret Icon
-            'xl:w-80', // Fix the width at wider viewports
-            'focus-visible-ring ring-inset',
-            'border border-r-0 border-l-0' // left and right borders off
-          )}
-          onChange={e => {
-            onSelectStudent(parseInt((e.target as HTMLInputElement).value));
-          }}
-        >
-          {options}
-        </select>
-        <Icon
-          classes="absolute top-0.5 right-3 pointer-events-none text-grey-4"
-          name="caretDown"
-        />{' '}
-      </span>
-    );
   };
 
   return (
@@ -121,35 +67,52 @@ export default function StudentSelector({
           <span>{`${students.length} Students`}</span>
         )}
       </label>
-      <div className="flex flex-row">
-        <IconButton
-          classes={classnames(
-            'px-3',
-            // IconButton styling sets a border radius. Turn it off on the
-            // right for better alignment with the select element
-            'rounded-r-none',
-            'focus-visible-ring ring-inset'
-          )}
-          icon="arrowLeft"
-          title="previous student"
-          disabled={!hasPrevView}
-          onClick={onPrevView}
-          variant="dark"
-        />
-        <div className="w-full">{buildStudentList()}</div>
-        <IconButton
-          classes={classnames(
-            'px-3',
-            // Turn off border radius on left for better alignment with select
-            'rounded-l-none',
-            'focus-visible-ring ring-inset'
-          )}
-          icon="arrowRight"
-          title="next student"
-          disabled={!hasNextView}
-          onClick={onNextView}
-          variant="dark"
-        />
+      {/**
+       * This <div> is needed as a container because InputGroup establishes a
+       * new flex layout. This ensures that this <div>'s contents amount to a
+       * single flex-child of the outermost <div> here.
+       */}
+      <div>
+        <InputGroup>
+          <IconButton
+            icon={ArrowLeftIcon}
+            title="Previous student"
+            disabled={!hasPrevView}
+            onClick={onPrevView}
+            variant="dark"
+          />
+          <Select
+            aria-label="Select student"
+            classes="xl:w-80"
+            onChange={e => {
+              onSelectStudent(parseInt((e.target as HTMLInputElement).value));
+            }}
+          >
+            <option
+              key={'all-students'}
+              selected={selectedStudentIndex === -1}
+              value={-1}
+            >
+              All Students
+            </option>
+            {students.map((student, i) => (
+              <option
+                key={`student-${i}`}
+                selected={selectedStudentIndex === i}
+                value={i}
+              >
+                {student.displayName}
+              </option>
+            ))}
+          </Select>
+          <IconButton
+            icon={ArrowRightIcon}
+            title="Next student"
+            disabled={!hasNextView}
+            onClick={onNextView}
+            variant="dark"
+          />
+        </InputGroup>
       </div>
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
@@ -1,30 +1,27 @@
 import { Icon, IconButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
-/**
- * @typedef Student
- * @prop {string} displayName
- */
+type Student = {
+  displayName: string;
+};
 
-/**
- * @typedef StudentSelectorProps
- * @prop {(index: number) => void} onSelectStudent -
- *   Callback invoked when the selected student changes
- * @prop {number} selectedStudentIndex -
- *   Index of selected student in `students` or -1 if no student is selected
- * @prop {Student[]} students - Ordered list of students to display in the drop-down
- */
+export type StudentSelectorProps = {
+  /** Callback invoked when the selected student changes */
+  onSelectStudent: (index: number) => void;
+  /** Index of selected student in `students` or -1 if no student is selected */
+  selectedStudentIndex: number;
+  /** Ordered list of students to display in the drop-down */
+  students: Student[];
+};
 
 /**
  * A student navigation tool which shows a student selection list and a previous and next button.
- *
- * @param {StudentSelectorProps} props
  */
 export default function StudentSelector({
   onSelectStudent,
   selectedStudentIndex,
   students,
-}) {
+}: StudentSelectorProps) {
   // Disable the next button if at the end of the list. The length is equal to
   // the student list plus the default "All Students" option.
   const hasNextView = selectedStudentIndex + 1 < students.length;
@@ -87,9 +84,7 @@ export default function StudentSelector({
             'border border-r-0 border-l-0' // left and right borders off
           )}
           onChange={e => {
-            onSelectStudent(
-              parseInt(/** @type {HTMLInputElement} */ (e.target).value)
-            );
+            onSelectStudent(parseInt((e.target as HTMLInputElement).value));
           }}
         >
           {options}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
     "@hypothesis/frontend-build": "1.2.0",
-    "@hypothesis/frontend-shared": "5.7.0",
+    "@hypothesis/frontend-shared": "^5.7.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,10 +1126,10 @@
     fancy-log "^1.3.3"
     glob "^7.2.0"
 
-"@hypothesis/frontend-shared@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.7.0.tgz#be76d200c15ba3e889738f7226a5b87207766ef8"
-  integrity sha512-qB5+WhvXUha73QjZPkN4losbpKZQt2sL4zhblW3URBs3aWE9HYZFpI7V+QuvyYRdtSyCTHQohWn5pnXrtek+WA==
+"@hypothesis/frontend-shared@^5.7.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.9.0.tgz#1ccd6007e237c90fee77689417bfd19a0fde0498"
+  integrity sha512-FyeTvDLJ55Ma676f3pJoy1Ybst++eiNnDAuXgIH0tlYBE+OTg2paQBnC7evb19E9O1m0m9zpTZV0TKjjQTF7SA==
   dependencies:
     highlight.js "^11.6.0"
 
@@ -3898,9 +3898,9 @@ he@1.2.0:
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 highlight.js@^11.6.0:
-  version "11.6.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.6.0.tgz#a50e9da05763f1bb0c1322c8f4f755242cff3f5a"
-  integrity sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.7.0.tgz#3ff0165bc843f8c9bce1fd89e2fda9143d24b11e"
+  integrity sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
This PR updates the `StudentSelector` component and makes some small adjustments to the `GradingToolbar` in advance of some UI enhancements in this area.

It:

* Converts `StudentSelector` to TSX
* Updates the `@hypothesis/frontend-shared` package such that the `Select` component is available
* Updates shared components in `StudentSelector`, including the use of `Select` and simplifies component use/layout
* Tightens and lightens some text in `GradingToolbar` to reduce vertical space used and to de-emphasize the course name a tad

User-facing changes:

* Text weight and color of assignment name, course name at left side of `GradingBar`
* Shorter overall height of `GradingBar`[^1]
* Padding and proportional icon sizes in the student-selector drop-down and adjacent `IconButton`s. These small adjustments bring these UI bits more into line with our common UI patterns.

Before:

<img width="1568" alt="image" src="https://user-images.githubusercontent.com/439947/217629012-64ea5ddb-02b6-468e-b269-cef96be28b70.png">

After[^2]:

<img width="1565" alt="image" src="https://user-images.githubusercontent.com/439947/217629092-7430d0bd-7c2a-4ca5-b880-f53c6ef2548d.png">

(Despite apparent differences, the select (drop-down) field is the same width in both screenshots).


[^1]: Don't worry, I did read the brief. I know we're going to want to make this bit of interface yet shorter for situations in which the grading elements are not relevant. This is just a starting step.
[^2]: I am having some woes with my local Via this afternoon which prevent me from getting a localhost assignment to a place where there are students who have made annotations, thus preventing me from showing a non-empty select list here.