### PR TITLE
Speed up LMS's unit tests by running them in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: .coverage.*
+          path: .coverage
   Coverage:
     needs: tests
     runs-on: ubuntu-latest

--- a/requirements/bddtests.in
+++ b/requirements/bddtests.in
@@ -6,4 +6,5 @@ factory-boy
 h-matchers
 webtest
 behave
+filelock
 -r prod.txt

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -98,6 +98,8 @@ factory-boy==3.3.0
     # via -r requirements/bddtests.in
 faker==8.1.2
     # via factory-boy
+filelock==3.12.3
+    # via -r requirements/bddtests.in
 frozenlist==1.2.0
     # via
     #   -r requirements/prod.txt
@@ -367,6 +369,7 @@ typing-extensions==4.7.1
     #   -r requirements/prod.txt
     #   alembic
     #   async-timeout
+    #   filelock
     #   kombu
     #   sqlalchemy
 tzdata==2023.3

--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -7,3 +7,4 @@ factory-boy
 pytest-factoryboy
 h-matchers
 webtest
+filelock

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -98,6 +98,8 @@ factory-boy==3.3.0
     #   pytest-factoryboy
 faker==8.1.2
     # via factory-boy
+filelock==3.12.3
+    # via -r requirements/functests.in
 frozenlist==1.2.0
     # via
     #   -r requirements/prod.txt
@@ -365,6 +367,7 @@ typing-extensions==4.7.1
     #   -r requirements/prod.txt
     #   alembic
     #   async-timeout
+    #   filelock
     #   kombu
     #   pytest-factoryboy
     #   sqlalchemy

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -131,7 +131,9 @@ click-repl==0.2.0
     #   -r requirements/tests.txt
     #   celery
 coverage[toml]==7.2.7
-    # via -r requirements/tests.txt
+    # via
+    #   -r requirements/tests.txt
+    #   pytest-cov
 cryptography==41.0.3
     # via
     #   -r requirements/bddtests.txt
@@ -158,6 +160,10 @@ exceptiongroup==1.0.0rc9
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest
+execnet==2.0.2
+    # via
+    #   -r requirements/tests.txt
+    #   pytest-xdist
 factory-boy==3.3.0
     # via
     #   -r requirements/bddtests.txt
@@ -170,6 +176,11 @@ faker==8.1.2
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   factory-boy
+filelock==3.12.3
+    # via
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 freezegun==1.2.2
     # via -r requirements/tests.txt
 frozenlist==1.2.0
@@ -411,6 +422,10 @@ prompt-toolkit==3.0.29
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   click-repl
+psutil==5.9.5
+    # via
+    #   -r requirements/tests.txt
+    #   pytest-xdist
 psycopg2==2.9.6
     # via
     #   -r requirements/bddtests.txt
@@ -514,11 +529,25 @@ pytest==7.4.0
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+    #   pytest-cov
     #   pytest-factoryboy
+    #   pytest-xdist
+pytest-cov==4.1.0
+    # via
+    #   -r requirements/tests.txt
+    #   pytest-cover
+pytest-cover==3.0.0
+    # via
+    #   -r requirements/tests.txt
+    #   pytest-coverage
+pytest-coverage==0.0
+    # via -r requirements/tests.txt
 pytest-factoryboy==2.5.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+pytest-xdist[psutil]==3.3.1
+    # via -r requirements/tests.txt
 python-dateutil==2.8.2
     # via
     #   -r requirements/bddtests.txt
@@ -639,6 +668,7 @@ typing-extensions==4.7.1
     #   -r requirements/tests.txt
     #   alembic
     #   async-timeout
+    #   filelock
     #   kombu
     #   pylint
     #   pytest-factoryboy

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,7 +1,7 @@
 pip-tools
 pip-sync-faster
 -r prod.txt
-coverage[toml]
+pytest-coverage
 pytest
 factory-boy
 pytest-factoryboy
@@ -9,3 +9,5 @@ h-matchers
 httpretty
 freezegun
 aioresponses
+pytest-xdist[psutil]
+filelock

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -82,7 +82,7 @@ click-repl==0.2.0
     #   -r requirements/prod.txt
     #   celery
 coverage[toml]==7.2.7
-    # via -r requirements/tests.in
+    # via pytest-cov
 cryptography==41.0.3
     # via
     #   -r requirements/prod.txt
@@ -96,12 +96,16 @@ ecdsa==0.17.0
     #   python-jose
 exceptiongroup==1.0.0rc9
     # via pytest
