### PR TITLE
Revert "Update dependencies of direct dependencies"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
-  allow:
-    - dependency-type: "all"
 - package-ecosystem: "npm"
   directory: "/"
   schedule:


### PR DESCRIPTION
Reverts hypothesis/lms#5942


This seems to lead to  "Dependabot timed out during its update"

See:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/troubleshooting-dependabot-errors#dependabot-timed-out-during-its-update