### PR TITLE
PoC - Support editing an assignment via a client-side transition

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -448,6 +448,9 @@ class JSConfig:
             # launches its BasicLtiLaunchApp, whereas in
             # "content-item-selection" mode it launches its FilePickerApp.
             "mode": None,
+
+            # Add common fields with info about the LMS we are running in.
+            "product": self._get_product_info(),
         }
 
         if self._lti_user:

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -3,7 +3,7 @@
  * JSON HTTP requests.
  */
 
-import type { APICallInfo } from './config';
+import type { APICallInfo, FilePickerConfig } from './config';
 
 /**
  * Object representing a file or folder resource in the LMS's file storage.
@@ -82,4 +82,29 @@ export type JSTORMetadata = {
  */
 export type JSTORThumbnail = {
   image: string;
+};
+
+/**
+ * Configuration for an assignment.
+ */
+export type Assignment = {
+  id: string;
+  group_set_id: string;
+  document: {
+    url: string;
+  };
+};
+
+/**
+ * Response for an `/api/assignment/{id}/config` call.
+ *
+ * This includes the current assignment configuration and, currently,
+ * the metadata needed to launch the file picker app to reconfigure the
+ * assignment.
+ *
+ * TODO: Split file picker config into separate API call?
+ */
+export type AssignmentConfig = {
+  assignment: Assignment;
+  filePicker: Omit<FilePickerConfig, 'formAction' | 'formFields'>;
 };

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
-import type { ConfigObject } from '../config';
+import type { AppMode, ConfigObject } from '../config';
 import { Config } from '../config';
 import type { ServiceMap } from '../services';
 import { Services } from '../services';
@@ -15,11 +15,47 @@ export type AppRootProps = {
   services: ServiceMap;
 };
 
