### PR TITLE
Rename existing ADMIN permission to STAFF

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -36,7 +36,7 @@ class Permissions(Enum):
     LTI_LAUNCH_ASSIGNMENT = "lti_launch_assignment"
     LTI_CONFIGURE_ASSIGNMENT = "lti_configure_assignment"
     API = "api"
-    ADMIN = "admin"
+    STAFF = "staff"
     GRADE_ASSIGNMENT = "grade_assignment"
 
 
@@ -191,7 +191,7 @@ class LMSGoogleSecurityPolicy(GoogleSecurityPolicy):
         userid = self.authenticated_userid(request)
 
         if userid and userid.endswith("@hypothes.is"):
-            return Identity(userid, permissions=[Permissions.ADMIN])
+            return Identity(userid, permissions=[Permissions.STAFF])
 
         return Identity("", [])
 

--- a/lms/views/admin/application_instance/create.py
+++ b/lms/views/admin/application_instance/create.py
@@ -32,7 +32,7 @@ class CreateAppInstanceSchemaV13(CreateAppInstanceSchema):
     lti_registration_id = fields.Str(required=True)
 
 
-@view_defaults(route_name="admin.instance.create", permission=Permissions.ADMIN)
+@view_defaults(route_name="admin.instance.create", permission=Permissions.STAFF)
 class CreateApplicationInstanceViews(BaseApplicationInstanceView):
     def __init__(self, request):
         super().__init__(request)

--- a/lms/views/admin/application_instance/downgrade.py
+++ b/lms/views/admin/application_instance/downgrade.py
@@ -8,7 +8,7 @@ class DowngradeApplicationInstanceView(BaseApplicationInstanceView):
     @view_config(
         route_name="admin.instance.downgrade",
         request_method="POST",
-        permission=Permissions.ADMIN,
+        permission=Permissions.STAFF,
     )
     def downgrade_instance(self):
         ai = self.application_instance

--- a/lms/views/admin/application_instance/move_organization.py
+++ b/lms/views/admin/application_instance/move_organization.py
@@ -10,7 +10,7 @@ class MoveOrgApplicationInstanceView(BaseApplicationInstanceView):
         route_name="admin.instance.move_org",
         request_method="POST",
         require_csrf=True,
-        permission=Permissions.ADMIN,
+        permission=Permissions.STAFF,
     )
     def move_application_instance_org(self):
         ai = self.application_instance

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -37,7 +37,7 @@ class SearchApplicationInstanceSchema(PyramidRequestSchema):
 @view_defaults(
     route_name="admin.instance.search",
     renderer="lms:templates/admin/application_instance/search.html.jinja2",
-    permission=Permissions.ADMIN,
+    permission=Permissions.STAFF,
 )
 class SearchApplicationInstanceViews(BaseApplicationInstanceView):
     @view_config(request_method="GET")

--- a/lms/views/admin/application_instance/show.py
+++ b/lms/views/admin/application_instance/show.py
@@ -8,7 +8,7 @@ class ShowApplicationInstanceView(BaseApplicationInstanceView):
     @view_config(
         route_name="admin.instance",
         renderer="lms:templates/admin/application_instance/show.html.jinja2",
-        permission=Permissions.ADMIN,
+        permission=Permissions.STAFF,
         request_method="GET",
     )
     def show_instance(self):

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -31,7 +31,7 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
         route_name="admin.instance",
         request_method="POST",
         require_csrf=True,
-        permission=Permissions.ADMIN,
+        permission=Permissions.STAFF,
     )
     def update_instance(self):
         ai = self.application_instance
@@ -61,7 +61,7 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
         route_name="admin.instance.settings",
         request_method="POST",
         require_csrf=True,
-        permission=Permissions.ADMIN,
+        permission=Permissions.STAFF,
     )
     def update_instance_settings(self):
         ai = self.application_instance

--- a/lms/views/admin/application_instance/upgrade.py
+++ b/lms/views/admin/application_instance/upgrade.py
@@ -18,7 +18,7 @@ class UpgradeApplicationInstanceSchema(PyramidRequestSchema):
     deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
 
 
-@view_defaults(permission=Permissions.ADMIN, route_name="admin.instance.upgrade")
+@view_defaults(permission=Permissions.STAFF, route_name="admin.instance.upgrade")
 class UpgradeApplicationInstanceViews(BaseApplicationInstanceView):
     def __init__(self, request):
         super().__init__(request)

--- a/lms/views/admin/email.py
+++ b/lms/views/admin/email.py
@@ -8,7 +8,7 @@ from lms.security import Permissions
 from lms.tasks.email_digests import send_instructor_email_digests
 
 
-@view_defaults(route_name="admin.email", permission=Permissions.ADMIN)
+@view_defaults(route_name="admin.email", permission=Permissions.STAFF)
 class AdminEmailViews:
     def __init__(self, request):
         self.request = request

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -77,7 +77,7 @@ URL_SUGGESTIONS = {
 }
 
 
-@view_defaults(request_method="GET", permission=Permissions.ADMIN)
+@view_defaults(request_method="GET", permission=Permissions.STAFF)
 class AdminLTIRegistrationViews:
     def __init__(self, request):
         self.request = request

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -32,7 +32,7 @@ class NewOrganizationSchema(PyramidRequestSchema):
     name = fields.Str(required=True, validate=validate.Length(min=1))
 
 
-@view_defaults(request_method="GET", permission=Permissions.ADMIN)
+@view_defaults(request_method="GET", permission=Permissions.STAFF)
 class AdminOrganizationViews:
     def __init__(self, request):
         self.request = request

--- a/lms/views/admin/role.py
+++ b/lms/views/admin/role.py
@@ -7,7 +7,7 @@ from lms.services.application_instance import ApplicationInstanceService
 from lms.services.lti_role_service import LTIRoleService
 
 
-@view_defaults(permission=Permissions.ADMIN)
+@view_defaults(permission=Permissions.STAFF)
 class AdminRoleViews:
     def __init__(self, request):
         self.request = request

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -45,7 +45,7 @@ class TestLMSGoogleSecurityPolicy:
                 "testuser@hypothes.is",
                 Identity(
                     userid="testuser@hypothes.is",
-                    permissions=[Permissions.ADMIN],
+                    permissions=[Permissions.STAFF],
                 ),
             ),
             ("testuser@example.com", Identity(userid="", permissions=[])),
@@ -67,7 +67,7 @@ class TestLMSGoogleSecurityPolicy:
     @pytest.mark.parametrize(
         "permission,expected_result",
         [
-            (Permissions.ADMIN, Allowed("allowed")),
+            (Permissions.STAFF, Allowed("allowed")),
             ("some-other-permission", Denied("denied")),
         ],
     )


### PR DESCRIPTION
Currently anyone with a company's email is considered an ADMIN. Changing that to STAFF.

This would make adding a more privileged "ADMIN" permissions easier to review.