### PR TITLE
Add backend support for page ranges in VitalSource assignment URLs

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -135,6 +135,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "vitalsource_api.books.toc", "/api/vitalsource/books/{book_id}/toc"
     )
+    config.add_route("vitalsource_api.document_url", "/api/vitalsource/document_url")
     config.add_route("vitalsource_api.launch_url", "/api/vitalsource/launch_url")
 
     config.add_route("youtube_api.videos", "/api/youtube/videos/{video_id}")

--- a/lms/services/vitalsource/_client.py
+++ b/lms/services/vitalsource/_client.py
@@ -65,10 +65,16 @@ class VitalSourceClient:
 
         book_info = _BookInfoSchema(response).parse()
 
+        # This should be the same as `book_id` but it comes from the
+        # authoritative source. This might make a difference if the VS APIs
+        # normalize or redirect IDs.
+        vbid = book_info["vbid"]
+
         return {
-            "id": book_info["vbid"],
+            "id": vbid,
             "title": book_info["title"],
             "cover_image": book_info["resource_links"]["cover_image"],
+            "url": VSBookLocation(vbid).document_url,
         }
 
     def get_table_of_contents(self, book_id: str) -> List[dict]:
@@ -91,7 +97,7 @@ class VitalSourceClient:
 
         toc = _BookTOCSchema(response).parse()["table_of_contents"]
         for chapter in toc:
-            chapter["url"] = VSBookLocation(book_id, chapter["cfi"]).document_url
+            chapter["url"] = VSBookLocation(book_id, cfi=chapter["cfi"]).document_url
 
         return toc
 

--- a/lms/services/vitalsource/model.py
+++ b/lms/services/vitalsource/model.py
@@ -1,5 +1,7 @@
 import re
 from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import quote_plus, unquote_plus
 
 
 @dataclass
@@ -9,23 +11,63 @@ class VSBookLocation:
     book_id: str
     """Id of the book"""
 
-    cfi: str
-    """Location within than book."""
+    cfi: Optional[str] = None
+    """Location within the book, specified as a CFI."""
+
+    page: Optional[str] = None
+    """
+    Location within the book, specified as a page number.
+
+    In most cases this will be a 1-based number, but some pages may use other
+    numbering systems (eg. Roman numerals, prefixes).
+
+    Page numbers are usually unique within a book, but this is not guaranteed.
+    In the event that a page number corresponds to multiple locations, this
+    VSBookLocation is taken to refer to the first such location.
+    """
 
     @property
     def document_url(self):
         """Get our internal representation of this location."""
 
-        return f"vitalsource://book/bookID/{self.book_id}/cfi/{self.cfi}"
+        url = f"vitalsource://book/bookID/{self.book_id}"
 
-    #: A regex for parsing the BOOK_ID and CFI parts out of one of our custom
-    #: vitalsource://book/bookID/BOOK_ID/cfi/CFI URLs.
+        if self.cfi:
+            # CFIs are currently not escaped. This could create parsing
+            # ambiguities when query params are added to the URL. If we change
+            # this we need to avoid breaking existing assignments.
+            url += f"/cfi/{self.cfi}"
+        elif self.page:
+            url += f"/page/{quote_plus(self.page)}"
+
+        return url
+
+    #: A regex for parsing the BOOK_ID and location parts out of one of our
+    #: custom vitalsource://book/bookID/BOOK_ID/LOCATION_TYPE/LOCATION URLs.
     _DOCUMENT_URL_REGEX = re.compile(
-        r"vitalsource:\/\/book\/bookID\/(?P<book_id>[^\/]*)\/cfi\/(?P<cfi>.*)"
+        r"vitalsource:\/\/book\/bookID\/(?P<book_id>[^\/]*)\/(?P<loc_type>[^\/]*)\/(?P<loc>.*)"
     )
 
     @classmethod
     def from_document_url(cls, document_url):
         """Get a location from our internal representation."""
 
-        return cls(**cls._DOCUMENT_URL_REGEX.search(document_url).groupdict())
+        match = cls._DOCUMENT_URL_REGEX.search(document_url)
+        if match is None:
+            raise ValueError("URL is not a valid vitalsource:// URL")
+
+        book_id = match["book_id"]
+        loc_type = match["loc_type"]
+        loc = match["loc"]
+
+        if loc_type not in ("cfi", "page"):
+            raise ValueError("Invalid book location specifier")
+
+        if loc_type == "page":
+            loc = unquote_plus(loc)
+
+        return cls(
+            book_id=book_id,
+            cfi=loc if loc_type == "cfi" else None,
+            page=loc if loc_type == "page" else None,
+        )

