### PR TITLE
Update buttons and layout of `FilePickerApp` (configure-assignment panels)

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -1,4 +1,4 @@
-import { Button, SpinnerOverlay } from '@hypothesis/frontend-shared';
+import { OptionButton, SpinnerOverlay } from '@hypothesis/frontend-shared';
 import { useMemo, useState } from 'preact/hooks';
 
 import type { Book, File, Chapter } from '../api-types';
@@ -297,93 +297,97 @@ export default function ContentSelector({
   return (
     <>
       {isLoadingIndicatorVisible && <SpinnerOverlay />}
-      <div className="flex flex-row p-y-2">
-        <div className="flex flex-col space-y-1">
-          <Button
-            onClick={() => selectDialog('url')}
-            variant="primary"
-            data-testid="url-button"
+      <div className="grid grid-cols-2 gap-y-2 gap-x-3 max-w-[28rem]">
+        <OptionButton
+          data-testid="url-button"
+          details="Web page | PDF"
+          onClick={() => selectDialog('url')}
+          title="Enter a URL to a web page or PDF"
+        >
+          URL
+        </OptionButton>
+        {canvasFilesEnabled && (
+          <OptionButton
+            data-testid="canvas-file-button"
+            details="PDF"
+            onClick={() => selectDialog('canvasFile')}
+            title="Select PDF from Canvas"
           >
-            Enter URL of web page or PDF
-          </Button>
-          {canvasFilesEnabled && (
-            <Button
-              onClick={() => selectDialog('canvasFile')}
-              variant="primary"
-              data-testid="canvas-file-button"
-            >
-              Select PDF from Canvas
-            </Button>
-          )}
-          {blackboardFilesEnabled && (
-            <Button
-              onClick={() => selectDialog('blackboardFile')}
-              variant="primary"
-              data-testid="blackboard-file-button"
-            >
-              Select PDF from Blackboard
-            </Button>
-          )}
-          {d2lFilesEnabled && (
-            <Button
-              onClick={() => selectDialog('d2lFile')}
-              variant="primary"
-              data-testid="d2l-file-button"
-            >
-              Select PDF from D2L
-            </Button>
-          )}
-          {googlePicker && (
-            <Button
-              onClick={showGooglePicker}
-              variant="primary"
-              data-testid="google-drive-button"
-            >
-              Select PDF from Google Drive
-            </Button>
-          )}
-          {jstorEnabled && (
-            <Button
-              onClick={() => selectDialog('jstor')}
-              variant="primary"
-              data-testid="jstor-button"
-            >
-              Select JSTOR article
-            </Button>
-          )}
-          {oneDriveFilesEnabled && (
-            <Button
-              onClick={showOneDrivePicker}
-              variant="primary"
-              data-testid="onedrive-button"
-            >
-              Select PDF from OneDrive
-            </Button>
-          )}
-          {vitalSourceEnabled && (
-            <Button
-              onClick={() => selectDialog('vitalSourceBook')}
-              variant="primary"
-              data-testid="vitalsource-button"
-            >
-              Select book from VitalSource
-            </Button>
-          )}
-          {youtubeEnabled && (
-            <Button
-              onClick={() => selectDialog('youtube')}
-              variant="primary"
-              data-testid="youtube-button"
-            >
-              Select video from YouTube
-            </Button>
-          )}
-        </div>
-        {/** This flex-grow element takes up remaining horizontal space so that
-         * buttons don't span full width unecessarily.
-         */}
-        <div className="grow" />
+            Canvas
+          </OptionButton>
+        )}
+        {blackboardFilesEnabled && (
+          <OptionButton
+            data-testid="blackboard-file-button"
+            details="PDF"
+            onClick={() => selectDialog('blackboardFile')}
+            title="Select PDF from Blackboard"
+          >
+            Blackboard
+          </OptionButton>
+        )}
+        {d2lFilesEnabled && (
+          <OptionButton
+            data-testid="d2l-file-button"
+            details="PDF"
+            onClick={() => selectDialog('d2lFile')}
+            title="Select PDF from D2L"
+          >
+            D2L
+          </OptionButton>
+        )}
+        {googlePicker && (
+          <OptionButton
+            details="PDF"
+            data-testid="google-drive-button"
+            onClick={showGooglePicker}
+            title="Select PDF from Google Drive"
+          >
+            Google Drive
+          </OptionButton>
+        )}
+        {jstorEnabled && (
+          <OptionButton
+            data-testid="jstor-button"
+            details="Article"
+            onClick={() => selectDialog('jstor')}
+            title="Select JSTOR article"
+          >
+            JSTOR
+          </OptionButton>
+        )}
+        {oneDriveFilesEnabled && (
+          <OptionButton
+            data-testid="onedrive-button"
+            details="PDF"
+            onClick={showOneDrivePicker}
+            title="Select PDF from OneDrive"
+          >
+            OneDrive
+          </OptionButton>
+        )}
+        {vitalSourceEnabled && (
+          <OptionButton
+            data-testid="vitalsource-button"
+            details="Book"
+            onClick={() => selectDialog('vitalSourceBook')}
+            title="Select book from VitalSource"
+          >
+            VitalSource
+          </OptionButton>
+        )}
+        {youtubeEnabled && (
+          <OptionButton
+            data-testid="youtube-button"
+            details="Video"
+            onClick={() => selectDialog('youtube')}
+            title="Select video from YouTube"
+          >
+            YouTube
+          </OptionButton>
+        )}
       </div>
+
       <div>{dialog}</div>
     </>
   );

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -299,7 +299,7 @@ describe('FilePickerApp', () => {
 
       assert.equal(
         wrapper.find('[data-testid="content-summary"]').text(),
-        'en.wikipedia.org/…/Cannonball_Baker_Sea-To-Shining-Sea_Memorial_…'
+        'en.wikipedia.org/…/Cannonball_Baker_Sea-To-Shinin…'
       );
     });
 
@@ -408,43 +408,46 @@ describe('FilePickerApp', () => {
       const wrapper = renderFilePicker();
       const description = wrapper.find('[data-testid="content-summary"]');
       assert.equal(description.text(), 'https://test.com/example.pdf');
-      assert.isTrue(wrapper.exists('Button[data-testid="edit-content"]'));
+      assert.isTrue(wrapper.exists('button[data-testid="edit-content"]'));
     });
 
     it('shows "Save" button instead of "Continue" button', () => {
       const wrapper = renderFilePicker();
-      const saveButton = wrapper.find('Button[data-testid="save-button"]');
+      const saveButton = wrapper.find('button[data-testid="save-button"]');
       assert.equal(saveButton.text(), 'Save');
     });
 
-    it('allows editing content selection', () => {
-      const wrapper = renderFilePicker();
+    [true, false].forEach(groupsEnabled => {
+      it('allows editing content selection', () => {
+        fakeConfig.product.settings.groupsEnabled = groupsEnabled;
+        const wrapper = renderFilePicker();
 
-      // Initially the content selector form is not visible.
-      assert.isFalse(wrapper.exists('ContentSelector'));
+        // Initially the content selector form is not visible.
+        assert.isFalse(wrapper.exists('ContentSelector'));
 
-      // Clicking on the change/edit button next to the content description
-      // should show the content selector.
-      clickButton(wrapper, 'edit-content');
-      const contentSelector = wrapper.find('ContentSelector');
-      assert.isTrue(contentSelector.exists());
-      assert.deepEqual(contentSelector.prop('initialContent'), {
-        type: 'url',
-        url: 'https://test.com/example.pdf',
-      });
-
-      // Selecting new content should revert back to showing the content
-      // description.
-      act(() => {
-        contentSelector.prop('onSelectContent')({
+        // Clicking on the change/edit button next to the content description
+        // should show the content selector.
+        clickButton(wrapper, 'edit-content');
+        const contentSelector = wrapper.find('ContentSelector');
+        assert.isTrue(contentSelector.exists());
+        assert.deepEqual(contentSelector.prop('initialContent'), {
           type: 'url',
-          url: 'https://othersite.com/test.pdf',
+          url: 'https://test.com/example.pdf',
         });
+
+        // Selecting new content should revert back to showing the content
+        // description.
+        act(() => {
+          contentSelector.prop('onSelectContent')({
+            type: 'url',
+            url: 'https://othersite.com/test.pdf',
+          });
+        });
+        wrapper.update();
+        assert.isFalse(wrapper.exists('ContentSelector'));
+        const description = wrapper.find('[data-testid="content-summary"]');
+        assert.equal(description.text(), 'https://othersite.com/test.pdf');
       });
-      wrapper.update();
-      assert.isFalse(wrapper.exists('ContentSelector'));
-      const description = wrapper.find('[data-testid="content-summary"]');
-      assert.equal(description.text(), 'https://othersite.com/test.pdf');
     });
 
     it('cancels editing content when clicking "Cancel" button', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,9 +1238,9 @@
     glob "^7.2.0"
 
 "@hypothesis/frontend-shared@^6.1.1":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.2.0.tgz#c226a2b4509ac46b2de4a82559d367b18b027f5a"
-  integrity sha512-3fFbVlwTbb7KzZL2AcPrbgj1svaQfpgRNqX00GDD1B3SRm8391hnHiWs0hKnElyJmJ3gcTyguRNCw4zVGzw9Iw==
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.3.0.tgz#4b5b5190edab671747a1506316647bd0f5c61862"
+  integrity sha512-vM8BeeLgHJiW4iOi25ZDVFfzM/LE4YGMMT/stWhFIycTJ+g6oujkyDtn1Xu+ZN2GolBtY3Jx3bovvLCVFcW+PA==
   dependencies:
     highlight.js "^11.6.0"
     wouter-preact "^2.10.0-alpha.1"


### PR DESCRIPTION
This PR updates the buttons and polishes the layout of the `FilePickerApp` and `ContentSelector` components, that is, the assignment-configuration UI.

User-visible changes include:

* New buttons (`OptionButton`) for selecting assignment content, and these are laid out in two columns to optimize space
* Change `Button` to `LinkButton` for the "Change" (content) button for improved alignment and visibility
* Small fixes to alignment and consistency in spacing

Dev-visible changes include styling/layout refactoring in `FilePickerApp` and some removal of unnecessary styles.


## Configuring an assignment in Canvas

### Before

<img width="828" alt="image" src="https://github.com/hypothesis/lms/assets/439947/1d194154-c8c3-4dbb-94c8-565f9978911f">

### After

<img width="832" alt="image" src="https://github.com/hypothesis/lms/assets/439947/42cff24e-ce24-4f68-bd48-6d896fc8e07d">

### Before

<img width="836" alt="image" src="https://github.com/hypothesis/lms/assets/439947/212cba9d-8ee0-440e-8224-06d3b1d2ae38">

### After

<img width="823" alt="image" src="https://github.com/hypothesis/lms/assets/439947/7db3022e-f462-4c46-adc7-41406d0f18ab">

## Editing an assignment in Blackboard

### Before

<img width="689" alt="image" src="https://github.com/hypothesis/lms/assets/439947/5cc83d53-f1f1-46ee-841c-205cf81d6c4c">

### After

<img width="677" alt="image" src="https://github.com/hypothesis/lms/assets/439947/d5b3bc4c-c35d-48de-8a3a-cc513f2609de">

### Before

<img width="674" alt="image" src="https://github.com/hypothesis/lms/assets/439947/89e1c3b7-81df-42c2-913d-4cb111488ab3">

### After

<img width="693" alt="image" src="https://github.com/hypothesis/lms/assets/439947/3aa7808a-7d0d-4a2c-8b95-1532616c35fa">


Fixes https://github.com/hypothesis/lms/issues/2955

Part of https://github.com/hypothesis/lms/issues/5328