### PR TITLE
Add page range inputs to VitalSource book picker

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -72,6 +72,9 @@ export type TableOfContentsEntry = {
   page: string;
   title: string;
 
+  /** EPUB CFI of this chapter. */
+  cfi: string;
+
   /** Document URL to use for this chapter when creating an assignment. */
   url: string;
 

--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -1,18 +1,92 @@
-import { Button, ModalDialog } from '@hypothesis/frontend-shared';
+import { Button, Input, ModalDialog } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useCallback, useMemo, useEffect, useState } from 'preact/hooks';
 
 import type { Book, TableOfContentsEntry } from '../api-types';
 import { useService, VitalSourceService } from '../services';
+import type { ContentRange, Selection } from '../services/vitalsource';
 import BookSelector from './BookSelector';
 import ErrorDisplay from './ErrorDisplay';
 import TableOfContentsPicker from './TableOfContentsPicker';
 
 export type BookPickerProps = {
+  /**
+   * Whether the user can select a range of pages for the assignment, as opposed
+   * to just a start point.
+   */
+  allowPageRangeSelection?: boolean;
+
   onCancel: () => void;
-  /** Callback invoked when both a book and chapter have been selected */
-  onSelectBook: (b: Book, e: TableOfContentsEntry) => void;
+
+  /**
+   * Callback invoked when both a book and chapter have been selected.
+   *
+   * @param selection - The content selected by the user
+   * @param documentURL - The corresponding document URL for use as the
+   *   assignment's document URL
+   */
+  onSelectBook: (selection: Selection, documentURL: string) => void;
 };
