### PR TITLE
Changes for SQLA2.0 compatibility on the unit tests

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -149,11 +149,11 @@ def _session(request):  # pragma: no cover
     # always closed.
     @request.add_finished_callback
     def close_the_sqlalchemy_session(_request):
-        connections = (
-            session.transaction._connections  # pylint:disable=protected-access
-        )
-        if len(connections) > 1:
-            LOG.warning("closing an unclosed DB session")
+        transaction = session.get_transaction()
+        if transaction:
+            connections = transaction._connections  # pylint:disable=protected-access
+            if len(connections) > 1:
+                LOG.warning("closing an unclosed DB session")
         session.close()
 
     return session

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -120,7 +120,7 @@ def init(engine, drop=False, stamp=True):  # pragma: nocover
 
 def make_engine(settings):
     """Construct a sqlalchemy engine from the passed ``settings``."""
-    return sqlalchemy.create_engine(settings["database_url"])
+    return sqlalchemy.create_engine(settings["database_url"], future=True)
 
 
 SESSION = sessionmaker()
@@ -128,7 +128,7 @@ SESSION = sessionmaker()
 
 def _session(request):  # pragma: no cover
     engine = request.registry["sqlalchemy.engine"]
-    session = SESSION(bind=engine)
+    session = SESSION(bind=engine, future=True)
 
     # If the request has a transaction manager, associate the session with it.
     try:

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -113,6 +113,8 @@ def init(engine, drop=False, stamp=True):  # pragma: nocover
             BASE.metadata.drop_all(engine)
         BASE.metadata.create_all(engine)
 
+        "NOPE"
+
         if stamp:
             alembic.command.stamp(alembic.config.Config("conf/alembic.ini"), "head")
 

--- a/lms/services/group_info.py
+++ b/lms/services/group_info.py
@@ -35,9 +35,12 @@ class GroupInfoService:
         if not group_info:
             group_info = GroupInfo(
                 authority_provided_id=grouping.authority_provided_id,
-                application_instance=grouping.application_instance,
             )
             self._db.add(group_info)
+            # SQLA not happy if added directly ot the object before adding it to the session
+            # "GroupInfo" object is being merged into a Session along the backref cascade path for relationship
+            # doing it in two stages here as a work around
+            group_info.application_instance = grouping.application_instance
 
         # This is very strange. The DB layout is wrong here. You can "steal" a
         # group info row from another application instance by updating it with

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -329,7 +329,7 @@ six==1.15.0
     #   python-dateutil
 soupsieve==2.2.1
     # via beautifulsoup4
-sqlalchemy==1.4.47
+sqlalchemy==2.0.15
     # via
     #   -r requirements/prod.txt
     #   alembic
@@ -359,11 +359,12 @@ translationstring==1.4
     # via
     #   -r requirements/prod.txt
     #   pyramid
-typing-extensions==4.0.0
+typing-extensions==4.6.3
     # via
     #   -r requirements/prod.txt
     #   alembic
     #   async-timeout
+    #   sqlalchemy
 urllib3==1.26.15
     # via
     #   -r requirements/prod.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -332,7 +332,7 @@ six==1.15.0
     #   google-auth
     #   mailchimp-transactional
     #   python-dateutil
-sqlalchemy==1.4.47
+sqlalchemy==2.0.15
     # via
     #   -r requirements/prod.txt
     #   alembic
@@ -367,11 +367,12 @@ translationstring==1.4
     # via
     #   -r requirements/prod.txt
     #   pyramid
-typing-extensions==4.0.0
+typing-extensions==4.6.3
     # via
     #   -r requirements/prod.txt
     #   alembic
     #   async-timeout
+    #   sqlalchemy
 urllib3==1.26.15
     # via
     #   -r requirements/prod.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -319,7 +319,7 @@ six==1.15.0
     #   python-dateutil
 soupsieve==2.2.1
     # via beautifulsoup4
-sqlalchemy==1.4.47
+sqlalchemy==2.0.15
     # via
     #   -r requirements/prod.txt
     #   alembic
@@ -349,11 +349,12 @@ translationstring==1.4
     # via
     #   -r requirements/prod.txt
     #   pyramid
-typing-extensions==4.0.0
+typing-extensions==4.6.3
     # via
     #   -r requirements/prod.txt
     #   alembic
     #   async-timeout
+    #   sqlalchemy
 urllib3==1.26.15
     # via
     #   -r requirements/prod.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -567,7 +567,7 @@ soupsieve==2.2.1
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   beautifulsoup4
-sqlalchemy==1.4.47
+sqlalchemy==2.0.15
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -620,7 +620,7 @@ translationstring==1.4
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pyramid
-typing-extensions==4.0.0
+typing-extensions==4.6.3
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -629,6 +629,7 @@ typing-extensions==4.0.0
     #   astroid
     #   async-timeout
     #   pylint
