### PR TITLE
Add a new AI setting to control the use of the LMS grading scale

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -44,6 +44,7 @@ class ApplicationSettings(JSONSettings):
             name="Auto Assigned To Organisation",
         ),
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
+        JSONSetting("hypothesis", "lms_grading_scale", asbool),
     )
 
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -98,6 +98,7 @@
     <fieldset class="box">
         <legend class="label has-text-centered">General settings</legend>
         {{ settings_checkbox("Enable instructor email digests", "hypothesis", "instructor_email_digests_enabled") }}
+        {{ settings_checkbox("LMS grading scale", "hypothesis", "lms_grading_scale", default=False) }}
     </fieldset>
 
     <fieldset class="box">

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -193,7 +193,12 @@ class BasicLaunchViews:
 
                 # Display the grading interface in the toolbar
                 self.context.js_config.enable_toolbar_grading(
-                    students=students, score_maximum=score_maximum
+                    students=students,
+                    score_maximum=score_maximum
+                    if self.request.lti_user.application_instance.settings.get(
+                        "hypothesis", "lms_grading_scale", False
+                    )
+                    else None,
                 )
 
             if not self.request.lti_user.is_instructor:

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -238,6 +238,7 @@ class TestBasicLaunchViews:
     @pytest.mark.parametrize("use_toolbar_grading", [True, False])
     @pytest.mark.parametrize("is_gradable", [True, False])
     @pytest.mark.parametrize("is_instructor", [True, False])
+    @pytest.mark.parametrize("lms_grading_scale", [True, False])
     def test__show_document_configures_toolbar(
         self,
         svc,
@@ -251,7 +252,11 @@ class TestBasicLaunchViews:
         is_instructor,
         grading_info_service,
         lti_grading_service,
+        lms_grading_scale,
     ):
+        pyramid_request.lti_user.application_instance.settings.set(
+            "hypothesis", "lms_grading_scale", lms_grading_scale
+        )
         assignment = factories.Assignment(is_gradable=is_gradable)
         if is_instructor:
             request.getfixturevalue("user_is_instructor")
@@ -282,7 +287,9 @@ class TestBasicLaunchViews:
 
                 context.js_config.enable_toolbar_grading.assert_called_once_with(
                     students=grading_info_service.get_students_for_grading.return_value,
-                    score_maximum=lti_grading_service.get_score_maximum.return_value,
+                    score_maximum=lti_grading_service.get_score_maximum.return_value
+                    if lms_grading_scale
+                    else None,
                 )
             else:
                 grading_info_service.upsert_from_request.assert_called_once_with(


### PR DESCRIPTION
## Testing

- Switch to `dynamic-max-score` and follow the instructions there
- Switch to this branch `score-max-flag` and rebase `dynamic-max-score`

Check that these are back to a scale of 10:
https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View
https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3349/View


- Enable the new setting

http://localhost:8001/admin/instance/106/ (hypothesis section, LMS grading scale)

These are back to the 5 and 100 scales:

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View
https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3349/View
