### PR TITLE
Delete unused D2L setting `create_line_item`

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -25,7 +25,6 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("desire2learn", "client_secret", JSONSetting.AES_SECRET),
         JSONSetting("desire2learn", "groups_enabled", asbool),
         JSONSetting("desire2learn", "files_enabled", asbool),
-        JSONSetting("desire2learn", "create_line_item", asbool),
         JSONSetting("google_drive", "files_enabled", asbool),
         JSONSetting("microsoft_onedrive", "files_enabled", asbool),
         JSONSetting("vitalsource", "enabled", asbool),

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -3,44 +3,9 @@ from lms.services.lti_grading.interface import LTIGradingService
 
 
 class D2LMiscPlugin(MiscPlugin):
-    def __init__(self, create_line_item: bool):
-        self._create_line_item = create_line_item
-
     # Deep linking in D2L implies creating a new assignment.
     # Prompt for a title to set it for the new assignment.
     deep_linking_prompt_for_title = True
-
-    def post_configure_assignment(self, request):
-        """
-        Run any actions needed after configuring an assignment.
-
-        D2L doesn't create the container that holds grades (line item) LTI 1.3
-        assignments.
-
-        As a work-around, as soon as we configure the assignment on our end
-        we'll use the LTIA grading API to create a new line item we can use
-        later to record the grade.
-        """
-        # Nothing to do if line item creation is off, or it's already there
-        if not self._create_line_item or super().is_assignment_gradable(
-            request.lti_params
-        ):
-            return
-
-        request.find_service(LTIGradingService).create_line_item(
-            resource_link_id=request.lti_params.get("resource_link_id"),
-            label=request.lti_params.get("resource_link_title"),
-        )
-
-    def is_assignment_gradable(self, lti_params):
-        """Check if the assignment of the current launch is gradable."""
-        if self._create_line_item and lti_params["lti_version"] == "1.3.0":
-            # D2L doesn't automatically create a line item for assignments by
-            # default like it does for 1.1. If we are creating them
-            # automatically all assignments will be gradable.
-            return True
-
-        return super().is_assignment_gradable(lti_params)
 
     def get_ltia_aud_claim(self, lti_registration):
         # In D2L this value is always the same and different from
@@ -59,4 +24,4 @@ class D2LMiscPlugin(MiscPlugin):
 
     @classmethod
     def factory(cls, _context, request):
-        return cls(request.product.settings.custom.get("create_line_item", False))
+        return cls()

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -1,5 +1,3 @@
-from pyramid.request import Request
-
 from lms.models import LTIParams, LTIRegistration
 
 
@@ -25,15 +23,6 @@ class MiscPlugin:
 
     # Whether or not to prompt for an assignment title while deep linking.
     deep_linking_prompt_for_title = False
