### PR TITLE
Update dependencies of direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
+  allow:
+    - dependency-type: "all"
 - package-ecosystem: "npm"
   directory: "/"
   schedule:


### PR DESCRIPTION
Many dependencies of dependencies are:

- Not pinned
- Never bumped to a new version

I'm not sure if I'm reading this correctly:

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow

but maybe this will send us PR for those that can be updated.