### PR TITLE
Add prettier plugin to sort imports in a consistent way

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "singleQuote": true,
-  "importOrder": [
-    "^[./]"
-  ],
-  "importOrderSeparation": true
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,8 @@
 {
   "arrowParens": "avoid",
-  "singleQuote": true
+  "singleQuote": true,
+  "importOrder": [
+    "^[./]"
+  ],
+  "importOrderSeparation": true
 }

--- a/lms/static/scripts/bootstrap.js
+++ b/lms/static/scripts/bootstrap.js
@@ -1,16 +1,16 @@
+// Register the same set of icons that is available in the app.
+import { registerIcons } from '@hypothesis/frontend-shared';
+import { configure } from 'enzyme';
+import { Adapter } from 'enzyme-adapter-preact-pure';
+import 'preact/debug';
+
+import iconSet from './frontend_apps/icons';
+
 // Expose sinon assertions.
 sinon.assert.expose(assert, { prefix: null });
 
 // Configure Enzyme for UI tests.
-import 'preact/debug';
-
-import { configure } from 'enzyme';
-import { Adapter } from 'enzyme-adapter-preact-pure';
 configure({ adapter: new Adapter() });
-
-// Register the same set of icons that is available in the app.
-import { registerIcons } from '@hypothesis/frontend-shared';
-import iconSet from './frontend_apps/icons';
 
 registerIcons(iconSet);
 

--- a/lms/static/scripts/bootstrap.js
+++ b/lms/static/scripts/bootstrap.js
@@ -1,4 +1,3 @@
-// Register the same set of icons that is available in the app.
 import { registerIcons } from '@hypothesis/frontend-shared';
 import { configure } from 'enzyme';
 import { Adapter } from 'enzyme-adapter-preact-pure';
@@ -12,6 +11,7 @@ sinon.assert.expose(assert, { prefix: null });
 // Configure Enzyme for UI tests.
 configure({ adapter: new Adapter() });
 
+// Register the same set of icons that is available in the app.
 registerIcons(iconSet);
 
 // Ensure that uncaught exceptions between tests result in the tests failing.

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -2,7 +2,6 @@
  * Types for objects exchanged between the LMS frontend and backend via
  * JSON HTTP requests.
  */
