### PR TITLE
Make ContentFrame allow cross-origin clipboard-write permission

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentFrame.tsx
@@ -17,9 +17,9 @@ export default function ContentFrame({ url, iframeRef }: ContentFrameProps) {
       // too).
       //
       // "autoplay" - Enables Play button to work without first clicking on video
-      // "clipboard-write" - Used by "Copy transcript" button
+      // "clipboard-write *" - Used by: Via's video player, the Hypothesis client sidebar
       // "fullscreen" - Enables full-screen button in player
-      allow="autoplay; clipboard-write; fullscreen"
+      allow="autoplay; clipboard-write *; fullscreen"
       className={classnames(
         // It's important that this content render full width and grow to fill
         // available flex space. n.b. It may be rendered together with grading


### PR DESCRIPTION
This PR ensures the `iframe` wrapped by `ContentFrame` allows `clipboard-write` from any origin.

This is required to make copying exported annotations work when proxying a site with via inside an LMS assignment.