### PR TITLE
Reduce `send_instructor_email_digests` rate limit

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -120,7 +120,7 @@ def send_instructor_email_digest_tasks(*, batch_size):
     max_retries=2,
     retry_backoff=3600,
     retry_backoff_max=7200,
-    rate_limit="30/m",
+    rate_limit="10/m",
 )
 def send_instructor_email_digests(
     *, h_userids: List[str], created_after: str, created_before: str, **kwargs


### PR DESCRIPTION
Reduce the rate-limit of the `send_instructor_email_digests()` task from `30/m` to `10/m`. This is a desperate attempt to prevent problems that we've seen this morning with a small number of instances of this task failing. We increased the task's throughput yesterday and this morning it started failing. We've seen no evidence that the higher throughput is the cause for the failures, but we don't have any better ideas so let's try reducing the throughput.

Slack thread: https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1700644122131399