### PR TITLE
Adapt Canvas course copy fix to follow CourseCopyPlugin

### DIFF
--- a/lms/product/canvas/_plugin/course_copy.py
+++ b/lms/product/canvas/_plugin/course_copy.py
@@ -1,5 +1,49 @@
+from lms.services.exceptions import FileNotFoundInCourse
+
+
 class CanvasCourseCopyPlugin:
     """Handle course copy in Canvas."""
+
+    def __init__(self, api, file_service):
+        self._api = api
+        self._file_service = file_service
+
+    def is_file_in_course(self, course_id, file_id):
+        """Raise if the current user can't see file_id in course_id."""
+        for file in self._api.list_files(course_id):
+            # The Canvas API returns file IDs as ints but the file_id param
+            # that this method receives (from our proxy API) is a string.
+            # Convert ints to strings so that we can compare them.
+            if str(file["id"]) == file_id:
+                return
+
+        raise FileNotFoundInCourse("canvas_file_not_found_in_course", file_id)
+
+    def find_matching_file_in_course(self, course_id, file_ids):
+        """
+        Return the ID of a file in course_id that matches one of the files in file_ids.
+
+        Search for a file that the current Canvas user can see in course_id and
+        that matches one of the files in file_id's (same filename and size) and
+        return the matching file's ID.
+
+        Return None if no matching file is found.
+        """
+        for file_id in file_ids:
+            file = self._file_service.get(file_id, type_="canvas_file")
+
+            if not file:
+                continue
+
+            for file_dict in self._api.list_files(course_id):
+                if (
+                    file_dict["display_name"] == file.name
+                    and file_dict["size"] == file.size
+                    and str(file_dict["id"]) != file.lms_id
+                ):
+                    return str(file_dict["id"])
+
+        return None
 
     def find_matching_group_set_in_course(self, _course, _group_set_id):
         # We are not yet handling course copy for groups in Canvas.
@@ -9,5 +53,8 @@ class CanvasCourseCopyPlugin:
         return None
 
     @classmethod
-    def factory(cls, _context, _request):
-        return cls()
+    def factory(cls, _context, request):
+        return cls(
+            api=request.find_service(name="canvas_api_client"),
+            file_service=request.find_service(name="file"),
+        )

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -6,9 +6,9 @@ class CanvasService:
 
     api = None
 
-    def __init__(self, canvas_api, file_service):
+    def __init__(self, canvas_api, course_copy_plugin):
         self.api = canvas_api
