### PR TITLE
Add an admin page for testing the email digests feature

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -152,6 +152,8 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.registration.new", "/admin/registration")
     config.add_route("admin.registration.suggest_urls", "/admin/registration/urls")
 
+    config.add_route("admin.email", "/admin/email")
+
     config.add_route("lti.oidc", "/lti/1.3/oidc")
     config.add_route("lti.jwks", "/lti/1.3/jwks")
     config.add_route(

--- a/lms/templates/admin/base.html.jinja2
+++ b/lms/templates/admin/base.html.jinja2
@@ -27,6 +27,9 @@
       <a class="navbar-item" href="{{ request.route_url("admin.organizations") }}" >
         Organizations
       </a>
+      <a class="navbar-item" href="{{ request.route_url("admin.email") }}" >
+        Email
+      </a>
 
     <div class="navbar-end">
       <div class="navbar-item">

--- a/lms/templates/admin/email.html.jinja2
+++ b/lms/templates/admin/email.html.jinja2
@@ -1,0 +1,40 @@
+{% extends "lms:templates/admin/base.html.jinja2" %}
+
+{% import "macros.html.jinja2" as macros %}
+
+{% block header %}
+    Email
+{% endblock header %}
+
+{% block content %}
+  {% if request.session.peek_flash()  %}
+    <section class="section">
+      <div class="container">
+        <article class="message">
+          <div class="message-body">
+            <ul>
+            {% for message in request.session.pop_flash() %}
+              <li>{{ message }}</li>
+            {% endfor %}
+            </ul>
+          </div>
+        </article>
+      </div>
+    </section>
+  {% endif %}
+
+  <form method="POST" action="{{ request.route_url("admin.email") }}">
+      <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+
+      <fieldset class="box mt-6">
+          <legend class="label has-text-centered">Send Test Instructor Digest Emails</legend>
+
+          {{ macros.form_text_field(request, "To email", "to_email", placeholder="YOU@hypothes.is") }}
+          {{ macros.form_text_field(request, "User IDs", "h_userids", "acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is") }}
+          {{ macros.form_text_field(request, "Since", "since", "2023-02-27T00:00:00") }}
+          {{ macros.form_text_field(request, "Until", "until", "2023-02-28T00:00:00") }}
+      </fieldset>
+
+      <input type="submit" class="button is-info" value="Send"/>
+  </form>
+{% endblock content %}

--- a/lms/views/admin/email.py
+++ b/lms/views/admin/email.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta
+
+from pyramid.httpexceptions import HTTPBadRequest, HTTPFound
+from pyramid.view import view_config, view_defaults
+
+from lms.security import Permissions
+from lms.tasks.email_digests import send_instructor_email_digests
+
+
+@view_defaults(route_name="admin.email", permission=Permissions.ADMIN)
+class AdminEmailViews:
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(
+        route_name="admin.email",
+        request_method="GET",
+        renderer="lms:templates/admin/email.html.jinja2",
+    )
+    def get(self):
+        return {}
+
+    @view_config(route_name="admin.email", request_method="POST")
+    def post(self):
+        to_email = self.request.POST["to_email"].strip()
+        h_userids = self.request.POST["h_userids"].strip().split()
+        since = self.request.POST["since"].strip()
+        until = self.request.POST["until"].strip()
+
+        if not to_email:
+            raise HTTPBadRequest(
+                "You must enter an email address to send the test email(s) to."
+            )
+
+        if not to_email.endswith("@hypothes.is"):
+            raise HTTPBadRequest(
+                "Test emails can only be sent to @hypothes.is addresses."
+            )
+
+        if len(h_userids) > 3:
+            raise HTTPBadRequest(
+                "Test emails can only be sent for up to 3 users at once."
+            )
+
+        try:
+            since = datetime.fromisoformat(since)
+            until = datetime.fromisoformat(until)
+        except ValueError as exc:
+            raise HTTPBadRequest(
+                "Times must be in ISO 8601 format, for example: '2023-02-27T00:00:00'."
+            ) from exc
+
+        if until <= since:
+            raise HTTPBadRequest(
+                "The 'since' time must be earlier than the 'until' time."
+            )
+
+        if (until - since) > timedelta(days=30):
+            raise HTTPBadRequest(
+                "The 'since' and 'until' times must be less than 30 days apart."
+            )
+
+        send_instructor_email_digests.apply_async(
+            [h_userids, since.isoformat(), until.isoformat()],
+            {"override_to_email": to_email},
+        )
+
+        self.request.session.flash(
+            f"If the given users have any activity in the given timeframe then emails will be sent to {to_email}."
+        )
+
+        return HTTPFound(location=self.request.route_url("admin.email"))

--- a/tests/unit/lms/views/admin/email_test.py
+++ b/tests/unit/lms/views/admin/email_test.py
@@ -1,0 +1,84 @@
+import pytest
+from pyramid.httpexceptions import HTTPBadRequest, HTTPFound
+
+from lms.views.admin.email import AdminEmailViews
+
+
+class TestAdminEmailViews:
+    def test_get(self, views):
+        assert views.get() == {}
+
+    @pytest.mark.usefixtures("with_valid_post_params")
+    def test_post(self, views, send_instructor_email_digests):
+        response = views.post()
+
+        send_instructor_email_digests.apply_async.assert_called_once_with(
+            [["userid_1", "userid_2"], "2023-02-27T00:00:00", "2023-02-28T00:00:00"],
+            {"override_to_email": "someone@hypothes.is"},
+        )
+        assert isinstance(response, HTTPFound)
+        assert response.location == "http://example.com/admin/email"
+
+    @pytest.mark.usefixtures("with_valid_post_params")
+    @pytest.mark.parametrize(
+        "form,expected_error_message",
+        [
+            (
+                {"to_email": ""},
+                r"^You must enter an email address to send the test email\(s\) to\.$",
+            ),
+            (
+                {"to_email": " "},
+                r"^You must enter an email address to send the test email\(s\) to\.$",
+            ),
+            (
+                {"to_email": "someone@example.com"},
+                r"^Test emails can only be sent to @hypothes\.is addresses\.$",
+            ),
+            (
+                {"h_userids": "userid_1 userid_2 userid_3 userid_4"},
+                r"^Test emails can only be sent for up to 3 users at once\.$",
+            ),
+            ({"since": "invalid"}, r"^Times must be in ISO 8601 format"),
+            ({"until": "invalid"}, r"^Times must be in ISO 8601 format"),
+            (
+                {"since": "2023-02-28T00:00:00", "until": "2023-02-27T00:00:00"},
+                r"^The 'since' time must be earlier than the 'until' time\.$",
+            ),
+            (
+                {"since": "2023-02-28T00:00:00", "until": "2023-04-28T00:00:00"},
+                r"^The 'since' and 'until' times must be less than 30 days apart\.$",
+            ),
+        ],
+    )
+    def test_post_crashes_if_you_submit_invalid_values(
+        self,
+        views,
+        pyramid_request,
+        send_instructor_email_digests,
+        form,
+        expected_error_message,
+    ):
+        for key in form:
+            pyramid_request.POST[key] = form[key]
+
+        with pytest.raises(HTTPBadRequest, match=expected_error_message):
+            views.post()
+
+        send_instructor_email_digests.apply_async.assert_not_called()
+
+    @pytest.fixture
+    def with_valid_post_params(self, pyramid_request):
+        pyramid_request.POST["to_email"] = "someone@hypothes.is"
+        pyramid_request.POST["h_userids"] = "userid_1 userid_2"
+        pyramid_request.POST["since"] = "2023-02-27T00:00:00"
+        pyramid_request.POST["until"] = "2023-02-28T00:00:00"
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return AdminEmailViews(pyramid_request)
+
+
+@pytest.fixture(autouse=True)
+def send_instructor_email_digests(patch):
+    return patch("lms.views.admin.email.send_instructor_email_digests")


### PR DESCRIPTION
The page is very basic and unhelpful: it's only intended to be the quickest possible thing that I could implement that will enable me to test the email digests feature on QA and in prod. If we want to we can improve the page later when we have more time and less urgency around shipping an MVP of the feature.

# Testing

Go to <http://localhost:8001/admin/email>, enter an email address, and submit the form (the default values will do for the rest of the fields). In the terminal you should see [the celery task](https://github.com/hypothesis/lms/pull/5127) logging from the celery worker process that it was called with the right values.