### PR TITLE
Remove `tool_consumer_info_product_family_code` from `GradingInfo`

### DIFF
--- a/lms/models/grading_info.py
+++ b/lms/models/grading_info.py
@@ -62,7 +62,5 @@ class GradingInfo(CreatedUpdatedMixin, BASE):
     user_id = sa.Column(sa.UnicodeText(), nullable=False)
     context_id = sa.Column(sa.UnicodeText(), nullable=False)
     resource_link_id = sa.Column(sa.UnicodeText(), nullable=False)
-    # The "family" of LMS tool, e.g. "BlackboardLearn" or "canvas"
-    tool_consumer_info_product_family_code = sa.Column(sa.UnicodeText(), nullable=True)
     h_username = sa.Column(sa.UnicodeText(), nullable=False)
     h_display_name = sa.Column(sa.UnicodeText(), nullable=False)

--- a/tests/factories/grading_info.py
+++ b/tests/factories/grading_info.py
@@ -20,10 +20,6 @@ GradingInfo = make_factory(
     user_id=USER_ID,
     context_id=Faker("hexify", text="^" * 32),
     resource_link_id=RESOURCE_LINK_ID,
-    tool_consumer_info_product_family_code=Faker(
-        "random_element",
-        elements=["BlackBoardLearn", "moodle", "canvas", "sakai", "desire2learn"],
-    ),
     h_username=H_USERNAME,
     h_display_name=H_DISPLAY_NAME,
     application_instance=SubFactory(ApplicationInstance),

--- a/tests/unit/lms/models/grading_info_test.py
+++ b/tests/unit/lms/models/grading_info_test.py
@@ -17,7 +17,6 @@ class TestGradingInfo:
         assert lrs.user_id == "339483948"
         assert lrs.context_id == "random context"
         assert lrs.resource_link_id == "random resource link id"
-        assert lrs.tool_consumer_info_product_family_code == "MyFakeLTITool"
         assert lrs.h_username == "ltiuser1"
         assert lrs.h_display_name == "My Fake LTI User"
 
@@ -80,7 +79,6 @@ class TestGradingInfo:
             "user_id": "339483948",
             "context_id": "random context",
             "resource_link_id": "random resource link id",
-            "tool_consumer_info_product_family_code": "MyFakeLTITool",
             "h_username": "ltiuser1",
             "h_display_name": "My Fake LTI User",
         }

--- a/tests/unit/lms/services/grading_info_test.py
+++ b/tests/unit/lms/services/grading_info_test.py
@@ -135,15 +135,6 @@ class TestUpsertFromRequest:
 
         assert db_session.get_last_inserted() is None
 
-    @pytest.mark.parametrize("param", ("tool_consumer_info_product_family_code",))
-    def test_it_works_fine_with_optional_parameter_missing(
-        self, svc, pyramid_request, db_session, param
-    ):
-        del pyramid_request.POST[param]
-
-        svc.upsert_from_request(pyramid_request)
-        assert db_session.get_last_inserted() == Any.instance_of(GradingInfo)
-
     @classmethod
     def model_as_dict(cls, model):
         return {col: getattr(model, col) for col in model.columns()}
@@ -176,5 +167,4 @@ def lti_params():
         "lis_outcome_service_url": "https://somewhere.else",
         "context_id": "random context",
         "resource_link_id": "random resource link id",
-        "tool_consumer_info_product_family_code": "MyFakeLTITool",
     }


### PR DESCRIPTION
This value is present on the application instance, which grading info has a relationship with.

Removing the field here and doing the migration later. We are removing a null able columns so we have to first remove any usage of the column and later remove the column, opposite order than when adding new columns.


## Testing


- Truncate local grading info

```docker compose exec postgres psql -U postgres -c "truncate lis_result_sourcedid"```


- As a learner, `aunltd.S1` launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View?ou=6782

You'll get a new row on the table, no `tool_consumer_info_product_family_code`.


```
docker compose exec postgres psql -U postgres -c "select tool_consumer_info_product_family_code, id from  lis_result_sourcedid"


 tool_consumer_info_product_family_code | id  
----------------------------------------+-----
                                        | 111
(1 row)
```


- Launch the same assignments, as a instructor this time `HypothesisEng.Teacher`:

The student should show up in the drop down based on the data in `lis_result_sourcedid`.

Submit a grade for good measure.

