### PR TITLE
Use SelectNext for the GroupConfigSelector

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -1,6 +1,6 @@
-import { Checkbox, Link, Select } from '@hypothesis/frontend-shared';
+import { Checkbox, Link, SelectNext } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
 import type { GroupSet } from '../api-types';
 import { useConfig } from '../config';
@@ -46,6 +46,10 @@ function GroupSelect({
   selectedGroupSetId,
 }: GroupSelectProps) {
   const selectId = useUniqueId('GroupSetSelector__select');
+  const selectedGroupSet = useMemo(
+    () => groupSets?.find(({ id }) => id === selectedGroupSetId),
+    [groupSets, selectedGroupSetId]
+  );
 
   return (
     <div
@@ -60,33 +64,27 @@ function GroupSelect({
       >
         Group set
       </label>
-      <Select
+      <SelectNext
         disabled={loading}
-        id={selectId}
-        onInput={(e: Event) =>
-          onInput((e.target as HTMLSelectElement | null)?.value || null)
+        buttonId={selectId}
+        value={selectedGroupSet}
+        onChange={newValue => onInput(newValue?.id ?? null)}
+        buttonContent={
+          <>
+            {loading && 'Fetching group sets…'}
+            {!loading &&
+              (selectedGroupSet?.name ?? (
+                <span className="text-grey-6">Select group set…</span>
+              ))}
+          </>
         }
       >
-        {loading && <option>Fetching group sets…</option>}
-        {groupSets && (
-          <>
-            <option disabled selected={selectedGroupSetId === null}>
-              Select group set
-            </option>
-            <hr />
-            {groupSets.map(gs => (
-              <option
-                key={gs.id}
-                value={gs.id}
-                selected={gs.id === selectedGroupSetId}
-                data-testid="groupset-option"
-              >
-                {gs.name}
-              </option>
-            ))}
-          </>
-        )}
-      </Select>
+        {groupSets?.map(gs => (
+          <SelectNext.Option key={gs.id} value={gs}>
+            {() => gs.name}
+          </SelectNext.Option>
+        ))}
+      </SelectNext>
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -1,3 +1,4 @@
+import { SelectNext } from '@hypothesis/frontend-shared';
 import {
   mockImportedComponents,
   waitForElement,
@@ -124,24 +125,20 @@ describe('GroupConfigSelector', () => {
       groupConfig: { useGroupSet: true, groupConfig: null },
     });
 
-    // While groups are being fetched, the `<select>` should be visible but disabled
+    // While groups are being fetched, the `<SelectNext>` should be visible but disabled
     // and display a fetching status.
-    const groupSetSelect = wrapper.find('select');
+    const groupSetSelect = wrapper.find(SelectNext);
     assert.isTrue(groupSetSelect.exists());
     assert.isTrue(groupSetSelect.prop('disabled'));
-    assert.equal(groupSetSelect.find('option').length, 1);
-    assert.equal(groupSetSelect.find('option').text(), 'Fetching group sets…');
+    assert.equal(groupSetSelect.find('Button').text(), 'Fetching group sets…');
 
     // Once group sets are fetched, they should be rendered as `<option>`s.
-    const options = await waitForElement(
-      wrapper,
-      'option[data-testid="groupset-option"]'
-    );
+    const options = await waitForElement(wrapper, SelectNext.Option);
     assert.equal(options.length, fakeGroupSets.length);
 
     fakeGroupSets.forEach((gs, i) => {
       assert.equal(options.at(i).text(), gs.name);
-      assert.equal(options.at(i).prop('value'), gs.id);
+      assert.equal(options.at(i).prop('value'), gs);
     });
   });
 
@@ -152,20 +149,17 @@ describe('GroupConfigSelector', () => {
       onChangeGroupConfig,
     });
 
-    const options = await waitForElement(
-      wrapper,
-      'option[data-testid="groupset-option"]'
-    );
+    const options = await waitForElement(wrapper, SelectNext.Option);
     assert.equal(options.length, fakeGroupSets.length);
     assert.notCalled(onChangeGroupConfig);
 
-    const select = wrapper.find('select').getDOMNode();
+    const select = wrapper.find(SelectNext);
 
     options.forEach((option, i) => {
       onChangeGroupConfig.resetHistory();
 
-      select.value = option.prop('value');
-      select.dispatchEvent(new Event('input'));
+      select.props().onChange(option.prop('value'));
+      wrapper.update();
 
       assert.calledWith(onChangeGroupConfig, {
         useGroupSet: true,
@@ -192,10 +186,7 @@ describe('GroupConfigSelector', () => {
     fakeAPICall.withArgs(groupSetsAPIRequest).resolves(fakeGroupSets);
     authModal.prop('onAuthComplete')();
 
-    const options = await waitForElement(
-      wrapper,
-      'option[data-testid="groupset-option"]'
-    );
+    const options = await waitForElement(wrapper, SelectNext.Option);
     assert.equal(options.length, fakeGroupSets.length);
   });
 
@@ -227,10 +218,7 @@ describe('GroupConfigSelector', () => {
       authModal.prop('onRetry')();
     });
 
-    const options = await waitForElement(
-      wrapper,
-      'option[data-testid="groupset-option"]'
-    );
+    const options = await waitForElement(wrapper, SelectNext.Option);
     assert.equal(options.length, fakeGroupSets.length);
   });
 


### PR DESCRIPTION
Refactor `GroupConfigSelector` to replace the deprecated `Select` component with the new `SelectNext`.

> This is in draft while I try to figure out an awkward behavior of the select while used inside a scrollable container.