### PR TITLE
Round scores submitted to the grading API.

### DIFF
--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -27,9 +27,11 @@ class GradingViews:
     def record_result(self):
         """Proxy result (grade/score) to LTI Result API."""
 
+        # Fix any float point arithmetic issues
+        score = round(self.parsed_params["score"], 4)
+
         self.lti_grading_service.record_result(
-            self.parsed_params["lis_result_sourcedid"],
-            score=self.parsed_params["score"],
+            self.parsed_params["lis_result_sourcedid"], score
         )
 
         return {}

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -175,11 +175,22 @@ class TestReadResult:
 
 
 class TestRecordResult:
-    def test_it_records_result(self, pyramid_request, lti_grading_service):
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (0.7000000000000001, 0.7),
+            (0.7123000000000001, 0.7123),
+            (0.000000000000001, 0),
+        ],
+    )
+    def test_it_records_result(
+        self, pyramid_request, lti_grading_service, score, expected
+    ):
+        pyramid_request.parsed_params["score"] = score
         GradingViews(pyramid_request).record_result()
 
         lti_grading_service.record_result.assert_called_once_with(
-            "modelstudent-assignment1", score=pyramid_request.parsed_params["score"]
+            "modelstudent-assignment1", score=expected
         )
 
     @pytest.fixture


### PR DESCRIPTION
Part of the effort to fix and reduce noise of exceptions around grading:

- https://github.com/hypothesis/product-backlog/issues/1305


Avoid any artifacts caused by float point arithmetic.

Should fix errors like: https://hypothesis.sentry.io/issues/3971708774/events/ad948f09096c4b8d957ce7c9f9960605/?project=259908

```
Response(status_code=400, reason='Incorrect score received{"scoreMaximum": 1, "scoreGiven": 0.7000000000000001
```