### PR TITLE
Improve how screen readers announce file picker errors

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookSelector.tsx
@@ -6,12 +6,13 @@ import {
   Thumbnail,
 } from '@hypothesis/frontend-shared';
 import classNames from 'classnames';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useEffect, useId, useRef, useState } from 'preact/hooks';
 
 import type { Book } from '../api-types';
 import { formatErrorMessage } from '../errors';
 import { useService, VitalSourceService } from '../services';
 import { extractBookID } from '../utils/vitalsource';
+import ErrorMessage from './ErrorMessage';
 import UIMessage from './UIMessage';
 
 export type BookSelectorProps = {
@@ -46,6 +47,7 @@ export default function BookSelector({
   const vsService = useService(VitalSourceService);
 
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const errorId = useId();
 
   // is a request in-flight via the vitalsource service?
   const [isLoadingBook, setIsLoadingBook] = useState(false);
@@ -183,6 +185,7 @@ export default function BookSelector({
             placeholder="e.g. https://bookshelf.vitalsource.com/#/books/012345678..."
             readOnly={isLoadingBook}
             spellcheck={false}
+            aria-errormessage={errorId}
           />
           <IconButton
             icon={ArrowRightIcon}
@@ -198,11 +201,7 @@ export default function BookSelector({
           </UIMessage>
         )}
 
-        {error && (
-          <UIMessage status="error" data-testid="error-message">
-            {error}
-          </UIMessage>
-        )}
+        <ErrorMessage error={error} id={errorId} data-testid="error-message" />
       </div>
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/ErrorMessage.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorMessage.tsx
@@ -1,0 +1,20 @@
+import type { ComponentChildren, JSX } from 'preact';
+
+import UIMessage from './UIMessage';
+
+// Excluding role attribute, as it will always be set as `role="alert"`
+export type ErrorMessageProps = Omit<
+  JSX.HTMLAttributes<HTMLDivElement>,
+  'role'
+> & {
+  error: ComponentChildren;
+  role?: never;
+};
+
+export default function ErrorMessage({ error, ...rest }: ErrorMessageProps) {
+  return (
+    <div {...rest} role="alert">
+      {!!error && <UIMessage status="error">{error}</UIMessage>}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
@@ -1,5 +1,5 @@
 import { Button, ModalDialog } from '@hypothesis/frontend-shared';
-import type { ModalDialogProps } from '@hypothesis/frontend-shared/lib/components/feedback/ModalDialog';
+import type { PanelModalDialogProps } from '@hypothesis/frontend-shared/lib/components/feedback/ModalDialog';
 import type { ComponentChildren } from 'preact';
 import { useRef } from 'preact/hooks';
 
@@ -61,7 +61,7 @@ type ErrorModalBaseProps = {
 };
 
 /** `title` is optional for this component but required by `Modal` */
-export type ErrorModalProps = Omit<ModalDialogProps, 'title'> &
+export type ErrorModalProps = Omit<PanelModalDialogProps, 'title'> &
   ErrorModalBaseProps;
 
 /**

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
@@ -9,7 +9,7 @@ import {
   Thumbnail,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import { useRef, useState } from 'preact/hooks';
+import { useId, useRef, useState } from 'preact/hooks';
 
 import type { JSTORMetadata, JSTORThumbnail } from '../api-types';
 import { formatErrorMessage } from '../errors';
@@ -17,6 +17,7 @@ import { urlPath, useAPIFetch } from '../utils/api';
 import type { FetchResult } from '../utils/fetch';
 import { useUniqueId } from '../utils/hooks';
 import { articleIdFromUserInput, jstorURLFromArticleId } from '../utils/jstor';
+import ErrorMessage from './ErrorMessage';
 import UIMessage from './UIMessage';
 
 export type JSTORPickerProps = {
@@ -70,6 +71,7 @@ export default function JSTORPicker({
   } else if (metadata.data?.content_status === 'no_access') {
     renderedError = 'Your institution does not have access to this item.';
   }
+  const errorId = useId();
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   // The last confirmed value of the URL-entry text input
@@ -189,11 +191,13 @@ export default function JSTORPicker({
               elementRef={inputRef}
               id={inputId}
               name="jstorURL"
+              feedback={renderedError ? 'error' : undefined}
               onChange={() => onURLChange()}
               onInput={() => resetCurrentArticle()}
               onKeyDown={onKeyDown}
               placeholder="e.g. https://www.jstor.org/stable/1234"
               spellcheck={false}
+              aria-errormessage={errorId}
             />
             <IconButton
               icon={ArrowRightIcon}
@@ -236,9 +240,7 @@ export default function JSTORPicker({
             </>
           )}
 
-          {renderedError && (
-            <UIMessage status="error">{renderedError}</UIMessage>
-          )}
+          <ErrorMessage error={renderedError} id={errorId} />
         </div>
       </div>
     </ModalDialog>

--- a/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLFormWithPreview.tsx
@@ -7,9 +7,10 @@ import {
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren, RefObject } from 'preact';
+import { useId } from 'preact/hooks';
 
 import { useUniqueId } from '../utils/hooks';
-import UIMessage from './UIMessage';
+import ErrorMessage from './ErrorMessage';
 
 export type ThumbnailData = {
   image?: string;
@@ -52,6 +53,7 @@ export default function URLFormWithPreview({
 }: URLFormWithPreviewProps) {
   const orientation = thumbnail?.orientation ?? 'square';
   const inputId = useUniqueId('url');
+  const errorId = useId();
   const onChange = () => onURLChange(inputRef.current!.value);
   const onKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Enter') {
@@ -103,11 +105,13 @@ export default function URLFormWithPreview({
             elementRef={inputRef}
             id={inputId}
             name="URL"
+            feedback={error ? 'error' : undefined}
             onChange={onChange}
             onKeyDown={onKeyDown}
             onInput={onInput}
             placeholder={urlPlaceholder}
             spellcheck={false}
+            aria-errormessage={errorId}
           />
           <IconButton
             icon={ArrowRightIcon}
@@ -119,11 +123,7 @@ export default function URLFormWithPreview({
 
         {children}
 
-        {error && (
-          <UIMessage status="error" data-testid="error-message">
-            {error}
-          </UIMessage>
-        )}
+        <ErrorMessage error={error} id={errorId} data-testid="error-message" />
       </div>
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -1,8 +1,8 @@
 import { Button, ModalDialog, Input } from '@hypothesis/frontend-shared';
-import { useRef, useState } from 'preact/hooks';
+import { useId, useRef, useState } from 'preact/hooks';
 
 import { isYouTubeURL } from '../utils/youtube';
-import UIMessage from './UIMessage';
+import ErrorMessage from './ErrorMessage';
 
 export type URLPickerProps = {
   /** The initial value of the URL input field. */
@@ -31,6 +31,7 @@ export default function URLPicker({
   // Holds an error message corresponding to client-side validation of the
   // input field
   const [error, setError] = useState<string | null>(null);
+  const errorId = useId();
 
   const submit = (event: Event) => {
     event.preventDefault();
@@ -99,13 +100,12 @@ export default function URLPicker({
             name="url"
             placeholder="e.g. https://example.com/article.pdf"
             required
+            aria-errormessage={errorId}
           />
         </form>
         {/** setting a height here "preserves space" for this error display
          * and prevents the dialog size from jumping when an error is rendered */}
-        <div className="h-4 min-h-4">
-          {!!error && <UIMessage status="error">{error}</UIMessage>}
-        </div>
+        <ErrorMessage error={error} className="h-4 min-h-4" id={errorId} />
       </div>
     </ModalDialog>
   );

--- a/lms/static/scripts/frontend_apps/components/test/ErrorMessage-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorMessage-test.js
@@ -1,0 +1,16 @@
+import { mount } from 'enzyme';
+
+import ErrorMessage from '../ErrorMessage';
+
+describe('ErrorMessage', () => {
+  function createErrorMessage(props = {}) {
+    return mount(<ErrorMessage {...props} />);
+  }
+
+  [null, undefined, 'error message', false, 45].forEach(error => {
+    it('renders error only if it has a truthy value', () => {
+      const wrapper = createErrorMessage({ error });
+      assert.equal(wrapper.exists('UIMessage'), !!error);
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/JSTORPicker-test.js
@@ -236,11 +236,11 @@ describe('JSTORPicker', () => {
       const wrapper = renderJSTORPicker();
       updateURL(wrapper, 'foo');
 
-      const errorMessage = wrapper.find('UIMessage[status="error"]');
+      const errorMessage = wrapper.find('ErrorMessage');
 
       assert.isTrue(errorMessage.exists());
       assert.include(
-        errorMessage.text(),
+        errorMessage.prop('error'),
         "That doesn't look like a JSTOR article link or ID"
       );
     });
@@ -269,10 +269,10 @@ describe('JSTORPicker', () => {
       new Error('No such article')
     );
 
-    const errorMessage = wrapper.find('UIMessage[status="error"]');
+    const errorMessage = wrapper.find('ErrorMessage');
     assert.isTrue(errorMessage.exists());
     assert.include(
-      errorMessage.text(),
+      errorMessage.prop('error'),
       'Unable to fetch article details: No such article'
     );
   });
@@ -358,9 +358,9 @@ describe('JSTORPicker', () => {
 
       assert.isTrue(wrapper.find(buttonSelector).props().disabled);
 
-      const errorMessage = wrapper.find('UIMessage[status="error"]');
+      const errorMessage = wrapper.find('ErrorMessage');
       assert.isTrue(errorMessage.exists());
-      assert.equal(errorMessage.text().trim(), expectedError);
+      assert.equal(errorMessage.prop('error').trim(), expectedError);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^7.1.0",
+    "@hypothesis/frontend-shared": "^7.4.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,15 +1968,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "@hypothesis/frontend-shared@npm:7.1.0"
+"@hypothesis/frontend-shared@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "@hypothesis/frontend-shared@npm:7.4.0"
   dependencies:
     highlight.js: ^11.6.0
-    wouter-preact: ^2.10.0-alpha.1
+    wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 3dc7b2c82df68d7b17fa166c8ac78ad8317924129b241207ee5ae91a9e2688bcac5be7262735c98e8ec64aaa2654cdcfa4dd1476191b67b3bb2e8b96174339e2
+  checksum: 5744240cc37d0f2d30ff34f240cb95606c0f846fda8b52fba18d60ec5e402fde39629c3ff32593b36db3949a9556dc7c2f7985d2c281215d7877d87151d5b458
   languageName: node
   linkType: hard
 
@@ -7651,7 +7651,7 @@ __metadata:
     "@babel/preset-react": ^7.23.3
     "@babel/preset-typescript": ^7.23.3
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^7.1.0
+    "@hypothesis/frontend-shared": ^7.4.0
     "@hypothesis/frontend-testing": ^1.2.0
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^25.0.7
@@ -8174,6 +8174,13 @@ __metadata:
     minipass: ^3.0.0
     yallist: ^4.0.0
   checksum: f1fdeac0b07cf8f30fcf12f4b586795b97be856edea22b5e9072707be51fc95d41487faec3f265b42973a304fe3a64acd91a44a3826a963e37b37bafde0212c3
+  languageName: node
+  linkType: hard
+
+"mitt@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mitt@npm:3.0.1"
+  checksum: b55a489ac9c2949ab166b7f060601d3b6d893a852515ae9eca4e11df01c013876df777ea109317622b5c1c60e8aae252558e33c8c94e14124db38f64a39614b1
   languageName: node
   linkType: hard
 
@@ -9560,6 +9567,13 @@ __metadata:
     define-properties: ^1.2.0
     set-function-name: ^2.0.0
   checksum: 869edff00288442f8d7fa4c9327f91d85f3b3acf8cbbef9ea7a220345cf23e9241b6def9263d2c1ebcf3a316b0aa52ad26a43a84aa02baca3381717b3e307f47
+  languageName: node
+  linkType: hard
+
+"regexparam@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "regexparam@npm:3.0.0"
+  checksum: c8649af1538ccc12b5c5d250525f61bd370227dce41f4fb908433a9651e18b7be21dd8f8518c322dd9ebd75f7caaaea4921e374c39a469c11d4f9d0c738043e0
   languageName: node
   linkType: hard
 
@@ -11523,12 +11537,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wouter-preact@npm:^2.10.0-alpha.1, wouter-preact@npm:^2.11.0":
+"wouter-preact@npm:^2.11.0":
   version: 2.11.0
   resolution: "wouter-preact@npm:2.11.0"
   peerDependencies:
     preact: ^10.0.0
   checksum: c4dd3f995dc664ecc2043a3ece6a415b85e88261a47f52a690354ee38a957eb8b03eac479a165dd464d867d1903774afa5c31b574c6fb0bfb991d191caea7243
+  languageName: node
+  linkType: hard
+
+"wouter-preact@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "wouter-preact@npm:3.0.0"
+  dependencies:
+    mitt: ^3.0.1
+    regexparam: ^3.0.0
+  peerDependencies:
+    preact: ^10.0.0
+  checksum: 253927b4dbf0906220f71f103f3934e649debc4a5f2c94c84e3097a9072c3c2d967b559421b626acb555437ab3aa416ed0faabedd2cf95fb3c61fdbb83370bca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/frontend-shared/pull/1450

Closes https://github.com/hypothesis/lms/issues/6012

This PR improves how screen readers announce error messages and invalid inputs when configuring the content for an assignment using any content picker.

The improvements include:

* Adding `role="alert"` to the error, so that it gets announced.
* Adding `aria-invalid="true"` to inputs when there's an error (from https://github.com/hypothesis/frontend-shared/pull/1450)
* Linking the input with the error message via `aria-errormessage={errorId}`

The first item will make the error be announced as soon as the form is submitted, regardless of doing it via "Submit" click or <kbd>Enter</kbd> press while some input is focused.

The last two items will make screen readers indicate the input is invalid and what's the associated error, when they gain focus.

### Considerations

The original accessibility review suggested the use of `aria-describedby={errorId}` to link the error and the input. However, I found that combining that with `role="alert"`/`aria-live` caused the error to be announced twice if the form was submitted via <kbd>Enter</kbd> press on the input.

Using `aria-errormessage={errorId}` we avoid this, while we still ensure the error is announced when the input is focused again.

### Testing steps

1. Open the content picker of an existing assignment or create a new one.
2. Run a screen reader.
3. Enter an invalid value and press <kbd>Enter</kbd> -> It should announce the error once.
4. Focus out of the input, and focus back in -> Among other things, it should announce the input is invalid, followed by the error message.
5. Close the content picker and open it again.
6. Enter an invalid value and click submit (or the arrow button if using JSTOR/YouTube/VitalSource) -> It should announce the error once.