### PR TITLE
Update book-picker modal and focus routing

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
+import { Button, ModalDialog } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
@@ -69,7 +69,7 @@ export default function BookPicker({
     (step === 'select-book' && book) || (step === 'select-chapter' && chapter);
 
   return (
-    <Modal
+    <ModalDialog
       classes={classnames(
         // Set a fix height when selecting a chapter so the modal content
         // doesn't resize after loading.
@@ -85,7 +85,7 @@ export default function BookPicker({
           ? 'Paste link to VitalSource book'
           : 'Pick where to start reading' // "Select a chapter"
       }
-      width="lg"
+      size="lg"
       buttons={
         <>
           <Button data-testid="cancel-button" onClick={onCancel}>
@@ -138,6 +138,6 @@ export default function BookPicker({
           error={error}
         />
       )}
-    </Modal>
+    </ModalDialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ChapterList.tsx
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.tsx
@@ -1,4 +1,5 @@
 import { DataTable, Scroll } from '@hypothesis/frontend-shared/lib/next';
+import { useEffect, useRef } from 'preact/hooks';
 
 import type { Chapter } from '../api-types';
 
@@ -28,6 +29,16 @@ export default function ChapterList({
   onSelectChapter,
   onUseChapter,
 }: ChapterListProps) {
+  const tableRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    // Focus the data-table widget when the component is first rendered
+    tableRef.current!.focus();
+    // We only want to run this effect once.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const columns = [
     {
       label: 'Title',
@@ -43,6 +54,7 @@ export default function ChapterList({
   return (
     <Scroll>
       <DataTable
+        elementRef={tableRef}
         title="Table of Contents"
         columns={columns}
         loading={isLoading}
@@ -50,6 +62,8 @@ export default function ChapterList({
         onSelectRow={onSelectChapter}
         onConfirmRow={onUseChapter}
         selectedRow={selectedChapter}
+        data-testid="chapter-table"
+        tabIndex={-1}
       />
     </Scroll>
   );

--- a/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ChapterList-test.js
@@ -25,6 +25,43 @@ describe('ChapterList', () => {
       />
     );
 
+  describe('initial focus', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('focuses the URL text input element', () => {
+      const beforeFocused = document.activeElement;
+
+      const wrapper = mount(
+        <ChapterList
+          chapters={chapterData}
+          selectedChapter={null}
+          onSelectChapter={noop}
+          onUseChapter={noop}
+        />,
+        {
+          attachTo: container,
+        }
+      );
+
+      const focused = document.activeElement;
+      const table = wrapper
+        .find('table[data-testid="chapter-table"]')
+        .getDOMNode();
+
+      assert.notEqual(beforeFocused, focused);
+      assert.equal(focused, table);
+    });
+  });
+
   it('renders chapter titles', () => {
     const chapterList = renderChapterList();
     const rows = chapterList.find('tbody tr');


### PR DESCRIPTION
This PR updates the `BookPicker` modal from `Modal` to the newer `ModalDialog` to benefit from improved behavior. The contents of this modal show either a "book selector" or a list of chapters in the selected book.

Once the modal was updated and had focus trapping and routing, it was more obvious that we needed to route focus for the "chapter selection" step, so that has been added here as well — the table of chapters receives focus so that the user can navigate more quickly.

Part of #5293

No visual/design changes, just behavior.

<img width="837" alt="image" src="https://user-images.githubusercontent.com/439947/232524607-e5a3680f-1c29-442c-a229-08b08087e96a.png">

<img width="875" alt="image" src="https://user-images.githubusercontent.com/439947/232524679-6fcb769b-c275-4cda-a04e-3ef8874b6350.png">


### Testing

On this branch, create or edit an assignment locally in an LMS with VitalSource enabled (I believe it is enabled for our canvas instance, e.g.). Click into the "VitalSource book" option.
