### PR TITLE
New unsubscribe mechanism for digest emails

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ LMS. Each of these is mandatory to get the service working correctly.
 | `SESSION_COOKIE_SECRET`           | `random-string-12345`                  | An arbitrary secret value                       |
 | `VIA_SECRET`                      | `matching-string-from-via`             | Must match the shared secret from Via           |
 | `VIA_URL`                         | `https://via9.hypothes.is/`            | The matching Via                                |
+| `WEB_APP_URL`                     | `https://lms.hypothes.is/`             | Root URL of the web app                         |
 
 See also:
 

--- a/lms/config.py
+++ b/lms/config.py
@@ -104,6 +104,8 @@ SETTINGS = (
     _Setting("mailchimp_digests_subaccount"),
     _Setting("mailchimp_digests_email"),
     _Setting("mailchimp_digests_name"),
+    # Point to the URL the web app runs on. Useful in celery tasks and the shell
+    _Setting("web_app_url"),
 )
 
 

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -5,6 +5,7 @@ from lms.models.assignment_grouping import AssignmentGrouping
 from lms.models.assignment_membership import AssignmentMembership
 from lms.models.course import LegacyCourse
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
+from lms.models.email_unsubscribe import EmailUnsubscribe
 from lms.models.event import Event, EventData, EventType, EventUser
 from lms.models.exceptions import ReusedConsumerKey
 from lms.models.file import File

--- a/lms/models/email_unsubscribe.py
+++ b/lms/models/email_unsubscribe.py
@@ -1,0 +1,19 @@
+import sqlalchemy as sa
+
+from lms.db import BASE
+from lms.models._mixins import CreatedUpdatedMixin
+
+
+class EmailUnsubscribe(CreatedUpdatedMixin, BASE):
+    """A list of users not to send certain types of emails to."""
+
+    __tablename__ = "email_unsubscribe"
+    __table_args__ = (sa.UniqueConstraint("h_userid", "tag"),)
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+
+    h_userid = sa.Column(sa.Unicode, nullable=False)
+    """Which H user unsubscribed from the email"""
+
+    tag = sa.Column(sa.UnicodeText(), nullable=False)
+    """Identify the type of email to not receive anymore"""

--- a/lms/models/email_unsubscribe.py
+++ b/lms/models/email_unsubscribe.py
@@ -1,11 +1,16 @@
+from enum import Enum
+
 import sqlalchemy as sa
 
-from lms.db import BASE
+from lms.db import BASE, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
 
 
 class EmailUnsubscribe(CreatedUpdatedMixin, BASE):
     """A list of users not to send certain types of emails to."""
+
+    class Tag(str, Enum):
+        INSTRUCTOR_DIGEST = "instructor_digest"
 
     __tablename__ = "email_unsubscribe"
     __table_args__ = (sa.UniqueConstraint("h_userid", "tag"),)
@@ -15,5 +20,5 @@ class EmailUnsubscribe(CreatedUpdatedMixin, BASE):
     h_userid = sa.Column(sa.Unicode, nullable=False)
     """Which H user unsubscribed from the email"""
 
-    tag = sa.Column(sa.UnicodeText(), nullable=False)
+    tag = varchar_enum(Tag, nullable=False)
     """Identify the type of email to not receive anymore"""

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -131,7 +131,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     )
     config.add_route("vitalsource_api.launch_url", "/api/vitalsource/launch_url")
 
-    config.add_route("email.unsubscribe", "/email/unsubscribe/{token}")
+    config.add_route("email.unsubscribe", "/email/unsubscribe")
     config.add_route("email.unsubscribed", "/email/unsubscribed")
 
     config.add_route("admin.index", "/admin/")

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -131,6 +131,9 @@ def includeme(config):  # pylint:disable=too-many-statements
     )
     config.add_route("vitalsource_api.launch_url", "/api/vitalsource/launch_url")
 
+    config.add_route("email.unsubscribe", "/email/unsubscribe/{token}")
+    config.add_route("email.unsubscribed", "/email/unsubscribed")
+
     config.add_route("admin.index", "/admin/")
 
     config.add_route("admin.instance.search", "/admin/instances/")

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -4,6 +4,7 @@ from lms.services.canvas import CanvasService
 from lms.services.d2l_api.client import D2LAPIClient
 from lms.services.digest import DigestService
 from lms.services.document_url import DocumentURLService
+from lms.services.email_unsubscribe import EmailUnsubscribeService
 from lms.services.event import EventService
 from lms.services.exceptions import (
     CanvasAPIError,
@@ -124,6 +125,10 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.digest.service_factory", iface=DigestService
     )
+    config.register_service_factory(
+        "lms.services.email_unsubscribe.factory", iface=EmailUnsubscribeService
+    )
+
     # Plugins are not the same as top level services but we want to register them as pyramid services too
     # Importing them here to:
     # - Don't pollute the lms.services namespace

