### PR TITLE
Enable grading scale for all instances

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -47,7 +47,6 @@ class ApplicationSettings(JSONSettings):
         ),
         JSONSetting("hypothesis", "import_export_enabled", asbool),
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
-        JSONSetting("hypothesis", "lms_grading_scale", asbool),
         JSONSetting("hypothesis", "grading_comments", asbool),
     )
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -114,7 +114,6 @@
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox("Enable import/export in client", "hypothesis", "import_export_enabled", default=False) }}
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
-                            {{ settings_checkbox("LMS grading scale", "hypothesis", "lms_grading_scale", default=False) }}
                             {{ settings_checkbox("Grading comments", "hypothesis", "grading_comments", default=False) }}
                         </fieldset>
                         <fieldset class="box">

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -193,12 +193,7 @@ class BasicLaunchViews:
 
                 # Display the grading interface in the toolbar
                 self.context.js_config.enable_toolbar_grading(
-                    students=students,
-                    score_maximum=score_maximum
-                    if self.request.lti_user.application_instance.settings.get(
-                        "hypothesis", "lms_grading_scale", False
-                    )
-                    else None,
+                    students=students, score_maximum=score_maximum
                 )
 
             if not self.request.lti_user.is_instructor:

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -237,7 +237,6 @@ class TestBasicLaunchViews:
     @pytest.mark.parametrize("use_toolbar_grading", [True, False])
     @pytest.mark.parametrize("is_gradable", [True, False])
     @pytest.mark.parametrize("is_instructor", [True, False])
-    @pytest.mark.parametrize("lms_grading_scale", [True, False])
     def test__show_document_configures_toolbar(
         self,
         svc,
@@ -251,11 +250,7 @@ class TestBasicLaunchViews:
         is_instructor,
         grading_info_service,
         lti_grading_service,
-        lms_grading_scale,
     ):
-        pyramid_request.lti_user.application_instance.settings.set(
-            "hypothesis", "lms_grading_scale", lms_grading_scale
-        )
         assignment = factories.Assignment(is_gradable=is_gradable)
         if is_instructor:
             request.getfixturevalue("user_is_instructor")
@@ -286,9 +281,7 @@ class TestBasicLaunchViews:
 
                 context.js_config.enable_toolbar_grading.assert_called_once_with(
                     students=grading_info_service.get_students_for_grading.return_value,
-                    score_maximum=lti_grading_service.get_score_maximum.return_value
-                    if lms_grading_scale
-                    else None,
+                    score_maximum=lti_grading_service.get_score_maximum.return_value,
                 )
             else:
                 grading_info_service.upsert.assert_called_once_with(


### PR DESCRIPTION
We are already reading the scale value in all instances, the flag removed here just handles exposing it to the front end, sending the actual value instead of `None`.

For LTI1.1 instances the default implementation of get_score_maximum always returns None.

In case there's any issue with the feature rollback procedure will be to just revert this commit.


### Testing

### Sanity check a LTI1.1 assignment

- As `blackboardteacher` launch [localhost (make devdata) HTML Assignment](https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1)
- You'll get something like:

```DEBUG [lms.views.lti.basic_launch:188][MainThread] Score maximum for _36_1: None``` in the logs


### LTI1.3

- Login as `HypothesisEng.Teacher`
- Launch 
  - https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View
  - https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3349/View


You'll get

```[lms.views.lti.basic_launch:188][MainThread] Score maximum for 993_6782: 5.0```

and 

```[lms.views.lti.basic_launch:188][MainThread] Score maximum for 994_6782: 100.0```


in the logs.