### PR TITLE
[WIP] Fix for grading for launches after a LTI upgrade in Blackboard

### DIFF
--- a/lms/product/blackboard/__init__.py
+++ b/lms/product/blackboard/__init__.py
@@ -1,5 +1,6 @@
 from lms.product.blackboard._plugin.course_copy import BlackboardCourseCopyPlugin
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
+from lms.product.blackboard._plugin.misc import BlackboardMiscPlugin
 from lms.product.blackboard.product import Blackboard
 
 
@@ -11,4 +12,7 @@ def includeme(config):  # pragma: nocover
     )
     config.register_service_factory(
         BlackboardCourseCopyPlugin.factory, iface=BlackboardCourseCopyPlugin
+    )
+    config.register_service_factory(
+        BlackboardMiscPlugin.factory, iface=BlackboardMiscPlugin
     )

--- a/lms/product/blackboard/_plugin/misc.py
+++ b/lms/product/blackboard/_plugin/misc.py
@@ -1,0 +1,17 @@
+from lms.product.plugin.misc import MiscPlugin
+
+
+class BlackboardMiscPlugin(MiscPlugin):
+    def get_grading_user_id(self, application_instance, params: dict):
+        if application_instance.lti_version == "1.3.0":
+            # In LTI 1.3 we use the user id of the student.
+            # This happens to have the same value as lis_result_sourcedid in LTI1.3
+            # which allows to account for LTI upgrades done midterm for which
+            # we have the old LTI1.1 value for lis_result_sourcedid
+            return params["student_user_id"]
+
+        return super().get_grading_user_id(application_instance, params)
+
+    @staticmethod
+    def factory(_request, _context):
+        return BlackboardMiscPlugin()

--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from lms.product.blackboard._plugin.course_copy import BlackboardCourseCopyPlugin
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
+from lms.product.blackboard._plugin.misc import BlackboardMiscPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
 
@@ -17,6 +18,8 @@ class Blackboard(Product):
     )
 
     plugin_config: PluginConfig = PluginConfig(
-        grouping=BlackboardGroupingPlugin, course_copy=BlackboardCourseCopyPlugin
+        grouping=BlackboardGroupingPlugin,
+        course_copy=BlackboardCourseCopyPlugin,
+        misc=BlackboardMiscPlugin,
     )
     settings_key = "blackboard"

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -85,3 +85,11 @@ class MiscPlugin:
                 params[param] = value
 
         return params
+
+    def get_grading_user_id(self, params: dict):
+        """
+        Get the effective user_id to use with LTI grading API.
+
+        :param params: Parameters from our FE/BE grading APIs.
+        """
+        return params["lis_result_sourcedid"]

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -86,10 +86,6 @@ class MiscPlugin:
 
         return params
 
-    def get_grading_user_id(self, params: dict):
-        """
-        Get the effective user_id to use with LTI grading API.
-
-        :param params: Parameters from our FE/BE grading APIs.
-        """
+    def get_grading_user_id(self, _application_instance, params: dict):
+        """Get the effective user_id to use with LTI grading API."""
         return params["lis_result_sourcedid"]

--- a/lms/static/scripts/frontend_apps/services/grading.ts
+++ b/lms/static/scripts/frontend_apps/services/grading.ts
@@ -58,6 +58,7 @@ export class GradingService {
       params: {
         lis_result_sourcedid: student.LISResultSourcedId,
         lis_outcome_service_url: student.LISOutcomeServiceUrl,
+        student_user_id: student.lmsId,
       },
     });
   }

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -61,6 +61,9 @@ class APIReadResultSchema(PyramidRequestSchema):
     typically encodes the assignment context and LMS user.
     """
 
+    student_user_id = fields.Str(required=True)
+    """The LTIUser.user_id of the student being graded."""
+
 
 class APIRecordResultSchema(JSONPyramidRequestSchema):
     """Schema for validating proxy requests to LTI Outcomes API for recording grades."""

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -53,28 +53,30 @@ class APIReadResultSchema(PyramidRequestSchema):
     location = "query"
 
     lis_outcome_service_url = fields.Str(required=True)
-    """URL provided by the LMS to submit grades or other results to."""
+    """URL provided by the LMS to read and submit grades to.
+    This encodes the course and assignment in LTI1.3 and it's a generic URL in LTI1.1."""
 
     lis_result_sourcedid = fields.Str(required=True)
     """
-    Opaque identifier provided by the LMS to identify a submission. This
-    typically encodes the assignment context and LMS user.
+    Opaque identifier provided by the LMS to identify a student for grading.
+    In LTI1.1 this identifier also encodes the course and assignment.
     """
 
     student_user_id = fields.Str(required=True)
