### PR TITLE
Fix the email preferences page in Safari

### DIFF
--- a/lms/views/email.py
+++ b/lms/views/email.py
@@ -58,30 +58,20 @@ class EmailPreferencesViews:
     @view_config(
         route_name="email.preferences",
         request_method="GET",
-        request_param="token",
-    )
-    def preferences_redirect(self):
-        # The token has already been verified by the security policy, so we can
-        # just go right ahead with the redirect.
-        return HTTPFound(
-            location=self.request.route_url("email.preferences"),
-            # Set a cookie to keep the user logged in even though we're
-            # removing the authentication token from the URL.
-            headers=remember(self.request, self.request.authenticated_userid),
-        )
-
-    @view_config(
-        route_name="email.preferences",
-        request_method="GET",
         renderer="lms:templates/email/preferences.html.jinja2",
     )
     def preferences(self):
+        days = self.email_preferences_service.get_preferences(
+            self.request.authenticated_userid
+        ).days()
+        self.request.response.headers = remember(
+            self.request, self.request.authenticated_userid
+        )
+
         return {
             "jsConfig": {
                 "mode": "email-preferences",
-                "emailPreferences": self.email_preferences_service.get_preferences(
-                    self.request.authenticated_userid
-                ).days(),
+                "emailPreferences": days,
             }
         }
 


### PR DESCRIPTION
The `/email/preferences?token=xyz` URL currently redirects to
`/email/preferences` (no token) with a `Set-Cookie` header in the HTTP
redirect response.

Unfortunately Safari fails to set cookies when the `Set-Cookie` header
is in a redirect response, meaning email preferences links are currently
broken in Safari.

Fix this by *not* redirecting the browser, and showing the email
preferences UI at the `/email/preferences?token=xyz` URL (*with* token).

The downside of this is that the sensitive token is left in the
browser's location bar, but we plan to have some JavaScript code remove
the token from the URL in a follow-up commit.
