### PR TITLE
Add searching by public id to the application instance admin pages

### DIFF
--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -142,6 +142,7 @@ class ApplicationInstanceService:
         limit=100,
         email=None,
         settings=None,
+        organization_public_id=None,
     ) -> List[ApplicationInstance]:
         """Return the instances that match all of the passed parameters."""
 
@@ -156,6 +157,7 @@ class ApplicationInstanceService:
                 tool_consumer_instance_guid=tool_consumer_instance_guid,
                 email=email,
                 settings=settings,
+                organization_public_id=organization_public_id,
             )
             .order_by(
                 ApplicationInstance.last_launched.desc().nulls_last(),
@@ -165,6 +167,7 @@ class ApplicationInstanceService:
             .all()
         )
 
+    # pylint: disable=too-complex
     def _ai_search_query(
         self,
         *,
@@ -177,6 +180,7 @@ class ApplicationInstanceService:
         tool_consumer_instance_guid=None,
         email=None,
         settings=None,
+        organization_public_id=None,
     ):
         """Return a query with the passed parameters applied as filters."""
 
@@ -221,6 +225,11 @@ class ApplicationInstanceService:
         if settings:
             query = query.filter(
                 JSONSettings.matching(ApplicationInstance.settings, settings)
+            )
+
+        if organization_public_id:
+            query = query.filter(
+                ApplicationInstance.organization.has(public_id=organization_public_id)
             )
 
         return query

--- a/lms/templates/admin/application_instance/search.html.jinja2
+++ b/lms/templates/admin/application_instance/search.html.jinja2
@@ -20,7 +20,7 @@ Application instances
             <div class="column">
                 {{ macros.form_text_field(request, "Email / Domain", "email") }}
                 {{ macros.form_text_field(request, "Name", "name") }}
-                {{ macros.form_text_field(request, "ID", "id") }}
+                {{ macros.form_text_field(request, "Organization Public Id", "organization_public_id") }}
 
                 {% call macros.field_body("Setting") %}
                     <div class="select">
@@ -47,6 +47,7 @@ Application instances
             </div>
 
             <div class="column">
+                {{ macros.form_text_field(request, "ID", "id") }}
                 {{ macros.form_text_field(request, "GUID", "tool_consumer_instance_guid") }}
                 {{ macros.form_text_field(request, "Client ID", "client_id") }}
                 {{ macros.form_text_field(request, "Consumer key", "consumer_key") }}

--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -45,6 +45,11 @@
             <a class="button is-primary" href="{{ request.route_url("admin.instance.create", _query={"organization_public_id": org.public_id}) }}">
                 Add New LTI 1.1 instance
             </a>
+            {% if org.application_instances %}
+                <a class="button" href="{{ request.route_url("admin.instance.search", _query={"organization_public_id": org.public_id}) }}">
+                    Start search
+                </a>
+            {% endif %}
         </div>
 
         {% if org.application_instances %}

--- a/lms/views/admin/application_instance/_core.py
+++ b/lms/views/admin/application_instance/_core.py
@@ -2,13 +2,14 @@ from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 
 from lms.models import ApplicationInstance
 from lms.services import ApplicationInstanceNotFound
+from lms.services.application_instance import ApplicationInstanceService
 
 
 class BaseApplicationInstanceView:
     def __init__(self, request):
         self.request = request
-        self.application_instance_service = request.find_service(
-            name="application_instance"
+        self.application_instance_service: ApplicationInstanceService = (
+            request.find_service(name="application_instance")
         )
 
     @property

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -242,9 +242,21 @@ class TestApplicationInstanceService:
     def test_search_by_settings(self, service):
         ai = factories.ApplicationInstance.create(settings={"group": {"key": "value"}})
 
-        found = service.search(settings={"group.key": "value"})
+        instances = service.search(settings={"group.key": "value"})
 
-        assert found == [ai]
+        assert instances == [ai]
+
+    def test_search_by_organization_id(self, service, db_session):
+        organization = factories.Organization()
+        ai = factories.ApplicationInstance.create(
+            settings={"group": {"key": "value"}}, organization=organization
+        )
+        # Flush to ensure the organization has a public_id
+        db_session.flush()
+
+        instances = service.search(organization_public_id=organization.public_id)
+
+        assert instances == [ai]
 
     def test_search_order(self, service):
         now, before = datetime.now(), datetime.now() - timedelta(hours=1)

--- a/tests/unit/lms/views/admin/application_instance/search_test.py
+++ b/tests/unit/lms/views/admin/application_instance/search_test.py
@@ -2,6 +2,7 @@ import pytest
 from h_matchers import Any
 
 from lms.models.json_settings import JSONSetting
+from lms.models.public_id import InvalidPublicId
 from lms.views.admin.application_instance.search import (
     SETTINGS_BY_FIELD,
     SearchApplicationInstanceViews,
@@ -26,6 +27,7 @@ class TestSearchApplicationInstanceViews:
             "deployment_id": "DEPLOYMENT_ID",
             "tool_consumer_instance_guid": "TOOL_CONSUMER_INSTANCE_GUID",
             "email": "EMAIL",
+            "organization_public_id": "ORGANIZATION_PUBLIC_ID",
         }
 
         response = views.search_callback()
@@ -39,6 +41,7 @@ class TestSearchApplicationInstanceViews:
             deployment_id="DEPLOYMENT_ID",
             tool_consumer_instance_guid="TOOL_CONSUMER_INSTANCE_GUID",
             email="EMAIL",
+            organization_public_id="ORGANIZATION_PUBLIC_ID",
             settings=None,
         )
         assert response == {
@@ -92,6 +95,16 @@ class TestSearchApplicationInstanceViews:
 
         assert not views.search_callback()
         assert pyramid_request.session.peek_flash
+
+    def test_search_with_invalid_organization_public_id(
+        self, views, pyramid_request, application_instance_service
+    ):
+        application_instance_service.search.side_effect = InvalidPublicId
+
+        response = views.search_callback()
+
+        assert pyramid_request.session.peek_flash
+        assert response == {"settings": SETTINGS_BY_FIELD}
 
     @pytest.fixture
     def views(self, pyramid_request):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/5054

## Testing notes

 * You will need to have launched an assignment at least once to have an organization (dev data this?)
 * Visit: http://localhost:8001/admin/orgs
 * Find an org with at least one application instance
 * Click "Start search"
 * Use this to filter the search, it should work and display the correct application instances
 * Try breaking the organization id structure
 * You should see warnings