### PR TITLE
Disable image proxying for Moodle pages

### DIFF
--- a/lms/views/api/moodle/pages.py
+++ b/lms/views/api/moodle/pages.py
@@ -57,8 +57,12 @@ class PagesAPIViews:
                         "authorization": auth_token,
                     },
                 ),
-                # Disable proxying of iframes. This enables embedded widgets to work.
-                options={"via.proxy_frames": "0"},
+                options={
+                    # Disable proxying of iframes. This enables embedded widgets to work.
+                    "via.proxy_frames": "0",
+                    # Images from Moodle need cookie authentication, stop proxying them.
+                    "via.proxy_images": "0",
+                },
             )
         }
 

--- a/tests/unit/lms/views/api/moodle/pages_test.py
+++ b/tests/unit/lms/views/api/moodle/pages_test.py
@@ -53,7 +53,7 @@ class TestPageAPIViews:
                     "authorization": "TOKEN",
                 }
             ),
-            options={"via.proxy_frames": "0"},
+            options={"via.proxy_frames": "0", "via.proxy_images": "0"},
         )
         assert response == {"via_url": helpers.via_url.return_value}
 


### PR DESCRIPTION
Images from Moodle are only displayed if the cookie from the user with th Moodle instance can be read. Disable proxying to allow that.


## Testing

- Checkout https://github.com/hypothesis/viahtml/pull/629 in ViaHTML. You need to manually restart the server.
- Open https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=865&forceview=1
- The image from the page is now shown.