### PR TITLE
Give test application instances a GUID by default

### DIFF
--- a/tests/factories/application_instance.py
+++ b/tests/factories/application_instance.py
@@ -2,7 +2,11 @@ from factory import Faker, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from lms import models
-from tests.factories.attributes import OAUTH_CONSUMER_KEY, SHARED_SECRET
+from tests.factories.attributes import (
+    OAUTH_CONSUMER_KEY,
+    SHARED_SECRET,
+    TOOL_CONSUMER_INSTANCE_GUID,
+)
 
 ApplicationInstance = make_factory(
     models.ApplicationInstance,
@@ -13,4 +17,5 @@ ApplicationInstance = make_factory(
     lms_url=Faker("url", schemes=["https"]),
     requesters_email=Faker("email"),
     settings={},
+    tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
 )

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -301,7 +301,7 @@ class TestApplicationInstanceService:
     ):
         lms_data = {
             field: field + "_value",
-            "tool_consumer_instance_guid": "GUID",
+            "tool_consumer_instance_guid": application_instance.tool_consumer_instance_guid,
         }
 
         service.update_from_lti_params(application_instance, LTIParams(lms_data))
@@ -315,12 +315,14 @@ class TestApplicationInstanceService:
     def test_update_from_lti_params_no_guid_doesnt_change_values(
         self, service, organization_service, application_instance
     ):
+        guid = application_instance.tool_consumer_instance_guid
+
         service.update_from_lti_params(
             application_instance, LTIParams({"tool_consumer_instance_url": "NO EFFECT"})
         )
 
         organization_service.auto_assign_organization.assert_not_called()
-        assert application_instance.tool_consumer_instance_guid is None
+        assert application_instance.tool_consumer_instance_guid == guid
         assert application_instance.tool_consumer_info_product_family_code is None
 
     def test_update_from_lti_params_existing_guid(


### PR DESCRIPTION
Give test application instances from the `ApplicationInstance` factory a
randomly generated `tool_consumer_instance_guid` by default, instead of
`None`.

I think application instances usually have a GUID most of the time, so
this makes sense as a factory default.
