### PR TITLE
Migration for the LTIRoleOverride model

### DIFF
--- a/lms/migrations/versions/14e959ea6f99_role_overrides.py
+++ b/lms/migrations/versions/14e959ea6f99_role_overrides.py
@@ -1,0 +1,76 @@
+"""Create the role_overrides table.
+
+Revision ID: 14e959ea6f99
+Revises: 0c52a13c6cad
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "14e959ea6f99"
+down_revision = "0c52a13c6cad"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lti_role_override",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("lti_role_id", sa.Integer(), nullable=True),
+        sa.Column("application_instance_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "type",
+            sa.Enum(
+                "instructor",
+                "learner",
+                "admin",
+                name="roletype",
+                native_enum=False,
+                length=64,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "scope",
+            sa.Enum(
+                "course",
+                "institution",
+                "system",
+                name="rolescope",
+                native_enum=False,
+                length=64,
+            ),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["application_instance_id"],
+            ["application_instances.id"],
+            name=op.f(
+                "fk__lti_role_override__application_instance_id__application_instances"
+            ),
+            ondelete="cascade",
+        ),
+        sa.ForeignKeyConstraint(
+            ["lti_role_id"],
+            ["lti_role.id"],
+            name=op.f("fk__lti_role_override__lti_role_id__lti_role"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__lti_role_override")),
+        sa.UniqueConstraint(
+            "application_instance_id",
+            "lti_role_id",
+            name=op.f("uq__lti_role_override__application_instance_id"),
+        ),
+    )
+    op.create_index(
+        op.f("ix__lti_role_override_lti_role_id"),
+        "lti_role_override",
+        ["lti_role_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix__lti_role_override_lti_role_id"), table_name="lti_role_override"
+    )
+    op.drop_table("lti_role_override")


### PR DESCRIPTION
## Testing

### Migration forward

```
tox -e dev --run-command 'alembic upgrade head'

dev run-test-pre: PYTHONHASHSEED='3115633096'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 0c52a13c6cad -> 14e959ea6f99, Create the role_overrides table.
```


### Migration backwards


```
tox -e dev --run-command 'alembic downgrade -1'

dev run-test-pre: PYTHONHASHSEED='9935878'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic downgrade -1
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 14e959ea6f99 -> 0c52a13c6cad, Create the role_overrides table.
```

