### PR TITLE
WIP Trying to get an existing error to be handled LMSFilePicker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -13,6 +13,8 @@ import { apiCall } from '../utils/api';
 import AuthButton from './AuthButton';
 import Breadcrumbs from './Breadcrumbs';
 import ErrorDisplay from './ErrorDisplay';
+import { Link } from '@hypothesis/frontend-shared/lib/next';
+import ErrorModal from './ErrorModal';
 import FileList from './FileList';
 
 type NoFilesMessageProps = {
@@ -406,10 +408,35 @@ export default function LMSFilePicker({
       )}
 
       {dialogState.state === 'error' && (
-        <ErrorDisplay
-          description="There was a problem fetching files"
-          error={dialogState.error}
-        />
+        <ErrorModal  title="Developer key scopes missing">
+          <p>
+            A Canvas admin needs to edit {"Hypothesis's"} developer key and add
+            these scopes:
+          </p>
+          <ol className="px-4 list-decimal">
+            {dialogState.error.details.canvas_scopes.map(scope => (
+              <li key={scope}>
+                <code>{scope}</code>
+              </li>
+            ))}
+          </ol>
+          <p>
+            For more information see:{' '}
+            <Link
+              target="_blank"
+              href="https://github.com/hypothesis/lms/wiki/Canvas-API-Endpoints-Used-by-the-Hypothesis-LMS-App"
+              underline="always"
+            >
+              Canvas API Endpoints Used by the Hypothesis LMS App
+            </Link>
+            .
+          </p>
+        </ErrorModal>
+
+        //<ErrorDisplay
+         // description="There was a problem fetching files"
+         // error={dialogState.error}
+       // />
       )}
 
       {withFileUI && (


### PR DESCRIPTION
Just copy-pasting the ErrorModal here to demonstrate the effect:

![Screenshot from 2023-03-28 16-36-39](https://user-images.githubusercontent.com/1433832/228276740-d1d757ec-ab61-4690-a47d-ae255ef4cb51.png)


What I'm after is trying to reuse the same error code in different contexts, for example here I'm raising `canvas_invalid_scope` in an API response while the app is set in file picker mode and that's not handled the same as while in OAuthServerErrorCode.

IMO ideally error codes will match to a particular representation, one modal per error code.

So here canvas_invalid_scope could result in the same copy being presented while either:

- Failing to get a token while authorizing
- Failing to get a file while launching
- Failing to get a group set while launching
- Failing to get list of files while authorizing
- Failing to get list of group sets while authorizing

If those situations where slightly different I'd suggest we'd use different error codes. That's no the case now.

I realize that this might be more complicated as different contexts/modes might have different limitations of size, becoming a modal on modal type of situation, etc.