### PR TITLE
Store references to canvas pages in the DB

### DIFF
--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -27,11 +27,12 @@ def canvas_api_client_factory(_context, request):
         client_secret=developer_secret,
         redirect_uri=request.route_url("canvas_api.oauth.callback"),
     )
+    file_service = request.find_service(name="file")
 
     return CanvasAPIClient(
         authenticated_api,
-        file_service=request.find_service(name="file"),
-        pages_client=CanvasPagesClient(authenticated_api),
+        file_service=file_service,
+        pages_client=CanvasPagesClient(authenticated_api, file_service),
         folders_enabled=application_instance.settings.get(
             "canvas", "folders_enabled", default=False
         ),

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -28,10 +28,12 @@ class TestCanvasAPIClientFactory:
         canvas_api = canvas_api_client_factory(sentinel.context, pyramid_request)
 
         BasicClient.assert_called_once_with(application_instance.lms_host())
-        CanvasPagesClient.assert_called_once_with(AuthenticatedClient.return_value)
+        CanvasPagesClient.assert_called_once_with(
+            AuthenticatedClient.return_value, file_service
+        )
         CanvasAPIClient.assert_called_once_with(
             AuthenticatedClient.return_value,
-            file_service,
+            file_service=file_service,
             pages_client=CanvasPagesClient.return_value,
             folders_enabled=folders_enabled,
         )


### PR DESCRIPTION
As we do with other LMS-backed content (files in Canvas, D2L and Blackboard) we store a reference to the page in the file table for:

- Bookkeeping, being able to count the number of documents we've have seen.
- Debugging of live issues.
- And, more importantly, support our course copy process, when, once we have records of the documents in the DB we can compare the old course ones with the ones in the new course.

We store these now in "File", we should consider a future refactor to rename this table/model/service to something more generic like "Document".



## Testing

- https://github.com/hypothesis/lms/pull/5717/commits needs to be merged or rebase here to make testing easiser.

- Try to reconfigure using canvas pages: https://hypothesis.instructure.com/courses/125/assignments/5142/edit?return_to=https%3A%2F%2Fhypothesis.instructure.com%2Fcourses%2F125%2Fassignments%2F5142, no need to select any, just get the list.

- Check that the pages have been stored: 

```
docker compose exec postgres psql -U postgres -c "select type,name from file where type ='canvas_page';"                                                                                                                                                                                                                  
    type     |                             name                              
-------------+---------------------------------------------------------------
 canvas_page | Test page
 canvas_page | Test page Copy
 canvas_page | Designing your own Hypothesis activity: questions to consider
(3 rows)
```

- 