### PR TITLE
Make the deep linking window bigger in Canvas

### DIFF
--- a/lms/views/canvas/config.py
+++ b/lms/views/canvas/config.py
@@ -56,6 +56,8 @@ def config_json(request):
                             "target_link_uri": request.route_url(
                                 "content_item_selection"
                             ),
+                            "selection_width": 800,
+                            "selection_height": 600,
                         },
                         {
                             "text": "Hypothesis",
@@ -65,6 +67,8 @@ def config_json(request):
                             "target_link_uri": request.route_url(
                                 "content_item_selection"
                             ),
+                            "selection_width": 800,
+                            "selection_height": 600,
                         },
                     ],
                 },

--- a/tests/unit/lms/views/canvas/config_test.py
+++ b/tests/unit/lms/views/canvas/config_test.py
@@ -28,6 +28,8 @@ class TestConfigJSON:
                                 "placement": "link_selection",
                                 "message_type": "LtiDeepLinkingRequest",
                                 "target_link_uri": "http://example.com/content_item_selection",
+                                "selection_width": 800,
+                                "selection_height": 600,
                             },
                             {
                                 "text": "Hypothesis",
@@ -35,6 +37,8 @@ class TestConfigJSON:
                                 "placement": "assignment_selection",
                                 "message_type": "LtiDeepLinkingRequest",
                                 "target_link_uri": "http://example.com/content_item_selection",
+                                "selection_width": 800,
+                                "selection_height": 600,
                             },
                         ],
                     },


### PR DESCRIPTION
The JSON configuration for new LTI1.3 installs allows to explicitly assign a with and height.

### LTI1.3 only

This PR only changes the configuration for new LTI1.3 installs so admins following the instructions over https://web.hypothes.is/help/installing-hypothesis-in-canvas-lti-1-3-worldwide/ get the new size.

We could tackle 1.1 on the XML config in another PR but given that:

- Testing the XML path is way more complicated
- No new 1.1 installs have been created since January 

I'll leave this out of this PR.



### Testing 

Using a shortcut to test this:

- Loging Canvas admin in https://hypothesis.instructure.com/
- Head over https://hypothesis.instructure.com/accounts/1/developer_keys#
- Find `Hypothesis LTI1.3 (QA)`
- Toggle the selector at the top to "Paste JSON"
- Check that the changes of this PR are already present in that config.
- Start a  reconfiguration of: https://hypothesis.instructure.com/courses/319/assignments/3034/edit?name=QA+HTML+Assignment+&due_at=null&points_possible=0 

(right now the right tool there is just called "Hypothesis" but it should eventually change to "Hypothesis LTI1.3 (QA)" as the JSON config dictates)


### Updating existing installs

#### LTI 1.3

See the recording here, head to the details using "Manual Entry" as the method at the top and changet the values in both placements

  

https://user-images.githubusercontent.com/1433832/230427918-316f84d3-7916-4357-90bc-a4c4948d3ced.mp4


#### LTI1.1

I haven't found a sane way to change the value yet.
