### PR TITLE
Refactor lti launches to be more explicit about assignments 

### DIFF
--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -104,7 +104,7 @@ class CanvasGroupingPlugin(GroupingPlugin):
 
         return course.settings.get("canvas", "sections_enabled")
 
-    def get_group_set_id(self, request, assignment):
+    def get_group_set_id(self, request, _assignment, historical_assignment=None):
         # For canvas we add parameter to the launch URL as we don't store the
         # assignment during deep linking.
         return request.params.get("group_set")

--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -9,7 +9,9 @@ from lms.services.vitalsource import VSBookLocation
 
 class CanvasMiscPlugin(MiscPlugin):
     @lru_cache(1)
-    def get_document_url(self, request) -> Optional[str]:
+    def get_document_url(
+        self, request, assignment, historical_assignment
+    ) -> Optional[str]:
         """
         Get the configured document for this LTI launch.
 

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -43,8 +43,8 @@ class D2LMiscPlugin(MiscPlugin):
         # `lti_registration.token_url` as in other LMS
         return "https://api.brightspace.com/auth/token"
 
-    def get_document_url(self, request):
-        url = super().get_document_url(request)
+    def get_document_url(self, request, assignment, historical_assignment):
+        url = super().get_document_url(request, assignment, historical_assignment)
 
         if not url:
             # In D2L support both deep linking and DB backed assignment.

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -74,7 +74,7 @@ class GroupingPlugin:
         """Check if sections are enabled for this LMS, instance and course."""
         return bool(self.sections_type)
 
-    def get_group_set_id(self, request, assignment):
+    def get_group_set_id(self, _request, assignment, historical_assignment=None):
         """
         Get the group set ID for group launches.
 
@@ -82,11 +82,25 @@ class GroupingPlugin:
         have different sets of groups for the same course.
 
         This ID identifies a collection of groups.
+
+        `historical_assignment` might be none even when it might exist on the DB
+        (or even available as assignment.copied_form). The historical_assignment
+        is only relevant to get the config when creating an assignment for the
+        first time.
         """
-        if not self.group_type or not assignment:
+        if not self.group_type:
+            # Groups not enabled on this product
             return None
 
-        return assignment.extra.get("group_set_id") if assignment else None
+        if assignment:
+            return assignment.extra.get("group_set_id")
+
+        if historical_assignment:
+            # When creating new assignments, take the value from the previous
+            # version of the assignment
+            return historical_assignment.extra.get("group_set_id")
+
+        return None
 
 
 class GroupError(Exception):

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -40,27 +40,21 @@ class MiscPlugin:
         """Get the value of the `aud` claim used in LTI advantage requests."""
         return lti_registration.token_url
 
-    def get_document_url(self, request):
+    def get_document_url(
+        self,
+        request,  # pylint:disable=unused-argument
+        assignment,
+        historical_assignment,
+    ):
         """Get a document URL from an assignment launch."""
 
-        # For assignments that don't use deep linking the source of truth for this information is our DB.
-        assignment_service = request.find_service(name="assignment")
+        if assignment:
+            return assignment.document_url
 
-        assignment = assignment_service.get_assignment(
-            tool_consumer_instance_guid=request.lti_params.get(
-                "tool_consumer_instance_guid"
-            ),
-            resource_link_id=request.lti_params.get("resource_link_id"),
-        )
+        if historical_assignment:
+            return historical_assignment.document_url
 
-        if not assignment:
-            # If the current assignment is not yet in the DB maybe we
-            # are launching for the first time a copied assignment.
-            assignment = assignment_service.get_copied_from_assignment(
-                request.lti_params
-            )
-
-        return assignment.document_url if assignment else None
+        return None
 
     def get_deeplinking_launch_url(self, request, _assignment_configuration: dict):
         """

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -565,7 +565,7 @@ class JSConfig:
                     },
                     "context_id": self._request.lti_params["context_id"],
                     "group_set_id": self._request.product.plugin.grouping.get_group_set_id(
-                        self._request, assignment
+                        self._request, assignment, historical_assignment=None
                     ),
                     "group_info": {
                         key: value

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -33,6 +33,26 @@ class AssignmentService:
             .one_or_none()
         )
 
