### PR TITLE
Add migration for `oauth2_token.service` field

### DIFF
--- a/lms/migrations/versions/c64961cf7254_add_service_field_to_oauth2_token.py
+++ b/lms/migrations/versions/c64961cf7254_add_service_field_to_oauth2_token.py
@@ -1,0 +1,45 @@
+"""Add `service` field to oauth2_token.
+
+Revision ID: c64961cf7254
+Revises: 08dff0b683e7
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c64961cf7254"
+down_revision = "08dff0b683e7"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "oauth2_token",
+        sa.Column(
+            "service",
+            sa.Enum(
+                "lms",
+                "canvas_studio",
+                name="service",
+                native_enum=False,
+                length=64,
+            ),
+            nullable=False,
+            server_default=sa.text("'lms'"),
+        ),
+    )
+    op.drop_constraint("uq__oauth2_token__user_id", "oauth2_token")
+    op.create_unique_constraint(
+        "uq__oauth2_token__user_id",
+        "oauth2_token",
+        ["user_id", "application_instance_id", "service"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq__oauth2_token__user_id", "oauth2_token")
+    op.create_unique_constraint(
+        "uq__oauth2_token__user_id",
+        "oauth2_token",
+        ["user_id", "application_instance_id"],
+    )
+    op.drop_column("oauth2_token", "service")


### PR DESCRIPTION
This is an enum indicating which API an OAuth token refers to. There are initially two values:

 - "lms" - The LMS's main API (default)
 - "canvas_studio" - Canvas Studio API

This PR implements the migration in the simplest possible way. We might decide to change this to avoid locking the table during deployment. See https://github.com/hypothesis/lms/pull/6091#discussion_r1509113471.

Extracted from https://github.com/hypothesis/lms/pull/6091. Part of https://github.com/hypothesis/product-backlog/issues/1528.