### PR TITLE
Upgrade jinja2 to the latest version

### DIFF
--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -160,7 +160,7 @@ importlib-resources==6.1.1
     #   jsonschema-specifications
 iniconfig==1.1.1
     # via pytest
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/prod.txt
     #   data-tasks
@@ -183,7 +183,7 @@ mako==1.2.2
     # via
     #   -r requirements/prod.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/prod.txt
     #   jinja2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -158,7 +158,7 @@ ipython==8.4.0
     # via pyramid-ipython
 jedi==0.18.1
     # via ipython
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/prod.txt
     #   data-tasks
@@ -181,7 +181,7 @@ mako==1.2.2
     # via
     #   -r requirements/prod.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/prod.txt
     #   jinja2

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -162,7 +162,7 @@ inflection==0.5.1
     # via pytest-factoryboy
 iniconfig==1.1.1
     # via pytest
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/prod.txt
     #   data-tasks
@@ -185,7 +185,7 @@ mako==1.2.2
     # via
     #   -r requirements/prod.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/prod.txt
     #   jinja2

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -292,7 +292,7 @@ iniconfig==1.1.1
     #   pytest
 isort==5.13.2
     # via pylint
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -328,7 +328,7 @@ mako==1.2.2
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -550,7 +550,7 @@ pytest-factoryboy==2.5.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-pytest-xdist[psutil]==3.3.1
+pytest-xdist[psutil]==3.5.0
     # via
     #   -r requirements/tests.txt
     #   pytest-xdist

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -99,7 +99,7 @@ importlib-resources==6.1.1
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   data-tasks
     #   pyramid-jinja2
@@ -113,7 +113,7 @@ mailchimp-transactional==1.0.50
     # via -r requirements/prod.in
 mako==1.2.2
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   jinja2
     #   mako

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -30,7 +30,7 @@ jinja2==3.1.2
     # via cookiecutter
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -172,7 +172,7 @@ inflection==0.5.1
     # via pytest-factoryboy
 iniconfig==1.1.1
     # via pytest
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/prod.txt
     #   data-tasks
@@ -195,7 +195,7 @@ mako==1.2.2
     # via
     #   -r requirements/prod.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/prod.txt
     #   jinja2
@@ -320,9 +320,7 @@ pytest-cov==4.1.0
 pytest-factoryboy==2.5.1
     # via -r requirements/tests.in
 pytest-xdist[psutil]==3.5.0
-    # via
-    #   -r requirements/tests.in
-    #   pytest-xdist
+    # via -r requirements/tests.in
 python-dateutil==2.8.2
     # via
     #   -r requirements/prod.txt


### PR DESCRIPTION
First run:

- make requirements --always-make args='--upgrade-package markupsafe'

and then:

- make requirements --always-make args='--upgrade-package jinaj2'


