### PR TITLE
Create analytics miniapp

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -229,3 +229,5 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "lti.v11.deep_linking.form_fields", "/lti/1.1/deep_linking/form_fields"
     )
+
+    config.add_route("analytics.assignment", "/analytics/assignment/{id_}")

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -11,6 +11,7 @@ import EmailPreferencesApp from './EmailPreferencesApp';
 import ErrorDialogApp from './ErrorDialogApp';
 import FilePickerApp, { loadFilePickerConfig } from './FilePickerApp';
 import OAuth2RedirectErrorApp from './OAuth2RedirectErrorApp';
+import AnalyticsApp from './analytics/AnalyticsApp';
 
 export type AppRootProps = {
   /** Initial route and configuration for the frontend, read from the HTML page. */
@@ -42,6 +43,9 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
           </Route>
           <Route path="/email/preferences">
             <EmailPreferencesApp />
+          </Route>
+          <Route path="/analytics/assignment/:assignmentId">
+            <AnalyticsApp />
           </Route>
           <Route path="/app/error-dialog">
             <ErrorDialogApp />

--- a/lms/static/scripts/frontend_apps/components/analytics/AnalyticsApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/analytics/AnalyticsApp.tsx
@@ -1,0 +1,74 @@
+import classnames from 'classnames';
+import { useParams } from 'wouter-preact';
+
+import { useFetch } from '../../utils/fetch';
+import type { StudentsActivityTableProps } from './StudentsActivityTable';
+import StudentsActivityTable from './StudentsActivityTable';
+
+export default function AnalyticsApp() {
+  const { assignmentId = 'unknown' } = useParams();
+  const assignment = useFetch<StudentsActivityTableProps['assignment']>(
+    `${assignmentId}_assignment`,
+    () =>
+      // Fake assignment ingo that loads after 300ms
+      new Promise(resolve =>
+        setTimeout(
+          () =>
+            resolve({
+              name: 'Biology 101',
+              id: assignmentId,
+            }),
+          300,
+        ),
+      ),
+  );
+  const users = useFetch<StudentsActivityTableProps['students']>(
+    `${assignmentId}_students`,
+    () =>
+      // A fake list of users that loads after 600ms
+      new Promise(resolve =>
+        setTimeout(
+          () =>
+            resolve([
+              {
+                name: 'Jane Doe',
+                annotations: 5,
+                replies: 3,
+                lastActivity: '2024-01-28',
+              },
+              {
+                name: 'John Doe',
+                annotations: 8,
+                replies: 1,
+                lastActivity: '2024-03-09',
+              },
+            ]),
+          600,
+        ),
+      ),
+  );
+
+  return (
+    <div className="min-h-full bg-grey-2">
+      <div
+        className={classnames(
+          'flex justify-center p-3 mb-5 w-full',
+          'bg-white border-b shadow',
+        )}
+      >
+        <img
+          alt="Hypothesis logo"
+          src="/static/images/email_header.png"
+          className="h-10"
+        />
+      </div>
+      <div className="mx-auto max-w-6xl">
+        <StudentsActivityTable
+          students={users.data ?? []}
+          loading={users.isLoading}
+          assignment={assignment.data}
+        />
+      </div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/analytics/StudentsActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/analytics/StudentsActivityTable.tsx
@@ -1,0 +1,63 @@
+import { Card, CardContent, DataTable } from '@hypothesis/frontend-shared';
+
+type AssignmentInfo = {
+  id: string;
+  name: string;
+};
+
+type StudentStats = {
+  name: string;
+  lastActivity: string;
+  annotations: number;
+  replies: number;
+};
+
+export type StudentsActivityTableProps = {
+  assignment: AssignmentInfo | null;
+  students: StudentStats[];
+  loading?: boolean;
+};
+
+export default function StudentsActivityTable({
+  assignment,
+  students,
+  loading,
+}: StudentsActivityTableProps) {
+  const title = assignment
+    ? `Student activity for assignment ${assignment.name}`
+    : 'Loading assignment info...';
+
+  return (
+    <Card>
+      <CardContent>
+        <h2 className="text-brand mb-3 text-xl">{title}</h2>
+        <DataTable
+          title={title}
+          columns={[
+            { field: 'name', label: 'Name', classes: 'w-[70%]' },
+            {
+              field: 'annotations',
+              label: 'Annotations',
+              classes: 'text-right',
+            },
+            { field: 'replies', label: 'Replies', classes: 'text-right' },
+            {
+              field: 'lastActivity',
+              label: 'Last Activity',
+              classes: 'text-right',
+            },
+          ]}
+          rows={students}
+          renderItem={(r, field) =>
+            field === 'name' ? (
+              r[field]
+            ) : (
+              <div className="text-right">{r[field]}</div>
+            )
+          }
+          loading={loading}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -30,6 +30,7 @@ export type AppMode =
   | 'basic-lti-launch'
   | 'content-item-selection'
   | 'email-preferences'
+  | 'analytics'
   | 'error-dialog'
   | 'oauth2-redirect-error';
 

--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -22,11 +22,10 @@ import type { ServiceMap } from './services';
  * those routes and reloading the page results in a 404.
  */
 function routeForAppMode(mode: AppMode): string {
-  if (mode === 'email-preferences') {
-    // For the email-preferences mode, since this app is not designed to be
-    // opened in an iframe, but as the main window frame, we want to use a route
-    // that matches the server-side one.
-    return '/email/preferences';
+  // For apps not designed to be opened in an iframe, but as the main window
+  // frame, we want to keep the server-side route.
+  if (['email-preferences', 'analytics'].includes(mode)) {
+    return location.pathname;
   }
 
   return `/app/${mode}`;

--- a/lms/templates/analytics/application_instance.html.jinja2
+++ b/lms/templates/analytics/application_instance.html.jinja2
@@ -1,0 +1,22 @@
+{% extends "lms:templates/base.html.jinja2" %}
+{% block title %}Application instance {{ request.matchdict["id_"] }}{% endblock %}
+
+{% block content %}
+    <div style="width: 100%; height: 100%;" id="app"></div>
+{% endblock %}
+
+{% block styles %}
+    {% for url in  asset_urls("frontend_apps_css") %}
+        <link rel="stylesheet" href="{{ url }}">
+    {% endfor %}
+{% endblock %}
+
+{% block scripts %}
+    {# Not calling super() here, as the parent template tries to build the js-config using the JSConfig class, which is
+       not available here. #}
+    <script type="application/json" class="js-config">{{ jsConfig|tojson }}</script>
+    {% for url in asset_urls("frontend_apps_js") %}
+        <script type="module" src="{{ url }}"></script>
+    {% endfor %}
+{% endblock %}
+

--- a/lms/views/admin/application_instance/analytics.py
+++ b/lms/views/admin/application_instance/analytics.py
@@ -1,0 +1,17 @@
+from pyramid.view import view_config
+
+from lms.views.admin.application_instance._core import BaseApplicationInstanceView
+
+
+class AssignmentAnalyticsView(BaseApplicationInstanceView):
+    @view_config(
+        route_name="analytics.assignment",
+        renderer="lms:templates/analytics/application_instance.html.jinja2",
+        request_method="GET",
+    )
+    def show_analitycs(self):
+        js_config = {
+            "mode": "analytics",
+        }
+
+        return {"jsConfig": js_config}


### PR DESCRIPTION
This PR adds a new client mini-app that's provisionally served in the `/analytics/assignment/{id}` route.

The client-side mini-app matches the same route generated by the server, as we did with the email preferences.