### PR TITLE
Refactor `ApplicationSettings` to include a field spec

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,6 +1,5 @@
 from lms.models._mixins import CreatedUpdatedMixin
-from lms.models.application_instance import ApplicationInstance
-from lms.models.application_settings import ApplicationSettings
+from lms.models.application_instance import ApplicationInstance, ApplicationSettings
 from lms.models.assignment import Assignment
 from lms.models.assignment_grouping import AssignmentGrouping
 from lms.models.assignment_membership import AssignmentMembership
@@ -20,6 +19,7 @@ from lms.models.grouping import (
     GroupingMembership,
 )
 from lms.models.h_user import HUser
+from lms.models.json_settings import JSONSettings
 from lms.models.lti_params import CLAIM_PREFIX, LTIParams
 from lms.models.lti_registration import LTIRegistration
 from lms.models.lti_role import LTIRole

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -2,18 +2,38 @@ import logging
 from urllib.parse import urlparse
 
 import sqlalchemy as sa
+from pyramid.settings import asbool
 from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE
 from lms.models import CreatedUpdatedMixin
 from lms.models.exceptions import ReusedConsumerKey
-from lms.models.json_settings import JSONSettings
+from lms.models.json_settings import JSONSetting, JSONSettings
 
 LOG = logging.getLogger(__name__)
 
 
 class ApplicationSettings(JSONSettings):
-    ...
+    fields = (
+        JSONSetting("blackboard", "files_enabled", asbool),
+        JSONSetting("blackboard", "groups_enabled", asbool),
+        JSONSetting("canvas", "sections_enabled", asbool),
+        JSONSetting("canvas", "groups_enabled", asbool),
+        JSONSetting("desire2learn", "client_id"),
+        JSONSetting("desire2learn", "client_secret", JSONSetting.AES_SECRET),
+        JSONSetting("desire2learn", "groups_enabled", asbool),
+        JSONSetting("desire2learn", "files_enabled", asbool),
+        JSONSetting("desire2learn", "create_line_item", asbool),
+        JSONSetting("microsoft_onedrive", "files_enabled", asbool),
+        JSONSetting("vitalsource", "enabled", asbool),
+        JSONSetting("vitalsource", "user_lti_param"),
+        JSONSetting("vitalsource", "user_lti_pattern"),
+        JSONSetting("vitalsource", "api_key"),
+        JSONSetting("vitalsource", "disable_licence_check", asbool),
+        JSONSetting("jstor", "enabled", asbool),
+        JSONSetting("jstor", "site_code"),
+        JSONSetting("hypothesis", "notes"),
+    )
 
 
 class ApplicationInstance(CreatedUpdatedMixin, BASE):

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -6,10 +6,14 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE
 from lms.models import CreatedUpdatedMixin
-from lms.models.application_settings import ApplicationSettings
 from lms.models.exceptions import ReusedConsumerKey
+from lms.models.json_settings import JSONSettings
 
 LOG = logging.getLogger(__name__)
+
+
+class ApplicationSettings(JSONSettings):
+    ...
 
 
 class ApplicationInstance(CreatedUpdatedMixin, BASE):

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -32,7 +32,13 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("vitalsource", "disable_licence_check", asbool),
         JSONSetting("jstor", "enabled", asbool),
         JSONSetting("jstor", "site_code"),
-        JSONSetting("hypothesis", "notes"),
+        JSONSetting("hypothesis", "notes", name="Notes"),
+        JSONSetting(
+            "hypothesis",
+            "auto_assigned_to_org",
+            asbool,
+            name="Auto Assigned To Organisation",
+        ),
     )
 
 

--- a/lms/models/application_settings.py
+++ b/lms/models/application_settings.py
@@ -112,9 +112,9 @@ class ApplicationSettings(MutableDict):
             {
                 # Specify an exact key should have an exact value
                 "group.key": "exact_value_to_match"
-                # Specify an exact key should exist
+                # Specify an exact key should exist (use ellipsis literal)
                 "group.key": ...
-                # Specify a group should exist
+                # Specify a group should exist (use ellipsis literal)
                 "group": ...
             }
 
@@ -129,12 +129,16 @@ class ApplicationSettings(MutableDict):
             )
 
             if key is None:
+                # Search for the group to exist, but nothing more
                 clauses.append(column.has_key(group))
 
-            elif value is not ...:
-                clauses.append(column.contains({group: {key: value}}))
-            else:
+            elif value is ...:
+                # Look for the group and key, with any value
                 clauses.append(column[group].has_key(key))
