### PR TITLE
New endpoint to reconfigure assignments 

### DIFF
--- a/lms/models/event.py
+++ b/lms/models/event.py
@@ -14,6 +14,7 @@ class EventType(BASE):
         CONFIGURED_LAUNCH = "configured_launch"
         DEEP_LINKING = "deep_linking"
         AUDIT_TRAIL = "audit"
+        EDITED_ASSIGNMENT = "edited_assignment"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     type = varchar_enum(Type)

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -16,6 +16,13 @@ def includeme(config):  # pylint:disable=too-many-statements
         factory="lms.resources.LTILaunchResource",
     )
     config.add_route(
+        "edit_assignment",
+        "/assignment/edit",
+        request_method="POST",
+        factory="lms.resources.LTILaunchResource",
+    )
+
+    config.add_route(
         "lti_launches", "/lti_launches", factory="lms.resources.LTILaunchResource"
     )
     config.add_route(

--- a/lms/security.py
+++ b/lms/security.py
@@ -113,7 +113,7 @@ class SecurityPolicy:
                 partial(get_lti_user_from_bearer_token, location="headers")
             )
 
-        if path in {"/assignment"}:
+        if path in {"/assignment", "/assignment/edit"}:
             # LTUser serialized in a from for non deep-linked assignment configuration
             return LTIUserSecurityPolicy(
                 partial(get_lti_user_from_bearer_token, location="form")

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -93,7 +93,7 @@ class BasicLaunchViews:
             ],
             resource_link_id=self.request.lti_params.get("resource_link_id"),
         )
-        config = self._configure_js_for_file_picker()
+        config = self._configure_js_for_file_picker(route="edit_assignment")
         return {
             # Info about the assignment's current configuration
             "assignment": {
@@ -112,24 +112,40 @@ class BasicLaunchViews:
         schema=ConfigureAssignmentSchema,
         renderer="lms:templates/lti/basic_launch/basic_launch.html.jinja2",
     )
-    def configure_assignment(self):
+    def configure_assignment_callback(self):
         """
         Save the configuration from the file-picker for future launches.
 
         We then continue as if we were already configured with this document
         and display it to the user.
         """
-        extra = {}
-        if group_set := self.request.parsed_params.get("group_set"):
-            extra["group_set_id"] = group_set
+        return self._configure_and_show_document()
 
-        # Make any product-specific actions after configuring the assignment
-        self.request.product.plugin.misc.post_configure_assignment(self.request)
-
-        return self._show_document(
-            document_url=self.request.parsed_params["document_url"],
-            assignment_extra=extra,
+    @view_config(
+        route_name="edit_assignment",
+        permission=Permissions.LTI_CONFIGURE_ASSIGNMENT,
+        schema=ConfigureAssignmentSchema,
+        renderer="lms:templates/lti/basic_launch/basic_launch.html.jinja2",
+    )
+    def edit_assignment_callback(self):
+        """Edit the configuration of an existing assignment."""
+        assignment = self.assignment_service.get_assignment(
+            tool_consumer_instance_guid=self.request.lti_params[
+                "tool_consumer_instance_guid"
+            ],
+            resource_link_id=self.request.lti_params.get("resource_link_id"),
         )
+        self.request.registry.notify(
+            LTIEvent(
+                request=self.request,
+                type=LTIEvent.Type.EDITED_ASSIGNMENT,
+                data={
+                    "old_url": assignment.document_url,
+                    "old_group_set_id": assignment.extra.get("group_set_id"),
+                },
+            )
+        )
+        return self._configure_and_show_document()
 
     def _show_document(self, document_url, assignment_extra=None):
         """
@@ -196,7 +212,28 @@ class BasicLaunchViews:
             user=self.request.user, groups=[self.context.course]
         )
 
-    def _configure_js_for_file_picker(self) -> dict:
+    def _configure_and_show_document(self):
+        """
+        Prepare an assignment with new configuration and show it.
+
+        The configuration  could be because we are creating this assignment
+        for the first time or from an edit.
+        """
+        extra = {}
+        if group_set := self.request.parsed_params.get("group_set"):
+            extra["group_set_id"] = group_set
+
+        # Make any product-specific actions after configuring the assignment
+        self.request.product.plugin.misc.post_configure_assignment(self.request)
+
+        return self._show_document(
+            document_url=self.request.parsed_params["document_url"],
+            assignment_extra=extra,
+        )
+
+    def _configure_js_for_file_picker(
+        self, route: str = "configure_assignment"
+    ) -> dict:
         """
         Show the file-picker for the user to choose a document.
 
@@ -212,7 +249,7 @@ class BasicLaunchViews:
             return {}
 
         return self.context.js_config.enable_file_picker_mode(
-            form_action=self.request.route_url("configure_assignment"),
+            form_action=self.request.route_url(route),
             form_fields=self.request.lti_params.serialize(
                 authorization=self.context.js_config.auth_token
             ),


### PR DESCRIPTION
We'll point the frontend to this endpoint on `reconfigure_assignment_config`.

This view is very similar to the creation assignment except that we do
record a new event, `EDITED_ASSIGNMENT` for the editing one.



## Testing 


Existing behavior, nothing should have changed but as a sanity check:

- Reset the DB state:


```shell
tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate grouping,assignment,file cascade;"; make devdata;
```

- Configure this assignment:


https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View


### New edit functionality

- Enable "edit assignments" for the AI: http://localhost:8001/admin/instance/106/

- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View
 again, click the edit button and see a new request made to `https://localhost:48001/lti/reconfigure` on the browser's network tab.


- **Going from a group assignment to a course one doesn't currently work.**


- Check the new event in the DB

```
elect * from event join event_data on event_data.event_id = event.id;
-[ RECORD 1 ]-----------+------------------------------------------------------------------------------
id                      | 185
timestamp               | 2023-03-03 13:01:24.731058
type_id                 | 4
application_instance_id | 106
course_id               | 403
assignment_id           | 536
grouping_id             | 
event_id                | 185
extra                   | {"old_url": "d2l://file/course/6782/file_id/2490/", "old_group_set_id": null}
```


- Launch the assignment again, it should keep the new configuration.
