### PR TITLE
Extract everything related with the comment to its own component

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GradingComment.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingComment.tsx
@@ -1,0 +1,153 @@
+import type { TextareaProps } from '@hypothesis/frontend-shared';
+import {
+  Button,
+  CancelIcon,
+  IconButton,
+  NoteFilledIcon,
+  NoteIcon,
+  PointerUpIcon,
+  Textarea,
+  useClickAway,
+  useKeyPress,
+} from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import {
+  useCallback,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'preact/hooks';
+
+type CommentPopoverProps = {
+  disabled: boolean;
+  comment: string;
+  onInput?: TextareaProps['onInput'];
+  onSubmit?: (e: Event) => Promise<boolean>;
+  closePopover: () => void;
+};
+
+function CommentPopover({
+  disabled,
+  comment,
+  onInput,
+  onSubmit,
+  closePopover,
+}: CommentPopoverProps) {
+  const commentRef = useRef<HTMLTextAreaElement | null>(null);
+  const commentId = useId();
+
+  // Focus comment textarea when popover is open
+  useLayoutEffect(() => {
+    commentRef.current!.focus();
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      className={classnames(
+        'w-80 p-3',
+        'shadow border rounded bg-white',
+        'absolute top-[calc(100%+3px)] right-0'
+      )}
+      data-testid="comment-popover"
+    >
+      <PointerUpIcon
+        className={classnames(
+          'text-grey-3 fill-white',
+          'absolute inline z-2 w-[15px]',
+          // Position arrow over "Add comment" button
+          'right-[7px] top-[-9px]'
+        )}
+      />
+      <div className="flex items-center">
+        <label htmlFor={commentId} className="font-bold">
+          Add a comment:
+        </label>
+        <div className="grow" />
+        <IconButton
+          title="Close comment"
+          icon={CancelIcon}
+          classes="hover:bg-grey-3/50"
+          onClick={closePopover}
+          data-testid="comment-textless-close-button"
+        />
+      </div>
+      <Textarea
+        id={commentId}
+        classes="mt-1"
+        rows={10}
+        value={comment}
+        onInput={onInput}
+        elementRef={commentRef}
+      />
+      <div className="flex flex-row-reverse space-x-2 space-x-reverse mt-3">
+        <Button
+          variant="primary"
+          disabled={disabled}
+          onClick={async e => {
+            if (await onSubmit?.(e)) {
+              closePopover();
+            }
+          }}
+          data-testid="comment-submit-button"
+        >
+          Submit Grade
+        </Button>
+        <Button
+          icon={CancelIcon}
+          onClick={closePopover}
+          data-testid="comment-close-button"
+        >
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export type GradingCommentProps = Omit<CommentPopoverProps, 'closePopover'>;
+
+export default function GradingComment({
+  disabled,
+  comment,
+  onInput,
+  onSubmit,
+}: GradingCommentProps) {
+  const [showCommentPopover, setShowCommentPopover] = useState(false);
+  const closeCommentPopover = useCallback(
+    () => setShowCommentPopover(false),
+    []
+  );
+  const commentIsSet = !disabled && !!comment;
+  const containerRef = useRef<HTMLSpanElement | null>(null);
+
+  useKeyPress(['Escape'], closeCommentPopover);
+  useClickAway(containerRef, closeCommentPopover);
+
+  return (
+    <span className="relative" ref={containerRef}>
+      <Button
+        icon={commentIsSet ? NoteFilledIcon : NoteIcon}
+        disabled={disabled}
+        title={commentIsSet ? 'Edit comment' : 'Add comment'}
+        onClick={() => setShowCommentPopover(prev => !prev)}
+        expanded={showCommentPopover}
+        classes={classnames(
+          'border border-r-0 rounded-none ring-inset h-full relative',
+          'disabled:opacity-50'
+        )}
+        data-testid="comment-toggle-button"
+      />
+      {showCommentPopover && (
+        <CommentPopover
+          disabled={disabled}
+          closePopover={closeCommentPopover}
+          comment={comment}
+          onInput={onInput}
+          onSubmit={onSubmit}
+        />
+      )}
+    </span>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/GradingComment.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingComment.tsx
@@ -2,22 +2,15 @@ import type { TextareaProps } from '@hypothesis/frontend-shared';
 import {
   Button,
   CancelIcon,
-  IconButton,
+  CloseButton,
+  Dialog,
   NoteFilledIcon,
   NoteIcon,
   PointerUpIcon,
   Textarea,
-  useClickAway,
-  useKeyPress,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import {
-  useCallback,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'preact/hooks';
+import { useCallback, useId, useRef, useState } from 'preact/hooks';
 
 type CommentPopoverProps = {
   disabled: boolean;
@@ -37,20 +30,21 @@ function CommentPopover({
   const commentRef = useRef<HTMLTextAreaElement | null>(null);
   const commentId = useId();
 
-  // Focus comment textarea when popover is open
-  useLayoutEffect(() => {
-    commentRef.current!.focus();
-  }, []);
-
   return (
-    <div
-      role="dialog"
-      className={classnames(
+    <Dialog
+      variant="custom"
+      title=""
+      classes={classnames(
         'w-80 p-3',
         'shadow border rounded bg-white',
         'absolute top-[calc(100%+3px)] right-0'
       )}
       data-testid="comment-popover"
+      onClose={closePopover}
+      initialFocus={commentRef}
+      restoreFocus
+      closeOnClickAway
+      closeOnEscape
     >
       <PointerUpIcon
         className={classnames(
@@ -65,11 +59,9 @@ function CommentPopover({
           Add a comment:
         </label>
         <div className="grow" />
-        <IconButton
+        <CloseButton
           title="Close comment"
-          icon={CancelIcon}
           classes="hover:bg-grey-3/50"
-          onClick={closePopover}
           data-testid="comment-textless-close-button"
         />
       </div>
@@ -102,7 +94,7 @@ function CommentPopover({
           Close
         </Button>
       </div>
-    </div>
+    </Dialog>
   );
 }
 
@@ -120,13 +112,9 @@ export default function GradingComment({
     []
   );
   const commentIsSet = !disabled && !!comment;
-  const containerRef = useRef<HTMLSpanElement | null>(null);
-
-  useKeyPress(['Escape'], closeCommentPopover);
-  useClickAway(containerRef, closeCommentPopover);
 
   return (
-    <span className="relative" ref={containerRef}>
+    <span className="relative">
       <Button
         icon={commentIsSet ? NoteFilledIcon : NoteIcon}
         disabled={disabled}

--- a/lms/static/scripts/frontend_apps/components/GradingCommentButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingCommentButton.tsx
@@ -31,7 +31,6 @@ function CommentPopover({
   return (
     <Dialog
       variant="custom"
-      title=""
       classes={classnames(
         'w-80 p-3',
         'shadow border rounded bg-white',
@@ -43,6 +42,9 @@ function CommentPopover({
       restoreFocus
       closeOnClickAway
       closeOnEscape
+      // `title` is currently a mandatory Dialog prop, but it's not used when `variant="custom"`.
+      // We'll need to address it in the source. Setting an empty string as a workaround.
+      title=""
     >
       <PointerUpIcon
         className={classnames(
@@ -103,8 +105,7 @@ export type GradingCommentProps = {
 };
 
 /**
- * Grading button toggle button.
- * It opens/closes the internal grading comment popover.
+ * Grading comment toggle button and popover.
  */
 export default function GradingCommentButton({
   disabled,

--- a/lms/static/scripts/frontend_apps/components/GradingCommentButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingCommentButton.tsx
@@ -1,4 +1,4 @@
-import type { TextareaProps } from '@hypothesis/frontend-shared';
+import type { ButtonProps, TextareaProps } from '@hypothesis/frontend-shared';
 import {
   Button,
   CancelIcon,
@@ -13,15 +13,13 @@ import classnames from 'classnames';
 import { useCallback, useId, useRef, useState } from 'preact/hooks';
 
 type CommentPopoverProps = {
-  disabled: boolean;
   comment: string;
-  onInput?: TextareaProps['onInput'];
-  onSubmit?: (e: Event) => Promise<boolean>;
+  onInput: NonNullable<TextareaProps['onInput']>;
+  onSubmit: NonNullable<ButtonProps['onClick']>;
   closePopover: () => void;
 };
 
 function CommentPopover({
-  disabled,
   comment,
   onInput,
   onSubmit,
@@ -76,11 +74,9 @@ function CommentPopover({
       <div className="flex flex-row-reverse space-x-2 space-x-reverse mt-3">
         <Button
           variant="primary"
-          disabled={disabled}
-          onClick={async e => {
-            if (await onSubmit?.(e)) {
-              closePopover();
-            }
+          onClick={e => {
+            onSubmit(e);
+            closePopover();
           }}
           data-testid="comment-submit-button"
         >
@@ -98,10 +94,21 @@ function CommentPopover({
   );
 }
 
-export type GradingCommentProps = Omit<CommentPopoverProps, 'closePopover'>;
+export type GradingCommentProps = {
+  disabled: boolean;
+  loading: boolean;
+  comment: string;
+  onInput: NonNullable<TextareaProps['onInput']>;
+  onSubmit: NonNullable<ButtonProps['onClick']>;
+};
 
-export default function GradingComment({
+/**
+ * Grading button toggle button.
+ * It opens/closes the internal grading comment popover.
+ */
+export default function GradingCommentButton({
   disabled,
+  loading,
   comment,
   onInput,
   onSubmit,
@@ -111,7 +118,7 @@ export default function GradingComment({
     () => setShowCommentPopover(false),
     []
   );
-  const commentIsSet = !disabled && !!comment;
+  const commentIsSet = !loading && !!comment;
 
   return (
     <span className="relative">
@@ -129,7 +136,6 @@ export default function GradingComment({
       />
       {showCommentPopover && (
         <CommentPopover
-          disabled={disabled}
           closePopover={closeCommentPopover}
           comment={comment}
           onInput={onInput}

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -23,7 +23,7 @@ import { formatGrade, validateGrade } from '../utils/grade-validation';
 import { useUniqueId } from '../utils/hooks';
 import { useWarnOnPageUnload } from '../utils/use-warn-on-page-unload';
 import ErrorModal from './ErrorModal';
-import GradingComment from './GradingComment';
+import GradingCommentButton from './GradingCommentButton';
 import ValidationMessage from './ValidationMessage';
 
 export type SubmitGradeFormProps = {
@@ -175,7 +175,6 @@ export default function SubmitGradeForm({
     if (!result.valid) {
       setValidationMessageMessage(result.error);
       setValidationError(true);
-      return false;
     } else {
       setGradeSaving(true);
       try {
@@ -187,13 +186,10 @@ export default function SubmitGradeForm({
         grade.mutate({ grade: newGrade, comment: newComment });
         onUnsavedChanges?.(false);
         setGradeSaved(true);
-        return true;
       } catch (e) {
         setSubmitGradeError(e);
-        return false;
-      } finally {
-        setGradeSaving(false);
       }
+      setGradeSaving(false);
     }
   };
 
@@ -253,8 +249,9 @@ export default function SubmitGradeForm({
           </span>
 
           {acceptComments && (
-            <GradingComment
+            <GradingCommentButton
               disabled={disabled}
+              loading={grade.isLoading}
               comment={draftGrading.comment ?? grade.data?.comment ?? ''}
               onInput={e => handleInput(e, 'comment')}
               onSubmit={onSubmitGrade}

--- a/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
+++ b/lms/static/scripts/frontend_apps/components/SubmitGradeForm.tsx
@@ -1,17 +1,9 @@
 import {
   Button,
-  CancelIcon,
   CheckIcon,
-  IconButton,
   Input,
   Spinner,
   SpinnerOverlay,
-  NoteIcon,
-  NoteFilledIcon,
-  PointerUpIcon,
-  Textarea,
-  useKeyPress,
-  useClickAway,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import {
@@ -21,7 +13,6 @@ import {
   useRef,
   useCallback,
   useMemo,
-  useId,
 } from 'preact/hooks';
 
 import type { StudentInfo } from '../config';
@@ -32,6 +23,7 @@ import { formatGrade, validateGrade } from '../utils/grade-validation';
 import { useUniqueId } from '../utils/hooks';
 import { useWarnOnPageUnload } from '../utils/use-warn-on-page-unload';
 import ErrorModal from './ErrorModal';
+import GradingComment from './GradingComment';
 import ValidationMessage from './ValidationMessage';
 
 export type SubmitGradeFormProps = {
@@ -120,7 +112,6 @@ export default function SubmitGradeForm({
   const [gradeSaved, setGradeSaved] = useState(false);
 
   const disabled = !student;
-  const containerRef = useRef<HTMLDivElement | null>(null);
 
   // The following is state for local validation errors
   //
@@ -152,32 +143,6 @@ export default function SubmitGradeForm({
     [draftGrading.grade, draftGrading.comment, onUnsavedChanges, grade.data]
   );
 
-  // Comment-related state
-  const [showCommentPopover, setShowCommentPopover] = useState(false);
-  const closeCommentPopover = useCallback(
-    () => setShowCommentPopover(false),
-    []
-  );
-  // Comment is considered not set if:
-  //  * Draft is null, and previously loaded comment is "empty"
-  //  * Draft is not null, but falsy. It means it was explicitly removed, but maybe not saved yet
-  const commentIsSet =
-    !disabled &&
-    ((draftGrading.comment === null && !!grade.data?.comment) ||
-      !!draftGrading.comment);
-  const commentId = useId();
-  const commentRef = useRef<HTMLTextAreaElement | null>(null);
-
-  useKeyPress(['Escape'], closeCommentPopover);
-  useClickAway(containerRef, closeCommentPopover);
-
-  // Focus comment textarea when popover is open
-  useLayoutEffect(() => {
-    if (showCommentPopover) {
-      commentRef.current!.focus();
-    }
-  }, [showCommentPopover]);
-
   // Track if current grade has changed compared to what was originally loaded
   const hasUnsavedChanges = useMemo(
     () => hasGradeChanged(draftGrading, grade.data),
@@ -187,12 +152,11 @@ export default function SubmitGradeForm({
   // Make sure instructors are notified if there's a risk to lose unsaved data
   useWarnOnPageUnload(hasUnsavedChanges);
 
-  // Clear the previous grade and hide comment controls when the user changes.
+  // Clear the previous grade when the user changes.
   useEffect(() => {
     setGradeSaved(false);
-    closeCommentPopover();
     setDraftGrading({ grade: null, comment: null });
-  }, [student, closeCommentPopover]);
+  }, [student]);
 
   useLayoutEffect(() => {
     inputRef.current!.focus();
@@ -211,6 +175,7 @@ export default function SubmitGradeForm({
     if (!result.valid) {
       setValidationMessageMessage(result.error);
       setValidationError(true);
+      return false;
     } else {
       setGradeSaving(true);
       try {
@@ -221,12 +186,14 @@ export default function SubmitGradeForm({
         });
         grade.mutate({ grade: newGrade, comment: newComment });
         onUnsavedChanges?.(false);
-        closeCommentPopover();
         setGradeSaved(true);
+        return true;
       } catch (e) {
         setSubmitGradeError(e);
+        return false;
+      } finally {
+        setGradeSaving(false);
       }
-      setGradeSaving(false);
     }
   };
 
@@ -248,7 +215,7 @@ export default function SubmitGradeForm({
         <label htmlFor={gradeId} className="font-semibold text-xs">
           Grade (Out of {scoreMaximum})
         </label>
-        <div className="flex" ref={containerRef}>
+        <div className="flex">
           <span className="relative w-14">
             {validationMessage && (
               <ValidationMessage
@@ -286,78 +253,12 @@ export default function SubmitGradeForm({
           </span>
 
           {acceptComments && (
-            <span className="relative">
-              <Button
-                icon={commentIsSet ? NoteFilledIcon : NoteIcon}
-                disabled={disabled}
-                title={commentIsSet ? 'Edit comment' : 'Add comment'}
-                onClick={() => setShowCommentPopover(prev => !prev)}
-                expanded={showCommentPopover}
-                classes={classnames(
-                  'border border-r-0 rounded-none ring-inset h-full relative',
-                  'disabled:opacity-50'
-                )}
-                data-testid="comment-toggle-button"
-              />
-              {showCommentPopover && (
-                <div
-                  role="dialog"
-                  className={classnames(
-                    'w-80 p-3',
-                    'shadow border rounded bg-white',
-                    'absolute top-[calc(100%+3px)] right-0'
-                  )}
-                  data-testid="comment-popover"
-                >
-                  <PointerUpIcon
-                    className={classnames(
-                      'text-grey-3 fill-white',
-                      'absolute inline z-2 w-[15px]',
-                      // Position arrow over "Add comment" button
-                      'right-[7px] top-[-9px]'
-                    )}
-                  />
-                  <div className="flex items-center">
-                    <label htmlFor={commentId} className="font-bold">
-                      Add a comment:
-                    </label>
-                    <div className="grow" />
-                    <IconButton
-                      title="Close comment"
-                      icon={CancelIcon}
-                      classes="hover:bg-grey-3/50"
-                      onClick={closeCommentPopover}
-                      data-testid="comment-textless-close-button"
-                    />
-                  </div>
-                  <Textarea
-                    id={commentId}
-                    classes="mt-1"
-                    rows={10}
-                    value={draftGrading.comment ?? grade.data?.comment ?? ''}
-                    onInput={e => handleInput(e, 'comment')}
-                    elementRef={commentRef}
-                  />
-                  <div className="flex flex-row-reverse space-x-2 space-x-reverse mt-3">
-                    <Button
-                      variant="primary"
-                      disabled={disabled}
-                      onClick={onSubmitGrade}
-                      data-testid="comment-submit-button"
-                    >
-                      Submit Grade
-                    </Button>
-                    <Button
-                      icon={CancelIcon}
-                      onClick={closeCommentPopover}
-                      data-testid="comment-close-button"
-                    >
-                      Close
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </span>
+            <GradingComment
+              disabled={disabled}
+              comment={draftGrading.comment ?? grade.data?.comment ?? ''}
+              onInput={e => handleInput(e, 'comment')}
+              onSubmit={onSubmitGrade}
+            />
           )}
 
           <Button

--- a/lms/static/scripts/frontend_apps/components/test/GradingCommentButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GradingCommentButton-test.js
@@ -1,0 +1,151 @@
+import { mount } from 'enzyme';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import GradingCommentButton from '../GradingCommentButton';
+
+const noop = () => {};
+
+describe('GradingCommentButton', () => {
+  const getToggleButton = wrapper =>
+    wrapper.find('Button[data-testid="comment-toggle-button"]');
+
+  const togglePopover = wrapper =>
+    getToggleButton(wrapper).find('button').simulate('click');
+
+  const commentPopoverExists = wrapper =>
+    wrapper.exists('[data-testid="comment-popover"]');
+
+  const renderComponent = (props = {}) =>
+    mount(
+      <GradingCommentButton
+        comment="Good job!"
+        disabled={false}
+        loading={false}
+        onSubmit={noop}
+        onInput={noop}
+        {...props}
+      />
+    );
+
+  it('allows comment popover to be toggled', () => {
+    const wrapper = renderComponent();
+
+    // Popover is initially hidden
+    assert.isFalse(commentPopoverExists(wrapper));
+    assert.isFalse(getToggleButton(wrapper).prop('expanded'));
+
+    // Clicking the toggle will display the popover
+    togglePopover(wrapper);
+    assert.isTrue(commentPopoverExists(wrapper));
+    assert.isTrue(getToggleButton(wrapper).prop('expanded'));
+
+    // A second click will hide the popover
+    togglePopover(wrapper);
+    assert.isFalse(commentPopoverExists(wrapper));
+    assert.isFalse(getToggleButton(wrapper).prop('expanded'));
+  });
+
+  it('hides the popover when `Escape` is pressed', () => {
+    const wrapper = renderComponent();
+
+    // Show popover
+    togglePopover(wrapper);
+    assert.isTrue(commentPopoverExists(wrapper));
+
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape' })
+    );
+    wrapper.update();
+
+    assert.isFalse(commentPopoverExists(wrapper));
+  });
+
+  it('hides the popover when clicking away', () => {
+    const wrapper = renderComponent();
+
+    // Show popover
+    togglePopover(wrapper);
+    assert.isTrue(commentPopoverExists(wrapper));
+
+    const externalButton = document.createElement('button');
+    document.body.append(externalButton);
+    externalButton.click();
+    wrapper.update();
+
+    try {
+      assert.isFalse(commentPopoverExists(wrapper));
+    } finally {
+      // Make sure this button is removed even if the assert fails
+      externalButton.remove();
+    }
+  });
+
+  [
+    { loading: true, comment: '', expectedTitle: 'Add comment' },
+    { loading: false, comment: '', expectedTitle: 'Add comment' },
+    { loading: true, comment: 'A comment', expectedTitle: 'Add comment' },
+    { loading: false, comment: 'A comment', expectedTitle: 'Edit comment' },
+  ].forEach(({ comment, loading, expectedTitle }) => {
+    it('adds proper title to toggle button based on provided props', async () => {
+      const wrapper = renderComponent({ comment, loading });
+      assert.equal(getToggleButton(wrapper).prop('title'), expectedTitle);
+    });
+  });
+
+  ['comment-textless-close-button', 'comment-close-button'].forEach(
+    closeButtonTestId => {
+      it('closes popover when clicking close buttons', () => {
+        const wrapper = renderComponent();
+
+        togglePopover(wrapper);
+        assert.isTrue(commentPopoverExists(wrapper));
+
+        wrapper
+          .find(`button[data-testid="${closeButtonTestId}"]`)
+          .simulate('click');
+        assert.isFalse(commentPopoverExists(wrapper));
+      });
+    }
+  );
+
+  it('submits grade using internal popover submit button', async () => {
+    const onSubmit = sinon.stub();
+    const wrapper = renderComponent({ onSubmit });
+
+    togglePopover(wrapper);
+
+    wrapper
+      .find('button[data-testid="comment-submit-button"]')
+      .simulate('click');
+    assert.called(onSubmit);
+  });
+
+  it('updates comment on textarea input', async () => {
+    const onInput = sinon.stub();
+    const wrapper = renderComponent({ onInput });
+    togglePopover(wrapper);
+
+    wrapper.find('textarea').simulate('input');
+
+    assert.called(onInput);
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'Popover is closed',
+        content: () => renderComponent(),
+      },
+      {
+        name: 'Popover is open',
+        content: () => {
+          const wrapper = renderComponent();
+          togglePopover(wrapper);
+
+          return wrapper;
+        },
+      },
+    ])
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/SubmitGradeForm-test.js
@@ -340,113 +340,31 @@ describe('SubmitGradeForm', () => {
   });
 
   context('when comments are accepted', () => {
-    const getToggleButton = wrapper =>
-      wrapper.find('Button[data-testid="comment-toggle-button"]');
-
-    const togglePopover = wrapper =>
-      getToggleButton(wrapper).find('button').simulate('click');
-
-    const commentPopoverExists = wrapper =>
-      wrapper.exists('[data-testid="comment-popover"]');
-
     const changeComment = (wrapper, newComment) => {
-      wrapper.find('textarea').getDOMNode().value = newComment;
-      wrapper.find('textarea').simulate('input');
+      wrapper
+        .find('GradingCommentButton')
+        .props()
+        .onInput({
+          target: {
+            value: newComment,
+          },
+        });
+      wrapper.update();
     };
 
-    it('allows comment popover to be toggled', () => {
-      const wrapper = renderForm({ acceptComments: true });
-
-      // Popover is initially hidden
-      assert.isFalse(commentPopoverExists(wrapper));
-      assert.isFalse(getToggleButton(wrapper).prop('expanded'));
-
-      // Clicking the toggle will display the popover
-      togglePopover(wrapper);
-      assert.isTrue(commentPopoverExists(wrapper));
-      assert.isTrue(getToggleButton(wrapper).prop('expanded'));
-
-      // A second click will hide the popover
-      togglePopover(wrapper);
-      assert.isFalse(commentPopoverExists(wrapper));
-      assert.isFalse(getToggleButton(wrapper).prop('expanded'));
-    });
-
-    it('hides the popover when `Escape` is pressed', () => {
-      const wrapper = renderForm({ acceptComments: true });
-
-      // Show popover
-      togglePopover(wrapper);
-      assert.isTrue(commentPopoverExists(wrapper));
-
-      document.body.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Escape' })
-      );
-      wrapper.update();
-
-      assert.isFalse(commentPopoverExists(wrapper));
-    });
-
-    it('hides the popover when clicking away', () => {
-      const wrapper = renderForm({ acceptComments: true });
-
-      // Show popover
-      togglePopover(wrapper);
-      assert.isTrue(commentPopoverExists(wrapper));
-
-      const externalButton = document.createElement('button');
-      document.body.append(externalButton);
-      externalButton.click();
-      wrapper.update();
-
-      assert.isFalse(commentPopoverExists(wrapper));
-
-      externalButton.remove();
-    });
-
-    it('adds proper title to toggle button based on the existence of a comment', async () => {
-      const wrapper = renderForm({ acceptComments: true });
-
-      assert.equal(getToggleButton(wrapper).prop('title'), 'Add comment');
-      await waitForGradeFetch(wrapper);
-      assert.equal(getToggleButton(wrapper).prop('title'), 'Edit comment');
-    });
-
-    ['comment-textless-close-button', 'comment-close-button'].forEach(
-      closeButtonTestId => {
-        it('closes popover when clicking close buttons', () => {
-          const wrapper = renderForm({ acceptComments: true });
-
-          togglePopover(wrapper);
-          assert.isTrue(commentPopoverExists(wrapper));
-
-          wrapper
-            .find(`button[data-testid="${closeButtonTestId}"]`)
-            .simulate('click');
-          assert.isFalse(commentPopoverExists(wrapper));
-        });
-      }
-    );
-
-    it('focuses comment textarea when popover is opened', async () => {
-      const wrapper = renderForm({ acceptComments: true });
-      togglePopover(wrapper);
-
-      assert.equal(
-        document.activeElement,
-        wrapper.find('textarea').getDOMNode()
-      );
+    [true, false].forEach(acceptComments => {
+      it('renders GradingCommentButton', () => {
+        const wrapper = renderForm({ acceptComments });
+        assert.equal(acceptComments, wrapper.exists('GradingCommentButton'));
+      });
     });
 
     it('submits grade using internal popover submit button', async () => {
       const wrapper = renderForm({ acceptComments: true });
       const submit = () =>
-        wrapper
-          .find('button[data-testid="comment-submit-button"]')
-          .simulate('click');
+        wrapper.find('GradingCommentButton').props().onSubmit(new Event(''));
 
       await waitForGradeFetch(wrapper);
-      togglePopover(wrapper);
 
       // If we submit with no changes, the originally loaded comment will be sent
       submit();
@@ -464,21 +382,6 @@ describe('SubmitGradeForm', () => {
         grade: 1,
         comment: 'Something else',
       });
-    });
-
-    it('updates comment draft on textarea input', async () => {
-      const wrapper = renderForm({ acceptComments: true });
-
-      await waitForGradeFetch(wrapper);
-      togglePopover(wrapper);
-
-      // The textarea value is initially the fetched comment
-      assert.equal(wrapper.find('textarea').prop('value'), 'Good job!');
-
-      // Once the input is changed, the value will also change
-      changeComment(wrapper, 'New comment');
-
-      assert.equal(wrapper.find('textarea').prop('value'), 'New comment');
     });
   });
 


### PR DESCRIPTION
> This PR addresses points 1, 2 and 4 from https://github.com/hypothesis/lms/pull/5691#issuecomment-1715779932

This PR extracts everything related with the grading comment from `SubmitGradeForm` into a separated `GradingCommentButton` component.

This way, `SubmitGradeForm` has less responsibilities to handle, and all state management around the comment can be encapsulated on a component of its own.

### Decisions to discuss

- I initially thought only the popover part should be extracted, keeping the button as a "trigger" inside `SubmitGradeForm`. However, I ended up extracting everything that needs to render when `allowComments` is `true`, because it allowed to move all the state pieces and hooks away from `SubmitGradeForm`.
  I did create an individual `CommentPopover` component though, but it's "private" inside `GradingCommentButton`.
- ~On the previous PR I decided the click-away handler should work based on the whole grading form, meaning the popover does not hide if you click on the grade input, for example. This has the side effect that we now have to pass a `containerRef` prop down from `SubmitGradeForm` to `GradingCommentButton`.~
  ~If we decide to change this, and make the click-away trigger when clicking anywhere other than the popover itself, we could get rid of this prop.~
  I finally changed this and the click-away takes into consideration the modal itself. This is consistent with how the `Dialog`'s `closeOnClickAway` prop works (see next point).
- Update the `CommentPopover` component so that its top-level component is a `Dialog` instead of a `div[role="dialog"]`. This provides some behaviors out of the box, including:
    * Close on click away
    * Close on pressing `Escape`
    * Restore focus on close
    * Focus the textarea when opened
- In order to make sure the popover is closed when a grade is successfully submit, `onSubmitGrade` now needs to return `boolean`, so that `GradingCommentButton` can close the popover only when appropriate, and keep it open in case of error.
- The close state management is internal to `GradingCommentButton`, as I found ways to not needing to expose it to the parent (related with the points above).
  This is something we can change, and make it a component controlled by `SubmitGradeForm`.

### TODO

- [x] Adapt tests