### PR TITLE
Only send deep linking parameters when deep linking

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -27,6 +27,7 @@ import ErrorModal from './ErrorModal';
 import FilePickerFormFields from './FilePickerFormFields';
 import GroupConfigSelector from './GroupConfigSelector';
 import type { GroupConfig } from './GroupConfigSelector';
+import HiddenFormFields from './HiddenFormFields';
 
 export type ErrorInfo = {
   message: string;
@@ -460,14 +461,25 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
               </CardContent>
             )
           }
-          {content && (
-            <FilePickerFormFields
-              title={title}
-              content={content}
-              formFields={{ ...formFields, ...deepLinkingFields }}
-              groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
-            />
-          )}
+          {
+            // Render different fields depending on whether we are
+            // submitting the form to our backend, or to the LMS (aka. deep linking)
+            content && !deepLinkingFields && (
+              <FilePickerFormFields
+                title={title}
+                content={content}
+                formFields={formFields}
+                groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
+              />
+            )
+          }
+          {
+            // Or deep linking, submitting the form to the LMS.
+            content && deepLinkingFields && (
+              <HiddenFormFields fields={deepLinkingFields} />
+            )
+          }
+
           <input
             disabled={!canSubmit}
             style={{ display: 'none' }}

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -7,6 +7,8 @@ export type FilePickerFormFieldsProps = {
   /**
    * Form field values provided by the backend that should be rendered as
    * hidden input fields.
+   * These are used while using our own assignment configuration flow
+   * ie. while not using deep linking.
    */
   formFields: Record<string, string>;
 
@@ -24,13 +26,7 @@ export type FilePickerFormFieldsProps = {
  * Render the hidden form fields in the file picker form containing information
  * about the selected assignment.
  *
- * This form may be used in two different scenarios:
- *
- *  - A "Content Item Selection" form when configuring an assignment. In this
- *    case the form will look like "Section 3.2, Example Response" in
- *    https://www.imsglobal.org/specs/lticiv1p0/specification
- *  - When an assignment without any content configuration is launched.
- *    See the `configure_assignment` view.
+ * Used when an assignment without any content configuration is launched.
  */
 export default function FilePickerFormFields({
   title,

--- a/lms/static/scripts/frontend_apps/components/HiddenFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/HiddenFormFields.tsx
@@ -1,0 +1,19 @@
+export type HiddenFormFieldsProps = {
+  /**
+   * Form field values to be rendered as hidden inputs.
+   */
+  fields: Record<string, string>;
+};
+
+/**
+ * Render fields as hidden form fields.
+ */
+export default function HiddenFormFields({ fields }: HiddenFormFieldsProps) {
+  return (
+    <>
+      {Object.entries(fields).map(([field, value]) => (
+        <input key={field} type="hidden" name={field} value={value} />
+      ))}
+    </>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -85,6 +85,14 @@ describe('FilePickerApp', () => {
     });
   }
 
+  function checkHiddenFormFields(wrapper, { fields = {} }) {
+    const fieldsComponent = wrapper.find('HiddenFormFields');
+    assert.deepEqual(fieldsComponent.props(), {
+      children: [],
+      fields: fields,
+    });
+  }
+
   it('renders form with correct action', () => {
     const wrapper = renderFilePicker();
     const form = wrapper.find('form');
@@ -194,12 +202,8 @@ describe('FilePickerApp', () => {
       await waitFor(() => onSubmit.called, 100);
 
       wrapper.update();
-      checkFormFields(wrapper, {
-        content: {
-          type: 'url',
-          url: 'https://example.com',
-        },
-        formFields: fakeFormFields,
+      checkHiddenFormFields(wrapper, {
+        fields: fakeFormFields,
       });
     });
 

--- a/lms/static/scripts/frontend_apps/components/test/HiddenFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/HiddenFormFields-test.js
@@ -1,0 +1,22 @@
+import { mount } from 'enzyme';
+
+import HiddenFormFields from '../HiddenFormFields';
+
+describe('HiddenFormFields', () => {
+  const fields = { JWT: 'JWT', VERSION: '1.3.0' };
+
+  function createComponent(props = {}) {
+    return mount(<HiddenFormFields fields={fields} {...props} />);
+  }
+  it('renders form fields', () => {
+    const formFields = createComponent();
+
+    Object.entries(fields).forEach(([name, value]) => {
+      const field = formFields
+        .find('input[type="hidden"]')
+        .filter(`[name="${name}"]`);
+      assert.isTrue(field.exists());
+      assert.equal(field.prop('value'), value);
+    });
+  });
+});

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -223,7 +223,9 @@ class DeepLinkingFieldsViews:
                     "@context": "http://purl.imsglobal.org/ctx/lti/v1/ContentItem",
                     "@graph": [content_item],
                 }
-            )
+            ),
+            "lti_message_type": "ContentItemSelection",
+            "lti_version": "LTI-1p0",
         }
         if data := self.request.parsed_params.get("opaque_data_lti11"):
             # From: https://www.imsglobal.org/specs/lticiv1p0/specification

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -173,7 +173,11 @@ class TestDeepLinkingFieldsView:
         if title:
             content_items["@graph"][0]["title"] = title
 
-        expected_fields = {"content_items": json.dumps(content_items)}
+        expected_fields = {
+            "lti_message_type": "ContentItemSelection",
+            "lti_version": "LTI-1p0",
+            "content_items": json.dumps(content_items),
+        }
 
         if opaque_data_lti11:
             expected_fields["data"] = opaque_data_lti11


### PR DESCRIPTION
FilePickerFormFields is used in two contexts with the same goal but different targets.

It could be submitting a form to our own backend or completing a deep linking (DL) response flow, submitting the form to the LMS instead.

This commit changes the values submitted to limit them to only send the deep linking one when submit to the LMS.

The only LMS where we use LTI1.1 and deep linking doesn't seem to reject the extra parameters we send (title, group set... ) so there should't be functional changes there.

Other LMS which require the payload to be signed will get confused if the signature is for a set of fields (the DL ones) but the payload includes extra values.


### Testing

No new bhevour changes but lets sanity check the aspects impatcted by the change:


#### No deep linking

- In this [BB course ](https://aunltd-test.blackboard.com/ultra/courses/_19_1/cl/outline) create and configure a new assignment. It lunches and configures successfully


#### Deep linking
- Re-configure a canvas assignment: https://hypothesis.instructure.com/courses/125/assignments/5142/edit?name=Testing+creation&due_at=null&points_possible=0

- The form submitted to `https://hypothesis.instructure.com/courses/125/external_content/success/external_tool_dialog
` does not containg title, group set values outside the DL message:

![Screenshot from 2024-01-31 12-14-17](https://github.com/hypothesis/lms/assets/1433832/2d06eafc-d0b8-48da-881b-0b210a457608)


