### PR TITLE
Create components to handle email notifications preferences

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,7 @@ LMS. Each of these is mandatory to get the service working correctly.
 | `VIA_SECRET`                      | `matching-string-from-via`             | Must match the shared secret from Via           |
 | `VIA_URL`                         | `https://via9.hypothes.is/`            | The matching Via                                |
 | `HTTP_HOST`                       | `localhost:8001`                       | The app's HTTP hostname (used by Celery workers)|
+| `EMAIL_PREFERENCES_SECRET`        | `random-string-12345`                  | Signing secret for authentication tokens for the email preferences pages |
 
 See also:
 

--- a/lms/config.py
+++ b/lms/config.py
@@ -105,6 +105,7 @@ SETTINGS = (
     _Setting("mailchimp_digests_subaccount"),
     _Setting("mailchimp_digests_email"),
     _Setting("mailchimp_digests_name"),
+    _Setting("email_preferences_secret"),
 )
 
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -22,6 +22,7 @@ class JSConfig:
         BASIC_LTI_LAUNCH = "basic-lti-launch"
         FILE_PICKER = "content-item-selection"
         ERROR_DIALOG = "error-dialog"
+        EMAIL_NOTIFICATIONS = "email-notifications"
 
     class ErrorCode(str, Enum):
         BLACKBOARD_MISSING_INTEGRATION = "blackboard_missing_integration"
@@ -269,6 +270,18 @@ class JSConfig:
         )
         self._config["debug"]["values"] = self._get_lti_launch_debug_values()
         return self._config
+
+    def enable_email_notifications_mode(self, email_notifications_preferences):
+        """
+        Put the JavaScript code into "email notifications" mode.
+        This mode shows teachers the preferences for email notifications.
+        """
+        self._config.update(
+            {
+                "mode": JSConfig.Mode.EMAIL_NOTIFICATIONS,
+                "emailNotifications": email_notifications_preferences
+            }
+        )
 
     def add_deep_linking_api(self):
         """

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -139,7 +139,7 @@ def includeme(config):  # pylint:disable=too-many-statements
 
     config.add_route("youtube_api.videos", "/api/youtube/videos/{video_id}")
 
-    config.add_route("email.preferences", "/email/preferences")
+    config.add_route("email.preferences", "/email/preferences", factory="lms.resources.LTILaunchResource")
     config.add_route("email.unsubscribe", "/email/unsubscribe")
     config.add_route("email.unsubscribed", "/email/unsubscribed")
 

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -139,6 +139,7 @@ def includeme(config):  # pylint:disable=too-many-statements
 
     config.add_route("youtube_api.videos", "/api/youtube/videos/{video_id}")
 
+    config.add_route("email.preferences", "/email/preferences")
     config.add_route("email.unsubscribe", "/email/unsubscribe")
     config.add_route("email.unsubscribed", "/email/unsubscribed")
 

--- a/lms/security.py
+++ b/lms/security.py
@@ -63,25 +63,28 @@ class SecurityPolicy:
     """Top-level authentication policy that delegates to sub-policies."""
 
     def authenticated_userid(self, request):
-        return self.get_policy(request.path).authenticated_userid(request)
+        return self.get_policy(request).authenticated_userid(request)
 
     def identity(self, request):
-        return self.get_policy(request.path).identity(request)
+        return self.get_policy(request).identity(request)
 
     def permits(self, request, context, permission):
-        return self.get_policy(request.path).permits(request, context, permission)
+        return self.get_policy(request).permits(request, context, permission)
 
     def remember(self, request, userid, **kw):
-        return self.get_policy(request.path).remember(request, userid, **kw)
+        return self.get_policy(request).remember(request, userid, **kw)
 
     def forget(self, request):
-        return self.get_policy(request.path).forget(request)
+        return self.get_policy(request).forget(request)
 
     @staticmethod
     @lru_cache(maxsize=1)
-    def get_policy(path: str):
+    def get_policy(request: Request):
         """Pick the right policy based the request's path."""
         # pylint:disable=too-many-return-statements
+
+        path = request.path
+
         if path.startswith("/admin") or path.startswith("/googleauth"):
             return LMSGoogleSecurityPolicy()
 

--- a/lms/security.py
+++ b/lms/security.py
@@ -4,12 +4,14 @@ from functools import lru_cache, partial
 from typing import Callable, List, NamedTuple, Optional
 
 import sentry_sdk
+from pyramid.authentication import AuthTktCookieHelper
 from pyramid.request import Request
 from pyramid.security import Allowed, Denied
 from pyramid_googleauth import GoogleSecurityPolicy
 
 from lms.models import LTIUser
-from lms.services import UserService
+from lms.services import EmailPreferencesService, UserService
+from lms.services.email_preferences import InvalidTokenError, UnrecognisedURLError
 from lms.validation.authentication import (
     BearerTokenSchema,
     LTI11AuthSchema,
@@ -38,6 +40,7 @@ class Permissions(Enum):
     API = "api"
     ADMIN = "admin"
     GRADE_ASSIGNMENT = "grade_assignment"
+    EMAIL_PREFERENCES = "email.preferences"
 
 
 class UnautheticatedSecurityPolicy:  # pragma: no cover
@@ -125,6 +128,13 @@ class SecurityPolicy:
                 partial(get_lti_user_from_bearer_token, location="form")
             )
 
