### PR TITLE
Use resource_link_id instead of assignment.id in /sync

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -547,7 +547,7 @@ class JSConfig:
             # description. Anything we add here should be echoed back by the
             # frontend.
             "data": {
-                "assignment_id": assignment.id,
+                "resource_link_id": assignment.resource_link_id,
                 "lms": {
                     "product": self._request.product.family,
                 },

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -137,7 +137,7 @@ class AssignmentService:
         )
 
     def upsert_assignment_groupings(
-        self, assignment_id, groupings: List[Grouping]
+        self, assignment: Assignment, groupings: List[Grouping]
     ) -> List[AssignmentGrouping]:
         """Store details of any groups and courses an assignment is in."""
 
@@ -145,7 +145,7 @@ class AssignmentService:
         self._db.flush()
 
         values = [
-            {"assignment_id": assignment_id, "grouping_id": grouping.id}
+            {"assignment_id": assignment.id, "grouping_id": grouping.id}
             for grouping in groupings
         ]
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -200,7 +200,7 @@ class BasicLaunchViews:
         )
         # Store the relationship between the assignment and the course
         self.assignment_service.upsert_assignment_groupings(
-            assignment_id=assignment.id, groupings=[self.context.course]
+            assignment, groupings=[self.context.course]
         )
 
         return assignment

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -402,9 +402,14 @@ class TestJSConfigAPISync:
         "grouping_type", (Grouping.Type.GROUP, Grouping.Type.SECTION)
     )
     def test_it(
-        self, js_config, context, pyramid_request, grouping_type, grouping_plugin
+        self,
+        js_config,
+        context,
+        pyramid_request,
+        grouping_type,
+        grouping_plugin,
+        assignment,
     ):
-        assignment.id = 123456  # Ensure the assignment has an id
         pyramid_request.lti_params["context_id"] = "CONTEXT_ID"
         pyramid_request.params["learner_canvas_user_id"] = "CANVAS_USER_ID"
         pyramid_request.product.route.oauth2_authorize = "welcome"
@@ -418,7 +423,7 @@ class TestJSConfigAPISync:
             "authUrl": "http://example.com/welcome",
             "path": "/api/sync",
             "data": {
-                "assignment_id": assignment.id,
+                "resource_link_id": assignment.resource_link_id,
                 "lms": {"product": pyramid_request.product.family},
                 "context_id": "CONTEXT_ID",
                 "group_set_id": "GROUP_SET_ID",

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -203,7 +203,7 @@ class TestAssignmentService:
         )
         db_session.flush()
 
-        refs = svc.upsert_assignment_groupings(assignment.id, groupings)
+        refs = svc.upsert_assignment_groupings(assignment, groupings)
 
         assert refs == Any.list.containing(
             [

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -282,7 +282,7 @@ class TestBasicLaunchViews:
             lti_roles=lti_user.lti_roles,
         )
         assignment_service.upsert_assignment_groupings.assert_called_once_with(
-            assignment_id=assignment.id, groupings=[context.course]
+            assignment, groupings=[context.course]
         )
 
         context.js_config.enable_lti_launch_mode.assert_called_once_with(assignment)


### PR DESCRIPTION
Non sequential IDs are less guessable and resource_link_id is scoped to one institution.


## Testing

No functional changes here, just check that assignments that need the /sync API (groups, sections) still work:

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View

the payload for https://localhost:48001/api/sync

now includes the resource_link_id.