### PR TITLE
Enable clipboard-write permission for assignment content frame

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
@@ -13,6 +13,7 @@ export default function ContentFrame({ url, iframeRef }: ContentFrameProps) {
   return (
     <iframe
       ref={iframeRef}
+      allow="clipboard-write"
       className={classnames(
         // It's important that this content render full width and grow to fill
         // available flex space. n.b. It may be rendered together with grading


### PR DESCRIPTION
This enables the "Copy transcript" button to work in Via's video player app. Without this, the button works in a standalone Via tab, but fails when embedded in the LMS app with this error:

```
The Clipboard API has been blocked because of a permissions policy applied to
the current document. See https://goo.gl/EuHzyv for more details.
```

This error does not occur if visiting a video directly (eg. at https://qa-via.hypothes.is/https://www.youtube.com/watch?v=x8TO-nrUtSI). This is because in that context, both the top level and child iframes come from the same domain, and thus the restriction on cross-origin iframes doesn't get applied to it.

See also: https://web.dev/async-clipboard/#permissions-policy-integration

Note this fix will likely not work if our LMS app is being displayed inside an iframe instead of being loaded in a new tab, unless the LMS has added the same permission when it rendered the iframe containing our LMS app.

An additional or alternative solution I might look at will be for Via to fall back to the deprecated `document.execCommand("copy")` API. It could also avoid displaying the "Copy" button if it can detect that it doesn't have the necessary permissions. The change in this PR is trivial to implement, and might fix issues on other sites, so we might as well do it.

**Testing:**

1. Load a local LMS YouTube assignment in Chrome (eg. https://hypothesis.instructure.com/courses/125/assignments/4991, assuming this assignment still exist).
2. Click on the "Copy" button

Result on main: Nothing is copied. Error in the browser console.
Expected result on this branch: Transcript of video should be copied to clipboard, no errors about it in the console.