### PR TITLE
Update how content range configuration is passed to the client

### DIFF
--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -321,27 +321,45 @@ class TestAddDocumentURL:
             == vitalsource_service.get_book_reader_url.return_value
         )
 
-    @pytest.mark.parametrize("page_ranges_enabled", (True, False))
-    def test_vitalsource_sets_content_range(
-        self, js_config, vitalsource_service, course, assignment, page_ranges_enabled
+    @pytest.mark.parametrize(
+        "page_ranges_enabled,assignment_has_content_range",
+        [
+            (False, False),
+            (False, True),
+            (True, False),
+            (True, True),
+        ],
+    )
+    def test_vitalsource_sets_content_focus(
+        self,
+        js_config,
+        vitalsource_service,
+        course,
+        assignment,
+        page_ranges_enabled,
+        assignment_has_content_range,
     ):
         document_url = "vitalsource://book/bookID/book-id/page/20?end_page=30"
-        vitalsource_service.get_content_range.return_value = {
-            "start": "20",
-            "end": "30",
-        }
+        if assignment_has_content_range:
+            focus_config_from_url = {"page": "20-30"}
+        else:
+            focus_config_from_url = None
+
         vitalsource_service.page_ranges_enabled = page_ranges_enabled
+        vitalsource_service.get_client_focus_config.return_value = focus_config_from_url
 
         # `add_document_url` fetches the content range, `enable_lti_launch_mode`
         # adds it to the dict under `hypothesisClient`.
         js_config.add_document_url(document_url)
         js_config.enable_lti_launch_mode(course, assignment)
 
-        clientConfig = js_config.asdict()["hypothesisClient"]
-        if page_ranges_enabled:
-            assert clientConfig["contentRange"] == {"start": "20", "end": "30"}
+        client_config = js_config.asdict()["hypothesisClient"]
+        focus_config = client_config.get("focus", {})
+
+        if page_ranges_enabled and assignment_has_content_range:
+            assert focus_config["page"] == "20-30"
         else:
-            assert "contentRange" not in clientConfig
+            assert "page" not in focus_config
 
     def test_jstor_sets_config(self, js_config, jstor_service, pyramid_request):
         jstor_url = "jstor://DOI"

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -57,25 +57,23 @@ class TestVitalSourceService:
         assert url == reader_url
 
     @pytest.mark.parametrize(
-        "doc_url,expected_content_range",
+        "doc_url,expected_config",
         [
-            (
-                "vitalsource://book/bookID/BOOK-ID/cfi/CFI",
-                {"start": "CFI", "end": None},
-            ),
+            ("vitalsource://book/bookID/BOOK-ID/cfi/CFI", None),
+            ("vitalsource://book/bookID/BOOK-ID/page/42", None),
             (
                 "vitalsource://book/bookID/BOOK-ID/page/42?end_page=50",
-                {"start": "42", "end": "50"},
+                {"page": "42-50"},
             ),
             (
                 "vitalsource://book/bookID/BOOK-ID/cfi/CFI?end_cfi=END_CFI",
-                {"start": "CFI", "end": "END_CFI"},
+                {"cfi": {"range": "CFI-END_CFI", "label": "selected chapters"}},
             ),
         ],
     )
-    def test_get_content_range(self, svc, doc_url, expected_content_range):
-        content_range = svc.get_content_range(doc_url)
-        assert content_range == expected_content_range
+    def test_get_client_focus_config(self, svc, doc_url, expected_config):
+        config = svc.get_client_focus_config(doc_url)
+        assert config == expected_config
 
     def test_get_sso_redirect(self, svc, customer_client):
         result = svc.get_sso_redirect(


### PR DESCRIPTION
Following recent client chanes, the content range is now expected under the "focus" property instead of the "contentRange" property. eg:

```
{
  "focus": {
    // When content range is specified with pages.
    "page": "10-20",

    // When content range is specified via TOC selection.
    "cfi": {
      "range": "/2/4-/2/6",
      "label": "Chapter 1"
    }
  }
}
```

Once this lands I can do end-to-end testing that a VitalSource assignment with a page range or chapter range configured only shows annotations from that range.