### PR TITLE
Add a Celery task for sending instructor email digests

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -1,0 +1,43 @@
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+from lms.tasks.celery import app
+
+LOG = logging.getLogger(__name__)
+
+
+@app.task
+def send_instructor_email_digests(
+    h_userids: List[str],
+    since: str,
+    until: str,
+    override_to_email: Optional[str] = None,
+) -> None:
+    """
+    Generate and send instructor email digests to the given users.
+
+    The email digests will cover activity that occurred in the time period
+    described by the `since` and `until` arguments.
+
+    :param h_userids: the h_userid's of the instructors to email
+    :param since: the beginning of the time period as an ISO 8601 format string
+    :param until: the end of the time period as an ISO 8601 format string
+
+    :param override_to_email: send all the emails to this email address instead
+        of the users' email addresses (this is for test purposes)
+    """
+    # Caution: datetime.fromisoformat() doesn't support all ISO 8601 strings!
+    # This only works for the subset of ISO 8601 produced by datetime.isoformat().
+    since = datetime.fromisoformat(since)
+    until = datetime.fromisoformat(until)
+
+    with app.request_context() as request:  # pylint:disable=no-member
+        with request.tm:
+            LOG.info(
+                "send_instructor_email_digests(%r, %r, %r, override_to_email=%r)",
+                h_userids,
+                since,
+                until,
+                override_to_email,
+            )

--- a/tests/unit/lms/tasks/email_digests_test.py
+++ b/tests/unit/lms/tasks/email_digests_test.py
@@ -1,0 +1,55 @@
+import logging
+from contextlib import contextmanager
+from datetime import datetime
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.tasks.email_digests import send_instructor_email_digests
+
+
+class TestSendInstructorEmailDigests:
+    def test_it(self, caplog):
+        caplog.set_level(logging.INFO)
+        since = datetime(year=2023, month=3, day=1)
+        until = datetime(year=2023, month=3, day=2)
+
+        send_instructor_email_digests(
+            sentinel.h_userids,
+            since.isoformat(),
+            until.isoformat(),
+            sentinel.override_to_email,
+        )
+
+        assert caplog.record_tuples == [
+            (
+                "lms.tasks.email_digests",
+                logging.INFO,
+                "send_instructor_email_digests(sentinel.h_userids, datetime.datetime(2023, 3, 1, 0, 0), datetime.datetime(2023, 3, 2, 0, 0), override_to_email=sentinel.override_to_email)",
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        "since,until",
+        [
+            ("invalid", "2023-02-28T00:00:00"),
+            ("2023-02-28T00:00:00", "invalid"),
+            ("invalid", "invalid"),
+        ],
+    )
+    def test_it_crashes_if_since_or_until_is_invalid(self, since, until):
+        with pytest.raises(ValueError, match="^Invalid isoformat string"):
+            send_instructor_email_digests(sentinel.h_userids, since, until)
+
+
+@pytest.fixture(autouse=True)
+def app(patch, pyramid_request):
+    app = patch("lms.tasks.email_digests.app")
+
+    @contextmanager
+    def request_context():
+        yield pyramid_request
+
+    app.request_context = request_context
+
+    return app


### PR DESCRIPTION
Nothing calls this celery task yet. In the future it will be called by an admin page and by a periodic celery task.

This celery task doesn't actually call the services to send emails yet since the services don't exist yet. For now it just logs a message instead.