+
+type PageRangePickerProps = {
+  /** Current start of page range. */
+  start?: string;
+
+  /** Current end of page range. */
+  end?: string;
+
+  /**
+   * Indicates the start page that corresponds to the table of contents
+   * selection.
+   */
+  startPlaceholder?: string;
+
+  /**
+   * Indicates the approximate end page that corresponds to the table of
+   * contents selection. This is approximate because we don't have enough
+   * information to be certain of the exact end page.
+   */
+  endPlaceholder?: string;
+
+  onChangeStart?: (start: string) => void;
+  onChangeEnd?: (end: string) => void;
+};
+
+function PageRangePicker({
+  start,
+  startPlaceholder,
+  end,
+  endPlaceholder,
+  onChangeStart,
+  onChangeEnd,
+}: PageRangePickerProps) {
+  return (
+    <div className="font-bold" data-testid="page-range">
+      From page{' '}
+      <Input
+        aria-label="Start page"
+        classes="!w-16" // Override `w-full` default
+        data-testid="start-page"
+        placeholder={startPlaceholder}
+        value={start}
+        onInput={e =>
+          onChangeStart?.((e.target as HTMLInputElement).value.trim())
+        }
+      />{' '}
+      to{' '}
+      <Input
+        aria-label="End page"
+        classes="!w-16" // Override `w-full` default
+        data-testid="end-page"
+        placeholder={endPlaceholder}
+        value={end}
+        onInput={e =>
+          onChangeEnd?.((e.target as HTMLInputElement).value.trim())
+        }
+      />
+    </div>
+  );
+}
 
 /**
  * A dialog that allows the user to select a book and chapter to use in an assignment.
@@ -25,6 +99,7 @@ export type BookPickerProps = {
  * callback is called.
  */
 export default function BookPicker({
+  allowPageRangeSelection = false,
   onCancel,
   onSelectBook,
 }: BookPickerProps) {
@@ -34,27 +109,51 @@ export default function BookPicker({
     TableOfContentsEntry[] | null
   >(null);
   const [book, setBook] = useState<Book | null>(null);
-  const [chapter, setChapter] = useState<TableOfContentsEntry | null>(null);
-  const [step, setStep] = useState<'select-book' | 'select-chapter'>(
-    'select-book'
-  );
+
+  const [contentRange, setContentRange] = useState<ContentRange>();
+
+  const [step, setStep] = useState<'select-book' | 'select-toc'>('select-book');
   const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const confirmBook = useCallback((book: Book) => {
     setBook(book);
     setTableOfContents(null);
-    setStep('select-chapter');
+    setStep('select-toc');
   }, []);
 
   const confirmChapter = useCallback(
-    (chapter: TableOfContentsEntry) => {
-      onSelectBook(book!, chapter);
+    async (entry?: TableOfContentsEntry) => {
+      /* istanbul ignore next - early exit should be unreachable */
+      if (!contentRange) {
+        return;
+      }
+      const selection: Selection = {
+        book: book!,
+        content: entry ? { type: 'toc', start: entry } : contentRange,
+      };
+      try {
+        setLoading(true);
+        const documentURL = await vsService.fetchDocumentURL(selection);
+        onSelectBook(selection, documentURL);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
     },
-    [book, onSelectBook]
+    [book, contentRange, onSelectBook, vsService]
   );
 
+  const updatePageRange = (start: string, end: string) => {
+    setContentRange({ type: 'page', start, end });
+  };
+  const pageRange = contentRange?.type === 'page' ? contentRange : undefined;
+  const tocEntry =
+    (contentRange?.type === 'toc' ? contentRange.start : null) ?? null;
+
   useEffect(() => {
-    if (step === 'select-chapter' && !tableOfContents) {
+    if (step === 'select-toc' && !tableOfContents) {
       const currentBook = book!;
       vsService
         .fetchTableOfContents(currentBook.id)
@@ -63,15 +162,45 @@ export default function BookPicker({
     }
   }, [book, step, tableOfContents, vsService]);
 
+  const validContentRange =
+    contentRange?.type === 'toc' ||
+    (contentRange?.type === 'page' && contentRange.start && contentRange.end);
+
+  // Compute the page number that corresponds to the currently selected
+  // table-of-contents entry. This cannot always be determined and can be
+  // incorrect or off-by-one, due to limitations of the data from the API,
+  // so should only used as a hint.
+  const endPageForTOCRange = useMemo(() => {
+    if (!tableOfContents || !tocEntry) {
+      return '';
+    }
+    const idx = tableOfContents.indexOf(tocEntry);
+    const level = tocEntry.level ?? 0;
+    let endPage = tocEntry.page;
+    for (let i = idx + 1; i < tableOfContents.length; i++) {
+      const entryLevel = tableOfContents[i].level ?? 0;
+      if (entryLevel <= level) {
+        endPage = tableOfContents[i].page;
+        break;
+      }
+    }
+    return endPage;
+  }, [tableOfContents, tocEntry]);
+
   const canSubmit =
-    (step === 'select-book' && book) || (step === 'select-chapter' && chapter);
+    (step === 'select-book' && book) ||
+    (step === 'select-toc' && validContentRange);
+
+  const pageRangeHeading = allowPageRangeSelection
+    ? 'Choose chapter or page range'
+    : 'Pick where to start reading';
 
   return (
     <ModalDialog
       classes={classnames(
         // Set a fix height when selecting a chapter so the modal content
         // doesn't resize after loading.
-        { 'h-[25rem]': step === 'select-chapter' }
+        { 'h-[25rem]': step === 'select-toc' }
       )}
       // Opt out of Modal's automatic focus handling; route focus manually in
       // sub-components
@@ -81,26 +210,43 @@ export default function BookPicker({
       title={
         step === 'select-book'
           ? 'Paste link to VitalSource book'
-          : 'Pick where to start reading' // "Select a chapter"
+          : pageRangeHeading
       }
       size="lg"
       buttons={
         <>
+          {allowPageRangeSelection && step === 'select-toc' && (
+            <>
+              <PageRangePicker
+                start={pageRange?.start ?? ''}
+                startPlaceholder={tocEntry?.page}
+                end={pageRange?.end ?? ''}
+                endPlaceholder={endPageForTOCRange}
+                onChangeStart={start =>
+                  updatePageRange(start, pageRange?.end ?? '')
+                }
+                onChangeEnd={end =>
+                  updatePageRange(pageRange?.start ?? '', end)
+                }
+              />
+              <div className="flex-grow" />
+            </>
+          )}
           <Button data-testid="cancel-button" onClick={onCancel}>
             Cancel
           </Button>
           <Button
             key="submit"
             data-testid="select-button"
-            disabled={!canSubmit}
+            disabled={!canSubmit || loading}
             onClick={() => {
               // nb. The `book` and `chapter` checks should be redundant, as the button
               // should not be clickable if no book/chapter is selected, but they
               // keep TS happy.
               if (step === 'select-book' && book) {
                 confirmBook(book);
-              } else if (step === 'select-chapter' && chapter) {
-                confirmChapter(chapter);
+              } else if (step === 'select-toc' && contentRange) {
+                confirmChapter();
               }
             }}
             variant="primary"
@@ -117,12 +263,14 @@ export default function BookPicker({
           onSelectBook={setBook}
         />
       )}
-      {step === 'select-chapter' && !error && (
+      {step === 'select-toc' && !error && (
         <TableOfContentsPicker
           entries={tableOfContents || []}
           isLoading={!tableOfContents}
-          selectedEntry={chapter}
-          onSelectEntry={setChapter}
+          selectedEntry={tocEntry}
+          onSelectEntry={entry =>
+            setContentRange({ type: 'toc', start: entry })
+          }
           onConfirmEntry={confirmChapter}
         />
       )}

--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -23,10 +23,6 @@ export type BookPickerProps = {
  * The dialog has two steps: The user first chooses a book to use and then chooses
  * which chapter to use from that book. Once both are chosen the `onSelectBook`
  * callback is called.
- *
- * Note: The component logic is consistent about using the terminology of
- * "chapter" for content segments in a VitalSource eBook, but presents this
- * to the user as "location" and other slightly less precise language.
  */
 export default function BookPicker({
   onCancel,

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -1,7 +1,7 @@
 import { OptionButton, SpinnerOverlay } from '@hypothesis/frontend-shared';
 import { useMemo, useState } from 'preact/hooks';
 
-import type { Book, File, TableOfContentsEntry, Page } from '../api-types';
+import type { File, Page } from '../api-types';
 import { useConfig } from '../config';
 import { PickerCanceledError } from '../errors';
 import type { Content } from '../utils/content-item';
@@ -85,7 +85,10 @@ export default function ContentSelector({
         clientId: oneDriveClientId,
         redirectURI: oneDriveRedirectURI,
       },
-      vitalSource: { enabled: vitalSourceEnabled },
+      vitalSource: {
+        enabled: vitalSourceEnabled,
+        pageRangesEnabled: vitalSourcePageRangesEnabled,
+      },
       youtube: { enabled: youtubeEnabled },
     },
   } = useConfig(['filePicker']);
@@ -189,11 +192,14 @@ export default function ContentSelector({
     onSelectContent({ type: 'url', url: file.id });
   };
 
-  const selectVitalSourceBook = (book: Book, chapter: TableOfContentsEntry) => {
+  const selectVitalSourceBook = async (
+    selection: unknown,
+    documentURL: string
+  ) => {
     cancelDialog();
     onSelectContent({
       type: 'url',
-      url: chapter.url,
+      url: documentURL,
     });
   };
 
@@ -283,6 +289,7 @@ export default function ContentSelector({
     case 'vitalSourceBook':
       dialog = (
         <BookPicker
+          allowPageRangeSelection={vitalSourcePageRangesEnabled}
           onCancel={cancelDialog}
           onSelectBook={selectVitalSourceBook}
         />

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -1,5 +1,6 @@
 import {
   mockImportedComponents,
+  waitFor,
   waitForElement,
 } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
@@ -63,6 +64,15 @@ describe('BookPicker', () => {
 
   beforeEach(() => {
     fakeVitalSourceService = {
+      fetchDocumentURL: sinon.stub().callsFake(async selection => {
+        let content;
+        if (selection.content.type === 'page') {
+          content = `page/${selection.content.start}`;
+        } else {
+          content = `cfi/${selection.content.start.cfi}`;
+        }
+        return `vitalsource://books/bookID/${selection.book.id}/${content}`;
+      }),
       fetchTableOfContents: sinon
         .stub()
         .callsFake(async bookID => fakeBookData.chapters[bookID]),
@@ -100,12 +110,30 @@ describe('BookPicker', () => {
     return entry;
   };
 
+  /**
+   * Select the page range with a given start and end number.
+   *
+   * Page numbers can be specified as numbers or strings.
+   */
+  const selectPageRange = (wrapper, start = '', end = '') => {
+    const startInput = wrapper.find('input[data-testid="start-page"]');
+    const endInput = wrapper.find('input[data-testid="end-page"]');
+    startInput.getDOMNode().value = start.toString();
+    startInput.simulate('input');
+    endInput.getDOMNode().value = end.toString();
+    endInput.simulate('input');
+  };
+
   const clickSelectButton = wrapper => {
     act(() => {
       wrapper.find('button[data-testid="select-button"]').prop('onClick')();
     });
     wrapper.update();
   };
+
+  // Wait for the table of contents to finish loading.
+  const waitForTableOfContents = wrapper =>
+    waitForElement(wrapper, 'TableOfContentsPicker[isLoading=false]');
 
   it('renders book-selector component when picker is opened', () => {
     const picker = renderBookPicker();
@@ -149,11 +177,46 @@ describe('BookPicker', () => {
     assert.equal(tocPicker.prop('isLoading'), true);
     assert.calledWith(fakeVitalSourceService.fetchTableOfContents, 'book1');
 
-    await waitForElement(picker, 'TableOfContentsPicker[isLoading=false]');
+    await waitForTableOfContents(picker);
 
     // The table of contents for the selected book should be presented once fetched.
     tocPicker = picker.find('TableOfContentsPicker');
     assert.equal(tocPicker.prop('entries'), fakeBookData.chapters.book1);
+  });
+
+  [true, false].forEach(allowPageRangeSelection => {
+    it('displays page range picker if featur enabled', () => {
+      const picker = renderBookPicker({ allowPageRangeSelection });
+      selectBook(picker);
+      clickSelectButton(picker);
+      assert.equal(
+        picker.find('input[data-testid="start-page"]').exists(),
+        allowPageRangeSelection
+      );
+      assert.equal(
+        picker.find('input[data-testid="end-page"]').exists(),
+        allowPageRangeSelection
+      );
+    });
+  });
+
+  it('displays page numbers corresponding to selected chapter', async () => {
+    const onSelectBook = sinon.stub();
+    const picker = renderBookPicker({
+      allowPageRangeSelection: true,
+      onSelectBook,
+    });
+
+    selectBook(picker);
+    clickSelectButton(picker);
+
+    await waitForTableOfContents(picker);
+    selectChapter(picker);
+
+    const startInput = picker.find('input[data-testid="start-page"]');
+    const endInput = picker.find('input[data-testid="end-page"]');
+    assert.equal(startInput.prop('placeholder'), '1');
+    assert.equal(endInput.prop('placeholder'), '10');
   });
 
   it('invokes `onSelectBook` callback after a book and chapter are chosen', async () => {
@@ -163,11 +226,51 @@ describe('BookPicker', () => {
     const book = selectBook(picker);
     clickSelectButton(picker);
 
-    await waitForElement(picker, 'TableOfContentsPicker[isLoading=false]');
+    await waitForTableOfContents(picker);
     const chapter = selectChapter(picker);
     clickSelectButton(picker);
 
-    assert.calledWith(onSelectBook, book, chapter);
+    await waitFor(() => onSelectBook.called);
+    assert.calledWith(
+      onSelectBook,
+      {
+        book,
+        content: {
+          type: 'toc',
+          start: chapter,
+        },
+      },
+      'vitalsource://books/bookID/book1/cfi//1'
+    );
+  });
+
+  it('invokes `onSelectBook` callback after a book and page range are chosen', async () => {
+    const onSelectBook = sinon.stub();
+    const picker = renderBookPicker({
+      allowPageRangeSelection: true,
+      onSelectBook,
+    });
+
+    const book = selectBook(picker);
+    clickSelectButton(picker);
+
+    await waitForTableOfContents(picker);
+    selectPageRange(picker, 10, 20);
+    clickSelectButton(picker);
+
+    await waitFor(() => onSelectBook.called);
+    assert.calledWith(
+      onSelectBook,
+      {
+        book,
+        content: {
+          type: 'page',
+          start: '10',
+          end: '20',
+        },
+      },
+      'vitalsource://books/bookID/book1/page/10'
+    );
   });
 
   it('shows error that occurs while fetching table of contents', async () => {
@@ -176,6 +279,30 @@ describe('BookPicker', () => {
 
     const picker = renderBookPicker();
     selectBook(picker);
+    clickSelectButton(picker);
+
+    const errorDisplay = await waitForElement(picker, 'ErrorDisplay');
+
+    assert.equal(
+      errorDisplay.prop('description'),
+      'Unable to fetch book contents'
+    );
+    assert.equal(errorDisplay.prop('error'), error);
+    assert.isFalse(picker.exists('TableOfContentsPicker'));
+  });
+
+  it('shows error that occurs while fetching document URL', async () => {
+    const error = new Error('Something went wrong');
+    fakeVitalSourceService.fetchDocumentURL.rejects(error);
+
+    const onSelectBook = sinon.stub();
+    const picker = renderBookPicker({ onSelectBook });
+
+    selectBook(picker);
+    clickSelectButton(picker);
+
+    await waitForTableOfContents(picker);
+    selectChapter(picker);
     clickSelectButton(picker);
 
     const errorDisplay = await waitForElement(picker, 'ErrorDisplay');

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -185,7 +185,7 @@ describe('BookPicker', () => {
   });
 
   [true, false].forEach(allowPageRangeSelection => {
-    it('displays page range picker if featur enabled', () => {
+    it('displays page range picker if feature enabled', () => {
       const picker = renderBookPicker({ allowPageRangeSelection });
       selectBook(picker);
       clickSelectButton(picker);

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -623,12 +623,19 @@ describe('ContentSelector', () => {
 
       const picker = wrapper.find('BookPicker');
       interact(wrapper, () => {
-        picker
-          .props()
-          .onSelectBook(
-            { id: 'test-book' },
-            { url: 'vitalsource://book/BOOK_ID/cfi/CFI' }
-          );
+        picker.props().onSelectBook(
+          {
+            book: { id: 'test-book' },
+            content: {
+              type: 'toc',
+              start: {
+                cfi: 'CFI',
+                // ... other fields omitted.
+              },
+            },
+          },
+          'vitalsource://book/BOOK_ID/cfi/CFI'
+        );
       });
 
       assert.calledWith(onSelectContent, {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -117,6 +117,7 @@ export type FilePickerConfig = {
   };
   vitalSource: {
     enabled: boolean;
+    pageRangesEnabled: boolean;
   };
 };
 

--- a/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
@@ -9,6 +9,10 @@ describe('VitalSourceService', () => {
       assert.equal(authToken, 'dummy-token');
 
       switch (path) {
+        case '/api/vitalsource/document_url':
+          return {
+            document_url: 'vitalsource://books/bookID/BOOKSHELF-TUTORIAL',
+          };
         case '/api/vitalsource/books/BOOKSHELF-TUTORIAL':
           return {
             id: 'BOOKSHELF-TUTORIAL',
@@ -82,6 +86,54 @@ describe('VitalSourceService', () => {
       }
       assert.instanceOf(err, APIError);
       assert.equal(err.serverMessage, 'Book not found');
+    });
+  });
+
+  describe('#fetchDocumentURL', () => {
+    [
+      // TOC entry
+      {
+        selection: {
+          book: { id: 'BOOKSHELF-TUTORIAL' },
+          content: {
+            type: 'toc',
+            start: {
+              cfi: '/1/2',
+            },
+          },
+        },
+        expectedParams: {
+          book_id: 'BOOKSHELF-TUTORIAL',
+          cfi: '/1/2',
+        },
+      },
+      // Page range
+      {
+        selection: {
+          book: { id: 'BOOKSHELF-TUTORIAL' },
+          content: {
+            type: 'page',
+            start: '23',
+            end: '46',
+          },
+        },
+        expectedParams: {
+          book_id: 'BOOKSHELF-TUTORIAL',
+          page: '23',
+          end_page: '46',
+        },
+      },
+    ].forEach(({ selection, expectedParams }) => {
+      it('returns document URL', async () => {
+        const service = new VitalSourceService({ authToken: 'dummy-token' });
+        const url = await service.fetchDocumentURL(selection);
+        assert.calledWith(fakeAPICall, {
+          authToken: 'dummy-token',
+          path: '/api/vitalsource/document_url',
+          params: expectedParams,
+        });
+        assert.equal(url, 'vitalsource://books/bookID/BOOKSHELF-TUTORIAL');
+      });
     });
   });
 });

--- a/lms/static/scripts/frontend_apps/services/vitalsource.ts
+++ b/lms/static/scripts/frontend_apps/services/vitalsource.ts
@@ -1,6 +1,51 @@
 import type { Book, TableOfContentsEntry } from '../api-types';
 import { apiCall, urlPath } from '../utils/api';
 
+export type PageRange = {
+  type: 'page';
+  start?: string;
+  end?: string;
+};
+
+/**
+ * Range of entries in the table of contents.
+ *
+ * This currently only supports a start point because multi-selection is not yet
+ * implemented for the TOC picker tree view. If a user wants to select multiple
+ * chapters, they have to use a page range.
+ */
+export type TableOfContentsRange = {
+  type: 'toc';
+  start?: TableOfContentsEntry;
+};
+
+/**
+ * Represents a selected range of content in the book.
+ *
+ * This is expressed as _either_ a page range or a TOC range. Although there is
+ * a correspondence between the two, we cannot always represent a selection made
+ * using one method in the other form. Therefore whichever method of making a
+ * selection is used by the user, that's the canonical representation. Some
+ * examples of issues relating the two content range representations:
+ *
+ *  - Page ranges can start or end in the middle of a chapter
+ *  - Chapters can start or end in the middle of a page
+ *  - The APIs we use for VitalSource provide only the start page number, not
+ *    a page range.
+ *  - Although most books use Latin digits for their core content, page numbers
+ *    can use other numbering systems (eg. Roman numerals) and mix numbering
+ *    systems within the same book.
+ */
+export type ContentRange = PageRange | TableOfContentsRange;
+
+/**
+ * Details of a book and content range selected by the user.
+ */
+export type Selection = {
+  /** Selected book. */
+  book: Book;
+  content: ContentRange;
+};
 /**
  * Service for fetching information about available VitalSoure books and the
  * list of chapters in a book.
@@ -36,5 +81,42 @@ export class VitalSourceService {
       path: urlPath`/api/vitalsource/books/${bookId}/toc`,
       authToken: this._authToken,
     });
+  }
+
+  /**
+   * Translate a book and content selection to a document URL for an assignment.
+   *
+   * @param selection - The book and content selection
+   */
+  async fetchDocumentURL(selection: Selection): Promise<string> {
+    const { book, content } = selection;
+    const params: Record<string, string> = {};
+    if (content.type === 'toc' && content.start) {
+      // When the location is specified as a CFI, we only include the start
+      // point. This is because the book picker UI doesn't support selecting
+      // a range of chapters.
+      params.cfi = content.start.cfi;
+    }
+    if (content.type === 'page' && content.start) {
+      params.page = content.start;
+      if (content.end) {
+        params.end_page = content.end;
+      }
+    }
+
+    type DocumentURLResponse = {
+      document_url: string;
+    };
+
+    const response = await apiCall<DocumentURLResponse>({
+      authToken: this._authToken,
+      path: '/api/vitalsource/document_url',
+      params: {
+        book_id: book.id,
+        ...params,
+      },
+    });
+
+    return response.document_url;
   }
 }


### PR DESCRIPTION
When the VitalSource page ranges feature is enabled, display two new inputs in the chapter/page selection form to enter
the start and end page for the assignment. When the selection is confirmed, make a call to the backend API to generate a document URL that corresponds to the selected chapter or page range.

Partially implements https://github.com/hypothesis/lms/issues/5808. This does include the page range input, but not multi-selection in the tree view.

**Testing:**

1. Enable the "page ranges" feature for VitalSource for the instance you are testing with
2. Start creating a new Hypothesis assignment and select VitalSource as the content type
3. Enter a book URL and press Select

You should see two new inputs in the content selection form:

<img width="710" alt="vs-chapter" src="https://github.com/hypothesis/lms/assets/2458/a02c3598-e363-4f3f-bc6e-2ecf8af74614">

In this UI you can either select a single entry from the table of contents tree OR a enter a page range. When you select an entry in the TOC view, the _probable_ page range is shown in the page range input as a placeholder. This is only _probable_ because we can't determine the end page accurately. Instead the end page is just taken as the start page from the next entry in the TOC view at the same level as the selected entry.

When a page range is entered, the selection disappears from the table of contents view:

<img width="712" alt="vs-page-range" src="https://github.com/hypothesis/lms/assets/2458/9f9bd39b-03d6-4493-90d1-3ddcf82da336">

In general we cannot always reliably determine the exact chapter range that corresponds to a page range, but in future we might be able to indicate which chapters probably do.

4. Select either a chapter or page range and click submit. At this point an API call should be made to the new `/api/vitalsource/document_url` endpoint, which will return a `vitalsource://` URL that corresponds to the selected chapter (`/cfi/...` in the URL) or page (`/page/...` in the URL

**Known issue:**

When you enter a page range, this is correctly used to generate the `vitalsource://` document URL for the assignment, but the URL used to launch the VitalSource book reader does not reflect this. This is fixed in https://github.com/hypothesis/lms/pull/5851.