--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -11,6 +11,7 @@ from lms.models import (
     AssignmentGrouping,
     AssignmentMembership,
     Course,
+    EmailUnsubscribe,
     Grouping,
     LTIRole,
     User,

--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -15,7 +15,6 @@ from lms.models import (
     Grouping,
     LTIRole,
     User,
-    EmailUnsubscribe,
 )
 from lms.services.email_unsubscribe import EmailUnsubscribeService
 from lms.services.h_api import HAPI

--- a/lms/services/email_unsubscribe.py
+++ b/lms/services/email_unsubscribe.py
@@ -2,8 +2,6 @@ from datetime import timedelta
 from functools import partial
 from typing import Callable
 
-from sqlalchemy import exists
-
 from lms.models import EmailUnsubscribe
 from lms.services.jwt import JWTService
 from lms.services.upsert import bulk_upsert
@@ -31,14 +29,6 @@ class EmailUnsubscribeService:
             values=[data],
             index_elements=["h_userid", "tag"],
             update_columns=["updated"],
-        )
-
-    def is_unsubscribed(self, h_userid, tag):
-        """Check if `h_userid` is unsubscribed for `tag` type emails."""
-        return self._db.scalar(
-            exists()
-            .where(EmailUnsubscribe.h_userid == h_userid, EmailUnsubscribe.tag == tag)
-            .select()
         )
 
     def _generate_token(self, h_userid, tag):

--- a/lms/services/email_unsubscribe.py
+++ b/lms/services/email_unsubscribe.py
@@ -17,7 +17,7 @@ class EmailUnsubscribeService:
     def unsubscribe_url(self, h_userid, tag):
         """Generate the url for `email.unsubscribe` with the right token."""
         token = self._generate_token(h_userid, tag)
-        return self._route_url("email.unsubscribe", token=token)
+        return self._route_url("email.unsubscribe", _query={"token": token})
 
     def unsubscribe(self, token):
         """Create a new entry in EmailUnsubscribe based on the email and tag encode in `token`."""

--- a/lms/services/email_unsubscribe.py
+++ b/lms/services/email_unsubscribe.py
@@ -1,0 +1,63 @@
+from datetime import timedelta
+from functools import partial
+from typing import Callable
+
+from sqlalchemy import exists
+
+from lms.models import EmailUnsubscribe
+from lms.services.jwt import JWTService
+from lms.services.upsert import bulk_upsert
+
+
+class EmailUnsubscribeService:
+    def __init__(self, db, jwt_service: JWTService, secret: str, route_url: Callable):
+        self._db = db
+        self._jwt_service = jwt_service
+        self._secret = secret
+        self._route_url = route_url
+
+    def unsubscribe_url(self, h_userid, tag):
+        """Generate the url for `email.unsubscribe` with the right token."""
+        token = self._generate_token(h_userid, tag)
+        return self._route_url("email.unsubscribe", token=token)
+
+    def unsubscribe(self, token):
+        """Create a new entry in EmailUnsubscribe based on the email and tag encode in `token`."""
+        data = self._decode_token(token)
+
+        bulk_upsert(
+            self._db,
+            model_class=EmailUnsubscribe,
+            values=[data],
+            index_elements=["h_userid", "tag"],
+            update_columns=["updated"],
+        )
+
+    def is_unsubscribed(self, h_userid, tag):
+        """Check if `h_userid` is unsubscribed for `tag` type emails."""
+        return self._db.scalar(
+            exists()
+            .where(EmailUnsubscribe.h_userid == h_userid, EmailUnsubscribe.tag == tag)
+            .select()
+        )
+
+    def _generate_token(self, h_userid, tag):
+        return self._jwt_service.encode_with_secret(
+            {"h_userid": h_userid, "tag": tag},
+            self._secret,
+            lifetime=timedelta(days=30),
+        )
+
+    def _decode_token(self, token):
+        return self._jwt_service.decode_with_secret(token, self._secret)
+
+
+def factory(_context, request):
+    return EmailUnsubscribeService(
+        request.db,
+        request.find_service(iface=JWTService),
+        secret=request.registry.settings["jwt_secret"],
+        route_url=partial(
+            request.route_url, _app_url=request.registry.settings["web_app_url"]
+        ),
+    )

--- a/lms/services/mailchimp.py
+++ b/lms/services/mailchimp.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from typing import Optional
 
 import mailchimp_transactional
 
@@ -35,18 +36,27 @@ class MailchimpService:
     def __init__(self, api_key):
         self.mailchimp_client = mailchimp_transactional.Client(api_key)
 
