### PR TITLE
Use FileGeneric icon for LMS page documents

### DIFF
--- a/lms/static/scripts/frontend_apps/components/DocumentList.tsx
+++ b/lms/static/scripts/frontend_apps/components/DocumentList.tsx
@@ -1,6 +1,6 @@
 import {
   DataTable,
-  FileCodeFilledIcon,
+  FileGenericIcon,
   FilePdfFilledIcon,
   FolderIcon,
   Scroll,
@@ -63,7 +63,7 @@ export default function DocumentList<DocumentType extends Document>({
             {document.type === 'Folder' ? (
               <FolderIcon className="w-5 h-5" />
             ) : document.type === 'Page' ? (
-              <FileCodeFilledIcon className="w-5 h-5" />
+              <FileGenericIcon className="w-5 h-5" />
             ) : (
               <FilePdfFilledIcon className="w-5 h-5" />
             )}

--- a/lms/static/scripts/frontend_apps/components/test/DocumentList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DocumentList-test.js
@@ -42,7 +42,7 @@ describe('DocumentList', () => {
   [
     ['File', 'FilePdfFilledIcon'],
     ['Folder', 'FolderIcon'],
-    ['Page', 'FileCodeFilledIcon'],
+    ['Page', 'FileGenericIcon'],
   ].forEach(([type, expectedIcon]) => {
     it('renders documents with an icon, document name and date', () => {
       const wrapper = renderDocumentList({


### PR DESCRIPTION
As suggested by a couple people [in slack](https://hypothes-is.slack.com/archives/C07NXBDNW/p1696949673934889), this PR changes the icon we use for LMS (Canvas) pages documents in the `DocumentList`.

Before:

![image](https://github.com/hypothesis/lms/assets/2719332/9c473b79-e1bb-4b3d-9bb1-2663a2ebd074)

After:

![image](https://github.com/hypothesis/lms/assets/2719332/903fdcdc-b993-4253-b02f-53c0ca8834fa)
