### PR TITLE
Make sentry-sdk a direct requirement

### DIFF
--- a/.cookiecutter/includes/requirements/prod.in
+++ b/.cookiecutter/includes/requirements/prod.in
@@ -4,6 +4,7 @@ celery
 data-tasks
 h-api
 h-assets
+sentry-sdk
 h-pyramid-sentry
 h-vialib
 importlib_resources

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -5,56 +5,56 @@
 #    pip-compile --allow-unsafe requirements/bddtests.in
 #
 aiohttp==3.9.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 aiosignal==1.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
 alembic==1.13.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 amqp==5.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 attrs==23.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   jsonschema
     #   referencing
 beautifulsoup4==4.12.2
     # via webtest
 behave==1.2.6
-    # via -r bddtests.in
+    # via -r requirements/bddtests.in
 billiard==4.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 build==1.0.3
     # via pip-tools
 cachetools==5.3.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
 celery==5.3.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 certifi==2023.11.17
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 cffi==1.16.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cryptography
 charset-normalizer==3.3.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 click==8.1.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -62,76 +62,76 @@ click==8.1.7
     #   pip-tools
 click-didyoumean==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 cryptography==41.0.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 ecdsa==0.18.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   python-jose
 factory-boy==3.3.0
-    # via -r bddtests.in
+    # via -r requirements/bddtests.in
 faker==21.0.0
     # via factory-boy
 frozenlist==1.4.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   aiosignal
 google-auth==2.25.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth-oauthlib
 google-auth-oauthlib==1.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-googleauth
 greenlet==3.0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   sqlalchemy
 gunicorn==21.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-api==1.1.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-assets==1.0.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-matchers==1.2.15
-    # via -r bddtests.in
+    # via -r requirements/bddtests.in
 h-pyramid-sentry==1.2.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-testkit==1.0.1
-    # via -r bddtests.in
+    # via -r requirements/bddtests.in
 h-vialib==1.2.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 httpretty==1.1.4
-    # via -r bddtests.in
+    # via -r requirements/bddtests.in
 hupper==1.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 idna==3.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
     #   yarl
 importlib-metadata==7.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
     #   h-assets
@@ -139,58 +139,58 @@ importlib-metadata==7.0.1
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.20.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
 jsonschema-specifications==2023.12.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
 kombu==5.3.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 mailchimp-transactional==1.0.50
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 mako==1.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
 markupsafe==2.1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 marshmallow==3.20.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   webargs
 multidict==6.0.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   yarl
 newrelic==9.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 oauthlib==3.2.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   build
     #   gunicorn
     #   marshmallow
@@ -205,59 +205,59 @@ parse-type==0.6.2
     # via behave
 pastedeploy==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
 pip-sync-faster==0.0.3
-    # via -r bddtests.in
+    # via -r requirements/bddtests.in
 pip-tools==7.3.0
     # via
-    #   -r bddtests.in
+    #   -r requirements/bddtests.in
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 pluggy==1.3.0
     # via pytest
 prompt-toolkit==3.0.43
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   click-repl
 psycopg2==2.9.9
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 pyasn1==0.5.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
 pyasn1-modules==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
 pycparser==2.21
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cffi
 pycryptodomex==3.19.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyjwt[crypto]==2.8.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
     #   pyramid-googleauth
 pyproject-hooks==1.0.0
     # via build
 pyramid==2.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -267,62 +267,62 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-googleauth==1.0.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-jinja2==2.10
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-retry==2.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-services==2.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-tm==2.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytest==7.4.4
-    # via -r bddtests.in
+    # via -r requirements/bddtests.in
 python-dateutil==2.8.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   faker
     #   mailchimp-transactional
 python-jose[crypto,cryptography]==3.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-vialib
     #   python-jose
 referencing==0.32.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth-oauthlib
 rpds-py==0.15.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 rsa==4.9
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
     #   python-jose
 sentry-sdk==1.39.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.16.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   behave
     #   ecdsa
     #   mailchimp-transactional
@@ -332,49 +332,49 @@ soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.24
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.4.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 tabulate==0.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 transaction==4.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-tm
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 typing-extensions==4.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   sqlalchemy
 tzdata==2023.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 urllib3==2.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 venusian==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   amqp
     #   celery
     #   kombu
