### PR TITLE
Remove unnecessary `broker_transport_options`

### DIFF
--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -18,16 +18,6 @@ LOG = logging.getLogger(__name__)
 app = Celery("lms")
 app.conf.update(
     broker_url=os.environ.get("BROKER_URL"),
-    # What options should we have when sending messages to the queue?
-    broker_transport_options={
-        "max_retries": 2,
-        # The delay until the first retry
-        "interval_start": 0.2,
-        # How many seconds added to the interval for each retry
-        "interval_step": 0.2,
-        # Maximum number of seconds to sleep between each retry
-        "interval_max": 0.6,
-    },
     # Tell celery where our tasks are defined
     imports=("lms.tasks",),
     # Acknowledge tasks after the task has executed, rather than just before


### PR DESCRIPTION
I'm not sure why we need to change these from the defaults?

I'm actually not even sure these actually work.
`broker_transport_options` is a dict of options that will be passed to
the underlying "transport" (RabbitMQ), and it says "See your transport
user manual for supported options (if any)":

https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-transport-options

The [RabbitMQ manual](https://www.rabbitmq.com/documentation.html) doesn't say anything
about `max_retries`, `interval_start`, `interval_step` or `interval_max`
options.

These are Celery task retry policy options:

https://docs.celeryq.dev/en/stable/userguide/calling.html?highlight=interval_start#retry-policy

I don't think they do anything when passed to RabbitMQ via
`broker_transport_options`.
