### PR TITLE
Use LTIRoles for authorization

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -193,34 +193,8 @@ def _to_lti_v11(v13_params):
         v11_params.update({f"custom_{key}": value for key, value in custom.items()})
 
     if "roles" in v11_params:
-        context_roles = []
-        for role in v11_params["roles"]:
-            # Consider administrator regardless of their scope
-            if role.endswith("Administrator"):
-                context_roles.append(role)
-                continue
-
-            # From: https://www.imsglobal.org/spec/lti/v1p3#role-vocabularies
-            #
-            # Conforming implementations MAY recognize the simple
-            # names for context roles; thus, for example, vendors can use
-            # the following roles interchangeably:
-            #   http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor
-            #   Instructor
-            if "http://purl.imsglobal.org/vocab/lis/v2" not in role:
-                # If using the simple name, we'll take it
-                context_roles.append(role)
-
-            if role.startswith("http://purl.imsglobal.org/vocab/lis/v2/membership"):
-                # For roles that have the whole LIS 2.0 name, take only the one
-                # relevant for the current context. We'd need to expose the
-                # rest of the roles somewhere else if they become necessary /
-                # interesting, but for LTI 1.1 compatibility we only expose the
-                # roles of the current context (course) here.
-                context_roles.append(role)
-
         # We need to squish together the roles for v1.1 compatibility
-        v11_params["roles"] = ",".join(context_roles)
+        v11_params["roles"] = ",".join(v11_params["roles"])
 
     return v11_params
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,6 +10,7 @@ from pyramid.request import apply_request_extensions
 from lms import models
 from lms.db import SESSION
 from lms.models import ApplicationSettings
+from lms.models.lti_role import RoleScope, RoleType
 from lms.product import Product
 from lms.security import Identity
 from tests import factories
@@ -137,13 +138,17 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
 
 
 @pytest.fixture
-def user_is_learner(pyramid_request):
-    pyramid_request.lti_user.roles = "Learner"
+def user_is_learner(lti_user):
+    lti_user.lti_roles = [
+        factories.LTIRole(scope=RoleScope.COURSE, type=RoleType.LEARNER)
+    ]
 
 
 @pytest.fixture
-def user_is_instructor(pyramid_request):
-    pyramid_request.lti_user.roles = "Instructor"
+def user_is_instructor(lti_user):
+    lti_user.lti_roles = [
+        factories.LTIRole(scope=RoleScope.COURSE, type=RoleType.INSTRUCTOR)
+    ]
 
 
 def configure_jinja2_assets(config):

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -88,28 +88,6 @@ class TestLTIParams:
         assert params["user_id"] == "user_id-v11"
         assert params["resource_link_id"] == "resource_link_id-v11"
 
-    def test_ignores_non_context_roles(self, pyramid_request):
-        pyramid_request.lti_jwt = {
-            f"{CLAIM_PREFIX}/roles": [
-                # These roles do not relate to the current context (course) and
-                # should be ignored
-                "http://purl.imsglobal.org/vocab/lis/v2/system/person#User",
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
-                # We should accept either of these formats
-                "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
-                "Mentor",
-                # But we make an exception for admins, we consider them regarless of the scope
-                "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator",
-            ],
-        }
-
-        params = LTIParams.from_request(pyramid_request)
-
-        assert (
-            params["roles"]
-            == "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner,Mentor,http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"
-        )
-
     def test_serialize(self):
         lti_params = LTIParams(
             {

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -11,6 +11,7 @@ from tests import factories
 
 
 class TestUserService:
+    @pytest.mark.usefixtures("user_is_instructor")
     def test_upsert_user(self, service, lti_user, db_session):
         user = service.upsert_user(lti_user)
 
@@ -30,11 +31,10 @@ class TestUserService:
         )
         assert saved_user == user
 
+    @pytest.mark.usefixtures("user_is_learner")
     def test_upsert_user_doesnt_save_personal_details_for_students(
         self, service, lti_user, db_session
     ):
-        lti_user.roles = "Student"
-
         service.upsert_user(lti_user)
 
         saved_user = db_session.query(User).order_by(User.id.desc()).first()

--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -101,8 +101,10 @@ class TestViaURL:
         course_service,
         course_copy_plugin,
         is_instructor,
+        request,
     ):
-        pyramid_request.lti_user.roles = "instructor" if is_instructor else "student"
+        if is_instructor:
+            request.getfixturevalue("user_is_instructor")
         course_copy_plugin.is_file_in_course.return_value = True
 
         response = view()

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -24,8 +24,10 @@ def test_via_url(
     course_copy_plugin,
     is_instructor,
     oauth2_token_service,
+    request,
 ):
-    pyramid_request.lti_user.roles = "instructor" if is_instructor else "student"
+    if is_instructor:
+        request.getfixturevalue("user_is_instructor")
     course_copy_plugin.is_file_in_course.return_value = True
 
     response = via_url(sentinel.context, pyramid_request)
@@ -91,6 +93,7 @@ def test_it_when_file_not_in_course_fixed_by_course_copy(
     assert response == {"via_url": helpers.via_url.return_value}
 
 
+@pytest.mark.usefixtures("user_is_instructor")
 def test_it_when_file_not_in_course(
     d2l_api_client, course_service, course_copy_plugin, pyramid_request
 ):


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4749


We already deal with parsing the raw LTI "roles" parameter in LTIRole but we are trying to parse them again in LTIParams to use them to decide authorisation in LTIUser.

With this PR we use LTIRoles instead and centralizing the role handling in LTIRole.


### Testing

Quick sanity check:


- Reset the DB state


`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping,assignment,file cascade;"; make devdata`


- Launch the un-configured assignment as `aunltd.S1`

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View?ou=6782

You'll get:

```
Hypothesis assignment isn't configured

This assignment hasn't been configured yet. An instructor needs to launch the assignment to configure it.
```


- Try the same assignment as `HypothesisEng.Teacher`

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View?ou=6782


You'll get now the configuration window.