### PR TITLE
Add the ability to search for application instances by setting

### DIFF
--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -8,7 +8,12 @@ import sqlalchemy as sa
 from sqlalchemy.exc import NoResultFound
 
 from lms.db import full_text_match
-from lms.models import ApplicationInstance, LTIParams, LTIRegistration
+from lms.models import (
+    ApplicationInstance,
+    ApplicationSettings,
+    LTIParams,
+    LTIRegistration,
+)
 from lms.services.aes import AESService
 from lms.services.exceptions import SerializableError
 from lms.services.organization import OrganizationService
@@ -141,6 +146,7 @@ class ApplicationInstanceService:
         tool_consumer_instance_guid=None,
         limit=100,
         email=None,
+        settings=None,
     ) -> List[ApplicationInstance]:
         """Return the instances that match all of the passed parameters."""
 
@@ -154,6 +160,7 @@ class ApplicationInstanceService:
                 deployment_id=deployment_id,
                 tool_consumer_instance_guid=tool_consumer_instance_guid,
                 email=email,
+                settings=settings,
             )
             .order_by(
                 ApplicationInstance.last_launched.desc().nulls_last(),
@@ -174,6 +181,7 @@ class ApplicationInstanceService:
         deployment_id=None,
         tool_consumer_instance_guid=None,
         email=None,
+        settings=None,
     ):
         """Return a query with the passed parameters applied as filters."""
 
@@ -213,6 +221,11 @@ class ApplicationInstanceService:
                         ApplicationInstance.tool_consumer_instance_contact_email,
                     )
                 )
+            )
+
+        if settings:
+            query = query.filter(
+                ApplicationSettings.matching(ApplicationInstance.settings, settings)
             )
 
         return query

--- a/lms/templates/admin/application_instance/search.html.jinja2
+++ b/lms/templates/admin/application_instance/search.html.jinja2
@@ -21,14 +21,32 @@ Application instances
                 {{ macros.form_text_field(request, "Email / Domain", "email") }}
                 {{ macros.form_text_field(request, "Name", "name") }}
                 {{ macros.form_text_field(request, "ID", "id") }}
