### PR TITLE
Revert "Fetch oauth2 token by GUID instead of application instance ID"

### DIFF
--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -36,21 +36,6 @@ class TestOAuth2TokenService:
 
         assert result == oauth_token
 
-    def test_get_returns_token_from_another_ai_with_same_guid(
-        self, svc, oauth_token, lti_user, application_instance
-    ):
-        oauth_token = factories.OAuth2Token(
-            user_id=lti_user.user_id,
-            application_instance=factories.ApplicationInstance(
-                tool_consumer_instance_guid=application_instance.tool_consumer_instance_guid
-            ),
-        )
-
-        result = svc.get()
-
-        assert result == oauth_token
-        assert result.application_instance != application_instance
-
     def test_get_raises_OAuth2TokenError_with_mismatching_application_instance(
         self, db_session, lti_user
     ):


### PR DESCRIPTION
Reverts hypothesis/lms#5939

Reverting this as some light testing in QA showed this error:


https://hypothesis.sentry.io/issues/4526546787/?alert_rule_id=342674&alert_type=issue&environment=qa&notification_uuid=017ae769-e983-472e-b518-3132d8d0e698&project=259908&referrer=slack

The problem is that while from the point of view of the LMS the user is the same in all installs for the same GUID, we could have configured each of those install with different API client ids.

Probably not a very common setup but to properly support this we should make the query aware of the install settings and only count installs with the same GUID and same client ID. That shouldn't be too complicated but the way this is stored right now, specially for canvas, the query would be different per LMS.

Not worth the effort now unless we identify this switching between install as a cause for repeated oauth2 prompts.