-
 import type { APICallInfo } from './config';
 
 /**

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -1,6 +1,5 @@
 import { SpinnerOverlay } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
-
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import { useConfig } from '../config';
@@ -11,9 +10,8 @@ import type {
   AnnotationEventData,
   AnnotationEventType,
 } from '../services/client-rpc';
-import { apiCall } from '../utils/api';
 import AuthWindow from '../utils/AuthWindow';
-
+import { apiCall } from '../utils/api';
 import ContentFrame from './ContentFrame';
 import InstructorToolbar from './InstructorToolbar';
 import LaunchErrorDialog from './LaunchErrorDialog';

--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import type { Book, Chapter } from '../api-types';
 import { useService, VitalSourceService } from '../services';
-
 import BookSelector from './BookSelector';
 import ChapterList from './ChapterList';
 import ErrorDisplay from './ErrorDisplay';

--- a/lms/static/scripts/frontend_apps/components/BookSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.tsx
@@ -8,7 +8,6 @@ import {
   Thumbnail,
 } from '@hypothesis/frontend-shared/lib/next';
 import classNames from 'classnames';
-
 import { useEffect, useRef, useState } from 'preact/hooks';
 
 import type { Book } from '../api-types';

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -7,7 +7,6 @@ import { PickerCanceledError } from '../errors';
 import type { Content } from '../utils/content-item';
 import { GooglePickerClient } from '../utils/google-picker-client';
 import { OneDrivePickerClient } from '../utils/onedrive-picker-client';
-
 import BookPicker from './BookPicker';
 import type { ErrorInfo } from './FilePickerApp';
 import JSTORPicker from './JSTORPicker';

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
@@ -1,7 +1,6 @@
+import { Link, Scroll } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
-
-import { Link, Scroll } from '@hypothesis/frontend-shared/lib/next';
 
 import { formatErrorDetails, formatErrorMessage } from '../errors';
 import type { ErrorLike } from '../errors';

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -13,7 +13,6 @@ import { useConfig } from '../config';
 import { apiCall } from '../utils/api';
 import type { Content, URLContent } from '../utils/content-item';
 import { truncateURL } from '../utils/format';
-
 import ContentSelector from './ContentSelector';
 import ErrorModal from './ErrorModal';
 import FilePickerFormFields from './FilePickerFormFields';

--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -1,10 +1,10 @@
 import classnames from 'classnames';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
-import { apiCall } from '../utils/api';
 import { useConfig } from '../config';
 import type { StudentInfo } from '../config';
 import { ClientRPC, useService } from '../services';
+import { apiCall } from '../utils/api';
 import StudentSelector from './StudentSelector';
 import SubmitGradeForm from './SubmitGradeForm';
 

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -7,7 +7,6 @@ import { useConfig } from '../config';
 import { isAuthorizationError, GroupListEmptyError } from '../errors';
 import { apiCall } from '../utils/api';
 import { useUniqueId } from '../utils/hooks';
-
 import AuthorizationModal from './AuthorizationModal';
 import ErrorModal from './ErrorModal';
 

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -1,8 +1,8 @@
 import { LinkButton } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
-import GradingControls from './GradingControls';
 import { useConfig } from '../config';
+import GradingControls from './GradingControls';
 
 /**
  * Toolbar for instructors.

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -4,14 +4,12 @@ import {
   SpinnerOverlay,
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
-
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import type { File } from '../api-types';
 import type { APICallInfo } from '../config';
 import { isAuthorizationError } from '../errors';
 import { apiCall } from '../utils/api';
-
 import AuthButton from './AuthButton';
 import Breadcrumbs from './Breadcrumbs';
 import ErrorDisplay from './ErrorDisplay';

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -14,7 +14,6 @@ import { useService, GradingService } from '../services';
 import { useFetch } from '../utils/fetch';
 import { useUniqueId } from '../utils/hooks';
 import { formatToNumber, scaleGrade, validateGrade } from '../utils/validation';
-
 import ErrorModal from './ErrorModal';
 import ValidationMessage from './ValidationMessage';
 

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -4,7 +4,6 @@ import {
   Modal,
   Input,
 } from '@hypothesis/frontend-shared/lib/next';
-
 import { useRef, useState } from 'preact/hooks';
 
 export type URLPickerProps = {

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.js
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.js
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'preact/hooks';
 import classnames from 'classnames';
+import { useEffect, useState } from 'preact/hooks';
 
 /**
  * @typedef ValidationMessageProps

--- a/lms/static/scripts/frontend_apps/components/test/AuthButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AuthButton-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-
 import { act } from 'preact/test-utils';
 
 import AuthButton, { $imports } from '../AuthButton';

--- a/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLtiLaunchApp-test.js
@@ -1,15 +1,13 @@
 import { mount } from 'enzyme';
-
 import { act } from 'preact/test-utils';
 
-import { Config } from '../../config';
-import { ClientRPC, Services } from '../../services';
-import { APIError } from '../../errors';
-
-import BasicLTILaunchApp, { $imports } from '../BasicLTILaunchApp';
 import { checkAccessibility } from '../../../test-util/accessibility';
-import { delay, waitFor, waitForElement } from '../../../test-util/wait';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { delay, waitFor, waitForElement } from '../../../test-util/wait';
+import { Config } from '../../config';
+import { APIError } from '../../errors';
+import { ClientRPC, Services } from '../../services';
+import BasicLTILaunchApp, { $imports } from '../BasicLTILaunchApp';
 
 describe('BasicLTILaunchApp', () => {
   let fakeApiCall;

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-
 import { act } from 'preact/test-utils';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -1,7 +1,5 @@
 /* eslint-disable new-cap */
-
 import { mount } from 'enzyme';
-
 import { act } from 'preact/test-utils';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