+    #   sqlalchemy
 urllib3==1.26.15
     # via
     #   -r requirements/bddtests.txt

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -214,7 +214,7 @@ six==1.15.0
     #   google-auth
     #   mailchimp-transactional
     #   python-dateutil
-sqlalchemy==1.4.47
+sqlalchemy==2.0.15
     # via
     #   -r requirements/prod.in
     #   alembic
@@ -234,10 +234,11 @@ transaction==2.4.0
     #   zope-sqlalchemy
 translationstring==1.4
     # via pyramid
-typing-extensions==4.0.0
+typing-extensions==4.6.3
     # via
     #   alembic
     #   async-timeout
+    #   sqlalchemy
 urllib3==1.26.15
     # via
     #   mailchimp-transactional

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -324,7 +324,7 @@ six==1.15.0
     #   google-auth
     #   mailchimp-transactional
     #   python-dateutil
-sqlalchemy==1.4.47
+sqlalchemy==2.0.15
     # via
     #   -r requirements/prod.txt
     #   alembic
@@ -355,11 +355,12 @@ translationstring==1.4
     # via
     #   -r requirements/prod.txt
     #   pyramid
-typing-extensions==4.0.0
+typing-extensions==4.6.3
     # via
     #   -r requirements/prod.txt
     #   alembic
     #   async-timeout
+    #   sqlalchemy
 urllib3==1.26.15
     # via
     #   -r requirements/prod.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ TEST_SETTINGS = {
 
 @pytest.fixture(scope="session")
 def db_engine():
-    engine = sqlalchemy.create_engine(TEST_SETTINGS["database_url"])
+    engine = sqlalchemy.create_engine(TEST_SETTINGS["database_url"], future=True)
 
     # Delete all database tables and re-initialize the database schema based on
     # the current models. Doing this at the beginning of each test run ensures

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -62,7 +62,7 @@ def db_session(db_engine):
     """Get a standalone database session for preparing database state."""
 
     conn = db_engine.connect()
-    session = SESSION(bind=conn)
+    session = SESSION(bind=conn, future=True)
 
     factories.set_sqlalchemy_session(session, persistence="commit")
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -220,7 +220,7 @@ def db_session(db_engine):
     """
     conn = db_engine.connect()
     trans = conn.begin()
-    session = SESSION(bind=conn)
+    session = SESSION(bind=conn, future=True)
     session.begin_nested()
 
     @sqlalchemy.event.listens_for(session, "after_transaction_end")

--- a/tests/unit/lms/models/assignment_grouping_test.py
+++ b/tests/unit/lms/models/assignment_grouping_test.py
@@ -18,6 +18,9 @@ class TestAssignmentGrouping:
         assert rel.grouping == grouping
         assert rel.grouping_id == grouping.id
 
+    @pytest.mark.filterwarnings(
+        "ignore:transaction already deassociated from connection"
+    )
     def test_it_does_not_allow_duplicates(self, db_session, assignment, grouping):
         db_session.add(AssignmentGrouping(assignment=assignment, grouping=grouping))
         db_session.commit()

--- a/tests/unit/lms/models/assignment_membership_test.py
+++ b/tests/unit/lms/models/assignment_membership_test.py
@@ -22,6 +22,9 @@ class TestAssignmentMembership:
         assert membership.lti_role == lti_role
         assert membership.lti_role_id == lti_role.id
 
+    @pytest.mark.filterwarnings(
+        "ignore:transaction already deassociated from connection"
+    )
     def test_it_does_not_allow_duplicates(self, db_session, user, assignment, lti_role):
         db_session.add(
             AssignmentMembership(user=user, assignment=assignment, lti_role=lti_role)

--- a/tests/unit/lms/views/admin/application_instance/upgrade_test.py
+++ b/tests/unit/lms/views/admin/application_instance/upgrade_test.py
@@ -80,6 +80,9 @@ class TestUpgradeApplicationInstanceViews:
     def test_upgrade_instance_callback_already_upgraded(self, views):
         assert views.upgrade_instance_callback() == REDIRECT_TO_UPGRADE_AI
 
+    @pytest.mark.filterwarnings(
+        "ignore:transaction already deassociated from connection"
+    )
     @pytest.mark.usefixtures("with_upgrade_form")
     def test_upgrade_instance_callback_with_duplicate(
         self, views, db_session, lti_registration_service


### PR DESCRIPTION
TODO:

- [x]  Functests should work with `future=True` in connection
- [x] Replace `SQLALCHEMY_SILENCE_UBER_WARNING=1` for `SQLALCHEMY_WARN_20=1`
- [ ] Break down the steps of https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#x-2-x-migration-overview in this description
- [ ] Test the app with the new changes on SQLA 1.4



- [x] ~~Actually switching to SQLA2.0 is blocked by https://github.com/zopefoundation/zope.sqlalchemy/issues/76~~
- [ ] Pylint issue due to https://github.com/pylint-dev/pylint/issues/8138