### PR TITLE
Improve digest email subjects

### DIFF
--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -139,12 +139,28 @@ class DigestContext:
                 continue
 
             course_digests.append(
-                {"title": unified_course.title, "num_annotations": num_annotations}
+                {
+                    "title": unified_course.title,
+                    "num_annotations": num_annotations,
+                    "annotators": list(
+                        set(
+                            annotation["author"]["userid"]
+                            for annotation in unified_course.learner_annotations
+                        )
+                    ),
+                }
             )
 
         return {
             "total_annotations": sum(
                 course_digest["num_annotations"] for course_digest in course_digests
+            ),
+            "annotators": list(
+                set(
+                    annotator
+                    for course_digest in course_digests
+                    for annotator in course_digest["annotators"]
+                )
             ),
             "courses": course_digests,
         }

--- a/lms/templates/email/instructor_email_digest/subject.jinja2
+++ b/lms/templates/email/instructor_email_digest/subject.jinja2
@@ -1,1 +1,11 @@
-There has been some activity in Hypothesis
+{% if total_annotations > 1 and annotators|length > 1 and courses|length > 1 -%}
+Hypothesis: {{ total_annotations }} annotations from {{ annotators|length}} students in {{ courses|length }} courses
+{%- elif annotators|length > 1 -%}
+Hypothesis: {{ total_annotations }} annotations from {{ annotators|length}} students in 1 course
+{%- elif courses|length > 1 -%}
+Hypothesis: {{ total_annotations }} annotations from 1 student in {{ courses|length }} courses
+{%- elif total_annotations > 1 -%}
+Hypothesis: {{ total_annotations }} annotations from 1 student in 1 course
+{%- else -%}
+Hypothesis: one of your students made an annotation
+{%- endif %}


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/5656.

This changes the subject lines of instructor email digests from:

> There has been some activity in Hypothesis

To more informative subjects like:

> Hypothesis: 34 annotations from 16 students in 7 courses
> Hypothesis: 22 annotations from 5 students in 1 course
> Hypothesis: 3 annotations from 1 student in 2 courses
> Hypothesis: 2 annotations from 1 student in 1 course
> Hypothesis: one of your students made an annotation

## Testing

1. Log in to https://hypothesis.instructure.com/ as the `eng+canvasteacher@hypothes.is` user and launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873). This is to create the record of the instructor in your local DB. Also launch [a different assignment in a different course](https://hypothesis.instructure.com/courses/124/assignments/885)

2. Log in to https://hypothesis.instructure.com/ as the `eng+canvasstudent@hypothes.is` user, launch [the first assignment](https://hypothesis.instructure.com/courses/125/assignments/873), and create an annotation

3. Go to <http://localhost:8001/admin/email>, set the **Since** and **Until** dates so that they cover the time when you created the annotation, and click **Send**

4. Create a second student annotation in the same course, and use the admin page to send another email

5. Open [the other assignment in the other course](https://hypothesis.instructure.com/courses/124/assignments/885) and create a third student annotation, and use the admin page to send another email

6. Log in as a second student account (e.g. the `seanh+student` account), launch one of the assignments and create an annotation, and submit the admin page again

7. Log in to <https://login.mailchimp.com/> using the username and password in 1Password then go to <https://mandrillapp.com/login/> and use the **Login using Mailchimp** button. On the Mandrill dashboard hover over the Hypothesis username in the top-right and click **Turn on test mode**. Go to <https://mandrillapp.com/subaccounts/view?id=devdata> and you should see sent emails with subjects like:

   * Hypothesis: one of your students made an annotation
   * Hypothesis: 2 annotations from 1 student in 1 course
   * Hypothesis: 3 annotations from 1 student in 2 courses
   * Hypothesis: 4 annotations from 2 students in 2 courses