### PR TITLE
Remove unnecessary special case to get context_id while deeplinking

### DIFF
--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import asdict, dataclass, field, fields
 from typing import Dict, List, Optional
 
@@ -69,16 +68,8 @@ class LTIEvent(BaseEvent):
         return self.request.lti_user.application_instance_id
 
     def _get_course_id(self):
-        context_id = self.request.lti_params.get("context_id")
-        if not context_id:
-            try:
-                # If we are deeplinking we'll get the context_id from json instead
-                context_id = self.request.json.get("context_id")
-            except json.decoder.JSONDecodeError:
-                pass
-
         if course := self.request.find_service(name="course").get_by_context_id(
-            context_id
+            self.request.lti_params.get("context_id")
         ):
             return course.id
 

--- a/tests/unit/lms/events/test_event.py
+++ b/tests/unit/lms/events/test_event.py
@@ -1,5 +1,4 @@
-import json
-from unittest.mock import Mock, sentinel
+from unittest.mock import sentinel
 
 import pytest
 
@@ -30,33 +29,6 @@ class TestLTIEvent:
             sentinel.tool_guid, sentinel.resource_link_id
         )
         assert event.assignment_id == assignment_service.get_assignment.return_value.id
-
-    @pytest.mark.usefixtures(
-        "lti_role_service", "application_instance_service", "assignment_service"
-    )
-    def test_lti_event_when_context_id_from_json(self, pyramid_request, course_service):
-        del pyramid_request.lti_params["context_id"]
-        pyramid_request.json = {"context_id": sentinel.json_context_id}
-
-        event = LTIEvent(request=pyramid_request, type=sentinel.type)
-
-        course_service.get_by_context_id.assert_called_once_with(
-            sentinel.json_context_id
-        )
-        assert event.course_id == course_service.get_by_context_id.return_value.id
-
-    @pytest.mark.usefixtures(
-        "lti_role_service", "application_instance_service", "assignment_service"
-    )
-    def test_lti_event_when_context_id_from_invalid_json(
-        self, pyramid_request, course_service
-    ):
-        del pyramid_request.lti_params["context_id"]
-
-        event = LTIEvent(request=pyramid_request, type=sentinel.type)
-
-        course_service.get_by_context_id.assert_called_once_with(None)
-        assert event.course_id == course_service.get_by_context_id.return_value.id
 
     @pytest.mark.usefixtures(
         "lti_role_service", "application_instance_service", "assignment_service"
@@ -95,11 +67,6 @@ class TestLTIEvent:
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.json = Mock()
-        pyramid_request.json.get.side_effect = json.decoder.JSONDecodeError(
-            msg="", doc="", pos=0
-        )
-
         pyramid_request.lti_params.update(
             {
                 "context_id": sentinel.context_id,


### PR DESCRIPTION
This might have been necessary in previous versions of LTIParams but it doesn't seem to be necessary now.


## Testing

- Clear your events `docker compose exec postgres psql -U postgres -c "truncate event cascade;"`


- Test deeplinking in LTI1.1 with:

https://hypothesis.instructure.com/courses/125/assignments/4682/edit?name=Testing+creation+-+marcos&due_at=null&points_possible=0

tool `Hypothesis
localhost (make devdata) with Sections Enabled`

- Test deeplinking in LTI1.3 with:


https://hypothesis.instructure.com/courses/319/assignments/4924/edit?name=Testing+IDs+(marcos)&due_at=null&points_possible=0

tool `Hypothesis LTI1.3 (localhost)`


Should now have two different events linked to two different courses:


- docker compose exec postgres psql -U postgres -c "select timestamp, type, course_id from event join  event_type on event_type.id = type_id"