### PR TITLE
Sort the pages returned by the list endpoint alphabetically

### DIFF
--- a/lms/views/api/canvas/pages.py
+++ b/lms/views/api/canvas/pages.py
@@ -29,7 +29,7 @@ class PagesAPIViews:
             This exception is caught and handled by an exception view.
         """
         course_id = self.request.matchdict["course_id"]
-        return [
+        pages = [
             {
                 "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
                 "lms_id": page.id,
@@ -39,6 +39,7 @@ class PagesAPIViews:
             }
             for page in self.canvas.api.pages.list(course_id)
         ]
+        return sorted(pages, key=lambda page: page["display_name"].lower())
 
     @view_config(request_method="GET", route_name="canvas_api.pages.via_url")
     def via_url(self):

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -1,3 +1,4 @@
+import random
 from unittest.mock import sentinel
 
 import pytest
@@ -18,16 +19,19 @@ class TestPageAPIViews:
 
         result = PagesAPIViews(pyramid_request).list_pages()
 
-        assert result == [
-            {
-                "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
-                "lms_id": page.id,
-                "display_name": page.title,
-                "type": "Page",
-                "updated_at": page.updated_at,
-            }
-            for page in pages
-        ]
+        assert result == sorted(
+            [
+                {
+                    "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
+                    "lms_id": page.id,
+                    "display_name": page.title,
+                    "type": "Page",
+                    "updated_at": page.updated_at,
+                }
+                for page in pages
+            ],
+            key=lambda p: p["display_name"].lower(),
+        )
         canvas_service.api.pages.list.assert_called_once_with(course_id)
 
     def test_via_url(
@@ -81,10 +85,12 @@ class TestPageAPIViews:
 
     @pytest.fixture
     def pages(self):
-        return [
+        pages = [
             CanvasPage(id=i, title=f"title {i}", updated_at=f"updated {i}")
             for i in range(5)
         ]
+        random.shuffle(pages)
+        return pages
 
     @pytest.fixture
     def helpers(self, patch):


### PR DESCRIPTION
Not much more to add, basic alphabetically sorting based on the page's title.