### PR TITLE
Handle D2L api versioning per product

### DIFF
--- a/lms/services/d2l_api/_basic.py
+++ b/lms/services/d2l_api/_basic.py
@@ -3,9 +3,17 @@ from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
 TOKEN_URL = "https://auth.brightspace.com/core/connect/token"
 """This is constant for all D2L instances"""
 
+API_VERSIONS = {
+    "le": "1.51",
+    "lp": "1.31",
+}
+"""
+Minimum, non legacy version we can use for all needed endpoints in each D2l product.
 
-API_VERSION = "1.31"
-"""Minimum, non deprecated version we can use for all needed endpoints"""
+The mapping is non-exhaustive, we only list here the products we use.
+
+https://docs.valence.desire2learn.com/about.html#principal-version-table
+"""
 
 
 class BasicClient:
@@ -89,4 +97,7 @@ class BasicClient:
 
             https://docs.valence.desire2learn.com/basic/conventions.html#term-D2LPRODUCT
         """
-        return f"https://{self.lms_host}/d2l/api/{product}/{API_VERSION}{path}"
+        # Not using a default value here.
+        # If we use a new product we must include the version requirements explicitly  in `API_VERSIONS'
+        api_version = API_VERSIONS[product]
+        return f"https://{self.lms_host}/d2l/api/{product}/{api_version}{path}"

--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -8,7 +8,7 @@ from lms.services.d2l_api import D2LAPIClient
 from lms.validation.authentication import OAuthCallbackSchema
 
 GROUPS_SCOPES = ("groups:group:read",)
-FILES_SCOPES = ("content:toc:read", "content:topics:read")
+FILES_SCOPES = ("content:toc:read", "content:topics:read", "content:file:read")
 
 
 @view_config(

--- a/tests/unit/lms/services/d2l_api/_basic_test.py
+++ b/tests/unit/lms/services/d2l_api/_basic_test.py
@@ -2,7 +2,7 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.services.d2l_api._basic import API_VERSION, TOKEN_URL, BasicClient
+from lms.services.d2l_api._basic import API_VERSIONS, TOKEN_URL, BasicClient
 from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
 from tests import factories
 
@@ -30,7 +30,10 @@ class TestBasicClient:
     @pytest.mark.parametrize(
         "path,expected_url",
         [
-            ("/foo/bar", f"https://d2l.example.com/d2l/api/lp/{API_VERSION}/foo/bar"),
+            (
+                "/foo/bar",
+                f"https://d2l.example.com/d2l/api/lp/{API_VERSIONS['lp']}/foo/bar",
+            ),
             ("https://full.d2l.url.com/foo", "https://full.d2l.url.com/foo"),
         ],
     )
@@ -65,6 +68,16 @@ class TestBasicClient:
             basic_client.request("GET", "/foo")
 
         assert not exc_info.value.refreshable
+
+    @pytest.mark.parametrize(
+        "path,product,expected",
+        [
+            ("/api/groups", "lp", "https://d2l.example.com/d2l/api/lp/1.31/api/groups"),
+            ("/api/files", "le", "https://d2l.example.com/d2l/api/le/1.51/api/files"),
+        ],
+    )
+    def test_api_url(self, basic_client, path, product, expected):
+        assert basic_client.api_url(path, product) == expected
 
     @pytest.fixture
     def basic_client(self, http_service, oauth_http_service):

--- a/tests/unit/lms/views/api/d2l/authorize_test.py
+++ b/tests/unit/lms/views/api/d2l/authorize_test.py
@@ -19,9 +19,13 @@ class TestAuthorize:
     @pytest.mark.parametrize(
         "groups,files,scopes",
         [
-            (False, True, "content:toc:read content:topics:read"),
+            (False, True, "content:toc:read content:topics:read content:file:read"),
             (True, False, "groups:group:read"),
-            (True, True, "content:toc:read content:topics:read groups:group:read"),
+            (
+                True,
+                True,
+                "content:toc:read content:topics:read content:file:read groups:group:read",
+            ),
         ],
     )
     def test_it(


### PR DESCRIPTION
D2L classifies API calls in different internal products (eg Learning Platform, Learning Environment) each one of them having different API versioning.

Here we explicitly use one version number per product using the last non-legacy version listed here:

https://docs.valence.desire2learn.com/about.html#principal-version-table


As a side effect of updating the version for `le` we need a new scope for the files feature. The feature is not yet released to the costumers so it's not a problem.

After merging the PR we need to upgrade: https://github.com/hypothesis/lms/wiki/D2L-API-endpoints-and-scopes-Used-by-the-Hypothesis-LMS-App


### Testing


- Reset the DB state

```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping,assignment cascade;"; make devdata;```




- Exercise all our D2L endpoints configuring and then launching:

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View?ou=6782

pick D2L files and groups
