### PR TITLE
Update pattern-library sketches for edit-assignment workflow

### DIFF
--- a/lms/static/scripts/ui-playground/components/EditAssignment.tsx
+++ b/lms/static/scripts/ui-playground/components/EditAssignment.tsx
@@ -10,6 +10,7 @@ import {
 import Library from '@hypothesis/frontend-shared/lib/pattern-library/components/Library';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
+import { useState } from 'preact/hooks';
 
 function PickerCard({
   children,
@@ -74,6 +75,89 @@ function PickerCardRow({
       </div>
       <div className="space-y-3">{children}</div>
     </>
+  );
+}
+
+function ReselectContentExample() {
+  const [reselectActive, setReselectActive] = useState(false);
+  return (
+    <PickerCard
+      headerContent={
+        <div className="flex gap-x-1 mx-4 my-2">
+          <LinkButton classes="gap-x-1" underline="always">
+            <ArrowLeftIcon className="w-[0.875em] h-[0.875em]" />
+            Back to Assignment
+          </LinkButton>
+        </div>
+      }
+    >
+      <PickerCardHeader>Assignment details</PickerCardHeader>
+      <PickerCardContent>
+        <PickerCardRow label="Assignment content">
+          <div className="flex gap-x-2 items-center">
+            <div>
+              <i>https://www.example.com</i>
+            </div>
+            <div className="border-r">&nbsp;</div>
+            {reselectActive ? (
+              <LinkButton
+                classes="text-xs"
+                underline="always"
+                onClick={() => setReselectActive(!reselectActive)}
+              >
+                Cancel changes
+              </LinkButton>
+            ) : (
+              <LinkButton
+                classes="text-xs"
+                underline="always"
+                onClick={() => setReselectActive(!reselectActive)}
+              >
+                Change
+              </LinkButton>
+            )}
+          </div>
+        </PickerCardRow>
+        {reselectActive && (
+          <PickerCardRow>
+            <div
+              className={classnames(
+                // Style a slightly-recessed "well" for these controls
+                'bg-slate-0 p-4 rounded shadow-inner border space-y-2'
+              )}
+            >
+              <p>
+                Select updated content for your assignment from one of the
+                following sources:
+              </p>
+              <div className="flex">
+                <div className="flex flex-col space-y-1">
+                  <Button variant="primary">
+                    Enter URL of web page or PDF
+                  </Button>
+                  <Button variant="primary">Select PDF from Canvas</Button>
+                  <Button variant="primary">
+                    Select PDF from Google Drive
+                  </Button>
+                  <Button variant="primary">Select JSTOR article</Button>
+                  <Button variant="primary">Select PDF from OneDrive</Button>
+                </div>
+                <div className="grow" />
+              </div>
+            </div>
+          </PickerCardRow>
+        )}
+        <div className="col-span-2 border-b" />
+        <PickerCardRow label="Group assignment">
+          <Checkbox>This is a group assignment</Checkbox>
+        </PickerCardRow>
+      </PickerCardContent>
+      <CardContent>
+        <CardActions>
+          <Button variant="primary">Save</Button>
+        </CardActions>
+      </CardContent>
+    </PickerCard>
   );
 }
 
@@ -188,7 +272,7 @@ export default function EditAssignmentPage() {
         }
       >
         <Library.Pattern title="Edit assignment: initial view">
-          <p>Actions available to the user in this view:</p>
+          <p>Actions available in this view:</p>
           <ul>
             <li>
               Commit (save) assignment settings including any updated group
@@ -338,18 +422,19 @@ export default function EditAssignmentPage() {
           </Library.Example>
         </Library.Pattern>
 
-        <Library.Pattern title="Edit assignment: re-select content view">
-          <p>Actions available to the user in this view:</p>
-          <ul>
-            <li>
-              Re-select content from one of the available content-type options.
-            </li>
-            <li>
-              Go back to the previous screen (without re-selecting content)
-            </li>
-          </ul>
-          <Library.Example title="Edit-assignment, re-select content view: sketches">
-            <p>TODO</p>
+        <Library.Pattern title="Edit assignment: interactive view sketch">
+          <Library.Example title="Edit-assignment with re-selection of content">
+            <p>
+              This example demonstrates possible UI behavior when user clicks{' '}
+              {'"Change"'} button.
+            </p>
+            <p>
+              This variant keeps the user in the same screen for the entire edit
+              flow.
+            </p>
+            <Library.Demo>
+              <ReselectContentExample />
+            </Library.Demo>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>

--- a/lms/static/scripts/ui-playground/components/EditAssignment.tsx
+++ b/lms/static/scripts/ui-playground/components/EditAssignment.tsx
@@ -188,25 +188,20 @@ export default function EditAssignmentPage() {
         }
       >
         <Library.Pattern title="Edit assignment: initial view">
-          <p>
-            When transitioning from a launched assignment into the
-            edit-assignment flow, we want to take into account that the
-            assignment has already been configured.
-          </p>
-          <p>We want to make sure we:</p>
+          <p>Actions available to the user in this view:</p>
           <ul>
             <li>
-              {"Don't"} make instructors re-select content if they {"don't"}{' '}
-              want to;
+              Commit (save) assignment settings including any updated group
+              settings.
             </li>
+            <li>Exit (cancel) the edit flow.</li>
             <li>
-              Provide an obvious mechanism to exit the edit flow and get back to
-              the launched assignment
+              Elect to change the content for the assignment. This takes the
+              user to the {'"Edit assignment: re-select content view"'}.
             </li>
           </ul>
-          <Library.Example title="Sketches of initial edit-view elements">
-            <p>Elements of these sketches can be combined as desired.</p>
-            <Library.Demo title="Sketch 1">
+          <Library.Example title="Edit-assignment, initial view: sketches">
+            <Library.Demo>
               <PickerCard>
                 <PickerCardHeader>Assignment details</PickerCardHeader>
                 <PickerCardContent>
@@ -229,13 +224,13 @@ export default function EditAssignmentPage() {
                 <CardContent>
                   <CardActions>
                     <Button>Cancel</Button>
-                    <Button variant="primary">Continue</Button>
+                    <Button variant="primary">Save settings</Button>
                   </CardActions>
                 </CardContent>
               </PickerCard>
             </Library.Demo>
 
-            <Library.Demo title="Sketch 2">
+            <Library.Demo>
               <PickerCard
                 headerContent={
                   <div className="flex gap-x-1 mx-4 my-2">
@@ -267,13 +262,13 @@ export default function EditAssignmentPage() {
                 <CardContent>
                   <CardActions>
                     <Button>Cancel</Button>
-                    <Button variant="primary">Continue</Button>
+                    <Button variant="primary">Save</Button>
                   </CardActions>
                 </CardContent>
               </PickerCard>
             </Library.Demo>
 
-            <Library.Demo title="Sketch 3">
+            <Library.Demo>
               <PickerCard
                 headerContent={
                   <div className="flex gap-x-1 mx-4 my-2">
@@ -301,13 +296,13 @@ export default function EditAssignmentPage() {
                 </PickerCardContent>
                 <CardContent>
                   <CardActions>
-                    <Button variant="primary">Continue</Button>
+                    <Button variant="primary">Save</Button>
                   </CardActions>
                 </CardContent>
               </PickerCard>
             </Library.Demo>
 
-            <Library.Demo title="Sketch 4">
+            <Library.Demo>
               <PickerCard
                 headerContent={
                   <div className="flex gap-x-1 mx-4 my-2">
@@ -331,15 +326,30 @@ export default function EditAssignmentPage() {
                       </LinkButton>
                     </div>
                   </PickerCardRow>
+                  <div className="col-span-2 border-b" />
                 </PickerCardContent>
                 <CardContent>
                   <CardActions>
-                    <Button>Cancel</Button>
-                    <Button variant="primary">Continue</Button>
+                    <Button variant="primary">Save settings</Button>
                   </CardActions>
                 </CardContent>
               </PickerCard>
             </Library.Demo>
+          </Library.Example>
+        </Library.Pattern>
+
+        <Library.Pattern title="Edit assignment: re-select content view">
+          <p>Actions available to the user in this view:</p>
+          <ul>
+            <li>
+              Re-select content from one of the available content-type options.
+            </li>
+            <li>
+              Go back to the previous screen (without re-selecting content)
+            </li>
+          </ul>
+          <Library.Example title="Edit-assignment, re-select content view: sketches">
+            <p>TODO</p>
           </Library.Example>
         </Library.Pattern>
       </Library.Section>


### PR DESCRIPTION
This PR is a response to some discussion we had related to https://github.com/hypothesis/lms/pull/5157

It:

* Updates wording on the "commit" button action in the initial view to be more clear that it is a save/commit action
* Updates description of available actions on initial view
* Adds a section to hold sketches of "re-select content" view, with some notes about available actions in that UI

Not done yet: there are still problems to solve with the "re-select content" view. Coming soon. Trying to keep this stuff bite-sized.

See updates at http://localhost:8001/ui-playground/edit-assignment

Part of #5141 
Part of #5142