### PR TITLE
Add LTIUser.application_instance to replace application_instance_service.get_current

### DIFF
--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -66,12 +66,7 @@ class LTIEvent(BaseEvent):
         return [role.id for role in self.request.lti_user.lti_roles]
 
     def _get_application_instance_id(self):
-        if application_instance := self.request.find_service(
-            name="application_instance"
-        ).get_current():
-            return application_instance.id
-
-        return None
+        return self.request.lti_user.application_instance_id
 
     def _get_course_id(self):
         context_id = self.request.lti_params.get("context_id")

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 from typing import List
 
+from lms.models.application_instance import ApplicationInstance
 from lms.models.h_user import HUser
 from lms.models.lti_role import LTIRole, RoleScope, RoleType
 
 
 @dataclass
-class LTIUser:
+class LTIUser:  # pylint: disable=too-many-instance-attributes
     """An LTI user."""
 
     user_id: str
@@ -26,6 +27,9 @@ class LTIUser:
 
     application_instance_id: int
     """ID of the application instance this user belongs to"""
+
+    application_instance: ApplicationInstance = None
+    """Application instance this user belongs to"""
 
     email: str = ""
     """The user's email address."""

--- a/lms/product/factory.py
+++ b/lms/product/factory.py
@@ -2,18 +2,13 @@ from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
 from lms.product.d2l import D2L
 from lms.product.product import Product
-from lms.services.application_instance import ApplicationInstanceNotFound
 
 _PRODUCT_MAP = {product.family: product for product in (Blackboard, Canvas, D2L)}
 
 
 def get_product_from_request(request) -> Product:
     """Get the correct product object from the provided request."""
