### PR TITLE
Use the LMS `display_name` to build our own 

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -98,16 +98,13 @@ class LTIUser:  # pylint: disable=too-many-instance-attributes
         )
 
 
-def display_name(given_name, family_name, full_name):
+def display_name(given_name, family_name, full_name, custom_display_name):
     """
     Return an h-compatible display name the given name parts.
 
-    LTI 1.1 launch requests have separate given_name (lis_person_name_given),
-    family_name (lis_person_name_family) and full_name (lis_person_name_full)
-    parameters. This function returns a single display name string based on
-    these three separate names.
+    Try to come up with the best display_name based on the LTI parameters available.
     """
-    name = full_name.strip()
+    name = custom_display_name.strip() or full_name.strip()
 
     if not name:
         given_name = given_name.strip()

--- a/lms/services/lti_user.py
+++ b/lms/services/lti_user.py
@@ -31,6 +31,7 @@ class LTIUserService:
                 lti_params.get("lis_person_name_given", ""),
                 lti_params.get("lis_person_name_family", ""),
                 lti_params.get("lis_person_name_full", ""),
+                lti_params.get("custom_display_name", ""),
             ),
             email=lti_params.get("lis_person_contact_email_primary"),
             lti={

--- a/lms/templates/config.xml.jinja2
+++ b/lms/templates/config.xml.jinja2
@@ -18,6 +18,7 @@ http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
   <blti:custom>
     <lticm:property name="custom_canvas_course_id">$Canvas.course.id</lticm:property>
     <lticm:property name="custom_canvas_api_domain">$Canvas.api.domain</lticm:property>
+    <lticm:property name="custom_display_name">$Person.name.display</lticm:property>
   </blti:custom>
   <blti:extensions platform="canvas.instructure.com">
     <lticm:options name="link_selection">

--- a/lms/views/canvas/config.py
+++ b/lms/views/canvas/config.py
@@ -79,6 +79,7 @@ def config_json(request):
             "custom_canvas_course_id": "$Canvas.course.id",
             "custom_canvas_api_domain": "$Canvas.api.domain",
             "custom_canvas_user_id": "$Canvas.user.id",
+            "custom_display_name": "$Person.name.display",
         },
         "scopes": [
             "https://purl.imsglobal.org/spec/lti-ags/scope/score",

--- a/tests/unit/lms/models/lti_user_test.py
+++ b/tests/unit/lms/models/lti_user_test.py
@@ -76,35 +76,41 @@ class TestLTIUser:
 
 
 @pytest.mark.parametrize(
-    "given_name,family_name,full_name,expected_display_name",
+    "given_name,family_name,full_name,custom_display_name,expected_display_name",
     [
-        # It returns the full name if there is one.
-        ("given", "family", "full", "full"),
+        # It returns the display_name name if there is one.
+        ("given", "family", "full", "display", "display"),
+        # It returns the full name if there is one otherwise
+        ("given", "family", "full", "", "full"),
         # If there's no full name it concatenates given and family names.
-        ("given", "family", "", "given family"),
-        ("given", "family", " ", "given family"),
+        ("given", "family", "", "", "given family"),
+        ("given", "family", " ", "", "given family"),
         # If there's no full name or given name it uses just the family name.
-        ("", "family", " ", "family"),
+        ("", "family", " ", "", "family"),
         # If there's no full name or family name it uses just the given name.
-        ("given", "", "", "given"),
-        ("given", " ", " ", "given"),
+        ("given", "", "", "", "given"),
+        ("given", " ", " ", "", "given"),
         # If there's nothing else it just returns "Anonymous".
-        ("", "", "", "Anonymous"),
-        (" ", " ", " ", "Anonymous"),
+        ("", "", "", "", "Anonymous"),
+        (" ", " ", " ", "", "Anonymous"),
         # Test white space stripping
-        ("", "", " full ", "full"),
-        ("  given ", "", "", "given"),
-        ("", "  family ", "", "family"),
-        ("  given  ", "  family  ", "", "given family"),
+        ("", "", " full ", "", "full"),
+        ("  given ", "", "", "", "given"),
+        ("", "  family ", "", "", "family"),
+        ("  given  ", "  family  ", "", "", "given family"),
         # Test truncation
-        ("", "", "x" * 100, "x" * 29 + "…"),
-        ("x" * 100, "", "", "x" * 29 + "…"),
-        ("", "x" * 100, "", "x" * 29 + "…"),
-        ("given" * 3, "family" * 3, "", "givengivengiven familyfamilyf…"),
+        ("", "", "x" * 100, "", "x" * 29 + "…"),
+        ("x" * 100, "", "", "", "x" * 29 + "…"),
+        ("", "x" * 100, "", "", "x" * 29 + "…"),
+        ("given" * 3, "family" * 3, "", "", "givengivengiven familyfamilyf…"),
     ],
 )
-def test_display_name(given_name, family_name, full_name, expected_display_name):
-    display_name_ = display_name(given_name, family_name, full_name)
+def test_display_name(
+    given_name, family_name, full_name, custom_display_name, expected_display_name
+):
+    display_name_ = display_name(
+        given_name, family_name, full_name, custom_display_name
+    )
 
     assert display_name_ == expected_display_name
 

--- a/tests/unit/lms/services/lti_user_test.py
+++ b/tests/unit/lms/services/lti_user_test.py
@@ -20,6 +20,7 @@ class TestLTIUserService:
             lti_params["lis_person_name_given"],
             lti_params["lis_person_name_family"],
             lti_params["lis_person_name_full"],
+            lti_params["custom_display_name"],
         )
         assert lti_user.application_instance_id == application_instance.id
 
