### PR TITLE
Misc Application Instance refactors

### DIFF
--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -116,16 +116,10 @@ class ApplicationInstanceService:
             raise ApplicationInstanceNotFound()
 
         try:
-            return (
-                self._db.query(ApplicationInstance)
-                .join(LTIRegistration)
-                .filter(
-                    LTIRegistration.issuer == issuer,
-                    LTIRegistration.client_id == client_id,
-                    ApplicationInstance.deployment_id == deployment_id,
-                )
-                .one()
-            )
+            return self._ai_search_query(
+                issuer=issuer, client_id=client_id, deployment_id=deployment_id
+            ).one()
+
         except NoResultFound as err:
             raise ApplicationInstanceNotFound() from err
 


### PR DESCRIPTION
This PR has two pretty un-related changes in it which both change the Application Instance service:

 * We have a search based service for the most part (a service with various end-points around a powerful private search function), but one method which could have used this internal search method was instead re-implementing it. This fixes that.
 * There was a suggestion in feedback in other PRs to move the code for matching emails out into the same file as the full text search helper `full_text_match`
    * This PR moves it into a private helper in the same file
    * We don't use it anywhere else yet, so moving it to the shared file seems premature
    * This hopefully helps readability of the main search function

## Review notes

The two different changes are in different commits.