### PR TITLE
Increase timeout to get LTI1.3 tokens

### DIFF
--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -58,6 +58,7 @@ class LTIAHTTPService:
                 "client_assertion": signed_jwt,
                 "scope": " ".join(scopes),
             },
+            timeout=(20, 20),
         )
 
         return response.json()["access_token"]

--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -36,6 +36,7 @@ class TestLTIAHTTPService:
                 "client_assertion": jwt_service.encode_with_private_key.return_value,
                 "scope": "SCOPE_1 SCOPE_2",
             },
+            timeout=(20, 20),
         )
         http_service.request.assert_called_once_with(
             "POST",


### PR DESCRIPTION
We've seen a high number of timeouts while hitting this endpoint, increasing the timeout to see the effect in the logs and adjust accordingly.


## Testing

### Timeout 

There's no clear way to test the timeout but:

- After the increase in the number of workers in LMS EBS I'm more confident that this won't have a negative effect
- I got one of this while testing the submissions locally so somehow Canvas does take over 10s to answer that call.
- They seem to be very frequent from this sentry search:

https://hypothesis.sentry.io/issues/?project=259908&query=is%3Aunresolved+%2Flogin%2Foauth2%2Ftoken&referrer=issue-list&sort=freq&statsPeriod=14d

