### PR TITLE
Fix import ordering in `ErrorModal`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
@@ -1,5 +1,5 @@
-import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
 import type { ModalProps } from '@hypothesis/frontend-shared/lib/components/feedback/Modal';
+import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
 import type { ComponentChildren } from 'preact';
 import { useRef } from 'preact/hooks';
 


### PR DESCRIPTION
[Linting fail in CI](https://github.com/hypothesis/lms/actions/runs/4283069533/jobs/7458146748#step:5:12) when merging PRs today; looks like changes to `ErrorModal` preceded some changes to `prettier` import ordering.