### PR TITLE
Add DocumentService to handle the parsing of our URI schemas

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -3,6 +3,7 @@ from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.canvas import CanvasService
 from lms.services.d2l_api.client import D2LAPIClient
 from lms.services.digest import DigestService
+from lms.services.document import DocumentService
 from lms.services.email_unsubscribe import EmailUnsubscribeService
 from lms.services.event import EventService
 from lms.services.exceptions import (
@@ -128,6 +129,9 @@ def includeme(config):
     )
     config.register_service_factory(
         "lms.services.youtube.factory", iface=YouTubeService
+    )
+    config.register_service_factory(
+        "lms.services.document.factory", iface=DocumentService
     )
 
     # Plugins are not the same as top level services but we want to register them as pyramid services too

--- a/lms/services/document.py
+++ b/lms/services/document.py
@@ -1,0 +1,39 @@
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+DOCUMENT_URL_REGEXES = {
+    # canvas://file/course/COURSE_ID/file_id/FILE_ID
+    "canvas": re.compile(
+        r"canvas:\/\/file\/course\/(?P<course_id>[^\/]*)\/file_id\/(?P<file_id>[^\/]*)"
+    ),
+    # blackboard://content-resource/<file_id>/ URLs
+    "blackboard": re.compile(r"blackboard:\/\/content-resource\/(?P<file_id>[^\/]*)\/"),
+    # d2l://file/course/COURSE_ID/file_id/FILE_ID.
+    "d2l": re.compile(
+        r"d2l:\/\/file\/course\/(?P<course_id>[^\/]*)\/file_id\/(?P<file_id>[^\/]*)\/"
+    ),
+}
+
+
+@dataclass
+class DocumentURLParts:
+    file_id: str
+    course_id: Optional[str] = None
+
+
+class DocumentService:
+    def get_document_url_parts(self, url: str) -> Optional[DocumentURLParts]:
+        """Return the parts of a given document_url."""
+        for regexp in DOCUMENT_URL_REGEXES.values():
+            if match := regexp.search(url):
+                match_dict = match.groupdict()
+                return DocumentURLParts(
+                    course_id=match_dict.get("course_id"), file_id=match_dict["file_id"]
+                )
+
+        return None
+
+
+def factory(_context, _request) -> DocumentService:
+    return DocumentService()

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -30,6 +30,7 @@ class FilesAPIViews:
 
         :raise lms.services.CanvasAPIError: if the Canvas API request fails.
             This exception is caught and handled by an exception view.
