### PR TITLE
Add grading comment controls

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -12,6 +12,7 @@ import SubmitGradeForm from './SubmitGradeForm';
 export type GradingControlsProps = {
   students: StudentInfo[];
   scoreMaximum?: number;
+  acceptComments?: boolean;
 };
 
 /**
@@ -34,6 +35,7 @@ function localeSort<Item>(items: Item[], key: keyof Item): Item[] {
 export default function GradingControls({
   students: unorderedStudents,
   scoreMaximum,
+  acceptComments,
 }: GradingControlsProps) {
   const {
     api: { authToken, sync: syncAPICallInfo },
@@ -134,6 +136,7 @@ export default function GradingControls({
           student={selectedStudent}
           scoreMaximum={scoreMaximum}
           onUnsavedChanges={setHasUnsavedChanges}
+          acceptComments={acceptComments}
         />
       </div>
     </div>

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -23,6 +23,7 @@ export default function InstructorToolbar() {
     editingEnabled,
     gradingEnabled,
     scoreMaximum,
+    acceptGradingComments,
   } = instructorToolbar;
 
   const withGradingControls = gradingEnabled && !!students;
@@ -75,6 +76,7 @@ export default function InstructorToolbar() {
         <GradingControls
           students={students}
           scoreMaximum={scoreMaximum ?? undefined}
+          acceptComments={acceptGradingComments}
         />
       ) : (
         <div />

--- a/lms/static/scripts/frontend_apps/components/test/InstructorToolbar-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/InstructorToolbar-test.js
@@ -57,11 +57,18 @@ describe('InstructorToolbar', () => {
     assert.isTrue(wrapper.exists('[data-testid="edit"]'));
   });
 
-  it('renders grading controls when grading is enabled', () => {
-    fakeInstructorToolbar.gradingEnabled = true;
-    fakeInstructorToolbar.students = [];
-    const wrapper = renderToolbar();
-    assert.isTrue(wrapper.exists('GradingControls'));
+  [true, false, undefined].forEach(acceptComments => {
+    it('renders grading controls when grading is enabled', () => {
+      fakeInstructorToolbar.gradingEnabled = true;
+      fakeInstructorToolbar.students = [];
+      fakeInstructorToolbar.acceptGradingComments = acceptComments;
+
+      const wrapper = renderToolbar();
+      const gradingControls = wrapper.find('GradingControls');
+
+      assert.isTrue(gradingControls.exists());
+      assert.equal(gradingControls.prop('acceptComments'), acceptComments);
+    });
   });
 
   it('does not render grading controls when grading is not enabled', () => {

--- a/lms/static/scripts/frontend_apps/services/grading.ts
+++ b/lms/static/scripts/frontend_apps/services/grading.ts
@@ -16,6 +16,7 @@ export type Student = {
  */
 export type FetchGradeResult = {
   currentScore?: number | null;
+  comment?: string | null;
 };
 
 /**
@@ -31,7 +32,15 @@ export class GradingService {
   /**
    * Submits a student's grade to the LTI endpoint.
    */
-  submitGrade({ student, grade }: { student: Student; grade: number }) {
+  submitGrade({
+    student,
+    grade,
+    comment,
+  }: {
+    student: Student;
+    grade: number;
+    comment?: string;
+  }) {
     return apiCall<void>({
       authToken: this._authToken,
       path: '/api/lti/result',
@@ -40,6 +49,7 @@ export class GradingService {
         lis_outcome_service_url: student.LISOutcomeServiceUrl,
         student_user_id: student.lmsId,
         score: grade,
+        comment,
       },
     });
   }

--- a/lms/static/scripts/frontend_apps/services/test/grading-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/grading-test.js
@@ -40,25 +40,31 @@ describe('GradingService', () => {
   });
 
   describe('#submitGrade', () => {
-    it('calls "POST /api/lti/result" API', async () => {
-      await gradingService.submitGrade({
-        student: {
-          LISResultSourcedId: 0,
-          LISOutcomeServiceUrl: 'url',
-          lmsId: 'studentId',
-        },
-        grade: 1,
-      });
-      assert.calledWithMatch(fakeAPICall, {
-        authToken: 'dummy-token',
-        path: '/api/lti/result',
-        data: {
-          lis_result_sourcedid: 0,
-          lis_outcome_service_url: 'url',
-          student_user_id: 'studentId',
-          score: 1,
-        },
-      });
-    });
+    [{ grade: 1 }, { grade: 8, comment: 'Good job!' }].forEach(
+      ({ grade, comment }) => {
+        it('calls "POST /api/lti/result" API', async () => {
+          await gradingService.submitGrade({
+            student: {
+              LISResultSourcedId: 0,
+              LISOutcomeServiceUrl: 'url',
+              lmsId: 'studentId',
+            },
+            grade,
+            comment,
+          });
+          assert.calledWithMatch(fakeAPICall, {
+            authToken: 'dummy-token',
+            path: '/api/lti/result',
+            data: {
+              lis_result_sourcedid: 0,
+              lis_outcome_service_url: 'url',
+              student_user_id: 'studentId',
+              score: grade,
+              comment,
+            },
+          });
+        });
+      }
+    );
   });
 });


### PR DESCRIPTION
> Part of https://github.com/hypothesis/product-backlog/issues/1472

Allow instructors to provide a grading comment for every student.

[Grabación de pantalla desde 2023-09-11 12-27-28.webm](https://github.com/hypothesis/lms/assets/2719332/b7764df7-d702-4714-bf2c-a86e166f4184)

### Testing steps

1.Make sure you enable the feature flag as described in https://github.com/hypothesis/lms/pull/5649
2. Open https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3349/View
3. The grading bar should show a new button next to the grade, which toggles a dropdown with a textarea that can be used to define a grading comment.
4. When you select a student, the icon will changed to a "filled" state if the comment is not empty. The comment should be prefilled if there was one for this student.
5. Saving the grading will also save the comment for this student.

### TODO

- [x] Add tests
- [x] Initial feedback on state management

### Considerations

* I considered extracting the UI pieces around handling the comment to its own independent component, but I think I'll do that separately, as it involves some decisions on what goes there and what does not that may divert our attention from the main topic.