### PR TITLE
Add `group_set_id` property to assignment

### DIFF
--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
@@ -73,6 +75,19 @@ class Assignment(CreatedUpdatedMixin, BASE):
 
     description = sa.Column(sa.Unicode, nullable=True)
     """The resource link description from LTI params."""
+
+    @property
+    def group_set_id(self) -> Optional[str]:
+        """Get the ID of the group set this assignment is configured with."""
+
+        if group_set_id := self.extra.get("group_set_id"):
+            # Different LMS's use integers/strings/uuids.
+            # Always return a string here an let the specific
+            # API services deal with the differences.
+            return str(group_set_id)
+
+        # The assignment is not configured as a groups one.
+        return None
 
     def get_canvas_mapped_file_id(self, file_id):
         return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -86,7 +86,7 @@ class GroupingPlugin:
         if not self.group_type or not assignment:
             return None
 
-        return assignment.extra.get("group_set_id") if assignment else None
+        return assignment.group_set_id if assignment else None
 
 
 class GroupError(Exception):

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -93,9 +93,7 @@ class AssignmentService:
             if historical_assignment := self.get_copied_from_assignment(lti_params):
                 assignment.copied_from = historical_assignment
 
-                if historical_assignment.extra.get("group_set_id") and not extra.get(
-                    "group_set_id"
-                ):
+                if historical_assignment.group_set_id and not extra.get("group_set_id"):
                     extra["group_set_id"] = historical_assignment.extra.get(
                         "group_set_id"
                     )

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -97,7 +97,7 @@ class BasicLaunchViews:
         return {
             # Info about the assignment's current configuration
             "assignment": {
-                "group_set_id": assignment.extra.get("group_set_id"),
+                "group_set_id": assignment.group_set_id,
                 "document": {
                     "url": assignment.document_url,
                 },
@@ -141,7 +141,7 @@ class BasicLaunchViews:
                 type=LTIEvent.Type.EDITED_ASSIGNMENT,
                 data={
                     "old_url": assignment.document_url,
-                    "old_group_set_id": assignment.extra.get("group_set_id"),
+                    "old_group_set_id": assignment.group_set_id,
                 },
             )
         )

--- a/tests/unit/lms/models/assignment_test.py
+++ b/tests/unit/lms/models/assignment_test.py
@@ -4,6 +4,12 @@ from lms.models import Assignment
 
 
 class TestAssignment:
+    @pytest.mark.parametrize("value,expected", [(None, None), (1, "1"), ("ID", "ID")])
+    def test_group_set_id(self, assignment, value, expected):
+        assignment.extra["group_set_id"] = value
+
+        assert assignment.group_set_id == expected
+
     def test_set_canvas_mapped_file_id_creates_a_new_mapping_if_none_exists(
         self, assignment
     ):

--- a/tests/unit/lms/product/plugin/grouping_test.py
+++ b/tests/unit/lms/product/plugin/grouping_test.py
@@ -35,12 +35,9 @@ class TestGroupingPlugin:
         assert not plugin.get_group_set_id(sentinel.request, assignment)
 
     def test_get_group_set_id(self, plugin_with_groups):
-        assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
+        assignment = factories.Assignment(extra={"group_set_id": "ID"})
 
-        assert (
-            plugin_with_groups.get_group_set_id(sentinel.request, assignment)
-            == sentinel.id
-        )
+        assert plugin_with_groups.get_group_set_id(sentinel.request, assignment) == "ID"
 
     @pytest.fixture
     def plugin(self):

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -151,7 +151,7 @@ class TestBasicLaunchViews:
             type=LTIEvent.Type.EDITED_ASSIGNMENT,
             data={
                 "old_url": assignment.document_url,
-                "old_group_set_id": assignment.extra.get.return_value,
+                "old_group_set_id": assignment.group_set_id,
             },
         )
         pyramid_request.registry.notify.has_call_with(LTIEvent.return_value)
@@ -231,7 +231,7 @@ class TestBasicLaunchViews:
         )
         assert response == {
             "assignment": {
-                "group_set_id": assignment.extra.get.return_value,
+                "group_set_id": assignment.group_set_id,
                 "document": {"url": assignment.document_url},
             },
             "filePicker": context.js_config.enable_file_picker_mode.return_value[


### PR DESCRIPTION
Hide the detail that this stored as part of `extra` to the callers.

This is motivated by this issue, there will be a follow up PR to handle the "set" side of this.

https://github.com/hypothesis/lms/pull/5157/files#diff-d112070830114606d1e631ca48df8d89c400ddbf74afbf2f76738479f67a18e1R178


## Testing

Launch the following group assignments in each LMS

### Canvas:

https://hypothesis.instructure.com/courses/125/assignments/1833

### D2L:

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View?ou=6782


### Blackboard 

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_398_1&course_id=_19_1

