### PR TITLE
Support for linebreaks in grading comments

### DIFF
--- a/lms/product/blackboard/__init__.py
+++ b/lms/product/blackboard/__init__.py
@@ -1,5 +1,6 @@
 from lms.product.blackboard._plugin.course_copy import BlackboardCourseCopyPlugin
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
+from lms.product.blackboard._plugin.misc import BlackboardMiscPlugin
 from lms.product.blackboard.product import Blackboard
 
 
@@ -11,4 +12,7 @@ def includeme(config):  # pragma: nocover
     )
     config.register_service_factory(
         BlackboardCourseCopyPlugin.factory, iface=BlackboardCourseCopyPlugin
+    )
+    config.register_service_factory(
+        BlackboardMiscPlugin.factory, iface=BlackboardMiscPlugin
     )

--- a/lms/product/blackboard/_plugin/misc.py
+++ b/lms/product/blackboard/_plugin/misc.py
@@ -1,0 +1,7 @@
+from lms.product.plugin.misc import MiscPlugin
+
+
+class BlackboardMiscPlugin(MiscPlugin):
+    @classmethod
+    def factory(cls, _request, _context):
+        return cls()

--- a/lms/product/blackboard/_plugin/misc.py
+++ b/lms/product/blackboard/_plugin/misc.py
@@ -2,6 +2,10 @@ from lms.product.plugin.misc import MiscPlugin
 
 
 class BlackboardMiscPlugin(MiscPlugin):
+    def format_grading_comment_for_lms(self, comment: str) -> str:
+        # Replace new lines by by html, otherwise format it lost when read back.
+        return comment.replace("\n", "<br/>")
+
     @classmethod
     def factory(cls, _request, _context):
         return cls()

--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from lms.product.blackboard._plugin.course_copy import BlackboardCourseCopyPlugin
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
+from lms.product.blackboard._plugin.misc import BlackboardMiscPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
 
@@ -17,6 +18,8 @@ class Blackboard(Product):
     )
 
     plugin_config: PluginConfig = PluginConfig(
-        grouping=BlackboardGroupingPlugin, course_copy=BlackboardCourseCopyPlugin
+        grouping=BlackboardGroupingPlugin,
+        course_copy=BlackboardCourseCopyPlugin,
+        misc=BlackboardMiscPlugin,
     )
     settings_key = "blackboard"

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -41,9 +41,12 @@ class MiscPlugin:
         return application_instance.lti_version == "1.3.0"
 
     def clean_lms_grading_comment(self, comment: str) -> str:
-        """Clean a comment,/ coming from the LMS to display it in our grading comment textarea"""
-        # On top of this, blackboard adds some HTML to the comments it returns
+        """Clean a comment coming from the LMS to display it in our grading comment textarea."""
         return strip_html_tags(comment)
+
+    def format_grading_comment_for_lms(self, comment: str) -> str:
+        """Format grading comment before sending it over via the API."""
+        return comment
 
     def is_assignment_gradable(self, lti_params: LTIParams) -> bool:
         """Check if the assignment of the current launch is gradable."""

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -1,4 +1,5 @@
 from lms.models import LTIParams, LTIRegistration
+from lms.services.html_service import strip_html_tags
 
 
 class MiscPlugin:
@@ -38,6 +39,11 @@ class MiscPlugin:
 
         # This is a LTI 1.3 only feature
         return application_instance.lti_version == "1.3.0"
+
+    def clean_lms_grading_comment(self, comment: str) -> str:
+        """Clean a comment,/ coming from the LMS to display it in our grading comment textarea"""
+        # On top of this, blackboard adds some HTML to the comments it returns
+        return strip_html_tags(comment)
 
     def is_assignment_gradable(self, lti_params: LTIParams) -> bool:
         """Check if the assignment of the current launch is gradable."""

--- a/lms/services/html_service.py
+++ b/lms/services/html_service.py
@@ -1,21 +1,26 @@
+import re
 from html.parser import HTMLParser
 
 
