### PR TITLE
Don't send the assignment id on the URL for pages endpoint

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -75,10 +75,7 @@ class JSConfig:
         elif document_url.startswith("canvas://page"):
             self._config["api"]["viaUrl"] = {
                 "authUrl": self._request.route_url(Canvas.route.oauth2_authorize),
-                "path": self._request.route_path(
-                    "canvas_api.pages.via_url",
-                    resource_link_id=self._request.lti_params["resource_link_id"],
-                ),
+                "path": self._request.route_path("canvas_api.pages.via_url"),
             }
 
         elif document_url.startswith("d2l://"):

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -116,10 +116,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "canvas_api.courses.pages.list", "/api/canvas/courses/{course_id}/pages"
     )
-    config.add_route(
-        "canvas_api.pages.via_url",
-        "/api/canvas/assignments/{resource_link_id}/pages/via_url",
-    )
+    config.add_route("canvas_api.pages.via_url", "/api/canvas/pages/via_url")
     config.add_route("canvas_api.pages.proxy", "/api/canvas/pages/proxy")
 
     # JSTOR article IDs need a custom pattern because they may contain a slash,

--- a/lms/views/api/canvas/pages.py
+++ b/lms/views/api/canvas/pages.py
@@ -45,7 +45,7 @@ class PagesAPIViews:
         application_instance = self.request.lti_user.application_instance
         assignment = self.request.find_service(name="assignment").get_assignment(
             application_instance.tool_consumer_instance_guid,
-            self.request.matchdict["resource_link_id"],
+            self.request.lti_user.lti.assignment_id,
         )
 
         # We build a token to authorize the view that fetches the actual

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -261,7 +261,7 @@ class TestAddDocumentURL:
 
         assert js_config.asdict()["api"]["viaUrl"] == {
             "authUrl": "http://example.com/api/canvas/oauth/authorize",
-            "path": "/api/canvas/assignments/TEST_RESOURCE_LINK_ID/pages/via_url",
+            "path": "/api/canvas/pages/via_url",
         }
 
     def test_it_adds_the_viaUrl_api_config_for_D2L_documents(self, js_config):

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -39,15 +39,13 @@ class TestPageAPIViews:
         lti_user,
         BearerTokenSchema,
     ):
-        pyramid_request.matchdict["resource_link_id"] = sentinel.resource_link_id
         assignment_service.get_assignment.return_value.document_url = "DOCUMENT_URL"
         BearerTokenSchema.return_value.authorization_param.return_value = "TOKEN"
 
         response = PagesAPIViews(pyramid_request).via_url()
 
         assignment_service.get_assignment.assert_called_once_with(
-            application_instance.tool_consumer_instance_guid,
-            sentinel.resource_link_id,
+            application_instance.tool_consumer_instance_guid, lti_user.lti.assignment_id
         )
         BearerTokenSchema.assert_called_once_with(pyramid_request)
         BearerTokenSchema.return_value.authorization_param.assert_called_once_with(


### PR DESCRIPTION
Instead of using a URL parameter use the value from LTIUser, which is signed.


Small simplification before starting the course copy work for Canvas pages. We should be using these values more often but let's start by not introducing new instances of the old method of passing assignment.


## Testing

- Sanity check, launch: https://hypothesis.instructure.com/courses/125/assignments/5142