### PR TITLE
Add context: 'void(0)' in tests rollup config

### DIFF
--- a/rollup-tests.config.mjs
+++ b/rollup-tests.config.mjs
@@ -11,6 +11,11 @@ export default {
     format: 'es',
     sourcemap: true,
   },
+  // Suppress a warning (https://rollupjs.org/guide/en/#error-this-is-undefined)
+  // due to https://github.com/babel/babel/issues/9149.
+  //
+  // Any code string other than "undefined" which evaluates to `undefined` will work here.
+  context: 'void(0)',
   treeshake: false,
   plugins: [
     // Replace some problematic dependencies which are imported but not actually

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,7 +754,7 @@
     "@babel/helper-module-transforms" "^7.20.11"
     "@babel/helper-plugin-utils" "^7.20.2"
 
-"@babel/plugin-transform-modules-commonjs@^7.21.2", "@babel/plugin-transform-modules-commonjs@^7.21.5":
+"@babel/plugin-transform-modules-commonjs@^7.21.5":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz#d69fb947eed51af91de82e4708f676864e5e47bc"
   integrity sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==


### PR DESCRIPTION
Get rid of a warning during tests, by adding `context: 'void(0)'` to rollup config.

The difference when running tests is this:

```diff
[09:56:30] Using gulpfile ~/work/lms/lms/gulpfile.mjs
[09:56:30] Starting 'test'...
[09:56:30] Starting 'build-css'...
[09:56:30] Starting '<anonymous>'...
[09:56:30] Building test bundle... (53 files)
[09:56:32] Finished 'build-css' after 1.88 s
- [09:56:40] Rollup warning: node_modules/@hypothesis/frontend-shared/lib/components/transition/Slider.js (86:5) The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten (https://rollupjs.org/guide/en/#error-this-is-undefined)
[09:56:43] Starting Karma...
```