### PR TITLE
Update shared components in `OAuth2RedirectErrorApp`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.tsx
@@ -3,13 +3,10 @@ import { Link } from '@hypothesis/frontend-shared';
 import { useConfig } from '../config';
 import ErrorModal from './ErrorModal';
 
-/** @typedef {import('../config').OAuthErrorConfig} OAuthErrorConfig */
-
-/**
- * @typedef OAuth2RedirectErrorAppProps
- * @prop {Location} [location] - Test seam
- */
-
+export type OAuth2RedirectErrorAppProps = {
+  /* Test seam */
+  location?: Location;
+};
 /**
  * Error Modal displayed when authorization with a third-party API via OAuth
  * fails.
@@ -18,13 +15,15 @@ import ErrorModal from './ErrorModal';
  *
  * @param {OAuth2RedirectErrorAppProps} props
  */
-export default function OAuth2RedirectErrorApp({ location = window.location }) {
+export default function OAuth2RedirectErrorApp({
+  location = window.location,
+}: OAuth2RedirectErrorAppProps) {
   const {
     OAuth2RedirectError: {
       authUrl = null,
       errorCode,
       errorDetails = '',
-      canvasScopes = /** @type {string[]} */ ([]),
+      canvasScopes = [],
     },
   } = useConfig(['OAuth2RedirectError']);
 
@@ -46,7 +45,7 @@ export default function OAuth2RedirectErrorApp({ location = window.location }) {
   }
 
   const retry = () => {
-    location.href = /** @type {string} */ (authUrl);
+    location.href = authUrl!;
   };
   const onRetry = authUrl ? retry : undefined;
 

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@hypothesis/frontend-shared';
+import { Link } from '@hypothesis/frontend-shared/lib/next';
 
 import { useConfig } from '../config';
 import ErrorModal from './ErrorModal';
@@ -77,6 +77,7 @@ export default function OAuth2RedirectErrorApp({
             <Link
               target="_blank"
               href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
+              underline="always"
             >
               Canvas API Endpoints Used by the Hypothesis LMS App
             </Link>
@@ -97,6 +98,7 @@ export default function OAuth2RedirectErrorApp({
               classes="inline"
               target="_blank"
               href="https://web.hypothes.is/help/enable-the-hypothesis-integration-with-blackboard-files/"
+              underline="always"
             >
               Enable the Hypothesis Integration With Blackboard Files
             </Link>


### PR DESCRIPTION
This PR converts `OAuth2RedirectErrorApp` to TSX and updates its shared components. The only change here is that I snuck in some underlines on the inline links.

Part of #5013