### PR TITLE
Youtube picker (JSTORPicker-based)

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -82,10 +82,9 @@ export default function ContentSelector({
         redirectURI: oneDriveRedirectURI,
       },
       vitalSource: { enabled: vitalSourceEnabled },
-      // youtube: { enabled: youtubeEnabled },
+      youtube: { enabled: youtubeEnabled },
     },
   } = useConfig(['filePicker']);
-  const youtubeEnabled = false;
 
   // Map the existing content selection to a dialog type and value. We don't
   // open the corresponding dialog immediately, but do pre-fill the dialog

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -12,6 +12,7 @@ import type { ErrorInfo } from './FilePickerApp';
 import JSTORPicker from './JSTORPicker';
 import LMSFilePicker from './LMSFilePicker';
 import URLPicker from './URLPicker';
+import YouTubePicker from './YouTubePicker';
 
 type DialogType =
   | 'blackboardFile'
@@ -20,6 +21,7 @@ type DialogType =
   | 'jstor'
   | 'url'
   | 'vitalSourceBook'
+  | 'youtube'
   | null;
 
 export type ContentSelectorProps = {
@@ -80,8 +82,10 @@ export default function ContentSelector({
         redirectURI: oneDriveRedirectURI,
       },
       vitalSource: { enabled: vitalSourceEnabled },
+      // youtube: { enabled: youtubeEnabled },
     },
   } = useConfig(['filePicker']);
+  const youtubeEnabled = false;
 
   // Map the existing content selection to a dialog type and value. We don't
   // open the corresponding dialog immediately, but do pre-fill the dialog
@@ -245,6 +249,11 @@ export default function ContentSelector({
         />
       );
       break;
+    case 'youtube':
+      dialog = (
+        <YouTubePicker onCancel={cancelDialog} onSelectURL={console.log} />
+      );
+      break;
     default:
       dialog = null;
   }
