### PR TITLE
Expose the scoreMaximum of the current assignment to the front end

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -298,11 +298,12 @@ class JSConfig:
         toolbar_config["editingEnabled"] = True
         self._config["instructorToolbar"] = toolbar_config
 
-    def enable_toolbar_grading(self, students):
+    def enable_toolbar_grading(self, students, score_maximum=None):
         toolbar_config = self._get_toolbar_config()
 
         toolbar_config["gradingEnabled"] = True
         toolbar_config["students"] = students
+        toolbar_config["scoreMaximum"] = score_maximum
 
         self._config["instructorToolbar"] = toolbar_config
 

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -53,6 +53,7 @@ export type InstructorConfig = {
   editingEnabled: boolean;
   gradingEnabled: boolean;
   students: StudentInfo[] | null;
+  scoreMaximum: number | null;
 };
 
 /**

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -192,7 +192,9 @@ class BasicLaunchViews:
                 )
 
                 # Display the grading interface in the toolbar
-                self.context.js_config.enable_toolbar_grading(students)
+                self.context.js_config.enable_toolbar_grading(
+                    students=students, score_maximum=score_maximum
+                )
 
             if not self.request.lti_user.is_instructor:
                 # Create or update a record of LIS result data for a student launch

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -366,7 +366,7 @@ class TestInstructorToolbar:
         self, js_config, pyramid_request, enable_editing, enable_grading
     ):
         if enable_grading:
-            js_config.enable_toolbar_grading(sentinel.students)
+            js_config.enable_toolbar_grading(sentinel.students, sentinel.score_maximum)
 
         if enable_editing:
             js_config.enable_toolbar_editing()
@@ -382,6 +382,7 @@ class TestInstructorToolbar:
         if enable_grading:
             expected["gradingEnabled"] = enable_grading
             expected["students"] = sentinel.students
+            expected["scoreMaximum"] = sentinel.score_maximum
 
         assert js_config.asdict()["instructorToolbar"] == expected
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -281,7 +281,8 @@ class TestBasicLaunchViews:
                 )
 
                 context.js_config.enable_toolbar_grading.assert_called_once_with(
-                    students=grading_info_service.get_students_for_grading.return_value
+                    students=grading_info_service.get_students_for_grading.return_value,
+                    score_maximum=lti_grading_service.get_score_maximum.return_value,
                 )
             else:
                 grading_info_service.upsert_from_request.assert_called_once_with(


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/5621


This value might be null if we are not able to retrieve it from the source LMS.

Not using this value at all, just exposing it to enable any work on the front end.