-    def send_template(
+    def send_template(  # pylint:disable=too-many-arguments
         self,
         template_name: str,
         sender: EmailSender,
         recipient: EmailRecipient,
         template_vars: dict,
+        unsubscribe_url: Optional[str] = None,
     ):
         """
         Send an email using Mailchimp Transactional's send-template API.
 
         https://mailchimp.com/developer/transactional/api/messages/send-using-message-template/
         """
+        headers = {}
+
+        if unsubscribe_url:
+            # If we do provide a unsubscribe_url expose it as template var
+            # and add the corresponding header for clients that support it.
+            template_vars["unsubscribe_url"] = unsubscribe_url
+            headers["List-Unsubscribe"] = unsubscribe_url
+
         params = {
             "template_name": template_name,
             # We're not using template_content but we still need to pass an
@@ -63,6 +73,7 @@ class MailchimpService:
                     {"name": key, "content": value}
                     for key, value in template_vars.items()
                 ],
+                "headers": headers,
             },
             "async": True,
         }

--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -13,8 +13,8 @@ from lms.models import (
     LTIRole,
     User,
 )
+from lms.services import DigestService
 from lms.services.digest import SendDigestsError
-from lms.services import DigestService, EmailUnsubscribeService
 from lms.tasks.celery import app
 
 LOG = logging.getLogger(__name__)

--- a/lms/templates/base.plain.html.jinja2
+++ b/lms/templates/base.plain.html.jinja2
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <main>
+      <h1>{{ title }}</h1>
+
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/lms/templates/email/unsubscribe_error.html.jinja2
+++ b/lms/templates/email/unsubscribe_error.html.jinja2
@@ -1,0 +1,15 @@
+{% extends 'templates/base.plain.html.jinja2' %}
+
+{% set title = "Expired unsubscribe link" %}
+
+{% block content %}
+<p>
+    It looks like the unsubscribe link that you clicked on was invalid or had expired.
+    Try clicking the unsubscribe link in a more recent email instead.
+</p>
+<p>
+    If the problem persists, you can
+     <a href="https://web.hypothes.is/get-help/?product=LMS_app" target="_blank" rel="noopener noreferrer">open a support ticket</a>
+     or visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer">help documents</a>.
+</p>
+{% endblock %}

--- a/lms/templates/email/unsubscribed.html.jinja2
+++ b/lms/templates/email/unsubscribed.html.jinja2
@@ -1,0 +1,3 @@
+{% extends 'templates/base.plain.html.jinja2' %}
+
+{% set title = "You've been unsubscribed" %}

--- a/lms/templates/message.html.jinja2
+++ b/lms/templates/message.html.jinja2
@@ -1,0 +1,9 @@
+{% extends 'templates/base.html.jinja2' %}
+
+{% block content %}
+  <main class="modal-content u-horizontally-center-children">
+    <h1>{{title}}</h1>
+    {{ message|safe }}
+    </p>
+  </main>
+{% endblock %}

--- a/lms/templates/message.html.jinja2
+++ b/lms/templates/message.html.jinja2
@@ -1,9 +1,0 @@
-{% extends 'templates/base.html.jinja2' %}
-
-{% block content %}
-  <main class="modal-content u-horizontally-center-children">
-    <h1>{{title}}</h1>
-    {{ message|safe }}
-    </p>
-  </main>
-{% endblock %}

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -1,6 +1,5 @@
 import logging
 
-from h_pyramid_sentry import report_exception
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
@@ -11,10 +10,7 @@ LOG = logging.getLogger(__name__)
 
 
 @view_config(
-    route_name="email.unsubscribe",
-    request_method="GET",
-    renderer="lms:templates/message.html.jinja2",
-    request_param="token",
+    route_name="email.unsubscribe", request_method="GET", request_param="token"
 )
 def unsubscribe(request):
     """Unsubscribe the email and tag combination encoded in token."""
@@ -24,21 +20,8 @@ def unsubscribe(request):
         )
     except (InvalidJWTError, ExpiredJWTError):
         LOG.exception("Invalid unsubscribe token")
-        report_exception()
-        return {
-            "title": "Expired unsubscribe link",
-            "message": """
-                    <p>
-                        It looks like the unsubscribe link that you clicked on was invalid or had expired.
-                        Try clicking the unsubscribe link in a more recent email instead.
-                    </p>
-                    <p>
-                        If the problem persists, you can
-                         <a href="https://web.hypothes.is/get-help/?product=LMS_app" target="_blank" rel="noopener noreferrer">open a support ticket</a>
-                         or visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer">help documents</a>.
-                    </p>
-                    """,
-        }
+        request.override_renderer = "lms:templates/email/unsubscribe_error.html.jinja2"
+        return {}
 
     return HTTPFound(location=request.route_url("email.unsubscribed"))
 