-class WhiteSpaceHTMLParser(HTMLParser):
-    def __init__(self):
+class WhiteSpaceHTMLParser(HTMLParser):  # pylint:disable=abstract-method
+    def __init__(self, tags_to_newline):
         super().__init__()
         self._chunks = []
+        self._tags_to_new_line = tags_to_newline or []
 
     def handle_data(self, data):
         self._chunks.append(data)
 
+    def handle_endtag(self, tag):
+        if tag in self._tags_to_new_line:
+            self._chunks.append("\n")
+
     def get_text(self) -> str:
-        # Strip leading/trailing whitespace and duplicate spaces
-        return " ".join("".join(self._chunks).split())
+        return "".join(self._chunks).strip()
 
 
-def strip_html_tags(html: str) -> str:
-    parser = WhiteSpaceHTMLParser()
+def strip_html_tags(html: str, tags_to_newline=None) -> str:
+    parser = WhiteSpaceHTMLParser(tags_to_newline)
     parser.feed(html)
     parser.close()
 

--- a/lms/services/html_service.py
+++ b/lms/services/html_service.py
@@ -16,7 +16,9 @@ class WhiteSpaceHTMLParser(HTMLParser):  # pylint:disable=abstract-method
             self._chunks.append("\n")
 
     def get_text(self) -> str:
-        return "".join(self._chunks).strip()
+        joined = "".join(self._chunks).strip()
+        # Remove any superfluous white space added after new lines
+        return re.sub(r"\n\s", "\n", joined)
 
 
 def strip_html_tags(html: str, tags_to_newline=None) -> str:

--- a/lms/services/html_service.py
+++ b/lms/services/html_service.py
@@ -1,16 +1,22 @@
 from html.parser import HTMLParser
 
 
-def strip_html_tags(html: str) -> str:
-    """Get plain text from a string which may contain HTML tags."""
+class WhiteSpaceHTMLParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._chunks = []
 
-    # Extract text nodes using HTMLParser. We rely on it being tolerant of
-    # invalid markup.
-    chunks = []
-    parser = HTMLParser()
-    parser.handle_data = chunks.append
+    def handle_data(self, data):
+        self._chunks.append(data)
+
+    def get_text(self) -> str:
+        # Strip leading/trailing whitespace and duplicate spaces
+        return " ".join("".join(self._chunks).split())
+
+
+def strip_html_tags(html: str) -> str:
+    parser = WhiteSpaceHTMLParser()
     parser.feed(html)
     parser.close()
 
-    # Strip leading/trailing whitespace and duplicate spaces
-    return " ".join("".join(chunks).split())
+    return parser.get_text()

--- a/lms/services/html_service.py
+++ b/lms/services/html_service.py
@@ -3,17 +3,12 @@ from html.parser import HTMLParser
 
 
 class WhiteSpaceHTMLParser(HTMLParser):  # pylint:disable=abstract-method
-    def __init__(self, tags_to_newline):
+    def __init__(self):
         super().__init__()
         self._chunks = []
-        self._tags_to_new_line = tags_to_newline or []
 
     def handle_data(self, data):
         self._chunks.append(data)
-
-    def handle_endtag(self, tag):
-        if tag in self._tags_to_new_line:
-            self._chunks.append("\n")
 
     def get_text(self) -> str:
         joined = "".join(self._chunks).strip()
@@ -21,9 +16,8 @@ class WhiteSpaceHTMLParser(HTMLParser):  # pylint:disable=abstract-method
         return re.sub(r"\n\s", "\n", joined)
 
 
-def strip_html_tags(html: str, tags_to_newline=None) -> str:
-    parser = WhiteSpaceHTMLParser(tags_to_newline)
+def strip_html_tags(html: str) -> str:
+    parser = WhiteSpaceHTMLParser()
     parser.feed(html)
     parser.close()
-
     return parser.get_text()