@@ -382,42 +382,42 @@ waitress==2.1.2
     # via webtest
 wcwidth==0.2.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   prompt-toolkit
 webargs==8.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 webob==1.8.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-vialib
     #   pyramid
     #   webtest
 webtest==3.0.0
-    # via -r bddtests.in
+    # via -r requirements/bddtests.in
 wheel==0.42.0
     # via pip-tools
 wired==0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-services
 xmltodict==0.13.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 yarl==1.9.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
 zipp==3.17.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-jinja2
 zope-interface==6.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-retry
     #   pyramid-services
@@ -425,14 +425,14 @@ zope-interface==6.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==3.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3.2
     # via pip-tools
 setuptools==69.0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pip-tools
     #   pyramid
     #   zope-deprecation

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,54 +5,54 @@
 #    pip-compile --allow-unsafe requirements/dev.in
 #
 aiohttp==3.9.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 aiosignal==1.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
 alembic==1.13.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 amqp==5.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 asttokens==2.4.1
     # via stack-data
 attrs==23.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   jsonschema
     #   referencing
 billiard==4.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 build==1.0.3
     # via pip-tools
 cachetools==5.3.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
 celery==5.3.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 certifi==2023.11.17
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 cffi==1.16.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cryptography
 charset-normalizer==3.3.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 click==8.1.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -60,74 +60,74 @@ click==8.1.7
     #   pip-tools
 click-didyoumean==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 cryptography==41.0.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 decorator==5.1.1
     # via ipython
 ecdsa==0.18.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   python-jose
 executing==2.0.1
     # via stack-data
 factory-boy==3.3.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 faker==21.0.0
     # via factory-boy
 frozenlist==1.4.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   aiosignal
 google-auth==2.25.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth-oauthlib
 google-auth-oauthlib==1.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-googleauth
 greenlet==3.0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   sqlalchemy
 gunicorn==21.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-api==1.1.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-assets==1.0.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-vialib==1.2.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 hupper==1.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 idna==3.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
     #   yarl
 importlib-metadata==7.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
     #   h-assets
@@ -135,7 +135,7 @@ importlib-metadata==7.0.1
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
 ipython==8.19.0
@@ -144,53 +144,53 @@ jedi==0.19.1
     # via ipython
 jinja2==3.1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.20.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
 jsonschema-specifications==2023.12.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
 kombu==5.3.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 mailchimp-transactional==1.0.50
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 mako==1.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
 markupsafe==2.1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 marshmallow==3.20.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   webargs
 matplotlib-inline==0.1.6
     # via ipython
 multidict==6.0.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   yarl
 newrelic==9.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 oauthlib==3.2.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   build
     #   gunicorn
     #   marshmallow
@@ -200,33 +200,33 @@ parso==0.8.3
     # via jedi
 pastedeploy==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
 pexpect==4.9.0
     # via ipython
 pip-sync-faster==0.0.3
-    # via -r dev.in
+    # via -r requirements/dev.in
 pip-tools==7.3.0
     # via
-    #   -r dev.in
+    #   -r requirements/dev.in
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 prompt-toolkit==3.0.43
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   click-repl
     #   ipython
 psycopg2==2.9.9
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 ptyprocess==0.7.0
     # via pexpect
@@ -234,32 +234,32 @@ pure-eval==0.2.2
     # via stack-data
 pyasn1==0.5.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
 pyasn1-modules==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
 pycparser==2.21
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cffi
 pycryptodomex==3.19.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pygments==2.17.2
     # via ipython
 pyjwt[crypto]==2.8.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
     #   pyramid-googleauth
 pyproject-hooks==1.0.0
     # via build
 pyramid==2.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -270,83 +270,83 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-googleauth==1.0.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-ipython==0.2
-    # via -r dev.in
+    # via -r requirements/dev.in
 pyramid-jinja2==2.10
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-retry==2.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-services==2.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-tm==2.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 python-dateutil==2.8.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   faker
     #   mailchimp-transactional
 python-jose[crypto,cryptography]==3.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-vialib
     #   python-jose
 referencing==0.32.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth-oauthlib
 rpds-py==0.15.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 rsa==4.9
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
     #   python-jose
 sentry-sdk==1.39.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.16.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   asttokens
     #   ecdsa
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.24
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.4.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 stack-data==0.6.3
     # via ipython
 supervisor==4.2.5
