### PR TITLE
Improve email admin page defaults

### DIFF
--- a/lms/templates/admin/email.html.jinja2
+++ b/lms/templates/admin/email.html.jinja2
@@ -31,8 +31,8 @@
 
           {{ macros.form_text_field(request, "To email", "to_email", placeholder="YOU@hypothes.is") }}
           {{ macros.form_text_field(request, "User IDs", "h_userids", "acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is") }}
-          {{ macros.form_text_field(request, "Since", "since", "2023-02-27T00:00:00") }}
-          {{ macros.form_text_field(request, "Until", "until", "2023-02-28T00:00:00") }}
+          {{ macros.form_text_field(request, "Since", "since", "2023-03-09T05:00:00") }}
+          {{ macros.form_text_field(request, "Until", "until", "2023-03-10T05:00:00") }}
       </fieldset>
 
       <input type="submit" class="button is-info" value="Send"/>


### PR DESCRIPTION
I've created test courses with nice names, instructors, student,
assignments and annotations on QA and prod that match the time frame in
this PR so that the admin page's default values will produce an
interesting-looking email.
