### PR TITLE
Use LTIUser to detect the LMS we are currently using

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -10,6 +10,9 @@ class LTI:
     course_id: str
     """ID of the course in the LMS, context_id using LTI naming"""
 
+    product_family: str
+    """Name of the type of the current LMS (canvas, moodle...)"""
+
     assignment_id: str | None = None
     """ID of the assignment in the LMS, resource_link_id using LTI naming"""
 

--- a/lms/product/factory.py
+++ b/lms/product/factory.py
@@ -1,20 +1,23 @@
-from lms.product.blackboard import Blackboard
-from lms.product.canvas import Canvas
-from lms.product.d2l import D2L
 from lms.product.family import Family
-from lms.product.moodle import Moodle
 from lms.product.product import Product
-
-_PRODUCT_MAP = {
-    product.family: product for product in (Blackboard, Canvas, D2L, Moodle)
-}
 
 
 def get_product_from_request(request) -> Product:
     """Get the correct product object from the provided request."""
+
+    # pylint:disable=import-outside-toplevel
+    from lms.product.blackboard import Blackboard
+    from lms.product.canvas import Canvas
+    from lms.product.d2l import D2L
+    from lms.product.moodle import Moodle
+
     ai = request.lti_user.application_instance
     family = Family(request.lti_user.lti.product_family)
 
-    product = _PRODUCT_MAP.get(family, Product).from_request(request, dict(ai.settings))
+    product_class = {
+        product.family: product for product in (Blackboard, Canvas, D2L, Moodle)
+    }.get(family, Product)
+
+    product = product_class.from_request(request, dict(ai.settings))
     product.family = family
     return product

--- a/lms/product/factory.py
+++ b/lms/product/factory.py
@@ -1,6 +1,7 @@
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
 from lms.product.d2l import D2L
+from lms.product.family import Family
 from lms.product.moodle import Moodle
 from lms.product.product import Product
 
@@ -11,48 +12,9 @@ _PRODUCT_MAP = {
 
 def get_product_from_request(request) -> Product:
     """Get the correct product object from the provided request."""
-    ai = request.lti_user.application_instance if request.lti_user else None
+    ai = request.lti_user.application_instance
+    family = Family(request.lti_user.lti.product_family)
 
-    family = _get_family(request, ai)
-    product = _PRODUCT_MAP.get(family, Product).from_request(
-        request, dict(ai.settings) if ai else {}
-    )
+    product = _PRODUCT_MAP.get(family, Product).from_request(request, dict(ai.settings))
     product.family = family
     return product
-
-
-def _get_family(
-    request, application_instance
-):  # pylint:disable=too-many-return-statements
-    # First, if we are in an LMS specific route, return that
-    # These are generally GET routes where we don't pass the `product` parameter back to us
-    if request.matched_route.name.startswith("canvas_api."):
-        return Product.Family.CANVAS
-
-    if request.matched_route.name.startswith("blackboard_api."):
-        return Product.Family.BLACKBOARD
-
-    # If we are in an API request, where we are forwarding the product type ourselves
-    if request.content_type == "application/json" and "lms" in request.json:
-        return Product.Family(request.json["lms"]["product"])
-
-    # In an LTI launch we'll use the parameters available to guess
-    if product_name := request.lti_params.get("tool_consumer_info_product_family_code"):
-        return Product.Family(product_name)
-
-    # If we don't get a hint from LTI check a canvas specific parameter
-    if "custom_canvas_course_id" in request.lti_params:
-        return Product.Family.CANVAS
-
-    # Another canvas-only fix, when the API params are not correctly set use the GUID
-    if request.lti_params.get("tool_consumer_instance_guid", "").endswith("canvas-lms"):
-        return Product.Family.CANVAS
-
-    # Finally try to match using the stored family_code in the application instance
-    # We use this in LTIOutcomesViews
-    if application_instance:
-        return Product.Family(
-            application_instance.tool_consumer_info_product_family_code
-        )
-
-    return Product.Family.UNKNOWN

--- a/lms/product/family.py
+++ b/lms/product/family.py
@@ -16,3 +16,25 @@ class Family(str, Enum):
     @classmethod
     def _missing_(cls, _value):
         return cls.UNKNOWN
+
+    @classmethod
+    def from_launch(cls, lti_params: dict):
+        """
+        Get the product of the current launch.
+
+        This method only applies for the initial launch made by from an LMS.
+        For any subsequent API calls see LTIUser.lti.product_family.
+        """
+        # We'll use the parameters available to guess
+        if product_name := lti_params.get("tool_consumer_info_product_family_code"):
+            return cls(product_name)
+
+        # If we don't get a hint from LTI check a canvas specific parameter
+        if "custom_canvas_course_id" in lti_params:
+            return cls.CANVAS
+
+        # Another canvas-only fix, when the API params are not correctly set use the GUID
+        if lti_params.get("tool_consumer_instance_guid", "").endswith("canvas-lms"):
+            return cls.CANVAS
+
+        return cls.UNKNOWN

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -325,9 +325,6 @@ class JSConfig:
                 "content_item_return_url": self._request.lti_params[
                     "content_item_return_url"
                 ],
-                "lms": {
-                    "product": self._request.product.family,
-                },
                 "context_id": self._request.lti_params["context_id"],
             },
         }
