### PR TITLE
Add router to LMS frontend and dummy implementation of View => Edit Assignment transitions

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'preact/hooks';
+import { Route, Switch } from 'wouter-preact';
 
 import type { ConfigObject } from '../config';
 import { Config } from '../config';
 import type { ServiceMap } from '../services';
 import { Services } from '../services';
 import BasicLTILaunchApp from './BasicLTILaunchApp';
+import DataLoader from './DataLoader';
 import ErrorDialogApp from './ErrorDialogApp';
 import FilePickerApp from './FilePickerApp';
 import OAuth2RedirectErrorApp from './OAuth2RedirectErrorApp';
@@ -16,32 +18,104 @@ export type AppRootProps = {
 };
 
 /**
+ * Return dummy configuration for the file picker app. This will be replaced
+ * with a call to the endpoint created in https://github.com/hypothesis/lms/pull/5120.
+ */
+/* istanbul ignore next */
+async function loadDummyFilePickerConfig(
+  config: ConfigObject
+): Promise<ConfigObject> {
+  // Add a fake delay so we can see the loading state initially.
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // Allow `simulateError` global to be set to trigger an error here.
+  if ((window as any).simulateError) {
+    throw new Error('Failed to load file picker config');
+  }
+
+  const apiCallInfo = { path: '/api/dummy' };
+
+  return {
+    ...config,
+    product: {
+      family: 'dummy',
+      api: {
+        listGroupSets: apiCallInfo,
+      },
+      settings: { groupsEnabled: false },
+    },
+    filePicker: {
+      formAction: 'dummy',
+      formFields: {},
+      ltiLaunchUrl: 'dummy',
+      blackboard: {
+        enabled: false,
+        listFiles: apiCallInfo,
+      },
+      d2l: {
+        enabled: false,
+        listFiles: apiCallInfo,
+      },
+      canvas: {
+        enabled: false,
+        listFiles: apiCallInfo,
+      },
+      google: {
+        clientId: 'dummy',
+        developerKey: 'dummy',
+        origin: 'dummy',
+      },
+      jstor: {
+        enabled: false,
+      },
+      microsoftOneDrive: {
+        enabled: false,
+        clientId: 'dummy',
+        redirectURI: 'dummy',
+      },
+      vitalSource: {
+        enabled: false,
+      },
+    },
+  };
+}
+
+/**
  * The root component for the LMS frontend.
  */
 export default function AppRoot({ initialConfig, services }: AppRootProps) {
-  const [config] = useState(initialConfig);
-
-  let root;
-  switch (config.mode) {
-    case 'basic-lti-launch':
-      root = <BasicLTILaunchApp />;
-      break;
-    case 'content-item-selection':
-      root = <FilePickerApp />;
-      break;
-    case 'error-dialog':
-      root = <ErrorDialogApp />;
-      break;
-    case 'oauth2-redirect-error':
-      root = <OAuth2RedirectErrorApp />;
-      break;
-    default:
-      throw new Error(`Unknown frontend app ${config.mode}`);
-  }
+  const [config, setConfig] = useState(initialConfig);
 
   return (
     <Config.Provider value={config}>
-      <Services.Provider value={services}>{root}</Services.Provider>
+      <Services.Provider value={services}>
+        <Switch>
+          <Route path="/app/basic-lti-launch">
+            <BasicLTILaunchApp />
+          </Route>
+          <Route path="/app/content-item-selection">
+            <DataLoader
+              load={
+                /* istanbul ignore next */
+                () => loadDummyFilePickerConfig(config)
+              }
+              onLoad={setConfig}
+              isLoaded={'filePicker' in config}
+            >
+              <FilePickerApp />
+            </DataLoader>
+          </Route>
+          <Route path="/app/error-dialog">
+            <ErrorDialogApp />
+          </Route>
+          <Route path="/app/oauth2-redirect-error">
+            <OAuth2RedirectErrorApp />
+          </Route>
+          <Route>
+            <div data-testid="notfound-message">Page not found</div>
+          </Route>
+        </Switch>
+      </Services.Provider>
     </Config.Provider>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -100,7 +100,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
                 () => loadDummyFilePickerConfig(config)
               }
               onLoad={setConfig}
-              isLoaded={'filePicker' in config}
+              loaded={'filePicker' in config}
             >
               <FilePickerApp />
             </DataLoader>

--- a/lms/static/scripts/frontend_apps/components/DataLoader.tsx
+++ b/lms/static/scripts/frontend_apps/components/DataLoader.tsx
@@ -1,0 +1,70 @@
+import { SpinnerOverlay } from '@hypothesis/frontend-shared/lib/next';
+import type { ComponentChildren } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+import ErrorModal from './ErrorModal';
+
+export type DataLoaderProps<Data> = {
+  /**
+   * Content to render if the required data is available.
+   *
+   * It is up to the parent component to store loaded data and pass it to
+   * the content.
+   */
+  children: ComponentChildren;
+
+  /** Function that fetches data if {@link isLoaded} is false. */
+  load: () => Promise<Data>;
+
+  /**
+   * Callback to invoke with the results of {@link load}.
+   *
+   * The parent component should persist the data and re-render the
+   * {@link DataLoader} and content with `isLoaded` set to `true`.
+   */
+  onLoad: (data: Data) => void;
+
+  /** Boolean indicating whether the required data is available. */
+  isLoaded: boolean;
+};
+
+/**
+ * Component which renders its children if required data is loaded, or otherwise
+ * initiates data loading and renders a loading indicator. If the content fails
+ * to load, an error is displayed.
+ *
+ * This component doesn't store the fetched data. It is up to the parent to
+ * handling persisting the data and passing it down to the content.
+ */
+export default function DataLoader<Data>({
+  children,
+  isLoaded,
+  load,
+  onLoad,
+}: DataLoaderProps<Data>) {
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (isLoaded) {
+      return;
+    }
+    load()
+      .then(onLoad)
+      .catch(err => {
+        setError(err);
+      });
+  }, [isLoaded, load, onLoad]);
+
+  if (error) {
+    return (
+      <ErrorModal
+        description="There was a problem loading this content"
+        error={error}
+      />
+    );
+  } else if (!isLoaded) {
+    return <SpinnerOverlay />;
+  } else {
+    return <>{children}</>;
+  }
+}

