### PR TITLE
Display existing configuration when editing an assignment

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.tsx
@@ -38,8 +38,6 @@ export type BookSelectorProps = {
  * fetch book metadata corresponding to that ID using the vitalsource service.
  * Renders a thumbnail of the book cover and the book title when a book is
  * loaded/found.
- *
- * @param {BookSelectorProps} props
  */
 export default function BookSelector({
   selectedBook,

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -33,7 +33,7 @@ export type ContentSelectorProps = {
 };
 
 function extractContentTypeAndValue(content: Content): [DialogType, string] {
-  if (content.type === 'url' && content.url.match(/^https?:/)) {
+  if (content.type === 'url' && content.url.match(/^https?:/i)) {
     return ['url', content.url];
   } else if (content.type === 'url' && content.url.startsWith('jstor:')) {
     return ['jstor', content.url.slice('jstor://'.length)];

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -23,16 +23,33 @@ type DialogType =
   | null;
 
 export type ContentSelectorProps = {
+  initialContent?: Content;
+
   onError: (ei: ErrorInfo) => void;
   onSelectContent: (c: Content) => void;
+
   /** Used for testing */
   defaultActiveDialog?: DialogType;
 };
+
+function extractContentTypeAndValue(content: Content): [DialogType, string] {
+  if (content.type === 'url' && content.url.match(/^https?:/)) {
+    return ['url', content.url];
+  } else if (content.type === 'url' && content.url.startsWith('jstor:')) {
+    return ['jstor', content.url.slice('jstor://'.length)];
+  } else {
+    // Other content types are not currently handled, which means that the user
+    // will need to select content starting from a blank state, as opposed to
+    // being able to adjust the selection.
+    return [null, ''];
+  }
+}
 
 /**
  * Component that allows the user to choose the content for an assignment.
  */
 export default function ContentSelector({
+  initialContent,
   defaultActiveDialog = null,
   onError,
   onSelectContent,
@@ -60,6 +77,15 @@ export default function ContentSelector({
       vitalSource: { enabled: vitalSourceEnabled },
     },
   } = useConfig(['filePicker']);
+
+  // Map the existing content selection to a dialog type and value. We don't
+  // open the corresponding dialog immediately, but do pre-fill the dialog
+  // in some cases if the user does open it.
+  const [initialType, initialValue] = useMemo(
+    () =>
+      initialContent ? extractContentTypeAndValue(initialContent) : [null, ''],
+    [initialContent]
+  );
 
   const [isLoadingIndicatorVisible, setLoadingIndicatorVisible] =
     useState(false);
@@ -137,10 +163,19 @@ export default function ContentSelector({
     });
   };
 
+  const getDefaultValue = (type: DialogType) =>
+    type === initialType ? initialValue : undefined;
+
   let dialog;
   switch (activeDialog) {
     case 'url':
-      dialog = <URLPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
+      dialog = (
+        <URLPicker
+          defaultURL={getDefaultValue('url')}
+          onCancel={cancelDialog}
+          onSelectURL={selectURL}
+        />
+      );
       break;
     case 'canvasFile':
       dialog = (
@@ -183,7 +218,13 @@ export default function ContentSelector({
       break;
 
     case 'jstor':
-      dialog = <JSTORPicker onCancel={cancelDialog} onSelectURL={selectURL} />;
+      dialog = (
+        <JSTORPicker
+          defaultArticle={getDefaultValue('jstor')}
+          onCancel={cancelDialog}
+          onSelectURL={selectURL}
+        />
+      );
       break;
     case 'vitalSourceBook':
       dialog = (

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -215,11 +215,14 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     (content: Content) => {
       setContent(content);
       setEditingContent(false);
-      if (!enableGroupConfig) {
+
+      // If this is a new assignment and the only choice the user has to make
+      // is the content, we submit as soon as they select the content.
+      if (!isEditing && !enableGroupConfig) {
         submit(content);
       }
     },
-    [enableGroupConfig, submit]
+    [enableGroupConfig, isEditing, submit]
   );
 
   return (
@@ -330,30 +333,36 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
               </div>
             </CardContent>
           </Scroll>
-          {content && enableGroupConfig && (
-            <CardContent>
-              <CardActions>
-                {editingContent && (
-                  <Button
-                    onClick={() => setEditingContent(false)}
-                    data-testid="cancel-edit-content"
-                  >
-                    Back
-                  </Button>
-                )}
-                {!editingContent && (
-                  <Button
-                    data-testid="save-button"
-                    disabled={groupConfig.useGroupSet && !groupConfig.groupSet}
-                    variant="primary"
-                    onClick={() => submit(content)}
-                  >
-                    {isEditing ? 'Save' : 'Continue'}
-                  </Button>
-                )}
-              </CardActions>
-            </CardContent>
-          )}
+          {
+            // See comments in `selectContent` about auto-submitting form if
+            // this is a new assignment and groups are not available.
+            content && (isEditing || enableGroupConfig) && (
+              <CardContent>
+                <CardActions>
+                  {editingContent && (
+                    <Button
+                      onClick={() => setEditingContent(false)}
+                      data-testid="cancel-edit-content"
+                    >
+                      Back
+                    </Button>
+                  )}
+                  {!editingContent && (
+                    <Button
+                      data-testid="save-button"
+                      disabled={
+                        groupConfig.useGroupSet && !groupConfig.groupSet
+                      }
+                      variant="primary"
+                      onClick={() => submit(content)}
+                    >
+                      {isEditing ? 'Save' : 'Continue'}
+                    </Button>
+                  )}
+                </CardActions>
+              </CardContent>
+            )
+          }
           {content && (
             <FilePickerFormFields
               content={content}

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -10,6 +10,10 @@ export type FilePickerFormFieldsProps = {
    */
   formFields: Record<string, string>;
 
+  /**
+   * ID of the group set or category selected for this assignment, or `null`
+   * if group sets have been disabled.
+   */
   groupSet: string | null;
 };
 
@@ -35,7 +39,7 @@ export default function FilePickerFormFields({
       {Object.entries(formFields).map(([field, value]) => (
         <input key={field} type="hidden" name={field} value={value} />
       ))}
-      {groupSet && <input type="hidden" name="group_set" value={groupSet} />}
+      <input type="hidden" name="group_set" value={groupSet ?? ''} />
       {content.type === 'url' && (
         // Set the `document_url` form field which is used by the `configure_assignment`
         // view. Used in LMSes where assignments are configured on first launch.

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -175,6 +175,13 @@ export default function GroupConfigSelector({
       if (groupSets.length === 0) {
         setFetchError(new GroupListEmptyError());
       } else {
+        // FIXME - Workaround a backend issue where group set IDs are returned
+        // as numbers instead of strings in D2L. The backend should be fixed
+        // to always return strings.
+        groupSets.forEach(gs => {
+          gs.id = String(gs.id);
+        });
+
         setGroupSets(groupSets);
       }
     } catch (error) {

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
@@ -21,6 +21,13 @@ import { useUniqueId } from '../utils/hooks';
 import { articleIdFromUserInput, jstorURLFromArticleId } from '../utils/jstor';
 
 export type JSTORPickerProps = {
+  /**
+   * Article to select when the picker is initially rendered.
+   *
+   * This can be a JSTOR article ID, DOI or stable URL.
+   */
+  defaultArticle?: string;
+
   onCancel: () => void;
   /** Callback to set the assignment's content to a JSTOR article URL */
   onSelectURL: (url: string) => void;
@@ -30,6 +37,7 @@ export type JSTORPickerProps = {
  * A picker that allows a user to enter a URL corresponding to a JSTOR article.
  */
 export default function JSTORPicker({
+  defaultArticle,
   onCancel,
   onSelectURL,
 }: JSTORPickerProps) {
@@ -37,7 +45,9 @@ export default function JSTORPicker({
 
   // Selected JSTOR article ID or DOI, updated when the user confirms what
   // they have pasted/typed into the input field.
-  const [articleId, setArticleId] = useState<string | null>(null);
+  const [articleId, setArticleId] = useState<string | null>(
+    defaultArticle ? articleIdFromUserInput(defaultArticle) : null
+  );
 
   const metadata: FetchResult<JSTORMetadata> = useAPIFetch(
     articleId ? urlPath`/api/jstor/articles/${articleId}` : null
@@ -171,6 +181,7 @@ export default function JSTORPicker({
 
           <InputGroup>
             <Input
+              defaultValue={defaultArticle}
               elementRef={inputRef}
               id={inputId}
               name="jstorURL"

--- a/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/OAuth2RedirectErrorApp.tsx
@@ -7,13 +7,12 @@ export type OAuth2RedirectErrorAppProps = {
   /* Test seam */
   location?: Location;
 };
+
 /**
  * Error Modal displayed when authorization with a third-party API via OAuth
  * fails.
  *
  * Dismissing the Modal will close the window.
- *
- * @param {OAuth2RedirectErrorAppProps} props
  */
 export default function OAuth2RedirectErrorApp({
   location = window.location,

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -7,6 +7,9 @@ import {
 import { useRef, useState } from 'preact/hooks';
 
 export type URLPickerProps = {
+  /** The initial value of the URL input field. */
+  defaultURL?: string;
+
   onCancel: () => void;
   /** Callback invoked with the entered URL when the user accepts the dialog */
   onSelectURL: (url: string) => void;
@@ -16,7 +19,11 @@ export type URLPickerProps = {
  * A dialog that allows the user to enter or paste the URL of a web page or
  * PDF file to use for an assignment.
  */
-export default function URLPicker({ onCancel, onSelectURL }: URLPickerProps) {
+export default function URLPicker({
+  defaultURL = '',
+  onCancel,
+  onSelectURL,
+}: URLPickerProps) {
   const input = useRef<HTMLInputElement | null>(null);
   const form = useRef<HTMLFormElement | null>(null);
 
@@ -75,6 +82,7 @@ export default function URLPicker({ onCancel, onSelectURL }: URLPickerProps) {
           <Input
             aria-label="Enter URL to web page or PDF"
             classes="grow"
+            defaultValue={defaultURL}
             hasError={!!error}
             elementRef={input}
             name="url"

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -163,6 +163,7 @@ describe('ContentSelector', () => {
       'http://example.com/1234',
       'https://arxiv.org/pdf/1234.pdf',
       'https://foobar.com/a%3Cb',
+      'HTTPS://EXAMPLE.COM/4567',
     ].forEach(url => {
       it('pre-fills URL input if `initialContent` is an HTTP URL', () => {
         const wrapper = renderContentSelector({

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -158,6 +158,39 @@ describe('ContentSelector', () => {
     });
   });
 
+  describe('`initialContent` prop', () => {
+    [
+      'http://example.com/1234',
+      'https://arxiv.org/pdf/1234.pdf',
+      'https://foobar.com/a%3Cb',
+    ].forEach(url => {
+      it('pre-fills URL input if `initialContent` is an HTTP URL', () => {
+        const wrapper = renderContentSelector({
+          defaultActiveDialog: 'url',
+          initialContent: { type: 'url', url },
+        });
+        assert.equal(wrapper.find('URLPicker').prop('defaultURL'), url);
+      });
+    });
+
+    it('does not open a dialog when `initialContent` is specified', () => {
+      const wrapper = renderContentSelector({
+        initialContent: { type: 'url', url: 'https://example.com' },
+      });
+      assert.isFalse(wrapper.exists('URLPicker'));
+    });
+
+    ['jstor://1234', 'unknown:foobar'].forEach(url => {
+      it('does not pre-fill URL input if `initialContent` is a non-HTTP URL', () => {
+        const wrapper = renderContentSelector({
+          defaultActiveDialog: 'url',
+          initialContent: { type: 'url', url },
+        });
+        assert.isUndefined(wrapper.find('URLPicker').prop('defaultURL'));
+      });
+    });
+  });
+
   describe('LMS file dialog', () => {
     [
       {
@@ -553,6 +586,17 @@ describe('ContentSelector', () => {
       });
 
       assert.isTrue(wrapper.exists('JSTORPicker'));
+    });
+
+    it('pre-fills article selection if `initialContent` specifies JSTOR content', () => {
+      const wrapper = renderContentSelector({
+        initialContent: { type: 'url', url: 'jstor://10.1234/5678' },
+        defaultActiveDialog: 'jstor',
+      });
+      assert.equal(
+        wrapper.find('JSTORPicker').prop('defaultArticle'),
+        '10.1234/5678'
+      );
     });
 
     it('submits JSTOR URL', () => {

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -390,10 +390,6 @@ describe('FilePickerApp', () => {
           url: 'https://test.com/example.pdf',
         },
       };
-
-      // FIXME - The existing assignment configuration and "Save" buttons
-      // should be visible even if groups are not enabled.
-      fakeConfig.product.settings.groupsEnabled = true;
     });
 
     /** Click the button to edit the existing content selection. */

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -16,6 +16,13 @@ function interact(wrapper, callback) {
   wrapper.update();
 }
 
+/**
+ * Click the button in `wrapper` with a given `data-testid` attribute.
+ */
+function clickButton(wrapper, testId) {
+  wrapper.find(`button[data-testid="${testId}"]`).simulate('click');
+}
+
 describe('FilePickerApp', () => {
   let container;
   let fakeConfig;
@@ -392,28 +399,6 @@ describe('FilePickerApp', () => {
       };
     });
 
-    /** Click the button to edit the existing content selection. */
-    function clickEditButton(wrapper) {
-      const editButton = wrapper.find('Button[data-testid="edit-content"]');
-      assert.isTrue(editButton.exists());
-      act(() => {
-        editButton.prop('onClick')();
-      });
-      wrapper.update();
-    }
-
-    /** Click the button to cancel editing the content selection. */
-    function clickCancelEditButton(wrapper) {
-      const cancelButton = wrapper.find(
-        'Button[data-testid="cancel-edit-content"]'
-      );
-      assert.isTrue(cancelButton.exists());
-      act(() => {
-        cancelButton.prop('onClick')();
-      });
-      wrapper.update();
-    }
-
     it('shows "Back to assignment" link', () => {
       const wrapper = renderFilePicker();
       assert.isTrue(wrapper.exists('[data-testid="back-link"]'));
@@ -440,7 +425,7 @@ describe('FilePickerApp', () => {
 
       // Clicking on the change/edit button next to the content description
       // should show the content selector.
-      clickEditButton(wrapper);
+      clickButton(wrapper, 'edit-content');
       const contentSelector = wrapper.find('ContentSelector');
       assert.isTrue(contentSelector.exists());
       assert.deepEqual(contentSelector.prop('initialContent'), {
@@ -464,8 +449,8 @@ describe('FilePickerApp', () => {
 
     it('cancels editing content when clicking "Cancel" button', () => {
       const wrapper = renderFilePicker();
-      clickEditButton(wrapper);
-      clickCancelEditButton(wrapper);
+      clickButton(wrapper, 'edit-content');
+      clickButton(wrapper, 'cancel-edit-content');
       assert.isFalse(wrapper.exists('ContentSelector'));
     });
   });

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -32,14 +32,27 @@ describe('FilePickerFormFields', () => {
     });
   });
 
-  it('adds a `group_set` hidden form field', () => {
-    const content = { type: 'url', url: 'https://example.com/' };
-    const formFields = createComponent({
-      content,
-      groupSet: 'groupSet1',
-    });
+  [
+    {
+      groupSet: null,
+      fieldValue: '',
+    },
+    {
+      groupSet: 'abcdef',
+      fieldValue: 'abcdef',
+    },
+  ].forEach(({ groupSet, fieldValue }) => {
+    it('adds a `group_set` hidden form field', () => {
+      const content = { type: 'url', url: 'https://example.com/' };
+      const formFields = createComponent({
+        content,
+        groupSet,
+      });
 
-    assert.isTrue(formFields.find('input[name="group_set"]').exists());
+      const groupSetField = formFields.find('input[name="group_set"]');
+      assert.isTrue(groupSetField.exists());
+      assert.equal(groupSetField.prop('value'), fieldValue);
+    });
   });
 
   it('renders `document_url` field for URL content', () => {

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -122,6 +122,21 @@ describe('JSTORPicker', () => {
     });
   });
 
+  it('pre-fills input field with `defaultArticle` value and fetches article metadata/thumbnail', () => {
+    const wrapper = mount(<JSTORPicker defaultArticle="1234" />);
+
+    // Input field should use existing article ID.
+    const input = wrapper.find('input[name="jstorURL"]').getDOMNode();
+    assert.equal(input.value, '1234');
+
+    // The metadata and thumbnail for the existing article should be fetched.
+    assert.calledWith(fakeArticleIdFromUserInput, '1234');
+    simulateMetadataFetch(wrapper, 'Test article');
+    simulateThumbnailFetch(wrapper);
+    assert.include(wrapper.text(), 'Test article');
+    assert.equal(wrapper.find('img').prop('src'), 'data:thumbnail-image-data');
+  });
+
   context('entering, changing and submitting article URL', () => {
     it('validates entered URL when the value of the text input changes', () => {
       const wrapper = renderJSTORPicker();

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -6,6 +6,16 @@ import URLPicker from '../URLPicker';
 describe('URLPicker', () => {
   const renderUrlPicker = (props = {}) => mount(<URLPicker {...props} />);
 
+  it('pre-fills input with `defaultURL` prop value', () => {
+    const wrapper = renderUrlPicker({
+      defaultURL: 'https://arxiv.org/pdf/1234.pdf',
+    });
+    assert.equal(
+      wrapper.find('input').getDOMNode().value,
+      'https://arxiv.org/pdf/1234.pdf'
+    );
+  });
+
   it('invokes `onSelectURL` when user submits a URL', () => {
     const onSelectURL = sinon.stub();
 

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -61,6 +61,17 @@ export type InstructorConfig = {
 export type SpeedGraderConfig = { submissionParams: object };
 
 /**
+ * Information about the current configuration of an assignment, for use when
+ * re-configuring an assignment.
+ */
+export type AssignmentConfig = {
+  group_set_id: string | null;
+  document: {
+    url: string;
+  };
+};
+
+/**
  * Configuration for the content/file picker app shown while configuring an
  * assignment.
  */
@@ -241,6 +252,9 @@ export type ConfigObject = {
 
   // Only present in "content-item-selection" mode.
   filePicker?: FilePickerConfig;
+
+  // Only present if re-configuring an existing assignment.
+  assignment?: AssignmentConfig;
 
   // Only present in "oauth2-redirect-error" mode.
   OAuth2RedirectError?: OAuthErrorConfig;


### PR DESCRIPTION
This updates the assignment configuration screens to display the existing assignment configuration when clicking "Edit" in the instructor toolbar, and allow the user to edit that configuration.

This PR doesn't include the latest changes from https://github.com/hypothesis/lms/pull/5215. I want to get the functional changes in this PR landed first, and then we can iterate from there.

**Summary of changes:**

- Display existing content and group configuration after clicking "Edit" button in instructor toolbar
- Add "Change" button next to content description
- When editing the content, pre-fill the URL and JSTOR picker dialogs with the existing content selection. Other picker types will require more work to support pre-filling
- Add a "Back to assignment" link at the top of the edit dialog
- Change the "Continue" button label to "Save" if we arrived at the configuration screen by editing an existing assignment
- When editing an existing assignment, display the content summary and require clicking the "Save" button to apply changes, even if groups is disabled for the LMS installation (when creating a new assignment, we auto-submit the form after content is selected if there is no decision about groups to be made).
- Always render the `group_set` field in the hidden form fields in the assignment configuration screen. This is necessary to support disabling groups for an assignment that previously had it enabled. Conceptually this form has `PATCH`-like semantics when editing an existing assignment, and so if a field is omitted, the existing groups configuration is left unchanged. Fixes https://github.com/hypothesis/lms/issues/5175.

**Preview of changing the content for an existing assignment:**

https://user-images.githubusercontent.com/2458/227929205-4ca861bb-2cfe-4874-8771-68596d10d941.mov

**Testing:**

1. Launch a PDF or HTML assignment in D2L as an instructor
2. Click the "Edit" button in the toolbar. You should see a summary of the existing configuration
3. Click the "Change" button and then select the URL option. The existing URL should be pre-filled in the dialog
4. Enter a new URL and save changes. The assignment should be launched with the new URL
5. Re-edit the assignment and try changing or clearing the group configuration. After saving the changes should be reflected if you re-edit the assignment.
6. Apply the diff below, reload, and try editing the assignment. The flow should be the same except that the "Groups" section of the form will not appear.

```diff
diff --git a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
index 71268c90..81852e69 100644
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -116,11 +116,12 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   const {
     api: { authToken },
     product: {
-      settings: { groupsEnabled: enableGroupConfig },
+      settings: { groupsEnabled: _enableGroupConfig },
     },
     assignment,
     filePicker: { deepLinkingAPI, formAction, formFields },
   } = useConfig(['filePicker']);
+  const enableGroupConfig = false;
 
   // Currently selected content for assignment.
   const [content, setContent] = useState<Content | null>(
```