### PR TITLE
Store student grades as events

### DIFF
--- a/lms/models/event.py
+++ b/lms/models/event.py
@@ -16,6 +16,7 @@ class EventType(BASE):
         AUDIT_TRAIL = "audit"
         EDITED_ASSIGNMENT = "edited_assignment"
         SUBMISSION = "submission"
+        GRADE = "grade"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     type = varchar_enum(Type)

--- a/lms/static/scripts/frontend_apps/services/grading.ts
+++ b/lms/static/scripts/frontend_apps/services/grading.ts
@@ -6,6 +6,9 @@ export type Student = {
 
   /** API URL for posting outcome results. */
   LISOutcomeServiceUrl: string;
+
+  /** LTI user id for this student. */
+  lmsId: string;
 };
 
 /**
@@ -35,6 +38,7 @@ export class GradingService {
       data: {
         lis_result_sourcedid: student.LISResultSourcedId,
         lis_outcome_service_url: student.LISOutcomeServiceUrl,
+        student_user_id: student.lmsId,
         score: grade,
       },
     });

--- a/lms/static/scripts/frontend_apps/services/test/grading-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/grading-test.js
@@ -45,20 +45,20 @@ describe('GradingService', () => {
         student: {
           LISResultSourcedId: 0,
           LISOutcomeServiceUrl: 'url',
+          lmsId: 'studentId',
         },
         grade: 1,
       });
-      assert.isTrue(
-        fakeAPICall.calledWithMatch({
-          authToken: 'dummy-token',
-          path: '/api/lti/result',
-          data: {
-            lis_result_sourcedid: 0,
-            lis_outcome_service_url: 'url',
-            score: 1,
-          },
-        })
-      );
+      assert.calledWithMatch(fakeAPICall, {
+        authToken: 'dummy-token',
+        path: '/api/lti/result',
+        data: {
+          lis_result_sourcedid: 0,
+          lis_outcome_service_url: 'url',
+          student_user_id: 'studentId',
+          score: 1,
+        },
+      });
     });
   });
 });

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -80,3 +80,6 @@ class APIRecordResultSchema(JSONPyramidRequestSchema):
     """
     Score — i.e. grade — for this submission. A value between 0 and 1, inclusive.
     """
+
+    student_user_id = fields.Str(required=True)
+    """The LTIUser.user_id of the student being graded."""

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -34,6 +34,17 @@ class GradingViews:
         self.lti_grading_service.record_result(
             self.parsed_params["lis_result_sourcedid"], score
         )
+        self.request.registry.notify(
+            LTIEvent(
+                request=self.request,
+                type=LTIEvent.Type.GRADE,
+                data={
+                    "student_user_id": self.parsed_params["student_user_id"],
+                    "score": score,
+                },
+            )
+        )
+
         return {}
 
     @view_config(

--- a/tests/unit/lms/validation/_api_test.py
+++ b/tests/unit/lms/validation/_api_test.py
@@ -113,7 +113,8 @@ class TestAPIRecordResultSchema:
         assert parsed_params == all_fields
 
     @pytest.mark.parametrize(
-        "field", ["lis_outcome_service_url", "lis_result_sourcedid", "score"]
+        "field",
+        ["lis_outcome_service_url", "lis_result_sourcedid", "score", "student_user_id"],
     )
     def test_it_raises_if_required_fields_missing(
         self, json_request, all_fields, field
@@ -148,6 +149,7 @@ class TestAPIRecordResultSchema:
             "lis_outcome_service_url": "https://hypothesis.shinylms.com/outcomes",
             "lis_result_sourcedid": "modelstudent-assignment1",
             "score": 0.5,
+            "student_user_id": "STUDENT_ID",
         }
 
 


### PR DESCRIPTION
For 

- https://github.com/hypothesis/lms/issues/5505


Similar to #5504 but for grades.

On top of user, course and & assignment (part of all LTIEvents), we want here to store also the actual numeric value of the score and the student being graded.



# Testing:

- Make sure to have `make devdata` up to date
- Log into D2L as `HypothesisEng.Teacher`
- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View?ou=6782
- Grade `aunltd Learner` with any grade
- Check the event is stored in the DB

```
docker compose exec postgres psql -U postgres -c "select event.id, course_id, assignment_id, type, extra from event join event_type on event_type.id = type_id join event_data on event_data.event_id = event.id where type = 'grade' order by event.id desc"
```
