### PR TITLE
New toggle to allow enabling/disabling google drive files

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -25,6 +25,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("desire2learn", "groups_enabled", asbool),
         JSONSetting("desire2learn", "files_enabled", asbool),
         JSONSetting("desire2learn", "create_line_item", asbool),
+        JSONSetting("google_drive", "files_enabled", asbool),
         JSONSetting("microsoft_onedrive", "files_enabled", asbool),
         JSONSetting("vitalsource", "enabled", asbool),
         JSONSetting("vitalsource", "user_lti_param"),

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -65,8 +65,14 @@ class FilePickerConfig:
     @classmethod
     def google_files_config(cls, request, application_instance):
         """Get Google file picker config."""
+        enabled = application_instance.settings.get(
+            "google_drive", "files_enabled", default=True
+        )
+        if not enabled:
+            return {"enabled": False}
 
         return {
+            "enabled": True,
             "clientId": request.registry.settings["google_client_id"],
             "developerKey": request.registry.settings["google_developer_key"],
             # Get the URL of the top-most page that the LMS app is running in.

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -311,7 +311,8 @@ class ApplicationInstanceService:
                     "sections_enabled": False,
                     "groups_enabled": bool(developer_key),
                     "files_enabled": bool(developer_key),
-                }
+                },
+                "google_drive": {"files_enabled": True},
             },
             deployment_id=deployment_id,
             lti_registration_id=lti_registration_id,

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -47,6 +47,7 @@ export default function ContentSelector({
       d2l: { enabled: d2lFilesEnabled, listFiles: d2lListFilesApi },
       canvas: { enabled: canvasFilesEnabled, listFiles: listFilesApi },
       google: {
+        enabled: googleDriveEnabled,
         clientId: googleClientId,
         developerKey: googleDeveloperKey,
         origin: googleOrigin,
@@ -78,7 +79,12 @@ export default function ContentSelector({
   // We do this eagerly to make the picker load faster if the user does click
   // on the "Select from Google Drive" button.
   const googlePicker = useMemo(() => {
-    if (!googleClientId || !googleDeveloperKey || !googleOrigin) {
+    if (
+      !googleDriveEnabled ||
+      !googleClientId ||
+      !googleDeveloperKey ||
+      !googleOrigin
+    ) {
       return null;
     }
     return new GooglePickerClient({
@@ -91,7 +97,7 @@ export default function ContentSelector({
       // tab.
       origin: window === window.top ? window.location.href : googleOrigin,
     });
-  }, [googleDeveloperKey, googleClientId, googleOrigin]);
+  }, [googleDriveEnabled, googleDeveloperKey, googleClientId, googleOrigin]);
 
   // Initialize the OneDrive client if credentials have been provided.
   // We do this eagerly to make the picker load faster if the user does click

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -260,6 +260,7 @@ describe('ContentSelector', () => {
   describe('Google picker', () => {
     beforeEach(() => {
       fakeConfig.filePicker.google = {
+        enabled: true,
         clientId: 'goog-client-id',
         developerKey: 'goog-developer-key',
         origin: 'https://test.chalkboard.com',
@@ -287,10 +288,23 @@ describe('ContentSelector', () => {
         btn.props().onClick();
       });
     }
+    it("doesn't show the Google Drive button if option is disabled", () => {
+      fakeConfig.filePicker.google.enabled = false;
+      const wrapper = renderContentSelector();
+
+      assert.isFalse(
+        wrapper.exists('Button[data-testid="google-drive-button"]')
+      );
+    });
 
     it('initializes Google Picker client when developer key is provided', () => {
+      const { developerKey, clientId, origin } = fakeConfig.filePicker.google;
       renderContentSelector();
-      assert.calledWith(FakeGooglePickerClient, fakeConfig.filePicker.google);
+      assert.calledWith(FakeGooglePickerClient, {
+        developerKey,
+        clientId,
+        origin,
+      });
     });
 
     it('shows "Select PDF from Google Drive" button if developer key is provided', () => {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -82,9 +82,10 @@ export type FilePickerConfig = {
     listFiles: APICallInfo;
   };
   google: {
-    clientId: string;
-    developerKey: string;
-    origin: string;
+    enabled: boolean;
+    clientId?: string;
+    developerKey?: string;
+    origin?: string;
   };
   jstor: {
     enabled: boolean;

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -136,6 +136,7 @@
 
     <fieldset class="box">
         <legend class="label has-text-centered">Content integrations</legend>
+        {{ settings_checkbox("Google Drive enabled", "google_drive", "files_enabled", default=True) }}
         {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
 
         {{ settings_checkbox("VitalSource enabled", "vitalsource", "enabled") }}

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -74,12 +74,14 @@ class TestFilePickerConfig:
 
         assert config == expected_config
 
+    @pytest.mark.parametrize("enabled", (True, False))
     @pytest.mark.parametrize(
         "origin_from", (None, "custom_canvas_api_domain", "lms_url")
     )
     def test_google_files_config(
-        self, pyramid_request, application_instance, origin_from
+        self, pyramid_request, application_instance, origin_from, enabled
     ):
+        application_instance.settings.set("google_drive", "files_enabled", enabled)
         if origin_from == "custom_canvas_api_domain":
             pyramid_request.lti_params["custom_canvas_api_domain"] = sentinel.origin
         elif origin_from == "lms_url":
@@ -89,11 +91,13 @@ class TestFilePickerConfig:
             pyramid_request, application_instance
         )
 
-        assert config == {
-            "clientId": "fake_client_id",
-            "developerKey": "fake_developer_key",
-            "origin": sentinel.origin if origin_from else None,
-        }
+        expected = {"enabled": enabled}
+        if enabled:
+            expected["clientId"] = "fake_client_id"
+            expected["developerKey"] = "fake_developer_key"
+            expected["origin"] = sentinel.origin if origin_from else None
+
+        assert config == expected
 
     @pytest.mark.parametrize("enabled", (True, False))
     def test_microsoft_onedrive(self, pyramid_request, application_instance, enabled):

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -175,7 +175,8 @@ class TestApplicationInstanceService:
                 "sections_enabled": False,
                 "groups_enabled": bool(developer_key),
                 "files_enabled": bool(developer_key),
-            }
+            },
+            "google_drive": {"files_enabled": True},
         }
 
         # Things we delegate to `update_application_instance`


### PR DESCRIPTION
After the canvas change the toggle for google drive  is the only one missing.

This change makes possible to disable google drive for schools that don't use it and makes the code more homogeneous around this. 

### Testing

- Check the initial state after `make devdata`

```
select  settings from application_instances where id = 8;
                                                                                                       settings                                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 {"jstor": {"enabled": true, "site_code": "hypothes.is"}, "canvas": {"groups_enabled": true, "sections_enabled": true}, "vitalsource": {"api_key": "T6EC3VGCFS682WAZ", "enabled": true, "user_lti_param": "user_id"}}
(1 row)
```

No mention of google here.


- Google drive is present while configuring: 

https://hypothesis.instructure.com/courses/125/assignments/4682/edit?name=Testing+creation+-+marcos&due_at=null&points_possible=0


- Check the default over

http://localhost:8001/admin/instance/8/


- Save the setting without any changes


```
select  settings from application_instances where id = 8;
                                                                                                                                                                                                                                                                                                                                                           settings                                                                                                                                                                                                                                                                                                                                                           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 {"jstor": {"enabled": true, "site_code": "hypothes.is"}, "canvas": {"files_enabled": false, "groups_enabled": true, "sections_enabled": true}, "blackboard": {"files_enabled": false, "groups_enabled": false}, "hypothesis": {"notes": null, "auto_assigned_to_org": false, "edit_assignments_enabled": false, "instructor_email_digests_enabled": false}, "vitalsource": {"api_key": "T6EC3VGCFS682WAZ", "enabled": true, "user_lti_param": "user_id", "user_lti_pattern": null, "disable_licence_check": false}, "desire2learn": {"client_id": null, "files_enabled": false, "groups_enabled": false, "create_line_item": false}, "google_drive": {"files_enabled": true}, "microsoft_onedrive": {"files_enabled": true}}
(1 row)
```

Google drive is now present on the settings.


- Disable the setting now http://localhost:8001/admin/instance/8/
- Check the button for GDrive it's not there now:

https://hypothesis.instructure.com/courses/125/assignments/4682/edit?name=Testing+creation+-+marcos&due_at=null&points_possible=0
