### PR TITLE
Preserve admin active tab after submitting form

### DIFF
--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -41,25 +41,25 @@
     <div class="tabs-wrapper">
         <div class="tabs is-fullwidth is-medium is-boxed is-toggle">
             <ul>
-                <li class="is-active">
+                <li data-section-id="info">
                     <a>Info</a>
                 </li>
-                <li>
+                <li data-section-id="settings">
                     <a>Settings</a>
                 </li>
-                <li>
+                <li data-section-id="role-overrides">
                     <a>Role Overrides</a>
                 </li>
-                <li>
+                <li data-section-id="danger">
                     <a>Danger</a>
                 </li>
             </ul>
         </div>
         <div class="tabs-content">
             <ul>
-                <li class="is-active">
+                <li data-section-id="info">
                     <form method="POST"
-                          action="{{ request.route_url("admin.instance", id_=instance.id) }}">
+                          action="{{ request.route_url("admin.instance", id_=instance.id) }}#info">
                         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
                         <fieldset class="box">
                             {{ macros.form_text_field(request, "Name", "name", field_value=instance.name) }}
@@ -106,9 +106,9 @@
                         </fieldset>
                     </form>
                 </li>
-                <li>
+                <li data-section-id="settings">
                     <form method="POST"
-                          action="{{ request.route_url("admin.instance.settings", id_=instance.id) }}">
+                          action="{{ request.route_url("admin.instance.settings", id_=instance.id) }}#settings">
                         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
                         <fieldset class="box">
                             <legend class="label has-text-centered">General settings</legend>
@@ -167,7 +167,7 @@
                         </div>
                     </form>
                 </li>
-                <li>
+                <li data-section-id="role-overrides">
                     <fieldset class="box">
                         <legend id="roles" class="label has-text-centered">Role overrides</legend>
                         <div class="block has-text-right">
@@ -185,7 +185,7 @@
                         {% endif %}
                     </fieldset>
                 </li>
-                <li>
+                <li data-section-id="danger">
                     <fieldset class="box has-background-danger-light">
                         <legend class="label has-text-centered has-text-danger">Danger zone</legend>
                         {% call macros.field_body(label="Downgrade to LTI 1.1") %}
@@ -201,7 +201,7 @@
                         {% endcall %}
                         {% call macros.field_body(label="Move to organization") %}
                             <form method="POST"
-                                  action="{{ request.route_url("admin.instance.move_org", id_=instance.id) }}">
+                                  action="{{ request.route_url("admin.instance.move_org", id_=instance.id) }}#danger">
                                 <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
                                 <input class="input" type="text" name="org_public_id">
                                 <input type="submit" class="button mb-2" value="Move">
@@ -213,4 +213,29 @@
             </ul>
         </div>
     </div>
+    <script>
+      function determineActiveSection() {
+        const activeSection = (window.location.hash || '#info').substring(1);
+        const tabs = document.querySelectorAll('[data-section-id]');
+
+        // Iterate over tabs and tab panels, adding is-active to those which data-section-id matches active section,
+        // and removing it for the rest.
+        tabs.forEach(tab => {
+          tab.classList.toggle('is-active', tab.dataset.sectionId === activeSection);
+        });
+      }
+
+      // Select the first tab on window load
+      window.addEventListener('load', determineActiveSection);
+      // Update selected tab on history change
+      window.addEventListener('popstate', determineActiveSection);
+
+      // Capture clicks in tabs, to update the location hash
+      document.querySelectorAll('.tabs li').forEach(tab => {
+        tab.addEventListener('click', () => {
+          const newActiveSection = tab.dataset.sectionId;
+          window.history.pushState(null, '', `#${newActiveSection}`);
+        });
+      });
+    </script>
 {% endblock %}

--- a/lms/templates/admin/role.override.new.html.jinja2
+++ b/lms/templates/admin/role.override.new.html.jinja2
@@ -7,7 +7,7 @@
         {{ macros.instance_preview(request, instance) }}
     </fieldset>
     <form method="POST"
-          action="{{ request.route_url("admin.role.override.new", id_=instance.id) }}">
+          action="{{ request.route_url("admin.role.override.new", id_=instance.id) }}#role-overrides">
         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
         <fieldset class="box mt-6">
             {{ macros.select("Value", "role_id", existing_roles, override.id if override else None, with_search=True) }}


### PR DESCRIPTION
With the recent addition of tabs in LMS admin pages, these changes ensure the active tab is preserved between form submissions.

It also allows to deeplink to one specific tab, and preserves a history of all visited tabs.

[Grabación de pantalla desde 2023-11-21 15-38-22.webm](https://github.com/hypothesis/lms/assets/2719332/cbd545d9-f57a-41ff-a49e-924c40695b66)

### Considerations

The implementation is a bit ugly. It requires you to remember to add a couple of attributes when new tabs are added, and remember to add the right hash to form actions that need to redirect to one specific tab.

All the JS code is also just dropped inside the main template. We may want to revisit this and move it to its own module.

### How it works

Every tab and their corresponding tab panel should have matching `data-section-id` attributes.

Every time a new section is added, they need to have those attributes, with a value that is unique.

If new sections render forms which require the user to be redirected to the section after submitting, the action needs to include a URL hash matching the value set in the tab's `data-section-id`.