--- a/lms/views/api/vitalsource.py
+++ b/lms/views/api/vitalsource.py
@@ -5,11 +5,24 @@ from lms.security import Permissions
 from lms.services import VitalSourceService
 from lms.validation import PyramidRequestSchema
 
+VBID_REGEX = r"^[\dA-Z-]+$"
+"""Regex that matches valid VitalSource book IDs."""
+
 
 class _BookSchema(PyramidRequestSchema):
     location = "matchdict"
 
-    book_id = fields.Str(required=True, validate=validate.Regexp(r"^[\dA-Z-]+$"))
+    book_id = fields.Str(required=True, validate=validate.Regexp(VBID_REGEX))
+
+
+class _DocumentURLSchema(PyramidRequestSchema):
+    location = "query"
+
+    book_id = fields.Str(required=True, validate=validate.Regexp(VBID_REGEX))
+    page = fields.Str()
+    cfi = fields.Str()
+    end_page = fields.Str()
+    end_cfi = fields.Str()
 
 
 @view_defaults(renderer="json", permission=Permissions.API)
@@ -25,6 +38,10 @@ class VitalSourceAPIViews:
     @view_config(route_name="vitalsource_api.books.toc", schema=_BookSchema)
     def table_of_contents(self):
         return self.svc.get_table_of_contents(self.request.matchdict["book_id"])
+
+    @view_config(route_name="vitalsource_api.document_url", schema=_DocumentURLSchema)
+    def document_url(self):
+        return {"document_url": self.svc.get_document_url(**self.request.parsed_params)}
 
     @view_config(route_name="vitalsource_api.launch_url")
     def launch_url(self):

--- a/tests/unit/lms/services/vitalsource/_client_test.py
+++ b/tests/unit/lms/services/vitalsource/_client_test.py
@@ -52,6 +52,7 @@ class TestVitalSourceClient:
             "id": "VBID",
             "title": "TITLE",
             "cover_image": "COVER_IMAGE",
+            "url": "vitalsource://book/bookID/VBID",
         }
 
     def test_get_table_of_contents(self, client, http_service):

--- a/tests/unit/lms/services/vitalsource/model_test.py
+++ b/tests/unit/lms/services/vitalsource/model_test.py
@@ -6,20 +6,40 @@ from lms.services.vitalsource import VSBookLocation
 
 class TestVSBookLocation:
     TEST_CASES = [
-        ("vitalsource://book/bookID/book-id/cfi//abc", "book-id", "/abc"),
-        ("vitalsource://book/bookID/book-id/cfi/abc", "book-id", "abc"),
+        # Book ID + CFI
+        ("vitalsource://book/bookID/book-id/cfi//abc", "book-id", "/abc", None),
+        ("vitalsource://book/bookID/book-id/cfi/abc", "book-id", "abc", None),
+        # Book ID + Page number
+        ("vitalsource://book/bookID/book-id/page/23", "book-id", None, "23"),
+        ("vitalsource://book/bookID/book-id/page/iv", "book-id", None, "iv"),
+        ("vitalsource://book/bookID/book-id/page/A+B", "book-id", None, "A B"),
     ]
 
-    @pytest.mark.parametrize("document_url,book_id,cfi", TEST_CASES)
-    def test_from_document_url(self, document_url, book_id, cfi):
+    @pytest.mark.parametrize("document_url,book_id,cfi,page", TEST_CASES)
+    def test_from_document_url(self, document_url, book_id, cfi, page):
         loc = VSBookLocation.from_document_url(document_url)
 
         assert loc == Any.instance_of(VSBookLocation).with_attrs(
-            {"book_id": book_id, "cfi": cfi}
+            {"book_id": book_id, "cfi": cfi, "page": page}
         )
 
