### PR TITLE
Store group_set_id in all assignments

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -219,9 +219,7 @@ class BasicLaunchViews:
         The configuration  could be because we are creating this assignment
         for the first time or from an edit.
         """
-        extra = {}
-        if group_set := self.request.parsed_params.get("group_set"):
-            extra["group_set_id"] = group_set
+        extra = {"group_set_id": self.request.parsed_params.get("group_set")}
 
         # Make any product-specific actions after configuring the assignment
         self.request.product.plugin.misc.post_configure_assignment(self.request)

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -82,7 +82,7 @@ class TestBasicLaunchViews:
     @pytest.mark.parametrize(
         "parsed_params,expected_extras",
         [
-            ({}, {}),
+            ({}, {"group_set_id": None}),
             ({"group_set": 42}, {"group_set_id": 42}),
         ],
     )
@@ -116,7 +116,8 @@ class TestBasicLaunchViews:
     @pytest.mark.parametrize(
         "parsed_params,expected_extras",
         [
-            ({}, {}),
+            ({}, {"group_set_id": None}),
+            ({"group_set": None}, {"group_set_id": None}),
             ({"group_set": 42}, {"group_set_id": 42}),
         ],
     )


### PR DESCRIPTION
Requires:

 * https://github.com/hypothesis/lms/pull/5157

Store the ID of the group set for groups assignments and null in other cases.

This allows for edits to clear the existing value.


# Testing

In `main` group_set is never sent as null, it is in this branch: `edit-assignment-display-prev-url`


So we'll rebase that to test the behavior. I din't make that the target branch as it might take longer to get that merged until the UI design is final.


- 
```shell
git checkout non-optional-group-set-extra; 
git rebase origin/edit-assignment-display-prev-url
```
- Enable editing on: http://localhost:8001/admin/instance/106/
- Launch and edit: https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View
- Toggle between groups enabled/disabled. The groups drop down will change between the course one and the individual groups.