### PR TITLE
Change "re-create" to "edit" in several launch errors

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -54,8 +54,10 @@ export default function LaunchErrorDialog({
   onRetry,
 }: LaunchErrorDialogProps) {
   const { instructorToolbar } = useConfig();
+  const canEdit = Boolean(instructorToolbar?.editingEnabled);
+
   let extraActions;
-  if (instructorToolbar?.editingEnabled) {
+  if (canEdit) {
     extraActions = (
       <RouterLink href="/app/content-item-selection">
         <Link underline="always" data-testid="edit-link">
@@ -104,7 +106,8 @@ export default function LaunchErrorDialog({
           <ul className="px-4 list-disc">
             <li>
               The file has been deleted from Blackboard: an instructor needs to
-              re-create the assignment with a new file
+              {canEdit ? 'edit' : 'recreate'} this assignment and select a new
+              file
             </li>
             <li>
               You don{"'"}t have permission to read the file: an instructor
@@ -132,8 +135,9 @@ export default function LaunchErrorDialog({
             </li>
           </ul>
           <p>
-            To fix the issue, recreate the assignment with a different file.
-            More information can be found in our document about{' '}
+            To fix the issue, {canEdit ? 'edit' : 'recreate'} this assignment
+            and select a different file. More information can be found in our
+            document about{' '}
             <ExternalLink href="https://web.hypothes.is/help/using-hypothesis-with-d2l-course-content-files/">
               Using Hypothesis With D2L Course Content Files
             </ExternalLink>

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -77,7 +77,7 @@ describe('LaunchErrorDialog', () => {
     {
       errorState: 'd2l_file_not_found_in_course_instructor',
       expectedText:
-        'To fix the issue, recreate the assignment with a different file.',
+        'To fix the issue, recreate this assignment and select a different file.',
       expectedTitle: "Hypothesis couldn't find the file in the course",
       hasRetry: true,
       withError: true,


### PR DESCRIPTION
When editing assignments is supported in the LMS, change the error message to mention _editing_ rather than _recreating_ the assignment.

There is one caveat which is that when a _student_ sees an error message in Blackboard, the frontend doesn't know whether editing is available for instructors or not. In that case the student will see "recreate" in the error message but the instructor will see "edit". This issue will go away once we have enabled editing assignments everywhere, as we can remove the code path that mentions recreating the assignment.

Part of #5219