### PR TITLE
Files course copy small refactors

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -160,6 +160,20 @@ class D2LGroup(Grouping):
 class Course(Grouping):
     __mapper_args__ = {"polymorphic_identity": Grouping.Type.COURSE}
 
+    def get_mapped_file_id(self, file_id):
+        """
+        Get a previously mapped file id in course.
+
+        Returns the original `file_id` if no mapped one can be found.
+        """
+        return self.extra.get("course_copy_file_mappings", {}).get(file_id, file_id)
+
+    def set_mapped_file_id(self, old_file_id, new_file_id):
+        """Store the mapping between old_file_id and new_file_id for future launches."""
+        self.extra.setdefault("course_copy_file_mappings", {})[
+            old_file_id
+        ] = new_file_id
+
 
 class GroupingMembership(CreatedUpdatedMixin, BASE):
     __tablename__ = "grouping_membership"

--- a/lms/product/blackboard/_plugin/course_copy.py
+++ b/lms/product/blackboard/_plugin/course_copy.py
@@ -18,12 +18,6 @@ class BlackboardCourseCopyPlugin:
             self._api.list_all_files, self.file_type, original_file_id, new_course_id
         )
 
-    def get_mapped_file_id(self, course, file_id):
-        return self._files_helper.get_mapped_file_id(course, file_id)
-
-    def set_mapped_file_id(self, course, old_file_id, new_file_id):
-        self._files_helper.set_mapped_file_id(course, old_file_id, new_file_id)
-
     @classmethod
     def factory(cls, _context, request):
         return cls(

--- a/lms/product/blackboard/_plugin/course_copy.py
+++ b/lms/product/blackboard/_plugin/course_copy.py
@@ -1,5 +1,4 @@
 from lms.product.plugin.course_copy import CourseCopyFilesHelper
-from lms.services.file import FileService
 
 
 class BlackboardCourseCopyPlugin:
@@ -7,25 +6,16 @@ class BlackboardCourseCopyPlugin:
 
     file_type = "blackboard_file"
 
-    def __init__(
-        self, api, file_service: FileService, files_helper: CourseCopyFilesHelper
-    ):
+    def __init__(self, api, files_helper: CourseCopyFilesHelper):
         self._api = api
-        self._file_service = file_service
         self._files_helper = files_helper
 
     def is_file_in_course(self, course_id, file_id):
-        return self._files_helper.is_file_in_course(
-            self._file_service, course_id, file_id, self.file_type
-        )
+        return self._files_helper.is_file_in_course(course_id, file_id, self.file_type)
 
     def find_matching_file_in_course(self, original_file_id, new_course_id):
         return self._files_helper.find_matching_file_in_course(
-            self._api.list_all_files,
-            self._file_service,
-            self.file_type,
-            original_file_id,
-            new_course_id,
+            self._api.list_all_files, self.file_type, original_file_id, new_course_id
         )
 
     def get_mapped_file_id(self, course, file_id):
@@ -38,6 +28,5 @@ class BlackboardCourseCopyPlugin:
     def factory(cls, _context, request):
         return cls(
             request.find_service(name="blackboard_api_client"),
-            file_service=request.find_service(name="file"),
-            files_helper=CourseCopyFilesHelper(),
+            request.find_service(CourseCopyFilesHelper),
         )

--- a/lms/product/d2l/_plugin/course_copy.py
+++ b/lms/product/d2l/_plugin/course_copy.py
@@ -1,6 +1,5 @@
 from lms.product.plugin.course_copy import CourseCopyFilesHelper
 from lms.services.d2l_api import D2LAPIClient
-from lms.services.file import FileService
 
 
 class D2LCourseCopyPlugin:
@@ -11,25 +10,17 @@ class D2LCourseCopyPlugin:
     def __init__(
         self,
         api: D2LAPIClient,
-        file_service: FileService,
         files_helper: CourseCopyFilesHelper,
     ):
         self._api = api
-        self._file_service = file_service
         self._files_helper = files_helper
 
     def is_file_in_course(self, course_id, file_id):
-        return self._files_helper.is_file_in_course(
-            self._file_service, course_id, file_id, self.file_type
-        )
+        return self._files_helper.is_file_in_course(course_id, file_id, self.file_type)
 
     def find_matching_file_in_course(self, original_file_id, new_course_id):
         return self._files_helper.find_matching_file_in_course(
-            self._api.list_files,
-            self._file_service,
-            self.file_type,
-            original_file_id,
-            new_course_id,
+            self._api.list_files, self.file_type, original_file_id, new_course_id
         )
 
     def get_mapped_file_id(self, course, file_id):
@@ -42,6 +33,5 @@ class D2LCourseCopyPlugin:
     def factory(cls, _context, request):
         return cls(
             request.find_service(D2LAPIClient),
-            file_service=request.find_service(name="file"),
-            files_helper=CourseCopyFilesHelper(),
+            files_helper=request.find_service(CourseCopyFilesHelper),
         )

--- a/lms/product/d2l/_plugin/course_copy.py
+++ b/lms/product/d2l/_plugin/course_copy.py
@@ -23,12 +23,6 @@ class D2LCourseCopyPlugin:
             self._api.list_files, self.file_type, original_file_id, new_course_id
         )
 
