### PR TITLE
Update shared components in `BookPicker`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -1,5 +1,5 @@
+import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
-import { LabeledButton, Modal } from '@hypothesis/frontend-shared';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import type { Book, Chapter } from '../api-types';
@@ -69,43 +69,43 @@ export default function BookPicker({
   const canSubmit =
     (step === 'select-book' && book) || (step === 'select-chapter' && chapter);
 
-  // Provide a spacious modal UI when listing chapters (taller modal)
-  const showChapters = step === 'select-chapter' && !error;
-
   return (
     <Modal
       // Opt out of Modal's automatic focus handling; route focus manually in
       // sub-components
-      initialFocus={null}
-      onCancel={onCancel}
-      contentClass={classnames('LMS-Dialog LMS-Dialog--wide', {
-        'LMS-Dialog--tall': showChapters,
-      })}
+      initialFocus={'manual'}
+      onClose={onCancel}
       title={
         step === 'select-book'
           ? 'Paste link to VitalSource book'
           : 'Pick where to start reading' // "Select a chapter"
       }
-      buttons={[
-        <LabeledButton
-          key="submit"
-          data-testid="select-button"
-          disabled={!canSubmit}
-          onClick={() => {
-            // nb. The `book` and `chapter` checks should be redundant, as the button
-            // should not be clickable if no book/chapter is selected, but they
-            // keep TS happy.
-            if (step === 'select-book' && book) {
-              confirmBook(book);
-            } else if (step === 'select-chapter' && chapter) {
-              confirmChapter(chapter);
-            }
-          }}
-          variant="primary"
-        >
-          {step === 'select-book' ? 'Select book' : 'Select'}
-        </LabeledButton>,
-      ]}
+      width="lg"
+      buttons={
+        <>
+          <Button data-testid="cancel-button" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            key="submit"
+            data-testid="select-button"
+            disabled={!canSubmit}
+            onClick={() => {
+              // nb. The `book` and `chapter` checks should be redundant, as the button
+              // should not be clickable if no book/chapter is selected, but they
+              // keep TS happy.
+              if (step === 'select-book' && book) {
+                confirmBook(book);
+              } else if (step === 'select-chapter' && chapter) {
+                confirmChapter(chapter);
+              }
+            }}
+            variant="primary"
+          >
+            {step === 'select-book' ? 'Select book' : 'Select'}
+          </Button>
+        </>
+      }
     >
       {step === 'select-book' && !error && (
         <BookSelector
@@ -115,13 +115,23 @@ export default function BookPicker({
         />
       )}
       {step === 'select-chapter' && !error && (
-        <ChapterList
-          chapters={chapterList || []}
-          isLoading={!chapterList}
-          selectedChapter={chapter}
-          onSelectChapter={setChapter}
-          onUseChapter={confirmChapter}
-        />
+        <div
+          className={classnames(
+            // Set a preferred height for this content to give it more vertical
+            // room. Max-height rules on the containing Modal will prevent the
+            // Modal from exceeding available viewport space. Overflowing
+            // content will scroll.
+            'min-h-[25rem]'
+          )}
+        >
+          <ChapterList
+            chapters={chapterList || []}
+            isLoading={!chapterList}
+            selectedChapter={chapter}
+            onSelectChapter={setChapter}
+            onUseChapter={confirmChapter}
+          />
+        </div>
       )}
       {error && (
         <ErrorDisplay

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -101,9 +101,7 @@ describe('BookPicker', () => {
 
   const clickSelectButton = wrapper => {
     act(() => {
-      wrapper
-        .find('LabeledButton[data-testid="select-button"]')
-        .prop('onClick')();
+      wrapper.find('button[data-testid="select-button"]').prop('onClick')();
     });
     wrapper.update();
   };
@@ -118,13 +116,25 @@ describe('BookPicker', () => {
 
   it('enables submit button when a book is selected', () => {
     const picker = renderBookPicker();
-    const buttonSelector = 'LabeledButton[data-testid="select-button"]';
+    const buttonSelector = 'button[data-testid="select-button"]';
 
     assert.isTrue(picker.find(buttonSelector).props().disabled);
     selectBook(picker);
 
     assert.isFalse(picker.find(buttonSelector).props().disabled);
     assert.equal(picker.find(buttonSelector).text(), 'Select book');
+  });
+
+  it('cancels the dialog when Cancel button clicked', () => {
+    const fakeCancel = sinon.stub();
+    const wrapper = renderBookPicker({ onCancel: fakeCancel });
+
+    act(() => {
+      wrapper.find('button[data-testid="cancel-button"]').simulate('click');
+    });
+    wrapper.update();
+
+    assert.calledOnce(fakeCancel);
   });
 
   it('fetches chapters and renders chapter list when a book is selected', async () => {
@@ -175,12 +185,5 @@ describe('BookPicker', () => {
     );
     assert.equal(errorDisplay.prop('error'), error);
     assert.isFalse(picker.exists('ChapterList'));
-
-    // The modal content should not have the class applied for showing the
-    // list of chapters. That class makes the modal too tall for comfort when
-    // displaying an error
-    const modalContent = picker.find('div[role="dialog"]');
-    assert.isTrue(modalContent.hasClass('LMS-Dialog--wide'));
-    assert.isFalse(modalContent.hasClass('LMS-Dialog--tall'));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,9 +1127,9 @@
     glob "^7.2.0"
 
 "@hypothesis/frontend-shared@^5.7.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.9.0.tgz#1ccd6007e237c90fee77689417bfd19a0fde0498"
-  integrity sha512-FyeTvDLJ55Ma676f3pJoy1Ybst++eiNnDAuXgIH0tlYBE+OTg2paQBnC7evb19E9O1m0m9zpTZV0TKjjQTF7SA==
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.9.1.tgz#e6353cff0a408b8a210ff1de20254cf7cefe62ef"
+  integrity sha512-j9o+5TtiUckHRwU1an5I77zfR1noW4IAswBtSbmOa1LwkuCH40sgGdysikIn+PYoqxC72Q0Dy2l4XtsH89c/Iw==
   dependencies:
     highlight.js "^11.6.0"
 


### PR DESCRIPTION
Part of #5013 

This PR updates the shared components in `BookPicker` (the component that renders the modal and main controls for selecting VitalSource content). The updated `Modal` component uses the updated `Panel` patten, so there are some minor differences in heading font proportions as there were in the `client` during these updates, but you'd have to be a pretty observant user to notice the change.

If the reviewer would like to test these changes:

* Ensure the local [Vitalsource Feature flag is enabled](http://localhost:8001/flags) (though I think it may be enabled by default now?). _NB_: LMS feature flags are managed in a different place than `h` feature flags.
* Create and/or launch a localhost assignment in Canvas, and get into the assignment configuration view.
* Choose the VitalSource content option from the "Assignment details" modal

This modal and the buttons (but not the other modal contents) is the `BookPicker` component:

<img width="845" alt="image" src="https://user-images.githubusercontent.com/439947/218160291-9b2a5bba-ece2-4dcc-bf61-906dedf63ec8.png">

One thing you might want to ensure is that clicking on the "Cancel" button in the modal, or the modal's close button ("X") does not submit the wrapping form (this will cause an error because no content has been selected). I had to make a change to the `frontend-shared` package to prevent this (setting a `type="button"` on button component elements).