### PR TITLE
Support saving assignments where the URL has been picked using the YouTubePicker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -249,7 +249,9 @@ export default function ContentSelector({
       );
       break;
     case 'youtube':
-      dialog = <YouTubePicker onCancel={cancelDialog} onSelectURL={() => {}} />;
+      dialog = (
+        <YouTubePicker onCancel={cancelDialog} onSelectURL={selectURL} />
+      );
       break;
     default:
       dialog = null;

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -53,8 +53,8 @@ export default function YouTubePicker({
   const onURLChange = (inputURL: string) => setCurrentURL(inputURL);
   const resetCurrentURL = () => setCurrentURL(undefined);
   const confirmSelection = () => {
-    if (videoId) {
-      onSelectURL(`youtube://${videoId}`);
+    if (currentURL) {
+      onSelectURL(currentURL);
     }
   };
 

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -637,14 +637,16 @@ describe('ContentSelector', () => {
   });
 
   describe('YouTube picker', () => {
-    it('renders YouTube picker button if enabled', () => {
+    beforeEach(() => {
       fakeConfig.filePicker.youtube.enabled = true;
+    });
+
+    it('renders YouTube picker button if enabled', () => {
       const wrapper = renderContentSelector();
       assert.isTrue(wrapper.exists('Button[data-testid="youtube-button"]'));
     });
 
     it('shows YouTube picker when YouTube button is clicked', () => {
-      fakeConfig.filePicker.youtube.enabled = true;
       const onSelectContent = sinon.stub();
       const wrapper = renderContentSelector({ onSelectContent });
 
@@ -654,6 +656,24 @@ describe('ContentSelector', () => {
       });
 
       assert.isTrue(wrapper.exists('YouTubePicker'));
+    });
+
+    it('supports selecting a URL', () => {
+      const onSelectContent = sinon.stub();
+      const wrapper = renderContentSelector({
+        defaultActiveDialog: 'youtube',
+        onSelectContent,
+      });
+
+      const picker = wrapper.find('YouTubePicker');
+      interact(wrapper, () => {
+        picker.props().onSelectURL('https://youtu.be/EU6TDnV5osM');
+      });
+
+      assert.calledWith(onSelectContent, {
+        type: 'url',
+        url: 'https://youtu.be/EU6TDnV5osM',
+      });
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -52,7 +52,7 @@ describe('YouTubePicker', () => {
     const wrapper = renderComponent();
 
     wrapper.find('button[data-testid="select-button"]').props().onClick();
-    assert.calledWith(fakeOnSelectURL, 'youtube://videoId');
+    assert.calledWith(fakeOnSelectURL, 'https://youtu.be/videoId');
   });
 
   [undefined, 'not-a-youtube-url'].forEach(defaultURL => {


### PR DESCRIPTION
Closes #5484

This enables the logic to actually save the selected URL on the YouTubePicker, allowing to create/edit assignments.

### Testing steps

1. Check out this branch
2. Try to create an assignment, selecting YouTube from the content selector
    * *This course https://hypothesis.instructure.com/courses/125/assignments has YouTube enabled*
3. Make sure you can complete the process, and then the video player with transcript is loaded for that video.

It's important to have your local `via` up to date for this to work.