### PR TITLE
Support generating VS book reader URLs when start is a page number

### DIFF
--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -102,8 +102,13 @@ class VitalSourceService:
         :param document_url: `vitalsource://` type URL identifying the document
         """
         loc = VSBookLocation.from_document_url(document_url)
+        prefix = f"https://hypothesis.vitalsource.com/books/{loc.book_id}"
 
-        return f"https://hypothesis.vitalsource.com/books/{loc.book_id}/cfi/{loc.cfi}"
+        if loc.cfi:
+            return f"{prefix}/cfi/{loc.cfi}"
+        if loc.page:
+            return f"{prefix}/page/{loc.page}"
+        return prefix  # pragma: nocover
 
     def get_sso_redirect(self, document_url, user_reference: str) -> str:
         """

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -35,10 +35,22 @@ class TestVitalSourceService:
 
         assert svc.sso_enabled == bool(enabled and customer_client and user_lti_param)
 
-    def test_get_book_reader_url(self, svc):
-        url = svc.get_book_reader_url("vitalsource://book/bookID/BOOK-ID/cfi/CFI")
-
-        assert url == "https://hypothesis.vitalsource.com/books/BOOK-ID/cfi/CFI"
+    @pytest.mark.parametrize(
+        "doc_url,reader_url",
+        [
+            (
+                "vitalsource://book/bookID/BOOK-ID/cfi/CFI",
+                "https://hypothesis.vitalsource.com/books/BOOK-ID/cfi/CFI",
+            ),
+            (
+                "vitalsource://book/bookID/BOOK-ID/page/42",
+                "https://hypothesis.vitalsource.com/books/BOOK-ID/page/42",
+            ),
+        ],
+    )
+    def test_get_book_reader_url(self, svc, doc_url, reader_url):
+        url = svc.get_book_reader_url(doc_url)
+        assert url == reader_url
 
     def test_get_sso_redirect(self, svc, customer_client):
         result = svc.get_sso_redirect(


### PR DESCRIPTION
Support vitalsource:// URLs with the start location specified as a page number rather than a CFI in `get_book_reader_url`.

I have confirmed with VS [1] that we can rely on the `/page/{number}` launch URL.

When combined with https://github.com/hypothesis/lms/pull/5849, it becomes possible to configure a VS assignment with a page range rather than a chapter URL, and have the book reader open at the specified page when the assignment is launched.

[1] https://vitalsource.slack.com/archives/C01208U1A2F/p1700227038259109