### PR TITLE
Split the various components of the digest service into their own files

### DIFF
--- a/lms/services/digest/__init__.py
+++ b/lms/services/digest/__init__.py
@@ -1,0 +1,2 @@
+from lms.services.digest.factory import service_factory
+from lms.services.digest.service import DigestService

--- a/lms/services/digest/_digest_context.py
+++ b/lms/services/digest/_digest_context.py
@@ -12,57 +12,6 @@ from lms.models import (
     LTIRole,
     User,
 )
-from lms.services.h_api import HAPI
-from lms.services.mailchimp import EmailRecipient, EmailSender, MailchimpService
-
-
-class DigestService:
-    """A service for generating "digests" (activity reports)."""
-
-    def __init__(self, db, h_api, mailchimp_service, sender):
-        self._db = db
-        self._h_api = h_api
-        self._mailchimp_service = mailchimp_service
-        self._sender = sender
-
-    def send_instructor_email_digests(
-        self, audience, updated_after, updated_before, override_to_email=None
-    ):
-        """Send instructor email digests for the given users and timeframe."""
-        annotations = self._h_api.get_annotations(
-            audience, updated_after, updated_before
-        )
-
-        # HAPI.get_annotations() returns an iterable.
-        # Turn it into a tuple because we need to iterate over it multiple times.
-        annotations = tuple(annotations)
-
-        context = DigestContext(self._db, audience, annotations)
-
-        for h_userid in audience:
-            digest = context.instructor_digest(h_userid)
-
-            if not digest["total_annotations"]:
-                # This user has no activity.
-                continue
-
-            unified_user = context.unified_users[h_userid]
-
-            if override_to_email is None:
-                to_email = unified_user.email
-            else:
-                to_email = override_to_email
-
-            if not to_email:
-                # We don't have an email address for this user.
-                continue
-
-            self._mailchimp_service.send_template(
-                "instructor-email-digest",
-                self._sender,
-                recipient=EmailRecipient(to_email, unified_user.display_name),
-                template_vars=digest,
-            )
 
 
 @dataclass(frozen=True)
@@ -317,16 +266,3 @@ class DigestContext:
                 .filter(LTIRole.type == "instructor", LTIRole.scope == "course")
             )
         )
-
-
-def service_factory(_context, request):
-    return DigestService(
-        db=request.db,
-        h_api=request.find_service(HAPI),
-        mailchimp_service=request.find_service(MailchimpService),
-        sender=EmailSender(
-            request.registry.settings.get("mailchimp_digests_subaccount"),
-            request.registry.settings.get("mailchimp_digests_email"),
-            request.registry.settings.get("mailchimp_digests_name"),
-        ),
-    )

--- a/lms/services/digest/factory.py
+++ b/lms/services/digest/factory.py
@@ -1,0 +1,16 @@
+from lms.services.digest.service import DigestService
+from lms.services.h_api import HAPI
+from lms.services.mailchimp import EmailSender, MailchimpService
+
+
+def service_factory(_context, request):
+    return DigestService(
+        db=request.db,
+        h_api=request.find_service(HAPI),
+        mailchimp_service=request.find_service(MailchimpService),
+        sender=EmailSender(
+            request.registry.settings.get("mailchimp_digests_subaccount"),
+            request.registry.settings.get("mailchimp_digests_email"),
+            request.registry.settings.get("mailchimp_digests_name"),
+        ),
+    )

--- a/lms/services/digest/service.py
+++ b/lms/services/digest/service.py
@@ -1,0 +1,51 @@
+from lms.services.digest._digest_context import DigestContext
+from lms.services.mailchimp import EmailRecipient
+
+
+class DigestService:
+    """A service for generating "digests" (activity reports)."""
+
+    def __init__(self, db, h_api, mailchimp_service, sender):
+        self._db = db
+        self._h_api = h_api
+        self._mailchimp_service = mailchimp_service
+        self._sender = sender
+
+    def send_instructor_email_digests(
+        self, audience, updated_after, updated_before, override_to_email=None
+    ):
+        """Send instructor email digests for the given users and timeframe."""
+        annotations = self._h_api.get_annotations(
+            audience, updated_after, updated_before
+        )
+
+        # HAPI.get_annotations() returns an iterable.
+        # Turn it into a tuple because we need to iterate over it multiple times.
+        annotations = tuple(annotations)
+
+        context = DigestContext(self._db, audience, annotations)
+
+        for h_userid in audience:
+            digest = context.instructor_digest(h_userid)
+
+            if not digest["total_annotations"]:
+                # This user has no activity.
+                continue
+
+            unified_user = context.unified_users[h_userid]
+
+            if override_to_email is None:
+                to_email = unified_user.email
+            else:
+                to_email = override_to_email
+
+            if not to_email:
+                # We don't have an email address for this user.
+                continue
+
+            self._mailchimp_service.send_template(
+                "instructor-email-digest",
+                self._sender,
+                recipient=EmailRecipient(to_email, unified_user.display_name),
+                template_vars=digest,
+            )

