### PR TITLE
Cache LTIA tokens in the DB

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -21,6 +21,7 @@ from lms.models.grouping import (
 )
 from lms.models.h_user import HUser
 from lms.models.json_settings import JSONSettings
+from lms.models.jwt_oauth2_token import JWTOAuth2Token
 from lms.models.lti_params import CLAIM_PREFIX, LTIParams
 from lms.models.lti_registration import LTIRegistration
 from lms.models.lti_role import LTIRole

--- a/lms/models/jwt_oauth2_token.py
+++ b/lms/models/jwt_oauth2_token.py
@@ -10,10 +10,12 @@ class JWTOAuth2Token(CreatedUpdatedMixin, BASE):
 
     https://datatracker.ietf.org/doc/html/rfc7523
 
-    Similar to models.OAuth2Token but using the JWT profile required by LTIA APIs.
+    Similar to `models.OAuth2Token` but using the JWT profile required by LTIA
+    APIs.
 
-    These tokens are not valid for a particular user but for one tool from the point of view of the LMS.
-    In our system that's identified by "LTIRegistration".
+    These tokens are not valid for a particular user but for one tool from the
+    point of view of the LMS. In our system that's identified by
+    "LTIRegistration".
 
     Tokens are also valid for one set of scopes only.
     """

--- a/lms/models/jwt_oauth2_token.py
+++ b/lms/models/jwt_oauth2_token.py
@@ -8,8 +8,6 @@ class JWTOAuth2Token(CreatedUpdatedMixin, BASE):
     """
     JWT based OAuth2Token.
 
-    https://datatracker.ietf.org/doc/html/rfc7523
-
     Similar to `models.OAuth2Token` but using the JWT profile required by LTIA
     APIs.
 
@@ -18,6 +16,11 @@ class JWTOAuth2Token(CreatedUpdatedMixin, BASE):
     "LTIRegistration".
 
     Tokens are also valid for one set of scopes only.
+
+    See the spec for the JWT Profile for OAuth 2.0 over:
+
+       https://datatracker.ietf.org/doc/html/rfc7523
+
     """
 
     __tablename__ = "jwt_oauth2_token"

--- a/lms/models/jwt_oauth2_token.py
+++ b/lms/models/jwt_oauth2_token.py
@@ -1,0 +1,45 @@
+import sqlalchemy as sa
+
+from lms.db import BASE
+from lms.models._mixins import CreatedUpdatedMixin
+
+
+class JWTOAuth2Token(CreatedUpdatedMixin, BASE):
+    """
+    JWT based OAuth2Token.
+
+    https://datatracker.ietf.org/doc/html/rfc7523
+
+    Similar to models.OAuth2Token but using the JWT profile required by LTIA APIs.
+
+    These tokens are not valid for a particular user but for one tool from the point of view of the LMS.
+    In our system that's identified by "LTIRegistration".
+
+    Tokens are also valid for one set of scopes only.
+    """
+
+    __tablename__ = "jwt_oauth2_token"
+    __table_args__ = (sa.UniqueConstraint("lti_registration_id", "scopes"),)
+
+    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+
+    # The LTIRegistration that this token belongs to foreign key
+    lti_registration_id = sa.Column(
+        sa.Integer(),
+        sa.ForeignKey("lti_registration.id", ondelete="cascade"),
+        nullable=False,
+    )
+
+    # The LTIRegistration that this token belongs to foreign key
+    lti_registration = sa.orm.relationship(
+        "LTIRegistration", foreign_keys=[lti_registration_id]
+    )
+
+    # Scopes this token is valid for
+    scopes = sa.Column(sa.UnicodeText(), nullable=False)
+
+    # The OAuth 2.0 access token, as received from the authorization server.
+    access_token = sa.Column(sa.UnicodeText(), nullable=False)
+
+    # Time at which the toke will expire
+    expires_at = sa.Column(sa.DateTime, nullable=False)

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -18,6 +18,7 @@ from lms.services.exceptions import (
 from lms.services.h_api import HAPI, HAPIError
 from lms.services.jstor import JSTORService
 from lms.services.jwt import JWTService
+from lms.services.jwt_oauth2_token import JWTOAuth2TokenService
 from lms.services.launch_verifier import (
     ConsumerKeyLaunchVerificationError,
     LTILaunchVerificationError,
@@ -105,6 +106,9 @@ def includeme(config):
     )
     config.register_service_factory("lms.services.aes.factory", iface=AESService)
     config.register_service_factory("lms.services.jwt.factory", iface=JWTService)
+    config.register_service_factory(
+        "lms.services.jwt_oauth2_token.factory", iface=JWTOAuth2TokenService
+    )
     config.register_service_factory("lms.services.rsa_key.factory", iface=RSAKeyService)
     config.register_service_factory(
         "lms.services.ltia_http.factory", iface=LTIAHTTPService

--- a/lms/services/jwt_oauth2_token.py
+++ b/lms/services/jwt_oauth2_token.py
@@ -13,7 +13,7 @@ class JWTOAuth2TokenService:
     def __init__(self, db):
         self._db = db
 
-    def save(
+    def save_token(
         self, lti_registration, scopes: List[str], access_token: str, expires_in: int
     ) -> JWTOAuth2Token:
         """
