### PR TITLE
Use early acknowledgement by default

### DIFF
--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -30,8 +30,6 @@ app.conf.update(
     },
     # Tell celery where our tasks are defined
     imports=("lms.tasks",),
-    # Acknowledge tasks after the task has executed, rather than just before
-    task_acks_late=True,
     # Don't store any results, we only use this for scheduling
     task_ignore_result=True,
     task_queues=[

--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -20,7 +20,7 @@ from lms.tasks.celery import app
 LOG = logging.getLogger(__name__)
 
 
-@app.task(bind=True, max_retries=2)
+@app.task(acks_late=True, bind=True, max_retries=2)
 def send_instructor_email_digest_tasks(self, *, batch_size, h_userids=None):
     """
     Generate and send instructor email digests.
@@ -110,7 +110,7 @@ def send_instructor_email_digest_tasks(self, *, batch_size, h_userids=None):
                 )
 
 
-@app.task(bind=True, max_retries=2)
+@app.task(acks_late=True, bind=True, max_retries=2)
 def send_instructor_email_digests(
     self,
     *,


### PR DESCRIPTION
Whether or not a task should use `acks_late=True` needs to be considered
carefully on a per-task basis:

* With early acknowledgement (Celery's default) if the worker dies
  mid-task then the task may never get finished
* With late acknowledgement the task may get run multiple times so
  either the task must be idempotent or you must be willing to tolerate
  duplication of any task side-effects

See https://docs.celeryq.dev/en/stable/faq.html#should-i-use-retry-or-acks-late

Early acknowledgement is Celery's default for good reason: running a
non-idempotent task multiple times could have disastrous consequences.

I think it's better not to change Celery's default here and to
explicitly mark any tasks that we *do* want to use late acknowledgement
with `acks_late=True` in the `@app.task()` decorator.

Note that I haven't added `acks_late=True` to the `rotate_keys()` task
so this commit changes that task from late to early acknowledgement. If
a worker gets terminated in the middle of executing that task I think
it's probably better not to risk running the task multiple times (at the
very least this seems like unnecessary work). The task is run
periodically every hour so we can just wait until the next hour.
