### PR TITLE
Store student submissions as events

### DIFF
--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -69,7 +69,7 @@ class LTIEvent(BaseEvent):
 
     def _get_course_id(self):
         if course := self.request.find_service(name="course").get_by_context_id(
-            self.request.lti_params.get("context_id")
+            self.request.lti_user.lti.course_id
         ):
             return course.id
 
@@ -77,8 +77,8 @@ class LTIEvent(BaseEvent):
 
     def _get_assignment_id(self):
         if assignment := self.request.find_service(name="assignment").get_assignment(
-            self.request.lti_params.get("tool_consumer_instance_guid"),
-            self.request.lti_params.get("resource_link_id"),
+            self.request.lti_user.tool_consumer_instance_guid,
+            self.request.lti_user.lti.assignment_id,
         ):
             return assignment.id
 

--- a/lms/models/event.py
+++ b/lms/models/event.py
@@ -15,6 +15,7 @@ class EventType(BASE):
         DEEP_LINKING = "deep_linking"
         AUDIT_TRAIL = "audit"
         EDITED_ASSIGNMENT = "edited_assignment"
+        SUBMISSION = "submission"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     type = varchar_enum(Type)

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from lms.models.application_instance import ApplicationInstance
 from lms.models.h_user import HUser
@@ -27,6 +27,12 @@ class LTIUser:  # pylint: disable=too-many-instance-attributes
 
     application_instance_id: int
     """ID of the application instance this user belongs to"""
+
+    context_id: str
+    """ID of the course in the LMS, context_id using LTI naming"""
+
+    resource_link_id: Optional[str] = None
+    """ID of the assignment in the LMS, resource_link_id using LTI naming"""
 
     application_instance: ApplicationInstance = None
     """Application instance this user belongs to"""

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -38,7 +38,20 @@ class LTIUser:  # pylint: disable=too-many-instance-attributes
     """ID of the application instance this user belongs to"""
 
     lti: LTI
-    """Additional information about the LTI launch"""
+    """
+    Additional information about the LTI launch.
+
+    Note that there's a bit of a backwards relationship here, we could have LTIUser inside LTI.
+
+    LTIUser is now a central part of the authentication system so more ambitions changes require big refactors but
+    there's an intention here to eventually replace the current:
+
+    request.lti_user
+
+    with something like:
+
+    request.lti_session or similar with contains the user and any other relevant values.
+    """
 
     application_instance: ApplicationInstance = None
     """Application instance this user belongs to"""

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -7,6 +7,15 @@ from lms.models.lti_role import LTIRole, RoleScope, RoleType
 
 
 @dataclass
+class LTI:
+    course_id: str
+    """ID of the course in the LMS, context_id using LTI naming"""
+
+    assignment_id: Optional[str] = None
+    """ID of the assignment in the LMS, resource_link_id using LTI naming"""
+
+
+@dataclass
 class LTIUser:  # pylint: disable=too-many-instance-attributes
     """An LTI user."""
 
@@ -28,11 +37,8 @@ class LTIUser:  # pylint: disable=too-many-instance-attributes
     application_instance_id: int
     """ID of the application instance this user belongs to"""
 
-    context_id: str
-    """ID of the course in the LMS, context_id using LTI naming"""
-
-    resource_link_id: Optional[str] = None
-    """ID of the assignment in the LMS, resource_link_id using LTI naming"""
+    lti: LTI
+    """Additional information about the LTI launch"""
 
     application_instance: ApplicationInstance = None
     """Application instance this user belongs to"""

--- a/lms/services/lti_user.py
+++ b/lms/services/lti_user.py
@@ -1,4 +1,4 @@
-from lms.models.lti_user import LTIUser, display_name
+from lms.models.lti_user import LTI, LTIUser, display_name
 from lms.services import LTIRoleService
 from lms.services.application_instance import ApplicationInstanceService
 
@@ -33,8 +33,10 @@ class LTIUserService:
                 lti_params.get("lis_person_name_full", ""),
             ),
             email=lti_params.get("lis_person_contact_email_primary"),
-            context_id=lti_params["context_id"],
-            resource_link_id=lti_params.get("resource_link_id"),
+            lti={
+                "course_id": lti_params.get("context_id"),
+                "assignment_id": lti_params.get("resource_link_id"),
+            },
         )
 
     @staticmethod
