### PR TITLE
Handle getting the configured group set in D2L

### DIFF
--- a/tests/unit/lms/product/d2l/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/grouping_test.py
@@ -129,15 +129,56 @@ class TestD2LGroupingPlugin:
             )
         assert err.value.error_code == ErrorCodes.GROUP_SET_EMPTY
 
-    def test_factory(self, pyramid_request, d2l_api_client):
+    def test_get_group_set_id_when_no_assignment(
+        self, plugin, pyramid_request, misc_plugin
+    ):
+        misc_plugin.get_deep_linked_assignment_configuration.return_value = {}
+
+        assert not plugin.get_group_set_id(pyramid_request, None, None)
+
+    @pytest.mark.usefixtures("with_deep_linked_group_set")
+    def test_get_group_set_id_when_no_group_set_in_db(self, plugin, pyramid_request):
+        assignment = factories.Assignment(extra={})
+
+        assert not plugin.get_group_set_id(pyramid_request, assignment, None)
+
+    @pytest.mark.usefixtures("with_deep_linked_group_set")
+    def test_get_group_set_id_from_historical_assignment(self, plugin, pyramid_request):
+        historical_assignment = factories.Assignment(
+            extra={"group_set_id": sentinel.id}
+        )
+
+        assert (
+            plugin.get_group_set_id(pyramid_request, None, historical_assignment)
+            == sentinel.id
+        )
+
+    @pytest.mark.usefixtures("with_deep_linked_group_set")
+    def test_get_group_set_id_from_assignment(self, plugin, pyramid_request):
+        assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
+
+        assert plugin.get_group_set_id(pyramid_request, assignment, None) == sentinel.id
+
+    @pytest.mark.usefixtures("with_deep_linked_group_set")
+    def test_get_group_set_id_from_deep_linking(self, plugin, pyramid_request):
+        assert plugin.get_group_set_id(pyramid_request, None, None) == sentinel.id
+
+    def test_factory(self, pyramid_request, d2l_api_client, misc_plugin):
         plugin = D2LGroupingPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, D2LGroupingPlugin)
         # pylint: disable=protected-access
         assert plugin._d2l_api == d2l_api_client
+        assert plugin._misc_plugin == misc_plugin
 
     @pytest.fixture
-    def plugin(self, d2l_api_client):
-        return D2LGroupingPlugin(d2l_api_client, sentinel.api_user_id)
+    def with_deep_linked_group_set(self, misc_plugin):
+        misc_plugin.get_deep_linked_assignment_configuration.return_value = {
+            "group_set": sentinel.id
+        }
+
+    @pytest.fixture
+    def plugin(self, d2l_api_client, misc_plugin):
+        return D2LGroupingPlugin(d2l_api_client, sentinel.api_user_id, misc_plugin)
 
     @pytest.fixture
     def course(self):


### PR DESCRIPTION
With the new support for deep linking the look up is as follows:

- If we have an assignment on the DB, use that.

This will reflect the state of the assignment taking into account any possible edits.

- If we haven't seen the assignment before but the assignment has been copied form another one in the DB, use that row.

This will handle first launches of copied courses.

- If we don't have an assignment or a copy take the value from deep linking.

This will cover the case of first launches after deep linking.


### Testing

- Clean the DB state

```docker compose exec postgres psql -U postgres -c "truncate assignment cascade"```

- Log in in D2L as `HypothesisEng.Teacher` 
- Create a deep linked assignment (Existing Activities -> Hypothesis link (deep linking) use a group set.
- The new assignment will have an URL as a title (#5544 )
- Launch the assignment
- Edit the assignment, deselect the group set. The assignment will become a "course" one.
- Edit the assignment and select a different group set than the deep linked one, eg "Empty group category"
- Launch, you'll get the selected group.
