### PR TITLE
Migration for the `email_unsubscribe` table

### DIFF
--- a/lms/migrations/versions/9f1e88367596_email_unsubscribe.py
+++ b/lms/migrations/versions/9f1e88367596_email_unsubscribe.py
@@ -1,0 +1,37 @@
+"""
+Add the email_unsubscribe table.
+
+Revision ID: 9f1e88367596
+Revises: f3d631c110bf
+Create Date: 2023-04-06 14:44:40.077112
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9f1e88367596"
+down_revision = "f3d631c110bf"
+
+
+def upgrade():
+    op.create_table(
+        "email_unsubscribe",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("tag", sa.UnicodeText(), nullable=False),
+        sa.Column("h_userid", sa.Unicode(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__email_unsubscribe")),
+        sa.UniqueConstraint(
+            "h_userid", "tag", name=op.f("uq__email_unsubscribe__h_userid")
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("email_unsubscribe")


### PR DESCRIPTION
## Testing

`hdev alembic upgrade head`

```
dev run-test-pre: PYTHONHASHSEED='145102197'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade f3d631c110bf -> 9f1e88367596, Add the email_unsubscribe table.
```



`hdev alembic downgrade -1`

```
dev run-test-pre: PYTHONHASHSEED='1070460438'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini downgrade -1
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 9f1e88367596 -> f3d631c110bf, Add the email_unsubscribe table
```