### PR TITLE
Install dependencies pip-sync-faster in tox's commands_pre instead of command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,8 +67,9 @@ setenv =
     SQLALCHEMY_SILENCE_UBER_WARNING=1
 whitelist_externals =
     tests,functests,bddtests,dockercompose: sh
-commands =
+commands_pre =
     pip-sync-faster requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
+commands =
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     tests: sh bin/create-db lms_test
     functests: sh bin/create-db lms_functests


### PR DESCRIPTION
Moving `pip-sync-faster` execution from tox's `commands` to `commands_pre`, so that it gets executed even when `commands` is overwritten via `--run-command`.