### PR TITLE
Allow enabling h `export_formats` feature flag per instance

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -46,6 +46,7 @@ class ApplicationSettings(JSONSettings):
             name="Auto Assigned To Organisation",
         ),
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
+        JSONSetting("hypothesis", "export_formats_enabled", asbool),
     )
 
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -113,6 +113,7 @@
                         <fieldset class="box">
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
+                            {{ settings_checkbox('Enable export formats', 'hypothesis', 'export_formats_enabled') }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -210,11 +210,17 @@ class BasicLaunchViews:
         self.context.js_config.add_document_url(assignment.document_url)
         self.context.js_config.enable_lti_launch_mode(self.course, assignment)
 
+        export_formats_enabled = (
+            self.request.lti_user.application_instance.settings.get(
+                "hypothesis", "export_formats_enabled", False
+            )
+        )
+
         # If there are any Hypothesis client feature flags that need to be
         # enabled based on the current application instance settings, those
         # should be enabled here via `self.context.js_config.enable_client_feature`.
-        #
-        # There are currently no such features.
+        if export_formats_enabled:
+            self.context.js_config.enable_client_feature("export_formats")
 
         # Run any non standard code for the current product
         self._misc_plugin.post_launch_assignment_hook(

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -292,6 +292,27 @@ class TestBasicLaunchViews:
 
         assert result == {}
 
+    @pytest.mark.parametrize("export_formats_feature", [True, False])
+    def test__show_document_enables_client_features(
+        self, svc, pyramid_request, context, assignment, export_formats_feature
+    ):
+        pyramid_request.lti_user.application_instance.settings.set(
+            "hypothesis", "export_formats_enabled", export_formats_feature
+        )
+
+        # pylint: disable=protected-access
+        svc._show_document(assignment)
+
+        enable_client_feature = context.js_config.enable_client_feature
+        enabled_features = set(
+            call.args[0] for call in enable_client_feature.call_args_list
+        )
+
+        if export_formats_feature:
+            assert "export_formats" in enabled_features
+        else:
+            assert "export_formats" not in enabled_features
+
     @pytest.fixture
     def assignment(self):
         return factories.Assignment(is_gradable=False)


### PR DESCRIPTION
Enable h `export_formats` feature flag via instance configuration, like we did with import/export.

### Testing steps

1. Disable `export_formats` in your local h instance: http://localhost:5000/admin/features
2. Enable export formats in your local LMS instance: http://localhost:8001/admin/instance/8/settings
  ![image](https://github.com/hypothesis/lms/assets/2719332/5c946ff9-98bd-446c-abf4-d2b20e4896ce)
3. Open https://hypothesis.instructure.com/courses/125/assignments/4989 and verify the formats dropdown and copy-to-clipboard button are displayed in the export pannel
  ![image](https://github.com/hypothesis/lms/assets/2719332/449950dc-1803-4804-87f7-75b16a3b6cc6)

### Considerations

In the assignment linked above, copying to clipboard works, but I have seen others where it doesn't (like https://hypothesis.instructure.com/courses/125/assignments/873).

~I'm still trying to figure this out, but it shouldn't block this particular PR.~

EDIT: We found the reasons for the issue above: There was missing permissions that had to be set in iframes generated by [LMS](https://github.com/hypothesis/lms/pull/6003) and [via](https://github.com/hypothesis/via/pull/1271).

Additionally, the wombat.js library used by pywb in viahtml, is overwritting the permissions set by the client. We have opened an issue there: https://github.com/webrecorder/wombat/issues/133