### PR TITLE
Remove `models.Regions`

### DIFF
--- a/bin/run_data_task.py
+++ b/bin/run_data_task.py
@@ -14,7 +14,7 @@ from data_tasks.python_script import PythonScript
 from psycopg2.extensions import parse_dsn
 from pyramid.paster import bootstrap
 
-from lms.models import Regions
+from lms.services import RegionService
 
 TASK_ROOT = importlib_resources.files("lms.data_tasks")
 
@@ -53,13 +53,11 @@ def main():
         request = env["request"]
         settings = env["registry"].settings
 
-        Regions.set_region(settings["h_authority"], settings["region_code"])
-
         scripts = data_tasks.from_dir(
             task_dir=TASK_ROOT / args.task,
             template_vars={
                 "db_user": parse_dsn(settings["database_url"].strip())["user"],
-                "region": Regions.get_region(),
+                "region": request.find_service(RegionService).get(),
                 "h_fdw": parse_dsn(settings["h_fdw_database_url"]),
                 "fdw_users": settings["fdw_users"],
             },

--- a/lms/app.py
+++ b/lms/app.py
@@ -3,7 +3,6 @@ import pyramid_tm
 from sqlalchemy.exc import IntegrityError
 
 from lms.config import configure
-from lms.models.region import Regions
 
 
 def configure_jinja2_assets(config):
@@ -14,12 +13,6 @@ def configure_jinja2_assets(config):
 
 def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config = configure(settings=settings)
-
-    # Set the singleton region, so it's accesible globally without going
-    # through the request object etc.
-    Regions.set_region(
-        config.registry.settings["h_authority"], config.registry.settings["region_code"]
-    )
 
     # Make sure that pyramid_exclog's tween runs under pyramid_tm's tween so
     # that pyramid_exclog doesn't re-open the DB session after pyramid_tm has

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -27,7 +27,7 @@ from lms.models.lti_role import LTIRole, LTIRoleOverride
 from lms.models.lti_user import LTIUser, display_name
 from lms.models.oauth2_token import OAuth2Token
 from lms.models.organization import Organization
-from lms.models.region import Region, Regions
+from lms.models.region import Region
 from lms.models.rsa_key import RSAKey
 from lms.models.task_done import TaskDone
 from lms.models.user import User

--- a/lms/models/_mixins/public_id.py
+++ b/lms/models/_mixins/public_id.py
@@ -1,8 +1,14 @@
+from os import environ
+
 import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 
 from lms.models.public_id import PublicId
-from lms.models.region import Regions
+from lms.models.region import Region
+
+
+def _get_current_region():
+    return Region(code=environ["REGION_CODE"], authority=environ["H_AUTHORITY"])
 
 
 class _PublicIdComparator(
@@ -17,7 +23,7 @@ class _PublicIdComparator(
                 # Using str here allows us to accept a public id object
                 public_id=str(other),
                 expect_model_code=self.expression.class_.public_id_model_code,
-                expect_region=Regions.get_region(),
+                expect_region=_get_current_region(),
             ).instance_id
         )
 
@@ -50,7 +56,7 @@ class PublicIdMixin:
 
         return str(
             PublicId(
-                region=Regions.get_region(),
+                region=_get_current_region(),
                 model_code=self.public_id_model_code,
                 instance_id=self._public_id,
             )

--- a/lms/models/region.py
+++ b/lms/models/region.py
@@ -16,39 +16,3 @@ class Region:
 
         #: Human readable description of the region.
         self.name: str = names[self.code]
-
-
-class Regions:
-    """A collection of all the regions as an enum like object."""
-
-    _current_region: Region = None
-
-    @classmethod
-    def get_region(cls) -> Region:
-        """
-        Get the region this app is running in.
-
-        :raises ValueError: If the active region has not been set
-        """
-        if cls._current_region is None:
-            raise ValueError(
-                "You must set the active region with `set_region()` "
-                "before it can be accessed"
-            )
-
-        return cls._current_region
-
-    @classmethod
-    def set_region(cls, authority: str, code: str):
-        """
-        Set the region this app is running in.
-
-        This is intended to be called once and accessed as a singleton via
-        `get_region()`.
-
-        :param authority: The H authority for this app.
-        :param code: The region code for this app.
-
-        :raises ValueError: If `code` isn't a known region code
-        """
-        cls._current_region = Region(code=code, authority=authority)

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -30,6 +30,7 @@ from lms.services.lti_role_service import LTIRoleService
 from lms.services.lti_user import LTIUserService
 from lms.services.ltia_http import LTIAHTTPService
 from lms.services.organization import OrganizationService
+from lms.services.region import RegionService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.user_preferences import UserPreferencesService
@@ -121,6 +122,7 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.organization.service_factory", iface=OrganizationService
     )
+    config.register_service_factory("lms.services.region.factory", iface=RegionService)
     config.register_service_factory(
         "lms.services.d2l_api.d2l_api_client_factory", iface=D2LAPIClient
     )

--- a/lms/services/region.py
+++ b/lms/services/region.py
@@ -1,0 +1,18 @@
+from lms.models import Region
+
+
+class RegionService:
+    def __init__(self, region_code: str, authority: str):
+        self._region_code = region_code
+        self._authority = authority
+
+    def get(self) -> Region:
+        """Return the region that the app is currently running in."""
+        return Region(code=self._region_code, authority=self._authority)
+
+
+def factory(_context, request) -> RegionService:
+    return RegionService(
+        region_code=request.registry.settings["region_code"],
+        authority=request.registry.settings["h_authority"],
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,3 +95,19 @@ def autopatcher(request, target, **kwargs):
 @pytest.fixture
 def patch(request):
     return functools.partial(autopatcher, request)
+
+
+@pytest.fixture(autouse=True)
+def envvars(monkeypatch):
+    # Because we (unfortunately) have code at the lowest level of our codebase
+    # (in the models) that's reading these envvars directly from os.environ we
+    # get lots of unit and functional tests across our test suite failing when
+    # these envvars don't exist.
+    #
+    # So as a workaround this fixture makes sure that these envvars are set for
+    # all tests.
+    #
+    # It would be better if our model code did not read os.environ, then we
+    # wouldn't need this fixture.
+    monkeypatch.setenv("REGION_CODE", "us")
+    monkeypatch.setenv("H_AUTHORITY", "lms.hypothes.is")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,6 @@ import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 
-from lms import models
 from lms.db import SESSION
 from lms.models import ApplicationSettings, LTIParams
 from lms.models.lti_role import Role, RoleScope, RoleType
@@ -325,8 +324,3 @@ def oauth_token(lti_user, application_instance):
         user_id=lti_user.user_id,
         application_instance=application_instance,
     )
-
-
-@pytest.fixture(autouse=True, scope="session")
-def with_us_region():
-    models.Regions.set_region(authority="lms.hypothes.is", code="us")

--- a/tests/unit/lms/app_test.py
+++ b/tests/unit/lms/app_test.py
@@ -27,15 +27,12 @@ class TestConfigureJinja2Assets:
 
 
 class TestCreateApp:
-    def test_it(self, configure, Regions):
+    def test_it(self, configure):
         settings = {"key": "value"}
 
         create_app(sentinel.pyramid_config, **settings)
 
         configure.assert_called_once_with(settings=settings)
-        Regions.set_region.assert_called_once_with(
-            sentinel.h_authority, sentinel.region_code
-        )
 
     @pytest.fixture(autouse=True)
     def registry(self, configure):
@@ -48,10 +45,6 @@ class TestCreateApp:
             "admin_auth_google_client_secret": sentinel.admin_auth_google_client_secret,
         }
         return registry
