### PR TITLE
Require admin permission on sensitive admin views

### DIFF
--- a/lms/views/admin/application_instance/create.py
+++ b/lms/views/admin/application_instance/create.py
@@ -32,7 +32,7 @@ class CreateAppInstanceSchemaV13(CreateAppInstanceSchema):
     lti_registration_id = fields.Str(required=True)
 
 
-@view_defaults(route_name="admin.instance.create", permission=Permissions.STAFF)
+@view_defaults(route_name="admin.instance.create", permission=Permissions.ADMIN)
 class CreateApplicationInstanceViews(BaseApplicationInstanceView):
     def __init__(self, request):
         super().__init__(request)

--- a/lms/views/admin/application_instance/downgrade.py
+++ b/lms/views/admin/application_instance/downgrade.py
@@ -8,7 +8,7 @@ class DowngradeApplicationInstanceView(BaseApplicationInstanceView):
     @view_config(
         route_name="admin.instance.downgrade",
         request_method="POST",
-        permission=Permissions.STAFF,
+        permission=Permissions.ADMIN,
     )
     def downgrade_instance(self):
         ai = self.application_instance

--- a/lms/views/admin/application_instance/move_organization.py
+++ b/lms/views/admin/application_instance/move_organization.py
@@ -10,7 +10,7 @@ class MoveOrgApplicationInstanceView(BaseApplicationInstanceView):
         route_name="admin.instance.move_org",
         request_method="POST",
         require_csrf=True,
-        permission=Permissions.STAFF,
+        permission=Permissions.ADMIN,
     )
     def move_application_instance_org(self):
         ai = self.application_instance

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -31,7 +31,7 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
         route_name="admin.instance",
         request_method="POST",
         require_csrf=True,
-        permission=Permissions.STAFF,
+        permission=Permissions.ADMIN,
     )
     def update_instance(self):
         ai = self.application_instance
@@ -61,7 +61,7 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
         route_name="admin.instance.settings",
         request_method="POST",
         require_csrf=True,
-        permission=Permissions.STAFF,
+        permission=Permissions.ADMIN,
     )
     def update_instance_settings(self):
         ai = self.application_instance

--- a/lms/views/admin/application_instance/upgrade.py
+++ b/lms/views/admin/application_instance/upgrade.py
@@ -18,7 +18,7 @@ class UpgradeApplicationInstanceSchema(PyramidRequestSchema):
     deployment_id = fields.Str(required=True, validate=validate.Length(min=1))
 
 
-@view_defaults(permission=Permissions.STAFF, route_name="admin.instance.upgrade")
+@view_defaults(permission=Permissions.ADMIN, route_name="admin.instance.upgrade")
 class UpgradeApplicationInstanceViews(BaseApplicationInstanceView):
     def __init__(self, request):
         super().__init__(request)

--- a/lms/views/admin/lti_registration.py
+++ b/lms/views/admin/lti_registration.py
@@ -77,7 +77,7 @@ URL_SUGGESTIONS = {
 }
 
 
-@view_defaults(request_method="GET", permission=Permissions.STAFF)
+@view_defaults(request_method="GET", permission=Permissions.ADMIN)
 class AdminLTIRegistrationViews:
     def __init__(self, request):
         self.request = request

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -32,7 +32,7 @@ class NewOrganizationSchema(PyramidRequestSchema):
     name = fields.Str(required=True, validate=validate.Length(min=1))
 
 
-@view_defaults(request_method="GET", permission=Permissions.STAFF)
+@view_defaults(request_method="GET", permission=Permissions.ADMIN)
 class AdminOrganizationViews:
     def __init__(self, request):
         self.request = request
@@ -44,6 +44,7 @@ class AdminOrganizationViews:
         route_name="admin.organizations",
         request_method="GET",
         renderer="lms:templates/admin/organization/search.html.jinja2",
+        permission=Permissions.STAFF,
     )
     def organizations(self):  # pragma: no cover
         return {}
@@ -77,6 +78,7 @@ class AdminOrganizationViews:
         route_name="admin.organization",
         request_method="GET",
         renderer="lms:templates/admin/organization/show.html.jinja2",
+        permission=Permissions.STAFF,
     )
     def show_organization(self):
         org_id = self.request.matchdict["id_"]
@@ -143,6 +145,7 @@ class AdminOrganizationViews:
         route_name="admin.organizations",
         request_method="POST",
         renderer="lms:templates/admin/organization/search.html.jinja2",
+        permission=Permissions.STAFF,
     )
     def search(self):
         if flash_validation(self.request, SearchOrganizationSchema):


### PR DESCRIPTION
**We need to add the right users to the prod environments before deploying this.**

## Testing

- Go to the admin pages, check that you can search for AI/Orgs and open them
- Try to write anything, you'll get "You don't have permission" alert.
- Get [this branch](https://github.com/hypothesis/devdata/pull/100) of devdata changes and apply them with 

`tox -e dev --run-command 'python bin/make_devdata -u file:///PATH_TO_DEV_DATA_CHECKOUT_WITH_THAT_BRANCH'`

(or just go ahead and merge that and run regular `make devdata`)

- Try again, you should be able to access the restricted paths.
