### PR TITLE
Fetch real file picker config when transitioning from View => Edit assignment

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -8,7 +8,7 @@ import { Services } from '../services';
 import BasicLTILaunchApp from './BasicLTILaunchApp';
 import DataLoader from './DataLoader';
 import ErrorDialogApp from './ErrorDialogApp';
-import FilePickerApp from './FilePickerApp';
+import FilePickerApp, { loadFilePickerConfig } from './FilePickerApp';
 import OAuth2RedirectErrorApp from './OAuth2RedirectErrorApp';
 
 export type AppRootProps = {
@@ -16,69 +16,6 @@ export type AppRootProps = {
   initialConfig: ConfigObject;
   services: ServiceMap;
 };
-
-/**
- * Return dummy configuration for the file picker app. This will be replaced
- * with a call to the endpoint created in https://github.com/hypothesis/lms/pull/5120.
- */
-/* istanbul ignore next */
-async function loadDummyFilePickerConfig(
-  config: ConfigObject
-): Promise<ConfigObject> {
-  // Add a fake delay so we can see the loading state initially.
-  await new Promise(resolve => setTimeout(resolve, 1000));
-
-  // Allow `simulateError` global to be set to trigger an error here.
-  if ((window as any).simulateError) {
-    throw new Error('Failed to load file picker config');
-  }
-
-  const apiCallInfo = { path: '/api/dummy' };
-
-  return {
-    ...config,
-    product: {
-      family: 'dummy',
-      api: {
-        listGroupSets: apiCallInfo,
-      },
-      settings: { groupsEnabled: false },
-    },
-    filePicker: {
-      formAction: 'dummy',
-      formFields: {},
-      ltiLaunchUrl: 'dummy',
-      blackboard: {
-        enabled: false,
-        listFiles: apiCallInfo,
-      },
-      d2l: {
-        enabled: false,
-        listFiles: apiCallInfo,
-      },
-      canvas: {
-        enabled: false,
-        listFiles: apiCallInfo,
-      },
-      google: {
-        clientId: 'dummy',
-        developerKey: 'dummy',
-        origin: 'dummy',
-      },
-      jstor: {
-        enabled: false,
-      },
-      microsoftOneDrive: {
-        enabled: false,
-        clientId: 'dummy',
-        redirectURI: 'dummy',
-      },
-      vitalSource: {
-        enabled: false,
-      },
-    },
-  };
-}
 
 /**
  * The root component for the LMS frontend.
@@ -95,10 +32,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
           </Route>
           <Route path="/app/content-item-selection">
             <DataLoader
-              load={
-                /* istanbul ignore next */
-                () => loadDummyFilePickerConfig(config)
-              }
+              load={() => loadFilePickerConfig(config)}
               onLoad={setConfig}
               loaded={'filePicker' in config}
             >

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import { useConfig } from '../config';
+import type { ConfigObject } from '../config';
 import { apiCall } from '../utils/api';
 import type { Content, URLContent } from '../utils/content-item';
 import { truncateURL } from '../utils/format';
@@ -67,6 +68,35 @@ function contentDescription(content: Content) {
       /* istanbul ignore next */
       throw new Error('Unknown content type');
   }
+}
+
+/**
+ * Fetch additional configuration needed by the file picker app.
+ *
+ * This is needed when transitioning to the file picker from another route.
+ *
+ * Returns the result of merging {@link config} with the configuration for
+ * the file picker app.
+ */
+export async function loadFilePickerConfig(
+  config: ConfigObject
+): Promise<ConfigObject> {
+  if (!config.editing) {
+    throw new Error('Assignment editing config missing');
+  }
+
+  const authToken = config.api.authToken;
+  const { path, data } = config.editing.getConfig;
+  const { filePicker } = await apiCall<Partial<ConfigObject>>({
+    authToken,
+    path,
+    data,
+  });
+
+  return {
+    ...config,
+    filePicker,
+  };
 }
 
 /**

--- a/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
@@ -92,18 +92,21 @@ describe('AppRoot', () => {
       './FilePickerApp': DummyFilePickerApp,
     });
 
-    // Render app initially in assignment view route.
+    // Simulate a launch that is initially viewing an assignment.
     const config = { mode: 'basic-lti-launch' };
     navigateTo('/app/basic-lti-launch');
     const wrapper = renderAppRoot({ config, services: new Map() });
     assert.isTrue(wrapper.exists('BasicLTILaunchApp'));
 
-    // Navigate to assignment edit route.
+    // Navigate to assignment edit route. This should cause the additional
+    // configuration needed by that route to be fetched.
     const updatedConfig = { ...config, filePicker: {} };
     fakeLoadFilePickerConfig.resolves(updatedConfig);
     navigateTo('/app/content-item-selection');
-    await waitForElement(wrapper, 'FilePickerApp');
 
+    // Once the additional configuration is fetched, the mocked FilePickerApp
+    // should be rendered.
+    await waitForElement(wrapper, 'FilePickerApp');
     assert.calledOnce(fakeLoadFilePickerConfig);
     assert.equal(actualConfig, updatedConfig);
   });

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -226,6 +226,9 @@ export type ConfigObject = {
     speedGrader?: SpeedGraderConfig;
   };
   contentBanner?: ContentBannerConfig;
+  editing?: {
+    getConfig: APICallInfo;
+  };
   instructorToolbar?: InstructorConfig;
   hypothesisClient?: ClientConfig;
   rpcServer?: {


### PR DESCRIPTION
This PR extends https://github.com/hypothesis/lms/pull/5134 to fetch the real file picker app configuration using backend APIs when clicking the "Edit" link from the assignment view route. With this change, it is now possible to change the content for an existing assignment, when editing is enabled for the LMS instance.

**Testing:**

1. View https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View as an instructor
2. Click "Edit" link in toolbar. You should see the assignment edit view, with the same content options as when configuring an assignment from scratch in this environment (URL, D2L file, Google Drive, OneDrive)
3. Click the URL option and enter a different PDF URL than the one that was previously used. Then click "Continue" to save changes.
4. Repeat steps 1-3 but with a different PDF URL

You can also change the group set here, but there is a known issue that removing a group set from an existing assignment does not yet work. Also if you pick a non-working group set at this stage, you won't be able to fix the problem until https://github.com/hypothesis/lms/pull/5163 lands. Hence I suggest not changing the group set when testing this PR.