-    def get_mapped_file_id(self, course, file_id):
-        return self._files_helper.get_mapped_file_id(course, file_id)
-
-    def set_mapped_file_id(self, course, old_file_id, new_file_id):
-        self._files_helper.set_mapped_file_id(course, old_file_id, new_file_id)
-
     @classmethod
     def factory(cls, _context, request):
         return cls(

--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -61,22 +61,6 @@ class CourseCopyFilesHelper:
         # or other edge case, for example a file was deleted after course copy or similar.
         return None
 
-    @staticmethod
-    def get_mapped_file_id(course, file_id):
-        """
-        Get a previously mapped file id in course.
-
-        Returns the original `file_id` if no mapped one can be found.
-        """
-        return course.extra.get("course_copy_file_mappings", {}).get(file_id, file_id)
-
-    @staticmethod
-    def set_mapped_file_id(course, old_file_id, new_file_id):
-        """Store the mapping between old_file_id and new_file_id for future launches."""
-        course.extra.setdefault("course_copy_file_mappings", {})[
-            old_file_id
-        ] = new_file_id
-
     @classmethod
     def factory(cls, _context, request):
         return cls(request.find_service(name="file"))
@@ -93,10 +77,4 @@ class CourseCopyPlugin:  # pragma: nocover
         raise NotImplementedError()
 
     def find_matching_file_in_course(self, *args, **kwargs):
-        raise NotImplementedError()
-
-    def get_mapped_file_id(self, *args, **kwargs):
-        raise NotImplementedError()
-
-    def set_mapped_file_id(self, course, old_file_id, new_file_id):
         raise NotImplementedError()

--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -76,5 +76,5 @@ class CourseCopyPlugin:  # pragma: nocover
     def is_file_in_course(self, course_id, file_id):
         raise NotImplementedError()
 
-    def find_matching_file_in_course(self, *args, **kwargs):
+    def find_matching_file_in_course(self, original_file_id, new_course_id):
         raise NotImplementedError()

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -115,3 +115,14 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.d2l_api.d2l_api_client_factory", iface=D2LAPIClient
     )
+
+    # Plugins are not the same as top level services but we want to register them as pyramid services too
+    # Importing them here to:
+    # - Don't pollute the lms.services namespace
+    # - Ease some circular-dependency problems
+    # pylint:disable=import-outside-toplevel
+    from lms.product.plugin.course_copy import CourseCopyFilesHelper
+
+    config.register_service_factory(
+        CourseCopyFilesHelper.factory, iface=CourseCopyFilesHelper
+    )

