### PR TITLE
Canvas Studio integration PoC

### DIFF
--- a/lms/db/_columns.py
+++ b/lms/db/_columns.py
@@ -1,7 +1,14 @@
 import sqlalchemy as sa
 
 
-def varchar_enum(enum, max_length=64, nullable=False, unique=False) -> sa.Column:
+def varchar_enum(  # pylint:disable=too-many-arguments
+    enum,
+    default=None,
+    max_length=64,
+    nullable=False,
+    server_default=None,
+    unique=False,
+) -> sa.Column:
     """Return a SA column type to store the python enum.Enum as a varchar in a table."""
     return sa.Column(
         sa.Enum(
@@ -18,6 +25,8 @@ def varchar_enum(enum, max_length=64, nullable=False, unique=False) -> sa.Column
             # Use the string values, not the keys to persist the values
             values_callable=lambda obj: [item.value for item in obj],
         ),
+        default=default,
         nullable=nullable,
+        server_default=server_default,
         unique=unique,
     )

--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -1,12 +1,32 @@
 """Database model for persisting OAuth 2 tokens."""
 
 import datetime
+from enum import Enum, unique
 
 import sqlalchemy as sa
 
-from lms.db import Base
+from lms.db import Base, varchar_enum
 
 __all__ = ["OAuth2Token"]
+
+
+@unique
+class Service(str, Enum):
+    """Enum of the different APIs that OAuth tokens may be used for."""
+
+    LMS = "lms"
+    """
+    The main API of the LMS that a user belongs to.
+
+    This is the API used for resources that are built-in to the LMS.
+    """
+
+    CANVAS_STUDIO = "canvas_studio"
+    """
+    Canvas Studio API.
+
+    See https://tw.instructuremedia.com/api/public/docs/.
+    """
 
 
 class OAuth2Token(Base):
@@ -75,3 +95,7 @@ class OAuth2Token(Base):
         server_default=sa.func.now(),  # pylint:disable=not-callable
         nullable=False,
     )
+
+    #: The API that this token is used with. In OAuth 2.0 parlance, this
+    #: identifies which kind of resource server the token can be passed to.
+    service = varchar_enum(Service, default="lms", server_default="lms", nullable=False)

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -80,6 +80,14 @@ class JSConfig:
                 "path": self._request.route_path("canvas_api.pages.via_url"),
             }
 
