### PR TITLE
Add help link on how to create Canvas pages

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -236,7 +236,7 @@ export default function ContentSelector({
           listFilesApi={listPagesApi}
           onCancel={cancelDialog}
           onSelectFile={selectCanvasPage}
-          missingFilesHelpLink="TODO"
+          missingFilesHelpLink="https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-create-a-new-page-in-a-course/ta-p/1031"
           documentType="page"
         />
       );


### PR DESCRIPTION
In order to know which link to use, I visited the one we have for Canvas files, and the same knowledge base page had references to pages documentation.

One of them is about creating a new page, which seems like the most sensible option.