### PR TITLE
Warn instructors about unsaved student grades when unloading page

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/use-warn-on-page-unload-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/use-warn-on-page-unload-test.js
@@ -1,0 +1,60 @@
+import { mount } from 'enzyme';
+import { useState } from 'preact/hooks';
+
+import { useWarnOnPageUnload } from '../use-warn-on-page-unload';
+
+describe('useWarnOnPageUnload', () => {
+  let fakeWindow;
+  const FakeComponent = () => {
+    const [isUnsaved, setUnsaved] = useState(true);
+
+    useWarnOnPageUnload(isUnsaved, fakeWindow);
+
+    return (
+      <button type="button" onClick={() => setUnsaved(false)}>
+        Set not unsaved
+      </button>
+    );
+  };
+  const createComponent = () => mount(<FakeComponent />);
+
+  beforeEach(() => {
+    fakeWindow = new EventTarget();
+    sinon.spy(fakeWindow, 'addEventListener');
+    sinon.spy(fakeWindow, 'removeEventListener');
+  });
+
+  it('registers event listener when unsaved data is true', () => {
+    createComponent();
+
+    assert.called(fakeWindow.addEventListener);
+    assert.notCalled(fakeWindow.removeEventListener);
+  });
+
+  it('unregisters event listener when unsaved data is false', () => {
+    const wrapper = createComponent();
+
+    wrapper.find('button').simulate('click');
+    wrapper.update();
+
+    assert.called(fakeWindow.removeEventListener);
+  });
+
+  it('unregisters event listener when component is unmounted', () => {
+    const wrapper = createComponent();
+    wrapper.unmount();
+
+    assert.called(fakeWindow.removeEventListener);
+  });
+
+  it('acts on provided event when listener is invoked', () => {
+    createComponent();
+
+    const event = new Event('beforeunload');
+    sinon.stub(event, 'preventDefault');
+
+    fakeWindow.dispatchEvent(event);
+
+    assert.called(event.preventDefault);
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/use-warn-on-page-unload.ts
+++ b/lms/static/scripts/frontend_apps/utils/use-warn-on-page-unload.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'preact/hooks';
+
+const noop = () => {};
+
+/**
+ * Registers an event listener to window's 'beforeunload' if `hasUnsavedData` is true.
+ * It also unregisters the event if `hasUnsavedData` is false or the component is unmounted.
+ *
+ * This event listener makes the browser warn the user about potential unsaved changes,
+ * and gives the user the opportunity to cancel the page unload if desired.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
+ */
+export function useWarnOnPageUnload(hasUnsavedData: boolean, window_ = window) {
+  useEffect(() => {
+    if (!hasUnsavedData) {
+      return noop;
+    }
+
+    const listener = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    window_.addEventListener('beforeunload', listener);
+
+    return () => window_.removeEventListener('beforeunload', listener);
+  }, [hasUnsavedData, window_]);
+}


### PR DESCRIPTION
> Closes #5672 

This PR adds a listener on window's `beforeunload`, so that we can warn instructors that accidentally try to leave the page with unsaved changes.

With this, if an instructor changed the student's grade and forgot to submit it, the browser will display a warning just before reloading the page or trying to navigate somewhere else, allowing the instructor to cancel it if it was a mistake.

### Considerations

Unfortunately, modern browsers do not allow for the warning confirm message to be customized, so we have to stick with default implementation.

See https://stackoverflow.com/a/38880926

### Todo

- [x] Tests

### Testing steps

1. Open an assignment, for example https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3349/View
2. Click anywhere that would take you away (like a menu link). You should be redirected to the new page.
3. Go back, and load one student, then do step 2 again. You should also be redirected to the new page.
4. Repeat step 3, but now change the grade and submit it. Then repeat step 2 and you should see the same result.
5. Repeat the process again, but this time do not submit the new grade. Now, trying to navigate somewhere else will result in a native browser warning.