### PR TITLE
Enable assignment editing for all institutions

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -35,7 +35,6 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("vitalsource", "disable_licence_check", asbool),
         JSONSetting("jstor", "enabled", asbool),
         JSONSetting("jstor", "site_code"),
-        JSONSetting("hypothesis", "edit_assignments_enabled", asbool),
         JSONSetting("hypothesis", "notes", name="Notes"),
         JSONSetting(
             "hypothesis",

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -285,7 +285,7 @@ class JSConfig:
         self._config.setdefault("filePicker", {})
         self._config["filePicker"]["deepLinkingAPI"] = config
 
-    def enable_instructor_toolbar(self, enable_editing=False, enable_grading=False):
+    def enable_instructor_toolbar(self, enable_editing=True, enable_grading=False):
         """
         Enable the toolbar with controls for instructors in LMS assignments.
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -97,7 +97,6 @@
 
     <fieldset class="box">
         <legend class="label has-text-centered">General settings</legend>
-        {{ settings_checkbox("Enable editing assignments", "hypothesis", "edit_assignments_enabled") }}
         {{ settings_checkbox("Enable instructor email digests", "hypothesis", "instructor_email_digests_enabled") }}
     </fieldset>
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -282,15 +282,9 @@ class BasicLaunchViews:
             # nb. Canvas does not currently use/support any functionality from the
             # instructor toolbar. For grading it uses SpeedGrader and we don't
             # support editing assignments.
-
-            enable_editing = self.context.application_instance.settings.get(
-                "hypothesis", "edit_assignments_enabled", default=False
+            self.context.js_config.enable_instructor_toolbar(
+                enable_grading=assignment.is_gradable
             )
-
-            if enable_editing or assignment.is_gradable:
-                self.context.js_config.enable_instructor_toolbar(
-                    enable_editing=enable_editing, enable_grading=assignment.is_gradable
-                )
 
         self.context.js_config.add_document_url(document_url)
         self.context.js_config.enable_lti_launch_mode(self.course, assignment)

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -323,36 +323,26 @@ class TestBasicLaunchViews:
 
         context.js_config.set_focused_user.assert_not_called()
 
-    @pytest.mark.usefixtures("with_gradable_assignment", "user_is_instructor")
-    def test__show_document_enables_instructor_toolbar_if_gradable(self, svc, context):
-        svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
-
-        context.js_config.enable_instructor_toolbar.assert_called_with(
-            enable_editing=False, enable_grading=True
-        )
-
-    @pytest.mark.usefixtures("user_is_instructor", "with_non_gradable_assignment")
-    def test__show_document_enables_instructor_toolbar_if_editable(self, svc, context):
-        context.application_instance.settings.set(
-            "hypothesis", "edit_assignments_enabled", True
-        )
+    @pytest.mark.usefixtures("user_is_instructor")
+    @pytest.mark.parametrize(
+        "assignment_fixture_name,enable_grading",
+        [("with_gradable_assignment", True), ("with_non_gradable_assignment", False)],
+    )
+    def test__show_document_enables_instructor_toolbar_for_instructors(
+        self, svc, context, assignment_fixture_name, request, enable_grading
+    ):
+        _ = request.getfixturevalue(assignment_fixture_name)
 
         svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
 
         context.js_config.enable_instructor_toolbar.assert_called_with(
-            enable_editing=True, enable_grading=False
+            enable_grading=enable_grading
         )
 
     @pytest.mark.usefixtures("with_gradable_assignment", "user_is_learner")
     def test__show_document_does_not_enable_instructor_toolbar_for_students(
         self, svc, context
     ):
-        svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
-
-        context.js_config.enable_instructor_toolbar.assert_not_called()
-
-    @pytest.mark.usefixtures("user_is_instructor", "with_non_gradable_assignment")
-    def test__show_document_does_not_enable_instructor_toolbar(self, svc, context):
         svc._show_document(sentinel.document_url)  # pylint: disable=protected-access
 
         context.js_config.enable_instructor_toolbar.assert_not_called()


### PR DESCRIPTION
**Don't merge until we have the green light to enable this for all schools.**


For:

- https://github.com/hypothesis/lms/issues/5195

Show the editing controls for all teachers in non-Canvas launches.

Doing this as a code change instead of a migration as it simplifies the code a bit and also allows an hypothetical rollback (a revert in this case) to go back to the exact same state relying on the DB data.


## Testing

- In `main` disable editing for http://localhost:8001/admin/instance/106/
- Switch to this branch, check the option is no longer configurable in the admin
- Launching https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View?ou=6782 as an instructor show the editing option.
