### PR TITLE
Upgrade python dependencies

### DIFF
--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -6,17 +6,17 @@
 #
 aiohttp==3.9.1
     # via -r requirements/prod.txt
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via
     #   -r requirements/prod.txt
     #   aiohttp
-alembic==1.12.0
+alembic==1.13.1
     # via -r requirements/prod.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
-async-timeout==4.0.1
+async-timeout==4.0.3
     # via
     #   -r requirements/prod.txt
     #   aiohttp
@@ -32,7 +32,7 @@ backports-zoneinfo[tzdata]==0.2.1
     #   backports-zoneinfo
     #   celery
     #   kombu
-beautifulsoup4==4.9.3
+beautifulsoup4==4.12.2
     # via webtest
 behave==1.2.6
     # via -r requirements/bddtests.in
@@ -40,15 +40,15 @@ billiard==4.2.0
     # via
     #   -r requirements/prod.txt
     #   celery
-build==0.8.0
+build==1.0.3
     # via pip-tools
-cachetools==4.2.2
+cachetools==5.3.2
     # via
     #   -r requirements/prod.txt
     #   google-auth
 celery==5.3.6
     # via -r requirements/prod.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/prod.txt
     #   mailchimp-transactional
@@ -58,11 +58,11 @@ cffi==1.16.0
     # via
     #   -r requirements/prod.txt
     #   cryptography
-charset-normalizer==2.0.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/prod.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/prod.txt
     #   celery
@@ -78,47 +78,47 @@ click-plugins==1.1.1
     # via
     #   -r requirements/prod.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/prod.txt
     #   celery
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/prod.txt
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
     # via -r requirements/prod.txt
-ecdsa==0.17.0
+ecdsa==0.18.0
     # via
     #   -r requirements/prod.txt
     #   python-jose
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via -r requirements/bddtests.in
-faker==8.1.2
+faker==21.0.0
     # via factory-boy
 filelock==3.13.1
     # via -r requirements/bddtests.in
-frozenlist==1.2.0
+frozenlist==1.4.1
     # via
     #   -r requirements/prod.txt
     #   aiohttp
     #   aiosignal
-google-auth==1.30.0
+google-auth==2.25.2
     # via
     #   -r requirements/prod.txt
     #   google-auth-oauthlib
-google-auth-oauthlib==0.4.4
+google-auth-oauthlib==1.2.0
     # via
     #   -r requirements/prod.txt
     #   pyramid-googleauth
-greenlet==1.0.0
+greenlet==3.0.3
     # via
     #   -r requirements/prod.txt
     #   sqlalchemy
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via -r requirements/prod.txt
 h-api==1.1.0
     # via -r requirements/prod.txt
@@ -132,7 +132,7 @@ h-vialib==1.2.1
     # via -r requirements/prod.txt
 httpretty==1.1.4
     # via -r requirements/bddtests.in
-hupper==1.10.2
+hupper==1.12
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -141,10 +141,11 @@ idna==3.6
     #   -r requirements/prod.txt
     #   requests
     #   yarl
-importlib-metadata==4.8.1
+importlib-metadata==7.0.1
     # via
     #   -r requirements/prod.txt
     #   alembic
+    #   build
     #   data-tasks
     #   h-api
     #   h-assets
@@ -158,18 +159,18 @@ importlib-resources==6.1.1
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
-jsonschema==4.19.1
+jsonschema==4.20.0
     # via
     #   -r requirements/prod.txt
     #   h-api
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/prod.txt
     #   jsonschema
@@ -179,11 +180,11 @@ kombu==5.3.4
     #   celery
 mailchimp-transactional==1.0.50
     # via -r requirements/prod.txt
-mako==1.2.2
+mako==1.3.0
     # via
     #   -r requirements/prod.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/prod.txt
     #   jinja2
@@ -193,7 +194,7 @@ marshmallow==3.20.1
     # via
     #   -r requirements/prod.txt
     #   webargs
-multidict==5.2.0
+multidict==6.0.4
     # via
     #   -r requirements/prod.txt
     #   aiohttp
@@ -204,26 +205,25 @@ oauthlib==3.2.2
     # via
     #   -r requirements/prod.txt
     #   requests-oauthlib
-packaging==21.3
+packaging==23.2
     # via
     #   -r requirements/prod.txt
     #   build
+    #   gunicorn
     #   marshmallow
     #   pytest
     #   webargs
     #   zope-sqlalchemy
-parse==1.19.0
+parse==1.20.0
     # via
     #   behave
     #   parse-type
-parse-type==0.5.2
+parse-type==0.6.2
     # via behave
-pastedeploy==2.1.0
+pastedeploy==3.1.0
     # via
     #   -r requirements/prod.txt
     #   plaster-pastedeploy
-pep517==0.12.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/bddtests.in
 pip-tools==7.3.0
@@ -234,18 +234,18 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/prod.txt
     #   jsonschema
-plaster==1.0
+plaster==1.1.2
     # via
     #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
-plaster-pastedeploy==0.7
+plaster-pastedeploy==1.0.1
     # via
     #   -r requirements/prod.txt
     #   pyramid
-pluggy==0.13.1
+pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/prod.txt
     #   click-repl
@@ -253,13 +253,13 @@ psycopg2==2.9.9
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/prod.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via
     #   -r requirements/prod.txt
     #   google-auth
@@ -274,10 +274,8 @@ pyjwt[crypto]==2.8.0
     #   -r requirements/prod.txt
     #   pyjwt
     #   pyramid-googleauth
-pyparsing==3.0.6
-    # via
-    #   -r requirements/prod.txt
-    #   packaging
+pyproject-hooks==1.0.0
+    # via build
 pyramid==2.0.2
     # via
     #   -r requirements/prod.txt
@@ -314,7 +312,7 @@ python-jose[crypto,cryptography]==3.3.0
     #   -r requirements/prod.txt
     #   h-vialib
     #   python-jose
-referencing==0.30.2
+referencing==0.32.0
     # via
     #   -r requirements/prod.txt
     #   h-api
@@ -329,17 +327,17 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/prod.txt
     #   google-auth-oauthlib
-rpds-py==0.10.3
+rpds-py==0.15.2
     # via
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-rsa==4.7.2
+rsa==4.9
     # via
     #   -r requirements/prod.txt
     #   google-auth
     #   python-jose
-sentry-sdk==1.14.0
+sentry-sdk==1.39.1
     # via
     #   -r requirements/prod.txt
     #   h-pyramid-sentry
@@ -347,13 +345,11 @@ six==1.16.0
     # via
     #   -r requirements/prod.txt
     #   behave
-    #   click-repl
     #   ecdsa
-    #   google-auth
     #   mailchimp-transactional
     #   parse-type
     #   python-dateutil
-soupsieve==2.2.1
+soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.23
     # via
@@ -369,15 +365,13 @@ tabulate==0.9.0
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-text-unidecode==1.3
-    # via faker
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
-transaction==2.4.0
+transaction==4.0
     # via
     #   -r requirements/prod.txt
     #   pyramid-tm
