### PR TITLE
Don't assign any permissions for LTI users with no roles

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -177,7 +177,9 @@ class LTIUserSecurityPolicy:
         if lti_user is None:
             return Identity("", [])
 
-        permissions = [Permissions.LTI_LAUNCH_ASSIGNMENT, Permissions.API]
+        permissions = []
+        if lti_user.is_learner or lti_user.is_instructor or lti_user.is_admin:
+            permissions = [Permissions.LTI_LAUNCH_ASSIGNMENT, Permissions.API]
 
         if lti_user.is_instructor:
             permissions.append(Permissions.LTI_CONFIGURE_ASSIGNMENT)

--- a/tests/bdd/features/lti_certification/section_3_types_of_roles.feature
+++ b/tests/bdd/features/lti_certification/section_3_types_of_roles.feature
@@ -84,8 +84,7 @@ Feature: Section 3 - Types of User Roles
 
      When I make an LTI launch request
 
-     Then the assigment opens successfully
-      And the user only has learner privileges
+     Then the response status code is 403
 
   @v1.0 @v1.1 @v1.2 @required
   Scenario: Test 3.7 - Launch as a user with an institution role which has no corresponding context role
@@ -99,8 +98,7 @@ Feature: Section 3 - Types of User Roles
 
      When I make an LTI launch request
 
-     Then the assigment opens successfully
-      And the user only has learner privileges
+     Then the response status code is 403
 
   @v1.0 @v1.1 @v1.2 @required
   Scenario: Test 3.8 - Launch as a user with an unrecognised role

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -158,6 +158,7 @@ def user_is_learner(lti_user):
         Role(scope=role.scope, type=role.type, value=role.value)
         for role in lti_user.lti_roles
     ]
+    return lti_user
 
 
 @pytest.fixture
@@ -169,6 +170,12 @@ def user_is_instructor(lti_user):
         Role(scope=role.scope, type=role.type, value=role.value)
         for role in lti_user.lti_roles
     ]
+
+
+@pytest.fixture
+def user_has_no_roles(lti_user):
+    lti_user.lti_roles = []
+    lti_user.effective_lti_roles = []
 
 
 def configure_jinja2_assets(config):


### PR DESCRIPTION
For https://github.com/hypothesis/support/issues/101
More info in https://hypothes-is.slack.com/archives/C2BLQDKHA/p1708114316485429

We currently allow any user that manages to do a valid launch to access the application with the basic LTI_LAUNCH and API permissions. This effectively is the same level of access as any legit student in a course.

Change that behaviour, if we can't map the LTI roles to neither of our own "learner", "instructor" or "admin" types, block access.

In general a person that's not part of a course won't be allowed to do the  launch on the first place by the LMS. However there are features that makes this possible, eg. you can change the visibility of a Canvas course to "institution" to make some of the course material available to all the school's users.


## Testing 

Always as `Hypothesis 101 Student`

#### In `main`

- Check that you can launch an assignment you are a member of:

https://hypothesis.instructure.com/courses/125/assignments/873

- Launching an assignment on a course with visibitilly "institution" will succeed:

https://hypothesis.instructure.com/courses/632/assignments/6381



##### In this branch, `block-lti-no-role:

- [Original course does still work
](https://hypothesis.instructure.com/courses/125/assignments/873)

- [We show sad H for the course you are not a member of](https://hypothesis.instructure.com/courses/632/assignments/6381)