### PR TITLE
Ensure FilePicker errors are announced by screen readers

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.tsx
@@ -6,12 +6,13 @@ import {
   Thumbnail,
 } from '@hypothesis/frontend-shared';
 import classNames from 'classnames';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useEffect, useId, useRef, useState } from 'preact/hooks';
 
 import type { Book } from '../api-types';
 import { formatErrorMessage } from '../errors';
 import { useService, VitalSourceService } from '../services';
 import { extractBookID } from '../utils/vitalsource';
+import ErrorMessage from './ErrorMessage';
 import UIMessage from './UIMessage';
 
 export type BookSelectorProps = {
@@ -44,8 +45,8 @@ export default function BookSelector({
   onSelectBook,
 }: BookSelectorProps) {
   const vsService = useService(VitalSourceService);
-
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const errorId = useId();
 
   // is a request in-flight via the vitalsource service?
   const [isLoadingBook, setIsLoadingBook] = useState(false);
@@ -183,6 +184,7 @@ export default function BookSelector({
             placeholder="e.g. https://bookshelf.vitalsource.com/#/books/012345678..."
             readOnly={isLoadingBook}
             spellcheck={false}
+            aria-labelledby={errorId}
           />
           <IconButton
             icon={ArrowRightIcon}
@@ -198,11 +200,7 @@ export default function BookSelector({
           </UIMessage>
         )}
 
-        {error && (
-          <UIMessage status="error" data-testid="error-message">
-            {error}
-          </UIMessage>
-        )}
+        <ErrorMessage error={error} id={errorId} data-testid="error-message" />
       </div>
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/ErrorMessage.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorMessage.tsx
@@ -1,0 +1,28 @@
+import type { ComponentChildren, JSX } from 'preact';
+
+import UIMessage from './UIMessage';
+
+// Excluding aria-live, as it will always be set as `aria-live="polite"
+export type ErrorMessageProps = Omit<
+  JSX.HTMLAttributes<HTMLDivElement>,
+  'aria-live'
+> & {
+  error: ComponentChildren;
+  'aria-live'?: never;
+};
+
+/**
+ * Renders a UIMessage[status="error"], with [role="alert"] and wrapped in an
+ * always-present [aria-live="polite"] container
+ */
+export default function ErrorMessage({ error, ...rest }: ErrorMessageProps) {
+  return (
+    <div {...rest} aria-live="polite">
+      {!!error && (
+        <UIMessage status="error" role="alert">
+          {error}
+        </UIMessage>
+      )}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
@@ -9,7 +9,7 @@ import {
   Thumbnail,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import { useRef, useState } from 'preact/hooks';
+import { useId, useRef, useState } from 'preact/hooks';
 
 import type { JSTORMetadata, JSTORThumbnail } from '../api-types';
 import { formatErrorMessage } from '../errors';
@@ -17,6 +17,7 @@ import { urlPath, useAPIFetch } from '../utils/api';
 import type { FetchResult } from '../utils/fetch';
 import { useUniqueId } from '../utils/hooks';
 import { articleIdFromUserInput, jstorURLFromArticleId } from '../utils/jstor';
+import ErrorMessage from './ErrorMessage';
 import UIMessage from './UIMessage';
 
 export type JSTORPickerProps = {
@@ -41,6 +42,7 @@ export default function JSTORPicker({
   onSelectURL,
 }: JSTORPickerProps) {
   const [error, setError] = useState<string | null>(null);
+  const errorId = useId();
 
   // Selected JSTOR article ID or DOI, updated when the user confirms what
   // they have pasted/typed into the input field.
@@ -194,6 +196,7 @@ export default function JSTORPicker({
               onKeyDown={onKeyDown}
               placeholder="e.g. https://www.jstor.org/stable/1234"
               spellcheck={false}
+              aria-labelledby={errorId}
             />
             <IconButton
               icon={ArrowRightIcon}
@@ -236,9 +239,7 @@ export default function JSTORPicker({
             </>
           )}
 
-          {renderedError && (
-            <UIMessage status="error">{renderedError}</UIMessage>
-          )}
+          <ErrorMessage error={renderedError} id={errorId} />
         </div>
       </div>
     </ModalDialog>

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -7,9 +7,10 @@ import {
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren, RefObject } from 'preact';
+import { useId } from 'preact/hooks';
 
 import { useUniqueId } from '../utils/hooks';
-import UIMessage from './UIMessage';
+import ErrorMessage from './ErrorMessage';
 
 export type ThumbnailData = {
   image?: string;
@@ -52,6 +53,7 @@ export default function URLFormWithPreview({
 }: URLFormWithPreviewProps) {
   const orientation = thumbnail?.orientation ?? 'square';
   const inputId = useUniqueId('url');
+  const errorId = useId();
   const onChange = () => onURLChange(inputRef.current!.value);
   const onKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Enter') {
@@ -108,6 +110,7 @@ export default function URLFormWithPreview({
             onInput={onInput}
             placeholder={urlPlaceholder}
             spellcheck={false}
+            aria-labelledby={errorId}
           />
           <IconButton
             icon={ArrowRightIcon}
@@ -119,11 +122,7 @@ export default function URLFormWithPreview({
 
         {children}
 
-        {error && (
-          <UIMessage status="error" data-testid="error-message">
-            {error}
-          </UIMessage>
-        )}
+        <ErrorMessage error={error} id={errorId} data-testid="error-message" />
       </div>
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -1,8 +1,8 @@
 import { Button, ModalDialog, Input } from '@hypothesis/frontend-shared';
-import { useRef, useState } from 'preact/hooks';
+import { useId, useRef, useState } from 'preact/hooks';
 
 import { isYouTubeURL } from '../utils/youtube';
-import UIMessage from './UIMessage';
+import ErrorMessage from './ErrorMessage';
 
 export type URLPickerProps = {
   /** The initial value of the URL input field. */
@@ -27,6 +27,7 @@ export default function URLPicker({
 }: URLPickerProps) {
   const input = useRef<HTMLInputElement | null>(null);
   const form = useRef<HTMLFormElement | null>(null);
+  const errorId = useId();
 
   // Holds an error message corresponding to client-side validation of the
   // input field
@@ -93,6 +94,7 @@ export default function URLPicker({
           <Input
             aria-label="Enter URL to web page or PDF"
             classes="grow"
+            aria-labelledby={errorId}
             defaultValue={defaultURL}
             feedback={error ? 'error' : undefined}
             elementRef={input}
@@ -103,9 +105,7 @@ export default function URLPicker({
         </form>
         {/** setting a height here "preserves space" for this error display
          * and prevents the dialog size from jumping when an error is rendered */}
-        <div className="h-4 min-h-4">
-          {!!error && <UIMessage status="error">{error}</UIMessage>}
-        </div>
+        <ErrorMessage error={error} className="h-4 min-h-4" id={errorId} />
       </div>
     </ModalDialog>
   );

--- a/lms/static/scripts/frontend_apps/components/test/ErrorMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorMessage-test.js
@@ -1,0 +1,16 @@
+import { mount } from 'enzyme';
+
+import ErrorMessage from '../ErrorMessage';
+
+describe('ErrorMessage', () => {
+  function createErrorMessage(props = {}) {
+    return mount(<ErrorMessage {...props} />);
+  }
+
+  [null, undefined, 'error message', false, 45].forEach(error => {
+    it('renders error only if it has a truthy value', () => {
+      const wrapper = createErrorMessage({ error });
+      assert.equal(wrapper.exists('UIMessage'), !!error);
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -236,11 +236,11 @@ describe('JSTORPicker', () => {
       const wrapper = renderJSTORPicker();
       updateURL(wrapper, 'foo');
 
-      const errorMessage = wrapper.find('UIMessage[status="error"]');
+      const errorMessage = wrapper.find('ErrorMessage');
 
       assert.isTrue(errorMessage.exists());
       assert.include(
-        errorMessage.text(),
+        errorMessage.prop('error'),
         "That doesn't look like a JSTOR article link or ID"
       );
     });
@@ -269,10 +269,10 @@ describe('JSTORPicker', () => {
       new Error('No such article')
     );
 
-    const errorMessage = wrapper.find('UIMessage[status="error"]');
+    const errorMessage = wrapper.find('ErrorMessage');
     assert.isTrue(errorMessage.exists());
     assert.include(
-      errorMessage.text(),
+      errorMessage.prop('error'),
       'Unable to fetch article details: No such article'
     );
   });
@@ -358,9 +358,9 @@ describe('JSTORPicker', () => {
 
       assert.isTrue(wrapper.find(buttonSelector).props().disabled);
 
-      const errorMessage = wrapper.find('UIMessage[status="error"]');
+      const errorMessage = wrapper.find('ErrorMessage');
       assert.isTrue(errorMessage.exists());
-      assert.equal(errorMessage.text().trim(), expectedError);
+      assert.equal(errorMessage.prop('error').trim(), expectedError);
     });
   });
 });


### PR DESCRIPTION
Closes #6012 

From the [2024 VPAT review](https://docs.google.com/document/d/1YdYr5jIsKEm4CkOQF9un3LUc-A8xLtwFP5kWbNpqYOM/edit#heading=h.gjdgxs), we were suggested these changes to ensure `FilePicker` errors are properly announced by screen readers:

> Recommendation for error messages
> To improve the accessibility of the input: 
> * Add a role=”alert” to the error message to announce it to assistive technology users in real time. 
> * Add an aria-describedby attribute to the input with a value that points to the id of the error message. This will communicate the error to users when they are within the input field.

This PR implements both, by creating a new component rendering an `aria-live` container for errors, and an error inside of it.

### Testing steps

1. Open a localhost assignment, and open the file picker.
2. Select any content type that has an input, like URL, book, JSTOR or YouTube.
3. Run a screen reader.
4. Introduce an invalid value in the input and press <kbd>Enter</kbd> -> The screen reader should announce the error message.
5. Focus some other element, then focus the input back -> The screen reader should announce the error message again.
6. Close the content selector and open it again.
7. Introduce an invalid value in the input and click "Submit" -> The screen reader should announce the error message.