### PR TITLE
Deep linking refactor and DL support in D2L

### DIFF
--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -16,12 +16,14 @@ class CanvasMiscPlugin(MiscPlugin):
         This will try all known methods for finding out, and will return None
         if no configuration can be found.
         """
+        deep_linked_parameters = self.get_deep_linked_assignment_configuration(request)
+
         for document_url_source in (
             self._from_deep_linking_provided_url,
             self._from_canvas_file,
             self._from_legacy_vitalsource_book,
         ):
-            if document_url := document_url_source(request):
+            if document_url := document_url_source(request, deep_linked_parameters):
                 return document_url
 
         return None
@@ -31,7 +33,7 @@ class CanvasMiscPlugin(MiscPlugin):
     _ENCODED_URL = re.compile("^[a-z][a-z0-9+.-]*%3a", re.IGNORECASE)
 
     @classmethod
-    def _from_deep_linking_provided_url(cls, request):
+    def _from_deep_linking_provided_url(cls, _request, deep_linked_configuration: dict):
         """
         Get the URL from the deep linking information.
 
@@ -39,7 +41,7 @@ class CanvasMiscPlugin(MiscPlugin):
         back to us from the LMS.
         """
 
-        if url := request.params.get("url"):
+        if url := deep_linked_configuration.get("url"):
             # Work around a bug in Canvas's handling of LTI Launch URLs in
             # SpeedGrader launches where query params get double-encoded.
             # See https://github.com/instructure/canvas-lms/issues/1486
@@ -49,7 +51,7 @@ class CanvasMiscPlugin(MiscPlugin):
         return url
 
     @classmethod
-    def _from_canvas_file(cls, request):
+    def _from_canvas_file(cls, request, deep_linked_configuration: dict):
         """
         Get a Canvas file URL.
 
