### PR TITLE
Make `make services` wait for healthchecks to pass using `--wait`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ $(call help,make help,print this help message)
 
 .PHONY: services
 $(call help,make services,start the services that the app needs)
-services: args?=up -d
+services: args?=up -d --wait
 services: python
 	@docker compose $(args)
 


### PR DESCRIPTION
This enables starting lms services and the dev server by running `make services && make dev`, without encountering errors due to the DB not being ready.

nb. The `--wait` flag is missing from the docs but see https://github.com/docker/compose/pull/8777.