### PR TITLE
Remove `is_canvas` from the `LTILaunchResource`

### DIFF
--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -3,23 +3,13 @@
 import logging
 from functools import cached_property
 
-from lms.product import Product
 from lms.resources._js_config import JSConfig
 
 LOG = logging.getLogger(__name__)
 
 
 class LTILaunchResource:
-    """
-    Context resource for LTI launch requests.
-
-    Many methods and properties of this class are only meant to be called when
-    request.parsed_params holds validated params from an LTI launch request and
-    might crash otherwise. So you should only call these methods after the
-    request has been validated with BasicLTILaunchSchema or similar (for
-    example from views that have schema=BasicLTILaunchSchema in their view
-    config).
-    """
+    """Context resource for LTI launch requests."""
 
     def __init__(self, request):
         """Return the context resource for an LTI launch request."""
@@ -29,11 +19,6 @@ class LTILaunchResource:
     def application_instance(self):
         """Return the current request's ApplicationInstance."""
         return self._request.find_service(name="application_instance").get_current()
-
-    @property
-    def is_canvas(self):
-        """Return True if Canvas is the LMS that launched us."""
-        return self._request.product.family == Product.Family.CANVAS
 
     @cached_property
     def js_config(self):

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -15,6 +15,7 @@ doesn't actually require basic launch requests to have this parameter.
 from pyramid.view import view_config, view_defaults
 
 from lms.events import LTIEvent
+from lms.product import Product
 from lms.security import Permissions
 from lms.services import DocumentURLService
 from lms.services.assignment import AssignmentService
@@ -258,7 +259,7 @@ class BasicLaunchViews:
         )
 
     def _configure_js_to_show_document(self, document_url, assignment):
-        if self.context.is_canvas:
+        if self.request.product.family == Product.Family.CANVAS:
             # For students in Canvas with grades to submit we need to enable
             # Speedgrader settings for gradable assignments
             # `lis_result_sourcedid` associates a specific user with an
@@ -301,7 +302,10 @@ class BasicLaunchViews:
             self.context.application_instance, self.request.lti_params
         )
 
-        if not self.request.lti_user.is_instructor and not self.context.is_canvas:
+        if (
+            not self.request.lti_user.is_instructor
+            and self.request.product.family != Product.Family.CANVAS
+        ):
             # Create or update a record of LIS result data for a student launch
             self.request.find_service(name="grading_info").upsert_from_request(
                 self.request

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -646,7 +646,6 @@ def context(application_instance):
         LTILaunchResource,
         spec_set=True,
         instance=True,
-        is_canvas=True,
         application_instance=application_instance,
     )
 

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -56,7 +56,7 @@ class TestFilePickerConfig:
 
         assert config == expected_config
 
-    @pytest.mark.usefixtures("with_is_canvas")
+    @pytest.mark.usefixtures("with_canvas")
     @pytest.mark.parametrize("files_enabled", [False, True])
     def test_canvas_config(self, pyramid_request, application_instance, files_enabled):
         application_instance.settings.set("canvas", "files_enabled", files_enabled)
@@ -137,7 +137,7 @@ class TestFilePickerConfig:
         assert config == {"enabled": enabled}
 
     @pytest.fixture
-    def with_is_canvas(self, pyramid_request):
+    def with_canvas(self, pyramid_request):
         pyramid_request.product.family = Product.Family.CANVAS
 
     @pytest.fixture

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -1,36 +1,17 @@
-from unittest.mock import sentinel
-
 import pytest
 
-from lms.product import Product
 from lms.resources import LTILaunchResource
 
-pytestmark = pytest.mark.usefixtures(
-    "application_instance_service",
-    "assignment_service",
-    "course_service",
+
+@pytest.mark.usefixtures(
+    "application_instance_service", "assignment_service", "course_service"
 )
-
-
 class TestLTILaunchResource:
     def test_application_instance(self, lti_launch, application_instance_service):
         assert (
             lti_launch.application_instance
             == application_instance_service.get_current.return_value
         )
-
-    @pytest.mark.parametrize(
-        "product,expected",
-        [
-            (Product.Family.CANVAS, True),
-            (Product.Family.BLACKBOARD, False),
-            (Product.Family.UNKNOWN, False),
-        ],
-    )
-    def test_is_canvas(self, pyramid_request, product, expected):
-        pyramid_request.product.family = product
-
-        assert LTILaunchResource(pyramid_request).is_canvas == expected
 
     def test_js_config(self, pyramid_request, JSConfig):
         lti_launch = LTILaunchResource(pyramid_request)
@@ -39,16 +20,6 @@ class TestLTILaunchResource:
 
         JSConfig.assert_called_once_with(lti_launch, pyramid_request)
         assert js_config == JSConfig.return_value
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.parsed_params = pyramid_request.lti_params = {
-            "tool_consumer_instance_guid": sentinel.tool_guid,
-            "resource_link_id": sentinel.resource_link_id,
-            "context_id": sentinel.context_id,
-            "context_title": sentinel.context_title,
-        }
-        return pyramid_request
 
     @pytest.fixture
     def lti_launch(self, pyramid_request):


### PR DESCRIPTION
Requires:

 * https://github.com/hypothesis/lms/pull/5224

I had originally thought to try removing all parts, but I think the next two are a bit harder for different reasons.

There should be no functional differences here.