### PR TITLE
Update modal in `JSTORPicker` to `ModalDialog`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
@@ -7,7 +7,7 @@ import {
   Input,
   InputGroup,
   Link,
-  Modal,
+  ModalDialog,
   Thumbnail,
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
@@ -129,12 +129,12 @@ export default function JSTORPicker({
   const isLoading = thumbnail.isLoading || metadata.isLoading;
 
   return (
-    <Modal
+    <ModalDialog
       initialFocus={inputRef}
       onClose={onCancel}
       scrollable={false}
       title="Select JSTOR article"
-      width="lg"
+      size="lg"
       buttons={[
         <Button data-testid="cancel-button" key="cancel" onClick={onCancel}>
           Cancel
@@ -246,6 +246,6 @@ export default function JSTORPicker({
           )}
         </div>
       </div>
-    </Modal>
+    </ModalDialog>
   );
 }


### PR DESCRIPTION
Another part of #5293 

This PR uses `ModalDialog` in the `JSTORPicker`

## Testing

Create or edit an assignment in an instance with JSTOR enabled. Select content via "Select JSTOR Article" button. Modal dialog should trap focus, not close on external click.

<img width="860" alt="image" src="https://user-images.githubusercontent.com/439947/232544033-3c1bdcac-72d0-44e3-b955-619cf8342af7.png">
