### PR TITLE
Disable proxying of iframes in Canvas Pages assignments

### DIFF
--- a/lms/views/api/canvas/pages.py
+++ b/lms/views/api/canvas/pages.py
@@ -134,6 +134,12 @@ class PagesAPIViews:
                         "authorization": auth_token,
                     },
                 ),
+                # Disable proxying of iframes. This enables embedded widgets to
+                # work if they require authentication or simply aren't compatible
+                # with viahtml's proxying.
+                #
+                # See https://github.com/hypothesis/support/issues/98.
+                options={"via.proxy_frames": "0"},
             )
         }
 

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -72,6 +72,7 @@ class TestPageAPIViews:
                     "authorization": "TOKEN",
                 }
             ),
+            options={"via.proxy_frames": "0"},
         )
         assert response == {"via_url": helpers.via_url.return_value}
 
@@ -106,6 +107,7 @@ class TestPageAPIViews:
                     "authorization": "TOKEN",
                 }
             ),
+            options={"via.proxy_frames": "0"},
         )
         assert response == {"via_url": helpers.via_url.return_value}
 
@@ -176,6 +178,7 @@ class TestPageAPIViews:
                     "authorization": "TOKEN",
                 }
             ),
+            options={"via.proxy_frames": "0"},
         )
         assert response == {"via_url": helpers.via_url.return_value}
 


### PR DESCRIPTION
By default ViaHTML rewrites all iframes to proxy them through the Via server. In the context of Canvas Pages assignments this breaks embeds which require authentication or which simply don't work in ViaHTML. This PR disables proxying for all iframes in Canvas Pages content, using the [`via.proxy_frames`](https://github.com/hypothesis/viahtml/pull/618) config.

Part of https://github.com/hypothesis/support/issues/98.

**Testing:**

If you load https://hypothesis.instructure.com/courses/125/assignments/5632 on `main` and inspect the video below the "Uploaded video" text in the page, you'll see that the video is part of an iframe that is proxied through Via. If you load the same assignment on this branch, you'll see that the video's iframe is not proxied.

Note that the YouTube iframe at the bottom of the page won't be proxied in either branch, since we have a separate mechanism to disable proxying for all YouTube frames.