### PR TITLE
Jstor picker form preview

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -30,6 +30,8 @@ export type URLFormWithPreviewProps = {
   /** Invoked every time the input URL changes, with the value that was input */
   onURLChange: (inputURL: string) => void;
   label: string;
+  /** Value to be set as "title" on the confirm button */
+  confirmBtnTitle: string;
   urlPlaceholder?: string;
   defaultURL?: string;
 };
@@ -44,6 +46,7 @@ export default function URLFormWithPreview({
   inputRef,
   onURLChange,
   label,
+  confirmBtnTitle,
   urlPlaceholder,
   defaultURL,
 }: URLFormWithPreviewProps) {
@@ -101,6 +104,7 @@ export default function URLFormWithPreview({
             id={inputId}
             name="URL"
             onChange={onChange}
+            onInput={() => onURLChange('')}
             onKeyDown={onKeyDown}
             placeholder={urlPlaceholder}
             spellcheck={false}
@@ -109,7 +113,7 @@ export default function URLFormWithPreview({
             icon={ArrowRightIcon}
             onClick={onChange}
             variant="dark"
-            title="Confirm URL"
+            title={confirmBtnTitle}
           />
         </InputGroup>
 

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -29,9 +29,11 @@ export type URLFormWithPreviewProps = {
   inputRef: RefObject<HTMLInputElement | undefined>;
   /** Invoked every time the input URL changes, with the value that was input */
   onURLChange: (inputURL: string) => void;
+  /** Forwarded to the input's onInput prop */
+  onInput?: () => void;
   label: string;
   /** Value to be set as "title" on the confirm button */
-  confirmBtnTitle: string;
+  confirmButtonTitle: string;
   urlPlaceholder?: string;
   defaultURL?: string;
 };
@@ -45,8 +47,9 @@ export default function URLFormWithPreview({
   thumbnail,
   inputRef,
   onURLChange,
+  onInput,
   label,
-  confirmBtnTitle,
+  confirmButtonTitle,
   urlPlaceholder,
   defaultURL,
 }: URLFormWithPreviewProps) {
@@ -104,7 +107,7 @@ export default function URLFormWithPreview({
             id={inputId}
             name="URL"
             onChange={onChange}
-            onInput={() => onURLChange('')}
+            onInput={onInput}
             onKeyDown={onKeyDown}
             placeholder={urlPlaceholder}
             spellcheck={false}
@@ -113,7 +116,7 @@ export default function URLFormWithPreview({
             icon={ArrowRightIcon}
             onClick={onChange}
             variant="dark"
-            title={confirmBtnTitle}
+            title={confirmButtonTitle}
           />
         </InputGroup>
 

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -26,6 +26,12 @@ export default function YouTubePicker({
   const { thumbnail, metadata } = useYouTubeVideoInfo(videoId);
 
   const verifyURL = (inputURL: string) => {
+    if (!inputURL) {
+      setVideoId(null);
+      setError(undefined);
+      return;
+    }
+
     const videoId = videoIdFromYouTubeURL(inputURL);
     if (videoId) {
       setVideoId(videoId);
@@ -66,11 +72,12 @@ export default function YouTubePicker({
       ]}
     >
       <URLFormWithPreview
+        label="Enter the URL of a YouTube video:"
+        urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"
+        confirmBtnTitle="Confirm URL"
         onURLChange={verifyURL}
         error={error}
         inputRef={inputRef}
-        urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"
-        label="Enter the URL of a YouTube video:"
         defaultURL={defaultURL}
         thumbnail={thumbnail ?? { orientation: 'landscape' }}
       >

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -26,12 +26,6 @@ export default function YouTubePicker({
   const { thumbnail, metadata } = useYouTubeVideoInfo(videoId);
 
   const verifyURL = (inputURL: string) => {
-    if (!inputURL) {
-      setVideoId(null);
-      setError(undefined);
-      return;
-    }
-
     const videoId = videoIdFromYouTubeURL(inputURL);
     if (videoId) {
       setVideoId(videoId);
@@ -74,7 +68,7 @@ export default function YouTubePicker({
       <URLFormWithPreview
         label="Enter the URL of a YouTube video:"
         urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"
-        confirmBtnTitle="Confirm URL"
+        confirmButtonTitle="Confirm URL"
         onURLChange={verifyURL}
         error={error}
         inputRef={inputRef}

--- a/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
@@ -8,6 +8,7 @@ describe('URLFormWithPreview', () => {
     mount(
       <URLFormWithPreview
         label="Default label"
+        confirmBtnTitle="Confirm URL"
         onURLChange={sinon.stub()}
         inputRef={createRef()}
         {...props}
@@ -138,6 +139,17 @@ describe('URLFormWithPreview', () => {
       button.simulate('click');
 
       assert.calledWith(onURLChange, 'https://example.com');
+    });
+
+    it('invokes `onURLChange` on input', () => {
+      const onURLChange = sinon.stub();
+      const wrapper = renderComponent({ onURLChange });
+      const input = wrapper.find('Input').find('input');
+
+      input.getDOMNode().value = 'https://example.com';
+      input.simulate('input');
+
+      assert.calledWith(onURLChange, '');
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
@@ -8,7 +8,7 @@ describe('URLFormWithPreview', () => {
     mount(
       <URLFormWithPreview
         label="Default label"
-        confirmBtnTitle="Confirm URL"
+        confirmButtonTitle="Confirm URL"
         onURLChange={sinon.stub()}
         inputRef={createRef()}
         {...props}
@@ -141,15 +141,15 @@ describe('URLFormWithPreview', () => {
       assert.calledWith(onURLChange, 'https://example.com');
     });
 
-    it('invokes `onURLChange` on input', () => {
-      const onURLChange = sinon.stub();
-      const wrapper = renderComponent({ onURLChange });
+    it('invokes provided onInput callback', () => {
+      const onInput = sinon.stub();
+      const wrapper = renderComponent({ onInput });
       const input = wrapper.find('Input').find('input');
 
       input.getDOMNode().value = 'https://example.com';
       input.simulate('input');
 
-      assert.calledWith(onURLChange, '');
+      assert.called(onInput);
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -96,30 +96,4 @@ describe('YouTubePicker', () => {
     assert.isTrue(metadata.exists());
     assert.equal(metadata.text(), 'The video title (Hypothesis)');
   });
-
-  it('resets error when the URL is empty', () => {
-    const wrapper = renderComponent();
-
-    wrapper.find('URLFormWithPreview').props().onURLChange('not-a-youtube-url');
-    wrapper.update();
-    assert.isDefined(wrapper.find('URLFormWithPreview').prop('error'));
-
-    wrapper.find('URLFormWithPreview').props().onURLChange('');
-    wrapper.update();
-    assert.isUndefined(wrapper.find('URLFormWithPreview').prop('error'));
-  });
-
-  it('resets select button when the URL is empty', () => {
-    const wrapper = renderComponent();
-
-    assert.isFalse(
-      wrapper.find('button[data-testid="select-button"]').prop('disabled')
-    );
-
-    wrapper.find('URLFormWithPreview').props().onURLChange('');
-    wrapper.update();
-    assert.isTrue(
-      wrapper.find('button[data-testid="select-button"]').prop('disabled')
-    );
-  });
 });

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -96,4 +96,30 @@ describe('YouTubePicker', () => {
     assert.isTrue(metadata.exists());
     assert.equal(metadata.text(), 'The video title (Hypothesis)');
   });
+
+  it('resets error when the URL is empty', () => {
+    const wrapper = renderComponent();
+
+    wrapper.find('URLFormWithPreview').props().onURLChange('not-a-youtube-url');
+    wrapper.update();
+    assert.isDefined(wrapper.find('URLFormWithPreview').prop('error'));
+
+    wrapper.find('URLFormWithPreview').props().onURLChange('');
+    wrapper.update();
+    assert.isUndefined(wrapper.find('URLFormWithPreview').prop('error'));
+  });
+
+  it('resets select button when the URL is empty', () => {
+    const wrapper = renderComponent();
+
+    assert.isFalse(
+      wrapper.find('button[data-testid="select-button"]').prop('disabled')
+    );
+
+    wrapper.find('URLFormWithPreview').props().onURLChange('');
+    wrapper.update();
+    assert.isTrue(
+      wrapper.find('button[data-testid="select-button"]').prop('disabled')
+    );
+  });
 });


### PR DESCRIPTION
This PR refactors the `JSTORPicker` component so that it uses `URLFormWithPreview` internally.

The `URLFormWithPreview` was introduced in https://github.com/hypothesis/lms/pull/5359, where a new `YouTubePicker` was created, based on `JSTORPicker`.

Since both components share a similar behavior, that PR introduced a component abstracting the commonalities, but the `JSTORPicker` was not yet changed to use it, to avoid diverting the attention of that PR.

This PR does the change.

### Testing steps

There should be no visual changes, and the component should behave the same, so it's important to compare error scenarios and happy paths between this branch and `main` branch.