### PR TITLE
Use the logged in users email to set the default in the admin pages

### DIFF
--- a/lms/templates/admin/email.html.jinja2
+++ b/lms/templates/admin/email.html.jinja2
@@ -29,7 +29,7 @@
       <fieldset class="box mt-6">
           <legend class="label has-text-centered">Send Test Instructor Digest Emails</legend>
 
-          {{ macros.form_text_field(request, "To email", "to_email", placeholder="YOU@hypothes.is") }}
+          {{ macros.form_text_field(request, "To email", "to_email", request.identity.userid, placeholder="YOU@hypothes.is") }}
           {{ macros.form_text_field(request, "User IDs", "h_userids", "acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is") }}
           {{ macros.form_text_field(request, "Since", "since", "2023-03-09T05:00:00") }}
           {{ macros.form_text_field(request, "Until", "until", "2023-03-10T05:00:00") }}


### PR DESCRIPTION
This uses the `request.identity.userid` which happens to be your email address as a result of our integration of Google auth.

## Testing notes

 * `make dev`
 * Visit: http://localhost:8001/admin/email
 * Notice your email address has filled out the email field by default