### PR TITLE
Map `fdw_users` to the H server on the report system

### DIFF
--- a/bin/run_data_task.py
+++ b/bin/run_data_task.py
@@ -58,9 +58,11 @@ def main():
         scripts = data_tasks.from_dir(
             task_dir=TASK_ROOT / args.task,
             template_vars={
+                # User that connects to the LMS DB
                 "db_user": parse_dsn(settings["database_url"].strip())["user"],
                 "region": Regions.get_region(),
                 "h_fdw": parse_dsn(settings["h_fdw_database_url"]),
+                # Additional users that get granted access to the FDW server
                 "fdw_users": settings["fdw_users"],
             },
         )

--- a/lms/data_tasks/report/create_from_scratch/00_schema/02_create_fdw_server.jinja2.sql
+++ b/lms/data_tasks/report/create_from_scratch/00_schema/02_create_fdw_server.jinja2.sql
@@ -11,10 +11,18 @@ CREATE SERVER "h_server" FOREIGN DATA WRAPPER postgres_fdw
         dbname '{{h_fdw.dbname}}'
 );
 
-DROP USER MAPPING IF EXISTS FOR "{{db_user}}" SERVER "h_server";
-CREATE USER MAPPING IF NOT EXISTS FOR "{{db_user}}"
-    SERVER "h_server"
-    OPTIONS (
-        user '{{h_fdw.user}}',
-        password '{{h_fdw.password}}' -- SECRET
-);
+
+{% macro map_fdw_users(users) %}
+    {% for user in users %}
+        DROP USER MAPPING IF EXISTS FOR "{{user}}" SERVER "h_server";
+        CREATE USER MAPPING IF NOT EXISTS FOR "{{user}}"
+            SERVER "h_server"
+            OPTIONS (
+                user '{{h_fdw.user}}',
+                password '{{h_fdw.password}}' -- SECRET
+        );
+    {% endfor %}
+{% endmacro %}
+
+
+{{ map_fdw_users(users=[db_user] + fdw_users) }}


### PR DESCRIPTION
This fixes mapping of users between the LMS DB and the H one via the FDW to, on top of adding the current DB user, add the ones defined in the fdw_users configuration option.