### PR TITLE
Hard-code the minimum TaskDone created_before date

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -146,6 +146,9 @@ def send_instructor_email_digest(
                 created_after = max(
                     datetime.fromisoformat(task_done_data["created_before"]),
                     created_after,
+                    # Don't count annotations from before we deployed https://github.com/hypothesis/lms/pull/5904.
+                    # This line can safely be removed on Weds 20th Dec 2023 or later.
+                    datetime(year=2023, month=12, day=13, hour=5, tzinfo=timezone.utc),
                 )
 
             digest_service = request.find_service(DigestService)

--- a/tests/unit/lms/tasks/email_digests_test.py
+++ b/tests/unit/lms/tasks/email_digests_test.py
@@ -305,7 +305,7 @@ class TestSendInstructorEmailDigests:
     @pytest.fixture
     def created_before(self):
         """Return the created_before arg that will be passed to send_instructor_email_digest()."""
-        return datetime.now(timezone.utc)
+        return datetime(year=2023, month=12, day=25, hour=5, tzinfo=timezone.utc)
 
     @pytest.fixture
     def make_task_done(self, h_userid, created_before):


### PR DESCRIPTION
This commit can be safely reverted on Weds 20th Dec 2023 or later.

Hard-code the minimum `TaskDone.data["created_before"]` date when
generating instructor email digests.

This is to get around an issue with deploying
https://github.com/hypothesis/lms/pull/5904, which changes
the email generation code so that each email counts annotations from the
time that each user's previous email counted annotations up to
(according to the `TaskDone` table) or seven days ago, whichever is most
recent.

The problem is that we would have to wait until seven days after
https://github.com/hypothesis/lms/pull/5903 (which fixed the code that
writes to `TaskDone`) was deployed before we could deploy
https://github.com/hypothesis/lms/pull/5904 because we would need at
least seven days of correct rows in the `TaskDone` table otherwise some
emails might count annotations that the user had already been notified
about (if the `TaskDone` row was not entered correctly when this user's
previous email was sent).

Get around this by hard-coding the day that we plan to deploy
https://github.com/hypothesis/lms/pull/5904 as the oldest day from which
annotations will be counted.
