### PR TITLE
Split email sending into a separate Celery task

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -29,7 +29,6 @@ from lms.services.lti_registration import LTIRegistrationService
 from lms.services.lti_role_service import LTIRoleService
 from lms.services.lti_user import LTIUserService
 from lms.services.ltia_http import LTIAHTTPService
-from lms.services.mailchimp import MailchimpService
 from lms.services.organization import OrganizationService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
@@ -109,9 +108,7 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.ltia_http.factory", iface=LTIAHTTPService
     )
-    config.register_service_factory(
-        "lms.services.mailchimp.factory", iface=MailchimpService
-    )
+    config.register_service_factory("lms.services.mailchimp.factory", name="mailchimp")
     config.register_service_factory(
         "lms.services.document_url.factory", iface=DocumentURLService
     )

--- a/lms/tasks/mailchimp.py
+++ b/lms/tasks/mailchimp.py
@@ -1,0 +1,16 @@
+"""Celery tasks for sending emails using Mailchimp."""
+
+from lms.services.mailchimp import EmailRecipient, EmailSender
+from lms.tasks.celery import app
+
+
+@app.task(acks_late=True, autoretry_for=(Exception,), max_retries=2, retry_backoff=3600)
+def send_template(*, sender, recipient, **kwargs) -> None:
+    """Send an email using Mailchimp's send-template API."""
+
+    sender = EmailSender(**sender)
+    recipient = EmailRecipient(**recipient)
+
+    with app.request_context() as request:  # pylint:disable=no-member
+        mailchimp_service = request.find_service(name="mailchimp")
+        mailchimp_service.send_template(sender=sender, recipient=recipient, **kwargs)

--- a/tests/unit/lms/tasks/mailchimp_test.py
+++ b/tests/unit/lms/tasks/mailchimp_test.py
@@ -1,0 +1,42 @@
+from contextlib import contextmanager
+from dataclasses import asdict
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.mailchimp import EmailRecipient, EmailSender
+from lms.tasks.mailchimp import send_template
+
+
+@pytest.mark.usefixtures("mailchimp_service")
+class TestSendTemplate:
+    def test_it(self, mailchimp_service):
+        sender = EmailSender("subaccount", "sender_email", "sender_name")
+        recipient = EmailRecipient("recipient_email", "recipient_name")
+
+        send_template(
+            sender=asdict(sender),
+            recipient=asdict(recipient),
+            template_name=sentinel.template_name,
+            template_vars=sentinel.template_vars,
+        )
+
+        mailchimp_service.send_template.assert_called_once_with(
+            sender=sender,
+            recipient=recipient,
+            template_name=sentinel.template_name,
+            template_vars=sentinel.template_vars,
+        )
+
+
+@pytest.fixture(autouse=True)
+def app(patch, pyramid_request):
+    app = patch("lms.tasks.mailchimp.app")
+
+    @contextmanager
+    def request_context():
+        yield pyramid_request
+
+    app.request_context = request_context
+
+    return app

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -297,7 +297,7 @@ def ltia_http_service(mock_service):
 
 @pytest.fixture
 def mailchimp_service(mock_service):
-    return mock_service(MailchimpService)
+    return mock_service(MailchimpService, service_name="mailchimp")
 
 
 @pytest.fixture


### PR DESCRIPTION
There are two reasons for doing this:

1. It makes the code in https://github.com/hypothesis/lms/pull/5347 simpler because the Celery task doesn't have to commit multiple transactions in a single task run

2. It makes for a large number of small tasks (one per email to be sent, one Mailchimp API call per task run) rather than a single large task (a single instance of a task looping over a list of emails to send and calling the Mailchimp API once for each).

   Lots of small tasks is better than one large task for a few reasons:

   1. It avoids hogging a Celery worker for a long time, allows other types of tasks to be interleaved
   2. A worker executing a long-running is more likely to get terminated mid-task. If late acknowledgement is used Rabbit will re-deliver the task to another worker which will have to start all over again. The same thing can of course happen to a short-running task but the amount of work lost that needs to be re-done is less. If early acknowledgement is used the task is not re-delivered and is never completed.

# Testing

1. Log in to https://hypothesis.instructure.com/ as the `eng+canvasteacher@hypothes.is` user and launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873). This is to create the record of the instructor in your local DB

2. Log in to https://hypothesis.instructure.com/ as the `eng+canvasstudent@hypothes.is` user, launch the same assignment, and create an annotation

3. Call `send_instructor_email_digests.delay()` to send a digest email to `eng+canvasteacher@hypothes.is`. Make sure the `updated_after` and `updated_before` times cover the time when you created the student annotation:

   ```python
   $ make shell
   >>> from lms.tasks.email_digests import send_instructor_email_digests
   >>> send_instructor_email_digests.delay(
       h_userids=["acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is"],
       updated_after="2023-04-30T05:00:00",
       updated_before="2023-05-02T05:00:00"
   )
   ```

   Alternatively use the [admin page](http://localhost:8001/admin/email).

4. You should see:

   1. The worker logging that it send an email:
   
      ```
      worker (stderr) | [2023-05-01 13:08:54,348: INFO/ForkPoolWorker-8] lms.tasks.mailchimp.send_template[c6ae86bf-8b81-49bb-aa54-a45d01639ea6] mailchimp_client.send_template({'template_name': 'instructor-email-digest', ...
      ```

   2. You can also log in to Mandrill and see the email that was sent. You need to enter [enter test mode](https://mailchimp.com/developer/transactional/docs/fundamentals/#switch-to-test-mode) and then browse to <https://mandrillapp.com/subaccounts/view?id=devdata> and you should see the email that was sent. (Note that you'll also see emails sent by other developers from their test environments here.)