### PR TITLE
Rename `EmailUnsubscribeService` to `EmailPreferencesService`

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -3,7 +3,7 @@ from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.canvas import CanvasService
 from lms.services.d2l_api.client import D2LAPIClient
 from lms.services.digest import DigestService
-from lms.services.email_unsubscribe import EmailUnsubscribeService
+from lms.services.email_preferences import EmailPreferencesService
 from lms.services.event import EventService
 from lms.services.exceptions import (
     CanvasAPIError,
@@ -124,7 +124,7 @@ def includeme(config):
         "lms.services.digest.service_factory", iface=DigestService
     )
     config.register_service_factory(
-        "lms.services.email_unsubscribe.factory", iface=EmailUnsubscribeService
+        "lms.services.email_preferences.factory", iface=EmailPreferencesService
     )
     config.register_service_factory(
         "lms.services.youtube.factory", iface=YouTubeService

--- a/lms/services/email_preferences.py
+++ b/lms/services/email_preferences.py
@@ -6,7 +6,7 @@ from lms.services.jwt import JWTService
 from lms.services.upsert import bulk_upsert
 
 
-class EmailUnsubscribeService:
+class EmailPreferencesService:
     def __init__(self, db, jwt_service: JWTService, secret: str, route_url: Callable):
         self._db = db
         self._jwt_service = jwt_service
@@ -42,7 +42,7 @@ class EmailUnsubscribeService:
 
 
 def factory(_context, request):
-    return EmailUnsubscribeService(
+    return EmailPreferencesService(
         request.db,
         request.find_service(iface=JWTService),
         secret=request.registry.settings["jwt_secret"],

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -3,7 +3,7 @@ import logging
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
-from lms.services import EmailUnsubscribeService
+from lms.services import EmailPreferencesService
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
 
 LOG = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 def unsubscribe(request):
     """Unsubscribe the email and tag combination encoded in token."""
     try:
-        request.find_service(EmailUnsubscribeService).unsubscribe(
+        request.find_service(EmailPreferencesService).unsubscribe(
             request.params["token"]
         )
     except (InvalidJWTError, ExpiredJWTError):

--- a/tests/unit/lms/services/digest_test.py
+++ b/tests/unit/lms/services/digest_test.py
@@ -31,7 +31,7 @@ class TestDigestService:
         db_session,
         send,
         sender,
-        email_unsubscribe_service,
+        email_preferences_service,
     ):
         context.user_infos = UserInfoFactory.create_batch(2)
         digests = context.instructor_digest.side_effect = [
@@ -75,7 +75,7 @@ class TestDigestService:
                     EmailRecipient(user_info.email, user_info.display_name)
                 ),
                 template_vars=digest,
-                unsubscribe_url=email_unsubscribe_service.unsubscribe_url.return_value,
+                unsubscribe_url=email_preferences_service.unsubscribe_url.return_value,
             )
             for user_info, digest in zip(context.user_infos, digests)
         ]
@@ -123,7 +123,7 @@ class TestDigestService:
 
         send.delay.assert_not_called()
 
-    @pytest.mark.usefixtures("email_unsubscribe_service")
+    @pytest.mark.usefixtures("email_preferences_service")
     def test_send_instructor_email_digests_uses_override_to_email(
         self, svc, context, send
     ):
@@ -202,12 +202,12 @@ class TestDigestService:
         return h_api
 
     @pytest.fixture
-    def svc(self, db_session, h_api, sender, email_unsubscribe_service):
+    def svc(self, db_session, h_api, sender, email_preferences_service):
         return DigestService(
             db=db_session,
             h_api=h_api,
             sender=sender,
-            email_unsubscribe_service=email_unsubscribe_service,
+            email_preferences_service=email_preferences_service,
         )
 
 
@@ -707,7 +707,7 @@ class TestDigestContext:
 
 
 class TestServiceFactory:
-    def test_it(self, pyramid_request, h_api, DigestService, email_unsubscribe_service):
+    def test_it(self, pyramid_request, h_api, DigestService, email_preferences_service):
         settings = pyramid_request.registry.settings
         settings["mailchimp_digests_subaccount"] = sentinel.digests_subaccount
         settings["mailchimp_digests_email"] = sentinel.digests_from_email
@@ -723,7 +723,7 @@ class TestServiceFactory:
                 sentinel.digests_from_email,
                 sentinel.digests_from_name,
             ),
-            email_unsubscribe_service=email_unsubscribe_service,
+            email_preferences_service=email_preferences_service,
         )
         assert service == DigestService.return_value
 

