### PR TITLE
Allow `None` values in non required LTI fields.

### DIFF
--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -26,10 +26,10 @@ class LTIV11CoreSchema(PyramidRequestSchema):
     user_id = fields.Str(required=True)
     roles = fields.Str(required=True)
     tool_consumer_instance_guid = fields.Str(required=True)
-    lis_person_name_given = fields.Str(load_default="")
-    lis_person_name_family = fields.Str(load_default="")
-    lis_person_name_full = fields.Str(load_default="")
-    lis_person_contact_email_primary = fields.Str(load_default="")
+    lis_person_name_given = fields.Str(load_default="", allow_none=True)
+    lis_person_name_family = fields.Str(load_default="", allow_none=True)
+    lis_person_name_full = fields.Str(load_default="", allow_none=True)
+    lis_person_contact_email_primary = fields.Str(load_default="", allow_none=True)
 
     @pre_load
     def _decode_jwt(self, data, **_kwargs):

--- a/tests/unit/lms/validation/_lti_launch_params_test.py
+++ b/tests/unit/lms/validation/_lti_launch_params_test.py
@@ -129,6 +129,22 @@ class TestBasicLTILaunchSchema:
     @pytest.mark.parametrize(
         "required_param",
         [
+            "lis_person_name_given",
+            "lis_person_name_family",
+            "lis_person_name_full",
+            "lis_person_contact_email_primary",
+        ],
+    )
+    def test_it_allow_none_values(self, pyramid_request, required_param):
+        pyramid_request.params[required_param] = None
+
+        schema = BasicLTILaunchSchema(pyramid_request)
+
+        schema.parse()
+
+    @pytest.mark.parametrize(
+        "required_param",
+        [
             "resource_link_id",
             "lti_version",
             "lti_message_type",


### PR DESCRIPTION
For: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1708624870185739


We have seen at least one school sending `null` here which caused the validation to fail for a field that was not required at all.