+        if path == "/email/preferences":
+            return EmailPreferencesSecurityPolicy(
+                secret=request.registry.settings["email_preferences_secret"],
+                domain=request.domain,
+                email_preferences_service=request.find_service(EmailPreferencesService),
+            )
+
         return UnautheticatedSecurityPolicy()
 
 
@@ -200,6 +210,56 @@ class LMSGoogleSecurityPolicy(GoogleSecurityPolicy):
 
     def permits(self, request, _context, permission):
         return _permits(self.identity(request), permission)
+
+
+class EmailPreferencesSecurityPolicy:
+    """The security policy for the email preferences page."""
+
+    def __init__(
+        self,
+        secret: str,
+        domain: str,
+        email_preferences_service: EmailPreferencesService,
+    ):
+        self.cookie = AuthTktCookieHelper(
+            secret=secret,
+            cookie_name="email.preferences",
+            secure=True,
+            timeout=60 * 5,
+            reissue_time=0,
+            max_age=60 * 5,
+            path="/email/preferences",
+            http_only=True,
+            domain=domain,
+        )
+        self.email_preferences_service = email_preferences_service
+
+    def identity(self, request):
+        try:
+            return self.email_preferences_service.h_userid(request.url)
+        except UnrecognisedURLError:
+            pass
+        except InvalidTokenError:
+            return None
+
+        try:
+            return self.cookie.identify(request)["userid"]
+        except (KeyError, TypeError):
+            return None
+
+    def authenticated_userid(self, request):
+        return self.identity(request)
+
+    def permits(self, request, _context, permission):
+        identity = self.identity(request)
+
+        if identity is not None and permission == Permissions.EMAIL_PREFERENCES:
+            return Allowed("Allowed")
+
+        return Denied("Denied")
+
+    def remember(self, request, userid, **_kw):
+        return self.cookie.remember(request, userid)
 
 
 def _permits(identity, permission):

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -32,6 +32,7 @@ from lms.services.ltia_http import LTIAHTTPService
 from lms.services.organization import OrganizationService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
+from lms.services.user_preferences import UserPreferencesService
 from lms.services.vitalsource import VitalSourceService
 from lms.services.youtube import YouTubeService
 
@@ -53,6 +54,9 @@ def includeme(config):
     )
     config.register_service_factory("lms.services.canvas.factory", iface=CanvasService)
     config.register_service_factory("lms.services.user.factory", iface=UserService)
+    config.register_service_factory(
+        "lms.services.user_preferences.factory", iface=UserPreferencesService
+    )
 
     config.register_service_factory("lms.services.h_api.service_factory", iface=HAPI)
     config.register_service_factory(

--- a/lms/services/email_preferences.py
+++ b/lms/services/email_preferences.py
@@ -38,9 +38,22 @@ class EmailPreferencesService:
         self._user_preferences_service = user_preferences_service
 
     def unsubscribe_url(self, h_userid, tag):
-        """Generate the url for `email.unsubscribe` with the right token."""
+        """Return an email unsubscribe URL for the given h_userid.
+
+        The URL will contain a scoped and time-limited authentication token for
+        the given h_userid in a query param.
+        """
         token = self._generate_token(h_userid, tag)
         return self._route_url("email.unsubscribe", _query={"token": token})
+
+    def preferences_url(self, h_userid):
+        """Return a URL for the email preferences page for the given h_userid.
+
+        The URL will contain a scoped and time-limited authentication token for
+        the given h_userid in a query param.
+        """
+        token = self._generate_token(h_userid)
+        return self._route_url("email.preferences", _query={"token": token})
 
     def unsubscribe(self, token):
         """Create a new entry in EmailUnsubscribe based on the email and tag encode in `token`."""
@@ -98,11 +111,14 @@ class EmailPreferencesService:
             },
         )
 
-    def _generate_token(self, h_userid, tag):
+    def _generate_token(self, h_userid, tag=None):
+        payload = {"h_userid": h_userid}
+
+        if tag is not None:
+            payload["tag"] = tag
+
         return self._jwt_service.encode_with_secret(
-            {"h_userid": h_userid, "tag": tag},
-            self._secret,
-            lifetime=timedelta(days=30),
+            payload, self._secret, lifetime=timedelta(days=30)
         )
 
     def _decode_token(self, token):

--- a/lms/services/user_preferences.py
+++ b/lms/services/user_preferences.py
@@ -1,0 +1,36 @@
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
+
+from lms.models import UserPreferences
+
+
+class UserPreferencesService:
+    def __init__(self, db):
+        self._db = db
+
+    def get(self, h_userid: str) -> UserPreferences:
+        """Return the user preferences for the given h_userid."""
+        try:
+            preferences = self._db.scalars(
+                select(UserPreferences).where(UserPreferences.h_userid == h_userid)
+            ).one()
+        except NoResultFound:
+            preferences = UserPreferences(h_userid=h_userid, preferences={})
+            self._db.add(preferences)
+
+        return preferences
+
+    def set(self, h_userid: str, new_preferences: dict) -> None:
+        """Insert the given new_preferences into h_userid's user preferences.
+
+        Existing items will be updated and new items will be created in
+        h_userid's user preferences as necessary.
+        """
+        preferences = self.get(h_userid)
+
+        for key, value in new_preferences.items():
+            preferences.preferences[key] = value
+
+
+def factory(_context, request) -> UserPreferencesService:
+    return UserPreferencesService(request.db)

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -7,6 +7,7 @@ import type { ServiceMap } from '../services';
 import { Services } from '../services';
 import BasicLTILaunchApp from './BasicLTILaunchApp';
 import DataLoader from './DataLoader';
