### PR TITLE
Use SelectNext for StudentSelector

### DIFF
--- a/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
@@ -3,7 +3,7 @@ import {
   ArrowRightIcon,
   IconButton,
   InputGroup,
-  Select,
+  SelectNext,
 } from '@hypothesis/frontend-shared';
 
 import type { StudentInfo } from '../config';
@@ -47,15 +47,6 @@ export default function StudentSelector<Student extends StudentOption>({
     onSelectStudent(selectedIndex === 0 ? null : students[selectedIndex - 1]);
   };
 
-  const handleSelectStudent = (e: Event) => {
-    const studentIndex = parseInt((e.target as HTMLInputElement).value);
-    if (studentIndex === -1) {
-      onSelectStudent(null);
-    } else {
-      onSelectStudent(students[studentIndex]);
-    }
-  };
-
   return (
     <>
       <label
@@ -86,29 +77,21 @@ export default function StudentSelector<Student extends StudentOption>({
             title="Previous student"
             variant="dark"
           />
-          <Select
-            classes="min-w-[12rem] xl:w-[20rem]"
+          <SelectNext
+            classes="md:w-[12rem] lg:w-[16rem] xl:w-[20rem]"
             aria-label="Select student"
-            id={selectId}
-            onChange={handleSelectStudent}
+            value={selectedStudent}
+            onChange={onSelectStudent}
+            buttonId={selectId}
+            buttonContent={selectedStudent?.displayName ?? 'All Students'}
           >
-            <option
-              key={'student-all'}
-              selected={!hasSelectedStudent}
-              value={-1}
-            >
-              All Students
-            </option>
+            <SelectNext.Option value={null}>All Students</SelectNext.Option>
             {students.map((studentOption, idx) => (
-              <option
-                key={`student-${idx}`}
-                selected={selectedIndex === idx}
-                value={idx}
-              >
+              <SelectNext.Option value={studentOption} key={`student-${idx}`}>
                 {studentOption.displayName}
-              </option>
+              </SelectNext.Option>
             ))}
-          </Select>
+          </SelectNext>
           <IconButton
             data-testid="next-student-button"
             disabled={selectedIndex >= students.length - 1}

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -41,7 +41,10 @@ describe('StudentSelector', () => {
 
   it('shall have "All Students" as the default option', () => {
     const wrapper = renderSelector({ selectedStudent: null });
-    assert.equal(wrapper.find('select [selected=true]').text(), 'All Students');
+    assert.equal(
+      wrapper.find('SelectNext').prop('buttonContent'),
+      'All Students'
+    );
     assert.equal(
       wrapper.find('[data-testid="student-selector-label"]').text(),
       '2 Students'
@@ -50,7 +53,7 @@ describe('StudentSelector', () => {
 
   it('sets the selected option to the reflect the selected student', () => {
     const wrapper = renderSelector({ selectedStudent: fakeStudents[1] });
-    assert.equal(wrapper.find('select [selected=true]').text(), 'Student 2');
+    assert.equal(wrapper.find('SelectNext').prop('buttonContent'), 'Student 2');
     assert.equal(
       wrapper.find('[data-testid="student-selector-label"]').text(),
       'Student 2 of 2'
@@ -63,17 +66,18 @@ describe('StudentSelector', () => {
       onSelectStudent: onChange,
       selectedStudent: fakeStudents[0],
     });
-    wrapper.find('select').simulate('change');
-    assert.isTrue(onChange.called);
+    wrapper.find('SelectNext').props().onChange(fakeStudents[1]);
+    assert.calledWith(onChange, fakeStudents[1]);
   });
 
   it('unsets the selected user when the "All Students" option is selected', () => {
     const onChange = sinon.spy();
     const wrapper = renderSelector({
-      // No student is selected
       onSelectStudent: onChange,
+      selectedStudent: fakeStudents[0],
     });
-    wrapper.find('select').simulate('change');
+    // No student is selected
+    wrapper.find('SelectNext').props().onChange(null);
     assert.calledWith(onChange, null);
   });
 

--- a/lms/static/scripts/ui-playground/components/ToolbarPage.tsx
+++ b/lms/static/scripts/ui-playground/components/ToolbarPage.tsx
@@ -9,7 +9,7 @@ import {
   InputGroup,
   LinkButton,
   ModalDialog,
-  Select,
+  SelectNext,
 } from '@hypothesis/frontend-shared';
 import type { ModalProps } from '@hypothesis/frontend-shared/lib/components/feedback/Modal';
 import Library from '@hypothesis/frontend-shared/lib/pattern-library/components/Library';
@@ -125,15 +125,23 @@ export default function ToolbarPage() {
                               title="previous student"
                               variant="dark"
                             />
-                            <Select
-                              aria-label="Select student"
-                              classes="xl:w-80"
-                              id="student-selector"
+                            <label
+                              className="sr-only"
+                              htmlFor="student-selector"
                             >
-                              <option key={'all-students'} value={-1}>
+                              Select student
+                            </label>
+                            <SelectNext
+                              classes="xl:!w-80"
+                              value={-1}
+                              onChange={() => {}}
+                              buttonId="student-selector"
+                              buttonContent="All Students"
+                            >
+                              <SelectNext.Option value={-1}>
                                 All Students
-                              </option>
-                            </Select>
+                              </SelectNext.Option>
+                            </SelectNext>
                             <IconButton
                               icon={ArrowRightIcon}
                               title="next student"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
     "@hypothesis/frontend-build": "^2.2.0",
-    "@hypothesis/frontend-shared": "^6.8.0",
+    "@hypothesis/frontend-shared": "^6.9.1",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-node-resolve": "^15.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,15 +1790,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^6.8.0":
-  version: 6.8.0
-  resolution: "@hypothesis/frontend-shared@npm:6.8.0"
+"@hypothesis/frontend-shared@npm:^6.9.1":
+  version: 6.9.1
+  resolution: "@hypothesis/frontend-shared@npm:6.9.1"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^2.10.0-alpha.1
   peerDependencies:
     preact: ^10.4.0
-  checksum: e2981d395929d9ddd5b6b78f35b4aebe5422ebbdaa48f6e65684cb1514534186e98559b2aadbaad77f3dc02652b73128c5bf3714d86b14f4104d5162d9d79466
+  checksum: 758644dfdd558540d6a5d4004b4dd0417c88a67d0ea13dd3653d57c143d3e5abe3bcecdb4d7ca4cab1b17ac2d4d9f0251f2efd72d082d214b120edc801d92c5e
   languageName: node
   linkType: hard
 
@@ -7315,7 +7315,7 @@ __metadata:
     "@babel/preset-react": ^7.22.15
     "@babel/preset-typescript": ^7.23.0
     "@hypothesis/frontend-build": ^2.2.0
-    "@hypothesis/frontend-shared": ^6.8.0
+    "@hypothesis/frontend-shared": ^6.9.1
     "@hypothesis/frontend-testing": ^1.0.1
     "@rollup/plugin-babel": ^6.0.3
     "@rollup/plugin-commonjs": ^25.0.4


### PR DESCRIPTION
> Requires https://github.com/hypothesis/frontend-shared/pull/1330

This PR replaces `Select` with `SelectNext` in the `StudentSelector`.

Before:

![image](https://github.com/hypothesis/lms/assets/2719332/723d90a9-779f-48e0-8213-1df2b5d0ebe8)

After:

![image](https://github.com/hypothesis/lms/assets/2719332/6033b630-e7f9-4fb4-b63f-2a75c722c264)

`SelectNext` needs to have a "fixed" size to make sure it does not resize when selected option changes, so I have changed its sizes to be:

* 20rem for extra large devices (this was already like that)
* 16rem for large devices
* 12rem for medium devices
* full (the default) for small and extra small devices, as the components collapse in a column there.

[Grabación de pantalla desde 2023-10-18 11-56-35.webm](https://github.com/hypothesis/lms/assets/2719332/34bbc54c-a3d7-4b4a-b3c3-f293ac6c352a)

### Testing steps

Open any assignment and verify students can be selected as with the regular select.