@@ -390,7 +384,7 @@ typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
     #   alembic
-    #   async-timeout
+    #   faker
     #   kombu
     #   sqlalchemy
 tzdata==2023.3
@@ -398,13 +392,13 @@ tzdata==2023.3
     #   -r requirements/prod.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
-venusian==3.0.0
+venusian==3.1.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -416,13 +410,13 @@ vine==5.1.0
     #   kombu
 waitress==2.1.2
     # via webtest
-wcwidth==0.2.5
+wcwidth==0.2.12
     # via
     #   -r requirements/prod.txt
     #   prompt-toolkit
 webargs==8.3.0
     # via -r requirements/prod.txt
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/prod.txt
     #   h-vialib
@@ -430,29 +424,29 @@ webob==1.8.6
     #   webtest
 webtest==3.0.0
     # via -r requirements/bddtests.in
-wheel==0.37.1
+wheel==0.42.0
     # via pip-tools
-wired==0.2.2
+wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
 xmltodict==0.13.0
     # via -r requirements/prod.txt
-yarl==1.7.2
+yarl==1.9.4
     # via
     #   -r requirements/prod.txt
     #   aiohttp
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/prod.txt
     #   importlib-metadata
     #   importlib-resources
-zope-deprecation==4.3.0
+zope-deprecation==5.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-jinja2
-zope-interface==5.1.0
+zope-interface==6.1
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -465,15 +459,12 @@ zope-sqlalchemy==3.1
     # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==67.4.0
+setuptools==69.0.3
     # via
     #   -r requirements/prod.txt
-    #   google-auth
-    #   gunicorn
     #   pip-tools
-    #   plaster
     #   pyramid
     #   zope-deprecation
     #   zope-interface

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -4,51 +4,53 @@
 #
 #    pip-compile --allow-unsafe requirements/checkformatting.in
 #
-black==23.11.0
+black==23.12.1
     # via -r requirements/checkformatting.in
-build==0.8.0
+build==1.0.3
     # via pip-tools
-click==8.0.3
+click==8.1.7
     # via
     #   black
     #   pip-tools
-importlib-metadata==4.12.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 isort==5.13.2
     # via -r requirements/checkformatting.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-packaging==23.0
+packaging==23.2
     # via
     #   black
     #   build
-pathspec==0.9.0
+pathspec==0.12.1
     # via black
-pep517==0.12.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/checkformatting.in
 pip-tools==7.3.0
     # via
     #   -r requirements/checkformatting.in
     #   pip-sync-faster
-platformdirs==2.4.0
+platformdirs==4.1.0
     # via black
-tomli==1.2.2
+pyproject-hooks==1.0.0
+    # via build
+tomli==2.0.1
     # via
     #   black
     #   build
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
 typing-extensions==4.9.0
     # via black
-wheel==0.37.1
+wheel==0.42.0
     # via pip-tools
-zipp==3.8.1
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==67.8.0
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile --allow-unsafe requirements/coverage.in
 #
-build==0.8.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via pip-tools
 coverage[toml]==7.3.4
     # via -r requirements/coverage.in
-importlib-metadata==4.12.0
-    # via pip-sync-faster
-packaging==21.3
-    # via build
-pep517==0.12.0
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
+packaging==23.2
     # via build
 pip-sync-faster==0.0.3
     # via -r requirements/coverage.in
@@ -22,21 +22,21 @@ pip-tools==7.3.0
     # via
     #   -r requirements/coverage.in
     #   pip-sync-faster
-pyparsing==3.0.9
-    # via packaging
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
     # via
     #   build
     #   coverage
-    #   pep517
     #   pip-tools
-wheel==0.37.1
+    #   pyproject-hooks
+wheel==0.42.0
     # via pip-tools
-zipp==3.8.1
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==67.8.0
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,19 +6,19 @@
 #
 aiohttp==3.9.1
     # via -r requirements/prod.txt
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via
     #   -r requirements/prod.txt
     #   aiohttp
-alembic==1.12.0
+alembic==1.13.1
     # via -r requirements/prod.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
-asttokens==2.0.5
+asttokens==2.4.1
     # via stack-data
-async-timeout==4.0.1
+async-timeout==4.0.3
     # via
     #   -r requirements/prod.txt
     #   aiohttp
@@ -40,15 +40,15 @@ billiard==4.2.0
     # via
     #   -r requirements/prod.txt
     #   celery
-build==0.8.0
+build==1.0.3
     # via pip-tools
-cachetools==4.2.2
+cachetools==5.3.2
     # via
     #   -r requirements/prod.txt
     #   google-auth
 celery==5.3.6
     # via -r requirements/prod.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/prod.txt
     #   mailchimp-transactional
@@ -58,11 +58,11 @@ cffi==1.16.0
     # via
     #   -r requirements/prod.txt
     #   cryptography
-charset-normalizer==2.0.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/prod.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/prod.txt
     #   celery
@@ -78,11 +78,11 @@ click-plugins==1.1.1
     # via
     #   -r requirements/prod.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/prod.txt
     #   celery
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/prod.txt
     #   pyjwt
@@ -91,34 +91,34 @@ data-tasks==0.0.3
     # via -r requirements/prod.txt
 decorator==5.1.1
     # via ipython
-ecdsa==0.17.0
+ecdsa==0.18.0
     # via
     #   -r requirements/prod.txt
     #   python-jose
-executing==0.8.3
+executing==2.0.1
     # via stack-data
 factory-boy==3.3.0
     # via -r requirements/dev.in
-faker==13.14.0
+faker==21.0.0
     # via factory-boy
-frozenlist==1.2.0
+frozenlist==1.4.1
     # via
     #   -r requirements/prod.txt
     #   aiohttp
     #   aiosignal
-google-auth==1.30.0
+google-auth==2.25.2
     # via
     #   -r requirements/prod.txt
     #   google-auth-oauthlib
-google-auth-oauthlib==0.4.4
+google-auth-oauthlib==1.2.0
     # via
     #   -r requirements/prod.txt
     #   pyramid-googleauth
-greenlet==1.0.0
+greenlet==3.0.3
     # via
     #   -r requirements/prod.txt
     #   sqlalchemy
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via -r requirements/prod.txt
 h-api==1.1.0
     # via -r requirements/prod.txt
@@ -128,7 +128,7 @@ h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
 h-vialib==1.2.1
     # via -r requirements/prod.txt
-hupper==1.10.2
+hupper==1.12
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -137,10 +137,11 @@ idna==3.6
     #   -r requirements/prod.txt
     #   requests
     #   yarl
-importlib-metadata==4.8.1
+importlib-metadata==7.0.1
     # via
     #   -r requirements/prod.txt
     #   alembic
+    #   build
     #   data-tasks
     #   h-api
     #   h-assets
@@ -154,20 +155,20 @@ importlib-resources==6.1.1
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
-ipython==8.4.0
+ipython==8.12.3
     # via pyramid-ipython
