### PR TITLE
Add support for Canvas folders in the LMS filepicker

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -20,7 +20,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("canvas", "sections_enabled", asbool),
         JSONSetting("canvas", "groups_enabled", asbool),
         JSONSetting("canvas", "files_enabled", asbool),
-        JSONSetting("canvas", "file_picker_folders", asbool),
+        JSONSetting("canvas", "folders_enabled", asbool),
         JSONSetting("desire2learn", "client_id"),
         JSONSetting("desire2learn", "client_secret", JSONSetting.AES_SECRET),
         JSONSetting("desire2learn", "groups_enabled", asbool),

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -20,6 +20,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("canvas", "sections_enabled", asbool),
         JSONSetting("canvas", "groups_enabled", asbool),
         JSONSetting("canvas", "files_enabled", asbool),
+        JSONSetting("canvas", "file_picker_folders", asbool),
         JSONSetting("desire2learn", "client_id"),
         JSONSetting("desire2learn", "client_secret", JSONSetting.AES_SECRET),
         JSONSetting("desire2learn", "groups_enabled", asbool),

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -52,6 +52,9 @@ class FilePickerConfig:
         course_id = request.lti_params.get("custom_canvas_course_id")
         config = {
             "enabled": files_enabled,
+            "withFolders": application_instance.settings.get(
+                "canvas", "file_picker_folders"
+            ),
             "listFiles": {
                 "authUrl": request.route_url(Canvas.route.oauth2_authorize),
                 "path": request.route_path(

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -52,8 +52,8 @@ class FilePickerConfig:
         course_id = request.lti_params.get("custom_canvas_course_id")
         config = {
             "enabled": files_enabled,
-            "withFolders": application_instance.settings.get(
-                "canvas", "file_picker_folders"
+            "foldersEnabled": application_instance.settings.get(
+                "canvas", "folders_enabled"
             ),
             "listFiles": {
                 "authUrl": request.route_url(Canvas.route.oauth2_authorize),

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -47,18 +47,18 @@ class CanvasAPIClient:
         self,
         authenticated_client,
         file_service: FileService,
-        with_folders: bool = False,
+        folders_enabled: bool = False,
     ):
         """
         Create a new CanvasAPIClient.
 
         :param authenticated_client: An instance of AuthenticatedClient
         :param file_service: FileService for persisting files from the API to the DB
-        :param with_folders: Whether to use folders while listing files
+        :param folders_enabled: Whether to use folders while listing files
         """
         self._client = authenticated_client
         self._file_service = file_service
-        self._with_folders = with_folders
+        self._folders_enabled = folders_enabled
 
     def get_token(self, authorization_code):
         """
@@ -266,7 +266,7 @@ class CanvasAPIClient:
             ]
         )
 
-        if self._with_folders:
+        if self._folders_enabled:
             folders = self._list_folders(course_id)
 
             # Organize every item (file and folders) by its parent ID

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -32,4 +32,7 @@ def canvas_api_client_factory(_context, request):
     return CanvasAPIClient(
         authenticated_api,
         file_service=request.find_service(name="file"),
+        with_folders=application_instance.settings.get(
+            "canvas", "file_picker_folders", default=False
+        ),
     )

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -32,7 +32,7 @@ def canvas_api_client_factory(_context, request):
     return CanvasAPIClient(
         authenticated_api,
         file_service=request.find_service(name="file"),
-        with_folders=application_instance.settings.get(
-            "canvas", "file_picker_folders", default=False
+        folders_enabled=application_instance.settings.get(
+            "canvas", "folders_enabled", default=False
         ),
     )

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -65,7 +65,7 @@ export default function ContentSelector({
       canvas: {
         enabled: canvasFilesEnabled,
         listFiles: listFilesApi,
-        withFolders: canvasWithFolders,
+        foldersEnabled: canvasWithFolders,
       },
       google: {
         enabled: googleDriveEnabled,

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -62,7 +62,11 @@ export default function ContentSelector({
         listFiles: blackboardListFilesApi,
       },
       d2l: { enabled: d2lFilesEnabled, listFiles: d2lListFilesApi },
-      canvas: { enabled: canvasFilesEnabled, listFiles: listFilesApi },
+      canvas: {
+        enabled: canvasFilesEnabled,
+        listFiles: listFilesApi,
+        withFolders: canvasWithFolders,
+      },
       google: {
         enabled: googleDriveEnabled,
         clientId: googleClientId,
@@ -191,6 +195,7 @@ export default function ContentSelector({
           onCancel={cancelDialog}
           onSelectFile={selectCanvasFile}
           missingFilesHelpLink="https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-upload-a-file-to-a-course/ta-p/618"
+          withBreadcrumbs={canvasWithFolders}
         />
       );
       break;

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -90,7 +90,7 @@ export type FilePickerConfig = {
   };
   canvas: {
     enabled: boolean;
-    withFolders: boolean;
+    foldersEnabled: boolean;
     listFiles: APICallInfo;
   };
   google: {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -90,6 +90,7 @@ export type FilePickerConfig = {
   };
   canvas: {
     enabled: boolean;
+    withFolders: boolean;
     listFiles: APICallInfo;
   };
   google: {

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -117,6 +117,7 @@
         {{ settings_checkbox("Files enabled", "canvas", "files_enabled") }}
         {{ settings_checkbox("Groups enabled", "canvas", "groups_enabled") }}
         {{ settings_checkbox("Sections enabled", "canvas", "sections_enabled") }}
+        {{ settings_checkbox("Folders enabled", "canvas", "file_picker_folders", default=False) }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -115,9 +115,9 @@
             placeholder="*" * 25 if instance.developer_secret else "")
         }}
         {{ settings_checkbox("Files enabled", "canvas", "files_enabled") }}
+        {{ settings_checkbox("Folders enabled", "canvas", "folders_enabled", default=False) }}
         {{ settings_checkbox("Groups enabled", "canvas", "groups_enabled") }}
         {{ settings_checkbox("Sections enabled", "canvas", "sections_enabled") }}
-        {{ settings_checkbox("Folders enabled", "canvas", "file_picker_folders", default=False) }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -24,6 +24,9 @@ FILES_SCOPES = (
     "url:GET|/api/v1/files/:id/public_url",
 )
 
+# Support for folders in our Canvas files integration.
+FOLDERS_SCOPES = ("url:GET|/api/v1/courses/:course_id/folders",)
+
 #: The Canvas API scopes that we need for our Sections feature.
 SECTIONS_SCOPES = (
     "url:GET|/api/v1/courses/:id",
@@ -50,6 +53,9 @@ def authorize(request):
     course_service = request.find_service(name="course")
 
     scopes = FILES_SCOPES
+
+    if application_instance.settings.get("canvas", "file_picker_folders"):
+        scopes += FOLDERS_SCOPES
 
     if application_instance.developer_key and (
         # If the instance could add a new course with sections...

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -54,7 +54,7 @@ def authorize(request):
 
     scopes = FILES_SCOPES
 
-    if application_instance.settings.get("canvas", "file_picker_folders"):
+    if application_instance.settings.get("canvas", "folders_enabled"):
         scopes += FOLDERS_SCOPES
 
     if application_instance.developer_key and (

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -67,7 +67,7 @@ class TestFilePickerConfig:
 
         expected_config = {
             "enabled": files_enabled,
-            "withFolders": Any(),
+            "foldersEnabled": Any(),
             "listFiles": {
                 "authUrl": "http://example.com/api/canvas/oauth/authorize",
                 "path": "/api/canvas/courses/COURSE_ID/files",

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import sentinel
 
 import pytest
+from h_matchers import Any
 
 from lms.product import Product
 from lms.resources._js_config import FilePickerConfig
@@ -66,6 +67,7 @@ class TestFilePickerConfig:
 
         expected_config = {
             "enabled": files_enabled,
+            "withFolders": Any(),
             "listFiles": {
                 "authUrl": "http://example.com/api/canvas/oauth/authorize",
                 "path": "/api/canvas/courses/COURSE_ID/files",

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -406,7 +406,7 @@ class TestCanvasAPIClientIntegrated:
         list_files_json,
         list_folders_json,
     ):
-        canvas_api_client._with_folders = True  # pylint:disable=protected-access
+        canvas_api_client._folders_enabled = True  # pylint:disable=protected-access
         http_session.send.side_effect = [
             factories.requests.Response(status_code=200, json_data=list_files_json),
             factories.requests.Response(status_code=200, json_data=list_folders_json),

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -11,13 +11,22 @@ pytestmark = pytest.mark.usefixtures(
 
 class TestCanvasAPIClientFactory:
     @pytest.mark.usefixtures("aes_service")
+    @pytest.mark.parametrize("with_folders", [True, False])
     def test_building_the_CanvasAPIClient(
-        self, pyramid_request, CanvasAPIClient, AuthenticatedClient, file_service
+        self,
+        pyramid_request,
+        CanvasAPIClient,
+        AuthenticatedClient,
+        file_service,
+        with_folders,
+        application_instance,
     ):
+        application_instance.settings.set("canvas", "file_picker_folders", with_folders)
+
         canvas_api = canvas_api_client_factory(sentinel.context, pyramid_request)
 
         CanvasAPIClient.assert_called_once_with(
-            AuthenticatedClient.return_value, file_service
+            AuthenticatedClient.return_value, file_service, with_folders=with_folders
         )
         assert canvas_api == CanvasAPIClient.return_value
 

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -11,22 +11,24 @@ pytestmark = pytest.mark.usefixtures(
 
 class TestCanvasAPIClientFactory:
     @pytest.mark.usefixtures("aes_service")
-    @pytest.mark.parametrize("with_folders", [True, False])
+    @pytest.mark.parametrize("folders_enabled", [True, False])
     def test_building_the_CanvasAPIClient(
         self,
         pyramid_request,
         CanvasAPIClient,
         AuthenticatedClient,
         file_service,
-        with_folders,
+        folders_enabled,
         application_instance,
     ):
-        application_instance.settings.set("canvas", "file_picker_folders", with_folders)
+        application_instance.settings.set("canvas", "folders_enabled", folders_enabled)
 
         canvas_api = canvas_api_client_factory(sentinel.context, pyramid_request)
 
         CanvasAPIClient.assert_called_once_with(
-            AuthenticatedClient.return_value, file_service, with_folders=with_folders
+            AuthenticatedClient.return_value,
+            file_service,
+            folders_enabled=folders_enabled,
         )
         assert canvas_api == CanvasAPIClient.return_value
 

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -76,7 +76,7 @@ class TestAuthorize:
     def test_instance_with_groups_enabled_triggers_groups_scopes(self, pyramid_request):
         self.assert_groups_scopes(authorize.authorize(pyramid_request))
 
-    @pytest.mark.usefixtures("with_file_picker_folders")
+    @pytest.mark.usefixtures("with_folders_enabled")
     def test_instance_with_folders_enabled_triggers_folders_scopes(
         self, pyramid_request
     ):
@@ -147,9 +147,9 @@ class TestAuthorize:
         )
 
     @pytest.fixture
-    def with_file_picker_folders(self, application_instance_service):
+    def with_folders_enabled(self, application_instance_service):
         application_instance_service.get_current.return_value.settings.set(
-            "canvas", "file_picker_folders", True
+            "canvas", "folders_enabled", True
         )
 
     @pytest.fixture


### PR DESCRIPTION
### Testing


#### Existing behavior

- Reconfigure https://hypothesis.instructure.com/courses/125/assignments/4682/edit?name=Testing+creation+-+marcos&due_at=null&points_possible=0 

##### Folders enabled

- Enable folder support: http://localhost:8001/admin/instance/8/
- Reconfigure https://hypothesis.instructure.com/courses/125/assignments/4682/edit?name=Testing+creation+-+marcos&due_at=null&points_possible=0 check the folder structure there matches the one at: https://hypothesis.instructure.com/courses/125/files/folder/Foo


### Releasing

- [ ] Quick call with support about the release
- [ ] Document new scope. Discuss if we should include it for new schools.
- [ ] Suggest new screen size while adding new scope for schools?
- [ ] Announce feature? Chat with marketing.

