### PR TITLE
Simplify the DL configuration to explicitly take `group_set`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -211,9 +211,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
         const data = {
           ...deepLinkingAPI.data,
           content,
-          extra_params: {
-            group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
-          },
+          group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
         };
         setDeepLinkingFields(
           await apiCall({

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -185,7 +185,7 @@ describe('FilePickerApp', () => {
         data: {
           ...deepLinkingAPIData,
           content: { type: 'url', url: 'https://example.com' },
-          extra_params: { group_set: null },
+          group_set: null,
         },
       });
 

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -86,9 +86,8 @@ class DeepLinkingFieldsRequestSchema(JSONPyramidRequestSchema):
     deep_linking_settings = fields.Dict(required=False, allow_none=True)
     content_item_return_url = fields.Str(required=True)
     content = fields.Dict(required=True)
+    group_set = fields.Str(required=False, allow_none=True)
     title = fields.Str(required=False, allow_none=True)
-
-    extra_params = fields.Dict(required=False)
 
 
 @view_defaults(
@@ -215,13 +214,10 @@ class DeepLinkingFieldsViews:
         """Turn front-end content information into assignment configuration."""
         content = request.parsed_params["content"]
 
-        # Filter out any `null` values to avoid adding a ?key=None on the
-        # resulting URL
-        params = {
-            key: value
-            for key, value in (request.parsed_params.get("extra_params") or {}).items()
-            if value is not None
-        }
+        params = {}
+
+        if group_set := request.parsed_params.get("group_set"):
+            params["group_set"] = group_set
 
         if title := request.parsed_params.get("title"):
             params["title"] = title

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -186,9 +186,10 @@ class TestDeepLinkingFieldsView:
         [
             ({}, {}),
             ({"title": "title"}, {"title": "title"}),
+            ({"group_set": "1"}, {"group_set": "1"}),
             (
-                {"extra_params": {"extra": "value", "none_value": None}},
-                {"extra": "value"},
+                {"group_set": "1", "title": "title"},
+                {"group_set": "1", "title": "title"},
             ),
         ],
     )


### PR DESCRIPTION
The older version was based on a dictionary allowing arbitrary values that obscured the fact that the only value there was `group_set`.

Deep linking is sufficiently complex to add trying to get what data we might get when we know exactly its shape.

We have an idea to introduce maybe a "AssignmentConfiguration" concept which could be the same in deep linking, assignment editing and assignment retrieval. I reckon this small change will make that more obvious.



## Testing

- Reconfigure https://hypothesis.instructure.com/courses/125/assignments/4682/edit?return_to=https%3A%2F%2Fhypothesis.instructure.com%2Fcourses%2F125%2Fassignments%2F4682 twice.

  1. - Selecting a group set (it becomes a groups assignment)
  2. - Not selecting a group set (it becomes a sections one)

