### PR TITLE
Add `s`, `services` and `t` to `make shell`'s Python environment

### DIFF
--- a/lms/pshell.py
+++ b/lms/pshell.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 
 from transaction.interfaces import NoTransaction
 
-from lms import models, tasks
+from lms import models, services, tasks
 
 
 def setup(env):
@@ -37,6 +37,9 @@ def setup(env):
 
     env["tasks"] = tasks
     env["tasks"].__doc__ = "The lms.tasks package."
+
+    env["s"] = env["services"] = services
+    env["s"].__doc__ = "The lms.services package."
 
     try:
         yield

--- a/lms/pshell.py
+++ b/lms/pshell.py
@@ -35,7 +35,7 @@ def setup(env):
     env["f"].__doc__ = "The test factories for quickly creating objects."
     factories.set_sqlalchemy_session(request.db)
 
-    env["tasks"] = tasks
+    env["t"] = env["tasks"] = tasks
     env["tasks"].__doc__ = "The lms.tasks package."
 
     env["s"] = env["services"] = services


### PR DESCRIPTION
Pre-import the `lms.services` package into `make shell`'s Python shell environment as both `services` and `s`. This just allows you to use services from `make shell` more conveniently, without having to import them yourself. For example:

```python
$ make shell
>>> request.find_service(s.EmailUnsubscribeService).unsubscribe_url("***", "instructor_digest")
'http://localhost:8001/email/unsubscribe?token=***'
```

Also add `t` as an alias for `tasks`, like we have `m` for `models`, `f` for `factories` and `s` for `services`.