### PR TITLE
Prefil YouTube URLs in YouTubePicker when there's a valid URL already selected

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -7,6 +7,7 @@ import { PickerCanceledError } from '../errors';
 import type { Content } from '../utils/content-item';
 import { GooglePickerClient } from '../utils/google-picker-client';
 import { OneDrivePickerClient } from '../utils/onedrive-picker-client';
+import { isYouTubeURL } from '../utils/youtube';
 import BookPicker from './BookPicker';
 import type { ErrorInfo } from './FilePickerApp';
 import JSTORPicker from './JSTORPicker';
@@ -179,6 +180,11 @@ export default function ContentSelector({
   const getDefaultValue = (type: DialogType) =>
     type === initialType ? initialValue : undefined;
 
+  const getDefaultValueIfYouTubeURL = () => {
+    const url = getDefaultValue('url');
+    return url && isYouTubeURL(url) ? url : undefined;
+  };
+
   let dialog;
   switch (activeDialog) {
     case 'url':
@@ -250,7 +256,11 @@ export default function ContentSelector({
       break;
     case 'youtube':
       dialog = (
-        <YouTubePicker onCancel={cancelDialog} onSelectURL={selectURL} />
+        <YouTubePicker
+          defaultURL={getDefaultValueIfYouTubeURL()}
+          onCancel={cancelDialog}
+          onSelectURL={selectURL}
+        />
       );
       break;
     default:

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -637,6 +637,8 @@ describe('ContentSelector', () => {
   });
 
   describe('YouTube picker', () => {
+    const getYouTubePicker = wrapper => wrapper.find('YouTubePicker');
+
     beforeEach(() => {
       fakeConfig.filePicker.youtube.enabled = true;
     });
@@ -665,7 +667,7 @@ describe('ContentSelector', () => {
         onSelectContent,
       });
 
-      const picker = wrapper.find('YouTubePicker');
+      const picker = getYouTubePicker(wrapper);
       interact(wrapper, () => {
         picker.props().onSelectURL('https://youtu.be/EU6TDnV5osM');
       });
@@ -674,6 +676,28 @@ describe('ContentSelector', () => {
         type: 'url',
         url: 'https://youtu.be/EU6TDnV5osM',
       });
+    });
+
+    [
+      'https://youtu.be/EU6TDnV5osM',
+      'https://www.youtube.com/watch?v=123',
+      'https://www.youtube.com/shorts/shortId',
+    ].forEach(url => {
+      it('sets default value when it is a YouTube URL', () => {
+        const wrapper = renderContentSelector({
+          defaultActiveDialog: 'youtube',
+          initialContent: { type: 'url', url },
+        });
+        assert.equal(getYouTubePicker(wrapper).prop('defaultURL'), url);
+      });
+    });
+
+    it('does not set default value when it is not a YouTube URL', () => {
+      const wrapper = renderContentSelector({
+        defaultActiveDialog: 'youtube',
+        initialContent: { type: 'url', url: 'http://example.com/1234' },
+      });
+      assert.isUndefined(getYouTubePicker(wrapper).prop('defaultURL'));
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/youtube-test.js
@@ -1,41 +1,58 @@
-import { videoIdFromYouTubeURL } from '../youtube';
+import { isYouTubeURL, videoIdFromYouTubeURL } from '../youtube';
 
 describe('youtube', () => {
+  const validURLs = [
+    { url: 'https://youtu.be/cKxqzvzlnKU', expectedId: 'cKxqzvzlnKU' },
+    { url: 'https://www.youtube.com/watch?v=123', expectedId: '123' },
+    {
+      url: 'https://www.youtube.com/watch?channel=hypothesis&v=foo',
+      expectedId: 'foo',
+    },
+    {
+      url: 'https://www.youtube.com/embed/embeddedId',
+      expectedId: 'embeddedId',
+    },
+    {
+      url: 'https://www.youtube.com/shorts/shortId',
+      expectedId: 'shortId',
+    },
+    {
+      url: 'https://www.youtube.com/live/liveId?feature=share',
+      expectedId: 'liveId',
+    },
+  ];
+  const invalidURLs = [
+    'foo',
+    'file://foo',
+    'https://example.com',
+    'https://youtube.com/watch',
+    'https://youtu.be',
+  ];
+
   describe('videoIdFromYouTubeURL', () => {
-    [
-      { url: 'https://youtu.be/cKxqzvzlnKU', expectedId: 'cKxqzvzlnKU' },
-      { url: 'https://www.youtube.com/watch?v=123', expectedId: '123' },
-      {
-        url: 'https://www.youtube.com/watch?channel=hypothesis&v=foo',
-        expectedId: 'foo',
-      },
-      {
-        url: 'https://www.youtube.com/embed/embeddedId',
-        expectedId: 'embeddedId',
-      },
-      {
-        url: 'https://www.youtube.com/shorts/shortId',
-        expectedId: 'shortId',
-      },
-      {
-        url: 'https://www.youtube.com/live/liveId?feature=share',
-        expectedId: 'liveId',
-      },
-    ].forEach(({ url, expectedId }) => {
+    validURLs.forEach(({ url, expectedId }) => {
       it('resolves ID from valid YouTube video', () => {
         assert.equal(videoIdFromYouTubeURL(url), expectedId);
       });
     });
 
-    [
-      'foo',
-      'file://foo',
-      'https://example.com',
-      'https://youtube.com/watch',
-      'https://youtu.be',
-    ].forEach(url => {
+    invalidURLs.forEach(url => {
       it('returns null for invalid YouTube videos', () => {
         assert.isNull(videoIdFromYouTubeURL(url));
+      });
+    });
+  });
+
+  describe('isYouTubeURL', () => {
+    validURLs.forEach(({ url }) => {
+      it('returns true for valid YouTube video', () => {
+        assert.isTrue(isYouTubeURL(url));
+      });
+    });
+
+    invalidURLs.forEach(url => {
+      it('returns false for invalid YouTube videos', () => {
+        assert.isFalse(isYouTubeURL(url));
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/utils/youtube.ts
+++ b/lms/static/scripts/frontend_apps/utils/youtube.ts
@@ -29,3 +29,7 @@ export function videoIdFromYouTubeURL(url: string): string | null {
   );
   return match?.[2] ?? null;
 }
+
+export function isYouTubeURL(url: string): boolean {
+  return videoIdFromYouTubeURL(url) !== null;
+}


### PR DESCRIPTION
This PR improves the `YouTubePicker` so that it pre-fills the selected URL when changing it, in case it is a valid YouTube URL.

### Testing steps

1. Edit/create an assignment, and choose YouTube in the content selector
2. Set a valid YouTube URL, for example https://youtu.be/EU6TDnV5osM
3. Press `Enter`, and once video details are loaded, click Continue
4. You'll see the selected URL, and next to it, a `Change` link. Clicking on it you'll get back to the content selector
5. If you select `YouTube` again, it will set the URL and load its details.

There are some considerations to tackle next:

1. Right now we are using the raw YouTube URL. This means the URL will also be preset in the `URLPicker`. We might need to handle this somehow. To be discussed.
2. If you first use the `URLPicker` to set a non-YouTube URL, then click `Change`, and then select `YouTube`, it should be smart enough to not set it.