--- a/lms/services/jstor/_article_metadata.py
+++ b/lms/services/jstor/_article_metadata.py
@@ -69,7 +69,7 @@ class ArticleMetadata:
             return titles
 
         if journal := self._data.get("journal"):
-            return {"type": "journal", "title": strip_html_tags(journal)}
+            return {"type": "journal", "title": self._strip_html_tags(journal)}
 
         return {"type": None, "title": None}
 
@@ -104,7 +104,7 @@ class ArticleMetadata:
         # Reviews of other works may not have a title of their own, but we can
         # generate one from the reviewed work's metadata.
         if reviewed_works := self._data.get("reviewed_works"):
-            return {"title": strip_html_tags(f"Review: {reviewed_works[0]}")}
+            return {"title": self._strip_html_tags(f"Review: {reviewed_works[0]}")}
 
         if titles := self._get_titles("title", "subtitle"):
             return titles
@@ -119,11 +119,16 @@ class ArticleMetadata:
         if title := self._data.get(title_key):
             # Some titles have a colon on the end. We'll remove these, so we
             # can more easily format these without checking for it.
-            titles["title"] = strip_html_tags(title).rstrip(": ")
+            titles["title"] = self._strip_html_tags(title).rstrip(": ")
 
             # Some articles have a subtitle which needs to be appended for the
             # title to make sense.
             if subtitle := self._data.get(subtitle_key):
-                titles["subtitle"] = strip_html_tags(subtitle)
+                titles["subtitle"] = self._strip_html_tags(subtitle)
 
         return titles
+
+    @staticmethod
+    def _strip_html_tags(html: str) -> str:
+        # Strip leading/trailing whitespace and duplicate spaces
+        return " ".join(strip_html_tags(html).split())

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -24,7 +24,7 @@ class LTI13GradingService(LTIGradingService):
         "https://purl.imsglobal.org/spec/lti-ags/scope/score",
     ]
 
-    def __init__(
+    def __init__(  # pylint:disable=too-many-arguments
         self,
         line_item_url,
         line_item_container_url,
@@ -90,7 +90,9 @@ class LTI13GradingService(LTIGradingService):
             "gradingProgress": "FullyGraded",
         }
         if comment:
-            payload["comment"] = comment
+            payload["comment"] = self._misc_plugin.format_grading_comment_for_lms(
+                comment
+            )
 
         if pre_record_hook:
             payload = pre_record_hook(score=score, request_body=payload)

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -4,11 +4,10 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from lms.product.family import Family
+from lms.product.plugin.misc import MiscPlugin
 from lms.services.exceptions import ExternalRequestError, StudentNotInCourse
 from lms.services.lti_grading.interface import GradingResult, LTIGradingService
 from lms.services.ltia_http import LTIAHTTPService
-
-from lms.product.plugin.misc import MiscPlugin
 
 LOG = logging.getLogger(__name__)
 

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -15,6 +15,7 @@ def service_factory(_context, request):
             line_item_container_url=request.lti_params.get("lineitems"),
             ltia_service=request.find_service(LTIAHTTPService),
             product_family=request.product.family,
+            misc_plugin=request.product.plugin.misc,
         )
 
     return LTI11GradingService(

--- a/tests/unit/lms/product/blackboard/_plugin/misc_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/misc_test.py
@@ -1,0 +1,18 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.product.blackboard._plugin.misc import BlackboardMiscPlugin
+
+
+class TestBlackboardMiscPlugin:
+    def test_accept_grading_comments(self, application_instance, plugin):
+        assert not plugin.accept_grading_comments(application_instance)
+
+    def test_factory(self, pyramid_request):
+        plugin = BlackboardMiscPlugin.factory(sentinel.context, pyramid_request)
+        assert isinstance(plugin, BlackboardMiscPlugin)
+
+    @pytest.fixture
+    def plugin(self):
+        return BlackboardMiscPlugin()

--- a/tests/unit/lms/product/blackboard/_plugin/misc_test.py
+++ b/tests/unit/lms/product/blackboard/_plugin/misc_test.py
@@ -6,8 +6,8 @@ from lms.product.blackboard._plugin.misc import BlackboardMiscPlugin
 
 
 class TestBlackboardMiscPlugin:
-    def test_accept_grading_comments(self, application_instance, plugin):
-        assert not plugin.accept_grading_comments(application_instance)
+    def test_format_grading_comment_for_lms(self, plugin):
+        assert plugin.format_grading_comment_for_lms("new\nline") == "new<br/>line"
 
     def test_factory(self, pyramid_request):
         plugin = BlackboardMiscPlugin.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/product/plugin/misc_test.py
+++ b/tests/unit/lms/product/plugin/misc_test.py
@@ -89,9 +89,24 @@ class TestMiscPlugin:
             plugin.get_deep_linked_assignment_configuration(pyramid_request) == expected
         )
 