@@ -511,7 +508,6 @@ class JSConfig:
         product = self._request.product
 
         product_info = {
-            "family": product.family,
             "settings": {
                 # Is the small groups feature enabled
                 "groupsEnabled": self._request.product.settings.groups_enabled,
@@ -531,11 +527,6 @@ class JSConfig:
                     "api.courses.group_sets.list",
                     course_id=self._request.lti_params["context_id"],
                 ),
-                "data": {
-                    "lms": {
-                        "product": self._request.product.family,
-                    }
-                },
             }
 
         return product_info
@@ -612,9 +603,6 @@ class JSConfig:
                 # frontend.
                 "data": {
                     "resource_link_id": assignment.resource_link_id,
-                    "lms": {
-                        "product": self._request.product.family,
-                    },
                     "context_id": self._request.lti_params["context_id"],
                     "group_set_id": self._request.product.plugin.grouping.get_group_set_id(
                         self._request, assignment, historical_assignment=None

--- a/lms/services/lti_user.py
+++ b/lms/services/lti_user.py
@@ -1,4 +1,5 @@
 from lms.models.lti_user import LTI, LTIUser, display_name
+from lms.product.family import Family
 from lms.services.application_instance import ApplicationInstanceService
 from lms.services.lti_role_service import LTIRoleService
 
@@ -37,6 +38,7 @@ class LTIUserService:
             lti={
                 "course_id": lti_params.get("context_id"),
                 "assignment_id": lti_params.get("resource_link_id"),
+                "product_family": Family.from_launch(lti_params),
             },
         )
 
@@ -57,6 +59,7 @@ class LTIUserService:
             "lti": {
                 "course_id": lti_user.lti.course_id,
                 "assignment_id": lti_user.lti.assignment_id,
+                "product_family": lti_user.lti.product_family,
             },
         }
 
@@ -75,6 +78,7 @@ class LTIUserService:
         lti = LTI(
             course_id=lti_data["course_id"],
             assignment_id=lti_data["assignment_id"],
+            product_family=lti_data["product_family"],
         )
 
         return LTIUser(

--- a/lms/views/api/sync.py
+++ b/lms/views/api/sync.py
@@ -1,4 +1,3 @@
-from marshmallow import Schema
 from pyramid.view import view_config
 from webargs import fields
 
@@ -8,10 +7,6 @@ from lms.validation._base import PyramidRequestSchema
 
 
 class APISyncSchema(PyramidRequestSchema):
-    class LMS(Schema):
-        product = fields.Str(required=True)
-
-    lms = fields.Nested(LMS, required=True)
     resource_link_id = fields.Str(required=True)
     context_id = fields.Str(required=True)
     group_set_id = fields.Str(required=False, allow_none=True)

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -12,7 +12,5 @@ LTIUser = make_factory(
     effective_lti_roles=[],
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     display_name=Faker("name"),
-    lti=LTI(
-        course_id=Faker("hexify", text="^" * 40),
-    ),
+    lti=LTI(course_id=Faker("hexify", text="^" * 40), product_family="UNKNOWN"),
 )

--- a/tests/unit/lms/product/factory_test.py
+++ b/tests/unit/lms/product/factory_test.py
@@ -1,6 +1,3 @@
-from contextlib import ExitStack
-from unittest.mock import Mock, patch
-
 import pytest
 
 from lms.product.blackboard import Blackboard
@@ -29,103 +26,10 @@ class TestGetProductFromRequest:
     ]
 
     @pytest.mark.parametrize("value,family,class_", PRODUCT_MAP)
