### PR TITLE
Set end CFI when choosing chapter from list if page ranges feature enabled

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BookPicker-test.js
@@ -255,29 +255,42 @@ describe('BookPicker', () => {
     assert.equal(endInput.prop('placeholder'), '10');
   });
 
-  it('invokes `onSelectBook` callback after a book and chapter are chosen', async () => {
-    const onSelectBook = sinon.stub();
-    const picker = renderBookPicker({ onSelectBook });
+  [
+    { allowPageRangeSelection: true },
+    { allowPageRangeSelection: false },
+  ].forEach(({ allowPageRangeSelection }) => {
+    it('invokes `onSelectBook` callback after a book and chapter are chosen', async () => {
+      const onSelectBook = sinon.stub();
+      const picker = renderBookPicker({
+        allowPageRangeSelection,
+        onSelectBook,
+      });
 
-    const book = selectBook(picker);
-    clickSelectButton(picker);
+      const book = selectBook(picker);
+      clickSelectButton(picker);
 
-    await waitForTableOfContents(picker);
-    const chapter = selectChapter(picker);
-    clickSelectButton(picker);
+      await waitForTableOfContents(picker);
+      const chapter = selectChapter(picker);
+      clickSelectButton(picker);
 
-    await waitFor(() => onSelectBook.called);
-    assert.calledWith(
-      onSelectBook,
-      {
-        book,
-        content: {
-          type: 'toc',
-          start: chapter,
+      const expectedEnd = allowPageRangeSelection
+        ? fakeBookData.chapters.book1[1] // Start of chapter after selection
+        : undefined;
+
+      await waitFor(() => onSelectBook.called);
+      assert.calledWith(
+        onSelectBook,
+        {
+          book,
+          content: {
+            type: 'toc',
+            start: chapter,
+            end: expectedEnd,
+          },
         },
-      },
-      'vitalsource://books/bookID/book1/cfi//1'
-    );
+        'vitalsource://books/bookID/book1/cfi//1'
+      );
+    });
   });
 
   it('invokes `onSelectBook` callback after a book and page range are chosen', async () => {

--- a/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/vitalsource-test.js
@@ -107,6 +107,25 @@ describe('VitalSourceService', () => {
           cfi: '/1/2',
         },
       },
+      {
+        selection: {
+          book: { id: 'BOOKSHELF-TUTORIAL' },
+          content: {
+            type: 'toc',
+            start: {
+              cfi: '/1/2',
+            },
+            end: {
+              cfi: '/1/4',
+            },
+          },
+        },
+        expectedParams: {
+          book_id: 'BOOKSHELF-TUTORIAL',
+          cfi: '/1/2',
+          end_cfi: '/1/4',
+        },
+      },
       // Page range
       {
         selection: {

--- a/lms/static/scripts/frontend_apps/services/vitalsource.ts
+++ b/lms/static/scripts/frontend_apps/services/vitalsource.ts
@@ -1,6 +1,12 @@
 import type { Book, TableOfContentsEntry } from '../api-types';
 import { apiCall, urlPath } from '../utils/api';
 
+/**
+ * Range of pages in the book.
+ *
+ * Page ranges are inclusive, as if the user enters `5-10` they would expect
+ * that page 10 is included.
+ */
 export type PageRange = {
   type: 'page';
   start?: string;
@@ -10,13 +16,15 @@ export type PageRange = {
 /**
  * Range of entries in the table of contents.
  *
- * This currently only supports a start point because multi-selection is not yet
- * implemented for the TOC picker tree view. If a user wants to select multiple
- * chapters, they have to use a page range.
+ * CFI ranges are exclusive, so the range includes `start` but not `end`. Since
+ * CFIs do not reference predictably-sized chunks of the document (eg. they
+ * could refer to a whole chapter, a page or a single paragraph) it is more
+ * convenient to treat them as points that refer to the start of a section.
  */
 export type TableOfContentsRange = {
   type: 'toc';
   start?: TableOfContentsEntry;
+  end?: TableOfContentsEntry;
 };
 
 /**
@@ -92,10 +100,10 @@ export class VitalSourceService {
     const { book, content } = selection;
     const params: Record<string, string> = {};
     if (content.type === 'toc' && content.start) {
-      // When the location is specified as a CFI, we only include the start
-      // point. This is because the book picker UI doesn't support selecting
-      // a range of chapters.
       params.cfi = content.start.cfi;
+      if (content.end) {
+        params.end_cfi = content.end.cfi;
+      }
     }
     if (content.type === 'page' && content.start) {
       params.page = content.start;


### PR DESCRIPTION
Previously when the page ranges feature was enabled we would configure the assignment with either a page range, if the user entered a page range, or a CFI start point (not a range) if the user chose a chapter. Now when the user chooses a chapter, we will instead configure the assignment with a CFI range, where the start point is the CFI of the entry the user selected, and the end point is the CFI of the next TOC entry at the same level as the one the user selected. This makes the experience consistent regardless of which selection method the user chooses.

The `[start-end)` CFI range will be picked up by the client when the assignment is launched and used to [filter annotations](https://github.com/hypothesis/client/pull/6019).

**Testing:**

- Configure an assignment in the VS picker with devtools open
- After selecting a book and chapter, the LMS frontend should make an `/api/vitalsource/document_url` API request to get the URL for the assignment. This should now include an `end_cfi` query param. Previously it did not.