@@ -22,7 +22,7 @@ class JWTOAuth2TokenService:
         If there's already one for this registration and scopes then overwrite
         its values; otherwise create a new one and add it to the DB.
         """
-        token = self.get(lti_registration, scopes, exclude_expired=False)
+        token = self.get_token(lti_registration, scopes, exclude_expired=False)
         if not token:
             token = JWTOAuth2Token(
                 lti_registration=lti_registration, scopes=self._normalize_scopes(scopes)
@@ -35,7 +35,7 @@ class JWTOAuth2TokenService:
 
         return token
 
-    def get(
+    def get_token(
         self, lti_registration, scopes: List[str], exclude_expired=True
     ) -> Optional[JWTOAuth2Token]:
         """

--- a/lms/services/jwt_oauth2_token.py
+++ b/lms/services/jwt_oauth2_token.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta
+from functools import lru_cache
+from typing import Optional
+
+from lms.models.jwt_oauth2_token import JWTOAuth2Token
+
+
+class JWTOAuth2TokenService:
+    """Save and retrieve JWTOAuth2Tokens from the DB."""
+
+    EXPIRATION_LEEWAY = 60
+    """Allowable wiggle room for expiry time to allow for request's delays."""
+
+    def __init__(self, db):
+        self._db = db
+
+    def save(
+        self, lti_registration, scopes: str, access_token: str, expires_in: int
+    ) -> JWTOAuth2Token:
+        """
+        Save a JWT OAuth2Token to the DB.
+
+        If there's already one for this registration and scopes then overwrite
+        its values; otherwise create a new one and add it to the DB.
+        """
+        token = self.get(lti_registration, scopes, exclude_expired=False)
+        if not token:
+            token = JWTOAuth2Token(lti_registration=lti_registration, scopes=scopes)
+            self._db.add(token)
+
+        token.access_token = access_token
+        token.received_at = datetime.now()
+        token.expires_at = datetime.now() + timedelta(seconds=expires_in)
+
+        return token
+
+    @lru_cache(maxsize=1)
+    def get(
+        self, lti_registration, scopes: str, exclude_expired=True
+    ) -> Optional[JWTOAuth2Token]:
+        """
+        Get a token for the given registration and scopes if present in the DB.
+
+        :param lti_registration: Registration for the token we are looking for
+        :param scopes: Scopes of the desired token
+        :param exclude_expired: Do not return expired tokens
+        """
+        query = self._db.query(JWTOAuth2Token).filter(
+            JWTOAuth2Token.lti_registration == lti_registration,
+            JWTOAuth2Token.scopes == scopes,
+        )
+        if exclude_expired:
+            query = query.filter(
+                (JWTOAuth2Token.expires_at - timedelta(seconds=self.EXPIRATION_LEEWAY))
+                >= datetime.now()
+            )
+
+        return query.one_or_none()
+
+
+def factory(_context, request):
+    return JWTOAuth2TokenService(request.db)

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -41,7 +41,7 @@ class LTIAHTTPService:
 
     def _get_access_token(self, scopes: List[str]) -> str:
         """Get a valid access token from the DB or get a new one from the LMS."""
