### PR TITLE
`page` => `pages` in content focus configuration

### DIFF
--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -126,7 +126,7 @@ class VitalSourceService:
         if loc.page and "end_page" in params:
             end_page = params["end_page"][-1]
             return {
-                "page": f"{loc.page}-{end_page}",
+                "pages": f"{loc.page}-{end_page}",
             }
 
         return None

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -63,7 +63,7 @@ class TestVitalSourceService:
             ("vitalsource://book/bookID/BOOK-ID/page/42", None),
             (
                 "vitalsource://book/bookID/BOOK-ID/page/42?end_page=50",
-                {"page": "42-50"},
+                {"pages": "42-50"},
             ),
             (
                 "vitalsource://book/bookID/BOOK-ID/cfi/CFI?end_cfi=END_CFI",


### PR DESCRIPTION
The client configuration currently uses the plural form. See https://github.com/hypothesis/client/blob/0a7f935fe4dbdc4e8ba816629935b3cb3b858297/src/types/config.ts#L110.