### PR TITLE
Style email preferences app layout

### DIFF
--- a/lms/static/scripts/frontend_apps/components/EmailPreferencesApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/EmailPreferencesApp.tsx
@@ -1,3 +1,5 @@
+import { InfoIcon, Link } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 import { useCallback, useState } from 'preact/hooks';
 
 import { useConfig } from '../config';
@@ -10,16 +12,41 @@ export default function EmailPreferencesApp() {
   const onSave = useCallback(() => setSaving(true), []);
 
   return (
-    <div className="h-full grid place-items-center">
-      <div className="w-96">
-        <EmailPreferences
-          selectedDays={selectedDays}
-          updateSelectedDays={newSelectedDays =>
-            setSelectedDays(prev => ({ ...prev, ...newSelectedDays }))
-          }
-          onSave={onSave}
-          saving={saving}
+    <div className="min-h-full bg-grey-2">
+      <div
+        className={classnames(
+          'flex justify-center p-3 w-full',
+          'bg-white border-b shadow'
+        )}
+      >
+        <img
+          alt="Hypothesis logo"
+          src="/static/images/email_header.png"
+          className="h-10"
         />
+      </div>
+      <div className="flex flex-col gap-y-4 py-8">
+        <div className="max-w-[450px] mx-auto">
+          <EmailPreferences
+            selectedDays={selectedDays}
+            updateSelectedDays={newSelectedDays =>
+              setSelectedDays(prev => ({ ...prev, ...newSelectedDays }))
+            }
+            onSave={onSave}
+            saving={saving}
+          />
+        </div>
+        <p className="text-center text-grey-8">
+          <InfoIcon className="inline" /> Do you need help? Visit our{' '}
+          <Link
+            variant="custom"
+            underline="always"
+            href="https://web.hypothes.is/help/"
+          >
+            help center
+          </Link>
+          .
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/5812

This PR adds preliminary styles to the email preferences app, as designed in https://www.figma.com/file/CDcGyBlGdi1oEuYXCeHW3Z/Hypothesis---Email-Digest-Preferences?type=design&mode=design

![image](https://github.com/hypothesis/lms/assets/2719332/ed5b68ea-d5b6-4b68-9eac-6c98721fccdf)

There's still some ongoing conversations around the design, so this might not be the final one, but it's a clear improvement over what we have now.

### Considerations / to be discussed

- I haven't found any other example of images set in FE components, other than dynamic images coming from API calls.
  For simplicity I have hardcoded the path for the logo one, and I have used the same logo we use on emails.
- The logo image is pretty big. We may want to use a smaller variation.
- I have added links to help topics and support, as we show those in the sidebar no matter the context, so I guess they would still apply here.
- The link to create a ticket in the sidebar includes a bunch of tracking parameters that I haven't added yet for simplicity. We may want to revisit this.

### Testing steps

1. Check out this branch.
2. Run `make shell` and then execute `request.find_service(s.EmailPreferencesService).preferences_url("9ea84c4bcfd9329b4495f5b27d8cb6@lms.hypothes.is", "")`
3. Visit the URL generated in previous step to observe the new layout.