-    """The LTIUser.user_id of the student being graded."""
+    """The LTIUser.user_id of the student."""
 
 
 class APIRecordResultSchema(JSONPyramidRequestSchema):
     """Schema for validating proxy requests to LTI Outcomes API for recording grades."""
 
     lis_outcome_service_url = fields.Str(required=True)
-    """URL provided by the LMS to submit grades or other results to."""
+    """URL provided by the LMS to read and submit grades to.
+    This encodes the course and assignment in LTI1.3 and it's a generic URL in LTI1.1."""
 
     lis_result_sourcedid = fields.Str(required=True)
     """
-    Opaque identifier provided by the LMS to identify a submission. This
-    typically encodes the assignment context and LMS user.
+    Opaque identifier provided by the LMS to identify a student for grading.
+    In LTI1.1 this identifier also encodes the course and assignment.
     """
 
     score = fields.Number(
@@ -85,4 +87,4 @@ class APIRecordResultSchema(JSONPyramidRequestSchema):
     """
 
     student_user_id = fields.Str(required=True)
-    """The LTIUser.user_id of the student being graded."""
+    """The LTIUser.user_id of the student."""

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -103,7 +103,9 @@ class GradingViews:
         return {}
 
     def _get_grading_user_id(self):
-        return self.request.product.plugin.misc.get_grading_user_id(self.parsed_params)
+        return self.request.product.plugin.misc.get_grading_user_id(
+            self.request.lti_user.application_instance, self.parsed_params
+        )
 
 
 class CanvasPreRecordHook:

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -103,7 +103,7 @@ class GradingViews:
         return {}
 
     def _get_grading_user_id(self):
-        return self.parsed_params["lis_result_sourcedid"]
+        return self.request.product.plugin.misc.get_grading_user_id(self.parsed_params)
 
 
 class CanvasPreRecordHook:


### PR DESCRIPTION
The issue is:

- Student A launches assignment, we record a row in GradingInfo
- The school admins upgrade to LTI1.3
- In the process the value of `lis_result_sourcedid` for that student changes
- A teacher tries to grade Student A, it gets a "Student not in course" as using the old `lis_result_sourcedid` we recorded, not the new LTI1.3 version of that.


The fix to rely in the fact that in LTI1.3 (**and in blackboard**) user_id == lis_result_sourcedid


[We can check that there's no LTI1.3 row where those two values are different with this query](https://metabase.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3QgbGlzX3Jlc3VsdF9zb3VyY2VkaWQsIHVzZXJfaWQgZnJvbSBsaXNfcmVzdWx0X3NvdXJjZWRpZFxuam9pbiBhcHBsaWNhdGlvbl9pbnN0YW5jZXMgb24gYXBwbGljYXRpb25faW5zdGFuY2VfaWQgPSBhcHBsaWNhdGlvbl9pbnN0YW5jZXMuaWRcbndoZXJlIFxuLS0ganVzdCBibGFja2JvYXJkXG50b29sX2NvbnN1bWVyX2luZm9fcHJvZHVjdF9mYW1pbHlfY29kZSA9ICdCbGFja2JvYXJkTGVhcm4nXG4tLSBvbmx5IExUSTEuMyBpbnN0YW5jZXNcbmFuZCBkZXBsb3ltZW50X2lkIGlzIG5vdCBudWxsIC0tIHRoZSBBSSBpcyBMVEkxLjMgbm93XG5hbmQgbGlzX3Jlc3VsdF9zb3VyY2VkaWQubGlzX291dGNvbWVfc2VydmljZV91cmwgbm90IGxpa2UgJyUvbHRpMTFncmFkZScgIC0tIHRoZSByZWNvcmQgd2FzIGNyZWF0ZWQgYWxyZWF5ZCBvbiB0aGUgTFRJMS4zIHZlcnNpb24gKGllLCBhZnRlciBhIHBvdGVudGlhbCB1cGdyYWRlKVxuYW5kIHVzZXJfaWQgPD4gbGlzX3Jlc3VsdF9zb3VyY2VkaWRcbm9yZGVyIGJ5IGxpc19yZXN1bHRfc291cmNlZGlkLmlkIGRlc2MiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo3fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==) and [check that they are the same with this other query](https://metabase.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3QgbGlzX3Jlc3VsdF9zb3VyY2VkaWQsIHVzZXJfaWQgZnJvbSBsaXNfcmVzdWx0X3NvdXJjZWRpZFxuam9pbiBhcHBsaWNhdGlvbl9pbnN0YW5jZXMgb24gYXBwbGljYXRpb25faW5zdGFuY2VfaWQgPSBhcHBsaWNhdGlvbl9pbnN0YW5jZXMuaWRcbndoZXJlIFxuLS0ganVzdCBibGFja2JvYXJkXG50b29sX2NvbnN1bWVyX2luZm9fcHJvZHVjdF9mYW1pbHlfY29kZSA9ICdCbGFja2JvYXJkTGVhcm4nXG4tLSBvbmx5IExUSTEuMyBpbnN0YW5jZXNcbmFuZCBkZXBsb3ltZW50X2lkIGlzIG5vdCBudWxsIC0tIHRoZSBBSSBpcyBMVEkxLjMgbm93XG5hbmQgbGlzX3Jlc3VsdF9zb3VyY2VkaWQubGlzX291dGNvbWVfc2VydmljZV91cmwgbm90IGxpa2UgJyUvbHRpMTFncmFkZScgIC0tIHRoZSByZWNvcmQgd2FzIGNyZWF0ZWQgYWxyZWF5ZCBvbiB0aGUgTFRJMS4zIHZlcnNpb24gKGllLCBhZnRlciBhIHBvdGVudGlhbCB1cGdyYWRlKVxuYW5kIHVzZXJfaWQgPSBsaXNfcmVzdWx0X3NvdXJjZWRpZFxub3JkZXIgYnkgbGlzX3Jlc3VsdF9zb3VyY2VkaWQuaWQgZGVzY1xuXG4iLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo3fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)


## Testing

(setting up an actual tool upgrade in BB is a long process that has to be repeated once per test, we are going to simulate the same effect)

- Start in `main`

- `make devdata` to have assignments and AI up to date
- Delete any GradingInfo to not interfere with the test:

```docker compose exec postgres psql -U postgres -c "truncate lis_result_sourcedid cascade"```


- (Probably open to browsers or use incognito mode)

- Login as a learner `blackboardstudent`

- Launch [LTI 1.1 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1)


- Launch [LTI 1.3 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1)

In the DB you'll end up with two rows for the same student, in this case in two different assignments (ie different resource_link_id):

```
select resource_link_id, lis_result_sourcedid, user_id, h_display_name from lis_result_sourcedid;
 resource_link_id |       lis_result_sourcedid       |             user_id              |   h_display_name   
------------------+----------------------------------+----------------------------------+--------------------
 _36_1            | bbgc24gi29                       | 075f3bec5d684e59acb882a12b9bed2c | Blackboard Student
 _2085_1          | 075f3bec5d684e59acb882a12b9bed2c | 075f3bec5d684e59acb882a12b9bed2c | Blackboard Student
```


- We are going to simulate the effect of the upgrade changing both rows to use the LTI1.1 id:

```
update lis_result_sourcedid set lis_result_sourcedid = 'bbgc24gi29';
UPDATE 2
```


- Login a a teacher `blackboardteacher`
- Launch the [LTI 1.3 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1) 

- There will be just one student in the dropdonw
- Selecting it returns a blank score (probably a separate issue)
- Try grading the student, you'll get a `Web-https (stderr)   | lms.services.exceptions.StudentNotInCourse: None ` error over `make dev`'s output.


- Switch to this branch `bb-grading-versions`
- Relaunch [LTI 1.3 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1) 
- Try fetching the score and submitting a new one.

- Check that fetching sending new scores still works over the [LTI 1.1 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1)
