### PR TITLE
Fix crash when presenting Canvas scope error message

### DIFF
--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -129,7 +129,10 @@ def oauth2_redirect(request):
     renderer="lms:templates/api/oauth2/redirect_error.html.jinja2",
 )
 def oauth2_redirect_error(request):
-    kwargs = {"auth_route": "canvas_api.oauth.authorize", "canvas_scopes": ALL_SCOPES}
+    kwargs = {
+        "auth_route": "canvas_api.oauth.authorize",
+        "canvas_scopes": list(ALL_SCOPES),
+    }
 
     if request.params.get("error") == "invalid_scope":
         kwargs["error_code"] = request.context.js_config.ErrorCode.CANVAS_INVALID_SCOPE

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -161,7 +161,7 @@ class TestOAuth2RedirectError:
 
         pyramid_request.context.js_config.enable_oauth2_redirect_error_mode.assert_called_with(
             auth_route="canvas_api.oauth.authorize",
-            canvas_scopes=ALL_SCOPES,
+            canvas_scopes=list(ALL_SCOPES),
         )
         assert not template_data
 


### PR DESCRIPTION
`JSConfig.enable_oauth2_redirect_error_mode` expects a `List[str]` but was being passed a `set[str]`. This caused an error later when attempting to JSON-serialize the value.

This was a regression introduced by https://github.com/hypothesis/lms/commit/5e86e5f958e2b03002cef31b95739b457fe50347.

Fixes https://hypothesis.sentry.io/issues/4576135028/?project=259908