-    def test_from_request_exact_match_lti(
-        self, pyramid_request, value, family, class_, application_instance
-    ):
-        pyramid_request.lti_params["tool_consumer_info_product_family_code"] = value
+    def test_from_launch(self, pyramid_request, value, family, class_):
+        pyramid_request.lti_user.lti.product_family = value
 
         product = get_product_from_request(pyramid_request)
 
-        class_.from_request.assert_called_once_with(
-            pyramid_request, application_instance.settings
-        )
-        assert product == class_.from_request.return_value
+        assert isinstance(product, class_)
         assert product.family == family
-
-    @pytest.mark.parametrize(
-        "route_name,family",
-        [
-            ("canvas_api.endpoint", Product.Family.CANVAS),
-            ("blackboard_api.endpoint", Product.Family.BLACKBOARD),
-        ],
-    )
-    def test_from_request_route_name(self, pyramid_request, route_name, family):
-        pyramid_request.matched_route.name = route_name
-        assert get_product_from_request(pyramid_request).family == family
-
-    @pytest.mark.parametrize("value,family,class_", PRODUCT_MAP)
-    def test_from_request_api(
-        self, pyramid_request, value, family, class_, application_instance
-    ):
-        pyramid_request.content_type = "application/json"
-        pyramid_request.json = {"lms": {"product": value}}
-
-        product = get_product_from_request(pyramid_request)
-
-        class_.from_request.assert_called_once_with(
-            pyramid_request, application_instance.settings
-        )
-        assert product == class_.from_request.return_value
-        assert product.family == family
-
-    @pytest.mark.parametrize("value", Product.Family)
-    def test_from_request_api_with_no_key(self, pyramid_request, value):
-        pyramid_request.content_type = "application/json"
-        pyramid_request.json = {"OTHERKEY": {"product": value}}
-
-        assert (
-            get_product_from_request(pyramid_request).family == Product.Family.UNKNOWN
-        )
-
-    @pytest.mark.parametrize(
-        "parameter,value,family",
-        [
-            ("custom_canvas_course_id", "any-value", Product.Family.CANVAS),
-            ("tool_consumer_instance_guid", "guid:canvas-lms", Product.Family.CANVAS),
-            ("tool_consumer_instance_guid", "guid:any-value", Product.Family.UNKNOWN),
-        ],
-    )
-    def test_from_request_canva_custom(self, pyramid_request, parameter, value, family):
-        pyramid_request.lti_params = {parameter: value}
-
-        product = get_product_from_request(pyramid_request)
-
-        assert product.family == family
-
-    @pytest.mark.parametrize("value,family,class_", PRODUCT_MAP)
-    def test_from_application_instance(
-        self, pyramid_request, application_instance, value, family, class_
-    ):
-        application_instance.tool_consumer_info_product_family_code = value
-
-        product = get_product_from_request(pyramid_request)
-
-        class_.from_request.assert_called_once_with(
-            pyramid_request, application_instance.settings
-        )
-        assert product == class_.from_request.return_value
-        assert product.family == family
-
-    def test_from_application_instance_when_missing(self, pyramid_request):
-        pyramid_request.lti_user = None
-
-        product = get_product_from_request(pyramid_request)
-
-        assert product.family == Product.Family.UNKNOWN
-
-    @pytest.fixture(autouse=True)
-    def with_mocked_from_request(self):
-        with ExitStack() as stack:
-            from_requests = [
-                stack.enter_context(patch.object(product_class, "from_request"))
-                for product_class in self.PRODUCTS
-            ]
-
-            yield from_requests
-
-    @pytest.fixture()
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.matched_route = Mock(spec_set=["name"])
-        pyramid_request.matched_route.name = "some.route"
-        pyramid_request.lti_params = {}
-        return pyramid_request

