### PR TITLE
Fallback to custom params for deep linking configuration in Canvas

### DIFF
--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -132,6 +132,8 @@ class CanvasMiscPlugin(MiscPlugin):
         for param in possible_parameters:
             if value := request.params.get(param):
                 params[param] = value
+            elif value := request.lti_params.get(f"custom_{param}"):
+                params[param] = value
 
         return params
 

--- a/tests/unit/lms/product/canvas/_plugin/misc_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/misc_test.py
@@ -156,6 +156,23 @@ class TestCanvasMiscPlugin:
             == "http://example.com/lti_launches?param=value"
         )
 
+    @pytest.mark.parametrize("url_param", (None, sentinel.from_url))
+    @pytest.mark.parametrize("custom_param", (None, sentinel.from_custom))
+    def test_get_deep_linked_assignment_configuration(
+        self, plugin, pyramid_request, url_param, custom_param
+    ):
+        pyramid_request.params["url"] = url_param
+        pyramid_request.lti_params["custom_url"] = custom_param
+
+        result = plugin.get_deep_linked_assignment_configuration(pyramid_request)
+
+        if url_param:
+            assert result["url"] == sentinel.from_url
+        elif custom_param:
+            assert result["url"] == sentinel.from_custom
+        else:
+            assert "url" not in result
+
     def test_factory(self, pyramid_request):
         plugin = CanvasMiscPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, CanvasMiscPlugin)


### PR DESCRIPTION
Fallback to custom params for deep linking configuration in Canvas
    
In canvas we have historically send the deep linking (DL) configuration
parameters as query parameters in the return URL.
    
When we started using DL in D2L we instead used LTI custom params which
can be arbitrary JSON which is more ergonomic than having to worry
about encoding issues in URLs.
    
Before this commit, and as part of the D2L work, we always send the
configuration as custom parameters even if never read them in Canvas,
relying only the URL.
    
Now, as part of the work with VitalSource we found that URL parameters
are not proxied in their LTI integration.
    
With this commit we continue reading the parameters from the URL as the
first option, for all existing Canvas installations, but we fallback to
custom parameters, for schools using the VS proxying.


## Testing


Sanity check an existing Canvas assignment: https://hypothesis.instructure.com/courses/125/assignments/873