### PR TITLE
Define client-side handled routes for every admin AI tab

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -149,9 +149,12 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.instance.create", "/admin/instance/create")
     config.add_route("admin.instance.upgrade", "/admin/instance/upgrade")
     config.add_route("admin.instance", "/admin/instance/{id_}/")
-    config.add_route("admin.instance.settings", "/admin/instance/{id_}/settings")
     config.add_route("admin.instance.downgrade", "/admin/instance/{id_}/downgrade")
     config.add_route("admin.instance.move_org", "/admin/instance/{id_}/move_org")
+    config.add_route(
+        "admin.instance.section",
+        "/admin/instance/{id_}/{section:info|settings|role-overrides|danger}",
+    )
 
     config.add_route(
         "admin.role.override.new", "/admin/instance/{id_}/role/overrides/new"

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -41,23 +41,23 @@
     <div class="tabs-wrapper">
         <div class="tabs is-fullwidth is-medium is-boxed is-toggle">
             <ul>
-                <li class="is-active">
+                <li data-section-id="info">
                     <a>Info</a>
                 </li>
-                <li>
+                <li data-section-id="settings">
                     <a>Settings</a>
                 </li>
-                <li>
+                <li data-section-id="role-overrides">
                     <a>Role Overrides</a>
                 </li>
-                <li>
+                <li data-section-id="danger">
                     <a>Danger</a>
                 </li>
             </ul>
         </div>
         <div class="tabs-content">
             <ul>
-                <li class="tab-panel is-active">
+                <li class="tab-panel" data-section-id="info">
                     <form method="POST"
                           action="{{ request.route_url("admin.instance", id_=instance.id) }}">
                         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
@@ -106,9 +106,9 @@
                         </fieldset>
                     </form>
                 </li>
-                <li class="tab-panel">
+                <li class="tab-panel" data-section-id="settings">
                     <form method="POST"
-                          action="{{ request.route_url("admin.instance.settings", id_=instance.id) }}">
+                          action="{{ request.route_url("admin.instance.section", id_=instance.id, section="settings") }}">
                         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
                         <fieldset class="box">
                             <legend class="label has-text-centered">General settings</legend>
@@ -167,7 +167,7 @@
                         </div>
                     </form>
                 </li>
-                <li class="tab-panel">
+                <li class="tab-panel" data-section-id="role-overrides">
                     <fieldset class="box">
                         <legend id="roles" class="label has-text-centered">Role overrides</legend>
                         <div class="block has-text-right">
@@ -185,7 +185,7 @@
                         {% endif %}
                     </fieldset>
                 </li>
-                <li class="tab-panel">
+                <li class="tab-panel" data-section-id="danger">
                     <fieldset class="box has-background-danger-light">
                         <legend class="label has-text-centered has-text-danger">Danger zone</legend>
                         {% call macros.field_body(label="Downgrade to LTI 1.1") %}
@@ -213,4 +213,37 @@
             </ul>
         </div>
     </div>
+    <script>
+      function determineActiveSection() {
+        const currentPath = window.location.pathname;
+        // Remove leading and trailing bars
+        const trimmedCurrentPath = currentPath.replace(/^\/+|\/+$/g, '');
+        // We assume all routes here have a common prefix consisting on three parts
+        return trimmedCurrentPath.split('/')[3] ?? 'info';
+      }
+
+      function updateActiveTab() {
+        const activeSection = determineActiveSection();
+        const tabs = document.querySelectorAll('[data-section-id]');
+
+        // Iterate over tabs and tab panels, adding is-active to those which data-section-id matches active section,
+        // and removing it for the rest.
+        tabs.forEach(tab => {
+          tab.classList.toggle('is-active', tab.dataset.sectionId === activeSection);
+        });
+      }
+
+      // Select the first tab on window load
+      window.addEventListener('load', updateActiveTab);
+      // Update selected tab on history change
+      window.addEventListener('popstate', updateActiveTab);
+
+      // Capture clicks in tabs, to update the URL
+      document.querySelectorAll('.tabs li').forEach(tab => {
+        tab.addEventListener('click', () => {
+          const newActiveSection = tab.dataset.sectionId;
+          window.history.pushState(null, '', newActiveSection);
+        });
+      });
+    </script>
 {% endblock %}

--- a/lms/views/admin/application_instance/show.py
+++ b/lms/views/admin/application_instance/show.py
@@ -1,15 +1,16 @@
-from pyramid.view import view_config
+from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
 from lms.views.admin.application_instance._core import BaseApplicationInstanceView
 
 
+@view_defaults(
+    renderer="lms:templates/admin/application_instance/show.html.jinja2",
+    permission=Permissions.STAFF,
+    request_method="GET",
+)
 class ShowApplicationInstanceView(BaseApplicationInstanceView):
-    @view_config(
-        route_name="admin.instance",
-        renderer="lms:templates/admin/application_instance/show.html.jinja2",
-        permission=Permissions.STAFF,
-        request_method="GET",
-    )
+    @view_config(route_name="admin.instance")
+    @view_config(route_name="admin.instance.section")
     def show_instance(self):
         return {"instance": self.application_instance}

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -58,7 +58,8 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
         return self._redirect("admin.instance", id_=ai.id)
 
     @view_config(
-        route_name="admin.instance.settings",
+        route_name="admin.instance.section",
+        match_param="section=settings",
         request_method="POST",
         require_csrf=True,
         permission=Permissions.ADMIN,
@@ -98,4 +99,4 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             f"Updated application instance settings for {ai.id}", "messages"
         )
 
-        return self._redirect("admin.instance", id_=ai.id)
+        return self._redirect("admin.instance.section", id_=ai.id, section="settings")

--- a/lms/views/admin/role.py
+++ b/lms/views/admin/role.py
@@ -47,7 +47,9 @@ class AdminRoleViews:
         )
 
         return HTTPFound(
-            location=self.request.route_url("admin.instance", id_=instance.id)
+            location=self.request.route_url(
+                "admin.instance.section", id_=instance.id, section="role-overrides"
+            )
         )
 
     @view_config(
@@ -102,6 +104,8 @@ class AdminRoleViews:
 
         return HTTPFound(
             location=self.request.route_url(
-                "admin.instance", id_=override.application_instance_id
+                "admin.instance.section",
+                id_=override.application_instance_id,
+                section="role-overrides",
             )
         )

--- a/tests/unit/lms/views/admin/role_test.py
+++ b/tests/unit/lms/views/admin/role_test.py
@@ -54,8 +54,9 @@ class TestAdminRoleViews:
         )
         assert response == temporary_redirect_to(
             pyramid_request.route_url(
-                "admin.instance",
+                "admin.instance.section",
                 id_=application_instance_service.get_by_id.return_value.id,
+                section="role-overrides",
             )
         )
 
