### PR TITLE
Revert "Hard-code the minimum TaskDone created_before date"

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -162,9 +162,6 @@ def send_instructor_email_digest(
                         tzinfo=timezone.utc
                     ),
                     created_after.replace(tzinfo=timezone.utc),
-                    # Don't count annotations from before we deployed https://github.com/hypothesis/lms/pull/5904.
-                    # This line can safely be removed on Weds 20th Dec 2023 or later.
-                    datetime(year=2023, month=12, day=13, hour=5, tzinfo=timezone.utc),
                 )
 
             digest_service = request.find_service(DigestService)

--- a/tests/unit/lms/tasks/email_digests_test.py
+++ b/tests/unit/lms/tasks/email_digests_test.py
@@ -345,7 +345,7 @@ class TestSendInstructorEmailDigests:
     @pytest.fixture
     def created_before(self):
         """Return the created_before arg that will be passed to send_instructor_email_digest()."""
-        return datetime(year=2023, month=12, day=25, hour=5, tzinfo=timezone.utc)
+        return datetime.now(timezone.utc)
 
     @pytest.fixture
     def make_task_done(self, h_userid, created_before):


### PR DESCRIPTION
This reverts <https://github.com/hypothesis/lms/pull/5916>. This PR is safe to merge on Weds 20th Dec 2023 or later.