+import EmailNotificationsApp from './EmailNotificationsApp';
 import ErrorDialogApp from './ErrorDialogApp';
 import FilePickerApp, { loadFilePickerConfig } from './FilePickerApp';
 import OAuth2RedirectErrorApp from './OAuth2RedirectErrorApp';
@@ -38,6 +39,9 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
             >
               <FilePickerApp />
             </DataLoader>
+          </Route>
+          <Route path="/app/email-notifications">
+            <EmailNotificationsApp />
           </Route>
           <Route path="/app/error-dialog">
             <ErrorDialogApp />

--- a/lms/static/scripts/frontend_apps/components/EmailNotificationsApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailNotificationsApp.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'preact/hooks';
+
+import { useConfig } from '../config';
+import EmailNotificationsPreferences from './EmailNotificationsPreferences';
+
+export default function EmailPreferencesApp() {
+  const { emailNotifications } = useConfig(['emailNotifications']);
+  const [selectedDays, setSelectedDays] = useState(emailNotifications);
+
+  return (
+    <div className="h-full grid place-items-center">
+      <div className="w-96">
+        <EmailNotificationsPreferences
+          selectedDays={selectedDays}
+          setSelectedDays={setSelectedDays}
+        />
+      </div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/EmailNotificationsPreferences.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailNotificationsPreferences.tsx
@@ -1,0 +1,96 @@
+import type { PanelProps } from '@hypothesis/frontend-shared';
+import { Button, Checkbox, Panel } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { StateUpdater } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
+
+import type { EmailNotificationsPreferences, WeekDay } from '../config';
+
+const dayNames: [WeekDay, string][] = [
+  [7, 'Sunday'],
+  [1, 'Monday'],
+  [2, 'Tuesday'],
+  [3, 'Wednesday'],
+  [4, 'Thursday'],
+  [5, 'Friday'],
+  [6, 'Saturday'],
+];
+
+export type EmailNotificationsPreferencesProps = {
+  selectedDays: EmailNotificationsPreferences;
+  setSelectedDays: StateUpdater<EmailNotificationsPreferences>;
+  onClose?: PanelProps['onClose'];
+};
+
+export default function EmailNotificationsPreferences({
+  onClose,
+  selectedDays,
+  setSelectedDays,
+}: EmailNotificationsPreferencesProps) {
+  const setAllTo = useCallback(
+    (enabled: boolean) =>
+      setSelectedDays({
+        1: enabled,
+        2: enabled,
+        3: enabled,
+        4: enabled,
+        5: enabled,
+        6: enabled,
+        7: enabled,
+      }),
+    [setSelectedDays]
+  );
+  const selectAll = useCallback(() => setAllTo(true), [setAllTo]);
+  const selectNone = useCallback(() => setAllTo(false), [setAllTo]);
+
+  return (
+    <Panel
+      onClose={onClose}
+      title="Email Notifications"
+      buttons={<Button variant="primary">Save</Button>}
+    >
+      <p className="font-bold">
+        Receive email notifications when your students annotate.
+      </p>
+      <p className="font-bold">Select the days you{"'"}d like your emails:</p>
+
+      <div className="flex justify-between px-4">
+        <div className="flex flex-col gap-1">
+          {dayNames.map(([day, name]) => (
+            <span
+              key={day}
+              className={classnames(
+                // The checked icon sets fill from the text color
+                'text-grey-6'
+              )}
+            >
+              <Checkbox
+                checked={selectedDays[day]}
+                onChange={() =>
+                  setSelectedDays(prev => ({ ...prev, [day]: !prev[day] }))
+                }
+              >
+                <span
+                  className={classnames(
+                    // Override the color set for the checkbox fill
+                    'text-grey-9'
+                  )}
+                >
+                  {name}
+                </span>
+              </Checkbox>
+            </span>
+          ))}
+        </div>
+        <div className="flex items-start gap-2">
+          <Button variant="secondary" onClick={selectAll}>
+            Select All
+          </Button>
+          <Button variant="secondary" onClick={selectNone}>
+            Select None
+          </Button>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -29,6 +29,7 @@ export type APICallInfo = {
 export type AppMode =
   | 'basic-lti-launch'
   | 'content-item-selection'
+  | 'email-notifications'
   | 'error-dialog'
   | 'oauth2-redirect-error';
 
@@ -219,6 +220,10 @@ export type Product = {
   api: ProductAPI;
 };
 
+export type WeekDay = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export type EmailNotificationsPreferences = Record<WeekDay, boolean>;
+
 /**
  * Data/configuration needed for frontend applications in the LMS app.
  * The `mode` property specifies which frontend application should load and
@@ -268,6 +273,9 @@ export type ConfigObject = {
 
   // Only present in "oauth2-redirect-error" mode.
   OAuth2RedirectError?: OAuthErrorConfig;
+
+  // Only present in "email-notifications" mode.
+  emailNotifications?: EmailNotificationsPreferences;
 };
 
 /**

--- a/lms/templates/email/expired_link.html.jinja2
+++ b/lms/templates/email/expired_link.html.jinja2
@@ -1,11 +1,11 @@
 {% extends 'templates/base.plain.html.jinja2' %}
 
-{% set title = "Expired unsubscribe link" %}
+{% set title = "Expired link" %}
 
 {% block content %}
 <p>
-    It looks like the unsubscribe link that you clicked on was invalid or had expired.
-    Try clicking the unsubscribe link in a more recent email instead.
+    The link that you clicked on has expired.
+    Try clicking a link in a more recent email instead.
 </p>
 <p>
     If the problem persists, you can

--- a/lms/templates/email/preferences.html.jinja2
+++ b/lms/templates/email/preferences.html.jinja2
@@ -1,33 +1,18 @@
-{% extends 'templates/base.plain.html.jinja2' %}
+{% extends "lms:templates/base.html.jinja2" %}
 
 {% block content %}
-{% for message in request.session.pop_flash() %}
-  <p><b>{{ message }}</b></p>
-{% endfor %}
+    <div style="width: 100%; height: 100%;" id="app"></div>
+{% endblock %}
 
-<form action="" method="post">
-  <fieldset>
-    <legend>Receive email notifications when your students annotate. Select
-    the days you'd like your emails:</legend>
+{% block styles %}
+    {% for url in  asset_urls("frontend_apps_css") %}
+        <link rel="stylesheet" href="{{ url }}">
+    {% endfor %}
+{% endblock %}
 
-    <ul style="list-style-type:none;">
-      <li><input type="checkbox" id="sunday" name="instructor_email_digests.days.7" {% if preferences["instructor_email_digests.days.7"] %}checked{% endif %} />
-      <label for="sunday">Sunday</label></li>
-      <li><input type="checkbox" id="monday" name="instructor_email_digests.days.1" {% if preferences["instructor_email_digests.days.1"] %}checked{% endif %} />
-      <label for="monday">Monday</label></li>
-      <li><input type="checkbox" id="tuesday" name="instructor_email_digests.days.2" {% if preferences["instructor_email_digests.days.2"] %}checked{% endif %} />
-      <label for="tuesday">Tuesday</label></li>
-      <li><input type="checkbox" id="wednesday" name="instructor_email_digests.days.3" {% if preferences["instructor_email_digests.days.3"] %}checked{% endif %} />
-      <label for="wednesday">Wednesday</label></li>
-      <li><input type="checkbox" id="thursday" name="instructor_email_digests.days.4" {% if preferences["instructor_email_digests.days.4"] %}checked{% endif %} />
-      <label for="thursday">Thursday</label></li>
-      <li><input type="checkbox" id="friday" name="instructor_email_digests.days.5" {% if preferences["instructor_email_digests.days.5"] %}checked{% endif %} />
-      <label for="friday">Friday</label></li>
-      <li><input type="checkbox" id="saturday" name="instructor_email_digests.days.6" {% if preferences["instructor_email_digests.days.6"] %}checked{% endif %} />
-      <label for="saturday">Saturday</label></li>
-    </ul>
-  </fieldset>
-
-  <button type="submit">Save</button>
-</form>
+{% block scripts %}
+    {{ super() }}
+    {% for url in asset_urls("frontend_apps_js") %}
+        <script type="module" src="{{ url }}"></script>
+    {% endfor %}
 {% endblock %}

--- a/lms/templates/email/preferences.html.jinja2
+++ b/lms/templates/email/preferences.html.jinja2
@@ -1,0 +1,33 @@
+{% extends 'templates/base.plain.html.jinja2' %}
+
+{% block content %}
+{% for message in request.session.pop_flash() %}
+  <p><b>{{ message }}</b></p>
+{% endfor %}
+
+<form action="" method="post">
+  <fieldset>
+    <legend>Receive email notifications when your students annotate. Select
+    the days you'd like your emails:</legend>
+
+    <ul style="list-style-type:none;">
+      <li><input type="checkbox" id="sunday" name="instructor_email_digests.days.7" {% if preferences["instructor_email_digests.days.7"] %}checked{% endif %} />
+      <label for="sunday">Sunday</label></li>
+      <li><input type="checkbox" id="monday" name="instructor_email_digests.days.1" {% if preferences["instructor_email_digests.days.1"] %}checked{% endif %} />
+      <label for="monday">Monday</label></li>
+      <li><input type="checkbox" id="tuesday" name="instructor_email_digests.days.2" {% if preferences["instructor_email_digests.days.2"] %}checked{% endif %} />
+      <label for="tuesday">Tuesday</label></li>
+      <li><input type="checkbox" id="wednesday" name="instructor_email_digests.days.3" {% if preferences["instructor_email_digests.days.3"] %}checked{% endif %} />
+      <label for="wednesday">Wednesday</label></li>
+      <li><input type="checkbox" id="thursday" name="instructor_email_digests.days.4" {% if preferences["instructor_email_digests.days.4"] %}checked{% endif %} />
+      <label for="thursday">Thursday</label></li>
+      <li><input type="checkbox" id="friday" name="instructor_email_digests.days.5" {% if preferences["instructor_email_digests.days.5"] %}checked{% endif %} />
+      <label for="friday">Friday</label></li>
+      <li><input type="checkbox" id="saturday" name="instructor_email_digests.days.6" {% if preferences["instructor_email_digests.days.6"] %}checked{% endif %} />
+      <label for="saturday">Saturday</label></li>
+    </ul>
+  </fieldset>
+
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -52,7 +52,8 @@ def forbidden(_request):
 
 @view_defaults(permission=Permissions.EMAIL_PREFERENCES)
 class EmailPreferencesViews:
-    def __init__(self, request):
+    def __init__(self, context, request):
+        self.context = context
         self.request = request
         self.email_preferences_service = request.find_service(EmailPreferencesService)
 
@@ -77,11 +78,12 @@ class EmailPreferencesViews:
         renderer="lms:templates/email/preferences.html.jinja2",
     )
     def preferences(self):
-        return {
-            "preferences": self.email_preferences_service.get_preferences(
+        self.context.js_config.enable_email_notifications_mode(
+            email_notifications_preferences=self.email_preferences_service.get_preferences(
                 self.request.authenticated_userid
-            ),
-        }
+            )
+        )
+        return {}
 
     @view_config(
         route_name="email.preferences",

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -1,8 +1,10 @@
 import logging
 
 from pyramid.httpexceptions import HTTPFound
-from pyramid.view import view_config
+from pyramid.security import remember
+from pyramid.view import forbidden_view_config, view_config, view_defaults
 
+from lms.security import Permissions
 from lms.services import EmailPreferencesService
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
 
@@ -13,7 +15,7 @@ LOG = logging.getLogger(__name__)
     route_name="email.unsubscribe",
     request_method="GET",
     request_param="token",
-    renderer="lms:templates/email/unsubscribe_error.html.jinja2",
+    renderer="lms:templates/email/expired_link.html.jinja2",
 )
 def unsubscribe(request):
     """Unsubscribe the email and tag combination encoded in token."""
@@ -36,3 +38,61 @@ def unsubscribe(request):
 def unsubscribed(_request):
     """Render a message after a successful email unsubscribe."""
     return {}
+
+
+@forbidden_view_config(
+    route_name="email.preferences",
+    request_method="GET",
+    request_param="token",
+    renderer="lms:templates/email/expired_link.html.jinja2",
+)
+def forbidden(_request):
+    return {}
+
+
+@view_defaults(permission=Permissions.EMAIL_PREFERENCES)
+class EmailPreferencesViews:
+    def __init__(self, request):
+        self.request = request
+        self.email_preferences_service = request.find_service(EmailPreferencesService)
+
+    @view_config(
+        route_name="email.preferences",
+        request_method="GET",
+        request_param="token",
+    )
+    def preferences_redirect(self):
+        # The token has already been verified by the security policy, so we can
+        # just go right ahead with the redirect.
+        return HTTPFound(
+            location=self.request.route_url("email.preferences"),
+            # Set a cookie to keep the user logged in even though we're
+            # removing the authentication token from the URL.
+            headers=remember(self.request, self.request.authenticated_userid),
+        )
+
+    @view_config(
+        route_name="email.preferences",
+        request_method="GET",
+        renderer="lms:templates/email/preferences.html.jinja2",
+    )
+    def preferences(self):
+        return {
+            "preferences": self.email_preferences_service.get_preferences(
+                self.request.authenticated_userid
+            ),
+        }
+
+    @view_config(
+        route_name="email.preferences",
+        request_method="POST",
+    )
+    def set_preferences(self):
+        self.email_preferences_service.set_preferences(
+            self.request.authenticated_userid,
+            {
+                key: self.request.params.get(key) == "on"
+                for key in self.email_preferences_service.DAY_KEYS
+            },
+        )
+        return HTTPFound(location=self.request.route_url("email.preferences"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ TEST_SETTINGS = {
     "blackboard_api_client_secret": "test_blackboard_api_client_secret",
     "vitalsource_api_key": "test_vs_api_key",
     "disable_key_rotation": False,
+    "email_preferences_secret": "test_email_preferences_secret",
 }
 
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -34,6 +34,7 @@ from tests.factories.oauth2_token import OAuth2Token
 from tests.factories.organization import Organization
 from tests.factories.rsa_key import RSAKey
 from tests.factories.user import User
+from tests.factories.user_preferences import UserPreferences
 
 
 def set_sqlalchemy_session(session, persistence=None):

--- a/tests/factories/user_preferences.py
+++ b/tests/factories/user_preferences.py
@@ -1,0 +1,9 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.attributes import H_USERID
+
+UserPreferences = make_factory(
+    models.UserPreferences, FACTORY_CLASS=SQLAlchemyModelFactory, h_userid=H_USERID
+)

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -6,6 +6,7 @@ from pyramid.security import Allowed, Denied
 
 from lms.security import (
     DeniedWithException,
+    EmailPreferencesSecurityPolicy,
     Identity,
     LMSGoogleSecurityPolicy,
     LTIUserSecurityPolicy,
@@ -18,6 +19,7 @@ from lms.security import (
     get_lti_user_from_oauth_callback,
     includeme,
 )
+from lms.services.email_preferences import InvalidTokenError, UnrecognisedURLError
 from lms.validation import ValidationError
 from tests import factories
 
@@ -82,6 +84,110 @@ class TestLMSGoogleSecurityPolicy:
     @pytest.fixture
     def policy(self):
         return LMSGoogleSecurityPolicy()
+
+
+class TestEmailPreferencesSecurityPolicy:
+    @pytest.mark.parametrize("method", ["identity", "authenticated_userid"])
+    def test_identity_returns_the_h_userid_from_the_token(
+        self, policy, pyramid_request, email_preferences_service, method
+    ):
+        identity = getattr(policy, method)(pyramid_request)
+
+        email_preferences_service.h_userid.assert_called_once_with(pyramid_request.url)
+        assert identity == email_preferences_service.h_userid.return_value
+
+    @pytest.mark.parametrize("method", ["identity", "authenticated_userid"])
+    def test_identity_returns_None_if_the_token_is_invalid(
+        self, policy, pyramid_request, email_preferences_service, method
+    ):
+        email_preferences_service.h_userid.side_effect = InvalidTokenError
+
+        assert getattr(policy, method)(pyramid_request) is None
+
+    @pytest.mark.parametrize("method", ["identity", "authenticated_userid"])
+    def test_identity_returns_the_h_userid_from_the_cookie(
+        self,
+        policy,
+        pyramid_request,
+        email_preferences_service,
+        AuthTktCookieHelper,
+        method,
+    ):
+        email_preferences_service.h_userid.side_effect = UnrecognisedURLError
+        AuthTktCookieHelper.return_value.identify.return_value = {
+            "userid": sentinel.h_userid
+        }
+
+        identity = getattr(policy, method)(pyramid_request)
+
+        AuthTktCookieHelper.return_value.identify.assert_called_once_with(
+            pyramid_request
+        )
+        assert identity == sentinel.h_userid
+
+    @pytest.mark.parametrize("method", ["identity", "authenticated_userid"])
+    @pytest.mark.parametrize("exception_class", [KeyError, TypeError])
+    def test_identity_returns_None_if_the_cookie_is_missing_or_invalid(
+        self,
+        policy,
+        pyramid_request,
+        email_preferences_service,
+        AuthTktCookieHelper,
+        exception_class,
+        method,
+    ):
+        email_preferences_service.h_userid.side_effect = UnrecognisedURLError
+        AuthTktCookieHelper.return_value.identify.side_effect = exception_class
+
+        assert getattr(policy, method)(pyramid_request) is None
+
+    @pytest.mark.parametrize(
+        "permission,expected_result",
+        [
+            (Permissions.EMAIL_PREFERENCES, Allowed("Allowed")),
+            ("foo", Denied("Denied")),
+        ],
+    )
+    def test_permits_when_authenticated(
+        self, pyramid_request, policy, permission, expected_result
+    ):
+        result = policy.permits(pyramid_request, sentinel.context, permission)
+
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
+        "permission,expected_result",
+        [(Permissions.EMAIL_PREFERENCES, Denied("Denied")), ("foo", Denied("Denied"))],
+    )
+    def test_permits_when_not_authenticated(
+        self,
+        pyramid_request,
+        policy,
+        permission,
+        expected_result,
+        email_preferences_service,
+    ):
+        email_preferences_service.h_userid.side_effect = InvalidTokenError
+
+        result = policy.permits(pyramid_request, sentinel.context, permission)
+
+        assert result == expected_result
+
+    def test_remember(self, policy, pyramid_request, AuthTktCookieHelper):
+        result = policy.remember(pyramid_request, sentinel.userid)
+
+        AuthTktCookieHelper.return_value.remember.assert_called_once_with(
+            pyramid_request, sentinel.userid
+        )
+        assert result == AuthTktCookieHelper.return_value.remember.return_value
+
+    @pytest.fixture
+    def policy(self, email_preferences_service):
+        return EmailPreferencesSecurityPolicy(
+            secret="test_email_preferences_secret",
+            domain="example.com",
+            email_preferences_service=email_preferences_service,
+        )
 
 
 @pytest.mark.usefixtures("pyramid_config")
@@ -258,6 +364,24 @@ class TestSecurityPolicy:
         LTIUserSecurityPolicy.assert_called_once_with(lti_user_getter)
         assert policy == LTIUserSecurityPolicy.return_value
 
+    def test_get_policy_email_preferences(
+        self,
+        pyramid_request,
+        policy,
+        email_preferences_service,
+        EmailPreferencesSecurityPolicy,
+    ):
+        pyramid_request.path = "/email/preferences"
+
+        sub_policy = policy.get_policy(pyramid_request)
+
+        EmailPreferencesSecurityPolicy.assert_called_once_with(
+            secret="test_email_preferences_secret",
+            domain="example.com",
+            email_preferences_service=email_preferences_service,
+        )
+        assert sub_policy == EmailPreferencesSecurityPolicy.return_value
+
     @pytest.mark.parametrize(
         "path,location",
         [
@@ -297,6 +421,10 @@ class TestSecurityPolicy:
     @pytest.fixture(autouse=True)
     def LMSGoogleSecurityPolicy(self, patch):
         return patch("lms.security.LMSGoogleSecurityPolicy")
+
+    @pytest.fixture(autouse=True)
+    def EmailPreferencesSecurityPolicy(self, patch):
+        return patch("lms.security.EmailPreferencesSecurityPolicy")
 
     @pytest.fixture(autouse=True)
     def UnautheticatedSecurityPolicy(self, patch):
@@ -418,3 +546,8 @@ class TestGetUser:
             pyramid_request.lti_user.user_id,
         )
         assert user == user_service.get.return_value
+
+
+@pytest.fixture(autouse=True)
+def AuthTktCookieHelper(patch):
+    return patch("lms.security.AuthTktCookieHelper")

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -189,7 +189,7 @@ class TestSecurityPolicy:
     def test_authenticated_userid(self, policy, get_policy, pyramid_request):
         user_id = policy.authenticated_userid(pyramid_request)
 
-        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.assert_called_once_with(pyramid_request)
         get_policy.return_value.authenticated_userid.assert_called_once_with(
             pyramid_request
         )
@@ -198,14 +198,14 @@ class TestSecurityPolicy:
     def test_identity(self, policy, get_policy, pyramid_request):
         user_id = policy.identity(pyramid_request)
 
-        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.assert_called_once_with(pyramid_request)
         get_policy.return_value.identity.assert_called_once_with(pyramid_request)
         assert user_id == get_policy.return_value.identity.return_value
 
     def test_permits(self, policy, get_policy, pyramid_request):
         user_id = policy.permits(pyramid_request, sentinel.context, sentinel.permission)
 
-        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.assert_called_once_with(pyramid_request)
         get_policy.return_value.permits.assert_called_once_with(
             pyramid_request, sentinel.context, sentinel.permission
         )
@@ -216,7 +216,7 @@ class TestSecurityPolicy:
             pyramid_request, sentinel.userid, kwarg=sentinel.kwargs
         )
 
-        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.assert_called_once_with(pyramid_request)
         get_policy.return_value.remember.assert_called_once_with(
             pyramid_request, sentinel.userid, kwarg=sentinel.kwargs
         )
@@ -225,7 +225,7 @@ class TestSecurityPolicy:
     def test_forgets(self, policy, pyramid_request, get_policy):
         user_id = policy.forget(pyramid_request)
 
-        get_policy.assert_called_once_with(pyramid_request.path)
+        get_policy.assert_called_once_with(pyramid_request)
         get_policy.return_value.forget.assert_called_once_with(pyramid_request)
         assert user_id == get_policy.return_value.forget.return_value
 
@@ -233,8 +233,9 @@ class TestSecurityPolicy:
         "path",
         ["/admin", "/admin/instance", "/googleauth"],
     )
-    def test_get_policy_google(self, path, LMSGoogleSecurityPolicy):
-        policy = SecurityPolicy.get_policy(path)
+    def test_get_policy_google(self, pyramid_request, path, LMSGoogleSecurityPolicy):
+        pyramid_request.path = path
+        policy = SecurityPolicy.get_policy(pyramid_request)
 
         assert policy == LMSGoogleSecurityPolicy.return_value
 
@@ -249,9 +250,10 @@ class TestSecurityPolicy:
         ],
     )
     def test_get_policy_lti_user(
-        self, path, lti_user_getter, policy, LTIUserSecurityPolicy
+        self, pyramid_request, path, lti_user_getter, policy, LTIUserSecurityPolicy
     ):
-        policy = policy.get_policy(path)
+        pyramid_request.path = path
+        policy = policy.get_policy(pyramid_request)
 
         LTIUserSecurityPolicy.assert_called_once_with(lti_user_getter)
         assert policy == LTIUserSecurityPolicy.return_value
@@ -267,9 +269,10 @@ class TestSecurityPolicy:
         ],
     )
     def test_picks_lti_launches_with_bearer_token(
-        self, path, location, LTIUserSecurityPolicy, policy
+        self, pyramid_request, path, location, LTIUserSecurityPolicy, policy
     ):
-        policy = policy.get_policy(path)
+        pyramid_request.path = path
+        policy = policy.get_policy(pyramid_request)
 
         LTIUserSecurityPolicy.assert_called_once()
         # Can't compare functions directly, discussion: https://bugs.python.org/issue3564
@@ -278,8 +281,11 @@ class TestSecurityPolicy:
         assert call_args[0].func.__name__ == "get_lti_user_from_bearer_token"
         assert policy == LTIUserSecurityPolicy.return_value
 
-    def test_unauthorized_policy(self, UnautheticatedSecurityPolicy, policy):
-        policy = policy.get_policy("/unknown")
+    def test_unauthorized_policy(
+        self, pyramid_request, UnautheticatedSecurityPolicy, policy
+    ):
+        pyramid_request.path = "/unknown"
+        policy = policy.get_policy(pyramid_request)
 
         UnautheticatedSecurityPolicy.assert_called_once()
         assert policy == UnautheticatedSecurityPolicy.return_value

--- a/tests/unit/lms/services/email_preferences_test.py
+++ b/tests/unit/lms/services/email_preferences_test.py
@@ -27,6 +27,16 @@ class TestEmailPreferencesService:
         )
         assert url == "http://example.com/email/unsubscribe?token=TOKEN"
 
+    def test_preferences_url(self, svc, jwt_service):
+        jwt_service.encode_with_secret.return_value = "TOKEN"
+
+        url = svc.preferences_url(sentinel.h_userid)
+
+        jwt_service.encode_with_secret.assert_called_once_with(
+            {"h_userid": sentinel.h_userid}, "SECRET", lifetime=timedelta(days=30)
+        )
+        assert url == "http://example.com/email/preferences?token=TOKEN"
+
     def test_unsubscribe(self, svc, bulk_upsert, jwt_service, db_session):
         jwt_service.decode_with_secret.return_value = {
             "h_userid": sentinel.h_userid,

--- a/tests/unit/lms/services/user_preferences_test.py
+++ b/tests/unit/lms/services/user_preferences_test.py
@@ -1,0 +1,61 @@
+from unittest.mock import sentinel
+
+import pytest
+from h_matchers import Any
+from sqlalchemy import select
+
+from lms.models import UserPreferences
+from lms.services.user_preferences import UserPreferencesService, factory
+from tests import factories
+
+
+class TestUserPreferencesService:
+    def test_get_returns_a_new_UserPreferences_if_none_exists(self, svc):
+        assert svc.get("test_h_userid") == Any.object.of_type(
+            UserPreferences
+        ).with_attrs({"h_userid": "test_h_userid", "preferences": {}})
+
+    def test_get_returns_an_existing_UserPreferences_if_one_exists(self, svc):
+        preferences = factories.UserPreferences()
+
+        assert svc.get(preferences.h_userid) is preferences
+
+    def test_set_creates_a_new_UserPreferences_if_none_exists(self, svc, db_session):
+        svc.set("test_h_userid", {"foo": "bar"})
+
+        assert db_session.scalars(
+            select(UserPreferences).where(UserPreferences.h_userid == "test_h_userid")
+        ).one().preferences == {"foo": "bar"}
+
+    @pytest.mark.parametrize(
+        "existing_preferences,expected_preferences",
+        [
+            ({}, {"foo": "bar"}),
+            ({"foo": "gar"}, {"foo": "bar"}),
+            ({"gar": "har"}, {"gar": "har", "foo": "bar"}),
+        ],
+    )
+    def test_set_updates_an_existing_UserPreferences_if_one_exists(
+        self, svc, existing_preferences, expected_preferences
+    ):
+        preferences = factories.UserPreferences(preferences=existing_preferences)
+
+        svc.set(preferences.h_userid, {"foo": "bar"})
+
+        assert preferences.preferences == expected_preferences
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return UserPreferencesService(db_session)
+
+
+class TestFactory:
+    def test_it(self, db_session, pyramid_request, UserPreferencesService):
+        result = factory(sentinel.context, pyramid_request)
+
+        UserPreferencesService.assert_called_once_with(db_session)
+        assert result == UserPreferencesService.return_value
+
+    @pytest.fixture(autouse=True)
+    def UserPreferencesService(self, patch):
+        return patch("lms.services.user_preferences.UserPreferencesService")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -43,6 +43,7 @@ from lms.services.oauth2_token import OAuth2TokenService
 from lms.services.oauth_http import OAuthHTTPService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
+from lms.services.user_preferences import UserPreferencesService
 from lms.services.vitalsource import VitalSourceService
 from lms.services.youtube import YouTubeService
 from tests import factories
@@ -86,6 +87,7 @@ __all__ = (
     "organization_service",
     "rsa_key_service",
     "user_service",
+    "user_preferences_service",
     "vitalsource_service",
     "email_preferences_service",
     "youtube_service",
@@ -323,6 +325,11 @@ def user_service(mock_service):
 
 
 @pytest.fixture
+def user_preferences_service(mock_service):
+    return mock_service(UserPreferencesService)
+
+
+@pytest.fixture
 def lti_user_service(mock_service):
     return mock_service(LTIUserService)
 
@@ -334,7 +341,9 @@ def vitalsource_service(mock_service):
 
 @pytest.fixture
 def email_preferences_service(mock_service):
-    return mock_service(EmailPreferencesService)
+    email_preferences_service = mock_service(EmailPreferencesService)
+    email_preferences_service.DAY_KEYS = EmailPreferencesService.DAY_KEYS
+    return email_preferences_service
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR introduces a new component to manage email notifications preferences, together with a new app/entry point that currently only renders that component.

![image](https://github.com/hypothesis/lms/assets/2719332/08a6af34-4265-4784-bf4c-5f5839e027f4)

### Introduced changes

- A new client app `email-notifications` mode is introduced.
- The `/email/preferences` route now loads a template which renders client-side, using `email-notifications` mode.
- The email preferences are exposed to the client via `useConfig`, on the new `emailNotifications` prop.

### Out of scope

There are some improvements that will be added in follow-up PRs

- Save preferences logic. Currently, the "Save" button does nothing.
- Loading the component from the sidebar.
  At some point the sidebar will conditionally include an option to open this same component.

### Testing steps

*TODO*

### To do

- [ ] Add FE tests
- [ ] Add/fix BE tests