@@ -100,7 +101,9 @@ class TestAdminRoleViews:
         AuditTrailEvent.notify.assert_called_once_with(pyramid_request, override)
         assert response == temporary_redirect_to(
             pyramid_request.route_url(
-                "admin.instance", id_=override.application_instance_id
+                "admin.instance.section",
+                id_=override.application_instance_id,
+                section="role-overrides",
             )
         )
 


### PR DESCRIPTION
This PR is an alternative to https://github.com/hypothesis/lms/pull/5842, with the difference that we use proper paths instead of URL hashes to identify the active tab.

[Grabación de pantalla desde 2023-11-22 10-48-25.webm](https://github.com/hypothesis/lms/assets/2719332/15864d73-533c-4599-aae7-691f516997ef)

### Introduced changes

* Defined new `admin.instance.section` route, which is the same as `admin.instance` but with an extra `section` route param at the end. This param needs to match `info|settings|role-overrides|danger`.
* Add client-side logic in `show.html.jinja2` template to:
  * Push state to the local history every time one tab is clicked, based on the tab's `data-section-id` attribute.
  * Determine the active tab based on the last segment of the URL when the page loads or the local history state changes.
* Update some redirects after form submissions, so that they go to the new `admin.instance.section` route with the appropriate section param.

### Considerations

* I tried to make the existing `admin.instance` route have an optional trailing `section` param, but the only way to do that is to set it with `.*` regexp, which cannot be combined with `info|settings|role-overrides|danger`.

### Testing steps

1. Check out this branch.
2. Go to http://localhost:8001/admin/instance/8/
3. Check that you can navigate through the different tabs, and you can also use the back and forward browser buttons to navigate through different visited sections.
4. Refreshing the page on any tab should not send you to the first tab.
5. Submitting any form should keep you on the same section.

### TODO

- [x] Fix tests