-        token = self._jwt_oauth2_token_service.get(self._lti_registration, scopes)
+        token = self._jwt_oauth2_token_service.get_token(self._lti_registration, scopes)
         if not token:
             LOG.debug("Requesting new LTIA JWT token")
             token = self._get_new_access_token(scopes)
@@ -86,7 +86,7 @@ class LTIAHTTPService:
             LOG.error("Non-json response: %s", response.text)
             raise
 
-        token = self._jwt_oauth2_token_service.save(
+        token = self._jwt_oauth2_token_service.save_token(
             lti_registration=self._lti_registration,
             scopes=scopes,
             access_token=token_data["access_token"],

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from datetime import datetime, timedelta
+from typing import List
 
 from requests.exceptions import JSONDecodeError
 
@@ -33,12 +34,12 @@ class LTIAHTTPService:
 
         assert "Authorization" not in headers
 
-        access_token = self._get_access_token(" ".join(scopes))
+        access_token = self._get_access_token(scopes)
         headers["Authorization"] = f"Bearer {access_token}"
 
         return self._http.request(method, url, headers=headers, **kwargs)
 
-    def _get_access_token(self, scopes: str) -> str:
+    def _get_access_token(self, scopes: List[str]) -> str:
         """Get a valid access token from the DB or get a new one from the LMS."""
         token = self._jwt_oauth2_token_service.get(self._lti_registration, scopes)
         if not token:
@@ -49,7 +50,7 @@ class LTIAHTTPService:
 
         return token.access_token
 
-    def _get_new_access_token(self, scopes: str) -> JWTOAuth2Token:
+    def _get_new_access_token(self, scopes: List[str]) -> JWTOAuth2Token:
         """
         Get an access token from the LMS to use in LTA services.
 
@@ -74,7 +75,7 @@ class LTIAHTTPService:
                 "grant_type": "client_credentials",
                 "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                 "client_assertion": signed_jwt,
-                "scope": scopes,
+                "scope": " ".join(scopes),
             },
             timeout=(20, 20),
         )

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 
 from requests.exceptions import JSONDecodeError
 
-from lms.models import LTIRegistration
+from lms.models import JWTOAuth2Token, LTIRegistration
 from lms.product.plugin.misc import MiscPlugin
-from lms.services.jwt import JWTService
+from lms.services import JWTOAuth2TokenService, JWTService
 
 LOG = logging.getLogger(__name__)
 
@@ -14,29 +14,42 @@ LOG = logging.getLogger(__name__)
 class LTIAHTTPService:
     """Send LTI Advantage requests and return the responses."""
 
-    def __init__(
+    def __init__(  # pylint:disable=too-many-arguments
         self,
         lti_registration: LTIRegistration,
         plugin: MiscPlugin,
         jwt_service: JWTService,
         http,
+        jwt_oauth2_token_service: JWTOAuth2TokenService,
     ):
         self._lti_registration = lti_registration
         self._jwt_service = jwt_service
         self._http = http
         self._plugin = plugin
+        self._jwt_oauth2_token_service = jwt_oauth2_token_service
 
     def request(self, method, url, scopes, headers=None, **kwargs):
         headers = headers or {}
 
         assert "Authorization" not in headers
 
-        access_token = self._get_access_token(scopes)
+        access_token = self._get_access_token(" ".join(scopes))
         headers["Authorization"] = f"Bearer {access_token}"
 
         return self._http.request(method, url, headers=headers, **kwargs)
 
-    def _get_access_token(self, scopes):
+    def _get_access_token(self, scopes: str) -> str:
+        """Get a valid access token from the DB or get a new one from the LMS."""
+        token = self._jwt_oauth2_token_service.get(self._lti_registration, scopes)
+        if not token:
+            LOG.debug("Requesting new LTIA JWT token")
+            token = self._get_new_access_token(scopes)
+        else:
+            LOG.debug("Using cached LTIA JWT token")
+
+        return token.access_token
+
+    def _get_new_access_token(self, scopes: str) -> JWTOAuth2Token:
         """
         Get an access token from the LMS to use in LTA services.
 
@@ -61,16 +74,24 @@ class LTIAHTTPService:
                 "grant_type": "client_credentials",
                 "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                 "client_assertion": signed_jwt,
-                "scope": " ".join(scopes),
+                "scope": scopes,
             },
             timeout=(20, 20),
         )
 
         try:
