### PR TITLE
Mark lti_message_hint as not required

### DIFF
--- a/lms/views/lti/oidc.py
+++ b/lms/views/lti/oidc.py
@@ -44,7 +44,7 @@ class OIDCRequestSchema(PyramidRequestSchema):
 
     target_link_uri = fields.Str(required=True)
     login_hint = fields.Str(required=True)
-    lti_message_hint = fields.Str(required=True)
+    lti_message_hint = fields.Str(required=False)
 
 
 @view_config(
@@ -70,7 +70,7 @@ def oidc_view(request):
         "response_mode": "form_post",
         "prompt": "none",
         "login_hint": params["login_hint"],
-        "lti_message_hint": params["lti_message_hint"],
+        "lti_message_hint": params.get("lti_message_hint"),
         # We might not have been provided the client id in the request, so use
         # the client id from the registration
         "client_id": registration.client_id,


### PR DESCRIPTION
Some LMSes don't send this value (Sakai) and ultimately is the LMS that's going to validate the value in the callback. We'll forward the value from the LMS even it's `None`.


## Testing

Sanity check a LTI1.3 launch in some LMS: https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View?ou=6782