### PR TITLE
Remove setting to enable export_formats client feature

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -45,7 +45,6 @@ class ApplicationSettings(JSONSettings):
             name="Auto Assigned To Organisation",
         ),
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
-        JSONSetting("hypothesis", "export_formats_enabled", asbool),
     )
 
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -113,7 +113,6 @@
                         <fieldset class="box">
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
-                            {{ settings_checkbox('Enable export formats', 'hypothesis', 'export_formats_enabled') }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -210,17 +210,11 @@ class BasicLaunchViews:
         self.context.js_config.add_document_url(assignment.document_url)
         self.context.js_config.enable_lti_launch_mode(self.course, assignment)
 
-        export_formats_enabled = (
-            self.request.lti_user.application_instance.settings.get(
-                "hypothesis", "export_formats_enabled", False
-            )
-        )
-
         # If there are any Hypothesis client feature flags that need to be
         # enabled based on the current application instance settings, those
         # should be enabled here via `self.context.js_config.enable_client_feature`.
-        if export_formats_enabled:
-            self.context.js_config.enable_client_feature("export_formats")
+        #
+        # There are currently no such features.
 
         # Run any non standard code for the current product
         self._misc_plugin.post_launch_assignment_hook(

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -292,27 +292,6 @@ class TestBasicLaunchViews:
 
         assert result == {}
 
-    @pytest.mark.parametrize("export_formats_feature", [True, False])
-    def test__show_document_enables_client_features(
-        self, svc, pyramid_request, context, assignment, export_formats_feature
-    ):
-        pyramid_request.lti_user.application_instance.settings.set(
-            "hypothesis", "export_formats_enabled", export_formats_feature
-        )
-
-        # pylint: disable=protected-access
-        svc._show_document(assignment)
-
-        enable_client_feature = context.js_config.enable_client_feature
-        enabled_features = set(
-            call.args[0] for call in enable_client_feature.call_args_list
-        )
-
-        if export_formats_feature:
-            assert "export_formats" in enabled_features
-        else:
-            assert "export_formats" not in enabled_features
-
     @pytest.fixture
     def assignment(self):
         return factories.Assignment(is_gradable=False)


### PR DESCRIPTION
The `export_formats` feature has been enable for everyone, so we no longer need a setting to enable it on a per LMS instance basis.

We still have the `h` feature flag which would allow to disable it for all LMS instances, in case something comes up.