--- a/tests/unit/lms/services/digest/_digest_context_test.py
+++ b/tests/unit/lms/services/digest/_digest_context_test.py
@@ -1,126 +1,15 @@
 from datetime import datetime
-from unittest.mock import call, sentinel
 
 import factory
 import pytest
 from h_matchers import Any
 
-from lms.services.digest import (
+from lms.services.digest._digest_context import (
     DigestContext,
-    DigestService,
     UnifiedCourse,
     UnifiedUser,
-    service_factory,
 )
-from lms.services.mailchimp import EmailRecipient, EmailSender
 from tests import factories
-
-
-class TestDigestService:
-    def test_send_instructor_email_digests(
-        self, svc, h_api, context, DigestContext, db_session, mailchimp_service, sender
-    ):
-        audience = ["userid1", "userid2"]
-        context.unified_users = {
-            "userid1": UnifiedUserFactory(h_userid="userid1"),
-            "userid2": UnifiedUserFactory(h_userid="userid2"),
-        }
-        digests = context.instructor_digest.side_effect = [
-            {"total_annotations": 1},
-            {"total_annotations": 2},
-        ]
-
-        svc.send_instructor_email_digests(
-            audience, sentinel.updated_after, sentinel.updated_before
-        )
-
-        h_api.get_annotations.assert_called_once_with(
-            audience, sentinel.updated_after, sentinel.updated_before
-        )
-        DigestContext.assert_called_once_with(
-            db_session, audience, tuple(h_api.get_annotations.return_value)
-        )
-        assert context.instructor_digest.call_args_list == [
-            call(h_userid) for h_userid in audience
-        ]
-        assert mailchimp_service.send_template.call_args_list == [
-            call(
-                "instructor-email-digest",
-                sender,
-                recipient=EmailRecipient(unified_user.email, unified_user.display_name),
-                template_vars=digest,
-            )
-            for unified_user, digest in zip(context.unified_users.values(), digests)
-        ]
-
-    def test_send_instructor_email_digests_doesnt_send_empty_digests(
-        self, svc, context, mailchimp_service
-    ):
-        context.instructor_digest.return_value = {"total_annotations": 0}
-
-        svc.send_instructor_email_digests(
-            [sentinel.h_userid], sentinel.updated_after, sentinel.updated_before
-        )
-
-        mailchimp_service.send_template.assert_not_called()
-
-    def test_send_instructor_email_digests_ignores_instructors_with_no_email_address(
-        self, svc, context, mailchimp_service
-    ):
-        context.unified_users = {sentinel.h_userid: UnifiedUserFactory(email=None)}
-        context.instructor_digest.return_value = {"total_annotations": 1}
-
-        svc.send_instructor_email_digests(
-            [sentinel.h_userid], sentinel.updated_after, sentinel.updated_before
-        )
-
-        mailchimp_service.send_template.assert_not_called()
-
-    def test_send_instructor_email_digests_uses_override_to_email(
-        self, svc, context, mailchimp_service
-    ):
-        context.instructor_digest.return_value = {"total_annotations": 1}
-
-        svc.send_instructor_email_digests(
-            [sentinel.h_userid],
-            sentinel.updated_after,
-            sentinel.updated_before,
-            override_to_email=sentinel.override_to_email,
-        )
-
-        assert (
-            mailchimp_service.send_template.call_args[1]["recipient"].email
-            == sentinel.override_to_email
-        )
-
-    @pytest.fixture(autouse=True)
-    def DigestContext(self, patch):
-        return patch("lms.services.digest.DigestContext")
-
-    @pytest.fixture
-    def context(self, DigestContext):
-        return DigestContext.return_value
-
-    @pytest.fixture
-    def sender(self):
-        return EmailSender(sentinel.subaccount, sentinel.from_email, sentinel.from_name)
-
-    @pytest.fixture
-    def h_api(self, h_api):
-        h_api.get_annotations.return_value = [
-            sentinel.annotation1,
-            sentinel.annotation2,
-        ]
-        return h_api
-
-    @pytest.fixture
-    def svc(self, db_session, h_api, mailchimp_service, sender):
-        return DigestService(
-            db=db_session,
-            h_api=h_api,
-            mailchimp_service=mailchimp_service,
-            sender=sender,
-        )
 
 
 class TestDigestContext:
@@ -544,32 +433,6 @@ class TestDigestContext:
         assert context.unified_courses == {}
 
 
-class TestServiceFactory:
-    def test_it(self, pyramid_request, h_api, mailchimp_service, DigestService):
-        settings = pyramid_request.registry.settings
-        settings["mailchimp_digests_subaccount"] = sentinel.digests_subaccount
-        settings["mailchimp_digests_email"] = sentinel.digests_from_email
-        settings["mailchimp_digests_name"] = sentinel.digests_from_name
-
-        service = service_factory(sentinel.context, pyramid_request)
-
-        DigestService.assert_called_once_with(
-            db=pyramid_request.db,
-            h_api=h_api,
-            mailchimp_service=mailchimp_service,
-            sender=EmailSender(
-                sentinel.digests_subaccount,
-                sentinel.digests_from_email,
-                sentinel.digests_from_name,
-            ),
-        )
-        assert service == DigestService.return_value
-
-    @pytest.fixture
-    def DigestService(self, patch):
-        return patch("lms.services.digest.DigestService")
-
-
 class Annotation(factory.Factory):
     """
     A factory for annotation dicts.
@@ -594,18 +457,6 @@ class Annotation(factory.Factory):
         obj["author"] = {"userid": obj.pop("userid")}
         obj["group"] = {"authority_provided_id": obj.pop("authority_provided_id")}
         return obj
-
-
-class UnifiedUserFactory(factory.Factory):
-    class Meta:
-        model = UnifiedUser
-
-    h_userid = factory.Sequence(lambda n: f"acct:user_{n}@lms.hypothes.is")
-    users = factory.LazyAttribute(
-        lambda o: factories.User.create_batch(2, h_userid=o.h_userid)
-    )
-    email = factory.Sequence(lambda n: f"user_{n}@example.com")
-    display_name = factory.Sequence(lambda n: f"User {n}")
 
 
 @pytest.fixture

--- a/tests/unit/lms/services/digest/factory_test.py
+++ b/tests/unit/lms/services/digest/factory_test.py
@@ -1,0 +1,32 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.digest import service_factory
+from lms.services.mailchimp import EmailSender
+
+
+class TestServiceFactory:
+    def test_it(self, pyramid_request, h_api, mailchimp_service, DigestService):
+        settings = pyramid_request.registry.settings
+        settings["mailchimp_digests_subaccount"] = sentinel.digests_subaccount
+        settings["mailchimp_digests_email"] = sentinel.digests_from_email
+        settings["mailchimp_digests_name"] = sentinel.digests_from_name
+
+        service = service_factory(sentinel.context, pyramid_request)
+
+        DigestService.assert_called_once_with(
+            db=pyramid_request.db,
+            h_api=h_api,
+            mailchimp_service=mailchimp_service,
+            sender=EmailSender(
+                sentinel.digests_subaccount,
+                sentinel.digests_from_email,
+                sentinel.digests_from_name,
+            ),
+        )
+        assert service == DigestService.return_value
+
+    @pytest.fixture
+    def DigestService(self, patch):
+        return patch("lms.services.digest.factory.DigestService")

--- a/tests/unit/lms/services/digest/service_test.py
+++ b/tests/unit/lms/services/digest/service_test.py
@@ -1,0 +1,128 @@
+from unittest.mock import call, sentinel
+
+import factory
+import pytest
+
+from lms.services.digest._digest_context import UnifiedUser
+from lms.services.digest.service import DigestService
+from lms.services.mailchimp import EmailRecipient, EmailSender
+from tests import factories
+
+
+class TestDigestService:
+    def test_send_instructor_email_digests(
+        self, svc, h_api, context, DigestContext, db_session, mailchimp_service, sender
+    ):
+        audience = ["userid1", "userid2"]
+        context.unified_users = {
+            "userid1": UnifiedUserFactory(h_userid="userid1"),
+            "userid2": UnifiedUserFactory(h_userid="userid2"),
+        }
+        digests = context.instructor_digest.side_effect = [
+            {"total_annotations": 1},
+            {"total_annotations": 2},
+        ]
+
+        svc.send_instructor_email_digests(
+            audience, sentinel.updated_after, sentinel.updated_before
+        )
+
+        h_api.get_annotations.assert_called_once_with(
+            audience, sentinel.updated_after, sentinel.updated_before
+        )
+        DigestContext.assert_called_once_with(
+            db_session, audience, tuple(h_api.get_annotations.return_value)
+        )
+        assert context.instructor_digest.call_args_list == [
+            call(h_userid) for h_userid in audience
+        ]
+        assert mailchimp_service.send_template.call_args_list == [
+            call(
+                "instructor-email-digest",
+                sender,
+                recipient=EmailRecipient(unified_user.email, unified_user.display_name),
+                template_vars=digest,
+            )
+            for unified_user, digest in zip(context.unified_users.values(), digests)
+        ]
+
+    def test_send_instructor_email_digests_doesnt_send_empty_digests(
+        self, svc, context, mailchimp_service
+    ):
+        context.instructor_digest.return_value = {"total_annotations": 0}
+
+        svc.send_instructor_email_digests(
+            [sentinel.h_userid], sentinel.updated_after, sentinel.updated_before
+        )
+
+        mailchimp_service.send_template.assert_not_called()
+
+    def test_send_instructor_email_digests_ignores_instructors_with_no_email_address(
+        self, svc, context, mailchimp_service
+    ):
+        context.unified_users = {sentinel.h_userid: UnifiedUserFactory(email=None)}
+        context.instructor_digest.return_value = {"total_annotations": 1}
+
+        svc.send_instructor_email_digests(
+            [sentinel.h_userid], sentinel.updated_after, sentinel.updated_before
+        )
+
+        mailchimp_service.send_template.assert_not_called()
+
+    def test_send_instructor_email_digests_uses_override_to_email(
+        self, svc, context, mailchimp_service
+    ):
+        context.instructor_digest.return_value = {"total_annotations": 1}
+
+        svc.send_instructor_email_digests(
+            [sentinel.h_userid],
+            sentinel.updated_after,
+            sentinel.updated_before,
+            override_to_email=sentinel.override_to_email,
+        )
+
+        assert (
+            mailchimp_service.send_template.call_args[1]["recipient"].email
+            == sentinel.override_to_email
+        )
+
+    @pytest.fixture(autouse=True)
+    def DigestContext(self, patch):
+        return patch("lms.services.digest.service.DigestContext")
+
+    @pytest.fixture
+    def context(self, DigestContext):
+        return DigestContext.return_value
+
+    @pytest.fixture
+    def sender(self):
+        return EmailSender(sentinel.subaccount, sentinel.from_email, sentinel.from_name)
+
+    @pytest.fixture
+    def h_api(self, h_api):
+        h_api.get_annotations.return_value = [
+            sentinel.annotation1,
+            sentinel.annotation2,
+        ]
+        return h_api
+
+    @pytest.fixture
+    def svc(self, db_session, h_api, mailchimp_service, sender):
+        return DigestService(
+            db=db_session,
+            h_api=h_api,
+            mailchimp_service=mailchimp_service,
+            sender=sender,
+        )
+
+
+class UnifiedUserFactory(factory.Factory):
+    class Meta:
+        model = UnifiedUser
+
+    h_userid = factory.Sequence(lambda n: f"acct:user_{n}@lms.hypothes.is")
+    users = factory.LazyAttribute(
+        lambda o: factories.User.create_batch(2, h_userid=o.h_userid)
+    )
+    email = factory.Sequence(lambda n: f"user_{n}@example.com")
+    display_name = factory.Sequence(lambda n: f"User {n}")


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/5194

This chops up the digest service into separate files to try and make it easier to navigate the files and see the tests related to them.

The functionality and interface should be identical.