@@ -51,8 +53,10 @@ class LTIUserService:
             "display_name": lti_user.display_name,
             "application_instance_id": lti_user.application_instance_id,
             "email": lti_user.email,
-            "context_id": lti_user.context_id,
-            "resource_link_id": lti_user.resource_link_id,
+            "lti": {
+                "course_id": lti_user.lti.course_id,
+                "assignment_id": lti_user.lti.assignment_id,
+            },
         }
 
     def deserialize(self, **kwargs: dict) -> LTIUser:
@@ -61,9 +65,17 @@ class LTIUserService:
         application_instance = self._application_instance_service.get_for_launch(
             kwargs["application_instance_id"]
         )
+        lti_data = kwargs.pop("lti")
+        lti = LTI(
+            course_id=lti_data["course_id"],
+            assignment_id=lti_data["assignment_id"],
+        )
 
         return LTIUser(
-            lti_roles=lti_roles, application_instance=application_instance, **kwargs
+            lti_roles=lti_roles,
+            application_instance=application_instance,
+            lti=lti,
+            **kwargs,
         )
 
 

--- a/lms/services/lti_user.py
+++ b/lms/services/lti_user.py
@@ -19,20 +19,22 @@ class LTIUserService:
         self._lti_roles_service = lti_role_service
         self._application_instance_service = application_instance_service
 
-    def from_auth_params(self, application_instance, lti_core_schema) -> LTIUser:
-        """Create an LTIUser from a LTIV11CoreSchema like dict."""
+    def from_lti_params(self, application_instance, lti_params) -> LTIUser:
+        """Create an LTIUser from a LTIParams."""
 
         return self.deserialize(
-            user_id=lti_core_schema["user_id"],
+            user_id=lti_params["user_id"],
             application_instance_id=application_instance.id,
-            roles=lti_core_schema["roles"],
-            tool_consumer_instance_guid=lti_core_schema["tool_consumer_instance_guid"],
+            roles=lti_params["roles"],
+            tool_consumer_instance_guid=lti_params["tool_consumer_instance_guid"],
             display_name=display_name(
-                lti_core_schema["lis_person_name_given"],
-                lti_core_schema["lis_person_name_family"],
-                lti_core_schema["lis_person_name_full"],
+                lti_params.get("lis_person_name_given", ""),
+                lti_params.get("lis_person_name_family", ""),
+                lti_params.get("lis_person_name_full", ""),
             ),
-            email=lti_core_schema["lis_person_contact_email_primary"],
+            email=lti_params.get("lis_person_contact_email_primary"),
+            context_id=lti_params["context_id"],
+            resource_link_id=lti_params.get("resource_link_id"),
         )
 
     @staticmethod
@@ -49,6 +51,8 @@ class LTIUserService:
             "display_name": lti_user.display_name,
             "application_instance_id": lti_user.application_instance_id,
             "email": lti_user.email,
+            "context_id": lti_user.context_id,
+            "resource_link_id": lti_user.resource_link_id,
         }
 
     def deserialize(self, **kwargs: dict) -> LTIUser:

--- a/lms/validation/authentication/_lti.py
+++ b/lms/validation/authentication/_lti.py
@@ -65,7 +65,9 @@ class LTI11AuthSchema(LTIV11CoreSchema):
                 {"consumer_key": ["Invalid OAuth 1 signature. Unknown consumer key."]}
             ) from err
 
-        return self._lti_user_service.from_auth_params(application_instance, kwargs)
+        return self._lti_user_service.from_lti_params(
+            application_instance, self.context["request"].lti_params
+        )
 
     @marshmallow.validates_schema
     def _verify_oauth_1(self, _data, **_kwargs):
@@ -130,4 +132,6 @@ class LTI13AuthSchema(LTIV11CoreSchema):
                 {"JWT": ["Invalid LTI1.3 params. Unknown application_instance."]}
             ) from err
 
-        return self._lti_user_service.from_auth_params(application_instance, kwargs)
+        return self._lti_user_service.from_lti_params(
+            application_instance, self.context["request"].lti_params
+        )

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -34,18 +34,6 @@ class GradingViews:
         self.lti_grading_service.record_result(
             self.parsed_params["lis_result_sourcedid"], score
         )
