### PR TITLE
Proxy listing canvas pages enpoint

### DIFF
--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -48,10 +48,12 @@ class FilePickerConfig:
         """Get Canvas files config."""
 
         files_enabled = application_instance.settings.get("canvas", "files_enabled")
+        pages_enabled = application_instance.settings.get("canvas", "pages_enabled")
 
         course_id = request.lti_params.get("custom_canvas_course_id")
         config = {
             "enabled": files_enabled,
+            "pagesEnabled": pages_enabled,
             "foldersEnabled": application_instance.settings.get(
                 "canvas", "folders_enabled"
             ),
@@ -62,6 +64,14 @@ class FilePickerConfig:
                 ),
             },
         }
+
+        if pages_enabled:
+            config["listPages"] = {
+                "authUrl": request.route_url(Canvas.route.oauth2_authorize),
+                "path": request.route_path(
+                    "canvas_api.courses.pages.list", course_id=course_id
+                ),
+            }
 
         return config
 

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -113,6 +113,10 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("lti_api.result.read", "/api/lti/result", request_method="GET")
     config.add_route("lti_api.result.record", "/api/lti/result", request_method="POST")
 
+    config.add_route(
+        "canvas_api.courses.pages.list", "/api/canvas/courses/{course_id}/pages"
+    )
+
     # JSTOR article IDs need a custom pattern because they may contain a slash,
     # after URL-decoding of the path.
     jstor_article_id_pat = r"(10\.[0-9]+/)?[^/]+"

--- a/lms/services/canvas_api/_pages.py
+++ b/lms/services/canvas_api/_pages.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import List
+
+from marshmallow import fields
+
+from lms.validation import RequestsResponseSchema
+
+
+@dataclass
+class CanvasPage:
+    id: str
+    title: str
+    updated_at: str
+
+
+class ListPagesSchema(RequestsResponseSchema):
+    many = True
+
+    id = fields.Integer(required=True, data_key="page_id")
+    title = fields.Str(required=True)
+    updated_at = fields.String(required=True)
+
+
+class CanvasPagesClient:
+    def __init__(self, client):
+        self._client = client
+
+    def list(self, course_id) -> List[CanvasPage]:
+        pages = self._client.send(
+            "GET",
+            f"courses/{course_id}/pages",
+            params={"published": 1},
+            schema=ListPagesSchema,
+        )
+
+        return [
+            CanvasPage(
+                id=page["id"], title=page["title"], updated_at=page["updated_at"]
+            )
+            for page in pages
+        ]

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -61,7 +61,12 @@ class CanvasAPIClient:
         self._file_service = file_service
         self._folders_enabled = folders_enabled
 
-        self.pages = CanvasPagesClient(authenticated_client)
+        self._pages = CanvasPagesClient(authenticated_client)
+
+    @property
+    def pages(self):
+        """Expose the Pages client."""
+        return self._pages
 
     def get_token(self, authorization_code):
         """

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -8,6 +8,7 @@ from typing import Dict, List
 import marshmallow
 from marshmallow import EXCLUDE, Schema, fields, post_load, validate, validates_schema
 
+from lms.services.canvas_api._pages import CanvasPagesClient
 from lms.services.exceptions import CanvasAPIError
 from lms.services.file import FileService
 from lms.validation import RequestsResponseSchema
@@ -59,6 +60,8 @@ class CanvasAPIClient:
         self._client = authenticated_client
         self._file_service = file_service
         self._folders_enabled = folders_enabled
+
+        self.pages = CanvasPagesClient(authenticated_client)
 
     def get_token(self, authorization_code):
         """

--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -48,6 +48,7 @@ class CanvasAPIClient:
         self,
         authenticated_client,
         file_service: FileService,
