### PR TITLE
Invert the default for deep linking title prompt

### DIFF
--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -8,6 +8,8 @@ from lms.services.vitalsource import VSBookLocation
 
 
 class CanvasMiscPlugin(MiscPlugin):
+    deep_linking_prompt_for_title = False
+
     def post_launch_assignment_hook(self, request, js_config, assignment):
         """
         Configure grading during a launch.

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -23,7 +23,7 @@ class MiscPlugin:
     """
 
     # Whether or not to prompt for an assignment title while deep linking.
-    deep_linking_prompt_for_title = False
+    deep_linking_prompt_for_title = True
 
     def post_launch_assignment_hook(
         self, request, js_config, assignment

--- a/tests/unit/lms/product/canvas/_plugin/misc_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/misc_test.py
@@ -8,6 +8,9 @@ from tests import factories
 
 
 class TestCanvasMiscPlugin:
+    def test_deep_linking_prompt_for_title(self, plugin):
+        assert not plugin.deep_linking_prompt_for_title
+
     @pytest.mark.parametrize("is_gradable", [True, False])
     @pytest.mark.parametrize("is_learner", [True, False])
     @pytest.mark.parametrize("grading_id", [None, sentinel.grading_id])

--- a/tests/unit/lms/product/plugin/misc_test.py
+++ b/tests/unit/lms/product/plugin/misc_test.py
@@ -9,7 +9,7 @@ from tests import factories
 
 class TestMiscPlugin:
     def test_deep_linking_prompt_for_title(self, plugin):
-        assert not plugin.deep_linking_prompt_for_title
+        assert plugin.deep_linking_prompt_for_title
 
     @pytest.mark.parametrize(
         "service_url,expected", [(None, False), (sentinel.service_url, True)]


### PR DESCRIPTION
Canvas was the first LMS to support DL and we didn't prompt for title there.

When we added support for DL in D2L we added this configuration option, making the Canvas behaviour the default.

After testing with BB and Moodle we have discovered that they also require prompting for title.

Change the default and special case to `False` in the Canvas plugin.



### Testing

#### Canvas

- Reconfigure [a canvas assignment](https://hypothesis.instructure.com/courses/125/assignments/5142/edit?name=Testing+creation&due_at=null&points_possible=0) 
- No prompt for title.


### D2L

- Create a new assignment [in this course](https://hypothesis.instructure.com/courses/125/assignments/5142/edit?name=Testing+creation&due_at=null&points_possible=0) using the DL flow. Existing Activities` -> 
`Hypothesis link (localhost)`

- You'll get the title prompt.