### PR TITLE
Remove token from query string in email-preferences mode

### DIFF
--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -90,8 +90,16 @@ export function init() {
 
   // Set route based on app mode.
   const routePath = routeForAppMode(config.mode);
+  const searchParams = new URLSearchParams(location.search);
   if (location.pathname !== routePath) {
     history.replaceState({}, 'unused', routePath);
+  } else if (config.mode === 'email-preferences' && searchParams.has('token')) {
+    // Remove auth token for email-preferences if present. We originally tried
+    // to do this server-side but Safari failed to preserve cookies after the
+    // token-stripping redirect.
+    const url = new URL(location.href);
+    url.searchParams.delete('token');
+    history.replaceState({}, 'unused', url);
   }
 
   // Render frontend application.

--- a/lms/static/scripts/frontend_apps/test/index-test.js
+++ b/lms/static/scripts/frontend_apps/test/index-test.js
@@ -94,4 +94,26 @@ describe('LMS frontend entry', () => {
       assert.calledWith(fakeContentInfoFetcher.fetch, contentBanner);
     });
   });
+
+  context('when email-preferences includes a token', () => {
+    beforeEach(() => {
+      fakeReadConfig.returns({ ...minimalConfig, mode: 'email-preferences' });
+    });
+
+    it('removes whole query string if `token` is the only param', () => {
+      history.replaceState(null, '', '?token=12345');
+
+      assert.equal('?token=12345', location.search);
+      init();
+      assert.equal('', location.search);
+    });
+
+    it('keeps other query params', () => {
+      history.replaceState(null, '', '?token=12345&foo=bar&something=else');
+
+      assert.equal('?token=12345&foo=bar&something=else', location.search);
+      init();
+      assert.equal('?foo=bar&something=else', location.search);
+    });
+  });
 });


### PR DESCRIPTION
This PR implements the client-side logic mentioned in https://github.com/hypothesis/lms/pull/5917, and so, it depends on that PR.

That PR works around an issue in Safari, which ignores `Set-Cookie` headers on redirect responses, by removing the redirect.

This PR ensures the token is removed from the URL, so that we keep a similar experience as before the change mentioned above.

### Testing steps

1. Check out this branch
2. Run `make shell`, and then `request.find_service(s.EmailPreferencesService).preferences_url("9ea84c4bcfd9329b4495f5b27d8cb6@lms.hypothes.is", "")`
3. Visit generated URL, to check the token is removed.
4. Copy the URL generated in step 2, modify it adding other query params, and "visit" it. It should only remove the token but keep the rest.