-    # via -r dev.in
+    # via -r requirements/dev.in
 tabulate==0.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 traitlets==5.14.0
     # via
@@ -354,73 +354,73 @@ traitlets==5.14.0
     #   matplotlib-inline
 transaction==4.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-tm
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 typing-extensions==4.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   sqlalchemy
 tzdata==2023.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 urllib3==2.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 venusian==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   prompt-toolkit
 webargs==8.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 webob==1.8.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-vialib
     #   pyramid
 wheel==0.42.0
     # via pip-tools
 wired==0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-services
 xmltodict==0.13.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 yarl==1.9.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
 zipp==3.17.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-jinja2
 zope-interface==6.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-retry
     #   pyramid-services
@@ -428,14 +428,14 @@ zope-interface==6.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==3.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3.2
     # via pip-tools
 setuptools==69.0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pip-tools
     #   pyramid
     #   supervisor

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -5,20 +5,20 @@
 #    pip-compile --allow-unsafe requirements/functests.in
 #
 aiohttp==3.9.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 aiosignal==1.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
 alembic==1.13.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 amqp==5.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 attrs==23.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   jsonschema
     #   referencing
@@ -26,33 +26,33 @@ beautifulsoup4==4.12.2
     # via webtest
 billiard==4.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 build==1.0.3
     # via pip-tools
 cachetools==5.3.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
 celery==5.3.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 certifi==2023.11.17
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 cffi==1.16.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cryptography
 charset-normalizer==3.3.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 click==8.1.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -60,78 +60,78 @@ click==8.1.7
     #   pip-tools
 click-didyoumean==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 cryptography==41.0.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 ecdsa==0.18.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   python-jose
 factory-boy==3.3.0
     # via
-    #   -r functests.in
+    #   -r requirements/functests.in
     #   pytest-factoryboy
 faker==21.0.0
     # via factory-boy
 frozenlist==1.4.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   aiosignal
 google-auth==2.25.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth-oauthlib
 google-auth-oauthlib==1.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-googleauth
 greenlet==3.0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   sqlalchemy
 gunicorn==21.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-api==1.1.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-assets==1.0.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-matchers==1.2.15
-    # via -r functests.in
+    # via -r requirements/functests.in
 h-pyramid-sentry==1.2.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-testkit==1.0.1
-    # via -r functests.in
+    # via -r requirements/functests.in
 h-vialib==1.2.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 httpretty==1.1.4
-    # via -r functests.in
+    # via -r requirements/functests.in
 hupper==1.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 idna==3.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
     #   yarl
 importlib-metadata==7.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
     #   h-assets
@@ -139,7 +139,7 @@ importlib-metadata==7.0.1
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
 inflection==0.5.1
@@ -148,51 +148,51 @@ iniconfig==2.0.0
     # via pytest
 jinja2==3.1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.20.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
 jsonschema-specifications==2023.12.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
 kombu==5.3.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 mailchimp-transactional==1.0.50
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 mako==1.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
 markupsafe==2.1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 marshmallow==3.20.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   webargs
 multidict==6.0.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   yarl
 newrelic==9.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 oauthlib==3.2.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   build
     #   gunicorn
     #   marshmallow
@@ -201,59 +201,59 @@ packaging==23.2
     #   zope-sqlalchemy
 pastedeploy==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
 pip-sync-faster==0.0.3
-    # via -r functests.in
+    # via -r requirements/functests.in
 pip-tools==7.3.0
     # via
-    #   -r functests.in
+    #   -r requirements/functests.in
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 pluggy==1.3.0
     # via pytest
 prompt-toolkit==3.0.43
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   click-repl
 psycopg2==2.9.9
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 pyasn1==0.5.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
 pyasn1-modules==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
 pycparser==2.21
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cffi
 pycryptodomex==3.19.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyjwt[crypto]==2.8.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
     #   pyramid-googleauth
 pyproject-hooks==1.0.0
     # via build
 pyramid==2.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -263,66 +263,66 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-googleauth==1.0.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-jinja2==2.10
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-retry==2.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-services==2.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-tm==2.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytest==7.4.4
     # via
-    #   -r functests.in
+    #   -r requirements/functests.in
     #   pytest-factoryboy
 pytest-factoryboy==2.6.0
