### PR TITLE
Remove re-definition of deep_linking_prompt_for_title

### DIFF
--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -3,10 +3,6 @@ from lms.services.lti_grading.interface import LTIGradingService
 
 
 class D2LMiscPlugin(MiscPlugin):
-    # Deep linking in D2L implies creating a new assignment.
-    # Prompt for a title to set it for the new assignment.
-    deep_linking_prompt_for_title = True
-
     def get_ltia_aud_claim(self, lti_registration):
         # In D2L this value is always the same and different from
         # `lti_registration.token_url` as in other LMS


### PR DESCRIPTION
True is already the default in the base class MiscPlugin