### PR TITLE
Handle invalid headers errors while decoding id_tokens

### DIFF
--- a/tests/unit/lms/services/jwt_test.py
+++ b/tests/unit/lms/services/jwt_test.py
@@ -129,6 +129,14 @@ class TestJWTService:
 
         assert "jwt" in exc_info.value.messages
 
+    def test_decode_lti_token_with_invalid_jwt_header(self, svc, jwt):
+        jwt.get_unverified_header.side_effect = InvalidTokenError()
+
+        with pytest.raises(ValidationError) as exc_info:
+            svc.decode_lti_token(sentinel.id_token)
+
+        assert "jwt" in exc_info.value.messages
+
     def test_decode_lti_token_with_invalid_jwt(self, svc, jwt):
         jwt.decode.side_effect = [{"aud": "AUD", "iss": "ISS"}, InvalidTokenError()]
 


### PR DESCRIPTION
Discovered while working on:

- https://github.com/hypothesis/product-backlog/issues/1515


Invalid headers cause 500 responses. Handle the same exception than while decoding the whole token.


I haven't seen this happen in the wild but the IMS certification tool does  send an invalid header.



## Testing instructions

Simulate an invalid token with:


- On `main`:

```
curl -X POST localhost:8001/lti_launches \
-H "Content-Type: application/x-www-form-urlencoded" \
-d 'id_token=test'
````

You'll get an unhandled:

```
jwt.exceptions.DecodeError: Not enough segments
```

- On `jwt-error-handling`

same test:


```
curl -X POST localhost:8001/lti_launches \
-H "Content-Type: application/x-www-form-urlencoded" \
-d 'id_token=test'
````

you'll get a similar error but this time it's handled like other JWT related ones:


```
[lms.services.jwt:95][MainThread] Invalid JWT. Not enough segment
```