### PR TITLE
Pass grading comments along to the LTIA grading API

### DIFF
--- a/lms/services/lti_grading/_v11.py
+++ b/lms/services/lti_grading/_v11.py
@@ -40,7 +40,7 @@ class LTI11GradingService(LTIGradingService):
         except (TypeError, KeyError, ValueError):
             return None
 
-    def record_result(self, grading_id, score=None, pre_record_hook=None):
+    def record_result(self, grading_id, score=None, pre_record_hook=None, comment=None):
         request = {"resultRecord": {"sourcedGUID": {"sourcedId": grading_id}}}
 
         if score is not None:

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -54,7 +54,7 @@ class LTI13GradingService(LTIGradingService):
     def get_score_maximum(self, resource_link_id) -> Optional[float]:
         return self._read_grading_configuration(resource_link_id).get("scoreMaximum")
 
-    def record_result(self, grading_id, score=None, pre_record_hook=None):
+    def record_result(self, grading_id, score=None, pre_record_hook=None, comment=None):
         payload = {
             "scoreMaximum": 1,
             "scoreGiven": score,
@@ -63,6 +63,9 @@ class LTI13GradingService(LTIGradingService):
             "activityProgress": "Completed",
             "gradingProgress": "FullyGraded",
         }
+        if comment:
+            payload["comment"] = comment
+
         if pre_record_hook:
             payload = pre_record_hook(score=score, request_body=payload)
 

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -56,7 +56,7 @@ class LTIGradingService:  # pragma: no cover
         """
         raise NotImplementedError()
 
-    def record_result(self, grading_id, score=None, pre_record_hook=None):
+    def record_result(self, grading_id, score=None, pre_record_hook=None, comment=None):
         """
         Set the score or content URL for a student submission to an assignment.
 
@@ -70,6 +70,7 @@ class LTIGradingService:  # pragma: no cover
             Defined as required by the LTI spec but is optional in Canvas if
             an `lti_launch_url` is set.
         :param pre_record_hook: Hook to allow modification of the request
+        :param comment: Comment to associate with the grade as feedback for the student
 
         :raise TypeError: if the given pre_record_hook returns a non-dict
         """

--- a/lms/validation/_api.py
+++ b/lms/validation/_api.py
@@ -83,3 +83,6 @@ class APIRecordResultSchema(JSONPyramidRequestSchema):
 
     student_user_id = fields.Str(required=True)
     """The LTIUser.user_id of the student being graded."""
+
+    comment = fields.Str(required=False, allow_none=True)
+    """Optional comment for the grade."""

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -39,7 +39,9 @@ class GradingViews:
         score = round(self.parsed_params["score"], 4)
 
         self.lti_grading_service.record_result(
-            self.parsed_params["lis_result_sourcedid"], score
+            self.parsed_params["lis_result_sourcedid"],
+            score,
+            comment=self.parsed_params.get("comment"),
         )
         self.request.registry.notify(
             LTIEvent(

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -186,14 +186,17 @@ class TestRecordResult:
             (0.000000000000001, 0),
         ],
     )
+    @pytest.mark.parametrize("comment", [None, sentinel.comment])
     def test_it_records_result(
-        self, pyramid_request, lti_grading_service, score, expected, LTIEvent
+        self, pyramid_request, lti_grading_service, score, expected, LTIEvent, comment
     ):
         pyramid_request.parsed_params["score"] = score
+        if comment:
+            pyramid_request.parsed_params["comment"] = comment
         GradingViews(pyramid_request).record_result()
 
         lti_grading_service.record_result.assert_called_once_with(
-            "modelstudent-assignment1", score=expected
+            "modelstudent-assignment1", score=expected, comment=comment
         )
         LTIEvent.assert_called_once_with(
             request=pyramid_request,


### PR DESCRIPTION
### Testing

- Launch [Gradable assignment (5 points)](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View)
- Send a grade, it should work as before

- Make a change similar to:

```diff
diff --git a/lms/views/api/grading.py b/lms/views/api/grading.py
index 7a43bf6d6..fef22e72b 100644
--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -41,7 +41,7 @@ class GradingViews:
         self.lti_grading_service.record_result(
             self.parsed_params["lis_result_sourcedid"],
             score,
-            comment=self.parsed_params["comment"],
+            comment=self.parsed_params.get("comment", "Very original comment"),
         )
         self.request.registry.notify(
             LTIEvent(
```


- Send a grade again [Gradable assignment (5 points)](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View)

- Check the comment is present on https://aunltd.brightspacedemo.com/d2l/lms/grades/admin/enter/grade_user_edit.d2l?ou=6782&d2l_iterId=645&d2l_itemId=355 (Ctrl+F for "5 points")


