### PR TITLE
Fix a `KeyError` in `DigestService`

### DIFF
--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -41,7 +41,7 @@ class DigestService:
             unified_user = UnifiedUser.make(self.db, h_userid)
             digest = self.helper.instructor_digest(unified_user, unified_courses)
 
-            if not digest["num_annotations"]:
+            if not digest["total_annotations"]:
                 continue
 
             if override_to_email is None:

--- a/tests/unit/lms/services/digest_test.py
+++ b/tests/unit/lms/services/digest_test.py
@@ -52,8 +52,8 @@ class TestDigestService:
             create_autospec(UnifiedUser, spec_set=True, instance=True),
         ]
         digests = helper.instructor_digest.side_effect = [
-            {"num_annotations": 1},
-            {"num_annotations": 2},
+            {"total_annotations": 1},
+            {"total_annotations": 2},
         ]
 
         svc.send_instructor_email_digests(
@@ -86,7 +86,7 @@ class TestDigestService:
     def test_send_instructor_email_digests_doesnt_send_empty_digests(
         self, svc, helper, mailchimp_service
     ):
-        helper.instructor_digest.return_value = {"num_annotations": 0}
+        helper.instructor_digest.return_value = {"total_annotations": 0}
 
         svc.send_instructor_email_digests(
             [sentinel.h_userid], sentinel.updated_after, sentinel.updated_before
@@ -97,7 +97,7 @@ class TestDigestService:
     def test_send_instructor_email_digests_uses_override_to_email(
         self, svc, helper, mailchimp_service
     ):
-        helper.instructor_digest.return_value = {"num_annotations": 1}
+        helper.instructor_digest.return_value = {"total_annotations": 1}
 
         svc.send_instructor_email_digests(
             [sentinel.h_userid],


### PR DESCRIPTION
Whoops. I guess this is why dataclasses are preferable to dicts.
