### PR TITLE
Add folders and pages scopes to Canvas scopes error

### DIFF
--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -41,9 +41,15 @@ GROUPS_SCOPES = (
 )
 
 
+# Support for creating assignments using Canvas Pages
 PAGES_SCOPES = (
     "url:GET|/api/v1/courses/:course_id/pages",
     "url:GET|/api/v1/courses/:course_id/pages/:url_or_id",
+)
+
+# All the scopes that our LMS app may use.
+ALL_SCOPES = (
+    FILES_SCOPES + FOLDERS_SCOPES + GROUPS_SCOPES + PAGES_SCOPES + SECTIONS_SCOPES
 )
 
 
@@ -127,10 +133,7 @@ def oauth2_redirect(request):
     renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
 )
 def oauth2_redirect_error(request):
-    kwargs = {
-        "auth_route": "canvas_api.oauth.authorize",
-        "canvas_scopes": FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
-    }
+    kwargs = {"auth_route": "canvas_api.oauth.authorize", "canvas_scopes": ALL_SCOPES}
 
     if request.params.get("error") == "invalid_scope":
         kwargs["error_code"] = request.context.js_config.ErrorCode.CANVAS_INVALID_SCOPE

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -8,6 +8,7 @@ from lms.resources._js_config import JSConfig
 from lms.services import CanvasAPIServerError
 from lms.views.api.canvas import authorize
 from lms.views.api.canvas.authorize import (
+    ALL_SCOPES,
     FILES_SCOPES,
     FOLDERS_SCOPES,
     GROUPS_SCOPES,
@@ -167,7 +168,7 @@ class TestOAuth2RedirectError:
 
         pyramid_request.context.js_config.enable_oauth2_redirect_error_mode.assert_called_with(
             auth_route="canvas_api.oauth.authorize",
-            canvas_scopes=FILES_SCOPES + SECTIONS_SCOPES + GROUPS_SCOPES,
+            canvas_scopes=ALL_SCOPES,
         )
         assert not template_data
 

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -7,14 +7,7 @@ from pyramid.httpexceptions import HTTPInternalServerError
 from lms.resources._js_config import JSConfig
 from lms.services import CanvasAPIServerError
 from lms.views.api.canvas import authorize
-from lms.views.api.canvas.authorize import (
-    ALL_SCOPES,
-    FILES_SCOPES,
-    FOLDERS_SCOPES,
-    GROUPS_SCOPES,
-    PAGES_SCOPES,
-    SECTIONS_SCOPES,
-)
+from lms.views.api.canvas.authorize import ALL_SCOPES, SCOPES
 
 pytestmark = pytest.mark.usefixtures(
     "application_instance_service", "course_service", "canvas_api_client"
@@ -111,21 +104,21 @@ class TestAuthorize:
         scopes = set(query_params["scope"][0].split())
 
         if groups_enabled:
-            assert set(GROUPS_SCOPES).issubset(scopes)
+            assert set(SCOPES["groups"]).issubset(scopes)
         if folders_enabled:
-            assert set(FOLDERS_SCOPES).issubset(scopes)
+            assert set(SCOPES["folders"]).issubset(scopes)
         if pages_enabled:
-            assert set(PAGES_SCOPES).issubset(scopes)
+            assert set(SCOPES["pages"]).issubset(scopes)
 
     def assert_sections_scopes(self, response):
         query_params = parse_qs(urlparse(response.location).query)
         assert set(query_params["scope"][0].split(" ")) == set(
-            FILES_SCOPES + SECTIONS_SCOPES
+            SCOPES["files"] + SCOPES["sections"]
         )
 
     def assert_file_scopes_only(self, response):
         query_params = parse_qs(urlparse(response.location).query)
-        assert set(query_params["scope"][0].split(" ")) == set(FILES_SCOPES)
+        assert set(query_params["scope"][0].split(" ")) == set(SCOPES["files"])
 
     @pytest.fixture
     def sections_not_supported(self, application_instance):


### PR DESCRIPTION
The error message shown to users when authorization fails due to missing scopes, was missing scopes for folders and pages:

<img width="705" alt="Canvas pages" src="https://github.com/hypothesis/lms/assets/2458/6ee5d97f-a7a2-463b-ac0a-d3d52fcb8e86">

In this PR I have continued the current behavior of listing all the scopes our app _can_ use in the error, although that may create some confusion because this message could reference scopes for in-development features that we won't actually use unless the feature is turned on.

See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1697628340572009