### PR TITLE
Improve FE tests resiliency

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -210,8 +210,14 @@ describe('FilePickerApp', () => {
 
       selectContent(wrapper, 'https://example.com');
 
+      const form = wrapper.find('form').getDOMNode();
+      const waitForFormSubmit = new Promise(resolve =>
+        form.addEventListener('submit', resolve)
+      );
+
       // Simulate implicit form submission, as if pressing Enter in title field.
-      wrapper.find('form').getDOMNode().requestSubmit();
+      form.requestSubmit();
+      await waitForFormSubmit;
 
       await waitFor(() => fakeAPICall.called);
       await waitFor(() => onSubmit.called);

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -185,25 +185,28 @@ describe('JSTORPicker', () => {
       );
     });
 
-    it('confirms the validated URL if "Enter" is pressed subsequently', () => {
+    it('confirms the validated URL if "Enter" is pressed subsequently', async () => {
       const onSelectURL = sinon.stub();
       const wrapper = renderJSTORPicker({ onSelectURL });
-      const input = getInput(wrapper);
-      const keyEvent = new Event('keydown');
-      keyEvent.key = 'Enter';
+      const input = getInput(wrapper).getDOMNode();
+      const keyEvent = new KeyboardEvent('keydown', { key: 'Enter' });
 
       setURL(wrapper, 'https://www.jstor.org/stable/1234');
 
       // First enter press will validate URL
       interact(wrapper, () => {
-        input.getDOMNode().dispatchEvent(keyEvent);
+        input.dispatchEvent(keyEvent);
       });
       assert.calledOnce(fakeArticleIdFromUserInput);
 
       simulateMetadataFetch(wrapper, 'test title');
 
+      const waitForKeyDown = new Promise(resolve =>
+        input.addEventListener('keydown', resolve)
+      );
       // Enter will submit if terms are checked and there is valid metadata fetched
-      input.getDOMNode().dispatchEvent(keyEvent);
+      input.dispatchEvent(keyEvent);
+      await waitForKeyDown;
 
       assert.calledOnce(onSelectURL);
       assert.calledWith(onSelectURL, 'jstor://1234');


### PR DESCRIPTION
This PR is an attempt to reduce the amount of random test failures during CI, for some tests which are asserting on the result of DOM events which have asynchronous callbacks.

The change in both tests implies listening for the same event in the test itself, and waiting for it to be dispatched, before trying to make any assertions.