### PR TITLE
Migration for grouping.copied_from_id

### DIFF
--- a/lms/migrations/versions/08dff0b683e7_grouping_copied_from.py
+++ b/lms/migrations/versions/08dff0b683e7_grouping_copied_from.py
@@ -1,0 +1,25 @@
+"""Add copied from ID to groupings."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "08dff0b683e7"
+down_revision = "522985f4fa6e"
+
+
+def upgrade() -> None:
+    op.add_column("grouping", sa.Column("copied_from_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        op.f("fk__grouping__copied_from_id__grouping"),
+        "grouping",
+        "grouping",
+        ["copied_from_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk__grouping__copied_from_id__grouping"), "grouping", type_="foreignkey"
+    )
+    op.drop_column("grouping", "copied_from_id")


### PR DESCRIPTION
Generated from: https://github.com/hypothesis/lms/pull/6046


### Testing


```
tox -e dev --run-command 'alembic upgrade head'

dev run-test-pre: PYTHONHASHSEED='791837797'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 522985f4fa6e -> 08dff0b683e7, Add copied from ID to groupings.
```