### PR TITLE
Add `h_userid` to `task_done.data`

### DIFF
--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -73,6 +73,7 @@ class DigestService:
             task_done_key = f"instructor_email_digest::{context.user_info.h_userid}::{datetime.now(timezone.utc).strftime('%Y-%m-%d')}"
             task_done_data = {
                 "type": "instructor_email_digest",
+                "h_userid": context.user_info.h_userid,
                 "created_before": created_before.isoformat(),
             }
         else:

--- a/tests/unit/lms/services/digest_test.py
+++ b/tests/unit/lms/services/digest_test.py
@@ -66,6 +66,7 @@ class TestDigestService:
             task_done_key=f"instructor_email_digest::{context.user_info.h_userid}::2023-04-30",
             task_done_data={
                 "type": "instructor_email_digest",
+                "h_userid": context.user_info.h_userid,
                 "created_before": created_before.isoformat(),
             },
             template="lms:templates/email/instructor_email_digest/",


### PR DESCRIPTION
Oops, in https://github.com/hypothesis/lms/pull/5858 I forgot to include
the `h_userid` in the `task_done.data` column (`h_userid` is needed
because we're going to need to find the latest `task_done` for a given h
user, so we're going to need to filter the `task_done` table by
`h_userid`).
