### PR TITLE
Store course group sets in the DB for course copy fixes

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import List
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
@@ -159,6 +160,22 @@ class D2LGroup(Grouping):
 
 class Course(Grouping):
     __mapper_args__ = {"polymorphic_identity": Grouping.Type.COURSE}
+
+    def set_group_sets(self, group_sets: List[dict]):
+        """
+        Store this course's available group sets.
+
+        We keep record of these for bookkeeping and as the basics to
+        dealt with groups while doing course copy.
+        """
+        # Different LMS might return additional fields but we only interested in the ID and the name.
+        # We explicitly cast ID to string to homogenise the data in all LMS's.
+        group_sets = [{"id": str(g["id"]), "name": g["name"]} for g in group_sets]
+        self.extra["group_sets"] = group_sets
+
+    def get_group_sets(self) -> List[dict]:
+        """Get this course's available group sets."""
+        return self.extra.get("group_sets", [])
 
     def get_mapped_file_id(self, file_id):
         """

--- a/lms/product/blackboard/_plugin/grouping.py
+++ b/lms/product/blackboard/_plugin/grouping.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from lms.models import Grouping
+from lms.models import Course, Grouping
 from lms.product.plugin.grouping import GroupError, GroupingPlugin
 from lms.services.exceptions import ExternalRequestError
 
@@ -22,8 +22,10 @@ class BlackboardGroupingPlugin(GroupingPlugin):
     def __init__(self, blackboard_api):
         self._blackboard_api = blackboard_api
 
-    def get_group_sets(self, course):
-        return self._blackboard_api.course_group_sets(course.lms_id)
+    def get_group_sets(self, course: Course):
+        group_sets = self._blackboard_api.course_group_sets(course.lms_id)
+        course.set_group_sets(group_sets)
+        return group_sets
 
     def get_groups_for_learner(self, _svc, course, group_set_id):
         if learner_groups := self._blackboard_api.course_groups(

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from lms.models import Grouping
+from lms.models import Course, Grouping
 from lms.product.plugin.grouping import GroupError, GroupingPlugin
 from lms.services.exceptions import CanvasAPIError
 
@@ -47,8 +47,12 @@ class CanvasGroupingPlugin(GroupingPlugin):
 
         return [sec for sec in course_sections if sec["id"] in learner_section_ids]
 
-    def get_group_sets(self, course):
-        return self._canvas_api.course_group_categories(self._custom_course_id(course))
+    def get_group_sets(self, course: Course):
+        group_sets = self._canvas_api.course_group_categories(
+            self._custom_course_id(course)
+        )
+        course.set_group_sets(group_sets)
+        return group_sets
 
     def get_groups_for_learner(self, _svc, course, group_set_id):
         # For learners, the groups they belong within the course

--- a/lms/product/d2l/_plugin/grouping.py
+++ b/lms/product/d2l/_plugin/grouping.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from lms.models import Grouping
+from lms.models import Course, Grouping
 from lms.product.plugin.grouping import GroupError, GroupingPlugin
 from lms.services import D2LAPIClient
 from lms.services.exceptions import ExternalRequestError
@@ -24,8 +24,10 @@ class D2LGroupingPlugin(GroupingPlugin):
         self._d2l_api = d2l_api
         self._api_user_id = api_user_id
 
-    def get_group_sets(self, course):
-        return self._d2l_api.course_group_sets(course.lms_id)
+    def get_group_sets(self, course: Course):
+        group_sets = self._d2l_api.course_group_sets(course.lms_id)
+        course.set_group_sets(group_sets)
+        return group_sets
 
     def get_groups_for_learner(self, _svc, course, group_set_id):
         if learner_groups := self._d2l_api.group_set_groups(

--- a/tests/factories/grouping.py
+++ b/tests/factories/grouping.py
@@ -14,6 +14,9 @@ def _grouping_factory(model_class, lms_name, parent=None):
         lms_id=factory.Faker("hexify", text="^" * 40),
         lms_name=lms_name,
         parent=parent,
+        # The SQLA model provides these as server_default
+        settings={},
+        extra={},
     )
 
 

--- a/tests/unit/lms/models/grouping_test.py
+++ b/tests/unit/lms/models/grouping_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import sentinel
+
 import pytest
 
 from lms.models import Course
@@ -50,3 +52,32 @@ class TestCourse:
         course.set_mapped_file_id("OLD", "NEW")
 
         assert course.extra["course_copy_file_mappings"]["OLD"] == "NEW"
+
+    @pytest.mark.parametrize(
+        "group_set,expected",
+        [
+            # No extra keys
+            (
+                {"id": "1", "name": "name", "extra": "value"},
+                {"id": "1", "name": "name"},
+            ),
+            # String ID
+            ({"id": 1111, "name": "name"}, {"id": "1111", "name": "name"}),
+        ],
+    )
+    def test_set_group_sets(self, group_set, expected):
+        course = factories.Course(extra={})
+
+        course.set_group_sets([group_set])
+
+        assert course.extra["group_sets"] == [expected]
+
+    def test_get_group_set(self):
+        course = factories.Course(extra={"group_sets": sentinel.group_sets})
+
+        assert course.get_group_sets() == sentinel.group_sets
+
+    def test_get_group_set_empty(self):
+        course = factories.Course(extra={})
+
+        assert not course.get_group_sets()

--- a/tests/unit/lms/product/blackboard/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/grouping_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, sentinel
+from unittest.mock import Mock, patch, sentinel
 
 import pytest
 
@@ -14,6 +14,9 @@ class TestBlackboardGroupingPlugin:
         api_group_sets = plugin.get_group_sets(course)
 
         blackboard_api_client.course_group_sets.assert_called_once_with(course.lms_id)
+        course.set_group_sets.assert_called_once_with(
+            blackboard_api_client.course_group_sets.return_value
+        )
         assert api_group_sets == blackboard_api_client.course_group_sets.return_value
 
     def test_get_groups_for_learner(
@@ -112,4 +115,6 @@ class TestBlackboardGroupingPlugin:
 
     @pytest.fixture
     def course(self):
-        return factories.Course()
+        course = factories.Course()
+        with patch.object(course, "set_group_sets"):
+            yield course

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import sentinel
+from unittest.mock import patch, sentinel
 
 import pytest
 
@@ -54,6 +54,9 @@ class TestCanvasGroupingPlugin:
 
         canvas_api_client.course_group_categories.assert_called_once_with(
             sentinel.canvas_course_id
+        )
+        course.set_group_sets.assert_called_once_with(
+            canvas_api_client.course_group_categories.return_value
         )
         assert api_group_sets == canvas_api_client.course_group_categories.return_value
 
@@ -192,9 +195,12 @@ class TestCanvasGroupingPlugin:
 
     @pytest.fixture
     def course(self):
-        return factories.Course(
+        course = factories.Course(
             extra={"canvas": {"custom_canvas_course_id": sentinel.canvas_course_id}}
         )
+
+        with patch.object(course, "set_group_sets"):
+            yield course
 
     @pytest.fixture
     def plugin(self, canvas_api_client):

--- a/tests/unit/lms/product/d2l/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/grouping_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, sentinel
+from unittest.mock import Mock, patch, sentinel
 
 import pytest
 
@@ -14,6 +14,9 @@ class TestD2LGroupingPlugin:
         api_group_sets = plugin.get_group_sets(course)
 
         d2l_api_client.course_group_sets.assert_called_once_with(course.lms_id)
+        course.set_group_sets.assert_called_once_with(
+            d2l_api_client.course_group_sets.return_value
+        )
         assert api_group_sets == d2l_api_client.course_group_sets.return_value
 
     def test_get_groups_for_learner(
@@ -113,4 +116,6 @@ class TestD2LGroupingPlugin:
 
     @pytest.fixture
     def course(self):
-        return factories.Course()
+        course = factories.Course()
+        with patch.object(course, "set_group_sets"):
+            yield course


### PR DESCRIPTION
Store group sets in Courses

Store the group sets metadata (name and ID) when we get it from the LMS's
API.

We'll later use this information to fix uses with groups and course
copy.


# Testing

- Clear any local state in the DB: `tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment,grouping cascade"; make devdata`

### Canvas


https://hypothesis.instructure.com/courses/125/assignments/3930/edit?name=Marcos+Assignment&due_at=null&points_possible=0

(pick the right LTI tool, configure with any document and check the `This is a group assignment`)

Getting the drop-down to populate with a list of group sets is what we are after.


### Blackboard 


https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1


Same process, configure and check the groups checkbox.


### D2L


Same story again: 

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View

(there are files in "scratch" area)


- Now we can query the group sets from the DB, in `make sql`:

```
select lms_name, extra from grouping where type ='course';
-[ RECORD 1 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
lms_name | Developer Test Course with Sections Enabled
extra    | {"canvas": {"custom_canvas_course_id": "125"}, "group_sets": [{"id": "121", "name": "Test group set"}, {"id": "122", "name": "Empty group set"}, {"id": "125", "name": "PoC"}, {"id": "129", "name": "Group Set with No Students in It"}]}
-[ RECORD 2 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
lms_name | Developer Test Course with Original Course View
extra    | {"group_sets": [{"id": "_46_1", "name": "Group Set 1"}, {"id": "_49_1", "name": "Group Set 2"}, {"id": "_64_1", "name": "Group set with 50 groups"}, {"id": "_54_1", "name": "Group Set With No Groups"}, {"id": "_55_1", "name": "Group Set With No Members"}, {"id": "_118_1", "name": "Lyza's Groups"}, {"id": "_61_1", "name": "test - groups - manual"}]}
-[ RECORD 3 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
lms_name | Developers test course
extra    | {"group_sets": [{"id": "22", "name": "Group Category testing"}, {"id": "23", "name": "Empty group category"}, {"id": "26", "name": "Support test Group Set"}]}
```
