### PR TITLE
Expose restricted YouTube videos through the video_info API

### DIFF
--- a/lms/services/youtube.py
+++ b/lms/services/youtube.py
@@ -58,11 +58,22 @@ class YouTubeService:
             raise VideoNotFound(video_id) from err
 
         snippet = item["snippet"]
+        content_details = item.get("contentDetails", {})
+        restrictions = []
+
+        # ytRating field docs: https://developers.google.com/youtube/v3/docs/videos#contentDetails.contentRating.ytRating
+        if (
+            content_details.get("contentRating", {}).get("ytRating", "")
+            == "ytAgeRestricted"
+        ):
+            restrictions.append("age")
+
         return {
             "image": snippet["thumbnails"]["medium"]["url"],
             "title": snippet["title"],
             "channel": snippet["channelTitle"],
-            "duration": item["contentDetails"]["duration"],  # ISO duration
+            "duration": content_details["duration"],  # ISO duration
+            "restrictions": restrictions,
         }
 
 


### PR DESCRIPTION
Extend the `video_info` YouTube API to include a property telling if a video has restrictions somehow.

The property currently only takes into consideration if the video is age-restricted, but it can include other restrictions afterwards (`"restrictions": [ <list of strings> ]`).

### Testing

The `/api/youtube/videos/{id}` endpoint now returns an `is_restricted` property that should be `true` if the video is age-restricted.

You can try this call using different videos to see the response:

```bash
curl --request GET \
  --url http://localhost:8001/api/youtube/videos/{id} \
  --header 'Authorization: Bearer <token>'
```

* Example video with age restriction: https://www.youtube.com/watch?v=HFlmHY8QFiY&ab_channel=JakePaul (`HFlmHY8QFiY`)
  ```json
  {
    "image": "https://i.ytimg.com/vi/HFlmHY8QFiY/mqdefault.jpg",
    "title": "Youtube Age Restricted This Video.",
    "channel": "Jake Paul",
    "duration": "PT18M50S",
    "restrictions": ["age"]
  }
  ```
* Example video with no age restriction: https://www.youtube.com/watch?v=EU6TDnV5osM&ab_channel=Hypothesis (`EU6TDnV5osM`)
  ```json
  {
    "image": "https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg",
    "title": "Hypothesis and Atlassian New Partnership Announced at the Team23 Conference",
    "channel": "Hypothesis",
    "duration": "PT2M20S",
    "restrictions": []
  }
  ```

> This PR is part of https://github.com/hypothesis/lms/issues/5449