### PR TITLE
Fallback to deep linked group set in all non-Canvas LMSes

### DIFF
--- a/lms/product/d2l/_plugin/grouping.py
+++ b/lms/product/d2l/_plugin/grouping.py
@@ -72,20 +72,6 @@ class D2LGroupingPlugin(GroupingPlugin):
 
         return groups
 
-    def get_group_set_id(self, request, assignment, historical_assignment=None):
-        if assignment:
-            # For existing assignments return the config in our DB
-            return assignment.extra.get("group_set_id")
-
-        if historical_assignment:
-            # When creating a new assignment, default to the value of original one if we have one
-            return historical_assignment.extra.get("group_set_id")
-
-        # D2L also supports deep linking, use that as the last fallback
-        return self._misc_plugin.get_deep_linked_assignment_configuration(request).get(
-            "group_set"
-        )
-
     @classmethod
     def factory(cls, _context, request):
         d2l_api = request.find_service(D2LAPIClient)

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -73,7 +73,7 @@ class GroupingPlugin:
         """Check if sections are enabled for this LMS, instance and course."""
         return bool(self.sections_type)
 
-    def get_group_set_id(self, _request, assignment, historical_assignment=None):
+    def get_group_set_id(self, request, assignment, historical_assignment=None):
         """
         Get the group set ID for group launches.
 
@@ -99,7 +99,10 @@ class GroupingPlugin:
             # version of the assignment
             return historical_assignment.extra.get("group_set_id")
 
-        return None
+        # For LMS that also supports deep linking, use that as the last fallback
+        return request.product.plugin.misc.get_deep_linked_assignment_configuration(
+            request
+        ).get("group_set")
 
 
 class GroupError(Exception):

--- a/tests/unit/lms/product/d2l/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/grouping_test.py
@@ -129,52 +129,12 @@ class TestD2LGroupingPlugin:
             )
         assert err.value.error_code == ErrorCodes.GROUP_SET_EMPTY
 
-    def test_get_group_set_id_when_no_assignment(
-        self, plugin, pyramid_request, misc_plugin
-    ):
-        misc_plugin.get_deep_linked_assignment_configuration.return_value = {}
-
-        assert not plugin.get_group_set_id(pyramid_request, None, None)
-
-    @pytest.mark.usefixtures("with_deep_linked_group_set")
-    def test_get_group_set_id_when_no_group_set_in_db(self, plugin, pyramid_request):
-        assignment = factories.Assignment(extra={})
-
-        assert not plugin.get_group_set_id(pyramid_request, assignment, None)
-
-    @pytest.mark.usefixtures("with_deep_linked_group_set")
-    def test_get_group_set_id_from_historical_assignment(self, plugin, pyramid_request):
-        historical_assignment = factories.Assignment(
-            extra={"group_set_id": sentinel.id}
-        )
-
-        assert (
-            plugin.get_group_set_id(pyramid_request, None, historical_assignment)
-            == sentinel.id
-        )
-
-    @pytest.mark.usefixtures("with_deep_linked_group_set")
-    def test_get_group_set_id_from_assignment(self, plugin, pyramid_request):
-        assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
-
-        assert plugin.get_group_set_id(pyramid_request, assignment, None) == sentinel.id
-
-    @pytest.mark.usefixtures("with_deep_linked_group_set")
-    def test_get_group_set_id_from_deep_linking(self, plugin, pyramid_request):
-        assert plugin.get_group_set_id(pyramid_request, None, None) == sentinel.id
-
     def test_factory(self, pyramid_request, d2l_api_client, misc_plugin):
         plugin = D2LGroupingPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, D2LGroupingPlugin)
         # pylint: disable=protected-access
         assert plugin._d2l_api == d2l_api_client
         assert plugin._misc_plugin == misc_plugin
-
-    @pytest.fixture
-    def with_deep_linked_group_set(self, misc_plugin):
-        misc_plugin.get_deep_linked_assignment_configuration.return_value = {
-            "group_set": sentinel.id
-        }
 
     @pytest.fixture
     def plugin(self, d2l_api_client, misc_plugin):

--- a/tests/unit/lms/product/plugin/grouping_test.py
+++ b/tests/unit/lms/product/plugin/grouping_test.py
@@ -21,33 +21,53 @@ class TestGroupingPlugin:
             == expected
         )
 
-    def test_get_group_set_id_when_disabled(self, plugin_without_groups):
+    def test_get_group_set_id_when_disabled(
+        self, plugin_without_groups, pyramid_request
+    ):
         assert not plugin_without_groups.get_group_set_id(
-            sentinel.request, sentinel.assignment
+            pyramid_request, sentinel.assignment
         )
 
-    def test_get_group_set_id_when_no_assignment(self, plugin):
-        assert not plugin.get_group_set_id(sentinel.request, None)
+    @pytest.mark.usefixtures("with_non_deep_linked_group_set")
+    def test_get_group_set_id_when_no_assignment(self, plugin, pyramid_request):
+        assert not plugin.get_group_set_id(pyramid_request, None)
 
-    def test_get_group_set_id_when_no_group_set(self, plugin):
+    def test_get_group_set_id_when_no_group_set(self, plugin, pyramid_request):
         assignment = factories.Assignment(extra={})
 
-        assert not plugin.get_group_set_id(sentinel.request, assignment, None)
+        assert not plugin.get_group_set_id(pyramid_request, assignment, None)
 
-    def test_get_group_set_id_from_historical_assignment(self, plugin):
+    def test_get_group_set_id_from_historical_assignment(self, plugin, pyramid_request):
         historical_assignment = factories.Assignment(
             extra={"group_set_id": sentinel.id}
         )
 
         assert (
-            plugin.get_group_set_id(sentinel.request, None, historical_assignment)
+            plugin.get_group_set_id(pyramid_request, None, historical_assignment)
             == sentinel.id
         )
 
-    def test_get_group_set_id(self, plugin):
+    def test_get_group_set_id(self, plugin, pyramid_request):
         assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
 
-        assert plugin.get_group_set_id(sentinel.request, assignment) == sentinel.id
+        assert plugin.get_group_set_id(pyramid_request, assignment) == sentinel.id
+
+    @pytest.mark.usefixtures("with_deep_linked_group_set")
+    def test_get_group_set_id_from_deep_linking(self, plugin, pyramid_request):
+        assert (
+            plugin.get_group_set_id(pyramid_request, None, None)
+            == sentinel.deep_linked_id
+        )
+
+    @pytest.fixture
+    def with_deep_linked_group_set(self, misc_plugin):
+        misc_plugin.get_deep_linked_assignment_configuration.return_value = {
+            "group_set": sentinel.deep_linked_id
+        }
+
+    @pytest.fixture
+    def with_non_deep_linked_group_set(self, misc_plugin):
+        misc_plugin.get_deep_linked_assignment_configuration.return_value = {}
 
     @pytest.fixture
     def plugin(self):


### PR DESCRIPTION
D2L was the first non-Canvas LMS where we supported DL and non DL flows.

While getting the groups configuration we can fallback to the DL in all non-Canvas LMSes instead making the D2L behaviour the default.

The DL configuration will be `{}` if DL was not used.