-jedi==0.18.1
+jedi==0.19.1
     # via ipython
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
-jsonschema==4.19.1
+jsonschema==4.20.0
     # via
     #   -r requirements/prod.txt
     #   h-api
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/prod.txt
     #   jsonschema
@@ -177,11 +178,11 @@ kombu==5.3.4
     #   celery
 mailchimp-transactional==1.0.50
     # via -r requirements/prod.txt
-mako==1.2.2
+mako==1.3.0
     # via
     #   -r requirements/prod.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/prod.txt
     #   jinja2
@@ -191,9 +192,9 @@ marshmallow==3.20.1
     # via
     #   -r requirements/prod.txt
     #   webargs
-matplotlib-inline==0.1.3
+matplotlib-inline==0.1.6
     # via ipython
-multidict==5.2.0
+multidict==6.0.4
     # via
     #   -r requirements/prod.txt
     #   aiohttp
@@ -204,22 +205,21 @@ oauthlib==3.2.2
     # via
     #   -r requirements/prod.txt
     #   requests-oauthlib
-packaging==21.3
+packaging==23.2
     # via
     #   -r requirements/prod.txt
     #   build
+    #   gunicorn
     #   marshmallow
     #   webargs
     #   zope-sqlalchemy
 parso==0.8.3
     # via jedi
-pastedeploy==2.1.0
+pastedeploy==3.1.0
     # via
     #   -r requirements/prod.txt
     #   plaster-pastedeploy
-pep517==0.12.0
-    # via build
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
@@ -233,16 +233,16 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/prod.txt
     #   jsonschema
-plaster==1.0
+plaster==1.1.2
     # via
     #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
-plaster-pastedeploy==0.7
+plaster-pastedeploy==1.0.1
     # via
     #   -r requirements/prod.txt
     #   pyramid
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/prod.txt
     #   click-repl
@@ -255,13 +255,13 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/prod.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via
     #   -r requirements/prod.txt
     #   google-auth
@@ -271,17 +271,15 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.19.0
     # via -r requirements/prod.txt
-pygments==2.15.0
+pygments==2.17.2
     # via ipython
 pyjwt[crypto]==2.8.0
     # via
     #   -r requirements/prod.txt
     #   pyjwt
     #   pyramid-googleauth
-pyparsing==3.0.6
-    # via
-    #   -r requirements/prod.txt
-    #   packaging
+pyproject-hooks==1.0.0
+    # via build
 pyramid==2.0.2
     # via
     #   -r requirements/prod.txt
@@ -319,7 +317,7 @@ python-jose[crypto,cryptography]==3.3.0
     #   -r requirements/prod.txt
     #   h-vialib
     #   python-jose
-referencing==0.30.2
+referencing==0.32.0
     # via
     #   -r requirements/prod.txt
     #   h-api
@@ -334,17 +332,17 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/prod.txt
     #   google-auth-oauthlib
-rpds-py==0.10.3
+rpds-py==0.15.2
     # via
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-rsa==4.7.2
+rsa==4.9
     # via
     #   -r requirements/prod.txt
     #   google-auth
     #   python-jose
-sentry-sdk==1.14.0
+sentry-sdk==1.39.1
     # via
     #   -r requirements/prod.txt
     #   h-pyramid-sentry
@@ -352,9 +350,7 @@ six==1.16.0
     # via
     #   -r requirements/prod.txt
     #   asttokens
-    #   click-repl
     #   ecdsa
-    #   google-auth
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.23
@@ -367,7 +363,7 @@ sqlparse==0.4.4
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-stack-data==0.3.0
+stack-data==0.6.3
     # via ipython
 supervisor==4.2.5
     # via -r requirements/dev.in
@@ -378,13 +374,13 @@ tabulate==0.9.0
 tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
-traitlets==5.3.0
+    #   pyproject-hooks
+traitlets==5.14.0
     # via
     #   ipython
     #   matplotlib-inline
-transaction==2.4.0
+transaction==4.0
     # via
     #   -r requirements/prod.txt
     #   pyramid-tm
@@ -397,7 +393,8 @@ typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
     #   alembic
-    #   async-timeout
+    #   faker
+    #   ipython
     #   kombu
     #   sqlalchemy
 tzdata==2023.3
@@ -405,13 +402,13 @@ tzdata==2023.3
     #   -r requirements/prod.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
-venusian==3.0.0
+venusian==3.1.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -421,40 +418,40 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.12
     # via
     #   -r requirements/prod.txt
     #   prompt-toolkit
 webargs==8.3.0
     # via -r requirements/prod.txt
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/prod.txt
     #   h-vialib
     #   pyramid
-wheel==0.37.1
+wheel==0.42.0
     # via pip-tools
-wired==0.2.2
+wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
 xmltodict==0.13.0
     # via -r requirements/prod.txt
-yarl==1.7.2
+yarl==1.9.4
     # via
     #   -r requirements/prod.txt
     #   aiohttp
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/prod.txt
     #   importlib-metadata
     #   importlib-resources
-zope-deprecation==4.3.0
+zope-deprecation==5.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-jinja2
-zope-interface==5.1.0
+zope-interface==6.1
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -467,16 +464,12 @@ zope-sqlalchemy==3.1
     # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==67.4.0
+setuptools==69.0.3
     # via
     #   -r requirements/prod.txt
-    #   google-auth
-    #   gunicorn
-    #   ipython
     #   pip-tools
-    #   plaster
     #   pyramid
     #   supervisor
     #   zope-deprecation

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -4,51 +4,53 @@
 #
 #    pip-compile --allow-unsafe requirements/format.in
 #
-black==23.11.0
+black==23.12.1
     # via -r requirements/format.in
-build==0.8.0
+build==1.0.3
     # via pip-tools
-click==8.0.3
+click==8.1.7
     # via
     #   black
     #   pip-tools
-importlib-metadata==4.12.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 isort==5.13.2
     # via -r requirements/format.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-packaging==23.0
+packaging==23.2
     # via
     #   black
     #   build
-pathspec==0.9.0
+pathspec==0.12.1
     # via black
-pep517==0.12.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/format.in
 pip-tools==7.3.0
     # via
     #   -r requirements/format.in
     #   pip-sync-faster
-platformdirs==2.4.0
+platformdirs==4.1.0
     # via black
-tomli==1.2.2
+pyproject-hooks==1.0.0
+    # via build
+tomli==2.0.1
     # via
     #   black
     #   build
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
 typing-extensions==4.9.0
     # via black
-wheel==0.37.1
+wheel==0.42.0
     # via pip-tools
-zipp==3.8.1
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==67.8.0
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -6,17 +6,17 @@
 #
 aiohttp==3.9.1
     # via -r requirements/prod.txt
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via
     #   -r requirements/prod.txt
     #   aiohttp
-alembic==1.12.0
+alembic==1.13.1
     # via -r requirements/prod.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
-async-timeout==4.0.1
+async-timeout==4.0.3
     # via
     #   -r requirements/prod.txt
     #   aiohttp
