### PR TITLE
Add explicit height to student select drop-down

### DIFF
--- a/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
@@ -83,7 +83,7 @@ export default function StudentSelector({
           />
           <Select
             aria-label="Select student"
-            classes="xl:w-80"
+            classes="xl:w-80 h-touch-minimum"
             onChange={e => {
               onSelectStudent(parseInt((e.target as HTMLInputElement).value));
             }}


### PR DESCRIPTION
I made a miscalculation when I created the `Select` shared component last week. It was based on this specific select interface (student drop-down) and I carried over the `h-touch-minimum` class (this sets the height of the `<select>` to 44px). The shared component itself shouldn't set an explicit height.

Add the class here to the passed `classes` so that it can be removed from the shared component.