### PR TITLE
Handle None roles

### DIFF
--- a/lms/models/lti_role.py
+++ b/lms/models/lti_role.py
@@ -18,6 +18,7 @@ class RoleType(str, Enum):
     INSTRUCTOR = "instructor"
     LEARNER = "learner"
     ADMIN = "admin"
+    NONE = "none"
 
 
 @unique
@@ -160,7 +161,7 @@ class _RoleParser:
         "Manager": RoleType.INSTRUCTOR,
         "Member": RoleType.LEARNER,
         "Mentor": RoleType.INSTRUCTOR,
-        "None": RoleType.LEARNER,
+        "None": RoleType.NONE,
         "Observer": RoleType.LEARNER,
         "Office": RoleType.INSTRUCTOR,
         "Other": RoleType.LEARNER,

--- a/lms/templates/admin/role.override.html.jinja2
+++ b/lms/templates/admin/role.override.html.jinja2
@@ -12,7 +12,7 @@
         <fieldset class="box mt-6">
             {{ macros.disabled_text_field("Value", override.value) }}
             {{ macros.select("Scope", "scope", [("course", "Course") ,("system", "System"), ("institution", "Institution")], override.scope) }}
-            {{ macros.select("Type", "type", [("learner", "Learner") ,("instructor", "Instructor"), ("admin", "Admin")], override.type) }}
+            {{ macros.select("Type", "type", [("learner", "Learner") ,("instructor", "Instructor"), ("admin", "Admin"), ("none", "None")], override.type) }}
         </fieldset>
         <input type="submit" class="button is-info" value="Save" />
         <input type="submit"

--- a/lms/templates/admin/role.override.new.html.jinja2
+++ b/lms/templates/admin/role.override.new.html.jinja2
@@ -12,7 +12,7 @@
         <fieldset class="box mt-6">
             {{ macros.select("Value", "role_id", existing_roles, override.id if override else None, with_search=True) }}
             {{ macros.select("Scope", "scope", [("course", "Course") ,("system", "System"), ("institution", "Institution")], override.scope if override else None) }}
-            {{ macros.select("Type", "type", [("learner", "Learner") ,("instructor", "Instructor"), ("admin", "Admin")], override.type if override else None) }}
+            {{ macros.select("Type", "type", [("learner", "Learner") ,("instructor", "Instructor"), ("admin", "Admin"), ("none", "None")], override.type if override else None) }}
         </fieldset>
         <input type="submit" class="button is-info" value="New" />
     </form>

--- a/tests/unit/lms/models/lti_role_test.py
+++ b/tests/unit/lms/models/lti_role_test.py
@@ -55,7 +55,7 @@ class TestLTIRole:
                 RoleType.INSTRUCTOR,
                 RoleScope.INSTITUTION,
             ),
-            ("urn:lti:instrole:ims/lis/None", RoleType.LEARNER, RoleScope.INSTITUTION),
+            ("urn:lti:instrole:ims/lis/None", RoleType.NONE, RoleScope.INSTITUTION),
             (
                 "urn:lti:instrole:ims/lis/Observer",
                 RoleType.LEARNER,
@@ -106,7 +106,7 @@ class TestLTIRole:
                 RoleType.ADMIN,
                 RoleScope.SYSTEM,
             ),
-            ("urn:lti:sysrole:ims/lis/None", RoleType.LEARNER, RoleScope.SYSTEM),
+            ("urn:lti:sysrole:ims/lis/None", RoleType.NONE, RoleScope.SYSTEM),
             ("urn:lti:sysrole:ims/lis/SysAdmin", RoleType.ADMIN, RoleScope.SYSTEM),
             ("Administrator", RoleType.ADMIN, RoleScope.COURSE),
             ("Alumni", RoleType.LEARNER, RoleScope.COURSE),
@@ -186,6 +186,12 @@ class TestLTIRole:
                 RoleScope.SYSTEM,
             ),
             (f"{_V13_PREFIX}system/person#User", RoleType.LEARNER, RoleScope.SYSTEM),
+            (f"{_V13_PREFIX}system/person#None", RoleType.NONE, RoleScope.SYSTEM),
+            (
+                f"{_V13_PREFIX}institution/person#None",
+                RoleType.NONE,
+                RoleScope.INSTITUTION,
+            ),
             (
                 "http://purl.imsglobal.org/vocab/lti/system/person#TestUser",
                 RoleType.LEARNER,


### PR DESCRIPTION
Related to: https://github.com/hypothesis/support/issues/101

Assign the correct "None" value to explicit None roles


https://www.imsglobal.org/specs/ltiv1p0/implementation-guide#toc-15 
https://www.imsglobal.org/spec/lti/v1p3#role-vocabularies

This doesn't have that many practical effects on it's own, see https://github.com/hypothesis/lms/pull/6052 for a change that does change permissions.

It does however correctly classify the roles and allows the admin pages "role overrides" the ability to ignore a role, ie. instead of assigning it to teacher/admin/student we can use "None" to ignore certain role in an institution.


From slack:

When we get one of those courses everyone can see you might get a None role. We classify that as LEARNER now which is incorrect but we correctly set the scope to "INSTITUTION" (school wide).

Our own is_learner doesn't take into account the INSTITUTION roles because "this guy is a student somewhere in the school"  is not relevant to a course launch.
The PR correctly classifies the role as "NONE" which doesn't have any immediate effects but it does allow to use the type on the admin pages.

Right now you could only set a role teacher/admin/learner so at the very least you had to assign someone as a learner. With this new type you can explicitly ignore it.
You could achieve the same thing with the scope INSTITUTION in the override but that was a bit of a hack and if we ever built a feature that uses the institution role it would break.


## Testing

- Launch https://hypothesis.instructure.com/courses/125/assignments/873
- All looks good
- Go over http://localhost:8001/admin/instance/8/role-overrides
- Create an override for "Instructor" with any scope and the type "None"
- Relaunch https://hypothesis.instructure.com/courses/125/assignments/873
- You'll get sad H
- Remove the override
- Launch https://hypothesis.instructure.com/courses/125/assignments/873
- All looks good


