### PR TITLE
Make sure directories ignored for deployment workflow are ignored recursively

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - '.cookiecutter/*'
-      - '.github/*'
-      - 'docs/*'
+      - '.cookiecutter/**'
+      - '.github/**'
+      - 'docs/**'
       - 'requirements/*'
       - '!requirements/requirements.txt'
-      - 'tests/*'
+      - 'tests/**'
       - '**/.gitignore'
       - '*.md'
       - 'tox.ini'


### PR DESCRIPTION
Some of the glob expressions in the `paths-ignore` for the deploy workflow are only taking into consideration the first directory level.

This changes that so that they are recursively ignored.