### PR TITLE
Migrate unsubscribes to preferences

### DIFF
--- a/lms/migrations/versions/68f4e83eec70_copy_email_unsubscribe_to_user_.py
+++ b/lms/migrations/versions/68f4e83eec70_copy_email_unsubscribe_to_user_.py
@@ -1,0 +1,95 @@
+"""Copy email_unsubscribe to user_preferences.
+
+Revision ID: 68f4e83eec70
+Revises: 6d72ce7efdeb
+"""
+import logging
+
+from alembic import op
+from sqlalchemy import Column, Integer, Unicode, UniqueConstraint, select, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+revision = "68f4e83eec70"
+down_revision = "6d72ce7efdeb"
+
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+log = logging.getLogger(__name__)
+
+
+class EmailUnsubscribe(Base):
+    __tablename__ = "email_unsubscribe"
+    id = Column(Integer(), autoincrement=True, primary_key=True)
+    h_userid = Column(Unicode, nullable=False)
+
+
+class UserPreferences(Base):
+    __tablename__ = "user_preferences"
+    id = Column(Integer, autoincrement=True, primary_key=True)
+    h_userid = Column(Unicode, nullable=False, unique=True)
+    preferences = Column(
+        MutableDict.as_mutable(JSONB),
+        server_default=text("'{}'::jsonb"),
+        nullable=False,
+    )
+
+
+ALL_DAYS_FALSE = {
+    "instructor_email_digests.days.mon": False,
+    "instructor_email_digests.days.tue": False,
+    "instructor_email_digests.days.wed": False,
+    "instructor_email_digests.days.thu": False,
+    "instructor_email_digests.days.fri": False,
+    "instructor_email_digests.days.sat": False,
+    "instructor_email_digests.days.sun": False,
+}
+
+
+def upgrade() -> None:
+    session = Session(bind=op.get_bind())
+
+    unsubscribes = session.scalars(select(EmailUnsubscribe)).all()
+
+    log.info("Found %s unsubscribes", len(unsubscribes))
+
+    existing_preferences = session.scalars(
+        select(UserPreferences).where(
+            UserPreferences.h_userid.in_(
+                [unsubscribe.h_userid for unsubscribe in unsubscribes]
+            )
+        )
+    ).all()
+
+    log.info("Found %s existing user_preferences rows", len(existing_preferences))
+
+    updated = 0
+    created = 0
+
+    for unsubscribe in unsubscribes:
+        for preferences in existing_preferences:
+            if preferences.h_userid == unsubscribe.h_userid:
+                preferences.preferences.update(ALL_DAYS_FALSE)
+                updated += 1
+                break
+        else:
+            session.add(
+                UserPreferences(
+                    h_userid=unsubscribe.h_userid, preferences=ALL_DAYS_FALSE
+                )
+            )
+            created += 1
+
+    session.commit()
+
+    log.info(
+        "Updated %s rows and created %s rows in user_preferences", updated, created
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Shouldn't be merged before https://github.com/hypothesis/lms/pull/5871.

Testing
=======

Create two `email_unsubscribe` rows and a `user_preferences` row corresponding to one of the `email_unsubscribe` rows:

```sql
$ make sql
postgres=# insert into email_unsubscribe (h_userid,tag) values ('h_userid1', 'tag1');
postgres=# insert into email_unsubscribe (h_userid,tag) values ('h_userid2', 'tag2');
insert into user_preferences (h_userid,preferences) values ('h_userid2', '{"instructor_email_digests.days.mon": true}'::jsonb);
```

Now run the migration:

```terminal
$ make db args='upgrade +1'
INFO  [alembic.runtime.migration] Running upgrade 6d72ce7efdeb -> 68f4e83eec70, Copy email_unsubscribe to user_preferences.
INFO  [68f4e83eec70_copy_email_unsubscribe_to_user__py] Found 2 unsubscribes
INFO  [68f4e83eec70_copy_email_unsubscribe_to_user__py] Found 1 existing user_preferences rows
INFO  [68f4e83eec70_copy_email_unsubscribe_to_user__py] Updated 1 rows and created 1 rows in user_preferences
```

You should now see that both users are unsubscribed in the `user_preferences` table:

```sql
postgres=# select * from user_preferences;
-[ RECORD 1 ]---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id          | 20
h_userid    | h_userid2
preferences | {"instructor_email_digests.days.fri": false, "instructor_email_digests.days.mon": false, "instructor_email_digests.days.sat": false, "instructor_email_digests.days.sun": false, "instructor_email_digests.days.thu": false, "instructor_email_digests.days.tue": false, "instructor_email_digests.days.wed": false}
created     | 2023-11-28 15:28:06.898647
updated     | 2023-11-28 15:28:06.898647
-[ RECORD 2 ]---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id          | 21
h_userid    | h_userid1
preferences | {"instructor_email_digests.days.fri": false, "instructor_email_digests.days.mon": false, "instructor_email_digests.days.sat": false, "instructor_email_digests.days.sun": false, "instructor_email_digests.days.thu": false, "instructor_email_digests.days.tue": false, "instructor_email_digests.days.wed": false}
created     | 2023-11-28 15:28:18.280195
updated     | 2023-11-28 15:28:18.280195
```