### PR TITLE
Simplify and consolidate `InstructorToolbar` and grading control layout

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -86,15 +86,22 @@ export default function GradingControls({
   }, [students, changeFocusedUser, selectedStudent]);
 
   return (
-    <div className={classnames('flex flex-col gap-2', 'sm:flex-row')}>
-      <div className="flex-grow-0 sm:flex-grow">
+    <div
+      className={classnames(
+        // Default and narrower screens: controls are stacked vertically
+        'flex gap-x-4 gap-y-2 flex-col',
+        // Wider screens: controls are in a single row
+        'md:flex-row'
+      )}
+    >
+      <div>
         <StudentSelector
           onSelectStudent={setSelectedStudent}
           students={students}
           selectedStudent={selectedStudent}
         />
       </div>
-      <div className="flex-grow sm:flex-grow-0">
+      <div>
         <SubmitGradeForm student={selectedStudent} />
       </div>
     </div>

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -23,15 +23,25 @@ export default function InstructorToolbar() {
     gradingEnabled,
   } = instructorToolbar;
 
+  const withGradingControls = gradingEnabled && !!students;
+
   return (
     <header
       className={classnames(
-        'grid grid-cols-1 items-center gap-y-2 p-2',
-        'lg:grid-cols-3 lg:gap-x-4 lg:px-3'
+        'p-2',
+        // Default and narrower screens: content is stacked vertically
+        'grid grid-cols-1 items-center gap-x-4 gap-y-2',
+        // Wider screens: assignment metadata and grading controls side by side
+        'md:grid-cols-[1fr_auto] md:py-1'
       )}
     >
       <div className="space-y-1">
-        <div className="flex gap-x-2 items-center">
+        <div
+          className={classnames(
+            // lays out assignment name and edit button
+            'flex gap-x-2 items-center'
+          )}
+        >
           <h1
             className="text-lg font-semibold leading-none"
             data-testid="assignment-name"
@@ -57,11 +67,7 @@ export default function InstructorToolbar() {
         </h2>
       </div>
 
-      <div
-        className={classnames('lg:col-span-2 lg:gap-4 ' /* cols 2-3 of 3 */)}
-      >
-        {gradingEnabled && students && <GradingControls students={students} />}
-      </div>
+      {withGradingControls ? <GradingControls students={students} /> : <div />}
     </header>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
@@ -5,7 +5,6 @@ import {
   InputGroup,
   Select,
 } from '@hypothesis/frontend-shared/lib/next';
-import classnames from 'classnames';
 
 import type { StudentInfo } from '../config';
 import { useUniqueId } from '../utils/hooks';
@@ -58,16 +57,9 @@ export default function StudentSelector<Student extends StudentOption>({
   };
 
   return (
-    <div
-      className={classnames(
-        // Narrower widths: label above field
-        'flex flex-col gap-1',
-        // Wider widths: label to left of field
-        'xl:flex-row xl:gap-3 xl:items-center'
-      )}
-    >
+    <>
       <label
-        className="flex-grow font-medium text-sm leading-none xl:text-right"
+        className="font-semibold text-xs"
         data-testid="student-selector-label"
         htmlFor={selectId}
       >
@@ -95,8 +87,8 @@ export default function StudentSelector<Student extends StudentOption>({
             variant="dark"
           />
           <Select
+            classes="min-w-[12rem] xl:w-[20rem]"
             aria-label="Select student"
-            classes="xl:w-80 h-touch-minimum"
             id={selectId}
             onChange={handleSelectStudent}
           >
@@ -127,6 +119,6 @@ export default function StudentSelector<Student extends StudentOption>({
           />
         </InputGroup>
       </div>
-    </div>
+    </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -123,22 +123,11 @@ export default function SubmitGradeForm({ student }: SubmitGradeFormProps) {
 
   return (
     <>
-      <form
-        className={classnames(
-          // At narrower width, label above input (columnar)
-          'flex flex-col gap-1',
-          // At wider width, label left of input (row)
-          'xl:flex-row xl:gap-3 xl:items-center'
-        )}
-        autoComplete="off"
-      >
-        <label
-          htmlFor={gradeId}
-          className="flex-grow font-medium text-sm leading-none"
-        >
+      <form autoComplete="off">
+        <label htmlFor={gradeId} className="font-semibold text-xs">
           Grade (Out of 10)
         </label>
-        <div className="flex flex-row">
+        <div className="flex">
           <span className="relative w-14">
             {validationMessage && (
               <ValidationMessage
@@ -152,7 +141,7 @@ export default function SubmitGradeForm({ student }: SubmitGradeFormProps) {
             )}
             <Input
               classes={classnames(
-                'h-touch-minimum text-center',
+                'text-center',
                 'disabled:opacity-50',
                 'border border-r-0 rounded-r-none',
                 {
@@ -179,7 +168,7 @@ export default function SubmitGradeForm({ student }: SubmitGradeFormProps) {
             icon={CheckIcon}
             type="submit"
             classes={classnames(
-              'h-touch-minimum border rounded-l-none ring-inset',
+              'border rounded-l-none ring-inset',
               'disabled:opacity-50'
             )}
             disabled={disabled}

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -42,13 +42,15 @@ export default function ValidationMessage({
       data-testid={showError ? 'message-open' : 'message-closed'}
       onClick={closeValidationError}
       className={classnames(
-        'absolute z-10 h-touch-minimum shadow',
+        'absolute z-10 shadow',
         'text-white border-0 bg-red-error whitespace-nowrap overflow-hidden',
         // Narrow viewports position the message to the right of the input
         'left-full',
         // Sm and larger breakpoints position the message to the left of the input
         'sm:left-0 sm:-translate-x-full',
         'focus-visible-ring',
+        // Make message the same height as its relative-positioned ancestor
+        'h-full',
         {
           'animate-validationMessageOpen': showError,
           'animate-validationMessageClose': !showError,


### PR DESCRIPTION
This PR makes some adjustments to the layout of the `InstructorToolbar` (assignment and metadata bar) displayed above assignments in LMS. Its goals are to:

* Make the layout's typography proportions, spacing and rhythm consistent across screen sizes
* Make the UI more consistent with established design patterns
* Simplify the layout implementation
* Encapsulate layout implementation to the appropriate components and ensure it's got comments where needed

### Before and After: Narrow screens

Height of controls and label font size is more proportionate.

Before:

<img width="651" alt="Screen Shot 2023-02-23 at 9 59 02 AM" src="https://user-images.githubusercontent.com/439947/220944029-c8fefd86-cbd8-4501-89bc-53fdcbaa7669.png">


After:

<img width="529" alt="Screen Shot 2023-02-23 at 9 42 08 AM" src="https://user-images.githubusercontent.com/439947/220943963-5529bd7b-fe61-49f1-bff2-48ec80fdab7a.png">

### Before and After: Medium screens

Tighter vertical space usage; label font weight increased; available space given to assignment metadata instead of stretching the student select[^1].

Before:
<img width="1098" alt="Screen Shot 2023-02-23 at 9 58 49 AM" src="https://user-images.githubusercontent.com/439947/220944430-18ab68db-2e2a-4b0f-8d79-e13aa22f433f.png">

After:
<img width="954" alt="Screen Shot 2023-02-23 at 9 42 40 AM" src="https://user-images.githubusercontent.com/439947/220944470-240185ff-18d5-44f1-bd08-e2ea1ee6d99f.png">


### Before and After: Wider screens

Stacked labels are more consistent with H design patterns and easier to scan; control height reduced.

Before:
<img width="1498" alt="Screen Shot 2023-02-23 at 9 58 13 AM" src="https://user-images.githubusercontent.com/439947/220945880-48616170-a4a1-4e68-b2e6-1bb8599e634d.png">

After:

<img width="1513" alt="Screen Shot 2023-02-23 at 9 34 15 AM" src="https://user-images.githubusercontent.com/439947/220945844-48f0976d-10a3-483f-98a8-c620c427d9c6.png">

### Regarding font size

I predict that commentary will arise over the use of `text-xs` for the input labels. I agree that the `text-xs` size, at 12px, is on the small end of what we'd call _legible_.

I do however feel that the text sizes in this interface are proportional _to each other_. There's a larger issue we need to address here regarding the teeny-tininess of the base font size that we use for LMS front-end interfaces. We could bump every font size in this interface up by one (note that the size of the inputs and the select label are still too small here because they are proportional to the base font size):

<img width="1504" alt="Screen Shot 2023-02-23 at 9 33 13 AM" src="https://user-images.githubusercontent.com/439947/220947174-6fcd0f40-3d94-4d2e-bbb0-e61904065f2a.png">

This sizing change introduces some other issues to chase down: At this larger size, the input labels and possibly the assignment name are too visually heavy. We could alleviate this by using a lighter font weight or (my preference) introducing a few additional text colors — we are very limited in that regard, currently. Again this leads me back to thinking about the bigger picture, which explodes scope.

So, while the label and edit-button text is on the small side, it's a) no smaller than other interface elements in our universe; b) proportional to the base font as it currently exists on LMS and c) doesn't violate any WCAG guidelines as such.

On that last item, WCAG doesn't define minimum font sizes. We're aiding the user here by emphasizing the text with high color and weight contrast.

Thus, my recommendation: Allow these interface elements to be small for the present. Recognize that typography sizing is due for a reckoning in all of our apps.

[^1]: The student drop-down will never be narrower than its contents dictate. Additionally, it's given a `min-width` of `12rem` for narrower screens and `20rem` on wide screens so it doesn't feel too skinny.