+execnet==2.0.2
+    # via pytest-xdist
 factory-boy==3.3.0
     # via
     #   -r requirements/tests.in
     #   pytest-factoryboy
 faker==8.1.2
     # via factory-boy
+filelock==3.12.3
+    # via -r requirements/tests.in
 freezegun==1.2.2
     # via -r requirements/tests.in
 frozenlist==1.2.0
@@ -237,6 +241,8 @@ prompt-toolkit==3.0.29
     # via
     #   -r requirements/prod.txt
     #   click-repl
+psutil==5.9.5
+    # via pytest-xdist
 psycopg2==2.9.6
     # via
     #   -r requirements/prod.txt
@@ -295,8 +301,18 @@ pyrsistent==0.17.3
 pytest==7.4.0
     # via
     #   -r requirements/tests.in
+    #   pytest-cov
     #   pytest-factoryboy
+    #   pytest-xdist
+pytest-cov==4.1.0
+    # via pytest-cover
+pytest-cover==3.0.0
+    # via pytest-coverage
+pytest-coverage==0.0
+    # via -r requirements/tests.in
 pytest-factoryboy==2.5.1
+    # via -r requirements/tests.in
+pytest-xdist[psutil]==3.3.1
     # via -r requirements/tests.in
 python-dateutil==2.8.2
     # via
@@ -354,7 +370,6 @@ text-unidecode==1.3
 tomli==2.0.0
     # via
     #   build
-    #   coverage
     #   pep517
     #   pytest
 transaction==2.4.0
@@ -371,6 +386,7 @@ typing-extensions==4.7.1
     #   -r requirements/prod.txt
     #   alembic
     #   async-timeout
+    #   filelock
     #   kombu
     #   pytest-factoryboy
     #   sqlalchemy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def db_engine(tmp_path_factory):
 
     # Use a filelock to only init the DB once even though we have multiple
     # parallel pytest-xdist workers. See:
-    # https://pytest-xdist.readthedocs.io/en/stable/how-to.html?highlight=filelock#making-session-scoped-fixtures-execute-only-once
+    # https://pytest-xdist.readthedocs.io/en/stable/how-to.html#making-session-scoped-fixtures-execute-only-once
 
     # The temporary directory shared by all pytest-xdist workers.
     shared_tmpdir = tmp_path_factory.getbasetemp().parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,12 @@ def db_engine(tmp_path_factory):
     shared_tmpdir = tmp_path_factory.getbasetemp().parent
 
     # The existence of this file records that a worker has initialized the DB.
-    done_file = shared_tmpdir / "db_initialized"
+    done_file = shared_tmpdir / "db_initialized.done"
 
-    with FileLock(str(done_file) + ".lock"):
+    # The lock file prevents workers from entering the `with` at the same time.
+    lock_file = shared_tmpdir / "db_initialized.lock"
+
+    with FileLock(str(lock_file)):
         if done_file.is_file():
             # Another worker already initialized the DB.
             pass

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands =
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle lms tests bin
     lint: pycodestyle lms tests bin
-    tests: coverage run -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
+    tests: python -m pytest --cov --numprocesses logical --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
     functests: python -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
     coverage: -coverage combine
     coverage: coverage report


### PR DESCRIPTION
On CI we already use parallel GitHub Actions jobs to run the different checks in parallel (formatting, lint, tests, functests, ...). Locally `make sure` uses `tox --parallel` to run each of these in parallel. This PR uses [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) to also run _the unit tests themselves_ in parallel in multiple processes (one process for each CPU core) whenever you run `make test`, `make sure`, or the _Tests_ job on CI.

This should make things significantly faster both locally and on CI, especially because the unit tests are by far the slowest part of CI.

A couple of tricks are required to get this working: we add [pytest-cov](https://github.com/pytest-dev/pytest-cov) because it has builtin support for pytest-xdist (combining the coverage from the different processes into one result) and we have to copy a hack from the pytest-xdist docs to only initialize the DB once per test session instead of all the parallel processes trying to do this at once and crashing.

This will have to be back-ported into the cookiecutter, but maybe we can just test it out by changing LMS directly first.

We might also want to make this same change to other projects if it's easy to do. Not all projects will benefit from this: there's some overhead to running the tests in parallel so it'll probably make small projects (like libraries) slower not faster. h might be slightly trickier to do because there's also Elasticsearch to worry about but I think pytest-xdist supports a test grouping thing so we can make all the Elasticsearch tests run together in serial in one process if we need to.