### PR TITLE
Youtube api proxy

### DIFF
--- a/lms/config.py
+++ b/lms/config.py
@@ -99,6 +99,7 @@ SETTINGS = (
     _Setting("blackboard_api_client_secret"),
     _Setting("jstor_api_url"),
     _Setting("jstor_api_secret"),
+    _Setting("youtube_api_key"),
     _Setting("disable_key_rotation", value_mapper=asbool),
     _Setting("mailchimp_api_key"),
     _Setting("mailchimp_digests_subaccount"),

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -131,6 +131,8 @@ def includeme(config):  # pylint:disable=too-many-statements
     )
     config.add_route("vitalsource_api.launch_url", "/api/vitalsource/launch_url")
 
+    config.add_route("youtube_api.videos", "/api/youtube/videos/{video_id}")
+
     config.add_route("email.unsubscribe", "/email/unsubscribe")
     config.add_route("email.unsubscribed", "/email/unsubscribed")
 

--- a/lms/services/youtube.py
+++ b/lms/services/youtube.py
@@ -1,21 +1,77 @@
+from lms.services import SerializableError
+from lms.services.http import HTTPService
+
+YOUTUBE_API_URL = "https://www.googleapis.com/youtube/v3"
+"""YouTube's API base URL"""
+
+
+class VideoNotFound(SerializableError):
+    def __init__(self, video_id):
+        super().__init__(
+            error_code="youtube_video_not_found", details={"video_id": video_id}
+        )
+
+
 class YoutubeService:
-    """An interface for dealing with Youtube API."""
+    """An interface for dealing with YouTube API."""
 
-    def __init__(self, enabled: bool):
+    def __init__(self, enabled: bool, api_key: str, http: HTTPService):
         """
-        Initialise the Youtube service.
+        Initialise the YouTube service.
 
-        :param enabled: Whether Youtube is enabled on this instance
+        :param enabled: Whether YouTube is enabled on this instance
+        :param api_key: YouTube API key
         """
         self._enabled = enabled
+        self._api_key = api_key
+        self._http = http
 
     @property
     def enabled(self) -> bool:
-        """Get whether this instance is configured for Youtube."""
+        """Get whether this instance is configured for YouTube."""
 
-        return self._enabled
+        return bool(self._enabled and self._api_key)
+
+    def video_info(self, video_id: str) -> dict:
+        """
+        Fetch YouTube video information.
+
+        :param video_id: A YouTube video ID
+        :raise VideoNotFound: If the video cannot be found
+        """
+
+        # Endpoint docs: https://developers.google.com/youtube/v3/docs/videos/list
+        resp = self._http.get(
+            url=f"{YOUTUBE_API_URL}/videos",
+            params={
+                "id": video_id,
+                "key": self._api_key,
+                "part": "contentDetails,snippet",
+                "maxResults": "1",
+            },
+        )
+        json_resp: dict = resp.json()
+
+        try:
+            item = json_resp["items"][0]
+        except IndexError as err:
+            raise VideoNotFound(video_id) from err
+
+        snippet = item["snippet"]
+        return {
+            "image": snippet["thumbnails"]["medium"]["url"],
+            "title": snippet["title"],
+            "channel": snippet["channelTitle"],
+            "duration": item["contentDetails"]["duration"],  # ISO duration
+        }
 
 
-def factory(_context, request):
+def factory(_context, request) -> YoutubeService:
     ai_settings = request.lti_user.application_instance.settings
-    return YoutubeService(enabled=ai_settings.get("youtube", "enabled"))
+    app_settings = request.registry.settings
+
+    return YoutubeService(
+        enabled=ai_settings.get("youtube", "enabled"),
+        api_key=app_settings.get("youtube_api_key"),
+        http=request.find_service(name="http"),
+    )

--- a/lms/views/api/youtube.py
+++ b/lms/views/api/youtube.py
@@ -8,15 +8,11 @@ from lms.services import YoutubeService
 class YouTubeAPIViews:
     def __init__(self, request):
         self.request = request
-        self.youtube_service: YoutubeService = request.find_service(iface=YoutubeService)
+        self.youtube_service: YoutubeService = request.find_service(
+            iface=YoutubeService
+        )
 
     @view_config(route_name="youtube_api.videos")
-    def video_info(self):
-        # The image is wrapped in an object to make API responses more uniform
-        # for consumers.
-        return {
-            "image": "https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg",
-            "title": "Hypothesis and Atlassian New Partnership Announced at the Team23 Conference",
-            "channel": "Hypothesis",
-            "duration": "PT2M20S"  # ISO duration
-        }
+    def video_info(self) -> dict:
+        video_id = self.request.matchdict["video_id"]
+        return self.youtube_service.video_info(video_id)

--- a/lms/views/api/youtube.py
+++ b/lms/views/api/youtube.py
@@ -1,0 +1,22 @@
+from pyramid.view import view_config, view_defaults
+
+from lms.security import Permissions
+from lms.services import YoutubeService
+
+
+@view_defaults(renderer="json", permission=Permissions.API)
+class YouTubeAPIViews:
+    def __init__(self, request):
+        self.request = request
+        self.youtube_service: YoutubeService = request.find_service(iface=YoutubeService)
+
+    @view_config(route_name="youtube_api.videos")
+    def video_info(self):
+        # The image is wrapped in an object to make API responses more uniform
+        # for consumers.
+        return {
+            "image": "https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg",
+            "title": "Hypothesis and Atlassian New Partnership Announced at the Team23 Conference",
+            "channel": "Hypothesis",
+            "duration": "PT2M20S"  # ISO duration
+        }

