### PR TITLE
Update shared components in `LMSFilePickerApp`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -1,8 +1,8 @@
 import {
-  FullScreenSpinner,
-  LabeledButton,
+  Button,
   Modal,
-} from '@hypothesis/frontend-shared';
+  SpinnerOverlay,
+} from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
 import { useCallback, useEffect, useState } from 'preact/hooks';
@@ -346,25 +346,25 @@ export default function LMSFilePicker({
       break;
     case 'reload':
       continueButton = (
-        <LabeledButton
+        <Button
           variant="primary"
           onClick={() => computeFilesToDisplay(true /* reload */)}
           data-testid="reload"
         >
           Reload
-        </LabeledButton>
+        </Button>
       );
       break;
     case 'select':
       continueButton = (
-        <LabeledButton
+        <Button
           variant="primary"
           disabled={continueAction.disabled}
           onClick={() => confirmSelectedItem()}
           data-testid="select"
         >
           {continueAction.label}
-        </LabeledButton>
+        </Button>
       );
       break;
   }
@@ -372,17 +372,27 @@ export default function LMSFilePicker({
   const withFileUI = ['fetching', 'fetched'].includes(dialogState.state);
 
   if (dialogState.state === 'fetching' && initialFetch) {
-    return <FullScreenSpinner />;
+    return <SpinnerOverlay />;
   }
 
   return (
     <Modal
-      contentClass={classnames('LMS-Dialog', {
-        'LMS-Dialog--wide LMS-Dialog--tall': withFileUI,
+      classes={classnames({
+        // Set a fixed height on the modal when displaying a list of files.
+        // This prevents the height of the modal changing as items are loaded.
+        'h-[25rem]': withFileUI,
       })}
       title="Select file"
-      onCancel={onCancel}
-      buttons={continueButton}
+      onClose={onCancel}
+      width="lg"
+      buttons={[
+        <Button data-testid="cancel-button" key="cancel" onClick={onCancel}>
+          Cancel
+        </Button>,
+        continueButton,
+      ]}
+      // The FileList UI handles its own (partial-content) scrolling
+      scrollable={!withFileUI}
     >
       {dialogState.state === 'authorizing' && (
         <p data-testid="authorization warning">

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -93,10 +93,10 @@ describe('LMSFilePicker', () => {
 
   it('shows a full-screen spinner when the component is fetching', async () => {
     const wrapper = renderFilePicker();
-    assert.isTrue(wrapper.find('FullScreenSpinner').exists());
+    assert.isTrue(wrapper.find('SpinnerOverlay').exists());
 
     await waitForElement(wrapper, 'FileList');
-    assert.isFalse(wrapper.find('FullScreenSpinner').exists());
+    assert.isFalse(wrapper.find('SpinnerOverlay').exists());
   });
 
   it('shows breadcrumbs if `withBreadcrumbs` enabled', async () => {
@@ -316,7 +316,7 @@ describe('LMSFilePicker', () => {
     const wrapper = renderFilePicker();
     const reloadButton = await waitForElement(
       wrapper,
-      'LabeledButton[data-testid="reload"]'
+      'button[data-testid="reload"]'
     );
     assert.equal(reloadButton.text(), 'Reload');
     assert.isNotOk(reloadButton.prop('disabled'));
@@ -342,10 +342,8 @@ describe('LMSFilePicker', () => {
     //
     // [1]: Because it's `fetching` and not `fetched`, the button's testid
     // is "select" instead of "reload"
-    await waitForElement(wrapper, 'LabeledButton[data-testid="select"]');
-    const waitingReloadButton = wrapper.find(
-      'LabeledButton[data-testid="select"]'
-    );
+    await waitForElement(wrapper, 'button[data-testid="select"]');
+    const waitingReloadButton = wrapper.find('button[data-testid="select"]');
     assert.isTrue(waitingReloadButton.prop('disabled'));
     assert.equal(waitingReloadButton.text(), 'Reload');
 
@@ -355,10 +353,8 @@ describe('LMSFilePicker', () => {
 
     // The component will move into a `fetched` state, and will once again
     // provide an enabled continue button to attempt a reload
-    await waitForElement(wrapper, 'LabeledButton[data-testid="reload"]');
-    const finalReloadButton = wrapper.find(
-      'LabeledButton[data-testid="reload"]'
-    );
+    await waitForElement(wrapper, 'button[data-testid="reload"]');
+    const finalReloadButton = wrapper.find('button[data-testid="reload"]');
     assert.equal(finalReloadButton.text(), 'Reload');
     assert.isNotOk(finalReloadButton.prop('disabled'));
   });
@@ -385,7 +381,7 @@ describe('LMSFilePicker', () => {
     // The file list is empty. The continue button should have a "Reload" label.
     const reloadButton = await waitForElement(
       wrapper,
-      'LabeledButton[data-testid="reload"]'
+      'button[data-testid="reload"]'
     );
     assert.equal(reloadButton.text(), 'Reload');
 
@@ -406,7 +402,7 @@ describe('LMSFilePicker', () => {
 
     const continueButton = await waitForElement(
       wrapper,
-      'LabeledButton[data-testid="select"]'
+      'button[data-testid="select"]'
     );
     assert.equal(continueButton.text(), 'Select');
     // No file is selected, so the button is disabled
@@ -477,7 +473,7 @@ describe('LMSFilePicker', () => {
 
     const button = await waitForElement(
       wrapper,
-      'LabeledButton[data-testid="select"]'
+      'button[data-testid="select"]'
     );
     assert.isTrue(button.prop('disabled'));
   });
@@ -490,7 +486,7 @@ describe('LMSFilePicker', () => {
     wrapper.update();
 
     assert.equal(
-      wrapper.find('LabeledButton[data-testid="select"]').prop('disabled'),
+      wrapper.find('button[data-testid="select"]').prop('disabled'),
       false
     );
   });
@@ -505,7 +501,7 @@ describe('LMSFilePicker', () => {
     fileList.prop('onSelectFile')(file);
     wrapper.update();
 
-    wrapper.find('LabeledButton[data-testid="select"]').prop('onClick')();
+    wrapper.find('button[data-testid="select"]').prop('onClick')();
 
     assert.calledWith(onSelectFile, file);
   });
@@ -516,7 +512,7 @@ describe('LMSFilePicker', () => {
     // test accomplishes what it's trying to accomplish: we're not rendering
     // the Modal
     assert.isTrue(wrapper.isEmptyRender());
-    assert.isTrue(wrapper.find('FullScreenSpinner').exists());
+    assert.isTrue(wrapper.find('SpinnerOverlay').exists());
 
     await waitForElement(wrapper, 'FileList');
     assert.isFalse(wrapper.isEmptyRender());


### PR DESCRIPTION
This PR updates the shared components in the `LMSFilePickerApp` component. User-visible changes are minor as we move to the updated `Modal` component and its `Panel`.

This component is best exercised through BlackBoard[^1], where you can see the contained file list in tandem with breadcrumbs.

<img width="714" alt="image" src="https://user-images.githubusercontent.com/439947/219720546-e0149c50-41f4-4beb-9fb5-8102de098ad4.png">

Part of #5013

[^1]: You can get to this component from assignment configuration by clicking the "Select PDF from BlackBoard" options.