### PR TITLE
Use `rounded` instead of `rounded-sm` for border radius defaults

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -51,7 +51,7 @@ function GroupSelect({
     <div
       className={classnames(
         // Style a slightly-recessed "well" for these controls
-        'bg-slate-0 p-4 rounded shadow-inner border'
+        'bg-slate-0 p-4 rounded-[4px] shadow-inner border'
       )}
     >
       <label

--- a/lms/static/scripts/ui-playground/components/EditAssignment.tsx
+++ b/lms/static/scripts/ui-playground/components/EditAssignment.tsx
@@ -123,7 +123,7 @@ function ReselectContentExample() {
             <div
               className={classnames(
                 // Style a slightly-recessed "well" for these controls
-                'bg-slate-0 p-4 rounded shadow-inner border space-y-2'
+                'bg-slate-0 p-4 rounded-[4px] shadow-inner border space-y-2'
               )}
             >
               <p>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -19,6 +19,10 @@ export default {
         validationMessageOpen: 'validationMessageOpen 0.3s forwards',
         validationMessageClose: 'validationMessageClose 0.3s forwards',
       },
+      borderRadius: {
+        // Equivalent to tailwind default `rounded-sm` size
+        DEFAULT: '0.125rem',
+      },
       fontFamily: {
         sans: [
           '"Helvetica Neue"',


### PR DESCRIPTION
See similar PR in the `client`: https://github.com/hypothesis/client/pull/5607

In component styles where the intent is to match the default border radius sizing, use unqualified `rounded` instead of `rounded-sm`. The default border radius happens to be 2px, which is equivalent to the default `rounded-sm` value out of the box with Tailwind, but the intent is instead "use the default border radius size". Use `rounded-[4px]` where the intent is literally 4px, not default.

Add a border-radius default to tailwind config.