### PR TITLE
Remove the `email_unsubscribe` table

### DIFF
--- a/lms/migrations/versions/522985f4fa6e_remove_the_email_unsubscribe_table.py
+++ b/lms/migrations/versions/522985f4fa6e_remove_the_email_unsubscribe_table.py
@@ -1,0 +1,18 @@
+"""Remove the email_unsubscribe table.
+
+Revision ID: 522985f4fa6e
+Revises: 68f4e83eec70
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "522985f4fa6e"
+down_revision = "68f4e83eec70"
+
+
+def upgrade() -> None:
+    op.drop_table("email_unsubscribe")
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/lms/pull/5895>.

This has now been replaced by the new `user_preferences` table.