### PR TITLE
Support full h userids in `HAPI.get_annotations()`

### DIFF
--- a/lms/services/mailchimp.py
+++ b/lms/services/mailchimp.py
@@ -46,6 +46,9 @@ class MailchimpService:
         """
         params = {
             "template_name": template_name,
+            # We're not using template_content but we still need to pass an
+            # empty value or the Mailchimp API call fails.
+            "template_content": [{}],
             "message": {
                 "subaccount": sender.subaccount,
                 "from_email": sender.email,
@@ -61,10 +64,10 @@ class MailchimpService:
             "async": True,
         }
 
+        LOG.info("mailchimp_client.send_template(%r)", params)
+
         if hasattr(self, "mailchimp_client"):
             self.mailchimp_client.messages.send_template(params)
-        else:
-            LOG.info(params)
 
 
 def factory(_context, request):


### PR DESCRIPTION
The bulk annotations API that was added to h works with h usernames not
userids (i.e. just the `"foo"` part from `"acct:foo@lms.hypothes.is"`)
both in the parameters that it accepts and in the body data that it
returns.

But the LMS app has only the full userids and not the usernames in its
DB.

So unless we change the h API to use full userids something in LMS is
going to have to do userid->username and username->userid conversion.

If we're going to be using usernames not userids in h APIs then these
userid->username and username->userid conversion methods are generally
going to be needed, and the `HAPI` service itself seems like a good
place to add them (most convenient for other code).

In the longer term we may want to change the bulk API in h to accept and
return full userids. This is probably the right long-term solution: h
userids are meant to be treated as opaque strings by external services
like LMS, so LMS shouldn't be working with plain usernames.

But for now I just want to get this working quickly.