### PR TITLE
Add application instance setting to enable editing assignments, and placeholder button in instructor toolbar

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -32,6 +32,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("vitalsource", "disable_licence_check", asbool),
         JSONSetting("jstor", "enabled", asbool),
         JSONSetting("jstor", "site_code"),
+        JSONSetting("hypothesis", "edit_assignments_enabled", asbool),
         JSONSetting("hypothesis", "notes", name="Notes"),
         JSONSetting(
             "hypothesis",

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -320,19 +320,6 @@ export default function BasicLTILaunchApp() {
     }
   }, [authToken, authURL, fetchContentURL, fetchGroups]);
 
-  const content = (
-    <div
-      className={classnames('flex flex-col h-full', {
-        invisible: !showContent,
-        visible: showContent,
-      })}
-      data-testid="content-wrapper"
-    >
-      <InstructorToolbar />
-      <ContentFrame url={contentURL ?? ''} />
-    </div>
-  );
-
   return (
     <div className="h-full">
       {showSpinner && <SpinnerOverlay />}
@@ -344,7 +331,16 @@ export default function BasicLTILaunchApp() {
           onRetry={authorizeAndFetchURL}
         />
       )}
-      {content}
+      <div
+        className={classnames('flex flex-col h-full', {
+          invisible: !showContent,
+          visible: showContent,
+        })}
+        data-testid="content-wrapper"
+      >
+        <InstructorToolbar />
+        <ContentFrame url={contentURL ?? ''} />
+      </div>
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -3,27 +3,32 @@ import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
 import { apiCall } from '../utils/api';
 import { useConfig } from '../config';
-import type { GradingConfig, StudentInfo } from '../config';
+import type { StudentInfo } from '../config';
 import { ClientRPC, useService } from '../services';
 import StudentSelector from './StudentSelector';
 import SubmitGradeForm from './SubmitGradeForm';
 
 export type GradingControlsProps = {
-  grading: GradingConfig;
+  /**
+   * List of students to grade.
+   *
+   * These will be sorted by display name before being presented.
+   */
+  students: StudentInfo[];
 };
 
 /**
  * Controls for grading students: a list of students to grade, and an input to
  * set a grade for the selected student.
  */
