### PR TITLE
Make email preferences load a client-side app

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -20,7 +20,6 @@ class JSConfig:
     class Mode(str, Enum):
         OAUTH2_REDIRECT_ERROR = "oauth2-redirect-error"
         BASIC_LTI_LAUNCH = "basic-lti-launch"
-        EMAIL_NOTIFICATIONS = "email-notifications"
         FILE_PICKER = "content-item-selection"
         ERROR_DIALOG = "error-dialog"
 

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -40,7 +40,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
               <FilePickerApp />
             </DataLoader>
           </Route>
-          <Route path="/app/email-notifications">
+          <Route path="/email/preferences">
             <EmailNotificationsApp />
           </Route>
           <Route path="/app/error-dialog">

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -55,7 +55,7 @@ export default function BasicLTILaunchApp() {
     // Content URL to show in the iframe.
     viaUrl: viaURL,
     canvas,
-  } = useConfig(['hypothesisClient']);
+  } = useConfig(['api', 'hypothesisClient']);
 
   const clientRPC = useService(ClientRPC);
 

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -91,7 +91,7 @@ export default function ContentSelector({
       },
       youtube: { enabled: youtubeEnabled },
     },
-  } = useConfig(['filePicker']);
+  } = useConfig(['api', 'filePicker']);
 
   // Map the existing content selection to a dialog type and value. We don't
   // open the corresponding dialog immediately, but do pre-fill the dialog

--- a/lms/static/scripts/frontend_apps/components/EmailNotificationsApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailNotificationsApp.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 
 import { useConfig } from '../config';
 import EmailNotificationsPreferences from './EmailNotificationsPreferences';
