### PR TITLE
Convert `ChapterList` to TSX and update shared components

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -71,10 +71,16 @@ export default function BookPicker({
 
   return (
     <Modal
+      classes={classnames(
+        // Set a fix height when selecting a chapter so the modal content
+        // doesn't resize after loading.
+        { 'h-[25rem]': step === 'select-chapter' }
+      )}
       // Opt out of Modal's automatic focus handling; route focus manually in
       // sub-components
       initialFocus={'manual'}
       onClose={onCancel}
+      scrollable={false}
       title={
         step === 'select-book'
           ? 'Paste link to VitalSource book'
@@ -115,23 +121,13 @@ export default function BookPicker({
         />
       )}
       {step === 'select-chapter' && !error && (
-        <div
-          className={classnames(
-            // Set a preferred height for this content to give it more vertical
-            // room. Max-height rules on the containing Modal will prevent the
-            // Modal from exceeding available viewport space. Overflowing
-            // content will scroll.
-            'min-h-[25rem]'
-          )}
-        >
-          <ChapterList
-            chapters={chapterList || []}
-            isLoading={!chapterList}
-            selectedChapter={chapter}
-            onSelectChapter={setChapter}
-            onUseChapter={confirmChapter}
-          />
-        </div>
+        <ChapterList
+          chapters={chapterList || []}
+          isLoading={!chapterList}
+          selectedChapter={chapter}
+          onSelectChapter={setChapter}
+          onUseChapter={confirmChapter}
+        />
       )}
       {error && (
         <ErrorDisplay

--- a/lms/static/scripts/frontend_apps/components/ChapterList.tsx
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.tsx
@@ -1,25 +1,25 @@
 import { Table } from '@hypothesis/frontend-shared';
 
-/**
- * @typedef {import('../api-types').Chapter} Chapter
- */
+import type { Chapter } from '../api-types';
 
-/**
- * @typedef ChapterListProps
- * @prop {Chapter[]} chapters - List of available chapters
- * @prop {boolean} [isLoading] - Whether to show a loading indicator
- * @prop {Chapter|null} selectedChapter - The chapter within `chapters` which is currently selected
- * @prop {(c: Chapter) => void} onSelectChapter - Callback invoked when the user selects a chapter
- * @prop {(c: Chapter) => void} onUseChapter -
- *   Callback invoked when user confirms they want to use the selected chapter for
- *   an assignment.
- */
+export type ChapterListProps = {
+  /** List of available chapters */
+  chapters: Chapter[];
+  isLoading?: boolean;
+  /** The Chapter within chapters which is currently selected */
+  selectedChapter: Chapter | null;
+  /** Callback invoked when a user selects a chapter */
+  onSelectChapter: (c: Chapter) => void;
+
+  /**
+   * Callback invoked when user confirms the selected chapter for an assignment
+   */
+  onUseChapter: (c: Chapter) => void;
+};
 
 /**
  * Component that presents a list of chapters from a book and allows the user
  * to choose one for an assignment.
- *
- * @param {ChapterListProps} props
  */
 export default function ChapterList({
   chapters,
@@ -27,7 +27,7 @@ export default function ChapterList({
   selectedChapter,
   onSelectChapter,
   onUseChapter,
-}) {
+}: ChapterListProps) {
   const columns = [
     {
       label: 'Title',

--- a/lms/static/scripts/frontend_apps/components/ChapterList.tsx
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.tsx
@@ -1,4 +1,4 @@
-import { Table } from '@hypothesis/frontend-shared';
+import { DataTable, Scroll } from '@hypothesis/frontend-shared/lib/next';
 
 import type { Chapter } from '../api-types';
 
@@ -31,29 +31,26 @@ export default function ChapterList({
   const columns = [
     {
       label: 'Title',
+      field: 'title',
     },
     {
       label: 'Location',
+      field: 'page',
       classes: 'w-32',
     },
   ];
 
   return (
-    <Table
-      accessibleLabel="Table of Contents"
-      classes="ChapterList"
-      tableHeaders={columns}
-      isLoading={isLoading}
-      items={chapters}
-      onSelectItem={onSelectChapter}
-      onUseItem={onUseChapter}
-      selectedItem={selectedChapter}
-      renderItem={chapter => (
-        <>
-          <td aria-label={chapter.title}>{chapter.title}</td>
-          <td>{chapter.page}</td>
-        </>
-      )}
-    />
+    <Scroll>
+      <DataTable
+        title="Table of Contents"
+        columns={columns}
+        loading={isLoading}
+        rows={chapters}
+        onSelectRow={onSelectChapter}
+        onConfirmRow={onUseChapter}
+        selectedRow={selectedChapter}
+      />
+    </Scroll>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
@@ -27,7 +27,7 @@ describe('ChapterList', () => {
 
   it('renders chapter titles', () => {
     const chapterList = renderChapterList();
-    const rows = chapterList.find('tbody > tr');
+    const rows = chapterList.find('tbody tr');
     assert.equal(rows.length, chapterData.length);
     assert.equal(rows.at(0).find('td').at(0).text(), chapterData[0].title);
     assert.equal(rows.at(0).find('td').at(1).text(), chapterData[0].page);
@@ -36,7 +36,7 @@ describe('ChapterList', () => {
   [true, false].forEach(isLoading => {
     it('shows loading indicator in table if chapters are being fetched', () => {
       const chapterList = renderChapterList({ isLoading });
-      assert.equal(chapterList.find('Table').prop('isLoading'), isLoading);
+      assert.equal(chapterList.find('DataTable').prop('loading'), isLoading);
     });
   });
 
@@ -44,7 +44,7 @@ describe('ChapterList', () => {
     const onSelectChapter = sinon.stub();
     const chapterList = renderChapterList({ onSelectChapter });
 
-    chapterList.find('Table').prop('onSelectItem')(chapterData[0]);
+    chapterList.find('DataTable').prop('onSelectRow')(chapterData[0]);
 
     assert.calledWith(onSelectChapter, chapterData[0]);
   });
@@ -53,7 +53,7 @@ describe('ChapterList', () => {
     const onUseChapter = sinon.stub();
     const chapterList = renderChapterList({ onUseChapter });
 
-    chapterList.find('Table').prop('onUseItem')(chapterData[0]);
+    chapterList.find('DataTable').prop('onConfirmRow')(chapterData[0]);
 
     assert.calledWith(onUseChapter, chapterData[0]);
   });


### PR DESCRIPTION
This PR converts `ChapterList` (VitalSource chapter-selection UI) to TSX and updates shared components within it. To maintain the same scroll and visual behavior, some adjustments were needed on the containing `Modal` in `BookPicker`.

The interface looks like so, unchanged from before:

<img width="836" alt="Screen Shot 2023-02-23 at 12 43 26 PM" src="https://user-images.githubusercontent.com/439947/220988018-f3725ed3-1541-494f-9c66-dfd9b0fd603f.png">

Part of #5013

### Testing, if you're so inclined

* Configure/Edit a Canvas assignment on localhost (I hope that localhost installs have VitalSource enabled by default?) and click the 'Select book from Vitalsource' button
* Select a VitalSource book (https://bookshelf.vitalsource.com/#/books/9781400847402 is a good option)
* Then you should see the chapter-selection interface relevant to these changes
