### PR TITLE
Log for early return due to a grade already existing while creating submissions.

### DIFF
--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from datetime import timezone
 
 from pyramid.view import view_config, view_defaults
@@ -11,6 +12,8 @@ from lms.validation import (
     APIRecordResultSchema,
     APIRecordSpeedgraderSchema,
 )
+
+LOG = logging.getLogger(__name__)
 
 
 @view_defaults(request_method="POST", renderer="json", permission=Permissions.API)
@@ -94,6 +97,10 @@ class GradingViews:
 
         # If we already have a score, then we've already recorded this info
         if self.lti_grading_service.read_result(lis_result_sourcedid):
+            LOG.debug(
+                "Grade already present, not recording submission. User ID: %s",
+                self.request.user.id,
+            )
             return None
 
         self.lti_grading_service.record_result(


### PR DESCRIPTION
Adding this for two reasons:

- Testing anything submission related locally for me always involves a panic because it doesn't work util a realize the grade was already there and try on a different assignment. 

- It might be useful for some debugging on a real issue about students missing submissions. 


I don't think this warrants creating a new "SUBMISSION_NOT_SENT_DUE_TO_GRADE" event type.



## Testing

- As `eng+canvasstudent@hypothes.is` launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873)
- Make an annotation
- Check the logs for:
```web (stderr)         | 2023-08-03 12:07:49,836 DEBUG [lms.views.api.grading:100][MainThread] Grade already present, not recording submission. User ID: 17```