### PR TITLE
Add a server side (postgres) default for application instance create

### DIFF
--- a/lms/migrations/versions/d737e73915b8_add_a_default_to_application_instance_.py
+++ b/lms/migrations/versions/d737e73915b8_add_a_default_to_application_instance_.py
@@ -1,0 +1,22 @@
+"""
+Add a default to application instance create.
+
+Revision ID: d737e73915b8
+Revises: 64fd59a9f4b6
+Create Date: 2023-02-09 13:20:08.536676
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d737e73915b8"
+down_revision = "64fd59a9f4b6"
+
+
+def upgrade():
+    op.alter_column("application_instances", "created", server_default=sa.func.now())
+
+
+def downgrade():
+    op.alter_column("application_instances", "created", server_default=None)


### PR DESCRIPTION
I think this was missed as we introduced the `CreatedUpdateMixin` which uses server side defaults over an existing column with Python defaults. I used an automatic alembic upgrade which didn't seem to spot the change.

This should fix problems with the create date with `make devdata`.
