### PR TITLE
Rename email-notifications app mode to email-preferences

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -7,7 +7,7 @@ import type { ServiceMap } from '../services';
 import { Services } from '../services';
 import BasicLTILaunchApp from './BasicLTILaunchApp';
 import DataLoader from './DataLoader';
-import EmailNotificationsApp from './EmailNotificationsApp';
+import EmailPreferencesApp from './EmailPreferencesApp';
 import ErrorDialogApp from './ErrorDialogApp';
 import FilePickerApp, { loadFilePickerConfig } from './FilePickerApp';
 import OAuth2RedirectErrorApp from './OAuth2RedirectErrorApp';
@@ -41,7 +41,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
             </DataLoader>
           </Route>
           <Route path="/email/preferences">
-            <EmailNotificationsApp />
+            <EmailPreferencesApp />
           </Route>
           <Route path="/app/error-dialog">
             <ErrorDialogApp />

--- a/lms/static/scripts/frontend_apps/components/EmailPreferences.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailPreferences.tsx
@@ -3,7 +3,7 @@ import { Button, Callout, Checkbox, Panel } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback } from 'preact/hooks';
 
-import type { EmailNotificationsPreferences, WeekDay } from '../config';
+import type { EmailPreferences as SelectedDays, WeekDay } from '../config';
 
 const dayNames: [WeekDay, string][] = [
   ['sun', 'Sunday'],
@@ -15,13 +15,11 @@ const dayNames: [WeekDay, string][] = [
   ['sat', 'Saturday'],
 ];
 
-export type EmailNotificationsPreferencesProps = {
+export type EmailPreferencesProps = {
   /** Currently selected days */
-  selectedDays: EmailNotificationsPreferences;
+  selectedDays: SelectedDays;
   /** Callback to fully or partially update currently selected days, without saving */
-  updateSelectedDays: (
-    newSelectedDays: Partial<EmailNotificationsPreferences>
-  ) => void;
+  updateSelectedDays: (newSelectedDays: Partial<SelectedDays>) => void;
 
   /** Callback invoked when saving currently selected days */
   onSave: (submitEvent: Event) => void;
@@ -43,14 +41,14 @@ export type EmailNotificationsPreferencesProps = {
   onClose?: PanelProps['onClose'];
 };
 
-export default function EmailNotificationsPreferences({
+export default function EmailPreferences({
   selectedDays,
   updateSelectedDays,
   onSave,
   saving = false,
   result,
   onClose,
-}: EmailNotificationsPreferencesProps) {
+}: EmailPreferencesProps) {
   const setAllTo = useCallback(
     (enabled: boolean) =>
       updateSelectedDays({

--- a/lms/static/scripts/frontend_apps/components/EmailPreferencesApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailPreferencesApp.tsx
@@ -1,18 +1,18 @@
 import { useCallback, useState } from 'preact/hooks';
 
 import { useConfig } from '../config';
-import EmailNotificationsPreferences from './EmailNotificationsPreferences';
+import EmailPreferences from './EmailPreferences';
 
-export default function EmailNotificationsApp() {
-  const { emailNotifications } = useConfig(['emailNotifications']);
-  const [selectedDays, setSelectedDays] = useState(emailNotifications);
+export default function EmailPreferencesApp() {
+  const { emailPreferences } = useConfig(['emailPreferences']);
+  const [selectedDays, setSelectedDays] = useState(emailPreferences);
   const [saving, setSaving] = useState(false);
   const onSave = useCallback(() => setSaving(true), []);
 
   return (
     <div className="h-full grid place-items-center">
       <div className="w-96">
-        <EmailNotificationsPreferences
+        <EmailPreferences
           selectedDays={selectedDays}
           updateSelectedDays={newSelectedDays =>
             setSelectedDays(prev => ({ ...prev, ...newSelectedDays }))

--- a/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
@@ -68,8 +68,8 @@ describe('AppRoot', () => {
       appComponent: 'FilePickerApp',
     },
     {
-      config: { mode: 'email-notifications' },
-      appComponent: 'EmailNotificationsApp',
+      config: { mode: 'email-preferences' },
+      appComponent: 'EmailPreferencesApp',
       route: '/email/preferences',
     },
     {

--- a/lms/static/scripts/frontend_apps/components/test/EmailPreferences-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/EmailPreferences-test.js
@@ -1,8 +1,8 @@
 import { mount } from 'enzyme';
 
-import EmailNotificationsPreferences from '../EmailNotificationsPreferences';
+import EmailPreferences from '../EmailPreferences';
 
-describe('EmailNotificationsPreferences', () => {
+describe('EmailPreferences', () => {
   let fakeUpdateSelectedDays;
   const initialSelectedDays = {
     sun: true,
@@ -20,7 +20,7 @@ describe('EmailNotificationsPreferences', () => {
 
   function createComponent(props = {}) {
     return mount(
-      <EmailNotificationsPreferences
+      <EmailPreferences
         selectedDays={initialSelectedDays}
         updateSelectedDays={fakeUpdateSelectedDays}
         {...props}

--- a/lms/static/scripts/frontend_apps/components/test/EmailPreferencesApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/EmailPreferencesApp-test.js
@@ -2,10 +2,10 @@ import { mockImportedComponents } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
 
 import { Config } from '../../config';
-import EmailNotificationsApp, { $imports } from '../EmailNotificationsApp';
+import EmailPreferencesApp, { $imports } from '../EmailPreferencesApp';
 
-describe('EmailNotificationsApp', () => {
-  const emailNotificationsConfig = {
+describe('EmailPreferencesApp', () => {
+  const emailPreferences = {
     mon: true,
     tue: true,
     wed: false,
@@ -25,21 +25,18 @@ describe('EmailNotificationsApp', () => {
 
   function createComponent() {
     return mount(
-      <Config.Provider value={{ emailNotifications: emailNotificationsConfig }}>
-        <EmailNotificationsApp />
+      <Config.Provider value={{ emailPreferences }}>
+        <EmailPreferencesApp />
       </Config.Provider>
     );
   }
 
   it('loads preferences from config', () => {
     const wrapper = createComponent();
-    const preferencesComponent = wrapper.find('EmailNotificationsPreferences');
+    const preferencesComponent = wrapper.find('EmailPreferences');
 
     assert.isTrue(preferencesComponent.exists());
-    assert.equal(
-      preferencesComponent.prop('selectedDays'),
-      emailNotificationsConfig
-    );
+    assert.equal(preferencesComponent.prop('selectedDays'), emailPreferences);
   });
 
   it('allows selected days to be updated', () => {
@@ -50,26 +47,23 @@ describe('EmailNotificationsApp', () => {
     };
 
     wrapper
-      .find('EmailNotificationsPreferences')
+      .find('EmailPreferences')
       .props()
       .updateSelectedDays(newSelectedDays);
     wrapper.update();
 
-    assert.deepEqual(
-      wrapper.find('EmailNotificationsPreferences').prop('selectedDays'),
-      {
-        ...emailNotificationsConfig,
-        ...newSelectedDays,
-      }
-    );
+    assert.deepEqual(wrapper.find('EmailPreferences').prop('selectedDays'), {
+      ...emailPreferences,
+      ...newSelectedDays,
+    });
   });
 
   it('when preferences are saved it sets saving to true', () => {
     const wrapper = createComponent();
 
-    wrapper.find('EmailNotificationsPreferences').props().onSave();
+    wrapper.find('EmailPreferences').props().onSave();
     wrapper.update();
 
-    assert.isTrue(wrapper.find('EmailNotificationsPreferences').prop('saving'));
+    assert.isTrue(wrapper.find('EmailPreferences').prop('saving'));
   });
 });

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -29,7 +29,7 @@ export type APICallInfo = {
 export type AppMode =
   | 'basic-lti-launch'
   | 'content-item-selection'
-  | 'email-notifications'
+  | 'email-preferences'
   | 'error-dialog'
   | 'oauth2-redirect-error';
 
@@ -223,7 +223,7 @@ export type Product = {
 
 export type WeekDay = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
 
-export type EmailNotificationsPreferences = Record<WeekDay, boolean>;
+export type EmailPreferences = Record<WeekDay, boolean>;
 
 /**
  * Data/configuration needed for frontend applications in the LMS app.
@@ -277,8 +277,8 @@ export type ConfigObject = {
   // Only present in "oauth2-redirect-error" mode.
   OAuth2RedirectError?: OAuthErrorConfig;
 
-  // Only present in "email-notifications" mode.
-  emailNotifications?: EmailNotificationsPreferences;
+  // Only present in "email-preferences" mode.
+  emailPreferences?: EmailPreferences;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -22,8 +22,8 @@ import type { ServiceMap } from './services';
  * those routes and reloading the page results in a 404.
  */
 function routeForAppMode(mode: AppMode): string {
-  if (mode === 'email-notifications') {
-    // For the email-notifications mode, since this app is not designed to be
+  if (mode === 'email-preferences') {
+    // For the email-preferences mode, since this app is not designed to be
     // opened in an iframe, but as the main window frame, we want to use a route
     // that matches the server-side one.
     return '/email/preferences';

--- a/lms/static/scripts/frontend_apps/test/index-test.js
+++ b/lms/static/scripts/frontend_apps/test/index-test.js
@@ -10,7 +10,7 @@ const minimalConfig = {
     allowedOrigins: ['https://example.com'],
   },
   mode: 'basic-lti-launch',
-  emailNotifications: {},
+  emailPreferences: {},
 };
 
 describe('LMS frontend entry', () => {
@@ -51,7 +51,7 @@ describe('LMS frontend entry', () => {
     $imports.$restore();
   });
 
-  ['basic-lti-launch', 'email-notifications'].forEach(mode => {
+  ['basic-lti-launch', 'email-preferences'].forEach(mode => {
     it('renders root component', () => {
       fakeReadConfig.returns({ ...minimalConfig, mode });
 

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -78,8 +78,8 @@ class EmailPreferencesViews:
     def preferences(self):
         return {
             "jsConfig": {
-                "mode": "email-notifications",
-                "emailNotifications": self.email_preferences_service.get_preferences(
+                "mode": "email-preferences",
+                "emailPreferences": self.email_preferences_service.get_preferences(
                     self.request.authenticated_userid
                 ).days(),
             }

--- a/tests/unit/lms/views/email_test.py
+++ b/tests/unit/lms/views/email_test.py
@@ -56,8 +56,8 @@ class TestEmailPreferencesViews:
         )
         assert result == {
             "jsConfig": {
-                "mode": "email-notifications",
-                "emailNotifications": email_preferences_service.get_preferences.return_value.days.return_value,
+                "mode": "email-preferences",
+                "emailPreferences": email_preferences_service.get_preferences.return_value.days.return_value,
             }
         }
 


### PR DESCRIPTION
This PR renames the `email-notifications` app mode to `email-preferences`, since the client-side URL used for it is now matching the server-side one, which is `/email/preferences`, and that way it is more consistent.

Additionally, also the config option and the components have been renamed to align with the "Email preferences" semantics.