--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -71,8 +71,8 @@ class BlackboardFilesAPIViews:
         course = self.request.find_service(name="course").get_by_context_id(course_id)
 
         document_url = self.request.params["document_url"]
-        file_id = self.course_copy_plugin.get_mapped_file_id(
-            course, DOCUMENT_URL_REGEX.search(document_url)["file_id"]
+        file_id = course.get_mapped_file_id(
+            DOCUMENT_URL_REGEX.search(document_url)["file_id"]
         )
         try:
             if self.request.lti_user.is_instructor:
@@ -95,9 +95,7 @@ class BlackboardFilesAPIViews:
             )
 
             # Store a mapping so we don't have to re-search next time.
-            self.course_copy_plugin.set_mapped_file_id(
-                course, file_id, found_file.lms_id
-            )
+            course.set_mapped_file_id(file_id, found_file.lms_id)
 
         via_url = helpers.via_url(self.request, public_url, content_type="pdf")
         return {"via_url": via_url}

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -38,8 +38,8 @@ def via_url(_context, request):
 
     course = request.find_service(name="course").get_by_context_id(course_id)
 
-    file_id = course_copy_plugin.get_mapped_file_id(
-        course, DOCUMENT_URL_REGEX.search(document_url)["file_id"]
+    file_id = course.get_mapped_file_id(
+        DOCUMENT_URL_REGEX.search(document_url)["file_id"]
     )
     try:
         if request.lti_user.is_instructor:
@@ -57,7 +57,7 @@ def via_url(_context, request):
         public_url = api_client.public_url(course_id, found_file.lms_id)
 
         # Store a mapping so we don't have to re-search next time.
-        course_copy_plugin.set_mapped_file_id(course, file_id, found_file.lms_id)
+        course.set_mapped_file_id(file_id, found_file.lms_id)
 
     access_token = request.find_service(name="oauth2_token").get().access_token
     headers = {"Authorization": f"Bearer {access_token}"}

--- a/tests/unit/lms/models/grouping_test.py
+++ b/tests/unit/lms/models/grouping_test.py
@@ -26,3 +26,27 @@ class TestCourse:
         course = Course(lms_name=name)
 
         assert course.name == expected_result
+
+    def test_get_mapped_file_empty_extra(self):
+        course = factories.Course(extra={})
+
+        assert course.get_mapped_file_id("ID") == "ID"
+
+    def test_get_mapped_file_empty_mapping(self):
+        course = factories.Course(extra={"course_copy_file_mappings": {}})
+
+        assert course.get_mapped_file_id("ID") == "ID"
+
+    def test_get_mapped_file(self):
+        course = factories.Course(
+            extra={"course_copy_file_mappings": {"ID": "OTHER_ID"}}
+        )
+
+        assert course.get_mapped_file_id("ID") == "OTHER_ID"
+
+    def test_set_mapped_file_id(self):
+        course = factories.Course(extra={})
+
+        course.set_mapped_file_id("OLD", "NEW")
+
+        assert course.extra["course_copy_file_mappings"]["OLD"] == "NEW"

--- a/tests/unit/lms/product/blackboard/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/course_copy_test.py
@@ -1,68 +1,64 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
 from lms.product.blackboard import BlackboardCourseCopyPlugin
-from lms.product.plugin.course_copy import CourseCopyFilesHelper
 
 
 class TestBlackboardCourseCopyPlugin:
-    def test_is_file_in_course(self, plugin, helper, file_service):
+    def test_is_file_in_course(self, plugin, course_copy_files_helper):
         result = plugin.is_file_in_course(sentinel.course_id, sentinel.file_id)
 
-        helper.is_file_in_course.assert_called_once_with(
-            file_service, sentinel.course_id, sentinel.file_id, "blackboard_file"
+        course_copy_files_helper.is_file_in_course.assert_called_once_with(
+            sentinel.course_id, sentinel.file_id, "blackboard_file"
         )
 
-        assert result == helper.is_file_in_course.return_value
+        assert result == course_copy_files_helper.is_file_in_course.return_value
 
     def test_find_matching_file_in_course(
-        self, plugin, helper, file_service, blackboard_api_client
+        self, plugin, course_copy_files_helper, blackboard_api_client
     ):
         result = plugin.find_matching_file_in_course(
             sentinel.original_file_id, sentinel.new_course_id
         )
 
-        helper.find_matching_file_in_course(
+        course_copy_files_helper.find_matching_file_in_course(
             blackboard_api_client.list_all_files,
-            file_service,
             "blackboard_file",
             sentinel.original_file_id,
             sentinel.new_course_id,
         )
 
-        assert result == helper.find_matching_file_in_course.return_value
+        assert (
+            result == course_copy_files_helper.find_matching_file_in_course.return_value
+        )
 
-    def test_get_mapped_file_id(self, plugin, helper):
+    def test_get_mapped_file_id(self, plugin, course_copy_files_helper):
         result = plugin.get_mapped_file_id(sentinel.course, sentinel.file_id)
 
-        helper.get_mapped_file_id.assert_called_once_with(
+        course_copy_files_helper.get_mapped_file_id.assert_called_once_with(
             sentinel.course, sentinel.file_id
         )
 
-        assert result == helper.get_mapped_file_id.return_value
+        assert result == course_copy_files_helper.get_mapped_file_id.return_value
 
-    def test_set_mapped_file_id(self, plugin, helper):
+    def test_set_mapped_file_id(self, plugin, course_copy_files_helper):
         plugin.set_mapped_file_id(
             sentinel.course, sentinel.old_file_id, sentinel.new_file_id
         )
 
-        helper.set_mapped_file_id.assert_called_once_with(
+        course_copy_files_helper.set_mapped_file_id.assert_called_once_with(
             sentinel.course, sentinel.old_file_id, sentinel.new_file_id
         )
 
-    @pytest.mark.usefixtures("blackboard_api_client", "file_service")
+    @pytest.mark.usefixtures("blackboard_api_client", "course_copy_files_helper")
     def test_factory(self, pyramid_request):
         plugin = BlackboardCourseCopyPlugin.factory(sentinel.context, pyramid_request)
 
         assert isinstance(plugin, BlackboardCourseCopyPlugin)
 
     @pytest.fixture
-    def helper(self):
-        return create_autospec(CourseCopyFilesHelper, spec_set=True, instance=True)
-
-    @pytest.fixture
-    def plugin(self, blackboard_api_client, file_service, helper):
+    def plugin(self, blackboard_api_client, course_copy_files_helper):
         return BlackboardCourseCopyPlugin(
-            api=blackboard_api_client, file_service=file_service, files_helper=helper
+            api=blackboard_api_client, files_helper=course_copy_files_helper
         )

--- a/tests/unit/lms/product/blackboard/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/course_copy_test.py
@@ -33,24 +33,6 @@ class TestBlackboardCourseCopyPlugin:
             result == course_copy_files_helper.find_matching_file_in_course.return_value
         )
 
-    def test_get_mapped_file_id(self, plugin, course_copy_files_helper):
-        result = plugin.get_mapped_file_id(sentinel.course, sentinel.file_id)
-
-        course_copy_files_helper.get_mapped_file_id.assert_called_once_with(
-            sentinel.course, sentinel.file_id
-        )
-
-        assert result == course_copy_files_helper.get_mapped_file_id.return_value
-
-    def test_set_mapped_file_id(self, plugin, course_copy_files_helper):
-        plugin.set_mapped_file_id(
-            sentinel.course, sentinel.old_file_id, sentinel.new_file_id
-        )
-
-        course_copy_files_helper.set_mapped_file_id.assert_called_once_with(
-            sentinel.course, sentinel.old_file_id, sentinel.new_file_id
-        )
-
     @pytest.mark.usefixtures("blackboard_api_client", "course_copy_files_helper")
     def test_factory(self, pyramid_request):
         plugin = BlackboardCourseCopyPlugin.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/product/d2l/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/course_copy_test.py
@@ -1,68 +1,64 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
 from lms.product.d2l import D2LCourseCopyPlugin
-from lms.product.plugin.course_copy import CourseCopyFilesHelper
 
 
 class TestD2LCourseCopyPlugin:
-    def test_is_file_in_course(self, plugin, helper, file_service):
+    def test_is_file_in_course(self, plugin, course_copy_files_helper):
         result = plugin.is_file_in_course(sentinel.course_id, sentinel.file_id)
 
-        helper.is_file_in_course.assert_called_once_with(
-            file_service, sentinel.course_id, sentinel.file_id, "d2l_file"
+        course_copy_files_helper.is_file_in_course.assert_called_once_with(
+            sentinel.course_id, sentinel.file_id, "d2l_file"
         )
 
-        assert result == helper.is_file_in_course.return_value
+        assert result == course_copy_files_helper.is_file_in_course.return_value
 
     def test_find_matching_file_in_course(
-        self, plugin, helper, file_service, d2l_api_client
+        self, plugin, course_copy_files_helper, d2l_api_client
     ):
         result = plugin.find_matching_file_in_course(
             sentinel.original_file_id, sentinel.new_course_id
         )
 
-        helper.find_matching_file_in_course(
+        course_copy_files_helper.find_matching_file_in_course(
             d2l_api_client.list_files,
-            file_service,
             "d2l_file",
             sentinel.original_file_id,
             sentinel.new_course_id,
         )
 
-        assert result == helper.find_matching_file_in_course.return_value
+        assert (
+            result == course_copy_files_helper.find_matching_file_in_course.return_value
+        )
 
-    def test_get_mapped_file_id(self, plugin, helper):
+    def test_get_mapped_file_id(self, plugin, course_copy_files_helper):
         result = plugin.get_mapped_file_id(sentinel.course, sentinel.file_id)
 
-        helper.get_mapped_file_id.assert_called_once_with(
+        course_copy_files_helper.get_mapped_file_id.assert_called_once_with(
             sentinel.course, sentinel.file_id
         )
 
-        assert result == helper.get_mapped_file_id.return_value
+        assert result == course_copy_files_helper.get_mapped_file_id.return_value
 
-    def test_set_mapped_file_id(self, plugin, helper):
+    def test_set_mapped_file_id(self, plugin, course_copy_files_helper):
         plugin.set_mapped_file_id(
             sentinel.course, sentinel.old_file_id, sentinel.new_file_id
         )
 
-        helper.set_mapped_file_id.assert_called_once_with(
+        course_copy_files_helper.set_mapped_file_id.assert_called_once_with(
             sentinel.course, sentinel.old_file_id, sentinel.new_file_id
         )
 
-    @pytest.mark.usefixtures("d2l_api_client", "file_service")
+    @pytest.mark.usefixtures("d2l_api_client", "course_copy_files_helper")
     def test_factory(self, pyramid_request):
         plugin = D2LCourseCopyPlugin.factory(sentinel.context, pyramid_request)
 
         assert isinstance(plugin, D2LCourseCopyPlugin)
 
     @pytest.fixture
-    def helper(self):
-        return create_autospec(CourseCopyFilesHelper, spec_set=True, instance=True)
-
-    @pytest.fixture
-    def plugin(self, d2l_api_client, file_service, helper):
+    def plugin(self, d2l_api_client, course_copy_files_helper):
         return D2LCourseCopyPlugin(
-            api=d2l_api_client, file_service=file_service, files_helper=helper
+            api=d2l_api_client, files_helper=course_copy_files_helper
         )

--- a/tests/unit/lms/product/d2l/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/course_copy_test.py
@@ -33,24 +33,6 @@ class TestD2LCourseCopyPlugin:
             result == course_copy_files_helper.find_matching_file_in_course.return_value
         )
 
-    def test_get_mapped_file_id(self, plugin, course_copy_files_helper):
-        result = plugin.get_mapped_file_id(sentinel.course, sentinel.file_id)
-
-        course_copy_files_helper.get_mapped_file_id.assert_called_once_with(
-            sentinel.course, sentinel.file_id
-        )
-
-        assert result == course_copy_files_helper.get_mapped_file_id.return_value
-
-    def test_set_mapped_file_id(self, plugin, course_copy_files_helper):
-        plugin.set_mapped_file_id(
-            sentinel.course, sentinel.old_file_id, sentinel.new_file_id
-        )
-
-        course_copy_files_helper.set_mapped_file_id.assert_called_once_with(
-            sentinel.course, sentinel.old_file_id, sentinel.new_file_id
-        )
-
     @pytest.mark.usefixtures("d2l_api_client", "course_copy_files_helper")
     def test_factory(self, pyramid_request):
         plugin = D2LCourseCopyPlugin.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/product/plugin/course_copy_test.py
+++ b/tests/unit/lms/product/plugin/course_copy_test.py
@@ -20,7 +20,7 @@ class TestCourseCopyFilesHelper:
         file_service.get.return_value = file
 
         is_in_course = helper.is_file_in_course(
-            file_service, sentinel.course_id, sentinel.file_id, sentinel.type
+            sentinel.course_id, sentinel.file_id, sentinel.type
         )
 
         file_service.get.assert_called_once_with(sentinel.file_id, sentinel.type)
@@ -38,7 +38,6 @@ class TestCourseCopyFilesHelper:
 
         new_file = helper.find_matching_file_in_course(
             store_new_course_files,
-            file_service,
             sentinel.file_type,
             sentinel.original_file_id,
             sentinel.new_course_id,
@@ -55,14 +54,13 @@ class TestCourseCopyFilesHelper:
         assert new_file
 
     def test_find_matching_file_raises_OAuth2TokenError(
-        self, helper, file_service, store_new_course_files
+        self, helper, store_new_course_files
     ):
         store_new_course_files.side_effect = OAuth2TokenError
 
         with pytest.raises(OAuth2TokenError):
             helper.find_matching_file_in_course(
                 store_new_course_files,
-                file_service,
                 sentinel.file_type,
                 sentinel.original_file_id,
                 sentinel.new_course_id,
@@ -75,7 +73,6 @@ class TestCourseCopyFilesHelper:
 
         assert not helper.find_matching_file_in_course(
             store_new_course_files,
-            file_service,
             sentinel.file_type,
             sentinel.original_file_id,
             sentinel.new_course_id,
@@ -95,7 +92,6 @@ class TestCourseCopyFilesHelper:
 
         assert not helper.find_matching_file_in_course(
             store_new_course_files,
-            file_service,
             sentinel.file_type,
             sentinel.original_file_id,
             sentinel.new_course_id,
@@ -130,9 +126,15 @@ class TestCourseCopyFilesHelper:
 
         assert course.extra["course_copy_file_mappings"]["OLD"] == "NEW"
 
+    @pytest.mark.usefixtures("file_service")
+    def test_factory(self, pyramid_request):
+        plugin = CourseCopyFilesHelper.factory(sentinel.context, pyramid_request)
+
+        assert isinstance(plugin, CourseCopyFilesHelper)
+
     @pytest.fixture
-    def helper(self):
-        return CourseCopyFilesHelper()
+    def helper(self, file_service):
+        return CourseCopyFilesHelper(file_service=file_service)
 
     @pytest.fixture
     def store_new_course_files(self):

--- a/tests/unit/lms/product/plugin/course_copy_test.py
+++ b/tests/unit/lms/product/plugin/course_copy_test.py
@@ -102,30 +102,6 @@ class TestCourseCopyFilesHelper:
             sentinel.original_file_id, type_=sentinel.file_type
         )
 
-    def test_get_mapped_file_empty_extra(self, helper):
-        course = factories.Course(extra={})
-
-        assert helper.get_mapped_file_id(course, "ID") == "ID"
-
-    def test_get_mapped_file_empty_mapping(self, helper):
-        course = factories.Course(extra={"course_copy_file_mappings": {}})
-
-        assert helper.get_mapped_file_id(course, "ID") == "ID"
-
-    def test_get_mapped_file(self, helper):
-        course = factories.Course(
-            extra={"course_copy_file_mappings": {"ID": "OTHER_ID"}}
-        )
-
-        assert helper.get_mapped_file_id(course, "ID") == "OTHER_ID"
-
-    def test_set_mapped_file_id(self, helper):
-        course = factories.Course(extra={})
-
-        helper.set_mapped_file_id(course, "OLD", "NEW")
-
-        assert course.extra["course_copy_file_mappings"]["OLD"] == "NEW"
-
     @pytest.mark.usefixtures("file_service")
     def test_factory(self, pyramid_request):
         plugin = CourseCopyFilesHelper.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -109,8 +109,8 @@ class TestViaURL:
 
         course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
         course = course_service.get_by_context_id.return_value
-        course_copy_plugin.get_mapped_file_id.assert_called_once_with(course, "FILE_ID")
-        file_id = course_copy_plugin.get_mapped_file_id.return_value
+        course.get_mapped_file_id.assert_called_once_with("FILE_ID")
+        file_id = course.get_mapped_file_id.return_value
 
         if is_instructor:
             course_copy_plugin.is_file_in_course.assert_called_once_with(
@@ -118,7 +118,7 @@ class TestViaURL:
             )
 
         blackboard_api_client.public_url.assert_called_once_with(
-            "COURSE_ID", course_copy_plugin.get_mapped_file_id.return_value
+            "COURSE_ID", course.get_mapped_file_id.return_value
         )
         helpers.via_url.assert_called_once_with(
             pyramid_request,
@@ -143,8 +143,8 @@ class TestViaURL:
 
         course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
         course = course_service.get_by_context_id.return_value
-        course_copy_plugin.get_mapped_file_id.assert_called_once_with(course, "FILE_ID")
-        file_id = course_copy_plugin.get_mapped_file_id.return_value
+        course.get_mapped_file_id.assert_called_once_with("FILE_ID")
+        file_id = course.get_mapped_file_id.return_value
 
         course_copy_plugin.is_file_in_course.assert_called_once_with(
             "COURSE_ID", file_id
@@ -156,9 +156,7 @@ class TestViaURL:
         blackboard_api_client.public_url.assert_called_once_with(
             "COURSE_ID", found_file.lms_id
         )
-        course_copy_plugin.set_mapped_file_id.assert_called_once_with(
-            course, file_id, found_file.lms_id
-        )
+        course.set_mapped_file_id.assert_called_once_with(file_id, found_file.lms_id)
 
         helpers.via_url.assert_called_once_with(
             pyramid_request,
@@ -179,8 +177,8 @@ class TestViaURL:
 
         course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
         course = course_service.get_by_context_id.return_value
-        course_copy_plugin.get_mapped_file_id.assert_called_once_with(course, "FILE_ID")
-        file_id = course_copy_plugin.get_mapped_file_id.return_value
+        course.get_mapped_file_id.assert_called_once_with("FILE_ID")
+        file_id = course.get_mapped_file_id.return_value
 
         course_copy_plugin.is_file_in_course.assert_called_once_with(
             "COURSE_ID", file_id

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -32,8 +32,8 @@ def test_via_url(
 
     course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
     course = course_service.get_by_context_id.return_value
-    course_copy_plugin.get_mapped_file_id.assert_called_once_with(course, "FILE_ID")
-    file_id = course_copy_plugin.get_mapped_file_id.return_value
+    course.get_mapped_file_id.assert_called_once_with("FILE_ID")
+    file_id = course.get_mapped_file_id.return_value
 
     if is_instructor:
         course_copy_plugin.is_file_in_course.assert_called_once_with(
@@ -41,7 +41,7 @@ def test_via_url(
         )
 
     d2l_api_client.public_url.assert_called_once_with(
-        "COURSE_ID", course_copy_plugin.get_mapped_file_id.return_value
+        "COURSE_ID", course.get_mapped_file_id.return_value
     )
     helpers.via_url.assert_called_once_with(
         pyramid_request,
@@ -67,8 +67,8 @@ def test_it_when_file_not_in_course_fixed_by_course_copy(
 
     course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
     course = course_service.get_by_context_id.return_value
-    course_copy_plugin.get_mapped_file_id.assert_called_once_with(course, "FILE_ID")
-    file_id = course_copy_plugin.get_mapped_file_id.return_value
+    course.get_mapped_file_id.assert_called_once_with("FILE_ID")
+    file_id = course.get_mapped_file_id.return_value
 
     course_copy_plugin.is_file_in_course.assert_called_once_with("COURSE_ID", file_id)
     course_copy_plugin.find_matching_file_in_course.assert_called_once_with(
@@ -76,9 +76,7 @@ def test_it_when_file_not_in_course_fixed_by_course_copy(
     )
     found_file = course_copy_plugin.find_matching_file_in_course.return_value
     d2l_api_client.public_url.assert_called_once_with("COURSE_ID", found_file.lms_id)
-    course_copy_plugin.set_mapped_file_id.assert_called_once_with(
-        course, file_id, found_file.lms_id
-    )
+    course.set_mapped_file_id.assert_called_once_with(file_id, found_file.lms_id)
 
     helpers.via_url.assert_called_once_with(
         pyramid_request,
@@ -103,8 +101,8 @@ def test_it_when_file_not_in_course(
 
     course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
     course = course_service.get_by_context_id.return_value
-    course_copy_plugin.get_mapped_file_id.assert_called_once_with(course, "FILE_ID")
-    file_id = course_copy_plugin.get_mapped_file_id.return_value
+    course.get_mapped_file_id.assert_called_once_with("FILE_ID")
+    file_id = course.get_mapped_file_id.return_value
 
     course_copy_plugin.is_file_in_course.assert_called_once_with("COURSE_ID", file_id)
     course_copy_plugin.find_matching_file_in_course.assert_called_once_with(

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from lms.product.plugin.course_copy import CourseCopyPlugin
+from lms.product.plugin.course_copy import CourseCopyFilesHelper, CourseCopyPlugin
 from lms.product.plugin.grouping import GroupingPlugin
 from lms.product.plugin.misc import MiscPlugin
 from lms.services import (
@@ -82,6 +82,7 @@ __all__ = (
     # Product plugins
     "grouping_plugin",
     "course_copy_plugin",
+    "course_copy_files_helper",
     "misc_plugin",
 )
 
@@ -302,6 +303,11 @@ def user_service(mock_service):
 @pytest.fixture
 def vitalsource_service(mock_service):
     return mock_service(VitalSourceService)
+
+
+@pytest.fixture
+def course_copy_files_helper(mock_service):
+    return mock_service(CourseCopyFilesHelper)
 
 
 @pytest.fixture


### PR DESCRIPTION
This tackles a few things mentioned in reviews before we introduce the new helper for groups:

- Makes the existing helper a service. This avoids having to pass a service around.
- Moves `extra` handling to he model
- Uses sane parameter names in the empty implementation of the plugin.


# Testing 

No behavior changes here, as a sanity check:


- make devdata
- tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping cascade;"


- Launch the scratch assignments and get a list of D2L and blackboard files in the original courses:

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View


Try these original courses:

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2374/View

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_39_1&course_id=_19_1


And the copied versions:

https://aunltd.brightspacedemo.com/d2l/le/content/6855/viewContent/2421/View

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1371_1&course_id=_139_1


