### PR TITLE
Add tolerant validation of page ranges in VitalSource picker

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useEffect, useState } from 'preact/hooks';
 import type { Book, TableOfContentsEntry } from '../api-types';
 import { useService, VitalSourceService } from '../services';
 import type { ContentRange, Selection } from '../services/vitalsource';
+import { isPageRangeValid } from '../utils/vitalsource';
 import BookSelector from './BookSelector';
 import ErrorDisplay from './ErrorDisplay';
 import TableOfContentsPicker from './TableOfContentsPicker';
@@ -164,7 +165,8 @@ export default function BookPicker({
 
   const validContentRange =
     contentRange?.type === 'toc' ||
-    (contentRange?.type === 'page' && contentRange.start && contentRange.end);
+    (contentRange?.type === 'page' &&
+      isPageRangeValid(contentRange.start ?? '', contentRange.end ?? ''));
 
   // Compute the page number that corresponds to the currently selected
   // table-of-contents entry. This cannot always be determined and can be

--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -184,6 +184,42 @@ describe('BookPicker', () => {
     assert.equal(tocPicker.prop('entries'), fakeBookData.chapters.book1);
   });
 
+  [
+    // nb. We don't test all cases here. See `isPageRangeValid` tests for more.
+    {
+      start: '',
+      end: '',
+      valid: false,
+    },
+    {
+      start: '10',
+      end: '',
+      valid: false,
+    },
+    {
+      start: '10',
+      end: '20',
+      valid: true,
+    },
+    {
+      start: '20',
+      end: '10',
+      valid: false,
+    },
+  ].forEach(({ start, end, valid }) => {
+    it('enables final submit button when a valid page range is selected', async () => {
+      const picker = renderBookPicker({ allowPageRangeSelection: true });
+      const buttonSelector = 'button[data-testid="select-button"]';
+
+      selectBook(picker);
+      clickSelectButton(picker);
+      await waitForTableOfContents(picker);
+      selectPageRange(picker, start, end);
+
+      assert.equal(picker.find(buttonSelector).props().disabled, !valid);
+    });
+  });
+
   [true, false].forEach(allowPageRangeSelection => {
     it('displays page range picker if feature enabled', () => {
       const picker = renderBookPicker({ allowPageRangeSelection });

--- a/lms/static/scripts/frontend_apps/utils/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/vitalsource-test.js
@@ -1,4 +1,4 @@
-import { extractBookID } from '../vitalsource';
+import { extractBookID, isPageRangeValid } from '../vitalsource';
 
 describe('extractBookID', () => {
   [
@@ -48,5 +48,37 @@ describe('extractBookID', () => {
     it(`should return null if no book ID found in string "${input}"`, () => {
       assert.isNull(extractBookID(input));
     });
+  });
+});
+
+describe('isPageRangeValid', () => {
+  it('returns false if `start` or `end` is empty', () => {
+    assert.isFalse(isPageRangeValid('12', ''));
+    assert.isFalse(isPageRangeValid('', '12'));
+  });
+
+  it('returns true if page range is not fully numeric', () => {
+    assert.isTrue(isPageRangeValid('i', 'iv'));
+    assert.isTrue(isPageRangeValid('400', 'A-1'));
+    assert.isTrue(isPageRangeValid('A-1', '400'));
+  });
+
+  it('returns true if page range is numeric and end >= start', () => {
+    assert.isTrue(isPageRangeValid('1', '10'));
+    assert.isTrue(isPageRangeValid('10', '10'));
+  });
+
+  it('returns false if page range is numeric and end < start', () => {
+    assert.isFalse(isPageRangeValid('10', '5'));
+    assert.isFalse(isPageRangeValid('100', '99'));
+  });
+
+  // We assume page numbers start from 1, though there is no doubt a programming
+  // book somewhere that uses 0-based numbering. I will wait until someone files
+  // an issue about it.
+  it('returns false if start page is <= 0', () => {
+    assert.isTrue(isPageRangeValid('1', '2'));
+    assert.isFalse(isPageRangeValid('0', '1'));
+    assert.isFalse(isPageRangeValid('-1', '0'));
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/vitalsource.ts
+++ b/lms/static/scripts/frontend_apps/utils/vitalsource.ts
@@ -32,3 +32,28 @@ export function extractBookID(input: string): string | null {
   }
   return null;
 }
+
+/**
+ * Report whether a page range is valid. A page range is considered valid if:
+ *
+ *  - The start and end are specified
+ *  - The start and end pages are numbers, and start >= end
+ *  - Either the start or end is not a number
+ *
+ * The last condition handles the cases where books have some page numbers that
+ * are not numeric (eg. roman numerals). In that case we don't try to compare
+ * them and just trust the user.
+ */
+export function isPageRangeValid(start: string, end: string): boolean {
+  if (!start || !end) {
+    return false;
+  }
+
+  const startInt = parseInt(start);
+  const endInt = parseInt(end);
+  if (isNaN(startInt) || isNaN(endInt)) {
+    return true;
+  }
+
+  return startInt >= 1 && endInt >= startInt;
+}


### PR DESCRIPTION
Validate that page ranges entered in the picker are valid, but in a tolerant way. We accept non-numeric page numbers, because books do use them for some pages, and don't check that the end page number is in-bounds, because we don't get the final page number from the API.