### PR TITLE
Use a more concrete CSS selector for tab contents

### DIFF
--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -57,7 +57,7 @@
         </div>
         <div class="tabs-content">
             <ul>
-                <li class="is-active">
+                <li class="tab-panel is-active">
                     <form method="POST"
                           action="{{ request.route_url("admin.instance", id_=instance.id) }}">
                         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
@@ -106,7 +106,7 @@
                         </fieldset>
                     </form>
                 </li>
-                <li>
+                <li class="tab-panel">
                     <form method="POST"
                           action="{{ request.route_url("admin.instance.settings", id_=instance.id) }}">
                         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
@@ -167,7 +167,7 @@
                         </div>
                     </form>
                 </li>
-                <li>
+                <li class="tab-panel">
                     <fieldset class="box">
                         <legend id="roles" class="label has-text-centered">Role overrides</legend>
                         <div class="block has-text-right">
@@ -185,7 +185,7 @@
                         {% endif %}
                     </fieldset>
                 </li>
-                <li>
+                <li class="tab-panel">
                     <fieldset class="box has-background-danger-light">
                         <legend class="label has-text-centered has-text-danger">Danger zone</legend>
                         {% call macros.field_body(label="Downgrade to LTI 1.1") %}

--- a/lms/templates/admin/base.html.jinja2
+++ b/lms/templates/admin/base.html.jinja2
@@ -40,11 +40,11 @@
         <script src="https://cdn.jsdelivr.net/npm/@vizuaalog/bulmajs@0.12.2/dist/bulma.min.js"></script>
         <style>
             {# For tabs support, see: https://bulmajs.tomerbe.co.uk/docs/0.12/2-core-components/tabs/#}
-            .tabs-content li {
+            .tabs-content .tab-panel {
                 display: none;
                 list-style: none;
             }
-            .tabs-content li.is-active {
+            .tabs-content .tab-panel.is-active {
                 display: block;
             }
             .selectize-input {

--- a/lms/templates/admin/organization/show.html.jinja2
+++ b/lms/templates/admin/organization/show.html.jinja2
@@ -33,7 +33,7 @@
         </div>
         <div class="tabs-content">
             <ul>
-                <li class="is-active">
+                <li class="tab-panel is-active">
                     <legend class="label has-text-centered">Organization</legend>
                     <form method="POST"
                           action="{{ request.route_url("admin.organization", id_=org.id) }}">
@@ -76,7 +76,7 @@
                     </div>
                 </div>
             </li>
-            <li>
+            <li class="tab-panel">
                 <fieldset class="box">
                     <legend class="label has-text-centered">Usage report</legend>
                     <form method="POST"
@@ -90,7 +90,7 @@
                         </div>
                     </fieldset>
                 </li>
-                <li>
+                <li class="tab-panel">
                     <fieldset class="box has-background-danger-light">
                         <legend class="label has-text-centered has-text-danger">Danger zone</legend>
                         {% call macros.field_body("Enabled") %}


### PR DESCRIPTION
THe current rule was hidden the Hierarchy section of organizations as it uses <li> elements.

Add a new class to the tab's li elements and use that in the selector.



# Testing

- Go over http://localhost:8001/admin/org/1 and check that at least one link shows up in the hierarchy section at the bottom. 