### PR TITLE
Add a method for calling the `h` bulk annotation end-point

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -9,7 +9,7 @@ from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
 from lms.product.d2l import D2L
 from lms.resources._js_config.file_picker_config import FilePickerConfig
-from lms.services import HAPIError, JSTORService, VitalSourceService
+from lms.services import HAPI, HAPIError, JSTORService, VitalSourceService
 from lms.validation.authentication import BearerTokenSchema
 from lms.views.helpers import via_url
 
@@ -331,9 +331,7 @@ class JSConfig:
         # retrieve that display name.
         try:
             display_name = (
-                self._request.find_service(name="h_api")
-                .get_user(focused_user)
-                .display_name
+                self._request.find_service(HAPI).get_user(focused_user).display_name
             )
         except HAPIError:
             display_name = "(Couldn't fetch student name)"

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -13,7 +13,7 @@ from lms.services.exceptions import (
     OAuth2TokenError,
     SerializableError,
 )
-from lms.services.h_api import HAPIError
+from lms.services.h_api import HAPI, HAPIError
 from lms.services.jstor import JSTORService
 from lms.services.jwt import JWTService
 from lms.services.launch_verifier import (
@@ -50,7 +50,7 @@ def includeme(config):
     config.register_service_factory("lms.services.canvas.factory", iface=CanvasService)
     config.register_service_factory("lms.services.user.factory", iface=UserService)
 
-    config.register_service_factory("lms.services.h_api.HAPI", name="h_api")
+    config.register_service_factory("lms.services.h_api.service_factory", iface=HAPI)
     config.register_service_factory(
         "lms.services.launch_verifier.LaunchVerifier", name="launch_verifier"
     )

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -3,6 +3,7 @@ from typing import List
 from h_api.bulk_api import CommandBuilder
 
 from lms.models import Grouping
+from lms.services import HAPI
 
 
 class LTIHService:
@@ -25,7 +26,7 @@ class LTIHService:
         self._application_instance_service = request.find_service(
             name="application_instance"
         )
-        self._h_api = request.find_service(name="h_api")
+        self._h_api: HAPI = request.find_service(HAPI)
         self._group_info_service = request.find_service(name="group_info")
 
     def sync(self, groupings: List[Grouping], group_info_params: dict):

--- a/tests/unit/lms/services/__init___test.py
+++ b/tests/unit/lms/services/__init___test.py
@@ -1,4 +1,5 @@
 import pytest
+from h_matchers import Any
 
 from lms.services import includeme
 from lms.services.canvas_api import canvas_api_client_factory
@@ -15,7 +16,6 @@ class TestIncludeme:
         "name,service_class",
         (
             ("canvas_api_client", canvas_api_client_factory),
-            ("h_api", HAPI),
             ("launch_verifier", LaunchVerifier),
             ("grading_info", GradingInfoService),
             ("group_info", GroupInfoService),
@@ -23,7 +23,17 @@ class TestIncludeme:
             ("oauth1", OAuth1Service),
         ),
     )
-    def test_it_has_the_expected_service(self, name, service_class, pyramid_config):
-        includeme(pyramid_config)
-
+    def test_it_has_the_expected_service_by_name(
+        self, name, service_class, pyramid_config
+    ):
         assert pyramid_config.find_service_factory(name=name) == service_class
+
+    @pytest.mark.parametrize("service_class", (HAPI,))
+    def test_it_has_the_expected_service(self, service_class, pyramid_request):
+        assert pyramid_request.find_service(service_class) == Any.instance_of(
+            service_class
+        )
+
+    @pytest.fixture(autouse=True)
+    def with_services_loaded(self, pyramid_config):
+        includeme(pyramid_config)

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -208,7 +208,7 @@ def grouping_service(mock_service):
 
 @pytest.fixture
 def h_api(mock_service):
-    h_api = mock_service(HAPI, service_name="h_api")
+    h_api = mock_service(HAPI)
     h_api.get_user.return_value = factories.HUser()
 
     return h_api


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/h/issues/7857

Requires:

 * https://github.com/hypothesis/h/pull/7865

This PR:

 * Adds a `get_annotations()` to the `HAPI` method.
 * We also move from an older style service which accepts context and request, to a separate service factory
     * This makes it more convenient to test it with the script as below

## Testing notes

 * Start all the services
 * Sign into: https://hypothesis.instructure.com/courses/125/assignments/873
 * As Hypothesis 101 Teacher: `eng+canvasteacher@hypothes.is`
 * Make an annotation
 * Copy the following script to your LMS directory:
```python
import os
from datetime import datetime, timedelta

from lms.services.h_api import HAPI
from lms.services.http import HTTPService


h_api = HAPI(
    authority=os.environ['H_AUTHORITY'],
    client_id=os.environ['H_CLIENT_ID'],
    client_secret=os.environ['H_CLIENT_SECRET'],
    h_private_url=os.environ['H_API_URL_PRIVATE'],
    http_service=HTTPService()
)

results = h_api.get_annotations(
    audience_usernames=['3a022b6c146dfd9df4ea8662178eac'],
    updated_before=datetime.now(),
    updated_after=datetime.now() - timedelta(days=356)
)

print(list(results))
```
 * Run: 
```shell
tox -e dev --run-command "python my_script.py"
```
* You should see some return values