### PR TITLE
Add missing type for report.event_type

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/02_entities/03_events/01_create_view.sql
+++ b/lms/data_tasks/report/create_from_scratch/02_entities/03_events/01_create_view.sql
@@ -1,7 +1,7 @@
 DROP TYPE IF EXISTS report.event_type CASCADE;
 
 CREATE TYPE report.event_type AS ENUM (
-    'configured_launch', 'deep_linking', 'audit'
+    'configured_launch', 'deep_linking', 'audit', 'edited_assignment'
 );
 
 DROP MATERIALIZED VIEW IF EXISTS report.events CASCADE;


### PR DESCRIPTION
Missing `edited_assignment` to fix:

```
invalid input value for enum report.event_type: "edited_assignment"
```

https://hypothesis.sentry.io/issues/4001511314/?referrer=slack


Not sure if we need to run a "from scratch" version of report to get this fixed. I'd say we do.

New type added here, some dicussion around the DB level constraint on the LMS side:  https://github.com/hypothesis/lms/pull/5140#discussion_r1124427751