### PR TITLE
FE deploy paths-ignore

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,11 @@ on:
       - '**/.gitignore'
       - '*.md'
       - 'tox.ini'
+      - 'rollup-tests.config.mjs'
+      - '**/test/*'
+      - '**/test-util/*'
+      - '**/bootstrap.js'
+      - '**/karma.config.js'
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Add patterns to be ignored on deploy pipeline for FE tests and test-related configs.

This will help us avoid a deployment to be triggered when only non-production files have been changed.