-
-    def post_configure_assignment(self, request: Request):  # pragma: nocover
-        """
-        Run any actions needed after configuring an assignment.
-
-        This doesn't apply on deep linked setups where:
-            - The exact moment of configuration is not know.
-            - The deep linking message could include details about grading.
-        """
 
     def post_launch_assignment_hook(
         self, request, js_config, assignment

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -48,24 +48,18 @@ class AssignmentService:
 
         return assignment
 
-    def _update_assignment(self, assignment, lti_params, document_url, group_set_id):
+    def update_assignment(self, request, assignment, document_url, group_set_id):
+        """Update an existing assignment."""
+
         assignment.document_url = document_url
         assignment.extra["group_set_id"] = group_set_id
 
         # Metadata based on the launch
-        assignment.title = lti_params.get("resource_link_title")
-        assignment.description = lti_params.get("resource_link_description")
-        assignment.is_gradable = self._misc_plugin.is_assignment_gradable(lti_params)
-        return assignment
-
-    def update_assignment(self, request, assignment, document_url, group_set_id):
-        """Update an existing assignment."""
-        assignment = self._update_assignment(
-            assignment, request.lti_params, document_url, group_set_id
+        assignment.title = request.lti_params.get("resource_link_title")
+        assignment.description = request.lti_params.get("resource_link_description")
+        assignment.is_gradable = self._misc_plugin.is_assignment_gradable(
+            request.lti_params
         )
-
-        # Make any product-specific actions after configuring the assignment
-        self._misc_plugin.post_configure_assignment(request)
 
         return assignment
 
@@ -143,9 +137,7 @@ class AssignmentService:
         # Always update the assignment configuration
         # It often will be the same one while launching the assignment again but
         # it might for example be an updated deep linked URL or similar.
-        return self._update_assignment(
-            assignment, lti_params, document_url, group_set_id
-        )
+        return self.update_assignment(request, assignment, document_url, group_set_id)
 
     def upsert_assignment_membership(
         self, assignment: Assignment, user: User, lti_roles: List[LTIRole]

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -131,7 +131,6 @@
         {{ settings_secret_field("API Client secret", "desire2learn", "client_secret") }}
         {{ settings_checkbox("Groups enabled", "desire2learn", "groups_enabled") }}
         {{ settings_checkbox("Files enabled", "desire2learn", "files_enabled") }}
-        {{ settings_checkbox("Create grade items", "desire2learn", "create_line_item") }}
     </fieldset>
 
     <fieldset class="box">

--- a/tests/unit/lms/product/d2l/_plugin/misc_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/misc_test.py
@@ -9,61 +9,6 @@ class TestD2LMiscPlugin:
     def test_deep_linking_prompt_for_title(self, plugin):
         assert plugin.deep_linking_prompt_for_title
 
-    def test_post_configure_assignment(
-        self, plugin, lti_grading_service, pyramid_request
-    ):
-        pyramid_request.lti_params = {
-            "lineitems": sentinel.lineitems,
-            "resource_link_id": sentinel.resource_link_id,
-            "resource_link_title": sentinel.resource_link_title,
-        }
-        # pylint:disable=protected-access
-        plugin._create_line_item = True
-
-        plugin.post_configure_assignment(pyramid_request)
-
-        lti_grading_service.create_line_item.assert_called_once_with(
-            sentinel.resource_link_id, sentinel.resource_link_title
-        )
-
-    def test_post_configure_assignment_gradable_assignment(
-        self, plugin, lti_grading_service, pyramid_request
-    ):
-        pyramid_request.lti_params = {
-            "lineitems": sentinel.lineitems,
-            "resource_link_id": sentinel.resource_link_id,
-            "resource_link_title": sentinel.resource_link_title,
-            "lis_outcome_service_url": sentinel.lis_outcome_service_url,
-        }
-        # pylint:disable=protected-access
-        plugin._create_line_item = True
-
-        plugin.post_configure_assignment(pyramid_request)
-
-        lti_grading_service.create_line_item.assert_not_called()
-
-    def test_post_configure_assignment_create_line_item_disabled(
-        self, plugin, lti_grading_service, pyramid_request
-    ):
-        plugin.post_configure_assignment(pyramid_request)
-
-        lti_grading_service.create_line_item.assert_not_called()
-
-    @pytest.mark.parametrize(
-        "create_line_item,version,expected",
-        [
-            (False, "1.1", False),
-            (False, "1.3.0", False),
-            (True, "1.1", False),
-            (True, "1.3.0", True),
-        ],
-    )
-    def test_is_assignment_gradable(self, plugin, create_line_item, version, expected):
-        # pylint:disable=protected-access
-        plugin._create_line_item = create_line_item
-
-        assert plugin.is_assignment_gradable({"lti_version": version}) == expected
-
     def test_get_ltia_aud_claim(self, plugin):
         assert (
             plugin.get_ltia_aud_claim(sentinel.registration)
@@ -109,7 +54,7 @@ class TestD2LMiscPlugin:
 
     @pytest.fixture
     def plugin(self):
-        return D2LMiscPlugin(create_line_item=False)
+        return D2LMiscPlugin()
 
     @pytest.fixture
     def MiscPlugin(self):

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -25,7 +25,7 @@ class TestAssignmentService:
 
         assert assignment in db_session.new
 
-    def test_update_assignment(self, svc, pyramid_request, misc_plugin):
+    def test_update_assignment(self, svc, pyramid_request):
         assignment = svc.update_assignment(
             pyramid_request,
             factories.Assignment(),
@@ -33,7 +33,6 @@ class TestAssignmentService:
             sentinel.group_set_id,
         )
 
-        misc_plugin.post_configure_assignment.assert_called_once_with(pyramid_request)
         assert assignment.document_url == sentinel.document_url
         assert assignment.extra["group_set_id"] == sentinel.group_set_id
 


### PR DESCRIPTION
This option which is not used in production brought significant complexity needing two plugin entry points to enable it.

Remove this feature and the MiscPlugin methods that were needed for it.

This is not enabled for any school, filter https://lms.hypothes.is/admin/instances/ for  `desire2learn.create_line_item`


While this option is not used the problem is trying to solve is still an issue. 

The current work around is to create the line item manually: 

https://web.hypothes.is/help/grading-student-annotations-in-d2l/ this is the prefered solution now in all D2L versions, see: https://github.com/hypothesis/lms/issues/4699#issuecomment-1372599744

The current work for supporting deep linking in D2L could be another avenue to solve this issue with another approach as we'll be in control of creating the assignments while deep linking.



## Testing

Sanity check a couple of launches:

- [Non gradable assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2374/View)
- [Gradable assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View)
