### PR TITLE
Update `LMSFilePicker` to use `ModalDialog`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -1,6 +1,6 @@
 import {
   Button,
-  Modal,
+  ModalDialog,
   SpinnerOverlay,
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
@@ -374,7 +374,7 @@ export default function LMSFilePicker({
   }
 
   return (
-    <Modal
+    <ModalDialog
       classes={classnames({
         // Set a fixed height on the modal when displaying a list of files.
         // This prevents the height of the modal changing as items are loaded.
@@ -382,7 +382,7 @@ export default function LMSFilePicker({
       })}
       title="Select file"
       onClose={onCancel}
-      width="lg"
+      size="lg"
       buttons={[
         <Button data-testid="cancel-button" key="cancel" onClick={onCancel}>
           Cancel
@@ -436,6 +436,6 @@ export default function LMSFilePicker({
           />
         </>
       )}
-    </Modal>
+    </ModalDialog>
   );
 }


### PR DESCRIPTION
This PR updates `LMSFilePicker` to use updated `ModalDialog` to get its accessibility and keyboard-navigation enhancements.

<img width="826" alt="image" src="https://user-images.githubusercontent.com/439947/232546435-0546364a-a125-4f85-9bd8-9778be7ad3f9.png">

Part of #5293 

A nice follow-up at some point would be to put initial focus on the table of files.

## Testing

Create or configure an assignment in Canvas with Canvas files enabled. Select the "PDF from Canvas" content option. The modal should trap focus and not close when clicks or focuses happen outside of it.