### PR TITLE
Migrate to non-deprecated components in ErrorDisplay

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
-import { Link, Scrollbox } from '@hypothesis/frontend-shared';
+import { Link, Scroll } from '@hypothesis/frontend-shared/lib/next';
 
 import { formatErrorDetails, formatErrorMessage } from '../errors';
 import type { ErrorLike } from '../errors';
@@ -112,7 +112,12 @@ export default function ErrorDisplay({
   const message = formatErrorMessage(error, /* prefix */ description);
 
   return (
-    <Scrollbox classes="LMS-Scrollbox">
+    <Scroll classes={classnames(
+      // FIXME This class can be removed once the Modal in LMSFilePicker
+      // has been updated to latest frontend-shared components.
+      // Now it is needed to overwrite a style set on the modal itself.
+      '!mt-0'
+    )}>
       <div className="pt-4 space-y-4">
         {message && <p data-testid="error-message">{toSentence(message)}</p>}
 
@@ -130,6 +135,6 @@ export default function ErrorDisplay({
         </p>
         <ErrorDetails error={error} />
       </div>
-    </Scrollbox>
+    </Scroll>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
@@ -112,12 +112,14 @@ export default function ErrorDisplay({
   const message = formatErrorMessage(error, /* prefix */ description);
 
   return (
-    <Scroll classes={classnames(
-      // FIXME This class can be removed once the Modal in LMSFilePicker
-      // has been updated to latest frontend-shared components.
-      // Now it is needed to overwrite a style set on the modal itself.
-      '!mt-0'
-    )}>
+    <Scroll
+      classes={classnames(
+        // FIXME This class can be removed once the Modal in LMSFilePicker
+        // has been updated to latest frontend-shared components.
+        // Now it is needed to overwrite a style set on the modal itself.
+        '!mt-0'
+      )}
+    >
       <div className="pt-4 space-y-4">
         {message && <p data-testid="error-message">{toSentence(message)}</p>}
 

--- a/lms/static/scripts/ui-playground/components/ErrorComponents.js
+++ b/lms/static/scripts/ui-playground/components/ErrorComponents.js
@@ -189,8 +189,8 @@ export default function ErrorComponents() {
           <p>
             The <code>ErrorDisplay</code> component is used to show information
             about errors to users. It is intended to be used within a Modal
-            context, and provides a <code>Scrollbox</code> to scroll content if
-            it is too tall for the containing element.
+            context, and provides a <code>Scroll</code> to scroll content if it
+            is too tall for the containing element.
           </p>
           <p>
             When information about an error is displayed to a user via{' '}

--- a/lms/static/styles/components/_shared.scss
+++ b/lms/static/styles/components/_shared.scss
@@ -33,18 +33,4 @@
   & h2 {
     margin: 0;
   }
-
-  & > .LMS-Scrollbox {
-    // Dialogs apply vertical spacing such that their immediate children are
-    // evenly spaced. This is a good thing, however, there is a certain edge case
-    // when we have a Scrollbox and we want it to scroll up flush against the
-    // bottom border of the Dialog header. In this case we want to explicitly
-    // disable the top margin so that it can be up against the header.
-    margin-top: 0;
-  }
-}
-
-.LMS-Scrollbox {
-  // The Scrollbox border in this case is distracting.
-  border: none;
 }


### PR DESCRIPTION
> This depends on https://github.com/hypothesis/lms/pull/5069

Migrate `ErrorDisplay` to non-deprecated components from the shared library.

There should be no visual changes. See the comparison here:

Before:

https://user-images.githubusercontent.com/2719332/220074105-b681e73b-2c07-4f15-8363-c3a209fb453a.mp4

After:

https://user-images.githubusercontent.com/2719332/220075744-271d427b-24ba-41a6-acc2-0d740eae3444.mp4