-            return response.json()["access_token"]
+            token_data = response.json()
         except JSONDecodeError:  # pragma: no cover
             LOG.error("Non-json response: %s", response.text)
             raise
+
+        token = self._jwt_oauth2_token_service.save(
+            lti_registration=self._lti_registration,
+            scopes=scopes,
+            access_token=token_data["access_token"],
+            expires_in=token_data["expires_in"],
+        )
+        return token
 
 
 def factory(_context, request):
@@ -79,4 +100,5 @@ def factory(_context, request):
         request.product.plugin.misc,
         request.find_service(JWTService),
         request.find_service(name="http"),
+        request.find_service(JWTOAuth2TokenService),
     )

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -18,7 +18,6 @@ from tests.factories.attributes import (
     TOOL_CONSUMER_INSTANCE_GUID,
     USER_ID,
 )
-from tests.factories.jwt_oauth2_token import JWTOAuth2Token
 from tests.factories.email_unsubscribe import EmailUnsubscribe
 from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo
@@ -26,6 +25,7 @@ from tests.factories.group_info import GroupInfo
 from tests.factories.grouping import BlackboardGroup, CanvasGroup, CanvasSection, Course
 from tests.factories.grouping_membership import GroupingMembership
 from tests.factories.h_user import HUser
+from tests.factories.jwt_oauth2_token import JWTOAuth2Token
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole
 from tests.factories.lti_user import LTIUser

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -18,6 +18,7 @@ from tests.factories.attributes import (
     TOOL_CONSUMER_INSTANCE_GUID,
     USER_ID,
 )
+from tests.factories.jwt_oauth2_token import JWTOAuth2Token
 from tests.factories.email_unsubscribe import EmailUnsubscribe
 from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo

--- a/tests/factories/jwt_oauth2_token.py
+++ b/tests/factories/jwt_oauth2_token.py
@@ -1,0 +1,13 @@
+from factory import SubFactory, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.attributes import ACCESS_TOKEN
+from tests.factories.lti_registration import LTIRegistration
+
+JWTOAuth2Token = make_factory(
+    models.JWTOAuth2Token,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    lti_registration=SubFactory(LTIRegistration),
+    access_token=ACCESS_TOKEN,
+)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -290,7 +290,7 @@ def application_instance(db_session):
 
 
 @pytest.fixture
-def lti_registration(db_session):
+def lti_registration():
     return factories.LTIRegistration()
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -290,9 +290,12 @@ def application_instance(db_session):
 
 
 @pytest.fixture
-def lti_v13_application_instance(db_session):
-    lti_registration = factories.LTIRegistration()
+def lti_registration(db_session):
+    return factories.LTIRegistration()
 