+    def create_assignment(self, tool_consumer_instance_guid, resource_link_id):
+        """Create a new assignment."""
+
+        assignment = Assignment(
+            tool_consumer_instance_guid=tool_consumer_instance_guid,
+            resource_link_id=resource_link_id,
+            extra={},
+        )
+        self._db.add(assignment)
+
+        return assignment
+
+    def update_assignment(self, assignment, document_url, group_set_id):
+        """Update an existing assignment."""
+
+        assignment.extra["group_set_id"] = group_set_id
+        assignment.document_url = document_url
+
+        return assignment
+
     def get_copied_from_assignment(self, lti_params) -> Optional[Assignment]:
         """Return the assignment that the current assignment was copied from."""
 

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -78,9 +78,9 @@ class AssignmentService:
 
     def get_assignment_for_launch(self, request) -> Optional[Assignment]:
         """
-        Get or create an assigment for the current launch.
+        Get or create an assignment for the current launch.
 
-        The returned assigment will have the relevant configuration for this launch.
+        The returned assignment will have the relevant configuration for this launch.
 
         Returns None if no assignment can be found or created.
         """
@@ -95,6 +95,8 @@ class AssignmentService:
         if not assignment:
             historical_assignment = self.get_copied_from_assignment(lti_params)
 
+        # Get the configuration for the assignment
+        # it might be based on the assignments we just queried or the request
         document_url = self._misc_plugin.get_document_url(
             request, assignment, historical_assignment
         )
@@ -124,7 +126,7 @@ class AssignmentService:
                         "group_set_id"
                     )
 
-        # Always update the assignment URL
+        # Always update the assignment configuration
         # It often will be the same one while launching the assignment again but
         # it might for example be an updated deep linked URL or similar.
         assignment.document_url = document_url

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -53,7 +53,7 @@ class AssignmentService:
 
         return assignment
 
-    def get_copied_from_assignment(self, lti_params) -> Optional[Assignment]:
+    def _get_copied_from_assignment(self, lti_params) -> Optional[Assignment]:
         """Return the assignment that the current assignment was copied from."""
 
         resource_link_history_params = [
@@ -94,7 +94,7 @@ class AssignmentService:
         assignment = self.get_assignment(tool_consumer_instance_guid, resource_link_id)
         historical_assignment = None
         if not assignment:
-            historical_assignment = self.get_copied_from_assignment(lti_params)
+            historical_assignment = self._get_copied_from_assignment(lti_params)
 
         # Get the configuration for the assignment
         # it might be based on the assignments we just queried or the request

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -17,8 +17,9 @@ from lms.services.upsert import bulk_upsert
 class AssignmentService:
     """A service for getting and setting assignments."""
 
-    def __init__(self, db: Session):
+    def __init__(self, db: Session, misc_plugin):
         self._db = db
+        self._misc_plugin = misc_plugin
 
     def get_assignment(self, tool_consumer_instance_guid, resource_link_id):
         """Get an assignment by resource_link_id."""
@@ -63,7 +64,6 @@ class AssignmentService:
         resource_link_id,
         document_url,
         lti_params: LTIParams,
-        is_gradable=False,
         extra=None,
     ) -> Assignment:
         """
@@ -74,7 +74,6 @@ class AssignmentService:
         or create a new one if none exist on the DB.
 
         Any existing document_url for this assignment will be overwritten.
-
 
         If we detect that the new assignment in the LMS has been copied from a
         historical assignment (perhaps by using the LMS's "course copy" feature)
@@ -106,7 +105,8 @@ class AssignmentService:
         assignment.document_url = document_url
         assignment.title = lti_params.get("resource_link_title")
         assignment.description = lti_params.get("resource_link_description")
-        assignment.is_gradable = is_gradable
+        assignment.is_gradable = self._misc_plugin.is_assignment_gradable(lti_params)
+
         if extra:
             assignment.extra = extra
 
@@ -164,4 +164,4 @@ class AssignmentService:
 
 
 def factory(_context, request):
-    return AssignmentService(db=request.db)
+    return AssignmentService(db=request.db, misc_plugin=request.product.plugin.misc)

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -236,7 +236,11 @@ class GroupingService:
         Grouping types describe how the course members are divided.
         If neither of the LMS grouping features are used "COURSE" is the default.
         """
-        if bool(self.plugin.get_group_set_id(request, assignment)):
+        if bool(
+            self.plugin.get_group_set_id(
+                request, assignment, historical_assignment=None
+            )
+        ):
             return Grouping.Type.GROUP
 
         if self.plugin.sections_enabled(request, self.application_instance, course):

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -109,7 +109,8 @@ class BasicLaunchViews:
             resource_link_id=self._resource_link_id,
         )
 