-
 import ErrorDialogApp from '../ErrorDialogApp';
 
 describe('ErrorDialogApp', () => {

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -1,8 +1,8 @@
 import { mount } from 'enzyme';
 
-import ErrorDisplay, { $imports } from '../ErrorDisplay';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
+import ErrorDisplay, { $imports } from '../ErrorDisplay';
 
 describe('ErrorDisplay', () => {
   let fakeFormatErrorDetails;

--- a/lms/static/scripts/frontend_apps/components/test/ErrorModal-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorModal-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 
-import ErrorModal, { $imports } from '../ErrorModal';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
+import ErrorModal, { $imports } from '../ErrorModal';
 
 describe('ErrorModal', () => {
   let fakeError;

--- a/lms/static/scripts/frontend_apps/components/test/FileList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FileList-test.js
@@ -1,8 +1,8 @@
 import { mount } from 'enzyme';
 
-import FileList, { $imports } from '../FileList';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
+import FileList, { $imports } from '../FileList';
 
 describe('FileList', () => {
   const testFiles = [

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -1,13 +1,12 @@
 /* eslint-disable new-cap */
-
-import { act } from 'preact/test-utils';
 import { mount } from 'enzyme';
-import { waitFor, waitForElement } from '../../../test-util/wait';
+import { act } from 'preact/test-utils';
 
-import { Config } from '../../config';
-import FilePickerApp, { $imports } from '../FilePickerApp';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { waitFor, waitForElement } from '../../../test-util/wait';
+import { Config } from '../../config';
+import FilePickerApp, { $imports } from '../FilePickerApp';
 
 function interact(wrapper, callback) {
   act(callback);

--- a/lms/static/scripts/frontend_apps/components/test/GradingControls-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GradingControls-test.js
@@ -1,8 +1,8 @@
-import { act } from 'preact/test-utils';
 import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';
+import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { waitFor } from '../../../test-util/wait';
 import { Config } from '../../config';
 import { ClientRPC, Services } from '../../services';

--- a/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/OAuth2RedirectErrorApp-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
-
 import OAuth2RedirectErrorApp from '../OAuth2RedirectErrorApp';
 
 describe('OAuth2RedirectErrorApp', () => {

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -1,8 +1,8 @@
 import { mount } from 'enzyme';
 
-import StudentSelector, { $imports } from '../StudentSelector';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
+import StudentSelector, { $imports } from '../StudentSelector';
 
 describe('StudentSelector', () => {
   let fakeStudents;

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 
-import URLPicker from '../URLPicker';
 import { checkAccessibility } from '../../../test-util/accessibility';
+import URLPicker from '../URLPicker';
 
 describe('URLPicker', () => {
   const renderUrlPicker = (props = {}) => mount(<URLPicker {...props} />);

--- a/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
@@ -1,8 +1,8 @@
 import { mount } from 'enzyme';
 
-import ValidationMessage, { $imports } from '../ValidationMessage';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
+import ValidationMessage, { $imports } from '../ValidationMessage';
 
 describe('ValidationMessage', () => {
   const renderMessage = (props = {}) => {

--- a/lms/static/scripts/frontend_apps/icons.js
+++ b/lms/static/scripts/frontend_apps/icons.js
@@ -1,5 +1,4 @@
 // @ts-nocheck - TS doesn't understand SVG imports.
-
 import {
   arrowLeft,
   arrowRight,

--- a/lms/static/scripts/frontend_apps/index.js
+++ b/lms/static/scripts/frontend_apps/index.js
@@ -1,11 +1,13 @@
+import { registerIcons } from '@hypothesis/frontend-shared';
 import 'focus-visible';
 import { render } from 'preact';
 
-import { readConfig, Config } from './config';
 import BasicLTILaunchApp from './components/BasicLTILaunchApp';
-import OAuth2RedirectErrorApp from './components/OAuth2RedirectErrorApp';
 import ErrorDialogApp from './components/ErrorDialogApp';
 import FilePickerApp from './components/FilePickerApp';
+import OAuth2RedirectErrorApp from './components/OAuth2RedirectErrorApp';
+import { readConfig, Config } from './config';
+import iconSet from './icons';
 import {
   ClientRPC,
   ContentInfoFetcher,
@@ -16,8 +18,6 @@ import {
 
 /** @typedef {import('./services/client-rpc').ClientConfig} ClientConfig */
 
-import { registerIcons } from '@hypothesis/frontend-shared';
-import iconSet from './icons';
 registerIcons(iconSet);
 
 export function init() {

--- a/lms/static/scripts/frontend_apps/services/vitalsource.js
+++ b/lms/static/scripts/frontend_apps/services/vitalsource.js
@@ -2,7 +2,6 @@
  * @typedef {import('../api-types').Book} Book
  * @typedef {import('../api-types').Chapter} Chapter
  */
-
 import { apiCall, urlPath } from '../utils/api';
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -1,8 +1,8 @@
 import { mount } from 'enzyme';
 
+import { waitFor } from '../../../test-util/wait';
 import { Config } from '../../config';
 import { APIError } from '../../errors';
-import { waitFor } from '../../../test-util/wait';
 import { apiCall, urlPath, useAPIFetch, $imports } from '../api';
 
 function createResponse(status, body) {

--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -1,8 +1,8 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import { useFetch } from '../fetch';
 import { delay } from '../../../test-util/wait';
+import { useFetch } from '../fetch';
 
 describe('useFetch', () => {
   let wrappers;

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -1,5 +1,4 @@
 /* eslint-disable new-cap */
-
 import { PickerCanceledError } from '../../errors';
 import {
   GOOGLE_DRIVE_SCOPE,

--- a/lms/static/scripts/postmessage_json_rpc/test/server-test.js
+++ b/lms/static/scripts/postmessage_json_rpc/test/server-test.js
@@ -1,5 +1,4 @@
 import { delay } from '../../test-util/wait';
-
 import { Server } from '../server';
 
 describe('Server', () => {

--- a/lms/static/scripts/ui-playground/components/ErrorComponents.js
+++ b/lms/static/scripts/ui-playground/components/ErrorComponents.js
@@ -1,16 +1,13 @@
-import { useState } from 'preact/hooks';
-
 import { LabeledButton } from '@hypothesis/frontend-shared';
-
-import { Config } from '../../frontend_apps/config';
+import Library from '@hypothesis/frontend-shared/lib/pattern-library/components/Library';
+import { useState } from 'preact/hooks';
 
 import ErrorDialogApp from '../../frontend_apps/components/ErrorDialogApp';
 import ErrorDisplay from '../../frontend_apps/components/ErrorDisplay';
 import ErrorModal from '../../frontend_apps/components/ErrorModal';
 import LaunchErrorDialog from '../../frontend_apps/components/LaunchErrorDialog';
 import OAuth2RedirectErrorApp from '../../frontend_apps/components/OAuth2RedirectErrorApp';
-
-import Library from '@hypothesis/frontend-shared/lib/pattern-library/components/Library';
+import { Config } from '../../frontend_apps/config';
 
 const fakeDetails = {
   foo: { bar: 'These fake details...' },

--- a/lms/static/scripts/ui-playground/components/ToolbarPage.tsx
+++ b/lms/static/scripts/ui-playground/components/ToolbarPage.tsx
@@ -1,3 +1,4 @@
+import type { ModalProps } from '@hypothesis/frontend-shared/lib/components/feedback/Modal';
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -12,7 +13,6 @@ import {
   Select,
 } from '@hypothesis/frontend-shared/lib/next';
 import Library from '@hypothesis/frontend-shared/lib/pattern-library/components/Library';
-import type { ModalProps } from '@hypothesis/frontend-shared/lib/components/feedback/Modal';
 import classnames from 'classnames';
 import { useState } from 'preact/hooks';
 

--- a/lms/static/scripts/ui-playground/index.js
+++ b/lms/static/scripts/ui-playground/index.js
@@ -1,10 +1,9 @@
 // Entry point for local webserver pattern-library bundle
 import { startApp } from '@hypothesis/frontend-shared/lib/pattern-library';
 
+import lmsIcons from '../frontend_apps/icons.js';
 import ErrorComponents from './components/ErrorComponents';
 import ToolbarPage from './components/ToolbarPage';
-
-import lmsIcons from '../frontend_apps/icons.js';
 
 /** @type {import('@hypothesis/frontend-shared/lib/pattern-library').PlaygroundRoute[]} */
 const extraRoutes = [

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.2",
     "@rollup/plugin-virtual": "^3.0.1",
+    "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "autoprefixer": "^10.4.13",
     "classnames": "^2.3.2",
     "eslint-plugin-mocha": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -77,5 +77,13 @@
     "sinon": "^15.0.1",
     "typescript": "^4.9.5"
   },
+  "prettier": {
+    "arrowParens": "avoid",
+    "singleQuote": true,
+    "importOrder": [
+      "^[./]"
+    ],
+    "importOrderSeparation": true
+  },
   "browserslist": "chrome 70, firefox 70, safari 11.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
@@ -46,6 +46,25 @@
     gensync "^1.0.0-beta.2"
     json5 "^2.2.2"
     semver "^6.3.0"
+
+"@babel/generator@7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
+  integrity sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.17.3":
+  version "7.21.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.1.tgz#951cc626057bc0af2c35cd23e9c64d384dea83dd"
+  integrity sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==
+  dependencies:
+    "@babel/types" "^7.21.0"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
 
 "@babel/generator@^7.20.7":
   version "7.20.7"
@@ -136,15 +155,15 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-environment-visitor@^7.16.7", "@babel/helper-environment-visitor@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
+  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
+
 "@babel/helper-environment-visitor@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz#b7eee2b5b9d70602e59d1a6cad7dd24de7ca6cd7"
   integrity sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==
-
-"@babel/helper-environment-visitor@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
-  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
@@ -152,6 +171,14 @@
   integrity sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-function-name@^7.16.7":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
+  integrity sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==
+  dependencies:
+    "@babel/template" "^7.20.7"
+    "@babel/types" "^7.21.0"
 
 "@babel/helper-function-name@^7.18.6":
   version "7.18.6"
@@ -177,7 +204,7 @@
     "@babel/template" "^7.18.10"
     "@babel/types" "^7.19.0"
 
-"@babel/helper-hoist-variables@^7.18.6":
+"@babel/helper-hoist-variables@^7.16.7", "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
   integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
@@ -298,7 +325,7 @@
   dependencies:
     "@babel/types" "^7.18.9"
 
-"@babel/helper-split-export-declaration@^7.18.6":
+"@babel/helper-split-export-declaration@^7.16.7", "@babel/helper-split-export-declaration@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
   integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
@@ -310,15 +337,15 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
 "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
-
-"@babel/helper-validator-identifier@^7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
-  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
@@ -367,6 +394,11 @@
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.7.tgz#66fe23b3c8569220817d5feb8b9dcdc95bb4f71b"
   integrity sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==
+
+"@babel/parser@^7.17.3", "@babel/parser@^7.20.5":
+  version "7.21.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.2.tgz#dacafadfc6d7654c3051a66d6fe55b6cb2f2a0b3"
+  integrity sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1053,6 +1085,22 @@
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
 
+"@babel/traverse@7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/traverse@^7.18.11", "@babel/traverse@^7.18.6", "@babel/traverse@^7.18.9", "@babel/traverse@^7.19.1", "@babel/traverse@^7.20.10", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.7":
   version "7.20.12"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.12.tgz#7f0f787b3a67ca4475adef1f56cb94f6abd4a4b5"
@@ -1068,6 +1116,23 @@
     "@babel/types" "^7.20.7"
     debug "^4.1.0"
     globals "^11.1.0"
+
+"@babel/types@7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.17.0", "@babel/types@^7.21.0":
+  version "7.21.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.2.tgz#92246f6e00f91755893c2876ad653db70c8310d1"
+  integrity sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
 
 "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.20.2", "@babel/types@^7.20.7", "@babel/types@^7.4.4":
   version "7.20.7"
@@ -1158,7 +1223,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@^3.0.3":
+"@jridgewell/resolve-uri@3.1.0", "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
@@ -1176,7 +1241,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
@@ -1188,6 +1253,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
+  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
@@ -1318,6 +1391,18 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#568d9beae00b0d835f4f8c53fd55714986492e61"
   integrity sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==
+
+"@trivago/prettier-plugin-sort-imports@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.1.1.tgz#71c3c1ae770c3738b6fc85710714844477574ffd"
+  integrity sha512-dQ2r2uzNr1x6pJsuh/8x0IRA3CBUB+pWEW3J/7N98axqt7SQSm+2fy0FLNXvXGg77xEDC7KHxJlHfLYyi7PDcw==
+  dependencies:
+    "@babel/generator" "7.17.7"
+    "@babel/parser" "^7.20.5"
+    "@babel/traverse" "7.17.3"
+    "@babel/types" "7.17.0"
+    javascript-natural-sort "0.7.1"
+    lodash "^4.17.21"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -4491,6 +4576,11 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+javascript-natural-sort@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
+
 jest-worker@^26.2.1:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
@@ -6332,7 +6422,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=


### PR DESCRIPTION
This adds `@trivago/prettier-plugin-sort-imports` to the project, so that we can ensure a consistent and automated imports sorting on front-end components via `prettier`.

This was already introduced in client. See https://github.com/hypothesis/client/pull/5237 and https://github.com/hypothesis/client/pull/5279