### PR TITLE
Update reporting with the new "submission" event type

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/02_entities/03_events/01_create_view.sql
+++ b/lms/data_tasks/report/create_from_scratch/02_entities/03_events/01_create_view.sql
@@ -1,7 +1,11 @@
 DROP TYPE IF EXISTS report.event_type CASCADE;
 
 CREATE TYPE report.event_type AS ENUM (
-    'configured_launch', 'deep_linking', 'audit', 'edited_assignment'
+    'configured_launch',
+    'deep_linking',
+    'audit',
+    'edited_assignment',
+    'submission'
 );
 
 DROP MATERIALIZED VIEW IF EXISTS report.events CASCADE;


### PR DESCRIPTION
From:

 * https://github.com/hypothesis/lms/pull/5504

We need to update the reporting types to match the new possible values in the event table. This can be released before the new event type safely, but reporting will fail if run after.