### PR TITLE
Take only `context_id` in `api.courses.group_sets.list`

### DIFF
--- a/lms/product/blackboard/_plugin/grouping.py
+++ b/lms/product/blackboard/_plugin/grouping.py
@@ -22,8 +22,8 @@ class BlackboardGroupingPlugin(GroupingPlugin):
     def __init__(self, blackboard_api):
         self._blackboard_api = blackboard_api
 
-    def get_group_sets(self, course_id):
-        return self._blackboard_api.course_group_sets(course_id)
+    def get_group_sets(self, course):
+        return self._blackboard_api.course_group_sets(course.lms_id)
 
     def get_groups_for_learner(self, _svc, course, group_set_id):
         if learner_groups := self._blackboard_api.course_groups(

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -47,8 +47,8 @@ class CanvasGroupingPlugin(GroupingPlugin):
 
         return [sec for sec in course_sections if sec["id"] in learner_section_ids]
 
-    def get_group_sets(self, course_id):
-        return self._canvas_api.course_group_categories(course_id)
+    def get_group_sets(self, course):
+        return self._canvas_api.course_group_categories(self._custom_course_id(course))
 
     def get_groups_for_learner(self, _svc, course, group_set_id):
         # For learners, the groups they belong within the course

--- a/lms/product/d2l/_plugin/grouping.py
+++ b/lms/product/d2l/_plugin/grouping.py
@@ -24,8 +24,8 @@ class D2LGroupingPlugin(GroupingPlugin):
         self._d2l_api = d2l_api
         self._api_user_id = api_user_id
 
-    def get_group_sets(self, course_id):
-        return self._d2l_api.course_group_sets(course_id)
+    def get_group_sets(self, course):
+        return self._d2l_api.course_group_sets(course.lms_id)
 
     def get_groups_for_learner(self, _svc, course, group_set_id):
         if learner_groups := self._d2l_api.group_set_groups(

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -45,7 +45,7 @@ class GroupingPlugin:
 
         return None
 
-    def get_group_sets(self, course_id) -> List[dict]:  # pragma: nocover
+    def get_group_sets(self, course) -> List[dict]:  # pragma: nocover
         """Return the list of group sets for the given course."""
         return []
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -444,16 +444,11 @@ class JSConfig:
         }
 
         if self._request.product.settings.groups_enabled:
-            # This should be abstracted as "lms_course_id" or similar in either
-            # LTIParams or as part of product.
-            api_course_id = self._request.lti_params.get(
-                "custom_canvas_course_id"
-            ) or self._request.lti_params.get("context_id")
-
             product_info["api"]["listGroupSets"] = {
                 "authUrl": self._request.route_url(product.route.oauth2_authorize),
                 "path": self._request.route_path(
-                    "api.courses.group_sets.list", course_id=api_course_id
+                    "api.courses.group_sets.list",
+                    course_id=self._request.lti_params["context_id"],
                 ),
                 "data": {
                     "lms": {

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -32,21 +32,24 @@ class CourseService:
             .count()
         )
 
-    def get_by_context_id(self, context_id) -> Optional[Course]:
+    def get_by_context_id(self, context_id, raise_on_missing=False) -> Optional[Course]:
         """
         Get a course (if one exists) by the GUID and context id.
 
         :param context_id: The course id from LTI params
-        """
+        :param raise_on_missing: Raise instead of returning None when no match can be found.
 
-        return (
-            self._db.query(Course)
-            .filter_by(
-                application_instance=self._application_instance,
-                authority_provided_id=self._get_authority_provided_id(context_id),
-            )
-            .one_or_none()
+        :raises: sqlalchemy.exc.NoResultFound when `raise_on_missing`=True and no matching course can be found.
+        """
+        query = self._db.query(Course).filter_by(
+            application_instance=self._application_instance,
+            authority_provided_id=self._get_authority_provided_id(context_id),
         )
+
+        if raise_on_missing:
+            return query.one()
+
+        return query.one_or_none()
 
     def upsert_course(self, context_id, name, extra, settings=None) -> Course:
         """

--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -68,7 +68,9 @@ class BlackboardFilesAPIViews:
         """Return the Via URL for annotating the given Blackboard file."""
 
         course_id = self.request.matchdict["course_id"]
-        course = self.request.find_service(name="course").get_by_context_id(course_id)
+        course = self.request.find_service(name="course").get_by_context_id(
+            course_id, raise_on_missing=True
+        )
 
         document_url = self.request.params["document_url"]
         file_id = course.get_mapped_file_id(

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -36,7 +36,9 @@ def via_url(_context, request):
     course_id = request.matchdict["course_id"]
     document_url = request.params["document_url"]
 
-    course = request.find_service(name="course").get_by_context_id(course_id)
+    course = request.find_service(name="course").get_by_context_id(
+        course_id, raise_on_missing=True
+    )
 
     file_id = course.get_mapped_file_id(
         DOCUMENT_URL_REGEX.search(document_url)["file_id"]

--- a/lms/views/api/groups.py
+++ b/lms/views/api/groups.py
@@ -11,6 +11,6 @@ from lms.security import Permissions
 )
 def course_group_sets(_context, request):
     course = request.find_service(name="course").get_by_context_id(
-        request.matchdict["course_id"]
+        request.matchdict["course_id"], raise_on_missing=True
     )
     return request.product.plugin.grouping.get_group_sets(course)

--- a/lms/views/api/groups.py
+++ b/lms/views/api/groups.py
@@ -10,6 +10,7 @@ from lms.security import Permissions
     route_name="api.courses.group_sets.list",
 )
 def course_group_sets(_context, request):
-    return request.product.plugin.grouping.get_group_sets(
+    course = request.find_service(name="course").get_by_context_id(
         request.matchdict["course_id"]
     )
+    return request.product.plugin.grouping.get_group_sets(course)

--- a/lms/views/api/sync.py
+++ b/lms/views/api/sync.py
@@ -28,7 +28,7 @@ class APISyncSchema(PyramidRequestSchema):
 def sync(request):
     grouping_service = request.find_service(name="grouping")
     course = request.find_service(name="course").get_by_context_id(
-        context_id=request.parsed_params["context_id"]
+        context_id=request.parsed_params["context_id"], raise_on_missing=True
     )
     grading_student_id = request.parsed_params.get("gradingStudentId")
 

--- a/tests/unit/lms/product/blackboard/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/grouping_test.py
@@ -10,12 +10,10 @@ from tests import factories
 
 
 class TestBlackboardGroupingPlugin:
-    def test_get_group_sets(self, plugin, blackboard_api_client):
-        api_group_sets = plugin.get_group_sets(sentinel.course_id)
+    def test_get_group_sets(self, plugin, blackboard_api_client, course):
+        api_group_sets = plugin.get_group_sets(course)
 
-        blackboard_api_client.course_group_sets.assert_called_once_with(
-            sentinel.course_id
-        )
+        blackboard_api_client.course_group_sets.assert_called_once_with(course.lms_id)
         assert api_group_sets == blackboard_api_client.course_group_sets.return_value
 
     def test_get_groups_for_learner(

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -49,11 +49,11 @@ class TestCanvasGroupingPlugin:
 
         assert api_groups == [{"id": 1}]
 
-    def test_get_group_sets(self, plugin, canvas_api_client):
-        api_group_sets = plugin.get_group_sets(sentinel.course_id)
+    def test_get_group_sets(self, plugin, canvas_api_client, course):
+        api_group_sets = plugin.get_group_sets(course)
 
         canvas_api_client.course_group_categories.assert_called_once_with(
-            sentinel.course_id
+            sentinel.canvas_course_id
         )
         assert api_group_sets == canvas_api_client.course_group_categories.return_value
 

--- a/tests/unit/lms/product/d2l/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/grouping_test.py
@@ -10,10 +10,10 @@ from tests import factories
 
 
 class TestD2LGroupingPlugin:
-    def test_get_group_sets(self, plugin, d2l_api_client):
-        api_group_sets = plugin.get_group_sets(sentinel.course_id)
+    def test_get_group_sets(self, plugin, d2l_api_client, course):
+        api_group_sets = plugin.get_group_sets(course)
 
-        d2l_api_client.course_group_sets.assert_called_once_with(sentinel.course_id)
+        d2l_api_client.course_group_sets.assert_called_once_with(course.lms_id)
         assert api_group_sets == d2l_api_client.course_group_sets.return_value
 
     def test_get_groups_for_learner(

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -3,6 +3,7 @@ from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
+from sqlalchemy.exc import NoResultFound
 
 from lms.models import CourseGroupsExportedFromH, Grouping
 from lms.services.course import CourseService, course_service_factory
@@ -44,6 +45,10 @@ class TestCourseService:
 
     def test_get_by_context_id_with_no_match(self, svc):
         assert svc.get_by_context_id("NO MATCH") is None
+
+    def test_get_by_context_id_with_no_match_and_raise_on_missing(self, svc):
+        with pytest.raises(NoResultFound):
+            svc.get_by_context_id("NO MATCH", raise_on_missing=True)
 
     def test_upsert_course(self, svc, grouping_service):
         course = svc.upsert_course(

--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -107,7 +107,9 @@ class TestViaURL:
 
         response = view()
 
-        course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
+        course_service.get_by_context_id.assert_called_once_with(
+            "COURSE_ID", raise_on_missing=True
+        )
         course = course_service.get_by_context_id.return_value
         course.get_mapped_file_id.assert_called_once_with("FILE_ID")
         file_id = course.get_mapped_file_id.return_value
@@ -141,7 +143,9 @@ class TestViaURL:
 
         response = view()
 
-        course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
+        course_service.get_by_context_id.assert_called_once_with(
+            "COURSE_ID", raise_on_missing=True
+        )
         course = course_service.get_by_context_id.return_value
         course.get_mapped_file_id.assert_called_once_with("FILE_ID")
         file_id = course.get_mapped_file_id.return_value
@@ -175,7 +179,9 @@ class TestViaURL:
 
         assert exc_info.value.error_code == "blackboard_file_not_found_in_course"
 
-        course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
+        course_service.get_by_context_id.assert_called_once_with(
+            "COURSE_ID", raise_on_missing=True
+        )
         course = course_service.get_by_context_id.return_value
         course.get_mapped_file_id.assert_called_once_with("FILE_ID")
         file_id = course.get_mapped_file_id.return_value

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -30,7 +30,9 @@ def test_via_url(
 
     response = via_url(sentinel.context, pyramid_request)
 
-    course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
+    course_service.get_by_context_id.assert_called_once_with(
+        "COURSE_ID", raise_on_missing=True
+    )
     course = course_service.get_by_context_id.return_value
     course.get_mapped_file_id.assert_called_once_with("FILE_ID")
     file_id = course.get_mapped_file_id.return_value
@@ -65,7 +67,9 @@ def test_it_when_file_not_in_course_fixed_by_course_copy(
 
     response = via_url(sentinel.context, pyramid_request)
 
-    course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
+    course_service.get_by_context_id.assert_called_once_with(
+        "COURSE_ID", raise_on_missing=True
+    )
     course = course_service.get_by_context_id.return_value
     course.get_mapped_file_id.assert_called_once_with("FILE_ID")
     file_id = course.get_mapped_file_id.return_value
@@ -99,7 +103,9 @@ def test_it_when_file_not_in_course(
     with pytest.raises(FileNotFoundInCourse):
         via_url(sentinel.context, pyramid_request)
 
-    course_service.get_by_context_id.assert_called_once_with("COURSE_ID")
+    course_service.get_by_context_id.assert_called_once_with(
+        "COURSE_ID", raise_on_missing=True
+    )
     course = course_service.get_by_context_id.return_value
     course.get_mapped_file_id.assert_called_once_with("FILE_ID")
     file_id = course.get_mapped_file_id.return_value

--- a/tests/unit/lms/views/api/sync_test.py
+++ b/tests/unit/lms/views/api/sync_test.py
@@ -28,7 +28,9 @@ class TestSync:
 
         returned_ids = sync(pyramid_request)
 
-        course_service.get_by_context_id.assert_called_once_with(sentinel.context_id)
+        course_service.get_by_context_id.assert_called_once_with(
+            sentinel.context_id, raise_on_missing=True
+        )
         grouping_method.assert_called_once_with(
             user=pyramid_request.user,
             lti_user=pyramid_request.lti_user,

--- a/tests/unit/lms/views/groups_test.py
+++ b/tests/unit/lms/views/groups_test.py
@@ -3,10 +3,13 @@ from unittest.mock import sentinel
 from lms.views.api.groups import course_group_sets
 
 
-def test_course_group_sets(pyramid_request, grouping_plugin):
-    pyramid_request.matchdict = {"course_id": "test_course_id"}
+def test_course_group_sets(pyramid_request, grouping_plugin, course_service):
+    pyramid_request.matchdict = {"course_id": sentinel.course_id}
 
     result = course_group_sets(sentinel.context, pyramid_request)
 
+    course_service.get_by_context_id.assert_called_once_with(sentinel.course_id)
+    grouping_plugin.get_group_sets.assert_called_once_with(
+        course_service.get_by_context_id.return_value
+    )
     assert result == grouping_plugin.get_group_sets.return_value
-    grouping_plugin.get_group_sets.assert_called_once_with("test_course_id")

--- a/tests/unit/lms/views/groups_test.py
+++ b/tests/unit/lms/views/groups_test.py
@@ -8,7 +8,9 @@ def test_course_group_sets(pyramid_request, grouping_plugin, course_service):
 
     result = course_group_sets(sentinel.context, pyramid_request)
 
-    course_service.get_by_context_id.assert_called_once_with(sentinel.course_id)
+    course_service.get_by_context_id.assert_called_once_with(
+        sentinel.course_id, raise_on_missing=True
+    )
     grouping_plugin.get_group_sets.assert_called_once_with(
         course_service.get_by_context_id.return_value
     )


### PR DESCRIPTION
Based on `context_id` we can get the course from the DB get the relevant data from there.

`course_id` was a different ID only in canvas and the grouping plugin was already aware of that difference.


# Testing

- There should not be behavior changes here but as sanity check we'll see if retrieving the group sets is still working on all LMS's

- Clear any local state in the DB: `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment,grouping cascade"; make devdata`

### Canvas


https://hypothesis.instructure.com/courses/125/assignments/3930/edit?name=Marcos+Assignment&due_at=null&points_possible=0


(pick the right LTI tool, configure with any document and check the `This is a group assignment`)

Getting the drop-down to populate with a list of group sets is what we are after.


### Blackboard 


https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1


Same process, configure and check the groups checkbox.


### D2L


Same story again: 

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View

(there are files in "scratch" area)