-    # via -r functests.in
+    # via -r requirements/functests.in
 python-dateutil==2.8.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   faker
     #   mailchimp-transactional
 python-jose[crypto,cryptography]==3.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-vialib
     #   python-jose
 referencing==0.32.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth-oauthlib
 rpds-py==0.15.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 rsa==4.9
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
     #   python-jose
 sentry-sdk==1.39.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.16.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   ecdsa
     #   mailchimp-transactional
     #   python-dateutil
@@ -330,50 +330,50 @@ soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.24
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.4.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 tabulate==0.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 transaction==4.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-tm
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 typing-extensions==4.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   pytest-factoryboy
     #   sqlalchemy
 tzdata==2023.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 urllib3==2.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 venusian==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   amqp
     #   celery
     #   kombu
@@ -381,42 +381,42 @@ waitress==2.1.2
     # via webtest
 wcwidth==0.2.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   prompt-toolkit
 webargs==8.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 webob==1.8.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-vialib
     #   pyramid
     #   webtest
 webtest==3.0.0
-    # via -r functests.in
+    # via -r requirements/functests.in
 wheel==0.42.0
     # via pip-tools
 wired==0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-services
 xmltodict==0.13.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 yarl==1.9.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
 zipp==3.17.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-jinja2
 zope-interface==6.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-retry
     #   pyramid-services
@@ -424,14 +424,14 @@ zope-interface==6.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==3.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3.2
     # via pip-tools
 setuptools==69.0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pip-tools
     #   pyramid
     #   zope-deprecation

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -6,94 +6,94 @@
 #
 aiohttp==3.9.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   aioresponses
 aioresponses==0.7.6
-    # via -r tests.txt
+    # via -r requirements/tests.txt
 aiosignal==1.3.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   aiohttp
 alembic==1.13.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 amqp==5.2.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   kombu
 astroid==3.0.2
     # via pylint
 attrs==23.1.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   aiohttp
     #   jsonschema
     #   referencing
 beautifulsoup4==4.12.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
     #   webtest
 behave==1.2.6
-    # via -r bddtests.txt
+    # via -r requirements/bddtests.txt
 billiard==4.2.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 build==1.0.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-tools
 cachetools==5.3.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   google-auth
 celery==5.3.6
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 certifi==2023.11.17
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 cffi==1.16.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   cryptography
 charset-normalizer==3.3.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   requests
 click==8.1.7
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -101,147 +101,148 @@ click==8.1.7
     #   pip-tools
 click-didyoumean==0.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 coverage[toml]==7.3.4
     # via
-    #   -r tests.txt
+    #   -r requirements/tests.txt
     #   coverage
     #   pytest-cov
 cryptography==41.0.7
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 dill==0.3.7
     # via pylint
 ecdsa==0.18.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   python-jose
 execnet==2.0.2
     # via
-    #   -r tests.txt
+    #   -r requirements/tests.txt
     #   pytest-xdist
 factory-boy==3.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest-factoryboy
 faker==21.0.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   factory-boy
 freezegun==1.4.0
-    # via -r tests.txt
+    # via -r requirements/tests.txt
 frozenlist==1.4.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   aiohttp
     #   aiosignal
 google-auth==2.25.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   google-auth-oauthlib
 google-auth-oauthlib==1.2.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid-googleauth
 greenlet==3.0.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   sqlalchemy
 gunicorn==21.2.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-api==1.1.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-assets==1.0.6
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-matchers==1.2.15
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-pyramid-sentry==1.2.4
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-testkit==1.0.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 h-vialib==1.2.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 httpretty==1.1.4
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 hupper==1.12
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
 idna==3.6
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   requests
     #   yarl
 importlib-metadata==7.0.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
     #   h-api
     #   h-assets
@@ -249,99 +250,99 @@ importlib-metadata==7.0.1
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
     #   h-api
 inflection==0.5.1
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest-factoryboy
 iniconfig==2.0.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest
 isort==5.13.2
     # via pylint
 jinja2==3.1.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.20.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-api
 jsonschema-specifications==2023.12.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   jsonschema
 kombu==5.3.4
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 mailchimp-transactional==1.0.50
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 mako==1.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   alembic
 markupsafe==2.1.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 marshmallow==3.20.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   webargs
 mccabe==0.7.0
     # via pylint
 multidict==6.0.4
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   aiohttp
     #   yarl
 newrelic==9.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 oauthlib==3.2.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   build
     #   gunicorn
     #   marshmallow
