### PR TITLE
Use EmailUnsubscribeService for digest emails

### DIFF
--- a/lms/models/email_unsubscribe.py
+++ b/lms/models/email_unsubscribe.py
@@ -1,11 +1,16 @@
+from enum import Enum
+
 import sqlalchemy as sa
 
-from lms.db import BASE
+from lms.db import BASE, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
 
 
 class EmailUnsubscribe(CreatedUpdatedMixin, BASE):
     """Store a denylist of for transactional emails."""
+
+    class Tag(str, Enum):
+        INSTRUCTOR_DIGEST = "instructor_digest"
 
     __tablename__ = "email_unsubscribe"
     __table_args__ = (sa.UniqueConstraint("h_userid", "tag"),)
@@ -15,5 +20,5 @@ class EmailUnsubscribe(CreatedUpdatedMixin, BASE):
     h_userid = sa.Column(sa.Unicode, nullable=False)
     """Which H user unsubscribed from the email"""
 
-    tag = sa.Column(sa.UnicodeText(), nullable=False)
+    tag = varchar_enum(Tag, nullable=False)
     """Identify the type of email to not receive anymore"""

--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -9,6 +9,7 @@ from lms.models import (
     AssignmentGrouping,
     AssignmentMembership,
     Course,
+    EmailUnsubscribe,
     Grouping,
     LTIRole,
     User,
@@ -65,19 +66,13 @@ class DigestService:
                 # We don't have an email address for this user.
                 continue
 
-            if self._email_unsubscribe_service.is_unsubscribed(
-                to_email, EmailUnsubscribeService.Tag.INSTRUCTOR_DIGEST
-            ):
-                # `to_email` unsubscribed from this type of email
-                continue
-
             self._mailchimp_service.send_template(
                 "instructor-email-digest",
                 self._sender,
                 recipient=EmailRecipient(to_email, unified_user.display_name),
                 template_vars=digest,
                 unsubscribe_url=self._email_unsubscribe_service.unsubscribe_url(
-                    to_email, EmailUnsubscribeService.Tag.INSTRUCTOR_DIGEST
+                    to_email, EmailUnsubscribe.Tag.INSTRUCTOR_DIGEST
                 ),
             )
 

--- a/lms/services/email_unsubscribe.py
+++ b/lms/services/email_unsubscribe.py
@@ -2,8 +2,6 @@ from datetime import timedelta
 from functools import partial
 from typing import Callable
 
-from sqlalchemy import exists
-
 from lms.models import EmailUnsubscribe
 from lms.services.jwt import JWTService
 from lms.services.upsert import bulk_upsert
@@ -31,14 +29,6 @@ class EmailUnsubscribeService:
             values=[data],
             index_elements=["h_userid", "tag"],
             update_columns=["updated"],
-        )
-
-    def is_unsubscribed(self, h_userid, tag):
-        """Check if `h_userid` is unsubscribed for `tag` type emails."""
-        return self._db.scalar(
-            exists()
-            .where(EmailUnsubscribe.h_userid == h_userid, EmailUnsubscribe.tag == tag)
-            .select()
         )
 
     def _generate_token(self, h_userid, tag):

--- a/tests/unit/lms/services/email_unsubscribe_test.py
+++ b/tests/unit/lms/services/email_unsubscribe_test.py
@@ -5,7 +5,6 @@ import pytest
 
 from lms.models import EmailUnsubscribe
 from lms.services.email_unsubscribe import EmailUnsubscribeService, factory
-from tests import factories
 
 
 class TestEmailUnsubscribeService:
@@ -42,23 +41,6 @@ class TestEmailUnsubscribeService:
             index_elements=["h_userid", "tag"],
             update_columns=["updated"],
         )
-
-    @pytest.mark.parametrize(
-        "tag,h_userid,expected",
-        [
-            ("digest", "OTHER_ID", False),
-            ("othertag", "OTHER_ID", False),
-            ("othertag", "UNSUBSCRIBED_ID", False),
-            ("digest", "UNSUBSCRIBED_ID", True),
-        ],
-    )
-    def test_is_unsubscribed(self, db_session, svc, h_userid, tag, expected):
-        factories.email_unsubscribe.EmailUnsubscribe(
-            tag="digest", h_userid="UNSUBSCRIBED_ID"
-        )
-        db_session.flush()
-
-        assert svc.is_unsubscribed(h_userid, tag) == expected
 
     @pytest.fixture
     def svc(self, db_session, jwt_service, pyramid_request):

--- a/tests/unit/lms/services/mailchimp_test.py
+++ b/tests/unit/lms/services/mailchimp_test.py
@@ -56,9 +56,48 @@ class TestSendTemplate:
                         {"name": "foo", "content": "FOO"},
                         {"name": "bar", "content": "BAR"},
                     ],
+                    "headers": {},
                 },
                 "async": True,
             }
+        )
+
+    def test_with_unsubscirbe_url(self, mailchimp_transactional):
+        svc = MailchimpService(sentinel.api_key)
+
+        svc.send_template(
+            sentinel.template_name,
+            EmailSender(
+                sentinel.subaccount_id,
+                sentinel.from_email,
+                sentinel.from_name,
+            ),
+            EmailRecipient(
+                sentinel.to_email,
+                sentinel.to_name,
+            ),
+            {},
+            sentinel.unsubscribe_url,
+        )
+
+        mailchimp_transactional.Client.return_value.messages.send_template.assert_called_once_with(
+            Any.dict.containing(
+                {
+                    "message": Any.dict.containing(
+                        {
+                            "headers": {
+                                "List-Unsubscribe": sentinel.unsubscribe_url,
+                            },
+                            "global_merge_vars": [
+                                {
+                                    "name": "unsubscribe_url",
+                                    "content": sentinel.unsubscribe_url,
+                                }
+                            ],
+                        }
+                    )
+                }
+            )
         )
 
     def test_if_theres_no_api_key_doesnt_call_mailchimp(self, mailchimp_client):


### PR DESCRIPTION
## Testing

- Tweak the sending code to use a new test template:

```diff 
--git a/lms/services/digest.py b/lms/services/digest.py
index 37c4b6f69..a87fdffd5 100644
--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -72,7 +72,8 @@ class DigestService:
                 continue
 
             self._mailchimp_service.send_template(
-                "instructor-email-digest",
+                # "instructor-email-digest",
+                "test-unsubcribe-link",
                 self._sender,
                 recipient=EmailRecipient(to_email, unified_user.display_name),
                 template_vars=digest,
```


- Check the new template 

https://mandrillapp.com/templates/code?id=test-unsubcribe-link

The HTML is copied from GH simple emails and the wording from mailchimp unsubscribe links.


- Go over http://localhost:8001/admin/email and kick-off a task
- Check the values in the console, a new unsubscribe variable will appear now and also the headers dict will be present.

- See the "sent" email over: https://mandrillapp.com/activity, click the link there (you might have to copied it, at least in chrome)

- You'll see a sad (to see you go) H page with the text `You've been unsubscribed` 


- There's a new row reflecting that on the DB:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from email_unsubscribe";
          created           |          updated           | id |        tag        |           email           
----------------------------+----------------------------+----+-------------------+---------------------------
 2023-04-11 08:41:06.980298 | 2023-04-11 08:41:50.155132 |  7 | instructor_digest | marcos.prieto@hypothes.is
```


- Back on  http://localhost:8001/admin/email, try to send the email again, it shouldn't print anything now.

- Remove the unsubscribe record: 

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate email_unsubscribe";
```


- Send again on  http://localhost:8001/admin/email. It should send it again.




