### PR TITLE
Improve error displayed in URLPicker when YouTube is not enabled

### DIFF
--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -47,10 +47,12 @@ export default function URLPicker({
           setError('Please use a URL that starts with "http" or "https"');
         }
       } else if (isYouTubeURL(rawInputValue)) {
+        // TODO If YouTube is enabled, take the user to the right content picker instead of displaying an error
+        //      instructing how to do it manually
         setError(
           youtubeEnabled
             ? 'To annotate a video, go back and choose the YouTube option.'
-            : 'Annotating YouTube videos is not yet supported. This feature is coming soon.'
+            : 'Annotating YouTube videos has been disabled at your organisation.'
         );
       } else {
         onSelectURL(input.current!.value);

--- a/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/URLPicker-test.js
@@ -99,7 +99,7 @@ describe('URLPicker', () => {
     {
       youtubeEnabled: false,
       expectedError:
-        'Annotating YouTube videos is not yet supported. This feature is coming soon.',
+        'Annotating YouTube videos has been disabled at your organisation.',
     },
   ].forEach(({ youtubeEnabled, expectedError }) => {
     it('does not invoke `onSelectURL` if URL is for a YouTube video', () => {


### PR DESCRIPTION
Since the behavior of the YouTube feature flag has/is going to be changed to be enabled by default, having it disabled no longer means that the feature is coming, but that it has been consciously disabled.

Because of that, this PR changes the error we display if someone tries to use a YouTube URL in the `URLPicker`, to simply state that it is not supported.