### PR TITLE
Allow authUrl to be null

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -108,7 +108,7 @@ export default function BasicLTILaunchApp() {
     error: Error,
     state: ErrorState,
     retry = true,
-    authURL?: string
+    authURL?: string | null
   ) => {
     // Here we always set the authorization URL, but we could improve UX by
     // not setting it if the problem is not related to authorization (eg.

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -18,7 +18,7 @@ export type APICallInfo = {
    * error. This is used when the API call requires an OAuth 2 authorization
    * flow to be completed with eg. an external LMS's API.
    */
-  authUrl?: string;
+  authUrl?: string | null;
   data?: object;
 };
 


### PR DESCRIPTION
This PR update the `authUrl` type to allow `null`, in preparation for Moodle support.

See https://github.com/hypothesis/lms/pull/6064/files#r1500879457