### PR TITLE
Add controls to handle grading comment

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -12,6 +12,7 @@ import SubmitGradeForm from './SubmitGradeForm';
 export type GradingControlsProps = {
   students: StudentInfo[];
   scoreMaximum?: number;
+  acceptGradingComments?: boolean;
 };
 
 /**
@@ -34,6 +35,7 @@ function localeSort<Item>(items: Item[], key: keyof Item): Item[] {
 export default function GradingControls({
   students: unorderedStudents,
   scoreMaximum,
+  acceptGradingComments,
 }: GradingControlsProps) {
   const {
     api: { authToken, sync: syncAPICallInfo },
@@ -134,6 +136,7 @@ export default function GradingControls({
           student={selectedStudent}
           scoreMaximum={scoreMaximum}
           onUnsavedChanges={setHasUnsavedChanges}
+          acceptGradingComments={acceptGradingComments}
         />
       </div>
     </div>

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -23,6 +23,7 @@ export default function InstructorToolbar() {
     editingEnabled,
     gradingEnabled,
     scoreMaximum,
+    acceptGradingComments,
   } = instructorToolbar;
 
   const withGradingControls = gradingEnabled && !!students;
@@ -75,6 +76,7 @@ export default function InstructorToolbar() {
         <GradingControls
           students={students}
           scoreMaximum={scoreMaximum ?? undefined}
+          acceptGradingComments={acceptGradingComments}
         />
       ) : (
         <div />

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -9,6 +9,7 @@ import {
   NoteIcon,
   NoteFilledIcon,
   PointerUpIcon,
+  Textarea,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import {
@@ -300,14 +301,9 @@ export default function SubmitGradeForm({
                     onClick={() => setShowCommentControls(false)}
                   />
                 </div>
-                <textarea
+                <Textarea
                   id={commentId}
-                  className={classnames(
-                    'focus-visible-ring ring-inset border rounded w-full p-2',
-                    'bg-grey-0 focus:bg-white disabled:bg-grey-1',
-                    'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
-                    { 'border-yellow-notice': commentHasBeenEdited }
-                  )}
+                  feedback={commentHasBeenEdited ? 'warning' : undefined}
                   rows={10}
                   value={commentValue}
                   onChange={e => {

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -110,9 +110,9 @@ export default function SubmitGradeForm({
   const [showCommentControls, setShowCommentControls] = useState(false);
   const [commentValue, setCommentValue] = useState<string>();
   const commentId = useId();
-  const commentIsSet =
-    !disabled && !!studentComments.current.get(student.userid);
+  const commentIsSet = !disabled && !!commentValue;
   const commentHasBeenEdited =
+    !gradeSaved &&
     !disabled &&
     !!grade.data &&
     grade.data.comment !== studentComments.current.get(student.userid);
@@ -153,9 +153,13 @@ export default function SubmitGradeForm({
       return;
     }
 
-    // Track initial comment for active student
     if (!studentComments.current.has(student.userid)) {
+      // Track initial comment for active student, and initialize comment to loaded grade
       studentComments.current.set(student.userid, grade.data.comment);
+      setCommentValue(grade.data.comment ?? '');
+    } else {
+      // If already tracked, initialize comment to that value
+      setCommentValue(studentComments.current.get(student.userid) ?? '');
     }
   }, [student, grade]);
 
@@ -252,21 +256,20 @@ export default function SubmitGradeForm({
 
           {acceptGradingComments && (
             <span className="relative">
-              {commentIsSet && (
-                <div className=" absolute top-[5px] right-[4px] rounded-full p-1 bg-red-error" />
-              )}
               <Button
-                // Using a regular Button instead of an IconButton for style consistency
-                // with the "Submit grade" button
                 icon={commentIsSet ? NoteFilledIcon : NoteIcon}
                 disabled={disabled}
                 title={commentIsSet ? 'Edit comment' : 'Add comment'}
                 onClick={() => setShowCommentControls(prev => !prev)}
                 classes={classnames(
-                  'border border-r-0 rounded-none ring-inset h-full',
+                  'border border-r-0 rounded-none ring-inset h-full relative',
                   'disabled:opacity-50'
                 )}
-              />
+              >
+                {commentHasBeenEdited && (
+                  <div className="absolute top-[5px] right-[4px] rounded-full p-1 bg-red-error" />
+                )}
+              </Button>
               <div
                 className={classnames(
                   'w-80 p-3 space-y-1',
@@ -306,7 +309,6 @@ export default function SubmitGradeForm({
                     { 'border-yellow-notice': commentHasBeenEdited }
                   )}
                   rows={10}
-                  defaultValue={grade.data?.comment ?? ''}
                   value={commentValue}
                   onChange={e => {
                     const newComment = (e.target as HTMLTextAreaElement).value;

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -101,7 +101,7 @@ export default function SubmitGradeForm({
   // Changes the input field's background to green for a short duration when true
   const [gradeSaved, setGradeSaved] = useState(false);
 
-  const disabled = !student || grade.isLoading;
+  const disabled = !student;
 
   // Comment-related state
   //
@@ -155,11 +155,11 @@ export default function SubmitGradeForm({
     }
 
     if (!studentComments.current.has(student.userid)) {
-      // Track initial comment for active student, and initialize comment to loaded grade
+      // Track initial comment for active student, and initialize comment with loaded value
       studentComments.current.set(student.userid, grade.data.comment);
       setCommentValue(grade.data.comment ?? '');
     } else {
-      // If already tracked, initialize comment to that value
+      // If already tracked, initialize comment with tracked one
       setCommentValue(studentComments.current.get(student.userid) ?? '');
     }
   }, [student, grade]);
@@ -189,6 +189,7 @@ export default function SubmitGradeForm({
         });
         grade.mutate({ grade: newGrade, comment: newComment });
         onUnsavedChanges?.(false);
+        setShowCommentControls(false);
         setGradeSaved(true);
       } catch (e) {
         setSubmitGradeError(e);
@@ -271,56 +272,69 @@ export default function SubmitGradeForm({
                   <div className="absolute top-[5px] right-[4px] rounded-full p-1 bg-red-error" />
                 )}
               </Button>
-              <div
-                className={classnames(
-                  'w-80 p-3 space-y-1',
-                  'shadow border rounded bg-white',
-                  'absolute top-full right-0',
-                  // Hiding via CSS instead of dynamic rendering, so that the
-                  // comment is not lost when closed.
-                  { hidden: !showCommentControls }
-                )}
-              >
-                <PointerUpIcon
+              {showCommentControls && (
+                <div
                   className={classnames(
-                    'text-grey-3 fill-white',
-                    'absolute inline z-2 w-[15px]',
-                    // Position arrow over "Add comment" button
-                    'right-[7px] top-[-9px]'
+                    'w-80 p-3',
+                    'shadow border rounded bg-white',
+                    'absolute top-[calc(100%+3px)] right-0'
                   )}
-                />
-                <div className="flex items-center">
-                  <label htmlFor={commentId} className="font-bold">
-                    Add a comment:
-                  </label>
-                  <div className="grow" />
-                  <IconButton
-                    title="Close comment"
-                    icon={CancelIcon}
-                    classes="hover:bg-grey-3/50"
-                    onClick={() => setShowCommentControls(false)}
+                >
+                  <PointerUpIcon
+                    className={classnames(
+                      'text-grey-3 fill-white',
+                      'absolute inline z-2 w-[15px]',
+                      // Position arrow over "Add comment" button
+                      'right-[7px] top-[-9px]'
+                    )}
                   />
-                </div>
-                <Textarea
-                  id={commentId}
-                  feedback={commentHasBeenEdited ? 'warning' : undefined}
-                  rows={10}
-                  value={commentValue}
-                  onChange={e => {
-                    const newComment = (e.target as HTMLTextAreaElement).value;
-                    setCommentValue(newComment);
+                  <div className="flex items-center">
+                    <label htmlFor={commentId} className="font-bold">
+                      Add a comment:
+                    </label>
+                    <div className="grow" />
+                    <IconButton
+                      title="Close comment"
+                      icon={CancelIcon}
+                      classes="hover:bg-grey-3/50"
+                      onClick={() => setShowCommentControls(false)}
+                    />
+                  </div>
+                  <Textarea
+                    id={commentId}
+                    feedback={commentHasBeenEdited ? 'warning' : undefined}
+                    classes="mt-1"
+                    rows={10}
+                    value={commentValue}
+                    onChange={e => {
+                      const newComment = (e.target as HTMLTextAreaElement)
+                        .value;
+                      setCommentValue(newComment);
 
-                    if (student) {
-                      studentComments.current.set(student.userid, newComment);
-                    }
-                  }}
-                />
-                {commentHasBeenEdited && (
-                  <p className="text-right text-yellow-notice">
-                    Some changes have not been saved
-                  </p>
-                )}
-              </div>
+                      if (student) {
+                        studentComments.current.set(student.userid, newComment);
+                      }
+                    }}
+                  />
+                  <div className="flex flex-row-reverse space-x-2 space-x-reverse mt-3">
+                    <Button
+                      variant="primary"
+                      disabled={disabled}
+                      onClick={onSubmitGrade}
+                    >
+                      {commentHasBeenEdited
+                        ? 'Update comment'
+                        : 'Save & Submit'}
+                    </Button>
+                    <Button
+                      icon={CancelIcon}
+                      onClick={() => setShowCommentControls(false)}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              )}
             </span>
           )}
 

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -1,9 +1,12 @@
 import {
   Button,
+  CancelIcon,
   CheckIcon,
+  IconButton,
   Input,
   Spinner,
   SpinnerOverlay,
+  NoteIcon,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import {
@@ -13,6 +16,7 @@ import {
   useRef,
   useCallback,
   useMemo,
+  useId,
 } from 'preact/hooks';
 
 import type { StudentInfo } from '../config';
@@ -41,6 +45,8 @@ export type SubmitGradeFormProps = {
 
   /** It lets parent components know if there are unsaved changes in the grading form */
   onUnsavedChanges?: (hasUnsavedChanges: boolean) => void;
