### PR TITLE
Remove the update to `users_sensitive` which is now a view

### DIFF
--- a/lms/data_tasks/report/refresh/01_entities_refresh.sql
+++ b/lms/data_tasks/report/refresh/01_entities_refresh.sql
@@ -4,9 +4,6 @@ ANALYSE report.raw_users;
 REFRESH MATERIALIZED VIEW CONCURRENTLY report.user_map;
 ANALYSE report.user_map;
 
-REFRESH MATERIALIZED VIEW CONCURRENTLY report.users_sensitive;
-ANALYSE report.users_sensitive;
-
 REFRESH MATERIALIZED VIEW CONCURRENTLY report.group_map;
 ANALYSE report.group_map;
 


### PR DESCRIPTION
For:

 * https://hypothesis.sentry.io/issues/4110010386/?project=259908&referrer=slack
 * https://github.com/hypothesis/report/issues/194

This was a materialized view, but now it's not, and so can't be updated.