### PR TITLE
Remove LMS family from the grading table, migration.

### DIFF
--- a/lms/migrations/versions/106d94be7705_remove_family_grading.py
+++ b/lms/migrations/versions/106d94be7705_remove_family_grading.py
@@ -1,0 +1,30 @@
+"""
+Remove tool_consumer_info_product_family_code from GradingInfo.
+
+Revision ID: 106d94be7705
+Revises: 973c9358b616
+Create Date: 2023-07-06 11:23:10.850486
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "106d94be7705"
+down_revision = "973c9358b616"
+
+
+def upgrade():
+    op.drop_column("lis_result_sourcedid", "tool_consumer_info_product_family_code")
+
+
+def downgrade():
+    op.add_column(
+        "lis_result_sourcedid",
+        sa.Column(
+            "tool_consumer_info_product_family_code",
+            sa.TEXT(),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )

--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -62,7 +62,5 @@ class GradingInfo(CreatedUpdatedMixin, BASE):
     user_id = sa.Column(sa.UnicodeText(), nullable=False)
     context_id = sa.Column(sa.UnicodeText(), nullable=False)
     resource_link_id = sa.Column(sa.UnicodeText(), nullable=False)
-    # The "family" of LMS tool, e.g. "BlackboardLearn" or "canvas"
-    tool_consumer_info_product_family_code = sa.Column(sa.UnicodeText(), nullable=True)
     h_username = sa.Column(sa.UnicodeText(), nullable=False)
     h_display_name = sa.Column(sa.UnicodeText(), nullable=False)

--- a/tests/factories/grading_info.py
+++ b/tests/factories/grading_info.py
@@ -20,10 +20,6 @@ GradingInfo = make_factory(
     user_id=USER_ID,
     context_id=Faker("hexify", text="^" * 32),
     resource_link_id=RESOURCE_LINK_ID,
-    tool_consumer_info_product_family_code=Faker(
-        "random_element",
-        elements=["BlackBoardLearn", "moodle", "canvas", "sakai", "desire2learn"],
-    ),
     h_username=H_USERNAME,
     h_display_name=H_DISPLAY_NAME,
     application_instance=SubFactory(ApplicationInstance),

--- a/tests/unit/lms/models/grading_info_test.py
+++ b/tests/unit/lms/models/grading_info_test.py
@@ -17,7 +17,6 @@ class TestGradingInfo:
         assert lrs.user_id == "339483948"
         assert lrs.context_id == "random context"
         assert lrs.resource_link_id == "random resource link id"
-        assert lrs.tool_consumer_info_product_family_code == "MyFakeLTITool"
         assert lrs.h_username == "ltiuser1"
         assert lrs.h_display_name == "My Fake LTI User"
 
@@ -80,7 +79,6 @@ class TestGradingInfo:
             "user_id": "339483948",
             "context_id": "random context",
             "resource_link_id": "random resource link id",
-            "tool_consumer_info_product_family_code": "MyFakeLTITool",
             "h_username": "ltiuser1",
             "h_display_name": "My Fake LTI User",
         }

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -135,15 +135,6 @@ class TestUpsertFromRequest:
 
         assert db_session.get_last_inserted() is None
 
-    @pytest.mark.parametrize("param", ("tool_consumer_info_product_family_code",))
-    def test_it_works_fine_with_optional_parameter_missing(
-        self, svc, pyramid_request, db_session, param
-    ):
-        del pyramid_request.POST[param]
-
-        svc.upsert_from_request(pyramid_request)
-        assert db_session.get_last_inserted() == Any.instance_of(GradingInfo)
-
     @classmethod
     def model_as_dict(cls, model):
         return {col: getattr(model, col) for col in model.columns()}
@@ -176,5 +167,4 @@ def lti_params():
         "lis_outcome_service_url": "https://somewhere.else",
         "context_id": "random context",
         "resource_link_id": "random resource link id",
-        "tool_consumer_info_product_family_code": "MyFakeLTITool",
     }


### PR DESCRIPTION
Needs:

- https://github.com/hypothesis/lms/pull/5554


Note that in this case, because we are removing an existing column, we first remove the code that uses it, then the column itself.


# Testing

```
hdev alembic upgrade head                                                                                                           
dev run-test-pre: PYTHONHASHSEED='4132713221'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic -c /home/marcos/hypo/lms/conf/alembic.ini upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 973c9358b616 -> 106d94be7705, Remove tool_consumer_info_product_family_code from GradingInfo.
```


After that repeat the testing described in:


- https://github.com/hypothesis/lms/pull/5554


(You won't be able to query the removed column now, of course), query something like:



```docker compose exec postgres psql -U postgres -c "select * from  lis_result_sourcedid"```