### PR TITLE
Generate usage reports in the admin pages

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -155,6 +155,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "admin.role.override.new", "/admin/instance/{id_}/role/overrides/new"
     )
+    config.add_route("admin.organization.usage", "/admin/org/{id_}/usage")
     config.add_route("admin.role.override", "/admin/role/overrides/{id_}")
     config.add_route("admin.role.override.delete", "/admin/role/overrides/{id_}/delete")
 

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -134,6 +134,35 @@ class HAPI:
                         author["userid"] = self.get_userid(author["username"])
                 yield annotation
 
+    def get_groups(
+        self,
+        groups: List[str],
+        annotations_created_after: datetime,
+        annotations_created_before: datetime,
+    ) -> Iterator[str]:
+        payload = {
+            "filter": {
+                "groups": groups,
+                "annotations_created": {
+                    "gt": _rfc3339_format(annotations_created_after),
+                    "lte": _rfc3339_format(annotations_created_before),
+                },
+            },
+        }
+
+        with self._api_request(
+            "POST",
+            path="bulk/groups",
+            body=json.dumps(payload),
+            headers={
+                "Content-Type": "application/vnd.hypothesis.v1+json",
+                "Accept": "application/vnd.hypothesis.v1+x-ndjson",
+            },
+            stream=True,
+        ) as response:
+            for line in response.iter_lines():
+                yield json.loads(line)
+
     # pylint: disable=too-many-arguments
     def _api_request(self, method, path, body=None, headers=None, stream=False):
         """

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -1,13 +1,35 @@
+from dataclasses import dataclass
+from datetime import datetime
 from logging import getLogger
 from typing import List, Optional
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Session
+from sqlalchemy import Date, func, select
+from sqlalchemy.orm import Session, aliased
 
 from lms.db import full_text_match
-from lms.models import ApplicationInstance, GroupInfo, Organization
+from lms.models import (
+    ApplicationInstance,
+    GroupInfo,
+    Grouping,
+    GroupingMembership,
+    Organization,
+    User,
+)
+from lms.services.h_api import HAPI
 
 LOG = getLogger(__name__)
+
+
+@dataclass
+class UsageReportRow:
+    name: Optional[str]
+    email: Optional[str]
+    h_userid: str
+
+    course_name: str
+    course_created: datetime
+    authority_provided_id: str
 
 
 class InvalidOrganizationParent(Exception):
@@ -17,8 +39,9 @@ class InvalidOrganizationParent(Exception):
 class OrganizationService:
     """A service for dealing with organization actions."""
 
-    def __init__(self, db_session: Session):
+    def __init__(self, db_session: Session, h_api: HAPI):
         self._db_session = db_session
+        self._h_api = h_api
 
     def get_by_id(self, id_: int) -> Optional[Organization]:
         """
@@ -216,6 +239,82 @@ class OrganizationService:
 
         return organization
 
+    def usage_report(
+        self,
+        organization: Organization,
+        since: datetime,
+        until: datetime,
+    ):
+        # Organizations that are children of the current one.
+        # It includes the current org ID.
+        organization_children = self._get_hierarchy_ids(
+            organization.id, include_parents=False
+        )
+        # All the groups that can hold annotations (courses and segments) from this org
+        groups_from_org = self._db_session.scalars(
+            select(Grouping.authority_provided_id)
+            .join(ApplicationInstance)
+            .where(
+                ApplicationInstance.organization_id.in_(organization_children),
+                # If a group was created after the date we are interested, exclude it
+                Grouping.created <= until,
+            )
+        ).all()
+
+        # Of those groups, get the ones that do have annotations in the time period
+        groups_with_annos = [
+            group.authority_provided_id
+            for group in self._h_api.get_groups(groups_from_org, since, until)
+        ]
+        # Based on those groups generate the usage report based on the definition of unique user:
+        # Users that belong to a course in which there are annotations in the time period
+        # pylint:disable=not-callable
+        parent = aliased(Grouping)
+        query = (
+            select(
+                func.coalesce(User.display_name, "<STUDENT>").label("name"),
+                func.coalesce(User.email, "<STUDENT>").label("email"),
+                User.h_userid.label("h_userid"),
+                Grouping.lms_name.label("course_name"),
+                func.date_trunc("day", Grouping.created)
+                .cast(Date)
+                .label("course_created"),
+                Grouping.authority_provided_id,
+            )
+            .select_from(User)
+            .join(GroupingMembership)
+            .join(Grouping)
+            .distinct()
+            .where(
+                Grouping.authority_provided_id.in_(
+                    # The report is based in courses so we query either
+                    # groupings with no parent (courses) or the parents of segments (courses)
+                    select(
+                        func.coalesce(
+                            parent.authority_provided_id, Grouping.authority_provided_id
+                        )
+                    )
+                    .select_from(Grouping)
+                    .outerjoin(parent, Grouping.parent_id == parent.id)
+                    .where(Grouping.authority_provided_id.in_(groups_with_annos))
+                ),
+                # We can't exactly know the state of membership in the past but we can
+                # know if someone was added to the group after the date we are interested
+                GroupingMembership.created <= until,
+            )
+        )
+        return [
+            UsageReportRow(
+                name=row.name,
+                email=row.email,
+                h_userid=row.h_userid,
+                course_name=row.course_name,
+                course_created=row.course_created,
+                authority_provided_id=row.authority_provided_id,
+            )
+            for row in self._db_session.execute(query).all()
+        ]
+
     def _move_organization_parent(self, organization: Organization, parent_public_id):
         """Change an organizations parent, without creating loops."""
 
