### PR TITLE
Add `mutate` API to `useFetch` result

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/fetch.ts
+++ b/lms/static/scripts/frontend_apps/utils/fetch.ts
@@ -64,7 +64,11 @@ export function useFetch<T = unknown>(
 
   useEffect(() => {
     const controller = new AbortController();
-    const mutate = (newValue: T) => setResult(r => ({ ...r, data: newValue }));
+    const mutate = (newValue: T) => {
+      // Prevent in-flight fetch from overwriting this value.
+      controller.abort();
+      setResult(r => ({ ...r, error: null, isLoading: false, data: newValue }));
+    };
     setResult({
       data: null,
       error: null,

--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -153,6 +153,13 @@ describe('useFetch', () => {
 
       assert.equal(getResultText(wrapper), 'Data: Saved');
     });
+
+    it('takes precedence over in-flight fetch', async () => {
+      const wrapper = renderWidget('some-key', async () => 'Some data');
+      wrapper.find('[data-testid="save"]').simulate('click');
+      await waitForFetch(wrapper);
+      assert.equal(getResultText(wrapper), 'Data: Saved');
+    });
   });
 
   describe('`retry` callback', () => {

--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -25,6 +25,9 @@ describe('useFetch', () => {
         <button data-testid="retry" onClick={thing.retry}>
           Retry
         </button>
+        <button data-testid="save" onClick={() => thing.mutate('Saved')}>
+          Save
+        </button>
       </>
     );
   }
@@ -138,6 +141,18 @@ describe('useFetch', () => {
     assert.throws(() => {
       renderWidget('some-key');
     }, 'Fetch key provided but no fetcher set');
+  });
+
+  describe('`mutate` callback', () => {
+    it('replaces fetched value with locally set value', async () => {
+      const wrapper = renderWidget('some-key', async () => 'Some data');
+      await waitForFetch(wrapper);
+      assert.equal(getResultText(wrapper), 'Data: Some data');
+
+      wrapper.find('[data-testid="save"]').simulate('click');
+
+      assert.equal(getResultText(wrapper), 'Data: Saved');
+    });
   });
 
   describe('`retry` callback', () => {


### PR DESCRIPTION
This is useful to replace the `useFetch` result, eg. following a local API call that updates it on the backend, without the delay that actually re-fetching the value would incur.

As with the `useFetch` API in general, this roughly follows the API of SWR (https://swr.vercel.app/docs/mutation).

Example of how this API could be used in `SubmitGradeForm` for example:

```diff
diff --git a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
index 6b31c606..3081e40b 100644
--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -61,6 +61,8 @@ export default function SubmitGradeForm({
     student ? () => fetchGrade(student) : undefined
   );
 
+  console.log('Stored grade', grade); // To demonstrate grade result was saved
+
   // The following is state for saving the grade
   //
   // If there is an error when submitting a grade?
@@ -96,7 +98,9 @@ export default function SubmitGradeForm({
 
   const onSubmitGrade = async (event: Event) => {
     event.preventDefault();
-    const result = validateGrade(inputRef.current!.value, scoreMaximum);
+
+    const newGrade = inputRef.current!.value;
+    const result = validateGrade(newGrade, scoreMaximum);
 
     if (!result.valid) {
       setValidationMessageMessage(result.error);
@@ -108,6 +112,7 @@ export default function SubmitGradeForm({
           student: student as StudentInfo,
           grade: result.grade,
         });
+        grade.mutate(newGrade);
         setGradeSaved(true);
       } catch (e) {
         setSubmitGradeError(e);
```

Note that the `grade.data` result is currently the scaled/formatted grade rather than the raw value returned from the backend. It would be more idiomatic/correct IMO for state state to be the raw value, with the formatted value computed as part of rendering.