### PR TITLE
Fix usage of `find_group_set` to the new style of Result

### DIFF
--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -102,11 +102,11 @@ class CourseCopyGroupsHelper:
         # We might have a record of this because we just called `grouping_plugin.get_group_sets` as the current user
         # or another user might have done it before for us.
         if new_group_set := self._course_service.find_group_set(
-            name=group_set["name"], context_id=course.lms_id
+            name=group_set.name, context_id=course.lms_id
         ):
             # We found a match, store it to save the search for next time
-            course.set_mapped_group_set_id(group_set_id, new_group_set["id"])
-            return new_group_set["id"]
+            course.set_mapped_group_set_id(group_set_id, new_group_set.id)
+            return new_group_set.id
 
         # No match
         return None

--- a/tests/unit/lms/product/plugin/course_copy_test.py
+++ b/tests/unit/lms/product/plugin/course_copy_test.py
@@ -136,13 +136,13 @@ class TestCourseCopyGroupsHelper:
             group_set_id=sentinel.group_set_id
         )
         course_service.find_group_set.assert_called_with(
-            name=course_service.find_group_set.return_value["name"],
+            name=course_service.find_group_set.return_value.name,
             context_id=course.lms_id,
         )
         course.set_mapped_group_set_id(
-            sentinel.group_set_id, course_service.find_group_set.return_value["id"]
+            sentinel.group_set_id, course_service.find_group_set.return_value.id
         )
-        assert new_group_set_id == course_service.find_group_set.return_value["id"]
+        assert new_group_set_id == course_service.find_group_set.return_value.id
 
     def test_find_matching_file_raises_OAuth2TokenError(self, helper, grouping_plugin):
         grouping_plugin.get_group_sets.side_effect = OAuth2TokenError
@@ -184,7 +184,7 @@ class TestCourseCopyGroupsHelper:
             group_set_id=sentinel.group_set_id
         )
         course_service.find_group_set.assert_called_with(
-            name=course_service.find_group_set.return_value["name"],
+            name=course_service.find_group_set.return_value.name,
             context_id=course.lms_id,
         )
         assert not new_group_set_id


### PR DESCRIPTION
Fixes: https://github.com/hypothesis/lms/issues/5645


See: https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#result-rows-act-like-named-tuples


This was not properly handled in the SQLA alchemy update.


### Testing

This affects course copy

### In `main`

- Configure [localhost scratch Assignment (LTI 1.3)](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2431/View) 

select any content and pick group sets until the list of group sets are listed. This will store them in the DB.

With this we get the original course group sets in the local DB.

- Launch a groups assignment over the copied course [LTI1.3: Group assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6898/viewContent/2785/View?ou=6898).

It will fail with `web-https (stderr)   | TypeError: tuple indices must be integers or slices, not str`


### In this branch

- Launch a groups assignment over the copied course [LTI1.3: Group assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6898/viewContent/2785/View?ou=6898)


It will fail again, this time with a modal for `Assignment's group category is empty` as the copied course doesn't have any students in it in the copied course.
