### PR TITLE
Fix course copy for groups assignments in blackboard

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -179,7 +179,7 @@ class Course(Grouping):
 
     def get_mapped_file_id(self, file_id):
         """
-        Get a previously mapped file id in course.
+        Get a previously mapped file id in a course.
 
         Returns the original `file_id` if no mapped one can be found.
         """
@@ -190,6 +190,22 @@ class Course(Grouping):
         self.extra.setdefault("course_copy_file_mappings", {})[
             old_file_id
         ] = new_file_id
+
+    def get_mapped_group_set_id(self, group_set_id):
+        """
+        Get a previously mapped group set id in a course.
+
+        Returns the given `group_set_id` if no mapped one can be found.
+        """
+        return self.extra.get("course_copy_group_set_mappings", {}).get(
+            group_set_id, group_set_id
+        )
+
+    def set_mapped_group_set_id(self, old_group_set_id, group_set_id):
+        """Store a mapping between old_group set id and group_set_id for future launches."""
+        self.extra.setdefault("course_copy_group_set_mappings", {})[
+            old_group_set_id
+        ] = group_set_id
 
 
 class GroupingMembership(CreatedUpdatedMixin, BASE):

--- a/lms/product/blackboard/_plugin/course_copy.py
+++ b/lms/product/blackboard/_plugin/course_copy.py
@@ -1,4 +1,4 @@
-from lms.product.plugin.course_copy import CourseCopyFilesHelper
+from lms.product.plugin.course_copy import CourseCopyFilesHelper, CourseCopyGroupsHelper
 
 
 class BlackboardCourseCopyPlugin:
@@ -6,9 +6,15 @@ class BlackboardCourseCopyPlugin:
 
     file_type = "blackboard_file"
 
-    def __init__(self, api, files_helper: CourseCopyFilesHelper):
+    def __init__(
+        self,
+        api,
+        files_helper: CourseCopyFilesHelper,
+        groups_helper: CourseCopyGroupsHelper,
+    ):
         self._api = api
         self._files_helper = files_helper
+        self._groups_helper = groups_helper
 
     def is_file_in_course(self, course_id, file_id):
         return self._files_helper.is_file_in_course(course_id, file_id, self.file_type)
@@ -18,9 +24,15 @@ class BlackboardCourseCopyPlugin:
             self._api.list_all_files, self.file_type, original_file_id, new_course_id
         )
 
+    def find_matching_group_set_in_course(self, course, group_set_id):
+        return self._groups_helper.find_matching_group_set_in_course(
+            course, group_set_id
+        )
+
     @classmethod
     def factory(cls, _context, request):
         return cls(
-            request.find_service(name="blackboard_api_client"),
-            request.find_service(CourseCopyFilesHelper),
+            api=request.find_service(name="blackboard_api_client"),
+            files_helper=request.find_service(CourseCopyFilesHelper),
+            groups_helper=request.find_service(CourseCopyGroupsHelper),
         )

--- a/lms/product/canvas/__init__.py
+++ b/lms/product/canvas/__init__.py
@@ -1,3 +1,4 @@
+from lms.product.canvas._plugin.course_copy import CanvasCourseCopyPlugin
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
 from lms.product.canvas.product import Canvas
 
@@ -7,4 +8,7 @@ def includeme(config):  # pragma: nocover
 
     config.register_service_factory(
         CanvasGroupingPlugin.factory, iface=CanvasGroupingPlugin
+    )
+    config.register_service_factory(
+        CanvasCourseCopyPlugin.factory, iface=CanvasCourseCopyPlugin
     )

--- a/lms/product/canvas/_plugin/course_copy.py
+++ b/lms/product/canvas/_plugin/course_copy.py
@@ -1,0 +1,13 @@
+class CanvasCourseCopyPlugin:
+    """Handle course copy in Canvas."""
+
+    def find_matching_group_set_in_course(self, _course, _group_set_id):
+        # We are not yet handling course copy for groups in Canvas.
+        # Canvas doesn't copy group sets during course copy so the approach taken
+        # in other LMS won't make sense here.
+        # We implement this method so we can call `find_mapped_group_set_id` in all LMS's
+        return None
+
+    @classmethod
+    def factory(cls, _context, _request):
+        return cls()

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from lms.product.canvas._plugin.course_copy import CanvasCourseCopyPlugin
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
@@ -15,6 +16,8 @@ class Canvas(Product):
         oauth2_refresh="canvas_api.oauth.refresh",
     )
 
