### PR TITLE
Use new canvas URLs in LTI registrations

### DIFF
--- a/lms/migrations/versions/0c52a13c6cad_canvas_sso_urls.py
+++ b/lms/migrations/versions/0c52a13c6cad_canvas_sso_urls.py
@@ -1,0 +1,68 @@
+"""
+Upgrade Canvas SSO URLs.
+
+Canvas has upgraded the URLs used in LTI1.3 registrations.
+
+The change is not mandatory or urgent but it should future proof the registrations.
+
+See: https://community.canvaslms.com/t5/The-Product-Blog/Minor-LTI-1-3-Changes-New-OIDC-Auth-Endpoint-Support-for/ba-p/551677
+
+
+Revision ID: 0c52a13c6cad
+Revises: 1872d16c28a4
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0c52a13c6cad"
+down_revision = "1872d16c28a4"
+
+# DB column, old URL, new URL
+URLS = (
+    # The OIDC Auth endpoint, also called the Authorization Redirect URL
+    (
+        "auth_login_url",
+        "https://canvas.instructure.com/api/lti/authorize_redirect",
+        "https://sso.canvaslms.com/api/lti/authorize_redirect",
+    ),
+    # The Canvas Public JWKs endpoint
+    (
+        "key_set_url",
+        "https://canvas.instructure.com/api/lti/security/jwks",
+        "https://sso.canvaslms.com/api/lti/security/jwks",
+    ),
+    # The Grant Host endpoint, sent as the aud claim in LTI Advantage API tokens
+    (
+        "token_url",
+        "https://canvas.instructure.com/login/oauth2/token",
+        "https://sso.canvaslms.com/login/oauth2/token",
+    ),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    for field, old_url, new_url in URLS:
+        result = conn.execute(
+            f"""
+            UPDATE lti_registration
+            SET {field} = '{new_url}'
+            WHERE {field} ='{old_url}'
+            """
+        )
+        print(f"\tUpdated lti_registration.{field}:", result.rowcount)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    for field, old_url, new_url in URLS:
+        result = conn.execute(
+            f"""
+            UPDATE lti_registration
+            SET {field} = '{old_url}'
+            WHERE {field} ='{new_url}'
+            """
+        )
+        print(f"\tDowngraded lti_registration.{field}:", result.rowcount)

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -60,9 +60,9 @@ URL_SUGGESTIONS = {
         "token_url": "https://developer.blackboard.com/api/v1/gateway/oauth2/jwttoken",
     },
     ".instructure.com": {
-        "auth_login_url": "https://canvas.instructure.com/api/lti/authorize_redirect",
-        "key_set_url": "https://canvas.instructure.com/api/lti/security/jwks",
-        "token_url": "https://canvas.instructure.com/login/oauth2/token",
+        "auth_login_url": "https://sso.canvaslms.com/api/lti/authorize_redirect",
+        "key_set_url": "https://sso.canvaslms.com/api/lti/security/jwks",
+        "token_url": "https://sso.canvaslms.com/login/oauth2/token",
     },
     ".brightspace.com": {
         "auth_login_url": "https://{issuer_host}/d2l/lti/authenticate",

--- a/tests/unit/lms/views/admin/lti_registration_test.py
+++ b/tests/unit/lms/views/admin/lti_registration_test.py
@@ -34,9 +34,9 @@ class TestAdminApplicationInstanceViews:
                 "https://hypothesis.instructure.com",
                 "client_id",
                 {
-                    "auth_login_url": "https://canvas.instructure.com/api/lti/authorize_redirect",
-                    "key_set_url": "https://canvas.instructure.com/api/lti/security/jwks",
-                    "token_url": "https://canvas.instructure.com/login/oauth2/token",
+                    "auth_login_url": "https://sso.canvaslms.com/api/lti/authorize_redirect",
+                    "key_set_url": "https://sso.canvaslms.com/api/lti/security/jwks",
+                    "token_url": "https://sso.canvaslms.com/login/oauth2/token",
                 },
             ),
             (


### PR DESCRIPTION
For:

- https://github.com/hypothesis/support/issues/35


See: https://community.canvaslms.com/t5/The-Product-Blog/Minor-LTI-1-3-Changes-New-OIDC-Auth-Endpoint-Support-for/ba-p/551677


```
URLs that will change:

The OIDC Auth endpoint, also called the Authorization Redirect URL
Old: https://canvas.instructure.com/api/lti/authorize_redirect
New: https://sso.canvaslms.com/api/lti/authorize_redirect

The Canvas Public JWKs endpoint
Old: https://canvas.instructure.com/api/lti/security/jwks
New: https://sso.canvaslms.com/api/lti/security/jwks

The Grant Host endpoint, sent as the aud claim in LTI Advantage API tokens
Old: https://canvas.instructure.com/login/oauth2/token
New: https://sso.canvaslms.com/login/oauth2/token
```

The old URLs will still work but there's some risk they wont in the future. 

I rather we make the change now wonder why something doesn't work in the future.

```
In the future, if a Canvas institution in which the tool is installed decides 
to enable the CSP feature and restrict domains that can serve content in
that institution, launches to the tool will fail unless the institution
admins explicitly add the old canvas.instructure.com domain to the CSP Domain Allowlist. 
```


A note about self hosted instances from the comments:


```
Self hosted canvas instances can continue to choose their own OIDC Auth domain
(usually the same domain that their instance is hosted at).
This switch is only for Instructure-hosted Canvas instances. 
I would recommend that self-hosted instances don't change their OIDC Auth domain.
```


## Testing

Checking the new endpoints work as expected:

- tox -e dev --run-command 'alembic upgrade head'

- Test the LTI1.3 endpoints with a launch, use a student login `eng+canvasstudent@hypothes.is`

https://hypothesis.instructure.com/courses/319/assignments/3308

- Create an annotation to force a submission (forcing usage of the token endpoint)

- Everything should work as before, celebrate.