@@ -350,118 +351,118 @@ packaging==23.2
     #   zope-sqlalchemy
 parse==1.20.0
     # via
-    #   -r bddtests.txt
+    #   -r requirements/bddtests.txt
     #   behave
     #   parse-type
 parse-type==0.6.2
     # via
-    #   -r bddtests.txt
+    #   -r requirements/bddtests.txt
     #   behave
 pastedeploy==3.1.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   plaster-pastedeploy
 pip-sync-faster==0.0.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r lint.in
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/lint.in
+    #   -r requirements/tests.txt
 pip-tools==7.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r lint.in
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/lint.in
+    #   -r requirements/tests.txt
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
 platformdirs==4.1.0
     # via pylint
 pluggy==1.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest
 prompt-toolkit==3.0.43
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   click-repl
 psutil==5.9.7
     # via
-    #   -r tests.txt
+    #   -r requirements/tests.txt
     #   pytest-xdist
 psycopg2==2.9.9
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
 pyasn1==0.5.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
 pyasn1-modules==0.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   google-auth
 pycodestyle==2.11.1
-    # via -r lint.in
+    # via -r requirements/lint.in
 pycparser==2.21
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   cffi
 pycryptodomex==3.19.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pydocstyle==6.3.0
-    # via -r lint.in
+    # via -r requirements/lint.in
 pyjwt[crypto]==2.8.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyjwt
     #   pyramid-googleauth
 pylint==3.0.3
-    # via -r lint.in
+    # via -r requirements/lint.in
 pyproject-hooks==1.0.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   build
 pyramid==2.0.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -472,114 +473,114 @@ pyramid==2.0.2
     #   pyramid-tm
 pyramid-exclog==1.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-googleauth==1.0.5
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-jinja2==2.10
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-retry==2.1.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-services==2.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pyramid-tm==2.5
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pytest==7.4.4
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pytest-cov
     #   pytest-factoryboy
     #   pytest-xdist
 pytest-cov==4.1.0
-    # via -r tests.txt
+    # via -r requirements/tests.txt
 pytest-factoryboy==2.6.0
     # via
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 pytest-xdist[psutil]==3.5.0
     # via
-    #   -r tests.txt
+    #   -r requirements/tests.txt
     #   pytest-xdist
 python-dateutil==2.8.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
     #   faker
     #   freezegun
     #   mailchimp-transactional
 python-jose[crypto,cryptography]==3.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-vialib
     #   python-jose
 referencing==0.32.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   mailchimp-transactional
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   google-auth-oauthlib
 rpds-py==0.15.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   jsonschema
     #   referencing
 rsa==4.9
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   google-auth
     #   python-jose
 sentry-sdk==1.39.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-pyramid-sentry
 six==1.16.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   behave
     #   ecdsa
     #   mailchimp-transactional
@@ -589,151 +590,151 @@ snowballstemmer==2.2.0
     # via pydocstyle
 soupsieve==2.5
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
     #   beautifulsoup4
 sqlalchemy==2.0.24
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.4.4
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
 tabulate==0.9.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   data-tasks
 toml==0.10.2
-    # via -r lint.in
+    # via -r requirements/lint.in
 tomlkit==0.12.3
     # via pylint
 transaction==4.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid-tm
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
 typing-extensions==4.9.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   alembic
     #   pytest-factoryboy
     #   sqlalchemy
 tzdata==2023.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   celery
 urllib3==2.1.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 venusian==3.1.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   amqp
     #   celery
     #   kombu
 waitress==2.1.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
     #   webtest
 wcwidth==0.2.12
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   prompt-toolkit
 webargs==8.3.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 webob==1.8.7
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   h-vialib
     #   pyramid
     #   webtest
 webtest==3.0.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
 wheel==0.42.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-tools
 wired==0.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid-services
 xmltodict==0.13.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 yarl==1.9.4
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   aiohttp
 zipp==3.17.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
     #   pyramid-jinja2
 zope-interface==6.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pyramid
     #   pyramid-retry
     #   pyramid-services
@@ -742,22 +743,22 @@ zope-interface==6.1
     #   zope-sqlalchemy
 zope-sqlalchemy==3.1
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3.2
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-tools
 setuptools==69.0.3
     # via
