### PR TITLE
Use `Intl.Collator` to sort students

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -28,24 +28,14 @@ export default function GradingControls({ grading }: GradingControlsProps) {
   // No initial current student selected
   const [currentStudentIndex, setCurrentStudentIndex] = useState(-1);
 
-  // Students sorted by displayName
+  // Students sorted by display name
   const students = useMemo(() => {
-    function compareNames(name1 = '', name2 = '') {
-      if (name1.toLowerCase() < name2.toLowerCase()) {
-        return -1;
-      } else if (name1.toLowerCase() > name2.toLowerCase()) {
-        return 1;
-      } else {
-        return 0;
-      }
-    }
-    // Make a copy
-    const students_ = [...unorderedStudents];
-
-    students_.sort((student1, student2) => {
-      return compareNames(student1.displayName, student2.displayName);
+    const collator = new Intl.Collator(undefined, {
+      sensitivity: 'accent',
     });
-    return students_;
+    return [...unorderedStudents].sort((a, b) =>
+      collator.compare(a.displayName, b.displayName)
+    );
   }, [unorderedStudents]);
 
   /**

--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -30,7 +30,7 @@ export default function GradingControls({ grading }: GradingControlsProps) {
 
   // Students sorted by display name
   const students = useMemo(() => {
-    const collator = new Intl.Collator(undefined, {
+    const collator = new Intl.Collator(undefined /* use default locale */, {
       sensitivity: 'accent',
     });
     return [...unorderedStudents].sort((a, b) =>

--- a/lms/static/scripts/frontend_apps/components/test/GradingControls-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GradingControls-test.js
@@ -139,7 +139,7 @@ describe('GradingControls', () => {
         displayName: 'Student Beta',
       },
       {
-        displayName: undefined,
+        displayName: '',
       },
     ];
     const wrapper = renderGrader();
@@ -149,7 +149,7 @@ describe('GradingControls', () => {
       .map(s => {
         return s.displayName;
       });
-    assert.match([undefined, 'Student Beta'], orderedStudentNames);
+    assert.match(['', 'Student Beta'], orderedStudentNames);
   });
 
   it('does not set a focus user by default', () => {


### PR DESCRIPTION
Use the browser's native API for case-insensitive comparison instead of rolling our own. The behavior should be the same as before for English locales, but the results should now be appropriate for the user's locale.

See also https://stackoverflow.com/a/2140723/434243 and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator.