### PR TITLE
Record occurrences of CANVAS_INVALID_SCOPE in the event table

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -107,6 +107,10 @@ def includeme(config):
     engine = make_engine(config.registry.settings)
     config.registry["sqlalchemy.engine"] = engine
 
+    # Register the DB session factory in case we need to create one session
+    # outside the request life cycle managed by zope's transaction manager
+    config.registry["sqlalchemy.factory"] = SESSION
+
     if config.registry.settings["dev"]:  # pragma: nocover
         init(engine)
 

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -107,10 +107,6 @@ def includeme(config):
     engine = make_engine(config.registry.settings)
     config.registry["sqlalchemy.engine"] = engine
 
-    # Register the DB session factory in case we need to create one session
-    # outside the request life cycle managed by zope's transaction manager
-    config.registry["sqlalchemy.factory"] = SESSION
-
     if config.registry.settings["dev"]:  # pragma: nocover
         init(engine)
 

--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -15,11 +15,11 @@ class BaseEvent:  # pylint:disable=too-many-instance-attributes
     Type = EventType.Type
     """Expose the type here for the callers convenience"""
 
-    request: Request
-    """Reference to the current request"""
-
     type: EventType.Type
     """Type of the event"""
+
+    request: Optional[Request] = None
+    """Reference to the current request"""
 
     user_id: Optional[int] = None
     """Which user is related to this event"""
@@ -44,6 +44,14 @@ class BaseEvent:  # pylint:disable=too-many-instance-attributes
             if not getattr(self, event_field.name) and hasattr(self, getter_name):
                 setattr(self, event_field.name, getattr(self, getter_name)())
 
+    def serialize(self) -> dict:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            # Excluded non-serializable fields
+            if field.name not in ["request"]
+        }
+
 
 @dataclass
 class LTIEvent(BaseEvent):
