### PR TITLE
Simplify alembic DB URL configuration

### DIFF
--- a/conf/alembic.ini
+++ b/conf/alembic.ini
@@ -1,6 +1,5 @@
 [alembic]
 script_location = lms/migrations
-sqlalchemy.url = postgresql://postgres@localhost:5433/postgres
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/lms/migrations/env.py
+++ b/lms/migrations/env.py
@@ -33,8 +33,11 @@ def run_migrations_offline():
     script output.
 
     """
-    url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    context.configure(
+        url=os.environ["DATABASE_URL"],
+        target_metadata=target_metadata,
+        literal_binds=True,
+    )
 
     with context.begin_transaction():
         context.run_migrations()
@@ -52,6 +55,7 @@ def run_migrations_online():
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        url=os.environ["DATABASE_URL"],
     )
 
     with connectable.connect() as connection:


### PR DESCRIPTION
Always read it from the `DATABASE_URL` environment variable.

This works on the local environment (where the env var is set by tox) and in EBS (environment variable also set there).


# Testing

Sanity check with something like:


```tox -e dev --run-command 'alembic downgrade -1'```