+        pages_client: CanvasPagesClient,
         folders_enabled: bool = False,
     ):
         """
@@ -61,7 +62,7 @@ class CanvasAPIClient:
         self._file_service = file_service
         self._folders_enabled = folders_enabled
 
-        self._pages = CanvasPagesClient(authenticated_client)
+        self._pages = pages_client
 
     @property
     def pages(self):

--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -1,6 +1,7 @@
 from lms.services.aes import AESService
 from lms.services.canvas_api._authenticated import AuthenticatedClient
 from lms.services.canvas_api._basic import BasicClient
+from lms.services.canvas_api._pages import CanvasPagesClient
 from lms.services.canvas_api.client import CanvasAPIClient
 
 
@@ -30,6 +31,7 @@ def canvas_api_client_factory(_context, request):
     return CanvasAPIClient(
         authenticated_api,
         file_service=request.find_service(name="file"),
+        pages_client=CanvasPagesClient(authenticated_api),
         folders_enabled=application_instance.settings.get(
             "canvas", "folders_enabled", default=False
         ),

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -93,8 +93,10 @@ export type FilePickerConfig = {
   };
   canvas: {
     enabled: boolean;
+    pagesEnabled?: boolean;
     foldersEnabled: boolean;
     listFiles: APICallInfo;
+    listPages: APICallInfo;
   };
   google: {
     enabled: boolean;

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -41,6 +41,9 @@ GROUPS_SCOPES = (
 )
 
 
+PAGES_SCOPES = ("url:GET|/api/v1/courses/:course_id/pages",)
+
+
 @view_config(
     request_method="GET",
     route_name="canvas_api.oauth.authorize",
@@ -54,6 +57,9 @@ def authorize(request):
 
     if application_instance.settings.get("canvas", "folders_enabled"):
         scopes += FOLDERS_SCOPES
+
+    if application_instance.settings.get("canvas", "pages_enabled"):
+        scopes += PAGES_SCOPES
 
     if application_instance.developer_key and (
         # If the instance could add a new course with sections...

--- a/lms/views/api/canvas/pages.py
+++ b/lms/views/api/canvas/pages.py
@@ -24,7 +24,7 @@ class PagesAPIViews:
                 "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
                 "lms_id": page.id,
                 "display_name": page.title,
-                "type": "File",
+                "type": "Page",
                 "updated_at": page.updated_at,
             }
             for page in self.canvas.api.pages.list(course_id)

--- a/lms/views/api/canvas/pages.py
+++ b/lms/views/api/canvas/pages.py
@@ -1,0 +1,31 @@
+from pyramid.view import view_config, view_defaults
+
+from lms.security import Permissions
+from lms.services.canvas import CanvasService
+
+
+@view_defaults(permission=Permissions.API, renderer="json")
+class PagesAPIViews:
+    def __init__(self, request):
+        self.request = request
+        self.canvas = request.find_service(CanvasService)
+
+    @view_config(request_method="GET", route_name="canvas_api.courses.pages.list")
+    def list_pages(self):
+        """
+        Return the list of pages in the given course.
+
+        :raise lms.services.CanvasAPIError: if the Canvas API request fails.
+            This exception is caught and handled by an exception view.
+        """
+        course_id = self.request.matchdict["course_id"]
+        return [
+            {
+                "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
+                "lms_id": page.id,
+                "display_name": page.title,
+                "type": "File",
+                "updated_at": page.updated_at,
+            }
+            for page in self.canvas.api.pages.list(course_id)
+        ]

--- a/tests/unit/lms/services/canvas_api/_pages_test.py
+++ b/tests/unit/lms/services/canvas_api/_pages_test.py
@@ -1,0 +1,43 @@
+import pytest
+from h_matchers import Any
+
+from lms.services.canvas_api._pages import CanvasPage, CanvasPagesClient
+from tests import factories
+
+
+@pytest.mark.usefixtures("http_session", "oauth_token")
+class TestCanvasPagesClient:
+    def test_list(self, pages_client, http_session):
+        pages = [
+            {"page_id": 1, "title": "PAGE 1", "updated_at": "UPDATED_AT_1"},
+            {"page_id": 2, "title": "PAGE 2", "updated_at": "UPDATED_AT_2"},
+        ]
+        http_session.send.return_value = factories.requests.Response(
+            status_code=200, json_data=pages
+        )
+
+        response_pages = pages_client.list("COURSE_ID")
+
+        self.assert_http_send(
+            http_session,
+            path="api/v1/courses/COURSE_ID/pages",
+            query={"published": "1", "per_page": "1000"},
+        )
+        assert response_pages == [
+            CanvasPage(
+                id=page["page_id"], title=page["title"], updated_at=page["updated_at"]
+            )
+            for page in pages
+        ]
+
+    def assert_http_send(
+        self, http_session, path, method="GET", query=None, timeout=(10, 10)
+    ):
+        http_session.send.assert_called_once_with(
+            Any.request(method, url=Any.url.with_path(path).with_query(query)),
+            timeout=timeout,
+        )
+
+    @pytest.fixture
+    def pages_client(self, authenticated_client):
+        return CanvasPagesClient(authenticated_client)

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -41,8 +41,7 @@ class TestCanvasAPIClientIntegrated:
     """
 
     def test_pages(self, canvas_api_client):
-        # pylint:disable=protected-access
-        assert canvas_api_client.pages == canvas_api_client._pages
+        assert canvas_api_client.pages == sentinel.pages_client
 
     def test_authenticated_users_sections(self, canvas_api_client, http_session):
         sections = [{"id": 1, "name": "name_1"}, {"id": 2, "name": "name_2"}]