@@ -53,8 +61,6 @@ class LTIEvent(BaseEvent):
     All the _get_`field`  method are used by the base class to
     fill up any missing fields
     """
-
-    # pylint:disable=no-member
 
     def _get_user_id(self):
         return self.request.user.id

--- a/lms/models/event.py
+++ b/lms/models/event.py
@@ -17,6 +17,7 @@ class EventType(BASE):
         EDITED_ASSIGNMENT = "edited_assignment"
         SUBMISSION = "submission"
         GRADE = "grade"
+        ERROR_CODE = "error_code"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     type = varchar_enum(Type)

--- a/lms/services/event.py
+++ b/lms/services/event.py
@@ -49,6 +49,10 @@ class EventService:
 
         return event_type.id
 
+    @classmethod
+    def from_db_session(cls, db):
+        return cls(db)
+
 
 def factory(_context, request):
-    return EventService(request.db)
+    return EventService.from_db_session(db=request.db)

--- a/lms/tasks/event.py
+++ b/lms/tasks/event.py
@@ -1,0 +1,12 @@
+from lms.events.event import BaseEvent
+from lms.tasks.celery import app
+
+
+@app.task
+def insert_event(event: dict) -> None:
+    with app.request_context() as request:  # pylint: disable=no-member
+        with request.tm:
+            # pylint:disable=import-outside-toplevel,cyclic-import
+            from lms.services.event import EventService
+
+            request.find_service(EventService).insert_event(BaseEvent(**event))

--- a/tests/unit/lms/events/event_test.py
+++ b/tests/unit/lms/events/event_test.py
@@ -2,9 +2,33 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.events import AuditTrailEvent, LTIEvent
+from lms.events import AuditTrailEvent, BaseEvent, LTIEvent
 from lms.events.event import _serialize_change
 from tests import factories
+
+
+class TestBaseEvent:
+    def test_serialize(self, pyramid_request):
+        assert BaseEvent(
+            request=pyramid_request,
+            type=sentinel.type,
+            user_id=sentinel.user_id,
+            role_ids=sentinel.role_ids,
+            application_instance_id=sentinel.application_instance_id,
+            course_id=sentinel.course_id,
+            assignment_id=sentinel.assignment_id,
+            grouping_id=sentinel.grouping_id,
+            data=sentinel.data,
+        ).serialize() == {
+            "type": sentinel.type,
+            "user_id": sentinel.user_id,
+            "role_ids": sentinel.role_ids,
+            "application_instance_id": sentinel.application_instance_id,
+            "course_id": sentinel.course_id,
+            "assignment_id": sentinel.assignment_id,
+            "grouping_id": sentinel.grouping_id,
+            "data": sentinel.data,
+        }
 
 
 class TestLTIEvent:

--- a/tests/unit/lms/services/event_test.py
+++ b/tests/unit/lms/services/event_test.py
@@ -85,13 +85,18 @@ class TestEventService:
     def svc(self, db_session):
         return EventService(db_session)
 
+    def test_from_db_session(self):
+        svc = EventService.from_db_session(sentinel.db)
+
+        assert svc._db == sentinel.db  # pylint:disable=protected-access
+
 
 class TestFactory:
     def test_it(self, pyramid_request, EventService):
         svc = factory(sentinel.context, pyramid_request)
 
-        EventService.assert_called_once_with(db=pyramid_request.db)
-        assert svc == EventService.return_value
+        EventService.from_db_session.assert_called_once_with(db=pyramid_request.db)
+        assert svc == EventService.from_db_session.return_value
 
     @pytest.fixture
     def EventService(self, patch):

--- a/tests/unit/lms/services/event_test.py
+++ b/tests/unit/lms/services/event_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import sentinel
 
 import pytest
+from celery.exceptions import OperationalError
 
 from lms.events import BaseEvent
 from lms.models import Event, EventData, EventType, EventUser
@@ -48,19 +49,17 @@ class TestEventService:
             event_user.lti_role_id for event_user in event_users
         }
 
-    def test_insert_event_no_user(self, svc, db_session):
-        svc.insert_event(
-            BaseEvent(request=sentinel.request, type=EventType.Type.CONFIGURED_LAUNCH)
-        )
+    def test_insert_event_no_user(self, svc, db_session, base_event):
+        svc.insert_event(base_event)
+
         assert not db_session.query(EventUser).one_or_none()
 
-    def test_insert_event_no_data(self, svc, db_session):
-        svc.insert_event(
-            BaseEvent(request=sentinel.request, type=EventType.Type.CONFIGURED_LAUNCH)
-        )
+    def test_insert_event_no_data(self, svc, db_session, base_event):
+        svc.insert_event(base_event)
+
         assert not db_session.query(EventData).one_or_none()
 
-    def test_insert_event_type(self, svc, db_session):
+    def test_insert_event_type(self, svc, db_session, base_event):
         type_query = db_session.query(EventType).filter_by(
             type=EventType.Type.CONFIGURED_LAUNCH
         )
@@ -75,28 +74,45 @@ class TestEventService:
         # Clear the @lru_cache of the private method
         svc._get_type_pk.cache_clear()  # pylint:disable=protected-access
         # Insert the event type again
-        svc.insert_event(
-            BaseEvent(request=sentinel.request, type=EventType.Type.CONFIGURED_LAUNCH)
-        )
+        svc.insert_event(base_event)
         # The type is the same as the first insert
         assert event_type == type_query.one()
+
+    def test_queue_event(self, svc, insert_event, base_event):
+        svc.queue_event(base_event)
+
+        insert_event.apply_async.assert_called_once_with(
+            (base_event.serialize(),), retry=False
+        )
+
+    def test_queue_event_with_OperationalError_doest_raise(
+        self, svc, insert_event, base_event
+    ):
+        insert_event.apply_async.side_effect = OperationalError
+
+        assert not svc.queue_event(base_event)
 
     @pytest.fixture
     def svc(self, db_session):
         return EventService(db_session)
 
-    def test_from_db_session(self):
-        svc = EventService.from_db_session(sentinel.db)
+    @pytest.fixture
+    def base_event(self):
+        return BaseEvent(
+            request=sentinel.request, type=EventType.Type.CONFIGURED_LAUNCH
+        )
 
-        assert svc._db == sentinel.db  # pylint:disable=protected-access
+    @pytest.fixture(autouse=True)
+    def insert_event(self, patch):
+        return patch("lms.services.event.insert_event")
 
 
 class TestFactory:
     def test_it(self, pyramid_request, EventService):
         svc = factory(sentinel.context, pyramid_request)
 
-        EventService.from_db_session.assert_called_once_with(db=pyramid_request.db)
-        assert svc == EventService.from_db_session.return_value
+        EventService.assert_called_once_with(db=pyramid_request.db)
+        assert svc == EventService.return_value
 
     @pytest.fixture
     def EventService(self, patch):

--- a/tests/unit/lms/tasks/event_test.py
+++ b/tests/unit/lms/tasks/event_test.py
@@ -1,0 +1,30 @@
+from contextlib import contextmanager
+
+import pytest
+
+from lms.tasks.event import insert_event
+
+
+def test_insert_event(event_service, BaseEvent):
+    insert_event({"type": "value"})
+
+    BaseEvent.assert_called_once_with(type="value")
+    event_service.insert_event.assert_called_once_with(BaseEvent.return_value)
+
+
+@pytest.fixture(autouse=True)
+def BaseEvent(patch):
+    return patch("lms.tasks.event.BaseEvent")
+
+
+@pytest.fixture(autouse=True)
+def app(patch, pyramid_request):
+    app = patch("lms.tasks.event.app")
+
+    @contextmanager
+    def request_context():
+        yield pyramid_request
+
+    app.request_context = request_context
+
+    return app

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -181,9 +181,7 @@ class TestOAuth2RedirectError:
             type=LTIEvent.Type.ERROR_CODE,
             data={"code": JSConfig.ErrorCode.CANVAS_INVALID_SCOPE},
         )
-        EventService.from_db_session.return_value.insert_event.assert_called_once_with(
-            LTIEvent.return_value
-        )
+        EventService.queue_event.assert_called_once_with(LTIEvent.return_value)
 
     def test_it_sets_the_error_details_if_theres_an_error_description(
         self, pyramid_request


### PR DESCRIPTION
Use the infrastructure to record events to also record instances where the backend emits a known error code to the frontend.

Start with the CANVAS_INVALID_SCOPE code in anticipation for the rollout of canvas pages.

Events stored this way record the install, course, assignment and user that are relevant.



### Testing
- Restart `make dev` to get the new task registered.

- Log in into Canvas with `eng+canvasteacher@hypothes.is`

- Launch any [assignment](https://hypothesis.instructure.com/courses/121/assignments/850) from the Missing Developer Key Scopes course

- You'll get an error dialog

- Check the events in the DB


```
docker compose exec postgres psql -U postgres -c "select event.*, extra from event join event_type on event_type.id = type_id join event_data on event_data.event_id = event.id where type = 'error_code'"  


                                                                                                                                           
 id  |         timestamp          | type_id | application_instance_id | course_id | assignment_id | grouping_id |              extra               
-----+----------------------------+---------+-------------------------+-----------+---------------+-------------+----------------------------------
 438 | 2023-12-14 14:28:45.770844 |      36 |                       5 |       549 |            50 |             | {"code": "canvas_invalid_scope"}

```


- Now stop your rabbit server with: `docker compose stop rabbit`
- Launch any [assignment](https://hypothesis.instructure.com/courses/121/assignments/850) from the Missing Developer Key Scopes course again
- The missing connection doesn't stop the dialog from showing.


