### PR TITLE
Refactor grading service to explicitly update the  model's fields

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -205,8 +205,10 @@ class BasicLaunchViews:
                 # Create or update a record of LIS result data for a student launch
                 # We'll query these rows to populate the student drop down in the
                 # instructor toolbar
-                self.request.find_service(name="grading_info").upsert_from_request(
-                    self.request
+                self.request.find_service(name="grading_info").upsert(
+                    self.request.lti_user,
+                    self.request.lti_params.get("lis_result_sourcedid"),
+                    self.request.lti_params.get("lis_outcome_service_url"),
                 )
 
         # Set up the JS config for the front-end

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -33,7 +33,6 @@ class TestBasicLaunchViews:
     ):
         BasicLaunchViews(context, pyramid_request)
 
-        # `_record_course()`
         course_service.get_from_launch.assert_called_once_with(
             pyramid_request.product, pyramid_request.lti_params
         )
@@ -292,8 +291,10 @@ class TestBasicLaunchViews:
                     else None,
                 )
             else:
-                grading_info_service.upsert_from_request.assert_called_once_with(
-                    pyramid_request
+                grading_info_service.upsert.assert_called_once_with(
+                    pyramid_request.lti_user,
+                    pyramid_request.lti_params.get("lis_result_sourcedid"),
+                    pyramid_request.lti_params.get("lis_outcome_service_url"),
                 )
 
         assert result == {}


### PR DESCRIPTION
Motivated by https://github.com/hypothesis/lms/pull/5890, removing the guilty Schema completely in this PR.



## Testing

- Remove existing grading records: `docker compose exec postgres psql -U postgres -c "truncate lis_result_sourcedid"`

- Login in D2L as `aunltd.S1`
- Launch [Gradable assignment (5 points)
](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View)


- Check a new record is created

`docker compose exec postgres psql -U postgres -c "select lis_outcome_service_url, lis_result_sourcedid, h_username from lis_result_sourcedid"` 

```                                                                      lis_outcome_service_url                                                                       |           lis_result_sourcedid           |           h_username           
--------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------+--------------------------------
 https://aunltd.brightspacedemo.com/d2l/api/lti/ags/2.0/deployment/ec9e6e7c-69fc-4123-a32c-e8afe4868c38/orgunit/6782/lineitems/d7a249a3-b4a3-4804-86aa-cd111e976fc3 | 748fc7f5-7ad7-4f7a-8cbf-49b5bc19dfec_355 | fc0c4acac9dfab3f4b3fb29b0d4bdd
(1 row)
```

- Modify the row in the DB

```docker compose exec postgres psql -U postgres -c "select lis_outcome_service_url, lis_result_sourcedid, h_username from lis_result_sourcedid"```


- Launch [Gradable assignment (5 points)
](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View) again

-  Check the record has been updated


`docker compose exec postgres psql -U postgres -c "select lis_outcome_service_url, lis_result_sourcedid, h_username from lis_result_sourcedid"` 


```
                                                                      lis_outcome_service_url                                                                       |           lis_result_sourcedid           |           h_username           
--------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------+--------------------------------
 https://aunltd.brightspacedemo.com/d2l/api/lti/ags/2.0/deployment/ec9e6e7c-69fc-4123-a32c-e8afe4868c38/orgunit/6782/lineitems/d7a249a3-b4a3-4804-86aa-cd111e976fc3 | 748fc7f5-7ad7-4f7a-8cbf-49b5bc19dfec_355 | fc0c4acac9dfab3f4b3fb29b0d4bdd
(1 row)
```

