### PR TITLE
Enable autoplay permission for content frame

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
@@ -13,7 +13,13 @@ export default function ContentFrame({ url, iframeRef }: ContentFrameProps) {
   return (
     <iframe
       ref={iframeRef}
-      allow="clipboard-write; fullscreen"
+      // Enable permissions required by Via's video player (and other content
+      // too).
+      //
+      // "autoplay" - Enables Play button to work without first clicking on video
+      // "clipboard-write" - Used by "Copy transcript" button
+      // "fullscreen" - Enables full-screen button in player
+      allow="autoplay; clipboard-write; fullscreen"
       className={classnames(
         // It's important that this content render full width and grow to fill
         // available flex space. n.b. It may be rendered together with grading


### PR DESCRIPTION
This enables the Play button in Via's video player to work, in Chrome, before the user has interacted with the YouTube iframe. See https://developer.chrome.com/blog/autoplay/#iframe-delegation.

Fixes https://github.com/hypothesis/via/issues/1136