-
-    @pytest.fixture(autouse=True)
-    def Regions(self, patch):
-        return patch("lms.app.Regions")
 
     @pytest.fixture(autouse=True)
     def configure(self, patch):

--- a/tests/unit/lms/models/region_test.py
+++ b/tests/unit/lms/models/region_test.py
@@ -1,9 +1,8 @@
-from unittest import mock
 from unittest.mock import sentinel
 
 import pytest
 
-from lms.models.region import Region, Regions
+from lms.models.region import Region
 
 
 class TestRegion:
@@ -20,27 +19,3 @@ class TestRegion:
     def test_it_crashes_if_the_code_is_unknown(self):
         with pytest.raises(KeyError):
             Region(code="unknown_code", authority=sentinel.authority_)
-
-
-class TestRegions:
-    def test_get_region(self, current_region):
-        current_region.return_value = Region(code="us", authority=sentinel.authority)
-
-        assert Regions.get_region() == current_region.return_value
-
-    def test_get_region_with_no_region(self, current_region):
-        current_region.return_value = None
-
-        with pytest.raises(ValueError):
-            Regions.get_region()
-
-    @pytest.mark.parametrize("bad_code", (None, "UNRECOGNIZED"))
-    def test_set_region_raises_for_bad_codes(self, bad_code):
-        with pytest.raises(KeyError):
-            Regions.set_region(sentinel.authority, bad_code)
-
-    @pytest.fixture
-    def current_region(self):
-        with mock.patch.object(Regions, "_current_region") as _current_region:
-            _current_region.__get__ = mock.Mock(return_value=None)
-            yield _current_region.__get__

--- a/tests/unit/lms/services/region_service_test.py
+++ b/tests/unit/lms/services/region_service_test.py
@@ -1,0 +1,29 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.models import Region
+from lms.services.region import RegionService, factory
+
+
+class TestRegionService:
+    def test_get(self, svc):
+        assert svc.get() == Region(code="us", authority=sentinel.authority)
+
+    @pytest.fixture
+    def svc(self):
+        return RegionService(region_code="us", authority=sentinel.authority)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, RegionService):
+        region_service = factory(sentinel.context, pyramid_request)
+
+        RegionService.assert_called_once_with(
+            region_code="us", authority="lms.hypothes.is"
+        )
+        assert region_service == RegionService.return_value
+
+    @pytest.fixture(autouse=True)
+    def RegionService(self, patch):
+        return patch("lms.services.region.RegionService")


### PR DESCRIPTION
Replace the `models.Regions` "enum" (and its custom approach to implementing a global singleton) with a simple service in our usual style.