### PR TITLE
Enable larger runners for tests and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - run: python -m pip install 'tox<4'
       - run: tox -e checkformatting
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v3
       - name: Install Python
@@ -61,7 +61,7 @@ jobs:
       - run: python -m pip install 'tox<4'
       - run: tox -e lint
   Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     services:
       postgres:
         image: postgres:11.5-alpine


### PR DESCRIPTION
Enable larger GitHub Actions runners for tests and lint. The new
`runs-on` values match the name of a larger runners group that I've
created in the `hypothesis` GitHub organization.
