### PR TITLE
Use YouTube video title as assignment description

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -152,6 +152,13 @@ export default function ContentSelector({
     onSelectContent({ type: 'url', url });
   };
 
+  const selectYouTubeURL = (url: string, title?: string) => {
+    cancelDialog();
+
+    const name = title && `YouTube: ${title}`;
+    onSelectContent({ type: 'url', url, name });
+  };
+
   const selectCanvasFile = (file: File) => {
     cancelDialog();
     onSelectContent({ type: 'file', file });
@@ -259,7 +266,7 @@ export default function ContentSelector({
         <YouTubePicker
           defaultURL={getDefaultValueIfYouTubeURL()}
           onCancel={cancelDialog}
-          onSelectURL={selectURL}
+          onSelectURL={selectYouTubeURL}
         />
       );
       break;

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -310,7 +310,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
 
                 <div data-testid="content-selector-container">
                   {content && currentStep !== 'content-selection' ? (
-                    <div className="flex gap-x-2 items-center">
+                    <div className="flex gap-x-2 items-start">
                       <span
                         className="break-words italic"
                         data-testid="content-summary"

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -15,7 +15,7 @@ export type YouTubePickerProps = {
 
   onCancel: () => void;
   /** Callback invoked with the entered URL when the user accepts the dialog */
-  onSelectURL: (url: string) => void;
+  onSelectURL: (url: string, videoName?: string) => void;
 };
 
 function formatRestrictionError(
@@ -42,6 +42,10 @@ function formatRestrictionError(
       </ul>
     </>
   );
+}
+
+function formatVideoName(videoInfo: YouTubeVideoInfo): string {
+  return `${videoInfo.title} (${videoInfo.channel})`;
 }
 
 export default function YouTubePicker({
@@ -87,7 +91,10 @@ export default function YouTubePicker({
   const resetCurrentURL = () => setCurrentURL(undefined);
   const confirmSelection = () => {
     if (currentURL) {
-      onSelectURL(currentURL);
+      const videoName = videoInfo.data
+        ? formatVideoName(videoInfo.data)
+        : undefined;
+      onSelectURL(currentURL, videoName);
     }
   };
 
@@ -131,7 +138,7 @@ export default function YouTubePicker({
         {!error && videoInfo.data?.title && videoInfo.data.channel && (
           <UIMessage data-testid="selected-video" status="success">
             <span className="font-bold italic">
-              {videoInfo.data.title} ({videoInfo.data.channel})
+              {formatVideoName(videoInfo.data)}
             </span>
           </UIMessage>
         )}

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -669,12 +669,18 @@ describe('ContentSelector', () => {
 
       const picker = getYouTubePicker(wrapper);
       interact(wrapper, () => {
-        picker.props().onSelectURL('https://youtu.be/EU6TDnV5osM');
+        picker
+          .props()
+          .onSelectURL(
+            'https://youtu.be/EU6TDnV5osM',
+            'The video title (channel)'
+          );
       });
 
       assert.calledWith(onSelectContent, {
         type: 'url',
         url: 'https://youtu.be/EU6TDnV5osM',
+        name: 'YouTube: The video title (channel)',
       });
     });
 

--- a/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/YouTubePicker-test.js
@@ -52,7 +52,26 @@ describe('YouTubePicker', () => {
     const wrapper = renderComponent();
 
     wrapper.find('button[data-testid="select-button"]').props().onClick();
-    assert.calledWith(fakeOnSelectURL, 'https://youtu.be/videoId');
+    assert.calledWith(fakeOnSelectURL, 'https://youtu.be/videoId', undefined);
+  });
+
+  it('invokes `onSelectURL` with video data, when available', () => {
+    fakeUseAPIFetch.returns({
+      data: {
+        title: 'The video title',
+        channel: 'Hypothesis',
+        restrictions: [],
+      },
+    });
+
+    const wrapper = renderComponent();
+
+    wrapper.find('button[data-testid="select-button"]').props().onClick();
+    assert.calledWith(
+      fakeOnSelectURL,
+      'https://youtu.be/videoId',
+      'The video title (Hypothesis)'
+    );
   });
 
   [undefined, 'not-a-youtube-url'].forEach(defaultURL => {


### PR DESCRIPTION
This PR changes the YouTubePicker to use selected video title and channel as the content name, instead of using the raw truncated URL.

![image](https://github.com/hypothesis/lms/assets/2719332/f42431a1-bbe3-425c-aabf-29ed60313e74)

### Testing steps

1. Create an assignment selecting YouTube content
2. Paste a valid video URL, like https://youtu.be/qQ6a0iOzyHE
3. Click `Continue`.
4. The Content should display `YouTube: {video name} ({video channel})` instead of the raw video URL.

### Out of scope

This PR does not cover the next things:

* Refactor layout to properly handle multi-line content names, or truncate content so that it does not span more than one line.
* Handle content name when an existing assignment is re-opened for edition (Blackboard and D2L only). See https://github.com/hypothesis/lms/pull/5500#issuecomment-1594694925