### PR TITLE
Change missed updated/created parameters

### DIFF
--- a/lms/views/admin/email.py
+++ b/lms/views/admin/email.py
@@ -66,8 +66,8 @@ class AdminEmailViews:
             (),
             {
                 "h_userids": h_userids,
-                "updated_after": since.isoformat(),
-                "updated_before": until.isoformat(),
+                "created_after": since.isoformat(),
+                "created_before": until.isoformat(),
                 "override_to_email": to_email,
                 "deduplicate": False,
             },

--- a/tests/unit/lms/views/admin/email_test.py
+++ b/tests/unit/lms/views/admin/email_test.py
@@ -18,8 +18,8 @@ class TestAdminEmailViews:
             (),
             {
                 "h_userids": ["userid_1", "userid_2"],
-                "updated_after": "2023-02-27T00:00:00",
-                "updated_before": "2023-02-28T00:00:00",
+                "created_after": "2023-02-27T00:00:00",
+                "created_before": "2023-02-28T00:00:00",
                 "override_to_email": "someone@hypothes.is",
                 "deduplicate": False,
             },


### PR DESCRIPTION
Missed in previous commit to adapt to the change in the bulk annotation API from updated to created filtering.