### PR TITLE
Add retries to the `send_instructor_email_digests_tasks()` task

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -15,7 +15,7 @@ LOG = logging.getLogger(__name__)
 
 
 @app.task
-def send_instructor_email_digest_tasks(batch_size):
+def send_instructor_email_digest_tasks(*, batch_size):
     """
     Generate and send instructor email digests.
 

--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -56,12 +56,9 @@ def send_instructor_email_digest_tasks(batch_size):
                 )
             ).all()
 
-            batches = [
-                h_userids[i : i + batch_size]
-                for i in range(0, len(h_userids), batch_size)
-            ]
+            while h_userids:
+                batch, h_userids = h_userids[:batch_size], h_userids[batch_size:]
 
-            for batch in batches:
                 send_instructor_email_digests.apply_async(
                     (),
                     {


### PR DESCRIPTION
### Problem

The `send_instructor_email_digests_tasks()` task does a DB query to retrieve the `h_userids`, splits them into batches, and then does a `for` loop to schedule instances of the `send_instructor_email_digests()` task for each batch:

https://github.com/hypothesis/lms/blob/95bdcdb3efe9ec88c7aab3f0f1c89e1ae12b8c2b/lms/tasks/email_digests.py#L17-L72

This could fail in a couple of ways:

1. The DB query could raise an exception (for example perhaps Postgres is overloaded and the query times out)
2. One of the Celery calls could raise an exception (for example perhaps CloudAMQP has an outage)

In either case the task could fail to schedule `send_instructor_email_digests()` instances for one or more of the batches of `h_userids`, meaning that users would not receive their email digests.

## Solution

Catch any exceptions that might be raised by the DB query or Celery calls and retry the task. In the case of the Celery calls only retry the task for those `h_userids` that failed to schedule so that we don't send duplicate emails, similar to what we did for the other Celery task in https://github.com/hypothesis/lms/pull/5279.