### PR TITLE
Read score maximum of assignments 

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 from sqlalchemy.orm import Session
@@ -11,6 +12,8 @@ from lms.models import (
     User,
 )
 from lms.services.upsert import bulk_upsert
+
+LOG = logging.getLogger(__name__)
 
 
 class AssignmentService:
@@ -53,7 +56,6 @@ class AssignmentService:
         assignment.title = lti_params.get("resource_link_title")
         assignment.description = lti_params.get("resource_link_description")
         assignment.is_gradable = self._misc_plugin.is_assignment_gradable(lti_params)
-
         return assignment
 
     def update_assignment(self, request, assignment, document_url, group_set_id):

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -15,6 +15,9 @@ class LTI13GradingService(LTIGradingService):
 
     LTIA_SCOPES = [
         "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+        # Although this is implied by scope/lineitem according to the spec
+        # Moodle requires this one explicitly for the GET
+        "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
         "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
         "https://purl.imsglobal.org/spec/lti-ags/scope/score",
     ]

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -8,7 +8,10 @@ def service_factory(_context, request):
 
     if application_instance.lti_version == "1.3.0":
         return LTI13GradingService(
-            line_item_url=request.parsed_params.get("lis_outcome_service_url"),
+            # Pick the value from the right dictionary depending on the context we are running
+            # either an API call from the frontend (parsed_params) or inside an LTI launch (lti_params).
+            line_item_url=request.parsed_params.get("lis_outcome_service_url")
+            or request.lti_params.get("lis_outcome_service_url"),
             line_item_container_url=request.lti_params.get("lineitems"),
             ltia_service=request.find_service(LTIAHTTPService),
         )

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -38,6 +38,15 @@ class LTIGradingService:  # pragma: no cover
         self.line_item_url = line_item_url
         self.line_item_container_url = line_item_container_url
 
+    def get_score_maximum(self, resource_link_id):
+        """
+        Read the grading configuration of an assignment.
+
+        In LTI nomenclature this is reading the line item container.
+        :param resource_link_id: ID of the assignment on the LMS.
+        """
+        return None
+
     def read_result(self, grading_id):
         """
         Return the last-submitted score for a given submission.

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -38,7 +38,7 @@ class LTIGradingService:  # pragma: no cover
         self.line_item_url = line_item_url
         self.line_item_container_url = line_item_container_url
 
-    def get_score_maximum(self, resource_link_id):
+    def get_score_maximum(self, resource_link_id):  # pylint:disable=unused-argument
         """
         Read the grading configuration of an assignment.
 

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -64,14 +64,15 @@ class TestLTI13GradingService:
 
     def test_get_score_maximum(self, svc, ltia_http_service):
         ltia_http_service.request.return_value.json.return_value = [
-            {"scoreMaximum": sentinel.score_max}
+            {"scoreMaximum": sentinel.score_max, "id": svc.line_item_url},
+            {"scoreMaximum": 1, "id": sentinel.other_lineitem},
         ]
 
         score = svc.get_score_maximum(sentinel.resource_link_id)
 
         ltia_http_service.request.assert_called_once_with(
             "GET",
-            "http://example.com/linesitems",
+            "http://example.com/lineitems",
             scopes=svc.LTIA_SCOPES,
             params={"resource_link_id": sentinel.resource_link_id},
             headers={"Accept": "application/vnd.ims.lis.v2.lineitemcontainer+json"},
@@ -82,6 +83,13 @@ class TestLTI13GradingService:
         ltia_http_service.request.side_effect = ExternalRequestError(
             response=Mock(status_code=500)
         )
+
+        assert svc.get_score_maximum(sentinel.resource_link_id) is None
+
+    def test_get_score_maximum_no_line_item(self, svc, ltia_http_service):
+        ltia_http_service.request.return_value.json.return_value = [
+            {"scoreMaximum": sentinel.score_max, "id": sentinel.other_lineitem}
+        ]
 
         assert not svc.get_score_maximum(sentinel.resource_link_id)
 
@@ -196,6 +204,6 @@ class TestLTI13GradingService:
     def svc(self, ltia_http_service):
         return LTI13GradingService(
             "http://example.com/lineitem",
-            "http://example.com/linesitems",
+            "http://example.com/lineitems",
             ltia_http_service,
         )

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -62,6 +62,29 @@ class TestLTI13GradingService:
 
         assert not svc.read_result(sentinel.user_id)
 
+    def test_get_score_maximum(self, svc, ltia_http_service):
+        ltia_http_service.request.return_value.json.return_value = [
+            {"scoreMaximum": sentinel.score_max}
+        ]
+
+        score = svc.get_score_maximum(sentinel.resource_link_id)
+
+        ltia_http_service.request.assert_called_once_with(
+            "GET",
+            "http://example.com/linesitems",
+            scopes=svc.LTIA_SCOPES,
+            params={"resource_link_id": sentinel.resource_link_id},
+            headers={"Accept": "application/vnd.ims.lis.v2.lineitemcontainer+json"},
+        )
+        assert score == sentinel.score_max
+
+    def test_get_score_maximum_with_error(self, svc, ltia_http_service):
+        ltia_http_service.request.side_effect = ExternalRequestError(
+            response=Mock(status_code=500)
+        )
+
+        assert not svc.get_score_maximum(sentinel.resource_link_id)
+
     @freeze_time("2022-04-04")
     def test_record_result(self, svc, ltia_http_service):
         svc.line_item_url = "https://lms.com/lineitems?param=1"

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -28,12 +28,28 @@ class TestFactory:
         )
         assert svc == LTI13GradingService.return_value
 