@@ -46,8 +29,8 @@ def unsubscribe(request):
 @view_config(
     route_name="email.unsubscribed",
     request_method="GET",
-    renderer="lms:templates/message.html.jinja2",
+    renderer="lms:templates/email/unsubscribed.html.jinja2",
 )
 def unsubscribed(_request):
     """Render a message after a successful email unsubscribe."""
-    return {"title": "You've been unsubscribed"}
+    return {}

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -1,0 +1,52 @@
+import logging
+
+from h_pyramid_sentry import report_exception
+from pyramid.httpexceptions import HTTPFound
+from pyramid.view import view_config
+
+from lms.services import EmailUnsubscribeService
+from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
+
+LOG = logging.getLogger(__name__)
+
+
+@view_config(
+    route_name="email.unsubscribe",
+    request_method="GET",
+    renderer="lms:templates/message.html.jinja2",
+)
+def unsubscribe(request):
+    """Unsubscribe the email and tag combination encoded in token."""
+    try:
+        request.find_service(EmailUnsubscribeService).unsubscribe(
+            request.matchdict["token"]
+        )
+    except (InvalidJWTError, ExpiredJWTError):
+        LOG.exception("Invalid unsubscribe token")
+        report_exception()
+        return {
+            "title": "Expired unsubscribe link",
+            "message": """
+                    <p>
+                        It looks like the unsubscribe link that you clicked on was invalid or had expired.
+                        Try clicking the unsubscribe link in a more recent email instead.
+                    </p>
+                    <p>
+                        If the problem persists, you can
+                         <a href="https://web.hypothes.is/get-help/?product=LMS_app" target="_blank" rel="noopener noreferrer">open a support ticket</a>
+                         or visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer">help documents</a>.
+                    </p>
+                    """,
+        }
+
+    return HTTPFound(location=request.route_url("email.unsubscribed"))
+
+
+@view_config(
+    route_name="email.unsubscribed",
+    request_method="GET",
+    renderer="lms:templates/message.html.jinja2",
+)
+def unsubscribed(_request):
+    """Render a message after a successful email unsubscribe."""
+    return {"title": "You've been unsubscribed"}

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -14,12 +14,13 @@ LOG = logging.getLogger(__name__)
     route_name="email.unsubscribe",
     request_method="GET",
     renderer="lms:templates/message.html.jinja2",
+    request_param="token",
 )
 def unsubscribe(request):
     """Unsubscribe the email and tag combination encoded in token."""
     try:
         request.find_service(EmailUnsubscribeService).unsubscribe(
-            request.matchdict["token"]
+            request.params["token"]
         )
     except (InvalidJWTError, ExpiredJWTError):
         LOG.exception("Invalid unsubscribe token")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ TEST_SETTINGS = {
     "blackboard_api_client_secret": "test_blackboard_api_client_secret",
     "vitalsource_api_key": "test_vs_api_key",
     "disable_key_rotation": False,
+    "web_app_url": "http://localhost:8001/",
 }
 
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -18,6 +18,7 @@ from tests.factories.attributes import (
     TOOL_CONSUMER_INSTANCE_GUID,
     USER_ID,
 )
+from tests.factories.email_unsubscribe import EmailUnsubscribe
 from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo
 from tests.factories.group_info import GroupInfo

--- a/tests/factories/email_unsubscribe.py
+++ b/tests/factories/email_unsubscribe.py
@@ -1,0 +1,12 @@
+from factory import Faker, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.attributes import H_USERID
+
+EmailUnsubscribe = make_factory(
+    models.EmailUnsubscribe,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    tag=Faker("word"),
+    h_userid=H_USERID,
+)

--- a/tests/unit/lms/services/digest_test.py
+++ b/tests/unit/lms/services/digest_test.py
@@ -20,8 +20,17 @@ from tests import factories
 
 class TestDigestService:
     def test_send_instructor_email_digests(
-        self, svc, h_api, context, DigestContext, db_session, mailchimp_service, sender
+        self,
+        svc,
+        h_api,
+        context,
+        DigestContext,
+        db_session,
+        mailchimp_service,
+        sender,
+        email_unsubscribe_service,
     ):
