### PR TITLE
Do not derive local state from prop in ValidationMessage

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ValidationMessage.tsx
+++ b/lms/static/scripts/frontend_apps/components/ValidationMessage.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { useEffect, useState } from 'preact/hooks';
 
 export type ValidationMessageProps = {
   /** Error message text. */
@@ -21,22 +20,15 @@ export default function ValidationMessage({
   open = false,
   onClose = () => {},
 }: ValidationMessageProps) {
-  const [showError, setShowError] = useState(open);
-
-  useEffect(() => {
-    setShowError(open);
-  }, [open]);
-
   const closeValidationError = (event: Event) => {
     event.preventDefault();
-    setShowError(false);
     onClose();
   };
 
   return (
     <input
       type="button"
-      data-testid={showError ? 'message-open' : 'message-closed'}
+      data-testid={open ? 'message-open' : 'message-closed'}
       onClick={closeValidationError}
       className={classnames(
         'absolute z-10 shadow',
@@ -49,12 +41,12 @@ export default function ValidationMessage({
         // Make message the same height as its relative-positioned ancestor
         'h-full',
         {
-          'animate-validationMessageOpen': showError,
-          'animate-validationMessageClose': !showError,
+          'animate-validationMessageOpen': open,
+          'animate-validationMessageClose': !open,
         }
       )}
       value={message}
-      tabIndex={showError ? 0 : -1}
+      tabIndex={open ? 0 : -1}
     />
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ValidationMessage-test.js
@@ -34,7 +34,7 @@ describe('ValidationMessage', () => {
     assert.equal(wrapper.find('input').props().value, 'some error');
   });
 
-  it('closes the message and calls `onClose` prop when clicked', () => {
+  it('calls `onClose` prop when clicked', () => {
     const onCloseProp = sinon.stub();
     const wrapper = renderMessage({
       onClose: onCloseProp,
@@ -43,7 +43,6 @@ describe('ValidationMessage', () => {
     });
     wrapper.find('input').simulate('click');
     assert.isTrue(onCloseProp.calledOnce);
-    assert.isTrue(wrapper.find('[data-testid="message-closed"]').exists());
   });
 
   it(


### PR DESCRIPTION
While sketching possible ways to display a comment box for grades (as part of https://github.com/hypothesis/product-backlog/issues/1472), I saw we were deriving a piece of local state from a prop in `ValidationMessage` component, which is actually unnecessary.

This PR removes that piece of state and directly uses the prop instead.

There should be no differences in behavior or UI. To ease testing it you can change this in `SubmitGradeForm`:

```diff
diff --git a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
index becb0d43..90f4827c 100644
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -120,7 +120,7 @@ export default function SubmitGradeForm({ student }: SubmitGradeFormProps) {
     setGradeSaved(false);
   };
 
-  const disabled = !student;
+  const disabled = false;
 
   return (
     <>
```

Then open any assignment and try to set invalid values on the grading input and click submit. The validation message should show.

If you click on the validation message or change the input value, the message should hide.