@@ -32,21 +32,21 @@ backports-zoneinfo[tzdata]==0.2.1
     #   backports-zoneinfo
     #   celery
     #   kombu
-beautifulsoup4==4.9.3
+beautifulsoup4==4.12.2
     # via webtest
 billiard==4.2.0
     # via
     #   -r requirements/prod.txt
     #   celery
-build==0.8.0
+build==1.0.3
     # via pip-tools
-cachetools==4.2.2
+cachetools==5.3.2
     # via
     #   -r requirements/prod.txt
     #   google-auth
 celery==5.3.6
     # via -r requirements/prod.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/prod.txt
     #   mailchimp-transactional
@@ -56,11 +56,11 @@ cffi==1.16.0
     # via
     #   -r requirements/prod.txt
     #   cryptography
-charset-normalizer==2.0.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/prod.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/prod.txt
     #   celery
@@ -76,49 +76,49 @@ click-plugins==1.1.1
     # via
     #   -r requirements/prod.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/prod.txt
     #   celery
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/prod.txt
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
     # via -r requirements/prod.txt
-ecdsa==0.17.0
+ecdsa==0.18.0
     # via
     #   -r requirements/prod.txt
     #   python-jose
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via
     #   -r requirements/functests.in
     #   pytest-factoryboy
-faker==8.1.2
+faker==21.0.0
     # via factory-boy
 filelock==3.13.1
     # via -r requirements/functests.in
-frozenlist==1.2.0
+frozenlist==1.4.1
     # via
     #   -r requirements/prod.txt
     #   aiohttp
     #   aiosignal
-google-auth==1.30.0
+google-auth==2.25.2
     # via
     #   -r requirements/prod.txt
     #   google-auth-oauthlib
-google-auth-oauthlib==0.4.4
+google-auth-oauthlib==1.2.0
     # via
     #   -r requirements/prod.txt
     #   pyramid-googleauth
-greenlet==1.0.0
+greenlet==3.0.3
     # via
     #   -r requirements/prod.txt
     #   sqlalchemy
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via -r requirements/prod.txt
 h-api==1.1.0
     # via -r requirements/prod.txt
@@ -132,7 +132,7 @@ h-vialib==1.2.1
     # via -r requirements/prod.txt
 httpretty==1.1.4
     # via -r requirements/functests.in
-hupper==1.10.2
+hupper==1.12
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -141,10 +141,11 @@ idna==3.6
     #   -r requirements/prod.txt
     #   requests
     #   yarl
-importlib-metadata==4.8.1
+importlib-metadata==7.0.1
     # via
     #   -r requirements/prod.txt
     #   alembic
+    #   build
     #   data-tasks
     #   h-api
     #   h-assets
@@ -160,18 +161,18 @@ importlib-resources==6.1.1
     #   jsonschema-specifications
 inflection==0.5.1
     # via pytest-factoryboy
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
-jsonschema==4.19.1
+jsonschema==4.20.0
     # via
     #   -r requirements/prod.txt
     #   h-api
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/prod.txt
     #   jsonschema
@@ -181,11 +182,11 @@ kombu==5.3.4
     #   celery
 mailchimp-transactional==1.0.50
     # via -r requirements/prod.txt
-mako==1.2.2
+mako==1.3.0
     # via
     #   -r requirements/prod.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/prod.txt
     #   jinja2
@@ -195,7 +196,7 @@ marshmallow==3.20.1
     # via
     #   -r requirements/prod.txt
     #   webargs
-multidict==5.2.0
+multidict==6.0.4
     # via
     #   -r requirements/prod.txt
     #   aiohttp
@@ -206,20 +207,19 @@ oauthlib==3.2.2
     # via
     #   -r requirements/prod.txt
     #   requests-oauthlib
-packaging==21.3
+packaging==23.2
     # via
     #   -r requirements/prod.txt
     #   build
+    #   gunicorn
     #   marshmallow
     #   pytest
     #   webargs
     #   zope-sqlalchemy
-pastedeploy==2.1.0
+pastedeploy==3.1.0
     # via
     #   -r requirements/prod.txt
     #   plaster-pastedeploy
-pep517==0.12.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/functests.in
 pip-tools==7.3.0
@@ -230,18 +230,18 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/prod.txt
     #   jsonschema
-plaster==1.0
+plaster==1.1.2
     # via
     #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
-plaster-pastedeploy==0.7
+plaster-pastedeploy==1.0.1
     # via
     #   -r requirements/prod.txt
     #   pyramid
-pluggy==0.13.1
+pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/prod.txt
     #   click-repl
@@ -249,13 +249,13 @@ psycopg2==2.9.9
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/prod.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via
     #   -r requirements/prod.txt
     #   google-auth
@@ -270,10 +270,8 @@ pyjwt[crypto]==2.8.0
     #   -r requirements/prod.txt
     #   pyjwt
     #   pyramid-googleauth
-pyparsing==3.0.6
-    # via
-    #   -r requirements/prod.txt
-    #   packaging
+pyproject-hooks==1.0.0
+    # via build
 pyramid==2.0.2
     # via
     #   -r requirements/prod.txt
@@ -301,7 +299,7 @@ pytest==7.4.3
     # via
     #   -r requirements/functests.in
     #   pytest-factoryboy
-pytest-factoryboy==2.5.1
+pytest-factoryboy==2.6.0
     # via -r requirements/functests.in
 python-dateutil==2.8.2
     # via
@@ -314,7 +312,7 @@ python-jose[crypto,cryptography]==3.3.0
     #   -r requirements/prod.txt
     #   h-vialib
     #   python-jose
-referencing==0.30.2
+referencing==0.32.0
     # via
     #   -r requirements/prod.txt
     #   h-api
@@ -329,29 +327,27 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/prod.txt
     #   google-auth-oauthlib
-rpds-py==0.10.3
+rpds-py==0.15.2
     # via
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-rsa==4.7.2
+rsa==4.9
     # via
     #   -r requirements/prod.txt
     #   google-auth
     #   python-jose
-sentry-sdk==1.14.0
+sentry-sdk==1.39.1
     # via
     #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.16.0
     # via
     #   -r requirements/prod.txt
-    #   click-repl
     #   ecdsa
-    #   google-auth
     #   mailchimp-transactional
     #   python-dateutil
-soupsieve==2.2.1
+soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.23
     # via
@@ -367,15 +363,13 @@ tabulate==0.9.0
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-text-unidecode==1.3
-    # via faker
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
-transaction==2.4.0
+transaction==4.0
     # via
     #   -r requirements/prod.txt
     #   pyramid-tm
@@ -388,7 +382,7 @@ typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
     #   alembic
-    #   async-timeout
+    #   faker
     #   kombu
     #   pytest-factoryboy
     #   sqlalchemy
@@ -397,13 +391,13 @@ tzdata==2023.3
     #   -r requirements/prod.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
-venusian==3.0.0
+venusian==3.1.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -415,13 +409,13 @@ vine==5.1.0
     #   kombu
 waitress==2.1.2
     # via webtest