+
+@pytest.fixture
+def lti_v13_application_instance(db_session, lti_registration):
     application_instance = factories.ApplicationInstance(
         developer_key="TEST_DEVELOPER_KEY",
         provisioning=True,

--- a/tests/unit/lms/services/jwt_oauth2_token_test.py
+++ b/tests/unit/lms/services/jwt_oauth2_token_test.py
@@ -12,14 +12,14 @@ class TestJWTOAuth2TokenServiceTest:
     @freeze_time("2022-04-04")
     @pytest.mark.parametrize("scopes", [("1", "2"), ("2", "1")])
     def test_it(self, svc, lti_registration, scopes):
-        token = svc.save(lti_registration, scopes, "ACCESS_TOKEN", 3600)
+        token = svc.save_token(lti_registration, scopes, "ACCESS_TOKEN", 3600)
 
-        assert svc.get(lti_registration, scopes) == token
+        assert svc.get_token(lti_registration, scopes) == token
         assert token.scopes == "1 2"
 
     @freeze_time("2022-04-04")
     def test_save_new_token(self, svc, lti_registration, scopes):
-        token = svc.save(lti_registration, scopes, "ACCESS_TOKEN", 3600)
+        token = svc.save_token(lti_registration, scopes, "ACCESS_TOKEN", 3600)
 
         assert token.access_token == "ACCESS_TOKEN"
         assert token.received_at == datetime(2022, 4, 4, 0)
@@ -33,7 +33,7 @@ class TestJWTOAuth2TokenServiceTest:
             expires_at=datetime.now(),
         )
 
-        token = svc.save(lti_registration, scopes, "ACCESS_TOKEN", 3600)
+        token = svc.save_token(lti_registration, scopes, "ACCESS_TOKEN", 3600)
 
         assert existing_token == token
         assert token.received_at == datetime(2022, 4, 4, 0)
@@ -48,7 +48,7 @@ class TestJWTOAuth2TokenServiceTest:
         )
         db_session.flush()
 
-        token = svc.get(lti_registration, scopes)
+        token = svc.get_token(lti_registration, scopes)
 
         assert existing_token == token
 
@@ -61,7 +61,7 @@ class TestJWTOAuth2TokenServiceTest:
         )
         db_session.flush()
 
-        token = svc.get(lti_registration, scopes)
+        token = svc.get_token(lti_registration, scopes)
 
         assert not token
 
@@ -76,7 +76,7 @@ class TestJWTOAuth2TokenServiceTest:
         )
         db_session.flush()
 
-        token = svc.get(lti_registration, scopes, exclude_expired=False)
+        token = svc.get_token(lti_registration, scopes, exclude_expired=False)
 
         assert token == expired_token
 

--- a/tests/unit/lms/services/jwt_oauth2_token_test.py
+++ b/tests/unit/lms/services/jwt_oauth2_token_test.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timedelta
+from unittest.mock import sentinel
+
+import pytest
+from freezegun import freeze_time
+
+from lms.services.jwt_oauth2_token import JWTOAuth2TokenService, factory
+from tests import factories
+
+
+class TestJWTOAuth2TokenServiceTest:
+    @freeze_time("2022-04-04")
+    def test_save_new_token(self, svc, lti_registration):
+        token = svc.save(lti_registration, "SCOPES", "ACCESS_TOKEN", 3600)
+
+        assert token.access_token == "ACCESS_TOKEN"
+        assert token.received_at == datetime(2022, 4, 4, 0)
+        assert token.expires_at == token.received_at + timedelta(seconds=3600)
+
+    @freeze_time("2022-04-04")
+    def test_save_existing_token(self, svc, lti_registration):
+        existing_token = factories.JWTOAuth2Token(
+            lti_registration=lti_registration,
+            scopes="SCOPES",
+            expires_at=datetime.now(),
+        )
+
+        token = svc.save(lti_registration, "SCOPES", "ACCESS_TOKEN", 3600)
+
+        assert existing_token == token
+        assert token.received_at == datetime(2022, 4, 4, 0)
+        assert token.expires_at == datetime(2022, 4, 4, 1)
+
+    @freeze_time("2022-04-04")
+    def test_get(self, svc, lti_registration, db_session):
+        existing_token = factories.JWTOAuth2Token(
+            lti_registration=lti_registration,
+            scopes="SCOPES",
+            expires_at=datetime.now() + timedelta(hours=1),
+        )
+        db_session.flush()
+
+        token = svc.get(lti_registration, "SCOPES")
+
+        assert existing_token == token
+
+    @freeze_time("2022-04-04")
+    def test_get_doesnt_return_expired(self, svc, lti_registration, db_session):
+        factories.JWTOAuth2Token(
+            lti_registration=lti_registration,
+            scopes="SCOPES",
+            expires_at=datetime.now() - timedelta(hours=1),
+        )
+        db_session.flush()
+
+        token = svc.get(lti_registration, "SCOPES")
+
+        assert not token
+
+    @freeze_time("2022-04-04")
+    def test_get_return_expired_with_flag(self, svc, lti_registration, db_session):
+        expired_token = factories.JWTOAuth2Token(
+            lti_registration=lti_registration,
+            scopes="SCOPES",
+            expires_at=datetime.now() - timedelta(hours=1),
+        )
+        db_session.flush()
+
+        token = svc.get(lti_registration, "SCOPES", exclude_expired=False)
+
+        assert token == expired_token
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return JWTOAuth2TokenService(db_session)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, JWTOAuth2TokenService):
+        service = factory(sentinel.context, pyramid_request)
+
+        JWTOAuth2TokenService.assert_called_once_with(pyramid_request.db)
+        assert service == JWTOAuth2TokenService.return_value
+
+    @pytest.fixture
+    def JWTOAuth2TokenService(self, patch):
+        return patch("lms.services.jwt_oauth2_token.JWTOAuth2TokenService")

