### PR TITLE
Fix typo in YouTube brand name

### DIFF
--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -1,7 +1,7 @@
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
 from lms.product.d2l import D2L
-from lms.services import JSTORService, VitalSourceService, YoutubeService
+from lms.services import JSTORService, VitalSourceService, YouTubeService
 
 
 class FilePickerConfig:
@@ -114,4 +114,4 @@ class FilePickerConfig:
 
     @classmethod
     def youtube_config(cls, request, _application_instance):
-        return {"enabled": request.find_service(YoutubeService).enabled}
+        return {"enabled": request.find_service(YouTubeService).enabled}

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -33,7 +33,7 @@ from lms.services.organization import OrganizationService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.vitalsource import VitalSourceService
-from lms.services.youtube import YoutubeService
+from lms.services.youtube import YouTubeService
 
 
 def includeme(config):
@@ -127,7 +127,7 @@ def includeme(config):
         "lms.services.email_unsubscribe.factory", iface=EmailUnsubscribeService
     )
     config.register_service_factory(
-        "lms.services.youtube.factory", iface=YoutubeService
+        "lms.services.youtube.factory", iface=YouTubeService
     )
 
     # Plugins are not the same as top level services but we want to register them as pyramid services too

--- a/lms/services/youtube.py
+++ b/lms/services/youtube.py
@@ -12,7 +12,7 @@ class VideoNotFound(SerializableError):
         )
 
 
-class YoutubeService:
+class YouTubeService:
     """An interface for dealing with YouTube API."""
 
     def __init__(self, enabled: bool, api_key: str, http: HTTPService):
@@ -66,11 +66,11 @@ class YoutubeService:
         }
 
 
-def factory(_context, request) -> YoutubeService:
+def factory(_context, request) -> YouTubeService:
     ai_settings = request.lti_user.application_instance.settings
     app_settings = request.registry.settings
 
-    return YoutubeService(
+    return YouTubeService(
         enabled=ai_settings.get("youtube", "enabled"),
         api_key=app_settings.get("youtube_api_key"),
         http=request.find_service(name="http"),

--- a/lms/views/api/youtube.py
+++ b/lms/views/api/youtube.py
@@ -1,15 +1,15 @@
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
-from lms.services import YoutubeService
+from lms.services import YouTubeService
 
 
 @view_defaults(renderer="json", permission=Permissions.API)
 class YouTubeAPIViews:
     def __init__(self, request):
         self.request = request
-        self.youtube_service: YoutubeService = request.find_service(
-            iface=YoutubeService
+        self.youtube_service: YouTubeService = request.find_service(
+            iface=YouTubeService
         )
 
     @view_config(route_name="youtube_api.videos")

--- a/tests/unit/lms/services/youtube_test.py
+++ b/tests/unit/lms/services/youtube_test.py
@@ -2,11 +2,11 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.services.youtube import VideoNotFound, YoutubeService, factory
+from lms.services.youtube import VideoNotFound, YouTubeService, factory
 from tests import factories
 
 
-class TestYoutubeService:
+class TestYouTubeService:
     @pytest.mark.parametrize(
         "enabled,api_key,expected_enabled",
         (
@@ -19,7 +19,7 @@ class TestYoutubeService:
         ),
     )
     def test_enabled(self, enabled, api_key, expected_enabled, http_service):
-        svc = YoutubeService(enabled=enabled, api_key=api_key, http=http_service)
+        svc = YouTubeService(enabled=enabled, api_key=api_key, http=http_service)
 
         assert svc.enabled == expected_enabled
 
@@ -61,14 +61,14 @@ class TestYoutubeService:
 
     @pytest.fixture
     def svc(self, http_service):
-        return YoutubeService(enabled=True, api_key="api_key", http=http_service)
+        return YouTubeService(enabled=True, api_key="api_key", http=http_service)
 
 
 class TestServiceFactory:
     @pytest.mark.usefixtures("application_instance_service")
     @pytest.mark.usefixtures("http_service")
     def test_it(
-        self, pyramid_request, application_instance, YoutubeService, http_service
+        self, pyramid_request, application_instance, YouTubeService, http_service
     ):
         application_instance.settings.set("youtube", "enabled", sentinel.enabled)
 
@@ -77,11 +77,11 @@ class TestServiceFactory:
 
         svc = factory(sentinel.context, pyramid_request)
 
-        YoutubeService.assert_called_once_with(
+        YouTubeService.assert_called_once_with(
             enabled=sentinel.enabled, api_key="api_key", http=http_service
         )
-        assert svc == YoutubeService.return_value
+        assert svc == YouTubeService.return_value
 
     @pytest.fixture
-    def YoutubeService(self, patch):
-        return patch("lms.services.youtube.YoutubeService")
+    def YouTubeService(self, patch):
+        return patch("lms.services.youtube.YouTubeService")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -48,7 +48,7 @@ from lms.services.oauth_http import OAuthHTTPService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.vitalsource import VitalSourceService
-from lms.services.youtube import YoutubeService
+from lms.services.youtube import YouTubeService
 from tests import factories
 
 __all__ = (
@@ -240,7 +240,7 @@ def jstor_service(mock_service):
 
 @pytest.fixture
 def youtube_service(mock_service):
-    return mock_service(YoutubeService)
+    return mock_service(YouTubeService)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR fixes some typos in the usage of `YouTube` brand, making sure we either use it all in lowercase, or with a capital `T`, so the possible values are `youtube` or `YouTube`, but never `Youtube`.