+const APP_MODES: readonly AppMode[] = [
+  'basic-lti-launch',
+  'content-item-selection',
+  'error-dialog',
+  'oauth2-redirect-error',
+] as const;
+
 export default function AppRoot({ initialConfig, services }: AppRootProps) {
   const [config, setConfig] = useState(initialConfig);
   config.update = (newConfig: Partial<ConfigObject>) => {
     setConfig({ ...config, ...newConfig });
   };
+
+  // Preserve the current frontend app mode in the window hash. This allows
+  // the browser's back button to work for eg. transitioning from editing an
+  // assignment back to viewing it.
+  //
+  // It would nice nicer to use proper URLs.
+  useEffect(() => {
+    const onHashChange = (event: HashChangeEvent) => {
+      const mode = new URL(event.newURL).hash.slice(1) as AppMode;
+      if (!APP_MODES.includes(mode)) {
+        return;
+      }
+
+      setConfig(config => {
+        if (config.mode === mode) {
+          return config;
+        }
+        return { ...config, mode };
+      });
+    };
+    window.addEventListener('hashchange', onHashChange);
+    return () => {
+      window.removeEventListener('hashchange', onHashChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    window.location.hash = config.mode;
+  }, [config.mode]);
 
   let root;
   switch (config.mode) {

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'preact/hooks';
+
+import type { ConfigObject } from '../config';
+import { Config } from '../config';
+import type { ServiceMap } from '../services';
+import { Services } from '../services';
+
+import BasicLTILaunchApp from './BasicLTILaunchApp';
+import OAuth2RedirectErrorApp from './OAuth2RedirectErrorApp';
+import ErrorDialogApp from './ErrorDialogApp';
+import FilePickerApp from './FilePickerApp';
+
+export type AppRootProps = {
+  initialConfig: ConfigObject;
+  services: ServiceMap;
+};
+
+export default function AppRoot({ initialConfig, services }: AppRootProps) {
+  const [config, setConfig] = useState(initialConfig);
+  config.update = (newConfig: Partial<ConfigObject>) => {
+    setConfig({ ...config, ...newConfig });
+  };
+
+  let root;
+  switch (config.mode) {
+    case 'basic-lti-launch':
+      root = <BasicLTILaunchApp />;
+      break;
+    case 'content-item-selection':
+      root = <FilePickerApp />;
+      break;
+    case 'error-dialog':
+      root = <ErrorDialogApp />;
+      break;
+    case 'oauth2-redirect-error':
+      root = <OAuth2RedirectErrorApp />;
+      break;
+    default:
+      throw new Error(`Unknown frontend app ${config.mode}`);
+  }
+
+  return (
+    <Config.Provider value={config}>
+      <Services.Provider value={services}>{root}</Services.Provider>
+    </Config.Provider>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -23,6 +23,16 @@ export default function InstructorToolbar() {
     gradingEnabled,
   } = instructorToolbar;
 
+  const onEditAssignment = () => {
+    // TODO:
+    //
+    // 1. Make call to `editing.getConfig` API to get assignment info.
+    // 2. Display editing UI above assignment content or transition to
+    //    assignment editing UI.
+    //      - How to do this? Use a Portal-type thing?
+    // 3.
+  };
+
   return (
     <header
       className={classnames(
@@ -42,6 +52,7 @@ export default function InstructorToolbar() {
             <LinkButton
               classes="text-xs"
               data-testid="edit"
+              onClick={onEditAssignment}
               title="Edit assignment settings"
               underline="always"
             >

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -1,30 +1,22 @@
 import { LinkButton } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
-import type { AssignmentConfig, Assignment } from '../api-types';
+import type { AssignmentConfig } from '../api-types';
 import type { FilePickerConfig } from '../config';
 import { useConfig } from '../config';
 import { apiCall } from '../utils/api';
 import GradingControls from './GradingControls';
 
-export type InstructorToolbarProps = {
-  onEditAssignment: (
-    assignment: Assignment,
-    filePicker: FilePickerConfig
-  ) => void;
-};
-
 /**
  * Toolbar for instructors.
  * Shows assignment information and grading controls (for gradeable assignments).
  */
-export default function InstructorToolbar({
-  onEditAssignment,
-}: InstructorToolbarProps) {
+export default function InstructorToolbar() {
   const {
     api: { authToken },
     editing,
     instructorToolbar,
+    update: updateConfig,
   } = useConfig();
 
   if (!instructorToolbar) {
@@ -45,7 +37,8 @@ export default function InstructorToolbar({
       return;
     }
 
-    // TODO - Enter loading state
+    // TODO - Display loading state while fetching existing assignment
+    // configuration.
 
     // 1. Make call to `editing.getConfig` API to get assignment info.
     const assignmentConfig = await apiCall<AssignmentConfig>({
@@ -60,14 +53,10 @@ export default function InstructorToolbar({
       formAction: editing.form_action,
     };
 
-    onEditAssignment(assignmentConfig.assignment, filePickerConfig);
-
-    // TODO:
-    //
-    // 2. Display editing UI above assignment content or transition to
-    //    assignment editing UI.
-    //      - How to do this? Use a Portal-type thing?
-    // 3.
+    updateConfig({
+      mode: 'content-item-selection',
+      filePicker: filePickerConfig,
+    });
   };
 
   return (

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -232,6 +232,7 @@ export type ConfigObject = {
     speedGrader?: SpeedGraderConfig;
   };
   contentBanner?: ContentBannerConfig;
+  editing?: EditConfig;
   instructorToolbar?: InstructorConfig;
   hypothesisClient: ClientConfig;
   rpcServer: {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -234,8 +234,8 @@ export type ConfigObject = {
   contentBanner?: ContentBannerConfig;
   editing?: EditConfig;
   instructorToolbar?: InstructorConfig;
-  hypothesisClient: ClientConfig;
-  rpcServer: {
+  hypothesisClient?: ClientConfig;
+  rpcServer?: {
     allowedOrigins: string[];
   };
   viaUrl: string;

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -44,6 +44,12 @@ export type StudentInfo = {
   lmsId: string;
 };
 
+export type EditConfig = {
+  getConfig: APICallInfo;
+  form_action: string;
+  formFields: Record<string, string>;
+};
+
 /**
  * Data needed to render the grading bar shown when an instructor views an assignment.
  */

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -248,6 +248,13 @@ export type ConfigObject = {
 
   // Only present in "oauth2-redirect-error" mode.
   OAuth2RedirectError?: OAuthErrorConfig;
+
+  /**
+   * Change the current configuration after the application has initialized.
+   *
+   * Note that this property is installed by the frontend entry point.
+   */
+  update: (newConfig: Partial<ConfigObject>) => void;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -45,6 +45,14 @@ export function init() {
     /* eslint-enable no-console */
   }
 
+  // Construct services used by the file picker app. We need this both for
+  // direct launches into this app, and for transitions from viewing to
+  // editing assignments.
+  services.set(
+    VitalSourceService,
+    new VitalSourceService({ authToken: config.api.authToken })
+  );
+
   // Render main component for current route.
   let app;
   switch (config.mode) {
@@ -75,10 +83,6 @@ export function init() {
       }
       break;
     case 'content-item-selection':
-      services.set(
-        VitalSourceService,
-        new VitalSourceService({ authToken: config.api.authToken })
-      );
       app = <FilePickerApp />;
       break;
     case 'error-dialog':

--- a/lms/views/assignment.py
+++ b/lms/views/assignment.py
@@ -36,7 +36,7 @@ def config(_context, request):
         # Info about the assignments current configuration
         "assignment": {
             "id": assignment.id,
-            "group_set_id": assignment.extra["group_set_id"],
+            "group_set_id": assignment.extra.get("group_set_id"),
             "document": {
                 "url": assignment.document_url,
             },


### PR DESCRIPTION
This is conceptually like https://github.com/hypothesis/lms/pull/5107, but it uses a client-side transition. Using a client-side transition has some advantages:

1. We can control the loading state shown while fetching assignment configuration, after clicking the "Edit" button
2. We can make the Back button work in the edit view, without requiring a major re-working of LMS assignment URLs