### PR TITLE
Rename views.lti to views.grading

### DIFF
--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -13,8 +13,8 @@ from lms.validation import (
 
 
 @view_defaults(request_method="POST", renderer="json", permission=Permissions.API)
-class LTIOutcomesViews:
-    """Views for proxy APIs interacting with LTI Outcome Management APIs."""
+class GradingViews:
+    """Views for proxy APIs interacting with LTI grading APIs."""
 
     def __init__(self, request):
         self.request = request
@@ -25,7 +25,7 @@ class LTIOutcomesViews:
 
     @view_config(route_name="lti_api.result.record", schema=APIRecordResultSchema)
     def record_result(self):
-        """Proxy result (grade/score) to LTI Outcomes Result API."""
+        """Proxy result (grade/score) to LTI Result API."""
 
         self.lti_grading_service.record_result(
             self.parsed_params["lis_result_sourcedid"],
@@ -40,7 +40,7 @@ class LTIOutcomesViews:
         schema=APIReadResultSchema,
     )
     def read_result(self):
-        """Proxy request for current result (grade/score) to LTI Outcomes Result API."""
+        """Proxy request for current result (grade/score) to LTI Result API."""
 
         current_score = self.lti_grading_service.read_result(
             self.parsed_params["lis_result_sourcedid"]
@@ -56,8 +56,9 @@ class LTIOutcomesViews:
         Record info to allow later grading of an assignment via Canvas Speedgrader.
 
         When a learner launches an assignment the LMS provides metadata that can
-        be later used to submit a score to the LMS using LTI Outcome Management
-        APIs. In Canvas, extensions to that API allow a custom LTI launch URL to be
+        be later used to submit a score to the LMS using LTI APIs.
+
+        In Canvas, extensions to that API allow a custom LTI launch URL to be
         submitted for use by the SpeedGrader [1].
 
         This view only supports SpeedGrader-based grading in Canvas by
@@ -90,7 +91,7 @@ class LTIOutcomesViews:
 
 
 class CanvasPreRecordHook:
-    # For details of Canvas extensions to the standard LTI Outcomes request see:
+    # For details of Canvas extensions to the standard LTI request see:
     # https://erau.instructure.com/doc/api/file.assignment_tools.html
 
     # We use a set date in the past when no other date is available to avoid creating new submissions.

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from h_matchers import Any
 
-from lms.views.api.lti import CanvasPreRecordHook, LTIOutcomesViews
+from lms.views.api.grading import CanvasPreRecordHook, GradingViews
 
 pytestmark = pytest.mark.usefixtures("lti_grading_service")
 
@@ -16,7 +16,7 @@ class TestRecordCanvasSpeedgraderSubmission:
     def test_it_passes_correct_params_to_read_current_score(
         self, pyramid_request, lti_grading_service
     ):
-        LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
+        GradingViews(pyramid_request).record_canvas_speedgrader_submission()
 
         lti_grading_service.read_result.assert_called_once_with(self.GRADING_ID)
 
@@ -25,7 +25,7 @@ class TestRecordCanvasSpeedgraderSubmission:
     ):
         lti_grading_service.read_result.return_value = 0.5
 
-        LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
+        GradingViews(pyramid_request).record_canvas_speedgrader_submission()
 
         lti_grading_service.record_result.assert_not_called()
 
@@ -34,7 +34,7 @@ class TestRecordCanvasSpeedgraderSubmission:
     ):
         lti_grading_service.read_result.return_value = None
 
-        LTIOutcomesViews(pyramid_request).record_canvas_speedgrader_submission()
+        GradingViews(pyramid_request).record_canvas_speedgrader_submission()
 
         lti_grading_service.record_result.assert_called_once_with(
             self.GRADING_ID,
@@ -150,7 +150,7 @@ class TestCanvasPreRecordHook:
 
 class TestReadResult:
     def test_it_proxies_to_read_result(self, pyramid_request, lti_grading_service):
-        LTIOutcomesViews(pyramid_request).read_result()
+        GradingViews(pyramid_request).read_result()
 
         lti_grading_service.read_result.assert_called_once_with(
             "modelstudent-assignment1"
@@ -159,7 +159,7 @@ class TestReadResult:
     def test_it_returns_current_score(self, pyramid_request, lti_grading_service):
         lti_grading_service.read_result.return_value = 0.5
 
-        current_score = LTIOutcomesViews(pyramid_request).read_result()
+        current_score = GradingViews(pyramid_request).read_result()
 
         assert current_score == {"currentScore": 0.5}
 
@@ -176,7 +176,7 @@ class TestReadResult:
 
 class TestRecordResult:
     def test_it_records_result(self, pyramid_request, lti_grading_service):
-        LTIOutcomesViews(pyramid_request).record_result()
+        GradingViews(pyramid_request).record_result()
 
         lti_grading_service.record_result.assert_called_once_with(
             "modelstudent-assignment1", score=pyramid_request.parsed_params["score"]


### PR DESCRIPTION
Although the views end up using LTI APIs, "grading" better reflects the focus of the views .