### PR TITLE
Explicitly exclude teachers from the is_learner check

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -48,6 +48,10 @@ class LTIUser:
     @property
     def is_learner(self):
         """Whether this user is a learner."""
+
+        if self.is_instructor:
+            return False
+
         return any(
             role.type == RoleType.LEARNER and role.scope == RoleScope.COURSE
             for role in self.lti_roles

--- a/tests/unit/lms/models/lti_user_test.py
+++ b/tests/unit/lms/models/lti_user_test.py
@@ -46,6 +46,17 @@ class TestLTIUser:
 
         assert lti_user.is_learner == is_learner
 
+    def test_is_learner_and_instructor_preference_for_instructor(self):
+        lti_user = factories.LTIUser(
+            lti_roles=[
+                LTIRole(scope=RoleScope.COURSE, type=RoleType.INSTRUCTOR),
+                LTIRole(scope=RoleScope.COURSE, type=RoleType.LEARNER),
+            ]
+        )
+
+        assert not lti_user.is_learner
+        assert lti_user.is_instructor
+
     @pytest.mark.parametrize(
         "role,is_admin",
         [


### PR DESCRIPTION
Our `is_learner` check doesn't exclude teachers so every teacher that also has a role we identify as a student will cause issues.

This situation is caused by:

- Legit teacher and instructor roles in the same course. Now we check the scope of the roles so a teacher that's also a student *in the same course* is probably a very rare occurrence.

- Unknown/un-mapped roles are always mapped to "learner" which is the less privileged role. The `is_learner` check will see those and return true. 


Other possible fixes:

- We could change the order of the conditionals listed below. Once the change is made it wouldn't be very clear that the ordering is relevant (ie checking is_instructor before is_learner). I reckon it would be easy to reintroduce bugs that way.

- Leave unknown roles as unmapped or map them to a "UNKNOWN" type. This might work but I reckon it would need constant maintenance. Also some of this roles are effectively "learner" ones that a teacher might also have.


- Expose a more explicit check something like `LTIRole.check_roles(is_instructor: bool, is_learner: bool)`

Probably a good solution but we seem to only care about one or the other exclusively. Lots of tests might need to change... I reckon we could introduce something along these lines once we need more fine-grained control over the roles for some feature.


- The solution in this PR. Just check `is_instructor` inside `is_learner` and return false if that's the case.


Should fix the issue described here:

https://hypothes-is.slack.com/archives/C2BLQDKHA/p1681742454834829?thread_ts=1681325497.461149&cid=C2BLQDKHA

I reckon we probably have a few edge cases around this that cause confusing bugs.


### All `is_learner` usage in the code base:

In the grouping service, in a three way conditional to use different cases for learners, teachers and teachers while grading

https://github.com/hypothesis/lms/blob/173740e80b99cb1d2f55bbf9e996f1664baf4de6/lms/services/grouping/service.py#L160
https://github.com/hypothesis/lms/blob/173740e80b99cb1d2f55bbf9e996f1664baf4de6/lms/services/grouping/service.py#L191


On launch we decide to whether to add `add_canvas_speedgrader_settings` based on:

https://github.com/hypothesis/lms/blob/173740e80b99cb1d2f55bbf9e996f1664baf4de6/lms/views/lti/basic_launch.py#L269