### PR TITLE
Change page column heading from "Location" to "Page"

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ChapterList.tsx
+++ b/lms/static/scripts/frontend_apps/components/ChapterList.tsx
@@ -50,7 +50,7 @@ export default function ChapterList({
         field: 'title',
       },
       {
-        label: 'Location',
+        label: 'Page',
         field: 'page',
         classes: 'w-32',
       },


### PR DESCRIPTION
I think the term "Location" was an attempt to be general in case the values were not actually pages. However the VitalSource API field from which we get these values, the VS EPUB publishers guide [1] and the VS UI all use the term "page", and the intent is that the values correspond to page numbers in a physical version of the book.

[1] https://www.vitalsource.com/products/vitalsource-epub3-implementation-guide-vitalsource-vvstdocsepub3implementguide