### PR TITLE
Add new method to allow storing page mappings between courses

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -177,11 +177,19 @@ class Course(Grouping):
         """Get this course's available group sets."""
         return self.extra.get("group_sets", [])
 
-    def _set_course_copy_mapped_key(self, key, old_id, new_id):
-        self.extra.setdefault(key, {})[old_id] = new_id
+    def get_mapped_page_id(self, page_id):
+        """
+        Get a previously mapped page id in a course.
 
-    def _get_course_copy_mapped_key(self, key, id_):
-        return self.extra.get(key, {}).get(id_, id_)
+        Returns the original `page_id` if no mapped one can be found.
+        """
+        return self._get_course_copy_mapped_key("course_copy_page_mappings", page_id)
+
+    def set_mapped_page_id(self, old_page_id, new_page_id):
+        """Store the mapping between old_page and new_page_id for future launches."""
+        self._set_course_copy_mapped_key(
+            "course_copy_page_mappings", old_page_id, new_page_id
+        )
 
     def get_mapped_file_id(self, file_id):
         """
@@ -212,6 +220,12 @@ class Course(Grouping):
         self._set_course_copy_mapped_key(
             "course_copy_group_set_mappings", old_group_set_id, group_set_id
         )
+
+    def _set_course_copy_mapped_key(self, key, old_id, new_id):
+        self.extra.setdefault(key, {})[old_id] = new_id
+
+    def _get_course_copy_mapped_key(self, key, id_):
+        return self.extra.get(key, {}).get(id_, id_)
 
 
 class GroupingMembership(CreatedUpdatedMixin, BASE):

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -177,19 +177,25 @@ class Course(Grouping):
         """Get this course's available group sets."""
         return self.extra.get("group_sets", [])
 
+    def _set_course_copy_mapped_key(self, key, old_id, new_id):
+        self.extra.setdefault(key, {})[old_id] = new_id
+
+    def _get_course_copy_mapped_key(self, key, id_):
+        return self.extra.get(key, {}).get(id_, id_)
+
     def get_mapped_file_id(self, file_id):
         """
         Get a previously mapped file id in a course.
 
         Returns the original `file_id` if no mapped one can be found.
         """
-        return self.extra.get("course_copy_file_mappings", {}).get(file_id, file_id)
+        return self._get_course_copy_mapped_key("course_copy_file_mappings", file_id)
 
     def set_mapped_file_id(self, old_file_id, new_file_id):
         """Store the mapping between old_file_id and new_file_id for future launches."""
-        self.extra.setdefault("course_copy_file_mappings", {})[
-            old_file_id
-        ] = new_file_id
+        self._set_course_copy_mapped_key(
+            "course_copy_file_mappings", old_file_id, new_file_id
+        )
 
     def get_mapped_group_set_id(self, group_set_id):
         """
@@ -197,15 +203,15 @@ class Course(Grouping):
 
         Returns the given `group_set_id` if no mapped one can be found.
         """
-        return self.extra.get("course_copy_group_set_mappings", {}).get(
-            group_set_id, group_set_id
+        return self._get_course_copy_mapped_key(
+            "course_copy_group_set_mappings", group_set_id
         )
 
     def set_mapped_group_set_id(self, old_group_set_id, group_set_id):
         """Store a mapping between old_group set id and group_set_id for future launches."""
-        self.extra.setdefault("course_copy_group_set_mappings", {})[
-            old_group_set_id
-        ] = group_set_id
+        self._set_course_copy_mapped_key(
+            "course_copy_group_set_mappings", old_group_set_id, group_set_id
+        )
 
 
 class GroupingMembership(CreatedUpdatedMixin, BASE):

--- a/tests/unit/lms/models/grouping_test.py
+++ b/tests/unit/lms/models/grouping_test.py
@@ -105,3 +105,27 @@ class TestCourse:
         course.set_mapped_group_set_id("OLD", "NEW")
 
         assert course.extra["course_copy_group_set_mappings"]["OLD"] == "NEW"
+
+    def test_get_mapped_page_id_empty_extra(self):
+        course = factories.Course(extra={})
+
+        assert course.get_mapped_page_id("ID") == "ID"
+
+    def test_get_mapped_page_id_empty_mapping(self):
+        course = factories.Course(extra={"course_copy_page_mappings": {}})
+
+        assert course.get_mapped_page_id("ID") == "ID"
+
+    def test_get_mapped_page_id(self):
+        course = factories.Course(
+            extra={"course_copy_page_mappings": {"ID": "OTHER_ID"}}
+        )
+
+        assert course.get_mapped_page_id("ID") == "OTHER_ID"
+
+    def test_set_mapped_page_id(self):
+        course = factories.Course(extra={})
+
+        course.set_mapped_page_id("OLD", "NEW")
+
+        assert course.extra["course_copy_page_mappings"]["OLD"] == "NEW"


### PR DESCRIPTION
Small PR to add these. It might lack a bit of context on the general course copy process but that PR is getting to big.


This is mostly a copy pasted of existing methods for files & groups and a small refactor to make it less of an actual copy paste.