### PR TITLE
Enable grouped updates for frontend dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,24 @@ updates:
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
+  groups:
+    babel:
+      patterns:
+        - '@babel/*'
+    eslint:
+      patterns:
+        - 'eslint*'
+        - '@typescript-eslint/*'
+    rollup:
+      patterns:
+        - 'rollup'
+        - '@rollup/*'
+    sentry:
+      patterns:
+        - '@sentry/*'
+    typescript-types:
+      patterns:
+        - '@types/*'
 - package-ecosystem: "docker"
   directory: "/"
   schedule:


### PR DESCRIPTION
This will reduce the overall volume of PRs and conflicts between PRs for updating frontend dependencies. The configuration was copied from the client repo.

We don't currently use Sentry in the frontend in this repo, but I left the configuration on there because I expect we will use it in future.

Assuming this works as expected, I'll roll it out to other projects that have significant frontend components.