### PR TITLE
Disable Celery task rate limits in dev

### DIFF
--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -67,6 +67,8 @@ app.conf.update(
     # This can be overridden on a per-task basis by adding time_limit=n to the
     # task's @app.task() arguments.
     task_time_limit=240,
+    # Disable Celery task rate limits in local development.
+    worker_disable_rate_limits=os.environ.get("DEV") == "true",
     # Tell celery where our tasks are defined
     imports=("lms.tasks",),
 )


### PR DESCRIPTION
For a while I've been occassionally noticing a strange behaviour in
local development: when testing something locally I'll often be
repeatedly doing some action that should trigger a Celery task but
sometimes the task does not appear to execute first, then after a while
it suddenly runs.

I finally realised what is causing this: the rate limits that we have on
some of our Celery tasks!

These rate limits serve no useful purpose in local development and only
cause delays and confusion, so just disable them in dev.
