### PR TITLE
Add permission for report to read the event and user tables

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/99_grant_permissions/01_grant_schema.jinja2.sql
+++ b/lms/data_tasks/report/create_from_scratch/99_grant_permissions/01_grant_schema.jinja2.sql
@@ -18,12 +18,14 @@
 
     GRANT USAGE ON SCHEMA report TO "{{fdw_user}}";
 
-    GRANT SELECT ON report.organization_activity TO "{{fdw_user}}";
-    GRANT SELECT ON report.organization_roles TO "{{fdw_user}}";
+    GRANT SELECT ON report.events TO "{{fdw_user}}";
     GRANT SELECT ON report.groups TO "{{fdw_user}}";
     GRANT SELECT ON report.group_map TO "{{fdw_user}}";
     GRANT SELECT ON report.group_bubbled_activity TO "{{fdw_user}}";
     GRANT SELECT ON report.group_bubbled_counts TO "{{fdw_user}}";
     GRANT SELECT ON report.group_roles TO "{{fdw_user}}";
+    GRANT SELECT ON report.organization_activity TO "{{fdw_user}}";
+    GRANT SELECT ON report.organization_roles TO "{{fdw_user}}";
+    GRANT SELECT ON report.users TO "{{fdw_user}}";
     GRANT SELECT ON report.users_sensitive TO "{{fdw_user}}";
 {% endfor %}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/194

This works fine in production, but if you follow the correct instructions locally, it doesn't work. This implies we have the wrong user in prod report, but we should fix this regardless.