### PR TITLE
Fix bug around canvas submissions after grading API changes

### DIFF
--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -103,7 +103,7 @@ class GradingViews:
         lis_result_sourcedid = self.parsed_params["lis_result_sourcedid"]
 
         # If we already have a score, then we've already recorded this info
-        if self.lti_grading_service.read_result(lis_result_sourcedid):
+        if self.lti_grading_service.read_result(lis_result_sourcedid).score:
             LOG.debug(
                 "Grade already present, not recording submission. User ID: %s",
                 self.request.user.id,

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -24,7 +24,9 @@ class TestRecordCanvasSpeedgraderSubmission:
     def test_it_does_not_record_result_if_score_already_exists(
         self, pyramid_request, lti_grading_service
     ):
-        lti_grading_service.read_result.return_value = 0.5
+        lti_grading_service.read_result.return_value = GradingResult(
+            score=0.5, comment=None
+        )
 
         GradingViews(pyramid_request).record_canvas_speedgrader_submission()
 
@@ -33,7 +35,9 @@ class TestRecordCanvasSpeedgraderSubmission:
     def test_it_passes_the_callback_if_there_is_no_score(
         self, pyramid_request, lti_grading_service, LTIEvent
     ):
-        lti_grading_service.read_result.return_value = None
+        lti_grading_service.read_result.return_value = GradingResult(
+            score=None, comment=None
+        )
 
         GradingViews(pyramid_request).record_canvas_speedgrader_submission()
 


### PR DESCRIPTION
The new version of read_result always returns a value even if the score is None.

Take this into account and check the score property of the new structure.


## Testing 

- In `main` open https://hypothesis.instructure.com/courses/125/assignments/5335 as `eng+canvasstudent@hypothes.is`, make an annotation. You'll see in the logs a message like: `Grade already present, not recording submission. User ID: 11`

- Switch to this branch `submission-bugfix`, reload the assignment https://hypothesis.instructure.com/courses/125/assignments/5335, make another annotation

- Nothing will show in the logs and a new submission event will be created:

```docker compose exec postgres psql -U postgres -c "select timestamp, type from event join event_type on event.type_id = event_type.id order by event.id desc;"```