-    #   -r bddtests.txt
-    #   -r functests.txt
-    #   -r tests.txt
+    #   -r requirements/bddtests.txt
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
     #   pip-tools
     #   pyramid
     #   zope-deprecation

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -12,6 +12,7 @@ celery
 data-tasks
 h-api
 h-assets
+sentry-sdk
 h-pyramid-sentry
 h-vialib
 importlib_resources

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,11 +5,11 @@
 #    pip-compile --allow-unsafe requirements/prod.in
 #
 aiohttp==3.9.2
-    # via -r prod.in
+    # via -r requirements/prod.in
 aiosignal==1.3.1
     # via aiohttp
 alembic==1.13.1
-    # via -r prod.in
+    # via -r requirements/prod.in
 amqp==5.2.0
     # via kombu
 attrs==23.1.0
@@ -22,7 +22,7 @@ billiard==4.2.0
 cachetools==5.3.2
     # via google-auth
 celery==5.3.6
-    # via -r prod.in
+    # via -r requirements/prod.in
 certifi==2023.11.17
     # via
     #   mailchimp-transactional
@@ -49,7 +49,7 @@ cryptography==41.0.7
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
-    # via -r prod.in
+    # via -r requirements/prod.in
 ecdsa==0.18.0
     # via python-jose
 frozenlist==1.4.1
@@ -63,15 +63,15 @@ google-auth-oauthlib==1.2.0
 greenlet==3.0.3
     # via sqlalchemy
 gunicorn==21.2.0
-    # via -r prod.in
+    # via -r requirements/prod.in
 h-api==1.1.0
-    # via -r prod.in
+    # via -r requirements/prod.in
 h-assets==1.0.6
-    # via -r prod.in
+    # via -r requirements/prod.in
 h-pyramid-sentry==1.2.4
-    # via -r prod.in
+    # via -r requirements/prod.in
 h-vialib==1.2.1
-    # via -r prod.in
+    # via -r requirements/prod.in
 hupper==1.12
     # via pyramid
 idna==3.6
@@ -86,7 +86,7 @@ importlib-metadata==7.0.1
     #   h-vialib
 importlib-resources==6.1.1
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   data-tasks
     #   h-api
 jinja2==3.1.3
@@ -100,7 +100,7 @@ jsonschema-specifications==2023.12.1
 kombu==5.3.4
     # via celery
 mailchimp-transactional==1.0.50
-    # via -r prod.in
+    # via -r requirements/prod.in
 mako==1.3.0
     # via alembic
 markupsafe==2.1.3
@@ -110,17 +110,17 @@ markupsafe==2.1.3
     #   pyramid-jinja2
 marshmallow==3.20.1
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   webargs
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
 newrelic==9.3.0
-    # via -r prod.in
+    # via -r requirements/prod.in
 oauthlib==3.2.2
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   requests-oauthlib
 packaging==23.2
     # via
@@ -140,7 +140,7 @@ prompt-toolkit==3.0.43
     # via click-repl
 psycopg2==2.9.9
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   data-tasks
 pyasn1==0.5.1
     # via
@@ -152,14 +152,14 @@ pyasn1-modules==0.3.0
 pycparser==2.21
     # via cffi
 pycryptodomex==3.19.1
-    # via -r prod.in
+    # via -r requirements/prod.in
 pyjwt[crypto]==2.8.0
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   pyramid-googleauth
 pyramid==2.0.2
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -169,24 +169,24 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.in
+    # via -r requirements/prod.in
 pyramid-googleauth==1.0.5
-    # via -r prod.in
+    # via -r requirements/prod.in
 pyramid-jinja2==2.10
-    # via -r prod.in
+    # via -r requirements/prod.in
 pyramid-retry==2.1.1
-    # via -r prod.in
+    # via -r requirements/prod.in
 pyramid-services==2.2
-    # via -r prod.in
+    # via -r requirements/prod.in
 pyramid-tm==2.5
-    # via -r prod.in
+    # via -r requirements/prod.in
 python-dateutil==2.8.2
     # via
     #   celery
     #   mailchimp-transactional
 python-jose[crypto,cryptography]==3.3.0
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   h-vialib
 referencing==0.32.0
     # via
@@ -195,12 +195,12 @@ referencing==0.32.0
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   mailchimp-transactional
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   google-auth-oauthlib
 rpds-py==0.15.2
     # via