-    plugin_config: PluginConfig = PluginConfig(grouping=CanvasGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(
+        grouping=CanvasGroupingPlugin, course_copy=CanvasCourseCopyPlugin
+    )
 
     settings_key = "canvas"

--- a/lms/product/d2l/_plugin/course_copy.py
+++ b/lms/product/d2l/_plugin/course_copy.py
@@ -23,6 +23,11 @@ class D2LCourseCopyPlugin:
             self._api.list_files, self.file_type, original_file_id, new_course_id
         )
 
+    def find_matching_group_set_in_course(self, course, group_set_id):
+        # We are not yet handling course copy for groups in D2L.
+        # We implement this method so we can call `find_mapped_group_set_id` in all LMS's
+        return None
+
     @classmethod
     def factory(cls, _context, request):
         return cls(

--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -66,6 +66,58 @@ class CourseCopyFilesHelper:
         return cls(request.find_service(name="file"))
 
 
+class CourseCopyGroupsHelper:
+    def __init__(self, course_service, grouping_plugin):
+        self._course_service = course_service
+        self._grouping_plugin = grouping_plugin
+
+    def find_matching_group_set_in_course(self, course, group_set_id):
+        """
+        Find the corresponding `group_set_id` in course.
+
+        This could different from `group_set_id` if course has been course copied and we still point to the old's course group set.
+        """
+        try:
+            # Get the current (copied) group sets, that will have the side effect of storing them in the DB
+            _ = self._grouping_plugin.get_group_sets(course)
+        except OAuth2TokenError:
+            # If the issue while trying to talk to the API is OAuth related
+            # let that bubble up and be dealt with.
+            raise
+        except ExternalRequestError:
+            # We might not have access to use the API for that endpoint.
+            # That will depend on our role and the course's permissions settings.
+            # We will continue anyway, maybe the group sets of the new course are already in the DB
+            # after an instructor launch corrected the issue.
+            pass
+
+        # Get the original group set from the DB
+        group_set = self._course_service.find_group_set(group_set_id=group_set_id)
+        if not group_set:
+            # If we haven't found it could that either:
+            # - The group set doesn't belong to this course
+            # - The original assignment was configured before we rolled out this feature,
+            #   and we didn't store the group sets in the DB.
+            return None
+
+        # Try to find a matching group set in the new course.
+        # We might have a record of this because we just called `grouping_plugin.get_group_sets` as the current user
+        # or another user might have done it before for us.
+        if new_group_set := self._course_service.find_group_set(
+            name=group_set["name"], context_id=course.lms_id
+        ):
+            # We found a match, store it to save the search for next time
+            course.set_mapped_group_set_id(group_set_id, new_group_set["id"])
+            return new_group_set["id"]
+
+        # No match
+        return None
+
+    @classmethod
+    def factory(cls, _context, request):
+        return cls(request.find_service(name="course"), request.product.plugin.grouping)
+
+
 class CourseCopyPlugin:  # pragma: nocover
     """
     Empty implementation of the CourseCopyPlugin protocol.
@@ -77,4 +129,7 @@ class CourseCopyPlugin:  # pragma: nocover
         raise NotImplementedError()
 
     def find_matching_file_in_course(self, original_file_id, new_course_id):
+        raise NotImplementedError()
+
+    def find_matching_group_set_in_course(self, _course, group_set_id):
         raise NotImplementedError()

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -121,8 +121,14 @@ def includeme(config):
     # - Don't pollute the lms.services namespace
     # - Ease some circular-dependency problems
     # pylint:disable=import-outside-toplevel
-    from lms.product.plugin.course_copy import CourseCopyFilesHelper
+    from lms.product.plugin.course_copy import (
+        CourseCopyFilesHelper,
+        CourseCopyGroupsHelper,
+    )
 
     config.register_service_factory(
         CourseCopyFilesHelper.factory, iface=CourseCopyFilesHelper
+    )
+    config.register_service_factory(
+        CourseCopyGroupsHelper.factory, iface=CourseCopyGroupsHelper
     )

--- a/tests/unit/lms/models/grouping_test.py
+++ b/tests/unit/lms/models/grouping_test.py
@@ -81,3 +81,27 @@ class TestCourse:
         course = factories.Course(extra={})
 
         assert not course.get_group_sets()
+
+    def test_get_mapped_group_set_empty_extra(self):
+        course = factories.Course(extra={})
+
+        assert course.get_mapped_group_set_id("ID") == "ID"
+
+    def test_get_mapped_group_set_id_empty_mapping(self):
+        course = factories.Course(extra={"course_copy_group_set_mappings": {}})
+
+        assert course.get_mapped_group_set_id("ID") == "ID"
+
+    def test_get_mapped_group_set_id(self):
+        course = factories.Course(
+            extra={"course_copy_group_set_mappings": {"ID": "OTHER_ID"}}
+        )
+
+        assert course.get_mapped_group_set_id("ID") == "OTHER_ID"
+
+    def test_set_mapped_group_set_id(self):
+        course = factories.Course(extra={})
+
+        course.set_mapped_group_set_id("OLD", "NEW")
+
+        assert course.extra["course_copy_group_set_mappings"]["OLD"] == "NEW"

--- a/tests/unit/lms/product/blackboard/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/course_copy_test.py
@@ -33,14 +33,34 @@ class TestBlackboardCourseCopyPlugin:
             result == course_copy_files_helper.find_matching_file_in_course.return_value
         )
 
-    @pytest.mark.usefixtures("blackboard_api_client", "course_copy_files_helper")
+    def test_find_matching_group_set_in_course(self, plugin, course_copy_groups_helper):
+        result = plugin.find_matching_group_set_in_course(
+            sentinel.course, sentinel.group_set_id
+        )
+
+        course_copy_groups_helper.find_matching_group_set_in_course.assert_called_once_with(
+            sentinel.course, sentinel.group_set_id
+        )
+
+        assert (
+            result
+            == course_copy_groups_helper.find_matching_group_set_in_course.return_value
+        )
+
+    @pytest.mark.usefixtures(
+        "blackboard_api_client", "course_copy_files_helper", "course_copy_groups_helper"
+    )
     def test_factory(self, pyramid_request):
         plugin = BlackboardCourseCopyPlugin.factory(sentinel.context, pyramid_request)
 
         assert isinstance(plugin, BlackboardCourseCopyPlugin)
 
     @pytest.fixture
-    def plugin(self, blackboard_api_client, course_copy_files_helper):
+    def plugin(
+        self, blackboard_api_client, course_copy_files_helper, course_copy_groups_helper
+    ):
         return BlackboardCourseCopyPlugin(
-            api=blackboard_api_client, files_helper=course_copy_files_helper
+            api=blackboard_api_client,
+            files_helper=course_copy_files_helper,
+            groups_helper=course_copy_groups_helper,
         )

--- a/tests/unit/lms/product/canvas/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/course_copy_test.py
@@ -1,0 +1,21 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.product.canvas import CanvasCourseCopyPlugin
+
+
+class TestCanvasCourseCopyPlugin:
+    def test_find_matching_group_set_in_course(self, plugin):
+        assert not plugin.find_matching_group_set_in_course(
+            sentinel.course, sentinel.group_set_id
+        )
+
+    def test_factory(self, pyramid_request):
+        plugin = CanvasCourseCopyPlugin.factory(sentinel.context, pyramid_request)
+
+        assert isinstance(plugin, CanvasCourseCopyPlugin)
+
+    @pytest.fixture
+    def plugin(self):
+        return CanvasCourseCopyPlugin()

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
@@ -54,9 +54,6 @@ class TestCanvasGroupingPlugin:
 
         canvas_api_client.course_group_categories.assert_called_once_with(
             sentinel.canvas_course_id
-        )
-        course.set_group_sets.assert_called_once_with(
-            canvas_api_client.course_group_categories.return_value
         )
         assert api_group_sets == canvas_api_client.course_group_categories.return_value
 
@@ -195,12 +192,9 @@ class TestCanvasGroupingPlugin:
 
     @pytest.fixture
     def course(self):
-        course = factories.Course(
+        return factories.Course(
             extra={"canvas": {"custom_canvas_course_id": sentinel.canvas_course_id}}
         )
-
-        with patch.object(course, "set_group_sets"):
-            yield course
 
     @pytest.fixture
     def plugin(self, canvas_api_client):

--- a/tests/unit/lms/product/d2l/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/course_copy_test.py
@@ -33,6 +33,11 @@ class TestD2LCourseCopyPlugin:
             result == course_copy_files_helper.find_matching_file_in_course.return_value
         )
 
+    def test_find_matching_group_set_in_course(self, plugin):
+        assert not plugin.find_matching_group_set_in_course(
+            sentinel.course, sentinel.group_set_id
+        )
+
     @pytest.mark.usefixtures("d2l_api_client", "course_copy_files_helper")
     def test_factory(self, pyramid_request):
         plugin = D2LCourseCopyPlugin.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/views/api/sync_test.py
+++ b/tests/unit/lms/views/api/sync_test.py
@@ -2,6 +2,7 @@ from unittest.mock import sentinel
 
 import pytest
 
+from lms.product.plugin.grouping import GroupError
 from lms.views.api.sync import sync
 from tests import factories
 from tests.conftest import TEST_SETTINGS
@@ -9,47 +10,162 @@ from tests.conftest import TEST_SETTINGS
 
 @pytest.mark.usefixtures("application_instance_service")
 class TestSync:
-    @pytest.mark.parametrize(
-        "grouping_method,extra_args",
-        (("get_groups", {"group_set_id": sentinel.group_set_id}), ("get_sections", {})),
-    )
-    def test_it(
+    def test_it_with_sections(
         self,
         pyramid_request,
         grouping_service,
         assignment_service,
         course_service,
         lti_h_service,
-        grouping_method,
-        extra_args,
     ):
-        pyramid_request.parsed_params.update(extra_args)
-        grouping_method = getattr(grouping_service, grouping_method)
+        returned_ids = sync(pyramid_request)
+
+        course_service.get_by_context_id.assert_called_once_with(
+            sentinel.context_id, raise_on_missing=True
+        )
+        grouping_service.get_sections.assert_called_once_with(
+            user=pyramid_request.user,
+            lti_user=pyramid_request.lti_user,
+            course=course_service.get_by_context_id.return_value,
+            grading_student_id=sentinel.grading_student_id,
+        )
+        lti_h_service.sync.assert_called_once_with(
+            grouping_service.get_sections.return_value, sentinel.group_info
+        )
+        assignment_service.upsert_assignment_groupings(
+            assignment_id=sentinel.assignment_id,
+            groupings=grouping_service.get_sections.return_value,
+        )
+
+        assert returned_ids == [
+            group.groupid(TEST_SETTINGS["h_authority"])
+            for group in grouping_service.get_sections.return_value
+        ]
+
+    @pytest.mark.usefixtures("course_copy_plugin")
+    def test_it_with_groups(
+        self,
+        pyramid_request,
+        grouping_service,
+        assignment_service,
+        course_service,
+        lti_h_service,
+    ):
+        pyramid_request.parsed_params["group_set_id"] = sentinel.group_set_id
 
         returned_ids = sync(pyramid_request)
 
         course_service.get_by_context_id.assert_called_once_with(
             sentinel.context_id, raise_on_missing=True
         )
-        grouping_method.assert_called_once_with(
+        course = course_service.get_by_context_id.return_value
+        course.get_mapped_group_set_id.assert_called_once_with(sentinel.group_set_id)
+        grouping_service.get_groups.assert_called_once_with(
             user=pyramid_request.user,
             lti_user=pyramid_request.lti_user,
-            course=course_service.get_by_context_id.return_value,
+            course=course,
             grading_student_id=sentinel.grading_student_id,
-            **extra_args,
+            group_set_id=course.get_mapped_group_set_id.return_value,
         )
         lti_h_service.sync.assert_called_once_with(
-            grouping_method.return_value, sentinel.group_info
+            grouping_service.get_groups.return_value, sentinel.group_info
         )
         assignment_service.upsert_assignment_groupings(
             assignment_id=sentinel.assignment_id,
-            groupings=grouping_method.return_value,
+            groupings=grouping_service.get_groups.return_value,
         )
 
         assert returned_ids == [
             group.groupid(TEST_SETTINGS["h_authority"])
-            for group in grouping_method.return_value
+            for group in grouping_service.get_groups.return_value
         ]
+
+    @pytest.mark.usefixtures("course_copy_plugin")
+    def test_it_with_groups_course_copy_fix(
+        self,
+        pyramid_request,
+        grouping_service,
+        course_service,
+        course_copy_plugin,
+        lti_h_service,
+        assignment_service,
+    ):
+        pyramid_request.parsed_params["group_set_id"] = sentinel.group_set_id
+
+        grouping_service.get_groups.side_effect = [
+            GroupError(sentinel.error_code, sentinel.group_set),
+            grouping_service.get_groups.return_value,
+        ]
+        course_copy_plugin.find_matching_group_set_in_course.return_value = (
+            sentinel.new_group_set_id
+        )
+
+        returned_ids = sync(pyramid_request)
+
+        course_service.get_by_context_id.assert_called_once_with(
+            sentinel.context_id, raise_on_missing=True
+        )
+        course = course_service.get_by_context_id.return_value
+        course.get_mapped_group_set_id.assert_called_once_with(sentinel.group_set_id)
+        grouping_service.get_groups.assert_any_call(
+            user=pyramid_request.user,
+            lti_user=pyramid_request.lti_user,
+            course=course,
+            grading_student_id=sentinel.grading_student_id,
+            group_set_id=course.get_mapped_group_set_id.return_value,
+        )
+
+        course_copy_plugin.find_matching_group_set_in_course.assert_called_once_with(
+            course, course.get_mapped_group_set_id.return_value
+        )
+
+        grouping_service.get_groups.assert_called_with(
+            user=pyramid_request.user,
+            lti_user=pyramid_request.lti_user,
+            course=course,
+            grading_student_id=sentinel.grading_student_id,
+            group_set_id=sentinel.new_group_set_id,
+        )
+
+        lti_h_service.sync.assert_called_once_with(
+            grouping_service.get_groups.return_value, sentinel.group_info
+        )
+        assignment_service.upsert_assignment_groupings(
+            assignment_id=sentinel.assignment_id,
+            groupings=grouping_service.get_groups.return_value,
+        )
+
+        assert returned_ids == [
+            group.groupid(TEST_SETTINGS["h_authority"])
+            for group in grouping_service.get_groups.return_value
+        ]
+
+    @pytest.mark.usefixtures("course_copy_plugin")
+    def test_it_with_groups_course_copy_doesnt_fix_it(
+        self, pyramid_request, grouping_service, course_service, course_copy_plugin
+    ):
+        pyramid_request.parsed_params["group_set_id"] = sentinel.group_set_id
+
+        grouping_service.get_groups.side_effect = GroupError(
+            sentinel.error_code, sentinel.group_set
+        )
+        course_copy_plugin.find_matching_group_set_in_course.return_value = None
+
+        with pytest.raises(GroupError):
+            sync(pyramid_request)
+
+        course_service.get_by_context_id.assert_called_once_with(
+            sentinel.context_id, raise_on_missing=True
+        )
+        course = course_service.get_by_context_id.return_value
+        course.get_mapped_group_set_id.assert_called_once_with(sentinel.group_set_id)
+        grouping_service.get_groups.assert_called_once_with(
+            user=pyramid_request.user,
+            lti_user=pyramid_request.lti_user,
+            course=course,
+            grading_student_id=sentinel.grading_student_id,
+            group_set_id=course.get_mapped_group_set_id.return_value,
+        )
 
     @pytest.fixture
     def grouping_service(self, grouping_service):

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,7 +2,11 @@ from unittest import mock
 
 import pytest
 
-from lms.product.plugin.course_copy import CourseCopyFilesHelper, CourseCopyPlugin
+from lms.product.plugin.course_copy import (
+    CourseCopyFilesHelper,
+    CourseCopyGroupsHelper,
+    CourseCopyPlugin,
+)
 from lms.product.plugin.grouping import GroupingPlugin
 from lms.product.plugin.misc import MiscPlugin
 from lms.services import (
@@ -83,6 +87,7 @@ __all__ = (
     "grouping_plugin",
     "course_copy_plugin",
     "course_copy_files_helper",
+    "course_copy_groups_helper",
     "misc_plugin",
 )
 
@@ -308,6 +313,11 @@ def vitalsource_service(mock_service):
 @pytest.fixture
 def course_copy_files_helper(mock_service):
     return mock_service(CourseCopyFilesHelper)
+
+
+@pytest.fixture
+def course_copy_groups_helper(mock_service):
+    return mock_service(CourseCopyGroupsHelper)
 
 
 @pytest.fixture


### PR DESCRIPTION
Handle course copy & group sets in Blackboard.


### Testing


### Canvas

Canvas doesn't copy group set during course copy so this code shound'thave any effect there:

- Reset the DB state

`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping,assignment cascade;"; make devdata;`

- Launch a non-copied groups assignment 

https://hypothesis.instructure.com/courses/125/assignments/1833


Working

- Launch a copied group assignment:

https://hypothesis.instructure.com/courses/521/assignments/4311

You'll get a modal poiting to the missing group as one of the possibliilties.



#### D2L

We are not tackling D2L groups in this PR (to simplify these testing instructions). Just check that everything works as it was before

- Reset the DB state

`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping,assignment cascade;"; make devdata;`


Both as `HypothesisEng.Teacher`

- Launch a groups assignment: 

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View?ou=6782

It should work as before


- Launch the copied one:
https://aunltd.brightspacedemo.com/d2l/le/content/6861/viewContent/2524/View?ou=6861

You'll get the `Assignment's group category no longer exists` modal


#### Blackboard

- Reset the DB state

`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping,assignment cascade;"; make devdata;`



### As a student (`blackboardstudent`)


- Launch the original group assignment:

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_398_1&course_id=_19_1


You'll get just one group on the drop-down (the one you are a member of, `Group set 2 1`)



- Launch the copied groups assignment

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1372_1&course_id=_139_1


You'll get a modal about not belonging to the right groups.

In error details that group set id is `_49_1`.


### As a teacher (blackbaordteacher)

- Launch the original group assignment:

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_398_1&course_id=_19_1


You'll get both groups in the drop-down.

- Launch the copied groups assignment

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1372_1&course_id=_139_1


You'll get a modal indicating that the group set is not in the group.

This simulates the case were the course was originally configured before the deploy of this feature and the group set list was never fetched after that. Every new course after this is deployed will have the group sets already stored in the DB.


- Launch the scratch assignment on the original course.

Select any type of file and pick the group assignment option, we just want to record the group sets in the DB.

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_183_1&course_id=_19_1


- Launch the copied groups assignment again

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1372_1&course_id=_139_1


Now the lunch is successful and we have record of the group set mapping:


```
postgres=# select extra->'course_copy_group_set_mappings' from grouping  where lms_id = 'c494dc384def49bfb66b9dd356010a63';                                                
      ?column?       
---------------------
 {"_49_1": "_598_1"}
(1 row)
```

### Again, as a student (`blackboardstudent`)


- Launch the copied groups assignment

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1372_1&course_id=_139_1

It will work this time as the mapping is now stored in the DB.

