### PR TITLE
Enable grading comments for all LTI1.3 instances

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -47,7 +47,6 @@ class ApplicationSettings(JSONSettings):
         ),
         JSONSetting("hypothesis", "import_export_enabled", asbool),
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
-        JSONSetting("hypothesis", "grading_comments", asbool),
     )
 
 

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -32,11 +32,6 @@ class MiscPlugin:
 
     def accept_grading_comments(self, application_instance):
         """Whether to accept comments while grading."""
-        if not application_instance.settings.get(
-            "hypothesis", "grading_comments", False
-        ):
-            return False
-
         # This is a LTI 1.3 only feature
         return application_instance.lti_version == "1.3.0"
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -114,7 +114,6 @@
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox("Enable import/export in client", "hypothesis", "import_export_enabled", default=False) }}
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
-                            {{ settings_checkbox("Grading comments", "hypothesis", "grading_comments", default=False) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/tests/unit/lms/product/plugin/misc_test.py
+++ b/tests/unit/lms/product/plugin/misc_test.py
@@ -22,18 +22,11 @@ class TestMiscPlugin:
         assert plugin.is_assignment_gradable(pyramid_request.lti_params) == expected
 
     @pytest.mark.parametrize("lti_v13", [True, False])
-    @pytest.mark.parametrize("grading_comments", [True, False])
-    def test_accept_grading_comments(self, request, plugin, lti_v13, grading_comments):
+    def test_accept_grading_comments(self, request, plugin, lti_v13):
         application_instance = request.getfixturevalue(
             "lti_v13_application_instance" if lti_v13 else "application_instance"
         )
-        application_instance.settings.set(
-            "hypothesis", "grading_comments", grading_comments
-        )
-
-        assert plugin.accept_grading_comments(application_instance) == (
-            grading_comments and lti_v13
-        )
+        assert plugin.accept_grading_comments(application_instance) == lti_v13
 
     def test_get_ltia_aud_claim(self, plugin, lti_registration):
         assert plugin.get_ltia_aud_claim(lti_registration) == lti_registration.token_url


### PR DESCRIPTION
Stop reading the application instance setting.

To rollback this change we'll have to just revert this commit to go back to read the current state of the DB.


### Testing
- As `HypothesisEng.Teacher`
- Sanity check the comment box is present in [this LTI1.3](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View) assignment but not in [the 1.1 one](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3350/View).

