### PR TITLE
Migration for Assignment.copied_form_id

### DIFF
--- a/lms/migrations/versions/5f0057d6d60f_assignment_copied_from.py
+++ b/lms/migrations/versions/5f0057d6d60f_assignment_copied_from.py
@@ -1,0 +1,35 @@
+"""
+Add copied_from_id to assignment.
+
+Revision ID: 5f0057d6d60f
+Revises: d737e73915b8
+Create Date: 2023-02-20 09:33:35.423402
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "5f0057d6d60f"
+down_revision = "d737e73915b8"
+
+
+def upgrade():
+    op.add_column(
+        "assignment", sa.Column("copied_from_id", sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        op.f("fk__assignment__copied_from_id__assignment"),
+        "assignment",
+        "assignment",
+        ["copied_from_id"],
+        ["id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk__assignment__copied_from_id__assignment"),
+        "assignment",
+        type_="foreignkey",
+    )
+    op.drop_column("assignment", "copied_from_id")


### PR DESCRIPTION
Usage in https://github.com/hypothesis/lms/pull/5068


Adds the new column as nullable

We currently use this information for course copy but we don't store in on the DB. Having this on the DB will allow us to answer questions about the efficacy of our course copy fix, how often course copy is issued etc.


### Testing

- Execute migration forward:

```hdev alembic upgrade head```


- Check the presence of the new column


``` tox -qe dockercompose -- exec postgres psql -U postgres -c "select copied_from_id from assignment;"```



- Execute migration backwards:



```hdev alembic downgrade -1```


