### PR TITLE
Increase the timeout on h API requests

### DIFF
--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -164,6 +164,7 @@ class HAPI:
                 auth=self._http_auth,
                 headers=headers,
                 stream=stream,
+                timeout=(60, 60),
                 **request_args,
             )
         except ExternalRequestError as err:

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -131,6 +131,7 @@ class TestHAPI:
                 }
             ),
             stream=True,
+            timeout=(60, 60),
         )
 
         assert result == expected_result
@@ -146,6 +147,7 @@ class TestHAPI:
                 auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
                 headers={"Hypothesis-Application": "lms"},
                 stream=False,
+                timeout=(60, 60),
                 data=sentinel.raw_body,
             )
         ]


### PR DESCRIPTION
Increase the timeout on all of LMS's requests to the h API from 10s to
60s.

Fixes https://github.com/hypothesis/lms/issues/5510.

LMS's requests to h's bulk annotation API have been timing out. Ideally
we've like these requests to be fast enough that they don't time out.
But if the requests do take a long time I think we'd prefer for LMS to
wait longer for the responses rather than failing.