@@ -57,29 +59,51 @@ class CanvasMiscPlugin(MiscPlugin):
         """
 
         if (
-            request.params.get("canvas_file")
+            deep_linked_configuration.get("canvas_file")
             and (course_id := request.lti_params.get("custom_canvas_course_id"))
-            and (file_id := request.params["file_id"])
+            and (file_id := deep_linked_configuration["file_id"])
         ):
             return f"canvas://file/course/{course_id}/file_id/{file_id}"
 
         return None
 
     @classmethod
-    def _from_legacy_vitalsource_book(cls, request):
+    def _from_legacy_vitalsource_book(cls, _request, deep_linked_configuration: dict):
         """
         Respond to a legacy configured VitalSource assignment.
 
         Newer Vitalsource assignments are configured with document URLs like
         `vitalsource://...`
         """
-        if request.params.get("vitalsource_book"):
+        if deep_linked_configuration.get("vitalsource_book"):
             return VSBookLocation(
-                book_id=request.params["book_id"],
-                cfi=request.params.get("cfi"),
+                book_id=deep_linked_configuration["book_id"],
+                cfi=deep_linked_configuration.get("cfi"),
             ).document_url
 
         return None
+
+    def get_deep_linked_assignment_configuration(self, request) -> dict:
+        params = {}
+
+        possible_parameters = [
+            "group_set",
+            # VS, legacy method
+            "vitalsource_book",
+            "book_id",
+            "cfi",
+            # Canvas files
+            "canvas_file",
+            "file_id",
+            # General document url of other types
+            "url",
+        ]
+
+        for param in possible_parameters:
+            if value := request.params.get(param):
+                params[param] = value
+
+        return params
 
     @classmethod
     def factory(cls, _context, _request):

--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -1,7 +1,7 @@
 import re
 from functools import lru_cache
 from typing import Optional
-from urllib.parse import unquote
+from urllib.parse import unquote, urlencode, urlparse
 
 from lms.product.plugin.misc import MiscPlugin
 from lms.services.vitalsource import VSBookLocation
@@ -104,6 +104,15 @@ class CanvasMiscPlugin(MiscPlugin):
                 params[param] = value
 
         return params
+
+    def get_deeplinking_launch_url(self, request, assignment_configuration: dict):
+        # In canvas we point to our generic launch URL
+        # and we encode the assignment configuration as query parameters.
+        return (
+            urlparse(request.route_url("lti_launches"))
+            ._replace(query=urlencode(assignment_configuration))
+            .geturl()
+        )
 
     @classmethod
     def factory(cls, _context, _request):

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -43,6 +43,16 @@ class D2LMiscPlugin(MiscPlugin):
         # `lti_registration.token_url` as in other LMS
         return "https://api.brightspace.com/auth/token"
 
+    def get_document_url(self, request):
+        url = super().get_document_url(request)
+
+        if not url:
+            # In D2L support both deep linking and DB backed assignment.
+            # Use the DL url as a fallback.
+            url = self.get_deep_linked_assignment_configuration(request).get("url")
+
+        return url
+
     @classmethod
     def factory(cls, _context, request):
         return cls(request.product.settings.custom.get("create_line_item", False))

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -74,5 +74,14 @@ class MiscPlugin:
         # The assignment configuration we'll be retrieved by other methods (eg, custom parameters) so that parameter is not used here.
         return request.route_url("lti_launches")
 
-    def get_deep_linked_assignment_configuration(self, _request):
-        return {}
+    def get_deep_linked_assignment_configuration(self, request):
+        """Get the configuration of an assignment that was original deep linked."""
+        params = {}
+        possible_parameters = ["url", "group_set"]
+
+        for param in possible_parameters:
+            # Get the value from the custom parameters set during deep linking
+            if value := request.lti_params.get(f"custom_{param}"):
+                params[param] = value
+
+        return params

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -61,3 +61,6 @@ class MiscPlugin:
             )
 
         return assignment.document_url if assignment else None
+
+    def get_deep_linked_assignment_configuration(self, _request):
+        return {}

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -62,5 +62,17 @@ class MiscPlugin:
 
         return assignment.document_url if assignment else None
 
+    def get_deeplinking_launch_url(self, request, _assignment_configuration: dict):
+        """
+        Launch URL for deep linked assignments.
+
+        To which URL to point the deep linked assignments in the LMS.
+        This URL wel'll be part of the deep link response message
+        to finish the configuration during a deep link request.
+        """
+        # In general we'll point to our regular basic launch URL.
+        # The assignment configuration we'll be retrieved by other methods (eg, custom parameters) so that parameter is not used here.
+        return request.route_url("lti_launches")
+
     def get_deep_linked_assignment_configuration(self, _request):
         return {}

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -8,7 +8,6 @@ is done by the front-end.
 When the LMS launches us with a deep linked assignment, we will get the
 document url as part of the launch params, instead of reading it from the DB in
 `assignment`.
-
 The flow is:
 
  - LMS calls us on `deep_linking_launch`
@@ -126,9 +125,14 @@ class DeepLinkingFieldsViews:
             "https://purl.imsglobal.org/spec/lti-dl/claim/content_items": [
                 {
                     "type": "ltiResourceLink",
+                    # The URL we will be called back on when the
+                    # assignment is launched from the LMS
                     "url": self.misc_plugin.get_deeplinking_launch_url(
                         self.request, assignment_configuration
                     ),
+                    # These values should be passed back to us as custom
+                    # LTI params, but Canvas doesn't seem to.
+                    "custom": assignment_configuration,
                 }
             ],
         }
@@ -185,9 +189,14 @@ class DeepLinkingFieldsViews:
                         {
                             "@type": "LtiLinkItem",
                             "mediaType": "application/vnd.ims.lti.v1.ltilink",
+                            # The URL we will be called back on when the
+                            # assignment is launched from the LMS
                             "url": self.misc_plugin.get_deeplinking_launch_url(
                                 self.request, assignment_configuration
                             ),
+                            # These values should be passed back to us as custom
+                            # LTI params, but Canvas doesn't seem to.
+                            "custom": assignment_configuration,
                         },
                     ],
                 }

--- a/tests/unit/lms/product/canvas/_plugin/misc_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/misc_test.py
@@ -99,6 +99,14 @@ class TestCanvasMiscPlugin:
         VSBookLocation.assert_called_once_with(book_id=sentinel.book_id, cfi=cfi)
         assert result == VSBookLocation.return_value.document_url
 
+    def test_get_deeplinking_launch_url(self, plugin, pyramid_request):
+        config = {"param": "value"}
+
+        assert (
+            plugin.get_deeplinking_launch_url(pyramid_request, config)
+            == "http://example.com/lti_launches?param=value"
+        )
+
     def test_factory(self, pyramid_request):
         plugin = CanvasMiscPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, CanvasMiscPlugin)

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -88,6 +88,7 @@ class TestDeepLinkingFieldsView:
                     {
                         "type": "ltiResourceLink",
                         "url": misc_plugin.get_deeplinking_launch_url.return_value,
+                        "custom": _get_assignment_configuration.return_value,
                     }
                 ],
                 "https://purl.imsglobal.org/spec/lti-dl/claim/data": sentinel.deep_linking_settings_data,
@@ -126,6 +127,8 @@ class TestDeepLinkingFieldsView:
         LTIEvent,
         misc_plugin,
     ):
+        misc_plugin.get_deeplinking_launch_url.return_value = "LAUNCH_URL"
+
         fields = views.file_picker_to_form_fields_v11()
 
         LTIEvent.assert_called_once_with(
@@ -141,7 +144,8 @@ class TestDeepLinkingFieldsView:
                 {
                     "@type": "LtiLinkItem",
                     "mediaType": "application/vnd.ims.lti.v1.ltilink",
-                    "url": misc_plugin.get_deeplinking_launch_url.return_value,
+                    "url": "LAUNCH_URL",
+                    "custom": _get_assignment_configuration.return_value,
                 },
             ],
         }
@@ -151,7 +155,7 @@ class TestDeepLinkingFieldsView:
         [
             (
                 {"type": "file", "file": {"id": 1}},
-                {"canvas_file": "true", "file_id": "1"},
+                {"canvas_file": "true", "file_id": 1},
             ),
             (
                 {"type": "url", "url": "https://example.com"},
@@ -217,4 +221,5 @@ class TestDeepLinkingFieldsView:
         with patch.object(
             views, "_get_assignment_configuration", autospec=True
         ) as patched:
+            patched.return_value = {}
             yield patched


### PR DESCRIPTION
One step towards, still a work in progress

- https://github.com/hypothesis/lms/issues/5543

Unblocks:

- https://github.com/hypothesis/lms/issues/5544


## Summary

- D2L doesn't allow us to submit a launch URL with query params as part of the return message in deep linking.
- Canvas doesn't fully support (it doesn't send them back) custom parameters in the DL response message but it does allow for them to be part of our DL message.

Based on this: 
- We refactor into a plugin the difference in the launch URL.
- We send the assignment configuration as custom parameters in all LMSes
- We refactor the get_document_url in canvas to explicitly read if from the DL configuration (which happens to be in the query params of the URL).
- In D2L we read the URL form the DL params as a fallback. In this case these params are from the custom parameters.


This PR doesn't:

- Support editing, group sets, etc in D2L deep linking. 
- Create a DeepLinkingPlugin or similar. I rather finish the interface over in Misc and do a move & boilerplate PR then. 




## Testing


- Existing deep linked assignments work as before:

https://hypothesis.instructure.com/courses/125/assignments/873


- Re-deep linking an assignment works too:

https://hypothesis.instructure.com/courses/125/assignments/4682/edit?name=Testing+creation+-+marcos&due_at=null&points_possible=0


- Existing DB backed assignment in D2L also work as before (make sure `make devdata` is up to date):


https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View



- Test deep linking in D2L, just creating and launch work, not editing, nor group sets:

  - Login in D2L as `HypothesisEng.Teacher`
  - Go to the content section of the test course: 
  https://aunltd.brightspacedemo.com/d2l/le/content/6782/Home?itemIdentifier=TOC
  - Click `Existing activities`  and select `Hypothesis link (deeplinking)` form the menu
  - Pick a D2L file
  - An assignment will be created with the name `https://localhost:48001/lti_launches` until (#5544 is fixed).
  - Launch that assignment.










