### PR TITLE
Add client-side routing for admin/orgs tabs

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -160,11 +160,14 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "admin.role.override.new", "/admin/instance/{id_}/role/overrides/new"
     )
-    config.add_route("admin.organization.usage", "/admin/org/{id_}/usage")
     config.add_route("admin.role.override", "/admin/role/overrides/{id_}")
     config.add_route("admin.role.override.delete", "/admin/role/overrides/{id_}/delete")
 
     config.add_route("admin.organization", "/admin/org/{id_}")
+    config.add_route(
+        "admin.organization.section",
+        "/admin/org/{id_}/{section:info|usage|danger}",
+    )
     config.add_route("admin.organization.toggle", "/admin/org/{id_}/toggle")
     config.add_route("admin.organizations", "/admin/orgs")
     config.add_route("admin.organization.move_org", "/admin/org/{id_}/move_org")

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -214,3 +214,7 @@
         </div>
     </div>
 {% endblock %}
+
+{% block extra_scripts %}
+    {{ macros.enable_tabs() }}
+{% endblock %}

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -213,37 +213,4 @@
             </ul>
         </div>
     </div>
-    <script>
-      function determineActiveSection() {
-        const currentPath = window.location.pathname;
-        // Remove leading and trailing bars
-        const trimmedCurrentPath = currentPath.replace(/^\/+|\/+$/g, '');
-        // We assume all routes here have a common prefix consisting on three parts
-        return trimmedCurrentPath.split('/')[3] ?? 'info';
-      }
-
-      function updateActiveTab() {
-        const activeSection = determineActiveSection();
-        const tabs = document.querySelectorAll('[data-section-id]');
-
-        // Iterate over tabs and tab panels, adding is-active to those which data-section-id matches active section,
-        // and removing it for the rest.
-        tabs.forEach(tab => {
-          tab.classList.toggle('is-active', tab.dataset.sectionId === activeSection);
-        });
-      }
-
-      // Select the first tab on window load
-      window.addEventListener('load', updateActiveTab);
-      // Update selected tab on history change
-      window.addEventListener('popstate', updateActiveTab);
-
-      // Capture clicks in tabs, to update the URL
-      document.querySelectorAll('.tabs li').forEach(tab => {
-        tab.addEventListener('click', () => {
-          const newActiveSection = tab.dataset.sectionId;
-          window.history.pushState(null, '', newActiveSection);
-        });
-      });
-    </script>
 {% endblock %}

--- a/lms/templates/admin/base.html.jinja2
+++ b/lms/templates/admin/base.html.jinja2
@@ -154,49 +154,6 @@
                 {% block content %}{% endblock %}
             </div>
         </section>
-
-        <script>
-          function pathSegments() {
-            const currentPath = window.location.pathname;
-            // Remove leading and trailing bars
-            const trimmedCurrentPath = currentPath.replace(/^\/+|\/+$/g, '');
-
-            return trimmedCurrentPath.split('/');
-          }
-
-          function determineActiveSection() {
-            // We assume all routes here have a common prefix consisting on three parts
-            return pathSegments()[3] ?? 'info';
-          }
-
-          function updateActiveTab() {
-            const activeSection = determineActiveSection();
-            const tabs = document.querySelectorAll('[data-section-id]');
-
-            // Iterate over tabs and tab panels, adding is-active to those which data-section-id matches active section,
-            // and removing it for the rest.
-            tabs.forEach(tab => {
-              tab.classList.toggle('is-active', tab.dataset.sectionId === activeSection);
-            });
-          }
-
-          // Select the first tab on window load
-          window.addEventListener('load', updateActiveTab);
-          // Update selected tab on history change
-          window.addEventListener('popstate', updateActiveTab);
-
-          // Capture clicks in tabs, to update the URL
-          document.querySelectorAll('.tabs li').forEach(tab => {
-            tab.addEventListener('click', () => {
-              const segments = pathSegments();
-              // We assume all routes here have a common prefix consisting on three parts
-              const prefix = `/${segments[0]}/${segments[1]}/${segments[2]}/`;
-              const newActiveSection = tab.dataset.sectionId;
-
-              window.history.pushState(null, '', `${prefix}${newActiveSection}`);
-            });
-          });
-        </script>
         {% block extra_scripts %}{% endblock %}
     </body>
 </html>

--- a/lms/templates/admin/base.html.jinja2
+++ b/lms/templates/admin/base.html.jinja2
@@ -154,6 +154,49 @@
                 {% block content %}{% endblock %}
             </div>
         </section>
