### PR TITLE
Handle non-embeddable YouTube videos in video_info API

### DIFF
--- a/tests/unit/lms/services/youtube_test.py
+++ b/tests/unit/lms/services/youtube_test.py
@@ -31,15 +31,22 @@ class TestYouTubeService:
             svc.video_info(video_id="invalid_video_id")
 
     @pytest.mark.parametrize(
-        "content_rating,expected_restrictions",
+        "content_rating, status,expected_restrictions",
         (
-            ({}, []),
-            ({"ytRating": "foo"}, []),
-            ({"ytRating": "ytAgeRestricted"}, ["age"]),
+            ({}, {}, []),
+            ({"ytRating": "foo"}, {}, []),
+            ({"ytRating": "foo"}, {"embeddable": True}, []),
+            ({"ytRating": "ytAgeRestricted"}, {}, ["age"]),
+            ({}, {"embeddable": False}, ["no_embed"]),
+            (
+                {"ytRating": "ytAgeRestricted"},
+                {"embeddable": False},
+                ["age", "no_embed"],
+            ),
         ),
     )
     def test_video_info_parses_json_response(
-        self, svc, http_service, content_rating, expected_restrictions
+        self, svc, http_service, content_rating, status, expected_restrictions
     ):
         response = factories.requests.Response(
             json_data={
@@ -58,6 +65,7 @@ class TestYouTubeService:
                             "duration": "P2M10S",
                             "contentRating": content_rating,
                         },
+                        "status": status,
                     }
                 ]
             }


### PR DESCRIPTION
This adds a new `no_embed` restriction to videos which are not embeddable.

### Testing steps

The `/api/youtube/videos/{id}` endpoint should now include `"no_embed"` in the `restrictions` property for non-embeddable videos.

You can try this call using different videos to see the response:

```bash
curl --request GET \
  --url http://localhost:8001/api/youtube/videos/{id} \
  --header 'Authorization: Bearer <token>'
```

* Example non-embeddable video: https://youtu.be/rw_scW4D3ik (`rw_scW4D3ik`)
  ```json
  {
    "image": "https://i.ytimg.com/vi/rw_scW4D3ik/mqdefault.jpg",
    "title": "youtube picker",
    "channel": "Alejandro Celaya",
    "duration": "PT38S",
    "restrictions": ["no_embed"]
  }
  ```
* Example video with no age restriction: https://youtu.be/EU6TDnV5osM (`EU6TDnV5osM`)
  ```json
  {
    "image": "https://i.ytimg.com/vi/EU6TDnV5osM/mqdefault.jpg",
    "title": "Hypothesis and Atlassian New Partnership Announced at the Team23 Conference",
    "channel": "Hypothesis",
    "duration": "PT2M20S",
    "restrictions": []
  }
  ```

> This PR is part of https://github.com/hypothesis/lms/issues/5449