-        return self._configure_and_show_document(assignment)
+        self._configure_assignment(assignment)
+        return self._show_document(assignment)
 
     @view_config(
         route_name="edit_assignment",
@@ -133,16 +134,11 @@ class BasicLaunchViews:
                 },
             )
         )
-        return self._configure_and_show_document(assignment)
+        self._configure_assignment(assignment)
+        return self._show_document(assignment)
 
     def _show_document(self, assignment):
-        """
-        Display a document to the user for annotation or grading.
-
-        :param document_url: URL of the document to display
-        :param assignment_extra: Any extra details to add to the assignment
-            when updating metadata.
-        """
+        """Display a document to the user for annotation or grading."""
 
         # Before any LTI assignments launch, create or update the Hypothesis
         # user and group corresponding to the LTI user and course.
@@ -175,11 +171,11 @@ class BasicLaunchViews:
         )
         return course
 
-    def _configure_and_show_document(self, assignment):
+    def _configure_assignment(self, assignment):
         """
-        Prepare an assignment with new configuration and show it.
+        Prepare an assignment with new configuration.
 
-        The configuration  could be because we are creating this assignment
+        The configuration could be because we are creating this assignment
         for the first time or from an edit.
         """
         self.assignment_service.update_assignment(
@@ -189,7 +185,6 @@ class BasicLaunchViews:
             group_set_id=self.request.parsed_params.get("group_set"),
         )
 