@@ -280,4 +379,7 @@ class OrganizationService:
 def service_factory(_context, request) -> OrganizationService:
     """Get a new instance of OrganizationService."""
 
-    return OrganizationService(db_session=request.db)
+    return OrganizationService(
+        db_session=request.db,
+        h_api=request.find_service(HAPI),
+    )

--- a/lms/templates/admin/base.html.jinja2
+++ b/lms/templates/admin/base.html.jinja2
@@ -12,15 +12,25 @@
                 {% endif %}
             {% endblock %}
         </title>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+                integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
+                crossorigin="anonymous"
+                referrerpolicy="no-referrer"></script>
+        {# Data tables #}
+        <link rel="stylesheet"
+              href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.css" />
+        <script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.js"></script>
+        {# Data tables buttons extension #}
+        <script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
+        <link rel="stylesheet"
+              href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.dataTables.min.css" />
+        <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
+        {# Selectize #}
         <link rel="stylesheet"
               href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.15.2/css/selectize.default.min.css"
               integrity="sha512-pTaEn+6gF1IeWv3W1+7X7eM60TFu/agjgoHmYhAfLEU8Phuf6JKiiE8YmsNC0aCgQv4192s4Vai8YZ6VNM6vyQ=="
               crossorigin="anonymous"
               referrerpolicy="no-referrer" />
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
-                integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
-                crossorigin="anonymous"
-                referrerpolicy="no-referrer"></script>
         <link rel="stylesheet"
               href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.15.2/js/selectize.min.js"

--- a/lms/templates/admin/organization.html.jinja2
+++ b/lms/templates/admin/organization.html.jinja2
@@ -17,73 +17,106 @@
 {% extends "lms:templates/admin/base.html.jinja2" %}
 {% block header %}Organization {{ org.id }}{% endblock %}
 {% block content %}
-    <fieldset class="box">
-        <legend class="label has-text-centered">Organization</legend>
-        <form method="POST"
-              action="{{ request.route_url("admin.organization", id_=org.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
-            {{ macros.disabled_text_field("ID", org.public_id) }}
-            {{ macros.form_text_field(request, "Name", "name", org.name) }}
-            {{ macros.settings_textarea(org, "Notes", "hypothesis", "notes") }}
-            {{ macros.created_updated_fields(org) }}
-            <div class="has-text-right mb-6">
-                <input type="submit" class="button is-primary" value="Save" />
-            </div>
-        </form>
-    </fieldset>
-    <fieldset class="box">
-        <legend class="label has-text-centered">Application instances</legend>
-        <div class="block has-text-right">
-            <a class="button is-primary"
-               href="{{ request.route_url("admin.instance.create", _query={"organization_public_id": org.public_id}) }}">
-                Add New LTI 1.1 instance
-            </a>
-            {% if org.application_instances %}
-                <a class="button"
-                   href="{{ request.route_url("admin.instance.search", _query={"organization_public_id": org.public_id}) }}">
-                    Start search
-                </a>
-            {% endif %}
-        </div>
-        {% if org.application_instances %}
-            {{ macros.instances_table(request, org.application_instances) }}
-        {% else %}
-            <div class="is-size-5 has-text-centered">No application instances</div>
-        {% endif %}
-    </fieldset>
-    <div class="box">
-        <legend class="label has-text-centered">Hierarchy</legend>
-        <div class="content">
+    <div class="tabs-wrapper">
+        <div class="tabs is-fullwidth is-medium is-boxed is-toggle">
             <ul>
-                {{ org_hierarchy(hierarchy_root, org) }}
+                <li class="is-active">
+                    <a>Info</a>
+                </li>
+                <li>
+                    <a>Usage report</a>
+                </li>
+                <li>
+                    <a>Danger Zone</a>
+                </li>
             </ul>
         </div>
-    </div>
-    <fieldset class="box has-background-danger-light">
-        <legend class="label has-text-centered has-text-danger">Danger zone</legend>
-        {% call macros.field_body("Enabled") %}
-            <form method="POST"
-                  action="{{ request.route_url("admin.organization.toggle", id_=org.id) }}">
-                <label class="checkbox">
-                    <input {% if org.enabled %}checked{% endif %} type="checkbox" name="enabled">
-                </label>
-                <p>
-                    <b>Disabling the organization will disable all associated application instances. ALL LMS integrations will break.</b>
-                </p>
-                <input type="submit" class="button mb-2" value="Update">
-            </form>
-        {% endcall %}
-        {% call macros.field_body(label="Move (or remove) parent organization") %}
-            <form method="POST"
-                  action="{{ request.route_url("admin.organization.move_org", id_=org.id) }}">
-                <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
-                <input class="input"
-                       type="text"
-                       name="parent_public_id"
-                       value="{{ org.parent.public_id or '' }}">
-                <input type="submit" class="button mb-2" value="Move">
-            </form>
-            <p>Moving this organization might have destructive effects.</p>
-        {% endcall %}
-    </fieldset>
-{% endblock %}
+        <div class="tabs-content">
+            <ul>
+                <li class="is-active">
+                    <legend class="label has-text-centered">Organization</legend>
+                    <form method="POST"
+                          action="{{ request.route_url("admin.organization", id_=org.id) }}">
+                        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+                        {{ macros.disabled_text_field("ID", org.public_id) }}
+                        {{ macros.form_text_field(request, "Name", "name", org.name) }}
+                        {{ macros.settings_textarea(org, "Notes", "hypothesis", "notes") }}
+                        {{ macros.created_updated_fields(org) }}
+                        <div class="has-text-right mb-6">
+                            <input type="submit" class="button is-primary" value="Save" />
+                        </div>
+                    </form>
+                </fieldset>
+                <fieldset class="box">
+                    <legend class="label has-text-centered">Application instances</legend>
+                    <div class="block has-text-right">
+                        <a class="button is-primary"
+                           href="{{ request.route_url("admin.instance.create", _query={"organization_public_id": org.public_id}) }}">
+                            Add New LTI 1.1 instance
+                        </a>
+                        {% if org.application_instances %}
+                            <a class="button"
+                               href="{{ request.route_url("admin.instance.search", _query={"organization_public_id": org.public_id}) }}">
+                                Start search
+                            </a>
+                        {% endif %}
+                    </div>
+                    {% if org.application_instances %}
+                        {{ macros.instances_table(request, org.application_instances) }}
+                    {% else %}
+                        <div class="is-size-5 has-text-centered">No application instances</div>
+                    {% endif %}
+                </fieldset>
+                <div class="box">
+                    <legend class="label has-text-centered">Hierarchy</legend>
+                    <div class="content">
+                        <ul>
+                            {{ org_hierarchy(hierarchy_root, org) }}
+                        </ul>
+                    </div>
+                </div>
+            </li>
+            <li>
+                <fieldset class="box">
+                    <legend class="label has-text-centered">Usage report</legend>
+                    <form method="POST"
+                          action="{{ request.route_url("admin.organization.usage", id_=org.id) }}">
+                        <div class="columns">
+                            <div class="column is-half">{{ macros.form_text_field(request, "Since", "since", "2023-10-01") }}</div>
+                            <div class="column is-half">{{ macros.form_text_field(request, "", "until", "2023-10-31") }}</div>
+                        </div>
+                        <div class="has-text-right mb-6">
+                            <input type="submit" class="button is-primary" value="Generate" />
+                        </div>
+                    </fieldset>
+                </li>
+                <li>
+                    <fieldset class="box has-background-danger-light">
+                        <legend class="label has-text-centered has-text-danger">Danger zone</legend>
+                        {% call macros.field_body("Enabled") %}
+                            <form method="POST"
+                                  action="{{ request.route_url("admin.organization.toggle", id_=org.id) }}">
+                                <label class="checkbox">
+                                    <input {% if org.enabled %}checked{% endif %} type="checkbox" name="enabled">
+                                </label>
+                                <p>
+                                    <b>Disabling the organization will disable all associated application instances. ALL LMS integrations will break.</b>
+                                </p>
+                                <input type="submit" class="button mb-2" value="Update">
+                            </form>
+                        {% endcall %}
+                        {% call macros.field_body(label="Move (or remove) parent organization") %}
+                            <form method="POST"
+                                  action="{{ request.route_url("admin.organization.move_org", id_=org.id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+                                <input class="input"
+                                       type="text"
+                                       name="parent_public_id"
+                                       value="{{ org.parent.public_id or '' }}">
+                                <input type="submit" class="button mb-2" value="Move">
+                            </form>
+                            <p>Moving this organization might have destructive effects.</p>
+                        {% endcall %}
+                    </fieldset>
+                </li>
+            {% endblock %}

--- a/lms/templates/admin/organization.usage.html.jinja2
+++ b/lms/templates/admin/organization.usage.html.jinja2
@@ -1,0 +1,46 @@
+{% import "macros.html.jinja2" as macros %}
+{% extends "lms:templates/admin/base.html.jinja2" %}
+{% block header %}Organization {{ org.id }} usage{% endblock %}
+{% block content %}
+    <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Organization</legend>
+        {{ macros.organization_preview(request,org) }}
+    </fieldset>
+    <fieldset class="box mt-6">
+        <div class="columns">
+            <div class="column is-half">{{ macros.disabled_text_field("Since", since.strftime("%Y-%m-%d") ) }}</div>
+            <div class="column is-half">{{ macros.disabled_text_field("Until", until.strftime("%Y-%m-%d") ) }}</div>
+        </div>
+    </fieldset>
+    <table class="table datatable">
+        <thead>
+            <tr>
+                <th>User</th>
+                <th>Email</th>
+                <th>User ID</th>
+                <th>Course</th>
+                <th>Course created</th>
+                <th>Course ID</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in report %}
+                <tr>
+                    <td>{{ row.name }}</td>
+                    <td>{{ row.email }}</td>
+                    <td>{{ row.h_userid }}</td>
+                    <td>{{ row.course_name }}</td>
+                    <td>{{ row.course_created }}</td>
+                    <td>{{ row.authority_provided_id }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}
+{% block extra_scripts %}
+    <script>
+$(function () {
+   let table = $('table.datatable').DataTable({dom: 'Bfrtip',buttons: ["csv"]});
+});
+    </script>
+{% endblock %}


### PR DESCRIPTION
## Goal

The main goal of this PR is two have method to generate usage reports that doesn't involve any other scripts or untested SQL.

Once deployed the data can be compared against the number over https://docs.google.com/spreadsheets/d/1kCG9OCU-tybqtkJmdMWx_75DUqgpNwrvdq0FfU-nqrg/edit#gid=0



## Testing

- Checkout this branch over in H https://github.com/hypothesis/h/pull/8275
- Open a couple of windows (normal and incognito?) as both `eng+canvasteacher@hypothes.is` and `eng+canvasstudent@hypothes.is`



- Make annotations as both users in this two separate assignments that belong to two different courses:

https://hypothesis.instructure.com/courses/125/assignments/873
https://hypothesis.instructure.com/courses/319/assignments/3308

- In the admin pages go to the organization: http://localhost:8001/admin/org/1, select the usage tab and pick a date range that includes the moment you made the annotations, generate the report.

- You get a table with the report inline, you can also export to CSV.









