### PR TITLE
Add more specific titles to content picker dialog close buttons

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -234,8 +234,9 @@ export default function BookPicker({
       )}
       // Opt out of Modal's automatic focus handling; route focus manually in
       // sub-components
-      initialFocus={'manual'}
+      initialFocus="manual"
       onClose={onCancel}
+      closeTitle="Close book picker"
       scrollable={false}
       title={
         step === 'select-book'

--- a/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/JSTORPicker.tsx
@@ -137,6 +137,7 @@ export default function JSTORPicker({
     <ModalDialog
       initialFocus={inputRef}
       onClose={onCancel}
+      closeTitle="Close JSTOR picker"
       scrollable={false}
       title="Select JSTOR article"
       size="lg"

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -400,6 +400,7 @@ export default function LMSFilePicker({
       })}
       title={`Select ${documentType}`}
       onClose={onCancel}
+      closeTitle="Close document picker"
       size="lg"
       buttons={[
         <Button data-testid="cancel-button" key="cancel" onClick={onCancel}>

--- a/lms/static/scripts/frontend_apps/components/URLPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/URLPicker.tsx
@@ -67,6 +67,7 @@ export default function URLPicker({
     <ModalDialog
       title="Enter URL"
       onClose={onCancel}
+      closeTitle="Close URL picker"
       buttons={[
         <Button data-testid="cancel-button" key="cancel" onClick={onCancel}>
           Cancel

--- a/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/YouTubePicker.tsx
@@ -102,6 +102,7 @@ export default function YouTubePicker({
     <ModalDialog
       title="Select YouTube video"
       onClose={onCancel}
+      closeTitle="Close YouTube picker"
       initialFocus={inputRef}
       size="lg"
       scrollable={false}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^7.4.0",
+    "@hypothesis/frontend-shared": "^7.5.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,15 +1968,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^7.4.0":
-  version: 7.4.0
-  resolution: "@hypothesis/frontend-shared@npm:7.4.0"
+"@hypothesis/frontend-shared@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "@hypothesis/frontend-shared@npm:7.5.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 5744240cc37d0f2d30ff34f240cb95606c0f846fda8b52fba18d60ec5e402fde39629c3ff32593b36db3949a9556dc7c2f7985d2c281215d7877d87151d5b458
+  checksum: 180cef619b7a0d9c74ff0f580db211d86b7c41359b8c8c3bec3c04c71a6d028cbea1dc52867191c3a3e9cdcaa4bc8635d997f6beddefd438f2fa5b7153a60a74
   languageName: node
   linkType: hard
 
@@ -7651,7 +7651,7 @@ __metadata:
     "@babel/preset-react": ^7.23.3
     "@babel/preset-typescript": ^7.23.3
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^7.4.0
+    "@hypothesis/frontend-shared": ^7.5.0
     "@hypothesis/frontend-testing": ^1.2.0
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^25.0.7


### PR DESCRIPTION
Depends on https://github.com/hypothesis/frontend-shared/pull/1460

All content picker close buttons used to have a generic "Close" title. This PR makes it more specific so that it's clear to non-sighted users what is going to be closed, when using a screen reader.