### PR TITLE
Add a migration to enable the YouTube feature

### DIFF
--- a/lms/migrations/versions/1872d16c28a4_enable_the_youtube_enabled_setting_for_.py
+++ b/lms/migrations/versions/1872d16c28a4_enable_the_youtube_enabled_setting_for_.py
@@ -1,0 +1,25 @@
+"""Enable the youtube.enabled setting for all application instances.
+
+Set the youtube.enabled setting to true for all application instances that
+currently have it explicitly set to false in the DB.
+
+Revision ID: 1872d16c28a4
+Revises: 106d94be7705
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "1872d16c28a4"
+down_revision = "106d94be7705"
+
+
+def upgrade() -> None:
+    op.get_bind().execute(
+        """UPDATE application_instances
+           SET settings = settings || jsonb '{"youtube":{"enabled": true}}'
+           WHERE settings -> 'youtube' -> 'enabled' = 'false';"""
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Add a DB migration to set the `youtube.enabled` application instance
setting to `true` for all those application instances that currently
have it set to `false`.

Combined with https://github.com/hypothesis/lms/pull/5598 (which enables
`youtube.enabled` for all instances that don't have a value for this
setting in the DB) this will enable the YouTube feature for all
application instances.

This migration is necessary because when you edit an instance in the
admin pages it writes the default value for every setting into the DB
for that instance, even if that setting wasn't edited. So any instances
that've been edited since the `youtube.enabled` setting was added to the
admin pages will have the previous default value of `false` in the DB.
