### PR TITLE
Emit an error code for AIs with provisioning disabled

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -495,10 +495,6 @@ class JSConfig:
         # We cache this property (@functools.lru_cache()) so that it's
         # mutable. You can do self._hypothesis_client["foo"] = "bar" and the
         # mutation will be preserved.
-
-        if not self._application_instance.provisioning:
-            return {}
-
         api_url = self._request.registry.settings["h_api_url_public"]
 
         # Generate a short-lived login token for the Hypothesis client.
@@ -522,9 +518,6 @@ class JSConfig:
 
     def _configure_groups(self, course, assignment):
         """Configure how the client will fetch groups when in LAUNCH mode."""
-        if not self._application_instance.provisioning:
-            return
-
         grouping_type = self._request.find_service(
             name="grouping"
         ).get_launch_grouping_type(self._request, course, assignment)

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -35,6 +35,24 @@ class AccountDisabled(SerializableError):
         )
 
 
+class ProvisioningDisabled(SerializableError):
+    """
+    Indicate that provisioning is not enabled for this instance.
+
+    We suspect this is not actually in use.
+    Revisit after a while to completely remove the notion of "provisioning"
+    """
+
+    def __init__(self, application_instance: ApplicationInstance):
+        super().__init__(
+            message="User and group provisioning not enabled for instance",
+            error_code="instance_provisioning",
+            details={
+                "application_instance_id": application_instance.id,
+            },
+        )
+
+
 def _email_or_domain_match(columns, email):
     """
     Get an SQL comparator for matching emails.
@@ -73,6 +91,8 @@ class ApplicationInstanceService:
             `ApplicationInstance`
         :raise AccountDisabled: If the organization associated with this
             instance is disabled
+        :raise ProvisioningDisabled: if the instance has provisioning
+            disabled
         """
         if id_:
             application_instance = self.get_by_id(id_)
@@ -90,6 +110,9 @@ class ApplicationInstanceService:
                     org.id,
                 )
                 raise AccountDisabled(application_instance)
+
+            if application_instance and not application_instance.provisioning:
+                raise ProvisioningDisabled(application_instance)
 
             return application_instance
 

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -41,9 +41,6 @@ class LTIHService:
         :raise ApplicationInstanceNotFound: if
             `request.lti_user.oauth_consumer_key` isn't in the DB
         """
-        if not self._application_instance.provisioning:
-            return
-
         self._h_api.execute_bulk(commands=self._yield_commands(groupings))
 
         # Keep a note of the groups locally for reporting purposes.

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -222,19 +222,6 @@ class TestEnableLTILaunchMode:
         # Confirm we pass the schema for the sync end-point
         APISyncSchema(pyramid_request).load(sync_config["data"])
 
-    @pytest.mark.usefixtures("with_provisioning_disabled")
-    def test_client_config_is_empty_if_provisioning_feature_is_disabled(
-        self, js_config
-    ):
-        js_config.enable_lti_launch_mode(course, assignment)
-        config = js_config.asdict()["hypothesisClient"]
-
-        assert config == {}
-
-    @pytest.fixture
-    def with_provisioning_disabled(self, pyramid_request):
-        pyramid_request.lti_user.application_instance.provisioning = False
-
 
 class TestAddDocumentURL:
     """Unit tests for JSConfig.add_document_url()."""

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -11,6 +11,7 @@ from lms.services import ApplicationInstanceNotFound
 from lms.services.application_instance import (
     AccountDisabled,
     ApplicationInstanceService,
+    ProvisioningDisabled,
     factory,
 )
 from lms.validation import ValidationError
@@ -41,6 +42,14 @@ class TestApplicationInstanceService:
         application_instance.organization = factories.Organization(enabled=False)
 
         with pytest.raises(AccountDisabled):
+            service.get_for_launch(application_instance.id)
+
+    def test_get_for_launch_raises_without_provisioning(
+        self, service, application_instance
+    ):
+        application_instance.provisioning = False
+
+        with pytest.raises(ProvisioningDisabled):
             service.get_for_launch(application_instance.id)
 
     def test_get_by_consumer_key(self, service, application_instance):

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -11,15 +11,6 @@ from tests import factories
 
 @pytest.mark.usefixtures("application_instance_service", "h_api", "group_info_service")
 class TestSync:
-    def test_sync_does_nothing_if_provisioning_is_disabled(
-        self, application_instance, lti_h_svc, h_api, grouping
-    ):
-        application_instance.provisioning = False
-
-        lti_h_svc.sync([grouping], sentinel.params)
-
-        h_api.execute_bulk.assert_not_called()
-
     def test_sync_catches_HAPIErrors(
         self, h_api, lti_h_svc, grouping, group_info_service
     ):


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/4381


Just few AI have this disabled and we've seen some launches from them.

This launches completely fail and result in a blank screen.

This commit doesn't remove the concept from the DB to keep track of which instances have it disabled in case we want to re-enable this.

Alternatively, if no costumers contact us about this we can completely remove the concept from the DB.


## Testing 


- Launch https://hypothesis.instructure.com/courses/123/assignments/865

compare the result in `main` (a blank screen) and in this branch:


![Screenshot from 2023-09-15 10-06-37](https://github.com/hypothesis/lms/assets/1433832/6f6554ce-0146-46be-bb3d-c4e8c889b01c)



Not the best dialog in the world but it does mention the issue and has a directly link to contact support.