@@ -6,6 +6,8 @@ import EmailNotificationsPreferences from './EmailNotificationsPreferences';
 export default function EmailNotificationsApp() {
   const { emailNotifications } = useConfig(['emailNotifications']);
   const [selectedDays, setSelectedDays] = useState(emailNotifications);
+  const [saving, setSaving] = useState(false);
+  const onSave = useCallback(() => setSaving(true), []);
 
   return (
     <div className="h-full grid place-items-center">
@@ -15,6 +17,8 @@ export default function EmailNotificationsApp() {
           updateSelectedDays={newSelectedDays =>
             setSelectedDays(prev => ({ ...prev, ...newSelectedDays }))
           }
+          onSave={onSave}
+          saving={saving}
         />
       </div>
     </div>

--- a/lms/static/scripts/frontend_apps/components/EmailNotificationsPreferences.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailNotificationsPreferences.tsx
@@ -6,13 +6,13 @@ import { useCallback } from 'preact/hooks';
 import type { EmailNotificationsPreferences, WeekDay } from '../config';
 
 const dayNames: [WeekDay, string][] = [
-  ['instructor_email_digests.days.sun', 'Sunday'],
-  ['instructor_email_digests.days.mon', 'Monday'],
-  ['instructor_email_digests.days.tue', 'Tuesday'],
-  ['instructor_email_digests.days.wed', 'Wednesday'],
-  ['instructor_email_digests.days.thu', 'Thursday'],
-  ['instructor_email_digests.days.fri', 'Friday'],
-  ['instructor_email_digests.days.sat', 'Saturday'],
+  ['sun', 'Sunday'],
+  ['mon', 'Monday'],
+  ['tue', 'Tuesday'],
+  ['wed', 'Wednesday'],
+  ['thu', 'Thursday'],
+  ['fri', 'Friday'],
+  ['sat', 'Saturday'],
 ];
 
 export type EmailNotificationsPreferencesProps = {
@@ -31,13 +31,13 @@ export default function EmailNotificationsPreferences({
   const setAllTo = useCallback(
     (enabled: boolean) =>
       updateSelectedDays({
-        'instructor_email_digests.days.sun': enabled,
-        'instructor_email_digests.days.mon': enabled,
-        'instructor_email_digests.days.tue': enabled,
-        'instructor_email_digests.days.wed': enabled,
-        'instructor_email_digests.days.thu': enabled,
-        'instructor_email_digests.days.fri': enabled,
-        'instructor_email_digests.days.sat': enabled,
+        sun: enabled,
+        mon: enabled,
+        tue: enabled,
+        wed: enabled,
+        thu: enabled,
+        fri: enabled,
+        sat: enabled,
       }),
     [updateSelectedDays]
   );

--- a/lms/static/scripts/frontend_apps/components/EmailNotificationsPreferences.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailNotificationsPreferences.tsx
@@ -1,5 +1,5 @@
 import type { PanelProps } from '@hypothesis/frontend-shared';
-import { Button, Checkbox, Panel } from '@hypothesis/frontend-shared';
+import { Button, Callout, Checkbox, Panel } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback } from 'preact/hooks';
 
@@ -16,17 +16,40 @@ const dayNames: [WeekDay, string][] = [
 ];
 
 export type EmailNotificationsPreferencesProps = {
+  /** Currently selected days */
   selectedDays: EmailNotificationsPreferences;
+  /** Callback to fully or partially update currently selected days, without saving */
   updateSelectedDays: (
     newSelectedDays: Partial<EmailNotificationsPreferences>
   ) => void;
+
+  /** Callback invoked when saving currently selected days */
+  onSave: (submitEvent: Event) => void;
+  /** Indicates if a save operation is in progress */
+  saving?: boolean;
+  /**
+   * Represents the result of saving preferences, which can be error or success,
+   * and includes a message to display.
+   */
+  result?: {
+    status: 'success' | 'error';
+    message: string;
+  };
+
+  /**
+   * Callback used to handle closing the panel.
+   * If not provided, then the panel won't be considered closable.
+   */
   onClose?: PanelProps['onClose'];
 };
 
 export default function EmailNotificationsPreferences({
-  onClose,
   selectedDays,
   updateSelectedDays,
+  onSave,
+  saving = false,
+  result,
+  onClose,
 }: EmailNotificationsPreferencesProps) {
   const setAllTo = useCallback(
     (enabled: boolean) =>
@@ -45,62 +68,77 @@ export default function EmailNotificationsPreferences({
   const selectNone = useCallback(() => setAllTo(false), [setAllTo]);
 
   return (
-    <Panel
-      onClose={onClose}
-      title="Email Notifications"
-      buttons={<Button variant="primary">Save</Button>}
-    >
-      <p className="font-bold">
-        Receive email notifications when your students annotate.
-      </p>
-      <p className="font-bold">Select the days you{"'"}d like your emails:</p>
+    <form onSubmit={onSave} method="post">
+      <Panel
+        onClose={onClose}
+        title="Email Notifications"
+        buttons={
+          <Button
+            variant="primary"
+            type="submit"
+            disabled={saving}
+            data-testid="save-button"
+          >
+            Save
+          </Button>
+        }
+      >
+        <p className="font-bold">
+          Receive email notifications when your students annotate.
+        </p>
+        <p className="font-bold">Select the days you{"'"}d like your emails:</p>
 
-      <div className="flex justify-between px-4">
-        <div className="flex flex-col gap-1">
-          {dayNames.map(([day, name]) => (
-            <span
-              key={day}
-              className={classnames(
-                // The checked icon sets fill from the text color
-                'text-grey-6'
-              )}
-            >
-              <Checkbox
-                checked={selectedDays[day]}
-                onChange={() =>
-                  updateSelectedDays({ [day]: !selectedDays[day] })
-                }
-                data-testid={`${day}-checkbox`}
+        <div className="flex justify-between px-4">
+          <div className="flex flex-col gap-1">
+            {dayNames.map(([day, name]) => (
+              <span
+                key={day}
+                className={classnames(
+                  // The checked icon sets fill from the text color
+                  'text-grey-6'
+                )}
               >
-                <span
-                  className={classnames(
-                    // Override the color set for the checkbox fill
-                    'text-grey-9'
-                  )}
+                <Checkbox
+                  name={day}
+                  checked={selectedDays[day]}
+                  onChange={() =>
+                    updateSelectedDays({ [day]: !selectedDays[day] })
+                  }
+                  data-testid={`${day}-checkbox`}
                 >
-                  {name}
-                </span>
-              </Checkbox>
-            </span>
-          ))}
+                  <span
+                    className={classnames(
+                      // Override the color set for the checkbox fill
+                      'text-grey-9'
+                    )}
+                  >
+                    {name}
+                  </span>
+                </Checkbox>
+              </span>
+            ))}
+          </div>
+          <div className="flex items-start gap-2">
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={selectAll}
+              data-testid="select-all-button"
+            >
+              Select all
+            </Button>
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={selectNone}
+              data-testid="select-none-button"
+            >
+              Select none
+            </Button>
+          </div>
         </div>
-        <div className="flex items-start gap-2">
-          <Button
-            variant="secondary"
-            onClick={selectAll}
-            data-testid="select-all-button"
-          >
-            Select all
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={selectNone}
-            data-testid="select-none-button"
-          >
-            Select none
-          </Button>
-        </div>
-      </div>
-    </Panel>
+        {result && <Callout status={result.status}>{result.message}</Callout>}
+      </Panel>
+    </form>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -105,7 +105,7 @@ export async function loadFilePickerConfig(
     throw new Error('Assignment editing config missing');
   }
 
-  const authToken = config.api.authToken;
+  const authToken = config.api!.authToken;
   const { path, data } = config.editing.getConfig;
   const { assignment, filePicker } = await apiCall<Partial<ConfigObject>>({
     authToken,
@@ -166,7 +166,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     },
     assignment,
     filePicker: { deepLinkingAPI, formAction, formFields, promptForTitle },
-  } = useConfig(['filePicker']);
+  } = useConfig(['api', 'filePicker']);
 
   // Currently selected content for assignment.
   const [content, setContent] = useState<Content | null>(

--- a/lms/static/scripts/frontend_apps/components/GradingControls.tsx
+++ b/lms/static/scripts/frontend_apps/components/GradingControls.tsx
@@ -39,7 +39,7 @@ export default function GradingControls({
 }: GradingControlsProps) {
   const {
     api: { authToken, sync: syncAPICallInfo },
-  } = useConfig();
+  } = useConfig(['api']);
 
   const clientRPC = useService(ClientRPC);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -153,7 +153,7 @@ export default function GroupConfigSelector({
     product: {
       api: { listGroupSets: listGroupSetsAPI },
     },
-  } = useConfig();
+  } = useConfig(['api']);
 
   const useGroupSet = groupConfig.useGroupSet;
   const groupSet = useGroupSet ? groupConfig.groupSet : null;

--- a/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
@@ -70,6 +70,7 @@ describe('AppRoot', () => {
     {
       config: { mode: 'email-notifications' },
       appComponent: 'EmailNotificationsApp',
+      route: '/email/preferences',
     },
     {
       config: { mode: 'error-dialog' },
@@ -79,9 +80,9 @@ describe('AppRoot', () => {
       config: { mode: 'oauth2-redirect-error' },
       appComponent: 'OAuth2RedirectErrorApp',
     },
-  ].forEach(({ config, appComponent }) => {
+  ].forEach(({ config, appComponent, route }) => {
     it('launches correct app for "mode" config', () => {
-      navigateTo(`/app/${config.mode}`);
+      navigateTo(route ?? `/app/${config.mode}`);
       const wrapper = renderAppRoot({ config, services: new Map() });
       assert.isTrue(wrapper.exists(appComponent));
     });

--- a/lms/static/scripts/frontend_apps/components/test/EmailNotificationsApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/EmailNotificationsApp-test.js
@@ -5,13 +5,13 @@ import EmailNotificationsApp from '../EmailNotificationsApp';
 
 describe('EmailNotificationsApp', () => {
   const emailNotificationsConfig = {
-    'instructor_email_digests.days.mon': true,
-    'instructor_email_digests.days.tue': true,
-    'instructor_email_digests.days.wed': false,
-    'instructor_email_digests.days.thu': false,
-    'instructor_email_digests.days.fri': true,
-    'instructor_email_digests.days.sat': false,
-    'instructor_email_digests.days.sun': true,
+    mon: true,
+    tue: true,
+    wed: false,
+    thu: false,
+    fri: true,
+    sat: false,
+    sun: true,
   };
 
   function createComponent() {
@@ -36,8 +36,8 @@ describe('EmailNotificationsApp', () => {
   it('allows selected days to be updated', () => {
     const wrapper = createComponent();
     const newSelectedDays = {
-      'instructor_email_digests.days.mon': false,
-      'instructor_email_digests.days.wed': true,
+      mon: false,
+      wed: true,
     };
 
     wrapper

--- a/lms/static/scripts/frontend_apps/components/test/EmailNotificationsApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/EmailNotificationsApp-test.js
@@ -1,7 +1,8 @@
+import { mockImportedComponents } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
-import EmailNotificationsApp from '../EmailNotificationsApp';
+import EmailNotificationsApp, { $imports } from '../EmailNotificationsApp';
 
 describe('EmailNotificationsApp', () => {
   const emailNotificationsConfig = {
@@ -13,6 +14,14 @@ describe('EmailNotificationsApp', () => {
     sat: false,
     sun: true,
   };
+
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
 
   function createComponent() {
     return mount(
@@ -53,5 +62,14 @@ describe('EmailNotificationsApp', () => {
         ...newSelectedDays,
       }
     );
+  });
+
+  it('when preferences are saved it sets saving to true', () => {
+    const wrapper = createComponent();
+
+    wrapper.find('EmailNotificationsPreferences').props().onSave();
+    wrapper.update();
+
+    assert.isTrue(wrapper.find('EmailNotificationsPreferences').prop('saving'));
   });
 });

--- a/lms/static/scripts/frontend_apps/components/test/EmailNotificationsPreferences-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/EmailNotificationsPreferences-test.js
@@ -5,13 +5,13 @@ import EmailNotificationsPreferences from '../EmailNotificationsPreferences';
 describe('EmailNotificationsPreferences', () => {
   let fakeUpdateSelectedDays;
   const initialSelectedDays = {
-    'instructor_email_digests.days.sun': true,
-    'instructor_email_digests.days.mon': true,
-    'instructor_email_digests.days.tue': false,
-    'instructor_email_digests.days.wed': true,
-    'instructor_email_digests.days.thu': false,
-    'instructor_email_digests.days.fri': false,
-    'instructor_email_digests.days.sat': true,
+    sun: true,
+    mon: true,
+    tue: false,
+    wed: true,
+    thu: false,
+    fri: false,
+    sat: true,
   };
 
   beforeEach(() => {
@@ -28,9 +28,7 @@ describe('EmailNotificationsPreferences', () => {
   }
 
   function getCheckbox(wrapper, day) {
-    return wrapper.find(
-      `Checkbox[data-testid="instructor_email_digests.days.${day}-checkbox"]`
-    );
+    return wrapper.find(`Checkbox[data-testid="${day}-checkbox"]`);
   }
 
   it('initially selects appropriate checkboxes', () => {
@@ -51,13 +49,13 @@ describe('EmailNotificationsPreferences', () => {
     wrapper.find('button[data-testid="select-all-button"]').simulate('click');
 
     assert.calledWith(fakeUpdateSelectedDays, {
-      'instructor_email_digests.days.sun': true,
-      'instructor_email_digests.days.mon': true,
-      'instructor_email_digests.days.tue': true,
-      'instructor_email_digests.days.wed': true,
-      'instructor_email_digests.days.thu': true,
-      'instructor_email_digests.days.fri': true,
-      'instructor_email_digests.days.sat': true,
+      sun: true,
+      mon: true,
+      tue: true,
+      wed: true,
+      thu: true,
+      fri: true,
+      sat: true,
     });
   });
 
@@ -67,25 +65,24 @@ describe('EmailNotificationsPreferences', () => {
     wrapper.find('button[data-testid="select-none-button"]').simulate('click');
 
     assert.calledWith(fakeUpdateSelectedDays, {
-      'instructor_email_digests.days.sun': false,
-      'instructor_email_digests.days.mon': false,
-      'instructor_email_digests.days.tue': false,
-      'instructor_email_digests.days.wed': false,
-      'instructor_email_digests.days.thu': false,
-      'instructor_email_digests.days.fri': false,
-      'instructor_email_digests.days.sat': false,
+      sun: false,
+      mon: false,
+      tue: false,
+      wed: false,
+      thu: false,
+      fri: false,
+      sat: false,
     });
   });
 
   ['sun', 'mon', 'thu'].forEach(day => {
     it('lets individual days be changed', () => {
       const wrapper = createComponent();
-      const dayKey = `instructor_email_digests.days.${day}`;
 
       getCheckbox(wrapper, day).props().onChange();
 
       assert.calledWith(fakeUpdateSelectedDays, {
-        [dayKey]: !initialSelectedDays[dayKey],
+        [day]: !initialSelectedDays[day],
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/components/test/EmailNotificationsPreferences-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/EmailNotificationsPreferences-test.js
@@ -18,11 +18,12 @@ describe('EmailNotificationsPreferences', () => {
     fakeUpdateSelectedDays = sinon.stub();
   });
 
-  function createComponent() {
+  function createComponent(props = {}) {
     return mount(
       <EmailNotificationsPreferences
         selectedDays={initialSelectedDays}
         updateSelectedDays={fakeUpdateSelectedDays}
+        {...props}
       />
     );
   }
@@ -85,5 +86,34 @@ describe('EmailNotificationsPreferences', () => {
         [day]: !initialSelectedDays[day],
       });
     });
+  });
+
+  [
+    { message: 'Error', status: 'error' },
+    { message: 'Success', status: 'success' },
+    undefined,
+  ].forEach(result => {
+    it('displays error message if provided', () => {
+      const wrapper = createComponent({ result });
+      assert.equal(wrapper.exists('Callout'), !!result);
+    });
+  });
+
+  [true, false].forEach(saving => {
+    it('disables save button while saving', () => {
+      const wrapper = createComponent({ saving });
+      const button = wrapper.find('Button[data-testid="save-button"]');
+
+      assert.equal(button.prop('disabled'), saving);
+    });
+  });
+
+  it('saves preferences', () => {
+    const onSave = sinon.stub();
+    const wrapper = createComponent({ onSave });
+
+    wrapper.find('form').simulate('submit');
+
+    assert.called(onSave);
   });
 });

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -221,14 +221,7 @@ export type Product = {
   api: ProductAPI;
 };
 
-export type WeekDay =
-  | 'instructor_email_digests.days.mon'
-  | 'instructor_email_digests.days.tue'
-  | 'instructor_email_digests.days.wed'
-  | 'instructor_email_digests.days.thu'
-  | 'instructor_email_digests.days.fri'
-  | 'instructor_email_digests.days.sat'
-  | 'instructor_email_digests.days.sun';
+export type WeekDay = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
 
 export type EmailNotificationsPreferences = Record<WeekDay, boolean>;
 
@@ -243,7 +236,9 @@ export type EmailNotificationsPreferences = Record<WeekDay, boolean>;
 export type ConfigObject = {
   // Configuration present in all modes.
   mode: AppMode;
-  api: {
+
+  // Present in most modes.
+  api?: {
     authToken: string;
 
     // Only present in "basic-lti-launch" mode.

--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -14,6 +14,13 @@ import {
 } from './services';
 import type { ServiceMap } from './services';
 
+/**
+ * Converts an app mode into its corresponding URL.
+ *
+ * For historical reasons, some resolve the mode itself prefixed with `/app/`,
+ * but that is not ideal, and should be avoided, because the BE is not aware of
+ * those routes and reloading the page results in a 404.
+ */
 function routeForAppMode(mode: AppMode): string {
   if (mode === 'email-notifications') {
     // For the email-notifications mode, since this app is not designed to be

--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -4,6 +4,7 @@ import { render } from 'preact';
 import 'preact/debug';
 
 import AppRoot from './components/AppRoot';
+import type { AppMode } from './config';
 import { readConfig } from './config';
 import {
   ClientRPC,
@@ -12,6 +13,17 @@ import {
   VitalSourceService,
 } from './services';
 import type { ServiceMap } from './services';
+
+function routeForAppMode(mode: AppMode): string {
+  if (mode === 'email-notifications') {
+    // For the email-notifications mode, since this app is not designed to be
+    // opened in an iframe, but as the main window frame, we want to use a route
+    // that matches the server-side one.
+    return '/email/preferences';
+  }
+
+  return `/app/${mode}`;
+}
 
 export function init() {
   // Read configuration embedded into page by backend.
@@ -39,12 +51,14 @@ export function init() {
   // Construct services used by the file picker app. We need this both for
   // direct launches into this app, and for transitions from viewing to
   // editing assignments.
-  services.set(
-    VitalSourceService,
-    new VitalSourceService({ authToken: config.api.authToken })
-  );
+  if (config.api?.authToken) {
+    services.set(
+      VitalSourceService,
+      new VitalSourceService({ authToken: config.api.authToken })
+    );
+  }
 
-  if (config.rpcServer && config.hypothesisClient) {
+  if (config.api && config.rpcServer && config.hypothesisClient) {
     const { authToken } = config.api;
     const clientRPC = new ClientRPC({
       authToken,
@@ -68,7 +82,7 @@ export function init() {
   }
 
   // Set route based on app mode.
-  const routePath = `/app/${config.mode}`;
+  const routePath = routeForAppMode(config.mode);
   if (location.pathname !== routePath) {
     history.replaceState({}, 'unused', routePath);
   }

--- a/lms/static/scripts/frontend_apps/test/index-test.js
+++ b/lms/static/scripts/frontend_apps/test/index-test.js
@@ -50,16 +50,20 @@ describe('LMS frontend entry', () => {
     $imports.$restore();
   });
 
-  it('renders root component', () => {
-    init();
+  ['basic-lti-launch', 'email-notifications'].forEach(mode => {
+    it('renders root component', () => {
+      fakeReadConfig.returns({ ...minimalConfig, mode });
 
-    const container = document.querySelector('#app');
-    assert.ok(container.querySelector('[data-testid=app-root]'));
+      init();
 
-    assert.called(AppRoot);
-    const props = AppRoot.args[0][0];
-    assert.equal(props.initialConfig, fakeReadConfig());
-    assert.instanceOf(props.services, Map);
+      const container = document.querySelector('#app');
+      assert.ok(container.querySelector('[data-testid=app-root]'));
+
+      assert.called(AppRoot);
+      const props = AppRoot.args[0][0];
+      assert.equal(props.initialConfig, fakeReadConfig());
+      assert.instanceOf(props.services, Map);
+    });
   });
 
   it('console logs debug values', () => {

--- a/lms/static/scripts/frontend_apps/test/index-test.js
+++ b/lms/static/scripts/frontend_apps/test/index-test.js
@@ -10,6 +10,7 @@ const minimalConfig = {
     allowedOrigins: ['https://example.com'],
   },
   mode: 'basic-lti-launch',
+  emailNotifications: {},
 };
 
 describe('LMS frontend entry', () => {

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -173,7 +173,7 @@ export function useAPIFetch<T = unknown>(
 ): FetchResult<T> {
   const {
     api: { authToken },
-  } = useConfig();
+  } = useConfig(['api']);
 
   const fetcher: Fetcher<T> | undefined = path
     ? signal =>

--- a/lms/templates/email/preferences.html.jinja2
+++ b/lms/templates/email/preferences.html.jinja2
@@ -1,23 +1,20 @@
-{% extends 'templates/base.plain.html.jinja2' %}
+{% extends "lms:templates/base.html.jinja2" %}
 
 {% block content %}
-{% for message in request.session.pop_flash() %}
-  <p><b>{{ message }}</b></p>
-{% endfor %}
+    <div style="width: 100%; height: 100%;" id="app"></div>
+{% endblock %}
 
-<form action="" method="post">
-  <fieldset>
-    <legend>Receive email notifications when your students annotate. Select
-    the days you'd like your emails:</legend>
+{% block styles %}
+    {% for url in  asset_urls("frontend_apps_css") %}
+        <link rel="stylesheet" href="{{ url }}">
+    {% endfor %}
+{% endblock %}
 
-    <ul style="list-style-type:none;">
-      {% for key, value in preferences.items() %}
-        <li><input type="checkbox" id="{{ key }}" name="{{ key }}" {% if value %}checked{% endif %} />
-        <label for="{{ key }}">{{ key }}</label></li>
-      {% endfor %}
-    </ul>
-  </fieldset>
-
-  <button type="submit">Save</button>
-</form>
+{% block scripts %}
+    {# Not calling super() here, as the parent template tries to build the js-config using the JSConfig class, which is
+       not available here. #}
+    <script type="application/json" class="js-config">{{ jsConfig|tojson }}</script>
+    {% for url in asset_urls("frontend_apps_js") %}
+        <script type="module" src="{{ url }}"></script>
+    {% endfor %}
 {% endblock %}

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -77,9 +77,12 @@ class EmailPreferencesViews:
     )
     def preferences(self):
         return {
-            "preferences": self.email_preferences_service.get_preferences(
-                self.request.authenticated_userid
-            ).days(),
+            "jsConfig": {
+                "mode": "email-notifications",
+                "emailNotifications": self.email_preferences_service.get_preferences(
+                    self.request.authenticated_userid
+                ).days(),
+            }
         }
 
     @view_config(

--- a/tests/unit/lms/views/email_test.py
+++ b/tests/unit/lms/views/email_test.py
@@ -57,7 +57,10 @@ class TestEmailPreferencesViews:
             pyramid_request.authenticated_userid
         )
         assert result == {
-            "preferences": email_preferences_service.get_preferences.return_value.days.return_value
+            "jsConfig": {
+                "mode": "email-notifications",
+                "emailNotifications": email_preferences_service.get_preferences.return_value.days.return_value,
+            }
         }
 
     def test_set_preferences(self, views, email_preferences_service, pyramid_request):


### PR DESCRIPTION
> This PR is effectively the same as https://github.com/hypothesis/lms/pull/5900, which was accidentally closed.

Part of https://github.com/hypothesis/lms/issues/5812

This PR updates the server template so that it injects client-side config for the email preferences app to load, as we do with the file picker, assignment launch, etc.

~The logic to save preferences is not implemented here, but in https://github.com/hypothesis/lms/pull/5902~ EDIT.: Both PRs are now merged together here.

### Testing steps

1. Check out this branch
2. Run `make shell`. Once in, run `request.find_service(s.EmailPreferencesService).preferences_url("9ea84c4bcfd9329b4495f5b27d8cb6@lms.hypothes.is", "")`.
  It should generate a URL.
3. Visit that URL. You should now see the client-side preact app, but the proper checkboxes should be selected.
4. Try changing some values and saving. It should reload the page and save the values.
5. Reloading the page should be possible, as the URLs handled by the client and the server match.