### PR TITLE
Base Assignment.is_gradable in the launch parameters directly in the service

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -165,24 +165,15 @@ class BasicLaunchViews:
             [self.course], self.request.lti_params
         )
 
-        # An assignment has been configured in the LMS as "gradable" if it has
-        # the `lis_outcome_service_url` param
-
-        assignment_gradable = self.request.product.plugin.misc.is_assignment_gradable(
-            self.request.lti_params
-        )
-
         # Store lots of info
-        assignment = self._record_assignment(
-            document_url, extra=assignment_extra, is_gradable=assignment_gradable
-        )
+        assignment = self._record_assignment(document_url, extra=assignment_extra)
 
         # Set up the JS config for the front-end
         self._configure_js_to_show_document(document_url, assignment)
 
         return {}
 
-    def _record_assignment(self, document_url, extra, is_gradable):
+    def _record_assignment(self, document_url, extra):
         # Store assignment details
         assignment = self.assignment_service.upsert_assignment(
             document_url=document_url,
@@ -192,7 +183,6 @@ class BasicLaunchViews:
             resource_link_id=self.request.lti_params.get("resource_link_id"),
             lti_params=self.request.lti_params,
             extra=extra,
-            is_gradable=is_gradable,
         )
 
         # Store the relationship between the assignment and the course

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -260,7 +260,6 @@ class TestBasicLaunchViews:
         context,
         lti_h_service,
         assignment_service,
-        misc_plugin,
         lti_user,
         course_service,
     ):
@@ -281,7 +280,6 @@ class TestBasicLaunchViews:
             resource_link_id=pyramid_request.lti_params["resource_link_id"],
             document_url=sentinel.document_url,
             lti_params=pyramid_request.lti_params,
-            is_gradable=misc_plugin.is_assignment_gradable.return_value,
             extra=sentinel.assignment_extra,
         )
         assignment = assignment_service.upsert_assignment.return_value


### PR DESCRIPTION
Instead of taking it as parameter follow the pattern we use for other attributes and look directly at the launch parameters to decide its value.

This paves the way to have a `get_assignment_from_launch` or similar.