### PR TITLE
Email preferences app

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -2,8 +2,6 @@ import functools
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pyramid.httpexceptions import HTTPClientError
-
 from lms.models import Assignment, GroupInfo, Grouping, HUser
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
@@ -22,6 +20,7 @@ class JSConfig:
         BASIC_LTI_LAUNCH = "basic-lti-launch"
         FILE_PICKER = "content-item-selection"
         ERROR_DIALOG = "error-dialog"
+        EMAIL_NOTIFICATIONS = "email-notifications"
 
     class ErrorCode(str, Enum):
         BLACKBOARD_MISSING_INTEGRATION = "blackboard_missing_integration"
@@ -269,6 +268,19 @@ class JSConfig:
         )
         self._config["debug"]["values"] = self._get_lti_launch_debug_values()
         return self._config
+
+    def enable_email_notifications_mode(self, email_notifications_preferences):
+        """
+        Put the JavaScript code into "email notifications" mode.
+
+        This mode shows teachers the preferences for email notifications.
+        """
+        self._config.update(
+            {
+                "mode": JSConfig.Mode.EMAIL_NOTIFICATIONS,
+                "emailNotifications": email_notifications_preferences
+            }
+        )
 
     def add_deep_linking_api(self):
         """

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -139,7 +139,7 @@ def includeme(config):  # pylint:disable=too-many-statements
 
     config.add_route("youtube_api.videos", "/api/youtube/videos/{video_id}")
 
-    config.add_route("email.settings", "/email/settings")
+    config.add_route("email.settings", "/email/settings", factory="lms.resources.LTILaunchResource")
     config.add_route("email.unsubscribe", "/email/unsubscribe")
     config.add_route("email.unsubscribed", "/email/unsubscribed")
 

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -7,6 +7,7 @@ import type { ServiceMap } from '../services';
 import { Services } from '../services';
 import BasicLTILaunchApp from './BasicLTILaunchApp';
 import DataLoader from './DataLoader';
+import EmailNotificationsApp from './EmailNotificationsApp';
 import ErrorDialogApp from './ErrorDialogApp';
 import FilePickerApp, { loadFilePickerConfig } from './FilePickerApp';
 import OAuth2RedirectErrorApp from './OAuth2RedirectErrorApp';
@@ -38,6 +39,9 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
             >
               <FilePickerApp />
             </DataLoader>
+          </Route>
+          <Route path="/app/email-notifications">
+            <EmailNotificationsApp />
           </Route>
           <Route path="/app/error-dialog">
             <ErrorDialogApp />

--- a/lms/static/scripts/frontend_apps/components/EmailNotificationsApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailNotificationsApp.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'preact/hooks';
+
+import { useConfig } from '../config';
+import EmailNotificationsPreferences from './EmailNotificationsPreferences';
+
+export default function EmailPreferencesApp() {
+  const { emailNotifications } = useConfig(['emailNotifications']);
+  const [selectedDays, setSelectedDays] = useState(emailNotifications);
+
+  return (
+    <div className="h-full grid place-items-center">
+      <div className="w-96">
+        <EmailNotificationsPreferences
+          selectedDays={selectedDays}
+          setSelectedDays={setSelectedDays}
+        />
+      </div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/EmailNotificationsPreferences.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailNotificationsPreferences.tsx
@@ -1,0 +1,96 @@
+import type { PanelProps } from '@hypothesis/frontend-shared';
+import { Button, Checkbox, Panel } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { StateUpdater } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
+
+import type { EmailNotificationsPreferences, WeekDay } from '../config';
+
+const dayNames: [WeekDay, string][] = [
+  [7, 'Sunday'],
+  [1, 'Monday'],
+  [2, 'Tuesday'],
+  [3, 'Wednesday'],
+  [4, 'Thursday'],
+  [5, 'Friday'],
+  [6, 'Saturday'],
+];
+
+export type EmailNotificationsPreferencesProps = {
+  selectedDays: EmailNotificationsPreferences;
+  setSelectedDays: StateUpdater<EmailNotificationsPreferences>;
+  onClose?: PanelProps['onClose'];
+};
+
+export default function EmailNotificationsPreferences({
+  onClose,
+  selectedDays,
+  setSelectedDays,
+}: EmailNotificationsPreferencesProps) {
+  const setAllTo = useCallback(
+    (enabled: boolean) =>
+      setSelectedDays({
+        1: enabled,
+        2: enabled,
+        3: enabled,
+        4: enabled,
+        5: enabled,
+        6: enabled,
+        7: enabled,
+      }),
+    [setSelectedDays]
+  );
+  const selectAll = useCallback(() => setAllTo(true), [setAllTo]);
+  const selectNone = useCallback(() => setAllTo(false), [setAllTo]);
+
+  return (
+    <Panel
+      onClose={onClose}
+      title="Email Notifications"
+      buttons={<Button variant="primary">Save</Button>}
+    >
+      <p className="font-bold">
+        Receive email notifications when your students annotate.
+      </p>
+      <p className="font-bold">Select the days you{"'"}d like your emails:</p>
+
+      <div className="flex justify-between px-4">
+        <div className="flex flex-col gap-1">
+          {dayNames.map(([day, name]) => (
+            <span
+              key={day}
+              className={classnames(
+                // The checked icon sets fill from the text color
+                'text-grey-6'
+              )}
+            >
+              <Checkbox
+                checked={selectedDays[day]}
+                onChange={() =>
+                  setSelectedDays(prev => ({ ...prev, [day]: !prev[day] }))
+                }
+              >
+                <span
+                  className={classnames(
+                    // Override the color set for the checkbox fill
+                    'text-grey-9'
+                  )}
+                >
+                  {name}
+                </span>
+              </Checkbox>
+            </span>
+          ))}
+        </div>
+        <div className="flex items-start gap-2">
+          <Button variant="secondary" onClick={selectAll}>
+            Select All
+          </Button>
+          <Button variant="secondary" onClick={selectNone}>
+            Select None
+          </Button>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -29,6 +29,7 @@ export type APICallInfo = {
 export type AppMode =
   | 'basic-lti-launch'
   | 'content-item-selection'
+  | 'email-notifications'
   | 'error-dialog'
   | 'oauth2-redirect-error';
 
@@ -219,6 +220,10 @@ export type Product = {
   api: ProductAPI;
 };
 
+export type WeekDay = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export type EmailNotificationsPreferences = Record<WeekDay, boolean>;
+
 /**
  * Data/configuration needed for frontend applications in the LMS app.
  * The `mode` property specifies which frontend application should load and
@@ -268,6 +273,8 @@ export type ConfigObject = {
 
   // Only present in "oauth2-redirect-error" mode.
   OAuth2RedirectError?: OAuthErrorConfig;
+
+  emailNotifications?: EmailNotificationsPreferences;
 };
 
 /**

--- a/lms/templates/email/settings.html.jinja2
+++ b/lms/templates/email/settings.html.jinja2
@@ -1,33 +1,18 @@
-{% extends 'templates/base.plain.html.jinja2' %}
+{% extends "lms:templates/base.html.jinja2" %}
 
 {% block content %}
-{% for message in request.session.pop_flash() %}
-  <p><b>{{ message }}</b></p>
-{% endfor %}
+    <div style="width: 100%; height: 100%;" id="app"></div>
+{% endblock %}
 
-<form action="" method="post">
-  <fieldset>
-    <legend>Receive email notifications when your students annotate. Select
-    the days you'd like your emails:</legend>
+{% block styles %}
+    {% for url in  asset_urls("frontend_apps_css") %}
+        <link rel="stylesheet" href="{{ url }}">
+    {% endfor %}
+{% endblock %}
 
-    <ul style="list-style-type:none;">
-      <li><input type="checkbox" id="sunday" name="sunday" {% if preferences.sunday %}checked{% endif %} />
-      <label for="sunday">Sunday</label></li>
-      <li><input type="checkbox" id="monday" name="monday" {% if preferences.monday %}checked{% endif %} />
-      <label for="monday">Monday</label></li>
-      <li><input type="checkbox" id="tuesday" name="tuesday" {% if preferences.tuesday %}checked{% endif %} />
-      <label for="tuesday">Tuesday</label></li>
-      <li><input type="checkbox" id="wednesday" name="wednesday" {% if preferences.wednesday %}checked{% endif %} />
-      <label for="wednesday">Wednesday</label></li>
-      <li><input type="checkbox" id="thursday" name="thursday" {% if preferences.thursday %}checked{% endif %} />
-      <label for="thursday">Thursday</label></li>
-      <li><input type="checkbox" id="friday" name="friday" {% if preferences.friday %}checked{% endif %} />
-      <label for="friday">Friday</label></li>
-      <li><input type="checkbox" id="saturday" name="saturday" {% if preferences.saturday %}checked{% endif %} />
-      <label for="saturday">Saturday</label></li>
-    </ul>
-  </fieldset>
-
-  <button type="submit">Save</button>
-</form>
+{% block scripts %}
+    {{ super() }}
+    {% for url in asset_urls("frontend_apps_js") %}
+        <script type="module" src="{{ url }}"></script>
+    {% endfor %}
 {% endblock %}

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -27,7 +27,8 @@ WEEK_DAYS = (
     renderer="lms:templates/email/settings.html.jinja2",
 )
 class EmailSettingsViews:
-    def __init__(self, request):
+    def __init__(self, context, request):
+        self.context = context
         self.request = request
 
     @view_config(route_name="email.settings", request_param="token")
@@ -42,9 +43,10 @@ class EmailSettingsViews:
 
     @view_config(route_name="email.settings")
     def settings(self):
-        return {
-            "preferences": self.get_preferences().get("instructor_email_digest", {})
-        }
+        self.context.js_config.enable_email_notifications_mode(
+            email_notifications_preferences=self.get_preferences().get("instructor_email_digest", {})
+        )
+        return {}
 
     @view_config(route_name="email.settings", request_method="POST")
     def save_settings(self):


### PR DESCRIPTION
This PR introduces a new component to manage email notifications preferences, together with a new app/entry point that currently only renders that component.

![image](https://github.com/hypothesis/lms/assets/2719332/08a6af34-4265-4784-bf4c-5f5839e027f4)

### Introduced changes

- A new client app `email-notifications` mode is introduced.
- The `/email/settings` route now loads a template which renders client-side, using `email-notifications` mode.
- The email preferences are exposed to the client via `useConfig`, on the new `emailNotifications` prop.

### Out of scope

There are some improvements that will be added in follow-up PRs

- Save preferences logic. Currently, the "Save" button does nothing.
- Loading the component from the sidebar.
  At some point the sidebar will conditionally include an option to open this same component.

### Testing steps

*TODO*

### To do

- [ ] Add FE tests
- [ ] Add/fix BE tests
