### PR TITLE
Convert API call helpers to TS, make return type generic

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -149,7 +149,7 @@ export default function BasicLTILaunchApp() {
       }
 
       try {
-        const groups = await apiCall({
+        const groups = await apiCall<string[]>({
           authToken,
           path: syncAPICallInfo.path,
           data: syncAPICallInfo.data,
@@ -188,7 +188,7 @@ export default function BasicLTILaunchApp() {
     let success;
     incFetchCount();
     try {
-      const { via_url: contentURL } = await apiCall({
+      const { via_url: contentURL } = await apiCall<{ via_url: string }>({
         authToken: authToken,
         path: viaAPICallInfo.path,
       });

--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -61,7 +61,7 @@ export default function GradingControls({ grading }: GradingControlsProps) {
           gradingStudentId: user.lmsId,
         };
         try {
-          groups = await apiCall({
+          groups = await apiCall<string[]>({
             authToken,
             path: syncAPICallInfo.path,
             data: studentGroupsCallData,

--- a/lms/static/scripts/frontend_apps/services/client-rpc.js
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.js
@@ -104,10 +104,12 @@ export class ClientRPC extends TinyEmitter {
       if (grantToken.hasExpired()) {
         const issuedAt = Date.now();
         try {
-          const response = await apiCall({
-            authToken,
-            path: '/api/grant_token',
-          });
+          const response = /** @type {{ grant_token: string }} */ (
+            await apiCall({
+              authToken,
+              path: '/api/grant_token',
+            })
+          );
           grantToken = new JWT(response.grant_token, issuedAt);
         } catch (err) {
           throw new Error(


### PR DESCRIPTION
 - Convert utilities for frontend -> backend API calls to TypeScript
 - Make `apiCall` generic over the return type and change the default from `any` to `unknown`. This forces callers to specify what properties they expect the result to have, if they try to use it. If they don't care about the shape of the response, they can just await the `Promise<unknown>` default.