### PR TITLE
Include `product` in the config for lti launch mode

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -438,6 +438,8 @@ class JSConfig:
             # launches its BasicLtiLaunchApp, whereas in
             # "content-item-selection" mode it launches its FilePickerApp.
             "mode": None,
+            # Add common fields with info about the LMS we are running in.
+            "product": self._get_product_info(),
         }
 
         if self._lti_user:

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -185,6 +185,8 @@ class JSConfig:
         This mode launches an assignment.
         """
         self._config["mode"] = JSConfig.Mode.BASIC_LTI_LAUNCH
+        # Info about the product we are currently running in
+        self._config["product"] = self._get_product_info()
 
         self._config["api"]["sync"] = self._sync_api(assignment)
 
@@ -438,8 +440,6 @@ class JSConfig:
             # launches its BasicLtiLaunchApp, whereas in
             # "content-item-selection" mode it launches its FilePickerApp.
             "mode": None,
-            # Add common fields with info about the LMS we are running in.
-            "product": self._get_product_info(),
         }
 
         if self._lti_user:

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -130,6 +130,11 @@ class TestEnableLTILaunchMode:
                     "LTI version": "LTI-1p0",
                 },
             },
+            "product": {
+                "api": {},
+                "family": "unknown",
+                "settings": {"groupsEnabled": False},
+            },
             "dev": False,
             "editing": {
                 "getConfig": {


### PR DESCRIPTION
When using the "Edit assignment" action in the instructor toolbar after
launching an assignment, we need this information, but previously it was only
available when the file picker app was launched directly.

Trying to add it in the base case created a problem where we needed to
read LTIParams to determine the product while rendering a template about
a validation error in LTIParams in the first place.

Will just add `product` in the modes where we need it for now.