+
+  acceptGradingComments?: boolean;
 };
 
 const DEFAULT_MAX_SCORE = 10;
@@ -53,6 +59,7 @@ export default function SubmitGradeForm({
   student,
   onUnsavedChanges,
   scoreMaximum = DEFAULT_MAX_SCORE,
+  acceptGradingComments = false,
 }: SubmitGradeFormProps) {
   const [fetchGradeErrorDismissed, setFetchGradeErrorDismissed] =
     useState(false);
@@ -83,6 +90,10 @@ export default function SubmitGradeForm({
   const [gradeSaving, setGradeSaving] = useState(false);
   // Changes the input field's background to green for a short duration when true
   const [gradeSaved, setGradeSaved] = useState(false);
+
+  // Toggles the comment textarea
+  const [showCommentControls, setShowCommentControls] = useState(false);
+  const commentTextId = useId();
 
   // The following is state for local validation errors
   //
@@ -204,6 +215,51 @@ export default function SubmitGradeForm({
               </div>
             )}
           </span>
+
+          {acceptGradingComments && (
+            <span className="relative">
+              <Button
+                icon={NoteIcon}
+                disabled={disabled}
+                title="Add comment"
+                onClick={() => setShowCommentControls(prev => !prev)}
+                classes={classnames(
+                  'border border-r-0 rounded-none ring-inset h-full',
+                  'disabled:opacity-50'
+                )}
+              />
+              <div
+                className={classnames(
+                  'w-80 p-2 space-y-1',
+                  'shadow border bg-white',
+                  'absolute top-full right-0',
+                  // Hiding via CSS instead of dynamic rendering, so that the
+                  // comment is not lost when closed.
+                  { hidden: !showCommentControls }
+                )}
+              >
+                <div className="flex items-center">
+                  <label htmlFor={commentTextId} className="font-bold">
+                    Add a comment:
+                  </label>
+                  <div className="grow" />
+                  <IconButton
+                    title="Close comment"
+                    icon={CancelIcon}
+                    onClick={() => setShowCommentControls(false)}
+                  />
+                </div>
+                <textarea
+                  id={commentTextId}
+                  className={classnames(
+                    'focus-visible-ring ring-inset border rounded w-full h-20 p-2',
+                    'bg-grey-0 focus:bg-white disabled:bg-grey-1',
+                    'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6'
+                  )}
+                />
+              </div>
+            </span>
+          )}
 
           <Button
             icon={CheckIcon}

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -8,6 +8,7 @@ import {
   SpinnerOverlay,
   NoteIcon,
   NoteFilledIcon,
+  PointerUpIcon,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import {
@@ -99,7 +100,10 @@ export default function SubmitGradeForm({
   // Changes the input field's background to green for a short duration when true
   const [gradeSaved, setGradeSaved] = useState(false);
 
+  const disabled = !student || grade.isLoading;
+
   // Comment-related state
+  //
   // Track comments set for students, to make sure unsaved changes are not lost
   // if the instructor moves to a different student
   const studentComments = useRef(new Map<string, string | null | undefined>());
@@ -107,9 +111,9 @@ export default function SubmitGradeForm({
   const [commentValue, setCommentValue] = useState<string>();
   const commentId = useId();
   const commentIsSet =
-    !!student && !!studentComments.current.get(student.userid);
+    !disabled && !!studentComments.current.get(student.userid);
   const commentHasBeenEdited =
-    !!student &&
+    !disabled &&
     !!grade.data &&
     grade.data.comment !== studentComments.current.get(student.userid);
 
@@ -203,8 +207,6 @@ export default function SubmitGradeForm({
     [grade.data, onUnsavedChanges]
   );
 
-  const disabled = !student || grade.isLoading;
-
   return (
     <>
       <form autoComplete="off">
@@ -250,7 +252,12 @@ export default function SubmitGradeForm({
 
           {acceptGradingComments && (
             <span className="relative">
+              {commentIsSet && (
+                <div className=" absolute top-[5px] right-[4px] rounded-full p-1 bg-red-error" />
+              )}
               <Button
+                // Using a regular Button instead of an IconButton for style consistency
+                // with the "Submit grade" button
                 icon={commentIsSet ? NoteFilledIcon : NoteIcon}
                 disabled={disabled}
                 title={commentIsSet ? 'Edit comment' : 'Add comment'}
@@ -262,14 +269,22 @@ export default function SubmitGradeForm({
               />
               <div
                 className={classnames(
-                  'w-80 p-2 space-y-1',
-                  'shadow border bg-white',
+                  'w-80 p-3 space-y-1',
+                  'shadow border rounded bg-white',
                   'absolute top-full right-0',
                   // Hiding via CSS instead of dynamic rendering, so that the
                   // comment is not lost when closed.
                   { hidden: !showCommentControls }
                 )}
               >
+                <PointerUpIcon
+                  className={classnames(
+                    'text-grey-3 fill-white',
+                    'absolute inline z-2 w-[15px]',
+                    // Position arrow over "Add comment" button
+                    'right-[7px] top-[-9px]'
+                  )}
+                />
                 <div className="flex items-center">
                   <label htmlFor={commentId} className="font-bold">
                     Add a comment:
@@ -278,17 +293,19 @@ export default function SubmitGradeForm({
                   <IconButton
                     title="Close comment"
                     icon={CancelIcon}
+                    classes="hover:bg-grey-3/50"
                     onClick={() => setShowCommentControls(false)}
                   />
                 </div>
                 <textarea
                   id={commentId}
                   className={classnames(
-                    'focus-visible-ring ring-inset border rounded w-full h-20 p-2',
+                    'focus-visible-ring ring-inset border rounded w-full p-2',
                     'bg-grey-0 focus:bg-white disabled:bg-grey-1',
                     'placeholder:text-color-grey-5 disabled:placeholder:color-grey-6',
                     { 'border-yellow-notice': commentHasBeenEdited }
                   )}
+                  rows={10}
                   defaultValue={grade.data?.comment ?? ''}
                   value={commentValue}
                   onChange={e => {

--- a/lms/static/scripts/frontend_apps/services/grading.ts
+++ b/lms/static/scripts/frontend_apps/services/grading.ts
@@ -16,6 +16,7 @@ export type Student = {
  */
 export type FetchGradeResult = {
   currentScore?: number | null;
+  comment?: string | null;
 };
 
 /**
@@ -31,7 +32,15 @@ export class GradingService {
   /**
    * Submits a student's grade to the LTI endpoint.
    */
-  submitGrade({ student, grade }: { student: Student; grade: number }) {
+  submitGrade({
+    student,
+    grade,
+    comment,
+  }: {
+    student: Student;
+    grade: number;
+    comment?: string;
+  }) {
     return apiCall<void>({
       authToken: this._authToken,
       path: '/api/lti/result',
@@ -40,6 +49,7 @@ export class GradingService {
         lis_outcome_service_url: student.LISOutcomeServiceUrl,
         student_user_id: student.lmsId,
         score: grade,
+        comment,
       },
     });
   }


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/5635
> Part of https://github.com/hypothesis/product-backlog/issues/1472

Allow instructors to configure a grading comment.

[Grabación de pantalla desde 2023-09-04 09-35-43.webm](https://github.com/hypothesis/lms/assets/2719332/ad9a1ff3-b4f1-4010-9dab-d11672f85c9c)

### Testing steps

1. If https://github.com/hypothesis/lms/pull/5649 is merged, make sure you enable the feature flag as described there
2. Open https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3349/View
3. The grading bar should show a new button next to the grade, which toggles a dropdown with a textarea that can be used to define a grading comment.
4. When you select a student, the icon will changed to a "filled" state if the comment is not empty. The comment should be prefilled if there was one for this student.
5. Saving the grading will also save the comment for this student.

### TODO

- [x] Sketch UI for comment field. Options:
  - IconButton that opens a "dropdown".
  - ~IconButton that opens a modal.~
- [x] Display visual indicator that a comment has been set while the "dropdown" is collapsed.
- [x] Pass `acceptGradingComments` from instructor toolbar config.
- [x] Set initial comment if available.
- [x] Submit comment when saving grades.
- [x] ~Make sure the user can't lose comments by clicking prev/next without submitting changes~ We finally addressed this differently.
- [x] Take feature flag introduced by https://github.com/hypothesis/lms/pull/5649 into consideration
- [ ] Add tests
- [x] Apply design improvements from https://github.com/hypothesis/product-backlog/issues/1472#issuecomment-1700461814
- [x] Close comment dropdown after successfully submitting grade
- [x] Label popover main button as "Submit grade", as it effectively does the same as the other "Submit grade" button.
- [x] Stop tracking unsaved comments. https://github.com/hypothesis/lms/issues/5673 supersedes it.

### Considerations

* The UI is not perfect. A dropdown makes it a bit more difficult to interact with the comment, but the available space does not give too many other options without a big change in the overall UI.
* I chose the icon from the ones we have available (see https://patterns.hypothes.is/data-icons). I was looking for something closer to the one called `AnnotateIcon`, but that's what we use for annotations, so it would be confusing.
* We may need to reword some messages (tooltips, warning messages, etc).