### PR TITLE
Generate annotation metadata and expose it to the client config

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -205,6 +205,10 @@ class JSConfig:
         # postMessage.
         self._config["hypothesisClient"] = self._hypothesis_client
 
+        self._config["hypothesisClient"][
+            "annotationMetadata"
+        ] = self._generate_annotation_metadata(assignment)
+
         # Configure group related settings
         self._configure_groups(course, assignment)
 
@@ -584,3 +588,6 @@ class JSConfig:
             "Application Instance ID": ai.id,
             "LTI version": ai.lti_version,
         }
+
+    def _generate_annotation_metadata(self, assignment):
+        return {"lms": {"assignment_id": assignment.resource_link_id}}

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -154,7 +154,10 @@ class TestEnableLTILaunchMode:
                         "grantToken": grant_token_service.generate_token.return_value,
                         "groups": Any(),
                     }
-                ]
+                ],
+                "annotationMetadata": {
+                    "lms": {"assignment_id": assignment.resource_link_id}
+                },
             },
             "mode": "basic-lti-launch",
             "rpcServer": {"allowedOrigins": ["http://localhost:5000"]},


### PR DESCRIPTION
Expose just the `assignment_id` as part of the metadata to be added to all annotations created in the LMS context.

For now the client will just use this information for new annotations (POST /api/annotation) to fill this information for now on.

This is enough for the immediate need, email digest.

We'll have to revisit this once we want to use this information for other proposes, for example retrieving annotations by group + assignment (or group + document + assignment) instead of just group + document. 


Needs: 

https://github.com/hypothesis/h/pull/8175
https://github.com/hypothesis/h/pull/8182