-        return self._show_document(assignment)
 
     def _configure_js_for_file_picker(
         self, route: str = "configure_assignment"

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -18,8 +18,6 @@ from lms.events import LTIEvent
 from lms.product import Product
 from lms.security import Permissions
 from lms.services.assignment import AssignmentService
-from lms.services.course import CourseService
-from lms.services.grouping import GroupingService
 from lms.validation import BasicLTILaunchSchema, ConfigureAssignmentSchema
 
 
@@ -35,9 +33,6 @@ class BasicLaunchViews:
         self.assignment_service: AssignmentService = request.find_service(
             name="assignment"
         )
-        self.grouping_service: GroupingService = request.find_service(name="grouping")
-        self.course_service: CourseService = request.find_service(name="course")
-
         self._guid = self.request.lti_params.get("tool_consumer_instance_guid")
         self._resource_link_id = self.request.lti_params.get("resource_link_id")
 
@@ -163,10 +158,10 @@ class BasicLaunchViews:
         return {}
 
     def _record_course(self):
-        course = self.course_service.get_from_launch(
+        course = self.request.find_service(name="course").get_from_launch(
             self.request.product, self.request.lti_params
         )
-        self.grouping_service.upsert_grouping_memberships(
+        self.request.find_service(name="grouping").upsert_grouping_memberships(
             user=self.request.user, groups=[course]
         )
         return course
@@ -184,7 +179,6 @@ class BasicLaunchViews:
             document_url=self.request.parsed_params["document_url"],
             group_set_id=self.request.parsed_params.get("group_set"),
         )
-
 
     def _configure_js_for_file_picker(
         self, route: str = "configure_assignment"

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -38,9 +38,10 @@ class BasicLaunchViews:
         self.grouping_service: GroupingService = request.find_service(name="grouping")
         self.course_service: CourseService = request.find_service(name="course")
 
-        self.request.lti_user.application_instance.check_guid_aligns(
-            self.request.lti_params.get("tool_consumer_instance_guid")
-        )
+        self._guid = self.request.lti_params.get("tool_consumer_instance_guid")
+        self._resource_link_id = self.request.lti_params.get("resource_link_id")
+
+        self.request.lti_user.application_instance.check_guid_aligns(self._guid)
         self.course = self._record_course()
         self._record_launch()
 
@@ -74,10 +75,8 @@ class BasicLaunchViews:
     def reconfigure_assignment_config(self):
         """Return the data needed to re-configure an assignment."""
         assignment = self.assignment_service.get_assignment(
-            tool_consumer_instance_guid=self.request.lti_params[
-                "tool_consumer_instance_guid"
-            ],
-            resource_link_id=self.request.lti_params.get("resource_link_id"),
+            tool_consumer_instance_guid=self._guid,
+            resource_link_id=self._resource_link_id,
         )
         config = self._configure_js_for_file_picker(route="edit_assignment")
         return {
@@ -106,10 +105,8 @@ class BasicLaunchViews:
         and display it to the user.
         """
         assignment = self.assignment_service.create_assignment(
-            tool_consumer_instance_guid=self.request.lti_params[
-                "tool_consumer_instance_guid"
-            ],
-            resource_link_id=self.request.lti_params.get("resource_link_id"),
+            tool_consumer_instance_guid=self._guid,
+            resource_link_id=self._resource_link_id,
         )
 
         return self._configure_and_show_document(assignment)
@@ -123,10 +120,8 @@ class BasicLaunchViews:
     def edit_assignment_callback(self):
         """Edit the configuration of an existing assignment."""
         assignment = self.assignment_service.get_assignment(
-            tool_consumer_instance_guid=self.request.lti_params[
-                "tool_consumer_instance_guid"
-            ],
-            resource_link_id=self.request.lti_params.get("resource_link_id"),
+            tool_consumer_instance_guid=self._guid,
+            resource_link_id=self._resource_link_id,
         )
         self.request.registry.notify(
             LTIEvent(

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -183,13 +183,11 @@ class BasicLaunchViews:
         for the first time or from an edit.
         """
         self.assignment_service.update_assignment(
+            self.request,
             assignment,
             document_url=self.request.parsed_params["document_url"],
             group_set_id=self.request.parsed_params.get("group_set"),
         )
-
-        # Make any product-specific actions after configuring the assignment
-        self.request.product.plugin.misc.post_configure_assignment(self.request)
 
         return self._show_document(assignment)
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -148,24 +148,15 @@ class BasicLaunchViews:
             [self.course], self.request.lti_params
         )
 
-        # An assignment has been configured in the LMS as "gradable" if it has
-        # the `lis_outcome_service_url` param
-
-        assignment_gradable = self.request.product.plugin.misc.is_assignment_gradable(
-            self.request.lti_params
-        )
-
         # Store lots of info
-        assignment = self._record_assignment(
-            document_url, extra=assignment_extra, is_gradable=assignment_gradable
-        )
+        assignment = self._record_assignment(document_url, extra=assignment_extra)
 
         # Set up the JS config for the front-end
         self._configure_js_to_show_document(document_url, assignment)
 
         return {}
 
-    def _record_assignment(self, document_url, extra, is_gradable):
+    def _record_assignment(self, document_url, extra):
         # Store assignment details
         assignment = self.assignment_service.upsert_assignment(
             document_url=document_url,
@@ -175,7 +166,6 @@ class BasicLaunchViews:
             resource_link_id=self.request.lti_params.get("resource_link_id"),
             lti_params=self.request.lti_params,
             extra=extra,
-            is_gradable=is_gradable,
         )
 
         # Store the relationship between the assignment and the course

--- a/tests/factories/assignment.py
+++ b/tests/factories/assignment.py
@@ -10,4 +10,5 @@ Assignment = make_factory(
     resource_link_id=RESOURCE_LINK_ID,
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     document_url=Faker("uri"),
+    extra={},
 )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,7 @@ from pyramid.request import apply_request_extensions
 
 from lms import models
 from lms.db import SESSION
-from lms.models import ApplicationSettings
+from lms.models import ApplicationSettings, LTIParams
 from lms.models.lti_role import RoleScope, RoleType
 from lms.product import Product
 from lms.security import Identity
@@ -124,7 +124,7 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
     )
 
     pyramid_request.lti_jwt = {}
-    pyramid_request.lti_params = {}
+    pyramid_request.lti_params = LTIParams(v11=lti_v11_params)
     pyramid_request.product = Product.from_request(
         pyramid_request, dict(application_instance.settings)
     )

--- a/tests/unit/lms/product/canvas/_plugin/misc_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/misc_test.py
@@ -7,7 +7,9 @@ from lms.product.canvas._plugin.misc import CanvasMiscPlugin
 
 class TestCanvasMiscPlugin:
     def test_get_document_url(self, plugin, pyramid_request):
-        assert not plugin.get_document_url(pyramid_request)
+        assert not plugin.get_document_url(
+            pyramid_request, sentinel.assignment, sentinel.historical_assignment
+        )
 
     @pytest.mark.parametrize(
         "url,expected",
@@ -74,16 +76,24 @@ class TestCanvasMiscPlugin:
         if url:
             pyramid_request.params["url"] = url
 
-        assert plugin.get_document_url(pyramid_request) == expected
+        assert (
+            plugin.get_document_url(
+                pyramid_request, sentinel.assignment, sentinel.historical_assignment
+            )
+            == expected
+        )
 
     def test_get_document_url_with_canvas_files(self, plugin, pyramid_request):
         pyramid_request.params["canvas_file"] = "any"
         pyramid_request.params["file_id"] = "FILE_ID"
         pyramid_request.lti_params["custom_canvas_course_id"] = "COURSE_ID"
 
-        result = plugin.get_document_url(pyramid_request)
-
-        assert result == "canvas://file/course/COURSE_ID/file_id/FILE_ID"
+        assert (
+            plugin.get_document_url(
+                pyramid_request, sentinel.assignment, sentinel.historical_assignment
+            )
+            == "canvas://file/course/COURSE_ID/file_id/FILE_ID"
+        )
 
     @pytest.mark.parametrize("cfi", (None, sentinel.cfi))
     def test_get_document_url_with_legacy_vitalsource_book(
@@ -94,7 +104,9 @@ class TestCanvasMiscPlugin:
         if cfi:
             pyramid_request.params["cfi"] = cfi
 
-        result = plugin.get_document_url(pyramid_request)
+        result = plugin.get_document_url(
+            pyramid_request, sentinel.assignment, sentinel.historical_assignment
+        )
 
         VSBookLocation.assert_called_once_with(book_id=sentinel.book_id, cfi=cfi)
         assert result == VSBookLocation.return_value.document_url

--- a/tests/unit/lms/product/d2l/_plugin/misc_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/misc_test.py
@@ -70,7 +70,12 @@ class TestD2LMiscPlugin:
     def test_get_document_default_behaviour(self, plugin, MiscPlugin):
         MiscPlugin.get_document_url.return_value = sentinel.url
 
-        assert plugin.get_document_url(sentinel.request) == sentinel.url
+        assert (
+            plugin.get_document_url(
+                sentinel.request, sentinel.assignment, sentinel.historical_assignment
+            )
+            == sentinel.url
+        )
 
     def test_get_document_deep_linked_fallback(
         self, plugin, MiscPlugin, get_deep_linked_assignment_configuration
@@ -78,7 +83,12 @@ class TestD2LMiscPlugin:
         MiscPlugin.get_document_url.return_value = None
         get_deep_linked_assignment_configuration.return_value = {"url": sentinel.url}
 
-        assert plugin.get_document_url(sentinel.request) == sentinel.url
+        assert (
+            plugin.get_document_url(
+                sentinel.request, sentinel.assignment, sentinel.historical_assignment
+            )
+            == sentinel.url
+        )
 
     def test_get_document_returns_none(
         self, plugin, MiscPlugin, get_deep_linked_assignment_configuration
@@ -86,7 +96,9 @@ class TestD2LMiscPlugin:
         MiscPlugin.get_document_url.return_value = None
         get_deep_linked_assignment_configuration.return_value = {}
 
-        assert not plugin.get_document_url(sentinel.request)
+        assert not plugin.get_document_url(
+            sentinel.request, sentinel.assignment, sentinel.historical_assignment
+        )
 
     def test_factory(self, pyramid_request):
         plugin = D2LMiscPlugin.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/product/factory_test.py
+++ b/tests/unit/lms/product/factory_test.py
@@ -125,4 +125,5 @@ class TestGetProductFromRequest:
     def pyramid_request(self, pyramid_request):
         pyramid_request.matched_route = Mock(spec_set=["name"])
         pyramid_request.matched_route.name = "some.route"
+        pyramid_request.lti_params = {}
         return pyramid_request

--- a/tests/unit/lms/product/plugin/grouping_test.py
+++ b/tests/unit/lms/product/plugin/grouping_test.py
@@ -21,32 +21,41 @@ class TestGroupingPlugin:
             == expected
         )
 
-    def test_get_group_set_id_when_disabled(self, plugin):
-        plugin.group_type = None
+    def test_get_group_set_id_when_disabled(self, plugin_without_groups):
+        assert not plugin_without_groups.get_group_set_id(
+            sentinel.request, sentinel.assignment
+        )
 
-        assert not plugin.get_group_set_id(sentinel.request, sentinel.assignment)
-
-    def test_get_group_set_id_when_no_assignment(self, plugin_with_groups):
-        assert not plugin_with_groups.get_group_set_id(sentinel.request, None)
+    def test_get_group_set_id_when_no_assignment(self, plugin):
+        assert not plugin.get_group_set_id(sentinel.request, None)
 
     def test_get_group_set_id_when_no_group_set(self, plugin):
         assignment = factories.Assignment(extra={})
 
-        assert not plugin.get_group_set_id(sentinel.request, assignment)
+        assert not plugin.get_group_set_id(sentinel.request, assignment, None)
 
-    def test_get_group_set_id(self, plugin_with_groups):
-        assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
+    def test_get_group_set_id_from_historical_assignment(self, plugin):
+        historical_assignment = factories.Assignment(
+            extra={"group_set_id": sentinel.id}
+        )
 
         assert (
-            plugin_with_groups.get_group_set_id(sentinel.request, assignment)
+            plugin.get_group_set_id(sentinel.request, None, historical_assignment)
             == sentinel.id
         )
 
-    @pytest.fixture
-    def plugin(self):
-        return GroupingPlugin()
+    def test_get_group_set_id(self, plugin):
+        assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
+
+        assert plugin.get_group_set_id(sentinel.request, assignment) == sentinel.id
 
     @pytest.fixture
-    def plugin_with_groups(self, plugin):
+    def plugin(self):
+        plugin = GroupingPlugin()
         plugin.group_type = Grouping.Type.BLACKBOARD_GROUP
+        return plugin
+
+    @pytest.fixture
+    def plugin_without_groups(self, plugin):
+        plugin.group_type = None
         return plugin

--- a/tests/unit/lms/product/plugin/misc_test.py
+++ b/tests/unit/lms/product/plugin/misc_test.py
@@ -22,43 +22,23 @@ class TestMiscPlugin:
         assert plugin.get_ltia_aud_claim(lti_registration) == lti_registration.token_url
 
     def test_get_document_url_with_assignment_in_db_existing_assignment(
-        self, plugin, pyramid_request, assignment_service
+        self, plugin, pyramid_request
     ):
-        assignment_service.get_assignment.return_value = factories.Assignment(
-            document_url=sentinel.document_url
-        )
+        assignment = factories.Assignment(document_url=sentinel.document_url)
         pyramid_request.lti_params["resource_link_id"] = sentinel.link_id
 
-        result = plugin.get_document_url(pyramid_request)
-
-        assignment_service.get_assignment.assert_called_once_with(
-            tool_consumer_instance_guid=pyramid_request.lti_params[
-                "tool_consumer_instance_guid"
-            ],
-            resource_link_id=sentinel.link_id,
+        result = plugin.get_document_url(
+            pyramid_request, assignment, sentinel.historical_assignment
         )
+
         assert result == sentinel.document_url
 
     def test_get_document_url_with_assignment_in_db_copied_assignment(
-        self, plugin, pyramid_request, assignment_service
+        self, plugin, pyramid_request
     ):
-        assignment_service.get_assignment.return_value = None
-        assignment_service.get_copied_from_assignment.return_value = (
-            factories.Assignment(document_url=sentinel.document_url)
-        )
-        pyramid_request.lti_params["resource_link_id"] = sentinel.link_id
+        historical_assignment = factories.Assignment(document_url=sentinel.document_url)
 
-        result = plugin.get_document_url(pyramid_request)
-
-        assignment_service.get_assignment.assert_called_once_with(
-            tool_consumer_instance_guid=pyramid_request.lti_params[
-                "tool_consumer_instance_guid"
-            ],
-            resource_link_id=sentinel.link_id,
-        )
-        assignment_service.get_copied_from_assignment.assert_called_once_with(
-            pyramid_request.lti_params
-        )
+        result = plugin.get_document_url(pyramid_request, None, historical_assignment)
 
         assert result == sentinel.document_url
 

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -41,9 +41,9 @@ class TestAssignmentService:
             "custom_ResourceLink.id.history",
         ),
     )
-    def test_get_copied_from_assignment(self, svc, param, assignment):
+    def test__get_copied_from_assignment(self, svc, param, assignment):
         assert (
-            svc.get_copied_from_assignment(
+            svc._get_copied_from_assignment(  # pylint:disable=protected-access
                 {
                     param: assignment.resource_link_id,
                     "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
@@ -52,16 +52,16 @@ class TestAssignmentService:
             == assignment
         )
 
-    def test_get_copied_from_assignment_not_found_bad_parameter(self, svc, assignment):
-        assert not svc.get_copied_from_assignment(
+    def test__get_copied_from_assignment_not_found_bad_parameter(self, svc, assignment):
+        assert not svc._get_copied_from_assignment(  # pylint:disable=protected-access
             {
                 "unknown_param": assignment.resource_link_id,
                 "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
             }
         )
 
-    def test_get_copied_from_assignment_not_found(self, svc, assignment):
-        assert not svc.get_copied_from_assignment(
+    def test__get_copied_from_assignment_not_found(self, svc, assignment):
+        assert not svc._get_copied_from_assignment(  # pylint:disable=protected-access
             {
                 "resource_link_id_history": "Unknown_RESOURCE_LINK_ID",
                 "tool_consumer_instance_guid": assignment.tool_consumer_instance_guid,
@@ -75,7 +75,7 @@ class TestAssignmentService:
         misc_plugin,
         get_assignment,
         grouping_plugin,
-        get_copied_from_assignment,
+        _get_copied_from_assignment,
     ):
         misc_plugin.get_document_url.return_value = sentinel.document_url
         grouping_plugin.get_group_set_id.return_value = sentinel.group_set_id
@@ -83,7 +83,7 @@ class TestAssignmentService:
 
         assignment = svc.get_assignment_for_launch(pyramid_request)
 
-        get_copied_from_assignment.assert_not_called()
+        _get_copied_from_assignment.assert_not_called()
         misc_plugin.get_document_url.assert_called_once_with(
             pyramid_request, get_assignment.return_value, None
         )
@@ -116,7 +116,7 @@ class TestAssignmentService:
         svc,
         misc_plugin,
         get_assignment,
-        get_copied_from_assignment,
+        _get_copied_from_assignment,
         create_assignment,
         group_set_id,
         grouping_plugin,
@@ -124,12 +124,12 @@ class TestAssignmentService:
         misc_plugin.get_document_url.return_value = sentinel.document_url
         create_assignment.return_value = factories.Assignment()
         get_assignment.return_value = None
-        get_copied_from_assignment.return_value = None
+        _get_copied_from_assignment.return_value = None
         grouping_plugin.get_group_set_id.return_value = group_set_id
 
         assignment = svc.get_assignment_for_launch(pyramid_request)
 
-        get_copied_from_assignment.assert_called_once_with(pyramid_request.lti_params)
+        _get_copied_from_assignment.assert_called_once_with(pyramid_request.lti_params)
         create_assignment.assert_called_once_with(
             "TEST_TOOL_CONSUMER_INSTANCE_GUID", "TEST_RESOURCE_LINK_ID"
         )
@@ -144,16 +144,16 @@ class TestAssignmentService:
         svc,
         misc_plugin,
         get_assignment,
-        get_copied_from_assignment,
+        _get_copied_from_assignment,
         create_assignment,
     ):
         misc_plugin.get_document_url.return_value = sentinel.document_url
         get_assignment.return_value = None
-        get_copied_from_assignment.return_value = sentinel.original_assignment
+        _get_copied_from_assignment.return_value = sentinel.original_assignment
 
         assignment = svc.get_assignment_for_launch(pyramid_request)
 
-        get_copied_from_assignment.assert_called_once_with(pyramid_request.lti_params)
+        _get_copied_from_assignment.assert_called_once_with(pyramid_request.lti_params)
         create_assignment.assert_called_once_with(
             "TEST_TOOL_CONSUMER_INSTANCE_GUID", "TEST_RESOURCE_LINK_ID"
         )
@@ -248,8 +248,8 @@ class TestAssignmentService:
             yield patched
 
     @pytest.fixture
-    def get_copied_from_assignment(self, svc):
-        with patch.object(svc, "get_copied_from_assignment", autospec=True) as patched:
+    def _get_copied_from_assignment(self, svc):
+        with patch.object(svc, "_get_copied_from_assignment", autospec=True) as patched:
             yield patched
 
 

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -25,11 +25,15 @@ class TestAssignmentService:
 
         assert assignment in db_session.new
 
-    def test_update_assignment(self, svc):
+    def test_update_assignment(self, svc, pyramid_request, misc_plugin):
         assignment = svc.update_assignment(
-            factories.Assignment(), sentinel.document_url, sentinel.group_set_id
+            pyramid_request,
+            factories.Assignment(),
+            sentinel.document_url,
+            sentinel.group_set_id,
         )
 
+        misc_plugin.post_configure_assignment.assert_called_once_with(pyramid_request)
         assert assignment.document_url == sentinel.document_url
         assert assignment.extra["group_set_id"] == sentinel.group_set_id
 

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -16,6 +16,24 @@ class TestAssignmentService:
     def test_get_assignment_without_match(self, svc, non_matching_params):
         assert svc.get_assignment(**non_matching_params) is None
 
+    def test_create_assignment(self, svc, db_session):
+
+        assignment = svc.create_assignment(sentinel.guid, sentinel.resource_link_id)
+
+        assert assignment.tool_consumer_instance_guid == sentinel.guid
+        assert assignment.resource_link_id == sentinel.resource_link_id
+        assert assignment.extra == {}
+
+        assert assignment in db_session.new
+
+    def test_update_assignment(self, svc):
+        assignment = svc.update_assignment(
+            factories.Assignment(), sentinel.document_url, sentinel.group_set_id
+        )
+
+        assert assignment.document_url == sentinel.document_url
+        assert assignment.extra["group_set_id"] == sentinel.group_set_id
+
     @pytest.mark.parametrize(
         "param",
         (

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -251,7 +251,6 @@ class TestBasicLaunchViews:
         context,
         lti_h_service,
         assignment_service,
-        misc_plugin,
         lti_user,
         course_service,
     ):
@@ -272,7 +271,6 @@ class TestBasicLaunchViews:
             resource_link_id=pyramid_request.lti_params["resource_link_id"],
             document_url=sentinel.document_url,
             lti_params=pyramid_request.lti_params,
-            is_gradable=misc_plugin.is_assignment_gradable.return_value,
             extra=sentinel.assignment_extra,
         )
         assignment = assignment_service.upsert_assignment.return_value

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -20,7 +20,6 @@ from tests import factories
     "lti_h_service",
     "lti_role_service",
     "grouping_service",
-    "misc_plugin",
 )
 class TestBasicLaunchViews:
     def test___init___(
@@ -78,7 +77,7 @@ class TestBasicLaunchViews:
         grading_info_service.upsert_from_request.assert_not_called()
 
     def test_configure_assignment_callback(
-        self, svc, pyramid_request, _show_document, misc_plugin, assignment_service
+        self, svc, pyramid_request, _show_document, assignment_service
     ):
         pyramid_request.parsed_params = {
             "document_url": sentinel.document_url,
@@ -92,11 +91,11 @@ class TestBasicLaunchViews:
             resource_link_id="TEST_RESOURCE_LINK_ID",
         )
         assignment_service.update_assignment.assert_called_once_with(
+            pyramid_request,
             assignment_service.create_assignment.return_value,
             document_url=sentinel.document_url,
             group_set_id=sentinel.group_set,
         )
-        misc_plugin.post_configure_assignment.assert_called_once_with(pyramid_request)
         _show_document.assert_called_once_with(
             assignment_service.create_assignment.return_value,
         )
@@ -106,7 +105,6 @@ class TestBasicLaunchViews:
         svc,
         pyramid_request,
         _show_document,
-        misc_plugin,
         assignment_service,
         LTIEvent,
     ):
@@ -131,8 +129,6 @@ class TestBasicLaunchViews:
             },
         )
         pyramid_request.registry.notify.has_call_with(LTIEvent.return_value)
-
-        misc_plugin.post_configure_assignment.assert_called_once_with(pyramid_request)
         _show_document.assert_called_once_with(
             assignment_service.get_assignment.return_value,
         )


### PR DESCRIPTION
This PR doesn't contain any D2L deep linking code but it's motivated by that.

Being more explicit about what we are doing with assignments and when will allow to plug a small difference for D2L (to handle groups).

I haven't explored here the idea we discussed about a potential "AssignmentConfiguration` dataclass or similar to keep things more focused now but I reckon is more evident in this PR where that would go.

The main change here are:

- replacing `upsert_assignment` with more explicit methods and a `get_assignment_for_launch`
- Add more parameters to the plugins that get document_url and group_set_id


## Testing

Some sanity checking Canvas and D2L, no new behaviors here.

### Canvas

- Use a teacher login, eg: `eng+canvasteacher@hypothes.is`

- [Reconfigure a canvas assignment](https://hypothesis.instructure.com/courses/125/assignments/4682/edit?return_to=https%3A%2F%2Fhypothesis.instructure.com%2Fcourses%2F125%2Fassignments%2F4682)


- Pick any document source, and groups
- Launch with that document on groups
- [Reconfigure a canvas assignment](https://hypothesis.instructure.com/courses/125/assignments/4682/edit?return_to=https%3A%2F%2Fhypothesis.instructure.com%2Fcourses%2F125%2Fassignments%2F4682)
 again
- Pick a different document source and disable groups
- Launch it and you'll get the new document and a sections drop down.



### D2L 

Use a teacher login, eg `HypothesisEng.Teacher`

- Truncate assignments to be able to use the scratch one 

```docker compose exec postgres psql -U postgres -c "truncate assignment cascade"```


- Launch and configure a [D2L assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View)
- Pick one document and a group set
- You'll get the document and group selection
- Launch it again from scratch D2L assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View)
- Click edit, select a different D2L document and disable groups.
- You'll get the new document and the course group.


