### PR TITLE
Fix for grading for grading infos created before a LTI upgrade

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -314,12 +314,23 @@ class JSConfig:
                     username=grading_info.h_username,
                     display_name=grading_info.h_display_name,
                 )
+
+                lis_result_sourced_id = grading_info.lis_result_sourcedid
+                if self._application_instance.lti_version == "1.3.0":
+                    # In LTI 1.3 lis_result_sourcedid == user_id
+                    # or rather the concept of lis_result_sourcedid doesn't really exists and the LTI1.3 grading API is based on the user id.
+                    # We take the user id value instead here for LTI1.3.
+                    # This is important in the case of upgrades that happen midterm, wih grading_infos from before the upgrade:
+                    # we might have only the LTI1.1 value for lis_result_sourcedid but if we pick the user id instead
+                    # we are guaranteed to get the right value for the LTI1.3 API
+                    lis_result_sourced_id = grading_info.user_id
+
                 students.append(
                     {
                         "userid": h_user.userid(self._authority),
                         "displayName": h_user.display_name,
                         "lmsId": grading_info.user_id,
-                        "LISResultSourcedId": grading_info.lis_result_sourcedid,
+                        "LISResultSourcedId": lis_result_sourced_id,
                         # We are using the value from the request instead of the one stored in GradingInfo.
                         # This allows us to still read and submit grades when something in the LMS changes.
                         # For example in LTI version upgrades, the endpoint is likely to change as we move from

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -90,6 +90,10 @@ class LTI13GradingService(LTIGradingService):
                     and "User in requested score is not enrolled in the org unit"
                     in err.response.text
                 )
+                or (
+                    err.status_code == 404
+                    and "User in requested score does not exist" in err.response.text
+                )
             ):
                 raise StudentNotInCourse(grading_id) from err
 

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -78,24 +78,18 @@ class LTI13GradingService(LTIGradingService):
                 # We silently shallow this type of error
                 return None
 
