### PR TITLE
Add GUID to LMS annotation metadata

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -587,4 +587,11 @@ class JSConfig:
         }
 
     def _generate_annotation_metadata(self, assignment):
-        return {"lms": {"assignment_id": assignment.resource_link_id}}
+        return {
+            "lms": {
+                "assignment": {
+                    "guid": self._application_instance.tool_consumer_instance_guid,
+                    "resource_link_id": assignment.resource_link_id,
+                },
+            },
+        }

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -156,7 +156,12 @@ class TestEnableLTILaunchMode:
                     }
                 ],
                 "annotationMetadata": {
-                    "lms": {"assignment_id": assignment.resource_link_id}
+                    "lms": {
+                        "assignment": {
+                            "guid": lti_user.application_instance.tool_consumer_instance_guid,
+                            "resource_link_id": assignment.resource_link_id,
+                        },
+                    }
                 },
             },
             "mode": "basic-lti-launch",


### PR DESCRIPTION
Add the assignment's `tool_consumer_instance_guid` to the metadata that the LMS app passes to the client for storage with annotations in h.

This is going to make it much easier to generate assignment data for digest emails in https://github.com/hypothesis/lms/pull/5755.

Also rename `assignment_id` to `resource_link_id` in the metadata so that it matches the name used for this field in the LMS app's code and DB, and restructure the metadata so that `resource_link_id` and `guid` are grouped together in an `assignment` sub-dict.
