### PR TITLE
Split the application instance admin pages into separate pages

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -131,7 +131,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.index", "/admin/")
 
     config.add_route("admin.instance.search", "/admin/instances/")
-    config.add_route("admin.instance.new", "/admin/instance/new")
+    config.add_route("admin.instance.create", "/admin/instance/create")
     config.add_route("admin.instance.upgrade", "/admin/instance/upgrade")
     config.add_route("admin.instance", "/admin/instance/{id_}/")
     config.add_route("admin.instance.downgrade", "/admin/instance/{id_}/downgrade")

--- a/lms/templates/admin/application_instance/create.html.jinja2
+++ b/lms/templates/admin/application_instance/create.html.jinja2
@@ -16,7 +16,7 @@ New application instance
     </fieldset>
 {% endif %}
 
-<form method="POST" action="{{ request.route_url("admin.instance.new") }}">
+<form method="POST" action="{{ request.route_url("admin.instance.create") }}">
     <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
     <input type="hidden" name="lti_registration_id" value="{{ lti_registration.id }}">
 

--- a/lms/templates/admin/application_instance/search.html.jinja2
+++ b/lms/templates/admin/application_instance/search.html.jinja2
@@ -8,7 +8,7 @@ Application instances
 {% block content %}
 
 <div class="block has-text-right">
-    <a class="button is-primary" href="{{request.route_url("admin.instance.new")}}">
+    <a class="button is-primary" href="{{request.route_url("admin.instance.create")}}">
         New LTI 1.1 application instance
     </a>
 </div>

--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -42,7 +42,7 @@
     <fieldset class="box">
     <legend class="label has-text-centered">Application instances</legend>
         <div class="block has-text-right">
-            <a class="button is-primary" href="{{ request.route_url("admin.instance.new", _query={"organization_public_id": org.public_id}) }}">
+            <a class="button is-primary" href="{{ request.route_url("admin.instance.create", _query={"organization_public_id": org.public_id}) }}">
                 Add New LTI 1.1 instance
             </a>
         </div>

--- a/lms/templates/admin/registration.html.jinja2
+++ b/lms/templates/admin/registration.html.jinja2
@@ -23,7 +23,7 @@
          <div class="block has-text-right">
             <a class="button is-primary" href="{{ request.route_url("admin.instance.upgrade", _query={"lti_registration_id": registration.id}) }}">Upgrade LTI 1.1 instance</a>
 
-            <a class="button is-primary" href="{{ request.route_url("admin.instance.new", _query={"lti_registration_id": registration.id}) }}">Add LTI 1.3 instance</a>
+            <a class="button is-primary" href="{{ request.route_url("admin.instance.create", _query={"lti_registration_id": registration.id}) }}">Add LTI 1.3 instance</a>
         </div>
 
         {% if registration.application_instances %}

--- a/lms/views/admin/application_instance/_core.py
+++ b/lms/views/admin/application_instance/_core.py
@@ -1,0 +1,46 @@
+from pyramid.httpexceptions import HTTPFound, HTTPNotFound
+from pyramid.settings import asbool
+
+from lms.models import ApplicationInstance
+from lms.services import ApplicationInstanceNotFound
+
+# Helper to declare settings as secret
+AES_SECRET = object()
+APPLICATION_INSTANCE_SETTINGS = {
+    ("blackboard", "files_enabled"): asbool,
+    ("blackboard", "groups_enabled"): asbool,
+    ("canvas", "sections_enabled"): asbool,
+    ("canvas", "groups_enabled"): asbool,
+    ("desire2learn", "client_id"): str,
+    ("desire2learn", "client_secret"): AES_SECRET,
+    ("desire2learn", "groups_enabled"): asbool,
+    ("desire2learn", "files_enabled"): asbool,
+    ("desire2learn", "create_line_item"): asbool,
+    ("microsoft_onedrive", "files_enabled"): asbool,
+    ("vitalsource", "enabled"): asbool,
+    ("vitalsource", "user_lti_param"): str,
+    ("vitalsource", "user_lti_pattern"): str,
+    ("vitalsource", "api_key"): str,
+    ("vitalsource", "disable_licence_check"): asbool,
+    ("jstor", "enabled"): asbool,
+    ("jstor", "site_code"): str,
+    ("hypothesis", "notes"): str,
+}
+
+
+class BaseApplicationInstanceView:
+    def __init__(self, request):
+        self.request = request
+        self.application_instance_service = request.find_service(
+            name="application_instance"
+        )
+
+    def _redirect(self, route_name, **kwargs):
+        return HTTPFound(location=self.request.route_url(route_name, **kwargs))
+
+    def _get_ai_or_404(self, id_) -> ApplicationInstance:
+        try:
+            return self.application_instance_service.get_by_id(id_=id_)
+
+        except ApplicationInstanceNotFound as err:
+            raise HTTPNotFound() from err

--- a/lms/views/admin/application_instance/_core.py
+++ b/lms/views/admin/application_instance/_core.py
@@ -35,12 +35,20 @@ class BaseApplicationInstanceView:
             name="application_instance"
         )
 
-    def _redirect(self, route_name, **kwargs):
-        return HTTPFound(location=self.request.route_url(route_name, **kwargs))
+    @property
+    def application_instance(self) -> ApplicationInstance:
+        """
+        Get the current application instance from the route by id.
 
-    def _get_ai_or_404(self, id_) -> ApplicationInstance:
+        :raises HTTPNotFound: If the application instance cannot be found.
+        """
         try:
-            return self.application_instance_service.get_by_id(id_=id_)
+            return self.application_instance_service.get_by_id(
+                id_=self.request.matchdict["id_"]
+            )
 
         except ApplicationInstanceNotFound as err:
             raise HTTPNotFound() from err
+
+    def _redirect(self, route_name, **kwargs):
+        return HTTPFound(location=self.request.route_url(route_name, **kwargs))

--- a/lms/views/admin/application_instance/create.py
+++ b/lms/views/admin/application_instance/create.py
@@ -1,0 +1,102 @@
+from marshmallow import validate
+from pyramid.view import view_config, view_defaults
+from sqlalchemy.exc import IntegrityError
+from webargs import fields
+
+from lms.models.public_id import InvalidPublicId
+from lms.security import Permissions
+from lms.services import LTIRegistrationService
+from lms.validation._base import PyramidRequestSchema
+from lms.views.admin import flash_validation
+from lms.views.admin.application_instance._core import BaseApplicationInstanceView
+
+
+class NewAppInstanceSchema(PyramidRequestSchema):
+    """Schema for creating a new application instance."""
+
+    location = "form"
+
+    developer_key = fields.Str(required=False, allow_none=True)
+    developer_secret = fields.Str(required=False, allow_none=True)
+
+    name = fields.Str(required=True, validate=validate.Length(min=1))
+    lms_url = fields.URL(required=True)
+    email = fields.Email(required=True)
+    organization_public_id = fields.Str(required=True, validate=validate.Length(min=1))
+
+
+class NewAppInstanceSchemaV13(NewAppInstanceSchema):
+    """Schema for creating a new LTI 1.3 application instance."""
+
+    deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
+    lti_registration_id = fields.Str(required=True)
+
+
+@view_defaults(route_name="admin.instance.new", permission=Permissions.ADMIN)
+class CreateApplicationInstanceViews(BaseApplicationInstanceView):
+    def __init__(self, request):
+        super().__init__(request)
+
+        self.lti_registration_service: LTIRegistrationService = request.find_service(
+            LTIRegistrationService
+        )
+
+    @view_config(
+        request_method="GET",
+        renderer="lms:templates/admin/application_instance/new.html.jinja2",
+    )
+    def new_instance_start(self):
+        """Show the page to kick off creating a new application instance."""
+
+        lti_registration = None
+        if lti_registration_id := self.request.params.get("lti_registration_id"):
+            lti_registration = self.lti_registration_service.get_by_id(
+                lti_registration_id.strip()
+            )
+
+        return dict(self.request.params, lti_registration=lti_registration)
+
+    @view_config(request_method="POST")
+    def new_instance_callback(self):
+        """Create an application instance (callback from the new AI page)."""
+
+        lti_registration_id = self.request.params.get("lti_registration_id", "").strip()
+        lti_registration_id = int(lti_registration_id) if lti_registration_id else None
+
+        if flash_validation(
+            self.request,
+            NewAppInstanceSchemaV13 if lti_registration_id else NewAppInstanceSchema,
+        ):
+            # Looks like something went wrong!
+            return self._redirect("admin.instance.new", _query=self.request.params)
+
+        try:
+            ai = self.application_instance_service.create_application_instance(
+                name=self.request.params["name"].strip(),
+                lms_url=self.request.params["lms_url"].strip(),
+                email=self.request.params["email"].strip(),
+                deployment_id=self.request.params.get("deployment_id", "").strip(),
+                developer_key=self.request.params.get("developer_key", "").strip(),
+                developer_secret=self.request.params.get(
+                    "developer_secret", ""
+                ).strip(),
+                organization_public_id=self.request.params.get(
+                    "organization_public_id", ""
+                ).strip(),
+                lti_registration_id=lti_registration_id,
+            )
+        except InvalidPublicId as err:
+            self.request.session.flash(
+                {"organization_public_id": [str(err)]}, "validation"
+            )
+
+            return self._redirect("admin.instance.new", _query=self.request.params)
+        except IntegrityError:
+            self.request.session.flash(
+                f"Application instance with deployment_id: {self.request.params['deployment_id']} already exists",
+                "errors",
+            )
+
+            return self._redirect("admin.instance.new", _query=self.request.params)
+
+        return self._redirect("admin.instance", id_=ai.id)

