### PR TITLE
Convert remaining Preact components to TypeScript

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
@@ -1,17 +1,15 @@
 import classnames from 'classnames';
+import type { Ref } from 'preact';
 
-/**
- * @typedef ContentFrameProps
- * @prop {string} url
- * @prop {import('preact').Ref<HTMLIFrameElement>} [iframeRef]
- */
+export type ContentFrameProps = {
+  url: string;
+  iframeRef?: Ref<HTMLIFrameElement>;
+};
 
 /**
  * An iframe that displays the content of an assignment.
- *
- * @param {ContentFrameProps} props
  */
-export default function ContentFrame({ url, iframeRef }) {
+export default function ContentFrame({ url, iframeRef }: ContentFrameProps) {
   return (
     <iframe
       ref={iframeRef}

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -1,15 +1,17 @@
-/**
- * @typedef {import('../utils/content-item').Content} Content
- * @typedef {import('./GroupConfigSelector').GroupConfig} GroupConfig
- */
+import type { Content } from '../utils/content-item';
 
-/**
- * @typedef FilePickerFormFieldsProps
- * @prop {Content} content - Content for the assignment
- * @prop {Record<string,string>} formFields - Form fields provided by the backend
- *   that should be included in the response without any changes
- * @prop {string|null} groupSet
- */
+export type FilePickerFormFieldsProps = {
+  /** Content for the assignment. */
+  content: Content;
+
+  /**
+   * Form field values provided by the backend that should be rendered as
+   * hidden input fields.
+   */
+  formFields: Record<string, string>;
+
+  groupSet: string | null;
+};
 
 /**
  * Render the hidden form fields in the file picker form containing information
@@ -22,14 +24,12 @@
  *    https://www.imsglobal.org/specs/lticiv1p0/specification
  *  - When an assignment without any content configuration is launched.
  *    See the `configure_assignment` view.
- *
- * @param {FilePickerFormFieldsProps} props
  */
 export default function FilePickerFormFields({
   content,
   formFields,
   groupSet,
-}) {
+}: FilePickerFormFieldsProps) {
   return (
     <>
       {Object.entries(formFields).map(([field, value]) => (

--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.tsx
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.tsx
@@ -1,36 +1,33 @@
 import classnames from 'classnames';
 import { useEffect, useState } from 'preact/hooks';
 
-/**
- * @typedef ValidationMessageProps
- * @prop {string} message - Error message text
- * @prop {boolean} [open] - Should this be open or closed
- * @prop {() => void} [onClose] - Optional callback when the error message is closed
- */
+export type ValidationMessageProps = {
+  /** Error message text. */
+  message: string;
+
+  /** Sets whether the message is visible. */
+  open?: boolean;
+
+  /** Callback invoked when message is closed. */
+  onClose?: () => void;
+};
 
 /**
- * Shows a single validation error message that can be open or closed.
- * A user can also close the message by clicking on it.
- *
- * @param {ValidationMessageProps} props
+ * Shows a single validation error message. The user can dismiss the message
+ * by clicking on it.
  */
 export default function ValidationMessage({
   message,
   open = false,
   onClose = () => {},
-}) {
+}: ValidationMessageProps) {
   const [showError, setShowError] = useState(open);
 
   useEffect(() => {
     setShowError(open);
   }, [open]);
 
-  /**
-   * Closes the validation error message and notifies parent
-   *
-   * @param {Event} event
-   */
-  const closeValidationError = event => {
+  const closeValidationError = (event: Event) => {
     event.preventDefault();
     setShowError(false);
     onClose();


### PR DESCRIPTION
This converts the few remaining components that were still using JSDoc types to `.tsx` files.