+    def test_clean_lms_grading_comment(self, plugin, strip_html_tags):
+        result = plugin.clean_lms_grading_comment(sentinel.comment)
+
+        strip_html_tags.assert_called_once_with(sentinel.comment)
+        assert result == strip_html_tags.return_value
+
+    def test_format_grading_comment_for_lms(self, plugin):
+        assert (
+            plugin.format_grading_comment_for_lms(sentinel.comment) == sentinel.comment
+        )
+
     @pytest.fixture
     def lti_registration(self):
         return factories.LTIRegistration()
+
+    @pytest.fixture
+    def strip_html_tags(self, patch):
+        return patch("lms.product.plugin.misc.strip_html_tags")
 
     @pytest.fixture
     def pyramid_request_with_custom_lti_params(self, pyramid_request):

--- a/tests/unit/lms/services/html_service_test.py
+++ b/tests/unit/lms/services/html_service_test.py
@@ -4,13 +4,16 @@ from lms.services.html_service import strip_html_tags
 
 
 @pytest.mark.parametrize(
-    "text,expected",
+    "text,expected,tags_to_new_line",
     [
-        ("<b>COLON :</b>", "COLON :"),
-        ("A <em>B</em>", "A B"),
-        (" C <em>D</em> E", "C D E"),
-        ("A<B", "A<B"),
+        ("<b>COLON :</b>", "COLON :", None),
+        ("A <em>B</em>", "A B", None),
+        (" C <em>D</em> E", "C D E", None),
+        ("A<B", "A<B", None),
+        ("<p>PARAGRAPH</p>OTHER", "PARAGRAPH\nOTHER", ["p"]),
+        ("<p>PARAGRAPH</p>OTHER<br/>ANOTHER", "PARAGRAPH\nOTHER\nANOTHER", ["p", "br"]),
+        ("<div>1\n <p>2</p>\n<p>3 </p>\n</div>", "1\n2\n3", ["p", "br"]),
     ],
 )
-def test_strip_html_tags(text, expected):
-    assert strip_html_tags(text) == expected
+def test_strip_html_tags(text, expected, tags_to_new_line):
+    assert strip_html_tags(text, tags_to_new_line) == expected

--- a/tests/unit/lms/services/html_service_test.py
+++ b/tests/unit/lms/services/html_service_test.py
@@ -4,16 +4,13 @@ from lms.services.html_service import strip_html_tags
 
 
 @pytest.mark.parametrize(
-    "text,expected,tags_to_new_line",
+    "text,expected",
     [
-        ("<b>COLON :</b>", "COLON :", None),
-        ("A <em>B</em>", "A B", None),
-        (" C <em>D</em> E", "C D E", None),
-        ("A<B", "A<B", None),
-        ("<p>PARAGRAPH</p>OTHER", "PARAGRAPH\nOTHER", ["p"]),
-        ("<p>PARAGRAPH</p>OTHER<br/>ANOTHER", "PARAGRAPH\nOTHER\nANOTHER", ["p", "br"]),
-        ("<div>1\n <p>2</p>\n<p>3 </p>\n</div>", "1\n2\n3", ["p", "br"]),
+        ("<b>COLON :</b>", "COLON :"),
+        ("A <em>B</em>", "A B"),
+        (" C <em>D</em> E", "C D E"),
+        ("A<B", "A<B"),
     ],
 )
