### PR TITLE
Add a default renderer instead of using override_renderer

### DIFF
--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -10,7 +10,10 @@ LOG = logging.getLogger(__name__)
 
 
 @view_config(
-    route_name="email.unsubscribe", request_method="GET", request_param="token"
+    route_name="email.unsubscribe",
+    request_method="GET",
+    request_param="token",
+    renderer="lms:templates/email/unsubscribe_error.html.jinja2",
 )
 def unsubscribe(request):
     """Unsubscribe the email and tag combination encoded in token."""
@@ -20,7 +23,6 @@ def unsubscribe(request):
         )
     except (InvalidJWTError, ExpiredJWTError):
         LOG.exception("Invalid unsubscribe token")
-        request.override_renderer = "lms:templates/email/unsubscribe_error.html.jinja2"
         return {}
 
     return HTTPFound(location=request.route_url("email.unsubscribed"))

--- a/tests/unit/lms/views/email_test.py
+++ b/tests/unit/lms/views/email_test.py
@@ -24,10 +24,6 @@ def test_unsubscribe_error(pyramid_request, email_unsubscribe_service, exception
 
     result = unsubscribe(pyramid_request)
 
-    assert (
-        pyramid_request.override_renderer
-        == "lms:templates/email/unsubscribe_error.html.jinja2"
-    )
     assert result == {}
 
 


### PR DESCRIPTION
For: 

https://hypothesis.sentry.io/issues/4090125145/?referrer=slack

Without the default we get:

```
ValueError: Could not convert return value of the view callable function
lms.views.email.unsubscribe into a response object. The value returned was {}.
You may have forgotten to define a renderer in the view configuration.
```

even if the template does indeed render correctly but we get a 500 error.

With this change we get the same response but with a 200 instead.