-
-    try:
-        ai = request.find_service(name="application_instance").get_current()
-    except ApplicationInstanceNotFound:
-        ai = None
+    ai = request.lti_user.application_instance if request.lti_user else None
 
     family = _get_family(request, ai)
     product = _PRODUCT_MAP.get(family, Product).from_request(

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -39,6 +39,10 @@ class JSConfig:
     def _h_user(self):
         return self._lti_user.h_user
 
+    @property
+    def _application_instance(self):
+        return self._lti_user.application_instance
+
     def add_document_url(self, document_url):
         """
         Set the document to the document at the given document_url.
@@ -224,7 +228,7 @@ class JSConfig:
             HTML form that we submit
         """
 
-        args = self._request, self._context.application_instance
+        args = self._request, self._application_instance
 
         self._config.update(
             {
@@ -275,7 +279,7 @@ class JSConfig:
                 "context_id": self._request.lti_params["context_id"],
             },
         }
-        if self._context.application_instance.lti_version == "1.3.0":
+        if self._application_instance.lti_version == "1.3.0":
             config["path"] = self._request.route_path(
                 "lti.v13.deep_linking.form_fields"
             )
@@ -300,7 +304,7 @@ class JSConfig:
             students = []
 
             grading_infos = self._grading_info_service.get_by_assignment(
-                application_instance=self._context.application_instance,
+                application_instance=self._application_instance,
                 context_id=self._request.lti_params.get("context_id"),
                 resource_link_id=self._request.lti_params.get("resource_link_id"),
             )
@@ -500,7 +504,7 @@ class JSConfig:
         # mutable. You can do self._hypothesis_client["foo"] = "bar" and the
         # mutation will be preserved.
 
-        if not self._context.application_instance.provisioning:
+        if not self._application_instance.provisioning:
             return {}
 
         api_url = self._request.registry.settings["h_api_url_public"]
@@ -526,7 +530,7 @@ class JSConfig:
 
     def _configure_groups(self, course, assignment):
         """Configure how the client will fetch groups when in LAUNCH mode."""
-        if not self._context.application_instance.provisioning:
+        if not self._application_instance.provisioning:
             return
 
         grouping_type = self._request.find_service(
@@ -578,7 +582,7 @@ class JSConfig:
 
     def _get_lti_launch_debug_values(self):
         """Debug values common to different types of LTI launches."""
-        ai = self._context.application_instance
+        ai = self._application_instance
 
         return {
             "Organization ID": ai.organization.public_id if ai.organization else None,

--- a/lms/resources/lti_launch.py
+++ b/lms/resources/lti_launch.py
@@ -15,11 +15,6 @@ class LTILaunchResource:
         """Return the context resource for an LTI launch request."""
         self._request = request
 
-    @property
-    def application_instance(self):
-        """Return the current request's ApplicationInstance."""
-        return self._request.find_service(name="application_instance").get_current()
-
     @cached_property
     def js_config(self):
         return JSConfig(self, self._request)

--- a/lms/security.py
+++ b/lms/security.py
@@ -248,8 +248,7 @@ def get_lti_user(request) -> Optional[LTIUser]:
 
 def _get_user(request):
     return request.find_service(UserService).get(
-        request.find_service(name="application_instance").get_current(),
-        request.lti_user.user_id,
+        request.lti_user.application_instance, request.lti_user.user_id
     )
 
 

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -54,17 +54,15 @@ class ApplicationInstanceService:
     def __init__(
         self,
         db,
-        request,
         aes_service: AESService,
         organization_service: OrganizationService,
     ):
         self._db = db
-        self._request = request
         self._aes_service = aes_service
         self._organization_service = organization_service
 
     @lru_cache(maxsize=1)
-    def get_current(self) -> ApplicationInstance:
+    def get_for_launch(self, id_) -> ApplicationInstance:
         """
         Return the current request's `ApplicationInstance`.
 
@@ -76,10 +74,8 @@ class ApplicationInstanceService:
         :raise AccountDisabled: If the organization associated with this
             instance is disabled
         """
-        if self._request.lti_user and self._request.lti_user.application_instance_id:
-            application_instance = self.get_by_id(
-                self._request.lti_user.application_instance_id
-            )
+        if id_:
+            application_instance = self.get_by_id(id_)
 
             # Check to see if this application instance belongs to a disabled
             # organization.
@@ -373,7 +369,6 @@ class ApplicationInstanceService:
 def factory(_context, request):
     return ApplicationInstanceService(
         db=request.db,
-        request=request,
         aes_service=request.find_service(AESService),
         organization_service=request.find_service(OrganizationService),
     )

--- a/lms/services/blackboard_api/factory.py
+++ b/lms/services/blackboard_api/factory.py
@@ -3,9 +3,7 @@ from lms.services.blackboard_api.client import BlackboardAPIClient
 
 
 def blackboard_api_client_factory(_context, request):
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
+    application_instance = request.lti_user.application_instance
     settings = request.registry.settings
 
     return BlackboardAPIClient(

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -11,9 +11,7 @@ def canvas_api_client_factory(_context, request):
     :param request: Pyramid request object
     :return: An instance of CanvasAPIClient
     """
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
+    application_instance = request.lti_user.application_instance
 
     developer_secret = application_instance.decrypted_developer_secret(
         request.find_service(AESService)

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -161,8 +161,6 @@ class CourseService:
 def course_service_factory(_context, request):
     return CourseService(
         db=request.db,
-        application_instance=request.find_service(
-            name="application_instance"
-        ).get_current(),
+        application_instance=request.lti_user.application_instance,
         grouping_service=request.find_service(name="grouping"),
     )

--- a/lms/services/d2l_api/factory.py
+++ b/lms/services/d2l_api/factory.py
@@ -4,9 +4,7 @@ from lms.services.d2l_api.client import D2LAPIClient
 
 
 def d2l_api_client_factory(_context, request):
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
+    application_instance = request.lti_user.application_instance
 
     return D2LAPIClient(
         BasicClient(

--- a/lms/services/file.py
+++ b/lms/services/file.py
@@ -89,8 +89,5 @@ class FileService:
 
 def factory(_context, request):
     return FileService(
-        application_instance=request.find_service(
-            name="application_instance"
-        ).get_current(),
-        db=request.db,
+        application_instance=request.lti_user.application_instance, db=request.db
     )

--- a/lms/services/grading_info.py
+++ b/lms/services/grading_info.py
@@ -57,12 +57,8 @@ class GradingInfoService:
             # LIS data is not present on the request.
             return
 
-        application_instance = request.find_service(
-            name="application_instance"
-        ).get_current()
-
         grading_info = self._find_or_create(
-            application_instance=application_instance,
+            application_instance=request.lti_user.application_instance,
             user_id=request.lti_user.user_id,
             context_id=parsed_params["context_id"],
             resource_link_id=parsed_params["resource_link_id"],

--- a/lms/services/grouping/factory.py
+++ b/lms/services/grouping/factory.py
@@ -4,8 +4,6 @@ from lms.services.grouping.service import GroupingService
 def service_factory(_context, request):
     return GroupingService(
         db=request.db,
-        application_instance=request.find_service(
-            name="application_instance"
-        ).get_current(),
+        application_instance=request.lti_user.application_instance,
         plugin=request.product.plugin.grouping,
     )

--- a/lms/services/jstor/factory.py
+++ b/lms/services/jstor/factory.py
@@ -2,10 +2,7 @@ from lms.services.jstor.service import JSTORService
 
 
 def service_factory(_context, request):
-    ai_settings = (
-        request.find_service(name="application_instance").get_current().settings
-    )
-
+    ai_settings = request.lti_user.application_instance.settings
     app_settings = request.registry.settings
 
     return JSTORService(

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -4,9 +4,7 @@ from lms.services.ltia_http import LTIAHTTPService
 
 
 def service_factory(_context, request):
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
+    application_instance = request.lti_user.application_instance
 
     if application_instance.lti_version == "1.3.0":
         return LTI13GradingService(

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -21,11 +21,9 @@ class LTIHService:
 
     def __init__(self, _context, request):
         self._h_user = request.lti_user.h_user
+        self._application_instance = request.lti_user.application_instance
 
         self._authority = request.registry.settings["h_authority"]
-        self._application_instance_service = request.find_service(
-            name="application_instance"
-        )
         self._h_api: HAPI = request.find_service(HAPI)
         self._group_info_service = request.find_service(name="group_info")
 
@@ -43,8 +41,7 @@ class LTIHService:
         :raise ApplicationInstanceNotFound: if
             `request.lti_user.oauth_consumer_key` isn't in the DB
         """
-        application_instance = self._application_instance_service.get_current()
-        if not application_instance.provisioning:
+        if not self._application_instance.provisioning:
             return
 
         self._h_api.execute_bulk(commands=self._yield_commands(groupings))

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -65,12 +65,8 @@ class LTIAHTTPService:
 
 
 def factory(_context, request):
-    lti_registration = (
-        request.find_service(name="application_instance").get_current().lti_registration
-    )
-
     return LTIAHTTPService(
-        lti_registration,
+        request.lti_user.application_instance.lti_registration,
         request.product.plugin.misc,
         request.find_service(JWTService),
         request.find_service(name="http"),

--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -6,9 +6,6 @@ class OAuth1Service:
 
     def __init__(self, _context, request):
         self._request = request
-        self._application_instance_service = request.find_service(
-            name="application_instance"
-        )
 
     def get_client(self):
         """
@@ -19,7 +16,7 @@ class OAuth1Service:
 
         :rtype: OAuth1
         """
-        application_instance = self._application_instance_service.get_current()
+        application_instance = self._request.lti_user.application_instance
 
         return OAuth1(
             client_key=application_instance.consumer_key,

--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -68,7 +68,5 @@ class OAuth2TokenService:
 
 def oauth2_token_service_factory(_context, request):
     return OAuth2TokenService(
-        request.db,
-        request.find_service(name="application_instance").get_current(),
-        request.lti_user.user_id,
+        request.db, request.lti_user.application_instance, request.lti_user.user_id
     )

--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -3,7 +3,7 @@ from lms.services.vitalsource.service import VitalSourceService
 
 
 def service_factory(_context, request):
-    settings = request.find_service(name="application_instance").get_current().settings
+    settings = request.lti_user.application_instance.settings
 
     global_key = request.registry.settings["vitalsource_api_key"]
     customer_key = settings.get("vitalsource", "api_key")

--- a/lms/services/youtube.py
+++ b/lms/services/youtube.py
@@ -17,7 +17,5 @@ class YoutubeService:
 
 
 def factory(_context, request):
-    ai_settings = (
-        request.find_service(name="application_instance").get_current().settings
-    )
+    ai_settings = request.lti_user.application_instance.settings
     return YoutubeService(enabled=ai_settings.get("youtube", "enabled"))

--- a/lms/views/api/blackboard/authorize.py
+++ b/lms/views/api/blackboard/authorize.py
@@ -13,9 +13,7 @@ from lms.validation.authentication import OAuthCallbackSchema
     permission=Permissions.API,
 )
 def authorize(request):
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
+    application_instance = request.lti_user.application_instance
     client_id = request.registry.settings["blackboard_api_client_id"]
     state = OAuthCallbackSchema(request).state_param()
 

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -47,9 +47,7 @@ GROUPS_SCOPES = (
     permission=Permissions.API,
 )
 def authorize(request):
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
+    application_instance = request.lti_user.application_instance
     course_service = request.find_service(name="course")
 
     scopes = FILES_SCOPES

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -38,10 +38,7 @@ class FilesAPIViews:
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
         """
-        application_instance = self.request.find_service(
-            name="application_instance"
-        ).get_current()
-
+        application_instance = self.request.lti_user.application_instance
         assignment = self.request.find_service(name="assignment").get_assignment(
             application_instance.tool_consumer_instance_guid,
             self.request.matchdict["resource_link_id"],

--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -28,9 +28,7 @@ def authorize(request):
     if not scopes:
         raise NotImplementedError("Trying to get a D2L without any scopes")
 
-    application_instance = request.find_service(
-        name="application_instance"
-    ).get_current()
+    application_instance = request.lti_user.application_instance
     state = OAuthCallbackSchema(request).state_param()
 
     return HTTPFound(

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -49,7 +49,7 @@ class BasicLaunchViews:
         self.grouping_service: GroupingService = request.find_service(name="grouping")
         self.course_service: CourseService = request.find_service(name="course")
 
-        self.context.application_instance.check_guid_aligns(
+        self.request.lti_user.application_instance.check_guid_aligns(
             self.request.lti_params.get("tool_consumer_instance_guid")
         )
         self.course = self._record_course()
@@ -293,7 +293,7 @@ class BasicLaunchViews:
         """Persist launch type independent info to the DB."""
 
         self.request.find_service(name="application_instance").update_from_lti_params(
-            self.context.application_instance, self.request.lti_params
+            self.request.lti_user.application_instance, self.request.lti_params
         )
 
         if (

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -64,7 +64,7 @@ def deep_linking_launch(context, request):
     """Handle deep linking launches."""
 
     request.find_service(name="application_instance").update_from_lti_params(
-        context.application_instance, request.lti_params
+        request.lti_user.application_instance, request.lti_params
     )
     course = request.find_service(name="course").get_from_launch(
         request.product, request.lti_params
@@ -107,9 +107,7 @@ class DeepLinkingFieldsViews:
 
     @view_config(route_name="lti.v13.deep_linking.form_fields")
     def file_picker_to_form_fields_v13(self):
-        application_instance = self.request.find_service(
-            name="application_instance"
-        ).get_current()
+        application_instance = self.request.lti_user.application_instance
 
         document_url = self._get_content_url(self.request)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -116,6 +116,7 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
     )
     pyramid_request.lti_user = factories.LTIUser(
         application_instance_id=application_instance.id,
+        application_instance=application_instance,
         user_id=lti_v11_params["user_id"],
         roles=lti_v11_params["roles"],
     )
@@ -281,6 +282,10 @@ def application_instance(db_session):
         provisioning=True,
         settings=ApplicationSettings({}),
     )
+
+    application_instance.settings.set("canvas", "sections_enabled", True)
+    application_instance.settings.set("canvas", "groups_enabled", False)
+
     # Force flush to get a non None application_instance.id
     db_session.flush()
     return application_instance

--- a/tests/unit/lms/events/test_event.py
+++ b/tests/unit/lms/events/test_event.py
@@ -11,7 +11,7 @@ class TestLTIEvent:
     def test_lti_event(
         self,
         pyramid_request,
-        application_instance_service,
+        application_instance,
         course_service,
         assignment_service,
         lti_user,
@@ -21,10 +21,7 @@ class TestLTIEvent:
 
         assert event.user_id == pyramid_request.user.id
         assert event.role_ids == [sentinel.id]
-        assert (
-            event.application_instance_id
-            == application_instance_service.get_current.return_value.id
-        )
+        assert event.application_instance_id == application_instance.id
 
         course_service.get_by_context_id.assert_called_once_with(sentinel.context_id)
         assert event.course_id == course_service.get_by_context_id.return_value.id
@@ -33,15 +30,6 @@ class TestLTIEvent:
             sentinel.tool_guid, sentinel.resource_link_id
         )
         assert event.assignment_id == assignment_service.get_assignment.return_value.id
-
-    @pytest.mark.usefixtures("lti_role_service", "course_service", "assignment_service")
-    def test_lti_event_when_no_application_instance(
-        self, pyramid_request, application_instance_service
-    ):
-        application_instance_service.get_current.return_value = None
-
-        event = LTIEvent(request=pyramid_request, type=sentinel.type)
-        assert not event.application_instance_id
 
     @pytest.mark.usefixtures(
         "lti_role_service", "application_instance_service", "assignment_service"

--- a/tests/unit/lms/product/factory_test.py
+++ b/tests/unit/lms/product/factory_test.py
@@ -7,7 +7,6 @@ from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
 from lms.product.factory import get_product_from_request
 from lms.product.product import Product
-from lms.services.application_instance import ApplicationInstanceNotFound
 
 
 @pytest.mark.usefixtures("application_instance_service")
@@ -105,12 +104,8 @@ class TestGetProductFromRequest:
         assert product == class_.from_request.return_value
         assert product.family == family
 
-    def test_from_application_instance_when_missing(
-        self, pyramid_request, application_instance_service
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound()
-        )
+    def test_from_application_instance_when_missing(self, pyramid_request):
+        pyramid_request.lti_user = None
 
         product = get_product_from_request(pyramid_request)
 

--- a/tests/unit/lms/resources/lti_launch_test.py
+++ b/tests/unit/lms/resources/lti_launch_test.py
@@ -7,12 +7,6 @@ from lms.resources import LTILaunchResource
     "application_instance_service", "assignment_service", "course_service"
 )
 class TestLTILaunchResource:
-    def test_application_instance(self, lti_launch, application_instance_service):
-        assert (
-            lti_launch.application_instance
-            == application_instance_service.get_current.return_value
-        )
-
     def test_js_config(self, pyramid_request, JSConfig):
         lti_launch = LTILaunchResource(pyramid_request)
 
@@ -20,10 +14,6 @@ class TestLTILaunchResource:
 
         JSConfig.assert_called_once_with(lti_launch, pyramid_request)
         assert js_config == JSConfig.return_value
-
-    @pytest.fixture
-    def lti_launch(self, pyramid_request):
-        return LTILaunchResource(pyramid_request)
 
     @pytest.fixture(autouse=True)
     def JSConfig(self, patch):

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -404,11 +404,11 @@ class TestGetLTIUser:
 
 
 class TestGetUser:
-    def test_it(self, pyramid_request, user_service, application_instance_service):
+    def test_it(self, pyramid_request, user_service):
         user = _get_user(pyramid_request)
 
         user_service.get.assert_called_once_with(
-            application_instance_service.get_current.return_value,
+            pyramid_request.lti_user.application_instance,
             pyramid_request.lti_user.user_id,
         )
         assert user == user_service.get.return_value

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -5,7 +5,7 @@ from pyramid.interfaces import ISecurityPolicy
 from pyramid.security import Allowed, Denied
 
 from lms.security import (
-    DeniedWithValidationError,
+    DeniedWithException,
     Identity,
     LMSGoogleSecurityPolicy,
     LTIUserSecurityPolicy,
@@ -162,7 +162,7 @@ class TestLTIUserSecurityPolicy:
 
         is_allowed = policy.permits(pyramid_request, None, "some-permission")
 
-        assert is_allowed == DeniedWithValidationError(validation_error)
+        assert is_allowed == DeniedWithException(validation_error)
 
     @pytest.mark.parametrize(
         "lti_user,expected_userid",

--- a/tests/unit/lms/services/blackboard_api/factory_test.py
+++ b/tests/unit/lms/services/blackboard_api/factory_test.py
@@ -6,7 +6,7 @@ from lms.services.blackboard_api.factory import blackboard_api_client_factory
 
 
 def test_blackboard_api_client_factory(
-    application_instance_service,
+    application_instance,
     http_service,
     file_service,
     oauth_http_service,
@@ -14,7 +14,6 @@ def test_blackboard_api_client_factory(
     BasicClient,
     BlackboardAPIClient,
 ):
-    application_instance = application_instance_service.get_current.return_value
     settings = pyramid_request.registry.settings
 
     service = blackboard_api_client_factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -34,18 +34,16 @@ class TestCanvasAPIClientFactory:
 
     @pytest.mark.usefixtures("aes_service")
     def test_building_the_BasicClient(
-        self, pyramid_request, BasicClient, application_instance_service
+        self, pyramid_request, BasicClient, application_instance
     ):
         canvas_api_client_factory(sentinel.context, pyramid_request)
 
-        BasicClient.assert_called_once_with(
-            application_instance_service.get_current.return_value.lms_host()
-        )
+        BasicClient.assert_called_once_with(application_instance.lms_host())
 
     def test_building_the_AuthenticatedClient(
         self,
         pyramid_request,
-        application_instance_service,
+        application_instance,
         AuthenticatedClient,
         BasicClient,
         oauth2_token_service,
@@ -56,10 +54,8 @@ class TestCanvasAPIClientFactory:
         AuthenticatedClient.assert_called_once_with(
             basic_client=BasicClient.return_value,
             oauth2_token_service=oauth2_token_service,
-            client_id=application_instance_service.get_current.return_value.developer_key,
-            client_secret=application_instance_service.get_current().decrypted_developer_secret(
-                aes_service
-            ),
+            client_id=application_instance.developer_key,
+            client_secret=application_instance.decrypted_developer_secret(aes_service),
             redirect_uri=pyramid_request.route_url("canvas_api.oauth.callback"),
         )
 

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -5,7 +5,7 @@ import pytest
 from h_matchers import Any
 from sqlalchemy.exc import NoResultFound
 
-from lms.models import CourseGroupsExportedFromH, Grouping
+from lms.models import ApplicationSettings, CourseGroupsExportedFromH, Grouping
 from lms.product.product import Product
 from lms.services.course import CourseService, course_service_factory
 from tests import factories
@@ -155,6 +155,7 @@ class TestCourseService:
                 created=datetime.datetime.utcnow(),
             )
         )
+        application_instance.settings = ApplicationSettings({})
         application_instance.settings.set(
             "canvas", "sections_enabled", canvas_sections_enabled
         )
@@ -258,20 +259,12 @@ class TestCourseService:
 
 
 class TestCourseServiceFactory:
-    def test_it(
-        self,
-        pyramid_request,
-        application_instance_service,
-        grouping_service,
-        CourseService,
-    ):
+    def test_it(self, pyramid_request, grouping_service, CourseService):
         svc = course_service_factory(sentinel.context, pyramid_request)
-
-        application_instance_service.get_current.assert_called_once_with()
 
         CourseService.assert_called_once_with(
             db=pyramid_request.db,
-            application_instance=application_instance_service.get_current.return_value,
+            application_instance=pyramid_request.lti_user.application_instance,
             grouping_service=grouping_service,
         )
 

--- a/tests/unit/lms/services/d2l_api/factory_test.py
+++ b/tests/unit/lms/services/d2l_api/factory_test.py
@@ -7,7 +7,6 @@ from lms.services.d2l_api.factory import d2l_api_client_factory
 
 
 def test_d2l_api_client_factory(
-    application_instance_service,
     http_service,
     oauth_http_service,
     aes_service,
@@ -18,7 +17,7 @@ def test_d2l_api_client_factory(
     lti_user,
 ):
     ai = create_autospec(ApplicationInstance)
-    application_instance_service.get_current.return_value = ai
+    pyramid_request.lti_user.application_instance = ai
 
     service = d2l_api_client_factory(sentinel.context, pyramid_request)
 

--- a/tests/unit/lms/services/grouping/factory_test.py
+++ b/tests/unit/lms/services/grouping/factory_test.py
@@ -7,14 +7,12 @@ from lms.services.grouping.factory import service_factory
 
 @pytest.mark.usefixtures("application_instance_service", "with_plugins")
 class TestFactory:
-    def test_it(self, pyramid_request, application_instance_service, GroupingService):
+    def test_it(self, pyramid_request, application_instance, GroupingService):
         svc = service_factory(sentinel.context, pyramid_request)
-
-        application_instance_service.get_current.assert_called_once_with()
 
         GroupingService.assert_called_once_with(
             db=pyramid_request.db,
-            application_instance=application_instance_service.get_current.return_value,
+            application_instance=application_instance,
             plugin=pyramid_request.product.plugin.grouping,
         )
 

--- a/tests/unit/lms/services/jstor/factory_test.py
+++ b/tests/unit/lms/services/jstor/factory_test.py
@@ -10,7 +10,7 @@ class TestServiceFactory:
     def test_it(
         self, pyramid_request, application_instance_service, JSTORService, user_agent
     ):
-        ai_settings = application_instance_service.get_current.return_value.settings
+        ai_settings = pyramid_request.lti_user.application_instance.settings
         ai_settings.set("jstor", "enabled", sentinel.jstor_enabled)
         ai_settings.set("jstor", "site_code", sentinel.jstor_site_code)
 

--- a/tests/unit/lms/services/jstor/factory_test.py
+++ b/tests/unit/lms/services/jstor/factory_test.py
@@ -7,9 +7,7 @@ from lms.services.jstor.factory import service_factory
 
 class TestServiceFactory:
     @pytest.mark.parametrize("user_agent", ("Example UA", None))
-    def test_it(
-        self, pyramid_request, application_instance_service, JSTORService, user_agent
-    ):
+    def test_it(self, pyramid_request, JSTORService, user_agent):
         ai_settings = pyramid_request.lti_user.application_instance.settings
         ai_settings.set("jstor", "enabled", sentinel.jstor_enabled)
         ai_settings.set("jstor", "site_code", sentinel.jstor_site_code)

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -7,14 +7,9 @@ from lms.services.lti_grading.factory import service_factory
 
 class TestFactory:
     def test_v11(
-        self,
-        pyramid_request,
-        application_instance_service,
-        LTI11GradingService,
-        http_service,
-        oauth1_service,
+        self, pyramid_request, LTI11GradingService, http_service, oauth1_service
     ):
-        application_instance_service.get_current.return_value = Mock(lti_version="1.1")
+        pyramid_request.lti_user.application_instance = Mock(lti_version="1.1")
 
         svc = service_factory(sentinel.context, pyramid_request)
 
@@ -23,16 +18,8 @@ class TestFactory:
         )
         assert svc == LTI11GradingService.return_value
 
-    def test_v13(
-        self,
-        pyramid_request,
-        LTI13GradingService,
-        application_instance_service,
-        ltia_http_service,
-    ):
-        application_instance_service.get_current.return_value = Mock(
-            lti_version="1.3.0"
-        )
+    def test_v13(self, pyramid_request, LTI13GradingService, ltia_http_service):
+        pyramid_request.lti_user.application_instance = Mock(lti_version="1.3.0")
 
         svc = service_factory(sentinel.context, pyramid_request)
 

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -4,7 +4,7 @@ import pytest
 from h_api.bulk_api import CommandBuilder
 
 from lms.models import Grouping
-from lms.services import ApplicationInstanceNotFound, HAPIError
+from lms.services import HAPIError
 from lms.services.lti_h import LTIHService
 from tests import factories
 
@@ -12,9 +12,9 @@ from tests import factories
 @pytest.mark.usefixtures("application_instance_service", "h_api", "group_info_service")
 class TestSync:
     def test_sync_does_nothing_if_provisioning_is_disabled(
-        self, application_instance_service, lti_h_svc, h_api, grouping
+        self, application_instance, lti_h_svc, h_api, grouping
     ):
-        application_instance_service.get_current.return_value.provisioning = False
+        application_instance.provisioning = False
 
         lti_h_svc.sync([grouping], sentinel.params)
 
@@ -69,16 +69,6 @@ class TestSync:
             CommandBuilder.group_membership.create("user_0", "group_0").raw,
             CommandBuilder.group_membership.create("user_0", "group_1").raw,
         ]
-
-    def test_sync_raises_if_theres_no_ApplicationInstance(
-        self, application_instance_service, grouping, lti_h_svc
-    ):
-        application_instance_service.get_current.side_effect = (
-            ApplicationInstanceNotFound
-        )
-
-        with pytest.raises(ApplicationInstanceNotFound):
-            lti_h_svc.sync([grouping], sentinel.params)
 
     def test_sync_upserts_the_GroupInfo_into_the_db(
         self, group_info_service, lti_h_svc, grouping

--- a/tests/unit/lms/services/lti_user_test.py
+++ b/tests/unit/lms/services/lti_user_test.py
@@ -48,8 +48,8 @@ class TestLTIUserService:
         }
 
     @pytest.fixture
-    def svc(self, lti_role_service):
-        return LTIUserService(lti_role_service)
+    def svc(self, lti_role_service, application_instance_service):
+        return LTIUserService(lti_role_service, application_instance_service)
 
     @pytest.fixture
     def display_name(self, patch):
@@ -57,7 +57,7 @@ class TestLTIUserService:
 
 
 class TestFactory:
-    @pytest.mark.usefixtures("lti_role_service")
+    @pytest.mark.usefixtures("lti_role_service", "application_instance_service")
     def test_it(self, pyramid_request):
         svc = factory(sentinel.context, pyramid_request)
 

--- a/tests/unit/lms/services/oauth1_test.py
+++ b/tests/unit/lms/services/oauth1_test.py
@@ -9,22 +9,18 @@ pytestmark = pytest.mark.usefixtures("application_instance_service")
 
 
 class TestOAuth1Service:
-    def test_we_configure_OAuth1_correctly(
-        self, service, OAuth1, application_instance_service
-    ):
+    def test_we_configure_OAuth1_correctly(self, service, OAuth1, application_instance):
         service.get_client()
 
         OAuth1.assert_called_once_with(
-            client_key=application_instance_service.get_current.return_value.consumer_key,
-            client_secret=application_instance_service.get_current.return_value.shared_secret,
+            client_key=application_instance.consumer_key,
+            client_secret=application_instance.shared_secret,
             signature_method="HMAC-SHA1",
             signature_type="auth_header",
             force_include_body=True,
         )
 
-    def test_we_can_be_used_to_sign_a_request(
-        self, service, application_instance_service
-    ):
+    def test_we_can_be_used_to_sign_a_request(self, service, application_instance):
         request = Request(
             "POST",
             url="http://example.com",
@@ -39,8 +35,7 @@ class TestOAuth1Service:
         assert auth_header.startswith("OAuth")
         assert 'oauth_version="1.0"' in auth_header
         assert (
-            f'oauth_consumer_key="{application_instance_service.get_current.return_value.consumer_key}"'
-            in auth_header
+            f'oauth_consumer_key="{application_instance.consumer_key}"' in auth_header
         )
         assert 'oauth_signature_method="HMAC-SHA1"' in auth_header
 

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -86,8 +86,7 @@ class TestOAuth2TokenService:
 
 
 class TestOAuth2TokenServiceFactory:
-    def test_it(self, pyramid_request, application_instance_service):
+    def test_it(self, pyramid_request):
         svc = oauth2_token_service_factory(mock.sentinel.context, pyramid_request)
 
-        application_instance_service.get_current.assert_called_once()
         assert isinstance(svc, OAuth2TokenService)

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -17,14 +17,13 @@ class TestServiceFactory:
         pyramid_request,
         VitalSourceService,
         VitalSourceClient,
-        application_instance_service,
         enabled,
         expected,
         customer_api_key,
     ):
         pyramid_request.registry.settings["vitalsource_api_key"] = None
         # This fixture is a bit odd and returns a real application instance
-        ai = application_instance_service.get_current()
+        ai = pyramid_request.lti_user.application_instance
         ai.settings.set("vitalsource", "user_lti_param", sentinel.user_lti_param)
         ai.settings.set("vitalsource", "user_lti_pattern", sentinel.user_lti_pattern)
         ai.settings.set("vitalsource", "api_key", customer_api_key)

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -17,13 +17,11 @@ from tests.matchers import temporary_redirect_to
 class TestAuthorize:
     def test_it_redirects_to_the_Blackboard_authorization_page(
         self,
-        application_instance_service,
+        application_instance,
         OAuthCallbackSchema,
         oauth_callback_schema,
         pyramid_request,
     ):
-        application_instance = application_instance_service.get_current.return_value
-
         response = authorize(pyramid_request)
 
         OAuthCallbackSchema.assert_called_once_with(pyramid_request)

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -20,27 +20,21 @@ pytestmark = pytest.mark.usefixtures(
 
 
 class TestAuthorize:
-    def test_it_redirects_to_the_right_Canvas_endpoint(
-        self, application_instance_service, pyramid_request
-    ):
+    def test_it_redirects_to_the_right_Canvas_endpoint(self, pyramid_request):
         response = authorize.authorize(pyramid_request)
 
         assert response.status_code == 302
-        application_instance_service.get_current.assert_called_once_with()
         assert response.location.startswith(
-            f"{application_instance_service.get_current.return_value.lms_url}login/oauth2/auth"
+            f"{pyramid_request.lti_user.application_instance.lms_url}login/oauth2/auth"
         )
 
-    def test_it_includes_the_client_id_in_a_query_param(
-        self, application_instance_service, pyramid_request
-    ):
+    def test_it_includes_the_client_id_in_a_query_param(self, pyramid_request):
         response = authorize.authorize(pyramid_request)
 
         query_params = parse_qs(urlparse(response.location).query)
 
-        application_instance_service.get_current.assert_called_once_with()
         assert query_params["client_id"] == [
-            str(application_instance_service.get_current.return_value.developer_key)
+            str(pyramid_request.lti_user.application_instance.developer_key)
         ]
 
     def test_it_includes_the_response_type_in_a_query_param(self, pyramid_request):
@@ -131,24 +125,24 @@ class TestAuthorize:
         ]
 
     @pytest.fixture
-    def sections_not_supported(self, application_instance_service):
-        application_instance_service.get_current.return_value.developer_key = None
+    def sections_not_supported(self, application_instance):
+        application_instance.developer_key = None
 
     @pytest.fixture
-    def sections_disabled(self, application_instance_service):
-        application_instance_service.get_current.return_value.settings.set(
+    def sections_disabled(self, pyramid_request):
+        pyramid_request.lti_user.application_instance.settings.set(
             "canvas", "sections_enabled", False
         )
 
     @pytest.fixture
-    def groups_enabled(self, application_instance_service):
-        application_instance_service.get_current.return_value.settings.set(
+    def groups_enabled(self, pyramid_request):
+        pyramid_request.lti_user.application_instance.settings.set(
             "canvas", "groups_enabled", True
         )
 
     @pytest.fixture
-    def with_folders_enabled(self, application_instance_service):
-        application_instance_service.get_current.return_value.settings.set(
+    def with_folders_enabled(self, pyramid_request):
+        pyramid_request.lti_user.application_instance.settings.set(
             "canvas", "folders_enabled", True
         )
 

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -19,13 +19,12 @@ class TestFilesAPIViews:
     def test_via_url(
         self,
         pyramid_request,
-        application_instance_service,
+        application_instance,
         assignment_service,
         canvas_service,
         helpers,
     ):
         document_url = "canvas://file/course/COURSE_ID/file_id/FILE_ID"
-        application_instance = application_instance_service.get_current.return_value
         assignment = assignment_service.get_assignment.return_value
         assignment.document_url = document_url
         pyramid_request.matchdict = {

--- a/tests/unit/lms/views/api/d2l/authorize_test.py
+++ b/tests/unit/lms/views/api/d2l/authorize_test.py
@@ -30,7 +30,6 @@ class TestAuthorize:
     )
     def test_it(
         self,
-        application_instance_service,
         OAuthCallbackSchema,
         oauth_callback_schema,
         pyramid_request,
@@ -39,7 +38,7 @@ class TestAuthorize:
         scopes,
     ):
         ai = create_autospec(ApplicationInstance)
-        application_instance_service.get_current.return_value = ai
+        pyramid_request.lti_user.application_instance = ai
         ai.settings.get.return_value = "CLIENT_ID"
         oauth_callback_schema.state_param.return_value = "STATE"
         pyramid_request.product.settings.groups_enabled = groups

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -49,7 +49,7 @@ class TestBasicLaunchViews:
         )
 
         # `_record_launch()`
-        context.application_instance.check_guid_aligns.assert_called_once_with(
+        pyramid_request.lti_user.application_instance.check_guid_aligns.assert_called_once_with(
             pyramid_request.lti_params["tool_consumer_instance_guid"]
         )
 
@@ -60,11 +60,12 @@ class TestBasicLaunchViews:
         pyramid_request,
         grading_info_service,
         application_instance_service,
+        lti_user,
     ):
         BasicLaunchViews(context, pyramid_request)
 
         application_instance_service.update_from_lti_params.assert_called_once_with(
-            context.application_instance, pyramid_request.lti_params
+            lti_user.application_instance, pyramid_request.lti_params
         )
 
         grading_info_service.upsert_from_request.assert_called_once_with(
@@ -351,9 +352,12 @@ class TestBasicLaunchViews:
         "with_gradable_assignment", "user_is_instructor", "with_canvas"
     )
     def test__show_document_does_not_enable_instructor_toolbar_in_canvas(
-        self, svc, context
+        self,
+        svc,
+        context,
+        application_instance,
     ):
-        context.application_instance.settings.set(
+        application_instance.settings.set(
             "hypothesis", "edit_assignments_enabled", True
         )
 
@@ -449,8 +453,6 @@ class TestBasicLaunchViews:
         context.js_config = mock.create_autospec(JSConfig, spec_set=True, instance=True)
 
         application_instance.check_guid_aligns = mock.Mock()
-        context.application_instance = application_instance
-
         return context
 
     @pytest.fixture

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -25,7 +25,7 @@ class TestDeepLinkingLaunch:
         deep_linking_launch(context, pyramid_request)
 
         application_instance_service.update_from_lti_params.assert_called_once_with(
-            context.application_instance, pyramid_request.lti_params
+            pyramid_request.lti_user.application_instance, pyramid_request.lti_params
         )
         course_service.get_from_launch.assert_called_once_with(
             pyramid_request.product, pyramid_request.lti_params

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -119,13 +119,9 @@ def mock_service(pyramid_config):
 
 @pytest.fixture
 def application_instance_service(mock_service, application_instance):
-    application_instance.settings.set("canvas", "sections_enabled", True)
-    application_instance.settings.set("canvas", "groups_enabled", False)
-
     application_instance_service = mock_service(
         ApplicationInstanceService, service_name="application_instance"
     )
-    application_instance_service.get_current.return_value = application_instance
     application_instance_service.get_by_consumer_key.return_value = application_instance
 
     return application_instance_service


### PR DESCRIPTION
Include application_instance in LTIUser

Removes the relationship between `ApplicationService.get_current` and LTIUser and takes it from the later throughout the application.

This involves a lot of repetitive changes in lots of files for arguably little gain but I reckon this will make any further changes easier in the future.

This also addresses as particular pet peeve of mine where we use `get_stuff_from_db` methods (get_current) many times in a request and have to use caching to avoid the actual query. Here the application instance gets retried early in the request and used when needed.

Application instance is mostly a authentication mechanism. This changes makes that more explicit.

##  Testing

Sanity check:

- Regular launch https://hypothesis.instructure.com/courses/125/assignments/873

- Deeplinking https://hypothesis.instructure.com/courses/125/assignments/873/edit?return_to=https%3A%2F%2Fhypothesis.instructure.com%2Fcourses%2F125%2Fassignments%2F873

- Disable the org here to test the error handling:

http://localhost:8001/admin/org/4
and launch again: https://hypothesis.instructure.com/courses/125/assignments/873