+
+        <script>
+          function pathSegments() {
+            const currentPath = window.location.pathname;
+            // Remove leading and trailing bars
+            const trimmedCurrentPath = currentPath.replace(/^\/+|\/+$/g, '');
+
+            return trimmedCurrentPath.split('/');
+          }
+
+          function determineActiveSection() {
+            // We assume all routes here have a common prefix consisting on three parts
+            return pathSegments()[3] ?? 'info';
+          }
+
+          function updateActiveTab() {
+            const activeSection = determineActiveSection();
+            const tabs = document.querySelectorAll('[data-section-id]');
+
+            // Iterate over tabs and tab panels, adding is-active to those which data-section-id matches active section,
+            // and removing it for the rest.
+            tabs.forEach(tab => {
+              tab.classList.toggle('is-active', tab.dataset.sectionId === activeSection);
+            });
+          }
+
+          // Select the first tab on window load
+          window.addEventListener('load', updateActiveTab);
+          // Update selected tab on history change
+          window.addEventListener('popstate', updateActiveTab);
+
+          // Capture clicks in tabs, to update the URL
+          document.querySelectorAll('.tabs li').forEach(tab => {
+            tab.addEventListener('click', () => {
+              const segments = pathSegments();
+              // We assume all routes here have a common prefix consisting on three parts
+              const prefix = `/${segments[0]}/${segments[1]}/${segments[2]}/`;
+              const newActiveSection = tab.dataset.sectionId;
+
+              window.history.pushState(null, '', `${prefix}${newActiveSection}`);
+            });
+          });
+        </script>
+        {% block extra_scripts %}{% endblock %}
     </body>
-    {% block extra_scripts %}{% endblock %}
 </html>

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -201,3 +201,42 @@
         </div>
     {% endcall %}
 {% endmacro %}
+{% macro enable_tabs(prefix_segments_amount=3, default_tab="info") %}
+    <script>
+      function pathSegments() {
+        const currentPath = window.location.pathname;
+        // Remove leading and trailing bars
+        const trimmedCurrentPath = currentPath.replace(/^\/+|\/+$/g, '');
+
+        return trimmedCurrentPath.split('/');
+      }
+
+      function updateActiveTab() {
+        const activeSection = pathSegments()[{{ prefix_segments_amount }}] ?? '{{ default_tab }}';
+        const tabs = document.querySelectorAll('[data-section-id]');
+
+        // Iterate over tabs and tab panels, adding is-active to those which data-section-id matches active section,
+        // and removing it for the rest.
+        tabs.forEach(tab => {
+          tab.classList.toggle('is-active', tab.dataset.sectionId === activeSection);
+        });
+      }
+
+      // Select the first tab on window load
+      window.addEventListener('load', updateActiveTab);
+      // Update selected tab on history change
+      window.addEventListener('popstate', updateActiveTab);
+
+      // Capture clicks in tabs, to update the URL
+      document.querySelectorAll('.tabs li').forEach(tab => {
+        tab.addEventListener('click', () => {
+          const segments = pathSegments().slice(0, {{ prefix_segments_amount }});
+          // We assume all routes here have a common prefix consisting on three parts
+          const prefix = `/${segments.join('/')}/`;
+          const newActiveSection = tab.dataset.sectionId;
+
+          window.history.pushState(null, '', `${prefix}${newActiveSection}`);
+        });
+      });
+    </script>
+{% endmacro %}

--- a/lms/templates/admin/organization/show.html.jinja2
+++ b/lms/templates/admin/organization/show.html.jinja2
@@ -20,104 +20,108 @@
     <div class="tabs-wrapper">
         <div class="tabs is-fullwidth is-medium is-boxed is-toggle">
             <ul>
-                <li class="is-active">
+                <li data-section-id="info">
                     <a>Info</a>
                 </li>
-                <li>
+                <li data-section-id="usage">
                     <a>Usage report</a>
                 </li>
-                <li>
+                <li data-section-id="danger">
                     <a>Danger Zone</a>
                 </li>
             </ul>
         </div>
         <div class="tabs-content">
             <ul>
