### PR TITLE
Remove icon vertical alignment in YouTubePicker error message

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -121,7 +121,7 @@ export default function URLFormWithPreview({
 
         {error && (
           <div
-            className="flex flex-row items-center space-x-2 text-red-error"
+            className="flex flex-row space-x-2 text-red-error"
             data-testid="error-message"
           >
             <CancelIcon />


### PR DESCRIPTION
This PR fixes an incorrect vertical alignment in the error message displayed in YouTubePicker, which makes it look odd when the error spans multiple lines.

This is how it currently looks in `main`:

![Captura desde 2023-06-07 09-48-04](https://github.com/hypothesis/lms/assets/2719332/dc6f45ff-5660-4ba1-b806-af0233c5d521)

And this is how it looks in this branch:

![Captura desde 2023-06-07 09-47-51](https://github.com/hypothesis/lms/assets/2719332/c4cfd61c-5c84-4448-9c09-d5085cab82eb)

> This PR only addresses the error in YouTubePicker, but we probably want to check other content pickers and consolidate it.