### PR TITLE
Add preferences links to emails

### DIFF
--- a/lms/services/digest.py
+++ b/lms/services/digest.py
@@ -60,6 +60,10 @@ class DigestService:
             # This user has no activity.
             return
 
+        digest["preferences_url"] = self._email_preferences_service.preferences_url(
+            context.user_info.h_userid, "instructor_digest"
+        )
+
         if override_to_email is None:
             to_email = context.user_info.email
         else:

--- a/lms/templates/email/instructor_email_digest/body.html.jinja2
+++ b/lms/templates/email/instructor_email_digest/body.html.jinja2
@@ -745,7 +745,7 @@
                                                     Hypothesis, 2261 Market Street, #632, San Francisco, California 94114, United States of America<br>
                                                     <br>
                                                     <br>
-                                                    <a href="{{ unsubscribe_url }}">Unsubscribe from this list</a>.
+                                                    <a href="{{ preferences_url}}">Change your email preferences</a> or <a href="{{ unsubscribe_url }}">unsubscribe from these emails</a>.
                                                   </td>
                                                 </tr>
                                               </tbody>

--- a/lms/templates/email/unsubscribed.html.jinja2
+++ b/lms/templates/email/unsubscribed.html.jinja2
@@ -1,3 +1,0 @@
-{% extends 'templates/base.plain.html.jinja2' %}
-
-{% set title = "You've been unsubscribed" %}

--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -26,16 +26,6 @@ def forbidden(_request):
     return {}
 
 
-@view_config(
-    route_name="email.unsubscribed",
-    request_method="GET",
-    renderer="lms:templates/email/unsubscribed.html.jinja2",
-)
-def unsubscribed(_request):
-    """Render a message after a successful email unsubscribe."""
-    return {}
-
-
 @view_defaults(permission=Permissions.EMAIL_PREFERENCES)
 class EmailPreferencesViews:
     def __init__(self, request):
@@ -52,8 +42,17 @@ class EmailPreferencesViews:
         self.request.find_service(EmailPreferencesService).unsubscribe(
             self.request.identity.h_userid
         )
+        self.request.session.flash(
+            "You've been unsubscribed from email notifications.",
+            "email_preferences_result",
+        )
 
-        return HTTPFound(location=self.request.route_url("email.unsubscribed"))
+        return HTTPFound(
+            location=self.request.route_url("email.preferences"),
+            # Set a cookie to keep the user logged in even though we're
+            # removing the authentication token from the URL.
+            headers=remember(self.request, self.request.authenticated_userid),
+        )
 
     @view_config(
         route_name="email.preferences",

--- a/tests/unit/lms/services/digest_test.py
+++ b/tests/unit/lms/services/digest_test.py
@@ -62,6 +62,13 @@ class TestDigestService:
             ],
         )
         context.instructor_digest.assert_called_once_with(context.user_info.h_userid)
+        email_preferences_service.preferences_url.assert_called_once_with(
+            context.user_info.h_userid, "instructor_digest"
+        )
+        assert (
+            context.instructor_digest.return_value["preferences_url"]
+            == email_preferences_service.preferences_url.return_value
+        )
         send.delay.assert_called_once_with(
             task_done_key=f"instructor_email_digest::{context.user_info.h_userid}::2023-04-30",
             task_done_data={


### PR DESCRIPTION
This effectively releases the weekly email digests feature, as it gives users access to the page where they can change their email preferences.

In a future commit the unsubscribe URLs will be changed to also redirect to the preferences page (after unsubscribing).

Screenshot of the email footer with the new link:

![image](https://github.com/hypothesis/lms/assets/22498/19d43ba0-49bf-4748-bd0e-cef4fbe476d6)