### PR TITLE
Convert Google and OneDrive file picker clients to TypeScript

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.ts
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.ts
@@ -13,10 +13,8 @@ export const GOOGLE_DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive';
  * `custom_canvas_api_domain` LTI launch parameter on the backend, in which
  * case it may be a domain rather than a URL. If so, this should really be handled
  * on the backend.
- *
- * @param {string} origin
  */
-function addHttps(origin) {
+function addHTTPS(origin: string) {
   if (origin.indexOf('://') !== -1) {
     return origin;
   }
@@ -24,24 +22,46 @@ function addHttps(origin) {
 }
 
 /**
- * Subset of the `Document` type returned by the Google Picker.
+ * `Document` type returned by the Google Picker.
  *
  * See https://developers.google.com/picker/docs/reference#document
- *
- * @typedef PickerDocument
- * @prop {string} id
- * @prop {string} name - Filename
- * @prop {string} url
- * @prop {string} [resourceKey] - A key which is present on a subset of older
- *   Google Drive files. If present this needs to be provided to various
- *   Google Drive APIs and share links (via the `resourcekey` query param).
- *
- *   As far as we understand, this key was added to old files to guard against
- *   their IDs being guessed.
- *
- *   See https://developers.google.com/drive/api/v3/resource-keys and
- *   https://support.google.com/drive/answer/10729743.
  */
+export type PickerDocument = {
+  id: string;
+
+  /** Filename of document. */
+  name: string;
+
+  url: string;
+
+  /**
+   * A key which is present on a subset of older Google Drive files. If present
+   * this needs to be provided to various Google Drive APIs and share links (via
+   * the `resourcekey` query param).
+   *
+   * As far as we understand, this key was added to old files to guard against
+   * their IDs being guessed.
+   *
+   * See https://developers.google.com/drive/api/v3/resource-keys and
+   * https://support.google.com/drive/answer/10729743.
+   */
+  resourceKey?: string;
+};
+
+export type GooglePickerOptions = {
+  /** API key obtained from the Google API console. */
+  developerKey: string;
+
+  /** Client ID obtained from the Google API console. */
+  clientId: string;
+
+  /**
+   * The origin of the top-most page in the frame where this picker will
+   * be served. This is needed when the picker is served inside an iframe
+   * with a different origin than the top-level page
+   */
+  origin: string;
+};
 
 /**
  * A wrapper around the Google Picker API client libraries.
@@ -50,52 +70,44 @@ function addHttps(origin) {
  * underlying libraries.
  */
 export class GooglePickerClient {
-  /**
-   * @param {object} options
-   * @param {string} options.developerKey -
-   *   API key obtained from the Google API console.
-   * @param {string} options.clientId -
-   *   Client ID obtained from the Google API console.
-   * @param {string} options.origin -
-   *   The origin of the top-most page in the frame where this picker will
-   *   be served. This is needed when the picker is served inside an iframe
-   *   with a different origin than the top-level page
-   */
-  constructor({ developerKey, clientId, origin }) {
+  private _accessToken: string | null;
+  private _clientId: string;
+  private _developerKey: string;
+  private _gapiClient: Promise<typeof gapi.client>;
+  private _gapiPicker: Promise<typeof google.picker>;
+  private _identityServices: Promise<typeof google.accounts>;
+  private _origin: string;
+
+  constructor({ developerKey, clientId, origin }: GooglePickerOptions) {
+    this._accessToken = null;
     this._clientId = clientId;
     this._developerKey = developerKey;
-    this._origin = addHttps(origin);
-
-    const libs = loadLibraries(['client', 'picker']);
+    this._origin = addHTTPS(origin);
 
     this._identityServices = loadIdentityServicesLibrary();
 
+    const libs = loadLibraries(['client', 'picker']);
     this._gapiClient = libs.then(({ client }) => client);
     this._gapiPicker = libs.then(({ picker }) => picker.api);
-
-    /** @type {string|null} */
-    this._accessToken = null;
   }
 
   /**
    * Authorize this application's access to the user's files in Google Drive.
    *
-   * @return {Promise<string>} - An access token for making Google Drive API requests.
-   *   The access token is cached for use in future Drive API calls.
+   * @return An access token for making Google Drive API requests. The access
+   *   token is cached for use in future Drive API calls.
    */
-  async requestAuthorization() {
+  async requestAuthorization(): Promise<string> {
     if (this._accessToken) {
       return this._accessToken;
     }
 
     const idServices = await this._identityServices;
 
-    /** @type {(err: Error) => void} */
-    let rejectAccessToken;
+    let rejectAccessToken: (err: Error) => void;
+    let resolveAccessToken: (token: string) => void;
 
-    /** @type {(token: string) => void} */
-    let resolveAccessToken;
-    const accessToken = new Promise((resolve, reject) => {
+    const accessToken = new Promise<string>((resolve, reject) => {
       resolveAccessToken = resolve;
       rejectAccessToken = reject;
     });
@@ -146,27 +158,26 @@ export class GooglePickerClient {
    * This will automatically call {@link requestAuthorization} to acquire
    * an access token.
    *
-   * @return {Promise<{ id: string, name: string, url: string }>}
+   * @return
    *   Document ID, filename and download URL of the selected file.
    *   The download URL is only available by users who have access to the file.
    *   To make it accessible to everyone, use `enablePublicViewing`.
    */
-  async showPicker() {
+  async showPicker(): Promise<{ id: string; name: string; url: string }> {
     const pickerLib = await this._gapiPicker;
     const accessToken = await this.requestAuthorization();
 
-    /** @type {(doc: PickerDocument) => void} */
-    let resolve;
+    let resolve: (doc: PickerDocument) => void;
 
-    /** @type {(e: Error) => void} */
-    let reject;
+    let reject: (e: Error) => void;
 
-    /**
-     * @param {object} args
-     *   @param {string} args.action
-     *   @param {PickerDocument[]} args.docs
-     */
-    function pickerCallback({ action, docs }) {
+    function pickerCallback({
+      action,
+      docs,
+    }: {
+      action: string;
+      docs: PickerDocument[];
+    }) {
       if (action === pickerLib.Action.PICKED) {
         const doc = docs[0];
         // nb. It would be better to get this URL from Google Drive instead of
@@ -183,7 +194,7 @@ export class GooglePickerClient {
       }
     }
 
-    const view = new pickerLib.View(pickerLib.ViewId.DOCS);
+    const view = new pickerLib.DocsView(pickerLib.ViewId.DOCS);
     view.setMimeTypes('application/pdf');
     const picker = new pickerLib.PickerBuilder()
       .addView(view)
@@ -203,7 +214,7 @@ export class GooglePickerClient {
   }
 
   /** Prepare Google API client library for making Google Drive API requests. */
-  async _initAPIClient() {
+  private async _initAPIClient() {
     const gapiClient = await this._gapiClient;
 
     if (!this._accessToken) {
@@ -224,20 +235,20 @@ export class GooglePickerClient {
   /**
    * Change the sharing settings on a document in Google Drive to make it
    * publicly viewable to anyone with the link.
-   *
-   * @param {string} docId
    */
-  async enablePublicViewing(docId) {
+  async enablePublicViewing(docId: string): Promise<void> {
     const gapiClient = await this._initAPIClient();
     const body = {
       type: 'anyone',
       role: 'reader',
     };
-    const request = gapiClient.drive.permissions.create({
+    // @ts-expect-error - We're missing types for `gapiClient.drive`.
+    const request: unknown = gapiClient.drive.permissions.create({
       fileId: docId,
       resource: body,
     });
     return new Promise((resolve, reject) => {
+      // @ts-expect-error - We're missing types for this.
       request.execute(resolve, reject);
     });
   }

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -40,7 +40,7 @@ function createGoogleLibFakes() {
     PickerBuilder: function () {
       return pickerBuilder;
     },
-    View: function () {
+    DocsView: function () {
       return pickerView;
     },
     ViewId: {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@types/gapi": "^0.0.44",
     "@types/google.accounts": "^0.0.6",
+    "@types/google.picker": "^0.0.39",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "axe-core": "^4.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,6 +1443,11 @@
   resolved "https://registry.yarnpkg.com/@types/google.accounts/-/google.accounts-0.0.6.tgz#f4b8571f93d9086f420b976de0fcb1b28307956e"
   integrity sha512-6+SAci9zmUjZFdKVghK0oeBOnf+uVT2Actd+SMC7AjUsejp+VuAw6OkTwasZrEo6I1By/Hlt+mKhuXvfLrcYMQ==
 
+"@types/google.picker@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/google.picker/-/google.picker-0.0.39.tgz#bb205ffb9736e8ec4a1af7cc87811d0fc5dc30fa"
+  integrity sha512-VnyuwmxPkipUPlTA6PmUeeIne7pSYSlq1xqoiyBCSTs47efEMhIlYaYHrzqW0DIvRa8HnkCDI40ltFzgke846Q==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"


### PR DESCRIPTION
Convert our wrappers around the Google and OneDrive file picker JS libs to TS.

**TODO:**

- [x] Verify that the Google picker works correctly after the `View` => `DocsView` change