### PR TITLE
Update shared components in `FileList`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FileList.tsx
+++ b/lms/static/scripts/frontend_apps/components/FileList.tsx
@@ -1,4 +1,9 @@
-import { Icon, Table } from '@hypothesis/frontend-shared';
+import {
+  DataTable,
+  FilePdfFilledIcon,
+  FolderIcon,
+  Scroll,
+} from '@hypothesis/frontend-shared/lib/next';
 import type { ComponentChildren } from 'preact';
 
 import type { File } from '../api-types';
@@ -37,37 +42,47 @@ export default function FileList({
   const columns = [
     {
       label: 'Name',
+      field: 'display_name',
     },
     {
       label: 'Last modified',
+      field: 'updated_at',
       classes: 'w-32',
     },
   ];
 
+  const renderItem = (file: File, field: keyof File) => {
+    switch (field) {
+      case 'display_name':
+        return (
+          <div className="flex flex-row items-center gap-x-2">
+            {file.type === 'Folder' ? (
+              <FolderIcon className="w-5 h-5" />
+            ) : (
+              <FilePdfFilledIcon className="w-5 h-5" />
+            )}
+            {file.display_name}
+          </div>
+        );
+      case 'updated_at':
+      default:
+        return file.updated_at ? formatDate(file.updated_at) : '';
+    }
+  };
+
   return (
-    <Table
-      accessibleLabel="File list"
-      emptyItemsMessage={noFilesMessage}
-      tableHeaders={columns}
-      isLoading={isLoading}
-      items={files}
-      selectedItem={selectedFile}
-      onSelectItem={onSelectFile}
-      onUseItem={onUseFile}
-      renderItem={file => (
-        <>
-          <td aria-label={file.display_name}>
-            <div className="flex flex-row items-center space-x-2">
-              <Icon
-                name={file.type && file.type === 'Folder' ? 'folder' : 'pdf'}
-                classes="w-5 h-5"
-              />
-              <div className="grow leading-snug">{file.display_name}</div>
-            </div>
-          </td>
-          <td>{file.updated_at && formatDate(file.updated_at)}</td>
-        </>
-      )}
-    />
+    <Scroll>
+      <DataTable
+        title="File list"
+        emptyMessage={noFilesMessage}
+        columns={columns}
+        loading={isLoading}
+        rows={files}
+        selectedRow={selectedFile}
+        onSelectRow={onSelectFile}
+        onConfirmRow={onUseFile}
+        renderItem={renderItem}
+      />
+    </Scroll>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/FileList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FileList-test.js
@@ -29,27 +29,18 @@ describe('FileList', () => {
 
   it('renders a table with "Name" and "Last modified" columns', () => {
     const wrapper = renderFileList();
-    const columns = wrapper
-      .find('Table')
-      .prop('tableHeaders')
-      .map(col => col.label);
-    assert.deepEqual(columns, ['Name', 'Last modified']);
+    const columns = wrapper.find('thead');
+    assert.include(columns.text(), 'Name');
+    assert.include(columns.text(), 'Last modified');
   });
 
   it('renders files with an icon, file name and date', () => {
     const wrapper = renderFileList();
-    const renderItem = wrapper.find('Table').prop('renderItem');
-    const itemWrapper = mount(
-      <table>
-        <tr>{renderItem(testFiles[0])}</tr>
-      </table>
-    );
     const formattedDate = new Date(testFiles[0]).toLocaleDateString();
-    assert.equal(
-      itemWrapper.find('td').at(0).text(),
-      testFiles[0].display_name
-    );
-    assert.equal(itemWrapper.find('td').at(1).text(), formattedDate);
+    const dataRow = wrapper.find('tbody tr').at(0);
+    assert.isTrue(dataRow.find('FilePdfFilledIcon').exists());
+    assert.equal(dataRow.find('td').at(0).text(), testFiles[0].display_name);
+    assert.equal(dataRow.find('td').at(1).text(), formattedDate);
   });
 
   it('renders a explanatory message when there are no files', () => {


### PR DESCRIPTION
This PR updates the shared components in `FileList`, using the new `DataTable` component. This looks pretty much like it did before (screenshots from BlackBoard, which has nested folders and thus breadcrumbs).

<img width="715" alt="Screen Shot 2023-02-22 at 2 14 01 PM" src="https://user-images.githubusercontent.com/439947/220735220-d4e6ccc9-a4cd-4eb4-ae7a-003cec6dcbd8.png">

<img width="712" alt="Screen Shot 2023-02-22 at 2 14 13 PM" src="https://user-images.githubusercontent.com/439947/220735229-7f220d74-c0a8-4947-b30c-90d72cc08321.png">

Part of #5013
