### PR TITLE
Fix course copy for groups assignments in D2L

### DIFF
--- a/lms/product/d2l/_plugin/course_copy.py
+++ b/lms/product/d2l/_plugin/course_copy.py
@@ -1,4 +1,4 @@
-from lms.product.plugin.course_copy import CourseCopyFilesHelper
+from lms.product.plugin.course_copy import CourseCopyFilesHelper, CourseCopyGroupsHelper
 from lms.services.d2l_api import D2LAPIClient
 
 
@@ -11,9 +11,11 @@ class D2LCourseCopyPlugin:
         self,
         api: D2LAPIClient,
         files_helper: CourseCopyFilesHelper,
+        groups_helper: CourseCopyGroupsHelper,
     ):
         self._api = api
         self._files_helper = files_helper
+        self._groups_helper = groups_helper
 
     def is_file_in_course(self, course_id, file_id):
         return self._files_helper.is_file_in_course(course_id, file_id, self.file_type)
@@ -24,13 +26,14 @@ class D2LCourseCopyPlugin:
         )
 
     def find_matching_group_set_in_course(self, course, group_set_id):
-        # We are not yet handling course copy for groups in D2L.
-        # We implement this method so we can call `find_mapped_group_set_id` in all LMS's
-        return None
+        return self._groups_helper.find_matching_group_set_in_course(
+            course, group_set_id
+        )
 
     @classmethod
     def factory(cls, _context, request):
         return cls(
             request.find_service(D2LAPIClient),
             files_helper=request.find_service(CourseCopyFilesHelper),
+            groups_helper=request.find_service(CourseCopyGroupsHelper),
         )

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -77,7 +77,7 @@ class CourseService:
 
     def find_group_set(self, group_set_id=None, name=None, context_id=None):
         """
-        Find group sets stored in Courses of this applications instance.
+        Find the first matching group set in this course.
 
         Group sets are stored as part of Course.extra, this method allows to query and filter them.
 
@@ -106,7 +106,7 @@ class CourseService:
         if name:
             query = query.filter(group_set.c.name == name)
 
-        return query.one_or_none()
+        return query.first()
 
     def _get_authority_provided_id(self, context_id):
         return self._grouping_service.get_authority_provided_id(

--- a/tests/unit/lms/product/d2l/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/course_copy_test.py
@@ -33,19 +33,34 @@ class TestD2LCourseCopyPlugin:
             result == course_copy_files_helper.find_matching_file_in_course.return_value
         )
 
-    def test_find_matching_group_set_in_course(self, plugin):
-        assert not plugin.find_matching_group_set_in_course(
+    def test_find_matching_group_set_in_course(self, plugin, course_copy_groups_helper):
+        result = plugin.find_matching_group_set_in_course(
             sentinel.course, sentinel.group_set_id
         )
 
-    @pytest.mark.usefixtures("d2l_api_client", "course_copy_files_helper")
+        course_copy_groups_helper.find_matching_group_set_in_course.assert_called_once_with(
+            sentinel.course, sentinel.group_set_id
+        )
+
+        assert (
+            result
+            == course_copy_groups_helper.find_matching_group_set_in_course.return_value
+        )
+
+    @pytest.mark.usefixtures(
+        "d2l_api_client", "course_copy_files_helper", "course_copy_groups_helper"
+    )
     def test_factory(self, pyramid_request):
         plugin = D2LCourseCopyPlugin.factory(sentinel.context, pyramid_request)
 
         assert isinstance(plugin, D2LCourseCopyPlugin)
 
     @pytest.fixture
-    def plugin(self, d2l_api_client, course_copy_files_helper):
+    def plugin(
+        self, d2l_api_client, course_copy_files_helper, course_copy_groups_helper
+    ):
         return D2LCourseCopyPlugin(
-            api=d2l_api_client, files_helper=course_copy_files_helper
+            api=d2l_api_client,
+            files_helper=course_copy_files_helper,
+            groups_helper=course_copy_groups_helper,
         )

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
-from sqlalchemy.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from lms.models import CourseGroupsExportedFromH, Grouping
 from lms.services.course import CourseService, course_service_factory
@@ -130,9 +130,8 @@ class TestCourseService:
         assert not svc.find_group_set(**params)
 
     @pytest.mark.usefixtures("course_with_group_sets")
-    def test_find_group_set_raises_with_more_than_one_result(self, svc):
-        with pytest.raises(MultipleResultsFound):
-            svc.find_group_set()
+    def test_find_group_set_returns_first_result(self, svc):
+        assert svc.find_group_set()
 
     @pytest.fixture
     def course(self, application_instance, grouping_service):


### PR DESCRIPTION
Handle course copy & group sets in D2L.


### Testing



#### D2L

- Reset the DB state

`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping,assignment cascade;"; make devdata;`



### As a student (`aunltd.S1`)


- Launch the original group assignment:

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View

You'll get just one group on the drop-down (the one you are a member of, `Test group 1`)


- Launch the copied groups assignment

https://aunltd.brightspacedemo.com/d2l/le/content/6861/viewContent/2524/View?ou=6861

You'll get an un-handled error with a 404

(not that this PR doesn't address that not being handled, see https://github.com/hypothesis/lms/issues/5055

You can see in the modal the failed URL containing the original group set ID, 22.

### As a teacher (`HypothesisEng.Teacher`)

- Launch the original group assignment:

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View

You'll get both groups in the drop-down.

- Launch the copied groups assignment

https://aunltd.brightspacedemo.com/d2l/le/content/6861/viewContent/2524/View?ou=6861

You'll get a modal indicating that the group category no longer exists.

This simulates the case were the course was originally configured before the deploy of this feature and the group set list was never fetched after that. Every new course after this is deployed will have the group sets already stored in the DB.


- Launch the scratch assignment on the original course.

Select any type of file and pick the group assignment option, we just want to record the group sets in the DB.

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View

- Launch the copied groups assignment again


https://aunltd.brightspacedemo.com/d2l/le/content/6861/viewContent/2524/View?ou=6861


Now the lunch is successful and we have record of the group set mapping:


```
select extra->'course_copy_group_set_mappings' from grouping  where lms_id = '6861';  
   ?column?   
--------------
 {"22": "52"}
(1 row)
```

### Again, as a student (`aunltd.S1`)


- Launch the copied groups assignment

https://aunltd.brightspacedemo.com/d2l/le/content/6861/viewContent/2524/View?ou=6861

It will work this time as the mapping is now stored in the DB.

