### PR TITLE
Youtube picker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -12,6 +12,7 @@ import type { ErrorInfo } from './FilePickerApp';
 import JSTORPicker from './JSTORPicker';
 import LMSFilePicker from './LMSFilePicker';
 import URLPicker from './URLPicker';
+import YouTubePicker from './YouTubePicker';
 
 type DialogType =
   | 'blackboardFile'
@@ -20,6 +21,7 @@ type DialogType =
   | 'jstor'
   | 'url'
   | 'vitalSourceBook'
+  | 'youtube'
   | null;
 
 export type ContentSelectorProps = {
@@ -80,8 +82,10 @@ export default function ContentSelector({
         redirectURI: oneDriveRedirectURI,
       },
       vitalSource: { enabled: vitalSourceEnabled },
+      // youtube: { enabled: youtubeEnabled },
     },
   } = useConfig(['filePicker']);
+  const youtubeEnabled = false;
 
   // Map the existing content selection to a dialog type and value. We don't
   // open the corresponding dialog immediately, but do pre-fill the dialog
@@ -245,6 +249,11 @@ export default function ContentSelector({
         />
       );
       break;
+    case 'youtube':
+      dialog = (
+        <YouTubePicker onCancel={cancelDialog} onSelectURL={console.log} />
+      );
+      break;
     default:
       dialog = null;
   }
@@ -361,6 +370,15 @@ export default function ContentSelector({
               data-testid="vitalsource-button"
             >
               Select book from VitalSource
+            </Button>
+          )}
+          {youtubeEnabled && (
+            <Button
+              onClick={() => selectDialog('youtube')}
+              variant="primary"
+              data-testid="youtube-button"
+            >
+              Enter URL of YouTube video
             </Button>
           )}
         </div>

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -1,0 +1,71 @@
+import { Button, ModalDialog } from '@hypothesis/frontend-shared';
+import { useRef, useState } from 'preact/hooks';
+
+import { InvalidArgumentError } from '../errors';
+import { validateYouTubeVideUrl } from '../utils/youtube';
+import URLPickerForm from './URLPickerForm';
+
+export type YouTubePickerProps = {
+  /** The initial value of the URL input field. */
+  defaultURL?: string;
+
+  onCancel: () => void;
+  /** Callback invoked with the entered URL when the user accepts the dialog */
+  onSelectURL: (url: string) => void;
+};
+
+export default function YouTubePicker({
+  onCancel,
+  defaultURL,
+  onSelectURL,
+}: YouTubePickerProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [error, setError] = useState<string>();
+
+  const onSubmit = (inputUrl: string) => {
+    try {
+      validateYouTubeVideUrl(inputUrl);
+
+      // Hide any error that is currently displayed
+      setError(undefined);
+      onSelectURL(inputUrl);
+    } catch (e) {
+      const errorMessage =
+        e instanceof InvalidArgumentError
+          ? e.message
+          : 'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"';
+      setError(errorMessage);
+    }
+  };
+
+  return (
+    <ModalDialog
+      title="YouTube"
+      onClose={onCancel}
+      initialFocus={inputRef}
+      buttons={[
+        <Button data-testid="cancel-button" key="cancel" onClick={onCancel}>
+          Cancel
+        </Button>,
+        <Button
+          data-testid="submit-button"
+          key="submit"
+          onClick={() => onSubmit(inputRef.current!.value)}
+          variant="primary"
+        >
+          Submit
+        </Button>,
+      ]}
+    >
+      <p>Enter the URL of a YouTube video:</p>
+      <URLPickerForm
+        onSubmit={onSubmit}
+        urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"
+        aria-label="Enter the URL of a YouTube video"
+        inputRef={inputRef}
+        defaultURL={defaultURL}
+        error={error}
+      />
+    </ModalDialog>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -64,6 +64,9 @@ describe('ContentSelector', () => {
         vitalSource: {
           enabled: false,
         },
+        youtube: {
+          enabled: false,
+        },
       },
     };
     $imports.$mock(mockImportedComponents());

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -1,0 +1,65 @@
+import { mount } from 'enzyme';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import YouTubePicker from '../YouTubePicker';
+
+const validYouTubeUrl = 'https://youtu.be/cKxqzvzlnKU';
+
+describe('YouTubePicker', () => {
+  const renderPicker = (props = {}) => mount(<YouTubePicker {...props} />);
+
+  it('pre-fills input with `defaultURL` prop value', () => {
+    const wrapper = renderPicker({
+      defaultURL: validYouTubeUrl,
+    });
+    assert.equal(
+      wrapper.find('URLPickerForm').prop('defaultURL'),
+      validYouTubeUrl
+    );
+  });
+
+  it('invokes `onSelectURL` when user submits a valid YouTube video', () => {
+    const onSelectURL = sinon.stub();
+
+    const wrapper = renderPicker({ onSelectURL });
+
+    wrapper.find('URLPickerForm').props().onSubmit(validYouTubeUrl);
+
+    assert.calledWith(onSelectURL, validYouTubeUrl);
+  });
+
+  it('does not invoke `onSelectURL` if URL is not valid', () => {
+    const onSelectURL = sinon.stub();
+
+    const wrapper = renderPicker({ onSelectURL });
+
+    wrapper.find('URLPickerForm').props().onSubmit('not-a-youtube-url');
+    wrapper.update();
+
+    assert.notCalled(onSelectURL);
+    const errorMessage = wrapper.find('[data-testid="error-message"]');
+    assert.isTrue(errorMessage.exists());
+    assert.include(errorMessage.text(), 'Please enter a YouTube URL');
+  });
+
+  it('invokes `onSelectURL` when submit button is clicked', () => {
+    const onSelectURL = sinon.stub();
+
+    const wrapper = renderPicker({ onSelectURL });
+
+    wrapper.find('URLPickerForm').prop('inputRef').current.value =
+      validYouTubeUrl;
+    wrapper.update();
+
+    wrapper.find('button[data-testid="submit-button"]').props().onClick();
+
+    assert.calledWith(onSelectURL, validYouTubeUrl);
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => renderPicker(),
+    })
+  );
+});

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -110,6 +110,8 @@ export class APIError extends Error {
   }
 }
 
