### PR TITLE
Enable Preact devtools in LMS frontend

### DIFF
--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -1,5 +1,7 @@
 import 'focus-visible';
 import { render } from 'preact';
+// Enable debugging checks and devtools. Removed in prod builds by Rollup config.
+import 'preact/debug';
 
 import AppRoot from './components/AppRoot';
 import { readConfig } from './config';


### PR DESCRIPTION
Import `preact/debug` in entry point to enable Preact devtools. There also needs to be Rollup configuration to strip this import in production builds. That was [already present](https://github.com/hypothesis/lms/blob/8e46bafc3b39efeaebb1db93c3e6aec8db8c207d/rollup.config.mjs#L17) due to the config having been copied from the client repository.

**Testing:**

1. Install [Preact devtools](https://chrome.google.com/webstore/detail/preact-developer-tools/ilcajpmogmhpliinlbcdebhbcanbghmd) and pin the extension.
2. Launch an assignment from this branch.  The extension's icon should be enabled and a "Preact" tab should appear in the browser devtools when open