### PR TITLE
Add feature flag for enabling VitalSource page range selection

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -30,6 +30,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("google_drive", "files_enabled", asbool),
         JSONSetting("microsoft_onedrive", "files_enabled", asbool),
         JSONSetting("vitalsource", "enabled", asbool),
+        JSONSetting("vitalsource", "page_ranges", asbool),
         JSONSetting("vitalsource", "user_lti_param"),
         JSONSetting("vitalsource", "user_lti_pattern"),
         JSONSetting("vitalsource", "api_key"),

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -111,10 +111,16 @@ class FilePickerConfig:
         }
 
     @classmethod
-    def vitalsource_config(cls, request, _application_instance):
+    def vitalsource_config(cls, request, application_instance):
         """Get VitalSource config."""
 
-        return {"enabled": request.find_service(VitalSourceService).enabled}
+        page_ranges = application_instance.settings.get(
+            "vitalsource", "page_ranges", default=False
+        )
+        return {
+            "enabled": request.find_service(VitalSourceService).enabled,
+            "pageRangesEnabled": page_ranges,
+        }
 
     @classmethod
     def jstor_config(cls, request, _application_instance):

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -157,6 +157,7 @@
                             {{ settings_text_field('VitalSource SSO user ID field', 'vitalsource', 'user_lti_param') }}
                             {{ settings_text_field('VitalSource SSO user ID regex', 'vitalsource', 'user_lti_pattern') }}
                             {{ settings_checkbox('VitalSource disable licence check on SSO', 'vitalsource', 'disable_licence_check') }}
+                            {{ settings_checkbox("VitalSource page range selection", "vitalsource", "page_ranges") }}
                             {{ settings_checkbox('JSTOR enabled', 'jstor', 'enabled') }}
                             {{ settings_text_field('JSTOR site code', 'jstor', 'site_code') }}
                             {{ settings_checkbox("YouTube enabled", "youtube", "enabled", default=True) }}

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -138,12 +138,19 @@ class TestFilePickerConfig:
 
         assert config == expected
 
-    def test_vitalsource_config(self, pyramid_request, vitalsource_service):
+    @pytest.mark.parametrize("page_ranges", (True, False))
+    def test_vitalsource_config(
+        self, pyramid_request, vitalsource_service, application_instance, page_ranges
+    ):
+        application_instance.settings.set("vitalsource", "page_ranges", page_ranges)
         config = FilePickerConfig.vitalsource_config(
-            pyramid_request, sentinel.application_instance
+            pyramid_request, application_instance
         )
 
-        assert config == {"enabled": vitalsource_service.enabled}
+        assert config == {
+            "enabled": vitalsource_service.enabled,
+            "pageRangesEnabled": page_ranges,
+        }
 
     @pytest.mark.parametrize("enabled", (True, False))
     def test_jstor_config(self, pyramid_request, jstor_service, enabled):


### PR DESCRIPTION
Add a feature flag that controls whether users can specify a page range for an assignment, as opposed to just a start point from the table of contents.

Part of https://github.com/hypothesis/lms/issues/5808