+export class InvalidArgumentError extends Error {}
+
 /**
  * Should the error be treated as an authorization error?
  *

--- a/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
@@ -1,0 +1,42 @@
+import { validateYouTubeVideUrl } from '../youtube';
+
+describe('youtube', () => {
+  [
+    {
+      url: 'foo',
+      expectedError:
+        'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"',
+    },
+    {
+      url: 'file://foo',
+      expectedError: 'Please use a URL that starts with "https"',
+    },
+    {
+      url: 'https://example.com',
+      expectedError: 'Please use a YouTube URL',
+    },
+    {
+      url: 'https://youtube.com/watch',
+      expectedError: 'Please, enter a URL for a specific YouTube video',
+    },
+    {
+      url: 'https://youtu.be',
+      expectedError: 'Please, enter a URL for a specific YouTube video',
+    },
+  ].forEach(({ url, expectedError }) => {
+    it('throws an error when provided URL is not a valid YouTube video', () => {
+      assert.throws(() => validateYouTubeVideUrl(url), expectedError);
+    });
+  });
+
+  [
+    'https://youtu.be/cKxqzvzlnKU',
+    'https://www.youtube.com/watch?v=cKxqzvzlnKU',
+    'https://www.youtube.com/watch?channel=hypothesis&v=cKxqzvzlnKU',
+    'https://www.youtube.com/embed/cKxqzvzlnKU',
+  ].forEach(url => {
+    it('does not throw when provided URL is a valid YouTube video', () => {
+      assert.doesNotThrow(() => validateYouTubeVideUrl(url));
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -1,0 +1,42 @@
+import { InvalidArgumentError } from '../errors';
+
+type YouTubeURL = string;
+
+/**
+ * Tries to match provided URL against known YouTube video URL formats,
+ * throwing an error in case of invalid YouTube URL
+ */
+export function validateYouTubeVideUrl(
+  youTubeUrl: string
+): asserts youTubeUrl is YouTubeURL {
+  let url;
+  try {
+    url = new URL(youTubeUrl);
+  } catch (e) {
+    throw new InvalidArgumentError(
+      'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"'
+    );
+  }
+
+  if (!url.protocol.startsWith('https')) {
+    throw new InvalidArgumentError('Please use a URL that starts with "https"');
+  }
+
+  if (!['www.youtube.com', 'youtube.com', 'youtu.be'].includes(url.host)) {
+    throw new InvalidArgumentError('Please use a YouTube URL');
+  }
+
+  // This regexp tries to match the video ID in the next possible URLs
+  //  * youtu.be/{id}
+  //  * {domain}/watch?v={id}[...]
+  //  * {domain}/embed/{id}[...]
+  // See https://stackoverflow.com/a/9102270 for details
+  const match = youTubeUrl.match(
+    /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/
+  );
+  if (!match?.[2]) {
+    throw new InvalidArgumentError(
+      'Please, enter a URL for a specific YouTube video'
+    );
+  }
+}


### PR DESCRIPTION
This PR adds a new content picker for YouTube videos.

It reuses some of the logic from the `URLPicker` (this PR is based on #5356)

![image](https://user-images.githubusercontent.com/2719332/235885660-4d286f95-66c5-46b3-9985-54175dc75e49.png)

![image](https://user-images.githubusercontent.com/2719332/235886023-c3c65355-fbf3-422b-8c28-b38558204c01.png)

![image](https://user-images.githubusercontent.com/2719332/235886078-781fe090-7259-4265-b418-cdf9290cfda6.png)

### Out of the scope of this PR

- Design of the content selectors. This just adds a new button as a simple entry point until the whole section is redesigned.
- Implement the logic after a valid YouTube URL has been set. That will come on a follow-up PR.
- Handle new feature flag to conditionally display the button. This will be done after https://github.com/hypothesis/lms/pull/5354

### Testing

- Check out this branch.
- Since the feature flag handling is not yet enabled, you need to manually enable thie new button. Go to `ContentSelector.tsx`, and set `const youtubeEnabled = true;`
  ```diff
  - const youtubeEnabled = false;
  + const youtubeEnabled = true;
  ```
- Open an assignment pointing to your localhost lms instance
- Select `Enter URL of YouTube video`.
- Verify that an error is displayed if the URL is not any of the known YouTube video patterns.
- Verify the URL is console-logged when a valid YouTube video is set.