### PR TITLE
Increase `send_instructor_email_digests` rate limit

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -120,7 +120,7 @@ def send_instructor_email_digest_tasks(*, batch_size):
     max_retries=2,
     retry_backoff=3600,
     retry_backoff_max=7200,
-    rate_limit="3/m",
+    rate_limit="30/m",
 )
 def send_instructor_email_digests(
     *, h_userids: List[str], created_after: str, created_before: str, **kwargs


### PR DESCRIPTION
Increase the rate limit of the `send_instructor_email_digests()` Celery task again, this time increasing it 10x from `3/m` to `30/m`.

This is to enable us to reduce the task's `batch_size` (which is specified in `h-periodic`), from its current value of `10` to just `1` to see whether we could get away with removing the batching feature. See: https://github.com/hypothesis/h-periodic/pull/389

Slack thread: https://hypothes-is.slack.com/archives/C1MA4E9B9/p1700130444868909?thread_ts=1699980253.387059&cid=C1MA4E9B9
