### PR TITLE
Take into consideration `groupsEnabled` flag in order to show groups config

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -389,7 +389,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                     {typeof title === 'string' && (
                       <>
                         <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep={true} verticalAlign="center">
+                        <PanelLabel isCurrentStep verticalAlign="center">
                           Title
                         </PanelLabel>
                         <Input
@@ -407,23 +407,27 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                         />
                       </>
                     )}
-                    <div className="sm:col-span-2 border-b" />
-                    <PanelLabel isCurrentStep={true}>
-                      Group assignment
-                    </PanelLabel>
-                    <div
-                      className={classnames(
-                        // Set a height on this container to give the group
-                        // <select> element room when it renders (avoid
-                        // changing the height of the Card later)
-                        'h-28'
-                      )}
-                    >
-                      <GroupConfigSelector
-                        groupConfig={groupConfig}
-                        onChangeGroupConfig={setGroupConfig}
-                      />
-                    </div>
+                    {enableGroupConfig && (
+                      <>
+                        <div className="sm:col-span-2 border-b" />
+                        <PanelLabel isCurrentStep={true}>
+                          Group assignment
+                        </PanelLabel>
+                        <div
+                          className={classnames(
+                            // Set a height on this container to give the group
+                            // <select> element room when it renders (avoid
+                            // changing the height of the Card later)
+                            'h-28'
+                          )}
+                        >
+                          <GroupConfigSelector
+                            groupConfig={groupConfig}
+                            onChangeGroupConfig={setGroupConfig}
+                          />
+                        </div>
+                      </>
+                    )}
                   </>
                 )}
               </div>

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -528,6 +528,13 @@ describe('FilePickerApp', () => {
         const description = wrapper.find('[data-testid="content-summary"]');
         assert.equal(description.text(), 'https://othersite.com/test.pdf');
       });
+
+      it('displays group config selector when groups are enabled', () => {
+        fakeConfig.product.settings.groupsEnabled = groupsEnabled;
+        const wrapper = renderFilePicker();
+
+        assert.equal(wrapper.exists('GroupConfigSelector'), groupsEnabled);
+      });
     });
 
     it('cancels editing content when clicking "Cancel" button', () => {


### PR DESCRIPTION
This PR ensures product's `groupsEnabled` setting is taken into consideration when editing an assignment, in order to not show the groups-related options if it is `false`.

This covers both if the LMS does not support groups, or if it does but they were disabled.

> **Note**
> This PR is easier to review [hidding whitespaces](https://github.com/hypothesis/lms/pull/5793/files?w=1)

### Testing

1. Check out this branch.
2. Open an assignment in a non-Canvas LMS, for example https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View.
3. Go to http://localhost:8001/admin/instance/{instance_id}/ and disable groups for the LMS you choose.
4. Reload the assignment and click "Edit". You should not see any reference to groups:
  ![image](https://github.com/hypothesis/lms/assets/2719332/7a8026cc-03ee-442a-9596-2f1a92eb460d)
5. Enable groups again and repeat previous step. You should see groups config now:
  ![image](https://github.com/hypothesis/lms/assets/2719332/15fb7c8c-b579-4cd0-97c9-f12f9500062b)

### Todo

- [x] Add tests

Fixes https://github.com/hypothesis/support/issues/36