-                <li class="tab-panel is-active">
-                    <legend class="label has-text-centered">Organization</legend>
-                    <form method="POST"
-                          action="{{ request.route_url("admin.organization", id_=org.id) }}">
-                        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
-                        {{ macros.disabled_text_field("ID", org.public_id) }}
-                        {{ macros.form_text_field(request, "Name", "name", org.name) }}
-                        {{ macros.settings_textarea(org, "Notes", "hypothesis", "notes") }}
-                        {{ macros.created_updated_fields(org) }}
-                        <div class="has-text-right mb-6">
-                            <input type="submit" class="button is-primary" value="Save" />
-                        </div>
-                    </form>
-                </fieldset>
-                <fieldset class="box">
-                    <legend class="label has-text-centered">Application instances</legend>
-                    <div class="block has-text-right">
-                        <a class="button is-primary"
-                           href="{{ request.route_url("admin.instance.create", _query={"organization_public_id": org.public_id}) }}">
-                            Add New LTI 1.1 instance
-                        </a>
-                        {% if org.application_instances %}
-                            <a class="button"
-                               href="{{ request.route_url("admin.instance.search", _query={"organization_public_id": org.public_id}) }}">
-                                Start search
-                            </a>
-                        {% endif %}
-                    </div>
-                    {% if org.application_instances %}
-                        {{ macros.instances_table(request, org.application_instances) }}
-                    {% else %}
-                        <div class="is-size-5 has-text-centered">No application instances</div>
-                    {% endif %}
-                </fieldset>
-                <div class="box">
-                    <legend class="label has-text-centered">Hierarchy</legend>
-                    <div class="content">
-                        <ul>
-                            {{ org_hierarchy(hierarchy_root, org) }}
-                        </ul>
-                    </div>
-                </div>
-            </li>
-            <li class="tab-panel">
-                <fieldset class="box">
-                    <legend class="label has-text-centered">Usage report</legend>
-                    <form method="POST"
-                          action="{{ request.route_url("admin.organization.usage", id_=org.id) }}">
-                        <div class="columns">
-                            <div class="column is-half">{{ macros.form_text_field(request, "Since", "since", "2023-10-01") }}</div>
-                            <div class="column is-half">{{ macros.form_text_field(request, "", "until", "2023-10-31") }}</div>
-                        </div>
-                        <div class="has-text-right mb-6">
-                            <input type="submit" class="button is-primary" value="Generate" />
-                        </div>
-                    </form>
-                </fieldset>
-            </li>
-            <li class="tab-panel">
-                <fieldset class="box has-background-danger-light">
-                    <legend class="label has-text-centered has-text-danger">Danger zone</legend>
-                    {% call macros.field_body("Enabled") %}
+                <li class="tab-panel" data-section-id="info">
+                    <fieldset>
+                        <legend class="label has-text-centered">Organization</legend>
                         <form method="POST"
-                              action="{{ request.route_url("admin.organization.toggle", id_=org.id) }}">
-                            <label class="checkbox">
-                                <input {% if org.enabled %}checked{% endif %} type="checkbox" name="enabled">
-                            </label>
-                            <p>
-                                <b>Disabling the organization will disable all associated application instances. ALL LMS integrations will break.</b>
-                            </p>
-                            <input type="submit" class="button mb-2" value="Update">
-                        </form>
-                    {% endcall %}
-                    {% call macros.field_body(label="Move (or remove) parent organization") %}
-                        <form method="POST"
-                              action="{{ request.route_url("admin.organization.move_org", id_=org.id) }}">
+                              action="{{ request.route_url("admin.organization", id_=org.id) }}">
                             <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
-                            <input class="input"
-                                   type="text"
-                                   name="parent_public_id"
-                                   value="{{ org.parent.public_id or '' }}">
-                            <input type="submit" class="button mb-2" value="Move">
+                            {{ macros.disabled_text_field("ID", org.public_id) }}
+                            {{ macros.form_text_field(request, "Name", "name", org.name) }}
+                            {{ macros.settings_textarea(org, "Notes", "hypothesis", "notes") }}
+                            {{ macros.created_updated_fields(org) }}
+                            <div class="has-text-right mb-6">
+                                <input type="submit" class="button is-primary" value="Save" />
+                            </div>
                         </form>