--- a/tests/unit/lms/services/jwt_oauth2_token_test.py
+++ b/tests/unit/lms/services/jwt_oauth2_token_test.py
@@ -10,65 +10,84 @@ from tests import factories
 
 class TestJWTOAuth2TokenServiceTest:
     @freeze_time("2022-04-04")
-    def test_save_new_token(self, svc, lti_registration):
-        token = svc.save(lti_registration, "SCOPES", "ACCESS_TOKEN", 3600)
+    @pytest.mark.parametrize("scopes", [("1", "2"), ("2", "1")])
+    def test_it(self, svc, lti_registration, scopes):
+        token = svc.save(lti_registration, scopes, "ACCESS_TOKEN", 3600)
+
+        assert svc.get(lti_registration, scopes) == token
+        assert token.scopes == "1 2"
+
+    @freeze_time("2022-04-04")
+    def test_save_new_token(self, svc, lti_registration, scopes):
+        token = svc.save(lti_registration, scopes, "ACCESS_TOKEN", 3600)
 
         assert token.access_token == "ACCESS_TOKEN"
         assert token.received_at == datetime(2022, 4, 4, 0)
         assert token.expires_at == token.received_at + timedelta(seconds=3600)
 
     @freeze_time("2022-04-04")
-    def test_save_existing_token(self, svc, lti_registration):
+    def test_save_existing_token(self, svc, lti_registration, scopes):
         existing_token = factories.JWTOAuth2Token(
             lti_registration=lti_registration,
-            scopes="SCOPES",
+            scopes=" ".join(scopes),
             expires_at=datetime.now(),
         )
 
-        token = svc.save(lti_registration, "SCOPES", "ACCESS_TOKEN", 3600)
+        token = svc.save(lti_registration, scopes, "ACCESS_TOKEN", 3600)
 
         assert existing_token == token
         assert token.received_at == datetime(2022, 4, 4, 0)
         assert token.expires_at == datetime(2022, 4, 4, 1)
 
     @freeze_time("2022-04-04")
-    def test_get(self, svc, lti_registration, db_session):
+    def test_get(self, svc, lti_registration, db_session, scopes):
         existing_token = factories.JWTOAuth2Token(
             lti_registration=lti_registration,
-            scopes="SCOPES",
+            scopes=" ".join(scopes),
             expires_at=datetime.now() + timedelta(hours=1),
         )
         db_session.flush()
 
-        token = svc.get(lti_registration, "SCOPES")
+        token = svc.get(lti_registration, scopes)
 
         assert existing_token == token
 
     @freeze_time("2022-04-04")
