### PR TITLE
PoC - Support editing an assignment via a server-side transition

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -212,7 +212,7 @@ class JSConfig:
             },
             # TODO These two probably make more sense in another nested key
             # Where to submit the eventual re-configure
-            "form_action": self._request.route_url("configure_assignment"),
+            "form_action": self._request.route_url("edit_assignment"),
             # What to send for that reconfiguration
             "formFields": self.forward_lti_parameters(),
         }

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -10,6 +10,12 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("canvas.v11.config", "/config_xml")
     config.add_route("canvas.v13.config", "/canvas/1.3/config")
     config.add_route(
+        "edit_assignment",
+        "/assignment/edit",
+        request_method="POST",
+        factory="lms.resources.LTILaunchResource",
+    )
+    config.add_route(
         "configure_assignment",
         "/assignment",
         request_method="POST",

--- a/lms/security.py
+++ b/lms/security.py
@@ -111,7 +111,7 @@ class SecurityPolicy:
                 partial(get_lti_user_from_bearer_token, location="headers")
             )
 
-        if path in {"/assignment"}:
+        if path in {"/assignment", "/assignment/edit"}:
             # LTUser serialized in a from for non deep-linked assignment configuration
             return LTIUserSecurityPolicy(
                 partial(get_lti_user_from_bearer_token, location="form")

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -3,7 +3,7 @@
  * JSON HTTP requests.
  */
 
-import type { APICallInfo } from './config';
+import type { APICallInfo, FilePickerConfig } from './config';
 
 /**
  * Object representing a file or folder resource in the LMS's file storage.
@@ -82,4 +82,29 @@ export type JSTORMetadata = {
  */
 export type JSTORThumbnail = {
   image: string;
+};
+
+/**
+ * Configuration for an assignment.
+ */
+export type Assignment = {
+  id: string;
+  group_set_id: string;
+  document: {
+    url: string;
+  };
+};
+
+/**
+ * Response for an `/api/assignment/{id}/config` call.
+ *
+ * This includes the current assignment configuration and, currently,
+ * the metadata needed to launch the file picker app to reconfigure the
+ * assignment.
+ *
+ * TODO: Split file picker config into separate API call?
+ */
+export type AssignmentConfig = {
+  assignment: Assignment;
+  filePicker: Omit<FilePickerConfig, 'formAction' | 'formFields'>;
 };

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -1,15 +1,36 @@
 import { LinkButton } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
-import GradingControls from './GradingControls';
 import { useConfig } from '../config';
+import GradingControls from './GradingControls';
+
+/** Create and submit a hidden form. */
+function submitForm(
+  method: 'GET' | 'POST',
+  action: string,
+  fields: Record<string, string>
+) {
+  const form = document.createElement('form');
+  form.method = method;
+  form.action = action;
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = name;
+    input.value = value;
+    form.append(input);
+  }
+  document.body.append(form);
+  form.submit();
+}
 
 /**
  * Toolbar for instructors.
  * Shows assignment information and grading controls (for gradeable assignments).
  */
 export default function InstructorToolbar() {
-  const { instructorToolbar } = useConfig();
+  const { editing, instructorToolbar } = useConfig();
+
   if (!instructorToolbar) {
     // User is not an instructor or toolbar is disabled in the current environment.
     return null;
@@ -22,6 +43,16 @@ export default function InstructorToolbar() {
     editingEnabled,
     gradingEnabled,
   } = instructorToolbar;
+
+  const onEdit = async () => {
+    if (!editing) {
+      return;
+    }
+    submitForm('POST', editing.form_action, {
+      ...editing.formFields,
+      edit: 'true',
+    });
+  };
 
   return (
     <header
@@ -42,6 +73,7 @@ export default function InstructorToolbar() {
             <LinkButton
               classes="text-xs"
               data-testid="edit"
+              onClick={onEdit}
               title="Edit assignment settings"
               underline="always"
             >

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -44,6 +44,12 @@ export type StudentInfo = {
   lmsId: string;
 };
 
+export type EditConfig = {
+  getConfig: APICallInfo;
+  form_action: string;
+  formFields: Record<string, string>;
+};
+
 /**
  * Data needed to render the grading bar shown when an instructor views an assignment.
  */
@@ -226,6 +232,7 @@ export type ConfigObject = {
     speedGrader?: SpeedGraderConfig;
   };
   contentBanner?: ContentBannerConfig;
+  editing?: EditConfig;
   instructorToolbar?: InstructorConfig;
   hypothesisClient: ClientConfig;
   rpcServer: {

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -58,6 +58,7 @@ from lms.validation._lti_launch_params import (
     BasicLTILaunchSchema,
     ConfigureAssignmentSchema,
     DeepLinkingLTILaunchSchema,
+    EditAssignmentSchema,
     LTIV11CoreSchema,
 )
 

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -164,3 +164,13 @@ class ConfigureAssignmentSchema(_CommonLTILaunchSchema):
     user_id = fields.Str(required=True)
     context_title = fields.Str(required=True)
     group_set = fields.Str(required=False, allow_none=True)
+
+
+class EditAssignmentSchema(_CommonLTILaunchSchema):
+    """Schema for validating requests to the configure_assignment() view."""
+
+    location = "form"
+
+    resource_link_id = fields.Str(required=True)
+    user_id = fields.Str(required=True)
+    context_title = fields.Str(required=True)

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -19,7 +19,11 @@ from lms.security import Permissions
 from lms.services import DocumentURLService, LTIRoleService
 from lms.services.assignment import AssignmentService
 from lms.services.grouping import GroupingService
-from lms.validation import BasicLTILaunchSchema, ConfigureAssignmentSchema
+from lms.validation import (
+    BasicLTILaunchSchema,
+    ConfigureAssignmentSchema,
+    EditAssignmentSchema,
+)
 from lms.validation.authentication import BearerTokenSchema
 
 
@@ -91,6 +95,19 @@ class BasicLaunchViews:
             self.request.override_renderer = "lms:templates/lti/basic_launch/unconfigured_launch_not_authorized.html.jinja2"
             return {}
 
+        self.context.js_config.enable_file_picker_mode(
+            form_action=self.request.route_url("configure_assignment"),
+            form_fields=self.context.js_config.forward_lti_parameters(),
+        )
+        return {}
+
+    @view_config(
+        route_name="edit_assignment",
+        permission=Permissions.LTI_CONFIGURE_ASSIGNMENT,
+        schema=EditAssignmentSchema,
+        renderer="lms:templates/file_picker.html.jinja2",
+    )
+    def edit_assignment(self):
         self.context.js_config.enable_file_picker_mode(
             form_action=self.request.route_url("configure_assignment"),
             form_fields=self.context.js_config.forward_lti_parameters(),


### PR DESCRIPTION
Add a proof of concept of initiating an assignment edit via a server-side transition when clicking "Edit assignment" in the instructor toolbar. This works by having the frontend create and submit a hidden form when clicking "Edit assignment". Clicking "Edit assignment" shows exactly the same form as if an un-configured assignment launch had happened.

The upside is that this code is very simple. The principle downside is that clicking the "Back" button after transitioning from View => Edit shows an error message in Chrome warning that loading the page will involve a form-resubmission:

<img width="1163" alt="Edit back to view" src="https://user-images.githubusercontent.com/2458/221187441-852ccf9b-4038-45ba-b02c-3bc642320d87.png">

This happens because the initial assignment launch was done via a form submission from the LMS. One way we could deal with this is by doing the View => Edit transition on the client side, then we can handle going Back however we like. Another possibility that occurred to me is that if the initial LTI launch did a transition from the `/lti_launch` route to an assignment-specific URL (eg. `POST /lti_launches` => `GET /api/assignments/{assignment_id}`) then we could do server-side transitions between routes in the iframe more easily. The initial LTI launch in this case would need to translate the data in the LTI launch form parameters into some persistent state within the iframe (eg. a session cookie).