-                        <p>Moving this organization might have destructive effects.</p>
-                    {% endcall %}
-                </fieldset>
-            </li>
-        {% endblock %}
+                    </fieldset>
+                    <fieldset class="box">
+                        <legend class="label has-text-centered">Application instances</legend>
+                        <div class="block has-text-right">
+                            <a class="button is-primary"
+                               href="{{ request.route_url("admin.instance.create", _query={"organization_public_id": org.public_id}) }}">
+                                Add New LTI 1.1 instance
+                            </a>
+                            {% if org.application_instances %}
+                                <a class="button"
+                                   href="{{ request.route_url("admin.instance.search", _query={"organization_public_id": org.public_id}) }}">
+                                    Start search
+                                </a>
+                            {% endif %}
+                        </div>
+                        {% if org.application_instances %}
+                            {{ macros.instances_table(request, org.application_instances) }}
+                        {% else %}
+                            <div class="is-size-5 has-text-centered">No application instances</div>
+                        {% endif %}
+                    </fieldset>
+                    <div class="box">
+                        <legend class="label has-text-centered">Hierarchy</legend>
+                        <div class="content">
+                            <ul>
+                                {{ org_hierarchy(hierarchy_root, org) }}
+                            </ul>
+                        </div>
+                    </div>
+                </li>
+                <li class="tab-panel" data-section-id="usage">
+                    <fieldset class="box">
+                        <legend class="label has-text-centered">Usage report</legend>
+                        <form method="POST"
+                              action="{{ request.route_url("admin.organization.section", id_=org.id, section="usage") }}">
+                            <div class="columns">
+                                <div class="column is-half">{{ macros.form_text_field(request, "Since", "since", "2023-10-01") }}</div>
+                                <div class="column is-half">{{ macros.form_text_field(request, "", "until", "2023-10-31") }}</div>
+                            </div>
+                            <div class="has-text-right mb-6">
+                                <input type="submit" class="button is-primary" value="Generate" />
+                            </div>
+                        </form>
+                    </fieldset>
+                </li>
+                <li class="tab-panel" data-section-id="danger">
+                    <fieldset class="box has-background-danger-light">
+                        <legend class="label has-text-centered has-text-danger">Danger zone</legend>
+                        {% call macros.field_body("Enabled") %}
+                            <form method="POST"
+                                  action="{{ request.route_url("admin.organization.toggle", id_=org.id) }}">
+                                <label class="checkbox">
+                                    <input {% if org.enabled %}checked{% endif %} type="checkbox" name="enabled">
+                                </label>
+                                <p>
+                                    <b>Disabling the organization will disable all associated application instances. ALL LMS integrations will break.</b>
+                                </p>
+                                <input type="submit" class="button mb-2" value="Update">
+                            </form>
+                        {% endcall %}
+                        {% call macros.field_body(label="Move (or remove) parent organization") %}
+                            <form method="POST"
+                                  action="{{ request.route_url("admin.organization.move_org", id_=org.id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+                                <input class="input"
+                                       type="text"
+                                       name="parent_public_id"
+                                       value="{{ org.parent.public_id or '' }}">
+                                <input type="submit" class="button mb-2" value="Move">
+                            </form>
+                            <p>Moving this organization might have destructive effects.</p>
+                        {% endcall %}
+                    </fieldset>
+                </li>
+            </ul>
+        </div>
+    </div>
+{% endblock %}

--- a/lms/templates/admin/organization/show.html.jinja2
+++ b/lms/templates/admin/organization/show.html.jinja2
@@ -125,3 +125,7 @@
         </div>
     </div>
 {% endblock %}
+
+{% block extra_scripts %}
+    {{ macros.enable_tabs() }}
+{% endblock %}

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -144,7 +144,9 @@ class AdminOrganizationViews:
         self.request.session.flash("Updated organization", "messages")
 
         return HTTPFound(
-            location=self.request.route_url("admin.organization.section", id_=org.id, section="danger")
+            location=self.request.route_url(
+                "admin.organization.section", id_=org.id, section="danger"
+            )
         )
 
     @view_config(

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -80,6 +80,12 @@ class AdminOrganizationViews:
         renderer="lms:templates/admin/organization/show.html.jinja2",
         permission=Permissions.STAFF,
     )
+    @view_config(
+        route_name="admin.organization.section",
+        request_method="GET",
+        renderer="lms:templates/admin/organization/show.html.jinja2",
+        permission=Permissions.STAFF,
+    )
     def show_organization(self):
         org_id = self.request.matchdict["id_"]
 
@@ -138,7 +144,7 @@ class AdminOrganizationViews:
         self.request.session.flash("Updated organization", "messages")
 
         return HTTPFound(
-            location=self.request.route_url("admin.organization", id_=org.id)
+            location=self.request.route_url("admin.organization.section", id_=org.id, section="danger")
         )
 
     @view_config(
@@ -165,7 +171,8 @@ class AdminOrganizationViews:
         return {"organizations": orgs}
 
     @view_config(
-        route_name="admin.organization.usage",
+        route_name="admin.organization.section",
+        match_param="section=usage",
         request_method="POST",
         permission=Permissions.STAFF,
         renderer="lms:templates/admin/organization/usage.html.jinja2",


### PR DESCRIPTION
This PR is a continuation of https://github.com/hypothesis/lms/pull/5845, which brings client-side routing to the organization tabs.

[Grabación de pantalla desde 2023-12-11 12-13-19.webm](https://github.com/hypothesis/lms/assets/2719332/186d3e4a-7221-42bb-9e56-825f07fb92b4)

In order to explicitly support the logic in more than one place, the script handling the client-side logic has been moved to a macro, which additionally allows for some extra configuration (default section, amount of segments to be considered common prefix, etc).

I have also taken the opportunity to fix some missing closing/opening tags, so it's better to review this PR [ignoring empty lines](https://github.com/hypothesis/lms/pull/5910/files?w=1), as there are many lines which only changed their indentation.