### PR TITLE
Different error codes for missing D2L files based on role

### DIFF
--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -64,9 +64,10 @@ class D2LTableOfContentsSchema(RequestsResponseSchema):
 
 
 class D2LAPIClient:
-    def __init__(self, basic_client, file_service):
+    def __init__(self, basic_client, file_service, lti_user):
         self._api = basic_client
         self._file_service = file_service
+        self._lti_user = lti_user
 
     def get_token(self, authorization_code):
         """
@@ -151,7 +152,10 @@ class D2LAPIClient:
         except ExternalRequestError as err:
             if err.status_code == 404:
                 raise FileNotFoundInCourse(
-                    "d2l_file_not_found_in_course", file_id
+                    "d2l_file_not_found_in_course_instructor"
+                    if self._lti_user.is_instructor
+                    else "d2l_file_not_found_in_course_student",
+                    file_id,
                 ) from err
             raise
 

--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -64,9 +64,8 @@ class D2LTableOfContentsSchema(RequestsResponseSchema):
 
 
 class D2LAPIClient:
-    def __init__(self, basic_client, request, file_service):
+    def __init__(self, basic_client, file_service):
         self._api = basic_client
-        self._request = request
         self._file_service = file_service
 
     def get_token(self, authorization_code):

--- a/lms/services/d2l_api/factory.py
+++ b/lms/services/d2l_api/factory.py
@@ -19,6 +19,5 @@ def d2l_api_client_factory(_context, request):
             http_service=request.find_service(name="http"),
             oauth_http_service=request.find_service(name="oauth_http"),
         ),
-        request=request,
         file_service=request.find_service(name="file"),
     )

--- a/lms/services/d2l_api/factory.py
+++ b/lms/services/d2l_api/factory.py
@@ -20,4 +20,5 @@ def d2l_api_client_factory(_context, request):
             oauth_http_service=request.find_service(name="oauth_http"),
         ),
         file_service=request.find_service(name="file"),
+        lti_user=request.lti_user,
     )

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -117,15 +117,48 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
-    case 'd2l_file_not_found_in_course':
+    case 'd2l_file_not_found_in_course_instructor':
       return (
         <ErrorModal
           {...defaultProps}
           title="Hypothesis couldn't find the file in the course"
         >
+          <p>This might have happened because:</p>
+          <ul className="px-4 list-disc">
+            <li>The file has been deleted from D2L</li>
+            <li>
+              The course was copied and the selected file is not available in
+              the new course.
+            </li>
+          </ul>
           <p>
-            This might have happened because the file has been deleted from D2L.
-            An instructor needs to re-create the assignment with a new file.
+            To fix the issue, recreate the assignment with a different file.
+            More information can be found in our document about{' '}
+            <ExternalLink href="https://web.hypothes.is/help/using-hypothesis-with-d2l-course-content-files/">
+              Using Hypothesis With D2L Course Content Files
+            </ExternalLink>
+            .
+          </p>
+        </ErrorModal>
+      );
+
+    case 'd2l_file_not_found_in_course_student':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          title="Hypothesis couldn't find the file in the course"
+        >
+          <p>This might have happened because:</p>
+          <ul className="px-4 list-disc">
+            <li>The file has been deleted from D2L</li>
+            <li>
+              The course was copied and the selected file is not available in
+              the new course.
+            </li>
+          </ul>
+          <p>
+            Please ask the course instructor to review the settings of this
+            assignment.
           </p>
         </ErrorModal>
       );

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -75,9 +75,17 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
-      errorState: 'd2l_file_not_found_in_course',
+      errorState: 'd2l_file_not_found_in_course_instructor',
       expectedText:
-        'An instructor needs to re-create the assignment with a new file.',
+        'To fix the issue, recreate the assignment with a different file.',
+      expectedTitle: "Hypothesis couldn't find the file in the course",
+      hasRetry: true,
+      withError: true,
+    },
+    {
+      errorState: 'd2l_file_not_found_in_course_student',
+      expectedText:
+        'Please ask the course instructor to review the settings of this assignment',
       expectedTitle: "Hypothesis couldn't find the file in the course",
       hasRetry: true,
       withError: true,

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -9,7 +9,8 @@ export type LTILaunchServerErrorCode =
   | 'blackboard_group_set_empty'
   | 'blackboard_group_set_not_found'
   | 'blackboard_student_not_in_group'
-  | 'd2l_file_not_found_in_course'
+  | 'd2l_file_not_found_in_course_student'
+  | 'd2l_file_not_found_in_course_instructor'
   | 'd2l_group_set_not_found'
   | 'd2l_group_set_empty'
   | 'd2l_student_not_in_group'
@@ -137,7 +138,8 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'blackboard_group_set_empty',
       'blackboard_group_set_not_found',
       'blackboard_student_not_in_group',
-      'd2l_file_not_found_in_course',
+      'd2l_file_not_found_in_course_instructor',
+      'd2l_file_not_found_in_course_student',
       'd2l_group_set_not_found',
       'd2l_group_set_empty',
       'd2l_student_not_in_group',

--- a/lms/static/scripts/ui-playground/components/ErrorComponents.tsx
+++ b/lms/static/scripts/ui-playground/components/ErrorComponents.tsx
@@ -466,7 +466,8 @@ export default function ErrorComponents() {
             <div className="grid grid-cols-2 gap-2">
               {(
                 [
-                  'd2l_file_not_found_in_course',
+                  'd2l_file_not_found_in_course_student',
+                  'd2l_file_not_found_in_course_instructor',
                   'd2l_group_set_not_found',
                   'd2l_group_set_empty',
                   'd2l_student_not_in_group',

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -46,7 +46,9 @@ def via_url(_context, request):
     try:
         if request.lti_user.is_instructor:
             if not course_copy_plugin.is_file_in_course(course_id, file_id):
-                raise FileNotFoundInCourse("d2l_file_not_found_in_course", file_id)
+                raise FileNotFoundInCourse(
+                    "d2l_file_not_found_in_course_instructor", file_id
+                )
 
         public_url = api_client.public_url(course_id, file_id)
 

--- a/tests/unit/lms/services/d2l_api/client_test.py
+++ b/tests/unit/lms/services/d2l_api/client_test.py
@@ -210,15 +210,34 @@ class TestD2LAPIClient:
         assert public_url == basic_client.api_url.return_value
 
     @pytest.mark.parametrize(
-        "status_code,exception,error_code",
+        "status_code,user_fixture_name,exception,error_code",
         [
-            (404, FileNotFoundInCourse, "d2l_file_not_found_in_course"),
-            (400, ExternalRequestError, None),
+            (
+                404,
+                "user_is_learner",
+                FileNotFoundInCourse,
+                "d2l_file_not_found_in_course_student",
+            ),
+            (
+                404,
+                "user_is_instructor",
+                FileNotFoundInCourse,
+                "d2l_file_not_found_in_course_instructor",
+            ),
+            (400, "user_is_learner", ExternalRequestError, None),
         ],
     )
     def test_public_url_raises(
-        self, svc, basic_client, status_code, exception, error_code
+        self,
+        svc,
+        basic_client,
+        status_code,
+        user_fixture_name,
+        exception,
+        error_code,
+        request,
     ):
+        _ = request.getfixturevalue(user_fixture_name)
         basic_client.request.side_effect = ExternalRequestError(
             response=factories.requests.Response(status_code=status_code)
         )
@@ -268,5 +287,5 @@ class TestD2LAPIClient:
         return create_autospec(BasicClient, instance=True, spec_set=True)
 
     @pytest.fixture
-    def svc(self, basic_client, file_service):
-        return D2LAPIClient(basic_client, file_service)
+    def svc(self, basic_client, file_service, lti_user):
+        return D2LAPIClient(basic_client, file_service, lti_user)

--- a/tests/unit/lms/services/d2l_api/client_test.py
+++ b/tests/unit/lms/services/d2l_api/client_test.py
@@ -268,5 +268,5 @@ class TestD2LAPIClient:
         return create_autospec(BasicClient, instance=True, spec_set=True)
 
     @pytest.fixture
-    def svc(self, basic_client, pyramid_request, file_service):
-        return D2LAPIClient(basic_client, pyramid_request, file_service)
+    def svc(self, basic_client, file_service):
+        return D2LAPIClient(basic_client, file_service)

--- a/tests/unit/lms/services/d2l_api/factory_test.py
+++ b/tests/unit/lms/services/d2l_api/factory_test.py
@@ -15,6 +15,7 @@ def test_d2l_api_client_factory(
     BasicClient,
     D2LAPIClient,
     file_service,
+    lti_user,
 ):
     ai = create_autospec(ApplicationInstance)
     application_instance_service.get_current.return_value = ai
@@ -34,7 +35,7 @@ def test_d2l_api_client_factory(
         oauth_http_service=oauth_http_service,
     )
     D2LAPIClient.assert_called_once_with(
-        BasicClient.return_value, file_service=file_service
+        BasicClient.return_value, file_service=file_service, lti_user=lti_user
     )
     assert service == D2LAPIClient.return_value
 

--- a/tests/unit/lms/services/d2l_api/factory_test.py
+++ b/tests/unit/lms/services/d2l_api/factory_test.py
@@ -34,7 +34,7 @@ def test_d2l_api_client_factory(
         oauth_http_service=oauth_http_service,
     )
     D2LAPIClient.assert_called_once_with(
-        BasicClient.return_value, request=pyramid_request, file_service=file_service
+        BasicClient.return_value, file_service=file_service
     )
     assert service == D2LAPIClient.return_value
 

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -99,7 +99,7 @@ def test_it_when_file_not_in_course(
 ):
     course_copy_plugin.is_file_in_course.return_value = False
     d2l_api_client.public_url.side_effect = FileNotFoundInCourse(
-        "d2l_file_not_found_in_course", file_id="FILE_ID"
+        "d2l_file_not_found_in_course_instructor", file_id="FILE_ID"
     )
     course_copy_plugin.find_matching_file_in_course.return_value = None
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4946



## Testing

#### Instructor:

- Login as `HypothesisEng.Teacher`
- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2376/View?ou=6782


#### Learner


- Login as `aunltd.S1`
- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2376/View?ou=6782

