### PR TITLE
Remove some unnecessary Celery worker settings

### DIFF
--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -29,10 +29,6 @@ app.conf.update(
     },
     # Tell celery where our tasks are defined
     imports=("lms.tasks",),
-    # Only accept one task at a time rather than pulling lots off the queue
-    # ahead of time. This lets other workers have a go if we fail
-    worker_prefetch_multiplier=1,
-    worker_disable_rate_limits=True,
 )
 
 


### PR DESCRIPTION
`worker_prefetch_multiplier` is `4` by default and the docs say this is usually a good choice unless you have very long-running tasks. We don't have very long-running tasks (nor should we: they'd be too likely to get terminated mid-task by a deployment or autoscaling down and have to begin again from the start with another worker). I don't see any reason to change Celery's default here:

https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-prefetch-multiplier

`worker_disable_rate_limits` disables all rate limits even if tasks have explicit rate limits set. I see no reason why we would want to do this:

https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-disable-rate-limits
