### PR TITLE
Migrate ErrorDialogApp to non-deprecated components from the pattern library

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@hypothesis/frontend-shared';
+import { Link } from '@hypothesis/frontend-shared/lib/next';
 
 import { useConfig } from '../config';
 import ErrorModal from './ErrorModal';


### PR DESCRIPTION
Migrating to TypeScript at the same time, as the component does not really need any changes related to that.

This PR is part of #5013