### PR TITLE
Don't include `Title` on the file picker form submission

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -396,7 +396,6 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                         <Input
                           data-testid="title-input"
                           id={titleInputId}
-                          name="Title"
                           // Max length is based on what D2L supports, which is the first LMS that
                           // supported setting a title in assignment configuration.
                           maxLength={150}


### PR DESCRIPTION
We only use title while deep linking in some LMSes and that should be part of the payload to form_fields that get later forwarded to the LMS via hidden fields.

While editing we don't allow updating the title because we can't change the title of an assignment on the LMS as a side effect of a launch.

While creating an assignment but not deep linking we don't use the title because we are using a regular type of launch,
the assignment is already created beforehand and this is the first launch, no opportunity to set the title from our side like in the editing scenario.