-    def test_get_doesnt_return_expired(self, svc, lti_registration, db_session):
+    def test_get_doesnt_return_expired(self, svc, lti_registration, db_session, scopes):
         factories.JWTOAuth2Token(
             lti_registration=lti_registration,
-            scopes="SCOPES",
+            scopes=" ".join(scopes),
             expires_at=datetime.now() - timedelta(hours=1),
         )
         db_session.flush()
 
-        token = svc.get(lti_registration, "SCOPES")
+        token = svc.get(lti_registration, scopes)
 
         assert not token
 
     @freeze_time("2022-04-04")
-    def test_get_return_expired_with_flag(self, svc, lti_registration, db_session):
+    def test_get_return_expired_with_flag(
+        self, svc, lti_registration, db_session, scopes
+    ):
         expired_token = factories.JWTOAuth2Token(
             lti_registration=lti_registration,
-            scopes="SCOPES",
+            scopes=" ".join(scopes),
             expires_at=datetime.now() - timedelta(hours=1),
         )
         db_session.flush()
 
-        token = svc.get(lti_registration, "SCOPES", exclude_expired=False)
+        token = svc.get(lti_registration, scopes, exclude_expired=False)
 
         assert token == expired_token
+
+    @pytest.fixture
+    def scopes(self):
+        return ["SCOPE_1", "SCOPE_2"]
+
+    @pytest.fixture(autouse=True)
+    def with_existing_group_infos(self):
+        # Add some "noise" tokens to make the tests more realistic
+        factories.JWTOAuth2Token.build_batch(3)
 
     @pytest.fixture
     def svc(self, db_session):

--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -21,7 +21,7 @@ class TestLTIAHTTPService:
         jwt_oauth2_token_service,
         scopes,
     ):
-        jwt_oauth2_token_service.get.return_value = None
+        jwt_oauth2_token_service.get_token.return_value = None
 
         response = svc.request("POST", "https://example.com", scopes)
 
@@ -52,11 +52,11 @@ class TestLTIAHTTPService:
             "POST",
             "https://example.com",
             headers={
-                "Authorization": f"Bearer {jwt_oauth2_token_service.save.return_value.access_token}"
+                "Authorization": f"Bearer {jwt_oauth2_token_service.save_token.return_value.access_token}"
             },
         )
         assert response == http_service.request.return_value
-        jwt_oauth2_token_service.save.assert_called_once_with(
+        jwt_oauth2_token_service.save_token.assert_called_once_with(
             application_instance.lti_registration,
             scopes,
             http_service.post.return_value.json.return_value["access_token"],
@@ -68,7 +68,7 @@ class TestLTIAHTTPService:
         self, svc, http_service, jwt_oauth2_token_service, scopes
     ):
         token = factories.JWTOAuth2Token()
-        jwt_oauth2_token_service.get.return_value = token
+        jwt_oauth2_token_service.get_token.return_value = token
 
         response = svc.request("POST", "https://example.com", scopes)
 
@@ -78,7 +78,7 @@ class TestLTIAHTTPService:
             headers={"Authorization": f"Bearer {token.access_token}"},
         )
         assert response == http_service.request.return_value
