### PR TITLE
New content selector

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -1,4 +1,5 @@
-import { Button, SpinnerOverlay } from '@hypothesis/frontend-shared';
+import { ButtonBase, SpinnerOverlay } from '@hypothesis/frontend-shared';
+import type { ComponentProps } from 'preact';
 import { useMemo, useState } from 'preact/hooks';
 
 import type { Book, File, Chapter } from '../api-types';
@@ -45,6 +46,32 @@ function extractContentTypeAndValue(content: Content): [DialogType, string] {
     // being able to adjust the selection.
     return [null, ''];
   }
+}
+
+type ContentSelectorButtonProps = ComponentProps<typeof ButtonBase> & {
+  contentType?: string;
+};
+
+function ContentSelectorButton({
+  children,
+  contentType = 'pdf',
+  ...rest
+}: ContentSelectorButtonProps) {
+  return (
+    <ButtonBase
+      classes="w-full bg-stone-50 rounded-sm border border-stone-300 gap-x-2 items-center"
+      {...rest}
+    >
+      <div className="grow text-start p-2">
+        <strong className="text-slate-600">{children}</strong>
+      </div>
+      <div className="text-end p-2">
+        <span className="uppercase text-[11px] text-stone-500">
+          {contentType}
+        </span>
+      </div>
+    </ButtonBase>
+  );
 }
 
 /**
@@ -298,85 +325,80 @@ export default function ContentSelector({
     <>
       {isLoadingIndicatorVisible && <SpinnerOverlay />}
       <div className="flex flex-row p-y-2">
-        <div className="flex flex-col space-y-1">
-          <Button
+        <div className="grid grid-cols-2 gap-2 w-full">
+          <ContentSelectorButton
             onClick={() => selectDialog('url')}
-            variant="primary"
+            contentType="web page | PDF"
             data-testid="url-button"
           >
-            Enter URL of web page or PDF
-          </Button>
+            URL
+          </ContentSelectorButton>
           {canvasFilesEnabled && (
-            <Button
+            <ContentSelectorButton
               onClick={() => selectDialog('canvasFile')}
-              variant="primary"
               data-testid="canvas-file-button"
             >
-              Select PDF from Canvas
-            </Button>
+              Canvas
+            </ContentSelectorButton>
           )}
           {blackboardFilesEnabled && (
-            <Button
+            <ContentSelectorButton
               onClick={() => selectDialog('blackboardFile')}
-              variant="primary"
               data-testid="blackboard-file-button"
             >
-              Select PDF from Blackboard
-            </Button>
+              Blackboard
+            </ContentSelectorButton>
           )}
           {d2lFilesEnabled && (
-            <Button
+            <ContentSelectorButton
               onClick={() => selectDialog('d2lFile')}
-              variant="primary"
               data-testid="d2l-file-button"
             >
-              Select PDF from D2L
-            </Button>
+              D2L
+            </ContentSelectorButton>
           )}
           {googlePicker && (
-            <Button
+            <ContentSelectorButton
               onClick={showGooglePicker}
-              variant="primary"
               data-testid="google-drive-button"
             >
-              Select PDF from Google Drive
-            </Button>
+              Google Drive
+            </ContentSelectorButton>
           )}
           {jstorEnabled && (
-            <Button
+            <ContentSelectorButton
               onClick={() => selectDialog('jstor')}
-              variant="primary"
+              contentType="article"
               data-testid="jstor-button"
             >
-              Select JSTOR article
-            </Button>
+              JSTOR
+            </ContentSelectorButton>
           )}
           {oneDriveFilesEnabled && (
-            <Button
+            <ContentSelectorButton
               onClick={showOneDrivePicker}
-              variant="primary"
               data-testid="onedrive-button"
             >
-              Select PDF from OneDrive
-            </Button>
+              OneDrive
+            </ContentSelectorButton>
           )}
           {vitalSourceEnabled && (
-            <Button
+            <ContentSelectorButton
               onClick={() => selectDialog('vitalSourceBook')}
-              variant="primary"
+              contentType="book"
               data-testid="vitalsource-button"
             >
-              Select book from VitalSource
-            </Button>
+              VitalSource
+            </ContentSelectorButton>
           )}
           {youtubeEnabled && (
-            <Button
+            <ContentSelectorButton
               onClick={() => selectDialog('youtube')}
-              variant="primary"
+              contentType="video"
               data-testid="youtube-button"
             >
-              Select video from YouTube
-            </Button>
+              YouTube
+            </ContentSelectorButton>
           )}
         </div>
         {/** This flex-grow element takes up remaining horizontal space so that

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -4,6 +4,7 @@ import {
   Card,
   CardActions,
   CardContent,
+  CardHeader,
   Link,
   Scroll,
   SpinnerOverlay,
@@ -260,24 +261,25 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
           </div>
         )}
         <Card
+          width="custom"
           classes={classnames(
+            'w-[700px]',
             // Ensure children that have overflow-scroll do not exceed the
             // height constraints
             'flex flex-col min-h-0'
           )}
         >
-          <div className="bg-slate-0 px-3 py-2 border-b border-slate-5">
-            <h1 className="text-xl text-slate-7 font-normal">
-              Assignment details
-            </h1>
-          </div>
+          <CardHeader variant="secondary" title="Assignment details" />
           <Scroll>
-            <CardContent size="lg">
-              <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-3">
-                <div className="text-end">
-                  <span className="font-medium text-sm leading-none text-slate-7">
+            <div className="px-3 py-6">
+              <div className="grid grid-cols-[14em_1fr] gap-x-6 gap-y-3">
+                <div className="space-y-1.5 pt-1">
+                  <div className="leading-none text-[14px] text-end font-medium text-slate-600 uppercase">
                     Assignment content
-                  </span>
+                  </div>
+                  <div className="text-[14px] text-end leading-none font-normal text-stone-500">
+                    <p>Select content for your assignment</p>
+                  </div>
                 </div>
                 <div className="space-y-3">
                   {content && !editingContent ? (
@@ -293,18 +295,11 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                       </Button>
                     </div>
                   ) : (
-                    <>
-                      <p>
-                        You can select content for your assignment from one of
-                        the following sources:
-                      </p>
-
-                      <ContentSelector
-                        initialContent={content ?? undefined}
-                        onSelectContent={selectContent}
-                        onError={setErrorInfo}
-                      />
-                    </>
+                    <ContentSelector
+                      initialContent={content ?? undefined}
+                      onSelectContent={selectContent}
+                      onError={setErrorInfo}
+                    />
                   )}
                 </div>
                 {content && !editingContent && enableGroupConfig && (
@@ -331,7 +326,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                   </>
                 )}
               </div>
-            </CardContent>
+            </div>
           </Scroll>
           {
             // See comments in `selectContent` about auto-submitting form if

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -98,13 +98,17 @@ describe('ContentSelector', () => {
   it('renders Canvas file picker button if Canvas file picker enabled', () => {
     fakeConfig.filePicker.canvas.enabled = true;
     const wrapper = renderContentSelector();
-    assert.isTrue(wrapper.exists('Button[data-testid="canvas-file-button"]'));
+    assert.isTrue(
+      wrapper.exists('ButtonBase[data-testid="canvas-file-button"]')
+    );
   });
 
   it('does not render Canvas file picker button if Canvas file picker not enabled', () => {
     fakeConfig.filePicker.canvas.enabled = false;
     const wrapper = renderContentSelector();
-    assert.isFalse(wrapper.exists('Button[data-testid="canvas-file-button"]'));
+    assert.isFalse(
+      wrapper.exists('ButtonBase[data-testid="canvas-file-button"]')
+    );
   });
 
   it('renders initial form with no dialog visible', () => {
@@ -113,7 +117,7 @@ describe('ContentSelector', () => {
     assert.isFalse(wrapper.exists('LMSFilePicker'));
     assert.isFalse(wrapper.exists('URLPicker'));
     assert.deepEqual(
-      wrapper.find('Button').map(button => button.prop('data-testid')),
+      wrapper.find('ButtonBase').map(button => button.prop('data-testid')),
       [
         'url-button',
         'canvas-file-button',
@@ -129,7 +133,7 @@ describe('ContentSelector', () => {
 
     assert.isFalse(isLoadingIndicatorVisible(wrapper));
 
-    const btn = wrapper.find('Button[data-testid="url-button"]');
+    const btn = wrapper.find('ButtonBase[data-testid="url-button"]');
     interact(wrapper, () => {
       btn.props().onClick();
     });
@@ -216,7 +220,9 @@ describe('ContentSelector', () => {
       it(`shows LMS file dialog when "Select PDF from ${test.name}" is clicked`, () => {
         const wrapper = renderContentSelector();
 
-        const btn = wrapper.find(`Button[data-testid="${test.buttonTestId}"]`);
+        const btn = wrapper.find(
+          `ButtonBase[data-testid="${test.buttonTestId}"]`
+        );
         interact(wrapper, () => {
           btn.props().onClick();
         });
@@ -320,7 +326,7 @@ describe('ContentSelector', () => {
     });
 
     function clickGoogleDriveButton(wrapper) {
-      const btn = wrapper.find('Button[data-testid="google-drive-button"]');
+      const btn = wrapper.find('ButtonBase[data-testid="google-drive-button"]');
       interact(wrapper, () => {
         btn.props().onClick();
       });
@@ -330,7 +336,7 @@ describe('ContentSelector', () => {
       const wrapper = renderContentSelector();
 
       assert.isFalse(
-        wrapper.exists('Button[data-testid="google-drive-button"]')
+        wrapper.exists('ButtonBase[data-testid="google-drive-button"]')
       );
     });
 
@@ -347,7 +353,7 @@ describe('ContentSelector', () => {
     it('shows "Select PDF from Google Drive" button if developer key is provided', () => {
       const wrapper = renderContentSelector();
       assert.isTrue(
-        wrapper.exists('Button[data-testid="google-drive-button"]')
+        wrapper.exists('ButtonBase[data-testid="google-drive-button"]')
       );
     });
 
@@ -425,7 +431,7 @@ describe('ContentSelector', () => {
     let picker;
 
     function clickOneDriveButton(wrapper) {
-      const btn = wrapper.find('Button[data-testid="onedrive-button"]');
+      const btn = wrapper.find('ButtonBase[data-testid="onedrive-button"]');
       interact(wrapper, () => {
         btn.props().onClick();
       });
@@ -455,7 +461,9 @@ describe('ContentSelector', () => {
       fakeConfig.filePicker.microsoftOneDrive.enabled = false; // clientId and redirectURI are defined
       const wrapper = renderContentSelector();
 
-      assert.isFalse(wrapper.exists('Button[data-testid="onedrive-button"]'));
+      assert.isFalse(
+        wrapper.exists('ButtonBase[data-testid="onedrive-button"]')
+      );
     });
 
     it('initializes OneDrive Picker client if parameters are provided', () => {
@@ -468,7 +476,9 @@ describe('ContentSelector', () => {
     it('shows the OneDrive button if option is enabled', () => {
       const wrapper = renderContentSelector();
 
-      assert.isTrue(wrapper.exists('Button[data-testid="onedrive-button"]'));
+      assert.isTrue(
+        wrapper.exists('ButtonBase[data-testid="onedrive-button"]')
+      );
     });
 
     it('shows OneDrive Picker when button is clicked', async () => {
@@ -546,7 +556,9 @@ describe('ContentSelector', () => {
     it('renders VitalSource picker button if enabled', () => {
       fakeConfig.filePicker.vitalSource.enabled = true;
       const wrapper = renderContentSelector();
-      assert.isTrue(wrapper.exists('Button[data-testid="vitalsource-button"]'));
+      assert.isTrue(
+        wrapper.exists('ButtonBase[data-testid="vitalsource-button"]')
+      );
     });
 
     it('shows VitalSource book picker when VitalSource button is clicked', () => {
@@ -554,7 +566,9 @@ describe('ContentSelector', () => {
       const onSelectContent = sinon.stub();
       const wrapper = renderContentSelector({ onSelectContent });
 
-      const button = wrapper.find('Button[data-testid="vitalsource-button"]');
+      const button = wrapper.find(
+        'ButtonBase[data-testid="vitalsource-button"]'
+      );
       interact(wrapper, () => {
         button.props().onClick();
       });
@@ -590,7 +604,7 @@ describe('ContentSelector', () => {
     it('renders JSTOR picker button if enabled', () => {
       fakeConfig.filePicker.jstor.enabled = true;
       const wrapper = renderContentSelector();
-      assert.isTrue(wrapper.exists('Button[data-testid="jstor-button"]'));
+      assert.isTrue(wrapper.exists('ButtonBase[data-testid="jstor-button"]'));
     });
 
     it('shows JSTOR picker when JSTOR button is clicked', () => {
@@ -598,7 +612,7 @@ describe('ContentSelector', () => {
       const onSelectContent = sinon.stub();
       const wrapper = renderContentSelector({ onSelectContent });
 
-      const button = wrapper.find('Button[data-testid="jstor-button"]');
+      const button = wrapper.find('ButtonBase[data-testid="jstor-button"]');
       interact(wrapper, () => {
         button.props().onClick();
       });
@@ -640,7 +654,7 @@ describe('ContentSelector', () => {
     it('renders YouTube picker button if enabled', () => {
       fakeConfig.filePicker.youtube.enabled = true;
       const wrapper = renderContentSelector();
-      assert.isTrue(wrapper.exists('Button[data-testid="youtube-button"]'));
+      assert.isTrue(wrapper.exists('ButtonBase[data-testid="youtube-button"]'));
     });
 
     it('shows YouTube picker when YouTube button is clicked', () => {
@@ -648,7 +662,7 @@ describe('ContentSelector', () => {
       const onSelectContent = sinon.stub();
       const wrapper = renderContentSelector({ onSelectContent });
 
-      const button = wrapper.find('Button[data-testid="youtube-button"]');
+      const button = wrapper.find('ButtonBase[data-testid="youtube-button"]');
       interact(wrapper, () => {
         button.props().onClick();
       });


### PR DESCRIPTION
Redesign content selector to fit more buttons in the same vertical space, and look a bit nicer.

Before:

![image](https://github.com/hypothesis/lms/assets/2719332/b7c79ddd-0e88-4d62-aaa7-a2dba5c33ec8)

After:

![image](https://github.com/hypothesis/lms/assets/2719332/7faa5c80-4cae-4170-a2a3-2cf47cbdb0ad)

### Testing steps

1. Checkout this branch
2. Open and edit an assignment (or create a new one)
3. The content selector should look like the second screenshot above
4. The behavior of the buttons should be the same as before

### TODO

- [ ] Pattern library example should match.
- [ ] Group selector title now does not match.
  ![image](https://github.com/hypothesis/lms/assets/2719332/7d9b8361-1415-4bfd-ab51-0ca903a3ddb5)
- [ ] Font size is different than in other apps, which means styles are slightly different than original proposal.
- [ ] Consider hover/active styles for buttons.