@@ -211,7 +211,9 @@ rsa==4.9
     #   google-auth
     #   python-jose
 sentry-sdk==1.39.1
-    # via h-pyramid-sentry
+    # via
+    #   -r requirements/prod.in
+    #   h-pyramid-sentry
 six==1.16.0
     # via
     #   ecdsa
@@ -219,17 +221,17 @@ six==1.16.0
     #   python-dateutil
 sqlalchemy==2.0.24
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.4.4
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   data-tasks
 tabulate==0.9.0
     # via
-    #   -r prod.in
+    #   -r requirements/prod.in
     #   data-tasks
 transaction==4.0
     # via
@@ -258,7 +260,7 @@ vine==5.1.0
 wcwidth==0.2.12
     # via prompt-toolkit
 webargs==8.3.0
-    # via -r prod.in
+    # via -r requirements/prod.in
 webob==1.8.7
     # via
     #   h-vialib
@@ -266,7 +268,7 @@ webob==1.8.7
 wired==0.3
     # via pyramid-services
 xmltodict==0.13.0
-    # via -r prod.in
+    # via -r requirements/prod.in
 yarl==1.9.4
     # via aiohttp
 zipp==3.17.0
@@ -284,7 +286,7 @@ zope-interface==6.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==3.1
-    # via -r prod.in
+    # via -r requirements/prod.in
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==69.0.3

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -21,7 +21,7 @@ click==8.1.7
     #   cookiecutter
     #   pip-tools
 cookiecutter==2.5.0
-    # via -r template.in
+    # via -r requirements/template.in
 idna==3.6
     # via requests
 importlib-metadata==7.0.1
@@ -37,10 +37,10 @@ mdurl==0.1.2
 packaging==23.2
     # via build
 pip-sync-faster==0.0.3
-    # via -r template.in
+    # via -r requirements/template.in
 pip-tools==7.3.0
     # via
-    #   -r template.in
+    #   -r requirements/template.in
     #   pip-sync-faster
 pygments==2.17.2
     # via rich

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,55 +6,55 @@
 #
 aiohttp==3.9.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aioresponses
 aioresponses==0.7.6
-    # via -r tests.in
+    # via -r requirements/tests.in
 aiosignal==1.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
 alembic==1.13.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 amqp==5.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   kombu
 attrs==23.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   jsonschema
     #   referencing
 billiard==4.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 build==1.0.3
     # via pip-tools
 cachetools==5.3.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
 celery==5.3.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 certifi==2023.11.17
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 cffi==1.16.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cryptography
 charset-normalizer==3.3.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
 click==8.1.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -62,15 +62,15 @@ click==8.1.7
     #   pip-tools
 click-didyoumean==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 coverage[toml]==7.3.4
     # via
@@ -78,70 +78,70 @@ coverage[toml]==7.3.4
     #   pytest-cov
 cryptography==41.0.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
     #   python-jose
 data-tasks==0.0.3
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 ecdsa==0.18.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   python-jose
 execnet==2.0.2
     # via pytest-xdist
 factory-boy==3.3.0
     # via
-    #   -r tests.in
+    #   -r requirements/tests.in
     #   pytest-factoryboy
 faker==21.0.0
     # via factory-boy
 freezegun==1.4.0
-    # via -r tests.in
+    # via -r requirements/tests.in
 frozenlist==1.4.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   aiosignal
 google-auth==2.25.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth-oauthlib
 google-auth-oauthlib==1.2.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-googleauth
 greenlet==3.0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   sqlalchemy
 gunicorn==21.2.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-api==1.1.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-assets==1.0.6
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-matchers==1.2.15
-    # via -r tests.in
+    # via -r requirements/tests.in
 h-pyramid-sentry==1.2.4
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 h-testkit==1.0.1
-    # via -r tests.in
+    # via -r requirements/tests.in
 h-vialib==1.2.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 httpretty==1.1.4
-    # via -r tests.in
+    # via -r requirements/tests.in
 hupper==1.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 idna==3.6
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests
     #   yarl
 importlib-metadata==7.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
     #   h-assets
@@ -149,7 +149,7 @@ importlib-metadata==7.0.1
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   h-api
 inflection==0.5.1
