### PR TITLE
Map extra LTI1.1 <-> LTI1.3 parameters

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -157,6 +157,10 @@ _V11_TO_V13 = (
         ],
     ),
     (
+        "lis_person_sourcedid",
+        [f"{CLAIM_PREFIX}/lis", "person_sourcedid"],
+    ),
+    (
         "deep_linking_settings",
         ["https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings"],
     ),
@@ -172,6 +176,15 @@ _V11_TO_V13 = (
     (
         "resource_link_id",
         [f"{CLAIM_PREFIX}/lti1p1", "resource_link_id"],
+    ),
+    # LMS dependant variables that are not part of the "custom" claim
+    (
+        "org_defined_id",
+        [
+            "https://purl.imsglobal.org/spec/lti/claim/launch_presentation",
+            "http://www.brightspace.com",
+            "org_defined_id",
+        ],
     ),
 )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -65,6 +65,9 @@ def lti_v13_params():
         "name": "FULL_NAME",
         "given_name": "GIVEN_NAME",
         "family_name": "FAMILY_NAME",
+        "https://purl.imsglobal.org/spec/lti/claim/lis": {
+            "person_sourcedid": "LIS_PERSON_SOURCEID"
+        },
         "https://purl.imsglobal.org/spec/lti/claim/context": {
             "id": "CONTEXT_ID",
             "label": "LTI",
@@ -86,6 +89,11 @@ def lti_v13_params():
         "https://purl.imsglobal.org/spec/lti/claim/custom": {
             "canvas_course_id": 319,
             "canvas_api_domain": "hypothesis.instructure.com",
+        },
+        "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
+            "http://www.brightspace.com": {
+                "org_defined_id": "ORG_DEFINED_ID",
+            }
         },
     }
 

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -23,6 +23,7 @@ class TestLTIParams:
             ("lis_person_name_family", "FAMILY_NAME"),
             ("lis_person_name_full", "FULL_NAME"),
             ("lis_person_contact_email_primary", "EMAIL"),
+            ("lis_person_sourcedid", "LIS_PERSON_SOURCEID"),
             ("context_id", "CONTEXT_ID"),
             ("context_title", "CONTEXT_TITLE"),
             ("lti_version", "LTI_VERSION"),
@@ -30,6 +31,7 @@ class TestLTIParams:
             ("resource_link_id", "RESOURCE_LINK_ID"),
             ("resource_link_title", "RESOURCE_LINK_TITLE"),
             ("resource_link_description", "RESOURCE_LINK_DESCRIPTION"),
+            ("org_defined_id", "ORG_DEFINED_ID"),
         ],
     )
     def test_v13_mappings(self, pyramid_request, lti_v13_params, lti_11_key, value):


### PR DESCRIPTION
These were missing but are only needed now for configuring the "user reference" field in some VitalSource integrations.