+        elif document_url.startswith("canvas-studio://media"):
+            self._config["api"]["viaUrl"] = {
+                "authUrl": self._request.route_url("canvas_studio_api.oauth.authorize"),
+                "path": self._request.route_path(
+                    "canvas_studio_api.via_url", _query={"document_url": document_url}
+                ),
+            }
+
         elif document_url.startswith("d2l://"):
             self._config["api"]["viaUrl"] = {
                 "authUrl": self._request.route_url(D2L.route.oauth2_authorize),
@@ -293,6 +301,7 @@ class JSConfig:
                     "d2l": FilePickerConfig.d2l_config(*args),
                     "moodle": FilePickerConfig.moodle_config(*args),
                     "canvas": FilePickerConfig.canvas_config(*args),
+                    "canvasStudio": FilePickerConfig.canvas_studio_config(*args),
                     "google": FilePickerConfig.google_files_config(*args),
                     "microsoftOneDrive": FilePickerConfig.microsoft_onedrive(*args),
                     "vitalSource": FilePickerConfig.vitalsource_config(*args),

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -102,6 +102,23 @@ class FilePickerConfig:
         return config
 
     @classmethod
+    def canvas_studio_config(cls, request, application_instance):
+        enabled = (
+            application_instance.settings.get("canvas_studio", "client_id") is not None
+        )
+
+        if not enabled:
+            return {"enabled": False}
+
+        return {
+            "enabled": True,
+            "listMedia": {
+                "authUrl": request.route_url("canvas_studio_api.oauth.authorize"),
+                "path": request.route_path("canvas_studio_api.media.list"),
+            },
+        }
+
+    @classmethod
     def google_files_config(cls, request, application_instance):
         """Get Google file picker config."""
         enabled = application_instance.settings.get(

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -131,6 +131,19 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("canvas_api.pages.via_url", "/api/canvas/pages/via_url")
     config.add_route("canvas_api.pages.proxy", "/api/canvas/pages/proxy")
 
+    config.add_route(
+        "canvas_studio_api.oauth.authorize", "/api/canvas_studio/oauth/authorize"
+    )
+    config.add_route(
+        "canvas_studio_api.oauth.callback", "/api/canvas_studio/oauth/callback"
+    )
+    config.add_route("canvas_studio_api.media.list", "/api/canvas_studio/media")
+    config.add_route(
+        "canvas_studio_api.collections.media.list",
+        "/api/canvas_studio/collections/{collection_id}/media",
+    )
+    config.add_route("canvas_studio_api.via_url", "/api/canvas_studio/via_url")
+
     # JSTOR article IDs need a custom pattern because they may contain a slash,
     # after URL-decoding of the path.
     jstor_article_id_pat = r"(10\.[0-9]+/)?[^/]+"

--- a/lms/security.py
+++ b/lms/security.py
@@ -100,6 +100,7 @@ class SecurityPolicy:
         if path in {
             "/canvas_oauth_callback",
             "/api/blackboard/oauth/callback",
+            "/api/canvas_studio/oauth/callback",
             "/api/d2l/oauth/callback",
         }:
             # LTIUser serialized in the state param for the oauth flow

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,6 +1,7 @@
 from lms.services.aes import AESService
 from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.canvas import CanvasService
+from lms.services.canvas_studio import CanvasStudioService
 from lms.services.d2l_api.client import D2LAPIClient
 from lms.services.digest import DigestService
 from lms.services.email_preferences import EmailPreferencesService, EmailPrefs
@@ -55,6 +56,9 @@ def includeme(config):
         "lms.services.canvas_api.canvas_api_client_factory", name="canvas_api_client"
     )
     config.register_service_factory("lms.services.canvas.factory", iface=CanvasService)
+    config.register_service_factory(
+        "lms.services.canvas_studio.factory", iface=CanvasStudioService
+    )
     config.register_service_factory("lms.services.user.factory", iface=UserService)
     config.register_service_factory(
         "lms.services.user_preferences.factory", iface=UserPreferencesService

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -1,0 +1,294 @@
+from typing import Literal, Optional, TypedDict
+from urllib.parse import urlencode, urljoin, urlparse, urlunparse
+
+from marshmallow import EXCLUDE, Schema, fields, post_load
+
+from lms.models.oauth2_token import Service
+from lms.services.aes import AESService
+from lms.validation._base import RequestsResponseSchema
+
+
+class CanvasStudioCollectionsSchema(RequestsResponseSchema):
+    """Schema for Canvas Studio /collections responses."""
+
+    class CollectionSchema(Schema):
+        class Meta:
+            unknown = EXCLUDE
+
+        id = fields.Integer(required=True)
+        name = fields.Str(required=True)
+        type = fields.Str(required=True)
+        created_at = fields.Str(required=False)
+
+    collections = fields.List(fields.Nested(CollectionSchema), required=True)
+
+    @post_load
+    def post_load(self, data, **_kwargs):
+        return data["collections"]
+
+
+class CanvasStudioCollectionMediaSchema(RequestsResponseSchema):
+    """Schema for Canvas Studio /collections/{id}/media responses."""
+
+    class MediaSchema(Schema):
+        class Meta:
+            unknown = EXCLUDE
+
+        id = fields.Integer(required=True)
+        title = fields.Str(required=True)
+        created_at = fields.Str(required=False)
+
+    media = fields.List(fields.Nested(MediaSchema), required=True)
+
+    @post_load
+    def post_load(self, data, **_kwargs):
+        return data["media"]
+
+
+class CanvasStudioCaptionFilesSchema(RequestsResponseSchema):
+    """Schema for Canvas Studio /media/{id}/caption_files responses."""
+
+    class CaptionFile(Schema):
+        class Meta:
+            unknown = EXCLUDE
+
+        status = fields.Str(required=True)
+        url = fields.Str(required=True)
+
+    caption_files = fields.List(fields.Nested(CaptionFile), required=True)
+
+    @post_load
+    def post_load(self, data, **_kwargs):
+        return data["caption_files"]
+
+
+class APICallInfo(TypedDict):
+    path: str
+    authUrl: str | None
+
+
+class File(TypedDict):
+    """Represents a file or folder in an LMS's file storage."""
+
+    type: Literal["File", "Folder"]
+
+    id: str
+    display_name: str
+    updated_at: str
+
+    contents: Optional[APICallInfo]
+    """API call to use to fetch contents of a folder."""
+
+
+class CanvasStudioService:
+    """
+        Service for authenticating with and making calls to the Canvas Studio API.
+
+    Useful links:
+
+        Authorization guide: https://community.canvaslms.com/t5/Canvas-Studio-Blog/Connecting-Studio-OAuth-via-Postman/ba-p/259739
+        API reference: https://tw.instructuremedia.com/api/public/docs/
+    """
+
+    def __init__(self, request):
+        # This avoids a circular dependency.
+        # TODO: Deal with this more cleanly.
+        from lms.services.oauth_http import create_service as create_oauth_http_service
+
+        application_instance = request.lti_user.application_instance
+
+        self._domain = application_instance.settings.get("canvas_studio", "domain")
+        self._client_id = application_instance.settings.get(
+            "canvas_studio", "client_id"
+        )
+        self._client_secret = application_instance.settings.get_secret(
+            request.find_service(AESService), "canvas_studio", "client_secret"
+        )
+        self._oauth_http_service = create_oauth_http_service(
+            request, service=Service.CANVAS_STUDIO
+        )
+        self._request = request
+
+    def get_access_token(self, code: str) -> None:
+        """
+        Fetch and persist an access token for Canvas Studio API calls.
+
+        :param code: Authorization code received from OAuth callback
+        """
+        token_url = self._api_url("oauth/token")
+        self._oauth_http_service.get_access_token(
+            token_url,
+            self.redirect_uri(),
+            auth=(self._client_id, self._client_secret),
+            authorization_code=code,
+        )
+
+    def authorization_url(self, state: str) -> str:
+        """
+        Construct the authorization endpoint URL for Canvas Studio.
+
+        This constructs the authorization URL for the Canvas Studio instance
+        associated with the current application instance.
+
+        :param state: `state` query param for the authorization request
+        """
+        auth_url = urlunparse(
+            (
+                "https",
+                self._domain,
+                "api/public/oauth/authorize",
+                "",
+                urlencode(
+                    {
+                        "client_id": self._client_id,
+                        "response_type": "code",
+                        "redirect_uri": self.redirect_uri(),
+                        "state": state,
+                    }
+                ),
+                "",
+            )
+        )
+
+        return auth_url
+
+    def redirect_uri(self) -> str:
+        """Return OAuth redirect URI for Canvas Studio."""
+        return self._request.route_url("canvas_studio_api.oauth.callback")
+
+    def list_video_library(self) -> list[File]:
+        """
+        List the videos and collections for the current user.
+
+        The result of this call corresponds to what the user sees if they
+        visit Canvas Studio from within their LMS, or use the Canvas Studio
+        picker when creating a Page.
+        """
+
+        collections = self._api_request("v1/collections", CanvasStudioCollectionsSchema)
+        user_collection = None
+
+        files = []
+        for collection in collections:
+            if collection["type"] == "user":
+                user_collection = collection
+                continue
+
+            files.append(
+                {
+                    "type": "Folder",
+                    "display_name": collection["name"],
+                    "updated_at": collection["created_at"],
+                    "id": str(collection["id"]),
+                    "contents": {
+                        "path": self._request.route_url(
+                            "canvas_studio_api.collections.videos.list",
+                            collection_id=collection["id"],
+                        )
+                    },
+                }
+            )
+
+        if user_collection:
+            files += self.list_collection(str(user_collection["id"]))
+
+        return files
+
+    def list_collection(self, collection_id: str) -> list[File]:
+        """List the videos in a collection."""
+
+        media = self._api_request(
+            f"v1/collections/{collection_id}/media", CanvasStudioCollectionMediaSchema
+        )
+
+        files = []
+        for item in media:
+            media_id = item["id"]
+            files.append(
+                {
+                    "type": "File",
+                    "id": f"canvas-studio://media/{media_id}",
+                    "display_name": item["title"],
+                    "updated_at": item["created_at"],
+                }
+            )
+
+        return files
+
+    @classmethod
+    def media_id_from_url(cls, url: str) -> str | None:
+        """Extract the media ID from a `canvas-studio://media/{media_id}` assignment URL."""
+        parsed = urlparse(url)
+        if parsed.scheme != "canvas-studio" or parsed.netloc != "media":
+            return None
+        return parsed.path[1:]
+
+    def get_canonical_video_url(self, media_id: str) -> str:
+        """
+        Return the URL to associate with annotations on a Canvas Studio video.
+        """
+        # We use the REST resource URL as a stable URL for the video.
+        # Example: "https://hypothesis.instructuremedia.com/api/public/v1/media/4"
+        return self._api_url(f"v1/media/{media_id}")
+
+    def get_video_download_url(self, media_id: str) -> str:
+        """Return temporary download URL for a video."""
+
+        from lms.services import ExternalRequestError
+
+        download_url = self._api_url(f"v1/media/{media_id}/download")
+        download_rsp = self._oauth_http_service.get(download_url, allow_redirects=False)
+        download_redirect = download_rsp.headers.get("Location")
+
+        if download_rsp.status_code != 302 or not download_redirect:
+            raise ExternalRequestError(
+                message=f"Media download did not return valid redirect",
+                response=download_rsp,
+            )
+
+        return download_redirect
+
+    def get_transcript_url(self, media_id: str) -> str | None:
+        """
+        Return URL of transcript for a video, in SRT (SubRip) format.
+
+        May return `None` if no transcript has been generated for the video.
+        """
+
+        captions = self._api_request(
+            f"v1/media/{media_id}/caption_files", CanvasStudioCaptionFilesSchema
+        )
+
+        for caption in captions:
+            if caption["status"] == "published":
+                url = urljoin(self._canvas_studio_site(), caption["url"])
+                return url
+
+        return None
+
+    def _api_request(self, path: str, schema_cls: RequestsResponseSchema) -> dict:
+        """
+        Make a request to the Canvas Studio API and parse the JSON response.
+        """
+        response = self._oauth_http_service.get(self._api_url(path))
+        return schema_cls(response).parse()
+
+    def _api_url(self, path: str) -> str:
+        """
+        Return the URL of a Canvas Studio API endpoint.
+
+        See https://tw.instructuremedia.com/api/public/docs/ for available
+        endpoints.
+
+        :param path: Path of endpoint relative to the API root
+        """
+
+        site = self._canvas_studio_site()
+        return f"{site}/api/public/{path}"
+
+    def _canvas_studio_site(self) -> str:
+        return f"https://{self._domain}"
+
+
+def factory(_context, request):
+    return CanvasStudioService(request)

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -19,6 +19,7 @@ type DialogType =
   | 'blackboardFile'
   | 'canvasFile'
   | 'canvasPage'
+  | 'canvasStudio'
   | 'd2lFile'
   | 'moodleFile'
   | 'moodlePage'
@@ -80,6 +81,10 @@ export default function ContentSelector({
         foldersEnabled: canvasWithFolders,
         pagesEnabled: canvasPagesEnabled,
         listPages: listPagesApi,
+      },
+      canvasStudio: {
+        enabled: canvasStudioEnabled,
+        listMedia: listCanvasStudioMediaApi,
       },
       google: {
         enabled: googleDriveEnabled,
@@ -188,6 +193,15 @@ export default function ContentSelector({
   const selectCanvasPage = (page: File | Page) =>
     selectPageAsURL(page, 'Canvas');
 
+  const selectCanvasStudio = (video: File | Page) => {
+    cancelDialog();
+    onSelectContent({
+      type: 'url',
+      url: video.id,
+      name: `Canvas Studio video: ${video.display_name}`,
+    });
+  };
+
   const selectMoodlePage = (page: File | Page) =>
     selectPageAsURL(page, 'Moodle');
 
@@ -236,6 +250,18 @@ export default function ContentSelector({
           onCancel={cancelDialog}
           onSelectFile={selectCanvasPage}
           missingFilesHelpLink="https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-create-a-new-page-in-a-course/ta-p/1031"
+          documentType="page"
+        />
+      );
+      break;
+    case 'canvasStudio':
+      dialog = (
+        <LMSFilePicker
+          authToken={authToken}
+          listFilesApi={listCanvasStudioMediaApi}
+          onCancel={cancelDialog}
+          onSelectFile={selectCanvasStudio}
+          missingFilesHelpLink="https://community.canvaslms.com/t5/Canvas-Studio-Guide/How-do-I-use-Canvas-Studio/ta-p/1678"
           documentType="page"
         />
       );
@@ -396,7 +422,15 @@ export default function ContentSelector({
             Canvas Page
           </OptionButton>
         )}
-
+        {canvasStudioEnabled && (
+          <OptionButton
+            data-testid="canvas-studio-button"
+            details="Canvas Studio"
+            onClick={() => selectDialog('canvasStudio')}
+          >
+          Canvas Studio
+          </OptionButton>
+        )}
         {blackboardFilesEnabled && (
           <OptionButton
             data-testid="blackboard-file-button"

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -63,6 +63,9 @@ function formatContentURL(content: URLContent) {
   if (content.url.startsWith('blackboard://')) {
     return 'PDF file in Blackboard';
   }
+  if (content.url.startsWith('canvas-studio://')) {
+    return 'Video in Canvas Studio';
+  }
   if (content.url.startsWith('d2l://')) {
     return 'PDF file in D2L';
   }

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -105,6 +105,10 @@ export type FilePickerConfig = {
     listFiles: APICallInfo;
     listPages: APICallInfo;
   };
+  canvasStudio: {
+    enabled: boolean;
+    listMedia: APICallInfo;
+  };
   google: {
     enabled: boolean;
     clientId?: string;

--- a/lms/templates/api/oauth2/client_side_redirect.html.jinja2
+++ b/lms/templates/api/oauth2/client_side_redirect.html.jinja2
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">    
+  <head>
+    <meta charset="UTF-8">
+    <title>Redirecting to {{ link_text }}</title>
+    <meta http-equiv="refresh" content="0; url={{ redirect_url }}">
+  </head>    
+  <body>
+  <p>Redirecting to <a href="{{ redirect_url }}">{{ link_text }}</a></p>.
+  </body>  
+</html>

--- a/lms/validation/authentication/_oauth.py
+++ b/lms/validation/authentication/_oauth.py
@@ -93,27 +93,26 @@ class OAuthCallbackSchema(PyramidRequestSchema):
 
         return jwt_str
 
-    def lti_user(self) -> LTIUser:
+    def lti_user(self, state=None) -> LTIUser:
         """
-        Return the LTIUser authenticated by the request's state param.
+        Return the LTIUser authenticated by state data in an OAuth callback.
 
-        Return the models.LTIUser authenticated by the current
-        request's ``state`` query parameter.
+        If ``state`` is None, the state is obtained from the current request's
+        ``state`` query parameter.
 
         :raise MissingStateParamError: if the request has no ``state`` query
             parameter
-        :raise ExpiredStateParamError: if the request's ``state`` param has
-            expired
-        :raise InvalidStateParamError: if the request's ``state`` param is
-            invalid
-        :rtype: str
+        :raise ExpiredStateParamError: if the state has expired
+        :raise InvalidStateParamError: if the state is invalid
         """
-        request = self.context["request"]
 
-        try:
-            state = request.params["state"]
-        except KeyError as err:
-            raise MissingStateParamError() from err
+        if state is None:
+            request = self.context["request"]
+
+            try:
+                state = request.params["state"]
+            except KeyError as err:
+                raise MissingStateParamError() from err
 
         decoded_user = self._decode_state(state)["user"]
         return self._lti_user_service.deserialize(**decoded_user)

--- a/lms/views/api/canvas_studio.py
+++ b/lms/views/api/canvas_studio.py
@@ -1,0 +1,150 @@
+"""
+Views for authorizing with Canvas Studio and listing videos.
+
+See `CanvasStudioService` for more details.
+"""
+
+from urllib.parse import urlencode, urlparse, urlunparse
+
+from pyramid.httpexceptions import HTTPBadRequest, HTTPFound
+from pyramid.view import view_config
+
+from lms.models.oauth2_token import Service
+from lms.security import Permissions
+from lms.services import CanvasStudioService
+from lms.services.exceptions import OAuth2TokenError
+from lms.services.oauth_http import create_service as create_oauth_http_service
+from lms.validation.authentication import OAuthCallbackSchema
+from lms.views.helpers import via_video_url
+
+
+# View for authorization popup which redirects to Canvas Studio's OAuth
+# authorization endpoint.
+#
+# Canvas Studio's OAuth implementation has several issues which complicate
+# using the standard OAuth flow:
+#
+# 1. Canvas Studio does not return the `state` parameter to us when it redirects
+#    after a successful authorization [1].
+# 2. Canvas Studio does not allow the use of unencrypted HTTP or `localhost`
+#    as a redirect URL for an OAuth client.
+#
+# To work around these issues, we use the following authentication flow:
+#
+# 1. User clicks button in UI to initiate Canvas Studio authorization
+# 2. The button opens `/api/canvas_studio/oauth/authorize` in a popup
+# 3. In development only, the popup redirects to change the host from
+#    http://localhost:8001 to https://hypothesis.local:48001/, keeping the
+#    path the same.
+# 4. The popup returns a 200 response which sets a cookie and does a client-side
+#    redirect to the Canvas Studio authorization endpoint.
+#
+#    We use a client-side redirect because setting cookies as part of a 302
+#    redirect response does not work in some browsers (including Chrome).
+# 5. The user completes authorization in the Canvas Studio UI
+# 6. Canvas Studio redirects to our `/api/canvas_studio/oauth/callback`
+#    endpoint, passing the authorization code, but not the `state`.
+# 7. We read the `state` parameter out of the cookie and then
+#    redirect to the `/api/canvas_studio/oauth/callback` URL that Canvas Studio
+#    should have used.
+#
+# [1] https://community.canvaslms.com/t5/Canvas-Developers-Group/Canvas-Studio-OAuth-authorization-does-not-send-state-parameter/td-p/596747
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.oauth.authorize",
+    renderer="lms:templates/api/oauth2/client_side_redirect.html.jinja2",
+    permission=Permissions.API,
+)
+def authorize(request):
+    if request.host_url == "http://localhost:8001":
+        redirect_url = request.url.replace(
+            request.host_url, "https://hypothesis.local:48001"
+        )
+        return HTTPFound(location=redirect_url)
+
+    canvas_studio_svc = request.find_service(CanvasStudioService)
+    oauth_state = OAuthCallbackSchema(request).state_param()
+    auth_url = canvas_studio_svc.authorization_url(oauth_state)
+
+    request.response.set_cookie("canvas_studio_oauth_state", oauth_state)
+
+    return {"redirect_url": auth_url, "link_text": "Canvas Studio login"}
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.oauth.callback",
+    renderer="lms:templates/api/oauth2/redirect.html.jinja2",
+    request_param="state",
+    schema=OAuthCallbackSchema,
+)
+def oauth2_redirect(request):
+    code = request.parsed_params["code"]
+    request.find_service(CanvasStudioService).get_access_token(code)
+    return {}
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.oauth.callback",
+    renderer="lms:templates/api/oauth2/redirect.html.jinja2",
+)
+def oauth2_redirect_missing_state(request):
+    code = request.params["code"]
+    state = request.cookies.get("canvas_studio_oauth_state")
+
+    # Generate the redirect URL which Canvas Studio should have generated.
+    url = request.route_url(
+        "canvas_studio_api.oauth.callback", _query={"code": code, "state": state}
+    )
+
+    return HTTPFound(location=url)
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.videos.list",
+    renderer="json",
+    permission=Permissions.API,
+)
+def list_videos(request):
+    svc = request.find_service(CanvasStudioService)
+    return svc.list_video_library()
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.collections.videos.list",
+    renderer="json",
+    permission=Permissions.API,
+)
+def list_collection(request):
+    svc = request.find_service(CanvasStudioService)
+    collection_id = request.matchdict["collection_id"]
+    return svc.list_collection(collection_id)
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.via_url",
+    renderer="json",
+    permission=Permissions.API,
+)
+def via_url(request):
+    svc = request.find_service(CanvasStudioService)
+    document_url = request.params.get("document_url")
+    media_id = (
+        CanvasStudioService.media_id_from_url(document_url) if document_url else None
+    )
+    if not media_id:
+        raise HTTPBadRequest("Missing or invalid `document_url` param")
+
+    canonical_url = svc.get_canonical_video_url(media_id)
+    download_url = svc.get_video_download_url(media_id)
+
+    # TODO - Handle case where transcript is not available.
+    transcript_url = svc.get_transcript_url(media_id)
+
+    via_url = via_video_url(request, canonical_url, download_url, transcript_url)
+
+    return {"via_url": via_url}

--- a/lms/views/helpers/__init__.py
+++ b/lms/views/helpers/__init__.py
@@ -1,3 +1,3 @@
-from lms.views.helpers._via import via_url
+from lms.views.helpers._via import via_url, via_video_url
 
-__all__ = ["via_url"]
+__all__ = ["via_url", "via_video_url"]

--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -11,6 +11,12 @@ def _common_via_params(request) -> dict:
     return {
         "via.client.requestConfigFromFrame.origin": request.host_url,
         "via.client.requestConfigFromFrame.ancestorLevel": "2",
+        # These parameters match defaults set in `h_vialib`. We reproduce them
+        # here to get consistent configuration between `via_url`,
+        # `via_video_url` etc.
+        "via.client.ignoreOtherConfiguration": "1",
+        "via.client.openSidebar": "1",
+        "via.external_link_mode": "new-tab",
     }
 
 
@@ -63,6 +69,7 @@ def via_video_url(
     :param transcript_url:
         URL of the video's transcript, in SRT or WebVTT formats.
     """
+
     via_service_url = urlparse(request.registry.settings["via_url"])
     via_url = urlunparse(
         (

--- a/tests/unit/lms/models/oauth2_token_test.py
+++ b/tests/unit/lms/models/oauth2_token_test.py
@@ -4,6 +4,7 @@ import pytest
 import sqlalchemy.exc
 
 from lms.models import OAuth2Token
+from lms.models.oauth2_token import Service
 
 
 class TestOAuth2Token:
@@ -18,6 +19,7 @@ class TestOAuth2Token:
                 refresh_token="test_refresh_token",
                 expires_in=3600,
                 received_at=now,
+                service=Service.CANVAS_STUDIO,
             )
         )
 
@@ -29,6 +31,7 @@ class TestOAuth2Token:
         assert token.refresh_token == "test_refresh_token"
         assert token.expires_in == 3600
         assert token.received_at == now
+        assert token.service == Service.CANVAS_STUDIO
 
     @pytest.mark.parametrize("column", ["user_id", "access_token"])
     def test_columns_that_cant_be_None(self, db_session, init_kwargs, column):
@@ -51,29 +54,16 @@ class TestOAuth2Token:
 
         assert token.application_instance_id == application_instance.id
 
-    def test_refresh_token_defaults_to_None(self, db_session, init_kwargs):
+    def test_defaults(self, db_session, init_kwargs):
         token = OAuth2Token(**init_kwargs)
         db_session.add(token)
 
         db_session.flush()
 
         assert token.refresh_token is None
-
-    def test_expires_in_defaults_to_None(self, db_session, init_kwargs):
-        token = OAuth2Token(**init_kwargs)
-        db_session.add(token)
-
-        db_session.flush()
-
         assert token.expires_in is None
-
-    def test_received_at_defaults_to_now(self, db_session, init_kwargs):
-        token = OAuth2Token(**init_kwargs)
-        db_session.add(token)
-
-        db_session.flush()
-
         assert isinstance(token.received_at, datetime.datetime)
+        assert token.service == Service.LMS
 
     @pytest.fixture
     def init_kwargs(self, application_instance):

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -46,6 +46,7 @@ class TestFilePickerMode:
         (
             ("blackboard_config", "blackboard"),
             ("canvas_config", "canvas"),
+            ("canvas_studio_config", "canvasStudio"),
             ("google_files_config", "google"),
             ("microsoft_onedrive", "microsoftOneDrive"),
             ("vitalsource_config", "vitalSource"),
@@ -266,6 +267,13 @@ class TestAddDocumentURL:
                 {
                     "authUrl": "http://example.com/api/canvas/oauth/authorize",
                     "path": "/api/canvas/pages/via_url",
+                },
+            ),
+            (
+                "canvas-studio://media/media_id",
+                {
+                    "authUrl": "http://example.com/api/canvas_studio/oauth/authorize",
+                    "path": "/api/canvas_studio/via_url?document_url=canvas-studio%3A%2F%2Fmedia%2Fmedia_id",
                 },
             ),
             (

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -119,6 +119,23 @@ class TestFilePickerConfig:
 
         assert config == expected_config
 
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_canvas_studio_config(self, pyramid_request, application_instance, enabled):
+        application_instance.settings.set(
+            "canvas_studio", "client_id", "some_id" if enabled else None
+        )
+        config = FilePickerConfig.canvas_studio_config(
+            pyramid_request, application_instance
+        )
+
+        assert config["enabled"] is enabled
+
+        if enabled:
+            assert config["listMedia"] == {
+                "authUrl": "http://example.com/api/canvas_studio/oauth/authorize",
+                "path": "/api/canvas_studio/media",
+            }
+
     @pytest.mark.parametrize("enabled", (True, False))
     @pytest.mark.parametrize(
         "origin_from", (None, "custom_canvas_api_domain", "lms_url")

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -407,6 +407,7 @@ class TestSecurityPolicy:
             ("/content_item_selection", get_lti_user_from_launch_params),
             ("/canvas_oauth_callback", get_lti_user_from_oauth_callback),
             ("/api/blackboard/oauth/callback", get_lti_user_from_oauth_callback),
+            ("/api/canvas_studio/oauth/callback", get_lti_user_from_oauth_callback),
             ("/api/d2l/oauth/callback", get_lti_user_from_oauth_callback),
         ],
     )

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -7,7 +7,11 @@ from pytest import param
 
 from lms.models import OAuth2Token
 from lms.services import OAuth2TokenError
-from lms.services.oauth2_token import OAuth2TokenService, Service, oauth2_token_service_factory
+from lms.services.oauth2_token import (
+    OAuth2TokenService,
+    Service,
+    oauth2_token_service_factory,
+)
 from tests import factories
 
 

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -7,7 +7,7 @@ from pytest import param
 
 from lms.models import OAuth2Token
 from lms.services import OAuth2TokenError
-from lms.services.oauth2_token import OAuth2TokenService, oauth2_token_service_factory
+from lms.services.oauth2_token import OAuth2TokenService, Service, oauth2_token_service_factory
 from tests import factories
 
 
@@ -28,6 +28,7 @@ class TestOAuth2TokenService:
                 "refresh_token": "refresh_token",
                 "expires_in": 1234,
                 "received_at": Any.instance_of(datetime),
+                "service": Service.LMS,
             }
         )
 

--- a/tests/unit/lms/validation/authentication/_oauth_test.py
+++ b/tests/unit/lms/validation/authentication/_oauth_test.py
@@ -54,7 +54,19 @@ class TestOauthCallbackSchema:
         )
         assert returned == lti_user_service.deserialize.return_value
 
-    def test_lti_user_raises_if_theres_no_state_param(self, schema, pyramid_request):
+    def test_lti_user_uses_explicitly_passed_state(
+        self, schema, jwt_service, lti_user_service, pyramid_request
+    ):
+        del pyramid_request.params["state"]
+
+        returned = schema.lti_user("custom_state")
+
+        jwt_service.decode_with_secret.assert_called_once_with(
+            "custom_state", "test_oauth2_state_secret"
+        )
+        assert returned == lti_user_service.deserialize.return_value
+
+    def test_lti_user_raises_if_theres_no_state(self, schema, pyramid_request):
         del pyramid_request.params["state"]
 
         with pytest.raises(MissingStateParamError):


### PR DESCRIPTION
This draft shows all the pieces needed to get Canvas Studio integration working end-to-end. From the user-facing perspective, this adds:

- Canvas Studio configuration per application instance.
- A "Canvas Studio" option in the file picker, which shows up when a Canvas Studio site is configured for the current app instance. This currently displays the same file picker UI as other cloud file storage. This should be tailored for selecting a video in future eg. by adding a thumbnail

The elements of this include:

- Supporting storing multiple OAuth 2 tokens for a given LTI user. This allows storing both a Canvas API token and a Canvas Studio API token for the same user. This is done by adding a `service` field to the `oauth2_token` table. The unique constraint on this table changes from `(application_instance, lti_user)` to `(application_instance, lti_user, service)`
- Adding three new settings for an application instance to record the Canvas Studio domain, client ID and client secret
- Adding a new "Canvas Studio" option to the file picker
- OAuth authorization and callback views for the Canvas Studio API
- API views to support the file picker
- A `CanvasStudioService` service to proxy the API

Canvas Studio's OAuth implementation has several issues that I've had to work around. See the notes at the top of `lms/views/api/canvas_studio.py` for an explanation.

Some things that are not yet implemented but will be needed:

- Changing various text in the file picker to be appropriate for selecting videos as opposed to files or pages
- Showing thumbnails in the file picker
- Checking that a video has an available transcript before allowing an assignment to be created
- Better error handling

Part of https://github.com/hypothesis/product-backlog/issues/1528