### PR TITLE
Don't consider `TaskDone` when generating email digests

### DIFF
--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Optional
 
 from sqlalchemy import Boolean, not_, select
 
@@ -10,7 +9,6 @@ from lms.models import (
     AssignmentMembership,
     Event,
     LTIRole,
-    TaskDone,
     User,
     UserPreferences,
 )
@@ -49,6 +47,7 @@ def send_instructor_email_digest_tasks():
     created_before = datetime(
         year=now.year, month=now.month, day=now.day, hour=5, tzinfo=timezone.utc
     )
+    created_after = created_before - timedelta(days=1)
 
     with app.request_context() as request:  # pylint:disable=no-member
         with request.tm:
@@ -59,7 +58,7 @@ def send_instructor_email_digest_tasks():
                     # Note here that we are considering earlier launches
                     # We rather take a few more courses that miss some cases
                     # where the launch that originated the annotations was made around the cutoff time.
-                    Event.timestamp >= created_before - timedelta(days=14),
+                    Event.timestamp >= created_after - timedelta(days=7),
                     Event.timestamp <= created_before,
                     # Only courses that belong to AIs with the feature enabled
                     ApplicationInstance.settings["hypothesis"][
@@ -108,6 +107,7 @@ def send_instructor_email_digest_tasks():
                     {
                         "h_userid": h_userid,
                         "created_before": created_before.isoformat(),
+                        "created_after": created_after.isoformat(),
                     },
                 )
 
@@ -121,7 +121,7 @@ def send_instructor_email_digest_tasks():
     rate_limit="10/m",
 )
 def send_instructor_email_digest(
-    *, h_userid: str, created_before: str, created_after: Optional[str] = None, **kwargs
+    *, h_userid: str, created_before: str, created_after: str, **kwargs
 ) -> None:
     """
     Generate and send instructor email digests to the given users.
@@ -131,10 +131,6 @@ def send_instructor_email_digest(
 
     If no `created_after` is given then it defaults to seven days before
     `created_before`.
-
-    Annotations that the user has already been emailed about (according to the
-    `task_done` table) won't be covered even if they fall between the
-    `created_after` and `created_before` dates.
 
     :param h_userid: the h_userid of the instructor to email
     :param created_before: cut-off time after which activity will not be
@@ -146,27 +142,10 @@ def send_instructor_email_digest(
     # Caution: datetime.fromisoformat() doesn't support all ISO 8601 strings!
     # This only works for the subset of ISO 8601 produced by datetime.isoformat().
     created_before = datetime.fromisoformat(created_before)
-
-    if created_after is None:
-        created_after = created_before - timedelta(days=7)
-    else:
-        created_after = datetime.fromisoformat(created_after)
+    created_after = datetime.fromisoformat(created_after)
 
     with app.request_context() as request:  # pylint:disable=no-member
         with request.tm:
-            task_done_data = _get_task_done_data(request.db, h_userid)
-
-            if task_done_data:
-                created_after = max(
-                    datetime.fromisoformat(task_done_data["created_before"]).replace(
-                        tzinfo=timezone.utc
-                    ),
-                    created_after.replace(tzinfo=timezone.utc),
-                    # Don't count annotations from before we deployed https://github.com/hypothesis/lms/pull/5904.
-                    # This line can safely be removed on Weds 20th Dec 2023 or later.
-                    datetime(year=2023, month=12, day=13, hour=5, tzinfo=timezone.utc),
-                )
-
             digest_service = request.find_service(DigestService)
 
             digest_service.send_instructor_email_digest(
@@ -175,26 +154,3 @@ def send_instructor_email_digest(
                 created_before=created_before,
                 **kwargs,
             )
-
-
-def _get_task_done_data(db_session, h_userid: str) -> Optional[dict]:
-    """Return the most recent matching TaskDone.data dict for h_userid."""
-    task_dones = db_session.scalars(
-        select(TaskDone)
-        .where(
-            TaskDone.data["type"].as_string() == "instructor_email_digest",
-            TaskDone.data["h_userid"].as_string() == h_userid,
-            TaskDone.data["created_before"].isnot(None),
-        )
-        .order_by(TaskDone.data["created_before"].desc())
-    )
-
-    for task_done in task_dones:
-        try:
-            datetime.fromisoformat(task_done.data["created_before"])
-        except ValueError:
-            continue
-        else:
-            return task_done.data
-
-    return None


### PR DESCRIPTION
This effectively reverts https://github.com/hypothesis/lms/pull/5904 although I've written this manually rather than using `git revert` because there have been other changes to the code since https://github.com/hypothesis/lms/pull/5904.

We're seeing performance issues with h's bulk annotation API which seem to have started when we merged the change to LMS that caused it to take `created_after` dates from the `TaskDone` table rather than using a fixed 24hr time range. [Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1702635892367009?thread_ts=1702624888.821809&cid=C4K6M7P5E).

This commit reverts the LMS code back to using a fixed time range for now, until we have time to deal with the performance issues in h.
