### PR TITLE
Display the searched for setting in the application instance table

### DIFF
--- a/lms/templates/admin/application_instance/search.html.jinja2
+++ b/lms/templates/admin/application_instance/search.html.jinja2
@@ -37,7 +37,7 @@ Application instances
                         </select>
                     </div>
                 {% endcall %}
-                {{ macros.form_text_field(request, "Settings Value", "settings_value") }}
+                {{ macros.form_text_field(request, "Setting Value", "settings_value") }}
 
                 {# This lines up in a less goofy way here than outside the column #}
                 {% call macros.field_body(label="") %}
@@ -62,9 +62,15 @@ Application instances
 
 
 {% if instances is defined %}
+    {% if request.params.get('settings_key') %}
+        {% set extra_fields = [
+             {"label": request.params.get('settings_key'), "name": "settings_focus_value"}
+        ] %}
+    {% endif %}
+
 <fieldset class="box mt-6">
     <legend class="label has-text-centered">Results</legend>
-    {{ macros.instances_table(request, instances) }}
+    {{ macros.instances_table(request, instances, extra_fields) }}
 </fieldset>
 {% endif %}
 

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -88,6 +88,8 @@
 {%- macro auto_format(value, html=True) -%}
     {%- if value is none -%}
         {% if html %}<span style="color:#aaa">-</span>{% else %}{% endif %}
+    {%- elif value is boolean -%}
+        {% if value %}✔️{% else %}❌{% endif %}
     {%- elif value.strftime -%}
         {{ value.strftime('%Y/%m/%d %H:%M') }}
     {%- elif value.startswith('http') and html -%}
@@ -128,18 +130,22 @@
 {% endmacro %}
 
 
-{% macro instances_table(request, instances) %}
-{{ object_list_table(
-    request, 'admin.instance', instances,
-    fields=[
-        {"label": "Name", "name": "name"},
-        {"label": "Created", "name": "created"},
-        {"label": "Last Launched", "name": "last_launched"},
-        {"label": "Product Family", "name": "tool_consumer_info_product_family_code"},
-        {"label": "Email", "name": "requesters_email"},
-        {"label": "LMS URL", "name": "lms_url"},
-    ]
-) }}
+{% macro instances_table(request, instances, extra_fields=None) %}
+    {% if not extra_fields %}
+        {% set extra_fields = [] %}
+    {% endif %}
+
+    {{ object_list_table(
+        request, 'admin.instance', instances,
+        fields=[
+            {"label": "Name", "name": "name"},
+            {"label": "Created", "name": "created"},
+            {"label": "Last Launched", "name": "last_launched"},
+            {"label": "Product Family", "name": "tool_consumer_info_product_family_code"},
+            {"label": "Email", "name": "requesters_email"},
+            {"label": "LMS URL", "name": "lms_url"},
+        ] + extra_fields
+    ) }}
 {% endmacro %}
 
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/5002

Requires:

 * https://github.com/hypothesis/lms/pull/5041

This PR adds an extra column that shows up in the search results when a setting value is searched for. It displays the value as the last value.

## Tasks

 * [x] "Settings value" should be "Setting value"
 * [x] Checkboxes should be disabled (you can toggle them, which might imply you can change the value, you can't).

## Testing notes

 * Visit: http://localhost:8001/admin/instances/
 * Press search
 * You should see the normal number of columns (without a settings value)
 * Choose `vitalsource.enabled` and search again
 * You should see values with a new column `vitalsource.enabled`
 * Disable `vitalsource.enabled` in one application instance and search again
 * You should see the value is presented as a check mark or cross according to the value
 * Search using `jstor.site_code`
 * You should see the results as a text value