### PR TITLE
Include the number of students who annotated, in the bodies of instructor email digests

### DIFF
--- a/lms/templates/email/instructor_email_digest/body.html.jinja2
+++ b/lms/templates/email/instructor_email_digest/body.html.jinja2
@@ -638,11 +638,13 @@
                                                             {% for course in courses %}
                                                               <p>
                                                                 <strong>{{ course.title }}</strong><br>
-                                                                {% if course.num_annotations == 1 %}
-                                                                  A student made an annotation in an assignment.
+                                                                {% if course.num_annotations > 1 and course.annotators|length > 1 %}
+                                                                  {{ course.annotators|length }} students made
+                                                                  {{ course.num_annotations }} annotations in assignments.
+                                                                {% elif course.num_annotations > 1 %}
+                                                                  1 student made {{ course.num_annotations }} annotations in assignments.
                                                                 {% else %}
-                                                                  Students made {{ course.num_annotations }} annotations in
-                                                                  assignments.
+                                                                  A student made an annotation in an assignment.
                                                                 {% endif %}
                                                               </p>
                                                             {% endfor %}

--- a/tests/unit/lms/services/mailchimp_test.py
+++ b/tests/unit/lms/services/mailchimp_test.py
@@ -2,6 +2,7 @@ import logging
 from unittest.mock import Mock, sentinel
 
 import pytest
+from factory import Sequence, make_factory
 from h_matchers import Any
 
 from lms.services.mailchimp import (
@@ -10,6 +11,14 @@ from lms.services.mailchimp import (
     MailchimpError,
     MailchimpService,
     factory,
+)
+
+#: A factory for course dicts as expected by the instructor_email_digest template.
+CourseDict = make_factory(
+    dict,
+    title=Sequence(lambda n: "Course {n}"),
+    num_annotations=3,
+    annotators=[sentinel.student_1, sentinel.student_2],
 )
 
 
@@ -22,7 +31,7 @@ class TestSend:
                 {
                     "total_annotations": 2,
                     "annotators": [sentinel.annotator_1, sentinel.annotator_2],
-                    "courses": [sentinel.course_1, sentinel.course_2],
+                    "courses": [CourseDict(), CourseDict()],
                 },
                 "Hypothesis: 2 annotations from 2 students in 2 courses",
             ),
@@ -31,7 +40,7 @@ class TestSend:
                 {
                     "total_annotations": 2,
                     "annotators": [sentinel.annotator_1, sentinel.annotator_2],
-                    "courses": [sentinel.course_1],
+                    "courses": [CourseDict()],
                 },
                 "Hypothesis: 2 annotations from 2 students in 1 course",
             ),
@@ -40,7 +49,7 @@ class TestSend:
                 {
                     "total_annotations": 2,
                     "annotators": [sentinel.annotator_1],
-                    "courses": [sentinel.course_1, sentinel.course_2],
+                    "courses": [CourseDict(), CourseDict()],
                 },
                 "Hypothesis: 2 annotations from 1 student in 2 courses",
             ),
@@ -49,7 +58,7 @@ class TestSend:
                 {
                     "total_annotations": 2,
                     "annotators": [sentinel.annotator_1],
-                    "courses": [sentinel.course_1],
+                    "courses": [CourseDict()],
                 },
                 "Hypothesis: 2 annotations from 1 student in 1 course",
             ),
@@ -58,7 +67,7 @@ class TestSend:
                 {
                     "total_annotations": 1,
                     "annotators": [sentinel.annotator_1],
-                    "courses": [sentinel.course_1],
+                    "courses": [CourseDict()],
                 },
                 "Hypothesis: one of your students made an annotation",
             ),


### PR DESCRIPTION
Fixes https://github.com/hypothesis/lms/issues/5676. 

This changes the line under each course in the bodies of instructor email digests from:

> Students made 9 annotations in assignments.
> A student made an annotation in an assignment.

To:

> 3 students made 9 annotations in assignments.
> 1 student made 3 annotations in assignments.
> A student made an annotation in an assignment.

## Testing

1. Log in to https://hypothesis.instructure.com/ as the `eng+canvasteacher@hypothes.is` user and launch [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873). This is to create the record of the instructor in your local DB. Also launch [a different assignment in a different course](https://hypothesis.instructure.com/courses/124/assignments/885)

2. Log in to https://hypothesis.instructure.com/ as the `eng+canvasstudent@hypothes.is` user, launch [the first assignment](https://hypothesis.instructure.com/courses/125/assignments/873), and create an annotation

3. Go to <http://localhost:8001/admin/email>, set the **Since** and **Until** dates so that they cover the time when you created the annotation, and click **Send**

4. Create a second student annotation in the same course, and use the admin page to send another email

5. Open [the other assignment in the other course](https://hypothesis.instructure.com/courses/124/assignments/885) and create a third student annotation, and use the admin page to send another email

6. Log in as a second student account (e.g. the `seanh+student` account), launch one of the assignments and create an annotation, and submit the admin page again

7. Log in to <https://login.mailchimp.com/> using the username and password in 1Password then go to <https://mandrillapp.com/login/> and use the **Login using Mailchimp** button. On the Mandrill dashboard hover over the Hypothesis username in the top-right and click **Turn on test mode**. Go to <https://mandrillapp.com/subaccounts/view?id=devdata> and you should see sent emails with lines like these in the bodies:

    * 2 students made 3 annotations in assignments.
    * 1 students made 2 annotations in assignments.
    * A student made an annotation in an assignment.