### PR TITLE
Sort application instance search by last launched / updated

### DIFF
--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -143,6 +143,7 @@ class ApplicationInstanceService:
         email=None,
     ) -> List[ApplicationInstance]:
         """Return the instances that match all of the passed parameters."""
+
         return (
             self._ai_search_query(
                 id_=id_,
@@ -153,6 +154,10 @@ class ApplicationInstanceService:
                 deployment_id=deployment_id,
                 tool_consumer_instance_guid=tool_consumer_instance_guid,
                 email=email,
+            )
+            .order_by(
+                ApplicationInstance.last_launched.desc().nulls_last(),
+                ApplicationInstance.updated.desc(),
             )
             .limit(limit)
             .all()


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4965

Generally the most recently launched or updated application instances are the most relevant. 

Due to our recent DB migration the updated date has been set by the last launched date, but in future it's possible that application instances could be created which never get launched. So that these application instances are not un-order we additionally sort by updated date as well.