### PR TITLE
Pass `scoreMaximum` from instructor config to `SubmitGradeForm`

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -10,6 +10,7 @@ import SubmitGradeForm from './SubmitGradeForm';
 
 export type GradingControlsProps = {
   students: StudentInfo[];
+  scoreMaximum?: number;
 };
 
 /**
@@ -31,6 +32,7 @@ function localeSort<Item>(items: Item[], key: keyof Item): Item[] {
  */
 export default function GradingControls({
   students: unorderedStudents,
+  scoreMaximum,
 }: GradingControlsProps) {
   const {
     api: { authToken, sync: syncAPICallInfo },
@@ -102,7 +104,10 @@ export default function GradingControls({
         />
       </div>
       <div>
-        <SubmitGradeForm student={selectedStudent} />
+        <SubmitGradeForm
+          student={selectedStudent}
+          scoreMaximum={scoreMaximum}
+        />
       </div>
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -7,7 +7,7 @@ import GradingControls from './GradingControls';
 
 /**
  * Toolbar for instructors.
- * Shows assignment information and grading controls (for gradeable assignments).
+ * Shows assignment information and grading controls (for gradable assignments).
  */
 export default function InstructorToolbar() {
   const { instructorToolbar } = useConfig();
@@ -22,6 +22,7 @@ export default function InstructorToolbar() {
     assignmentName,
     editingEnabled,
     gradingEnabled,
+    scoreMaximum,
   } = instructorToolbar;
 
   const withGradingControls = gradingEnabled && !!students;
@@ -70,7 +71,14 @@ export default function InstructorToolbar() {
         </h2>
       </div>
 
-      {withGradingControls ? <GradingControls students={students} /> : <div />}
+      {withGradingControls ? (
+        <GradingControls
+          students={students}
+          scoreMaximum={scoreMaximum ?? undefined}
+        />
+      ) : (
+        <div />
+      )}
     </header>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -135,17 +135,19 @@ describe('SubmitGradeForm', () => {
     );
   });
 
-  it("selects the input field's text when changing students and fetching the grade", async () => {
-    document.body.focus();
-    const wrapper = renderForm();
+  [5, 10, 20, 100, undefined].forEach(scoreMaximum => {
+    it("selects the input field's text when changing students and fetching the grade", async () => {
+      document.body.focus();
+      const wrapper = renderForm({ scoreMaximum });
 
-    await waitForGradeFetch(wrapper);
+      await waitForGradeFetch(wrapper);
 
-    wrapper.setProps({ student: fakeStudentAlt });
+      wrapper.setProps({ student: fakeStudentAlt });
 
-    await waitForGradeFetch(wrapper);
+      await waitForGradeFetch(wrapper);
 
-    assert.equal(document.getSelection().toString(), '10');
+      assert.equal(document.getSelection().toString(), `${scoreMaximum ?? 10}`);
+    });
   });
 
   context('validation messages', () => {
@@ -282,7 +284,7 @@ describe('SubmitGradeForm', () => {
       );
     });
 
-    it('sets hides the Spinner after the grade is fetched', async () => {
+    it('hides the Spinner after the grade is fetched', async () => {
       const wrapper = renderForm();
       await waitForGradeFetch(wrapper);
       assert.isFalse(


### PR DESCRIPTION
This PR is part of https://github.com/hypothesis/lms/issues/5621

Use the `maximumScore` from instructor toolbar config to determine the maximum score allowed in the grading bar, instead of using the hardcoded `10` value.

These assignments have different max scores:

* `5`: https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View
* `100`: https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3349/View

> When opening those ☝🏼, you may see a LMS error that the file was not found. A quick workaround involves editing the assignment so that the files are fetched in your local LMS instance, and then going back without changing anything nor saving.