-                {{ macros.form_text_field(request, "GUID", "tool_consumer_instance_guid") }}
+
+                {% call macros.field_body("Setting") %}
+                    <div class="select">
+                        <select name="settings_key">
+                            <option value="">-</option>
+                            {% for option in settings %}
+                                <option
+                                    value="{{ option }}"
+                                    {% if request.params.get("settings_key") == option %}
+                                        selected
+                                    {% endif %}
+                                >{{ option }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                {% endcall %}
+                {{ macros.form_text_field(request, "Settings Value", "settings_value") }}
 
                 {# This lines up in a less goofy way here than outside the column #}
                 {% call macros.field_body(label="") %}
                     <input type="submit" class="button is-info" value="Search" />
                 {% endcall %}
             </div>
+
             <div class="column">
+                {{ macros.form_text_field(request, "GUID", "tool_consumer_instance_guid") }}
                 {{ macros.form_text_field(request, "Client ID", "client_id") }}
                 {{ macros.form_text_field(request, "Consumer key", "consumer_key") }}
                 {{ macros.form_text_field(request, "Issuer", "issuer") }}

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from lms.models import ApplicationInstance, ApplicationSettings
+from lms.models import ApplicationInstance
 from tests import factories
 
 
@@ -123,30 +123,3 @@ class TestApplicationInstance:
     def application_instance(self):
         """Return an ApplicationInstance with minimal required attributes."""
         return factories.ApplicationInstance()
-
-
-class TestApplicationSettings:
-    @pytest.mark.parametrize(
-        "group,key,expected_value",
-        (
-            ("group", "key", "old_value"),
-            ("NEW", "key", None),
-            ("group", "NEW", None),
-            ("NEW", "NEW", None),
-        ),
-    )
-    def test_settings_can_be_retrieved(self, settings, group, key, expected_value):
-        assert settings.get(group, key) == expected_value
-
-    @pytest.mark.parametrize(
-        "group,key",
-        (("group", "key"), ("NEW", "key"), ("group", "NEW"), ("NEW", "NEW")),
-    )
-    def test_can_update_settings(self, settings, group, key):
-        settings.set(group, key, "new_value")
-
-        assert settings.get(group, key) == "new_value"
-
-    @pytest.fixture
-    def settings(self):
-        return ApplicationSettings({"group": {"key": "old_value"}})

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -239,6 +239,13 @@ class TestApplicationInstanceService:
             expected_names
         ).only()
 
+    def test_search_by_settings(self, service):
+        ai = factories.ApplicationInstance.create(settings={"group": {"key": "value"}})
+
+        found = service.search(settings={"group.key": "value"})
+
+        assert found == [ai]
+
     def test_search_order(self, service):
         now, before = datetime.now(), datetime.now() - timedelta(hours=1)
 

--- a/tests/unit/lms/views/admin/application_instance_test.py
+++ b/tests/unit/lms/views/admin/application_instance_test.py
@@ -8,7 +8,10 @@ from lms.models import ApplicationInstance
 from lms.models.public_id import InvalidPublicId
 from lms.services import ApplicationInstanceNotFound
 from lms.validation import ValidationError
-from lms.views.admin.application_instance import AdminApplicationInstanceViews
+from lms.views.admin.application_instance import (
+    APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+    AdminApplicationInstanceViews,
+)
 from tests import factories
 from tests.matchers import Any, temporary_redirect_to
 
@@ -277,9 +280,13 @@ class TestAdminApplicationInstanceViews:
         assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
 
     def test_search_start(self, views):
-        assert not views.search_start()
+        assert views.search_start() == {
+            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS
+        }
 
-    def test_search(self, pyramid_request, application_instance_service, views):
+    def test_search_callback(
+        self, pyramid_request, application_instance_service, views
+    ):
         pyramid_request.params = pyramid_request.POST = {
             "id": "1",
             "name": "NAME",
@@ -302,10 +309,42 @@ class TestAdminApplicationInstanceViews:
             deployment_id="DEPLOYMENT_ID",
             tool_consumer_instance_guid="TOOL_CONSUMER_INSTANCE_GUID",
             email="EMAIL",
+            settings=None,
         )
         assert response == {
-            "instances": application_instance_service.search.return_value
+            "instances": application_instance_service.search.return_value,
+            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS,
         }
+
+    @pytest.mark.parametrize(
+        "settings_key,settings_value,expected",
+        (
+            ("jstor.enabled", "True", {"jstor.enabled": True}),
+            ("jstor.enabled", "1", {"jstor.enabled": True}),
+            ("jstor.enabled", "0", {"jstor.enabled": False}),
+            ("jstor.enabled", "", {"jstor.enabled": ...}),
+            ("jstor.site_code", "True", {"jstor.site_code": "True"}),
+        ),
+    )
+    def test_search_callback_with_settings(
+        self,
+        views,
+        pyramid_request,
+        application_instance_service,
+        settings_key,
+        settings_value,
+        expected,
+    ):
+        pyramid_request.params = pyramid_request.POST = {
+            "settings_key": settings_key,
+            "settings_value": settings_value,
+        }
+
+        views.search_callback()
+
+        assert (
+            application_instance_service.search.call_args.kwargs["settings"] == expected
+        )
 
     def test_search_callback_invalid(self, views, pyramid_request):
         pyramid_request.POST = {"id": "not a number"}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/5002

This PR adds the ability to:

 * Search for application instances that have a given setting (regardless of content)
 * Search for application instances with a specific value in that setting

## Testing notes

 * `make devdata` - We rely on the settings to get the same results
 * Visit: http://localhost:8001/admin/instances/
 * Press "Search"
 * You should get lots of results
 * Pick "vitalsource.enabled" and search again
 * You should see three results
 * Visit one application instance and uncheck "vitalsource.enabled" add and name and save
 * Return to http://localhost:8001/admin/instances/
 * Pick "vitalsource.enabled" and search again
 * You should still see three results
 * Now fill out truthy type values "1" "True" etc. and search
 * You should only see two rows
 * Now fill out falsy type values "0" "false" etc. and search
* You should see one row