--- a/tests/unit/lms/product/family_test.py
+++ b/tests/unit/lms/product/family_test.py
@@ -1,0 +1,40 @@
+import pytest
+
+from lms.product.family import Family
+from lms.product.product import Product
+
+
+class TestFromLaunch:
+    PRODUCT_MAP = [
+        ("BlackboardLearn", Product.Family.BLACKBOARD),
+        ("canvas", Product.Family.CANVAS),
+        ("BlackbaudK12", Product.Family.BLACKBAUD),
+        ("desire2learn", Product.Family.D2L),
+        ("moodle", Product.Family.MOODLE),
+        ("schoology", Product.Family.SCHOOLOGY),
+        ("sakai", Product.Family.SAKAI),
+        ("wut", Product.Family.UNKNOWN),
+        ("", Product.Family.UNKNOWN),
+        (None, Product.Family.UNKNOWN),
+    ]
+
+    @pytest.mark.parametrize("value,family", PRODUCT_MAP)
+    def test_from_lti_parameter(self, value, family):
+        assert (
+            Family.from_launch({"tool_consumer_info_product_family_code": value})
+            == family
+        )
+
+    @pytest.mark.parametrize(
+        "parameter,value,family",
+        [
+            ("custom_canvas_course_id", "any-value", Product.Family.CANVAS),
+            ("tool_consumer_instance_guid", "guid:canvas-lms", Product.Family.CANVAS),
+            ("tool_consumer_instance_guid", "guid:any-value", Product.Family.UNKNOWN),
+        ],
+    )
+    def test_from_request_canvas_custom(self, parameter, value, family):
+        assert Family.from_launch({parameter: value}) == family
+
+    def test_fallback(self):
+        assert Family.from_launch({}) == Family.UNKNOWN

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -4,7 +4,7 @@ import pytest
 from h_matchers import Any
 
 from lms.models import Grouping, LTIParams
-from lms.product.product import Product, Routes
+from lms.product.product import Routes
 from lms.resources import LTILaunchResource, OAuth2RedirectResource
 from lms.resources._js_config import JSConfig
 from lms.services import HAPIError
@@ -70,7 +70,6 @@ class TestFilePickerMode:
 
         assert js_config.asdict()["product"] == {
             "api": {},
-            "family": "unknown",
             "settings": {"groupsEnabled": False},
         }
 
@@ -81,12 +80,10 @@ class TestFilePickerMode:
         js_config.enable_file_picker_mode(sentinel.form_action, sentinel.form_fields)
 
         assert js_config.asdict()["product"] == {
-            "family": "unknown",
             "api": {
                 "listGroupSets": {
                     "authUrl": "http://example.com/welcome",
                     "path": "/api/courses/test_course_id/group_sets",
-                    "data": {"lms": {"product": Product.Family.UNKNOWN}},
                 }
             },
             "settings": {"groupsEnabled": True},
@@ -132,7 +129,6 @@ class TestEnableLTILaunchMode:
             },
             "product": {
                 "api": {},
-                "family": "unknown",
                 "settings": {"groupsEnabled": False},
             },
             "dev": False,
@@ -215,7 +211,6 @@ class TestEnableLTILaunchMode:
             "path": "/api/sync",
             "data": {
                 "resource_link_id": assignment.resource_link_id,
-                "lms": {"product": pyramid_request.product.family},
                 "context_id": "CONTEXT_ID",
                 "group_set_id": "GROUP_SET_ID",
                 "group_info": {
@@ -604,7 +599,6 @@ class TestAddDeepLinkingAPI:
             "path": "/lti/1.1/deep_linking/form_fields",
             "data": {
                 "content_item_return_url": sentinel.content_item_return_url,
-                "lms": {"product": Product.Family.UNKNOWN},
                 "context_id": pyramid_request.lti_params["context_id"],
                 "opaque_data_lti11": sentinel.data,
             },
@@ -627,7 +621,6 @@ class TestAddDeepLinkingAPI:
             "data": {
                 "content_item_return_url": sentinel.content_item_return_url,
                 "opaque_data_lti13": sentinel.deep_linking_settings,
-                "lms": {"product": Product.Family.UNKNOWN},
                 "context_id": pyramid_request.lti_params["context_id"],
             },
         }

--- a/tests/unit/lms/services/lti_user_test.py
+++ b/tests/unit/lms/services/lti_user_test.py
@@ -47,6 +47,7 @@ class TestLTIUserService:
             "lti": {
                 "course_id": lti_user.lti.course_id,
                 "assignment_id": lti_user.lti.assignment_id,
+                "product_family": lti_user.lti.product_family,
             },
         }
 


### PR DESCRIPTION
Based on the Moodle work we have a need to deduplicate code around files/pages/course copy.

As a first step we are going to remove different way to detect which LMS is the current one and settle in just one method that will work in all situations.


## Testing

No behaviour changes with this PR, but sanity checking a few things.


- [Reconfigure a Canvas assignment](https://hypothesis.instructure.com/courses/125/assignments/5115/edit?name=Why+did+all+these+elephants+die%3F+&due_at=null&points_possible=100)
- Pick Canvas files
- [Launch a gradable D2L assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View)
- Grade a student