--- a/lms/views/admin/application_instance/downgrade.py
+++ b/lms/views/admin/application_instance/downgrade.py
@@ -11,7 +11,7 @@ class DowngradeApplicationInstanceView(BaseApplicationInstanceView):
         permission=Permissions.ADMIN,
     )
     def downgrade_instance(self):
-        ai = self._get_ai_or_404(self.request.matchdict["id_"])
+        ai = self.application_instance
 
         if ai.lti_version != "1.3.0":
             self.request.session.flash(

--- a/lms/views/admin/application_instance/downgrade.py
+++ b/lms/views/admin/application_instance/downgrade.py
@@ -1,0 +1,31 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+from lms.views.admin.application_instance._core import BaseApplicationInstanceView
+
+
+class DowngradeApplicationInstanceView(BaseApplicationInstanceView):
+    @view_config(
+        route_name="admin.instance.downgrade",
+        request_method="POST",
+        permission=Permissions.ADMIN,
+    )
+    def downgrade_instance(self):
+        ai = self._get_ai_or_404(self.request.matchdict["id_"])
+
+        if ai.lti_version != "1.3.0":
+            self.request.session.flash(
+                f"Application instance: '{ai.id}' is not on LTI 1.3.", "errors"
+            )
+        elif not ai.consumer_key:
+            self.request.session.flash(
+                f"Application instance: '{ai.id}' doesn't have a consumer key to fallback to.",
+                "errors",
+            )
+        else:
+            ai.lti_registration_id = None
+            ai.deployment_id = None
+
+            self.request.session.flash("Downgraded LTI 1.1 successful", "messages")
+
+        return self._redirect("admin.instance", id_=ai.id)

--- a/lms/views/admin/application_instance/move_organization.py
+++ b/lms/views/admin/application_instance/move_organization.py
@@ -1,0 +1,31 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+from lms.validation import ValidationError
+from lms.views.admin.application_instance._core import BaseApplicationInstanceView
+
+
+class MoveOrgApplicationInstanceView(BaseApplicationInstanceView):
+    @view_config(
+        route_name="admin.instance.move_org",
+        request_method="POST",
+        require_csrf=True,
+        permission=Permissions.ADMIN,
+    )
+    def move_application_instance_org(self):
+        ai = self._get_ai_or_404(self.request.matchdict["id_"])
+
+        try:
+            self.application_instance_service.update_application_instance(
+                ai,
+                organization_public_id=self.request.params.get(
+                    "org_public_id", ""
+                ).strip(),
+            )
+            self.request.session.flash(
+                f"Updated application instance {ai.id}", "messages"
+            )
+        except ValidationError as err:
+            self.request.session.flash(err.messages, "validation")
+
+        return self._redirect("admin.instance", id_=ai.id)

--- a/lms/views/admin/application_instance/move_organization.py
+++ b/lms/views/admin/application_instance/move_organization.py
@@ -13,7 +13,7 @@ class MoveOrgApplicationInstanceView(BaseApplicationInstanceView):
         permission=Permissions.ADMIN,
     )
     def move_application_instance_org(self):