@@ -646,4 +645,6 @@ class TestCanvasAPIClientIntegrated:
 
 @pytest.fixture
 def canvas_api_client(authenticated_client, file_service):
-    return CanvasAPIClient(authenticated_client, file_service)
+    return CanvasAPIClient(
+        authenticated_client, file_service, pages_client=sentinel.pages_client
+    )

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -40,6 +40,10 @@ class TestCanvasAPIClientIntegrated:
     of AuthenticatedClient and BasicClient.
     """
 
+    def test_pages(self, canvas_api_client):
+        # pylint:disable=protected-access
+        assert canvas_api_client.pages == canvas_api_client._pages
+
     def test_authenticated_users_sections(self, canvas_api_client, http_session):
         sections = [{"id": 1, "name": "name_1"}, {"id": 2, "name": "name_2"}]
         http_session.send.return_value = factories.requests.Response(

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -17,6 +17,8 @@ class TestCanvasAPIClientFactory:
         pyramid_request,
         CanvasAPIClient,
         AuthenticatedClient,
+        BasicClient,
+        CanvasPagesClient,
         file_service,
         folders_enabled,
         application_instance,
@@ -25,20 +27,15 @@ class TestCanvasAPIClientFactory:
 
         canvas_api = canvas_api_client_factory(sentinel.context, pyramid_request)
 
+        BasicClient.assert_called_once_with(application_instance.lms_host())
+        CanvasPagesClient.assert_called_once_with(AuthenticatedClient.return_value)
         CanvasAPIClient.assert_called_once_with(
             AuthenticatedClient.return_value,
             file_service,
+            pages_client=CanvasPagesClient.return_value,
             folders_enabled=folders_enabled,
         )
         assert canvas_api == CanvasAPIClient.return_value
-
-    @pytest.mark.usefixtures("aes_service")
-    def test_building_the_BasicClient(
-        self, pyramid_request, BasicClient, application_instance
-    ):
-        canvas_api_client_factory(sentinel.context, pyramid_request)
-
-        BasicClient.assert_called_once_with(application_instance.lms_host())
 
     def test_building_the_AuthenticatedClient(
         self,
@@ -66,6 +63,10 @@ class TestCanvasAPIClientFactory:
     @pytest.fixture(autouse=True)
     def AuthenticatedClient(self, patch):
         return patch("lms.services.canvas_api.factory.AuthenticatedClient")
+
+    @pytest.fixture(autouse=True)
+    def CanvasPagesClient(self, patch):
+        return patch("lms.services.canvas_api.factory.CanvasPagesClient")
 
     @pytest.fixture(autouse=True)
     def CanvasAPIClient(self, patch):

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -20,7 +20,7 @@ class TestPageAPIViews:
                 "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
                 "lms_id": page.id,
                 "display_name": page.title,
-                "type": "File",
+                "type": "Page",
                 "updated_at": page.updated_at,
             }
             for page in pages

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -1,0 +1,35 @@
+import pytest
+
+from lms.services.canvas_api._pages import CanvasPage
+from lms.views.api.canvas.pages import PagesAPIViews
+
+
+@pytest.mark.usefixtures(
+    "application_instance_service", "assignment_service", "canvas_service"
+)
+class TestPageAPIViews:
+    def test_list_pages(self, canvas_service, pyramid_request, pages):
+        course_id = "COURSE_ID"
+        pyramid_request.matchdict = {"course_id": course_id}
+        canvas_service.api.pages.list.return_value = pages
+
+        result = PagesAPIViews(pyramid_request).list_pages()
+
+        assert result == [
+            {
+                "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
+                "lms_id": page.id,
+                "display_name": page.title,
+                "type": "File",
+                "updated_at": page.updated_at,
+            }
+            for page in pages
+        ]
+        canvas_service.api.pages.list.assert_called_once_with(course_id)
+
+    @pytest.fixture
+    def pages(self):
+        return [
+            CanvasPage(id=i, title=f"title {i}", updated_at=f"updated {i}")
+            for i in range(5)
+        ]


### PR DESCRIPTION
# Testing

- Enable pages over:

http://localhost:8001/admin/instance/8/

- Use https://github.com/hypothesis/lms/pull/5717 (`canvas-pages-proxy) to get the FE bits needed to test the backend, you'll have to rebase this branch there.

- Re-configure the assignment over:
https://hypothesis.instructure.com/courses/125/assignments/5142/edit?name=Testing+creation&due_at=null&points_possible=0

- Pick Canvas Pages, it should display the pages in over: 
https://hypothesis.instructure.com/courses/125/pages






