### PR TITLE
Enable the YouTube feature by default

### DIFF
--- a/lms/services/youtube.py
+++ b/lms/services/youtube.py
@@ -92,7 +92,7 @@ def factory(_context, request) -> YouTubeService:
     app_settings = request.registry.settings
 
     return YouTubeService(
-        enabled=ai_settings.get("youtube", "enabled"),
+        enabled=ai_settings.get("youtube", "enabled", True),
         api_key=app_settings.get("youtube_api_key"),
         http=request.find_service(name="http"),
     )

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -148,7 +148,7 @@
         {{ settings_checkbox("JSTOR enabled", "jstor", "enabled") }}
         {{ settings_text_field("JSTOR site code", "jstor", "site_code") }}
 
-        {{ settings_checkbox("YouTube enabled", "youtube", "enabled") }}
+        {{ settings_checkbox("YouTube enabled", "youtube", "enabled", default=True) }}
     </fieldset>
 
     {{ macros.created_updated_fields(instance) }}


### PR DESCRIPTION
Enable the `"youtube.enabled"` feature by default for all application
instances that don't have this feature explicitly set to `false` in the
DB.

This will enable the feature for many application instances but not all:
whenever you edit an application instance using the admin pages it
writes the default value for settings such as `youtube.enabled` into
that application instance's settings in the DB even if that setting
wasn't changed. So application instances that've been edited in admin
pages since the `youtube.enabled` setting was added to the admin pages
will have `false` in the DB for that setting. We'll need to do a DB
migration to change those to `true`.