@@ -158,51 +158,51 @@ iniconfig==2.0.0
     # via pytest
 jinja2==3.1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
     #   pyramid-jinja2
 jsonschema==4.20.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
 jsonschema-specifications==2023.12.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
 kombu==5.3.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 mailchimp-transactional==1.0.50
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 mako==1.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
 markupsafe==2.1.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jinja2
     #   mako
     #   pyramid-jinja2
 marshmallow==3.20.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   webargs
 multidict==6.0.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
     #   yarl
 newrelic==9.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 oauthlib==3.2.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   build
     #   gunicorn
     #   marshmallow
@@ -211,61 +211,61 @@ packaging==23.2
     #   zope-sqlalchemy
 pastedeploy==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
 pip-sync-faster==0.0.3
-    # via -r tests.in
+    # via -r requirements/tests.in
 pip-tools==7.3.0
     # via
-    #   -r tests.in
+    #   -r requirements/tests.in
     #   pip-sync-faster
 plaster==1.1.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   plaster-pastedeploy
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 pluggy==1.3.0
     # via pytest
 prompt-toolkit==3.0.43
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   click-repl
 psutil==5.9.7
     # via pytest-xdist
 psycopg2==2.9.9
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 pyasn1==0.5.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyasn1-modules
     #   python-jose
     #   rsa
 pyasn1-modules==0.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
 pycparser==2.21
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   cffi
 pycryptodomex==3.19.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyjwt[crypto]==2.8.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyjwt
     #   pyramid-googleauth
 pyproject-hooks==1.0.0
     # via build
 pyramid==2.0.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-assets
     #   h-pyramid-sentry
     #   pyramid-exclog
@@ -275,160 +275,160 @@ pyramid==2.0.2
     #   pyramid-services
     #   pyramid-tm
 pyramid-exclog==1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-googleauth==1.0.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-jinja2==2.10
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-retry==2.1.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-services==2.2
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pyramid-tm==2.5
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 pytest==7.4.4
     # via
-    #   -r tests.in
+    #   -r requirements/tests.in
     #   pytest-cov
     #   pytest-factoryboy
     #   pytest-xdist
 pytest-cov==4.1.0
-    # via -r tests.in
+    # via -r requirements/tests.in
 pytest-factoryboy==2.6.0
-    # via -r tests.in
+    # via -r requirements/tests.in
 pytest-xdist[psutil]==3.5.0
-    # via -r tests.in
+    # via -r requirements/tests.in
 python-dateutil==2.8.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
     #   faker
     #   freezegun
     #   mailchimp-transactional
 python-jose[crypto,cryptography]==3.3.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-vialib
     #   python-jose
 referencing==0.32.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-api
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth-oauthlib
 rpds-py==0.15.2
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   jsonschema
     #   referencing
 rsa==4.9
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   google-auth
     #   python-jose
 sentry-sdk==1.39.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-pyramid-sentry
 six==1.16.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   ecdsa
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.24
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   data-tasks
     #   zope-sqlalchemy
 sqlparse==0.4.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 tabulate==0.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   data-tasks
 transaction==4.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-tm
     #   zope-sqlalchemy
 translationstring==1.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 typing-extensions==4.9.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   alembic
     #   pytest-factoryboy
     #   sqlalchemy
 tzdata==2023.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   celery
 urllib3==2.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
 venusian==3.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
 vine==5.1.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.12
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   prompt-toolkit
 webargs==8.3.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 webob==1.8.7
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   h-vialib
     #   pyramid
 wheel==0.42.0
     # via pip-tools
 wired==0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid-services
 xmltodict==0.13.0
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 yarl==1.9.4
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   aiohttp
 zipp==3.17.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   importlib-metadata
 zope-deprecation==5.0
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-jinja2
 zope-interface==6.1
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pyramid
     #   pyramid-retry
     #   pyramid-services
@@ -436,14 +436,14 @@ zope-interface==6.1
     #   wired
     #   zope-sqlalchemy
 zope-sqlalchemy==3.1
-    # via -r prod.txt
+    # via -r requirements/prod.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3.2
     # via pip-tools
 setuptools==69.0.3
     # via
-    #   -r prod.txt
+    #   -r requirements/prod.txt
     #   pip-tools
     #   pyramid
     #   zope-deprecation


### PR DESCRIPTION
So Dependabot keeps it up to date.
