### PR TITLE
Use the DB to avoid sending duplicate emails

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -29,6 +29,7 @@ from lms.models.oauth2_token import OAuth2Token
 from lms.models.organization import Organization
 from lms.models.region import Region, Regions
 from lms.models.rsa_key import RSAKey
+from lms.models.task_done import TaskDone
 from lms.models.user import User
 
 

--- a/lms/models/task_done.py
+++ b/lms/models/task_done.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, DateTime, Integer, UnicodeText, text
+
+from lms.db import BASE
+from lms.models._mixins import CreatedUpdatedMixin
+
+
+class TaskDone(CreatedUpdatedMixin, BASE):
+    __tablename__ = "task_done"
+
+    id = Column(Integer, autoincrement=True, primary_key=True)
+    key = Column(UnicodeText, nullable=False, unique=True)
+    expires_at = Column(
+        DateTime, nullable=False, server_default=text("now() + interval '30 days'")
+    )

--- a/lms/tasks/mailchimp.py
+++ b/lms/tasks/mailchimp.py
@@ -13,4 +13,7 @@ def send_template(*, sender, recipient, **kwargs) -> None:
 
     with app.request_context() as request:  # pylint:disable=no-member
         mailchimp_service = request.find_service(name="mailchimp")
-        mailchimp_service.send_template(sender=sender, recipient=recipient, **kwargs)
+        with request.tm:
+            mailchimp_service.send_template(
+                sender=sender, recipient=recipient, **kwargs
+            )

--- a/lms/views/admin/email.py
+++ b/lms/views/admin/email.py
@@ -67,6 +67,7 @@ class AdminEmailViews:
                 "updated_after": since.isoformat(),
                 "updated_before": until.isoformat(),
                 "override_to_email": to_email,
+                "deduplicate": False,
             },
         )
 

--- a/tests/unit/lms/views/admin/email_test.py
+++ b/tests/unit/lms/views/admin/email_test.py
@@ -19,6 +19,7 @@ class TestAdminEmailViews:
                 "updated_after": "2023-02-27T00:00:00",
                 "updated_before": "2023-02-28T00:00:00",
                 "override_to_email": "someone@hypothes.is",
+                "deduplicate": False,
             },
         )
         assert isinstance(response, HTTPFound)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/5346.

Depends on https://github.com/hypothesis/lms/pull/5331 and https://github.com/hypothesis/lms/pull/5337.

As discussed in https://github.com/hypothesis/lms/discussions/5284 use a new `task_done` DB table to avoid sending duplicate emails.
    
This isn't perfect because a Celery worker could be terminated after sending an email but before committing its transaction to the `task_done` table, in which case a duplicate email could still be sent. But it's probably good enough and probably the best we can do.

# Testing

1. Re-create your DB in order to get the `task_done` table from the models in this PR:

   ```terminal
   make services args=down && make services && make devdata
   ```

2. Log in to https://hypothesis.instructure.com/ as the `eng+canvasteacher@hypothes.is` user and launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873). This is to create the record of the instructor in your local DB

3. Log in to https://hypothesis.instructure.com/ as the `eng+canvasstudent@hypothes.is` user, launch the same assignment, and create an annotation

4. Call `send_instructor_email_digests.delay()` to send a digest email to `eng+canvasteacher@hypothes.is`. Make sure the `updated_after` and `updated_before` times cover the time when you created the student annotation:

   ```python
   $ make shell
   >>> from lms.tasks.email_digests import send_instructor_email_digests
   >>> send_instructor_email_digests.delay(
       h_userids=["acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is"],
       updated_after="2023-04-30T05:00:00",
       updated_before="2023-05-02T05:00:00"
   )
   ```

5. You should see:

   1. The worker logging that it send an email:
   
      ```
      worker (stderr) | [2023-05-01 13:08:54,348: INFO/ForkPoolWorker-8] lms.tasks.mailchimp.send_template[c6ae86bf-8b81-49bb-aa54-a45d01639ea6] mailchimp_client.send_template({'template_name': 'instructor-email-digest', ...
      ```

   2. A row that the worker has created in the `task_done` table:

      ```terminal
      $ make sql
      postgres=# select * from task_done;
      -[ RECORD 1 ]----------------------------------------------------------------------------------------
      created    | 2023-05-01 12:08:54.34693
      updated    | 2023-05-01 12:08:54.34693
      id         | 1
      key        | instructor_email_digest::acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is::2023-05-01
      expires_at | 2023-05-08 12:08:54.838494
      ```

   3. You can also log in to Mandrill and see the email that was sent. You need to enter [enter test mode](https://mailchimp.com/developer/transactional/docs/fundamentals/#switch-to-test-mode) and then browse to <https://mandrillapp.com/subaccounts/view?id=devdata> and you should see the email that was sent. (Note that you'll also see emails sent by other developers from their test environments here.)

6. Attempt to send a duplicate email by repeating the same call to `send_instructor_email_digests.delay()` again.

7. You should see:

   1. The worker logging that it's not sending a duplicate email:
   
      ```terminal
      worker (stderr) | [2023-05-01 13:16:25,798: INFO/ForkPoolWorker-1] lms.tasks.mailchimp.send_template[6f583db2-5bf7-421f-9b9c-f4e5f05a6d82] Not sending duplicate email instructor_email_digest::acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is::2023-05-01
      ```

   2. There should still be only one `task_done` row in the DB
   
   3. In Mandrill you should see that no second email was sent

You can also test using the [admin page](http://localhost:8001/admin/email) to send a digest email to `eng+canvasteacher@hypothes.is`. In this case it should send duplicate emails if you submit the form multiple times: I don't think we want duplication for the admin pages.