### PR TITLE
Replace deprecated  prop with

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.tsx
@@ -175,7 +175,7 @@ export default function BookSelector({
           <Input
             aria-label="VitalSource URL or ISBN"
             data-testid="vitalsource-input"
-            hasError={!!error}
+            feedback={error ? 'error' : undefined}
             elementRef={inputRef}
             name="vitalSourceURL"
             onChange={() => onUpdateURL(false /* confirmSelectedBook */)}

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -94,7 +94,7 @@ export default function URLPicker({
             aria-label="Enter URL to web page or PDF"
             classes="grow"
             defaultValue={defaultURL}
-            hasError={!!error}
+            feedback={error ? 'error' : undefined}
             elementRef={input}
             name="url"
             placeholder="e.g. https://example.com/article.pdf"


### PR DESCRIPTION
This removes the only remaining usages of deprecated frontend-shared symbols, in preparation for v7.0.0