-        jwt_oauth2_token_service.save.assert_not_called()
+        jwt_oauth2_token_service.save_token.assert_not_called()
 
     @pytest.fixture
     def svc(

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -35,6 +35,7 @@ from lms.services.h_api import HAPI
 from lms.services.http import HTTPService
 from lms.services.jstor import JSTORService
 from lms.services.jwt import JWTService
+from lms.services.jwt_oauth2_token import JWTOAuth2TokenService
 from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_h import LTIHService
@@ -76,6 +77,7 @@ __all__ = (
     "http_service",
     "jstor_service",
     "jwt_service",
+    "jwt_oauth2_token_service",
     "launch_verifier",
     "lti_grading_service",
     "lti_h_service",
@@ -246,6 +248,11 @@ def youtube_service(mock_service):
 @pytest.fixture
 def jwt_service(mock_service):
     return mock_service(JWTService)
+
+
+@pytest.fixture
+def jwt_oauth2_token_service(mock_service):
+    return mock_service(JWTOAuth2TokenService)
 
 
 @pytest.fixture


### PR DESCRIPTION
Continuation the quest of reducing noise around grading. 

We've seen lots of timeouts while getting tokens to use with the grading APIs, increasing the timeout is an option but caching these like we do for regular oauth2  tokens is a no-brainier and has been a TODO of the LTI1.3 integration for a while now.

These tokens can be reused by all users in a registrations so we should see a high rate of cache hits.

##  Testing 

Apply the migration to create the new table with:

```hdev alembic upgrade head```

In theory this should be the same in every LMS that supports LTI1.3 but let's try it in every one.



### D2L

- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View?ou=6782 **as an instructor**
- In the student selector pick "auntltd Learner"
- Check a new token is stored in the DB
``` tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from jwt_oauth2_token";```
- Check the logs for ```DEBUG [lms.services.ltia_http:58][MainThread] Requesting new LTIA JWT token````.
- Select "All students" and the student again to force another request
- The logs will now show ```DEBUG [lms.services.ltia_http:47][MainThread] Using cached LTIA JWT token```
- Expire the tokens with ```tox -qe dockercompose -- exec postgres psql -U postgres -c "update jwt_oauth2_token set expires_at=now()";```
- Launch and annotate again
- A new token is requested and the dates are updated on the DB:
```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select expires_at, created from jwt_oauth2_token";
```

### Canvas

- Truncate any tokens ```tox -qe dockercompose -- exec postgres psql -U postgres -c "truncate jwt_oauth2_token";```
- Launch https://hypothesis.instructure.com/courses/319/assignments/3308 **as a student**
- Make an annotation to trigger a submission
- Check a new token is stored in the DB
``` tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from jwt_oauth2_token";```
- Check the logs for ```DEBUG [lms.services.ltia_http:58][MainThread] Requesting new LTIA JWT token````.
- Refresh the assignment (launch it again), make another annotations to force another submission.
- The logs will now show ```DEBUG [lms.services.ltia_http:47][MainThread] Using cached LTIA JWT token```
- Expire the tokens with ```tox -qe dockercompose -- exec postgres psql -U postgres -c "update jwt_oauth2_token set expires_at=now()";```
- Launch and annotate again
- A new token is requested and the dates are updated on the DB:

```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select expires_at, received_at from jwt_oauth2_token";
```

### Blackboard

- Launch  
https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1
- In the student selector pick "blackboard student"
- Check a new token is stored in the DB
``` tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from jwt_oauth2_token";```
- Check the logs for ```DEBUG [lms.services.ltia_http:58][MainThread] Requesting new LTIA JWT token````.
- Select "All students" and the student again to force another request
- The logs will now show ```DEBUG [lms.services.ltia_http:47][MainThread] Using cached LTIA JWT token```
- Expire the tokens with ```tox -qe dockercompose -- exec postgres psql -U postgres -c "update jwt_oauth2_token set expires_at=now()";```
- Launch and annotate again
- A new token is requested and the dates are updated on the DB:
```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select expires_at, received_at from jwt_oauth2_token";
```

### Moodle 

Needs https://github.com/hypothesis/devdata/pull/89 merged 

- Launch https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=685 **as an instructor**
- In the student selector pick "Class clown"
- Check a new token is stored in the DB
``` tox -qe dockercompose -- exec postgres psql -U postgres -c "select * from jwt_oauth2_token";```
- Check the logs for ```DEBUG [lms.services.ltia_http:58][MainThread] Requesting new LTIA JWT token````.
- Select "All students" and the student again to force another request
- The logs will now show ```DEBUG [lms.services.ltia_http:47][MainThread] Using cached LTIA JWT token```
- Expire the tokens with ```tox -qe dockercompose -- exec postgres psql -U postgres -c "update jwt_oauth2_token set expires_at=now()";```
- Launch and annotate again
- A new token is requested and the dates are updated on the DB:
```
tox -qe dockercompose -- exec postgres psql -U postgres -c "select expires_at, received_at from jwt_oauth2_token";
```
