### PR TITLE
Handle known grading edge cases with an error code

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -268,6 +268,13 @@ class FileNotFoundInCourse(SerializableError):
         super().__init__(error_code=error_code, details={"file_id": file_id})
 
 
+class GradingError(SerializableError):
+    """Generic, grading related errors that are not handled indepently."""
+
+    def __init__(self, text):
+        super().__init__(error_code="grading_error", details={"text": text})
+
+
 class StudentNotInCourse(SerializableError):
     """A student is no longer in the current course."""
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/5495


Instead of just logging and swallowing the error emit an error code.

The UI won't handle these but we reduce the noise in sentry while
keeping the error in the logs and potentially informing the instructor that
"something" went wrong.