-
-        self.request.registry.notify(
-            LTIEvent(
-                request=self.request,
-                type=LTIEvent.Type.SCORED,
-                data={
-                    "student_user_id": self.parsed_params["student_user_id"],
-                    "score": score,
-                },
-            )
-        )
-
         return {}
 
     @view_config(
@@ -100,7 +88,9 @@ class GradingViews:
         self.lti_grading_service.record_result(
             lis_result_sourcedid, pre_record_hook=CanvasPreRecordHook(self.request)
         )
-
+        self.request.registry.notify(
+            LTIEvent(request=self.request, type=LTIEvent.Type.SUBMISSION)
+        )
         return {}
 
 

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -3,6 +3,7 @@ from datetime import timezone
 
 from pyramid.view import view_config, view_defaults
 
+from lms.events import LTIEvent
 from lms.security import Permissions
 from lms.services import LTIGradingService
 from lms.validation import (
@@ -32,6 +33,17 @@ class GradingViews:
 
         self.lti_grading_service.record_result(
             self.parsed_params["lis_result_sourcedid"], score
+        )
+
+        self.request.registry.notify(
+            LTIEvent(
+                request=self.request,
+                type=LTIEvent.Type.SCORED,
+                data={
+                    "student_user_id": self.parsed_params["student_user_id"],
+                    "score": score,
+                },
+            )
         )
 
         return {}

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -11,4 +11,5 @@ LTIUser = make_factory(
     lti_roles=[],
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     display_name=Faker("name"),
+    context_id=Faker("hexify", text="^" * 40),
 )

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,15 +1,17 @@
 from factory import Faker, fuzzy, make_factory
 
-from lms import models
+from lms.models.lti_user import LTI, LTIUser
 from tests.factories.attributes import TOOL_CONSUMER_INSTANCE_GUID, USER_ID
 
 LTIUser = make_factory(
-    models.LTIUser,
+    LTIUser,
     user_id=USER_ID,
     application_instance_id=fuzzy.FuzzyInteger(1, 9999999999),
     roles=Faker("random_element", elements=["Learner", "Instructor"]),
     lti_roles=[],
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     display_name=Faker("name"),
-    context_id=Faker("hexify", text="^" * 40),
+    lti=LTI(
+        course_id=Faker("hexify", text="^" * 40),
+    ),
 )

--- a/tests/unit/lms/events/test_event.py
+++ b/tests/unit/lms/events/test_event.py
@@ -22,11 +22,11 @@ class TestLTIEvent:
         assert event.role_ids == [sentinel.id]
         assert event.application_instance_id == application_instance.id
 
-        course_service.get_by_context_id.assert_called_once_with(sentinel.context_id)
+        course_service.get_by_context_id.assert_called_once_with(lti_user.lti.course_id)
         assert event.course_id == course_service.get_by_context_id.return_value.id
 
         assignment_service.get_assignment.assert_called_once_with(
-            sentinel.tool_guid, sentinel.resource_link_id
+            lti_user.tool_consumer_instance_guid, lti_user.lti.assignment_id
         )
         assert event.assignment_id == assignment_service.get_assignment.return_value.id
 

--- a/tests/unit/lms/services/lti_user_test.py
+++ b/tests/unit/lms/services/lti_user_test.py
@@ -6,22 +6,20 @@ from lms.services.lti_user import LTIUserService, factory
 
 
 class TestLTIUserService:
-    def test_from_lti_params(
-        self, application_instance, auth_params, svc, display_name
-    ):
-        lti_user = svc.from_lti_params(application_instance, auth_params)
+    def test_from_lti_params(self, application_instance, lti_params, svc, display_name):
+        lti_user = svc.from_lti_params(application_instance, lti_params)
 
-        assert lti_user.user_id == auth_params["user_id"]
-        assert lti_user.roles == auth_params["roles"]
+        assert lti_user.user_id == lti_params["user_id"]
+        assert lti_user.roles == lti_params["roles"]
         assert (
             lti_user.tool_consumer_instance_guid
-            == auth_params["tool_consumer_instance_guid"]
+            == lti_params["tool_consumer_instance_guid"]
         )
-        assert lti_user.email == auth_params["lis_person_contact_email_primary"]
+        assert lti_user.email == lti_params["lis_person_contact_email_primary"]
         assert lti_user.display_name == display_name(
-            auth_params["lis_person_name_given"],
-            auth_params["lis_person_name_family"],
-            auth_params["lis_person_name_full"],
+            lti_params["lis_person_name_given"],
+            lti_params["lis_person_name_family"],
+            lti_params["lis_person_name_full"],
         )
         assert lti_user.application_instance_id == application_instance.id
 
@@ -44,10 +42,14 @@ class TestLTIUserService:
             "display_name": lti_user.display_name,
             "application_instance_id": lti_user.application_instance_id,
             "email": lti_user.email,
+            "lti": {
+                "course_id": lti_user.lti.course_id,
+                "assignment_id": lti_user.lti.assignment_id,
+            },
         }
 
     @pytest.fixture
-    def auth_params(self):
+    def lti_params(self):
         return {
             "user_id": "USER_ID",
             "roles": "ROLES",
@@ -56,6 +58,8 @@ class TestLTIUserService:
             "lis_person_name_family": "LIS_PERSON_NAME_FAMILY",
             "lis_person_name_full": "LIS_PERSON_NAME_FULL",
             "lis_person_contact_email_primary": "LIS_PERSON_CONTACT_EMAIL_PRIMARY",
+            "context_id": "CONTEXT_ID",
+            "resource_link_id": "RESOURCE_LINK_ID",
         }
 
     @pytest.fixture

--- a/tests/unit/lms/services/lti_user_test.py
+++ b/tests/unit/lms/services/lti_user_test.py
@@ -6,10 +6,10 @@ from lms.services.lti_user import LTIUserService, factory
 
 
 class TestLTIUserService:
-    def test_from_auth_params(
+    def test_from_lti_params(
         self, application_instance, auth_params, svc, display_name
     ):
-        lti_user = svc.from_auth_params(application_instance, auth_params)
+        lti_user = svc.from_lti_params(application_instance, auth_params)
 
         assert lti_user.user_id == auth_params["user_id"]
         assert lti_user.roles == auth_params["roles"]
@@ -24,6 +24,17 @@ class TestLTIUserService:
             auth_params["lis_person_name_full"],
         )
         assert lti_user.application_instance_id == application_instance.id
+
+    def test_from_lti_params_without_name(
+        self, application_instance, lti_params, svc, display_name
+    ):
+        del lti_params["lis_person_name_given"]
+        del lti_params["lis_person_name_family"]
+        del lti_params["lis_person_name_full"]
+
+        lti_user = svc.from_lti_params(application_instance, lti_params)
+
+        assert lti_user.display_name == display_name("", "", "")
 
     def test_serialize(self, svc, lti_user):
         assert svc.serialize(lti_user) == {

--- a/tests/unit/lms/validation/authentication/_lti_test.py
+++ b/tests/unit/lms/validation/authentication/_lti_test.py
@@ -15,29 +15,15 @@ pytestmark = pytest.mark.usefixtures(
 
 class TestLTI11AuthSchema:
     def test_it_returns_the_lti_user_info(
-        self, schema, application_instance_service, lti_user_service
+        self, schema, application_instance_service, lti_user_service, pyramid_request
     ):
         lti_user = schema.lti_user()
 
-        lti_user_service.from_auth_params.assert_called_once_with(
+        lti_user_service.from_lti_params.assert_called_once_with(
             application_instance_service.get_by_consumer_key.return_value,
-            {
-                "oauth_signature_method": "SHA256",
-                "lis_person_name_family": "TEST_FAMILY_NAME",
-                "lis_person_contact_email_primary": "EMAIL",
-                "oauth_nonce": "TEST_NONCE",
-                "oauth_consumer_key": "TEST_OAUTH_CONSUMER_KEY",
-                "lis_person_name_full": "TEST_FULL_NAME",
-                "oauth_version": "1p0p0",
-                "lis_person_name_given": "TEST_GIVEN_NAME",
-                "oauth_signature": "TEST_OAUTH_SIGNATURE",
-                "roles": "Instructor",
-                "tool_consumer_instance_guid": "TEST_TOOL_CONSUMER_INSTANCE_GUID",
-                "user_id": "TEST_USER_ID",
-                "oauth_timestamp": "TEST_TIMESTAMP",
-            },
+            pyramid_request.lti_params,
         )
-        assert lti_user == lti_user_service.from_auth_params.return_value
+        assert lti_user == lti_user_service.from_lti_params.return_value
 
     def test_it_raises_missing_application_instance(
         self, schema, application_instance_service
@@ -102,15 +88,15 @@ class TestLTI11AuthSchema:
 
 class TestLTI13AuthSchema:
     def test_lti_user(
-        self, schema, schema_params, application_instance_service, lti_user_service
+        self, schema, pyramid_request, application_instance_service, lti_user_service
     ):
         lti_user = schema.lti_user()
 
-        lti_user_service.from_auth_params.assert_called_once_with(
+        lti_user_service.from_lti_params.assert_called_once_with(
             application_instance_service.get_by_deployment_id.return_value,
-            schema_params,
+            pyramid_request.lti_params,
         )
-        assert lti_user == lti_user_service.from_auth_params.return_value
+        assert lti_user == lti_user_service.from_lti_params.return_value
 
     def test_it_raises_missing_application_instance(
         self, schema, application_instance_service
@@ -135,10 +121,6 @@ class TestLTI13AuthSchema:
     @pytest.fixture
     def schema(self, pyramid_request):
         return LTI13AuthSchema(pyramid_request)
-
-    @pytest.fixture
-    def schema_params(self, schema):
-        return schema.parse()
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, lti_v13_params):

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -30,7 +30,7 @@ class TestRecordCanvasSpeedgraderSubmission:
         lti_grading_service.record_result.assert_not_called()
 
     def test_it_passes_the_callback_if_there_is_no_score(
-        self, pyramid_request, lti_grading_service
+        self, pyramid_request, lti_grading_service, LTIEvent
     ):
         lti_grading_service.read_result.return_value = None
 
@@ -41,6 +41,9 @@ class TestRecordCanvasSpeedgraderSubmission:
             pre_record_hook=Any.instance_of(CanvasPreRecordHook),
             # lti_launch_url=expected_launch_url,
             # submitted_at=datetime.datetime(2001, 1, 1, tzinfo=timezone.utc),
+        )
+        LTIEvent.assert_called_once_with(
+            request=pyramid_request, type=LTIEvent.Type.SUBMISSION
         )
 
     @pytest.fixture
@@ -203,3 +206,8 @@ class TestRecordResult:
             "score": 0.5,
         }
         return pyramid_request
+
+
+@pytest.fixture
+def LTIEvent(patch):
+    return patch("lms.views.api.grading.LTIEvent")

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -47,6 +47,10 @@ class TestRecordCanvasSpeedgraderSubmission:
         )
 
     @pytest.fixture
+    def LTIEvent(self, patch):
+        return patch("lms.views.api.grading.LTIEvent")
+
+    @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.parsed_params = {
             # Information that is needed to construct the LTI launch URL for
@@ -206,8 +210,3 @@ class TestRecordResult:
             "score": 0.5,
         }
         return pyramid_request
-
-
-@pytest.fixture
-def LTIEvent(patch):
-    return patch("lms.views.api.grading.LTIEvent")


### PR DESCRIPTION
Keep track of submissions made by students. This is now a canvas only feature in our implementation but there's nothing canvas specific about the events themselves.


## Testing

- Login as `eng+canvasstudent@hypothes.is` in Canvas
- Launch https://hypothesis.instructure.com/courses/125/assignments/4682
- Make an annotation
- Check the newly created event:

```shell
docker compose exec postgres psql -U postgres -c "select course_id, user_id, assignment_id, type from event join event_type on event_type.id = type_id join event_user on event_id = event.id where type = 'submission' order by event.id desc"
```

```
course_id | user_id | assignment_id |    type    
-----------+---------+---------------+------------
       155 |       7 |            47 | submission
```

## :warning: Do not merge! :warning:

We need to merge the following PRs from reporting first otherwise that stuff will fail:

 * https://github.com/hypothesis/lms/pull/5515
 * https://github.com/hypothesis/report/pull/238







