### PR TITLE
Update frontend build

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "normalize.css": "^8.0.1",
     "postcss": "^8.4.24",
     "preact": "10.15.1",
-    "rollup": "^2.79.1",
+    "rollup": "^3.25.1",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.62.1",
     "tailwindcss": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6362,10 +6362,10 @@ rollup-plugin-terser@^7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.79.1:
-  version "2.79.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
-  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
+rollup@^3.25.1:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.25.1.tgz#9fff79d22ff1a904b2b595a2fb9bc3793cb987d8"
+  integrity sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
This PR updates to the latest major versions of `@hypothesis/frontend-build` (2.2.0) and `rollup` (3.25.1).

It also updates to `sass` v1.63.3, and the dependencies of these three.