-def test_strip_html_tags(text, expected, tags_to_new_line):
-    assert strip_html_tags(text, tags_to_new_line) == expected
+def test_strip_html_tags(text, expected):
+    assert strip_html_tags(text) == expected

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -130,7 +130,7 @@ class TestLTI13GradingService:
 
     @freeze_time("2022-04-04")
     @pytest.mark.parametrize("comment", [sentinel.comment, None])
-    def test_record_result(self, svc, ltia_http_service, comment):
+    def test_record_result(self, svc, ltia_http_service, comment, misc_plugin):
         svc.line_item_url = "https://lms.com/lineitems?param=1"
 
         response = svc.record_result(sentinel.user_id, sentinel.score, comment=comment)
@@ -144,7 +144,8 @@ class TestLTI13GradingService:
             "gradingProgress": "FullyGraded",
         }
         if comment:
-            payload["comment"] = comment
+            misc_plugin.format_grading_comment_for_lms.assert_called_once_with(comment)
+            payload["comment"] = misc_plugin.format_grading_comment_for_lms.return_value
 
         ltia_http_service.request.assert_called_once_with(
             "POST",

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -18,7 +18,9 @@ class TestFactory:
         )
         assert svc == LTI11GradingService.return_value
 
-    def test_v13(self, pyramid_request, LTI13GradingService, ltia_http_service):
+    def test_v13(
+        self, pyramid_request, LTI13GradingService, ltia_http_service, misc_plugin
+    ):
         pyramid_request.lti_user.application_instance = Mock(lti_version="1.3.0")
 
         svc = service_factory(sentinel.context, pyramid_request)
@@ -28,11 +30,12 @@ class TestFactory:
             sentinel.lineitems,
             ltia_http_service,
             pyramid_request.product.family,
+            misc_plugin,
         )
         assert svc == LTI13GradingService.return_value
 
     def test_v13_line_item_url_from_lti_params(
-        self, pyramid_request, LTI13GradingService, ltia_http_service
+        self, pyramid_request, LTI13GradingService, ltia_http_service, misc_plugin
     ):
         del pyramid_request.parsed_params["lis_outcome_service_url"]
         pyramid_request.lti_user.application_instance = Mock(lti_version="1.3.0")
@@ -44,6 +47,7 @@ class TestFactory:
             sentinel.lineitems,
             ltia_http_service,
             pyramid_request.product.family,
+            misc_plugin,
         )
         assert svc == LTI13GradingService.return_value
 


### PR DESCRIPTION
Some LMS don't play nice with regular line breaks in grading comments (`\n`) but use HTML instead.

This PR uses a naive approach to maintain the new lines in our textarea. It doesn't however try to support the full range of HTML different LMSes support.


### Testing


### D2L

- Enable grading comments in http://localhost:8001/admin/instance/106/
- Lauch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View?ou=6782
- Read the comment, it contains new lines. Change the comment.
- Reload the assignment, read the comment again, it contains the changes.


### Moodle 

- Enable grading comments in http://localhost:8001/admin/instance/109/
- Lauch https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=685
- Read the comment, it contains new lines. Change the comment.
- Reload the assignment, read the comment again, it contains the changes.


### Blackboard

- Enable grading comments in http://localhost:8001/admin/instance/100/

- Launch [this gradable assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2483_1&displayName=LTI+1.3%2C+blackboard+file&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2483_1%26course_id%3D_19_1) as a **student** first


- Lauch [this gradable assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2483_1&displayName=LTI+1.3%2C+blackboard+file&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2483_1%26course_id%3D_19_1) now as a **teacher**
- Read the comment, it contains new lines. Change the comment.
- Reload the assignment, read the comment again, it contains the changes.




