### PR TITLE
Extract component wrapping URL input form

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -1,7 +1,7 @@
 import { Button, ModalDialog } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
 
-import UrlPickerForm from './UrlPickerForm';
+import URLPickerForm from './URLPickerForm';
 
 export type URLPickerProps = {
   /** The initial value of the URL input field. */
@@ -27,9 +27,9 @@ export default function URLPicker({
   // input field
   const [error, setError] = useState<string | undefined>();
 
-  const submit = () => {
+  const submit = (inputUrl: string) => {
     try {
-      const url = new URL(input.current!.value);
+      const url = new URL(inputUrl);
       if (!url.protocol.startsWith('http')) {
         if (url.protocol.startsWith('file')) {
           setError(
@@ -39,7 +39,7 @@ export default function URLPicker({
           setError('Please use a URL that starts with "http" or "https"');
         }
       } else {
-        onSelectURL(input.current!.value);
+        onSelectURL(inputUrl);
       }
     } catch (e) {
       setError('Please enter a URL, e.g. "https://www.example.com"');
@@ -57,7 +57,7 @@ export default function URLPicker({
         <Button
           data-testid="submit-button"
           key="submit"
-          onClick={submit}
+          onClick={() => submit(input.current!.value)}
           variant="primary"
         >
           Submit
@@ -67,7 +67,7 @@ export default function URLPicker({
     >
       <div className="space-y-4">
         <p>Enter the URL of any publicly available web page or PDF:</p>
-        <UrlPickerForm
+        <URLPickerForm
           onSubmit={submit}
           urlPlaceholder="e.g. https://example.com/article.pdf"
           aria-label="Enter URL to web page or PDF"

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -1,10 +1,7 @@
-import {
-  Button,
-  CancelIcon,
-  ModalDialog,
-  Input,
-} from '@hypothesis/frontend-shared';
+import { Button, ModalDialog } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
+
+import UrlPickerForm from './UrlPickerForm';
 
 export type URLPickerProps = {
   /** The initial value of the URL input field. */
@@ -25,14 +22,12 @@ export default function URLPicker({
   onSelectURL,
 }: URLPickerProps) {
   const input = useRef<HTMLInputElement | null>(null);
-  const form = useRef<HTMLFormElement | null>(null);
 
   // Holds an error message corresponding to client-side validation of the
   // input field
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | undefined>();
 
-  const submit = (event: Event) => {
-    event.preventDefault();
+  const submit = () => {
     try {
       const url = new URL(input.current!.value);
       if (!url.protocol.startsWith('http')) {
@@ -72,37 +67,14 @@ export default function URLPicker({
     >
       <div className="space-y-4">
         <p>Enter the URL of any publicly available web page or PDF:</p>
-        <form
-          ref={form}
-          className="flex flex-row items-center space-x-2"
+        <UrlPickerForm
           onSubmit={submit}
-        >
-          <label htmlFor="url">URL: </label>
-
-          <Input
-            aria-label="Enter URL to web page or PDF"
-            classes="grow"
-            defaultValue={defaultURL}
-            hasError={!!error}
-            elementRef={input}
-            name="url"
-            placeholder="e.g. https://example.com/article.pdf"
-            required
-          />
-        </form>
-        {/** setting a height here "preserves space" for this error display
-         * and prevents the dialog size from jumping when an error is rendered */}
-        <div
-          className="h-4 flex flex-row items-center space-x-1 text-red-error"
-          data-testid="error-message"
-        >
-          {!!error && (
-            <>
-              <CancelIcon />
-              <div className="grow">{error}</div>
-            </>
-          )}
-        </div>
+          urlPlaceholder="e.g. https://example.com/article.pdf"
+          aria-label="Enter URL to web page or PDF"
+          error={error}
+          defaultURL={defaultURL}
+          inputRef={input}
+        />
       </div>
     </ModalDialog>
   );

--- a/lms/static/scripts/frontend_apps/components/URLPickerForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPickerForm.tsx
@@ -1,32 +1,32 @@
 import { CancelIcon, Input } from '@hypothesis/frontend-shared';
-import type { Ref } from 'preact';
+import type { RefObject } from 'preact';
 
 import { useUniqueId } from '../utils/hooks';
 
-export type UrlPickerFormProps = {
-  onSubmit: () => void;
+export type URLPickerFormProps = {
+  onSubmit: (inputUrl: string) => void;
   error?: string;
   urlPlaceholder: string;
   defaultURL?: string;
   'aria-label': string;
-  inputRef?: Ref<HTMLElement | undefined>;
+  inputRef: RefObject<HTMLInputElement | undefined>;
 };
 
 /**
  * A form that displays a single URL input, and optionally, an error
  */
-export default function UrlPickerForm({
+export default function URLPickerForm({
   onSubmit,
   error,
   urlPlaceholder,
   defaultURL,
   'aria-label': ariaLabel,
   inputRef,
-}: UrlPickerFormProps) {
+}: URLPickerFormProps) {
   const id = useUniqueId('url');
   const submit = (event: Event) => {
     event.preventDefault();
-    onSubmit();
+    onSubmit(inputRef.current!.value);
   };
 
   return (

--- a/lms/static/scripts/frontend_apps/components/UrlPickerForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/UrlPickerForm.tsx
@@ -1,0 +1,64 @@
+import { CancelIcon, Input } from '@hypothesis/frontend-shared';
+import type { Ref } from 'preact';
+
+import { useUniqueId } from '../utils/hooks';
+
+export type UrlPickerFormProps = {
+  onSubmit: () => void;
+  error?: string;
+  urlPlaceholder: string;
+  defaultURL?: string;
+  'aria-label': string;
+  inputRef?: Ref<HTMLElement | undefined>;
+};
+
+/**
+ * A form that displays a single URL input, and optionally, an error
+ */
+export default function UrlPickerForm({
+  onSubmit,
+  error,
+  urlPlaceholder,
+  defaultURL,
+  'aria-label': ariaLabel,
+  inputRef,
+}: UrlPickerFormProps) {
+  const id = useUniqueId('url');
+  const submit = (event: Event) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <>
+      <form className="flex flex-row items-center space-x-2" onSubmit={submit}>
+        <label htmlFor={id}>URL: </label>
+
+        <Input
+          aria-label={ariaLabel}
+          classes="grow"
+          defaultValue={defaultURL}
+          hasError={!!error}
+          elementRef={inputRef}
+          name="url"
+          placeholder={urlPlaceholder}
+          required
+          id={id}
+        />
+      </form>
+      {/** setting a height here "preserves space" for this error display
+       * and prevents the dialog size from jumping when an error is rendered */}
+      <div
+        className="h-4 flex flex-row items-center space-x-1 text-red-error"
+        data-testid="error-message"
+      >
+        {!!error && (
+          <>
+            <CancelIcon />
+            <div className="grow">{error}</div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -11,7 +11,7 @@ describe('URLPicker', () => {
       defaultURL: 'https://arxiv.org/pdf/1234.pdf',
     });
     assert.equal(
-      wrapper.find('UrlPickerForm').prop('defaultURL'),
+      wrapper.find('URLPickerForm').prop('defaultURL'),
       'https://arxiv.org/pdf/1234.pdf'
     );
   });
@@ -19,12 +19,9 @@ describe('URLPicker', () => {
   it('invokes `onSelectURL` when user submits a URL', () => {
     const onSelectURL = sinon.stub();
 
-    const wrapper = renderUrlPicker({
-      onSelectURL,
-      defaultURL: 'https://example.com/foo',
-    });
+    const wrapper = renderUrlPicker({ onSelectURL });
 
-    wrapper.find('UrlPickerForm').props().onSubmit();
+    wrapper.find('URLPickerForm').props().onSubmit('https://example.com/foo');
 
     assert.calledWith(onSelectURL, 'https://example.com/foo');
   });
@@ -32,9 +29,9 @@ describe('URLPicker', () => {
   it('does not invoke `onSelectURL` if URL is not valid', () => {
     const onSelectURL = sinon.stub();
 
-    const wrapper = renderUrlPicker({ onSelectURL, defaultURL: 'not-a-url' });
+    const wrapper = renderUrlPicker({ onSelectURL });
 
-    wrapper.find('UrlPickerForm').props().onSubmit();
+    wrapper.find('URLPickerForm').props().onSubmit('not-a-url');
     wrapper.update();
 
     assert.notCalled(onSelectURL);
@@ -46,12 +43,9 @@ describe('URLPicker', () => {
   it('does not invoke `onSelectURL` if URL is for a non-http(s) protocol', () => {
     const onSelectURL = sinon.stub();
 
-    const wrapper = renderUrlPicker({
-      onSelectURL,
-      defaultURL: 'ftp:///warez.fun',
-    });
+    const wrapper = renderUrlPicker({ onSelectURL });
 
-    wrapper.find('UrlPickerForm').props().onSubmit();
+    wrapper.find('URLPickerForm').props().onSubmit('ftp:///warez.fun');
     wrapper.update();
 
     assert.notCalled(onSelectURL);
@@ -63,15 +57,26 @@ describe('URLPicker', () => {
     );
   });
 
+  it('invokes `onSelectURL` when submit button is clicked', () => {
+    const onSelectURL = sinon.stub();
+
+    const wrapper = renderUrlPicker({ onSelectURL });
+
+    wrapper.find('URLPickerForm').prop('inputRef').current.value =
+      'https://example.com/foo';
+    wrapper.update();
+
+    wrapper.find('button[data-testid="submit-button"]').props().onClick();
+
+    assert.calledWith(onSelectURL, 'https://example.com/foo');
+  });
+
   it('shows an additional error message if URL is for a local file', () => {
     const onSelectURL = sinon.stub();
 
-    const wrapper = renderUrlPicker({
-      onSelectURL,
-      defaultURL: 'file:///my/local.pdf',
-    });
+    const wrapper = renderUrlPicker({ onSelectURL });
 
-    wrapper.find('UrlPickerForm').props().onSubmit();
+    wrapper.find('URLPickerForm').props().onSubmit('file:///my/local.pdf');
     wrapper.update();
 
     assert.notCalled(onSelectURL);

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -11,7 +11,7 @@ describe('URLPicker', () => {
       defaultURL: 'https://arxiv.org/pdf/1234.pdf',
     });
     assert.equal(
-      wrapper.find('input').getDOMNode().value,
+      wrapper.find('UrlPickerForm').prop('defaultURL'),
       'https://arxiv.org/pdf/1234.pdf'
     );
   });
@@ -19,13 +19,12 @@ describe('URLPicker', () => {
   it('invokes `onSelectURL` when user submits a URL', () => {
     const onSelectURL = sinon.stub();
 
-    const wrapper = renderUrlPicker({ onSelectURL });
-    wrapper.find('input').getDOMNode().value = 'https://example.com/foo';
+    const wrapper = renderUrlPicker({
+      onSelectURL,
+      defaultURL: 'https://example.com/foo',
+    });
 
-    wrapper
-      .find('button[data-testid="submit-button"]')
-      .props()
-      .onClick(new Event('click'));
+    wrapper.find('UrlPickerForm').props().onSubmit();
 
     assert.calledWith(onSelectURL, 'https://example.com/foo');
   });
@@ -33,13 +32,9 @@ describe('URLPicker', () => {
   it('does not invoke `onSelectURL` if URL is not valid', () => {
     const onSelectURL = sinon.stub();
 
-    const wrapper = renderUrlPicker({ onSelectURL });
-    wrapper.find('input').getDOMNode().value = 'not-a-url';
+    const wrapper = renderUrlPicker({ onSelectURL, defaultURL: 'not-a-url' });
 
-    wrapper
-      .find('button[data-testid="submit-button"]')
-      .props()
-      .onClick(new Event('click'));
+    wrapper.find('UrlPickerForm').props().onSubmit();
     wrapper.update();
 
     assert.notCalled(onSelectURL);
@@ -51,13 +46,12 @@ describe('URLPicker', () => {
   it('does not invoke `onSelectURL` if URL is for a non-http(s) protocol', () => {
     const onSelectURL = sinon.stub();
 
-    const wrapper = renderUrlPicker({ onSelectURL });
-    wrapper.find('input').getDOMNode().value = 'ftp:///warez.fun';
+    const wrapper = renderUrlPicker({
+      onSelectURL,
+      defaultURL: 'ftp:///warez.fun',
+    });
 
-    wrapper
-      .find('button[data-testid="submit-button"]')
-      .props()
-      .onClick(new Event('click'));
+    wrapper.find('UrlPickerForm').props().onSubmit();
     wrapper.update();
 
     assert.notCalled(onSelectURL);
@@ -72,13 +66,12 @@ describe('URLPicker', () => {
   it('shows an additional error message if URL is for a local file', () => {
     const onSelectURL = sinon.stub();
 
-    const wrapper = renderUrlPicker({ onSelectURL });
-    wrapper.find('input').getDOMNode().value = 'file:///my/local.pdf';
+    const wrapper = renderUrlPicker({
+      onSelectURL,
+      defaultURL: 'file:///my/local.pdf',
+    });
 
-    wrapper
-      .find('button[data-testid="submit-button"]')
-      .props()
-      .onClick(new Event('click'));
+    wrapper.find('UrlPickerForm').props().onSubmit();
     wrapper.update();
 
     assert.notCalled(onSelectURL);

--- a/lms/static/scripts/frontend_apps/components/test/URLPickerForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPickerForm-test.js
@@ -1,10 +1,11 @@
 import { mount } from 'enzyme';
+import { createRef } from 'preact';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import UrlPickerForm from '../UrlPickerForm';
+import URLPickerForm from '../URLPickerForm';
 
 describe('URLPicker', () => {
-  const renderUrlPicker = (props = {}) => mount(<UrlPickerForm {...props} />);
+  const renderUrlPicker = (props = {}) => mount(<URLPickerForm {...props} />);
 
   it('pre-fills input with `defaultURL` prop value', () => {
     const wrapper = renderUrlPicker({
@@ -18,11 +19,15 @@ describe('URLPicker', () => {
 
   it('invokes `onSubmit` when user submits a URL', () => {
     const onSubmit = sinon.stub();
-    const wrapper = renderUrlPicker({ onSubmit });
+    const inputRef = createRef();
+    const wrapper = renderUrlPicker({ onSubmit, inputRef });
+
+    wrapper.find('input').getDOMNode().value = 'the-url';
+    wrapper.update();
 
     wrapper.find('form').props().onSubmit(new Event('click'));
 
-    assert.called(onSubmit);
+    assert.calledWith(onSubmit, 'the-url');
   });
 
   it(

--- a/lms/static/scripts/frontend_apps/components/test/URLPickerForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPickerForm-test.js
@@ -1,0 +1,34 @@
+import { mount } from 'enzyme';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import UrlPickerForm from '../UrlPickerForm';
+
+describe('URLPicker', () => {
+  const renderUrlPicker = (props = {}) => mount(<UrlPickerForm {...props} />);
+
+  it('pre-fills input with `defaultURL` prop value', () => {
+    const wrapper = renderUrlPicker({
+      defaultURL: 'https://arxiv.org/pdf/1234.pdf',
+    });
+    assert.equal(
+      wrapper.find('input').getDOMNode().value,
+      'https://arxiv.org/pdf/1234.pdf'
+    );
+  });
+
+  it('invokes `onSubmit` when user submits a URL', () => {
+    const onSubmit = sinon.stub();
+    const wrapper = renderUrlPicker({ onSubmit });
+
+    wrapper.find('form').props().onSubmit(new Event('click'));
+
+    assert.called(onSubmit);
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => renderUrlPicker(),
+    })
+  );
+});


### PR DESCRIPTION
> This PR is part of https://github.com/hypothesis/lms/issues/5328

This PR extracts the form and error rendering of `URLPicker` to a reusable `URLPickerForm` component, so that we can use it with other sources where a URL also needs to be provided, like YouTube.

The error handling and the wrapping modal is kept in `URLPicker`, so that we can add extra contents and validate the URL accordingly for every use case.