### PR TITLE
Add `reject_on_worker_lost` to email tasks

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -17,7 +17,13 @@ from lms.tasks.celery import app
 LOG = logging.getLogger(__name__)
 
 
-@app.task(acks_late=True, autoretry_for=(Exception,), max_retries=2, retry_backoff=3600)
+@app.task(
+    acks_late=True,
+    reject_on_worker_lost=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    retry_backoff=3600,
+)
 def send_instructor_email_digest_tasks(*, batch_size):
     """
     Generate and send instructor email digests.
@@ -82,7 +88,13 @@ def send_instructor_email_digest_tasks(*, batch_size):
                 )
 
 
-@app.task(acks_late=True, autoretry_for=(Exception,), max_retries=2, retry_backoff=3600)
+@app.task(
+    acks_late=True,
+    reject_on_worker_lost=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    retry_backoff=3600,
+)
 def send_instructor_email_digests(
     *, h_userids: List[str], updated_after: str, updated_before: str, **kwargs
 ) -> None:

--- a/lms/tasks/mailchimp.py
+++ b/lms/tasks/mailchimp.py
@@ -4,7 +4,13 @@ from lms.services.mailchimp import EmailRecipient, EmailSender
 from lms.tasks.celery import app
 
 
-@app.task(acks_late=True, autoretry_for=(Exception,), max_retries=2, retry_backoff=3600)
+@app.task(
+    acks_late=True,
+    reject_on_worker_lost=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    retry_backoff=3600,
+)
 def send_template(*, sender, recipient, **kwargs) -> None:
     """Send an email using Mailchimp's send-template API."""
 


### PR DESCRIPTION
Add `reject_on_worker_lost=True` to the Celery configs of the email-related tasks.

Apparently by default acknowledges tasks (removes them from the queue) if the worker process abruptly exits, is terminated, hits a Python `sys.exit()`, or receives a `KILL` or `INT` signal. Setting `reject_on_worker_lost=True` makes Celery re-queue the task instead.

There's good reason why this setting is disabled by default: Celery doesn't want to re-run a task if the task's code causes a kernel segfault or similar, or causes the machine to run out of memory, or if a sysadmin deliberately kills a worker process that's executing the task. Celery also doesn't want to cause message loops by re-queueing a task that always fails. The best discussion of it is near the top of this page in the Celery docs: https://docs.celeryq.dev/en/stable/userguide/tasks.html

For this reason I don't think we want to enable this setting globally. Most of our tasks don't need this. But I thought it worth enabling for the email tasks.

See also:

* https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.reject_on_worker_lost
* https://docs.celeryq.dev/en/stable/userguide/configuration.html?highlight=task_reject_on_worker_lost#std-setting-task_reject_on_worker_lost