--- a/tests/unit/lms/routes_test.py
+++ b/tests/unit/lms/routes_test.py
@@ -33,6 +33,11 @@ from pyramid.testing import DummyRequest
             {"article_id": "10.123/456"},
         ),
         ("/api/jstor/articles/10/456/thumbnail", None, None),
+        (
+            "/api/youtube/videos/456",
+            "youtube_api.videos",
+            {"video_id": "456"},
+        ),
     ],
 )
 def test_request_matches_expected_route(

--- a/tests/unit/lms/services/youtube_test.py
+++ b/tests/unit/lms/services/youtube_test.py
@@ -2,25 +2,84 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.services.youtube import YoutubeService, factory
+from lms.services.youtube import VideoNotFound, YoutubeService, factory
+from tests import factories
 
 
 class TestYoutubeService:
-    @pytest.mark.parametrize("enabled", (True, False, None))
-    def test_enabled(self, enabled):
-        svc = YoutubeService(enabled=enabled)
+    @pytest.mark.parametrize(
+        "enabled,api_key,expected_enabled",
+        (
+            (True, "api_key", True),
+            (True, "", False),
+            (False, "api_key", False),
+            (False, "", False),
+            (None, "api_key", False),
+            (None, "", False),
+        ),
+    )
+    def test_enabled(self, enabled, api_key, expected_enabled, http_service):
+        svc = YoutubeService(enabled=enabled, api_key=api_key, http=http_service)
 
-        assert svc.enabled == enabled
+        assert svc.enabled == expected_enabled
+
+    def test_video_info_raises_for_invalid_video(self, svc, http_service):
+        response = factories.requests.Response(json_data={"items": []})
+        http_service.get.return_value = response
+
+        with pytest.raises(VideoNotFound):
+            svc.video_info(video_id="invalid_video_id")
+
+    def test_video_info_parses_json_response(self, svc, http_service):
+        response = factories.requests.Response(
+            json_data={
+                "items": [
+                    {
+                        "snippet": {
+                            "title": "Some video",
+                            "channelTitle": "Hypothesis",
+                            "thumbnails": {
+                                "medium": {
+                                    "url": "https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg"
+                                }
+                            },
+                        },
+                        "contentDetails": {"duration": "P2M10S"},
+                    }
+                ]
+            }
+        )
+        http_service.get.return_value = response
+
+        result = svc.video_info(video_id="invalid_video_id")
+        assert result == {
+            "title": "Some video",
+            "channel": "Hypothesis",
+            "image": "https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg",
+            "duration": "P2M10S",
+        }
+
+    @pytest.fixture
+    def svc(self, http_service):
+        return YoutubeService(enabled=True, api_key="api_key", http=http_service)
 
 
 class TestServiceFactory:
     @pytest.mark.usefixtures("application_instance_service")
-    def test_it(self, pyramid_request, application_instance, YoutubeService):
+    @pytest.mark.usefixtures("http_service")
+    def test_it(
+        self, pyramid_request, application_instance, YoutubeService, http_service
+    ):
         application_instance.settings.set("youtube", "enabled", sentinel.enabled)
+
+        app_settings = pyramid_request.registry.settings
+        app_settings["youtube_api_key"] = "api_key"
 
         svc = factory(sentinel.context, pyramid_request)
 
-        YoutubeService.assert_called_once_with(enabled=sentinel.enabled)
+        YoutubeService.assert_called_once_with(
+            enabled=sentinel.enabled, api_key="api_key", http=http_service
+        )
         assert svc == YoutubeService.return_value
 
     @pytest.fixture

--- a/tests/unit/lms/views/api/youtube_test.py
+++ b/tests/unit/lms/views/api/youtube_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from lms.views.api.youtube import YouTubeAPIViews
+
+
+@pytest.mark.usefixtures("youtube_service")
+class TestYouTubeAPIViews:
+    def test_video_info(self, views, youtube_service, pyramid_request):
+        pyramid_request.matchdict["video_id"] = "test-video-id"
+
+        video_info = views.video_info()
+
+        youtube_service.video_info("test-video-id")
+        assert video_info == youtube_service.video_info.return_value
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return YouTubeAPIViews(pyramid_request)


### PR DESCRIPTION
This PR adds the basic functionality to proxy requests to YouTube API to get video information.

This is done 

### Testing steps

1. Check out this branch
2. Run `make devdata` to get the API key
3. Run the following request, and check that you get proper video information
    ```shell
    curl --request GET \
      --url http://localhost:8001/api/youtube/videos/EU6TDnV5osM \
      --header 'Authorization: Bearer <add_token_here>'
    ```
    It should produce a response like this:
    ```json
    {
      "image": "https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg",
      "title": "Hypothesis and Atlassian New Partnership Announced at the Team23 Conference",
      "channel": "Hypothesis",
      "duration": "PT2M20S"
    }
    ```
    (feel free to try other IDs and see the result)
4. Run the same command but providing an invalid video ID, and check the response looks like this:
    ```json
    {
      "error_code": "youtube_video_not_found",
      "details": {
        "video_id": "<provided_invalid_id>"
      }
    }
    ```

### TODO

- [x] Add tests for the youtube service
- [x] Add dev credentials to devdata (https://github.com/hypothesis/devdata/pull/85)

### Follow-up work

- Handle transcript languages in case there's no English
- Add prod and QA credentials to Elastic Beanstalk
- ~More strictly validate the response schema from YouTube, and fallback or raise errors in case of missing information~
- Consider caching video info, as the API has a maximum of 10,000 of these requests per month

> This PR is part of https://github.com/hypothesis/lms/issues/5404