### PR TITLE
Prompt for title in assignment config when `promptForTitle` flag is set by backend

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -231,6 +231,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
           ...deepLinkingAPI.data,
           content,
           group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
+          title,
         };
         setDeepLinkingFields(
           await apiCall({
@@ -255,6 +256,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       deepLinkingAPI,
       groupConfig.groupSet,
       groupConfig.useGroupSet,
+      title,
     ]
   );
 

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -215,8 +215,15 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     string
   > | null>(null);
 
+  const formRef = useRef<HTMLFormElement>(null);
+
   const submit = useCallback(
     async (content: Content) => {
+      // Validate form fields which are shown on the details screen.
+      if (!formRef.current?.reportValidity()) {
+        return;
+      }
+
       // Set shouldSubmit to true early to show the spinner while fetching form fields
       setShouldSubmit(true);
 
@@ -304,6 +311,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
         )}
         method="POST"
         onSubmit={onSubmit}
+        ref={formRef}
       >
         {isEditing && (
           <RouterLink href="/app/basic-lti-launch" data-testid="back-link">
@@ -365,10 +373,13 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                           data-testid="title-input"
                           id={titleInputId}
                           name="Title"
+                          // Max length is based on what D2L supports, which is the first LMS that
+                          // supported setting a title in assignment configuration.
+                          maxLength={150}
                           onInput={(e: Event) =>
                             setTitle((e.target as HTMLInputElement).value)
                           }
-                          placeholder="Hypothesis assignment"
+                          required
                           value={title}
                         />
                       </>

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -128,17 +128,23 @@ function PanelLabel({
   children,
   description,
   isCurrentStep,
+  verticalAlign = 'top',
 }: {
   children: ComponentChildren;
   description?: ComponentChildren;
   isCurrentStep: boolean;
+  verticalAlign?: 'top' | 'center';
 }) {
   return (
-    <div className="space-y-1.5 leading-none">
+    <div
+      className={classnames('space-y-1.5 leading-none', {
+        'flex flex-col justify-center': verticalAlign === 'center',
+      })}
+    >
       <div className="sm:text-end font-medium text-slate-600 uppercase">
         {children}
       </div>
-      {isCurrentStep && (
+      {isCurrentStep && description && (
         <div className="sm:text-end font-normal text-stone-500">
           {description}
         </div>
@@ -350,7 +356,9 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                     {typeof title === 'string' && (
                       <>
                         <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep={true}>Title</PanelLabel>
+                        <PanelLabel isCurrentStep={true} verticalAlign="center">
+                          Title
+                        </PanelLabel>
                         <Input
                           data-testid="title-input"
                           id={titleInputId}

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -15,6 +15,9 @@ export type FilePickerFormFieldsProps = {
    * if group sets have been disabled.
    */
   groupSet: string | null;
+
+  /** Assignment title chosen by the user, if supported by the current LMS. */
+  title: string | null;
 };
 
 /**
@@ -30,6 +33,7 @@ export type FilePickerFormFieldsProps = {
  *    See the `configure_assignment` view.
  */
 export default function FilePickerFormFields({
+  title,
   content,
   formFields,
   groupSet,
@@ -45,6 +49,7 @@ export default function FilePickerFormFields({
         // view. Used in LMSes where assignments are configured on first launch.
         <input name="document_url" type="hidden" value={content.url} />
       )}
+      {title !== null && <input type="hidden" name="title" value={title} />}
     </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -184,6 +184,7 @@ describe('FilePickerApp', () => {
           ...deepLinkingAPIData,
           content: { type: 'url', url: 'https://example.com' },
           group_set: null,
+          title: null,
         },
       });
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -348,6 +348,12 @@ describe('FilePickerApp', () => {
       });
     });
 
+    function clickContinueButton(wrapper) {
+      interact(wrapper, () => {
+        wrapper.find('Button[data-testid="save-button"]').props().onClick();
+      });
+    }
+
     [true, false].forEach(useGroupSet => {
       it('submits form when "Continue" button is clicked', () => {
         const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
@@ -357,9 +363,7 @@ describe('FilePickerApp', () => {
         selectGroupConfig(wrapper, { useGroupSet, groupSet: 'groupSet1' });
 
         assert.notCalled(onSubmit);
-        interact(wrapper, () => {
-          wrapper.find('Button[data-testid="save-button"]').props().onClick();
-        });
+        clickContinueButton(wrapper);
 
         assert.called(onSubmit);
         checkFormFields(wrapper, {
@@ -370,6 +374,29 @@ describe('FilePickerApp', () => {
           groupSet: useGroupSet ? 'groupSet1' : null,
         });
       });
+    });
+
+    it('does not submit form when "Continue" is clicked if there are validation errors', () => {
+      fakeConfig.filePicker.promptForTitle = true;
+
+      const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+      const wrapper = renderFilePicker({ onSubmit });
+
+      selectContent(wrapper, 'https://example.com');
+
+      // Make an input on the details screen invalid.
+      const titleInput = wrapper
+        .find('input[data-testid="title-input"]')
+        .getDOMNode();
+      titleInput.value = '';
+
+      clickContinueButton(wrapper);
+      assert.notCalled(onSubmit);
+
+      titleInput.value = 'No longer empty';
+      clickContinueButton(wrapper);
+
+      assert.called(onSubmit);
     });
 
     it('shows activity indicator when form is submitted', () => {

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -200,6 +200,23 @@ describe('FilePickerApp', () => {
       });
     });
 
+    it('fetches form field values via deep linking API on implicit form submission', async () => {
+      // Enable title field, which is a field where the user could trigger an
+      // implicit submission by pressing Enter.
+      fakeConfig.filePicker.promptForTitle = true;
+
+      const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+      const wrapper = renderFilePicker({ onSubmit });
+
+      selectContent(wrapper, 'https://example.com');
+
+      // Simulate implicit form submission, as if pressing Enter in title field.
+      wrapper.find('form').getDOMNode().requestSubmit();
+
+      await waitFor(() => fakeAPICall.called);
+      await waitFor(() => onSubmit.called);
+    });
+
     it('shows an error if the deepLinkingAPI call fails', async () => {
       const error = new Error('Something happened');
       const onSubmit = sinon.stub().callsFake(e => e.preventDefault());

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -15,6 +15,7 @@ describe('FilePickerFormFields', () => {
         content={{ type: 'url', url: 'https://testsite.example/' }}
         formFields={staticFormFields}
         groupSet={null}
+        title={null}
         {...props}
       />
     );
@@ -62,5 +63,15 @@ describe('FilePickerFormFields', () => {
     const documentURLField = formFields.find('input[name="document_url"]');
     assert.isTrue(documentURLField.exists());
     assert.equal(documentURLField.prop('value'), 'https://example.com/');
+  });
+
+  it('renders `title` field if `title` prop is set', () => {
+    const formFields = createComponent({
+      content: { type: 'url', url: 'https://example.com/' },
+      title: 'Example assignment',
+    });
+    const titleField = formFields.find('input[name="title"]');
+    assert.isTrue(titleField.exists());
+    assert.equal(titleField.prop('value'), 'Example assignment');
   });
 });


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/5568**

When the backend sets the `promptForTitle` flag to indicate that an assignment title should be entered by the user as part of the configuration, display a new "Title" input on the details screen. This is currently prefilled with "Hypothesis assignment" as a default. When the user submits the form, a new hidden "title" field will be added to the form submission.

<img width="666" alt="Title prompt" src="https://github.com/hypothesis/lms/assets/2458/3bb06366-af73-436b-a1a2-2cfde53d388c">

Please consider the layout here preliminary and subject to change. We have also discussed potentially moving this to a separate screen, or re-ordering it.

Part of https://github.com/hypothesis/lms/issues/5544

----

- [x] Decide what validation to add for this field (must be non-empty? max length?) and implement it
- [x] Add `title` field to the API call made to the `deepLinkingAPI.path` endpoint
- [x] Vertically align the label with the baseline of the input field (nb. screenshot above needs updating)
