### PR TITLE
Consolidate styling for UI messages in content pickers

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.tsx
@@ -1,7 +1,5 @@
 import {
   ArrowRightIcon,
-  CancelIcon,
-  CheckIcon,
   IconButton,
   InputGroup,
   Input,
@@ -14,6 +12,7 @@ import type { Book } from '../api-types';
 import { formatErrorMessage } from '../errors';
 import { useService, VitalSourceService } from '../services';
 import { extractBookID } from '../utils/vitalsource';
+import UIMessage from './UIMessage';
 
 export type BookSelectorProps = {
   /** The currently-selected book, if any */
@@ -194,23 +193,15 @@ export default function BookSelector({
         </InputGroup>
 
         {selectedBook && (
-          <div
-            className="flex flex-row items-center space-x-2"
-            data-testid="selected-book"
-          >
-            <CheckIcon className="text-green-success" />
-            <div className="grow font-bold italic">{selectedBook.title}</div>
-          </div>
+          <UIMessage status="success" data-testid="selected-book">
+            <span className="font-bold italic">{selectedBook.title}</span>
+          </UIMessage>
         )}
 
         {error && (
-          <div
-            className="flex flex-row items-center space-x-2 text-red-error"
-            data-testid="error-message"
-          >
-            <CancelIcon />
-            <div className="grow">{error}</div>
-          </div>
+          <UIMessage status="error" data-testid="error-message">
+            {error}
+          </UIMessage>
         )}
       </div>
     </div>

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
@@ -1,8 +1,6 @@
 import {
   ArrowRightIcon,
   Button,
-  CancelIcon,
-  CheckIcon,
   IconButton,
   Input,
   InputGroup,
@@ -19,6 +17,7 @@ import { urlPath, useAPIFetch } from '../utils/api';
 import type { FetchResult } from '../utils/fetch';
 import { useUniqueId } from '../utils/hooks';
 import { articleIdFromUserInput, jstorURLFromArticleId } from '../utils/jstor';
+import UIMessage from './UIMessage';
 
 export type JSTORPickerProps = {
   /**
@@ -205,20 +204,17 @@ export default function JSTORPicker({
           </InputGroup>
 
           {metadata.data && (
-            <div
-              className="flex flex-row space-x-2"
+            <UIMessage
+              status={canConfirmSelection ? 'success' : 'info'}
               data-testid="selected-book"
             >
-              {canConfirmSelection && (
-                <CheckIcon className="text-green-success" />
-              )}
-              <div className="grow font-bold italic">
+              <span className="font-bold italic">
                 {metadata.data.item.title}
                 {metadata.data.item.subtitle && (
                   <>: {metadata.data.item.subtitle}</>
                 )}
-              </div>
-            </div>
+              </span>
+            </UIMessage>
           )}
 
           {metadata.data && canConfirmSelection && (
@@ -241,13 +237,7 @@ export default function JSTORPicker({
           )}
 
           {renderedError && (
-            <div
-              className="flex flex-row items-center space-x-2 text-red-error"
-              data-testid="error-message"
-            >
-              <CancelIcon />
-              <div className="grow">{renderedError}</div>
-            </div>
+            <UIMessage status="error">{renderedError}</UIMessage>
           )}
         </div>
       </div>

--- a/lms/static/scripts/frontend_apps/components/UIMessage.tsx
+++ b/lms/static/scripts/frontend_apps/components/UIMessage.tsx
@@ -1,0 +1,46 @@
+import { CancelIcon, CheckIcon } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { ComponentChildren, JSX } from 'preact';
+
+export type UIMessageProps = {
+  status?: 'success' | 'error' | 'info';
+  children: ComponentChildren;
+} & JSX.HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Style a UI message associated with content-picking user inputs
+ */
+export default function UIMessage({
+  status = 'info',
+  children,
+  ...htmlAttributes
+}: UIMessageProps) {
+  let Icon;
+  if (status === 'error') {
+    Icon = CancelIcon;
+  } else if (status === 'success') {
+    Icon = CheckIcon;
+  }
+  return (
+    <div
+      data-component="UIMessage"
+      className={classnames('flex gap-x-1', {
+        'text-red-error': status === 'error',
+      })}
+      {...htmlAttributes}
+    >
+      {Icon && (
+        <div>
+          <Icon
+            className={classnames('w-4 h-4', {
+              'text-red-error': status === 'error',
+              'text-green-success': status === 'success',
+            })}
+            data-testid="uimessage-icon"
+          />
+        </div>
+      )}
+      <div className="grow">{children}</div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowRightIcon,
-  CancelIcon,
   IconButton,
   Input,
   InputGroup,
@@ -10,6 +9,7 @@ import classnames from 'classnames';
 import type { ComponentChildren, RefObject } from 'preact';
 
 import { useUniqueId } from '../utils/hooks';
+import UIMessage from './UIMessage';
 
 export type ThumbnailData = {
   image?: string;
@@ -120,13 +120,9 @@ export default function URLFormWithPreview({
         {children}
 
         {error && (
-          <div
-            className="flex flex-row items-center space-x-2 text-red-error"
-            data-testid="error-message"
-          >
-            <CancelIcon />
-            <div className="grow">{error}</div>
-          </div>
+          <UIMessage status="error" data-testid="error-message">
+            {error}
+          </UIMessage>
         )}
       </div>
     </div>

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -1,10 +1,7 @@
-import {
-  Button,
-  CancelIcon,
-  ModalDialog,
-  Input,
-} from '@hypothesis/frontend-shared';
+import { Button, ModalDialog, Input } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
+
+import UIMessage from './UIMessage';
 
 export type URLPickerProps = {
   /** The initial value of the URL input field. */
@@ -92,16 +89,8 @@ export default function URLPicker({
         </form>
         {/** setting a height here "preserves space" for this error display
          * and prevents the dialog size from jumping when an error is rendered */}
-        <div
-          className="h-4 flex flex-row items-center space-x-1 text-red-error"
-          data-testid="error-message"
-        >
-          {!!error && (
-            <>
-              <CancelIcon />
-              <div className="grow">{error}</div>
-            </>
-          )}
+        <div className="h-4 min-h-4">
+          {!!error && <UIMessage status="error">{error}</UIMessage>}
         </div>
       </div>
     </ModalDialog>

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -1,10 +1,11 @@
-import { Button, CheckIcon, ModalDialog } from '@hypothesis/frontend-shared';
+import { Button, ModalDialog } from '@hypothesis/frontend-shared';
 import { useMemo, useRef, useState } from 'preact/hooks';
 
 import type { YouTubeVideoInfo } from '../api-types';
 import { isAPIError } from '../errors';
 import { urlPath, useAPIFetch } from '../utils/api';
 import { videoIdFromYouTubeURL } from '../utils/youtube';
+import UIMessage from './UIMessage';
 import URLFormWithPreview from './URLFormWithPreview';
 
 export type YouTubePickerProps = {
@@ -95,12 +96,11 @@ export default function YouTubePicker({
         }}
       >
         {videoInfo.data?.title && videoInfo.data.channel && (
-          <div className="flex flex-row space-x-2" data-testid="selected-video">
-            <CheckIcon className="text-green-success" />
-            <div className="grow font-bold italic">
+          <UIMessage data-testid="selected-video" status="success">
+            <span className="font-bold italic">
               {videoInfo.data.title} ({videoInfo.data.channel})
-            </div>
-          </div>
+            </span>
+          </UIMessage>
         )}
       </URLFormWithPreview>
     </ModalDialog>

--- a/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookSelector-test.js
@@ -193,7 +193,7 @@ describe('BookSelector', () => {
       const wrapper = renderBookSelector();
       updateURL(wrapper, 'foo');
 
-      const errorMessage = wrapper.find('[data-testid="error-message"]');
+      const errorMessage = wrapper.find('UIMessage[status="error"]');
 
       assert.isTrue(errorMessage.exists());
       assert.include(
@@ -270,11 +270,10 @@ describe('BookSelector', () => {
           selectedBook: fakeBookData.book1,
         });
 
-        const selectedBook = wrapper.find('[data-testid="selected-book"]');
+        const selectedBook = wrapper.find('UIMessage[status="success"]');
 
         assert.isTrue(wrapper.find('Thumbnail img').exists());
         assert.include(selectedBook.text(), 'Book One');
-        assert.isTrue(selectedBook.find('CheckIcon').exists());
       });
     });
 
@@ -287,10 +286,10 @@ describe('BookSelector', () => {
         const wrapper = renderBookSelector();
         updateURL(wrapper, 'foo');
 
-        await waitForElement(wrapper, '[data-testid="error-message"]');
+        await waitForElement(wrapper, 'UIMessage[status="error"]');
 
         assert.calledWith(fakeFormatErrorMessage, error);
-        const errorMessage = wrapper.find('[data-testid="error-message"]');
+        const errorMessage = wrapper.find('UIMessage[status="error"]');
         assert.include(errorMessage.text(), 'Something went wrong');
       });
     });

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -236,14 +236,13 @@ describe('JSTORPicker', () => {
       const wrapper = renderJSTORPicker();
       updateURL(wrapper, 'foo');
 
-      const errorMessage = wrapper.find('[data-testid="error-message"]');
+      const errorMessage = wrapper.find('UIMessage[status="error"]');
 
       assert.isTrue(errorMessage.exists());
       assert.include(
         errorMessage.text(),
         "That doesn't look like a JSTOR article link or ID"
       );
-      assert.isTrue(errorMessage.find('CancelIcon').exists());
     });
   });
 
@@ -270,7 +269,7 @@ describe('JSTORPicker', () => {
       new Error('No such article')
     );
 
-    const errorMessage = wrapper.find('[data-testid="error-message"]');
+    const errorMessage = wrapper.find('UIMessage[status="error"]');
     assert.isTrue(errorMessage.exists());
     assert.include(
       errorMessage.text(),
@@ -359,7 +358,7 @@ describe('JSTORPicker', () => {
 
       assert.isTrue(wrapper.find(buttonSelector).props().disabled);
 
-      const errorMessage = wrapper.find('[data-testid="error-message"]');
+      const errorMessage = wrapper.find('UIMessage[status="error"]');
       assert.isTrue(errorMessage.exists());
       assert.equal(errorMessage.text().trim(), expectedError);
     });

--- a/lms/static/scripts/frontend_apps/components/test/UIMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/UIMessage-test.js
@@ -1,0 +1,33 @@
+import { mount } from 'enzyme';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import UIMessage from '../UIMessage';
+
+describe('UIMessage', () => {
+  const renderComponent = (props = {}) =>
+    mount(<UIMessage {...props}>This is a message</UIMessage>);
+
+  it('renders a checkmark next to success messages', () => {
+    const wrapper = renderComponent({ status: 'success' });
+    assert.isTrue(wrapper.find('[data-testid="uimessage-icon"]').exists());
+    assert.isTrue(wrapper.find('CheckIcon').exists());
+  });
+
+  it('renders a cancel icon next to error messages', () => {
+    const wrapper = renderComponent({ status: 'error' });
+    assert.isTrue(wrapper.find('[data-testid="uimessage-icon"]').exists());
+    assert.isTrue(wrapper.find('CancelIcon').exists());
+  });
+
+  it('does not render an icon next to info messages', () => {
+    const wrapper = renderComponent();
+    assert.isFalse(wrapper.find('[data-testid="uimessage-icon"]').exists());
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => renderComponent(),
+    })
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
@@ -38,7 +38,7 @@ describe('URLFormWithPreview', () => {
   it('displays error if provided', () => {
     const error = 'Something went wrong';
     const wrapper = renderComponent({ error });
-    const errorComponent = wrapper.find('[data-testid="error-message"]');
+    const errorComponent = wrapper.find('UIMessage[status="error"]');
 
     assert.isTrue(errorComponent.exists());
     assert.equal(errorComponent.text(), error);

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -43,7 +43,7 @@ describe('URLPicker', () => {
     wrapper.update();
 
     assert.notCalled(onSelectURL);
-    const errorMessage = wrapper.find('[data-testid="error-message"]');
+    const errorMessage = wrapper.find('UIMessage[status="error"]');
     assert.isTrue(errorMessage.exists());
     assert.include(errorMessage.text(), 'Please enter a URL');
   });
@@ -61,7 +61,7 @@ describe('URLPicker', () => {
     wrapper.update();
 
     assert.notCalled(onSelectURL);
-    const errorMessage = wrapper.find('[data-testid="error-message"]');
+    const errorMessage = wrapper.find('UIMessage[status="error"]');
     assert.isTrue(errorMessage.exists());
     assert.include(
       errorMessage.text(),
@@ -82,7 +82,7 @@ describe('URLPicker', () => {
     wrapper.update();
 
     assert.notCalled(onSelectURL);
-    const errorMessage = wrapper.find('[data-testid="error-message"]');
+    const errorMessage = wrapper.find('UIMessage[status="error"]');
     assert.isTrue(errorMessage.exists());
     assert.include(
       errorMessage.text(),


### PR DESCRIPTION
This PR extracts a common component for styling success and error messages in content pickers. This ensures that colors, spacing, alignment and sizing are consistent.

For the most part, user-facing changes are very subtle, but I notice that it does fix one visual nit with multi-line messages (icons too small), as shown below (`UIMessage` icons are always a fixed size, preventing this).

This change removes `items-center` (vertical icon centering) rules; icons are always top-aligned with text now.

The motivation for this change was message styling in the new YouTube picker.

Before:

<img width="702" alt="Screen Shot 2023-06-07 at 12 41 07 PM" src="https://github.com/hypothesis/lms/assets/439947/3aef57db-7921-4a35-b954-7725e6d5555a">

After:

<img width="693" alt="Screen Shot 2023-06-07 at 12 39 50 PM" src="https://github.com/hypothesis/lms/assets/439947/08205611-6bc5-4010-82b1-e02c9099f740">