+        email_unsubscribe_service.is_unsubscribed.side_effect = [False, False]
         context.unified_users = UnifiedUserFactory.create_batch(2)
         digests = context.instructor_digest.side_effect = [
             {"total_annotations": 1},
@@ -41,12 +50,17 @@ class TestDigestService:
         assert context.instructor_digest.call_args_list == [
             call(user.h_userid) for user in context.unified_users
         ]
+        assert email_unsubscribe_service.is_unsubscribed.call_args_list == [
+            call(unified_user.email, "instructor_digest")
+            for unified_user in context.unified_users
+        ]
         assert mailchimp_service.send_template.call_args_list == [
             call(
                 "instructor-email-digest",
                 sender,
                 recipient=EmailRecipient(unified_user.email, unified_user.display_name),
                 template_vars=digest,
+                unsubscribe_url=email_unsubscribe_service.unsubscribe_url.return_value,
             )
             for unified_user, digest in zip(context.unified_users, digests)
         ]
@@ -75,6 +89,20 @@ class TestDigestService:
 
         mailchimp_service.send_template.assert_not_called()
 
+    def test_send_instructor_email_digests_doesnt_send_sent_to_unsubscribed(
+        self, svc, context, mailchimp_service, email_unsubscribe_service
+    ):
+        email_unsubscribe_service.is_unsubscribed.return_value = True
+        context.unified_users = [UnifiedUserFactory()]
+        context.instructor_digest.return_value = {"total_annotations": 1}
+
+        svc.send_instructor_email_digests(
+            sentinel.audience, sentinel.updated_after, sentinel.updated_before
+        )
+
+        mailchimp_service.send_template.assert_not_called()
+
+    @pytest.mark.usefixtures("email_unsubscribe_service")
     def test_send_instructor_email_digests_uses_override_to_email(
         self, svc, context, mailchimp_service
     ):
@@ -149,6 +177,11 @@ class TestDigestService:
         return EmailSender(sentinel.subaccount, sentinel.from_email, sentinel.from_name)
 
     @pytest.fixture
+    def email_unsubscribe_service(self, email_unsubscribe_service):
+        email_unsubscribe_service.is_unsubscribed.return_value = False
+        return email_unsubscribe_service
+
+    @pytest.fixture
     def h_api(self, h_api):
         h_api.get_annotations.return_value = [
             sentinel.annotation1,
@@ -157,12 +190,15 @@ class TestDigestService:
         return h_api
 
     @pytest.fixture
-    def svc(self, db_session, h_api, mailchimp_service, sender):
+    def svc(
+        self, db_session, h_api, mailchimp_service, sender, email_unsubscribe_service
+    ):
         return DigestService(
             db=db_session,
             h_api=h_api,
             mailchimp_service=mailchimp_service,
             sender=sender,
+            email_unsubscribe_service=email_unsubscribe_service,
         )
 
 
@@ -574,7 +610,14 @@ class TestDigestContext:
 
 
 class TestServiceFactory:
-    def test_it(self, pyramid_request, h_api, mailchimp_service, DigestService):
+    def test_it(
+        self,
+        pyramid_request,
+        h_api,
+        mailchimp_service,
+        DigestService,
+        email_unsubscribe_service,
+    ):
         settings = pyramid_request.registry.settings
         settings["mailchimp_digests_subaccount"] = sentinel.digests_subaccount
         settings["mailchimp_digests_email"] = sentinel.digests_from_email
@@ -591,6 +634,7 @@ class TestServiceFactory:
                 sentinel.digests_from_email,
                 sentinel.digests_from_name,
             ),
+            email_unsubscribe_service=email_unsubscribe_service,
         )
         assert service == DigestService.return_value
 

--- a/tests/unit/lms/services/digest_test.py
+++ b/tests/unit/lms/services/digest_test.py
@@ -132,6 +132,7 @@ class TestDigestService:
                 Any(),
                 recipient=EmailRecipient(unified_user.email, unified_user.display_name),
                 template_vars=Any(),
+                unsubscribe_url=Any(),
             )
             for unified_user, digest in zip(context.unified_users, digests)
         ]

