### PR TITLE
Update shared components in `JSTORPicker`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -80,7 +80,7 @@ describe('JSTORPicker', () => {
     $imports.$restore();
   });
 
-  const getInput = wrapper => wrapper.find('TextInput').find('input');
+  const getInput = wrapper => wrapper.find('Input').find('input');
 
   // Set the value of the input field but do not fire any events
   const setURL = (wrapper, url) => {
@@ -224,7 +224,7 @@ describe('JSTORPicker', () => {
         errorMessage.text(),
         "That doesn't look like a JSTOR article link or ID"
       );
-      assert.isTrue(errorMessage.find('Icon[name="cancel"]').exists());
+      assert.isTrue(errorMessage.find('CancelIcon').exists());
     });
   });
 
@@ -269,7 +269,7 @@ describe('JSTORPicker', () => {
     assert.isTrue(wrapper.exists('img'));
     assert.isTrue(wrapper.exists('[data-testid="selected-book"]'));
 
-    const input = wrapper.find('TextInput');
+    const input = wrapper.find('Input');
     interact(wrapper, () => {
       input.prop('onInput')();
     });
@@ -280,7 +280,7 @@ describe('JSTORPicker', () => {
 
   it('enables submit button when valid JSTOR metadata has been fetched', () => {
     const wrapper = renderJSTORPicker();
-    const buttonSelector = 'LabeledButton[data-testid="select-button"]';
+    const buttonSelector = 'Button[data-testid="select-button"]';
 
     assert.isTrue(wrapper.find(buttonSelector).props().disabled);
 
@@ -308,7 +308,7 @@ describe('JSTORPicker', () => {
   ].forEach(({ contentStatus, expectedError }) => {
     it('disables submit button and shows error if content is not available', () => {
       const wrapper = renderJSTORPicker();
-      const buttonSelector = 'LabeledButton[data-testid="select-button"]';
+      const buttonSelector = 'Button[data-testid="select-button"]';
 
       assert.isTrue(wrapper.find(buttonSelector).props().disabled);
       updateURL(wrapper);


### PR DESCRIPTION
This is it! The last component to update!

Unfortunately, the JSTOR Thumbnail API service isn't working for me today, so I wasn't able to exercise the component fully in-situ. I used some "placekitten" images to ensure that the `Thumbnail` object-fit and aspect ratio was still as we desire (to wit: fill the thumbnail space per its aspect ratio, clip off the bottom of the thumbnail image it exceeds the height of the thumbnail dimentions):

<img width="724" alt="Screen Shot 2023-02-27 at 12 36 50 PM" src="https://user-images.githubusercontent.com/439947/221649955-0161a295-bc3e-44e4-a814-c86d09aaae9b.png">

There should not be any significant visual changes here (missing thumbnail image is because of API issues):

<img width="734" alt="Screen Shot 2023-02-27 at 12 37 09 PM" src="https://user-images.githubusercontent.com/439947/221650196-3f70484b-6c33-46b1-b18f-c4ea76b90b27.png">

Fixes #5013