### PR TITLE
Support editing assignment from launch error dialog

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
@@ -38,18 +38,25 @@ type ErrorModalBaseProps = {
   error?: ErrorLike | null;
 
   /**
-   * A callback for retrying the failed action. When present, a retry button
-   * will be rendered.
+   * Additional actions that will be displayed in the footer of the dialog.
    */
-  onRetry?: () => void;
-  /** Text for retry button, if present. */
-  retryLabel?: string;
+  extraActions?: ComponentChildren;
 
   /**
    * A callback for closing/canceling the modal. If not provided, the modal
    * will not be closeable.
    */
   onCancel?: () => void;
+
+  /**
+   * A callback for retrying the failed action. When present, a retry button
+   * will be rendered.
+   */
+  onRetry?: () => void;
+
+  /** Text for retry button, if present. */
+  retryLabel?: string;
+
   title?: string;
 };
 
@@ -66,6 +73,7 @@ export default function ErrorModal({
   children,
   description,
   error,
+  extraActions,
   onCancel,
   onRetry,
   retryLabel = 'Try again',
@@ -84,6 +92,7 @@ export default function ErrorModal({
           {cancelLabel}
         </Button>
       )}
+      {extraActions}
       {onRetry && (
         <Button
           elementRef={focusedDialogButton}

--- a/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
@@ -87,12 +87,12 @@ export default function ErrorModal({
   const focusedDialogButton = useRef<HTMLButtonElement | null>(null);
   const buttons = (
     <>
+      {extraActions}
       {onCancel && (
         <Button data-testid="cancel-button" onClick={onCancel}>
           {cancelLabel}
         </Button>
       )}
-      {extraActions}
       {onRetry && (
         <Button
           elementRef={focusedDialogButton}

--- a/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
@@ -12,7 +12,13 @@ type ErrorModalBaseProps = {
    * provided.
    */
   busy?: boolean;
+
+  /**
+   * Content of the dialog. This should be a human-readable explanation of the
+   * problem that occurred and may include hints on how to fix it.
+   */
   children?: ComponentChildren;
+
   /**
    * Text displayed on the Modal's cancel button. Only relevant when `onCancel`
    * is provided.

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -1,5 +1,7 @@
 import { Link } from '@hypothesis/frontend-shared/lib/next';
+import { Link as RouterLink } from 'wouter-preact';
 
+import { useConfig } from '../config';
 import type { ErrorLike } from '../errors';
 import type { ErrorState } from './BasicLTILaunchApp';
 import ErrorModal from './ErrorModal';
@@ -51,9 +53,22 @@ export default function LaunchErrorDialog({
   errorState,
   onRetry,
 }: LaunchErrorDialogProps) {
+  const { instructorToolbar } = useConfig();
+  let extraActions;
+  if (instructorToolbar?.editingEnabled) {
+    extraActions = (
+      <RouterLink href="/app/content-item-selection">
+        <Link underline="always" data-testid="edit-link">
+          Edit assignment
+        </Link>
+      </RouterLink>
+    );
+  }
+
   // Common properties for error dialog.
   const defaultProps = {
     busy,
+    extraActions,
     error,
 
     // FIXME: Retrying the launch is enabled by default, but many error cases

--- a/lms/static/scripts/frontend_apps/components/test/ErrorModal-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorModal-test.js
@@ -47,6 +47,20 @@ describe('ErrorModal', () => {
     assert.equal(cancelButton.text(), 'Oh no!');
   });
 
+  it('renders extra actions if provided', () => {
+    const extraActions = (
+      <>
+        <button data-testid="button-a">Click me</button>
+        <button data-testid="button-b">No, pick me!</button>
+      </>
+    );
+
+    const wrapper = createComponent({ extraActions });
+
+    assert.isTrue(wrapper.exists('[data-testid="button-a"]'));
+    assert.isTrue(wrapper.exists('[data-testid="button-b"]'));
+  });
+
   it('Passes title on to Modal', () => {
     const wrapper = createComponent({
       title: 'My custom title',


### PR DESCRIPTION
Add an "Edit assignment" link to the launch error dialog, if the user is an instructor and assignment editing is enabled. This makes it possible to fix certain errors by editing the assignment, when previously it would have required re-creating the assignment.

<img width="626" alt="Edit assignment link in LaunchErrorDialog" src="https://user-images.githubusercontent.com/2458/224363176-c57a4fd6-a305-42d4-a721-5339655e5c2c.png">

See https://github.com/hypothesis/lms/pull/5163#issuecomment-1463681889 for testing notes.