### PR TITLE
Support displaying restrictions in YouTubePicker

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -83,6 +83,8 @@ export type JSTORThumbnail = {
   image: string;
 };
 
+export type YouTubeVideoRestriction = 'age' | 'no_embed';
+
 /**
  * Response for an `/api/youtube/videos/{video_id}` call.
  */
@@ -90,4 +92,5 @@ export type YouTubeVideoInfo = {
   title: string;
   channel: string;
   image: string;
+  restrictions: YouTubeVideoRestriction[];
 };

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -21,8 +21,8 @@ export type ThumbnailData = {
 export type URLFormWithPreviewProps = {
   /** Optional extra content to be rendered together with the input and thumbnail */
   children?: ComponentChildren;
-  /** An error message to highlight that something went wrong */
-  error?: string;
+  /** Error content to highlight that something went wrong */
+  error?: ComponentChildren;
   /** Thumbnail info to be displayed, if known */
   thumbnail?: ThumbnailData;
   /** Reference to be set on the URL input */


### PR DESCRIPTION
This PR is part of https://github.com/hypothesis/lms/issues/5449

It adds the ability to display meaningful errors when a proper YouTube video URL is provided, but the video itself has one or more restrictions that would make it impossible to use in an assignment.

The implementation is based on suggestions from https://github.com/hypothesis/lms/pull/5480#discussion_r1227089387

Age-restricted video (https://youtu.be/HFlmHY8QFiY)

![image](https://github.com/hypothesis/lms/assets/2719332/4f514437-e217-4b33-8b75-fe0cd11ba9bd)

Not embeddable video (https://youtu.be/rw_scW4D3ik)

![image](https://github.com/hypothesis/lms/assets/2719332/659ab50f-429b-4b95-848f-4835d36aa480)

Multiple restrictions (https://youtu.be/VdjCpC2_vSA)

![image](https://github.com/hypothesis/lms/assets/2719332/f57baa54-f7f9-4cfb-91d4-b328022fe76b)

### TODO

- ~Choose the right messages to display for every restriction. Current messages are placeholders.~ On a follow-up PR
- ~Consider extracting `restrictionsToError` from `YouTubePicker`. It could even be a component on its own.~ Discarded. Too soon to build abstraction
- [x] Review how to display errors when there's more than one restriction (or if more than one should be displayed at all).
- [x] Think if video title should be displayed when there are restrictions or not.
- ~Consider possible changes to make restriction more clear. E.g., applying a blurry mask to the image.~ On a follow-up PR
- [x] Fix tests and cover new cases.