### PR TITLE
Use tri-state enabled/disabled/default controls for feature flags

### DIFF
--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -12,12 +12,16 @@
         {% endif %}
     </span>
 {% endblock %}
-{% macro settings_checkbox(label, setting, sub_setting, field_name, default=False) %}
+{# Tri-state checkbox with enabled/disabled/use-default options. #}
+{% macro settings_checkbox(label, setting, sub_setting, field_name, default=None) %}
     {% call macros.field_body(label) %}
-        <label class="checkbox">
-            <input {% if instance.settings.get(setting, sub_setting, default) %}checked{% endif %}
-                   type="checkbox"
-                   name="{{ setting }}.{{ sub_setting }}">
+        {% set value = instance.settings.get(setting, sub_setting, default) %}
+        <label class="select">
+            <select name="{{setting}}.{{sub_setting}}">
+              <option value="true" {% if value is true %}selected{% endif %}>Enabled</option>
+              <option value="false" {% if value is false %}selected{% endif %}>Disabled</option>
+              <option value="none" {% if value is none %}selected {% endif %}>Default</option>
+            </select>
         </label>
     {% endcall %}
 {% endmacro %}

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -82,7 +82,10 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             value = value.strip() if value else None
 
             if field.format is asbool:
-                value = value == "on"
+                if value == "none":
+                    value = None
+                else:
+                    value = asbool(value)
                 ai.settings.set(field.group, field.key, value)
 
             elif field.format == JSONSetting.AES_SECRET:

--- a/tests/unit/lms/views/admin/application_instance/update_test.py
+++ b/tests/unit/lms/views/admin/application_instance/update_test.py
@@ -87,16 +87,16 @@ class TestUpdateApplicationInstanceView:
     @pytest.mark.parametrize(
         "setting,sub_setting,value,expected",
         (
-            # Boolean fields
-            ("canvas", "groups_enabled", "on", True),
-            ("canvas", "sections_enabled", "", False),
-            ("blackboard", "files_enabled", "other", False),
-            ("blackboard", "groups_enabled", "off", False),
+            # Tri-state boolean fields
+            ("canvas", "groups_enabled", "true", True),
+            ("canvas", "sections_enabled", "false", False),
+            ("blackboard", "files_enabled", "none", None),
+            ("blackboard", "groups_enabled", "false", False),
             ("desire2learn", "client_id", "client_id", "client_id"),
-            ("desire2learn", "groups_enabled", "off", False),
-            ("microsoft_onedrive", "files_enabled", "on", True),
-            ("vitalsource", "enabled", "on", True),
-            ("jstor", "enabled", "off", False),
+            ("desire2learn", "groups_enabled", "false", False),
+            ("microsoft_onedrive", "files_enabled", "true", True),
+            ("vitalsource", "enabled", "true", True),
+            ("jstor", "enabled", "false", False),
             # String fields
             ("jstor", "site_code", "CODE", "CODE"),
             ("jstor", "site_code", "  CODE  ", "CODE"),


### PR DESCRIPTION
Use tri-state dropdown controls instead of checkboxes to represent the state of feature flags in the admin UI. This allows the UI to represent the `None` value of a setting which means "use the default value".

This resolves an issue where changing any setting for an application instance would change all feature flags currently to `None` to `False`, thereby explicitly turning the feature flag off for the instance, and causing the state not to change if the default was subsequently changed.

Fixes https://github.com/hypothesis/lms/issues/3460

---

**Preview:**

<img width="1188" alt="Tri-state feature flags" src="https://github.com/hypothesis/lms/assets/2458/fd386724-8209-4e00-a858-541fdf4355e7">
