### PR TITLE
Enable new search UI in client when page ranges feature is enabled

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -113,6 +113,7 @@ class JSConfig:
                 )
 
             if svc.page_ranges_enabled:
+                self.enable_client_feature("search_panel")
                 content_config = svc.get_client_focus_config(document_url)
                 if content_config:
                     self._update_focus_config(content_config)

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -356,6 +356,9 @@ class TestAddDocumentURL:
         client_config = js_config.asdict()["hypothesisClient"]
         focus_config = client_config.get("focus", {})
 
+        if page_ranges_enabled:
+            assert "search_panel" in js_config.asdict()["hypothesisClient"]["features"]
+
         if page_ranges_enabled and assignment_has_content_range:
             assert focus_config["page"] == "20-30"
         else:


### PR DESCRIPTION
For the assignment page ranges feature to be usable in the client, the new search UI [1] needs to be enabled.

[1] https://github.com/hypothesis/client/issues/600