### PR TITLE
Remove unnecessary `task_ignore_result` setting

### DIFF
--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -29,8 +29,6 @@ app.conf.update(
     },
     # Tell celery where our tasks are defined
     imports=("lms.tasks",),
-    # Don't store any results, we only use this for scheduling
-    task_ignore_result=True,
     # Only accept one task at a time rather than pulling lots off the queue
     # ahead of time. This lets other workers have a go if we fail
     worker_prefetch_multiplier=1,


### PR DESCRIPTION
I'm pretty sure this doesn't do anything: we don't have a results backend configured. If we did have one I don't see why we'd change Celery's default here.
