### PR TITLE
Reload dev gunicorn on any template edition regardless of subdir

### DIFF
--- a/conf/gunicorn-dev.conf.py
+++ b/conf/gunicorn-dev.conf.py
@@ -1,4 +1,6 @@
+from glob import glob
+
 bind = "0.0.0.0:8001"
 reload = True
-reload_extra_files = "lms/templates"
+reload_extra_files = glob("lms/templates/**/*", recursive=True)
 timeout = 0


### PR DESCRIPTION
Passing `reload_extra_files = "lms/templates"` to gunicorn makes it to be reloaded only when a file directly under `lms/templates` is edited.

This PR ensures all nested template subdirs are also taken into consideration, by using `glob`.

The only limitation is that it will not watch for dirs that do not exist at the moment of starting the server. That would still require a manual reloading.