### PR TITLE
Forward opaque deep linking data in LTI1.1

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -310,9 +310,11 @@ class JSConfig:
             config["path"] = self._request.route_path(
                 "lti.v13.deep_linking.form_fields"
             )
-            config["data"]["deep_linking_settings"] = self._request.lti_params.get(
+            config["data"]["opaque_data_lti13"] = self._request.lti_params.get(
                 "deep_linking_settings"
             )
+        else:
+            config["data"]["opaque_data_lti11"] = self._request.lti_params.get("data")
 
         self._config.setdefault("filePicker", {})
         self._config["filePicker"]["deepLinkingAPI"] = config

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -586,6 +586,7 @@ class TestAddDeepLinkingAPI:
         pyramid_request.lti_params.update(
             {
                 "content_item_return_url": sentinel.content_item_return_url,
+                "data": sentinel.data,
             }
         )
 
@@ -598,6 +599,7 @@ class TestAddDeepLinkingAPI:
                 "content_item_return_url": sentinel.content_item_return_url,
                 "lms": {"product": Product.Family.UNKNOWN},
                 "context_id": pyramid_request.lti_params["context_id"],
+                "opaque_data_lti11": sentinel.data,
             },
         }
 
@@ -617,7 +619,7 @@ class TestAddDeepLinkingAPI:
             "path": "/lti/1.3/deep_linking/form_fields",
             "data": {
                 "content_item_return_url": sentinel.content_item_return_url,
-                "deep_linking_settings": sentinel.deep_linking_settings,
+                "opaque_data_lti13": sentinel.deep_linking_settings,
                 "lms": {"product": Product.Family.UNKNOWN},
                 "context_id": pyramid_request.lti_params["context_id"],
             },

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -118,7 +118,7 @@ class TestDeepLinkingFieldsView:
     def test_it_for_v13_missing_deep_linking_settings_data(
         self, jwt_service, views, pyramid_request, settings
     ):
-        pyramid_request.parsed_params["deep_linking_settings"] = settings
+        pyramid_request.parsed_params["opaque_data_lti13"] = settings
 
         views.file_picker_to_form_fields_v13()
 
@@ -131,6 +131,7 @@ class TestDeepLinkingFieldsView:
         )
 
     @pytest.mark.parametrize("title", [None, "title"])
+    @pytest.mark.parametrize("opaque_data_lti11", [None, "DATA"])
     def test_it_for_v11(
         self,
         views,
@@ -139,8 +140,11 @@ class TestDeepLinkingFieldsView:
         LTIEvent,
         misc_plugin,
         title,
+        opaque_data_lti11,
     ):
         misc_plugin.get_deeplinking_launch_url.return_value = "LAUNCH_URL"
+        pyramid_request.parsed_params["opaque_data_lti11"] = opaque_data_lti11
+
         if title:
             _get_assignment_configuration.return_value = {"title": title}
 
@@ -169,6 +173,10 @@ class TestDeepLinkingFieldsView:
             content_items["@graph"][0]["title"] = title
 
         assert json.loads(fields["content_items"]) == content_items
+        if opaque_data_lti11:
+            assert fields["data"] == opaque_data_lti11
+        else:
+            assert "data" not in fields
 
     @pytest.mark.parametrize(
         "content,expected_from_content",
@@ -219,7 +227,7 @@ class TestDeepLinkingFieldsView:
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.parsed_params = {
-            "deep_linking_settings": {"data": sentinel.deep_linking_settings_data},
+            "opaque_data_lti13": {"data": sentinel.deep_linking_settings_data},
             "content": {"type": "url", "url": "https://example.com"},
             "extra_params": {},
         }


### PR DESCRIPTION
Similar to the "deep_linking_settings" in LTI1.3 the LMS could include
some data in the deep linking launch that must be forwarded in the
response message.

The only LMS where we use deep linking with LTI1.1 doesn't use this
feature so this has been unnoticed for years. Canvas does send the `data` value but it doesn't check we send it back.

In preparation to support deep linking in LTI1.1 in combination with VitalSource we need to be spec complaint.


## Testing

Canvas does not use the new value so we'll just double check that nothing is broken.

- Re-configure a canvas assignment: https://hypothesis.instructure.com/courses/125/assignments/5142/edit?name=Testing+creation&due_at=null&points_possible=0

- The form submitted to `https://hypothesis.instructure.com/courses/125/external_content/success/external_tool_dialog
` does now contain `data`.