-    @pytest.mark.parametrize("document_url,book_id,cfi", TEST_CASES)
-    def test_document_url(self, document_url, book_id, cfi):
-        loc = VSBookLocation(book_id, cfi)
+    @pytest.mark.parametrize(
+        "document_url,expected",
+        [
+            ("https://example.org", "URL is not a valid vitalsource:// URL"),
+            (
+                "vitalsource://book/bookID/a-book/pageindex/123",
+                "Invalid book location specifier",
+            ),
+        ],
+    )
+    def test_from_document_url_invalid(self, document_url, expected):
+        with pytest.raises(ValueError) as exc_info:
+            VSBookLocation.from_document_url(document_url)
+        assert str(exc_info.value) == expected
+
+    @pytest.mark.parametrize("document_url,book_id,cfi,page", TEST_CASES)
+    def test_document_url(self, document_url, book_id, cfi, page):
+        loc = VSBookLocation(book_id, cfi, page)
 
         assert loc.document_url == document_url

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -116,6 +116,57 @@ class TestVitalSourceService:
         with pytest.raises(VitalSourceMalformedRegex):
             VitalSourceService.compile_user_lti_pattern(bad_pattern)
 
+    @pytest.mark.parametrize(
+        "page,cfi,end_page,end_cfi,expected",
+        [
+            # Book ID only
+            (
+                None,
+                None,
+                None,
+                None,
+                "vitalsource://book/bookID/some_book",
+            ),
+            # Book ID + start CFI
+            (
+                None,
+                "/1/2",
+                None,
+                None,
+                "vitalsource://book/bookID/some_book/cfi//1/2",
+            ),
+            # Book ID + start page
+            (
+                "23",
+                None,
+                None,
+                None,
+                "vitalsource://book/bookID/some_book/page/23",
+            ),
+            # Book ID + start and end page
+            (
+                "23",
+                None,
+                "46",
+                None,
+                "vitalsource://book/bookID/some_book/page/23?end_page=46",
+            ),
+            # Book ID + start and end CFI
+            (
+                None,
+                "/1/2",
+                None,
+                "/3/4",
+                "vitalsource://book/bookID/some_book/cfi//1/2?end_cfi=%2F3%2F4",
+            ),
+        ],
+    )
+    def test_get_document_url(self, svc, page, cfi, end_page, end_cfi, expected):
+        url = svc.get_document_url(
+            book_id="some_book", page=page, cfi=cfi, end_page=end_page, end_cfi=end_cfi
+        )
+        assert url == expected
+
     @pytest.fixture
     def global_client(self):
         return create_autospec(VitalSourceClient, instance=True, spec_set=True)

--- a/tests/unit/lms/views/api/vitalsource_test.py
+++ b/tests/unit/lms/views/api/vitalsource_test.py
@@ -23,6 +23,18 @@ class TestVitalSourceAPIViews:
         vitalsource_service.get_table_of_contents.assert_called_once_with("BOOK-ID")
         assert response == vitalsource_service.get_table_of_contents.return_value
 
+    def test_document_url(self, view, pyramid_request, vitalsource_service):
+        pyramid_request.parsed_params = {"book_id": "a-book", "cfi": "start-cfi"}
+
+        response = view.document_url()
+
+        vitalsource_service.get_document_url.assert_called_once_with(
+            **pyramid_request.parsed_params
+        )
+        assert response == {
+            "document_url": vitalsource_service.get_document_url.return_value
+        }
+
     def test_launch_url(self, view, pyramid_request, vitalsource_service):
         pyramid_request.params["user_reference"] = sentinel.user_reference
         pyramid_request.params["document_url"] = sentinel.document_url


### PR DESCRIPTION
Make changes to how VS book locations are represented in the backend to support the upcoming page-range selection feature. Also add an API to generate VS document URLs. This is not currently used by the frontend.

 - Support specifying the start location of a VS assignment as a page number rather than a CFI. For certain books this allows specifying a more precise starting point, compared to using CFIs that correspond to table-of-contents entries.

 - Add an API for the frontend to generate the document URL for a VitalSource assignment.

   Previously the frontend received the document URL from entries in the table of contents API response. We are now adding the ability to configure a page range for an assignment, so it will no longer be possible to enumerate all document URLs in the TOC response. Instead provide a separate API that the frontend can call with the page/chapter range to generate a URL.

One backend issue that is *not* addressed in this PR is adjusting the book reader launch URL that is used when the location is a page. I have verified though that the VS book reader has a supported way to open a book at a specific page number.

Part of https://github.com/hypothesis/lms/issues/5809.