### PR TITLE
s/Choose chapter/Choose a chapter

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -194,7 +194,7 @@ export default function BookPicker({
     (step === 'select-toc' && validContentRange);
 
   const pageRangeHeading = allowPageRangeSelection
-    ? 'Choose chapter or page range'
+    ? 'Choose a chapter or page range'
     : 'Pick where to start reading';
 
   return (


### PR DESCRIPTION
Ensure the heading reads as "Choose one chapter or a page range" instead of "Choose a range of chapters or pages".

See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1701195297687609?thread_ts=1701191809.129689&cid=C4K6M7P5E