### PR TITLE
Allow use of full-screen mode in assignment content

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
@@ -13,7 +13,7 @@ export default function ContentFrame({ url, iframeRef }: ContentFrameProps) {
   return (
     <iframe
       ref={iframeRef}
-      allow="clipboard-write"
+      allow="clipboard-write; fullscreen"
       className={classnames(
         // It's important that this content render full width and grow to fill
         // available flex space. n.b. It may be rendered together with grading


### PR DESCRIPTION
This enables the full-screen button in the YouTube video player to work, as long as the assignment is loaded in a new tab or the permission is also enabled for the iframe created by the LMS.

**Testing:**

1. Go to https://hypothesis.instructure.com/courses/125/assignments/4989
2. Start playing the video
3. Click the full-screen button in the video player. On `main` it will be disabled. On this branch it should work.
