### PR TITLE
Reduce the number of email digest recipient candidates

### DIFF
--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -19,6 +19,7 @@ from tests.factories.attributes import (
     USER_ID,
 )
 from tests.factories.email_unsubscribe import EmailUnsubscribe
+from tests.factories.event import Event
 from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo
 from tests.factories.group_info import GroupInfo

--- a/tests/factories/event.py
+++ b/tests/factories/event.py
@@ -1,0 +1,6 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+Event = make_factory(models.Event, FACTORY_CLASS=SQLAlchemyModelFactory)


### PR DESCRIPTION
# Testing 

SQL soup testing:


[This is the new query, complete with dates based on today's task](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiIgIFdJVEggY2FuZGlkYXRlX2NvdXJzZXMgQVMgXG4gIChTRUxFQ1QgZXZlbnQuY291cnNlX2lkIEFTIGNvdXJzZV9pZCBcbiAgRlJPTSBldmVudCBKT0lOIGFwcGxpY2F0aW9uX2luc3RhbmNlcyBPTiBhcHBsaWNhdGlvbl9pbnN0YW5jZXMuaWQgPSBldmVudC5hcHBsaWNhdGlvbl9pbnN0YW5jZV9pZCBcbiAgV0hFUkUgZXZlbnQudGltZXN0YW1wID49ICcyMDIzLTA5LTE4VDA1OjAwOjAwJyBBTkQgZXZlbnQudGltZXN0YW1wIDw9ICcyMDIzLTA5LTIwVDA1OjAwOjAwJyBBTkQgKChhcHBsaWNhdGlvbl9pbnN0YW5jZXMuc2V0dGluZ3MgLT4naHlwb3RoZXNpcycpIC0-PiAnaW5zdHJ1Y3Rvcl9lbWFpbF9kaWdlc3RzX2VuYWJsZWQnID0gJ3RydWUnKVxuICApXG4gICBTRUxFQ1QgRElTVElOQ1QgXCJ1c2VyXCIuaF91c2VyaWQgXG4gICBGUk9NIFwidXNlclwiIEpPSU4gYXNzaWdubWVudF9tZW1iZXJzaGlwIE9OIFwidXNlclwiLmlkID0gYXNzaWdubWVudF9tZW1iZXJzaGlwLnVzZXJfaWQgSk9JTiBhc3NpZ25tZW50X2dyb3VwaW5nIE9OIGFzc2lnbm1lbnRfZ3JvdXBpbmcuYXNzaWdubWVudF9pZCA9IGFzc2lnbm1lbnRfbWVtYmVyc2hpcC5hc3NpZ25tZW50X2lkIEpPSU4gbHRpX3JvbGUgT04gbHRpX3JvbGUuaWQgPSBhc3NpZ25tZW50X21lbWJlcnNoaXAubHRpX3JvbGVfaWQgXG4gICBXSEVSRSBhc3NpZ25tZW50X2dyb3VwaW5nLmdyb3VwaW5nX2lkIElOIChTRUxFQ1QgY2FuZGlkYXRlX2NvdXJzZXMuY291cnNlX2lkIFxuICAgRlJPTSBjYW5kaWRhdGVfY291cnNlcykgQU5EIGx0aV9yb2xlLnR5cGUgPSAnaW5zdHJ1Y3RvcicgQU5EIChcInVzZXJcIi5oX3VzZXJpZCBOT1QgSU4gKFNFTEVDVCBlbWFpbF91bnN1YnNjcmliZS5oX3VzZXJpZCBcbiAgIEZST00gZW1haWxfdW5zdWJzY3JpYmUgXG4gICBXSEVSRSBlbWFpbF91bnN1YnNjcmliZS50YWcgPSAnaW5zdHJ1Y3Rvcl9kaWdlc3QnKSkiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo1fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)


[This other query, selects, from the task_done table all userids that are not present in the new version](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo1LCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3Qgc3BsaXRfcGFydChrZXksJzo6JywgMiksIGVtYWlsX3Vuc3Vic2NyaWJlLmNyZWF0ZWQgPiB0YXNrX2RvbmUuY3JlYXRlZCB1bnN1Yl9hZnRlciBmcm9tIHRhc2tfZG9uZSBcbmxlZnQgb3V0ZXIgam9pbiBlbWFpbF91bnN1YnNjcmliZSBvbiBzcGxpdF9wYXJ0KGtleSwnOjonLCAyKSA9IGVtYWlsX3Vuc3Vic2NyaWJlLmhfdXNlcmlkXG53aGVyZSB0YXNrX2RvbmUuY3JlYXRlZCA-PSAnMjAyMy0wOS0yMCcgYW5kIHRhc2tfZG9uZS5jcmVhdGVkIDwgJzIwMjMtMDktMjEnXG5hbmQgc3BsaXRfcGFydChrZXksJzo6JywgMikgbm90IGluIChcbiAgV0lUSCBjYW5kaWRhdGVfY291cnNlcyBBUyBcbiAgKFNFTEVDVCBldmVudC5jb3Vyc2VfaWQgQVMgY291cnNlX2lkIFxuICBGUk9NIGV2ZW50IEpPSU4gYXBwbGljYXRpb25faW5zdGFuY2VzIE9OIGFwcGxpY2F0aW9uX2luc3RhbmNlcy5pZCA9IGV2ZW50LmFwcGxpY2F0aW9uX2luc3RhbmNlX2lkIFxuICBXSEVSRSBldmVudC50aW1lc3RhbXAgPj0gJzIwMjMtMDktMThUMDU6MDA6MDAnIEFORCBldmVudC50aW1lc3RhbXAgPD0gJzIwMjMtMDktMjBUMDU6MDA6MDAnIEFORCAoKGFwcGxpY2F0aW9uX2luc3RhbmNlcy5zZXR0aW5ncyAtPidoeXBvdGhlc2lzJykgLT4-ICdpbnN0cnVjdG9yX2VtYWlsX2RpZ2VzdHNfZW5hYmxlZCcgPSAndHJ1ZScpXG4gIClcbiAgIFNFTEVDVCBESVNUSU5DVCBcInVzZXJcIi5oX3VzZXJpZCBcbiAgIEZST00gXCJ1c2VyXCIgSk9JTiBhc3NpZ25tZW50X21lbWJlcnNoaXAgT04gXCJ1c2VyXCIuaWQgPSBhc3NpZ25tZW50X21lbWJlcnNoaXAudXNlcl9pZCBKT0lOIGFzc2lnbm1lbnRfZ3JvdXBpbmcgT04gYXNzaWdubWVudF9ncm91cGluZy5hc3NpZ25tZW50X2lkID0gYXNzaWdubWVudF9tZW1iZXJzaGlwLmFzc2lnbm1lbnRfaWQgSk9JTiBsdGlfcm9sZSBPTiBsdGlfcm9sZS5pZCA9IGFzc2lnbm1lbnRfbWVtYmVyc2hpcC5sdGlfcm9sZV9pZCBcbiAgIFdIRVJFIGFzc2lnbm1lbnRfZ3JvdXBpbmcuZ3JvdXBpbmdfaWQgSU4gKFNFTEVDVCBjYW5kaWRhdGVfY291cnNlcy5jb3Vyc2VfaWQgXG4gICBGUk9NIGNhbmRpZGF0ZV9jb3Vyc2VzKSBBTkQgbHRpX3JvbGUudHlwZSA9ICdpbnN0cnVjdG9yJyBBTkQgKFwidXNlclwiLmhfdXNlcmlkIE5PVCBJTiAoU0VMRUNUIGVtYWlsX3Vuc3Vic2NyaWJlLmhfdXNlcmlkIFxuICAgRlJPTSBlbWFpbF91bnN1YnNjcmliZSBcbiAgIFdIRVJFIGVtYWlsX3Vuc3Vic2NyaWJlLnRhZyA9ICdpbnN0cnVjdG9yX2RpZ2VzdCcpKVxuKSIsInRlbXBsYXRlLXRhZ3MiOnt9fSwidHlwZSI6Im5hdGl2ZSJ9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319)


There's a second column there with whatever we have an unsubscribe created after the task_done. In this example that accounts from one of the missing users.


[For the rest I queried for the settings of the application instances they belong to and got this result](https://report.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo1LCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3QgaF91c2VyaWQsIHNldHRpbmdzLT4naHlwb3RoZXNpcyctPj4naW5zdHJ1Y3Rvcl9lbWFpbF9kaWdlc3RzX2VuYWJsZWQnXG5mcm9tIFwidXNlclwiIFxuam9pbiBhcHBsaWNhdGlvbl9pbnN0YW5jZXMgb24gYXBwbGljYXRpb25faW5zdGFuY2VzLmlkID0gYXBwbGljYXRpb25faW5zdGFuY2VfaWRcbndoZXJlIGhfdXNlcmlkIGluXG4oJ2FjY3Q6NmEwZDQ1ODdhM2M3ODk0NjZjYmVmODRkZDJkOWFlQGxtcy5oeXBvdGhlcy5pcycsXG4nYWNjdDo0Y2NhYTFiZjkxNDQ4MTNjMjBjN2EwMDAzZjQ0NmRAbG1zLmh5cG90aGVzLmlzJyxcbidhY2N0OjcyZTg1YjRiOTc1NDI3ZmUyYmQ3YjkzYjBjMDdiZkBsbXMuaHlwb3RoZXMuaXMnLFxuJ2FjY3Q6MTAwMjU2NjIzNzI4ZmYzOTc4YzdlNGU1N2EyYTc4QGxtcy5oeXBvdGhlcy5pcycsXG4nYWNjdDpjMmM2OTRjYzY5YzA5NGEyMjJkNjU4ZjZjZThkOWNAbG1zLmh5cG90aGVzLmlzJ1xuKSBcbmFuZCBzZXR0aW5ncy0-J2h5cG90aGVzaXMnLT4-J2luc3RydWN0b3JfZW1haWxfZGlnZXN0c19lbmFibGVkJyA9ICdmYWxzZSciLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sInR5cGUiOiJuYXRpdmUifSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)


In the old version we take the user from the "user" table and find any applications instance where they have this setting enabled. This might be an application instance they used last semester for example.

In the new version we consider the applications instance of course that had recent launches. I reckon this is less confusing, if a school asked us to disabled this we'd do it in the most recent installation, not in all the used in the past.

The underlying issue for this confusion is that, like most settings, this should be an organization-wide one instead of per AI. We don't have that yet.
