### PR TITLE
Log non-JSON responses from LTIA token requests

### DIFF
--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -1,9 +1,14 @@
+import logging
 import uuid
 from datetime import datetime, timedelta
+
+from requests.exceptions import JSONDecodeError
 
 from lms.models import LTIRegistration
 from lms.product.plugin.misc import MiscPlugin
 from lms.services.jwt import JWTService
+
+LOG = logging.getLogger(__name__)
 
 
 class LTIAHTTPService:
@@ -61,7 +66,11 @@ class LTIAHTTPService:
             timeout=(20, 20),
         )
 
-        return response.json()["access_token"]
+        try:
+            return response.json()["access_token"]
+        except JSONDecodeError:  # pragma: no cover
+            LOG.error("Non-json response: %s", response.text)
+            raise
 
 
 def factory(_context, request):


### PR DESCRIPTION
Help debug some issues we are seeing where the LTIA service is returning a 200 response but with no JSON.


See: https://hypothesis.sentry.io/issues/4209873926/?project=259908&referrer=slack