### PR TITLE
Require STAFF permission for the usage endpoint

### DIFF
--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -167,6 +167,7 @@ class AdminOrganizationViews:
     @view_config(
         route_name="admin.organization.usage",
         request_method="POST",
+        permission=Permissions.STAFF,
         renderer="lms:templates/admin/organization/usage.html.jinja2",
     )
     def usage(self):


### PR DESCRIPTION
This endpoint is the whole reason to add the new ADMIN permission. This one should be allowed for all STAFF members, not only admins.