### PR TITLE
Update modal in `URLPicker` to use `ModalDialog`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
   CancelIcon,
-  Modal,
+  ModalDialog,
   Input,
 } from '@hypothesis/frontend-shared/lib/next';
 import { useRef, useState } from 'preact/hooks';
@@ -52,7 +52,7 @@ export default function URLPicker({
   };
 
   return (
-    <Modal
+    <ModalDialog
       title="Enter URL"
       onClose={onCancel}
       buttons={[
@@ -104,6 +104,6 @@ export default function URLPicker({
           )}
         </div>
       </div>
-    </Modal>
+    </ModalDialog>
   );
 }


### PR DESCRIPTION
This PR updates `URLPicker` to use the newer `ModalDialog` to get focus-trapping and keyboard-navigation and other behavioral improvements. No design changes, just behavior changes.

Part of #5293

<img width="851" alt="image" src="https://user-images.githubusercontent.com/439947/232541277-b368e5f7-b7cb-4161-a117-d4bb18a2a413.png">

## Testing

Create/configure an assignment on this branch and choose the "Enter URL of web page or PDF" option. Focus should be trapped in the modal, and clicking or tabbing or focusing outside of the modal should not close it.