### PR TITLE
Attempt at fixing flaky test on AI search by name

### DIFF
--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
-from factory import Faker
+from factory import Faker, Sequence
 from freezegun import freeze_time
 from h_matchers import Any
 
@@ -351,6 +351,7 @@ class TestApplicationInstanceService:
                     lti_registration=registration,
                     tool_consumer_instance_guid=Faker("hexify", text="^" * 32),
                     deployment_id=Faker("hexify", text="^" * 8),
+                    name=Sequence(lambda n: f"Application Instance {n}"),
                 )
             )
 


### PR DESCRIPTION
We've seen failures in CI that hint at duplicate name values (created by default in the factory by `Faker("company")`

Try using a different strategy for the name in these test to see if that fixes the occasional failure.



https://github.com/hypothesis/lms/actions/runs/7058488361/job/19214171307
https://github.com/hypothesis/lms/actions/runs/7030081608/job/19128913472