-export default function GradingControls({ grading }: GradingControlsProps) {
+export default function GradingControls({
+  students: unorderedStudents,
+}: GradingControlsProps) {
   const {
     api: { authToken, sync: syncAPICallInfo },
   } = useConfig();
 
   const clientRPC = useService(ClientRPC);
-
-  const unorderedStudents = grading.students;
 
   // No initial current student selected
   const [currentStudentIndex, setCurrentStudentIndex] = useState(-1);

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
 import GradingControls from './GradingControls';
@@ -8,11 +9,19 @@ import { useConfig } from '../config';
  * Shows assignment information and grading controls (for gradeable assignments).
  */
 export default function InstructorToolbar() {
-  const { grading } = useConfig();
-
-  if (!grading?.enabled) {
+  const { instructorToolbar } = useConfig();
+  if (!instructorToolbar) {
+    // User is not an instructor or toolbar is disabled in the current environment.
     return null;
   }
+
+  const {
+    students,
+    courseName,
+    assignmentName,
+    editingEnabled,
+    gradingEnabled,
+  } = instructorToolbar;
 
   return (
     <header
@@ -26,20 +35,22 @@ export default function InstructorToolbar() {
           className="text-lg font-semibold leading-none"
           data-testid="assignment-name"
         >
-          {grading.assignmentName}
+          {assignmentName}
         </h1>
         <h2
           className="text-sm font-normal text-color-text-light leading-none"
           data-testid="course-name"
         >
-          {grading.courseName}
+          {courseName}
         </h2>
       </div>
+
+      {editingEnabled && <Button data-testid="edit">Edit</Button>}
 
       <div
         className={classnames('lg:col-span-2 lg:gap-4 ' /* cols 2-3 of 3 */)}
       >
-        <GradingControls grading={grading} />
+        {gradingEnabled && students && <GradingControls students={students} />}
       </div>
     </header>
   );

--- a/lms/static/scripts/frontend_apps/components/test/GradingControls-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GradingControls-test.js
@@ -12,7 +12,6 @@ describe('GradingControls', () => {
   let fakeApiCall;
   let fakeConfig;
   let fakeStudents;
-  let fakeGrading;
   let fakeClientRPC;
 
   /**
@@ -53,10 +52,6 @@ describe('GradingControls', () => {
         lmsId: '456',
       },
     ];
-    fakeGrading = {
-      enabled: true,
-      students: fakeStudents,
-    };
 
     fakeClientRPC = {
       setFocusedUser: sinon.stub(),
@@ -80,7 +75,7 @@ describe('GradingControls', () => {
       <Config.Provider value={fakeConfig}>
         <Services.Provider value={services}>
           <GradingControls
-            grading={fakeGrading}
+            students={fakeStudents}
             clientRPC={fakeClientRPC}
             {...props}
           />
@@ -91,7 +86,7 @@ describe('GradingControls', () => {
 
   it('orders the students by displayName', () => {
     // Un-order students
-    fakeGrading.students = [
+    fakeStudents = [
       {
         displayName: 'Student Beta',
       },
@@ -134,7 +129,7 @@ describe('GradingControls', () => {
 
   it('puts students with empty displayNames at the beginning of sorted students', () => {
     // Un-order students
-    fakeGrading.students = [
+    fakeStudents = [
       {
         displayName: 'Student Beta',
       },

--- a/lms/static/scripts/frontend_apps/components/test/InstructorToolbar-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/InstructorToolbar-test.js
@@ -7,11 +7,12 @@ import InstructorToolbar, { $imports } from '../InstructorToolbar';
 
 describe('InstructorToolbar', () => {
   let fakeConfig;
-  let fakeGrading;
+  let fakeInstructorToolbar;
 
   beforeEach(() => {
-    fakeGrading = {
-      enabled: true,
+    fakeInstructorToolbar = {
+      editingEnabled: false,
+      gradingEnabled: false,
       courseName: 'course name',
       assignmentName: 'course assignment',
     };
@@ -19,7 +20,7 @@ describe('InstructorToolbar', () => {
       api: {
         authToken: 'dummyAuthToken',
       },
-      grading: fakeGrading,
+      instructorToolbar: fakeInstructorToolbar,
     };
 
     $imports.$mock(mockImportedComponents());
@@ -37,18 +38,35 @@ describe('InstructorToolbar', () => {
     );
   };
 
-  it('does not render assignment info when grading config is not set', () => {
-    delete fakeConfig.grading;
+  it('does not render assignment info when config is not set', () => {
+    delete fakeConfig.instructorToolbar;
 
     const wrapper = renderToolbar();
     assert.equal(wrapper.find('[data-testid="assignment-name"]').length, 0);
   });
 
-  it('does not render assignment info when grading is not enabled', () => {
-    fakeGrading.enabled = false;
-
+  it('does not render edit button if editing assignments is disabled', () => {
+    fakeInstructorToolbar.editingEnabled = false;
     const wrapper = renderToolbar();
-    assert.equal(wrapper.find('[data-testid="assignment-name"]').length, 0);
+    assert.isFalse(wrapper.exists('[data-testid="edit"]'));
+  });
+
+  it('renders edit button if editing assignments is enabled', () => {
+    fakeInstructorToolbar.editingEnabled = true;
+    const wrapper = renderToolbar();
+    assert.isTrue(wrapper.exists('[data-testid="edit"]'));
+  });
+
+  it('renders grading controls when grading is enabled', () => {
+    fakeInstructorToolbar.gradingEnabled = true;
+    fakeInstructorToolbar.students = [];
+    const wrapper = renderToolbar();
+    assert.isTrue(wrapper.exists('GradingControls'));
+  });
+
+  it('does not render grading controls when grading is not enabled', () => {
+    const wrapper = renderToolbar();
+    assert.isFalse(wrapper.exists('GradingControls'));
   });
 
   it('sets the assignment and course names', () => {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -47,11 +47,12 @@ export type StudentInfo = {
 /**
  * Data needed to render the grading bar shown when an instructor views an assignment.
  */
-export type GradingConfig = {
+export type InstructorConfig = {
   assignmentName: string;
   courseName: string;
-  enabled: boolean;
-  students: StudentInfo[];
+  editingEnabled: boolean;
+  gradingEnabled: boolean;
+  students: StudentInfo[] | null;
 };
 
 /**
@@ -225,7 +226,7 @@ export type ConfigObject = {
     speedGrader?: SpeedGraderConfig;
   };
   contentBanner?: ContentBannerConfig;
-  grading?: GradingConfig; // Only present for instructors
+  instructorToolbar?: InstructorConfig;
   hypothesisClient: ClientConfig;
   rpcServer: {
     allowedOrigins: string[];

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -93,7 +93,11 @@
                 {{ macros.disabled_text_field("Version", instance.tool_consumer_info_version) }}
             </div>
         </div>
+    </fieldset>
 
+    <fieldset class="box">
+        <legend class="label has-text-centered">General settings</legend>
+        {{ settings_checkbox("Enable editing assignments", "hypothesis", "edit_assignments_enabled") }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -222,11 +222,19 @@ class BasicLaunchViews:
             if focused_user := self.request.params.get("focused_user"):
                 self.context.js_config.set_focused_user(focused_user)
 
-        elif assignment.is_gradable and self.request.lti_user.is_instructor:
-            # Only show the grading interface to teachers who aren't in Canvas,
-            # as Canvas uses its own built in Speedgrader
+        elif self.request.lti_user.is_instructor:
+            # nb. Canvas does not currently use/support any functionality from the
+            # instructor toolbar. For grading it uses SpeedGrader and we don't
+            # support editing assignments.
 
-            self.context.js_config.enable_grading_bar()
+            enable_editing = self.context.application_instance.settings.get(
+                "hypothesis", "edit_assignments_enabled", default=False
+            )
+
+            if enable_editing or assignment.is_gradable:
+                self.context.js_config.enable_instructor_toolbar(
+                    enable_editing=enable_editing, enable_grading=assignment.is_gradable
+                )
 
         self.context.js_config.add_document_url(document_url)
         self.context.js_config.enable_lti_launch_mode(assignment)


### PR DESCRIPTION
This PR adds a `hypothesis.edit_assignments_enabled` setting to application instances and adds the plumbing needed to make the setting available to the frontend and display a placeholder "Edit" button in the instructor toolbar if enabled.

**Summary of changes:**

 - Add `hypothesis.edit_assignments_enabled` setting to application instances
 - Rename `grading` key in frontend config to `instructorToolbar`, and rename the associated JSConfig methods
 - Rename `grading.enabled` to `instructorToolbar.gradingEnabled`
 - Add `instructorToolbar.editingEnabled` field which reflects the `edit_assignments_enabled` application instance setting
 - In the backend, the instructor toolbar to be displayed if we're not in Canvas and either grading is enabled or assignment editing is enabled
 - In the frontend, add a placeholder Edit button in `InstructorToolbar` component that is displayed if editing is enabled

**Testing:**

1. Launch the assignment at https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View and it should look the same as before
2. Go to http://localhost:8001/admin/instance/106/ and check "Enable editing assignments" option
3. Relaunch the assignment from (1) and you should see a new "Edit assignment" button in the toolbar (ignore styling/layout issues) which does nothing when clicked