### PR TITLE
Link to a more concrete article for missing D2L files

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -174,7 +174,9 @@ export default function ContentSelector({
           listFilesApi={d2lListFilesApi}
           onCancel={cancelDialog}
           onSelectFile={selectD2LFile}
-          missingFilesHelpLink={'https://web.hypothes.is/help-categories/d2l/'}
+          missingFilesHelpLink={
+            'https://web.hypothes.is/help/using-hypothesis-with-d2l-course-content-files/'
+          }
           withBreadcrumbs
         />
       );

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -226,7 +226,8 @@ describe('ContentSelector', () => {
           type: 'url',
           url: 'd2l://content-resource/123',
         },
-        missingFilesHelpLink: 'https://web.hypothes.is/help-categories/d2l/',
+        missingFilesHelpLink:
+          'https://web.hypothes.is/help/using-hypothesis-with-d2l-course-content-files/',
       },
     ].forEach(test => {
       it(`supports selecting a file from the ${test.name} file dialog`, () => {


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4770


I used the /d2l/ folder before as a placeholder, using the new article about this now.