### PR TITLE
Remove handling of missing Mailchimp API keys

### DIFF
--- a/lms/services/mailchimp.py
+++ b/lms/services/mailchimp.py
@@ -29,8 +29,7 @@ class EmailRecipient:
 
 class MailchimpService:
     def __init__(self, api_key):
-        if api_key:
-            self.mailchimp_client = mailchimp_transactional.Client(api_key)
+        self.mailchimp_client = mailchimp_transactional.Client(api_key)
 
     def send_template(
         self,
@@ -65,10 +64,8 @@ class MailchimpService:
         }
 
         LOG.info("mailchimp_client.send_template(%r)", params)
-
-        if hasattr(self, "mailchimp_client"):
-            self.mailchimp_client.messages.send_template(params)
+        self.mailchimp_client.messages.send_template(params)
 
 
 def factory(_context, request):
-    return MailchimpService(request.registry.settings.get("mailchimp_api_key"))
+    return MailchimpService(request.registry.settings["mailchimp_api_key"])

--- a/tests/unit/lms/services/mailchimp_test.py
+++ b/tests/unit/lms/services/mailchimp_test.py
@@ -61,29 +61,6 @@ class TestSendTemplate:
             }
         )
 
-    def test_if_theres_no_api_key_doesnt_call_mailchimp(self, mailchimp_client):
-        svc = MailchimpService(None)
-
-        svc.send_template(
-            sentinel.template_name,
-            EmailSender(
-                sentinel.subaccount_id,
-                sentinel.from_email,
-                sentinel.from_name,
-            ),
-            EmailRecipient(
-                sentinel.to_email,
-                sentinel.to_name,
-            ),
-            {},
-        )
-
-        mailchimp_client.messages.send_template.assert_not_called()
-
-    @pytest.fixture
-    def mailchimp_client(self, mailchimp_transactional):
-        return mailchimp_transactional.Client.return_value
-
 
 class TestFactory:
     def test_it(self, pyramid_request, MailchimpService):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/devdata/pull/80/

Now that we have a Mailchimp API key in dev don't bother with handling the case of a missing API key. Just let the `mailchimp_transactional` client crash when you try to send an email.

Unfortunately this doesn't result in a nice error message. We do get a nice JSON error response from the Mailchimp API with "Invalid API key" as the error message. But Mailchimp's Python client swallows this error response and completely hides it, and then raises a `PicklingError` instead. This appears to be a bug in the Mailchimp Transactional Python client's error handling.

As long as you've run `make devdata` this should never happen, but it might happen if someone is setting up a new production instance of LMS and doesn't set `MAILCHIMP_API_KEY`. So it might be worth adding our own handling of a missing `MAILCHIMP_API_KEY` to log a more helpful error message. I think we may want to do this in [lms/config.py](https://github.com/hypothesis/lms/blob/de6cb4593fb7ce569c64fab0dbc425779e83da9b/lms/config.py#L103) rather than in `MailchimpService` itself: add generic support for "required" envvars and have it crash with a nice error message if one is missing.
