### PR TITLE
Sign deep linking request in LTI1.1

### DIFF
--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -57,7 +57,7 @@ class OAuth1Service:
         # Include the data we want to send in the payload
         payload.update(data)
 
-        # Clean parameters and generate the plaint text to sign
+        # Clean parameters and generate the plain text to sign
         params = signature.collect_parameters(
             body=payload, exclude_oauth_signature=False, with_realm=False
         )

--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -75,9 +75,7 @@ class OAuth1Service:
 
         return payload
 
-    def get_auth_parameters(
-        self, url: str, data: dict, method: str = "POST"
-    ) -> dict[str, str]:
+    def sign_2(self, url, method, data):
         request = Request(
             method,
             url=url,

--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -3,9 +3,8 @@ import hashlib
 import hmac
 import uuid
 from datetime import datetime
-from urllib import parse
 
-from requests import Request
+from oauthlib.oauth1.rfc5849 import signature
 from requests_oauthlib import OAuth1
 
 
@@ -15,76 +14,63 @@ class OAuth1Service:
     def __init__(self, _context, request):
         self._request = request
 
-    def get_client(self, signature_type="auth_header"):
+    def get_client(self) -> OAuth1:
         """
         Get an OAUth1 client that can be used to sign HTTP requests.
 
         To sign a request with the client pass it as the `auth` parameter to
         `requests.post()`.
-
-        :rtype: OAuth1
         """
         application_instance = self._request.lti_user.application_instance
 
         return OAuth1(
             client_key=application_instance.consumer_key,
-            client_secret=application_instance.shared_secret + "&",
+            client_secret=application_instance.shared_secret,
             signature_method="HMAC-SHA1",
-            signature_type=signature_type,
+            signature_type="auth_header",
             # Include the body when signing the request, this defaults to
             # `False` for non-form encoded bodies.
             force_include_body=True,
         )
 
-    def sign(self, url, method, data):
+    def sign(self, url: str, method: str, data: dict) -> dict:
+        """
+        Sign data following the oauth1 spec.
+
+        Useful when not using these values for a HTTP requests with the client from get_client.
+        """
         application_instance = self._request.lti_user.application_instance
 
         client_key = application_instance.consumer_key
+        # Secret and token need to joined by "&".
+        # We don't have a token but the trailing `&` is required
         client_secret = application_instance.shared_secret + "&"
 
         # Oauth values
         payload = {
             "oauth_version": "1.0",
             "oauth_nonce": uuid.uuid4().hex,
-            "oauth_timestamp": round(datetime.now().timestamp()),
+            "oauth_timestamp": str(round(datetime.now().timestamp())),
             "oauth_consumer_key": client_key,
             "oauth_signature_method": "HMAC-SHA1",
         }
         # Include the data we want to send in the payload
         payload.update(data)
 
-        signature_parts = [
-            method.upper(),
-            # We need to encode `/`, don't include it in "safe"
-            parse.quote(url, safe=""),
-            # These need to be sorted before generating a string
-            parse.quote_plus(
-                parse.urlencode(sorted(payload.items()), quote_via=parse.quote)
-            ),
-        ]
-        raw_text = "&".join(signature_parts)
+        # Clean parameters and generate the plaint text to sign
+        params = signature.collect_parameters(
+            body=payload, exclude_oauth_signature=False, with_realm=False
+        )
+        normalized_parameters = signature.normalize_parameters(params)
+        base_string = signature.signature_base_string(
+            method, url, normalized_parameters
+        )
 
         # Generate the digest
         hashed = hmac.new(
-            client_secret.encode("utf-8"), raw_text.encode("utf-8"), hashlib.sha1
+            client_secret.encode("utf-8"), base_string.encode("utf-8"), hashlib.sha1
         )
         digest = base64.b64encode(hashed.digest()).decode("utf-8")
 
-        # And append it to the payload
         payload["oauth_signature"] = digest
-
         return payload
-
-    def sign_2(self, url, method, data):
-        request = Request(
-            method,
-            url=url,
-            headers=data,
-            auth=self.get_client(signature_type="body"),
-        )
-        raw_params = request.prepare().body
-
-        return {
-            key.decode(): value[0].decode()
-            for key, value in parse.parse_qs(raw_params).items()
-        }

--- a/lms/services/oauth1.py
+++ b/lms/services/oauth1.py
@@ -1,3 +1,11 @@
+import base64
+import hashlib
+import hmac
+import uuid
+from datetime import datetime
+from urllib import parse
+
+from requests import Request
 from requests_oauthlib import OAuth1
 
 
@@ -7,7 +15,7 @@ class OAuth1Service:
     def __init__(self, _context, request):
         self._request = request
 
-    def get_client(self):
+    def get_client(self, signature_type="auth_header"):
         """
         Get an OAUth1 client that can be used to sign HTTP requests.
 
@@ -20,10 +28,65 @@ class OAuth1Service:
 
         return OAuth1(
             client_key=application_instance.consumer_key,
-            client_secret=application_instance.shared_secret,
+            client_secret=application_instance.shared_secret + "&",
             signature_method="HMAC-SHA1",
-            signature_type="auth_header",
+            signature_type=signature_type,
             # Include the body when signing the request, this defaults to
             # `False` for non-form encoded bodies.
             force_include_body=True,
         )
+
+    def sign(self, url, method, data):
+        application_instance = self._request.lti_user.application_instance
+
+        client_key = application_instance.consumer_key
+        client_secret = application_instance.shared_secret + "&"
+
+        # Oauth values
+        payload = {
+            "oauth_version": "1.0",
+            "oauth_nonce": uuid.uuid4().hex,
+            "oauth_timestamp": round(datetime.now().timestamp()),
+            "oauth_consumer_key": client_key,
+            "oauth_signature_method": "HMAC-SHA1",
+        }
+        # Include the data we want to send in the payload
+        payload.update(data)
+
+        signature_parts = [
+            method.upper(),
+            # We need to encode `/`, don't include it in "safe"
+            parse.quote(url, safe=""),
+            # These need to be sorted before generating a string
+            parse.quote_plus(
+                parse.urlencode(sorted(payload.items()), quote_via=parse.quote)
+            ),
+        ]
+        raw_text = "&".join(signature_parts)
+
+        # Generate the digest
+        hashed = hmac.new(
+            client_secret.encode("utf-8"), raw_text.encode("utf-8"), hashlib.sha1
+        )
+        digest = base64.b64encode(hashed.digest()).decode("utf-8")
+
+        # And append it to the payload
+        payload["oauth_signature"] = digest
+
+        return payload
+
+    def get_auth_parameters(
+        self, url: str, data: dict, method: str = "POST"
+    ) -> dict[str, str]:
+        request = Request(
+            method,
+            url=url,
+            headers=data,
+            auth=self.get_client(signature_type="body"),
+        )
+        raw_params = request.prepare().body
+
+        return {
+            key.decode(): value[0].decode()
+            for key, value in parse.parse_qs(raw_params).items()
+        }

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -214,6 +214,8 @@ class DeepLinkingFieldsViews:
         if title := assignment_configuration.get("title"):
             content_item["title"] = title
 
+        oauth1_service = self.request.find_service(name="oauth1")
+
         payload = {
             "content_items": json.dumps(
                 {
@@ -227,7 +229,9 @@ class DeepLinkingFieldsViews:
             # An opaque value which should be returned by the TP in its response.
             payload["data"] = data
 
-        return payload
+        return oauth1_service.sign(
+            self.request.parsed_params["content_item_return_url"], "post", payload
+        )
 
     @staticmethod
     def _get_assignment_configuration(request) -> dict:

--- a/tests/unit/lms/services/oauth1_test.py
+++ b/tests/unit/lms/services/oauth1_test.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import pytest
@@ -43,6 +44,130 @@ class TestOAuth1Service:
         # one is present.
         assert "oauth_signature=" in auth_header
 
+    @pytest.mark.parametrize(
+        "key,secret,nonce,timestamp,data,url,method,signature",
+        [
+            # https://lti.tools/oauth/
+            (
+                "dpf43f3p2l4k3l03",
+                "kd94hf93k423kf44",
+                "kllo9940pd9333jh",
+                1191242096,
+                {"size": "original", "file": "vacation.jpg"},
+                "http://photos.example.net/photos",
+                "GET",
+                "Jg5MXVnexhzMDTv7IBUy3goIGqc=",
+            ),
+            # https://lti.tools/oauth/ with content items
+            (
+                "dpf43f3p2l4k3l03",
+                "kd94hf93k423kf44",
+                "kllo9940pd9333jh",
+                1191242096,
+                {
+                    "content_items": json.dumps(
+                        {
+                            "@context": "http://purl.imsglobal.org/ctx/lti/v1/ContentItem",
+                            "@graph": [
+                                {
+                                    "mediaType": "application/vnd.ims.lti.v1.ltilink",
+                                    "@type": "LtiLinkItem",
+                                    "url": "http://localhost/lti",
+                                    "title": "Sample LTI launch",
+                                    "text": "This is an example of an LTI launch link set via the Content-Item launch message.  Please launch it to pass the related certification test.",
+                                    "icon": {
+                                        "@id": "https://apps.imsglobal.org//lti/cert/images/icon.png",
+                                        "height": 50,
+                                        "width": 50,
+                                    },
+                                    "placementAdvice": {
+                                        "displayHeight": 400,
+                                        "displayWidth": 400,
+                                        "presentationDocumentTarget": "IFRAME",
+                                    },
+                                    "lineItem": {
+                                        "@type": "LineItem",
+                                        "label": "Chapter 13 quiz",
+                                        "reportingMethod": "res:totalScore",
+                                        "assignedActivity": {
+                                            "@id": "http://toolprovider.example.com/assessment/66400",
+                                            "activityId": "a-9334df-33",
+                                        },
+                                        "scoreConstraints": {
+                                            "@type": "NumericLimits",
+                                            "normalMaximum": 100,
+                                            "extraCreditMaximum": 10,
+                                            "totalMaximum": 110,
+                                        },
+                                    },
+                                    "custom": {
+                                        "imscert": "launchbHYnJGxZ",
+                                        "contextHistory": "$Context.id.history",
+                                        "resourceHistory": "$ResourceLink.id.history",
+                                        "dueDate": "$ResourceLink.submission.endDateTime",
+                                        "userName": "$User.username",
+                                        "userEmail": "$Person.email.primary",
+                                        "userSysRoles": "@X@user.role@X@",
+                                        "source": "link",
+                                    },
+                                },
+                            ],
+                        },
+                        separators=(",", ":"),
+                    ),
+                },
+                "http://photos.example.net/photos",
+                "GET",
+                "7cZohgSjlkbH8mR1mwIh6+4BM80=",
+            ),
+            # Blackboard
+            (
+                "",
+                "",
+                "9d9764e4-7920-4d78-9ee9-4a2ca8188ec4",
+                1706518363,
+                {
+                    "content_items": '{"@context":"http://purl.imsglobal.org/ctx/lti/v1/ContentItem","@graph":[{"mediaType":"application/vnd.ims.lti.v1.ltilink","@type":"LtiLinkItem","url":"http://localhost/lti","title":"Sample LTI launch","text":"This is an example of an LTI launch link set via the Content-Item launch message.  Please launch it to pass the related certification test.","icon":{"@id" :"https://apps.imsglobal.org//lti/cert/images/icon.png","height":50,"width":50},"placementAdvice":{"displayHeight":400,"displayWidth":400,"presentationDocumentTarget":"IFRAME"},"lineItem":{"@type":"LineItem","label":"Chapter 13 quiz","reportingMethod":"res:totalScore","assignedActivity":{"@id":"http://toolprovider.example.com/assessment/66400","activityId":"a-9334df-33"},"scoreConstraints":{"@type":"NumericLimits","normalMaximum":100,"extraCreditMaximum":10,"totalMaximum":110}},"custom":{"imscert":"launch»bHYnJGxZ","contextHistory":"$Context.id.history","resourceHistory":"$ResourceLink.id.history","dueDate":"$ResourceLink.submission.endDateTime","userName":"$User.username","userEmail":"$Person.email.primary","userSysRoles":"@X@user.role@X@","source":"link"}}]}',
+                    "data": "_19_1::_27_1::-1::true::false::_299_1::3b1b99704eca4f72b759484388f03fa7::false::false",
+                    "lti_message_type": "ContentItemSelection",
+                    "lti_version": "LTI-1p0",
+                    "oauth_callback": "about:blank",
+                },
+                "https://aunltd-test.blackboard.com/webapps/blackboard/controller/lti/contentitem",
+                "POST",
+                "a5G1Lwe9gdLe3yiyYbTlRzYQMas=",
+            ),
+        ],
+    )
+    def test_sign(
+        self,
+        service,
+        uuid,
+        datetime,
+        application_instance,
+        key,
+        secret,
+        nonce,
+        timestamp,
+        data,
+        url,
+        method,
+        signature,
+    ):
+        application_instance.consumer_key = key
+        application_instance.shared_secret = secret
+
+        uuid.uuid4.return_value.hex = nonce
+        datetime.now.return_value.timestamp.return_value = timestamp
+
+        result = service.sign(url, method, data)
+
+        assert result["oauth_signature_method"] == "HMAC-SHA1"
+        assert result["oauth_nonce"] == nonce
+        assert result["oauth_timestamp"] == timestamp
+        assert result["oauth_consumer_key"] == key
+        assert result["oauth_signature"] == signature
+
     @pytest.fixture
     def service(self, context, pyramid_request):
         return OAuth1Service(context, pyramid_request)
@@ -51,6 +176,14 @@ class TestOAuth1Service:
     def context(self):
         # We don't use context, so it doesn't matter what it is
         return mock.sentinel.context
+
+    @pytest.fixture
+    def uuid(self, patch):
+        return patch("lms.services.oauth1.uuid")
+
+    @pytest.fixture
+    def datetime(self, patch):
+        return patch("lms.services.oauth1.datetime")
 
     @pytest.fixture
     def OAuth1(self, patch):


### PR DESCRIPTION
LTI1.1 messages sent to the LMS should be signed. That includes server-to-server messages (like the grading API) and deep linking ones that are client-to-server.

For the grading API we use OAuth1.get_client which returns a http client we can use to make requests and attaches the required parameters transparently

However for deep linking we need the frontend to be ultimately the one making the requests (submitting a form to the LMS) so we need to generate those parameters and forward them to the frontend first.

While this is required by the spec Canvas doesn't enforce signing nor does it seem to check it's validity.

The testing below just confirms that things continue working on Canvas and that new signing parameters are indeed being sent to Canvas.


## Testing


- Re-configure a canvas assignment: https://hypothesis.instructure.com/courses/125/assignments/5142/edit?name=Testing+creation&due_at=null&points_possible=0

- The form submitted to `https://hypothesis.instructure.com/courses/125/external_content/success/external_tool_dialog
` does now contain a bunch of `oauth_` parameters:
![Screenshot from 2024-01-30 15-54-18](https://github.com/hypothesis/lms/assets/1433832/f7a8d4e3-d9ce-4b1b-b0fd-191bdfb9e766)



 