### PR TITLE
Update shared components in `BookSelector`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.tsx
@@ -1,10 +1,13 @@
 import {
-  Icon,
+  ArrowRightIcon,
+  CancelIcon,
+  CheckIcon,
   IconButton,
-  TextInput,
-  TextInputWithButton,
+  InputGroup,
+  Input,
   Thumbnail,
-} from '@hypothesis/frontend-shared';
+} from '@hypothesis/frontend-shared/lib/next';
+import classNames from 'classnames';
 
 import { useEffect, useRef, useState } from 'preact/hooks';
 
@@ -148,45 +151,57 @@ export default function BookSelector({
 
   return (
     <div className="flex flex-row space-x-3">
-      <Thumbnail isLoading={isLoadingBook} classes="w-32 h-40">
-        {selectedBook && (
-          <img
-            alt={`Book cover for ${selectedBook.title}`}
-            src={selectedBook.cover_image}
-            data-testid="cover-image"
-          />
-        )}
-      </Thumbnail>
+      <div className="w-[132px]">
+        <Thumbnail loading={isLoadingBook} ratio="4/5">
+          {selectedBook && (
+            <img
+              alt={`Book cover for ${selectedBook.title}`}
+              className={classNames(
+                // Use `object-fit: contain` instead of default `cover`
+                // This ensures none of the image is cropped
+                // TODO: Remove !-rule when
+                // https://github.com/hypothesis/frontend-shared/issues/842 is
+                // resolved
+                '!object-contain'
+              )}
+              src={selectedBook.cover_image}
+              data-testid="cover-image"
+            />
+          )}
+        </Thumbnail>
+      </div>
       <div className="grow space-y-2">
         <p>
           Paste a link or ISBN for the VitalSource book you&apos;d like to use:
         </p>
 
-        <TextInputWithButton>
-          <TextInput
-            readOnly={isLoadingBook}
+        <InputGroup>
+          <Input
+            aria-label="VitalSource URL or ISBN"
+            data-testid="vitalsource-input"
             hasError={!!error}
-            inputRef={inputRef}
+            elementRef={inputRef}
             name="vitalSourceURL"
             onChange={() => onUpdateURL(false /* confirmSelectedBook */)}
             onKeyDown={onKeyDown}
             placeholder="e.g. https://bookshelf.vitalsource.com/#/books/012345678..."
+            readOnly={isLoadingBook}
             spellcheck={false}
           />
           <IconButton
-            icon="arrowRight"
-            variant="dark"
+            icon={ArrowRightIcon}
             onClick={() => onUpdateURL(false /* confirmSelectedBook */)}
             title="Find book"
+            variant="dark"
           />
-        </TextInputWithButton>
+        </InputGroup>
 
         {selectedBook && (
           <div
             className="flex flex-row items-center space-x-2"
             data-testid="selected-book"
           >
-            <Icon name="check" classes="text-green-success" />
+            <CheckIcon className="text-green-success" />
             <div className="grow font-bold italic">{selectedBook.title}</div>
           </div>
         )}
@@ -196,7 +211,7 @@ export default function BookSelector({
             className="flex flex-row items-center space-x-2 text-red-error"
             data-testid="error-message"
           >
-            <Icon name="cancel" />
+            <CancelIcon />
             <div className="grow">{error}</div>
           </div>
         )}

--- a/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
@@ -56,7 +56,8 @@ describe('BookSelector', () => {
     $imports.$restore();
   });
 
-  const getInput = wrapper => wrapper.find('TextInput').find('input');
+  const getInput = wrapper =>
+    wrapper.find('input[data-testid="vitalsource-input"]');
 
   // Set the value of the input field but do not fire any events
   const setURL = (wrapper, url) => {
@@ -199,7 +200,7 @@ describe('BookSelector', () => {
         errorMessage.text(),
         "That doesn't look like a VitalSource book link"
       );
-      assert.isTrue(errorMessage.find('Icon[name="cancel"]').exists());
+      assert.isTrue(errorMessage.find('CancelIcon').exists());
     });
   });
 
@@ -258,9 +259,9 @@ describe('BookSelector', () => {
 
       updateURL(wrapper, 'a valid URL');
 
-      assert.isTrue(wrapper.find('Thumbnail').props().isLoading);
+      assert.isTrue(wrapper.find('Thumbnail').props().loading);
 
-      await waitForElement(wrapper, 'Thumbnail[isLoading=false]');
+      await waitForElement(wrapper, 'Thumbnail[loading=false]');
     });
 
     context('a book has been loaded and selected', () => {
@@ -273,7 +274,7 @@ describe('BookSelector', () => {
 
         assert.isTrue(wrapper.find('Thumbnail img').exists());
         assert.include(selectedBook.text(), 'Book One');
-        assert.isTrue(selectedBook.find('Icon[name="check"]').exists());
+        assert.isTrue(selectedBook.find('CheckIcon').exists());
       });
     });
 


### PR DESCRIPTION
Part of #5013 

This PR updates shared components in the `BookSelector` component.

There are very minor visual changes: the dimensions of the thumbnail at left, padding and/or size of input field and submit button — a couple of pixels here or there, but nothing that most folks would notice.

This component is responsible for the contents of the book-picker modal for selecting a book (step one of two in the VitalSource picker flow) not including the modal "chrome" and buttons:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/439947/218477442-0a32ed90-f70c-40ce-8dbe-097f86441ba3.png">

Happy path:

<img width="704" alt="image" src="https://user-images.githubusercontent.com/439947/218477547-7c8583d5-0585-4b1e-9203-ab62bcfb617d.png">

Sad path:

<img width="708" alt="image" src="https://user-images.githubusercontent.com/439947/218477587-177c2633-c4bd-4059-a599-f0030e0a4de1.png">

## Testing

See initial steps in https://github.com/hypothesis/lms/pull/5017 (to get to the picker)

Valid VitalSource book URLs you can use are:

* `https://bookshelf.vitalsource.com/#/books/9781400847402`
* `https://bookshelf.vitalsource.com/#/books/BOOKSHELF-TUTORIAL`

During update I kicked up a shortcoming in the recently-revamped `Thumbnail` shared component: it is being too restrictive about the `object-fit` of its first child. Workaround is commented in the code and linked to a ticket to track it.