### PR TITLE
Increase `send_instructor_email_digests` rate limit

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -120,7 +120,7 @@ def send_instructor_email_digest_tasks(*, batch_size):
     max_retries=2,
     retry_backoff=3600,
     retry_backoff_max=7200,
-    rate_limit="1/m",
+    rate_limit="3/m",
 )
 def send_instructor_email_digests(
     *, h_userids: List[str], created_after: str, created_before: str, **kwargs


### PR DESCRIPTION
Increase the rate limit of the `send_instructor_email_digests()` Celery task. This is because I want to try decreasing the task's `batch_size` (see https://github.com/hypothesis/h-periodic/pull/385) and correspondingly increasing its `rate_limit` to see what effect that has on performance, with an eye towards potentially removing the batching feature altogether in order to simplify adding future features to this code.
