### PR TITLE
Make sure YouTube picker save is reset when editing its content

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -29,6 +29,8 @@ export type URLFormWithPreviewProps = {
   inputRef: RefObject<HTMLInputElement | undefined>;
   /** Invoked every time the input URL changes, with the value that was input */
   onURLChange: (inputURL: string) => void;
+  /** Invoked when the input content is modified */
+  onInput: () => void;
   label: string;
   urlPlaceholder?: string;
   defaultURL?: string;
@@ -43,6 +45,7 @@ export default function URLFormWithPreview({
   thumbnail,
   inputRef,
   onURLChange,
+  onInput,
   label,
   urlPlaceholder,
   defaultURL,
@@ -102,6 +105,7 @@ export default function URLFormWithPreview({
             name="URL"
             onChange={onChange}
             onKeyDown={onKeyDown}
+            onInput={onInput}
             placeholder={urlPlaceholder}
             spellcheck={false}
           />

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -67,6 +67,7 @@ export default function YouTubePicker({
     >
       <URLFormWithPreview
         onURLChange={verifyURL}
+        onInput={() => setVideoId(null)}
         error={error}
         inputRef={inputRef}
         urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -23,6 +23,10 @@ export default function YouTubePicker({
     (defaultURL && videoIdFromYouTubeURL(defaultURL)) || null
   );
   const [error, setError] = useState<string>();
+  const resetToInitialState = () => {
+    setVideoId(null);
+    setError(undefined);
+  };
   const { thumbnail, metadata } = useYouTubeVideoInfo(videoId);
 
   const verifyURL = (inputURL: string) => {
@@ -67,7 +71,7 @@ export default function YouTubePicker({
     >
       <URLFormWithPreview
         onURLChange={verifyURL}
-        onInput={() => setVideoId(null)}
+        onInput={resetToInitialState}
         error={error}
         inputRef={inputRef}
         urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"

--- a/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
@@ -9,6 +9,7 @@ describe('URLFormWithPreview', () => {
       <URLFormWithPreview
         label="Default label"
         onURLChange={sinon.stub()}
+        onInput={sinon.stub()}
         inputRef={createRef()}
         {...props}
       />
@@ -138,6 +139,16 @@ describe('URLFormWithPreview', () => {
       button.simulate('click');
 
       assert.calledWith(onURLChange, 'https://example.com');
+    });
+
+    it('invokes `onInput` when URL input content is modified', () => {
+      const onInput = sinon.stub();
+      const wrapper = renderComponent({ onInput });
+      const input = wrapper.find('Input').find('input');
+
+      input.simulate('input');
+
+      assert.called(onInput);
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
@@ -107,7 +107,7 @@ describe('URLFormWithPreview', () => {
     it('invokes `onURLChange` when the value of the url input changes', () => {
       const onURLChange = sinon.stub();
       const wrapper = renderComponent({ onURLChange });
-      const input = wrapper.find('Input').find('input');
+      const input = wrapper.find('input');
 
       input.getDOMNode().value = 'https://example.com';
       input.simulate('change');
@@ -132,7 +132,7 @@ describe('URLFormWithPreview', () => {
     it('invokes `onURLChange` when confirm button is clicked', () => {
       const onURLChange = sinon.stub();
       const wrapper = renderComponent({ onURLChange });
-      const input = wrapper.find('Input').find('input');
+      const input = wrapper.find('input');
       const button = wrapper.find('IconButton').find('button');
 
       input.getDOMNode().value = 'https://example.com';
@@ -140,15 +140,14 @@ describe('URLFormWithPreview', () => {
 
       assert.calledWith(onURLChange, 'https://example.com');
     });
+  });
 
-    it('invokes `onInput` when URL input content is modified', () => {
-      const onInput = sinon.stub();
-      const wrapper = renderComponent({ onInput });
-      const input = wrapper.find('Input').find('input');
+  it('invokes `onInput` when URL input content is modified', () => {
+    const onInput = sinon.stub();
+    const wrapper = renderComponent({ onInput });
 
-      input.simulate('input');
+    wrapper.find('input').simulate('input');
 
-      assert.called(onInput);
-    });
+    assert.called(onInput);
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -110,4 +110,19 @@ describe('YouTubePicker', () => {
     // As soon as input changes, the video is reset, disabling the button
     assert.isTrue(wrapper.find(buttonSelector).prop('disabled'));
   });
+
+  it('resets visible errors on URL input', () => {
+    const wrapper = renderComponent();
+
+    // Invoking onURLChange with an invalid URL will set the error
+    wrapper.find('URLFormWithPreview').props().onURLChange('not-a-youtube-url');
+    wrapper.update();
+    assert.isDefined(wrapper.find('URLFormWithPreview').prop('error'));
+
+    wrapper.find('URLFormWithPreview').props().onInput();
+    wrapper.update();
+
+    // As soon as input changes, the error is unset
+    assert.isUndefined(wrapper.find('URLFormWithPreview').prop('error'));
+  });
 });

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -96,4 +96,18 @@ describe('YouTubePicker', () => {
     assert.isTrue(metadata.exists());
     assert.equal(metadata.text(), 'The video title (Hypothesis)');
   });
+
+  it('resets selected video on URL input', () => {
+    const wrapper = renderComponent();
+    const buttonSelector = 'button[data-testid="select-button"]';
+
+    // The button is initially enabled
+    assert.isFalse(wrapper.find(buttonSelector).prop('disabled'));
+
+    wrapper.find('URLFormWithPreview').props().onInput();
+    wrapper.update();
+
+    // As soon as input changes, the video is reset, disabling the button
+    assert.isTrue(wrapper.find(buttonSelector).prop('disabled'));
+  });
 });


### PR DESCRIPTION
This PR makes sure invalid content cannot be saved in YouTube picker if you introduce a valid URL (which enables the "continue" button), but before pressing "continue" you edit it to set invalid content.

It also resets any visible error message to make it behave like the JSTORPicker.

Before:

[Grabación de pantalla desde 2023-05-31 10-01-16.webm](https://github.com/hypothesis/lms/assets/2719332/32aed01f-4677-4ba3-8186-6177f9f569d6)

After:

[Grabación de pantalla desde 2023-05-31 10-13-30.webm](https://github.com/hypothesis/lms/assets/2719332/060998cf-d545-47ff-be48-4834911a7f98)

### Testing steps

1. Checkout this branch
2. Enable youtube in an LMS instance (http://localhost:8001/admin/instance/{id}/)
    ![image](https://github.com/hypothesis/lms/assets/2719332/e70e16e8-ceaf-4fca-8be2-a839c451cb82)
3. Try to edit/create a course on that instance
4. Select YouTube video, and introduce a valid video URL in the text field, like https://www.youtube.com/watch?v=EU6TDnV5osM&ab_channel=Hypothesis, then press `Enter`.
    * The "continue" button gets enabled.
5. Try to edit the URL
    * The "continue" button gets disabled.

If you do the same in `main`, you could be able to input something invalid in step 5, and the button does not get disabled until the input looses focus.