### PR TITLE
Correct example D2L file URLs in frontend comments and tests

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -119,13 +119,13 @@ export default function ContentSelector({
 
   const selectBlackboardFile = (file: File) => {
     cancelDialog();
-    // file.id shall be a url of the form blackboard://content-resource/{file_id}
+    // file.id is a URL with a `blackboard://` prefix.
     onSelectContent({ type: 'url', url: file.id });
   };
 
   const selectD2LFile = (file: File) => {
     cancelDialog();
-    // file.id shall be a url of the form d2l://content-resource/{file_id}
+    // file.id is a URL with a `d2l://` prefix.
     onSelectContent({ type: 'url', url: file.id });
   };
 

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -221,10 +221,10 @@ describe('ContentSelector', () => {
       {
         name: 'd2l',
         dialogName: 'd2lFile',
-        file: { id: 'd2l://content-resource/123' },
+        file: { id: 'd2l://file/course/123/file_id/456' },
         result: {
           type: 'url',
-          url: 'd2l://content-resource/123',
+          url: 'd2l://file/course/123/file_id/456',
         },
         missingFilesHelpLink:
           'https://web.hypothes.is/help/using-hypothesis-with-d2l-course-content-files/',

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -252,7 +252,7 @@ describe('FilePickerApp', () => {
       {
         content: {
           type: 'url',
-          url: 'd2l://content-resource/1/',
+          url: 'd2l://file/course/123/file_id/456',
         },
         summary: 'PDF file in D2L',
       },


### PR DESCRIPTION
The D2L file URLs given in tests and comments in the frontend did not match the actual structure used. This didn't cause any functional problems because the frontend treats these URLs as opaque, except for the scheme. Having incorrect examples may cause confusion for developers in future though.