-        ai = self._get_ai_or_404(self.request.matchdict["id_"])
+        ai = self.application_instance
 
         try:
             self.application_instance_service.update_application_instance(

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -6,9 +6,16 @@ from lms.security import Permissions
 from lms.validation import PyramidRequestSchema
 from lms.views.admin import flash_validation
 from lms.views.admin._schemas import EmptyStringInt
-from lms.views.admin.application_instance.view import (
+from lms.views.admin.application_instance._core import (
+    AES_SECRET,
     APPLICATION_INSTANCE_SETTINGS,
-    APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+    BaseApplicationInstanceView,
+)
+
+APPLICATION_INSTANCE_SETTINGS_COLUMNS = tuple(
+    f"{group}.{key}"
+    for (group, key), type_ in sorted(APPLICATION_INSTANCE_SETTINGS.items())
+    if type_ != AES_SECRET
 )
 
 
@@ -26,19 +33,12 @@ class SearchApplicationInstanceSchema(PyramidRequestSchema):
 
 
 @view_defaults(
-    request_method="GET",
-    permission=Permissions.ADMIN,
     route_name="admin.instance.search",
     renderer="lms:templates/admin/application_instance/search.html.jinja2",
+    permission=Permissions.ADMIN,
 )
-class SearchApplicationInstanceViews:
-    def __init__(self, request):
-        self.request = request
-        self.application_instance_service = request.find_service(
-            name="application_instance"
-        )
-
-    @view_config()
+class SearchApplicationInstanceViews(BaseApplicationInstanceView):
+    @view_config(request_method="GET")
     def search_start(self):
         return {"settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS}
 

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -1,0 +1,78 @@
+from marshmallow import validate
+from pyramid.view import view_config, view_defaults
+from webargs import fields
+
+from lms.security import Permissions
+from lms.validation import PyramidRequestSchema
+from lms.views.admin import flash_validation
+from lms.views.admin._schemas import EmptyStringInt
+from lms.views.admin.application_instance.view import (
+    APPLICATION_INSTANCE_SETTINGS,
+    APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+)
+
+
+class SearchApplicationInstanceSchema(PyramidRequestSchema):
+    location = "form"
+
+    # Max value for postgres `integer` type
+    id = EmptyStringInt(required=False, validate=validate.Range(max=2147483647))
+    name = fields.Str(required=False)
+    consumer_key = fields.Str(required=False)
+    issuer = fields.Str(required=False)
+    client_id = fields.Str(required=False)
+    deployment_id = fields.Str(required=False)
+    tool_consumer_instance_guid = fields.Str(required=False)
+
+
+@view_defaults(
+    request_method="GET",
+    permission=Permissions.ADMIN,
+    route_name="admin.instance.search",
+    renderer="lms:templates/admin/application_instance/search.html.jinja2",
+)
+class SearchApplicationInstanceViews:
+    def __init__(self, request):
+        self.request = request
+        self.application_instance_service = request.find_service(
+            name="application_instance"
+        )
+
+    @view_config()
+    def search_start(self):
+        return {"settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS}
+
+    @view_config(request_method="POST", require_csrf=True)
+    def search_callback(self):
+        if flash_validation(self.request, SearchApplicationInstanceSchema):
+            return {}
+
+        settings = None
+        if settings_key := self.request.params.get("settings_key"):
+            if settings_value := self.request.params.get("settings_value"):
+                settings_value = APPLICATION_INSTANCE_SETTINGS.get(
+                    tuple(settings_key.split("."))
+                )(settings_value)
+            else:
+                settings_value = ...
+
+            settings = {settings_key: settings_value}
+
+        instances = self.application_instance_service.search(
+            id_=self.request.params.get("id"),
+            name=self.request.params.get("name"),
+            consumer_key=self.request.params.get("consumer_key"),
+            issuer=self.request.params.get("issuer"),
+            client_id=self.request.params.get("client_id"),
+            deployment_id=self.request.params.get("deployment_id"),
+            tool_consumer_instance_guid=self.request.params.get(
+                "tool_consumer_instance_guid"
+            ),
+            email=self.request.params.get("email"),
+            settings=settings,
+        )
+
+        return {
+            "instances": instances,
+            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+        }

--- a/lms/views/admin/application_instance/show.py
+++ b/lms/views/admin/application_instance/show.py
@@ -12,5 +12,4 @@ class ShowApplicationInstanceView(BaseApplicationInstanceView):
         request_method="GET",
     )
     def show_instance(self):
-        ai = self._get_ai_or_404(self.request.matchdict["id_"])
-        return {"instance": ai}
+        return {"instance": self.application_instance}

--- a/lms/views/admin/application_instance/show.py
+++ b/lms/views/admin/application_instance/show.py
@@ -1,0 +1,16 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+from lms.views.admin.application_instance._core import BaseApplicationInstanceView
+
+
+class ShowApplicationInstanceView(BaseApplicationInstanceView):
+    @view_config(
+        route_name="admin.instance",
+        renderer="lms:templates/admin/application_instance/show.html.jinja2",
+        permission=Permissions.ADMIN,
+        request_method="GET",
+    )
+    def show_instance(self):
+        ai = self._get_ai_or_404(self.request.matchdict["id_"])
+        return {"instance": ai}

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -38,7 +38,7 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
         permission=Permissions.ADMIN,
     )
     def update_instance(self):
-        ai = self._get_ai_or_404(self.request.matchdict["id_"])
+        ai = self.application_instance
 
         if flash_validation(self.request, UpdateApplicationInstanceSchema):
             # Looks like something went wrong!

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -2,6 +2,7 @@ from marshmallow import fields, validate
 from pyramid.settings import asbool
 from pyramid.view import view_config
 
+from lms.security import Permissions
 from lms.services.aes import AESService
 from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import flash_validation
@@ -24,7 +25,7 @@ class UpdateApplicationInstanceSchema(PyramidRequestSchema):
     developer_secret = fields.Str(required=False)
 
 
-class AdminApplicationInstanceViews(BaseApplicationInstanceView):
+class UpdateApplicationInstanceView(BaseApplicationInstanceView):
     def __init__(self, request):
         super().__init__(request)
 
@@ -32,13 +33,10 @@ class AdminApplicationInstanceViews(BaseApplicationInstanceView):
 
     @view_config(
         route_name="admin.instance",
-        renderer="lms:templates/admin/application_instance/show.html.jinja2",
+        request_method="POST",
+        require_csrf=True,
+        permission=Permissions.ADMIN,
     )
-    def show_instance(self):
-        ai = self._get_ai_or_404(self.request.matchdict["id_"])
-        return {"instance": ai}
-
-    @view_config(route_name="admin.instance", request_method="POST", require_csrf=True)
     def update_instance(self):
         ai = self._get_ai_or_404(self.request.matchdict["id_"])
 

--- a/lms/views/admin/application_instance/upgrade.py
+++ b/lms/views/admin/application_instance/upgrade.py
@@ -1,0 +1,97 @@
+from marshmallow import validate
+from pyramid.httpexceptions import HTTPClientError
+from pyramid.view import view_config, view_defaults
+from sqlalchemy.exc import IntegrityError
+from webargs import fields
+
+from lms.security import Permissions
+from lms.services import ApplicationInstanceNotFound, LTIRegistrationService
+from lms.validation._base import PyramidRequestSchema
+from lms.views.admin import flash_validation
+from lms.views.admin.application_instance._core import BaseApplicationInstanceView
+
+
+class UpgradeApplicationInstanceSchema(PyramidRequestSchema):
+    location = "form"
+
+    consumer_key = fields.Str(required=True, validate=validate.Length(min=1))
+    deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
+
+
+@view_defaults(permission=Permissions.ADMIN, route_name="admin.instance.upgrade")
+class UpgradeApplicationInstanceViews(BaseApplicationInstanceView):
+    def __init__(self, request):
+        super().__init__(request)
+
+        self.lti_registration_service: LTIRegistrationService = request.find_service(
+            LTIRegistrationService
+        )
+
+    @view_config(
+        request_method="GET",
+        renderer="lms:templates/admin/application_instance/upgrade.html.jinja2",
+    )
+    def upgrade_instance_start(self):
+        if lti_registration_id := self.request.params.get("lti_registration_id"):
+            lti_registration = self.lti_registration_service.get_by_id(
+                lti_registration_id.strip()
+            )
+        else:
+            # This shouldn't really happen, but belt and braces
+            raise HTTPClientError("`lti_registration_id` is required for an upgrade")
+
+        return dict(self.request.params, lti_registration=lti_registration)
+
+    @view_config(request_method="POST")
+    def upgrade_instance_callback(self):
+        if flash_validation(self.request, UpgradeApplicationInstanceSchema):
+            return self._redirect("admin.instance.upgrade", _query=self.request.params)
+
+        consumer_key = self.request.params["consumer_key"].strip()
+        deployment_id = self.request.params["deployment_id"].strip()
+
+        # Find the Application instance we are upgrading
+        try:
+            application_instance = (
+                self.application_instance_service.get_by_consumer_key(consumer_key)
+            )
+        except ApplicationInstanceNotFound:
+            self.request.session.flash(
+                f"Can't find application instance: '{consumer_key}' for upgrade.",
+                "errors",
+            )
+
+            return self._redirect("admin.instance.upgrade", _query=self.request.params)
+
+        # Don't allow to change instances that already on 1.3
+        if application_instance.lti_version == "1.3.0":
+            self.request.session.flash(
+                f"Application instance: '{consumer_key}' is already on LTI 1.3.",
+                "errors",
+            )
+
+            return self._redirect("admin.instance.upgrade", _query=self.request.params)
+        # Set the LTI1.3 values
+        application_instance.lti_registration = self.lti_registration_service.get_by_id(
+            self.request.params.get("lti_registration_id", "").strip()
+        )
+        application_instance.deployment_id = deployment_id
+        try:
+            # Flush here to find if we are making a duplicate in the process of
+            # upgrading
+            self.request.db.flush()
+
+        except IntegrityError:
+            # Leave a clean transaction, otherwise  we get a:
+            #   "PendingRollbackError: This Session's transaction has been
+            #   rolled back due to a previous exception during flush."
+            self.request.db.rollback()
+
+            self.request.session.flash(
+                f"Application instance with deployment_id: {self.request.params['deployment_id']} already exists",
+                "errors",
+            )
+
+            return self._redirect("admin.instance.upgrade", _query=self.request.params)
+
+        return self._redirect("admin.instance", id_=application_instance.id)

--- a/lms/views/admin/application_instance/view.py
+++ b/lms/views/admin/application_instance/view.py
@@ -3,7 +3,7 @@ from pyramid.settings import asbool
 from pyramid.view import view_config
 
 from lms.services.aes import AESService
-from lms.validation._base import PyramidRequestSchema, ValidationError
+from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import flash_validation
 from lms.views.admin.application_instance._core import (
     AES_SECRET,
@@ -37,29 +37,6 @@ class AdminApplicationInstanceViews(BaseApplicationInstanceView):
     def show_instance(self):
         ai = self._get_ai_or_404(self.request.matchdict["id_"])
         return {"instance": ai}
-
-    @view_config(
-        route_name="admin.instance.move_org",
-        request_method="POST",
-        require_csrf=True,
-    )
-    def move_application_instance_org(self):
-        ai = self._get_ai_or_404(self.request.matchdict["id_"])
-
-        try:
-            self.application_instance_service.update_application_instance(
-                ai,
-                organization_public_id=self.request.params.get(
-                    "org_public_id", ""
-                ).strip(),
-            )
-            self.request.session.flash(
-                f"Updated application instance {ai.id}", "messages"
-            )
-        except ValidationError as err:
-            self.request.session.flash(err.messages, "validation")
-
-        return self._redirect("admin.instance", id_=ai.id)
 
     @view_config(route_name="admin.instance", request_method="POST", require_csrf=True)
     def update_instance(self):

--- a/lms/views/admin/application_instance/view.py
+++ b/lms/views/admin/application_instance/view.py
@@ -30,27 +30,6 @@ class AdminApplicationInstanceViews(BaseApplicationInstanceView):
 
         self._aes_service = request.find_service(AESService)
 
-    @view_config(route_name="admin.instance.downgrade", request_method="POST")
-    def downgrade_instance(self):
-        ai = self._get_ai_or_404(self.request.matchdict["id_"])
-
-        if ai.lti_version != "1.3.0":
-            self.request.session.flash(
-                f"Application instance: '{ai.id}' is not on LTI 1.3.", "errors"
-            )
-        elif not ai.consumer_key:
-            self.request.session.flash(
-                f"Application instance: '{ai.id}' doesn't have a consumer key to fallback to.",
-                "errors",
-            )
-        else:
-            ai.lti_registration_id = None
-            ai.deployment_id = None
-
-            self.request.session.flash("Downgraded LTI 1.1 successful", "messages")
-
-        return self._redirect("admin.instance", id_=ai.id)
-
     @view_config(
         route_name="admin.instance",
         renderer="lms:templates/admin/application_instance/show.html.jinja2",

--- a/tests/functional/views/admin_test.py
+++ b/tests/functional/views/admin_test.py
@@ -1,5 +1,30 @@
-def test_admin_authentication_redirects_to_google(app):
-    response = app.get("/admin/instances/")
+import pytest
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    (
+        # Create
+        ("get", "/admin/instance/create"),
+        ("post", "/admin/instance/create"),
+        # Downgrade
+        ("post", "/admin/instance/1234/downgrade"),
+        # Move org
+        ("post", "/admin/instance/1234/move_org"),
+        # Search
+        ("get", "/admin/instances/"),
+        ("post", "/admin/instances/"),
+        # Show
+        ("get", "/admin/instance/1234/"),
+        # Update
+        ("post", "/admin/instance/1234/"),
+        # Upgrade
+        ("get", "/admin/instance/upgrade"),
+        ("post", "/admin/instance/upgrade"),
+    ),
+)
+def test_admin_authentication_redirects_to_google(app, method, path):
+    response = getattr(app, method)(path)
 
     assert response.status_code == 302
     assert response.location.startswith("http://localhost/googleauth/login")

--- a/tests/unit/lms/views/admin/application_instance/_core_test.py
+++ b/tests/unit/lms/views/admin/application_instance/_core_test.py
@@ -1,0 +1,29 @@
+from unittest.mock import sentinel
+
+import pytest
+from pyramid.httpexceptions import HTTPNotFound
+
+from lms.services import ApplicationInstanceNotFound
+from lms.views.admin.application_instance._core import BaseApplicationInstanceView
+
+
+@pytest.mark.usefixtures("application_instance_service")
+class TestBaseApplicationInstanceView:
+    def test_application_instance(
+        self, view, application_instance_service, ai_from_matchdict
+    ):
+        ai = view.application_instance
+
+        application_instance_service.get_by_id.assert_called_once_with(id_=sentinel.id_)
+
+        assert ai == ai_from_matchdict
+
+    @pytest.mark.usefixtures("ai_from_matchdict")
+    def test_application_instance_with_no_ai(self, view, application_instance_service):
+        application_instance_service.get_by_id.side_effect = ApplicationInstanceNotFound
+        with pytest.raises(HTTPNotFound):
+            assert view.application_instance
+
+    @pytest.fixture
+    def view(self, pyramid_request):
+        return BaseApplicationInstanceView(pyramid_request)

--- a/tests/unit/lms/views/admin/application_instance/conftest.py
+++ b/tests/unit/lms/views/admin/application_instance/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import sentinel
+
 import pytest
 
 from tests import factories
@@ -10,3 +12,13 @@ def with_lti_13_ai(application_instance, db_session):
     db_session.flush()
     application_instance.lti_registration_id = lti_registration.id
     application_instance.deployment_id = "ID"
+
+
+@pytest.fixture
+def ai_from_matchdict(
+    pyramid_request, application_instance_service, application_instance
+):
+    pyramid_request.matchdict["id_"] = sentinel.id_
+    application_instance_service.get_by_id.return_value = application_instance
+
+    return application_instance

--- a/tests/unit/lms/views/admin/application_instance/conftest.py
+++ b/tests/unit/lms/views/admin/application_instance/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from tests import factories
+
+
+@pytest.fixture
+def with_lti_13_ai(application_instance, db_session):
+    lti_registration = factories.LTIRegistration()
+    # Get a valid ID for the registration
+    db_session.flush()
+    application_instance.lti_registration_id = lti_registration.id
+    application_instance.deployment_id = "ID"

--- a/tests/unit/lms/views/admin/application_instance/create_test.py
+++ b/tests/unit/lms/views/admin/application_instance/create_test.py
@@ -6,15 +6,15 @@ from sqlalchemy.exc import IntegrityError
 from lms.models.public_id import InvalidPublicId
 from lms.views.admin.application_instance.create import CreateApplicationInstanceViews
 
-REDIRECT_TO_NEW_AI = Any.instance_of(HTTPFound).with_attrs(
-    {"location": Any.string.containing("/admin/instance/new")}
+REDIRECT_TO_CREATE_AI = Any.instance_of(HTTPFound).with_attrs(
+    {"location": Any.string.containing("/admin/instance/create")}
 )
 
 
 @pytest.mark.usefixtures("application_instance_service", "lti_registration_service")
 class TestCreateApplicationInstanceViews:
     @pytest.mark.parametrize("lti_registration_id", ("123", "  123   "))
-    def test_new_instance_start_v13(
+    def test_create_start_v13(
         self, views, pyramid_request, lti_registration_service, lti_registration_id
     ):
         pyramid_request.params = {
@@ -23,7 +23,7 @@ class TestCreateApplicationInstanceViews:
             "key_2": "value_2",
         }
 
-        response = views.new_instance_start()
+        response = views.create_start()
 
         lti_registration_service.get_by_id.assert_called_once_with("123")
         assert response == dict(
@@ -31,18 +31,18 @@ class TestCreateApplicationInstanceViews:
             lti_registration=lti_registration_service.get_by_id.return_value,
         )
 
-    def test_new_instance_start_v11(self, views, pyramid_request):
+    def test_create_start_v11(self, views, pyramid_request):
         pyramid_request.params["lti_registration_id"] = None
 
-        response = views.new_instance_start()
+        response = views.create_start()
 
         assert not response["lti_registration"]
 
-    @pytest.mark.usefixtures("ai_new_params_v13")
-    def test_new_instance_callback_v13(self, views, application_instance_service):
+    @pytest.mark.usefixtures("create_ai_params_v13")
+    def test_create_callback_v13(self, views, application_instance_service):
         application_instance_service.create_application_instance.return_value.id = 12345
 
-        response = views.new_instance_callback()
+        response = views.create_callback()
 
         application_instance_service.create_application_instance.assert_called_once_with(
             name="NAME",
@@ -58,26 +58,26 @@ class TestCreateApplicationInstanceViews:
             {"location": Any.string.containing("/admin/instance/12345")}
         )
 
-    @pytest.mark.usefixtures("ai_new_params_v11")
-    def test_new_instance_callback_v11(self, views):
-        response = views.new_instance_callback()
+    @pytest.mark.usefixtures("create_ai_params_v11")
+    def test_create_callback_v11(self, views):
+        response = views.create_callback()
 
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {"location": Any.string.containing("/admin/instance/")}
         )
 
-    @pytest.mark.usefixtures("ai_new_params_v13")
+    @pytest.mark.usefixtures("create_ai_params_v13")
     @pytest.mark.parametrize(
         "exception", (IntegrityError(Any(), Any(), Any()), InvalidPublicId)
     )
-    def test_new_instance_callback_with_errors(
+    def test_create_callback_with_errors(
         self, views, application_instance_service, exception
     ):
         application_instance_service.create_application_instance.side_effect = exception
 
-        response = views.new_instance_callback()
+        response = views.create_callback()
 
-        assert response == REDIRECT_TO_NEW_AI
+        assert response == REDIRECT_TO_CREATE_AI
 
     _V11_NEW_AI_BAD_FIELDS = [
         ("lms_url", "not a url"),
@@ -89,33 +89,33 @@ class TestCreateApplicationInstanceViews:
     @pytest.mark.parametrize(
         "param,bad_value", _V11_NEW_AI_BAD_FIELDS + [("deployment_id", None)]
     )
-    def test_new_instance_callback_v13_required_fields(
-        self, views, ai_new_params_v13, param, bad_value
+    def test_create_callback_v13_required_fields(
+        self, views, create_ai_params_v13, param, bad_value
     ):
-        ai_new_params_v13[param] = bad_value
+        create_ai_params_v13[param] = bad_value
 
-        response = views.new_instance_callback()
+        response = views.create_callback()
 
-        assert response == REDIRECT_TO_NEW_AI
+        assert response == REDIRECT_TO_CREATE_AI
 
     @pytest.mark.parametrize("param,bad_value", _V11_NEW_AI_BAD_FIELDS)
-    def test_new_instance_callback_v11_required_fields(
-        self, views, ai_new_params_v11, param, bad_value
+    def test_create_callback_v11_required_fields(
+        self, views, create_ai_params_v11, param, bad_value
     ):
-        ai_new_params_v11[param] = bad_value
+        create_ai_params_v11[param] = bad_value
 
-        response = views.new_instance_callback()
+        response = views.create_callback()
 
-        assert response == REDIRECT_TO_NEW_AI
-
-    @pytest.fixture
-    def ai_new_params_v13(self, ai_new_params_v11):
-        ai_new_params_v11["deployment_id"] = "  22222  "
-        ai_new_params_v11["lti_registration_id"] = "  54321 "
-        return ai_new_params_v11
+        assert response == REDIRECT_TO_CREATE_AI
 
     @pytest.fixture
-    def ai_new_params_v11(self, pyramid_request):
+    def create_ai_params_v13(self, create_ai_params_v11):
+        create_ai_params_v11["deployment_id"] = "  22222  "
+        create_ai_params_v11["lti_registration_id"] = "  54321 "
+        return create_ai_params_v11
+
+    @pytest.fixture
+    def create_ai_params_v11(self, pyramid_request):
         params = {
             "name": "  NAME  ",
             "lms_url": "http://example.com",

--- a/tests/unit/lms/views/admin/application_instance/create_test.py
+++ b/tests/unit/lms/views/admin/application_instance/create_test.py
@@ -1,0 +1,132 @@
+import pytest
+from h_matchers import Any
+from pyramid.httpexceptions import HTTPFound
+from sqlalchemy.exc import IntegrityError
+
+from lms.models.public_id import InvalidPublicId
+from lms.views.admin.application_instance.create import CreateApplicationInstanceViews
+
+REDIRECT_TO_NEW_AI = Any.instance_of(HTTPFound).with_attrs(
+    {"location": Any.string.containing("/admin/instance/new")}
+)
+
+
+@pytest.mark.usefixtures("application_instance_service", "lti_registration_service")
+class TestCreateApplicationInstanceViews:
+    @pytest.mark.parametrize("lti_registration_id", ("123", "  123   "))
+    def test_new_instance_start_v13(
+        self, views, pyramid_request, lti_registration_service, lti_registration_id
+    ):
+        pyramid_request.params = {
+            "lti_registration_id": lti_registration_id,
+            "key_1": "value_1",
+            "key_2": "value_2",
+        }
+
+        response = views.new_instance_start()
+
+        lti_registration_service.get_by_id.assert_called_once_with("123")
+        assert response == dict(
+            pyramid_request.params,
+            lti_registration=lti_registration_service.get_by_id.return_value,
+        )
+
+    def test_new_instance_start_v11(self, views, pyramid_request):
+        pyramid_request.params["lti_registration_id"] = None
+
+        response = views.new_instance_start()
+
+        assert not response["lti_registration"]
+
+    @pytest.mark.usefixtures("ai_new_params_v13")
+    def test_new_instance_callback_v13(self, views, application_instance_service):
+        application_instance_service.create_application_instance.return_value.id = 12345
+
+        response = views.new_instance_callback()
+
+        application_instance_service.create_application_instance.assert_called_once_with(
+            name="NAME",
+            lms_url="http://example.com",
+            email="test@example.com",
+            deployment_id="22222",
+            developer_key="DEVELOPER_KEY",
+            developer_secret="DEVELOPER_SECRET",
+            organization_public_id="us.lms.org.ID",
+            lti_registration_id=54321,
+        )
+        assert response == Any.instance_of(HTTPFound).with_attrs(
+            {"location": Any.string.containing("/admin/instance/12345")}
+        )
+
+    @pytest.mark.usefixtures("ai_new_params_v11")
+    def test_new_instance_callback_v11(self, views):
+        response = views.new_instance_callback()
+
+        assert response == Any.instance_of(HTTPFound).with_attrs(
+            {"location": Any.string.containing("/admin/instance/")}
+        )
+
+    @pytest.mark.usefixtures("ai_new_params_v13")
+    @pytest.mark.parametrize(
+        "exception", (IntegrityError(Any(), Any(), Any()), InvalidPublicId)
+    )
+    def test_new_instance_callback_with_errors(
+        self, views, application_instance_service, exception
+    ):
+        application_instance_service.create_application_instance.side_effect = exception
+
+        response = views.new_instance_callback()
+
+        assert response == REDIRECT_TO_NEW_AI
+
+    _V11_NEW_AI_BAD_FIELDS = [
+        ("lms_url", "not a url"),
+        ("email", "not an email"),
+        ("organization_public_id", None),
+        ("name", None),
+    ]
+
+    @pytest.mark.parametrize(
+        "param,bad_value", _V11_NEW_AI_BAD_FIELDS + [("deployment_id", None)]
+    )
+    def test_new_instance_callback_v13_required_fields(
+        self, views, ai_new_params_v13, param, bad_value
+    ):
+        ai_new_params_v13[param] = bad_value
+
+        response = views.new_instance_callback()
+
+        assert response == REDIRECT_TO_NEW_AI
+
+    @pytest.mark.parametrize("param,bad_value", _V11_NEW_AI_BAD_FIELDS)
+    def test_new_instance_callback_v11_required_fields(
+        self, views, ai_new_params_v11, param, bad_value
+    ):
+        ai_new_params_v11[param] = bad_value
+
+        response = views.new_instance_callback()
+
+        assert response == REDIRECT_TO_NEW_AI
+
+    @pytest.fixture
+    def ai_new_params_v13(self, ai_new_params_v11):
+        ai_new_params_v11["deployment_id"] = "  22222  "
+        ai_new_params_v11["lti_registration_id"] = "  54321 "
+        return ai_new_params_v11
+
+    @pytest.fixture
+    def ai_new_params_v11(self, pyramid_request):
+        params = {
+            "name": "  NAME  ",
+            "lms_url": "http://example.com",
+            "email": "test@example.com",
+            "developer_key": "DEVELOPER_KEY",
+            "developer_secret": "DEVELOPER_SECRET",
+            "organization_public_id": "   us.lms.org.ID   ",
+        }
+        pyramid_request.POST = pyramid_request.params = params
+        return params
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return CreateApplicationInstanceViews(pyramid_request)

--- a/tests/unit/lms/views/admin/application_instance/downgrade_test.py
+++ b/tests/unit/lms/views/admin/application_instance/downgrade_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+from lms.views.admin.application_instance.downgrade import (
+    DowngradeApplicationInstanceView,
+)
+from tests.matchers import temporary_redirect_to
+
+
+@pytest.mark.usefixtures("application_instance_service")
+class TestDowngradeApplicationInstanceView:
+    @pytest.mark.usefixtures("with_lti_13_ai")
+    def test_downgrade_instance(self, view, pyramid_request, ai_from_matchdict):
+        response = view.downgrade_instance()
+
+        assert not ai_from_matchdict.lti_registration_id
+        assert not ai_from_matchdict.deployment_id
+        assert response == temporary_redirect_to(
+            pyramid_request.route_url("admin.instance", id_=ai_from_matchdict.id)
+        )
+
+    @pytest.mark.usefixtures("ai_from_matchdict")
+    def test_downgrade_instance_no_lti13(self, view, pyramid_request):
+        view.downgrade_instance()
+
+        assert pyramid_request.session.peek_flash("errors")
+
+    @pytest.mark.usefixtures("with_lti_13_ai")
+    def test_downgrade_instance_no_consumer_key(
+        self, view, pyramid_request, ai_from_matchdict
+    ):
+        ai_from_matchdict.consumer_key = None
+
+        view.downgrade_instance()
+
+        assert pyramid_request.session.peek_flash("errors")
+
+    @pytest.fixture
+    def view(self, pyramid_request):
+        return DowngradeApplicationInstanceView(pyramid_request)

--- a/tests/unit/lms/views/admin/application_instance/move_organization_test.py
+++ b/tests/unit/lms/views/admin/application_instance/move_organization_test.py
@@ -1,0 +1,49 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.validation import ValidationError
+from lms.views.admin.application_instance.move_organization import (
+    MoveOrgApplicationInstanceView,
+)
+from tests.matchers import temporary_redirect_to
+
+
+@pytest.mark.usefixtures("application_instance_service")
+class TestAdminApplicationInstanceViews:
+    def test_move_application_instance_org(
+        self, view, pyramid_request, ai_from_matchdict, application_instance_service
+    ):
+        pyramid_request.params["org_public_id"] = "PUBLIC_ID"
+
+        response = view.move_application_instance_org()
+
+        application_instance_service.update_application_instance.assert_called_once_with(
+            ai_from_matchdict, organization_public_id="PUBLIC_ID"
+        )
+        assert response == temporary_redirect_to(
+            pyramid_request.route_url("admin.instance", id_=ai_from_matchdict.id)
+        )
+
+    @pytest.mark.usefixtures("ai_from_matchdict")
+    def test_move_application_instance_org_invalid_organization_id(
+        self, view, pyramid_request, application_instance_service
+    ):
+        pyramid_request.params["org_public_id"] = "PUBLIC_ID"
+        application_instance_service.update_application_instance.side_effect = (
+            ValidationError(messages=sentinel.messages)
+        )
+
+        response = view.move_application_instance_org()
+
+        assert pyramid_request.session.peek_flash("validation")
+        assert response == temporary_redirect_to(
+            pyramid_request.route_url(
+                "admin.instance",
+                id_=application_instance_service.get_by_id.return_value.id,
+            )
+        )
+
+    @pytest.fixture
+    def view(self, pyramid_request):
+        return MoveOrgApplicationInstanceView(pyramid_request)

--- a/tests/unit/lms/views/admin/application_instance/search_test.py
+++ b/tests/unit/lms/views/admin/application_instance/search_test.py
@@ -1,8 +1,8 @@
 import pytest
 
-from lms.views.admin.application_instance.search import SearchApplicationInstanceViews
-from lms.views.admin.application_instance.view import (
+from lms.views.admin.application_instance.search import (
     APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+    SearchApplicationInstanceViews,
 )
 
 

--- a/tests/unit/lms/views/admin/application_instance/search_test.py
+++ b/tests/unit/lms/views/admin/application_instance/search_test.py
@@ -1,0 +1,86 @@
+import pytest
+
+from lms.views.admin.application_instance.search import SearchApplicationInstanceViews
+from lms.views.admin.application_instance.view import (
+    APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+)
+
+
+@pytest.mark.usefixtures("application_instance_service")
+class TestSearchApplicationInstanceViews:
+    def test_search_start(self, views):
+        assert views.search_start() == {
+            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS
+        }
+
+    def test_search_callback(
+        self, pyramid_request, application_instance_service, views
+    ):
+        pyramid_request.params = pyramid_request.POST = {
+            "id": "1",
+            "name": "NAME",
+            "consumer_key": "CONSUMER_KEY",
+            "issuer": "ISSUER",
+            "client_id": "CLIENT_ID",
+            "deployment_id": "DEPLOYMENT_ID",
+            "tool_consumer_instance_guid": "TOOL_CONSUMER_INSTANCE_GUID",
+            "email": "EMAIL",
+        }
+
+        response = views.search_callback()
+
+        application_instance_service.search.assert_called_once_with(
+            id_="1",
+            name="NAME",
+            consumer_key="CONSUMER_KEY",
+            issuer="ISSUER",
+            client_id="CLIENT_ID",
+            deployment_id="DEPLOYMENT_ID",
+            tool_consumer_instance_guid="TOOL_CONSUMER_INSTANCE_GUID",
+            email="EMAIL",
+            settings=None,
+        )
+        assert response == {
+            "instances": application_instance_service.search.return_value,
+            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+        }
+
+    @pytest.mark.parametrize(
+        "settings_key,settings_value,expected",
+        (
+            ("jstor.enabled", "True", {"jstor.enabled": True}),
+            ("jstor.enabled", "1", {"jstor.enabled": True}),
+            ("jstor.enabled", "0", {"jstor.enabled": False}),
+            ("jstor.enabled", "", {"jstor.enabled": ...}),
+            ("jstor.site_code", "True", {"jstor.site_code": "True"}),
+        ),
+    )
+    def test_search_callback_with_settings(
+        self,
+        views,
+        pyramid_request,
+        application_instance_service,
+        settings_key,
+        settings_value,
+        expected,
+    ):
+        pyramid_request.params = pyramid_request.POST = {
+            "settings_key": settings_key,
+            "settings_value": settings_value,
+        }
+
+        views.search_callback()
+
+        assert (
+            application_instance_service.search.call_args.kwargs["settings"] == expected
+        )
+
+    def test_search_callback_invalid(self, views, pyramid_request):
+        pyramid_request.POST = {"id": "not a number"}
+
+        assert not views.search_callback()
+        assert pyramid_request.session.peek_flash
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return SearchApplicationInstanceViews(pyramid_request)

--- a/tests/unit/lms/views/admin/application_instance/show_test.py
+++ b/tests/unit/lms/views/admin/application_instance/show_test.py
@@ -1,7 +1,5 @@
 import pytest
-from pyramid.httpexceptions import HTTPNotFound
 
-from lms.services import ApplicationInstanceNotFound
 from lms.views.admin.application_instance.show import ShowApplicationInstanceView
 
 
@@ -11,13 +9,6 @@ class TestAdminApplicationInstanceViews:
         response = view.show_instance()
 
         assert response["instance"].id == ai_from_matchdict.id
-
-    @pytest.mark.usefixtures("ai_from_matchdict")
-    def test_show_instance_not_found(self, view, application_instance_service):
-        application_instance_service.get_by_id.side_effect = ApplicationInstanceNotFound
-
-        with pytest.raises(HTTPNotFound):
-            view.show_instance()
 
     @pytest.fixture
     def view(self, pyramid_request):

--- a/tests/unit/lms/views/admin/application_instance/show_test.py
+++ b/tests/unit/lms/views/admin/application_instance/show_test.py
@@ -1,0 +1,24 @@
+import pytest
+from pyramid.httpexceptions import HTTPNotFound
+
+from lms.services import ApplicationInstanceNotFound
+from lms.views.admin.application_instance.show import ShowApplicationInstanceView
+
+
+@pytest.mark.usefixtures("application_instance_service")
+class TestAdminApplicationInstanceViews:
+    def test_show_instance_id(self, view, ai_from_matchdict):
+        response = view.show_instance()
+
+        assert response["instance"].id == ai_from_matchdict.id
+
+    @pytest.mark.usefixtures("ai_from_matchdict")
+    def test_show_instance_not_found(self, view, application_instance_service):
+        application_instance_service.get_by_id.side_effect = ApplicationInstanceNotFound
+
+        with pytest.raises(HTTPNotFound):
+            view.show_instance()
+
+    @pytest.fixture
+    def view(self, pyramid_request):
+        return ShowApplicationInstanceView(pyramid_request)

--- a/tests/unit/lms/views/admin/application_instance/update_test.py
+++ b/tests/unit/lms/views/admin/application_instance/update_test.py
@@ -4,26 +4,12 @@ import pytest
 from pyramid.httpexceptions import HTTPNotFound
 
 from lms.services import ApplicationInstanceNotFound
-from lms.views.admin.application_instance.view import AdminApplicationInstanceViews
+from lms.views.admin.application_instance.update import UpdateApplicationInstanceView
 from tests.matchers import temporary_redirect_to
 
 
-@pytest.mark.usefixtures(
-    "application_instance_service", "organization_service", "aes_service"
-)
-class TestAdminApplicationInstanceViews:
-    def test_show_instance_id(self, views, ai_from_matchdict):
-        response = views.show_instance()
-
-        assert response["instance"].id == ai_from_matchdict.id
-
-    @pytest.mark.usefixtures("ai_from_matchdict")
-    def test_show_instance_not_found(self, views, application_instance_service):
-        application_instance_service.get_by_id.side_effect = ApplicationInstanceNotFound
-
-        with pytest.raises(HTTPNotFound):
-            views.show_instance()
-
+@pytest.mark.usefixtures("application_instance_service", "aes_service")
+class TestUpdateApplicationInstanceView:
     @pytest.mark.usefixtures("with_minimal_fields_for_update")
     def test_update_instance(self, views, pyramid_request, ai_from_matchdict):
         response = views.update_instance()
@@ -160,4 +146,4 @@ class TestAdminApplicationInstanceViews:
 
     @pytest.fixture
     def views(self, pyramid_request):
-        return AdminApplicationInstanceViews(pyramid_request)
+        return UpdateApplicationInstanceView(pyramid_request)

--- a/tests/unit/lms/views/admin/application_instance/update_test.py
+++ b/tests/unit/lms/views/admin/application_instance/update_test.py
@@ -1,9 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from pyramid.httpexceptions import HTTPNotFound
 
-from lms.services import ApplicationInstanceNotFound
 from lms.views.admin.application_instance.update import UpdateApplicationInstanceView
 from tests.matchers import temporary_redirect_to
 
@@ -132,13 +130,6 @@ class TestUpdateApplicationInstanceView:
             ai_from_matchdict.settings.set_secret.assert_called_once_with(
                 aes_service, setting, sub_setting, "SECRET"
             )
-
-    @pytest.mark.usefixtures("ai_from_matchdict")
-    def test_update_instance_not_found(self, views, application_instance_service):
-        application_instance_service.get_by_id.side_effect = ApplicationInstanceNotFound
-
-        with pytest.raises(HTTPNotFound):
-            views.update_instance()
 
     @pytest.fixture
     def with_minimal_fields_for_update(self, pyramid_request):

--- a/tests/unit/lms/views/admin/application_instance/upgrade_test.py
+++ b/tests/unit/lms/views/admin/application_instance/upgrade_test.py
@@ -1,0 +1,126 @@
+import pytest
+from h_matchers import Any
+from pyramid.httpexceptions import HTTPClientError, HTTPFound
+
+from lms.models import ApplicationInstance
+from lms.services import ApplicationInstanceNotFound
+from lms.views.admin.application_instance.upgrade import UpgradeApplicationInstanceViews
+from tests import factories
+from tests.matchers import temporary_redirect_to
+
+REDIRECT_TO_UPGRADE_AI = Any.instance_of(HTTPFound).with_attrs(
+    {"location": Any.string.containing("/admin/instance/upgrade")}
+)
+
+
+@pytest.mark.usefixtures("application_instance_service", "lti_registration_service")
+class TestUpgradeApplicationInstanceViews:
+    @pytest.mark.parametrize("lti_registration_id", ("123", "  123   "))
+    def test_upgrade_instance_start(
+        self, views, pyramid_request, lti_registration_service, lti_registration_id
+    ):
+        pyramid_request.params = {
+            "lti_registration_id": lti_registration_id,
+            "key_1": "value_1",
+            "key_2": "value_2",
+        }
+
+        response = views.upgrade_instance_start()
+
+        lti_registration_service.get_by_id.assert_called_once_with("123")
+        assert response == dict(
+            pyramid_request.params,
+            lti_registration=lti_registration_service.get_by_id.return_value,
+        )
+
+    def test_upgrade_instance_start_with_no_registration_id(
+        self, views, pyramid_request
+    ):
+        pyramid_request.params.pop("lti_registration_id", None)
+
+        with pytest.raises(HTTPClientError):
+            views.upgrade_instance_start()
+
+    @pytest.mark.usefixtures("with_upgrade_form")
+    def test_upgrade_instance_callback(
+        self,
+        views,
+        pyramid_request,
+        application_instance,
+        application_instance_service,
+        lti_registration_service,
+    ):
+        lti_registration = factories.LTIRegistration()
+        lti_registration_service.get_by_id.return_value = lti_registration
+        assert not application_instance.lti_registration
+
+        response = views.upgrade_instance_callback()
+
+        application_instance_service.get_by_consumer_key.assert_called_once_with(
+            application_instance.consumer_key
+        )
+        assert application_instance.lti_registration == lti_registration
+        assert (
+            application_instance.deployment_id
+            == pyramid_request.params["deployment_id"]
+        )
+        assert response == temporary_redirect_to(
+            pyramid_request.route_url("admin.instance", id_=application_instance.id)
+        )
+
+    @pytest.mark.usefixtures("with_upgrade_form")
+    def test_upgrade_instance_callback_with_no_deployment_id(
+        self, views, pyramid_request
+    ):
+        del pyramid_request.POST["deployment_id"]
+
+        assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
+
+    @pytest.mark.usefixtures("with_upgrade_form", "with_lti_13_ai")
+    def test_upgrade_instance_callback_already_upgraded(self, views):
+        assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
+
+    @pytest.mark.usefixtures("with_upgrade_form")
+    def test_upgrade_instance_callback_with_duplicate(
+        self, views, db_session, lti_registration_service
+    ):
+        lti_registration = factories.LTIRegistration()
+        lti_registration_service.get_by_id.return_value = lti_registration
+        factories.ApplicationInstance(
+            lti_registration=lti_registration, deployment_id="DEPLOYMENT_ID"
+        )
+
+        response = views.upgrade_instance_callback()
+
+        assert response == REDIRECT_TO_UPGRADE_AI
+
+        # Show that the DB connection has not been permanently broken. This
+        # would cause us to fail completely when trying to present the error.
+        # We are checking we do _not_ raise `PendingRollbackError` here.
+        db_session.query(ApplicationInstance).all()
+
+    @pytest.mark.usefixtures("with_upgrade_form")
+    def test_upgrade_instance_callback_with_non_existent_instance(
+        self, views, application_instance_service
+    ):
+        application_instance_service.get_by_consumer_key.side_effect = (
+            ApplicationInstanceNotFound
+        )
+
+        assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
+
+    @pytest.fixture
+    def with_upgrade_form(self, pyramid_request, application_instance):
+        pyramid_request.POST = pyramid_request.params = {
+            "name": "NAME",
+            "lms_url": "http://lms-url.com",
+            "email": "test@email.com",
+            "deployment_id": "DEPLOYMENT_ID",
+            "consumer_key": application_instance.consumer_key,
+        }
+
+        return pyramid_request
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return UpgradeApplicationInstanceViews(pyramid_request)

--- a/tests/unit/lms/views/admin/application_instance/view_test.py
+++ b/tests/unit/lms/views/admin/application_instance/view_test.py
@@ -1,25 +1,16 @@
 from unittest.mock import patch, sentinel
 
 import pytest
-from pyramid.httpexceptions import HTTPClientError, HTTPFound, HTTPNotFound
+from pyramid.httpexceptions import HTTPNotFound
 
-from lms.models import ApplicationInstance
 from lms.services import ApplicationInstanceNotFound
 from lms.validation import ValidationError
 from lms.views.admin.application_instance.view import AdminApplicationInstanceViews
-from tests import factories
-from tests.matchers import Any, temporary_redirect_to
-
-REDIRECT_TO_UPGRADE_AI = Any.instance_of(HTTPFound).with_attrs(
-    {"location": Any.string.containing("/admin/instance/upgrade")}
-)
+from tests.matchers import temporary_redirect_to
 
 
 @pytest.mark.usefixtures(
-    "application_instance_service",
-    "lti_registration_service",
-    "organization_service",
-    "aes_service",
+    "application_instance_service", "organization_service", "aes_service"
 )
 class TestAdminApplicationInstanceViews:
     def test_move_application_instance_org(
@@ -80,100 +71,6 @@ class TestAdminApplicationInstanceViews:
         views.downgrade_instance()
 
         assert pyramid_request.session.peek_flash("errors")
-
-    @pytest.mark.parametrize("lti_registration_id", ("123", "  123   "))
-    def test_upgrade_instance_start(
-        self, views, pyramid_request, lti_registration_service, lti_registration_id
-    ):
-        pyramid_request.params = {
-            "lti_registration_id": lti_registration_id,
-            "key_1": "value_1",
-            "key_2": "value_2",
-        }
-
-        response = views.upgrade_instance_start()
-
-        lti_registration_service.get_by_id.assert_called_once_with("123")
-        assert response == dict(
-            pyramid_request.params,
-            lti_registration=lti_registration_service.get_by_id.return_value,
-        )
-
-    def test_upgrade_instance_start_with_no_registration_id(
-        self, views, pyramid_request
-    ):
-        pyramid_request.params.pop("lti_registration_id", None)
-
-        with pytest.raises(HTTPClientError):
-            views.upgrade_instance_start()
-
-    @pytest.mark.usefixtures("with_upgrade_form")
-    def test_upgrade_instance_callback(
-        self,
-        views,
-        pyramid_request,
-        application_instance,
-        application_instance_service,
-        lti_registration_service,
-    ):
-        lti_registration = factories.LTIRegistration()
-        lti_registration_service.get_by_id.return_value = lti_registration
-        assert not application_instance.lti_registration
-
-        response = views.upgrade_instance_callback()
-
-        application_instance_service.get_by_consumer_key.assert_called_once_with(
-            application_instance.consumer_key
-        )
-        assert application_instance.lti_registration == lti_registration
-        assert (
-            application_instance.deployment_id
-            == pyramid_request.params["deployment_id"]
-        )
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url("admin.instance", id_=application_instance.id)
-        )
-
-    @pytest.mark.usefixtures("with_upgrade_form")
-    def test_upgrade_instance_callback_with_no_deployment_id(
-        self, views, pyramid_request
-    ):
-        del pyramid_request.POST["deployment_id"]
-
-        assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
-
-    @pytest.mark.usefixtures("with_upgrade_form", "with_lti_13_ai")
-    def test_upgrade_instance_callback_already_upgraded(self, views):
-        assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
-
-    @pytest.mark.usefixtures("with_upgrade_form")
-    def test_upgrade_instance_callback_with_duplicate(
-        self, views, db_session, lti_registration_service
-    ):
-        lti_registration = factories.LTIRegistration()
-        lti_registration_service.get_by_id.return_value = lti_registration
-        factories.ApplicationInstance(
-            lti_registration=lti_registration, deployment_id="DEPLOYMENT_ID"
-        )
-
-        response = views.upgrade_instance_callback()
-
-        assert response == REDIRECT_TO_UPGRADE_AI
-
-        # Show that the DB connection has not been permanently broken. This
-        # would cause us to fail completely when trying to present the error.
-        # We are checking we do _not_ raise `PendingRollbackError` here.
-        db_session.query(ApplicationInstance).all()
-
-    @pytest.mark.usefixtures("with_upgrade_form")
-    def test_upgrade_instance_callback_with_non_existent_instance(
-        self, views, application_instance_service
-    ):
-        application_instance_service.get_by_consumer_key.side_effect = (
-            ApplicationInstanceNotFound
-        )
-
-        assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
 
     def test_show_instance_id(self, views, ai_from_matchdict):
         response = views.show_instance()
@@ -325,18 +222,6 @@ class TestAdminApplicationInstanceViews:
         application_instance_service.get_by_id.return_value = application_instance
 
         return application_instance
-
-    @pytest.fixture
-    def with_upgrade_form(self, pyramid_request, application_instance):
-        pyramid_request.POST = pyramid_request.params = {
-            "name": "NAME",
-            "lms_url": "http://lms-url.com",
-            "email": "test@email.com",
-            "deployment_id": "DEPLOYMENT_ID",
-            "consumer_key": application_instance.consumer_key,
-        }
-
-        return pyramid_request
 
     @pytest.fixture
     def with_minimal_fields_for_update(self, pyramid_request):

--- a/tests/unit/lms/views/admin/application_instance/view_test.py
+++ b/tests/unit/lms/views/admin/application_instance/view_test.py
@@ -46,32 +46,6 @@ class TestAdminApplicationInstanceViews:
             )
         )
 
-    @pytest.mark.usefixtures("with_lti_13_ai")
-    def test_downgrade_instance(self, views, pyramid_request, ai_from_matchdict):
-        response = views.downgrade_instance()
-
-        assert not ai_from_matchdict.lti_registration_id
-        assert not ai_from_matchdict.deployment_id
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url("admin.instance", id_=ai_from_matchdict.id)
-        )
-
-    @pytest.mark.usefixtures("ai_from_matchdict")
-    def test_downgrade_instance_no_lti13(self, views, pyramid_request):
-        views.downgrade_instance()
-
-        assert pyramid_request.session.peek_flash("errors")
-
-    @pytest.mark.usefixtures("with_lti_13_ai")
-    def test_downgrade_instance_no_consumer_key(
-        self, views, pyramid_request, ai_from_matchdict
-    ):
-        ai_from_matchdict.consumer_key = None
-
-        views.downgrade_instance()
-
-        assert pyramid_request.session.peek_flash("errors")
-
     def test_show_instance_id(self, views, ai_from_matchdict):
         response = views.show_instance()
 
@@ -213,15 +187,6 @@ class TestAdminApplicationInstanceViews:
 
         with pytest.raises(HTTPNotFound):
             views.update_instance()
-
-    @pytest.fixture
-    def ai_from_matchdict(
-        self, pyramid_request, application_instance_service, application_instance
-    ):
-        pyramid_request.matchdict["id_"] = sentinel.id_
-        application_instance_service.get_by_id.return_value = application_instance
-
-        return application_instance
 
     @pytest.fixture
     def with_minimal_fields_for_update(self, pyramid_request):

--- a/tests/unit/lms/views/admin/application_instance/view_test.py
+++ b/tests/unit/lms/views/admin/application_instance/view_test.py
@@ -8,10 +8,7 @@ from lms.models import ApplicationInstance
 from lms.models.public_id import InvalidPublicId
 from lms.services import ApplicationInstanceNotFound
 from lms.validation import ValidationError
-from lms.views.admin.application_instance import (
-    APPLICATION_INSTANCE_SETTINGS_COLUMNS,
-    AdminApplicationInstanceViews,
-)
+from lms.views.admin.application_instance.view import AdminApplicationInstanceViews
 from tests import factories
 from tests.matchers import Any, temporary_redirect_to
 
@@ -278,79 +275,6 @@ class TestAdminApplicationInstanceViews:
         )
 
         assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
-
-    def test_search_start(self, views):
-        assert views.search_start() == {
-            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS
-        }
-
-    def test_search_callback(
-        self, pyramid_request, application_instance_service, views
-    ):
-        pyramid_request.params = pyramid_request.POST = {
-            "id": "1",
-            "name": "NAME",
-            "consumer_key": "CONSUMER_KEY",
-            "issuer": "ISSUER",
-            "client_id": "CLIENT_ID",
-            "deployment_id": "DEPLOYMENT_ID",
-            "tool_consumer_instance_guid": "TOOL_CONSUMER_INSTANCE_GUID",
-            "email": "EMAIL",
-        }
-
-        response = views.search_callback()
-
-        application_instance_service.search.assert_called_once_with(
-            id_="1",
-            name="NAME",
-            consumer_key="CONSUMER_KEY",
-            issuer="ISSUER",
-            client_id="CLIENT_ID",
-            deployment_id="DEPLOYMENT_ID",
-            tool_consumer_instance_guid="TOOL_CONSUMER_INSTANCE_GUID",
-            email="EMAIL",
-            settings=None,
-        )
-        assert response == {
-            "instances": application_instance_service.search.return_value,
-            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS,
-        }
-
-    @pytest.mark.parametrize(
-        "settings_key,settings_value,expected",
-        (
-            ("jstor.enabled", "True", {"jstor.enabled": True}),
-            ("jstor.enabled", "1", {"jstor.enabled": True}),
-            ("jstor.enabled", "0", {"jstor.enabled": False}),
-            ("jstor.enabled", "", {"jstor.enabled": ...}),
-            ("jstor.site_code", "True", {"jstor.site_code": "True"}),
-        ),
-    )
-    def test_search_callback_with_settings(
-        self,
-        views,
-        pyramid_request,
-        application_instance_service,
-        settings_key,
-        settings_value,
-        expected,
-    ):
-        pyramid_request.params = pyramid_request.POST = {
-            "settings_key": settings_key,
-            "settings_value": settings_value,
-        }
-
-        views.search_callback()
-
-        assert (
-            application_instance_service.search.call_args.kwargs["settings"] == expected
-        )
-
-    def test_search_callback_invalid(self, views, pyramid_request):
-        pyramid_request.POST = {"id": "not a number"}
-
-        assert not views.search_callback()
-        assert pyramid_request.session.peek_flash
 
     def test_show_instance_id(self, views, ai_from_matchdict):
         response = views.show_instance()

--- a/tests/unit/lms/views/admin/application_instance/view_test.py
+++ b/tests/unit/lms/views/admin/application_instance/view_test.py
@@ -1,10 +1,9 @@
-from unittest.mock import patch, sentinel
+from unittest.mock import patch
 
 import pytest
 from pyramid.httpexceptions import HTTPNotFound
 
 from lms.services import ApplicationInstanceNotFound
-from lms.validation import ValidationError
 from lms.views.admin.application_instance.view import AdminApplicationInstanceViews
 from tests.matchers import temporary_redirect_to
 
@@ -13,39 +12,6 @@ from tests.matchers import temporary_redirect_to
     "application_instance_service", "organization_service", "aes_service"
 )
 class TestAdminApplicationInstanceViews:
-    def test_move_application_instance_org(
-        self, views, pyramid_request, ai_from_matchdict, application_instance_service
-    ):
-        pyramid_request.params["org_public_id"] = "PUBLIC_ID"
-
-        response = views.move_application_instance_org()
-
-        application_instance_service.update_application_instance.assert_called_once_with(
-            ai_from_matchdict, organization_public_id="PUBLIC_ID"
-        )
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url("admin.instance", id_=ai_from_matchdict.id)
-        )
-
-    @pytest.mark.usefixtures("ai_from_matchdict")
-    def test_move_application_instance_org_invalid_organization_id(
-        self, views, pyramid_request, application_instance_service
-    ):
-        pyramid_request.params["org_public_id"] = "PUBLIC_ID"
-        application_instance_service.update_application_instance.side_effect = (
-            ValidationError(messages=sentinel.messages)
-        )
-
-        response = views.move_application_instance_org()
-
-        assert pyramid_request.session.peek_flash("validation")
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url(
-                "admin.instance",
-                id_=application_instance_service.get_by_id.return_value.id,
-            )
-        )
-
     def test_show_instance_id(self, views, ai_from_matchdict):
         response = views.show_instance()
 

--- a/tests/unit/lms/views/admin/application_instance/view_test.py
+++ b/tests/unit/lms/views/admin/application_instance/view_test.py
@@ -2,19 +2,13 @@ from unittest.mock import patch, sentinel
 
 import pytest
 from pyramid.httpexceptions import HTTPClientError, HTTPFound, HTTPNotFound
-from sqlalchemy.exc import IntegrityError
 
 from lms.models import ApplicationInstance
-from lms.models.public_id import InvalidPublicId
 from lms.services import ApplicationInstanceNotFound
 from lms.validation import ValidationError
 from lms.views.admin.application_instance.view import AdminApplicationInstanceViews
 from tests import factories
 from tests.matchers import Any, temporary_redirect_to
-
-REDIRECT_TO_NEW_AI = Any.instance_of(HTTPFound).with_attrs(
-    {"location": Any.string.containing("/admin/instance/new")}
-)
 
 REDIRECT_TO_UPGRADE_AI = Any.instance_of(HTTPFound).with_attrs(
     {"location": Any.string.containing("/admin/instance/upgrade")}
@@ -28,101 +22,6 @@ REDIRECT_TO_UPGRADE_AI = Any.instance_of(HTTPFound).with_attrs(
     "aes_service",
 )
 class TestAdminApplicationInstanceViews:
-    @pytest.mark.parametrize("lti_registration_id", ("123", "  123   "))
-    def test_new_instance_start_v13(
-        self, views, pyramid_request, lti_registration_service, lti_registration_id
-    ):
-        pyramid_request.params = {
-            "lti_registration_id": lti_registration_id,
-            "key_1": "value_1",
-            "key_2": "value_2",
-        }
-
-        response = views.new_instance_start()
-
-        lti_registration_service.get_by_id.assert_called_once_with("123")
-        assert response == dict(
-            pyramid_request.params,
-            lti_registration=lti_registration_service.get_by_id.return_value,
-        )
-
-    def test_new_instance_start_v11(self, views, pyramid_request):
-        pyramid_request.params["lti_registration_id"] = None
-
-        response = views.new_instance_start()
-
-        assert not response["lti_registration"]
-
-    @pytest.mark.usefixtures("ai_new_params_v13")
-    def test_new_instance_callback_v13(self, views, application_instance_service):
-        application_instance_service.create_application_instance.return_value.id = 12345
-
-        response = views.new_instance_callback()
-
-        application_instance_service.create_application_instance.assert_called_once_with(
-            name="NAME",
-            lms_url="http://example.com",
-            email="test@example.com",
-            deployment_id="22222",
-            developer_key="DEVELOPER_KEY",
-            developer_secret="DEVELOPER_SECRET",
-            organization_public_id="us.lms.org.ID",
-            lti_registration_id=54321,
-        )
-        assert response == Any.instance_of(HTTPFound).with_attrs(
-            {"location": Any.string.containing("/admin/instance/12345")}
-        )
-
-    @pytest.mark.usefixtures("ai_new_params_v11")
-    def test_new_instance_callback_v11(self, views):
-        response = views.new_instance_callback()
-
-        assert response == Any.instance_of(HTTPFound).with_attrs(
-            {"location": Any.string.containing("/admin/instance/")}
-        )
-
-    @pytest.mark.usefixtures("ai_new_params_v13")
-    @pytest.mark.parametrize(
-        "exception", (IntegrityError(Any(), Any(), Any()), InvalidPublicId)
-    )
-    def test_new_instance_callback_with_errors(
-        self, views, application_instance_service, exception
-    ):
-        application_instance_service.create_application_instance.side_effect = exception
-
-        response = views.new_instance_callback()
-
-        assert response == REDIRECT_TO_NEW_AI
-
-    _V11_NEW_AI_BAD_FIELDS = [
-        ("lms_url", "not a url"),
-        ("email", "not an email"),
-        ("organization_public_id", None),
-        ("name", None),
-    ]
-
-    @pytest.mark.parametrize(
-        "param,bad_value", _V11_NEW_AI_BAD_FIELDS + [("deployment_id", None)]
-    )
-    def test_new_instance_callback_v13_required_fields(
-        self, views, ai_new_params_v13, param, bad_value
-    ):
-        ai_new_params_v13[param] = bad_value
-
-        response = views.new_instance_callback()
-
-        assert response == REDIRECT_TO_NEW_AI
-
-    @pytest.mark.parametrize("param,bad_value", _V11_NEW_AI_BAD_FIELDS)
-    def test_new_instance_callback_v11_required_fields(
-        self, views, ai_new_params_v11, param, bad_value
-    ):
-        ai_new_params_v11[param] = bad_value
-
-        response = views.new_instance_callback()
-
-        assert response == REDIRECT_TO_NEW_AI
-
     def test_move_application_instance_org(
         self, views, pyramid_request, ai_from_matchdict, application_instance_service
     ):
@@ -426,33 +325,6 @@ class TestAdminApplicationInstanceViews:
         application_instance_service.get_by_id.return_value = application_instance
 
         return application_instance
-
-    @pytest.fixture
-    def ai_new_params_v13(self, ai_new_params_v11):
-        ai_new_params_v11["deployment_id"] = "  22222  "
-        ai_new_params_v11["lti_registration_id"] = "  54321 "
-        return ai_new_params_v11
-
-    @pytest.fixture
-    def ai_new_params_v11(self, pyramid_request):
-        params = {
-            "name": "  NAME  ",
-            "lms_url": "http://example.com",
-            "email": "test@example.com",
-            "developer_key": "DEVELOPER_KEY",
-            "developer_secret": "DEVELOPER_SECRET",
-            "organization_public_id": "   us.lms.org.ID   ",
-        }
-        pyramid_request.POST = pyramid_request.params = params
-        return params
-
-    @pytest.fixture
-    def with_lti_13_ai(self, application_instance, db_session):
-        lti_registration = factories.LTIRegistration()
-        # Get a valid ID for the registration
-        db_session.flush()
-        application_instance.lti_registration_id = lti_registration.id
-        application_instance.deployment_id = "ID"
 
     @pytest.fixture
     def with_upgrade_form(self, pyramid_request, application_instance):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4998

Changes in this PR:

 * The existing views are split off into their own classes
     * Tests have been split up too
     * This results in more lines overall, but each is much smaller and easier to read
 * A small base class for the views has been introduced
    * This changed the `_get_ai_or_404` into a property `application_instance`
  * New has been renamed to "create" to be more CRUD'y
  * Expanded the functional tests to hit all of the end-points to ensure we have the new classes covered by the admin permission

The idea here is that the search is about to get more complicated, and it would be good to not bloat the already huge files.