### PR TITLE
Use a durable RabbitMQ exchange and queue

### DIFF
--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 
 import celery.signals
 from celery import Celery
-from kombu import Exchange, Queue
 from pyramid.scripting import prepare
 
 from lms.app import create_app
@@ -34,14 +33,6 @@ app.conf.update(
     task_acks_late=True,
     # Don't store any results, we only use this for scheduling
     task_ignore_result=True,
-    task_queues=[
-        Queue(
-            "celery",
-            durable=True,
-            routing_key="celery",
-            exchange=Exchange("celery", type="direct", durable=True),
-        ),
-    ],
     # Only accept one task at a time rather than pulling lots off the queue
     # ahead of time. This lets other workers have a go if we fail
     worker_prefetch_multiplier=1,

--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -37,10 +37,9 @@ app.conf.update(
     task_queues=[
         Queue(
             "celery",
-            # We don't care if the messages are lost if the broker restarts
-            durable=False,
+            durable=True,
             routing_key="celery",
-            exchange=Exchange("celery", type="direct", durable=False),
+            exchange=Exchange("celery", type="direct", durable=True),
         ),
     ],
     # Only accept one task at a time rather than pulling lots off the queue


### PR DESCRIPTION
Use a durable RabbitMQ exchange and queue so that any messages are persisted to disk and will survive after a RabbitMQ crash or restart.

A durable exchange and queue may not have been necessary when all we had was the `rotate_keys()` periodic task (although it wouldn't have done any harm) but now that we have the email digests tasks we want our messages to survive RabbitMQ crashes or restarts. We don't want queued messages to be lost and emails not to be delivered.

In general we should set `durable=True` unless we have a good reason not to: it generally won't do any harm and often it will be important not to lose messages in RabbitMQ restarts.

In order for messages to actually be persisted to disk the `delivery_mode` of the message also needs to be set to `2`. Celery does this by default and I've tested locally that persistent delivery mode is being used for LMS's messages.

For docs on RabbitMQ **Message durability** see here: https://www.rabbitmq.com/tutorials/tutorial-two-python.html

Celery uses persistent delivery mode by default: https://docs.celeryq.dev/en/stable/userguide/configuration.html?highlight=persistent#task-default-delivery-mode
