### PR TITLE
Require admin privileges for the role pages

### DIFF
--- a/lms/views/admin/role.py
+++ b/lms/views/admin/role.py
@@ -7,7 +7,7 @@ from lms.services.application_instance import ApplicationInstanceService
 from lms.services.lti_role_service import LTIRoleService
 
 
-@view_defaults(permission=Permissions.STAFF)
+@view_defaults(permission=Permissions.ADMIN)
 class AdminRoleViews:
     def __init__(self, request):
         self.request = request


### PR DESCRIPTION
This are not generally interesting for the general staff role.