### PR TITLE
Stop sending `fields` to the annotation bulk API in H

### DIFF
--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -114,7 +114,6 @@ class HAPI:
                     "lte": _rfc3339_format(updated_before),
                 },
             },
-            "fields": ["author.username", "group.authority_provided_id"],
         }
 
         with self._api_request(

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -127,7 +127,6 @@ class TestHAPI:
                             "lte": "2002-02-03T04:05:06+00:00",
                         },
                     },
-                    "fields": ["author.username", "group.authority_provided_id"],
                 }
             ),
             stream=True,


### PR DESCRIPTION
Support for `fields` has been removed from H, stop sending it.


Removed from H in https://github.com/hypothesis/h/pull/8170