### PR TITLE
Return a template for canvas pages instead of a raw Response

### DIFF
--- a/lms/templates/api/canvas/page.html.jinja2
+++ b/lms/templates/api/canvas/page.html.jinja2
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <title>{{title}}</title>
+  </head>
+  <body>
+    <h1>{{title}}</h1>
+    {{body|safe}}
+  </body>
+</html>

--- a/lms/views/api/canvas/pages.py
+++ b/lms/views/api/canvas/pages.py
@@ -1,6 +1,5 @@
 import re
 
-from pyramid.response import Response
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
@@ -67,7 +66,11 @@ class PagesAPIViews:
             )
         }
 
-    @view_config(request_method="GET", route_name="canvas_api.pages.proxy")
+    @view_config(
+        request_method="GET",
+        route_name="canvas_api.pages.proxy",
+        renderer="lms:templates/api/canvas/page.html.jinja2",
+    )
     def proxy(self):
         """Proxy the contents of a canvas page."""
         document_url_match = DOCUMENT_URL_REGEX.search(
@@ -76,5 +79,7 @@ class PagesAPIViews:
         page = self.canvas.api.pages.page(
             document_url_match["course_id"], document_url_match["page_id"]
         )
-
-        return Response(body=page.body)
+        return {
+            "title": page.title,
+            "body": page.body,
+        }

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -2,7 +2,6 @@ from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
-from pyramid.response import Response
 
 from lms.services.canvas_api._pages import CanvasPage
 from lms.views.api.canvas.pages import PagesAPIViews
@@ -70,13 +69,13 @@ class TestPageAPIViews:
             "document_url"
         ] = "canvas://page/course/COURSE_ID/page_id/PAGE_ID"
         canvas_service.api.pages.page.return_value = CanvasPage(
-            id=1, title="Title", updated_at="updated", body="BODY"
+            id=1, title=sentinel.title, updated_at="updated", body=sentinel.body
         )
 
         response = PagesAPIViews(pyramid_request).proxy()
 
         canvas_service.api.pages.page.assert_called_once_with("COURSE_ID", "PAGE_ID")
-        assert response.text == Response("BODY").text
+        assert response == {"title": sentinel.title, "body": sentinel.body}
 
     @pytest.fixture
     def pages(self):


### PR DESCRIPTION
Pretty basic HTML page with just the title and the body.


## Testing

- Launch https://hypothesis.instructure.com/courses/125/assignments/5142

It looks similar to the vession in `main` but it does include the title now.


