### PR TITLE
Simplify `send_instructor_email_digest_tasks()`

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import List
 
-from h_pyramid_sentry import report_exception
 from sqlalchemy import and_, select
 
 from lms.models import (
@@ -74,26 +73,14 @@ def send_instructor_email_digest_tasks(*, batch_size):
                 for i in range(0, len(h_userids), batch_size)
             ]
 
-            failed = False
-
             for batch in batches:
-                try:
-                    send_instructor_email_digests.apply_async(
-                        (),
-                        {
-                            "h_userids": batch,
-                            "updated_after": updated_after,
-                            "updated_before": updated_before,
-                        },
-                    )
-                except Exception as err:  # pylint:disable=broad-exception-caught
-                    failed = True
-                    LOG.exception(err)
-                    report_exception(err)
-
-            if failed:
-                raise RuntimeError(
-                    "One or more send_instructor_email_digests() batches failed to schedule"
+                send_instructor_email_digests.apply_async(
+                    (),
+                    {
+                        "h_userids": batch,
+                        "updated_after": updated_after,
+                        "updated_before": updated_before,
+                    },
                 )
 
 


### PR DESCRIPTION
There's no need for the task to catch exceptions raised by
`send_instructor_email_digests.apply_async()`. This used to make more
sense because `send_instructor_email_digest_tasks()` used to manually
retry itself with only those `h_userids` for which
`send_instructor_email_digests.apply_async()` hadn't already been
successfully scheduled. But now that we use the `task_done` table to
avoid sending duplicate emails
(https://github.com/hypothesis/lms/pull/5347) this is less necessary:

If a call to `send_instructor_email_digests.apply_async()` fails then
`send_instructor_email_digest_tasks()` will raise, breaking out of its
`for` loop, and Celery will retry the whole
`send_instructor_email_digest_tasks()` call again. Hopefully on the
second or third attempt it'll make it all the way through the `for` loop
and all the batches of emails will be scheduled.

This is arguably less robust than what's on `main` but it simplifies the
code.
