### PR TITLE
Add Celery task time limits

### DIFF
--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -38,6 +38,35 @@ app.conf.update(
         "interval_start": 0.2,
         "interval_step": 0.2,
     },
+    # Tell Celery to kill any task run (by raising
+    # celery.exceptions.SoftTimeLimitExceeded) if it takes longer than
+    # task_soft_time_limit seconds.
+    #
+    # See: https://docs.celeryq.dev/en/stable/userguide/workers.html#time-limits
+    #
+    # This is to protect against task runs hanging forever which blocks a
+    # Celery worker and prevents Celery retries from kicking in.
+    #
+    # This can be overridden on a per-task basis by adding soft_time_limit=n to
+    # the task's @app.task() arguments.
+    #
+    # We're using soft rather than hard time limits because hard time limits
+    # don't trigger Celery retries whereas soft ones do. Soft time limits also
+    # give the task a chance to catch SoftTimeLimitExceeded and do some cleanup
+    # before exiting.
+    task_soft_time_limit=120,
+    # Tell Celery to force-terminate any task run (by terminating the worker
+    # process and replacing it with a new one) if it takes linger than
+    # task_time_limit seconds.
+    #
+    # This is needed to defend against tasks hanging during cleanup: if
+    # task_soft_time_limit expires the task can catch SoftTimeLimitExceeded and
+    # could then hang again in the exception handler block. task_time_limit
+    # ensures that the task is force-terminated in that case.
+    #
+    # This can be overridden on a per-task basis by adding time_limit=n to the
+    # task's @app.task() arguments.
+    task_time_limit=240,
     # Tell celery where our tasks are defined
     imports=("lms.tasks",),
 )


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/5428.

This is to protect against Celery task runs hanging forever blocking a Celery worker and preventing Celery retries from kicking in.

Arguably this might actually shoot us in the foot: in [yesterday's incident with the email digests tasks](https://docs.google.com/document/d/1kLX8qEjik3K8kwL-g_p_ovKwSFehQ5if4A5iXu6qp1g/) we saw a task that should only take a few seconds take instead 5.5hrs but the task then did complete successfully. If we had a task time limit (of less than 5.5hrs) then Celery would have killed the task and, assuming the issue was persistent so that each of Celery's two retries of the task would also have tried to take 5.5hrs, Celery would have killed the two retries and the task would never have completed at all.

On the other hand I really don't think we want tasks that should finish in seconds to be consistently taking hours: this means the task is blocking a Celery worker for far too long and is far too likely to get killed by a deployment or autoscaling down before completing anyway. Celery tasks should complete in seconds, not hours. So in cases of consistently slow tasks we really need to fix the task anyway (which we hopefully [have done](https://github.com/hypothesis/lms/pull/5425)).

In the case of a task that is usually fast but just randomly hangs one time (some sort of one-off incident) the time limit is exactly what we want: the task will be killed and restarted and will hopefully succeed on one of its finite number of retries.

Further Work
============

We should probably add this to all our other Celery-using apps as well.

Testing
=======

Hack one of the Celery tasks to make it run forever:

```diff
diff --git a/lms/tasks/email_digests.py b/lms/tasks/email_digests.py
index 423e65a8c..fca9880ff 100644
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -35,6 +35,11 @@ def send_instructor_email_digest_tasks(*, batch_size):
     EST is 5 hours behind UTC (ignoring daylight savings for simplicity: we
     don't need complete accuracy in the timing).
     """
+    from time import sleep
+    while True:
+        print("Sleeping..")
+        sleep(1)
+
     now = datetime.now(timezone.utc)
     updated_before = datetime(year=now.year, month=now.month, day=now.day, hour=5)
     updated_after = updated_before - timedelta(days=1)
```

Now run `make dev` in one shell and in another shell run `make shell` and kick off an instance of the task:

```python
$ make shell
>>> from lms.tasks.email_digests import send_instructor_email_digest_tasks
>>> send_instructor_email_digest_tasks.delay(batch_size=42)
<AsyncResult: d418fb0f-f007-4537-ae1f-3c7e802401fb>
```

Over in the first shell you'll see the task running. After two minutes you should see Celery kill the task and schedule a retry.

If you hack the task to also take forever to clean up after a soft time limit then after four minutes you'll see Celery force-terminate the task (and not schedule a retry):

```diff
diff --git a/lms/tasks/email_digests.py b/lms/tasks/email_digests.py
index 423e65a8c..4714549ef 100644
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -35,6 +35,18 @@ def send_instructor_email_digest_tasks(*, batch_size):
     EST is 5 hours behind UTC (ignoring daylight savings for simplicity: we
     don't need complete accuracy in the timing).
     """
+    from time import sleep
+    from celery.exceptions import SoftTimeLimitExceeded
+
+    try:
+        while True:
+            print("Sleeping..")
+            sleep(1)
+    except SoftTimeLimitExceeded:
+        while True:
+            print("Still sleeping..")
+            sleep(1)
+
     now = datetime.now(timezone.utc)
     updated_before = datetime(year=now.year, month=now.month, day=now.day, hour=5)
     updated_after = updated_before - timedelta(days=1)
```
