### PR TITLE
Change `UnifiedUser.users` to `UnifiedUser.user_ids`

### DIFF
--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -70,7 +70,7 @@ class UnifiedUser:
     """All User's for a given h_userid, unified across all ApplicationInstance's."""
 
     h_userid: str
-    users: Tuple[User]
+    user_ids: Tuple[int]
     email: Optional[str]
     display_name: Optional[str]
 
@@ -169,7 +169,7 @@ class DigestContext:
 
             self._unified_users[h_userid] = UnifiedUser(
                 h_userid=h_userid,
-                users=tuple(users),
+                user_ids=tuple(user.id for user in users),
                 email=email,
                 display_name=display_name,
             )
@@ -309,11 +309,7 @@ class DigestContext:
                         (course.id for course in courses)
                     )
                 )
-                .filter(
-                    AssignmentMembership.user_id.in_(
-                        user.id for user in unified_user.users
-                    )
-                )
+                .filter(AssignmentMembership.user_id.in_(unified_user.user_ids))
                 .filter(LTIRole.type == "instructor", LTIRole.scope == "course")
             )
         )


### PR DESCRIPTION
Use a tuple of `models.User.id` ints instead of a tuple of `models.User` objects. This means that `DigestContext.unified_users()` and `DigestContext.unified_courses()` now don't return any ORM objects which may make them easier to optimise because they no longer need to use the SQLAlchemy ORM.

This might also be useful in future if we want to record each individual email send in the DB immediately (rather than at the end of the whole batch) because that would require us to commit a transaction after each send and by not holding on to any ORM objects we avoid any potential `DetachedInstanceError`'s caused by the transaction commits.