### PR TITLE
Breakdown YouTube assignments counts

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/02_entities/04_assignments/01_create_view.sql
+++ b/lms/data_tasks/report/create_from_scratch/02_entities/04_assignments/01_create_view.sql
@@ -25,8 +25,10 @@ CREATE MATERIALIZED VIEW report.assignments AS (
             WHEN STARTS_WITH(url, 'jstor://') THEN 'JSTOR'
             WHEN STARTS_WITH(url, 'https://drive.google.com') THEN 'Google Drive'
             WHEN STARTS_WITH(url, 'https://api.onedrive.com') THEN 'Microsoft OneDrive'
-            -- This isn't live yet, and when it is, we probably won't do it like this
-            -- WHEN STARTS_WITH(url, 'https://www.youtube.com/watch') THEN 'YouTube'
+
+            WHEN STARTS_WITH(url, 'https://www.youtube.com') THEN 'YouTube'
+            WHEN STARTS_WITH(url, 'https://youtube.com') THEN 'YouTube'
+            WHEN STARTS_WITH(url, 'https://youtu.be') THEN 'YouTube'
 
             -- We're assuming we've caught everything by here, but anything we
             -- miss will be in this pot. This should be Via stuff hopefully.


### PR DESCRIPTION
Using the domains from:

https://github.com/hypothesis/lms/blob/youtube-document-url/lms/static/scripts/frontend_apps/utils/youtube.ts#L13

This could in theory capture some URLs that don't point to a video but I reckon that in the context of analytics this is probably acceptable. The same is true for drive / one drive.

If we eventually store these  URLs in some sort of `youtube://` schema we'd probably want to keep this for backwards compatibility.