+        :raise ValueError: if we fail to parse the file's URL.
         """
         application_instance = self.request.lti_user.application_instance
         assignment = self.request.find_service(name="assignment").get_assignment(
@@ -40,6 +41,9 @@ class FilesAPIViews:
         document_url_parts = self.request.find_service(
             DocumentService
         ).get_document_url_parts(assignment.document_url)
+        if not document_url_parts:
+            raise ValueError("Invalid URL for Canvas file")
+
         public_url = self.canvas.public_url_for_file(
             assignment,
             document_url_parts.file_id,

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -1,15 +1,10 @@
-import re
-
 from pyramid.view import view_config
 
 from lms.security import Permissions
 from lms.services.d2l_api import D2LAPIClient
+from lms.services.document import DocumentService
 from lms.services.exceptions import FileNotFoundInCourse
 from lms.views import helpers
-
-DOCUMENT_URL_REGEX = re.compile(
-    r"d2l:\/\/file\/course\/(?P<course_id>[^\/]*)\/file_id\/(?P<file_id>[^\/]*)\/"
-)
 
 
 @view_config(
@@ -41,7 +36,9 @@ def via_url(_context, request):
     )
 
     file_id = course.get_mapped_file_id(
-        DOCUMENT_URL_REGEX.search(document_url)["file_id"]
+        request.find_service(DocumentService)
+        .get_document_url_parts(document_url)
+        .file_id
     )
     try:
         if request.lti_user.is_instructor:

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -35,11 +35,13 @@ def via_url(_context, request):
         course_id, raise_on_missing=True
     )
 
-    file_id = course.get_mapped_file_id(
-        request.find_service(DocumentService)
-        .get_document_url_parts(document_url)
-        .file_id
+    document_url_parts = request.find_service(DocumentService).get_document_url_parts(
+        document_url
     )
+    if not document_url_parts:
+        raise ValueError("Invalid URL for D2L file")
+
+    file_id = course.get_mapped_file_id(document_url_parts.file_id)
     try:
         if request.lti_user.is_instructor:
             if not course_copy_plugin.is_file_in_course(course_id, file_id):

--- a/tests/unit/lms/services/document_test.py
+++ b/tests/unit/lms/services/document_test.py
@@ -1,0 +1,41 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.document import DocumentService, factory
+
+
+class TestDocumentService:
+    @pytest.mark.parametrize(
+        "url,course_id,file_id",
+        [
+            ("canvas://file/course/COURSE_ID/file_id/FILE_ID", "COURSE_ID", "FILE_ID"),
+            ("d2l://file/course/COURSE_ID/file_id/FILE_ID/", "COURSE_ID", "FILE_ID"),
+            ("blackboard://content-resource/FILE_ID/", None, "FILE_ID"),
+            ("unknown://NO_COURSE/NO_FILE/", None, None),
+        ],
+    )
+    def test_get_document_url_parts(self, svc, url, course_id, file_id):
+        parts = svc.get_document_url_parts(url)
+
+        if file_id:
+            assert parts.course_id == course_id
+            assert parts.file_id == file_id
+        else:
+            assert not parts
+
+    @pytest.fixture
+    def svc(self):
+        return DocumentService()
+
+
+class TestServiceFactory:
+    def test_it(self, pyramid_request, DocumentService):
+        svc = factory(sentinel.context, pyramid_request)
+
+        DocumentService.assert_called_once()
+        assert svc == DocumentService.return_value
+
+    @pytest.fixture
+    def DocumentService(self, patch):
+        return patch("lms.services.document.DocumentService")

--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -136,6 +136,17 @@ class TestViaURL:
         )
         assert response == {"via_url": helpers.via_url.return_value}
 
+    @pytest.mark.usefixtures("blackboard_api_client", "course_service")
+    def test_via_url_with_wrong_url(
+        self,
+        view,
+        document_service,
+    ):
+        document_service.get_document_url_parts.return_value = None
+
+        with pytest.raises(ValueError):
+            view()
+
     @pytest.mark.usefixtures("user_is_instructor", "document_service")
     def test_it_when_file_not_in_course_fixed_by_course_copy(
         self,

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from lms.services.document import DocumentURLParts
 from lms.views.api.canvas.files import FilesAPIViews
 
 
@@ -23,6 +24,7 @@ class TestFilesAPIViews:
         assignment_service,
         canvas_service,
         helpers,
+        document_service,
     ):
         document_url = "canvas://file/course/COURSE_ID/file_id/FILE_ID"
         assignment = assignment_service.get_assignment.return_value
@@ -32,6 +34,7 @@ class TestFilesAPIViews:
         }
         result = FilesAPIViews(pyramid_request).via_url()
 
+        document_service.get_document_url_parts.assert_called_once_with(document_url)
         assignment_service.get_assignment.assert_called_once_with(
             application_instance.tool_consumer_instance_guid,
             "test_resource_link_id",
@@ -48,6 +51,13 @@ class TestFilesAPIViews:
             content_type="pdf",
         )
         assert result == {"via_url": helpers.via_url.return_value}
+
+    @pytest.fixture
+    def document_service(self, document_service):
+        document_service.get_document_url_parts.return_value = DocumentURLParts(
+            file_id="FILE_ID", course_id="COURSE_ID"
+        )
+        return document_service
 
     @pytest.fixture(params=("instructor", "learner"))
     def with_teacher_or_student(self, request, pyramid_request):

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -52,6 +52,16 @@ class TestFilesAPIViews:
         )
         assert result == {"via_url": helpers.via_url.return_value}
 
+    @pytest.mark.usefixtures("with_teacher_or_student")
+    def test_via_url_with_wrong_url(self, pyramid_request, document_service):
+        document_service.get_document_url_parts.return_value = None
+        pyramid_request.matchdict = {
+            "resource_link_id": "test_resource_link_id",
+        }
+
+        with pytest.raises(ValueError):
+            FilesAPIViews(pyramid_request).via_url()
+
     @pytest.fixture
     def document_service(self, document_service):
         document_service.get_document_url_parts.return_value = DocumentURLParts(

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -61,6 +61,14 @@ def test_via_url(
     assert response == {"via_url": helpers.via_url.return_value}
 
 
+@pytest.mark.usefixtures("course_copy_plugin", "d2l_api_client", "course_service")
+def test_via_url_with_wrong_url(document_service, pyramid_request):
+    document_service.get_document_url_parts.return_value = None
+
+    with pytest.raises(ValueError):
+        via_url(sentinel.context, pyramid_request)
+
+
 @pytest.mark.usefixtures("user_is_instructor", "document_service")
 def test_it_when_file_not_in_course_fixed_by_course_copy(
     d2l_api_client,

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -19,6 +19,7 @@ from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
 from lms.services.d2l_api import D2LAPIClient
 from lms.services.digest import DigestService
+from lms.services.document import DocumentService
 from lms.services.email_unsubscribe import EmailUnsubscribeService
 from lms.services.event import EventService
 from lms.services.file import FileService
@@ -61,6 +62,7 @@ __all__ = (
     "course_service",
     "d2l_api_client",
     "digest_service",
+    "document_service",
     "event_service",
     "file_service",
     "grading_info_service",
@@ -360,3 +362,8 @@ def grouping_plugin(mock_service):
 @pytest.fixture
 def misc_plugin(mock_service):
     return mock_service(MiscPlugin)
+
+
+@pytest.fixture
+def document_service(mock_service):
+    return mock_service(DocumentService)


### PR DESCRIPTION
Centralizing these will allow to more easily add functions to go from `document_url` to File.


## Testing 

Needs: https://github.com/hypothesis/devdata/pull/98 merged 

Launch the following "file" assignments in different LMSes:

- https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2374/View
- https://hypothesis.instructure.com/courses/125/assignments/875
- https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_39_1&course_id=_19_1
