### PR TITLE
Do not allow YouTube video URLs when using the URLPicker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -200,6 +200,7 @@ export default function ContentSelector({
           defaultURL={getDefaultValue('url')}
           onCancel={cancelDialog}
           onSelectURL={selectURL}
+          youtubeEnabled={youtubeEnabled}
         />
       );
       break;

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -1,6 +1,7 @@
 import { Button, ModalDialog, Input } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
 
+import { isYouTubeURL } from '../utils/youtube';
 import UIMessage from './UIMessage';
 
 export type URLPickerProps = {
@@ -10,6 +11,8 @@ export type URLPickerProps = {
   onCancel: () => void;
   /** Callback invoked with the entered URL when the user accepts the dialog */
   onSelectURL: (url: string) => void;
+  /** Indicates if YouTube transcript annotations are enabled */
+  youtubeEnabled?: boolean;
 };
 
 /**
@@ -20,6 +23,7 @@ export default function URLPicker({
   defaultURL = '',
   onCancel,
   onSelectURL,
+  youtubeEnabled = false,
 }: URLPickerProps) {
   const input = useRef<HTMLInputElement | null>(null);
   const form = useRef<HTMLFormElement | null>(null);
@@ -31,7 +35,9 @@ export default function URLPicker({
   const submit = (event: Event) => {
     event.preventDefault();
     try {
-      const url = new URL(input.current!.value);
+      const rawInputValue = input.current!.value;
+      const url = new URL(rawInputValue);
+
       if (!url.protocol.startsWith('http')) {
         if (url.protocol.startsWith('file')) {
           setError(
@@ -40,6 +46,12 @@ export default function URLPicker({
         } else {
           setError('Please use a URL that starts with "http" or "https"');
         }
+      } else if (isYouTubeURL(rawInputValue)) {
+        setError(
+          youtubeEnabled
+            ? 'To annotate a video, go back and choose the YouTube option.'
+            : 'Annotating YouTube videos is not yet supported. This feature is coming soon.'
+        );
       } else {
         onSelectURL(input.current!.value);
       }

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -90,6 +90,37 @@ describe('URLPicker', () => {
     );
   });
 
+  [
+    {
+      youtubeEnabled: true,
+      expectedError:
+        'To annotate a video, go back and choose the YouTube option.',
+    },
+    {
+      youtubeEnabled: false,
+      expectedError:
+        'Annotating YouTube videos is not yet supported. This feature is coming soon.',
+    },
+  ].forEach(({ youtubeEnabled, expectedError }) => {
+    it('does not invoke `onSelectURL` if URL is for a YouTube video', () => {
+      const onSelectURL = sinon.stub();
+
+      const wrapper = renderUrlPicker({ onSelectURL, youtubeEnabled });
+      wrapper.find('input').getDOMNode().value = 'https://youtu.be/EU6TDnV5osM';
+
+      wrapper
+        .find('button[data-testid="submit-button"]')
+        .props()
+        .onClick(new Event('click'));
+      wrapper.update();
+
+      assert.notCalled(onSelectURL);
+      const errorMessage = wrapper.find('UIMessage[status="error"]');
+      assert.isTrue(errorMessage.exists());
+      assert.include(errorMessage.text(), expectedError);
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({


### PR DESCRIPTION
Since we are currently using raw YouTube video URLs for video assignments, there's a possibility that someone configures it using the regular `URLPicker` instead of the `YouTubePicker`.

This is problematic, as the latter performs some extra validation that is not performed by the `URLPicker` (is a public existing video, it's not age-restricted, it's embeddable, etc).

Bypassing these validations could result in an assignment which fails for students at a later point in time.

This PRs adds a simple check that displays an error if a YouTube video URL is set in the `URLPicker`. The message is different if youtube is not allowed for the active course.

YouTube enabled:

![image](https://github.com/hypothesis/lms/assets/2719332/15d4070b-3db0-4e77-9a0e-306187546053)

YouTube not enabled:

![image](https://github.com/hypothesis/lms/assets/2719332/a89735a3-7f46-40fd-bea3-e8f2024130fa)

### Considerations / TODO

* [x] There are other possible approaches to address this problem. They were listed in https://github.com/hypothesis/lms/issues/5499, but this seems like the simplest way to "get away with it" for now.
* [x] We need to define an error which is meaningful enough. I considered mentioning what to do next, e.g. "Go back and select YouTube instead", but considering YouTube is enabled/disabled by course, this might be the wrong assumption.
* [x] Related to the above, we might consider letting YouTube video URLs through, when YouTube is not enabled for the course, or dynamically display different error messages.

This PR closes #5499