### PR TITLE
Add formatting to dates and URLs in tables and disabled form fields

### DIFF
--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -15,7 +15,7 @@
 
 {% macro disabled_text_field(label, value) %}
     {% call field_body(label) %}
-        <input class="input" disabled type="text" value="{{value}}">
+        <input class="input" disabled type="text" value="{{ auto_format(value, html=False) }}">
     {% endcall %}
 {% endmacro %}
 
@@ -80,6 +80,24 @@
 {% endmacro %}
 
 
+{#
+    Attempt to guess the correct way to format something by inspecting it.
+    This supports an `html` mode which is good for displaying content inline,
+    and a non-html mode for displaying values in form fields.
+#}
+{%- macro auto_format(value, html=True) -%}
+    {%- if value is none -%}
+        {% if html %}<span style="color:#aaa">-</span>{% else %}{% endif %}
+    {%- elif value.strftime -%}
+        {{ value.strftime('%Y/%m/%d %H:%M') }}
+    {%- elif value.startswith('http') and html -%}
+        <a href="{{ value }}">{{ value }}</a>
+    {%- else -%}
+        {{ value }}
+    {%- endif -%}
+{%- endmacro -%}
+
+
 {% macro object_list_table(request, route, objects, fields) %}
 <div class="container">
     <div class="table-container">
@@ -99,13 +117,7 @@
                     <a class="button" href="{{ request.route_url(route, id_=object.id) }}">View</a>
                   </td>
                   {% for field in fields %}
-                  <td>
-                    {% if object[field.name] is none %}
-                        <span style="color:#aaa">-</span>
-                    {% else %}
-                        {{ object[field.name] }}
-                    {% endif %}
-                  </td>
+                  <td>{{ auto_format(object[field.name]) }}</td>
                   {% endfor %}
                </tr>
             {% endfor %}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4965
 
 After slamming my head off of many different ways to try and get this done, I've settled on a slightly auto-magical system which applies formatting to many places we present information. This will get applied to:
 
  * All table fields
  * All disabled value fields

And attempts to detect a sensible way to format something based on the content it's formatting. 

The nice feature of this approach is it's all native Jinja2 and requires no Python code at all.

## Testing notes

 * Search for application instances
 * Observe the create and update dates are formatted
 * Look for missing last_update dates and see that they get a `-` 
 * Observe the LMS URL is formatted as a link

View various other objects like application instances or organizations on their detail pages:

 * Note create and update fields have formatting
 * Look at an application instance with a null last launched date and note it does not have HTML in it