-wcwidth==0.2.5
+wcwidth==0.2.12
     # via
     #   -r requirements/prod.txt
     #   prompt-toolkit
 webargs==8.3.0
     # via -r requirements/prod.txt
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/prod.txt
     #   h-vialib
@@ -429,29 +423,29 @@ webob==1.8.6
     #   webtest
 webtest==3.0.0
     # via -r requirements/functests.in
-wheel==0.37.1
+wheel==0.42.0
     # via pip-tools
-wired==0.2.2
+wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
 xmltodict==0.13.0
     # via -r requirements/prod.txt
-yarl==1.7.2
+yarl==1.9.4
     # via
     #   -r requirements/prod.txt
     #   aiohttp
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/prod.txt
     #   importlib-metadata
     #   importlib-resources
-zope-deprecation==4.3.0
+zope-deprecation==5.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-jinja2
-zope-interface==5.1.0
+zope-interface==6.1
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -464,15 +458,12 @@ zope-sqlalchemy==3.1
     # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==67.4.0
+setuptools==69.0.3
     # via
     #   -r requirements/prod.txt
-    #   google-auth
-    #   gunicorn
     #   pip-tools
-    #   plaster
     #   pyramid
     #   zope-deprecation
     #   zope-interface

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -12,26 +12,26 @@ aiohttp==3.9.1
     #   aioresponses
 aioresponses==0.7.6
     # via -r requirements/tests.txt
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   aiohttp
-alembic==1.12.0
+alembic==1.13.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   kombu
-astroid==3.0.1
+astroid==3.0.2
     # via pylint
-async-timeout==4.0.1
+async-timeout==4.0.3
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -53,7 +53,7 @@ backports-zoneinfo[tzdata]==0.2.1
     #   backports-zoneinfo
     #   celery
     #   kombu
-beautifulsoup4==4.9.3
+beautifulsoup4==4.12.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -66,13 +66,13 @@ billiard==4.2.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   celery
-build==0.8.0
+build==1.0.3
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pip-tools
-cachetools==4.2.2
+cachetools==5.3.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -83,7 +83,7 @@ celery==5.3.6
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -97,13 +97,13 @@ cffi==1.16.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   cryptography
-charset-normalizer==2.0.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -125,18 +125,18 @@ click-plugins==1.1.1
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   celery
-coverage[toml]==7.2.7
+coverage[toml]==7.3.4
     # via
     #   -r requirements/tests.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -148,15 +148,15 @@ data-tasks==0.0.3
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-dill==0.3.4
+dill==0.3.7
     # via pylint
-ecdsa==0.17.0
+ecdsa==0.18.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   python-jose
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.2.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -172,7 +172,7 @@ factory-boy==3.3.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest-factoryboy
-faker==8.1.2
+faker==21.0.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -183,34 +183,34 @@ filelock==3.13.1
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-freezegun==1.2.2
+freezegun==1.4.0
     # via -r requirements/tests.txt
-frozenlist==1.2.0
+frozenlist==1.4.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   aiohttp
     #   aiosignal
-google-auth==1.30.0
+google-auth==2.25.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   google-auth-oauthlib
-google-auth-oauthlib==0.4.4
+google-auth-oauthlib==1.2.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pyramid-googleauth
-greenlet==1.0.0
+greenlet==3.0.3
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   sqlalchemy
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -245,7 +245,7 @@ httpretty==1.1.4
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-hupper==1.10.2
+hupper==1.12
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -258,12 +258,13 @@ idna==3.6
     #   -r requirements/tests.txt
     #   requests
     #   yarl
-importlib-metadata==4.8.1
+importlib-metadata==7.0.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   alembic
+    #   build
     #   data-tasks
     #   h-api
     #   h-assets
@@ -284,7 +285,7 @@ inflection==0.5.1
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest-factoryboy
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -292,20 +293,20 @@ iniconfig==1.1.1
     #   pytest
 isort==5.13.2
     # via pylint
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   data-tasks
     #   pyramid-jinja2
-jsonschema==4.19.1
+jsonschema==4.20.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   h-api
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -322,13 +323,13 @@ mailchimp-transactional==1.0.50
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-mako==1.2.2
+mako==1.3.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -342,9 +343,9 @@ marshmallow==3.20.1
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   webargs
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
-multidict==5.2.0
+multidict==6.0.4
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -362,37 +363,32 @@ oauthlib==3.2.2
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   requests-oauthlib
-packaging==21.3
+packaging==23.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   build
+    #   gunicorn
     #   marshmallow
     #   pytest
     #   webargs
     #   zope-sqlalchemy
-parse==1.19.0
+parse==1.20.0
     # via
     #   -r requirements/bddtests.txt
     #   behave
     #   parse-type
-parse-type==0.5.2
+parse-type==0.6.2
     # via
     #   -r requirements/bddtests.txt
     #   behave
-pastedeploy==2.1.0
+pastedeploy==3.1.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   plaster-pastedeploy
-pep517==0.12.0
-    # via
-    #   -r requirements/bddtests.txt
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   build
 pip-sync-faster==0.0.3
     # via
     #   -r requirements/bddtests.txt
@@ -412,34 +408,34 @@ pkgutil-resolve-name==1.3.10
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   jsonschema
-plaster==1.0
+plaster==1.1.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   plaster-pastedeploy
     #   pyramid
-plaster-pastedeploy==0.7
+plaster-pastedeploy==1.0.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pyramid
-platformdirs==2.2.0
+platformdirs==4.1.0
     # via pylint
-pluggy==0.13.1
+pluggy==1.3.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.7
     # via
     #   -r requirements/tests.txt
     #   pytest-xdist
@@ -449,7 +445,7 @@ psycopg2==2.9.9
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   data-tasks
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -457,7 +453,7 @@ pyasn1==0.4.8
     #   pyasn1-modules
     #   python-jose
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -487,12 +483,12 @@ pyjwt[crypto]==2.8.0
     #   pyramid-googleauth
 pylint==3.0.3
     # via -r requirements/lint.in
-pyparsing==3.0.6
+pyproject-hooks==1.0.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-    #   packaging
+    #   build
 pyramid==2.0.2
     # via
     #   -r requirements/bddtests.txt
@@ -546,11 +542,11 @@ pytest==7.4.3
     #   pytest-xdist
 pytest-cov==4.1.0
     # via -r requirements/tests.txt
-pytest-factoryboy==2.5.1
+pytest-factoryboy==2.6.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-pytest-xdist[psutil]==3.3.1
+pytest-xdist[psutil]==3.5.0
     # via
     #   -r requirements/tests.txt
     #   pytest-xdist
@@ -570,7 +566,7 @@ python-jose[crypto,cryptography]==3.3.0
     #   -r requirements/tests.txt
     #   h-vialib
     #   python-jose
-referencing==0.30.2
+referencing==0.32.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -591,21 +587,21 @@ requests-oauthlib==1.3.1
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   google-auth-oauthlib
-rpds-py==0.10.3
+rpds-py==0.15.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   jsonschema
     #   referencing