--- a/lms/static/scripts/frontend_apps/components/DataLoader.tsx
+++ b/lms/static/scripts/frontend_apps/components/DataLoader.tsx
@@ -13,19 +13,19 @@ export type DataLoaderProps<Data> = {
    */
   children: ComponentChildren;
 
-  /** Function that fetches data if {@link isLoaded} is false. */
+  /** Function that fetches data if {@link loaded} is false. */
   load: () => Promise<Data>;
 
   /**
    * Callback to invoke with the results of {@link load}.
    *
    * The parent component should persist the data and re-render the
-   * {@link DataLoader} and content with `isLoaded` set to `true`.
+   * {@link DataLoader} and content with `loaded` set to `true`.
    */
   onLoad: (data: Data) => void;
 
   /** Boolean indicating whether the required data is available. */
-  isLoaded: boolean;
+  loaded: boolean;
 };
 
 /**
@@ -38,14 +38,14 @@ export type DataLoaderProps<Data> = {
  */
 export default function DataLoader<Data>({
   children,
-  isLoaded,
+  loaded,
   load,
   onLoad,
 }: DataLoaderProps<Data>) {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (isLoaded) {
+    if (loaded) {
       return;
     }
     load()
@@ -53,7 +53,7 @@ export default function DataLoader<Data>({
       .catch(err => {
         setError(err);
       });
-  }, [isLoaded, load, onLoad]);
+  }, [loaded, load, onLoad]);
 
   if (error) {
     return (
@@ -62,7 +62,7 @@ export default function DataLoader<Data>({
         error={error}
       />
     );
-  } else if (!isLoaded) {
+  } else if (!loaded) {
     return <SpinnerOverlay />;
   } else {
     return <>{children}</>;

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -1,5 +1,6 @@
-import { LinkButton } from '@hypothesis/frontend-shared/lib/next';
+import { Link } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
+import { Link as RouterLink } from 'wouter-preact';
 
 import { useConfig } from '../config';
 import GradingControls from './GradingControls';
@@ -49,14 +50,16 @@ export default function InstructorToolbar() {
             {assignmentName}
           </h1>
           {editingEnabled && (
-            <LinkButton
-              classes="text-xs"
-              data-testid="edit"
-              title="Edit assignment settings"
-              underline="always"
-            >
-              Edit
-            </LinkButton>
+            <RouterLink href="/app/content-item-selection">
+              <Link
+                classes="text-xs"
+                data-testid="edit"
+                title="Edit assignment settings"
+                underline="always"
+              >
+                Edit
+              </Link>
+            </RouterLink>
           )}
         </div>
         <h2

--- a/lms/static/scripts/frontend_apps/components/test/DataLoader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DataLoader-test.js
@@ -1,0 +1,62 @@
+import { mount } from 'enzyme';
+import { useState } from 'preact/hooks';
+
+import { waitForElement } from '../../../test-util/wait';
+import DataLoader from '../DataLoader';
+
+async function fetchMessage() {
+  return 'Example message';
+}
+
+function TestContent({ message }) {
+  return <div data-testid="content">{message}</div>;
+}
+
+function TestContainer({ initialMessage = null, load = fetchMessage }) {
+  const [message, setMessage] = useState(initialMessage);
+
+  return (
+    <div>
+      <DataLoader isLoaded={message !== null} load={load} onLoad={setMessage}>
+        <TestContent message={message} />
+      </DataLoader>
+    </div>
+  );
+}
+
+describe('DataLoader', () => {
+  it('renders content if loaded', () => {
+    const wrapper = mount(<TestContainer initialMessage="Test" />);
+    const content = wrapper.find('[data-testid="content"]');
+    assert.isTrue(content.exists());
+    assert.equal(content.text(), 'Test');
+  });
+
+  it('loads content if not already loaded', async () => {
+    const load = sinon.spy(async () => 'Hello world');
+    const wrapper = mount(<TestContainer load={load} />);
+
+    assert.isTrue(wrapper.exists('SpinnerOverlay'));
+    assert.calledOnce(load);
+
+    const content = await waitForElement(wrapper, '[data-testid="content"]');
+    assert.equal(content.text(), 'Hello world');
+    assert.isFalse(wrapper.exists('SpinnerOverlay'));
+  });
+
+  it('renders error if content failed to load', async () => {
+    const error = new Error('Request failed');
+    const load = sinon.spy(async () => {
+      throw error;
+    });
+    const wrapper = mount(<TestContainer load={load} />);
+
+    assert.isTrue(wrapper.exists('SpinnerOverlay'));
+    assert.calledOnce(load);
+
+    const errorDisplay = await waitForElement(wrapper, 'ErrorModal');
+    assert.equal(errorDisplay.prop('error'), error);
+    assert.isFalse(wrapper.exists('[data-testid="content"]'));
+    assert.isFalse(wrapper.exists('SpinnerOverlay'));
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/DataLoader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DataLoader-test.js
@@ -17,7 +17,7 @@ function TestContainer({ initialMessage = null, load = fetchMessage }) {
 
   return (
     <div>
-      <DataLoader isLoaded={message !== null} load={load} onLoad={setMessage}>
+      <DataLoader loaded={message !== null} load={load} onLoad={setMessage}>
         <TestContent message={message} />
       </DataLoader>
     </div>

--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -65,6 +65,12 @@ export function init() {
     }
   }
 
+  // Set route based on app mode.
+  const routePath = `/app/${config.mode}`;
+  if (location.pathname !== routePath) {
+    history.replaceState({}, 'unused', routePath);
+  }
+
   // Render frontend application.
   const rootEl = document.querySelector('#app');
   /* istanbul ignore next */

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.58.3",
     "tailwindcss": "^3.2.7",
-    "tiny-emitter": "^2.1.0"
+    "tiny-emitter": "^2.1.0",
+    "wouter-preact": "^2.10.0-alpha.1"
   },
   "devDependencies": {
     "@types/gapi": "^0.0.44",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7198,6 +7198,11 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
+wouter-preact@^2.10.0-alpha.1:
+  version "2.10.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/wouter-preact/-/wouter-preact-2.10.0-alpha.1.tgz#213394a210d1566f8bd5bfc794909b10cafb09b2"
+  integrity sha512-V6K8YBIURy9PHbF1e2P0gCuhCy0Oe0GbD1EZ1VxEWLU/rtBZ7IwkTj+6QVJ236NFbCklDuwL68PiUg44sSgq/w==
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"


### PR DESCRIPTION
Add infrastructure to the LMS frontend to support transitioning between modes/routes after the application is initially launched, and connect up the "Edit assignment" link in the instructor toolbar to show how this can be used.

 - In order to enable Back/Forwards to work, and to enable us to use off-the-shelf routing solutions, change the LMS frontend to store the current frontend "mode" or application in the URL. The initial URL structure for frontend apps is `/app/${mode}`.  The URLs are only referenced on the client side and cannot be visited directly (doing so will return a 404).

 - Add [wouter](https://github.com/molefrog/wouter) dependency for routing. This is a popular minimalist solution with Preact support.

 - Convert the "Edit" button in the instructor toolbar to a `<Link>` and wrap it in a wouter `<Link>` (aliased to `RouterLink` to avoid confusion) so that clicking it triggers a client-side navigation.

 - Add a `DataLoader` utility to help with deferred rendering of routes if they need config/data that is not immediately available. This is the case when transitioning from the "view assignment" route to "edit assignment". I fully expect the details of this component (eg. amount of configurability, how loading/error states are rendered) to change in future. This is just a first stab at a convenient helper to show something while a route is loading.
 
    When adding new route transitions we have a choice of whether to implement loading of new configuration/data within the route or using this utility, or some combination of the two. There is a trade-off between ease-of-implementation and flexibility here.

 - Add dummy logic in `AppRoot` to fetch configuration for the file picker app if not present in the initial app config. This currently simulates a slow API call, to illustrate the loading state and then returns fake configuration that is enough to display the file picker, but not for submitting changes to work.

---

**Testing:**

1. Launch an assignment as an instructor in an LMS that uses our instructor/grading toolbar (eg. https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View)
2. Click the "Edit" link in the instructor toolbar. You should see a loading spinner followed by a minimal version (nb. and also not fully working) of the file picker app
3. Click the browser back/forwards buttons. These should switch between viewing and editing the assignment. When clicking "Edit" a second time, you won't see the loading state again, as we re-use the cached config
4. Re-launch the assignment and set `window.simulateError = true` in the console for the LMS app frame
5. Click on the "Edit" link in the toolbar, you should see the loading state followed by an error.

If you inspect the iframe's location (eg. via `location.href`) you'll see that it is set to `http://localhost:8001/app/{frontend_mode}` and changes as you switch between view/edit modes.