### PR TITLE
Add rounded corners to UI components

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ChapterList.tsx
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.tsx
@@ -1,4 +1,8 @@
-import { DataTable, Scroll } from '@hypothesis/frontend-shared';
+import {
+  DataTable,
+  Scroll,
+  ScrollContainer,
+} from '@hypothesis/frontend-shared';
 import { useEffect, useMemo, useRef } from 'preact/hooks';
 
 import type { Chapter } from '../api-types';
@@ -55,19 +59,22 @@ export default function ChapterList({
   );
 
   return (
-    <Scroll>
-      <DataTable
-        elementRef={tableRef}
-        title="Table of Contents"
-        columns={columns}
-        loading={isLoading}
-        rows={chapters}
-        onSelectRow={onSelectChapter}
-        onConfirmRow={onUseChapter}
-        selectedRow={selectedChapter}
-        data-testid="chapter-table"
-        tabIndex={-1}
-      />
-    </Scroll>
+    <ScrollContainer rounded>
+      <Scroll>
+        <DataTable
+          elementRef={tableRef}
+          title="Table of Contents"
+          columns={columns}
+          loading={isLoading}
+          rows={chapters}
+          onSelectRow={onSelectChapter}
+          onConfirmRow={onUseChapter}
+          selectedRow={selectedChapter}
+          data-testid="chapter-table"
+          tabIndex={-1}
+          borderless
+        />
+      </Scroll>
+    </ScrollContainer>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -345,6 +345,7 @@ export default function ContentSelector({
       {isLoadingIndicatorVisible && <SpinnerOverlay />}
       <div className="grid grid-cols-2 gap-y-2 gap-x-3 max-w-[28rem]">
         <OptionButton
+          rounded
           data-testid="url-button"
           details="Web page | PDF"
           onClick={() => selectDialog('url')}
@@ -354,6 +355,7 @@ export default function ContentSelector({
         </OptionButton>
         {canvasFilesEnabled && (
           <OptionButton
+            rounded
             data-testid="canvas-file-button"
             details="PDF"
             onClick={() => selectDialog('canvasFile')}
@@ -364,6 +366,7 @@ export default function ContentSelector({
         )}
         {canvasPagesEnabled && (
           <OptionButton
+            rounded
             data-testid="canvas-page-button"
             details="Page"
             onClick={() => selectDialog('canvasPage')}
@@ -375,6 +378,7 @@ export default function ContentSelector({
 
         {blackboardFilesEnabled && (
           <OptionButton
+            rounded
             data-testid="blackboard-file-button"
             details="PDF"
             onClick={() => selectDialog('blackboardFile')}
@@ -385,6 +389,7 @@ export default function ContentSelector({
         )}
         {d2lFilesEnabled && (
           <OptionButton
+            rounded
             data-testid="d2l-file-button"
             details="PDF"
             onClick={() => selectDialog('d2lFile')}
@@ -395,6 +400,7 @@ export default function ContentSelector({
         )}
         {googlePicker && (
           <OptionButton
+            rounded
             details="PDF"
             data-testid="google-drive-button"
             onClick={showGooglePicker}
@@ -405,6 +411,7 @@ export default function ContentSelector({
         )}
         {jstorEnabled && (
           <OptionButton
+            rounded
             data-testid="jstor-button"
             details="Article"
             onClick={() => selectDialog('jstor')}
@@ -415,6 +422,7 @@ export default function ContentSelector({
         )}
         {oneDriveFilesEnabled && (
           <OptionButton
+            rounded
             data-testid="onedrive-button"
             details="PDF"
             onClick={showOneDrivePicker}
@@ -425,6 +433,7 @@ export default function ContentSelector({
         )}
         {vitalSourceEnabled && (
           <OptionButton
+            rounded
             data-testid="vitalsource-button"
             details="Book"
             onClick={() => selectDialog('vitalSourceBook')}
@@ -435,6 +444,7 @@ export default function ContentSelector({
         )}
         {youtubeEnabled && (
           <OptionButton
+            rounded
             data-testid="youtube-button"
             details="Video"
             onClick={() => selectDialog('youtube')}

--- a/lms/static/scripts/frontend_apps/components/DocumentList.tsx
+++ b/lms/static/scripts/frontend_apps/components/DocumentList.tsx
@@ -4,6 +4,7 @@ import {
   FilePdfFilledIcon,
   FolderIcon,
   Scroll,
+  ScrollContainer,
 } from '@hypothesis/frontend-shared';
 import type { ComponentChildren } from 'preact';
 
@@ -77,18 +78,21 @@ export default function DocumentList<DocumentType extends Document>({
   };
 
   return (
-    <Scroll>
-      <DataTable
-        title={title}
-        emptyMessage={noDocumentsMessage}
-        columns={columns}
-        loading={isLoading}
-        rows={documents}
-        selectedRow={selectedDocument}
-        onSelectRow={onSelectDocument}
-        onConfirmRow={onUseDocument}
-        renderItem={renderItem}
-      />
-    </Scroll>
+    <ScrollContainer rounded>
+      <Scroll>
+        <DataTable
+          title={title}
+          emptyMessage={noDocumentsMessage}
+          columns={columns}
+          loading={isLoading}
+          rows={documents}
+          selectedRow={selectedDocument}
+          onSelectRow={onSelectDocument}
+          onConfirmRow={onUseDocument}
+          renderItem={renderItem}
+          borderless
+        />
+      </Scroll>
+    </ScrollContainer>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
@@ -35,7 +35,7 @@ function ErrorDetails({ error }: ErrorDetailsProps) {
 
   return (
     <details
-      className="border"
+      className="border rounded overflow-hidden"
       onToggle={onDetailsToggle}
       data-testid="error-details"
     >

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -345,7 +345,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
           </RouterLink>
         )}
         {/* Card constrains overflow-scroll children to height constraints */}
-        <Card classes="flex flex-col min-h-0">
+        <Card classes="flex flex-col min-h-0 overflow-hidden">
           <CardHeader variant="secondary" title="Assignment details" />
           <Scroll>
             <CardContent size="lg">

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -51,7 +51,7 @@ function GroupSelect({
     <div
       className={classnames(
         // Style a slightly-recessed "well" for these controls
-        'bg-slate-0 p-4 rounded-[4px] shadow-inner border'
+        'bg-slate-0 p-4 rounded shadow-inner border'
       )}
     >
       <label

--- a/lms/static/styles/_base.scss
+++ b/lms/static/styles/_base.scss
@@ -14,4 +14,11 @@
     @apply text-tiny;
     @apply text-grey-9;
   }
+
+  :root {
+    // This is the same as default tailwind values
+    // Once our overwrites have been removed from the preset, this can be dropped
+    --h-border-radius: 0.25rem;
+    --h-border-radius-lg: 0.5rem;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.2",
     "@hypothesis/frontend-build": "^2.2.0",
-    "@hypothesis/frontend-shared": "^6.9.1",
+    "@hypothesis/frontend-shared": "^6.10.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -17,10 +17,6 @@ export default {
       animation: {
         gradeSubmitSuccess: 'gradeSubmitSuccess 2s ease-out forwards',
       },
-      borderRadius: {
-        // Equivalent to tailwind default `rounded-sm` size
-        DEFAULT: '0.125rem',
-      },
       fontFamily: {
         sans: [
           '"Helvetica Neue"',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,15 +1797,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@hypothesis/frontend-shared@npm:6.9.1"
+"@hypothesis/frontend-shared@npm:^6.10.1":
+  version: 6.10.1
+  resolution: "@hypothesis/frontend-shared@npm:6.10.1"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^2.10.0-alpha.1
   peerDependencies:
     preact: ^10.4.0
-  checksum: 758644dfdd558540d6a5d4004b4dd0417c88a67d0ea13dd3653d57c143d3e5abe3bcecdb4d7ca4cab1b17ac2d4d9f0251f2efd72d082d214b120edc801d92c5e
+  checksum: 98aef4921e533b38b691022c9ec21368547144d551a25ad13384e5669808f5d99a24bb22ea27aed8ca8b251d60b53885bdf73474c6b7ee762a1128f0d06e8a97
   languageName: node
   linkType: hard
 
@@ -7432,7 +7432,7 @@ __metadata:
     "@babel/preset-react": ^7.22.15
     "@babel/preset-typescript": ^7.23.2
     "@hypothesis/frontend-build": ^2.2.0
-    "@hypothesis/frontend-shared": ^6.9.1
+    "@hypothesis/frontend-shared": ^6.10.1
     "@hypothesis/frontend-testing": ^1.0.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^25.0.7


### PR DESCRIPTION
Take advantage of rounded corner capabilities from [frontend-shared](https://github.com/hypothesis/frontend-shared/pull/1289), and add missing rounded corners where needed for consistency.

The visual changes are relatively small, so I'm adding this with no feature flags.

> **Note**
> This PR is easier to review ignoring whitespaces https://github.com/hypothesis/lms/pull/5815/files?w=1

### Testing steps

Sanity check an assignment, including:

- Grading bar, with and without comment enabled.
- Content picker (edit and create)
- Different content types.
- Errors (authorization and such).

Closes #5811  