### PR TITLE
Refactor LTIResource.course and move it to CourseService

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -509,7 +509,7 @@ class JSConfig:
 
         return {
             # For documentation of these Hypothesis client settings see:
-            # https://h.readthedocs.io/projects/client/en/latest/publishers/config/#configuring-the-client-using-json
+            # https://h.readthedocs.io/projects/client/en/latest/publishers/config.html#configuring-the-client-using-json
             "services": [
                 {
                     "allowFlagging": False,

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -178,7 +178,7 @@ class JSConfig:
         if message:
             self._config["errorDialog"]["errorMessage"] = message
 
-    def enable_lti_launch_mode(self, assignment: Assignment):
+    def enable_lti_launch_mode(self, course, assignment: Assignment):
         """
         Put the JavaScript code into "LTI launch" mode.
 

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -26,25 +26,6 @@ class LTILaunchResource:
         """Return the context resource for an LTI launch request."""
         self._request = request
 
-    @cached_property
-    def course(self):
-        """Get the course this LTI launch based on the request's params."""
-        course_service = self._request.find_service(name="course")
-
-        if existing_course := course_service.get_by_context_id(
-            self._request.parsed_params["context_id"]
-        ):
-            # Keep existing `extra` instead of replacing it with the default
-            extra = existing_course.extra
-        else:
-            extra = self._new_course_extra()
-
-        return course_service.upsert_course(
-            context_id=self._request.parsed_params["context_id"],
-            name=self._request.parsed_params["context_title"],
-            extra=extra,
-        )
-
     @property
     def application_instance(self):
         """Return the current request's ApplicationInstance."""
@@ -58,28 +39,3 @@ class LTILaunchResource:
     @cached_property
     def js_config(self):
         return JSConfig(self, self._request)
-
-    @property
-    def grouping_type(self) -> Grouping.Type:
-        assignment = self._request.find_service(name="assignment").get_assignment(
-            self._request.lti_params["tool_consumer_instance_guid"],
-            self._request.lti_params.get("resource_link_id"),
-        )
-        return self._request.find_service(name="grouping").get_launch_grouping_type(
-            self._request, self.course, assignment
-        )
-
-    def _new_course_extra(self):
-        """Extra information to store for new courses."""
-        extra = {}
-
-        if self.is_canvas:
-            extra = {
-                "canvas": {
-                    "custom_canvas_course_id": self._request.parsed_params.get(
-                        "custom_canvas_course_id"
-                    )
-                }
-            }
-
-        return extra

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -3,7 +3,6 @@
 import logging
 from functools import cached_property
 
-from lms.models import Grouping
 from lms.product import Product
 from lms.resources._js_config import JSConfig
 

--- a/lms/views/api/gateway.py
+++ b/lms/views/api/gateway.py
@@ -56,11 +56,14 @@ def h_lti(context, request):
     # course group. This means they will see annotations at the course level
     # right away. If the course uses groups or sections, they won't see
     # anything until they launch an assignment and get put in a group.
-    request.find_service(name="lti_h").sync([context.course], request.lti_params)
+    course = request.find_service(name="course").get_from_launch(
+        request.product, request.lti_params
+    )
+    request.find_service(name="lti_h").sync([course], request.lti_params)
 
     return {
         "api": {"h": _GatewayService.render_h_connection_info(request)},
-        "data": _GatewayService.render_lti_context(request, context.course),
+        "data": _GatewayService.render_lti_context(request, course),
     }
 
 

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -66,7 +66,10 @@ def deep_linking_launch(context, request):
     request.find_service(name="application_instance").update_from_lti_params(
         context.application_instance, request.lti_params
     )
-    request.find_service(name="lti_h").sync([context.course], request.params)
+    course = request.find_service(name="course").get_from_launch(
+        request.product, request.lti_params
+    )
+    request.find_service(name="lti_h").sync([course], request.params)
 
     context.js_config.enable_file_picker_mode(
         form_action=request.parsed_params["content_item_return_url"],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -138,6 +138,11 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
 
 
 @pytest.fixture
+def product(pyramid_request):
+    return pyramid_request.product
+
+
+@pytest.fixture
 def user_is_learner(lti_user):
     lti_user.lti_roles = [
         factories.LTIRole(scope=RoleScope.COURSE, type=RoleType.LEARNER)

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -523,21 +523,6 @@ class TestJSConfigHypothesisClient:
         context.application_instance.provisioning = False
 
 
-class TestJSConfigRPCServer:
-    """Unit tests for the "rpcServer" sub-dict of JSConfig."""
-
-    def test_it(self, config):
-        assert config == {"allowedOrigins": ["http://localhost:5000"]}
-
-    @pytest.fixture
-    def config(self, config, js_config, assignment):
-        # Call enable_lti_launch_mode() so that the "rpcServer" section gets
-        # inserted into the config.
-        js_config.enable_lti_launch_mode(assignment)
-
-        return config["rpcServer"]
-
-
 class TestEnableOAuth2RedirectErrorMode:
     def test_it(self, js_config):
         js_config.enable_oauth2_redirect_error_mode(

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from lms.product import Product
 from lms.resources import LTILaunchResource
-from tests import factories
 
 pytestmark = pytest.mark.usefixtures(
     "application_instance_service",

--- a/tests/unit/lms/views/api/gateway_test.py
+++ b/tests/unit/lms/views/api/gateway_test.py
@@ -15,14 +15,14 @@ from tests import factories
 
 @pytest.mark.usefixtures("lti_h_service")
 class TestHLTI:
-    def test_it(self, context, pyramid_request, _GatewayService):
+    def test_it(self, course_service, context, pyramid_request, _GatewayService):
         response = h_lti(context, pyramid_request)
 
         _GatewayService.render_h_connection_info.assert_called_once_with(
             pyramid_request
         )
         _GatewayService.render_lti_context.assert_called_once_with(
-            pyramid_request, context.course
+            pyramid_request, course_service.get_from_launch.return_value
         )
         assert response == {
             "api": {"h": _GatewayService.render_h_connection_info.return_value},
@@ -37,11 +37,13 @@ class TestHLTI:
         with pytest.raises(HTTPForbidden):
             h_lti(context, pyramid_request)
 
-    def test_syncs_the_user_to_h(self, context, pyramid_request, lti_h_service):
+    def test_syncs_the_user_to_h(
+        self, course_service, context, pyramid_request, lti_h_service
+    ):
         h_lti(context, pyramid_request)
 
         lti_h_service.sync.assert_called_once_with(
-            [context.course], pyramid_request.lti_params
+            [course_service.get_from_launch.return_value], pyramid_request.lti_params
         )
 
     @pytest.fixture(autouse=True)
@@ -132,7 +134,9 @@ class Test_GatewayService:
         )
 
 
-@pytest.mark.usefixtures("grant_token_service", "lti_h_service", "grouping_service")
+@pytest.mark.usefixtures(
+    "grant_token_service", "lti_h_service", "grouping_service", "course_service"
+)
 class TestHLTIConsumer:
     # These tests are "consumer tests" and ensure we meet the spec we have
     # provided to our users in our documentation

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -24,6 +24,7 @@ class TestHasDocumentURL:
 
 @pytest.mark.usefixtures(
     "assignment_service",
+    "course_service",
     "application_instance_service",
     "grading_info_service",
     "lti_h_service",

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -15,16 +15,23 @@ from tests import factories
 @pytest.mark.usefixtures("application_instance_service", "lti_h_service")
 class TestDeepLinkingLaunch:
     def test_it(
-        self, context, pyramid_request, lti_h_service, application_instance_service
+        self,
+        context,
+        pyramid_request,
+        lti_h_service,
+        application_instance_service,
+        course_service,
     ):
         deep_linking_launch(context, pyramid_request)
 
         application_instance_service.update_from_lti_params.assert_called_once_with(
             context.application_instance, pyramid_request.lti_params
         )
-
+        course_service.get_from_launch.assert_called_once_with(
+            pyramid_request.product, pyramid_request.lti_params
+        )
         lti_h_service.sync.assert_called_once_with(
-            [context.course], pyramid_request.params
+            [course_service.get_from_launch.return_value], pyramid_request.params
         )
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="TEST_CONTENT_ITEM_RETURN_URL",


### PR DESCRIPTION
[For a cleanup task on the course copy project](https://github.com/hypothesis/lms/issues/4924)


Refactor to move `LTIResrouce.course` to `CourseService`.

I don't think the line count reflects a massive simplification butit addresses a few small issues:

- `.course` being a property it needed an explanation about it's side effect nature.

- I much prefer the patter of query thing -> use thing/pass thing along. Rather than potentially caching it along the way.

- Some of the tests is JSConfig tested the same thing twice which made changes a bit of a pain. There's room for improvement there but they are  clearer now. 


It doesn't however:

- Continue moving things out of LTIResource. Had to stop somewhere.
- Tackle the conditional for Product.Family.Canvas which is now in the service
- Make a bigger refactor in JSConfig

Those can be addressed in future PRs.


## Testing

No behavior changes, as a sanity check I've:


- Tested deep linking here: https://hypothesis.instructure.com/courses/125/assignments/4682/edit?name=Testing+creation+-+marcos&due_at=null&points_possible=0

- Tested basic launch + sync api with https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View?ou=6782


