### PR TITLE
Update Makefile to enable waiting for healthchecks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ $(call help,make help,print this help message)
 
 .PHONY: services
 $(call help,make services,start the services that the app needs)
-services: args?=up -d
+services: args?=up -d --wait
 services: python
 	@docker compose $(args)
 


### PR DESCRIPTION
This is the result of running `make template`, to apply the changes from https://github.com/hypothesis/cookiecutters/pull/141.