### PR TITLE
Add stylesheet for Canvas Pages assignments

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -15,8 +15,9 @@ gulp.task('watch-js', () => watchJS('./rollup.config.mjs'));
 gulp.task('build-css', () =>
   buildCSS(
     [
-      './lms/static/styles/lms.scss',
+      './lms/static/styles/canvas_pages/canvas_pages.scss',
       './lms/static/styles/frontend_apps.scss',
+      './lms/static/styles/lms.scss',
       './lms/static/styles/ui-playground.scss',
     ],
     { tailwindConfig }

--- a/lms/assets.ini
+++ b/lms/assets.ini
@@ -1,5 +1,8 @@
 [bundles]
 
+canvas_pages_css =
+  styles/canvas_pages.css
+
 frontend_apps_js =
   scripts/browser_check.bundle.js
   scripts/frontend_apps.bundle.js

--- a/lms/static/styles/canvas_pages/canvas_pages.scss
+++ b/lms/static/styles/canvas_pages/canvas_pages.scss
@@ -1,0 +1,189 @@
+// This stylesheet contains a re-implementation of the styles used by Canvas
+// Pages, with the intent to make Canvas Pages served through our LMS app + Via
+// look close to how the page looks in Canvas.
+//
+// We don't vendor the original stylesheets from Canvas because they are large
+// and combine styling for both Canvas Pages and other parts of the Canvas UI.
+// Also Canvas is AGPLv3 licensed, whereas Hypothesis uses a BSD license.
+//
+// The basic approach to creating this stylesheet was:
+//
+// 1. Create a Canvas Page which uses all the available content blocks and
+//    formatting options.
+// 2. Go through the different elements and extract the custom styles (ie.
+//    those which are not part of the user agent stylesheet). In some cases
+//    these can be simplified by omitting workarounds for old browsers.
+//
+// The main upstream sources for Canvas Pages' CSS bundles are:
+//
+// - https://github.com/instructure/canvas-lms/blob/master/app/stylesheets/bundles/common.scss
+// - https://github.com/instructure/canvas-lms/blob/master/app/stylesheets/bundles/wiki_page.scss
+
+// Import the Lato 2.0 font that Canvas uses (aka "Lato Extended" in Canvas).
+// See https://www.latofonts.com and https://fonts.adobe.com/fonts/lato.
+@import 'https://use.typekit.net/ugv8jys.css';
+
+:root {
+  font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+
+  // On macOS this property is needed to give the font the right weight,
+  // otherwise it looks heavier than Canvas Pages' native presentation.
+  -webkit-font-smoothing: antialiased;
+
+  --link-color: #0374b5;
+}
+
+// Element styles.
+a {
+  color: var(--link-color);
+}
+
+blockquote {
+  padding: 0 0 0 15px;
+  margin: 0 0 20px;
+  border-left: 5px solid #c7cdd1;
+
+  p {
+    margin-bottom: 0;
+    font-size: 1rem;
+    font-weight: 300;
+    line-height: 25px;
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: normal;
+  line-height: 1.5;
+  margin: 6px 0;
+  text-rendering: optimizelegibility;
+}
+
+h1,
+h2 {
+  font-size: 1.8em;
+}
+
+h3 {
+  font-size: 1.5em;
+}
+
+h4 {
+  font-size: 18px;
+}
+
+hr {
+  margin: 20px 0;
+  border: 0;
+  border-top: 1px solid #c7cdd1;
+  border-bottom: none;
+}
+
+iframe,
+video {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  max-width: 100%;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  vertical-align: middle;
+  border: 0;
+}
+
+p {
+  margin: 12px 0;
+}
+
+code,
+pre {
+  font-family: Monaco, Menlo, Consolas, 'Courier New', monospace;
+  font-size: 0.75rem;
+  border-radius: 6px;
+  background-color: #f5f5f5;
+  border: 1px solid #c7cdd1;
+}
+
+pre {
+  color: #2d3b45;
+  display: block;
+  padding: 9px;
+  margin: 0 0 12px;
+  line-height: 1.2;
+  word-break: break-all;
+  word-wrap: break-word;
+  white-space: pre;
+  white-space: pre-wrap;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub,
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
+}
+
+table {
+  max-width: 100%;
+  background-color: transparent;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+ul,
+ol {
+  padding: 0;
+  margin: 0 0 6px 25px;
+}
+
+// Classes for the content and container. Canvas's own presentation of pages
+// includes containers with similar class names, which these are modeled after.
+
+.page-title {
+  color: #666;
+  font-size: 2.5em;
+  font-weight: 200;
+  margin: 15px 0;
+}
+
+.user-content {
+  padding: 0 24px 0 12px;
+  overflow-wrap: break-word;
+}
+
+// Classes referenced in the HTML returned from Canvas.
+
+.border {
+  border-width: 0px;
+  border-style: solid;
+  border-color: #c7cdd1;
+}
+
+.border-round {
+  border-radius: 4px;
+}
+
+.border-trbl {
+  border-width: 1px;
+}
+
+.math_equation_latex {
+  display: inline-block;
+  text-align: center;
+}

--- a/lms/templates/api/canvas/page.html.jinja2
+++ b/lms/templates/api/canvas/page.html.jinja2
@@ -3,10 +3,15 @@
   <head>
     <meta charset=utf-8>
     <link rel="canonical" href="{{canonical_url}}" />
+    {% for url in asset_urls("canvas_pages_css") %}
+      <link rel="stylesheet" href="{{ url }}">
+    {% endfor %}
     <title>{{title}}</title>
   </head>
   <body>
-    <h1>{{title}}</h1>
-    {{body|safe}}
+    <main class="user-content">
+      <h1 class="page-title">{{title}}</h1>
+      {{body|safe}}
+    </main>
   </body>
 </html>


### PR DESCRIPTION
Add a stylesheet for the HTML content of Canvas Pages assignments. For reasons outlined at the top of canvas_pages.scss, this commit uses a re-implementation of the styling that Canvas provides for Pages. This includes the Lato font, imported via an Adobe TypeKit project [1] and styling for all of the elements that can be created using Pages' WYSIWYG editor.

Canvas Pages re-use "common" stylesheets that include > 500KB of styles for other parts of the UI, which in principle Canvas Pages HTML could reference, although we assume virtually no pages will.

Fixes https://github.com/hypothesis/lms/issues/5746

[1] https://fonts.adobe.com/fonts/lato. This is the native "home" of the Lato font. To get the typekit.net URL referenced in this commit I created a minimal Web Project and added all the Lato fonts to it.

---

**Testing:**

1. Create a Hypothesis assignment using this Canvas Page: https://hypothesis.instructure.com/courses/125/pages/canvas-page-that-uses-all-the-features
2. Verify that the presentation of the page's content in the Hypothesis assignment matches what you see when you visit the URL directly.
3. Try other pages, verify that the presentation in Hypothesis closely matches the page's "native" presentation