-rsa==4.7.2
+rsa==4.9
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   google-auth
     #   python-jose
-sentry-sdk==1.14.0
+sentry-sdk==1.39.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -617,15 +613,13 @@ six==1.16.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   behave
-    #   click-repl
     #   ecdsa
-    #   google-auth
     #   mailchimp-transactional
     #   parse-type
     #   python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle
-soupsieve==2.2.1
+soupsieve==2.5
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -650,28 +644,22 @@ tabulate==0.9.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   data-tasks
-text-unidecode==1.3
-    # via
-    #   -r requirements/bddtests.txt
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   faker
 toml==0.10.2
     # via -r requirements/lint.in
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   build
     #   coverage
-    #   pep517
     #   pip-tools
     #   pylint
+    #   pyproject-hooks
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.12.3
     # via pylint
-transaction==2.4.0
+transaction==4.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -691,7 +679,7 @@ typing-extensions==4.9.0
     #   -r requirements/tests.txt
     #   alembic
     #   astroid
-    #   async-timeout
+    #   faker
     #   kombu
     #   pylint
     #   pytest-factoryboy
@@ -703,7 +691,7 @@ tzdata==2023.3
     #   -r requirements/tests.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -711,7 +699,7 @@ urllib3==1.26.18
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
-venusian==3.0.0
+venusian==3.1.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -730,7 +718,7 @@ waitress==2.1.2
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   webtest
-wcwidth==0.2.5
+wcwidth==0.2.12
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -741,7 +729,7 @@ webargs==8.3.0
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -753,13 +741,13 @@ webtest==3.0.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
-wheel==0.37.1
+wheel==0.42.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pip-tools
-wired==0.2.2
+wired==0.3
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -770,27 +758,27 @@ xmltodict==0.13.0
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-yarl==1.7.2
+yarl==1.9.4
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   aiohttp
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   importlib-metadata
     #   importlib-resources
-zope-deprecation==4.3.0
+zope-deprecation==5.0
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pyramid
     #   pyramid-jinja2
-zope-interface==5.1.0
+zope-interface==6.1
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
@@ -808,21 +796,18 @@ zope-sqlalchemy==3.1
     #   -r requirements/tests.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pip-tools
-setuptools==67.4.0
+setuptools==69.0.3
     # via
     #   -r requirements/bddtests.txt
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-    #   google-auth
-    #   gunicorn
     #   pip-tools
-    #   plaster
     #   pyramid
     #   zope-deprecation
     #   zope-interface

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -6,13 +6,13 @@
 #
 aiohttp==3.9.1
     # via -r requirements/prod.in
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via aiohttp
-alembic==1.12.0
+alembic==1.13.1
     # via -r requirements/prod.in
-amqp==5.1.1
+amqp==5.2.0
     # via kombu
-async-timeout==4.0.1
+async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
     # via
@@ -25,20 +25,20 @@ backports-zoneinfo[tzdata]==0.2.1
     #   kombu
 billiard==4.2.0
     # via celery
-cachetools==4.2.2
+cachetools==5.3.2
     # via google-auth
 celery==5.3.6
     # via -r requirements/prod.in
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 cffi==1.16.0
     # via cryptography
-charset-normalizer==2.0.1
+charset-normalizer==3.3.2
     # via requests
-click==8.1.3
+click==8.1.7
     # via
     #   celery
     #   click-didyoumean
@@ -48,27 +48,27 @@ click-didyoumean==0.3.0
     # via celery
 click-plugins==1.1.1
     # via celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via celery
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
     # via -r requirements/prod.in
-ecdsa==0.17.0
+ecdsa==0.18.0
     # via python-jose
-frozenlist==1.2.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-google-auth==1.30.0
+google-auth==2.25.2
     # via google-auth-oauthlib
-google-auth-oauthlib==0.4.4
+google-auth-oauthlib==1.2.0
     # via pyramid-googleauth
-greenlet==1.0.0
+greenlet==3.0.3
     # via sqlalchemy
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via -r requirements/prod.in
 h-api==1.1.0
     # via -r requirements/prod.in
@@ -78,13 +78,13 @@ h-pyramid-sentry==1.2.4
     # via -r requirements/prod.in
 h-vialib==1.2.1
     # via -r requirements/prod.in
-hupper==1.10.2
+hupper==1.12
     # via pyramid
 idna==3.6
     # via
     #   requests
     #   yarl
-importlib-metadata==4.8.1
+importlib-metadata==7.0.1
     # via
     #   alembic
     #   data-tasks
@@ -99,21 +99,21 @@ importlib-resources==6.1.1
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   data-tasks
     #   pyramid-jinja2
-jsonschema==4.19.1
+jsonschema==4.20.0
     # via h-api
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 kombu==5.3.4
     # via celery
 mailchimp-transactional==1.0.50
     # via -r requirements/prod.in
-mako==1.2.2
+mako==1.3.0
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   jinja2
     #   mako
@@ -122,7 +122,7 @@ marshmallow==3.20.1
     # via
     #   -r requirements/prod.in
     #   webargs
-multidict==5.2.0
+multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
@@ -132,33 +132,34 @@ oauthlib==3.2.2
     # via
     #   -r requirements/prod.in
     #   requests-oauthlib
-packaging==21.3
+packaging==23.2
     # via
+    #   gunicorn
     #   marshmallow
     #   webargs
     #   zope-sqlalchemy
-pastedeploy==2.1.0
+pastedeploy==3.1.0
     # via plaster-pastedeploy
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-plaster==1.0
+plaster==1.1.2
     # via
     #   plaster-pastedeploy
     #   pyramid
-plaster-pastedeploy==0.7
+plaster-pastedeploy==1.0.1
     # via pyramid
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.43
     # via click-repl
 psycopg2==2.9.9
     # via
     #   -r requirements/prod.in
     #   data-tasks
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   pyasn1-modules
     #   python-jose
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
@@ -168,8 +169,6 @@ pyjwt[crypto]==2.8.0
     # via
     #   -r requirements/prod.in
     #   pyramid-googleauth
-pyparsing==3.0.6
-    # via packaging
 pyramid==2.0.2
     # via
     #   -r requirements/prod.in
@@ -201,7 +200,7 @@ python-jose[crypto,cryptography]==3.3.0
     # via
     #   -r requirements/prod.in
     #   h-vialib
-referencing==0.30.2
+referencing==0.32.0
     # via
     #   h-api
     #   jsonschema
@@ -215,21 +214,19 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/prod.in
     #   google-auth-oauthlib
-rpds-py==0.10.3
+rpds-py==0.15.2
     # via
     #   jsonschema
     #   referencing
-rsa==4.7.2
+rsa==4.9
     # via
     #   google-auth
     #   python-jose
-sentry-sdk==1.14.0
+sentry-sdk==1.39.1
     # via h-pyramid-sentry
 six==1.16.0
     # via
