### PR TITLE
Enable PYTHONDEVMODE in the tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ setenv =
     dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:5433/postgres}
     tests: DATABASE_URL = {env:UNITTESTS_DATABASE_URL:postgresql://postgres@localhost:5433/lms_tests}
+    dev,tests,functests: PYTHONDEVMODE = {env:PYTHONDEVMODE:1}
     functests: DATABASE_URL = {env:FUNCTESTS_DATABASE_URL:postgresql://postgres@localhost:5433/lms_functests}
     # Make `import lms` work in `make shell`.
     dev: PYTHONPATH = .


### PR DESCRIPTION
https://docs.python.org/3/library/devmode.html#devmode

From https://docs.python.org/3/whatsnew/3.9.html#you-should-check-for-deprecationwarning-in-your-code
```
More generally, try to run your tests in the Python Development Mode
which helps to prepare your code to make it
compatible with the next Python version.
```