@@ -29,10 +30,11 @@ class TestLTIUserService:
         del lti_params["lis_person_name_given"]
         del lti_params["lis_person_name_family"]
         del lti_params["lis_person_name_full"]
+        del lti_params["custom_display_name"]
 
         lti_user = svc.from_lti_params(application_instance, lti_params)
 
-        assert lti_user.display_name == display_name("", "", "")
+        assert lti_user.display_name == display_name("", "", "", "")
 
     def test_serialize(self, svc, lti_user):
         assert svc.serialize(lti_user) == {
@@ -58,6 +60,7 @@ class TestLTIUserService:
             "lis_person_name_family": "LIS_PERSON_NAME_FAMILY",
             "lis_person_name_full": "LIS_PERSON_NAME_FULL",
             "lis_person_contact_email_primary": "LIS_PERSON_CONTACT_EMAIL_PRIMARY",
+            "custom_display_name": "CUSTOM_DISPLAY_NAME",
             "context_id": "CONTEXT_ID",
             "resource_link_id": "RESOURCE_LINK_ID",
         }

--- a/tests/unit/lms/views/canvas/config_test.py
+++ b/tests/unit/lms/views/canvas/config_test.py
@@ -49,6 +49,7 @@ class TestConfigJSON:
                 "custom_canvas_course_id": "$Canvas.course.id",
                 "custom_canvas_api_domain": "$Canvas.api.domain",
                 "custom_canvas_user_id": "$Canvas.user.id",
+                "custom_display_name": "$Person.name.display",
             },
             "scopes": [
                 "https://purl.imsglobal.org/spec/lti-ags/scope/score",


### PR DESCRIPTION
For: https://github.com/hypothesis/support/issues/94

---

We already use a combination of parameters to build our display_name. Use the LMS actual "display_name" when available to build a better version of the name.

This PR also adds the custom variable in Canvas so it's available in new installs.


### Testing

Make annotations in 
- LTI1.3 https://hypothesis.instructure.com/courses/319/assignments/3308
- LTI1.1 https://hypothesis.instructure.com/courses/125/assignments/873

You'll get the display name in the client.
