### PR TITLE
Support displaying multiple errors when trying to load one YouTube video

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -21,8 +21,8 @@ export type ThumbnailData = {
 export type URLFormWithPreviewProps = {
   /** Optional extra content to be rendered together with the input and thumbnail */
   children?: ComponentChildren;
-  /** An error message to highlight that something went wrong */
-  error?: string;
+  /** A list of error messages to highlight that something went wrong */
+  errors?: string[];
   /** Thumbnail info to be displayed, if known */
   thumbnail?: ThumbnailData;
   /** Reference to be set on the URL input */
@@ -41,7 +41,7 @@ export type URLFormWithPreviewProps = {
  */
 export default function URLFormWithPreview({
   children,
-  error,
+  errors,
   thumbnail,
   inputRef,
   onURLChange,
@@ -119,9 +119,13 @@ export default function URLFormWithPreview({
 
         {children}
 
-        {error && (
+        {errors && errors.length > 0 && (
           <UIMessage status="error" data-testid="error-message">
-            {error}
+            <div className="space-y-2">
+              {errors.map((error, index) => (
+                <p key={`${error}_${index}`}>{error}</p>
+              ))}
+            </div>
           </UIMessage>
         )}
       </div>

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -83,7 +83,7 @@ export default function YouTubePicker({
       <URLFormWithPreview
         onURLChange={onURLChange}
         onInput={resetCurrentURL}
-        error={error}
+        errors={error && [error]}
         inputRef={inputRef}
         urlPlaceholder="e.g. https://www.youtube.com/watch?v=cKxqzvzlnKU"
         label="Enter the URL of a YouTube video:"

--- a/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLFormWithPreview-test.js
@@ -37,7 +37,7 @@ describe('URLFormWithPreview', () => {
 
   it('displays error if provided', () => {
     const error = 'Something went wrong';
-    const wrapper = renderComponent({ error });
+    const wrapper = renderComponent({ errors: [error] });
     const errorComponent = wrapper.find('UIMessage[status="error"]');
 
     assert.isTrue(errorComponent.exists());

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -86,7 +86,7 @@ describe('YouTubePicker', () => {
     wrapper.find('URLFormWithPreview').props().onURLChange('not-a-youtube-url');
     wrapper.update();
 
-    assert.isDefined(wrapper.find('URLFormWithPreview').prop('error'));
+    assert.isDefined(wrapper.find('URLFormWithPreview').prop('errors'));
 
     // Invoking onURLChange with a valid URL will remove the error above
     wrapper
@@ -95,7 +95,7 @@ describe('YouTubePicker', () => {
       .onURLChange('https://youtube.com/watch?v=videoId');
     wrapper.update();
 
-    assert.isUndefined(wrapper.find('URLFormWithPreview').prop('error'));
+    assert.isUndefined(wrapper.find('URLFormWithPreview').prop('errors'));
   });
 
   it('displays video info when available', () => {
@@ -150,7 +150,7 @@ describe('YouTubePicker', () => {
       const wrapper = renderComponent();
 
       assert.equal(
-        wrapper.find('URLFormWithPreview').prop('error'),
+        wrapper.find('URLFormWithPreview').prop('errors')[0],
         expectedError
       );
     });
@@ -162,12 +162,12 @@ describe('YouTubePicker', () => {
     // Invoking onURLChange with an invalid URL will set the error
     wrapper.find('URLFormWithPreview').props().onURLChange('not-a-youtube-url');
     wrapper.update();
-    assert.isDefined(wrapper.find('URLFormWithPreview').prop('error'));
+    assert.isDefined(wrapper.find('URLFormWithPreview').prop('errors'));
 
     wrapper.find('URLFormWithPreview').props().onInput();
     wrapper.update();
 
     // As soon as input changes, the error is unset
-    assert.isUndefined(wrapper.find('URLFormWithPreview').prop('error'));
+    assert.isUndefined(wrapper.find('URLFormWithPreview').prop('errors'));
   });
 });


### PR DESCRIPTION
This PR adds support to potentially display more than one error when loading a video in the `YouTubePicker`.

Currently, there are no visual changes, as we don't support any case with more than one error yet, but this will allow to split efforts on how the errors look like (design/UI/UX) and how they are handled from a business logic point of view.

The use case is that, if a video has multiple restrictions (age-restricted, non-embeddable, etc), we want to show all the information to the user at once.

### Testing steps

As mentioned above, right now there's no way to trigger a path which results in more than one error being rendered, but it can be faked by going to `YouTubePicker.tsx`, and applying this change:

```diff
- errors={error && [error]}
+ errors={error && [error, error]}
```

Then open an assignment, select YouTube as the content source, and set an invalid YouTube URL. It should render the error twice.

![image](https://github.com/hypothesis/lms/assets/2719332/25fa20ba-c59b-477a-9322-05f15ccb3cc5)