--- a/tests/unit/lms/services/email_preferences_test.py
+++ b/tests/unit/lms/services/email_preferences_test.py
@@ -4,10 +4,10 @@ from unittest.mock import sentinel
 import pytest
 
 from lms.models import EmailUnsubscribe
-from lms.services.email_unsubscribe import EmailUnsubscribeService, factory
+from lms.services.email_preferences import EmailPreferencesService, factory
 
 
-class TestEmailUnsubscribeService:
+class TestEmailPreferencesService:
     def test_unsubscribe_url(self, svc, jwt_service):
         jwt_service.encode_with_secret.return_value = "TOKEN"
 
@@ -44,29 +44,29 @@ class TestEmailUnsubscribeService:
 
     @pytest.fixture
     def svc(self, db_session, jwt_service, pyramid_request):
-        return EmailUnsubscribeService(
+        return EmailPreferencesService(
             db_session, jwt_service, "SECRET", pyramid_request.route_url
         )
 
     @pytest.fixture
     def bulk_upsert(self, patch):
-        return patch("lms.services.email_unsubscribe.bulk_upsert")
+        return patch("lms.services.email_preferences.bulk_upsert")
 
 
 class TestFactory:
     def test_it(
-        self, pyramid_request, EmailUnsubscribeService, db_session, jwt_service
+        self, pyramid_request, EmailPreferencesService, db_session, jwt_service
     ):
         svc = factory(sentinel.context, pyramid_request)
 
-        EmailUnsubscribeService.assert_called_once_with(
+        EmailPreferencesService.assert_called_once_with(
             db_session,
             jwt_service,
             secret="test_secret",
             route_url=pyramid_request.route_url,
         )
-        assert svc == EmailUnsubscribeService.return_value
+        assert svc == EmailPreferencesService.return_value
 
     @pytest.fixture
-    def EmailUnsubscribeService(self, patch):
-        return patch("lms.services.email_unsubscribe.EmailUnsubscribeService")
+    def EmailPreferencesService(self, patch):
+        return patch("lms.services.email_preferences.EmailPreferencesService")

--- a/tests/unit/lms/views/email_test.py
+++ b/tests/unit/lms/views/email_test.py
@@ -7,20 +7,20 @@ from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
 from lms.views.email import unsubscribe, unsubscribed
 
 
-def test_unsubscribe(pyramid_request, email_unsubscribe_service):
+def test_unsubscribe(pyramid_request, email_preferences_service):
     pyramid_request.params["token"] = sentinel.token
 
     result = unsubscribe(pyramid_request)
 
-    email_unsubscribe_service.unsubscribe.assert_called_once_with(sentinel.token)
+    email_preferences_service.unsubscribe.assert_called_once_with(sentinel.token)
     assert isinstance(result, HTTPFound)
     assert result.location == "http://example.com/email/unsubscribed"
 
 
 @pytest.mark.parametrize("exception", [ExpiredJWTError, InvalidJWTError])
-def test_unsubscribe_error(pyramid_request, email_unsubscribe_service, exception):
+def test_unsubscribe_error(pyramid_request, email_preferences_service, exception):
     pyramid_request.params["token"] = sentinel.token
-    email_unsubscribe_service.unsubscribe.side_effect = exception
+    email_preferences_service.unsubscribe.side_effect = exception
 
     result = unsubscribe(pyramid_request)
 

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -19,7 +19,7 @@ from lms.services.canvas_api import CanvasAPIClient
 from lms.services.course import CourseService
 from lms.services.d2l_api import D2LAPIClient
 from lms.services.digest import DigestService
-from lms.services.email_unsubscribe import EmailUnsubscribeService
+from lms.services.email_preferences import EmailPreferencesService
 from lms.services.event import EventService
 from lms.services.file import FileService
 from lms.services.grading_info import GradingInfoService
@@ -87,7 +87,7 @@ __all__ = (
     "rsa_key_service",
     "user_service",
     "vitalsource_service",
-    "email_unsubscribe_service",
+    "email_preferences_service",
     "youtube_service",
     # Product plugins
     "grouping_plugin",
@@ -333,8 +333,8 @@ def vitalsource_service(mock_service):
 
 
 @pytest.fixture
-def email_unsubscribe_service(mock_service):
-    return mock_service(EmailUnsubscribeService)
+def email_preferences_service(mock_service):
+    return mock_service(EmailPreferencesService)
 
 
 @pytest.fixture


### PR DESCRIPTION
This is because we're getting to be adding a `preferences_url()` method and other public methods to this service, it's not going to be just for unsubscribes anymore. Also, the service will be changed to read and write the new `EmailPreferences` model and the current `EmailUnsubscribe` model will eventually be removed.
