### PR TITLE
Don't guard against no user for JSTOR tracking ID

### DIFF
--- a/lms/services/jstor/factory.py
+++ b/lms/services/jstor/factory.py
@@ -17,9 +17,7 @@ def service_factory(_context, request):
         # conveniently available unique user ID in a standardized format and
         # doesn't contain private info (email addresses etc.).
         headers={
-            "Tracking-User-ID": request.lti_user.h_user.username
-            if request.lti_user
-            else None,
+            "Tracking-User-ID": request.lti_user.h_user.username,
             "Tracking-User-Agent": request.headers.get("User-Agent", None),
         },
     )

--- a/tests/unit/lms/services/jstor/factory_test.py
+++ b/tests/unit/lms/services/jstor/factory_test.py
@@ -7,14 +7,8 @@ from lms.services.jstor.factory import service_factory
 
 class TestServiceFactory:
     @pytest.mark.parametrize("user_agent", ("Example UA", None))
-    @pytest.mark.parametrize("with_user", (True, False))
     def test_it(
-        self,
-        pyramid_request,
-        application_instance_service,
-        JSTORService,
-        user_agent,
-        with_user,
+        self, pyramid_request, application_instance_service, JSTORService, user_agent
     ):
         ai_settings = application_instance_service.get_current.return_value.settings
         ai_settings.set("jstor", "enabled", sentinel.jstor_enabled)
@@ -26,8 +20,6 @@ class TestServiceFactory:
 
         if user_agent:
             pyramid_request.headers["User-Agent"] = user_agent
-        if not with_user:
-            pyramid_request.lti_user = None
 
         svc = service_factory(sentinel.context, pyramid_request)
 
@@ -37,9 +29,7 @@ class TestServiceFactory:
             enabled=sentinel.jstor_enabled,
             site_code=sentinel.jstor_site_code,
             headers={
-                "Tracking-User-ID": pyramid_request.lti_user.h_user.username
-                if with_user
-                else None,
+                "Tracking-User-ID": pyramid_request.lti_user.h_user.username,
                 "Tracking-User-Agent": user_agent,
             },
         )


### PR DESCRIPTION
Getting the app settings already implicitly relies on lti_user existing to get the right application instance.

Simplify the code eliminating the conditional.


(Prompted by the WIP refactor in https://github.com/hypothesis/lms/pull/5334)