### PR TITLE
Always set `underline` prop for `Link`, `LinkBase`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/Breadcrumbs.tsx
+++ b/lms/static/scripts/frontend_apps/components/Breadcrumbs.tsx
@@ -25,14 +25,16 @@ export default function Breadcrumbs<Item>({
     <ul className="flex flex-wrap leading-none">
       {breadcrumbs.map((item, idx) => (
         <li className="flex" key={idx}>
-          <LinkButton onClick={() => onSelectItem(item)}>
+          <LinkButton onClick={() => onSelectItem(item)} underline="none">
             {renderItem(item)}
           </LinkButton>
           <span className="mx-2">›</span>
         </li>
       ))}
       <li>
-        <LinkButton disabled>{renderItem(currentItem)}</LinkButton>
+        <LinkButton disabled underline="none">
+          {renderItem(currentItem)}
+        </LinkButton>
       </li>
     </ul>
   );

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.tsx
@@ -45,7 +45,11 @@ export default function ErrorDialogApp() {
             <li>
               This consumer key has already been used on another site. A site
               admin must{' '}
-              <Link target="_blank" href="https://web.hypothes.is/get-help/">
+              <Link
+                target="_blank"
+                href="https://web.hypothes.is/get-help/"
+                underline="none"
+              >
                 request a new consumer key
               </Link>{' '}
               for this site and re-install Hypothesis.
@@ -53,7 +57,11 @@ export default function ErrorDialogApp() {
             <li>
               This {"site's"} tool_consumer_instance_guid has changed. A site
               admin must{' '}
-              <Link target="_blank" href="https://web.hypothes.is/get-help/">
+              <Link
+                target="_blank"
+                href="https://web.hypothes.is/get-help/"
+                underline="none"
+              >
                 ask us to update the consumer key
               </Link>
               .

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
@@ -125,11 +125,19 @@ export default function ErrorDisplay({
         {children}
         <p data-testid="error-links">
           If the problem persists, you can{' '}
-          <Link href={supportURL(message, error)} target="_blank">
+          <Link
+            href={supportURL(message, error)}
+            target="_blank"
+            underline="none"
+          >
             open a support ticket
           </Link>{' '}
           or visit our{' '}
-          <Link href="https://web.hypothes.is/help/" target="_blank">
+          <Link
+            href="https://web.hypothes.is/help/"
+            target="_blank"
+            underline="none"
+          >
             help documents
           </Link>
           .

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -108,6 +108,7 @@ function NoGroupsError({ onCancel }: { onCancel: () => void }) {
           <Link
             href="https://web.hypothes.is/?s=group&ht-kb-search=1&lang=%0D%0A%09%09"
             target="_blank"
+            underline="none"
           >
             help articles about using groups
           </Link>


### PR DESCRIPTION
This little PR updates usages of `Link` and `LinkButton` components to ensure they always set the `underline` prop. This will allow us to change the default value of that prop for future uses without disrupting any existing styling.