### PR TITLE
Handle multiple entries on the _history LTI parameter

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -43,6 +43,9 @@ class AssignmentService:
 
         for param in resource_link_history_params:
             if historical_resource_link_id := lti_params.get(param):
+                # History might have a long chain of comma separated
+                # copies of copies, take the most recent one.
+                historical_resource_link_id = historical_resource_link_id.split(",")[0]
                 if historical_assignment := self.get_assignment(
                     tool_consumer_instance_guid=lti_params.get(
                         "tool_consumer_instance_guid"

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -116,18 +116,25 @@ class TestAssignmentService:
             "custom_ResourceLink.id.history",
         ),
     )
+    @pytest.mark.parametrize(
+        "value,expected",
+        (
+            ("ORIGINAL_ID", "ORIGINAL_ID"),
+            ("COPY_OF_ORIGINAL,ORIGINAL_ID", "COPY_OF_ORIGINAL"),
+        ),
+    )
     def test_upsert_assignment_with_copied_fromr(
-        self, svc, copied_from_param, db_session
+        self, svc, copied_from_param, value, expected, db_session
     ):
         upsert_params = dict(
             self.upsert_kwargs,
             resource_link_id="NEW_ID",
             tool_consumer_instance_guid="MATCHING_GUID",
         )
-        upsert_params["lti_params"][copied_from_param] = "ORIGINAL_ID"
+        upsert_params["lti_params"][copied_from_param] = value
         upsert_params["lti_params"]["tool_consumer_instance_guid"] = "MATCHING_GUID"
         original_assignment = factories.Assignment(
-            resource_link_id="ORIGINAL_ID", tool_consumer_instance_guid="MATCHING_GUID"
+            resource_link_id=expected, tool_consumer_instance_guid="MATCHING_GUID"
         )
         db_session.flush()
 


### PR DESCRIPTION
`resource_link_id_history` points to the resource link id the current one
was copied from.

For copies of a copy the LMS might include a comma separated list of ID.

From the spec https://www.imsglobal.org/spec/lti/v1p3#lti-resourcelink-variables

```
ResourceLink.id.history

A comma-separated list of URL-encoded resource link ID values representing the ID of the link from a previous copy of the context;
the most recent copy should appear first in the list followed by any earlier IDs in reverse chronological order.

If the link was first added to the current context then this variable should have an empty value.
```


## Testing


Needs:

- https://github.com/hypothesis/devdata/pull/82 merged


### First in `main`

- Reset your local assignments

`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment cascade;"; make devdata`



- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View?ou=6782 
the original, you'll get the URL from the DB/db data


- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6888/viewContent/2644/View?ou=6888 the first copy, it will work

- https://aunltd.brightspacedemo.com/d2l/le/content/6898/viewContent/2773/View?ou=6898 copy of the copy. It won't detect the copy


### Switch to this branch

- Reset your local assignments

`tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate assignment cascade;"; make devdata`


- Launch the assignment again, the lasat one will be correclty configured.



