### PR TITLE
Handle D2L token errors explicitly as OAuth2TokenError

### DIFF
--- a/lms/services/d2l_api/_basic.py
+++ b/lms/services/d2l_api/_basic.py
@@ -86,6 +86,14 @@ class BasicClient:
                 # server.
                 raise OAuth2TokenError(refreshable=False) from err
 
+            if (
+                "http://docs.valence.desire2learn.com/res/apiprop.html#invalid-token"
+                in response_text
+            ):
+                # There's a few known responses from D2L we rather tackle explicitly as OAuth2TokenError.
+                # They are part of regular operation and they would otherwise fill up the logs with noise.
+                raise OAuth2TokenError(refreshable=err.refreshable) from err
+
             raise
 
     def api_url(self, path, product="lp"):

--- a/tests/unit/lms/services/d2l_api/_basic_test.py
+++ b/tests/unit/lms/services/d2l_api/_basic_test.py
@@ -55,7 +55,7 @@ class TestBasicClient:
 
         assert not exc_info.value.refreshable
 
-    def test_request_raises_OAuth2TokenError_if_the_request_fails_with_an_access_token_error(
+    def test_request_raises_OAuth2TokenError_if_the_request_fails_with_insufficient_scope(
         self, basic_client, oauth_http_service
     ):
         oauth_http_service.request.side_effect = ExternalRequestError(
@@ -68,6 +68,23 @@ class TestBasicClient:
             basic_client.request("GET", "/foo")
 
         assert not exc_info.value.refreshable
+
+    def test_request_raises_OAuth2TokenError_if_the_request_fails_with_an_access_token_error(
+        self, basic_client, oauth_http_service
+    ):
+        oauth_http_service.request.side_effect = ExternalRequestError(
+            response=factories.requests.Response(
+                status_code=401,
+                json_data={
+                    "type": "http://docs.valence.desire2learn.com/res/apiprop.html#invalid-token"
+                },
+            )
+        )
+
+        with pytest.raises(OAuth2TokenError) as exc_info:
+            basic_client.request("GET", "/foo")
+
+        assert exc_info.value.refreshable
 
     @pytest.mark.parametrize(
         "path,product,expected",


### PR DESCRIPTION
This helps reducing noise on sentry as this are expected responses from D2L.


Needed to reduce the noise to tackle:

- https://github.com/hypothesis/product-backlog/issues/1305