--- a/tests/unit/lms/services/email_unsubscribe_test.py
+++ b/tests/unit/lms/services/email_unsubscribe_test.py
@@ -1,0 +1,102 @@
+from datetime import timedelta
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.models import EmailUnsubscribe
+from lms.services.email_unsubscribe import EmailUnsubscribeService, factory
+from tests import factories
+
+
+class TestEmailUnsubscribeService:
+    def test_unsubscribe_url(self, svc, jwt_service):
+        jwt_service.encode_with_secret.return_value = "TOKEN"
+
+        url = svc.unsubscribe_url(sentinel.email, sentinel.tag)
+
+        jwt_service.encode_with_secret.assert_called_once_with(
+            {"h_userid": sentinel.email, "tag": sentinel.tag},
+            "SECRET",
+            lifetime=timedelta(days=30),
+        )
+        assert url == "http://example.com/email/unsubscribe/TOKEN"
+
+    def test_unsubscribe(self, svc, bulk_upsert, jwt_service, db_session):
+        jwt_service.decode_with_secret.return_value = {
+            "h_userid": sentinel.h_userid,
+            "tag": sentinel.tag,
+        }
+
+        svc.unsubscribe(sentinel.token)
+
+        jwt_service.decode_with_secret.assert_called_once_with(sentinel.token, "SECRET")
+        bulk_upsert.assert_called_once_with(
+            db_session,
+            model_class=EmailUnsubscribe,
+            values=[
+                {
+                    "h_userid": sentinel.h_userid,
+                    "tag": sentinel.tag,
+                }
+            ],
+            index_elements=["h_userid", "tag"],
+            update_columns=["updated"],
+        )
+
+    @pytest.mark.parametrize(
+        "tag,h_userid,expected",
+        [
+            ("digest", "OTHER_ID", False),
+            ("othertag", "OTHER_ID", False),
+            ("othertag", "UNSUBSCRIBED_ID", False),
+            ("digest", "UNSUBSCRIBED_ID", True),
+        ],
+    )
+    def test_is_unsubscribed(self, db_session, svc, h_userid, tag, expected):
+        factories.email_unsubscribe.EmailUnsubscribe(
+            tag="digest", h_userid="UNSUBSCRIBED_ID"
+        )
+        db_session.flush()
+
+        assert svc.is_unsubscribed(h_userid, tag) == expected
+
+    @pytest.fixture
+    def svc(self, db_session, jwt_service, pyramid_request):
+        return EmailUnsubscribeService(
+            db_session, jwt_service, "SECRET", pyramid_request.route_url
+        )
+
+    @pytest.fixture
+    def bulk_upsert(self, patch):
+        return patch("lms.services.email_unsubscribe.bulk_upsert")
+
+
+class TestFactory:
+    def test_it(
+        self,
+        pyramid_request,
+        EmailUnsubscribeService,
+        db_session,
+        jwt_service,
+        partial,
+    ):
+        svc = factory(sentinel.context, pyramid_request)
+
+        partial.assert_called_once_with(
+            pyramid_request.route_url, _app_url="http://localhost:8001/"
+        )
+        EmailUnsubscribeService.assert_called_once_with(
+            db_session,
+            jwt_service,
+            secret="test_secret",
+            route_url=partial.return_value,
+        )
+        assert svc == EmailUnsubscribeService.return_value
+
+    @pytest.fixture
+    def EmailUnsubscribeService(self, patch):
+        return patch("lms.services.email_unsubscribe.EmailUnsubscribeService")
+
+    @pytest.fixture
+    def partial(self, patch):
+        return patch("lms.services.email_unsubscribe.partial")

--- a/tests/unit/lms/services/email_unsubscribe_test.py
+++ b/tests/unit/lms/services/email_unsubscribe_test.py
@@ -18,7 +18,7 @@ class TestEmailUnsubscribeService:
             "SECRET",
             lifetime=timedelta(days=30),
         )
-        assert url == "http://example.com/email/unsubscribe/TOKEN"
+        assert url == "http://example.com/email/unsubscribe?token=TOKEN"
 
     def test_unsubscribe(self, svc, bulk_upsert, jwt_service, db_session):
         jwt_service.decode_with_secret.return_value = {

--- a/tests/unit/lms/services/email_unsubscribe_test.py
+++ b/tests/unit/lms/services/email_unsubscribe_test.py
@@ -5,7 +5,6 @@ import pytest
 
 from lms.models import EmailUnsubscribe
 from lms.services.email_unsubscribe import EmailUnsubscribeService, factory
-from tests import factories
 
 
 class TestEmailUnsubscribeService:
@@ -42,23 +41,6 @@ class TestEmailUnsubscribeService:
             index_elements=["h_userid", "tag"],
             update_columns=["updated"],
         )
-
-    @pytest.mark.parametrize(
-        "tag,h_userid,expected",
-        [
-            ("digest", "OTHER_ID", False),
-            ("othertag", "OTHER_ID", False),
-            ("othertag", "UNSUBSCRIBED_ID", False),
-            ("digest", "UNSUBSCRIBED_ID", True),
-        ],
-    )
-    def test_is_unsubscribed(self, db_session, svc, h_userid, tag, expected):
-        factories.email_unsubscribe.EmailUnsubscribe(
-            tag="digest", h_userid="UNSUBSCRIBED_ID"
-        )
-        db_session.flush()
-
-        assert svc.is_unsubscribed(h_userid, tag) == expected
 
     @pytest.fixture
     def svc(self, db_session, jwt_service, pyramid_request):

--- a/tests/unit/lms/tasks/email_digests_test.py
+++ b/tests/unit/lms/tasks/email_digests_test.py
@@ -36,25 +36,19 @@ class TestSendInstructurEmailDigestsTasks:
             batch_size=3
         )
 