@@ -361,6 +370,15 @@ export default function ContentSelector({
               data-testid="vitalsource-button"
             >
               Select book from VitalSource
+            </Button>
+          )}
+          {youtubeEnabled && (
+            <Button
+              onClick={() => selectDialog('youtube')}
+              variant="primary"
+              data-testid="youtube-button"
+            >
+              Select video from YouTube
             </Button>
           )}
         </div>

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -249,9 +249,7 @@ export default function ContentSelector({
       );
       break;
     case 'youtube':
-      dialog = (
-        <YouTubePicker onCancel={cancelDialog} onSelectURL={console.log} />
-      );
+      dialog = <YouTubePicker onCancel={cancelDialog} onSelectURL={() => {}} />;
       break;
     default:
       dialog = null;

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -19,34 +19,35 @@ export type ThumbnailData = {
 };
 
 export type URLFormWithPreviewProps = {
+  /** Optional extra content to be rendered together with the input and thumbnail */
   children?: ComponentChildren;
+  /** An error message to highlight that something went wrong */
   error?: string;
+  /** Thumbnail info to be displayed, if known */
   thumbnail?: ThumbnailData;
+  /** Reference to be set on the URL input */
   inputRef: RefObject<HTMLInputElement | undefined>;
-  urlPlaceholder?: string;
-  onURLChange: (inputUrl: string) => void;
+  /** Invoked every time the input URL changes, with the value that was input */
+  onURLChange: (inputURL: string) => void;
   label: string;
+  urlPlaceholder?: string;
   defaultURL?: string;
 };
 
 /**
- * Wraps a URL input and a Thumbnail were some kind of preview related with that URL is supposed to be displayed.
- * It also allows to optionally provide the next props:
- *  * `children`: Optional extra content that will be rendered right below the URL input.
- *  * `error`: An error message that will be rendered right below the URL input.
- *             Text is in red and will include a CancelIcon.
- *  * `defaultURL`: An initial value for the URL input. Mostly useful for tests.
+ * Wraps a URL input and a preview of the content available at the entered URL.
  */
 export default function URLFormWithPreview({
   children,
   error,
   thumbnail,
   inputRef,
-  urlPlaceholder,
   onURLChange,
   label,
+  urlPlaceholder,
   defaultURL,
 }: URLFormWithPreviewProps) {
+  const orientation = thumbnail?.orientation ?? 'square';
   const inputId = useUniqueId('url');
   const onChange = () => onURLChange(inputRef.current!.value);
   const onKeyDown = (event: KeyboardEvent) => {
@@ -56,7 +57,6 @@ export default function URLFormWithPreview({
       onChange();
     }
   };
-  const ratio = thumbnail?.orientation ?? 'square';
 
   return (
     <div className="flex flex-row space-x-2">
@@ -66,15 +66,15 @@ export default function URLFormWithPreview({
           // space in the containing Modal
           'w-[200px] min-w-[200px]',
           {
-            'h-[200px]': ratio === 'square', // Default
-            'h-[120px]': ratio === 'landscape',
+            'h-[200px]': orientation === 'square', // Default
+            'h-[120px]': orientation === 'landscape',
           }
         )}
       >
         <Thumbnail
           size="sm"
           loading={thumbnail?.isLoading}
-          ratio={ratio === 'square' ? '1/1' : '16/9'}
+          ratio={orientation === 'square' ? '1/1' : '16/9'}
         >
           {thumbnail?.image && (
             <img
@@ -109,7 +109,7 @@ export default function URLFormWithPreview({
             icon={ArrowRightIcon}
             onClick={onChange}
             variant="dark"
-            title="Find URL"
+            title="Confirm URL"
           />
         </InputGroup>
 

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -20,8 +20,8 @@ export type ThumbnailData = {
 
 export type URLFormWithPreviewProps = {
   children?: ComponentChildren;
-  thumbnail?: ThumbnailData;
   error?: string;
+  thumbnail?: ThumbnailData;
   inputRef: RefObject<HTMLInputElement | undefined>;
   urlPlaceholder?: string;
   onURLChange: (inputUrl: string) => void;
@@ -29,10 +29,18 @@ export type URLFormWithPreviewProps = {
   defaultURL?: string;
 };
 
+/**
+ * Wraps a URL input and a Thumbnail were some kind of preview related with that URL is supposed to be displayed.
+ * It also allows to optionally provide the next props:
+ *  * `children`: Optional extra content that will be rendered right below the URL input.
+ *  * `error`: An error message that will be rendered right below the URL input.
+ *             Text is in red and will include a CancelIcon.
+ *  * `defaultURL`: An initial value for the URL input. Mostly useful for tests.
+ */
 export default function URLFormWithPreview({
   children,
-  thumbnail,
   error,
+  thumbnail,
   inputRef,
   urlPlaceholder,
   onURLChange,
@@ -101,7 +109,7 @@ export default function URLFormWithPreview({
             icon={ArrowRightIcon}
             onClick={onChange}
             variant="dark"
-            title="Find video"
+            title="Find URL"
           />
         </InputGroup>
 

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -11,10 +11,11 @@ import type { ComponentChildren, RefObject } from 'preact';
 
 import { useUniqueId } from '../utils/hooks';
 
-type ThumbnailData = {
+export type ThumbnailData = {
   image?: string;
   alt?: string;
   isLoading?: boolean;
+  ratio?: 'square' | 'landscape';
 };
 
 export type URLFormWithPreviewProps = {
@@ -47,6 +48,7 @@ export default function URLFormWithPreview({
       onChange();
     }
   };
+  const ratio = thumbnail?.ratio ?? 'square';
 
   return (
     <div className="flex flex-row space-x-2">
@@ -54,10 +56,18 @@ export default function URLFormWithPreview({
         className={classnames(
           // Negative vertical margins allow thumbnail to use up more vertical
           // space in the containing Modal
-          '-mb-12 -mt-2 w-[200px] min-w-[200px] h-[200px]'
+          'w-[200px] min-w-[200px]',
+          {
+            'h-[200px]': ratio === 'square', // Default
+            'h-[120px]': ratio === 'landscape',
+          }
         )}
       >
-        <Thumbnail size="sm" loading={thumbnail?.isLoading} ratio="1/1">
+        <Thumbnail
+          size="sm"
+          loading={thumbnail?.isLoading}
+          ratio={ratio === 'square' ? '1/1' : '16/9'}
+        >
           {thumbnail?.image && (
             <img
               className={classnames(

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -15,7 +15,7 @@ export type ThumbnailData = {
   image?: string;
   alt?: string;
   isLoading?: boolean;
-  ratio?: 'square' | 'landscape';
+  orientation?: 'square' | 'landscape';
 };
 
 export type URLFormWithPreviewProps = {
@@ -48,7 +48,7 @@ export default function URLFormWithPreview({
       onChange();
     }
   };
-  const ratio = thumbnail?.ratio ?? 'square';
+  const ratio = thumbnail?.orientation ?? 'square';
 
   return (
     <div className="flex flex-row space-x-2">
@@ -101,7 +101,7 @@ export default function URLFormWithPreview({
             icon={ArrowRightIcon}
             onClick={onChange}
             variant="dark"
-            title="Find article"
+            title="Find video"
           />
         </InputGroup>
 

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -1,0 +1,112 @@
+import {
+  ArrowRightIcon,
+  CancelIcon,
+  IconButton,
+  Input,
+  InputGroup,
+  Thumbnail,
+} from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { ComponentChildren, RefObject } from 'preact';
+
+import { useUniqueId } from '../utils/hooks';
+
+type ThumbnailData = {
+  image?: string;
+  alt?: string;
+  isLoading?: boolean;
+};
+
+export type URLFormWithPreviewProps = {
+  children?: ComponentChildren;
+  thumbnail?: ThumbnailData;
+  error?: string;
+  inputRef: RefObject<HTMLInputElement | undefined>;
+  urlPlaceholder?: string;
+  onURLChange: (inputUrl: string) => void;
+  label: string;
+  defaultURL?: string;
+};
+
+export default function URLFormWithPreview({
+  children,
+  thumbnail,
+  error,
+  inputRef,
+  urlPlaceholder,
+  onURLChange,
+  label,
+  defaultURL,
+}: URLFormWithPreviewProps) {
+  const inputId = useUniqueId('url');
+  const onChange = () => onURLChange(inputRef.current!.value);
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      onChange();
+    }
+  };
+
+  return (
+    <div className="flex flex-row space-x-2">
+      <div
+        className={classnames(
+          // Negative vertical margins allow thumbnail to use up more vertical
+          // space in the containing Modal
+          '-mb-12 -mt-2 w-[200px] min-w-[200px] h-[200px]'
+        )}
+      >
+        <Thumbnail size="sm" loading={thumbnail?.isLoading} ratio="1/1">
+          {thumbnail?.image && (
+            <img
+              className={classnames(
+                // Set up object positioning to "top". Bottom of thumbnail
+                // image is "cropped" as necessary to fit container.
+                'object-top'
+              )}
+              alt={thumbnail.alt}
+              src={thumbnail.image}
+            />
+          )}
+        </Thumbnail>
+      </div>
+      <div className="space-y-2 grow flex flex-col">
+        <p>
+          <label htmlFor={inputId}>{label}</label>
+        </p>
+
+        <InputGroup>
+          <Input
+            defaultValue={defaultURL}
+            elementRef={inputRef}
+            id={inputId}
+            name="URL"
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+            placeholder={urlPlaceholder}
+            spellcheck={false}
+          />
+          <IconButton
+            icon={ArrowRightIcon}
+            onClick={onChange}
+            variant="dark"
+            title="Find article"
+          />
+        </InputGroup>
+
+        {children}
+
+        {error && (
+          <div
+            className="flex flex-row items-center space-x-2 text-red-error"
+            data-testid="error-message"
+          >
+            <CancelIcon />
+            <div className="grow">{error}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -1,9 +1,10 @@
-import { Button, ModalDialog } from '@hypothesis/frontend-shared';
+import { Button, CheckIcon, ModalDialog } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
 
 import { InvalidArgumentError } from '../errors';
 import {
-  validateYouTubeVideUrl,
+  useYouTubeVideoInfo,
+  validateYouTubeVideoUrl,
   videoIdFromYouTubeUrl,
 } from '../utils/youtube';
 import URLFormWithPreview from './URLFormWithPreview';
@@ -27,10 +28,11 @@ export default function YouTubePicker({
     defaultURL && videoIdFromYouTubeUrl(defaultURL)
   );
   const [error, setError] = useState<string>();
+  const { thumbnail, metadata } = useYouTubeVideoInfo(videoId);
 
   const verifyUrl = (inputUrl: string) => {
     try {
-      const videoId = validateYouTubeVideUrl(inputUrl);
+      const videoId = validateYouTubeVideoUrl(inputUrl);
 
       setVideoId(videoId);
       setError(undefined);
@@ -68,7 +70,7 @@ export default function YouTubePicker({
           onClick={confirmSelection}
           variant="primary"
         >
-          Accept and continue
+          Continue
         </Button>,
       ]}
     >
@@ -79,8 +81,17 @@ export default function YouTubePicker({
         urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"
         label="Enter the URL of a YouTube video:"
         defaultURL={defaultURL}
-        thumbnail={undefined}
-      />
+        thumbnail={thumbnail ?? { ratio: 'landscape' }}
+      >
+        {metadata && (
+          <div className="flex flex-row space-x-2" data-testid="selected-book">
+            <CheckIcon className="text-green-success" />
+            <div className="grow font-bold italic">
+              {metadata.title} ({metadata.channel})
+            </div>
+          </div>
+        )}
+      </URLFormWithPreview>
     </ModalDialog>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -1,12 +1,7 @@
 import { Button, CheckIcon, ModalDialog } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
 
-import { InvalidArgumentError } from '../errors';
-import {
-  useYouTubeVideoInfo,
-  validateYouTubeVideoURL,
-  videoIdFromYouTubeURL,
-} from '../utils/youtube';
+import { useYouTubeVideoInfo, videoIdFromYouTubeURL } from '../utils/youtube';
 import URLFormWithPreview from './URLFormWithPreview';
 
 export type YouTubePickerProps = {
@@ -25,25 +20,21 @@ export default function YouTubePicker({
 }: YouTubePickerProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [videoId, setVideoId] = useState(
-    defaultURL && videoIdFromYouTubeURL(defaultURL)
+    (defaultURL && videoIdFromYouTubeURL(defaultURL)) || null
   );
   const [error, setError] = useState<string>();
   const { thumbnail, metadata } = useYouTubeVideoInfo(videoId);
 
   const verifyURL = (inputURL: string) => {
-    try {
-      const videoId = validateYouTubeVideoURL(inputURL);
-
+    const videoId = videoIdFromYouTubeURL(inputURL);
+    if (videoId) {
       setVideoId(videoId);
       setError(undefined);
-    } catch (e) {
-      const errorMessage =
-        e instanceof InvalidArgumentError
-          ? e.message
-          : 'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"';
-
-      setVideoId(undefined);
-      setError(errorMessage);
+    } else {
+      setVideoId(null);
+      setError(
+        'URL must be a YouTube video, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"'
+      );
     }
   };
   const confirmSelection = () => {

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -1,0 +1,86 @@
+import { Button, ModalDialog } from '@hypothesis/frontend-shared';
+import { useRef, useState } from 'preact/hooks';
+
+import { InvalidArgumentError } from '../errors';
+import {
+  validateYouTubeVideUrl,
+  videoIdFromYouTubeUrl,
+} from '../utils/youtube';
+import URLFormWithPreview from './URLFormWithPreview';
+
+export type YouTubePickerProps = {
+  /** The initial value of the URL input field. */
+  defaultURL?: string;
+
+  onCancel: () => void;
+  /** Callback invoked with the entered URL when the user accepts the dialog */
+  onSelectURL: (url: string) => void;
+};
+
+export default function YouTubePicker({
+  onCancel,
+  defaultURL,
+  onSelectURL,
+}: YouTubePickerProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [videoId, setVideoId] = useState(
+    defaultURL && videoIdFromYouTubeUrl(defaultURL)
+  );
+  const [error, setError] = useState<string>();
+
+  const verifyUrl = (inputUrl: string) => {
+    try {
+      const videoId = validateYouTubeVideUrl(inputUrl);
+
+      setVideoId(videoId);
+      setError(undefined);
+    } catch (e) {
+      const errorMessage =
+        e instanceof InvalidArgumentError
+          ? e.message
+          : 'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"';
+
+      setVideoId(undefined);
+      setError(errorMessage);
+    }
+  };
+  const confirmSelection = () => {
+    if (videoId) {
+      onSelectURL(`youtube://${videoId}`);
+    }
+  };
+
+  return (
+    <ModalDialog
+      title="Select YouTube video"
+      onClose={onCancel}
+      initialFocus={inputRef}
+      size="lg"
+      scrollable={false}
+      buttons={[
+        <Button data-testid="cancel-button" key="cancel" onClick={onCancel}>
+          Cancel
+        </Button>,
+        <Button
+          data-testid="select-button"
+          disabled={!videoId}
+          key="submit"
+          onClick={confirmSelection}
+          variant="primary"
+        >
+          Accept and continue
+        </Button>,
+      ]}
+    >
+      <URLFormWithPreview
+        onURLChange={verifyUrl}
+        error={error}
+        inputRef={inputRef}
+        urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"
+        label="Enter the URL of a YouTube video:"
+        defaultURL={defaultURL}
+        thumbnail={undefined}
+      />
+    </ModalDialog>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -4,8 +4,8 @@ import { useRef, useState } from 'preact/hooks';
 import { InvalidArgumentError } from '../errors';
 import {
   useYouTubeVideoInfo,
-  validateYouTubeVideoUrl,
-  videoIdFromYouTubeUrl,
+  validateYouTubeVideoURL,
+  videoIdFromYouTubeURL,
 } from '../utils/youtube';
 import URLFormWithPreview from './URLFormWithPreview';
 
@@ -25,14 +25,14 @@ export default function YouTubePicker({
 }: YouTubePickerProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [videoId, setVideoId] = useState(
-    defaultURL && videoIdFromYouTubeUrl(defaultURL)
+    defaultURL && videoIdFromYouTubeURL(defaultURL)
   );
   const [error, setError] = useState<string>();
   const { thumbnail, metadata } = useYouTubeVideoInfo(videoId);
 
-  const verifyUrl = (inputUrl: string) => {
+  const verifyURL = (inputURL: string) => {
     try {
-      const videoId = validateYouTubeVideoUrl(inputUrl);
+      const videoId = validateYouTubeVideoURL(inputURL);
 
       setVideoId(videoId);
       setError(undefined);
@@ -75,7 +75,7 @@ export default function YouTubePicker({
       ]}
     >
       <URLFormWithPreview
-        onURLChange={verifyUrl}
+        onURLChange={verifyURL}
         error={error}
         inputRef={inputRef}
         urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -84,7 +84,7 @@ export default function YouTubePicker({
         thumbnail={thumbnail ?? { orientation: 'landscape' }}
       >
         {metadata && (
-          <div className="flex flex-row space-x-2" data-testid="selected-book">
+          <div className="flex flex-row space-x-2" data-testid="selected-video">
             <CheckIcon className="text-green-success" />
             <div className="grow font-bold italic">
               {metadata.title} ({metadata.channel})

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -81,7 +81,7 @@ export default function YouTubePicker({
         urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"
         label="Enter the URL of a YouTube video:"
         defaultURL={defaultURL}
-        thumbnail={thumbnail ?? { ratio: 'landscape' }}
+        thumbnail={thumbnail ?? { orientation: 'landscape' }}
       >
         {metadata && (
           <div className="flex flex-row space-x-2" data-testid="selected-book">

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -635,4 +635,25 @@ describe('ContentSelector', () => {
       });
     });
   });
+
+  describe('YouTube picker', () => {
+    it('renders YouTube picker button if enabled', () => {
+      fakeConfig.filePicker.youtube.enabled = true;
+      const wrapper = renderContentSelector();
+      assert.isTrue(wrapper.exists('Button[data-testid="youtube-button"]'));
+    });
+
+    it('shows YouTube picker when YouTube button is clicked', () => {
+      fakeConfig.filePicker.youtube.enabled = true;
+      const onSelectContent = sinon.stub();
+      const wrapper = renderContentSelector({ onSelectContent });
+
+      const button = wrapper.find('Button[data-testid="youtube-button"]');
+      interact(wrapper, () => {
+        button.props().onClick();
+      });
+
+      assert.isTrue(wrapper.exists('YouTubePicker'));
+    });
+  });
 });

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -64,6 +64,9 @@ describe('ContentSelector', () => {
         vitalSource: {
           enabled: false,
         },
+        youtube: {
+          enabled: false,
+        },
       },
     };
     $imports.$mock(mockImportedComponents());

--- a/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
@@ -128,7 +128,7 @@ describe('URLFormWithPreview', () => {
       assert.calledWith(onURLChange, 'https://example.com');
     });
 
-    it('invokes `onURLChange` when "Find video" is clicked', () => {
+    it('invokes `onURLChange` when confirm button is clicked', () => {
       const onURLChange = sinon.stub();
       const wrapper = renderComponent({ onURLChange });
       const input = wrapper.find('Input').find('input');

--- a/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
@@ -1,0 +1,143 @@
+import { mount } from 'enzyme';
+import { createRef } from 'preact';
+
+import URLFormWithPreview from '../URLFormWithPreview';
+
+describe('URLFormWithPreview', () => {
+  const renderComponent = (props = {}) =>
+    mount(
+      <URLFormWithPreview
+        label="Default label"
+        onURLChange={sinon.stub()}
+        inputRef={createRef()}
+        {...props}
+      />
+    );
+
+  it('pre-fills input with `defaultURL` prop value', () => {
+    const wrapper = renderComponent({
+      defaultURL: 'https://arxiv.org/pdf/1234.pdf',
+    });
+    assert.equal(
+      wrapper.find('input').getDOMNode().value,
+      'https://arxiv.org/pdf/1234.pdf'
+    );
+  });
+
+  it('displays children if provided', () => {
+    const wrapper = renderComponent({
+      children: <span data-testid="form-children">Foo</span>,
+    });
+    const childrenComponent = wrapper.find('[data-testid="form-children"]');
+
+    assert.isTrue(childrenComponent.exists());
+    assert.equal(childrenComponent.text(), 'Foo');
+  });
+
+  it('displays error if provided', () => {
+    const error = 'Something went wrong';
+    const wrapper = renderComponent({ error });
+    const errorComponent = wrapper.find('[data-testid="error-message"]');
+
+    assert.isTrue(errorComponent.exists());
+    assert.equal(errorComponent.text(), error);
+  });
+
+  it('displays label as provided', () => {
+    const label = 'Introduce some URL';
+    const wrapper = renderComponent({ label });
+    const labelComponent = wrapper.find('label');
+
+    assert.isTrue(labelComponent.exists());
+    assert.equal(labelComponent.text(), label);
+  });
+
+  [
+    { orientation: 'square', expectedClass: 'h-[200px]' },
+    { orientation: 'landscape', expectedClass: 'h-[120px]' },
+  ].forEach(({ orientation, expectedClass }) => {
+    it(`has proper thumbnail container classes for "${orientation}" orientation`, () => {
+      const wrapper = renderComponent({
+        thumbnail: { orientation },
+      });
+      const thumbnailContainer = wrapper.find('Thumbnail').parent();
+
+      assert.include(thumbnailContainer.prop('className'), expectedClass);
+    });
+  });
+
+  [
+    { orientation: 'square', expectedRatio: '1/1' },
+    { orientation: 'landscape', expectedRatio: '16/9' },
+  ].forEach(({ orientation, expectedRatio }) => {
+    it(`has proper thumbnail ratio for "${orientation}" orientation`, () => {
+      const wrapper = renderComponent({
+        thumbnail: { orientation },
+      });
+      const thumbnail = wrapper.find('Thumbnail');
+
+      assert.equal(thumbnail.prop('ratio'), expectedRatio);
+    });
+  });
+
+  it('does not render thumbnail img if not provided', () => {
+    const wrapper = renderComponent();
+    const thumbnail = wrapper.find('Thumbnail');
+
+    assert.isFalse(thumbnail.find('img').exists());
+  });
+
+  it('renders thumbnail img if provided', () => {
+    const wrapper = renderComponent({
+      thumbnail: {
+        image: 'https://placekitten.com/400/400',
+        alt: 'Placeholder kitten',
+      },
+    });
+    const thumbnail = wrapper.find('Thumbnail');
+    const img = thumbnail.find('img');
+
+    assert.isTrue(img.exists());
+    assert.equal(img.prop('src'), 'https://placekitten.com/400/400');
+    assert.equal(img.prop('alt'), 'Placeholder kitten');
+  });
+
+  context('entering, changing and submitting URL', () => {
+    it('invokes `onURLChange` when the value of the url input changes', () => {
+      const onURLChange = sinon.stub();
+      const wrapper = renderComponent({ onURLChange });
+      const input = wrapper.find('Input').find('input');
+
+      input.getDOMNode().value = 'https://example.com';
+      input.simulate('change');
+
+      assert.calledWith(onURLChange, 'https://example.com');
+    });
+
+    it('invokes `onURLChange` when Enter key is pressed on url input', () => {
+      const onURLChange = sinon.stub();
+      const wrapper = renderComponent({ onURLChange });
+      const inputDomNode = wrapper.find('Input').find('input').getDOMNode();
+
+      const keyEvent = new Event('keydown');
+      keyEvent.key = 'Enter';
+
+      inputDomNode.value = 'https://example.com';
+      inputDomNode.dispatchEvent(keyEvent);
+
+      assert.calledWith(onURLChange, 'https://example.com');
+    });
+
+    it('invokes `onURLChange` when "Find video" is clicked', () => {
+      const onURLChange = sinon.stub();
+      const wrapper = renderComponent({ onURLChange });
+      const input = wrapper.find('Input').find('input');
+      const button = wrapper.find('IconButton').find('button');
+
+      input.getDOMNode().value = 'https://example.com';
+      button.simulate('click');
+
+      assert.calledWith(onURLChange, 'https://example.com');
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -1,0 +1,99 @@
+import { mount } from 'enzyme';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+import YouTubePicker, { $imports } from '../YouTubePicker';
+
+describe('YouTubePicker', () => {
+  let fakeUseYouTubeVideoInfo;
+  let fakeOnCancel;
+  let fakeOnSelectURL;
+
+  beforeEach(() => {
+    fakeUseYouTubeVideoInfo = sinon.stub().returns({});
+    fakeOnCancel = sinon.stub();
+    fakeOnSelectURL = sinon.stub();
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../utils/youtube': { useYouTubeVideoInfo: fakeUseYouTubeVideoInfo },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  const renderComponent = (props = {}) =>
+    mount(
+      <YouTubePicker
+        onCancel={fakeOnCancel}
+        onSelectURL={fakeOnSelectURL}
+        defaultURL="https://youtu.be/videoId"
+        {...props}
+      />
+    );
+
+  it('invokes `onCancel` when dialog is closed', () => {
+    const wrapper = renderComponent();
+
+    wrapper.find('ModalDialog').props().onClose();
+    assert.called(fakeOnCancel);
+  });
+
+  it('invokes `onCancel` when Cancel button is clicked', () => {
+    const wrapper = renderComponent();
+
+    wrapper.find('button[data-testid="cancel-button"]').props().onClick();
+    assert.called(fakeOnCancel);
+  });
+
+  it('invokes `onSelectURL` when Continue button is clicked', () => {
+    const wrapper = renderComponent();
+
+    wrapper.find('button[data-testid="select-button"]').props().onClick();
+    assert.calledWith(fakeOnSelectURL, 'youtube://videoId');
+  });
+
+  [undefined, 'not-a-youtube-url'].forEach(defaultURL => {
+    it('disables Continue button as long as a valid URL has not been set', () => {
+      const wrapper = renderComponent({ defaultURL });
+      assert.isTrue(
+        wrapper.find('button[data-testid="select-button"]').prop('disabled')
+      );
+    });
+  });
+
+  it('sets validation error when trying to set an invalid URL', () => {
+    const wrapper = renderComponent();
+
+    // Invoking onURLChange with an invalid URL will set the error
+    wrapper.find('URLFormWithPreview').props().onURLChange('not-a-youtube-url');
+    wrapper.update();
+
+    assert.isDefined(wrapper.find('URLFormWithPreview').prop('error'));
+
+    // Invoking onURLChange with a valid URL will remove the error above
+    wrapper
+      .find('URLFormWithPreview')
+      .props()
+      .onURLChange('https://youtube.com/watch?v=videoId');
+    wrapper.update();
+
+    assert.isUndefined(wrapper.find('URLFormWithPreview').prop('error'));
+  });
+
+  it('displays video metadata when available', () => {
+    fakeUseYouTubeVideoInfo.returns({
+      metadata: {
+        title: 'The video title',
+        channel: 'Hypothesis',
+      },
+    });
+
+    const wrapper = renderComponent();
+    const metadata = wrapper.find('[data-testid="selected-video"]');
+
+    assert.isTrue(metadata.exists());
+    assert.equal(metadata.text(), 'The video title (Hypothesis)');
+  });
+});

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -110,6 +110,8 @@ export class APIError extends Error {
   }
 }
 
+export class InvalidArgumentError extends Error {}
+
 /**
  * Should the error be treated as an authorization error?
  *

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -110,8 +110,6 @@ export class APIError extends Error {
   }
 }
 
-export class InvalidArgumentError extends Error {}
-
 /**
  * Should the error be treated as an authorization error?
  *

--- a/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
@@ -1,7 +1,7 @@
-import { validateYouTubeVideoUrl, videoIdFromYouTubeUrl } from '../youtube';
+import { validateYouTubeVideoURL, videoIdFromYouTubeURL } from '../youtube';
 
 describe('youtube', () => {
-  describe('videoIdFromYouTubeUrl', () => {
+  describe('videoIdFromYouTubeURL', () => {
     [
       { url: 'https://youtu.be/cKxqzvzlnKU', expectedId: 'cKxqzvzlnKU' },
       { url: 'https://www.youtube.com/watch?v=123', expectedId: '123' },
@@ -23,7 +23,7 @@ describe('youtube', () => {
       },
     ].forEach(({ url, expectedId }) => {
       it('resolves ID from valid YouTube video', () => {
-        assert.equal(videoIdFromYouTubeUrl(url), expectedId);
+        assert.equal(videoIdFromYouTubeURL(url), expectedId);
       });
     });
   });
@@ -53,7 +53,7 @@ describe('youtube', () => {
       },
     ].forEach(({ url, expectedError }) => {
       it('throws an error when provided URL is not a valid YouTube video', () => {
-        assert.throws(() => validateYouTubeVideoUrl(url), expectedError);
+        assert.throws(() => validateYouTubeVideoURL(url), expectedError);
       });
     });
 
@@ -67,7 +67,7 @@ describe('youtube', () => {
       'https://www.youtube.com/live/cKxqzvzlnKU?feature=share',
     ].forEach(url => {
       it('does not throw when provided URL is a valid YouTube video', () => {
-        assert.doesNotThrow(() => validateYouTubeVideoUrl(url));
+        assert.doesNotThrow(() => validateYouTubeVideoURL(url));
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
@@ -13,6 +13,14 @@ describe('youtube', () => {
         url: 'https://www.youtube.com/embed/embeddedId',
         expectedId: 'embeddedId',
       },
+      {
+        url: 'https://www.youtube.com/shorts/shortId',
+        expectedId: 'shortId',
+      },
+      {
+        url: 'https://www.youtube.com/live/liveId?feature=share',
+        expectedId: 'liveId',
+      },
     ].forEach(({ url, expectedId }) => {
       it('resolves ID from valid YouTube video', () => {
         assert.equal(videoIdFromYouTubeUrl(url), expectedId);
@@ -54,6 +62,9 @@ describe('youtube', () => {
       'https://www.youtube.com/watch?v=cKxqzvzlnKU',
       'https://www.youtube.com/watch?channel=hypothesis&v=cKxqzvzlnKU',
       'https://www.youtube.com/embed/cKxqzvzlnKU',
+      'https://www.youtube.com/shorts/cKxqzvzlnKU',
+      'https://www.youtube.com/live/cKxqzvzlnKU',
+      'https://www.youtube.com/live/cKxqzvzlnKU?feature=share',
     ].forEach(url => {
       it('does not throw when provided URL is a valid YouTube video', () => {
         assert.doesNotThrow(() => validateYouTubeVideoUrl(url));

--- a/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
@@ -1,0 +1,63 @@
+import { validateYouTubeVideUrl, videoIdFromYouTubeUrl } from '../youtube';
+
+describe('youtube', () => {
+  describe('videoIdFromYouTubeUrl', () => {
+    [
+      { url: 'https://youtu.be/cKxqzvzlnKU', expectedId: 'cKxqzvzlnKU' },
+      { url: 'https://www.youtube.com/watch?v=123', expectedId: '123' },
+      {
+        url: 'https://www.youtube.com/watch?channel=hypothesis&v=foo',
+        expectedId: 'foo',
+      },
+      {
+        url: 'https://www.youtube.com/embed/embeddedId',
+        expectedId: 'embeddedId',
+      },
+    ].forEach(({ url, expectedId }) => {
+      it('resolves ID from valid YouTube video', () => {
+        assert.equal(videoIdFromYouTubeUrl(url), expectedId);
+      });
+    });
+  });
+
+  describe('validateYouTubeVideUrl', () => {
+    [
+      {
+        url: 'foo',
+        expectedError:
+          'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"',
+      },
+      {
+        url: 'file://foo',
+        expectedError: 'Please use a URL that starts with "https"',
+      },
+      {
+        url: 'https://example.com',
+        expectedError: 'Please use a YouTube URL',
+      },
+      {
+        url: 'https://youtube.com/watch',
+        expectedError: 'Please, enter a URL for a specific YouTube video',
+      },
+      {
+        url: 'https://youtu.be',
+        expectedError: 'Please, enter a URL for a specific YouTube video',
+      },
+    ].forEach(({ url, expectedError }) => {
+      it('throws an error when provided URL is not a valid YouTube video', () => {
+        assert.throws(() => validateYouTubeVideUrl(url), expectedError);
+      });
+    });
+
+    [
+      'https://youtu.be/cKxqzvzlnKU',
+      'https://www.youtube.com/watch?v=cKxqzvzlnKU',
+      'https://www.youtube.com/watch?channel=hypothesis&v=cKxqzvzlnKU',
+      'https://www.youtube.com/embed/cKxqzvzlnKU',
+    ].forEach(url => {
+      it('does not throw when provided URL is a valid YouTube video', () => {
+        assert.doesNotThrow(() => validateYouTubeVideUrl(url));
+      });
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
@@ -1,4 +1,4 @@
-import { validateYouTubeVideoURL, videoIdFromYouTubeURL } from '../youtube';
+import { videoIdFromYouTubeURL } from '../youtube';
 
 describe('youtube', () => {
   describe('videoIdFromYouTubeURL', () => {
@@ -26,48 +26,16 @@ describe('youtube', () => {
         assert.equal(videoIdFromYouTubeURL(url), expectedId);
       });
     });
-  });
-
-  describe('validateYouTubeVideoUrl', () => {
-    [
-      {
-        url: 'foo',
-        expectedError:
-          'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"',
-      },
-      {
-        url: 'file://foo',
-        expectedError: 'Please use a URL that starts with "https"',
-      },
-      {
-        url: 'https://example.com',
-        expectedError: 'Please use a YouTube URL',
-      },
-      {
-        url: 'https://youtube.com/watch',
-        expectedError: 'Please, enter a URL for a specific YouTube video',
-      },
-      {
-        url: 'https://youtu.be',
-        expectedError: 'Please, enter a URL for a specific YouTube video',
-      },
-    ].forEach(({ url, expectedError }) => {
-      it('throws an error when provided URL is not a valid YouTube video', () => {
-        assert.throws(() => validateYouTubeVideoURL(url), expectedError);
-      });
-    });
 
     [
-      'https://youtu.be/cKxqzvzlnKU',
-      'https://www.youtube.com/watch?v=cKxqzvzlnKU',
-      'https://www.youtube.com/watch?channel=hypothesis&v=cKxqzvzlnKU',
-      'https://www.youtube.com/embed/cKxqzvzlnKU',
-      'https://www.youtube.com/shorts/cKxqzvzlnKU',
-      'https://www.youtube.com/live/cKxqzvzlnKU',
-      'https://www.youtube.com/live/cKxqzvzlnKU?feature=share',
+      'foo',
+      'file://foo',
+      'https://example.com',
+      'https://youtube.com/watch',
+      'https://youtu.be',
     ].forEach(url => {
-      it('does not throw when provided URL is a valid YouTube video', () => {
-        assert.doesNotThrow(() => validateYouTubeVideoURL(url));
+      it('returns null for invalid YouTube videos', () => {
+        assert.isNull(videoIdFromYouTubeURL(url));
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
@@ -1,4 +1,4 @@
-import { validateYouTubeVideUrl, videoIdFromYouTubeUrl } from '../youtube';
+import { validateYouTubeVideoUrl, videoIdFromYouTubeUrl } from '../youtube';
 
 describe('youtube', () => {
   describe('videoIdFromYouTubeUrl', () => {
@@ -20,7 +20,7 @@ describe('youtube', () => {
     });
   });
 
-  describe('validateYouTubeVideUrl', () => {
+  describe('validateYouTubeVideoUrl', () => {
     [
       {
         url: 'foo',
@@ -45,7 +45,7 @@ describe('youtube', () => {
       },
     ].forEach(({ url, expectedError }) => {
       it('throws an error when provided URL is not a valid YouTube video', () => {
-        assert.throws(() => validateYouTubeVideUrl(url), expectedError);
+        assert.throws(() => validateYouTubeVideoUrl(url), expectedError);
       });
     });
 
@@ -56,7 +56,7 @@ describe('youtube', () => {
       'https://www.youtube.com/embed/cKxqzvzlnKU',
     ].forEach(url => {
       it('does not throw when provided URL is a valid YouTube video', () => {
-        assert.doesNotThrow(() => validateYouTubeVideUrl(url));
+        assert.doesNotThrow(() => validateYouTubeVideoUrl(url));
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -1,13 +1,26 @@
 import { useEffect, useState } from 'preact/hooks';
 
 import type { ThumbnailData } from '../components/URLFormWithPreview';
-import { InvalidArgumentError } from '../errors';
 
 /**
  * Tries to resolve the video ID from a YouTube URL
- * @return Undefined if the ID could not be resolved
+ * @return null if the ID could not be resolved
  */
-export function videoIdFromYouTubeURL(url: string): string | undefined {
+export function videoIdFromYouTubeURL(url: string): string | null {
+  let parsedURL;
+  try {
+    parsedURL = new URL(url);
+  } catch (e) {
+    return null;
+  }
+
+  if (
+    !parsedURL.protocol.startsWith('http') ||
+    !['www.youtube.com', 'youtube.com', 'youtu.be'].includes(parsedURL.host)
+  ) {
+    return null;
+  }
+
   // This regexp tries to match the video ID in the next possible URLs
   //  * youtu.be/{id}
   //  * {domain}/watch?v={id}[...]
@@ -18,46 +31,11 @@ export function videoIdFromYouTubeURL(url: string): string | undefined {
   const match = url.match(
     /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|shorts\/|live\/|watch\?v=|&v=)([^#&?]*).*/
   );
-
-  return match?.[2];
-}
-
-/**
- * Tries to match provided URL against known YouTube video URL formats,
- * throwing an error in case of invalid YouTube URL
- */
-export function validateYouTubeVideoURL(url: string): string {
-  let parsedURL;
-  try {
-    parsedURL = new URL(url);
-  } catch (e) {
-    throw new InvalidArgumentError(
-      'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"'
-    );
-  }
-
-  if (!parsedURL.protocol.startsWith('https')) {
-    throw new InvalidArgumentError('Please use a URL that starts with "https"');
-  }
-
-  if (
-    !['www.youtube.com', 'youtube.com', 'youtu.be'].includes(parsedURL.host)
-  ) {
-    throw new InvalidArgumentError('Please use a YouTube URL');
-  }
-
-  const videoId = videoIdFromYouTubeURL(url);
-  if (!videoId) {
-    throw new InvalidArgumentError(
-      'Please, enter a URL for a specific YouTube video'
-    );
-  }
-
-  return videoId;
+  return match?.[2] ?? null;
 }
 
 /* istanbul ignore next */
-export function useYouTubeVideoInfo(videoId?: string) {
+export function useYouTubeVideoInfo(videoId: string | null) {
   // TODO Use dummy data for now, until a proper API has been implemented
   const [thumbnail, setThumbnail] = useState<ThumbnailData>();
   const [metadata, setMetadata] = useState<{

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -54,6 +54,7 @@ export function validateYouTubeVideoUrl(youTubeUrl: string): string {
   return videoId;
 }
 
+/* istanbul ignore next */
 export function useYouTubeVideoInfo(videoId?: string) {
   // TODO Use dummy data for now, until a proper API has been implemented
   const [thumbnail, setThumbnail] = useState<ThumbnailData>();

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'preact/hooks';
+
+import type { ThumbnailData } from '../components/URLFormWithPreview';
 import { InvalidArgumentError } from '../errors';
 
 /**
@@ -21,7 +24,7 @@ export function videoIdFromYouTubeUrl(youTubeUrl: string): string | undefined {
  * Tries to match provided URL against known YouTube video URL formats,
  * throwing an error in case of invalid YouTube URL
  */
-export function validateYouTubeVideUrl(youTubeUrl: string): string {
+export function validateYouTubeVideoUrl(youTubeUrl: string): string {
   let url;
   try {
     url = new URL(youTubeUrl);
@@ -47,4 +50,34 @@ export function validateYouTubeVideUrl(youTubeUrl: string): string {
   }
 
   return videoId;
+}
+
+export function useYouTubeVideoInfo(videoId?: string) {
+  // TODO Use dummy data for now, until a proper API has been implemented
+  const [thumbnail, setThumbnail] = useState<ThumbnailData>();
+  const [metadata, setMetadata] = useState<{
+    title: string;
+    channel: string;
+  }>();
+
+  useEffect(() => {
+    if (videoId) {
+      setThumbnail({
+        alt: 'Youtube video',
+        image: 'https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg',
+        isLoading: false,
+        ratio: 'landscape',
+      });
+      setMetadata({
+        title:
+          'Hypothesis and Atlassian New Partnership Announced at the Team23 Conference',
+        channel: 'Hypothesis',
+      });
+    } else {
+      setThumbnail(undefined);
+      setMetadata(undefined);
+    }
+  }, [videoId]);
+
+  return { thumbnail, metadata };
 }

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -7,7 +7,7 @@ import { InvalidArgumentError } from '../errors';
  * Tries to resolve the video ID from a YouTube URL
  * @return Undefined if the ID could not be resolved
  */
-export function videoIdFromYouTubeUrl(youTubeUrl: string): string | undefined {
+export function videoIdFromYouTubeURL(url: string): string | undefined {
   // This regexp tries to match the video ID in the next possible URLs
   //  * youtu.be/{id}
   //  * {domain}/watch?v={id}[...]
@@ -15,7 +15,7 @@ export function videoIdFromYouTubeUrl(youTubeUrl: string): string | undefined {
   //  * {domain}/shorts/{id}[...]
   //  * {domain}/live/{id}[...]
   // See https://stackoverflow.com/a/9102270 for details
-  const match = youTubeUrl.match(
+  const match = url.match(
     /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|shorts\/|live\/|watch\?v=|&v=)([^#&?]*).*/
   );
 
@@ -26,25 +26,27 @@ export function videoIdFromYouTubeUrl(youTubeUrl: string): string | undefined {
  * Tries to match provided URL against known YouTube video URL formats,
  * throwing an error in case of invalid YouTube URL
  */
-export function validateYouTubeVideoUrl(youTubeUrl: string): string {
-  let url;
+export function validateYouTubeVideoURL(url: string): string {
+  let parsedURL;
   try {
-    url = new URL(youTubeUrl);
+    parsedURL = new URL(url);
   } catch (e) {
     throw new InvalidArgumentError(
       'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"'
     );
   }
 
-  if (!url.protocol.startsWith('https')) {
+  if (!parsedURL.protocol.startsWith('https')) {
     throw new InvalidArgumentError('Please use a URL that starts with "https"');
   }
 
-  if (!['www.youtube.com', 'youtube.com', 'youtu.be'].includes(url.host)) {
+  if (
+    !['www.youtube.com', 'youtube.com', 'youtu.be'].includes(parsedURL.host)
+  ) {
     throw new InvalidArgumentError('Please use a YouTube URL');
   }
 
-  const videoId = videoIdFromYouTubeUrl(youTubeUrl);
+  const videoId = videoIdFromYouTubeURL(url);
   if (!videoId) {
     throw new InvalidArgumentError(
       'Please, enter a URL for a specific YouTube video'

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -68,7 +68,7 @@ export function useYouTubeVideoInfo(videoId?: string) {
         alt: 'Youtube video',
         image: 'https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg',
         isLoading: false,
-        ratio: 'landscape',
+        orientation: 'landscape',
       });
       setMetadata({
         title:

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -12,9 +12,11 @@ export function videoIdFromYouTubeUrl(youTubeUrl: string): string | undefined {
   //  * youtu.be/{id}
   //  * {domain}/watch?v={id}[...]
   //  * {domain}/embed/{id}[...]
+  //  * {domain}/shorts/{id}[...]
+  //  * {domain}/live/{id}[...]
   // See https://stackoverflow.com/a/9102270 for details
   const match = youTubeUrl.match(
-    /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/
+    /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|shorts\/|live\/|watch\?v=|&v=)([^#&?]*).*/
   );
 
   return match?.[2];

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -15,7 +15,7 @@ export function videoIdFromYouTubeURL(url: string): string | null {
   }
 
   if (
-    !parsedURL.protocol.startsWith('http') ||
+    !parsedURL.protocol.match(/^https?:$/) ||
     !['www.youtube.com', 'youtube.com', 'youtu.be'].includes(parsedURL.host)
   ) {
     return null;

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -1,0 +1,50 @@
+import { InvalidArgumentError } from '../errors';
+
+/**
+ * Tries to resolve the video ID from a YouTube URL
+ * @return Undefined if the ID could not be resolved
+ */
+export function videoIdFromYouTubeUrl(youTubeUrl: string): string | undefined {
+  // This regexp tries to match the video ID in the next possible URLs
+  //  * youtu.be/{id}
+  //  * {domain}/watch?v={id}[...]
+  //  * {domain}/embed/{id}[...]
+  // See https://stackoverflow.com/a/9102270 for details
+  const match = youTubeUrl.match(
+    /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/
+  );
+
+  return match?.[2];
+}
+
+/**
+ * Tries to match provided URL against known YouTube video URL formats,
+ * throwing an error in case of invalid YouTube URL
+ */
+export function validateYouTubeVideUrl(youTubeUrl: string): string {
+  let url;
+  try {
+    url = new URL(youTubeUrl);
+  } catch (e) {
+    throw new InvalidArgumentError(
+      'Please enter a YouTube URL, e.g. "https://www.youtube.com/watch?v=cKxqzvzlnKU"'
+    );
+  }
+
+  if (!url.protocol.startsWith('https')) {
+    throw new InvalidArgumentError('Please use a URL that starts with "https"');
+  }
+
+  if (!['www.youtube.com', 'youtube.com', 'youtu.be'].includes(url.host)) {
+    throw new InvalidArgumentError('Please use a YouTube URL');
+  }
+
+  const videoId = videoIdFromYouTubeUrl(youTubeUrl);
+  if (!videoId) {
+    throw new InvalidArgumentError(
+      'Please, enter a URL for a specific YouTube video'
+    );
+  }
+
+  return videoId;
+}


### PR DESCRIPTION
> This PR is part of https://github.com/hypothesis/lms/issues/5328

This PR adds a new content picker for YouTube videos, which is based in `JSTORPicker`.

![image](https://user-images.githubusercontent.com/2719332/235932213-718f5fa1-c518-4e21-bd1e-fc057d21d278.png)

![image](https://user-images.githubusercontent.com/2719332/236179439-475a676b-9b55-4c8c-8445-67a0617016b0.png)

![image](https://user-images.githubusercontent.com/2719332/236179378-0e595a66-5fc7-4b02-a7fb-fb178b6b03dc.png)

### Out of the scope of this PR

- Design of the content selectors. This just adds a new button as a simple entry point until the whole section is redesigned.
- Implement the logic after a valid YouTube URL has been set. That will come on a follow-up PR.

### Testing

- Check out this branch.
- Enable the feature flag by going to `http://localhost:8001/admin/instance/{instance_id}/` and checking **YouTube enabled**:
  ![image](https://user-images.githubusercontent.com/2719332/236158855-d6f339a7-640c-4f3f-ba80-3e1fd404eba6.png)
- Open an assignment pointing to your localhost lms instance
- Click on `Select video from YouTube`.
- Verify that an error is displayed if the URL is not any of the known YouTube video patterns.
- Verify a dummy thumbnail, title and channel name is displayed when a valid YouTube video is set.
- The **Continue** button does nothing for now.

### TODO

- [x] Add a dummy video title and channel name to `URLFormWithPreview`
- [x] Add tests for `URLFormWithPreview`
- [x] Add tests to `YouTubePicker`