### PR TITLE
Fetch oauth2 token by GUID instead of application instance ID

### DIFF
--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -36,6 +36,21 @@ class TestOAuth2TokenService:
 
         assert result == oauth_token
 
+    def test_get_returns_token_from_another_ai_with_same_guid(
+        self, svc, oauth_token, lti_user, application_instance
+    ):
+        oauth_token = factories.OAuth2Token(
+            user_id=lti_user.user_id,
+            application_instance=factories.ApplicationInstance(
+                tool_consumer_instance_guid=application_instance.tool_consumer_instance_guid
+            ),
+        )
+
+        result = svc.get()
+
+        assert result == oauth_token
+        assert result.application_instance != application_instance
+
     def test_get_raises_OAuth2TokenError_with_mismatching_application_instance(
         self, db_session, lti_user
     ):


### PR DESCRIPTION
When multiple installs co-exists in the same school different token requests invalidate each other causing multiple authorization requests to the LMS.

A launch in one install will request a new token, invalidating any others.

Another launch in the same school, by the same user but in a different install will not try to use the same token, request a new one invalidating the existing one.


### Testing

- On `main`
- Launch both

  - https://hypothesis.instructure.com/courses/125/assignments/873
  - https://hypothesis.instructure.com/courses/319/assignments/3308

You'll get an authorization dialog when switching from one to another.


- Repeat the test on this branch, `oauth2-guid`, no auth dialog.