### PR TITLE
Keep track of which is the source course for copied ones

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -86,6 +86,7 @@ class Grouping(CreatedUpdatedMixin, Base):
     parent_id = sa.Column(sa.Integer(), nullable=True)
     children = sa.orm.relationship(
         "Grouping",
+        foreign_keys=[parent_id, application_instance_id],
         backref=sa.orm.backref(
             "parent",
             remote_side=[id, application_instance_id],
@@ -126,6 +127,11 @@ class Grouping(CreatedUpdatedMixin, Base):
     )
 
     memberships = sa.orm.relationship("GroupingMembership", back_populates="grouping")
+
+    copied_from_id = sa.Column(
+        sa.Integer(), sa.ForeignKey("grouping.id"), nullable=True
+    )
+    """ID of the course grouping this one was copied from using the course copy feature in the LMS."""
 
     @property
     def name(self):

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -34,24 +34,27 @@ class GroupingService:
         grouping_dicts: list[dict],
         type_: Grouping.Type,
         parent: Grouping | None = None,
+        copied_from: Grouping | None = None,
     ) -> list[Grouping]:
         """
         Upsert a Grouping generating the authority_provided_id based on its parent.
 
         :param grouping_dicts: A list of dicts containing the grouping information
-        :param parent: Parent grouping for all upserted groups
         :param type_: Type of the groupings
+        :param parent: Parent grouping for all upserted groups
+        :param copied_from: Orignal grouping this one was copied from
         """
         if not grouping_dicts:
             return []
 
+        parent_id = None
         if parent:
             if not parent.id:
                 # Make sure we have a PK for the parent before upserting
                 self._db.flush()
             parent_id = parent.id
-        else:
-            parent_id = None
+
+        copied_from_id = copied_from.id if copied_from else None
 
         values = [
             {
@@ -63,6 +66,7 @@ class GroupingService:
                 "updated": func.now(),  # pylint:disable=not-callable
                 # From params
                 "parent_id": parent_id,
+                "copied_from_id": copied_from_id,
                 "type": type_,
                 # Things the caller provides
                 "lms_id": grouping["lms_id"],


### PR DESCRIPTION
Depends on: https://github.com/hypothesis/lms/pull/6047


Same mechanisms and naming convenient than the same concept in Assignments.

Moodle doesn't support the assignment level variable so this could be used as plan B for supporting course copy (eg, first known which is the source course an from then infer the source assignment).

For now this is useful own its own to start recording this data.


## Testing

- Create the new column:
 
`tox -e dev --run-command 'alembic upgrade head'`



- Clean any courses in the DB:


```docker compose exec postgres psql -U postgres -c "truncate grouping cascade;"```


- Launch an assignment on a non copied course:

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2374/View



- Launch the equivalent assignment on the copied course:

https://aunltd.brightspacedemo.com/d2l/le/content/6888/viewContent/2668/View



- Check the state in the DB:

```docker compose exec postgres psql -U postgres -c "select grouping.lms_name as name, original.lms_name as original_name from grouping left outer  join grouping original on grouping.copied_from_id = original.id;"```

```
                 name                 |     original_name      
--------------------------------------+------------------------
 Developers test course               | 
 Course Copy - Developers test course | Developers test course
(2 rows)
```
