### PR TITLE
Expose a setting in the filepicker to prompt for an assignment title

### DIFF
--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -6,6 +6,10 @@ class D2LMiscPlugin(MiscPlugin):
     def __init__(self, create_line_item: bool):
         self._create_line_item = create_line_item
 
+    # Deep linking in D2L implies creating a new assignment.
+    # Prompt for a title to set it for the new assignment.
+    deep_linking_prompt_for_title = True
+
     def post_configure_assignment(self, request):
         """
         Run any actions needed after configuring an assignment.

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -15,13 +15,16 @@ class MiscPlugin:
     the code base.
 
     New methods here should not try to get a very tight API as easier to
-    refactor once multiple MS have the same issue vs getting the right
+    refactor once multiple LMSes have the same issue vs getting the right
     parameters in the first occurrence.
 
     Once any of these is implemented by more than one product or a group of
     methods looks like it could belong to their own plugin it's time to
     refactor them out.
     """
+
+    # Whether or not to prompt for an assignment title while deep linking.
+    deep_linking_prompt_for_title = False
 
     def post_configure_assignment(self, request: Request):  # pragma: nocover
         """

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -215,7 +215,7 @@ class JSConfig:
             },
         }
 
-    def enable_file_picker_mode(self, form_action, form_fields):
+    def enable_file_picker_mode(self, form_action, form_fields, prompt_for_title=False):
         """
         Put the JavaScript code into "file picker" mode.
 
@@ -226,6 +226,7 @@ class JSConfig:
             submit the user's chosen document to
         :param form_fields: the fields (keys and values) to include in the
             HTML form that we submit
+        :param prompt_for_title: Whether or not to prompt for a title while configuring the assignment
         """
 
         args = self._request, self._application_instance
@@ -238,6 +239,7 @@ class JSConfig:
                 "filePicker": {
                     "formAction": form_action,
                     "formFields": form_fields,
+                    "promptForTitle": prompt_for_title,
                     # The "content item selection" that we submit to Canvas's
                     # content_item_return_url is actually an LTI launch URL with
                     # the selected document URL or file_id as a query parameter. To

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -78,6 +78,7 @@ export type AssignmentConfig = {
 export type FilePickerConfig = {
   formAction: string;
   formFields: Record<string, string>;
+  promptForTitle: boolean;
   deepLinkingAPI?: APICallInfo;
   ltiLaunchUrl: string;
   blackboard: {

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -76,6 +76,7 @@ def deep_linking_launch(context, request):
             "lti_message_type": "ContentItemSelection",
             "lti_version": request.parsed_params["lti_version"],
         },
+        prompt_for_title=request.product.plugin.misc.deep_linking_prompt_for_title,
     )
 
     context.js_config.add_deep_linking_api()

--- a/tests/unit/lms/product/d2l/_plugin/misc_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/misc_test.py
@@ -6,6 +6,9 @@ from lms.product.d2l._plugin.misc import D2LMiscPlugin
 
 
 class TestD2LMiscPlugin:
+    def test_deep_linking_prompt_for_title(self, plugin):
+        assert plugin.deep_linking_prompt_for_title
+
     def test_post_configure_assignment(
         self, plugin, lti_grading_service, pyramid_request
     ):

--- a/tests/unit/lms/product/plugin/misc_test.py
+++ b/tests/unit/lms/product/plugin/misc_test.py
@@ -8,6 +8,9 @@ from tests import factories
 
 
 class TestMiscPlugin:
+    def test_deep_linking_prompt_for_title(self, plugin):
+        assert not plugin.deep_linking_prompt_for_title
+
     @pytest.mark.parametrize(
         "service_url,expected", [(None, False), (sentinel.service_url, True)]
     )

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -12,7 +12,7 @@ from lms.views.lti.deep_linking import DeepLinkingFieldsViews, deep_linking_laun
 from tests import factories
 
 
-@pytest.mark.usefixtures("application_instance_service", "lti_h_service", "misc_plugin")
+@pytest.mark.usefixtures("application_instance_service", "lti_h_service")
 class TestDeepLinkingLaunch:
     def test_it(
         self,
@@ -21,6 +21,7 @@ class TestDeepLinkingLaunch:
         lti_h_service,
         application_instance_service,
         course_service,
+        misc_plugin,
     ):
         deep_linking_launch(context, pyramid_request)
 
@@ -39,6 +40,7 @@ class TestDeepLinkingLaunch:
                 "lti_message_type": "ContentItemSelection",
                 "lti_version": "TEST_LTI_VERSION",
             },
+            prompt_for_title=misc_plugin.deep_linking_prompt_for_title,
         )
         context.js_config.add_deep_linking_api.assert_called_once()
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/5544


The default, false, will apply in Canvas where the assignment title is set directly on the LMS.

In D2L the assignment title will be set up as part of our deep linking message so we'll prompt for a title there.


This PR only add the hint for the frontend to prompt for the title or not. No actual prompting happens here.