### PR TITLE
Record extra data in the `TaskDone.data` column

### DIFF
--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -73,11 +73,17 @@ class DigestService:
 
             if deduplicate:
                 task_done_key = f"instructor_email_digest::{user_info.h_userid}::{datetime.now(timezone.utc).strftime('%Y-%m-%d')}"
+                task_done_data = {
+                    "type": "instructor_email_digest",
+                    "created_before": created_before.isoformat(),
+                }
             else:
                 task_done_key = None
+                task_done_data = None
 
             send.delay(
                 task_done_key=task_done_key,
+                task_done_data=task_done_data,
                 template="lms:templates/email/instructor_email_digest/",
                 sender=asdict(self._sender),
                 recipient=asdict(EmailRecipient(to_email, user_info.display_name)),

--- a/lms/services/mailchimp.py
+++ b/lms/services/mailchimp.py
@@ -50,6 +50,7 @@ class MailchimpService:
         template_vars: dict,
         unsubscribe_url: Optional[str] = None,
         task_done_key: Optional[str] = None,
+        task_done_data: Optional[dict] = None,
     ):
         """
         Send an email using Mailchimp Transactional's API.
@@ -102,7 +103,7 @@ class MailchimpService:
 
         if task_done_key:
             # Record the email send in the DB to avoid sending duplicates.
-            self.db.add(TaskDone(key=task_done_key))
+            self.db.add(TaskDone(key=task_done_key, data=task_done_data))
 
 
 def factory(_context, request):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/5857.

Begin recording additional data in the `TaskDone.data` column that's
going to be needed in future when we want each user's email digest to
count annotations from *the time that particular user's last email
digest counted annotations until* rather than just from a fixed 24hr
period.

The extra data that we're recording is:

1. The type (`"instructor_email_digest"`), to allow easily filtering for
   only this type of `TaskDone` entry
2. The time (`created_before`) up until which the email that was sent
   counted annotations until
