### PR TITLE
Add simple message to handle canvas_page_not_found_in_course

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -264,8 +264,8 @@ class SerializableError(Exception):
 class FileNotFoundInCourse(SerializableError):
     """A file wasn't found in the current course."""
 
-    def __init__(self, error_code: str, file_id):
-        super().__init__(error_code=error_code, details={"file_id": file_id})
+    def __init__(self, error_code: str, document_id):
+        super().__init__(error_code=error_code, details={"document_id": document_id})
 
 
 class StudentNotInCourse(SerializableError):

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -212,6 +212,21 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
+    case 'canvas_page_not_found_in_course':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          title="Hypothesis couldn't find the page in the course"
+        >
+          <p>This might have happened because:</p>
+
+          <ul className="px-4 list-disc">
+            <li>The page has been deleted from Canvas</li>
+            <li>The course was copied from another course</li>
+          </ul>
+        </ErrorModal>
+      );
+
     case 'canvas_group_set_not_found':
       return (
         <ErrorModal

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -75,6 +75,13 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
+      errorState: 'canvas_page_not_found_in_course',
+      expectedText: 'The page has been deleted from Canvas',
+      expectedTitle: "Hypothesis couldn't find the page in the course",
+      hasRetry: true,
+      withError: true,
+    },
+    {
       errorState: 'd2l_file_not_found_in_course_instructor',
       expectedText:
         'To fix the issue, recreate this assignment and select a different file.',

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -9,18 +9,19 @@ export type LTILaunchServerErrorCode =
   | 'blackboard_group_set_empty'
   | 'blackboard_group_set_not_found'
   | 'blackboard_student_not_in_group'
-  | 'd2l_file_not_found_in_course_student'
-  | 'd2l_file_not_found_in_course_instructor'
-  | 'd2l_group_set_not_found'
-  | 'd2l_group_set_empty'
-  | 'd2l_student_not_in_group'
   | 'canvas_api_permission_error'
   | 'canvas_file_not_found_in_course'
-  | 'canvas_group_set_not_found'
   | 'canvas_group_set_empty'
+  | 'canvas_group_set_not_found'
+  | 'canvas_page_not_found_in_course'
   | 'canvas_student_not_in_group'
-  | 'vitalsource_user_not_found'
-  | 'vitalsource_no_book_license';
+  | 'd2l_file_not_found_in_course_instructor'
+  | 'd2l_file_not_found_in_course_student'
+  | 'd2l_group_set_empty'
+  | 'd2l_group_set_not_found'
+  | 'd2l_student_not_in_group'
+  | 'vitalsource_no_book_license'
+  | 'vitalsource_user_not_found';
 
 /**
  * An `Error` or error-like object. This allows components in the application
@@ -149,6 +150,7 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'd2l_student_not_in_group',
       'canvas_api_permission_error',
       'canvas_file_not_found_in_course',
+      'canvas_page_not_found_in_course',
       'canvas_group_set_not_found',
       'canvas_group_set_empty',
       'canvas_student_not_in_group',

--- a/lms/static/scripts/ui-playground/components/ErrorComponents.tsx
+++ b/lms/static/scripts/ui-playground/components/ErrorComponents.tsx
@@ -446,6 +446,7 @@ export default function ErrorComponents() {
                 [
                   'canvas_api_permission_error',
                   'canvas_file_not_found_in_course',
+                  'canvas_page_not_found_in_course',
                   'canvas_group_set_not_found',
                   'canvas_group_set_empty',
                   'canvas_student_not_in_group',

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -99,7 +99,7 @@ def test_it_when_file_not_in_course(
 ):
     course_copy_plugin.is_file_in_course.return_value = False
     d2l_api_client.public_url.side_effect = FileNotFoundInCourse(
-        "d2l_file_not_found_in_course_instructor", file_id="FILE_ID"
+        "d2l_file_not_found_in_course_instructor", document_id="FILE_ID"
     )
     course_copy_plugin.find_matching_file_in_course.return_value = None
 


### PR DESCRIPTION
# Testing

- (Enable pages locally or self-merge https://github.com/hypothesis/devdata/pull/99 & `make devdata`)


- Login to canvas with 'eng+coursecopystudent`.
- Remove any info that could "solve" course copy issues: 

`docker compose exec postgres psql -U postgres -c "truncate grouping, file cascade"`

- Launch https://hypothesis.instructure.com/courses/607/assignments/5815
- Marvel at the new error message. Adapted from the files ones. We can extended it, include links etc, as we see any issues in the future.
