### PR TITLE
Include a canonical URL for canvas pages

### DIFF
--- a/lms/services/canvas_api/_pages.py
+++ b/lms/services/canvas_api/_pages.py
@@ -14,6 +14,9 @@ class CanvasPage:
 
     body: Optional[str] = None
 
+    def canonical_url(self, lms_host, course_id):
+        return f"https://{lms_host}/courses/{course_id}/pages/{self.id}"
+
 
 class ListPagesSchema(RequestsResponseSchema):
     many = True

--- a/lms/templates/api/canvas/page.html.jinja2
+++ b/lms/templates/api/canvas/page.html.jinja2
@@ -2,6 +2,7 @@
 <html lang=en>
   <head>
     <meta charset=utf-8>
+    <link rel="canonical" href="{{canonical_url}}" />
     <title>{{title}}</title>
   </head>
   <body>

--- a/lms/views/api/canvas/pages.py
+++ b/lms/views/api/canvas/pages.py
@@ -76,10 +76,12 @@ class PagesAPIViews:
         document_url_match = DOCUMENT_URL_REGEX.search(
             self.request.params["document_url"]
         )
-        page = self.canvas.api.pages.page(
-            document_url_match["course_id"], document_url_match["page_id"]
-        )
+        course_id = document_url_match["course_id"]
+        page = self.canvas.api.pages.page(course_id, document_url_match["page_id"])
         return {
+            "canonical_url": page.canonical_url(
+                self.request.lti_user.application_instance.lms_host(), course_id
+            ),
             "title": page.title,
             "body": page.body,
         }

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -64,7 +64,7 @@ class TestPageAPIViews:
         )
         assert response == {"via_url": helpers.via_url.return_value}
 
-    def test_proxy(self, canvas_service, pyramid_request):
+    def test_proxy(self, canvas_service, pyramid_request, application_instance):
         pyramid_request.params[
             "document_url"
         ] = "canvas://page/course/COURSE_ID/page_id/PAGE_ID"
@@ -75,7 +75,11 @@ class TestPageAPIViews:
         response = PagesAPIViews(pyramid_request).proxy()
 
         canvas_service.api.pages.page.assert_called_once_with("COURSE_ID", "PAGE_ID")
-        assert response == {"title": sentinel.title, "body": sentinel.body}
+        assert response == {
+            "title": sentinel.title,
+            "body": sentinel.body,
+            "canonical_url": f"https://{application_instance.lms_host()}/courses/COURSE_ID/pages/1",
+        }
 
     @pytest.fixture
     def pages(self):


### PR DESCRIPTION
Using the ID version of the page in canvas itself which Canvas redirects to the version using the slug.

This is the more obvious URL for us to use but the most important aspect is that is stable rather than actually being a real URL.


## Testing

- Launch https://hypothesis.instructure.com/courses/125/assignments/5142
- Make an annotation
- Reload the page
- The annotation is still there

-  The canonical URL is href="https://hypothesis.instructure.com/courses/125/pages/1392 which takes you, after a redirect, to https://hypothesis.instructure.com/courses/125/pages/test-page