### PR TITLE
Return the response instead of json for record_result

### DIFF
--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -66,7 +66,7 @@ class LTI13GradingService(LTIGradingService):
                 scopes=self.LTIA_SCOPES,
                 json=payload,
                 headers={"Content-Type": "application/vnd.ims.lis.v1.score+json"},
-            ).json()
+            )
 
         except ExternalRequestError as err:
             if (
@@ -76,7 +76,7 @@ class LTI13GradingService(LTIGradingService):
             ):
                 LOG.error("record_result: maximum number of allowed attempts")
                 # We silently shallow this type of error
-                return {}
+                return None
 
             raise
 

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -82,7 +82,7 @@ class TestLTI13GradingService:
             },
             headers={"Content-Type": "application/vnd.ims.lis.v1.score+json"},
         )
-        assert response == ltia_http_service.request.return_value.json.return_value
+        assert response == ltia_http_service.request.return_value
 
     def test_record_result_raises_ExternalRequestError(self, svc, ltia_http_service):
         ltia_http_service.request.side_effect = ExternalRequestError(
@@ -102,7 +102,7 @@ class TestLTI13GradingService:
 
         response = svc.record_result(sentinel.user_id, sentinel.score)
 
-        assert response == {}
+        assert not response
 
     def test_create_line_item(self, svc, ltia_http_service):
         response = svc.create_line_item(


### PR DESCRIPTION
The spec allows the response to be empty (204 No Content) so this was causing issues in some LMS.

Some LMS do return json all the time and others return it only for errors.

Introduced in #5098 