### PR TITLE
Add application instance setting to enable import/export

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -43,6 +43,7 @@ class ApplicationSettings(JSONSettings):
             asbool,
             name="Auto Assigned To Organisation",
         ),
+        JSONSetting("hypothesis", "import_export_enabled", asbool),
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
         JSONSetting("hypothesis", "lms_grading_scale", asbool),
         JSONSetting("hypothesis", "grading_comments", asbool),

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -1,6 +1,6 @@
 import functools
 from enum import Enum
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pyramid.httpexceptions import HTTPClientError
 
@@ -373,6 +373,19 @@ class JSConfig:
             "events": ["create", "update"],
         }
 
+    def enable_client_feature(self, feature: str):
+        """
+        Enable a feature flag in the client.
+
+        The effective set of enabled feature flags is the union of flags enabled
+        via this method and flags enabled for the H user.
+
+        :param feature: A feature flag to enable.
+        """
+        current_features: List[str] = self._hypothesis_client.setdefault("features", [])
+        if feature not in current_features:
+            current_features.append(feature)
+
     @property
     def auth_token(self):
         """Return the authToken setting."""
@@ -466,7 +479,7 @@ class JSConfig:
 
     @property
     @functools.lru_cache()
-    def _hypothesis_client(self):
+    def _hypothesis_client(self) -> Dict[str, Any]:
         """
         Return the config object for the Hypothesis client.
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -97,6 +97,7 @@
 
     <fieldset class="box">
         <legend class="label has-text-centered">General settings</legend>
+        {{ settings_checkbox("Enable import/export in client", "hypothesis", "import_export_enabled", default=False) }}
         {{ settings_checkbox("Enable instructor email digests", "hypothesis", "instructor_email_digests_enabled") }}
         {{ settings_checkbox("LMS grading scale", "hypothesis", "lms_grading_scale", default=False) }}
         {{ settings_checkbox("Grading comments", "hypothesis", "grading_comments", default=False) }}

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -213,6 +213,15 @@ class BasicLaunchViews:
         self.context.js_config.add_document_url(assignment.document_url)
         self.context.js_config.enable_lti_launch_mode(self.course, assignment)
 
+        import_export_enabled = self.request.lti_user.application_instance.settings.get(
+            "hypothesis", "import_export_enabled", False
+        )
+
+        if import_export_enabled:
+            js_config = self.context.js_config
+            js_config.enable_client_feature("import_annotations")
+            js_config.enable_client_feature("export_annotations")
+
         # Run any non standard code for the current product
         self._misc_plugin.post_launch_assignment_hook(
             self.request, self.context.js_config, assignment

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -298,6 +298,29 @@ class TestBasicLaunchViews:
 
         assert result == {}
 
+    @pytest.mark.parametrize("import_export_feature", [True, False])
+    def test__show_document_enables_client_features(
+        self, svc, pyramid_request, context, assignment, import_export_feature
+    ):
+        pyramid_request.lti_user.application_instance.settings.set(
+            "hypothesis", "import_export_enabled", import_export_feature
+        )
+
+        # pylint: disable=protected-access
+        svc._show_document(assignment)
+
+        expected_features = set()
+        if import_export_feature:
+            expected_features.add("import_annotations")
+            expected_features.add("export_annotations")
+
+        enable_client_feature = context.js_config.enable_client_feature
+        actual_features = set(
+            call.args[0] for call in enable_client_feature.call_args_list
+        )
+
+        assert actual_features == expected_features
+
     @pytest.fixture
     def assignment(self):
         return factories.Assignment(is_gradable=False)


### PR DESCRIPTION
 - Add general infrastructure to enable the LMS app to enable feature flags in the Hypothesis client on a per-application instance level. These flags will be added to the feature flags in the H user profile.

 - Use this infrastructure to add an AI setting that enables the import/export features in the client

Part of https://github.com/hypothesis/client/issues/5803

----

**Testing:**

~~Check out this PR together with https://github.com/hypothesis/client/issues/5803 in the client repo.~~

1. Go to http://localhost:5000/admin/features and ensure the `import_annotations` and `export_annotations` features are not enabled for everyone
2. Load the assignment at https://hypothesis.instructure.com/courses/125/assignments/874. Check that the Import / Export UI is missing in the client.
3. Go to http://localhost:8001/admin/instance/8/, check the option to enable import/export in the client and save
4. Reload the assignment from (2) and verify that the Import/Export UI is present in the client