### PR TITLE
Add dates to the user table in reporting

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/05_entities_decorated/01_users/01_create_view.jinja2.sql
+++ b/lms/data_tasks/report/create_from_scratch/05_entities_decorated/01_users/01_create_view.jinja2.sql
@@ -2,6 +2,45 @@ DROP MATERIALIZED VIEW IF EXISTS report.users CASCADE;
 
 CREATE MATERIALIZED VIEW report.users AS (
     WITH
+        user_modify_dates AS (
+            -- Look for evidence of activity based on created and updated dates
+            SELECT
+                user_map.user_id,
+                MIN(lms_user.created) AS first_active_date,
+                MAX(lms_user.updated) AS last_active_date
+            FROM report.user_map
+            JOIN "user" AS lms_user ON
+                lms_user.id = user_map.lms_user_id
+            GROUP BY user_map.user_id
+        ),
+
+        user_activity_dates AS (
+            SELECT
+                user_id,
+                MIN(active_date) AS first_active_date,
+                MAX(active_date) AS last_active_date
+            FROM (
+                -- Using a weekly timestamp here loses us some accuracy, but
+                -- it's way faster than going through the whole annotation table
+                SELECT
+                    user_id,
+                    created_week AS active_date
+                FROM report.user_activity
+
+                UNION
+
+                -- Ideally we'd power this metric entirely with login info, but
+                -- our data doesn't go back far enough. So we merge it with
+                -- annotation information to give us a better idea
+                SELECT
+                    user_id,
+                    timestamp_week AS active_date
+                FROM report.events
+                WHERE event_type IN ('deep_linking', 'configured_launch')
+            ) AS data
+            GROUP BY user_id
+        ),
+
         user_details AS (
             SELECT DISTINCT
                 user_map.user_id,
@@ -44,15 +83,28 @@ CREATE MATERIALIZED VIEW report.users AS (
         user_details.display_name,
         user_details.email,
         raw_users.username,
-        CASE
-            WHEN user_details.is_teacher IS true THEN true ELSE false
-        END AS is_teacher,
         -- Add a column which indicates that a user is a teacher in at least
         -- one context. This helps us notice / demonstrate we are only keeping
         -- teacher contact info. Keeping student contact info out of region is
         -- not permitted.
-        raw_users.registered_date
+        CASE
+            WHEN user_details.is_teacher IS true THEN true ELSE false
+        END AS is_teacher,
+        -- Daily resolution is fine. Some of these are only accurate to the week
+        LEAST(
+            raw_users.registered_date,
+            user_modify_dates.first_active_date,
+            user_activity_dates.first_active_date
+        )::DATE AS first_active_date,
+        GREATEST(
+            user_activity_dates.last_active_date,
+            user_modify_dates.last_active_date
+        )::DATE AS last_active_date
     FROM report.raw_users
     LEFT OUTER JOIN user_details ON
         user_details.user_id = raw_users.id
+    LEFT OUTER JOIN user_modify_dates ON
+        user_modify_dates.user_id = raw_users.id
+    LEFT OUTER JOIN user_activity_dates ON
+        user_activity_dates.user_id = raw_users.id
 ) WITH NO DATA;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/product-backlog/issues/1460

This adds a few extra date fields to the user:

 * `first_active_date`
 * `last_active_date`

They are all a slightly merged and fudged version of the truth from many different sources, but approximate the suggested values.

This is useful for seeing when someone first became a user and when they last interacted with the system. This will simplify some down-stream requests, and allow us to put this on the user dashboard easily.

## Testing notes

 * This query runs fine in metabase, so you can try it out there