-        self._finder = CanvasFileFinder(canvas_api, file_service)
+        self._course_copy_plugin = course_copy_plugin
 
     def public_url_for_file(
         self, assignment, file_id, course_id, check_in_course=False
@@ -32,7 +32,7 @@ class CanvasService:
 
         try:
             if check_in_course:
-                self._finder.assert_file_in_course(course_id, effective_file_id)
+                self._course_copy_plugin.is_file_in_course(course_id, effective_file_id)
             return self.api.public_url(effective_file_id)
         except (FileNotFoundInCourse, CanvasAPIPermissionError):
             # The user can't see the file in the course. This could be because:
@@ -45,7 +45,7 @@ class CanvasService:
             #
             # We'll try to find another copy of the same file that the current
             # user *can* see in the current course and use that instead.
-            found_file_id = self._finder.find_matching_file_in_course(
+            found_file_id = self._course_copy_plugin.find_matching_file_in_course(
                 course_id,
                 # Use a set to avoid searching for the same ID twice if file_id
                 # and effective_file_id are the same.
@@ -64,53 +64,8 @@ class CanvasService:
             return url
 
 
-class CanvasFileFinder:
-    """A helper for finding file IDs in the Canvas API."""
-
-    def __init__(self, canvas_api, file_service):
-        self._api = canvas_api
-        self._file_service = file_service
-
-    def assert_file_in_course(self, course_id, file_id):
-        """Raise if the current user can't see file_id in course_id."""
-        for file in self._api.list_files(course_id):
-            # The Canvas API returns file IDs as ints but the file_id param
-            # that this method receives (from our proxy API) is a string.
-            # Convert ints to strings so that we can compare them.
-            if str(file["id"]) == file_id:
-                return
-
-        raise FileNotFoundInCourse("canvas_file_not_found_in_course", file_id)
-
-    def find_matching_file_in_course(self, course_id, file_ids):
-        """
-        Return the ID of a file in course_id that matches one of the files in file_ids.
-
-        Search for a file that the current Canvas user can see in course_id and
-        that matches one of the files in file_id's (same filename and size) and
-        return the matching file's ID.
-
-        Return None if no matching file is found.
-        """
-        for file_id in file_ids:
-            file = self._file_service.get(file_id, type_="canvas_file")
-
-            if not file:
-                continue
-
-            for file_dict in self._api.list_files(course_id):
-                if (
-                    file_dict["display_name"] == file.name
-                    and file_dict["size"] == file.size
-                    and str(file_dict["id"]) != file.lms_id
-                ):
-                    return str(file_dict["id"])
-
-        return None
-
-
 def factory(_context, request):
     return CanvasService(
         canvas_api=request.find_service(name="canvas_api_client"),
-        file_service=request.find_service(name="file"),
+        course_copy_plugin=request.product.plugin.course_copy,
     )

--- a/tests/unit/lms/product/canvas/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/course_copy_test.py
@@ -1,8 +1,10 @@
-from unittest.mock import sentinel
+from unittest.mock import call, sentinel
 
 import pytest
 
 from lms.product.canvas import CanvasCourseCopyPlugin
+from lms.services.exceptions import FileNotFoundInCourse
+from tests import factories
 
 
 class TestCanvasCourseCopyPlugin:
@@ -11,11 +13,122 @@ class TestCanvasCourseCopyPlugin:
             sentinel.course, sentinel.group_set_id
         )
 
+    def test_is_file_in_course_doesnt_raise_if_the_file_is_in_the_course(
+        self, plugin, canvas_api_client
+    ):
+        canvas_api_client.list_files.return_value = [
+            {"id": sentinel.file_id},
+            {"id": sentinel.other_file_id},
+        ]
+
+        plugin.is_file_in_course(sentinel.course_id, str(sentinel.file_id))
+
+    def test_is_file_in_course_course_raises_if_the_file_isnt_in_the_course(
+        self, plugin, canvas_api_client
+    ):
+        canvas_api_client.list_files.return_value = [{"id": sentinel.other_file_id}]
+
+        with pytest.raises(FileNotFoundInCourse) as excinfo:
+            plugin.is_file_in_course(sentinel.course_id, sentinel.file_id)
+
+        assert excinfo.value.error_code == "canvas_file_not_found_in_course"
+
+    def test_find_matching_file_in_course_returns_the_matching_file_id(
+        self, plugin, canvas_api_client, file_service
+    ):
+        file_service.get.return_value = factories.File()
+        canvas_api_client.list_files.return_value = [
+            {"id": 1, "display_name": "File 1", "size": 1024},
+            {
+                "id": sentinel.matching_file_id,
+                "display_name": file_service.get.return_value.name,
+                "size": file_service.get.return_value.size,
+            },
+        ]
+
+        matching_file_id = plugin.find_matching_file_in_course(
+            sentinel.course_id, [sentinel.file_id]
+        )
+
+        file_service.get.assert_called_once_with(sentinel.file_id, type_="canvas_file")
+        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
+        assert matching_file_id == str(sentinel.matching_file_id)
+
+    def test_find_matching_file_in_course_with_multiple_file_ids(
+        self, plugin, canvas_api_client, file_service
+    ):
+        matching_file = factories.File()
+        file_service.get.side_effect = [
+            # The first file_id isn't found in the DB.
+            None,
+            # The second file_id is in the DB but not found in the course.
+            factories.File(),
+            # The third file_id *will* be found in the course.
+            matching_file,
+        ]
+        canvas_api_client.list_files.return_value = [
+            {
+                "id": sentinel.matching_file_id,
+                "display_name": matching_file.name,
+                "size": matching_file.size,
+            },
+        ]
+
+        matching_file_id = plugin.find_matching_file_in_course(
+            sentinel.course_id,
+            [sentinel.file_id_1, sentinel.file_id_2, sentinel.file_id_3],
+        )
+
+        # It looked up each file_id in the DB in turn.
+        assert file_service.get.call_args_list == [
+            call(sentinel.file_id_1, type_="canvas_file"),
+            call(sentinel.file_id_2, type_="canvas_file"),
+            call(sentinel.file_id_3, type_="canvas_file"),
+        ]
+        assert matching_file_id == str(sentinel.matching_file_id)
+
+    def test_find_matching_file_in_course_returns_None_if_theres_no_file_in_the_db(
+        self, plugin, file_service
+    ):
+        file_service.get.return_value = None
+
+        assert not plugin.find_matching_file_in_course(
+            sentinel.course_id, [sentinel.file_id]
+        )
+
+    def test_find_matching_file_in_course_returns_None_if_theres_no_match(
+        self, plugin, file_service
+    ):
+        file_service.get.return_value = factories.File(name="foo")
+
+        assert not plugin.find_matching_file_in_course(
+            sentinel.course_id, [sentinel.file_id]
+        )
+
+    def test_find_matching_file_in_course_doesnt_return_the_same_file(
+        self, plugin, canvas_api_client, file_service
+    ):
+        # If the response from the Canvas API contains a "matching" file dict
+        # that happens to be the *same* file as the one we're searching for (it
+        # has the same id) find_matching_file_in_course() should not return
+        # the same file_id as it was asked to search for a match for.
+        matching_file_dict = canvas_api_client.list_files.return_value[1]
+        file_service.get.return_value = factories.File(
+            lms_id=str(matching_file_dict["id"]),
+            name=matching_file_dict["display_name"],
+            size=matching_file_dict["size"],
+        )
+
+        assert not plugin.find_matching_file_in_course(
+            sentinel.course_id, [sentinel.file_id]
+        )
+
+    @pytest.mark.usefixtures("canvas_api_client", "file_service")
     def test_factory(self, pyramid_request):
         plugin = CanvasCourseCopyPlugin.factory(sentinel.context, pyramid_request)
 
         assert isinstance(plugin, CanvasCourseCopyPlugin)
 
     @pytest.fixture
-    def plugin(self):
-        return CanvasCourseCopyPlugin()
+    def plugin(self, canvas_api_client, file_service):
+        return CanvasCourseCopyPlugin(api=canvas_api_client, file_service=file_service)

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -4,7 +4,7 @@ from unittest.mock import call, sentinel
 import pytest
 
 from lms.services import CanvasAPIPermissionError, CanvasService
-from lms.services.canvas import CanvasFileFinder, factory
+from lms.services.canvas import factory
 from lms.services.exceptions import FileNotFoundInCourse
 from tests import factories
 
@@ -14,31 +14,28 @@ class TestPublicURLForFile:
     def test_the_happy_path(
         self,
         canvas_api_client,
-        canvas_file_finder,
+        course_copy_plugin,
         check_in_course,
-        file_service,
         public_url_for_file,
-        CanvasFileFinder,
     ):
         url = public_url_for_file(sentinel.file_id, check_in_course=check_in_course)
 
-        CanvasFileFinder.assert_called_once_with(canvas_api_client, file_service)
         if check_in_course:
-            canvas_file_finder.assert_file_in_course.assert_called_once_with(
+            course_copy_plugin.is_file_in_course.assert_called_once_with(
                 sentinel.course_id, sentinel.file_id
             )
         else:
-            canvas_file_finder.assert_file_in_course.assert_not_called()
+            course_copy_plugin.is_file_in_course.assert_not_called()
         canvas_api_client.public_url.assert_called_once_with(sentinel.file_id)
         assert url == canvas_api_client.public_url.return_value
 
     @pytest.mark.usefixtures("with_mapped_file_id")
     def test_if_theres_a_mapped_file_id_it_uses_it(
-        self, canvas_api_client, canvas_file_finder, public_url_for_file
+        self, canvas_api_client, course_copy_plugin, public_url_for_file
     ):
         url = public_url_for_file(sentinel.file_id, check_in_course=True)
 
-        canvas_file_finder.assert_file_in_course.assert_called_once_with(
+        course_copy_plugin.is_file_in_course.assert_called_once_with(
             sentinel.course_id, sentinel.mapped_file_id
         )
         canvas_api_client.public_url.assert_called_once_with(sentinel.mapped_file_id)
@@ -48,20 +45,20 @@ class TestPublicURLForFile:
     def test_if_the_file_isnt_in_the_course_it_finds_a_matching_file_instead(
         self,
         canvas_api_client,
-        canvas_file_finder,
+        course_copy_plugin,
         assignment,
         public_url_for_file,
     ):
-        canvas_file_finder.assert_file_in_course.side_effect = FileNotFoundInCourse(
+        course_copy_plugin.is_file_in_course.side_effect = FileNotFoundInCourse(
             "canvas_file_not_found_in_course", sentinel.file_id
         )
-        canvas_file_finder.find_matching_file_in_course.return_value = (
+        course_copy_plugin.find_matching_file_in_course.return_value = (
             sentinel.found_file_id
         )
 
         url = public_url_for_file(sentinel.file_id, check_in_course=True)
 
-        canvas_file_finder.find_matching_file_in_course.assert_called_once_with(
+        course_copy_plugin.find_matching_file_in_course.assert_called_once_with(
             sentinel.course_id, {sentinel.file_id, sentinel.mapped_file_id}
         )
         assert (
@@ -73,12 +70,12 @@ class TestPublicURLForFile:
 
     @pytest.mark.usefixtures("with_mapped_file_id")
     def test_if_the_file_isnt_in_the_course_and_theres_no_matching_file_it_raises(
-        self, canvas_file_finder, public_url_for_file
+        self, course_copy_plugin, public_url_for_file
     ):
-        canvas_file_finder.assert_file_in_course.side_effect = FileNotFoundInCourse(
+        course_copy_plugin.is_file_in_course.side_effect = FileNotFoundInCourse(
             "canvas_file_not_found_in_course", sentinel.file_id
         )
-        canvas_file_finder.find_matching_file_in_course.return_value = None
+        course_copy_plugin.find_matching_file_in_course.return_value = None
 
         with pytest.raises(FileNotFoundInCourse):
             public_url_for_file(sentinel.file_id, check_in_course=True)
@@ -87,7 +84,7 @@ class TestPublicURLForFile:
     def test_if_theres_a_permissions_error_it_finds_a_matching_file_instead(
         self,
         canvas_api_client,
-        canvas_file_finder,
+        course_copy_plugin,
         assignment,
         public_url_for_file,
     ):
@@ -95,13 +92,13 @@ class TestPublicURLForFile:
             CanvasAPIPermissionError,
             sentinel.url,
         ]
-        canvas_file_finder.find_matching_file_in_course.return_value = (
+        course_copy_plugin.find_matching_file_in_course.return_value = (
             sentinel.found_file_id
         )
 
         url = public_url_for_file(sentinel.file_id)
 
-        canvas_file_finder.find_matching_file_in_course.assert_called_once_with(
+        course_copy_plugin.find_matching_file_in_course.assert_called_once_with(
             sentinel.course_id, {sentinel.file_id, sentinel.mapped_file_id}
         )
         assert (
@@ -116,10 +113,10 @@ class TestPublicURLForFile:
 
     @pytest.mark.usefixtures("with_mapped_file_id")
     def test_if_theres_a_permissions_error_and_theres_no_matching_file_it_raises(
-        self, canvas_api_client, canvas_file_finder, public_url_for_file
+        self, canvas_api_client, course_copy_plugin, public_url_for_file
     ):
         canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
-        canvas_file_finder.find_matching_file_in_course.return_value = None
+        course_copy_plugin.find_matching_file_in_course.return_value = None
 
         with pytest.raises(CanvasAPIPermissionError):
             public_url_for_file(sentinel.file_id)
@@ -127,12 +124,12 @@ class TestPublicURLForFile:
     def test_it_doesnt_save_a_mapped_file_id_if_getting_that_files_public_url_fails(
         self,
         canvas_api_client,
-        canvas_file_finder,
+        course_copy_plugin,
         assignment,
         public_url_for_file,
     ):
         canvas_api_client.public_url.side_effect = CanvasAPIPermissionError
-        canvas_file_finder.find_matching_file_in_course.return_value = (
+        course_copy_plugin.find_matching_file_in_course.return_value = (
             sentinel.found_file_id
         )
 
@@ -161,138 +158,16 @@ class TestPublicURLForFile:
             course_id=sentinel.course_id,
         )
 
-    @pytest.fixture(autouse=True)
-    def CanvasFileFinder(self, patch):
-        return patch("lms.services.canvas.CanvasFileFinder")
-
-    @pytest.fixture
-    def canvas_file_finder(self, CanvasFileFinder):
-        return CanvasFileFinder.return_value
-
-
-class TestCanvasFileFinder:
-    def test_assert_file_in_course_doesnt_raise_if_the_file_is_in_the_course(
-        self, finder, canvas_api_client
-    ):
-        canvas_api_client.list_files.return_value = [
-            {"id": sentinel.file_id},
-            {"id": sentinel.other_file_id},
-        ]
-
-        finder.assert_file_in_course(sentinel.course_id, str(sentinel.file_id))
-
-    def test_assert_file_in_course_raises_if_the_file_isnt_in_the_course(
-        self, finder, canvas_api_client
-    ):
-        canvas_api_client.list_files.return_value = [{"id": sentinel.other_file_id}]
-
-        with pytest.raises(FileNotFoundInCourse) as excinfo:
-            finder.assert_file_in_course(sentinel.course_id, sentinel.file_id)
-
-        assert excinfo.value.error_code == "canvas_file_not_found_in_course"
-
-    def test_find_matching_file_in_course_returns_the_matching_file_id(
-        self, finder, canvas_api_client, file_service
-    ):
-        file_service.get.return_value = factories.File()
-        canvas_api_client.list_files.return_value = [
-            {"id": 1, "display_name": "File 1", "size": 1024},
-            {
-                "id": sentinel.matching_file_id,
-                "display_name": file_service.get.return_value.name,
-                "size": file_service.get.return_value.size,
-            },
-        ]
-
-        matching_file_id = finder.find_matching_file_in_course(
-            sentinel.course_id, [sentinel.file_id]
-        )
-
-        file_service.get.assert_called_once_with(sentinel.file_id, type_="canvas_file")
-        canvas_api_client.list_files.assert_called_once_with(sentinel.course_id)
-        assert matching_file_id == str(sentinel.matching_file_id)
-
-    def test_find_matching_file_in_course_with_multiple_file_ids(
-        self, finder, canvas_api_client, file_service
-    ):
-        matching_file = factories.File()
-        file_service.get.side_effect = [
-            # The first file_id isn't found in the DB.
-            None,
-            # The second file_id is in the DB but not found in the course.
-            factories.File(),
-            # The third file_id *will* be found in the course.
-            matching_file,
-        ]
-        canvas_api_client.list_files.return_value = [
-            {
-                "id": sentinel.matching_file_id,
-                "display_name": matching_file.name,
-                "size": matching_file.size,
-            },
-        ]
-
-        matching_file_id = finder.find_matching_file_in_course(
-            sentinel.course_id,
-            [sentinel.file_id_1, sentinel.file_id_2, sentinel.file_id_3],
-        )
-
-        # It looked up each file_id in the DB in turn.
-        assert file_service.get.call_args_list == [
-            call(sentinel.file_id_1, type_="canvas_file"),
-            call(sentinel.file_id_2, type_="canvas_file"),
-            call(sentinel.file_id_3, type_="canvas_file"),
-        ]
-        assert matching_file_id == str(sentinel.matching_file_id)
-
-    def test_find_matching_file_in_course_returns_None_if_theres_no_file_in_the_db(
-        self, finder, file_service
-    ):
-        file_service.get.return_value = None
-
-        assert not finder.find_matching_file_in_course(
-            sentinel.course_id, [sentinel.file_id]
-        )
-
-    def test_find_matching_file_in_course_returns_None_if_theres_no_match(
-        self, finder, file_service
-    ):
-        file_service.get.return_value = factories.File(name="foo")
-
-        assert not finder.find_matching_file_in_course(
-            sentinel.course_id, [sentinel.file_id]
-        )
-
-    def test_find_matching_file_in_course_doesnt_return_the_same_file(
-        self, finder, canvas_api_client, file_service
-    ):
-        # If the response from the Canvas API contains a "matching" file dict
-        # that happens to be the *same* file as the one we're searching for (it
-        # has the same id) find_matching_file_in_course() should not return
-        # the same file_id as it was asked to search for a match for.
-        matching_file_dict = canvas_api_client.list_files.return_value[1]
-        file_service.get.return_value = factories.File(
-            lms_id=str(matching_file_dict["id"]),
-            name=matching_file_dict["display_name"],
-            size=matching_file_dict["size"],
-        )
-
-        assert not finder.find_matching_file_in_course(
-            sentinel.course_id, [sentinel.file_id]
-        )
-
-    @pytest.fixture
-    def finder(self, canvas_api_client, file_service):
-        return CanvasFileFinder(canvas_api_client, file_service)
-
 
 class TestFactory:
-    def test_it(self, pyramid_request, CanvasService, canvas_api_client, file_service):
-        result = factory("*any*", request=pyramid_request)
+    def test_it(
+        self, pyramid_request, CanvasService, canvas_api_client, course_copy_plugin
+    ):
+        result = factory(sentinel.context, request=pyramid_request)
 
         assert result == CanvasService.return_value
         CanvasService.assert_called_once_with(
-            canvas_api=canvas_api_client, file_service=file_service
+            canvas_api=canvas_api_client, course_copy_plugin=course_copy_plugin
         )
 
     @pytest.fixture
@@ -301,5 +176,5 @@ class TestFactory:
 
 
 @pytest.fixture
-def canvas_service(canvas_api_client, file_service):
-    return CanvasService(canvas_api_client, file_service)
+def canvas_service(canvas_api_client, course_copy_plugin):
+    return CanvasService(canvas_api_client, course_copy_plugin)


### PR DESCRIPTION
Adapt the course copy fix for Canvas to the CourseCopyPlugin
format without any functional changes.

It should be possible to eventually share more code with the rest of the
LMS's but that will require data migrations and more careful testing.

This change aligns the code location so it matches the expectations set
by the plugin.


### Testing

Nothing should have changed regarding Canvas files but lets do a sanity check of the process:

- Reset you DB state

tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping,assignment,file cascade;"; make devdata;


- Launch a copied assignment that uses Canvas files

https://hypothesis.instructure.com/courses/521/assignments/4305


It will fail


- Get the list of files from the orignial course
 
 Configure an assignment there, pick the localhost tool and pick "Canvas files", getting the file picker to show the files is enough:

https://hypothesis.instructure.com/courses/125/assignments/3930/edit?name=Marcos+Assignment&due_at=2023-02-02T06%3A59%3A59.000Z&points_possible=0


- Launch the copied assignment again:
https://hypothesis.instructure.com/courses/521/assignments/4305

It should work this time.