-            if (
+            for expected_code, expected_text in [
                 # Blackboard
-                (
-                    err.status_code == 400
-                    and "User could not be found:" in err.response.text
-                )
+                (400, "User could not be found:"),
                 # D2L
-                or (
-                    err.status_code == 403
-                    and "User in requested score is not enrolled in the org unit"
-                    in err.response.text
-                )
-                or (
-                    err.status_code == 404
-                    and "User in requested score does not exist" in err.response.text
-                )
-            ):
-                raise StudentNotInCourse(grading_id) from err
+                (403, "User in requested score is not enrolled in the org unit"),
+                (404, "User in requested score does not exist"),
+            ]:
+                if (
+                    err.status_code == expected_code
+                    and expected_text in err.response.text
+                ):
+                    raise StudentNotInCourse(grading_id) from err
 
             raise
 

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -97,6 +97,7 @@ class TestLTI13GradingService:
         [
             (400, "User could not be found:"),
             (403, "User in requested score is not enrolled in the org unit"),
+            (404, "User in requested score does not exist"),
         ],
     )
     def test_record_result_raises_StudentNotInCourse(


### PR DESCRIPTION
For:

- https://github.com/hypothesis/support/issues/43




The issue is:

- Student A launches assignment, we record a row in GradingInfo
- The school admins upgrade to LTI1.3
- In the process the value of `lis_result_sourcedid` for that student changes
- A teacher tries to grade Student A, it gets a "Student not in course" as using the old `lis_result_sourcedid` we recorded, not the new LTI1.3 version of that.


We'll rely on the fact user_id being the same in both LTI version. This is in theory not always true but we use the `lti/claim/lti1p1` to account for that already in the code:

https://github.com/hypothesis/lms/blob/main/lms/models/lti_params.py#L170

Doing the same test in 4 LMSes to prove that.

## Testing

(setting up an actual tool upgrade in the LMS is a long process that has to be repeated once per test, we are going to simulate the same effect modifying the DB)


### Canvas

We use speed grader there so this doesn't apply in Canvas.

### Blackboard

- Start in `main`

- `make devdata` to have assignments and AI up to date
- Delete any GradingInfo to not interfere with the test:

```docker compose exec postgres psql -U postgres -c "truncate lis_result_sourcedid cascade"```

- Login as a learner `blackboardstudent`

- Launch [LTI 1.1 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1)


- Launch [LTI 1.3 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1)

In the DB you'll end up with two rows for the same student, in this case in two different assignments (ie different resource_link_id):

```
select resource_link_id, lis_result_sourcedid, user_id, h_display_name from lis_result_sourcedid;
 resource_link_id |       lis_result_sourcedid       |             user_id              |   h_display_name   
------------------+----------------------------------+----------------------------------+--------------------
 _36_1            | bbgc24gi29                       | 075f3bec5d684e59acb882a12b9bed2c | Blackboard Student
 _2085_1          | 075f3bec5d684e59acb882a12b9bed2c | 075f3bec5d684e59acb882a12b9bed2c | Blackboard Student
```

- We are going to simulate the effect of the upgrade changing both rows to use the LTI1.1 id:

```
update lis_result_sourcedid set lis_result_sourcedid = 'bbgc24gi29';
UPDATE 2
```

- Login a a teacher `blackboardteacher`
- Launch the [LTI 1.3 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1) 

- There will be just one student in the drop down
- Selecting it returns a blank score (probably a separate issue)
- Try grading the student, you'll get a `Web-https (stderr)   | lms.services.exceptions.StudentNotInCourse: None ` error over `make dev`'s output.


- Switch to this branch `lti13-grading-id`
- Relaunch [LTI 1.3 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1) 
- Try fetching the score and submitting a new one.

- Check that fetching and sending new scores still works over the [LTI 1.1 assignment](https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1)


### D2L


- Start in `main`

- `make devdata` to have assignments and AI up to date
- Delete any GradingInfo to not interfere with the test:

```docker compose exec postgres psql -U postgres -c "truncate lis_result_sourcedid cascade"```

- Login as a learner `aunltd.S1`

- Launch [LTI 1.1 assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2128/View)


- Launch [LTI 1.3 assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View)

In the DB you'll end up with two rows for the same student, in this case in two different assignments (ie different resource_link_id):

```
select resource_link_id, lis_result_sourcedid, user_id, h_display_name from lis_result_sourcedid;
                resource_link_id                |           lis_result_sourcedid           |                 user_id                  | h_display_name 
------------------------------------------------+------------------------------------------+------------------------------------------+----------------
 F7373A6B-A469-426E-8F99-138CEF897E95-1192_6782 | deafa39f-1d3b-4cc4-ad0e-91447f9e0aff     | 748fc7f5-7ad7-4f7a-8cbf-49b5bc19dfec_355 | aunltd Learner
 F7373A6B-A469-426E-8F99-138CEF897E95-1200_6782 | 748fc7f5-7ad7-4f7a-8cbf-49b5bc19dfec_355 | 748fc7f5-7ad7-4f7a-8cbf-49b5bc19dfec_355 | aunltd Learner
```


- We are going to simulate the effect of the upgrade changing both rows to use the LTI1.1 id:

```
update lis_result_sourcedid set lis_result_sourcedid = 'deafa39f-1d3b-4cc4-ad0e-91447f9e0aff';
UPDATE 2
```

- Login a a teacher `HypothesisEng.Teacher`
- Launch the [LTI 1.3 assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View)

- There will be just one student in the drop down
- Selecting it returns a blank score (probably a separate issue)
- Try grading the student, you'll get a un-handled error. Fixed also on this PR.

- Switch to this branch `lti13-grading-id`
- Relaunch [LTI 1.3 assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View)
- Try fetching the score and submitting a new one.

- Check that fetching and sending new scores still works over the [LTI 1.1 assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2128/View)


### Moodle


- Start in `main`

- `make devdata` to have assignments and AI up to date
- Delete any GradingInfo to not interfere with the test:

```docker compose exec postgres psql -U postgres -c "truncate lis_result_sourcedid cascade"```

- Login as a learner `moodystudent`

- Launch [LTI 1.1 assignment](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=110)


- Launch [LTI 1.3 assignment](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=685)

In the DB you'll end up with two rows for the same student, in this case in two different assignments (ie different resource_link_id):

```
select resource_link_id, lis_result_sourcedid, user_id, h_display_name from lis_result_sourcedid;
 resource_link_id |                                                                  lis_result_sourcedid                                                                   | user_id | h_display_name 
------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+---------+----------------
 88               | {"data":{"instanceid":"88","userid":"12","typeid":"10","launchid":827951945},"hash":"0161b669b33fa04e7fde7b9c9f26ee3f3a9875e3ce83d5a689655c1d74a5fc1c"} | 12      | Class Clown
 620              | 12                                                                                                                                                      | 12      | Class Clown
(2 rows)
```


- We are going to simulate the effect of the upgrade changing both rows to use the LTI1.1 id:

```
update lis_result_sourcedid set lis_result_sourcedid = '{"data":{"instanceid":"88","userid":"12","typeid":"10","launchid":827951945},"hash":"0161b669b33fa04e7fde7b9c9f26ee3f3a9875e3ce83d5a689655c1d74a5fc1c"}';
UPDATE 2
```

- Login a a teacher `moodleteacher`
- Launch the [LTI 1.3 assignment](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=685)

- There will be just one student in the drop down
- Selecting it returns a blank score (probably a separate issue)
- Try grading the student, you'll get a un-handled error.
- Switch to this branch `lti13-grading-id`
- Relaunch [LTI 1.3 assignment](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=685)
- Try fetching the score and submitting a new one.

- Check that fetching and sending new scores still works over the [LTI 1.1 assignment](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=110)