-    #   click-repl
     #   ecdsa
-    #   google-auth
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.23
@@ -246,7 +243,7 @@ tabulate==0.9.0
     # via
     #   -r requirements/prod.in
     #   data-tasks
-transaction==2.4.0
+transaction==4.0
     # via
     #   pyramid-tm
     #   zope-sqlalchemy
@@ -255,48 +252,47 @@ translationstring==1.4
 typing-extensions==4.9.0
     # via
     #   alembic
-    #   async-timeout
     #   kombu
     #   sqlalchemy
 tzdata==2023.3
     # via
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
-venusian==3.0.0
+venusian==3.1.0
     # via pyramid
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.12
     # via prompt-toolkit
 webargs==8.3.0
     # via -r requirements/prod.in
-webob==1.8.6
+webob==1.8.7
     # via
     #   h-vialib
     #   pyramid
-wired==0.2.2
+wired==0.3
     # via pyramid-services
 xmltodict==0.13.0
     # via -r requirements/prod.in
-yarl==1.7.2
+yarl==1.9.4
     # via aiohttp
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources
-zope-deprecation==4.3.0
+zope-deprecation==5.0
     # via
     #   pyramid
     #   pyramid-jinja2
-zope-interface==5.1.0
+zope-interface==6.1
     # via
     #   pyramid
     #   pyramid-retry
@@ -308,11 +304,8 @@ zope-sqlalchemy==3.1
     # via -r requirements/prod.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==67.4.0
+setuptools==69.0.3
     # via
-    #   google-auth
-    #   gunicorn
-    #   plaster
     #   pyramid
     #   zope-deprecation
     #   zope-interface

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile --allow-unsafe requirements/template.in
 #
-arrow==1.2.3
+arrow==1.3.0
     # via cookiecutter
 binaryornot==0.4.4
     # via cookiecutter
-build==0.10.0
+build==1.0.3
     # via pip-tools
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-chardet==5.1.0
+chardet==5.2.0
     # via binaryornot
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via requests
-click==8.1.3
+click==8.1.7
     # via
     #   cookiecutter
     #   pip-tools
@@ -24,17 +24,19 @@ cookiecutter==2.5.0
     # via -r requirements/template.in
 idna==3.6
     # via requests
-importlib-metadata==6.6.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 jinja2==3.1.2
     # via cookiecutter
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-packaging==23.1
+packaging==23.2
     # via build
 pip-sync-faster==0.0.3
     # via -r requirements/template.in
@@ -42,7 +44,7 @@ pip-tools==7.3.0
     # via
     #   -r requirements/template.in
     #   pip-sync-faster
-pygments==2.16.1
+pygments==2.17.2
     # via rich
 pyproject-hooks==1.0.0
     # via build
@@ -50,11 +52,11 @@ python-dateutil==2.8.2
     # via arrow
 python-slugify==8.0.1
     # via cookiecutter
-pyyaml==6.0
+pyyaml==6.0.1
     # via cookiecutter
 requests==2.31.0
     # via cookiecutter
-rich==13.5.3
+rich==13.7.0
     # via cookiecutter
 six==1.16.0
     # via python-dateutil
@@ -65,17 +67,19 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
+types-python-dateutil==2.8.19.14
+    # via arrow
 typing-extensions==4.9.0
     # via rich
-urllib3==1.26.18
+urllib3==2.1.0
     # via requests
-wheel==0.40.0
+wheel==0.42.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==67.8.0
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -10,17 +10,17 @@ aiohttp==3.9.1
     #   aioresponses
 aioresponses==0.7.6
     # via -r requirements/tests.in
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via
     #   -r requirements/prod.txt
     #   aiohttp
-alembic==1.12.0
+alembic==1.13.1
     # via -r requirements/prod.txt
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
-async-timeout==4.0.1
+async-timeout==4.0.3
     # via
     #   -r requirements/prod.txt
     #   aiohttp
@@ -40,15 +40,15 @@ billiard==4.2.0
     # via
     #   -r requirements/prod.txt
     #   celery
-build==0.8.0
+build==1.0.3
     # via pip-tools
-cachetools==4.2.2
+cachetools==5.3.2
     # via
     #   -r requirements/prod.txt
     #   google-auth
 celery==5.3.6
     # via -r requirements/prod.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/prod.txt
     #   mailchimp-transactional
@@ -58,11 +58,11 @@ cffi==1.16.0
     # via
     #   -r requirements/prod.txt
     #   cryptography
-charset-normalizer==2.0.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/prod.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/prod.txt
     #   celery
@@ -78,26 +78,26 @@ click-plugins==1.1.1
     # via
     #   -r requirements/prod.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/prod.txt
     #   celery
-coverage[toml]==7.2.7
+coverage[toml]==7.3.4
     # via
     #   coverage
     #   pytest-cov
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/prod.txt
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
     # via -r requirements/prod.txt
-ecdsa==0.17.0
+ecdsa==0.18.0
     # via
     #   -r requirements/prod.txt
     #   python-jose
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
@@ -105,30 +105,30 @@ factory-boy==3.3.0
     # via
     #   -r requirements/tests.in
     #   pytest-factoryboy
-faker==8.1.2
+faker==21.0.0
     # via factory-boy
 filelock==3.13.1
     # via -r requirements/tests.in
-freezegun==1.2.2
+freezegun==1.4.0
     # via -r requirements/tests.in
-frozenlist==1.2.0
+frozenlist==1.4.1
     # via
     #   -r requirements/prod.txt
     #   aiohttp
     #   aiosignal
-google-auth==1.30.0
+google-auth==2.25.2
     # via
     #   -r requirements/prod.txt
     #   google-auth-oauthlib
-google-auth-oauthlib==0.4.4
+google-auth-oauthlib==1.2.0
     # via
     #   -r requirements/prod.txt
     #   pyramid-googleauth
-greenlet==1.0.0
+greenlet==3.0.3
     # via
     #   -r requirements/prod.txt
     #   sqlalchemy
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via -r requirements/prod.txt
 h-api==1.1.0
     # via -r requirements/prod.txt
@@ -142,7 +142,7 @@ h-vialib==1.2.1
     # via -r requirements/prod.txt
 httpretty==1.1.4
     # via -r requirements/tests.in
-hupper==1.10.2
+hupper==1.12
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -151,10 +151,11 @@ idna==3.6
     #   -r requirements/prod.txt
     #   requests
     #   yarl
-importlib-metadata==4.8.1
+importlib-metadata==7.0.1
     # via
     #   -r requirements/prod.txt
     #   alembic
+    #   build
     #   data-tasks
     #   h-api
     #   h-assets
@@ -170,18 +171,18 @@ importlib-resources==6.1.1
     #   jsonschema-specifications
 inflection==0.5.1
     # via pytest-factoryboy
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
-jsonschema==4.19.1
+jsonschema==4.20.0
     # via
     #   -r requirements/prod.txt
     #   h-api
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/prod.txt
     #   jsonschema
