### PR TITLE
Handle students no longer in the course while scoring them

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -268,6 +268,15 @@ class FileNotFoundInCourse(SerializableError):
         super().__init__(error_code=error_code, details={"file_id": file_id})
 
 
+class StudentNotInCourse(SerializableError):
+    """A student is no longer in the current course."""
+
+    def __init__(self, grading_id):
+        super().__init__(
+            error_code="student_not_in_course", details={"grading_id": grading_id}
+        )
+
+
 def _repr_external_request_exception(exception):
     # Include the details of the request and response for debugging. This
     # appears in the logs and in tools like Sentry and Papertrail.


### PR DESCRIPTION
We can't detect this situation before we try to submit the grade but we can detect the error returned by the grading API.

We could take other actions from here but for now we are only detecting the situation.

We return a new error code that the frontend can't yet handle differently.


D2L: https://hypothesis.sentry.io/issues/3971708774/events/1a08561d4c7e4b38b8f226b34a1054f4/?project=259908
BB: https://hypothesis.sentry.io/issues/3971708774/events/5e01537778014ecd89fce8af70cd7e75/?project=259908


### Testing

- Needs  https://github.com/hypothesis/devdata/pull/83 merged
- `make devdata`

#### D2L

- Login an instructor and try to grade "Student Not In Courses" for this assignment: https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View?ou=6782

- You'll get an error dialog. Note this won't have any helpful text until a solution for https://github.com/hypothesis/lms/pull/5330 gets merged.

- The `/result` endpoint returns something like:
```{"error_code": "student_not_in_course", "details": {"grading_id": "c0ec4f92-882d-41b6-ac85-1da2b252ebe6_377"}}```


#### Blackboard

- Same operation but on https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1