+        first_batch = [user.h_userid for user in participating_instructors[:3]]
+        second_batch = [participating_instructors[-1].h_userid]
+
         assert send_instructor_email_digests.apply_async.call_args_list == [
             call(
                 (),
                 {
-                    "h_userids": [
-                        user.h_userid for user in participating_instructors[:3]
-                    ],
+                    "h_userids": batch,
                     "updated_after": "2023-03-08T05:00:00",
                     "updated_before": "2023-03-09T05:00:00",
                 },
-            ),
-            call(
-                (),
-                {
-                    "h_userids": [participating_instructors[-1].h_userid],
-                    "updated_after": "2023-03-08T05:00:00",
-                    "updated_before": "2023-03-09T05:00:00",
-                },
-            ),
+            )
+            for batch in [first_batch, second_batch]
         ]
 
     def test_it_retries_if_the_db_query_raises(
@@ -215,7 +209,7 @@ class TestSendInstructurEmailDigestsTasks:
 
         make_instructors(users)
 
-        return users
+        return sorted(users, key=lambda u: u.h_userid)
 
     @pytest.fixture
     def unsubscribed_instructors(self, participating_instructors):

--- a/tests/unit/lms/views/email_test.py
+++ b/tests/unit/lms/views/email_test.py
@@ -8,7 +8,7 @@ from lms.views.email import unsubscribe, unsubscribed
 
 
 def test_unsubscribe(pyramid_request, email_unsubscribe_service):
-    pyramid_request.matchdict["token"] = sentinel.token
+    pyramid_request.params["token"] = sentinel.token
 
     result = unsubscribe(pyramid_request)
 
@@ -19,7 +19,7 @@ def test_unsubscribe(pyramid_request, email_unsubscribe_service):
 
 @pytest.mark.parametrize("exception", [ExpiredJWTError, InvalidJWTError])
 def test_unsubscribe_error(pyramid_request, email_unsubscribe_service, exception):
-    pyramid_request.matchdict["token"] = sentinel.token
+    pyramid_request.params["token"] = sentinel.token
     email_unsubscribe_service.unsubscribe.side_effect = exception
 
     result = unsubscribe(pyramid_request)

--- a/tests/unit/lms/views/email_test.py
+++ b/tests/unit/lms/views/email_test.py
@@ -1,0 +1,31 @@
+from unittest.mock import sentinel
+
+import pytest
+from pyramid.httpexceptions import HTTPFound
+
+from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
+from lms.views.email import unsubscribe, unsubscribed
+
+
+def test_unsubscribe(pyramid_request, email_unsubscribe_service):
+    pyramid_request.matchdict["token"] = sentinel.token
+
+    result = unsubscribe(pyramid_request)
+
+    email_unsubscribe_service.unsubscribe.assert_called_once_with(sentinel.token)
+    assert isinstance(result, HTTPFound)
+    assert result.location == "http://example.com/email/unsubscribed"
+
+
+@pytest.mark.parametrize("exception", [ExpiredJWTError, InvalidJWTError])
+def test_unsubscribe_error(pyramid_request, email_unsubscribe_service, exception):
+    pyramid_request.matchdict["token"] = sentinel.token
+    email_unsubscribe_service.unsubscribe.side_effect = exception
+
+    result = unsubscribe(pyramid_request)
+
+    assert result == {"message": "Something went wrong while unsubscribing."}
+
+
+def test_unsubscribed(pyramid_request):
+    assert unsubscribed(pyramid_request) == {"message": "You've been unsubscribed"}

--- a/tests/unit/lms/views/email_test.py
+++ b/tests/unit/lms/views/email_test.py
@@ -24,8 +24,21 @@ def test_unsubscribe_error(pyramid_request, email_unsubscribe_service, exception
 
     result = unsubscribe(pyramid_request)
 
-    assert result == {"message": "Something went wrong while unsubscribing."}
+    assert result == {
+        "title": "Expired unsubscribe link",
+        "message": """
+                    <p>
+                        It looks like the unsubscribe link that you clicked on was invalid or had expired.
+                        Try clicking the unsubscribe link in a more recent email instead.
+                    </p>
+                    <p>
+                        If the problem persists, you can
+                         <a href="https://web.hypothes.is/get-help/?product=LMS_app" target="_blank" rel="noopener noreferrer">open a support ticket</a>
+                         or visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer">help documents</a>.
+                    </p>
+                    """,
+    }
 
 
 def test_unsubscribed(pyramid_request):
-    assert unsubscribed(pyramid_request) == {"message": "You've been unsubscribed"}
+    assert unsubscribed(pyramid_request) == {"title": "You've been unsubscribed"}

--- a/tests/unit/lms/views/email_test.py
+++ b/tests/unit/lms/views/email_test.py
@@ -24,21 +24,12 @@ def test_unsubscribe_error(pyramid_request, email_unsubscribe_service, exception
 
     result = unsubscribe(pyramid_request)
 
-    assert result == {
-        "title": "Expired unsubscribe link",
-        "message": """
-                    <p>
-                        It looks like the unsubscribe link that you clicked on was invalid or had expired.
-                        Try clicking the unsubscribe link in a more recent email instead.
-                    </p>
-                    <p>
-                        If the problem persists, you can
-                         <a href="https://web.hypothes.is/get-help/?product=LMS_app" target="_blank" rel="noopener noreferrer">open a support ticket</a>
-                         or visit our <a href="https://web.hypothes.is/help/" target="_blank" rel="noopener noreferrer">help documents</a>.
-                    </p>
-                    """,
-    }
+    assert (
+        pyramid_request.override_renderer
+        == "lms:templates/email/unsubscribe_error.html.jinja2"
+    )
+    assert result == {}
 
 
 def test_unsubscribed(pyramid_request):
-    assert unsubscribed(pyramid_request) == {"title": "You've been unsubscribed"}
+    assert not unsubscribed(pyramid_request)

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -90,6 +90,7 @@ __all__ = (
     "rsa_key_service",
     "user_service",
     "vitalsource_service",
+    "email_unsubscribe_service",
     # Product plugins
     "grouping_plugin",
     "course_copy_plugin",
@@ -330,6 +331,11 @@ def lti_user_service(mock_service):
 @pytest.fixture
 def vitalsource_service(mock_service):
     return mock_service(VitalSourceService)
+
+
+@pytest.fixture
+def email_unsubscribe_service(mock_service):
+    return mock_service(EmailUnsubscribeService)
 
 
 @pytest.fixture

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -24,6 +24,7 @@ from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
 from lms.services.d2l_api import D2LAPIClient
 from lms.services.digest import DigestService
+from lms.services.email_unsubscribe import EmailUnsubscribeService
 from lms.services.event import EventService
 from lms.services.file import FileService
 from lms.services.grading_info import GradingInfoService

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ passenv =
     dev: JSTOR_API_URL
     dev: JSTOR_API_SECRET
     dev: DISABLE_KEY_ROTATION
+    dev: WEB_APP_URL
 deps =
     -r requirements/{env:TOX_ENV_NAME}.txt
 depends =
@@ -68,6 +69,7 @@ setenv =
     VIA_SECRET = not_a_secret
     FDW_USERS = {env:FDW_USERS:report-fdw}
     SQLALCHEMY_SILENCE_UBER_WARNING=1
+    WEB_APP_URL=http://localhost:8001
 whitelist_externals =
     tests,functests,bddtests,dockercompose: sh
 commands_pre =


### PR DESCRIPTION
Adds the basic model, service and view to handle email unsubscribed.


Needs: https://github.com/hypothesis/lms/pull/5261

## Before merging:

- [x] Set the new en var in all environments

## After merging 

- [ ] Update the digest template to include the link
- [ ] Remove rule to include mailchimp own link

## Testing

- Tweak the sending code to use a new test template:

```diff 
--git a/lms/services/digest.py b/lms/services/digest.py
index 37c4b6f69..a87fdffd5 100644
--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -72,7 +72,8 @@ class DigestService:
                 continue
 
             self._mailchimp_service.send_template(
-                "instructor-email-digest",
+                # "instructor-email-digest",
+                "test-unsubcribe-link",
                 self._sender,
                 recipient=EmailRecipient(to_email, unified_user.display_name),
                 template_vars=digest,
```


- Check the new template 

https://mandrillapp.com/templates/code?id=test-unsubcribe-link

The HTML is copied from GH simple emails and the wording from mailchimp unsubscribe links.



- Log in to https://hypothesis.instructure.com/ first as `eng+canvasteacher@hypothes.is` and then as `eng+canvasteacher2@hypothes.is` and launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873) as each. This is to create the records of the instructors in your local DB.

- Log in as `eng+canvasstudent@hypothes.is`, launch the same assignment, and create an annotation.


- Go over http://localhost:8001/admin/email and kick-off a task

Include the ids: 

```
acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is acct:9ea84c4bcfd9329b4495f5b27d8cb6@lms.hypothes.is
```

and the relevant dates.


- Check the values in the console, a new unsubscribe variable will appear now and also the headers dict will be present.

- See the "sent" emails over: https://mandrillapp.com/activity, click the link there in one of them (you might have to copied it, at least in chrome)

- You'll see a page with `You've been unsubscribed` 

- There's a new row reflecting that on the DB:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from email_unsubscribe";
          created           |          updated           | id |        tag        |                      h_userid                       
----------------------------+----------------------------+----+-------------------+-----------------------------------------------------
 2023-04-13 08:25:30.864655 | 2023-04-13 08:25:30.864655 |  3 | instructor_digest | acct:9ea84c4bcfd9329b4495f5b27d8cb6@lms.hypothes.is       
```


- Back on  http://localhost:8001/admin/email, try to send the email again, it should only send one email now.


- Remove the unsubscribe record: 

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate email_unsubscribe";
```


- Send again on  http://localhost:8001/admin/email. It should send both it this time.