@@ -191,11 +192,11 @@ kombu==5.3.4
     #   celery
 mailchimp-transactional==1.0.50
     # via -r requirements/prod.txt
-mako==1.2.2
+mako==1.3.0
     # via
     #   -r requirements/prod.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.1.3
     # via
     #   -r requirements/prod.txt
     #   jinja2
@@ -205,7 +206,7 @@ marshmallow==3.20.1
     # via
     #   -r requirements/prod.txt
     #   webargs
-multidict==5.2.0
+multidict==6.0.4
     # via
     #   -r requirements/prod.txt
     #   aiohttp
@@ -216,20 +217,19 @@ oauthlib==3.2.2
     # via
     #   -r requirements/prod.txt
     #   requests-oauthlib
-packaging==21.3
+packaging==23.2
     # via
     #   -r requirements/prod.txt
     #   build
+    #   gunicorn
     #   marshmallow
     #   pytest
     #   webargs
     #   zope-sqlalchemy
-pastedeploy==2.1.0
+pastedeploy==3.1.0
     # via
     #   -r requirements/prod.txt
     #   plaster-pastedeploy
-pep517==0.12.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/tests.in
 pip-tools==7.3.0
@@ -240,34 +240,34 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/prod.txt
     #   jsonschema
-plaster==1.0
+plaster==1.1.2
     # via
     #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
-plaster-pastedeploy==0.7
+plaster-pastedeploy==1.0.1
     # via
     #   -r requirements/prod.txt
     #   pyramid
-pluggy==0.13.1
+pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/prod.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.7
     # via pytest-xdist
 psycopg2==2.9.9
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/prod.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via
     #   -r requirements/prod.txt
     #   google-auth
@@ -282,10 +282,8 @@ pyjwt[crypto]==2.8.0
     #   -r requirements/prod.txt
     #   pyjwt
     #   pyramid-googleauth
-pyparsing==3.0.6
-    # via
-    #   -r requirements/prod.txt
-    #   packaging
+pyproject-hooks==1.0.0
+    # via build
 pyramid==2.0.2
     # via
     #   -r requirements/prod.txt
@@ -317,12 +315,10 @@ pytest==7.4.3
     #   pytest-xdist
 pytest-cov==4.1.0
     # via -r requirements/tests.in
-pytest-factoryboy==2.5.1
+pytest-factoryboy==2.6.0
     # via -r requirements/tests.in
 pytest-xdist[psutil]==3.5.0
-    # via
-    #   -r requirements/tests.in
-    #   pytest-xdist
+    # via -r requirements/tests.in
 python-dateutil==2.8.2
     # via
     #   -r requirements/prod.txt
@@ -335,7 +331,7 @@ python-jose[crypto,cryptography]==3.3.0
     #   -r requirements/prod.txt
     #   h-vialib
     #   python-jose
-referencing==0.30.2
+referencing==0.32.0
     # via
     #   -r requirements/prod.txt
     #   h-api
@@ -350,26 +346,24 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/prod.txt
     #   google-auth-oauthlib
-rpds-py==0.10.3
+rpds-py==0.15.2
     # via
     #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
-rsa==4.7.2
+rsa==4.9
     # via
     #   -r requirements/prod.txt
     #   google-auth
     #   python-jose
-sentry-sdk==1.14.0
+sentry-sdk==1.39.1
     # via
     #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.16.0
     # via
     #   -r requirements/prod.txt
-    #   click-repl
     #   ecdsa
-    #   google-auth
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.23
@@ -386,16 +380,14 @@ tabulate==0.9.0
     # via
     #   -r requirements/prod.txt
     #   data-tasks
-text-unidecode==1.3
-    # via faker
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   build
     #   coverage
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
-transaction==2.4.0
+transaction==4.0
     # via
     #   -r requirements/prod.txt
     #   pyramid-tm
@@ -408,7 +400,7 @@ typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
     #   alembic
-    #   async-timeout
+    #   faker
     #   kombu
     #   pytest-factoryboy
     #   sqlalchemy
@@ -417,13 +409,13 @@ tzdata==2023.3
     #   -r requirements/prod.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
-venusian==3.0.0
+venusian==3.1.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -433,40 +425,40 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.12
     # via
     #   -r requirements/prod.txt
     #   prompt-toolkit
 webargs==8.3.0
     # via -r requirements/prod.txt
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/prod.txt
     #   h-vialib
     #   pyramid
-wheel==0.37.1
+wheel==0.42.0
     # via pip-tools
-wired==0.2.2
+wired==0.3
     # via
     #   -r requirements/prod.txt
     #   pyramid-services
 xmltodict==0.13.0
     # via -r requirements/prod.txt
-yarl==1.7.2
+yarl==1.9.4
     # via
     #   -r requirements/prod.txt
     #   aiohttp
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/prod.txt
     #   importlib-metadata
     #   importlib-resources
-zope-deprecation==4.3.0
+zope-deprecation==5.0
     # via
     #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-jinja2
-zope-interface==5.1.0
+zope-interface==6.1
     # via
     #   -r requirements/prod.txt
     #   pyramid
@@ -479,15 +471,12 @@ zope-sqlalchemy==3.1
     # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==67.4.0
+setuptools==69.0.3
     # via
     #   -r requirements/prod.txt
-    #   google-auth
-    #   gunicorn
     #   pip-tools
-    #   plaster
     #   pyramid
     #   zope-deprecation
     #   zope-interface

--- a/tests/unit/lms/services/application_instance_test.py
+++ b/tests/unit/lms/services/application_instance_test.py
@@ -227,18 +227,20 @@ class TestApplicationInstanceService:
     @pytest.mark.parametrize(
         "query,expected_names",
         (
-            ("A@example.com", ["a"]),
-            ("other.example.com", ["b"]),
-            ("example.com", ["a", "c"]),
+            ("marcos@one.example.com", ["marcos"]),
+            ("other.example.com", ["sean"]),
+            ("one.example.com", ["marcos", "ian"]),
         ),
     )
     def test_search_by_email(self, service, query, expected_names):
-        factories.ApplicationInstance.create(name="a", requesters_email="A@example.com")
         factories.ApplicationInstance.create(
-            name="b", requesters_email="B@other.example.com"
+            name="marcos", requesters_email="MARCOS@one.example.com"
         )
         factories.ApplicationInstance.create(
-            name="c", tool_consumer_instance_contact_email="C@example.com"
+            name="sean", requesters_email="SEAN@other.example.com"
+        )
+        factories.ApplicationInstance.create(
+            name="ian", tool_consumer_instance_contact_email="IAN@one.example.com"
         )
 
         instances = service.search(email=query)


### PR DESCRIPTION
This is the result of running:

make requirements --always-make args='--upgrade'

Non top level dependencies can become outdated as dependabot doesn't send PR for those.

On top of that upgrading single packages with all the existing constraints might make impassible to satisfy all constraints.

This approach makes sure we are up to date with all our dependencies as specified on the .in files but without considering any constraints in the .txt files.