### PR TITLE
New canvas setting to manage sections membership

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -21,6 +21,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("canvas", "groups_enabled", asbool),
         JSONSetting("canvas", "files_enabled", asbool),
         JSONSetting("canvas", "folders_enabled", asbool),
+        JSONSetting("canvas", "strict_section_membership", asbool),
         JSONSetting("desire2learn", "client_id"),
         JSONSetting("desire2learn", "client_secret", JSONSetting.AES_SECRET),
         JSONSetting("desire2learn", "groups_enabled", asbool),

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -117,6 +117,7 @@
         {{ settings_checkbox("Folders enabled", "canvas", "folders_enabled", default=False) }}
         {{ settings_checkbox("Groups enabled", "canvas", "groups_enabled") }}
         {{ settings_checkbox("Sections enabled", "canvas", "sections_enabled") }}
+        {{ settings_checkbox("Sections strict membership", "canvas", "strict_section_membership", default=False) }}
     </fieldset>
 
     <fieldset class="box">

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -30,6 +30,18 @@ class TestCanvasGroupingPlugin:
         )
         assert api_groups == canvas_api_client.course_sections.return_value
 
+    def test_get_sections_for_instructor_with_strict_membership(
+        self, canvas_api_client, course, grouping_service, plugin
+    ):
+        plugin._strict_section_membership = True  # pylint:disable=protected-access
+
+        api_groups = plugin.get_sections_for_instructor(grouping_service, course)
+
+        canvas_api_client.authenticated_users_sections.assert_called_once_with(
+            sentinel.canvas_course_id
+        )
+        assert api_groups == canvas_api_client.authenticated_users_sections.return_value
+
     def test_get_sections_for_grading(
         self, canvas_api_client, course, grouping_service, plugin
     ):
@@ -198,4 +210,4 @@ class TestCanvasGroupingPlugin:
 
     @pytest.fixture
     def plugin(self, canvas_api_client):
-        return CanvasGroupingPlugin(canvas_api_client)
+        return CanvasGroupingPlugin(canvas_api_client, strict_section_membership=False)


### PR DESCRIPTION
For:

- https://github.com/hypothesis/support/issues/60
- https://github.com/hypothesis/private-issues/issues/65


With the new `strict_section_membership` mode we'll only display the section/s the instructor belongs to. With the setting off we'll list all sections available in the course.

The learner operation remains the same, it only list the sections the learner belongs to in all cases.


## Testing

- Log in canvas as `eng+canvasteacher@hypothes.is`

- Test the existing behavior, launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873)


You'll get a drop down with three sections

- Enable the new setting on http://localhost:8001/admin/instance/8/

- Launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873) again

You'll only see one section one, the one the teacher belongs to