### PR TITLE
Use `ModalDialog` in `ErrorModal`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
@@ -1,5 +1,5 @@
 import type { ModalProps } from '@hypothesis/frontend-shared/lib/components/feedback/Modal';
-import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
+import { Button, ModalDialog } from '@hypothesis/frontend-shared/lib/next';
 import type { ComponentChildren } from 'preact';
 import { useRef } from 'preact/hooks';
 
@@ -107,7 +107,7 @@ export default function ErrorModal({
     </>
   );
   return (
-    <Modal
+    <ModalDialog
       buttons={buttons}
       initialFocus={focusedDialogButton}
       onClose={onCancel}
@@ -121,6 +121,6 @@ export default function ErrorModal({
         </ErrorDisplay>
       )}
       {!error && children}
-    </Modal>
+    </ModalDialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/ErrorModal-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorModal-test.js
@@ -26,7 +26,10 @@ describe('ErrorModal', () => {
       error: fakeError,
     });
 
-    assert.equal(wrapper.find('Modal').props().title, 'Something went wrong');
+    assert.equal(
+      wrapper.find('ModalDialog').props().title,
+      'Something went wrong'
+    );
   });
 
   it('renders a close button if cancel callback provided', () => {
@@ -66,7 +69,7 @@ describe('ErrorModal', () => {
       title: 'My custom title',
     });
 
-    const modalProps = wrapper.find('Modal').props();
+    const modalProps = wrapper.find('ModalDialog').props();
     assert.equal(modalProps.title, 'My custom title');
   });
 


### PR DESCRIPTION
All right, this is the last modal update! This PR updates `ErrorModal` to use `ModalDialog` for its improved behavior.

You can explore this by visiting the [LMS errors pattern library page](http://localhost:8001/ui-playground/errors) on this branch (easy testing!). Most of the modal examples here don't have a proper `onClose` handler, but the first example under "ErrorModal" does. 

The other modal examples on this page should show focus trapping and keyboard navigation is working.

Note that `summary` elements (e.g. the "Error Details" sections) are not part of the tab navigation sequence. This is probably not great, but would need to be fixed in the hook in `frontend-shared` that generates the tab sequence. And I'll do a little research on it beforehand.

Part of #5293 