+    def test_v13_line_item_url_from_lti_params(
+        self, pyramid_request, LTI13GradingService, ltia_http_service
+    ):
+        del pyramid_request.parsed_params["lis_outcome_service_url"]
+        pyramid_request.lti_user.application_instance = Mock(lti_version="1.3.0")
+
+        svc = service_factory(sentinel.context, pyramid_request)
+
+        LTI13GradingService.assert_called_once_with(
+            sentinel.grading_url, sentinel.lineitems, ltia_http_service
+        )
+        assert svc == LTI13GradingService.return_value
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.parsed_params = {
             "lis_outcome_service_url": sentinel.grading_url
         }
-        pyramid_request.lti_params = {"lineitems": sentinel.lineitems}
+        pyramid_request.lti_params = {
+            "lineitems": sentinel.lineitems,
+            "lis_outcome_service_url": sentinel.grading_url,
+        }
 
         return pyramid_request
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -250,6 +250,7 @@ class TestBasicLaunchViews:
         is_gradable,
         is_instructor,
         grading_info_service,
+        lti_grading_service,
     ):
         assignment = factories.Assignment(is_gradable=is_gradable)
         if is_instructor:
@@ -274,6 +275,11 @@ class TestBasicLaunchViews:
                     resource_link_id="TEST_RESOURCE_LINK_ID",
                     lis_outcome_service_url=sentinel.grading_url,
                 )
+
+                lti_grading_service.get_score_maximum.assert_called_once_with(
+                    assignment.resource_link_id
+                )
+
                 context.js_config.enable_toolbar_grading.assert_called_once_with(
                     students=grading_info_service.get_students_for_grading.return_value
                 )


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/5621


In this PR we'll just read the value from the LMS in LTI1.3. Out of scope is storing it in the DB, actually using this value and anything LTI 1.1 related.

Splinting the PRs this way we can focus on LMS compatibility in this PR

### Testing


In all LMSes look in the `make dev` console for a line like:


```DEBUG [lms.views.lti.basic_launch:185][MainThread] Score maximum for F7373A6B-A469-426E-8F99-138CEF897E95-1632_6782: 88.0```



### D2L


as `HypothesisEng.Teacher` launch  https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View?ou=6782


### Blackboard

as `blackboardteacher`  https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1


### Moodle

as `moodleteacher` https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=685
