### PR TITLE
Add an endpoint to handle all types of LTI launches

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -20,7 +20,7 @@ class Grouping(CreatedUpdatedMixin, BASE):
         BLACKBOARD_GROUP = "blackboard_group"
         D2L_GROUP = "d2l_group"
 
-        # These are the LMS agnostic versions of the ones avobe.
+        # These are the LMS agnostic versions of the ones above.
         # They don't get stored in the DB but are meaningful in the codebase
         SECTION = "section"
         GROUP = "group"

--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -136,13 +136,18 @@ class CanvasMiscPlugin(MiscPlugin):
         return params
 
     def get_deeplinking_launch_url(self, request, assignment_configuration: dict):
-        # In canvas we point to our generic launch URL
-        # and we encode the assignment configuration as query parameters.
-        return (
-            urlparse(request.route_url("lti_launches"))
+        route_name = "lti_launches"
+        if request.json.get("single_lti_endpoint"):
+            # If we are using the single-endpoint flow, point to that
+            route_name = "lti.launch"
+
+        # In canvas we encode the assignment configuration as query parameters.
+        url = (
+            urlparse(request.route_url(route_name))
             ._replace(query=urlencode(assignment_configuration))
             .geturl()
         )
+        return url
 
     @classmethod
     def factory(cls, _context, _request):

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -288,6 +288,8 @@ class JSConfig:
                     "product": self._request.product.family,
                 },
                 "context_id": self._request.lti_params["context_id"],
+                # Pass if we are using the single endpoint setup
+                "single_lti_endpoint": self._request.params.get("single_lti_endpoint"),
             },
         }
         if self._application_instance.lti_version == "1.3.0":

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -35,6 +35,7 @@ def includeme(config):  # pylint:disable=too-many-statements
         "/lti/reconfigure",
         factory="lms.resources.LTILaunchResource",
     )
+    config.add_route("lti.launch", "/lti")
 
     config.add_route("api.sync", "/api/sync", request_method="POST")
     config.add_route(

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -143,6 +143,24 @@ class BasicLTILaunchSchema(_CommonLTILaunchSchema):
         super().handle_error(error, data, many=many, **kwargs)
 
 
+class LTILaunchSchema(_CommonLTILaunchSchema):
+    """Generic schema for any type of LTI launch"""
+
+    lti_message_type = fields.Str(
+        validate=OneOf(
+            [
+                # LTI 1.1
+                "basic-lti-launch-request",
+                "ContentItemSelectionRequest",
+                # LTI1.3
+                "LtiResourceLinkRequest",
+                "LtiDeepLinkingRequest",
+            ],
+        ),
+        required=True,
+    )
+
+
 class DeepLinkingLTILaunchSchema(_CommonLTILaunchSchema):
     """Schema for deep linking LTI launches."""
 

--- a/lms/views/lti/launch.py
+++ b/lms/views/lti/launch.py
@@ -1,0 +1,38 @@
+from pyramid.httpexceptions import HTTPNotFound
+from pyramid.request import Request
+from pyramid.view import view_config
+import logging
+
+from lms.validation._lti_launch_params import LTILaunchSchema
+
+LOG = logging.getLogger(__name__)
+
+
+@view_config(request_method="POST", route_name="lti.launch", schema=LTILaunchSchema)
+def launch(request):
+    """LTI launch handler that dispatches to the right type of launch view depending of the message."""
+    message_type = request.lti_params.get("lti_message_type")
+
+    view_name = None
+
+    if message_type in ("basic-lti-launch-request", "LtiResourceLinkRequest"):
+        view_name = "lti_launches"
+
+    elif message_type in ("ContentItemSelectionRequest", "LtiDeepLinkingRequest"):
+        view_name = "content_item_selection"
+    else:
+        return HTTPNotFound()
+
+    LOG.debug(
+        "LTI launch view dispatch. Message type: %s. View: %s", message_type, view_name
+    )
+    sub_request = Request.blank(
+        request.route_path(view_name, _query=request.GET),
+        # We flag this request as coming from this endpoint
+        POST=dict(request.POST, single_lti_endpoint=1),
+    )
+
+    # We don't want to use an HTTP redirect as that might interfere with LTI auth chain
+    # Use a pyramid sub request to invoke the right view.
+    # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/subrequest.html
+    return request.invoke_subrequest(sub_request, use_tweens=True)

--- a/lms/views/lti/resource_link.py
+++ b/lms/views/lti/resource_link.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
     permission=Permissions.LTI_LAUNCH_ASSIGNMENT,
     schema=BasicLTILaunchSchema,
 )
-class BasicLaunchViews:
+class ResourceLinkLaunchViews:
     def __init__(self, context, request):
         self.context = context
         self.request = request

--- a/tests/unit/lms/views/lti/resource_link_test.py
+++ b/tests/unit/lms/views/lti/resource_link_test.py
@@ -7,7 +7,7 @@ from lms.models import LTIParams
 from lms.resources import LTILaunchResource
 from lms.resources._js_config import JSConfig
 from lms.security import Permissions
-from lms.views.lti.basic_launch import BasicLaunchViews
+from lms.views.lti.resource_link import ResourceLinkLaunchViews
 from tests import factories
 
 
@@ -21,7 +21,7 @@ from tests import factories
     "grouping_service",
     "misc_plugin",
 )
-class TestBasicLaunchViews:
+class TestResourceLinkLaunchViews:
     def test___init___(
         self,
         context,
@@ -31,7 +31,7 @@ class TestBasicLaunchViews:
         application_instance_service,
         lti_user,
     ):
-        BasicLaunchViews(context, pyramid_request)
+        ResourceLinkLaunchViews(context, pyramid_request)
 
         # `_record_course()`
         course_service.get_from_launch.assert_called_once_with(
@@ -154,7 +154,7 @@ class TestBasicLaunchViews:
         has_permission.return_value = False
         assignment_service.get_assignment_for_launch.return_value = None
 
-        response = BasicLaunchViews(context, pyramid_request).lti_launch()
+        response = ResourceLinkLaunchViews(context, pyramid_request).lti_launch()
 
         has_permission.assert_called_once_with(Permissions.LTI_CONFIGURE_ASSIGNMENT)
         assert (
@@ -327,7 +327,7 @@ class TestBasicLaunchViews:
 
     @pytest.fixture
     def svc(self, context, pyramid_request):
-        return BasicLaunchViews(context, pyramid_request)
+        return ResourceLinkLaunchViews(context, pyramid_request)
 
     @pytest.fixture
     def _show_document(self, svc):


### PR DESCRIPTION
We have to often fight LMS and integrations to make sure they use the right URL for the right LTI launch type.

Launches always include the type of launch the are, so there no real necessity to have two endpoints.

The approach in this PR accomplished this with what I think is the least amount of code changes necessary. This would be something we'll only use for new schools. 