### PR TITLE
Fix unsaved changes not being properly tracked when changes are discarded

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -63,6 +63,7 @@ export default function GradingControls({
 
       if (discardChanges) {
         setSelectedStudent(newSelectedStudent);
+        setHasUnsavedChanges(false);
       }
     },
     [hasUnsavedChanges, selectedStudent]

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -12,6 +12,7 @@ import {
   useState,
   useRef,
   useCallback,
+  useMemo,
 } from 'preact/hooks';
 
 import type { StudentInfo } from '../config';
@@ -99,13 +100,9 @@ export default function SubmitGradeForm({
   const [draftGradeValue, setDraftGradeValue] = useState<string | null>(null);
 
   // Track if current grade has changed compared to what was originally loaded
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState<boolean>(false);
-  const updateHasUnsavedChanges = useCallback(
-    (hasUnsavedChanges: boolean) => {
-      setHasUnsavedChanges(hasUnsavedChanges);
-      onUnsavedChanges?.(hasUnsavedChanges);
-    },
-    [onUnsavedChanges]
+  const hasUnsavedChanges = useMemo(
+    () => draftGradeValue !== null && draftGradeValue !== grade.data,
+    [draftGradeValue, grade.data]
   );
 
   // Make sure instructors are notified if there's a risk to lose unsaved data
@@ -139,7 +136,7 @@ export default function SubmitGradeForm({
           grade: result.grade,
         });
         grade.mutate(newGrade);
-        updateHasUnsavedChanges(false);
+        onUnsavedChanges?.(false);
         setGradeSaved(true);
       } catch (e) {
         setSubmitGradeError(e);
@@ -158,9 +155,9 @@ export default function SubmitGradeForm({
       setDraftGradeValue(newDraftGradeValue);
 
       // Check if there are unsavedChanges
-      updateHasUnsavedChanges(newDraftGradeValue !== grade.data);
+      onUnsavedChanges?.(newDraftGradeValue !== grade.data);
     },
-    [grade.data, updateHasUnsavedChanges]
+    [grade.data, onUnsavedChanges]
   );
 
   const disabled = !student;

--- a/lms/static/scripts/frontend_apps/components/test/GradingControls-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GradingControls-test.js
@@ -268,6 +268,10 @@ describe('GradingControls', () => {
       act(() => wrapper.find('SubmitGradeForm').props().onUnsavedChanges(true));
     const getSelectedStudent = wrapper =>
       wrapper.find('StudentSelector').props().selectedStudent;
+    const selectStudent = (wrapper, student) =>
+      act(() =>
+        wrapper.find('StudentSelector').props().onSelectStudent(student)
+      );
 
     [
       // Selected student should still be the first
@@ -291,16 +295,33 @@ describe('GradingControls', () => {
         fakeConfirm.resolves(discardChanges);
 
         // Try to select another student
-        await act(() =>
-          wrapper
-            .find('StudentSelector')
-            .props()
-            .onSelectStudent(fakeStudents[1])
-        );
+        await selectStudent(wrapper, fakeStudents[1]);
         wrapper.update();
 
         assert.equal(getSelectedStudent(wrapper), expectedStudentAfterChange());
       });
+    });
+
+    it('resets unsaved changes when student is changed and changes are discarded', async () => {
+      const wrapper = renderGrader();
+      await selectFirstStudent(wrapper);
+
+      await setUnsavedChanges(wrapper);
+      wrapper.update();
+      fakeConfirm.resolves(true);
+
+      // Try to select another student
+      await selectStudent(wrapper, fakeStudents[1]);
+      wrapper.update();
+
+      assert.calledOnce(fakeConfirm);
+
+      // Select first student again
+      await selectFirstStudent(wrapper);
+      wrapper.update();
+
+      // It should not have called confirm for a second time
+      assert.calledOnce(fakeConfirm);
     });
   });
 


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/hypothesis/lms/pull/5686, where the value of `hasUnsavedChanges` runs out of sync if you change to another student and decide to discard changes.

When this happens, the flag is kept with value `true`, making the confirm dialog be displayed every time you change student, even if no changes were actually made.

### Root cause

Some context to understand how this of state works:

* We initialize `hasUnsavedChanges` to `false`.
* Every time the grade is edited, we check if it is different than the originally loaded grade and if so, `hasUnsavedChanges` is set to `true`.
* When the grade is submit, we reset `hasUnsavedChanges` to `false`.
* Every time `hasUnsavedChanges` value changes, we need to invoke an optional `onUnsavedChanges` prop callback with the new value.

The first implementation we did involved deriving `hasUnsavedChanges` from other pieces of state, making sure it was always up to date without having to explicitly call a "setter". This piece of state was also memoized.

Then, `onUnsavedChanges` was called via `useEffect` every time the above changed.

This had some implications, though (see https://github.com/hypothesis/lms/pull/5686#discussion_r1319834066), and because of that, this approach was discarded in favor of handling `hasUnsavedChanges` via `useState`, and explicitly updating its value every time the grade changed or it was submitted.

However, one case was missed, which is when student changes, but the grade has not been submitted. This happens if the instructor decides to discard changes.

This cased the setter to never be invoked, leaving it with it's old `true` value.

### Proposed fix

The fix I'm proposing here implies handling `hasUnsavedChanges` as a piece of derived state again, as it has the benefit of getting automatically updated every time a grade is loaded.

The confusion raised during previous PR review is addressed by tracking previous value of `hasUnsavedChanges` and comparing it with the new one on every render. If it has changed, we call `onUnsavedChanges`.

So we move from this (the original proposal that was not merged):

```tsx
const hasUnsavedChanges = useMemo(...);
useEffect(() => {
  onUnsavedChanges?.(hasUnsavedChanges);
}, [onUnsavedChanges, hasUnsavedChanges]);
```

to something like this:

```tsx
const hasUnsavedChanges = useMemo(...);
const prevHasUnsavedChanges = useRef(hasUnsavedChanges);
if (prevHasUnsavedChanges.current !== hasUnsavedChanges) {
  onUnsavedChanges?.(hasUnsavedChanges);
}
prevHasUnsavedChanges.current = hasUnsavedChanges;
```

I believe we have used this pattern in other occasions, and it's one of the recommendations from react docs https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes (see proposed solution there)

### Testing steps

1. Check out this branch
2. Open https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3349/View
3. Load one student, change its grade, then try to switch to another student.
4. When asked, select "Discard changes"
5. Once new student loads, try to go back to previous one, without making any change
6. The student should be loaded without you being asked to discard changes.

If you try the same on `main`, step 5 will result in the modal being displayed again, warning you have unsaved changes, even though that's not true.