### PR TITLE
`FilePickerApp` design updates, part 1: "Chrome"/layout structure

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -28,6 +28,8 @@ gulp.task('watch-css', () => {
     [
       './lms/static/styles/**/*.{css,scss}',
       './lms/static/scripts/frontend_apps/**/*.js',
+      './lms/static/scripts/frontend_apps/**/*.ts',
+      './lms/static/scripts/frontend_apps/**/*.tsx',
       './lms/static/scripts/ui-playground/**/*.js',
     ],
     { ignoreInitial: false },

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -239,7 +239,7 @@ export default function ContentSelector({
     <>
       {isLoadingIndicatorVisible && <SpinnerOverlay />}
       <div className="flex flex-row p-y-2">
-        <div className="flex flex-col space-y-1.5">
+        <div className="flex flex-col space-y-1">
           <Button
             onClick={() => selectDialog('url')}
             variant="primary"

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -1,8 +1,12 @@
 import {
   Button,
+  Card,
   CardActions,
+  CardContent,
+  Scroll,
   SpinnerOverlay,
 } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import { useConfig } from '../config';
@@ -171,47 +175,96 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   );
 
   return (
-    <main>
+    <main
+      className={classnames(
+        // Full-width and -height light-grey background
+        'bg-grey-1 w-full h-full p-2'
+      )}
+    >
+      {/*
+       * The <form> is styled as a constraining container that determines
+       * the Card's dimensions
+       */}
       <form
-        className="grid grid-cols-[auto_1fr] gap-4 w-[500px] max-w-[80vw] mx-auto mt-4"
         action={formAction}
+        className={classnames(
+          // Preferred width of 640px, not to exceed 80vw
+          'w-[640px] max-w-[80vw]',
+          // Constrain Card height to the height of this container
+          'flex flex-col min-h-0 h-full',
+          // Center the Card horizontally
+          'mx-auto'
+        )}
         method="POST"
         onSubmit={onSubmit}
       >
-        <h1 className="col-span-2 text-2xl font-bold">Assignment details</h1>
-        <div className="text-end">
-          <span className="font-bold">Assignment content</span>
-        </div>
-        <div className="space-y-3">
-          {content ? (
-            <i data-testid="content-summary" style="break-all">
-              {contentDescription(content)}
-            </i>
-          ) : (
-            <>
-              <p>
-                You can select content for your assignment from one of the
-                following sources:
-              </p>
-              <ContentSelector
-                onSelectContent={selectContent}
-                onError={setErrorInfo}
-              />
-            </>
+        <Card
+          classes={classnames(
+            // Ensure children that have overflow-scroll do not exceed the
+            // height constraints
+            'flex flex-col min-h-0'
           )}
-        </div>
-        {content && enableGroupConfig && (
-          <>
-            <div className="text-end">
-              <span className="font-bold">Group assignment</span>
-            </div>
-            <div>
-              <GroupConfigSelector
-                groupConfig={groupConfig}
-                onChangeGroupConfig={setGroupConfig}
-              />
-            </div>
-            <div className="col-span-2">
+        >
+          <div className="bg-slate-0 px-3 py-2 border-b border-slate-5">
+            <h1 className="text-xl text-slate-7 font-normal">
+              Assignment details
+            </h1>
+          </div>
+          <Scroll>
+            <CardContent size="lg">
+              <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-3">
+                <div className="text-end">
+                  <span className="font-medium text-sm leading-none text-slate-7">
+                    Assignment content
+                  </span>
+                </div>
+                <div className="space-y-3">
+                  {content ? (
+                    <i data-testid="content-summary" style="break-all">
+                      {contentDescription(content)}
+                    </i>
+                  ) : (
+                    <>
+                      <p>
+                        You can select content for your assignment from one of
+                        the following sources:
+                      </p>
+
+                      <ContentSelector
+                        onSelectContent={selectContent}
+                        onError={setErrorInfo}
+                      />
+                    </>
+                  )}
+                </div>
+                {content && enableGroupConfig && (
+                  <>
+                    <div className="col-span-2 border-b" />
+                    <div className="text-end">
+                      <span className="font-medium text-sm leading-none text-slate-7">
+                        Group assignment
+                      </span>
+                    </div>
+                    <div
+                      className={classnames(
+                        // Set a height on this container to give the group
+                        // <select> element room when it renders (avoid
+                        // changing the height of the Card later)
+                        'h-28'
+                      )}
+                    >
+                      <GroupConfigSelector
+                        groupConfig={groupConfig}
+                        onChangeGroupConfig={setGroupConfig}
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            </CardContent>
+          </Scroll>
+          {content && enableGroupConfig && (
+            <CardContent>
               <CardActions>
                 <Button
                   disabled={groupConfig.useGroupSet && !groupConfig.groupSet}
@@ -221,26 +274,26 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                   Continue
                 </Button>
               </CardActions>
-            </div>
-          </>
-        )}
-        {content && (
-          <FilePickerFormFields
-            content={content}
-            formFields={{ ...formFields, ...deepLinkingFields }}
-            groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
+            </CardContent>
+          )}
+          {content && (
+            <FilePickerFormFields
+              content={content}
+              formFields={{ ...formFields, ...deepLinkingFields }}
+              groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
+            />
+          )}
+          <input style={{ display: 'none' }} ref={submitButton} type="submit" />
+        </Card>
+        {shouldSubmit && <SpinnerOverlay />}
+        {errorInfo && (
+          <ErrorModal
+            description={errorInfo.message}
+            error={errorInfo.error}
+            onCancel={() => setErrorInfo(null)}
           />
         )}
-        <input style={{ display: 'none' }} ref={submitButton} type="submit" />
       </form>
-      {shouldSubmit && <SpinnerOverlay />}
-      {errorInfo && (
-        <ErrorModal
-          description={errorInfo.message}
-          error={errorInfo.error}
-          onCancel={() => setErrorInfo(null)}
-        />
-      )}
     </main>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, Link } from '@hypothesis/frontend-shared/lib/next';
+import { Checkbox, Link, Select } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import type { GroupSet } from '../api-types';
@@ -48,9 +49,19 @@ function GroupSelect({
   const selectId = useUniqueId('GroupSetSelector__select');
 
   return (
-    <>
-      <label htmlFor={selectId}>Group set: </label>
-      <select
+    <div
+      className={classnames(
+        // Style a slightly-recessed "well" for these controls
+        'bg-slate-0 p-4 rounded shadow-inner border'
+      )}
+    >
+      <label
+        htmlFor={selectId}
+        className="text-xs uppercase text-slate-7 font-medium"
+      >
+        Group set
+      </label>
+      <Select
         disabled={loading}
         id={selectId}
         onInput={(e: Event) =>
@@ -76,8 +87,8 @@ function GroupSelect({
             ))}
           </>
         )}
-      </select>
-    </>
+      </Select>
+    </div>
   );
 }
 
@@ -230,7 +241,7 @@ export default function GroupConfigSelector({
   }
 
   return (
-    <>
+    <div className="space-y-3">
       <Checkbox
         checked={useGroupSet}
         onInput={(e: Event) =>
@@ -242,7 +253,6 @@ export default function GroupConfigSelector({
       >
         This is a group assignment
       </Checkbox>
-
       {useGroupSet && (
         <GroupSelect
           loading={fetchingGroupSets}
@@ -251,6 +261,6 @@ export default function GroupConfigSelector({
           onInput={onGroupSelectChange}
         />
       )}
-    </>
+    </div>
   );
 }

--- a/lms/templates/file_picker.html.jinja2
+++ b/lms/templates/file_picker.html.jinja2
@@ -1,7 +1,7 @@
 {% extends "lms:templates/base.html.jinja2" %}
 
 {% block content %}
-  <div id="app"></div>
+  <div style="width: 100%; height: 100%;" id="app"></div>
 {% endblock %}
 
 {% block styles %}


### PR DESCRIPTION
This is the first of 2 or 3 PRs to address some design technical debt in the `FilePickerApp`. The changes in this PR address the broader layout and design _structure_. A subsequent PR will address the file-picker buttons, which are, let's be honest, a little bit hideous.

This PR:

* Adds a grey backdrop to the app so that file-picker controls don't look at sea on larger screens (e.g. in BlackBoard, D2L...)
* Uses a `Card` and other common components to make design patterns more conventional
* Ensures that over-height content (but not headers or buttons) will scroll. Having said that, the full set of file-picker buttons _should_ fit in the shortest known context, the little Canvas modal, without scrolling.
* Drops in the shared `Select` component for the group-configuration step and styles adjacent controls. Note also that the "Continue" button will no longer move downward when the group-configuration control is enabled (by selecting the checkbox).

Yes, those buttons are still terrible! That's the next step.

This PR does not make any functional changes.

### Before

<img width="829" alt="image" src="https://user-images.githubusercontent.com/439947/218838893-fa9fae87-2f3f-40d1-b670-86f777347a61.png">

Group configuration screen:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/439947/218839102-69d42a32-2526-44aa-9fd9-31e2e06b6e06.png">

In BlackBoard:

<img width="1647" alt="image" src="https://user-images.githubusercontent.com/439947/218839327-70ba7349-45a7-4193-a742-27fa167edab7.png">


### After

<img width="841" alt="image" src="https://user-images.githubusercontent.com/439947/218838493-8add09c9-3c95-4ae8-9dde-e7f3b0713ec6.png">


Group configuration screen:

<img width="887" alt="image" src="https://user-images.githubusercontent.com/439947/218838429-e664fffe-5561-4e5e-915f-e0a881f42742.png">


<img width="866" alt="image" src="https://user-images.githubusercontent.com/439947/218838356-a74668fc-b5c1-44b5-94b1-cf67597653ca.png">

In BlackBoard:

<img width="1648" alt="image" src="https://user-images.githubusercontent.com/439947/218838702-39413002-3efd-4f27-afb0-748f8158f7d0.png">


Overheight content will scroll:

<img width="825" alt="image" src="https://user-images.githubusercontent.com/439947/218838587-24913930-56ff-4850-91b1-1a88735c8f1c.png">