+
+            else:
+                # Look for the group and key, with a specific value
+                clauses.append(column.contains({group: {key: value}}))
 
         return sa.and_(*clauses)
 

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -2,7 +2,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE
-from lms.models.application_settings import ApplicationSettings
+from lms.models.json_settings import JSONSettings
 
 
 class LegacyCourse(BASE):
@@ -29,7 +29,7 @@ class LegacyCourse(BASE):
 
     settings = sa.Column(
         "settings",
-        ApplicationSettings.as_mutable(JSONB),
+        JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.mutable import MutableDict
 
 from lms.db import BASE, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
-from lms.models.application_settings import ApplicationSettings
+from lms.models.json_settings import JSONSettings
 
 MAX_GROUP_NAME_LENGTH = 25
 
@@ -114,7 +114,7 @@ class Grouping(CreatedUpdatedMixin, BASE):
 
     settings = sa.Column(
         "settings",
-        ApplicationSettings.as_mutable(JSONB),
+        JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -6,9 +6,9 @@ from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import InstrumentedAttribute
 
 
-class ApplicationSettings(MutableDict):
+class JSONSettings(MutableDict):
     """
-    Model for accessing and updating application settings.
+    Model for accessing and updating settings stored as JSON.
 
     This is a dict subclass, but you should use the custom get() and set()
     methods below to get and set values because they're safer and more
@@ -20,8 +20,7 @@ class ApplicationSettings(MutableDict):
     For example in the code below the change to "sections_enabled" will not be
     saved when the transaction is committed:
 
-    >>> ai = db.query(models.ApplicationInstance).filter_by(...).one()
-    >>> ai.settings["canvas"]["sections_enabled"] = False
+    >>> model.settings["canvas"]["sections_enabled"] = False
 
     The safe thing to do is to use the custom set() method because it makes
     sure that your changes are saved.
@@ -30,11 +29,10 @@ class ApplicationSettings(MutableDict):
     they will be saved. In this example the changes to both "sections_enabled"
     and "bar" will be saved:
 
-    >>> ai = db.query(models.ApplicationInstance).filter_by(...).one()
-    >>> ai.settings["canvas"]["sections_enabled"] = False
-    >>> ai.settings["foo"]["bar"] = "gar"
-    >>> # Notify SQLAlchemy that ai.settings has changed so it knows to save it.
-    >>> ai.settings.changed()
+    >>> model.settings["canvas"]["sections_enabled"] = False
+    >>> model.settings["foo"]["bar"] = "gar"
+    >>> # Notify SQLAlchemy that settings have changed, so it knows to save it.
+    >>> model.settings.changed()
     """
 
     def get(self, group, key, default=None):
@@ -45,7 +43,7 @@ class ApplicationSettings(MutableDict):
 
         :param group: The name of the group of settings
         :param key: The key in that group
-        :param default: Default value if the group/key combiantion is missing
+        :param default: Default value if the group/key combination is missing
         :return: The value or None
         """
         return super().get(group, {}).get(key, default)

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -1,9 +1,41 @@
 import base64
-from typing import Optional
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
 
 import sqlalchemy as sa
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import InstrumentedAttribute
+
+
+@dataclass
+class JSONSetting:
+    """Describe a permitted field in a JSONSettings object."""
+
+    # Helper to declare settings as secret. This can be used with format
+    AES_SECRET = object()
+
+    group: str
+    """The group name that this setting is a part of."""
+
+    key: str
+    """The key within the grouo that this setting is a part of."""
+
+    format: Any = str
+    """An identifier to say what type of field this is."""
+
+    name: Optional[str] = None
+    """An optional name for the field."""
+
+    @property
+    def compound_key(self) -> str:
+        """Get the group and key as a single value."""
+        return f"{self.group}.{self.key}"
+
+    @property
+    def label(self) -> str:
+        """Get a label for this field."""
+
+        return self.name or self.compound_key
 
 
 class JSONSettings(MutableDict):
@@ -33,6 +65,11 @@ class JSONSettings(MutableDict):
     >>> model.settings["foo"]["bar"] = "gar"
     >>> # Notify SQLAlchemy that settings have changed, so it knows to save it.
     >>> model.settings.changed()
+    """
+
+    fields: Optional[Tuple[JSONSetting]] = None
+    """
+    An optional spec for the acceptable fields and types.
     """
 
     def get(self, group, key, default=None):

--- a/lms/models/organization.py
+++ b/lms/models/organization.py
@@ -3,7 +3,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from lms.db import BASE
 from lms.models._mixins import CreatedUpdatedMixin, PublicIdMixin
-from lms.models.application_settings import ApplicationSettings
+from lms.models.json_settings import JSONSettings
 
 
 class Organization(CreatedUpdatedMixin, PublicIdMixin, BASE):
@@ -41,7 +41,7 @@ class Organization(CreatedUpdatedMixin, PublicIdMixin, BASE):
 
     settings = sa.Column(
         "settings",
-        ApplicationSettings.as_mutable(JSONB),
+        JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -8,12 +8,7 @@ import sqlalchemy as sa
 from sqlalchemy.exc import NoResultFound
 
 from lms.db import full_text_match
-from lms.models import (
-    ApplicationInstance,
-    ApplicationSettings,
-    LTIParams,
-    LTIRegistration,
-)
+from lms.models import ApplicationInstance, JSONSettings, LTIParams, LTIRegistration
 from lms.services.aes import AESService
 from lms.services.exceptions import SerializableError
 from lms.services.organization import OrganizationService
@@ -225,7 +220,7 @@ class ApplicationInstanceService:
 
         if settings:
             query = query.filter(
-                ApplicationSettings.matching(ApplicationInstance.settings, settings)
+                JSONSettings.matching(ApplicationInstance.settings, settings)
             )
 
         return query

--- a/lms/templates/admin/application_instance/search.html.jinja2
+++ b/lms/templates/admin/application_instance/search.html.jinja2
@@ -26,13 +26,14 @@ Application instances
                     <div class="select">
                         <select name="settings_key">
                             <option value="">-</option>
-                            {% for option in settings %}
+
+                            {% for setting in settings.values() %}
                                 <option
-                                    value="{{ option }}"
-                                    {% if request.params.get("settings_key") == option %}
+                                    value="{{ setting.compound_key }}"
+                                    {% if request.params.get("settings_key") == setting.compound_key %}
                                         selected
                                     {% endif %}
-                                >{{ option }}</option>
+                                >{{ setting.label }}</option>
                             {% endfor %}
                         </select>
                     </div>
@@ -62,9 +63,9 @@ Application instances
 
 
 {% if instances is defined %}
-    {% if request.params.get('settings_key') %}
+    {% if settings_focus %}
         {% set extra_fields = [
-             {"label": request.params.get('settings_key'), "name": "settings_focus_value"}
+             {"label": settings_focus.label, "name": "settings_focus_value"}
         ] %}
     {% endif %}
 

--- a/lms/views/admin/application_instance/_core.py
+++ b/lms/views/admin/application_instance/_core.py
@@ -1,31 +1,7 @@
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
-from pyramid.settings import asbool
 
 from lms.models import ApplicationInstance
 from lms.services import ApplicationInstanceNotFound
-
-# Helper to declare settings as secret
-AES_SECRET = object()
-APPLICATION_INSTANCE_SETTINGS = {
-    ("blackboard", "files_enabled"): asbool,
-    ("blackboard", "groups_enabled"): asbool,
-    ("canvas", "sections_enabled"): asbool,
-    ("canvas", "groups_enabled"): asbool,
-    ("desire2learn", "client_id"): str,
-    ("desire2learn", "client_secret"): AES_SECRET,
-    ("desire2learn", "groups_enabled"): asbool,
-    ("desire2learn", "files_enabled"): asbool,
-    ("desire2learn", "create_line_item"): asbool,
-    ("microsoft_onedrive", "files_enabled"): asbool,
-    ("vitalsource", "enabled"): asbool,
-    ("vitalsource", "user_lti_param"): str,
-    ("vitalsource", "user_lti_pattern"): str,
-    ("vitalsource", "api_key"): str,
-    ("vitalsource", "disable_licence_check"): asbool,
-    ("jstor", "enabled"): asbool,
-    ("jstor", "site_code"): str,
-    ("hypothesis", "notes"): str,
-}
 
 
 class BaseApplicationInstanceView:

--- a/tests/unit/lms/models/json_settings_test.py
+++ b/tests/unit/lms/models/json_settings_test.py
@@ -3,8 +3,26 @@ import base64
 import pytest
 
 from lms.models import ApplicationInstance, JSONSettings
+from lms.models.json_settings import JSONSetting
 from lms.services.aes import AESService
 from tests import factories
+
+
+class TestJSONSetting:
+    def test_compound_key(self):
+        setting = JSONSetting("group", "key")
+
+        assert setting.compound_key == "group.key"
+
+    @pytest.mark.parametrize(
+        "setting,expected",
+        (
+            (JSONSetting("group", "key"), "group.key"),
+            (JSONSetting("group", "key", name="name"), "name"),
+        ),
+    )
+    def test_label(self, setting, expected):
+        assert setting.label == expected
 
 
 class TestJSONSettings:

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -2,7 +2,7 @@ from unittest.mock import patch, sentinel
 
 import pytest
 
-from lms.models import ApplicationSettings
+from lms.models import JSONSettings
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin, ErrorCodes
 from lms.product.plugin.grouping import GroupError
 from lms.services import CanvasAPIError
@@ -174,7 +174,7 @@ class TestCanvasGroupingPlugin:
     def test_sections_enabled_course_settings(self, plugin, enabled, pyramid_request):
         application_instance = factories.ApplicationInstance(developer_key=True)
         course = factories.Course(
-            settings=ApplicationSettings({"canvas": {"sections_enabled": enabled}})
+            settings=JSONSettings({"canvas": {"sections_enabled": enabled}})
         )
 
         assert (

--- a/tests/unit/lms/views/admin/application_instance/search_test.py
+++ b/tests/unit/lms/views/admin/application_instance/search_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from lms.views.admin.application_instance.search import (
-    APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+    SETTING_NAMES,
     SearchApplicationInstanceViews,
 )
 from tests import factories
@@ -10,9 +10,7 @@ from tests import factories
 @pytest.mark.usefixtures("application_instance_service")
 class TestSearchApplicationInstanceViews:
     def test_search_start(self, views):
-        assert views.search_start() == {
-            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS
-        }
+        assert views.search_start() == {"settings": SETTING_NAMES}
 
     def test_search_callback(
         self, pyramid_request, application_instance_service, views
@@ -43,7 +41,7 @@ class TestSearchApplicationInstanceViews:
         )
         assert response == {
             "instances": application_instance_service.search.return_value,
-            "settings": APPLICATION_INSTANCE_SETTINGS_COLUMNS,
+            "settings": SETTING_NAMES,
         }
 
     @pytest.mark.parametrize(

--- a/tests/unit/lms/views/admin/application_instance/search_test.py
+++ b/tests/unit/lms/views/admin/application_instance/search_test.py
@@ -1,7 +1,9 @@
 import pytest
+from h_matchers import Any
 
+from lms.models.json_settings import JSONSetting
 from lms.views.admin.application_instance.search import (
-    SETTING_NAMES,
+    SETTINGS_BY_FIELD,
     SearchApplicationInstanceViews,
 )
 from tests import factories
@@ -10,7 +12,7 @@ from tests import factories
 @pytest.mark.usefixtures("application_instance_service")
 class TestSearchApplicationInstanceViews:
     def test_search_start(self, views):
-        assert views.search_start() == {"settings": SETTING_NAMES}
+        assert views.search_start() == {"settings": SETTINGS_BY_FIELD}
 
     def test_search_callback(
         self, pyramid_request, application_instance_service, views
@@ -41,7 +43,8 @@ class TestSearchApplicationInstanceViews:
         )
         assert response == {
             "instances": application_instance_service.search.return_value,
-            "settings": SETTING_NAMES,
+            "settings": SETTINGS_BY_FIELD,
+            "settings_focus": None,
         }
 
     @pytest.mark.parametrize(
@@ -79,6 +82,9 @@ class TestSearchApplicationInstanceViews:
             application_instance_service.search.call_args.kwargs["settings"] == expected
         )
 
+        assert response["settings_focus"] == Any.instance_of(JSONSetting).with_attrs(
+            {"compound_key": settings_key}
+        )
         assert response["instances"][0].settings_focus_value == "SETTING"
 
     def test_search_callback_invalid(self, views, pyramid_request):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/5002

This PR:

 * Splits the `ApplicationSettings` object into a specialized sub-class and a more generic `JSONSettings` class
 * `JSONSettings` is used on groups and organizations
 * `ApplicationSettings` is only used on the application instance
 * We now list the fields which are supported directly on the object
 * The admin pages uses these values
 * Added the `hypothesis.auto_assigned_to_org` field
 * Added a "label" which can be based on a name different from the compound key

A bit unrelated from this PR:

 * Added some more notes and clarity to the `matching()` function for settings

## Testing notes

 * Visit: http://localhost:8001/admin/instances/
 * Notice the drop down has "Notes" and "Auto Assigned To Organisation"
 * Select "Notes" and search
 * Notice that the label in the table is "Notes"

Other things to double check:

 * You can still set settings on the application instance page
 * You can still set settings on the organization page