### PR TITLE
Add user preferences services

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -3,7 +3,7 @@ from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.canvas import CanvasService
 from lms.services.d2l_api.client import D2LAPIClient
 from lms.services.digest import DigestService
-from lms.services.email_preferences import EmailPreferencesService
+from lms.services.email_preferences import EmailPreferencesService, EmailPrefs
 from lms.services.event import EventService
 from lms.services.exceptions import (
     CanvasAPIError,
@@ -32,6 +32,7 @@ from lms.services.ltia_http import LTIAHTTPService
 from lms.services.organization import OrganizationService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
+from lms.services.user_preferences import UserPreferencesService
 from lms.services.vitalsource import VitalSourceService
 from lms.services.youtube import YouTubeService
 
@@ -53,6 +54,9 @@ def includeme(config):
     )
     config.register_service_factory("lms.services.canvas.factory", iface=CanvasService)
     config.register_service_factory("lms.services.user.factory", iface=UserService)
+    config.register_service_factory(
+        "lms.services.user_preferences.factory", iface=UserPreferencesService
+    )
 
     config.register_service_factory("lms.services.h_api.service_factory", iface=HAPI)
     config.register_service_factory(

--- a/lms/services/email_preferences.py
+++ b/lms/services/email_preferences.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict, dataclass
 from datetime import timedelta
 from typing import Callable
 from urllib.parse import parse_qs, urlparse
@@ -6,6 +7,7 @@ from lms.models import EmailUnsubscribe
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
 from lms.services.jwt import JWTService
 from lms.services.upsert import bulk_upsert
+from lms.services.user_preferences import UserPreferencesService
 
 
 class UnrecognisedURLError(Exception):
@@ -16,12 +18,37 @@ class InvalidTokenError(Exception):
     pass
 
 
+@dataclass(frozen=True)
+class EmailPrefs:  # pylint:disable=too-many-instance-attributes
+    DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+
+    h_userid: str
+    mon: bool = True
+    tue: bool = True
+    wed: bool = True
+    thu: bool = True
+    fri: bool = True
+    sat: bool = True
+    sun: bool = True
+
+    def days(self) -> dict:
+        return {key: value for key, value in asdict(self).items() if key in self.DAYS}
+
+
 class EmailPreferencesService:
-    def __init__(self, db, jwt_service: JWTService, secret: str, route_url: Callable):
+    def __init__(  # pylint:disable=too-many-arguments
+        self,
+        db,
+        secret: str,
+        route_url: Callable,
+        jwt_service: JWTService,
+        user_preferences_service: UserPreferencesService,
+    ):
         self._db = db
-        self._jwt_service = jwt_service
         self._secret = secret
         self._route_url = route_url
+        self._jwt_service = jwt_service
+        self._user_preferences_service = user_preferences_service
 
     def unsubscribe_url(self, h_userid, tag):
         """Generate the url for `email.unsubscribe` with the right token."""
@@ -60,6 +87,28 @@ class EmailPreferencesService:
         except (ExpiredJWTError, InvalidJWTError) as err:
             raise InvalidTokenError() from err
 
+    KEY_PREFIX = "instructor_email_digests.days."
+
+    def get_preferences(self, h_userid) -> EmailPrefs:
+        """Return h_userid's email preferences."""
+        user_preferences = self._user_preferences_service.get(h_userid)
+
+        return EmailPrefs(
+            h_userid=user_preferences.h_userid,
+            **{
+                key[len(self.KEY_PREFIX) :]: value
+                for key, value in user_preferences.preferences.items()
+                if key.startswith(self.KEY_PREFIX)
+            },
+        )
+
+    def set_preferences(self, prefs: EmailPrefs) -> None:
+        """Create or update h_userid's email preferences."""
+        self._user_preferences_service.set(
+            prefs.h_userid,
+            {self.KEY_PREFIX + key: value for key, value in prefs.days().items()},
+        )
+
     def _generate_token(self, h_userid, tag):
         return self._jwt_service.encode_with_secret(
             {"h_userid": h_userid, "tag": tag},
@@ -74,7 +123,8 @@ class EmailPreferencesService:
 def factory(_context, request):
     return EmailPreferencesService(
         request.db,
-        request.find_service(iface=JWTService),
         secret=request.registry.settings["jwt_secret"],
         route_url=request.route_url,
+        jwt_service=request.find_service(iface=JWTService),
+        user_preferences_service=request.find_service(UserPreferencesService),
     )

--- a/lms/services/user_preferences.py
+++ b/lms/services/user_preferences.py
@@ -1,0 +1,36 @@
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
+
+from lms.models import UserPreferences
+
+
+class UserPreferencesService:
+    def __init__(self, db):
+        self._db = db
+
+    def get(self, h_userid: str) -> UserPreferences:
+        """Return the user preferences for the given h_userid."""
+        try:
+            preferences = self._db.scalars(
+                select(UserPreferences).where(UserPreferences.h_userid == h_userid)
+            ).one()
+        except NoResultFound:
+            preferences = UserPreferences(h_userid=h_userid, preferences={})
+            self._db.add(preferences)
+
+        return preferences
+
+    def set(self, h_userid: str, new_preferences: dict) -> None:
+        """Insert the given new_preferences into h_userid's user preferences.
+
+        Existing items will be updated and new items will be created in
+        h_userid's user preferences as necessary.
+        """
+        preferences = self.get(h_userid)
+
+        for key, value in new_preferences.items():
+            preferences.preferences[key] = value
+
+
+def factory(_context, request) -> UserPreferencesService:
+    return UserPreferencesService(request.db)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -34,6 +34,7 @@ from tests.factories.oauth2_token import OAuth2Token
 from tests.factories.organization import Organization
 from tests.factories.rsa_key import RSAKey
 from tests.factories.user import User
+from tests.factories.user_preferences import UserPreferences
 
 
 def set_sqlalchemy_session(session, persistence=None):

--- a/tests/factories/user_preferences.py
+++ b/tests/factories/user_preferences.py
@@ -1,0 +1,9 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.attributes import H_USERID
+
+UserPreferences = make_factory(
+    models.UserPreferences, FACTORY_CLASS=SQLAlchemyModelFactory, h_userid=H_USERID
+)

--- a/tests/unit/lms/services/email_preferences_test.py
+++ b/tests/unit/lms/services/email_preferences_test.py
@@ -6,21 +6,86 @@ import pytest
 from lms.models import EmailUnsubscribe
 from lms.services.email_preferences import (
     EmailPreferencesService,
+    EmailPrefs,
     InvalidTokenError,
     UnrecognisedURLError,
     factory,
 )
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
+from tests import factories
+
+
+class TestEmailPrefs:
+    @pytest.mark.parametrize(
+        "kwargs,expected_attrs",
+        (
+            (
+                {},
+                {
+                    "mon": True,
+                    "tue": True,
+                    "wed": True,
+                    "thu": True,
+                    "fri": True,
+                    "sat": True,
+                    "sun": True,
+                },
+            ),
+            (
+                {
+                    "mon": False,
+                    "tue": False,
+                    "wed": False,
+                    "thu": False,
+                    "fri": False,
+                    "sat": False,
+                    "sun": False,
+                },
+                {
+                    "mon": False,
+                    "tue": False,
+                    "wed": False,
+                    "thu": False,
+                    "fri": False,
+                    "sat": False,
+                    "sun": False,
+                },
+            ),
+        ),
+    )
+    def test___init__(self, kwargs, expected_attrs):
+        prefs = EmailPrefs(h_userid=sentinel.h_userid, **kwargs)
+
+        assert prefs.h_userid == sentinel.h_userid
+        for attr, value in expected_attrs.items():
+            assert getattr(prefs, attr) == value
+
+    def test_days(self):
+        prefs = EmailPrefs(
+            h_userid=sentinel.h_userid, mon=False, wed=False, fri=False, sun=False
+        )
+
+        days = prefs.days()
+
+        assert days == {
+            "mon": False,
+            "tue": True,
+            "wed": False,
+            "thu": True,
+            "fri": False,
+            "sat": True,
+            "sun": False,
+        }
 
 
 class TestEmailPreferencesService:
     def test_unsubscribe_url(self, svc, jwt_service):
         jwt_service.encode_with_secret.return_value = "TOKEN"
 
-        url = svc.unsubscribe_url(sentinel.email, sentinel.tag)
+        url = svc.unsubscribe_url(sentinel.h_userid, sentinel.tag)
 
         jwt_service.encode_with_secret.assert_called_once_with(
-            {"h_userid": sentinel.email, "tag": sentinel.tag},
+            {"h_userid": sentinel.h_userid, "tag": sentinel.tag},
             "SECRET",
             lifetime=timedelta(days=30),
         )
@@ -76,10 +141,46 @@ class TestEmailPreferencesService:
         with pytest.raises(InvalidTokenError):
             svc.h_userid("https://example.com?token=test_token")
 
+    def test_get_preferences(self, svc, user_preferences_service):
+        user_preferences_service.get.return_value = factories.UserPreferences(
+            h_userid=sentinel.h_userid,
+            preferences={
+                "instructor_email_digests.days.mon": True,
+                "instructor_email_digests.days.tue": False,
+            },
+        )
+
+        preferences = svc.get_preferences(sentinel.h_userid)
+
+        user_preferences_service.get.assert_called_once_with(sentinel.h_userid)
+        assert preferences == EmailPrefs(
+            h_userid=sentinel.h_userid, mon=True, tue=False
+        )
+
+    def test_set_preferences(self, svc, user_preferences_service):
+        svc.set_preferences(EmailPrefs(sentinel.h_userid, tue=True, wed=False))
+
+        user_preferences_service.set.assert_called_once_with(
+            sentinel.h_userid,
+            {
+                "instructor_email_digests.days.mon": True,
+                "instructor_email_digests.days.tue": True,
+                "instructor_email_digests.days.wed": False,
+                "instructor_email_digests.days.thu": True,
+                "instructor_email_digests.days.fri": True,
+                "instructor_email_digests.days.sat": True,
+                "instructor_email_digests.days.sun": True,
+            },
+        )
+
     @pytest.fixture
-    def svc(self, db_session, jwt_service, pyramid_request):
+    def svc(self, db_session, jwt_service, pyramid_request, user_preferences_service):
         return EmailPreferencesService(
-            db_session, jwt_service, "SECRET", pyramid_request.route_url
+            db_session,
+            "SECRET",
+            pyramid_request.route_url,
+            jwt_service,
+            user_preferences_service,
         )
 
     @pytest.fixture
@@ -89,15 +190,21 @@ class TestEmailPreferencesService:
 
 class TestFactory:
     def test_it(
-        self, pyramid_request, EmailPreferencesService, db_session, jwt_service
+        self,
+        pyramid_request,
+        EmailPreferencesService,
+        db_session,
+        jwt_service,
+        user_preferences_service,
     ):
         svc = factory(sentinel.context, pyramid_request)
 
         EmailPreferencesService.assert_called_once_with(
             db_session,
-            jwt_service,
             secret="test_secret",
             route_url=pyramid_request.route_url,
+            jwt_service=jwt_service,
+            user_preferences_service=user_preferences_service,
         )
         assert svc == EmailPreferencesService.return_value
 

--- a/tests/unit/lms/services/user_preferences_test.py
+++ b/tests/unit/lms/services/user_preferences_test.py
@@ -1,0 +1,61 @@
+from unittest.mock import sentinel
+
+import pytest
+from h_matchers import Any
+from sqlalchemy import select
+
+from lms.models import UserPreferences
+from lms.services.user_preferences import UserPreferencesService, factory
+from tests import factories
+
+
+class TestUserPreferencesService:
+    def test_get_returns_a_new_UserPreferences_if_none_exists(self, svc):
+        assert svc.get("test_h_userid") == Any.object.of_type(
+            UserPreferences
+        ).with_attrs({"h_userid": "test_h_userid", "preferences": {}})
+
+    def test_get_returns_an_existing_UserPreferences_if_one_exists(self, svc):
+        preferences = factories.UserPreferences()
+
+        assert svc.get(preferences.h_userid) is preferences
+
+    def test_set_creates_a_new_UserPreferences_if_none_exists(self, svc, db_session):
+        svc.set("test_h_userid", {"foo": "bar"})
+
+        assert db_session.scalars(
+            select(UserPreferences).where(UserPreferences.h_userid == "test_h_userid")
+        ).one().preferences == {"foo": "bar"}
+
+    @pytest.mark.parametrize(
+        "existing_preferences,expected_preferences",
+        [
+            ({}, {"foo": "bar"}),
+            ({"foo": "gar"}, {"foo": "bar"}),
+            ({"gar": "har"}, {"gar": "har", "foo": "bar"}),
+        ],
+    )
+    def test_set_updates_an_existing_UserPreferences_if_one_exists(
+        self, svc, existing_preferences, expected_preferences
+    ):
+        preferences = factories.UserPreferences(preferences=existing_preferences)
+
+        svc.set(preferences.h_userid, {"foo": "bar"})
+
+        assert preferences.preferences == expected_preferences
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return UserPreferencesService(db_session)
+
+
+class TestFactory:
+    def test_it(self, db_session, pyramid_request, UserPreferencesService):
+        result = factory(sentinel.context, pyramid_request)
+
+        UserPreferencesService.assert_called_once_with(db_session)
+        assert result == UserPreferencesService.return_value
+
+    @pytest.fixture(autouse=True)
+    def UserPreferencesService(self, patch):
+        return patch("lms.services.user_preferences.UserPreferencesService")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -43,6 +43,7 @@ from lms.services.oauth2_token import OAuth2TokenService
 from lms.services.oauth_http import OAuthHTTPService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
+from lms.services.user_preferences import UserPreferencesService
 from lms.services.vitalsource import VitalSourceService
 from lms.services.youtube import YouTubeService
 from tests import factories
@@ -86,6 +87,7 @@ __all__ = (
     "organization_service",
     "rsa_key_service",
     "user_service",
+    "user_preferences_service",
     "vitalsource_service",
     "email_preferences_service",
     "youtube_service",
@@ -320,6 +322,11 @@ def rsa_key_service(mock_service):
 @pytest.fixture
 def user_service(mock_service):
     return mock_service(UserService)
+
+
+@pytest.fixture
+def user_preferences_service(mock_service):
+    return mock_service(UserPreferencesService)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add two services for working with the new `UserPreferences` model:

1. `UserPreferencesService` is a generic service for getting and setting a user's preferences

2. The existing `EmailPreferencesService` gains new `get_preferences()` and `set_preferences()` methods. These are restricted to getting and setting a user's email preferences only. They're built on top of the new `UserPreferencesService`.

These services just encapsulate some preferences-related logic that I didn't want to put in the views directly. For example we may have multiple preferences views in future--perhaps both an HTML form for getting and setting a user's preferences, and a JSON API. Both views can use these services.

Usage
-----

```python
>>> user_preferences_svc = request.find_service(s.UserPreferencesService)
>>> # This will create h_userid's preferences it none exists.
>>> prefs = user_preferences_svc.get("h_userid")
>>> prefs
UserPreferences(id=None, h_userid='h_userid', preferences={}, created=None, updated=None)
>>> # You can mutate preferences and changes will be saved to the DB.
>>> prefs.preferences["foo"] = "bar"
```

Mutable objects such as dicts and lists aren't a good idea as preferences values, so no lists or nested dicts. The reason is that SQLAlchemy cannot detect changes to nested lists and dicts, they won't be saved. It's a real fiddle and believe me, not worth dealing with.

The `set()` method can be used to inject preferences into a user's existing preferences. If the given preferences already exist they'll be overwritten. If they don't exist they'll be added. Other existing preferences will not be changed. You can't delete preferences with this method, only add/update them. Again, this will create `h_userid`'s `user_preferences` row if none exists:

```python
>>> user_preferences_svc.set("h_userid", {"foo": "bar"})
```

The `EmailPreferencesService.{get,set}_preferences()` methods wrap `UserPreferencesService` and add email-specific behaviour:

```python
>>> email_preferences_svc = request.find_service(s.EmailPreferencesService)
>>> # Again this will create h_userid's user_preferences row if none exists.
>>> # It'll also set all seven days to True for h_userid (if they're not already set).
>>> # This is not the same as user_preferences_svc.get():
>>> # it returns a dict rather than a `UserPreferences` model,
>>> # and changes to this dict will not be automatically saved.
>>> email_preferences_svc.get_preferences("h_userid")
{'instructor_email_digests.days.1': True,
 'instructor_email_digests.days.2': True,
 'instructor_email_digests.days.3': True,
 'instructor_email_digests.days.4': True,
 'instructor_email_digests.days.5': True,
 'instructor_email_digests.days.6': True,
 'instructor_email_digests.days.7': True}
>>> # Use set_preferences() to set a preference.
>>> # The given preferences dict will be merged with the user's existing preferences,
>>> # overwriting existing preferences or adding new ones as necessary.
>>> email_preferences_svc.set_preferences("h_userid", {"instructor_email_digests.days.1": False})