### PR TITLE
Only consider admins roles that are sytem or course wide

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -89,7 +89,11 @@ class LTIUser:  # pylint: disable=too-many-instance-attributes
     @property
     def is_admin(self):
         """Whether this user is an admin."""
-        return any(role.type == RoleType.ADMIN for role in self.lti_roles)
+        return any(
+            role.type == RoleType.ADMIN
+            and role.scope in [RoleScope.COURSE, RoleScope.SYSTEM]
+            for role in self.lti_roles
+        )
 
 
 def display_name(given_name, family_name, full_name):

--- a/tests/unit/lms/models/lti_user_test.py
+++ b/tests/unit/lms/models/lti_user_test.py
@@ -18,7 +18,7 @@ class TestLTIUser:
         "role,is_instructor",
         [
             (LTIRole(scope=RoleScope.COURSE, type=RoleType.ADMIN), True),
-            (LTIRole(scope=RoleScope.INSTITUTION, type=RoleType.ADMIN), True),
+            (LTIRole(scope=RoleScope.COURSE, type=RoleType.ADMIN), True),
             (LTIRole(scope=RoleScope.COURSE, type=RoleType.INSTRUCTOR), True),
             (
                 LTIRole(scope=RoleScope.INSTITUTION, type=RoleType.INSTRUCTOR),
@@ -61,8 +61,9 @@ class TestLTIUser:
         "role,is_admin",
         [
             (LTIRole(scope=RoleScope.COURSE, type=RoleType.ADMIN), True),
-            (LTIRole(scope=RoleScope.INSTITUTION, type=RoleType.ADMIN), True),
-            (LTIRole(scope=RoleScope.INSTITUTION, type=RoleType.INSTRUCTOR), False),
+            (LTIRole(scope=RoleScope.SYSTEM, type=RoleType.ADMIN), True),
+            (LTIRole(scope=RoleScope.INSTITUTION, type=RoleType.ADMIN), False),
+            (LTIRole(scope=RoleScope.SYSTEM, type=RoleType.INSTRUCTOR), False),
         ],
     )
     def test_is_admin(self, role, is_admin):


### PR DESCRIPTION
For:

- https://github.com/hypothesis/support/issues/46


That issue describes a problem for when someone that's both an admin and a student gets inconsistent behaviour.

This doesn't necessarily solve that but I reckon will make it more rare fixing a bug where we identify someone as an admin when they are not in fact and admin **in the current context**.


See discussion over: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1698048084437489